### PR TITLE
fix: render fenced code blocks without language as block elements

### DIFF
--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -1,3 +1,4 @@
+import type { Element } from "hast";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -34,16 +35,14 @@ export function MarkdownContent({ content }: MarkdownContentProps) {
             {children}
           </blockquote>
         ),
-        code: ({ className, children }) => {
-          const isInline = !className;
-          if (isInline) {
-            return (
-              <code className="bg-muted rounded px-1.5 py-0.5 text-sm font-mono">
-                {children}
-              </code>
-            );
-          }
-          const language = className?.replace("language-", "") ?? "";
+        pre: ({ children, node }) => {
+          const firstChild = node?.children?.[0];
+          const langClass =
+            firstChild?.type === "element"
+              ? (((firstChild as Element).properties?.className as string[] | undefined)?.[0] ?? "")
+              : "";
+          const language = langClass.replace("language-", "");
+
           return (
             <div className="my-2 rounded-lg overflow-hidden border border-border">
               {language && (
@@ -51,13 +50,17 @@ export function MarkdownContent({ content }: MarkdownContentProps) {
                   {language}
                 </div>
               )}
-              <pre className="bg-muted/30 p-3 overflow-x-auto">
-                <code className="text-sm font-mono leading-relaxed">{children}</code>
+              <pre className="bg-muted/30 p-3 overflow-x-auto text-sm font-mono leading-relaxed [&_code]:bg-transparent [&_code]:p-0 [&_code]:rounded-none">
+                {children}
               </pre>
             </div>
           );
         },
-        pre: ({ children }) => <>{children}</>,
+        code: ({ children }) => (
+          <code className="bg-muted rounded px-1.5 py-0.5 text-sm font-mono">
+            {children}
+          </code>
+        ),
         hr: () => <hr className="my-4 border-border" />,
         table: ({ children }) => (
           <div className="overflow-x-auto my-2">


### PR DESCRIPTION
## What

Fix markdown rendering so fenced code blocks without a language specifier display as proper preformatted blocks instead of inline code.

## Why

The `code` component used `!className` to detect inline vs block code. Fenced code blocks without a language (` ``` `) produce `<code>` elements with no `className`, so they were treated as inline code. This collapsed whitespace, rendering tree diagrams and other multi-line content on a single wrapped line.

## Key Changes

- Move block code rendering from `code` to `pre` (the reliable block indicator)
- Extract language from the hast AST node with proper `Element` typing
- Use Tailwind `[&_code]` descendant selectors on `<pre>` to strip inline styling from nested `<code>` elements
- `code` component now handles only inline styling; `pre` handles all block wrapping