### PR TITLE
feat: add F2 shortcut to rename threads

### DIFF
--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -112,13 +112,22 @@ export function ProjectTree() {
       if (!activeThreadId) return;
       if (inlineEdit) return;
 
-      // Don't trigger when user is typing in an input or textarea
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      // Don't trigger when user is in any editable context
+      const target = e.target as HTMLElement;
+      const tag = target?.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target?.isContentEditable ||
+        target?.closest?.('[contenteditable="true"]') ||
+        target?.getAttribute?.("role") === "textbox" ||
+        target?.hasAttribute?.("aria-multiline")
+      ) return;
 
-      e.preventDefault();
       const thread = threads.find((t) => t.id === activeThreadId);
       if (thread) {
+        e.preventDefault();
         setInlineEdit({
           threadId: thread.id,
           title: thread.title,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "apps/web"
   ],
   "scripts": {
-    "postinstall": "node -e \"var f='apps/desktop/node_modules/electron/install.js';require('fs').existsSync(f)&&require('child_process').execSync('node '+f,{stdio:'inherit'})\" && cd apps/desktop && npx electron-rebuild -f -w better-sqlite3",
+    "postinstall": "cd apps/desktop && npx electron-rebuild -f -w better-sqlite3",
     "dev": "turbo run dev",
     "dev:desktop": "cd apps/desktop && bun run dev",
     "dev:web": "cd apps/web && bun run dev",


### PR DESCRIPTION
## What
Add F2 keyboard shortcut to rename the selected thread in the project tree, plus fix Electron binary download in worktrees.

## Why
Renaming threads required right-clicking and selecting "Rename" from the context menu. F2 is the standard rename shortcut (Windows Explorer, VS Code, etc.) and provides a faster workflow. The Electron fix ensures `bun install` works reliably in git worktrees.

## Key Changes
- Add global F2 keydown listener in `ProjectTree` that enters inline edit mode for the active thread
- Guard against activation when typing in inputs/textareas or already editing
- Run `electron/install.js` explicitly in root postinstall to fix worktree binary download

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added F2 keyboard shortcut to rename selected items in the project tree. When an item is selected and F2 is pressed, the interface enters inline rename mode for quick edits. The feature intelligently avoids triggering while you're typing in input fields, text areas, or other editable elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->