### PR TITLE
fix: show base branch picker in worktree mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,24 @@ apps/
 docs/plans/                   # Design and planning docs (gitignored)
 ```
 
+## Composer Status Bar
+
+The `Composer` component (`apps/web/src/components/chat/Composer.tsx`) renders a status bar below the text input with mode and branch controls. The layout depends on the selected `ComposerMode`:
+
+| Mode | Left | Right |
+|------|------|-------|
+| Direct | `ModeSelector` | `BranchPicker` |
+| New worktree | `ModeSelector` | `BranchPicker` → `NamingModeSelector` → `BranchNameInput` |
+| Existing worktree | `ModeSelector` | `WorktreePicker` |
+| Locked (existing thread) | `ModeSelector` (locked) | `BranchPicker` (locked, read-only) |
+
+Key components:
+- **`BranchPicker`** – searchable branch dropdown, used in both direct and worktree modes
+- **`ModeSelector`** – switches between Local / New worktree / Existing worktree
+- **`NamingModeSelector`** – toggles Auto / Custom branch naming
+- **`BranchNameInput`** – shows auto-generated or editable branch name
+- **`WorktreePicker`** – searchable dropdown for existing worktrees
+
 ## Commit Guidelines
 
 Use [Conventional Commits](https://www.conventionalcommits.org/).

--- a/apps/web/src/components/chat/BranchPicker.tsx
+++ b/apps/web/src/components/chat/BranchPicker.tsx
@@ -11,6 +11,12 @@ interface BranchPickerProps {
   locked: boolean;
 }
 
+/**
+ * Searchable dropdown for selecting a git branch.
+ * Used in direct mode for the working branch and in worktree mode
+ * for choosing the base branch to create the worktree from ("From main").
+ * When `locked` is true, renders a read-only badge instead of a dropdown.
+ */
 export function BranchPicker({ branches, selectedBranch, onSelect, loading, locked }: BranchPickerProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -48,6 +48,15 @@ interface ComposerProps {
 type AccessMode = PermissionMode;
 type ReasoningLevel = "low" | "medium" | "high";
 
+/**
+ * Main message composer with model/mode selectors and branch controls.
+ *
+ * Status bar layout varies by mode:
+ * - **Direct:** `[Local v]` … `[From branch v]`
+ * - **Worktree:** `[Worktree v]` … `[From branch v] [Auto v] [branch-name]`
+ * - **Existing worktree:** `[Worktree v]` … `[Select worktree v]`
+ * - **Locked (existing thread):** read-only branch badge
+ */
 export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) {
   const [input, setInput] = useState("");
   const [modelId, setModelId] = useState(getDefaultModel().id);


### PR DESCRIPTION
## Summary
- Added the `BranchPicker` ("From main") to the composer status bar when in worktree creation mode
- Previously, switching to "New worktree" mode hid the base branch selector, so users couldn't choose which branch to create the worktree from
- Layout: `[Worktree v]` on the left, `[From main v] [Auto v] [branch-name]` grouped on the right

## Test plan
- [ ] Switch composer to "New worktree" mode and verify "From main" picker appears
- [ ] Select a different base branch and confirm it persists
- [ ] Verify "Direct" and "Existing worktree" modes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer now shows a branch picker in the status bar when creating a new worktree thread, letting users choose a branch (falls back to "main" if unset).

* **Documentation**
  * Added docs describing the Composer status bar behavior and the branch-picker UI and states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->