### PR TITLE
fix: format work timer as human-readable duration

### DIFF
--- a/apps/web/src/components/chat/StreamingIndicator.tsx
+++ b/apps/web/src/components/chat/StreamingIndicator.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Loader2 } from "lucide-react";
+import { formatDuration } from "../../lib/time";
 
 interface StreamingIndicatorProps {
   startTime?: number;
@@ -23,7 +24,7 @@ export function StreamingIndicator({ startTime }: StreamingIndicatorProps) {
   return (
     <div className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground">
       <Loader2 size={14} className="animate-spin" />
-      <span>Working for {elapsed}s</span>
+      <span>Working for {formatDuration(elapsed)}</span>
     </div>
   );
 }

--- a/apps/web/src/lib/time.ts
+++ b/apps/web/src/lib/time.ts
@@ -1,3 +1,16 @@
+export function formatDuration(totalSeconds: number): string {
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
 export function relativeTime(dateStr: string): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();


### PR DESCRIPTION
## What
Format the streaming indicator's elapsed time as a human-readable duration instead of raw seconds.

## Why
Displaying "Working for 800s" forces users to do mental math. "13m 20s" is instantly readable.

## Key Changes
- Add `formatDuration()` utility to `apps/web/src/lib/time.ts` that converts seconds into `Xs`, `Xm Ys`, or `Xh Ym`
- Use `formatDuration()` in `StreamingIndicator` instead of appending `s` to the raw count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The elapsed time display in the streaming indicator now appears in a human-readable format (e.g., "1 m 30 s") instead of raw seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->