### PR TITLE
feat: enable Claude config loading (CLAUDE.md, skills, hooks)

### DIFF
--- a/apps/desktop/src/main/sidecar/client.ts
+++ b/apps/desktop/src/main/sidecar/client.ts
@@ -76,6 +76,12 @@ export class SidecarClient extends EventEmitter {
       permissionMode: isBypass ? ("bypassPermissions" as const) : ("default" as const),
       ...(isBypass ? { allowDangerouslySkipPermissions: true } : {}),
       abortController,
+      // Load CLAUDE.md, skills, hooks, and settings from user + project config
+      settingSources: ["user" as const, "project" as const, "local" as const],
+      // Activate Claude Code system prompt so the agent respects slash commands and conventions
+      systemPrompt: { type: "preset" as const, preset: "claude_code" as const },
+      // Enable Claude Code tools (Read, Write, Edit, Bash, Glob, Grep, Agent, etc.)
+      tools: { type: "preset" as const, preset: "claude_code" as const },
     };
 
     try {


### PR DESCRIPTION
## What
Enable full Claude Code configuration loading in the Agent SDK integration so that CLAUDE.md files, skills, hooks, settings, and slash commands work when running Claude through Mcode.

## Why
The SDK was running in isolation mode (no `settingSources`), which meant only memory files were discovered. User-level and project-level CLAUDE.md, skills from `.claude/skills/`, hooks from `settings.json`, and slash commands were all silently ignored.

## Key Changes
- Add `settingSources: ["user", "project", "local"]` to load config from `~/.claude/` and `.claude/`
- Add `systemPrompt: { type: "preset", preset: "claude_code" }` to activate the Claude Code system prompt
- Add `tools: { type: "preset", preset: "claude_code" }` to enable full Claude Code tool surface

Single file changed: `apps/desktop/src/main/sidecar/client.ts` (+6 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now loads settings from multiple sources: user, project, and local configurations
  * Claude Code tools and system conventions are now enabled for enhanced functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->