### PR TITLE
feat: semantic tool call rendering with per-type renderers

### DIFF
--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -3,8 +3,6 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { MessageList } from "./MessageList";
 import { Composer } from "./Composer";
-import { StreamingIndicator } from "./StreamingIndicator";
-import { ToolCallCard } from "./ToolCallCard";
 import { HeaderActions } from "./HeaderActions";
 
 export function ChatView() {
@@ -17,13 +15,7 @@ export function ChatView() {
   const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
   const messages = useThreadStore((s) => s.messages);
 
-  const agentStartTimes = useThreadStore((s) => s.agentStartTimes);
-  const toolCallsRaw = useThreadStore((s) =>
-    activeThreadId ? s.toolCallsByThread[activeThreadId] : undefined
-  );
-  const toolCalls = toolCallsRaw ?? [];
   const isAgentRunning = activeThreadId ? runningThreadIds.has(activeThreadId) : false;
-  const agentStartTime = activeThreadId ? agentStartTimes[activeThreadId] : undefined;
 
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const activeThread = threads.find((t) => t.id === activeThreadId);
@@ -105,19 +97,7 @@ export function ChatView() {
             </p>
           </div>
         ) : (
-          <>
-            <MessageList />
-
-            {/* Active tool calls - inline within the message flow */}
-            {toolCalls.length > 0 && (
-              <div className="px-4 py-2 max-h-[300px] overflow-y-auto">
-                <ToolCallCard toolCalls={toolCalls} />
-              </div>
-            )}
-
-            {/* Streaming indicator with timer */}
-            {isAgentRunning && <StreamingIndicator startTime={agentStartTime} />}
-          </>
+          <MessageList />
         )}
       </div>
 

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -1,22 +1,114 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useMemo, useCallback } from "react";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { MessageBubble } from "./MessageBubble";
+import { ToolCallCard } from "./ToolCallCard";
+import { StreamingIndicator } from "./StreamingIndicator";
+import { StreamingBubble } from "./StreamingBubble";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import type { ToolCall } from "@/transport/types";
+
+const EMPTY_TOOL_CALLS: ToolCall[] = [];
 
 export function MessageList() {
   const messages = useThreadStore((s) => s.messages);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
+  const agentStartTimes = useThreadStore((s) => s.agentStartTimes);
+  const streamingText = useThreadStore((s) =>
+    activeThreadId ? s.streamingByThread[activeThreadId] : undefined
+  );
+  const toolCallsRaw = useThreadStore((s) =>
+    activeThreadId ? s.toolCallsByThread[activeThreadId] : undefined
+  );
+  const fadingToolCallsRaw = useThreadStore((s) =>
+    activeThreadId ? s.fadingToolCallsByThread[activeThreadId] : undefined
+  );
+  const toolCalls = toolCallsRaw ?? EMPTY_TOOL_CALLS;
+  const fadingToolCalls = fadingToolCallsRaw ?? EMPTY_TOOL_CALLS;
+  const isAgentRunning = activeThreadId ? runningThreadIds.has(activeThreadId) : false;
+  const agentStartTime = activeThreadId ? agentStartTimes[activeThreadId] : undefined;
+
+  const hasActiveToolCalls = toolCalls.length > 0;
+  const hasFadingToolCalls = fadingToolCalls.length > 0;
+  const hasStreamingText = !!streamingText;
+
+  // Split messages: render tool calls between the last user message and
+  // the final assistant reply so they appear inline rather than at the bottom.
+  const { beforeMessages, lastAssistantMsg } = useMemo(() => {
+    const showToolCalls = hasActiveToolCalls || hasFadingToolCalls;
+    if (!showToolCalls || messages.length === 0) {
+      return { beforeMessages: messages, lastAssistantMsg: null };
+    }
+    // Find the last assistant message — tool calls belong just before it
+    const lastIdx = messages.length - 1;
+    const last = messages[lastIdx];
+    if (last.role === "assistant") {
+      return {
+        beforeMessages: messages.slice(0, lastIdx),
+        lastAssistantMsg: last,
+      };
+    }
+    return { beforeMessages: messages, lastAssistantMsg: null };
+  }, [messages, hasActiveToolCalls, hasFadingToolCalls]);
+
+  // Throttled scroll-to-bottom: use instant during streaming to avoid jank,
+  // smooth for discrete events. Throttle to at most once per 200ms.
+  const scrollToBottom = useCallback((smooth: boolean) => {
+    if (scrollTimerRef.current) return;
+    scrollTimerRef.current = setTimeout(() => {
+      scrollTimerRef.current = null;
+      bottomRef.current?.scrollIntoView({ behavior: smooth ? "smooth" : "instant" });
+    }, 200);
+  }, []);
+
+  // Discrete events (new message, tool call) → smooth scroll
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages.length]);
+    scrollToBottom(true);
+  }, [messages.length, toolCalls.length, isAgentRunning, scrollToBottom]);
+
+  // Streaming deltas → throttled instant scroll
+  useEffect(() => {
+    if (streamingText) scrollToBottom(false);
+  }, [streamingText, scrollToBottom]);
 
   return (
     <ScrollArea className="h-full">
       <div className="flex flex-col gap-4 p-4">
-        {messages.map((msg) => (
+        {beforeMessages.map((msg) => (
           <MessageBubble key={msg.id} message={msg} />
         ))}
+
+        {/* Active tool calls — inline between user message and assistant reply */}
+        {hasActiveToolCalls && (
+          <ToolCallCard toolCalls={toolCalls} />
+        )}
+
+        {/* Fading tool calls — completed calls lingering so user sees final state */}
+        {hasFadingToolCalls && !hasActiveToolCalls && (
+          <div className="animate-fade-out">
+            <ToolCallCard toolCalls={fadingToolCalls} />
+          </div>
+        )}
+
+        {/* The last assistant message renders after tool calls */}
+        {lastAssistantMsg && (
+          <MessageBubble key={lastAssistantMsg.id} message={lastAssistantMsg} />
+        )}
+
+        {/* Live streaming text — renders the response as it arrives */}
+        {hasStreamingText && (
+          <StreamingBubble content={streamingText} />
+        )}
+
+        {/* Streaming indicator with semantic phase labels */}
+        {isAgentRunning && !hasStreamingText && (
+          <StreamingIndicator startTime={agentStartTime} activeToolCalls={toolCalls} />
+        )}
+
         <div ref={bottomRef} />
       </div>
     </ScrollArea>

--- a/apps/web/src/components/chat/StreamingBubble.tsx
+++ b/apps/web/src/components/chat/StreamingBubble.tsx
@@ -1,0 +1,23 @@
+import { Bot } from "lucide-react";
+import { MarkdownContent } from "./MarkdownContent";
+
+interface StreamingBubbleProps {
+  content: string;
+}
+
+export function StreamingBubble({ content }: StreamingBubbleProps) {
+  if (!content) return null;
+
+  return (
+    <div className="flex gap-3">
+      <div className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted">
+        <Bot size={14} className="text-muted-foreground" />
+      </div>
+      <div className="flex-1">
+        <div className="rounded-xl bg-muted/50 px-4 py-3 text-sm text-foreground">
+          <MarkdownContent content={content} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/StreamingIndicator.tsx
+++ b/apps/web/src/components/chat/StreamingIndicator.tsx
@@ -1,12 +1,27 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Loader2 } from "lucide-react";
 import { formatDuration } from "../../lib/time";
+import type { ToolCall } from "@/transport/types";
+import { TOOL_PHASE_LABELS } from "./tool-renderers/constants";
 
 interface StreamingIndicatorProps {
   startTime?: number;
+  activeToolCalls?: ToolCall[];
 }
 
-export function StreamingIndicator({ startTime }: StreamingIndicatorProps) {
+function derivePhaseLabel(toolCalls?: ToolCall[]): string {
+  if (!toolCalls || toolCalls.length === 0) return "Thinking...";
+
+  const incomplete = toolCalls.filter((tc) => !tc.isComplete);
+  if (incomplete.length > 0) {
+    const latest = incomplete[incomplete.length - 1];
+    return TOOL_PHASE_LABELS[latest.toolName] ?? "Working...";
+  }
+
+  return "Pulling the next step together...";
+}
+
+export function StreamingIndicator({ startTime, activeToolCalls }: StreamingIndicatorProps) {
   const [elapsed, setElapsed] = useState(0);
 
   useEffect(() => {
@@ -21,10 +36,13 @@ export function StreamingIndicator({ startTime }: StreamingIndicatorProps) {
     return () => clearInterval(interval);
   }, [startTime]);
 
+  const phaseLabel = useMemo(() => derivePhaseLabel(activeToolCalls), [activeToolCalls]);
+
   return (
-    <div className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground">
-      <Loader2 size={14} className="animate-spin" />
-      <span>Working for {formatDuration(elapsed)}</span>
+    <div className="flex items-center gap-2 px-4 py-3">
+      <Loader2 size={14} className="animate-spin text-muted-foreground" />
+      <span className="animate-shimmer-text text-sm">{phaseLabel}</span>
+      <span className="text-muted-foreground/50 text-xs">({formatDuration(elapsed)})</span>
     </div>
   );
 }

--- a/apps/web/src/components/chat/ToolCallCard.tsx
+++ b/apps/web/src/components/chat/ToolCallCard.tsx
@@ -1,72 +1,80 @@
 import { useState } from "react";
-import type { LucideIcon } from "lucide-react";
-import { Bot, Check, ChevronDown, ChevronRight, FileText, FilePen, FolderSearch, Globe,
-  Loader2, Pencil, Search, Terminal, Wrench, X } from "lucide-react";
 import type { ToolCall } from "@/transport/types";
+import { getRenderer } from "./tool-renderers";
+import { ChevronRight } from "lucide-react";
+import { TOOL_LABELS, TOOL_ICONS } from "./tool-renderers/constants";
 
 interface ToolCallCardProps {
   toolCalls: ToolCall[];
 }
 
-const TOOL_ICONS: Record<string, LucideIcon> = {
-  Glob: FolderSearch, Grep: Search, Read: FileText, Write: FilePen,
-  Edit: Pencil, Bash: Terminal, Agent: Bot, WebSearch: Globe, WebFetch: Globe,
-};
-
-function summarizeInput(_name: string, input: Record<string, unknown>): string {
-  for (const key of ["pattern", "file_path", "query", "path"]) {
-    if (input[key]) return String(input[key]);
-  }
-  if (input.command) return String(input.command).slice(0, 80);
-  const keys = Object.keys(input);
-  return keys.length > 0 ? `${keys[0]}: ${String(input[keys[0]]).slice(0, 60)}` : "";
+interface ToolCallGroup {
+  toolName: string;
+  calls: ToolCall[];
 }
 
-function ToolCallItem({ toolCall }: { toolCall: ToolCall }) {
-  const [expanded, setExpanded] = useState(false);
+/** Group consecutive tool calls of the same type */
+function groupConsecutive(toolCalls: ToolCall[]): ToolCallGroup[] {
+  const groups: ToolCallGroup[] = [];
+  for (const tc of toolCalls) {
+    const last = groups[groups.length - 1];
+    if (last && last.toolName === tc.toolName) {
+      last.calls.push(tc);
+    } else {
+      groups.push({ toolName: tc.toolName, calls: [tc] });
+    }
+  }
+  return groups;
+}
 
-  const Icon = TOOL_ICONS[toolCall.toolName] ?? Wrench;
-  const summary = summarizeInput(toolCall.toolName, toolCall.toolInput);
+function CollapsedGroup({
+  group,
+  isActive,
+  lastToolId,
+}: {
+  group: ToolCallGroup;
+  isActive: boolean;
+  lastToolId: string | undefined;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const Icon = TOOL_ICONS[group.toolName];
+  const label = TOOL_LABELS[group.toolName] ?? group.toolName;
 
   return (
-    <div>
+    <div
+      className={`rounded-lg border bg-muted/15 overflow-hidden ${
+        isActive ? "animate-tool-pulse border-border/60" : "border-border/40"
+      }`}
+    >
       <button
         type="button"
-        onClick={() => setExpanded((prev) => !prev)}
-        className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs hover:bg-muted/40"
+        onClick={() => setExpanded((p) => !p)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs cursor-pointer hover:bg-muted/30"
       >
-        <Icon size={12} className="shrink-0 text-muted-foreground" />
-        <span className="shrink-0 text-foreground/70">{toolCall.toolName}</span>
-        {summary && (
-          <span className="min-w-0 flex-1 truncate text-muted-foreground/70">{summary}</span>
-        )}
-        <span className="flex shrink-0 items-center gap-1">
-          {!toolCall.isComplete && (
-            <Loader2 size={10} className="animate-spin text-muted-foreground" />
-          )}
-          {toolCall.isComplete && !toolCall.isError && (
-            <Check size={10} className="text-emerald-500" />
-          )}
-          {toolCall.isComplete && toolCall.isError && (
-            <X size={10} className="text-red-500" />
-          )}
-          <ChevronRight
-            size={10}
-            className={`text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""}`}
-          />
+        {Icon && <Icon size={14} className="shrink-0 text-muted-foreground" />}
+        <span className="font-medium text-foreground/80">
+          {label} ({group.calls.length})
         </span>
+        <div className="flex flex-1 items-center justify-end gap-1">
+          <ChevronRight
+            size={12}
+            className={`shrink-0 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""}`}
+          />
+        </div>
       </button>
 
       {expanded && (
-        <div className="ml-5 mr-2 mt-0.5 mb-1">
-          <pre className="max-h-48 overflow-auto rounded bg-muted/40 p-2 text-xs text-muted-foreground">
-            {JSON.stringify(toolCall.toolInput, null, 2)}
-          </pre>
-          {toolCall.output && (
-            <pre className="mt-1 max-h-48 overflow-auto rounded bg-muted/40 p-2 text-xs text-muted-foreground">
-              {toolCall.output}
-            </pre>
-          )}
+        <div className="border-t border-border/30 px-2 py-1.5 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
+          {group.calls.map((tc) => {
+            const Renderer = getRenderer(tc.toolName);
+            return (
+              <Renderer
+                key={tc.id}
+                toolCall={tc}
+                isActive={tc.id === lastToolId}
+              />
+            );
+          })}
         </div>
       )}
     </div>
@@ -74,33 +82,39 @@ function ToolCallItem({ toolCall }: { toolCall: ToolCall }) {
 }
 
 export function ToolCallCard({ toolCalls }: ToolCallCardProps) {
-  const [collapsed, setCollapsed] = useState(false);
-
   if (toolCalls.length === 0) return null;
 
+  const groups = groupConsecutive(toolCalls);
+  const lastToolId = toolCalls[toolCalls.length - 1]?.id;
+  const lastGroup = groups[groups.length - 1];
+
   return (
-    <div className="flex gap-3">
-      <div className="w-6 shrink-0" />
-      <div className="max-h-[200px] flex-1 overflow-y-auto">
-        <button
-          type="button"
-          onClick={() => setCollapsed((prev) => !prev)}
-          className="flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground"
-        >
-          <ChevronDown
-            size={10}
-            className={`transition-transform ${collapsed ? "-rotate-90" : ""}`}
+    // max-h must match the max-height in the fade-out keyframe (index.css)
+    <div className="flex flex-col gap-1.5 max-h-[400px] overflow-y-auto">
+      {groups.map((group, i) => {
+        const isLastGroup = group === lastGroup;
+        // Single item in group — render directly
+        if (group.calls.length === 1) {
+          const tc = group.calls[0];
+          const Renderer = getRenderer(tc.toolName);
+          return (
+            <Renderer
+              key={tc.id}
+              toolCall={tc}
+              isActive={tc.id === lastToolId}
+            />
+          );
+        }
+        // Multiple consecutive same-type — render as collapsed group
+        return (
+          <CollapsedGroup
+            key={`group-${i}-${group.toolName}`}
+            group={group}
+            isActive={isLastGroup}
+            lastToolId={lastToolId}
           />
-          Tool calls ({toolCalls.length})
-        </button>
-        {!collapsed && (
-          <div className="flex flex-col">
-            {toolCalls.map((tc) => (
-              <ToolCallItem key={tc.id} toolCall={tc} />
-            ))}
-          </div>
-        )}
-      </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/components/chat/tool-renderers/AgentRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/AgentRenderer.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { Bot } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+
+export function AgentRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const [showResult, setShowResult] = useState(false);
+  const description = String(toolCall.toolInput.description ?? "");
+  const prompt = String(toolCall.toolInput.prompt ?? "");
+  const summary = description || prompt.slice(0, 80) + (prompt.length > 80 ? "..." : "");
+
+  return (
+    <ToolCallWrapper
+      icon={Bot}
+      label="Thinking deeper..."
+      badge={summary}
+      isActive={isActive}
+    >
+      <div className="space-y-1.5">
+        {prompt && (
+          <pre className="rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
+            {prompt}
+          </pre>
+        )}
+        {toolCall.output && (
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowResult((p) => !p)}
+              className="text-xs text-muted-foreground/70 hover:text-foreground transition-colors"
+            >
+              {showResult ? "Hide result" : "Show result"}
+            </button>
+            {showResult && (
+              <pre className="mt-1 max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
+                {toolCall.output}
+              </pre>
+            )}
+          </div>
+        )}
+      </div>
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/BashRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/BashRenderer.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { Terminal } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+import { ShowMoreButton } from "./ShowMoreButton";
+
+const MAX_LINES = 20;
+
+export function BashRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const [showAll, setShowAll] = useState(false);
+  const command = String(toolCall.toolInput.command ?? "");
+  const description = toolCall.toolInput.description
+    ? String(toolCall.toolInput.description)
+    : undefined;
+  const outputLines = toolCall.output?.split("\n") ?? [];
+  const visible = showAll ? outputLines : outputLines.slice(0, MAX_LINES);
+
+  const badge = description ?? command.slice(0, 60) + (command.length > 60 ? "..." : "");
+
+  return (
+    <ToolCallWrapper
+      icon={Terminal}
+      label="Ran command"
+      badge={badge}
+      isActive={isActive}
+    >
+      <div className="space-y-1.5">
+        <pre className="rounded bg-zinc-900 px-2.5 py-1.5 text-[11px] leading-relaxed text-zinc-300 font-mono overflow-x-auto">
+          <span className="select-none text-zinc-500">$ </span>{command}
+        </pre>
+
+        {outputLines.length > 0 && (
+          <div>
+            <pre
+              className={`max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono ${
+                toolCall.isError ? "border-l-2 border-red-500/50" : ""
+              }`}
+            >
+              {visible.join("\n")}
+            </pre>
+            <ShowMoreButton
+              totalCount={outputLines.length}
+              visibleCount={MAX_LINES}
+              expanded={showAll}
+              onToggle={() => setShowAll((p) => !p)}
+            />
+          </div>
+        )}
+      </div>
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/EditRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/EditRenderer.tsx
@@ -1,0 +1,42 @@
+import { Pencil } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+import { buildSimpleDiff } from "@/lib/diff";
+import { basename } from "@/lib/path";
+
+export function EditRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const filePath = String(toolCall.toolInput.file_path ?? "");
+  const oldStr = String(toolCall.toolInput.old_string ?? "");
+  const newStr = String(toolCall.toolInput.new_string ?? "");
+  const lines = buildSimpleDiff(oldStr, newStr);
+
+  return (
+    <ToolCallWrapper
+      icon={Pencil}
+      label="Edited file"
+      badge={basename(filePath)}
+      isActive={isActive}
+      defaultExpanded
+    >
+      {lines.length > 0 && (
+        <div className="rounded border border-border/30 overflow-hidden font-mono text-[11px] leading-relaxed">
+          {lines.map((line, i) => (
+            <div
+              key={i}
+              className={`px-3 py-0.5 ${
+                line.type === "remove"
+                  ? "bg-red-500/10 text-red-400"
+                  : "bg-green-500/10 text-green-400"
+              }`}
+            >
+              <span className="select-none text-muted-foreground/40 mr-2 inline-block w-3 text-right">
+                {line.type === "remove" ? "−" : "+"}
+              </span>
+              {line.content}
+            </div>
+          ))}
+        </div>
+      )}
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/GenericRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/GenericRenderer.tsx
@@ -1,0 +1,36 @@
+import { Wrench } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+
+function summarizeInput(input: Record<string, unknown>): string {
+  for (const key of ["pattern", "file_path", "query", "path"]) {
+    if (input[key]) return String(input[key]);
+  }
+  if (input.command) return String(input.command).slice(0, 80);
+  const keys = Object.keys(input);
+  return keys.length > 0 ? `${keys[0]}: ${String(input[keys[0]]).slice(0, 60)}` : "";
+}
+
+export function GenericRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const summary = summarizeInput(toolCall.toolInput);
+
+  return (
+    <ToolCallWrapper
+      icon={Wrench}
+      label={toolCall.toolName}
+      badge={summary}
+      isActive={isActive}
+    >
+      <div className="space-y-1.5">
+        <pre className="max-h-48 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono">
+          {JSON.stringify(toolCall.toolInput, null, 2)}
+        </pre>
+        {toolCall.output && (
+          <pre className="max-h-48 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
+            {toolCall.output}
+          </pre>
+        )}
+      </div>
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/GlobRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/GlobRenderer.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { FolderSearch, Folder, File } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+import { ShowMoreButton } from "./ShowMoreButton";
+
+const MAX_VISIBLE = 15;
+
+function parseFiles(output: string | null): string[] {
+  if (!output) return [];
+  return output.split("\n").filter((l) => l.trim().length > 0);
+}
+
+export function GlobRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const [showAll, setShowAll] = useState(false);
+  const files = parseFiles(toolCall.output);
+  const pattern = String(toolCall.toolInput.pattern ?? "");
+
+  const label = files.length > 0
+    ? `Listed ${files.length} file${files.length !== 1 ? "s" : ""}`
+    : "Listed directory";
+
+  const visible = showAll ? files : files.slice(0, MAX_VISIBLE);
+
+  return (
+    <ToolCallWrapper
+      icon={FolderSearch}
+      label={label}
+      badge={pattern}
+      isActive={isActive}
+    >
+      {files.length > 0 && (
+        <div className="space-y-0.5">
+          {visible.map((f, i) => {
+            const isDir = f.endsWith("/");
+            const IconEl = isDir ? Folder : File;
+            return (
+              <div key={i} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <IconEl size={12} className="shrink-0 opacity-60" />
+                <span className="truncate">{f}</span>
+              </div>
+            );
+          })}
+          <ShowMoreButton
+            totalCount={files.length}
+            visibleCount={MAX_VISIBLE}
+            expanded={showAll}
+            onToggle={() => setShowAll((p) => !p)}
+          />
+        </div>
+      )}
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/GrepRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/GrepRenderer.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { Search, File } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+import { ShowMoreButton } from "./ShowMoreButton";
+
+const MAX_VISIBLE = 15;
+
+export function GrepRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const [showAll, setShowAll] = useState(false);
+  const pattern = String(toolCall.toolInput.pattern ?? "");
+  const lines = (toolCall.output ?? "").split("\n").filter((l) => l.trim());
+  const visible = showAll ? lines : lines.slice(0, MAX_VISIBLE);
+
+  const label = lines.length > 0
+    ? `Found ${lines.length} result${lines.length !== 1 ? "s" : ""}`
+    : "Searched files";
+
+  return (
+    <ToolCallWrapper
+      icon={Search}
+      label={label}
+      badge={pattern}
+      isActive={isActive}
+    >
+      {lines.length > 0 && (
+        <div className="space-y-0.5">
+          {visible.map((line, i) => (
+            <div key={i} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <File size={12} className="shrink-0 opacity-60" />
+              <span className="truncate font-mono text-[11px]">{line}</span>
+            </div>
+          ))}
+          <ShowMoreButton
+            totalCount={lines.length}
+            visibleCount={MAX_VISIBLE}
+            expanded={showAll}
+            onToggle={() => setShowAll((p) => !p)}
+          />
+        </div>
+      )}
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/ReadRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/ReadRenderer.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { FileText } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+import { ShowMoreButton } from "./ShowMoreButton";
+import { basename } from "@/lib/path";
+
+const MAX_LINES = 20;
+
+export function ReadRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const [showAll, setShowAll] = useState(false);
+  const filePath = String(toolCall.toolInput.file_path ?? "");
+  const lines = toolCall.output?.split("\n") ?? [];
+  const visible = showAll ? lines : lines.slice(0, MAX_LINES);
+
+  return (
+    <ToolCallWrapper
+      icon={FileText}
+      label="Read file"
+      badge={basename(filePath)}
+      isActive={isActive}
+    >
+      {lines.length > 0 && (
+        <div>
+          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono">
+            {visible.join("\n")}
+          </pre>
+          <ShowMoreButton
+            totalCount={lines.length}
+            visibleCount={MAX_LINES}
+            expanded={showAll}
+            onToggle={() => setShowAll((p) => !p)}
+          />
+        </div>
+      )}
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/ShowMoreButton.tsx
+++ b/apps/web/src/components/chat/tool-renderers/ShowMoreButton.tsx
@@ -1,0 +1,20 @@
+interface ShowMoreButtonProps {
+  totalCount: number;
+  visibleCount: number;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function ShowMoreButton({ totalCount, visibleCount, expanded, onToggle }: ShowMoreButtonProps) {
+  if (totalCount <= visibleCount) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="mt-1 text-xs text-muted-foreground/70 hover:text-foreground transition-colors"
+    >
+      {expanded ? "Show less" : `Show ${totalCount - visibleCount} more`}
+    </button>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/ToolCallWrapper.tsx
+++ b/apps/web/src/components/chat/tool-renderers/ToolCallWrapper.tsx
@@ -1,0 +1,99 @@
+import { useState, type ReactNode, Component, type ErrorInfo } from "react";
+import type { LucideIcon } from "lucide-react";
+import { ChevronRight } from "lucide-react";
+
+interface ToolCallWrapperProps {
+  icon: LucideIcon;
+  label: string;
+  badge?: string;
+  isActive?: boolean;
+  children?: ReactNode;
+  defaultExpanded?: boolean;
+}
+
+/** Catches render errors in tool renderers so they don't crash the whole chat. */
+class ToolCallErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("[ToolCallRenderer]", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-lg border border-border/40 bg-muted/15 px-3 py-2 text-xs text-muted-foreground">
+          Tool call render error
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function ToolCallWrapperInner({
+  icon: Icon,
+  label,
+  badge,
+  isActive = false,
+  children,
+  defaultExpanded = false,
+}: ToolCallWrapperProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const hasContent = !!children;
+
+  return (
+    <div
+      className={`rounded-lg border overflow-hidden ${
+        isActive
+          ? "animate-tool-pulse border-border/60 bg-muted/20"
+          : "border-border/40 bg-muted/15"
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => hasContent && setExpanded((p) => !p)}
+        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs ${hasContent ? "cursor-pointer hover:bg-muted/30" : "cursor-default"}`}
+      >
+        <Icon size={14} className="shrink-0 text-muted-foreground" />
+        <span className="font-medium text-foreground/80">{label}</span>
+
+        <div className="flex flex-1 items-center justify-end gap-2 min-w-0">
+          {badge && (
+            <span className="max-w-[200px] truncate rounded-full bg-secondary px-2 py-0.5 text-[10px] font-normal text-secondary-foreground">
+              {badge}
+            </span>
+          )}
+
+          {hasContent && (
+            <ChevronRight
+              size={12}
+              className={`shrink-0 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""}`}
+            />
+          )}
+        </div>
+      </button>
+
+      {expanded && children && (
+        <div className="border-t border-border/30 px-3 py-2">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ToolCallWrapper(props: ToolCallWrapperProps) {
+  return (
+    <ToolCallErrorBoundary>
+      <ToolCallWrapperInner {...props} />
+    </ToolCallErrorBoundary>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/WebRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/WebRenderer.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { Globe } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+import { ShowMoreButton } from "./ShowMoreButton";
+
+const MAX_LINES = 15;
+
+export function WebRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const [showAll, setShowAll] = useState(false);
+  const isSearch = toolCall.toolName === "WebSearch";
+  const badge = String(toolCall.toolInput.query ?? toolCall.toolInput.url ?? "");
+  const lines = (toolCall.output ?? "").split("\n");
+  const visible = showAll ? lines : lines.slice(0, MAX_LINES);
+
+  return (
+    <ToolCallWrapper
+      icon={Globe}
+      label={isSearch ? "Searched web" : "Fetched page"}
+      badge={badge}
+      isActive={isActive}
+    >
+      {lines.length > 0 && lines[0].trim() && (
+        <div>
+          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
+            {visible.join("\n")}
+          </pre>
+          <ShowMoreButton
+            totalCount={lines.length}
+            visibleCount={MAX_LINES}
+            expanded={showAll}
+            onToggle={() => setShowAll((p) => !p)}
+          />
+        </div>
+      )}
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/WriteRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/WriteRenderer.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { FilePen } from "lucide-react";
+import type { ToolRendererProps } from "./types";
+import { ToolCallWrapper } from "./ToolCallWrapper";
+import { ShowMoreButton } from "./ShowMoreButton";
+import { basename } from "@/lib/path";
+
+const MAX_LINES = 10;
+
+export function WriteRenderer({ toolCall, isActive }: ToolRendererProps) {
+  const [showAll, setShowAll] = useState(false);
+  const filePath = String(toolCall.toolInput.file_path ?? "");
+  const content = String(toolCall.toolInput.content ?? "");
+  const lines = content.split("\n");
+  const visible = showAll ? lines : lines.slice(0, MAX_LINES);
+
+  return (
+    <ToolCallWrapper
+      icon={FilePen}
+      label="Created file"
+      badge={basename(filePath)}
+      isActive={isActive}
+    >
+      {lines.length > 0 && (
+        <div>
+          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono">
+            {visible.join("\n")}
+          </pre>
+          <ShowMoreButton
+            totalCount={lines.length}
+            visibleCount={MAX_LINES}
+            expanded={showAll}
+            onToggle={() => setShowAll((p) => !p)}
+          />
+        </div>
+      )}
+    </ToolCallWrapper>
+  );
+}

--- a/apps/web/src/components/chat/tool-renderers/constants.ts
+++ b/apps/web/src/components/chat/tool-renderers/constants.ts
@@ -1,0 +1,44 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Bot, FileText, FilePen, FolderSearch, Globe,
+  Pencil, Search, Terminal, Wrench,
+} from "lucide-react";
+
+export const TOOL_LABELS: Record<string, string> = {
+  Glob: "Listed directory",
+  Read: "Read file",
+  Edit: "Edited file",
+  Write: "Created file",
+  Bash: "Ran command",
+  Grep: "Searched files",
+  Agent: "Delegated task",
+  WebSearch: "Searched web",
+  WebFetch: "Fetched page",
+};
+
+export const TOOL_ICONS: Record<string, LucideIcon> = {
+  Glob: FolderSearch,
+  Grep: Search,
+  Read: FileText,
+  Write: FilePen,
+  Edit: Pencil,
+  Bash: Terminal,
+  Agent: Bot,
+  WebSearch: Globe,
+  WebFetch: Globe,
+};
+
+export const DEFAULT_ICON = Wrench;
+
+/** Present-tense phase labels shown in the streaming indicator. */
+export const TOOL_PHASE_LABELS: Record<string, string> = {
+  Glob: "Searching the codebase...",
+  Grep: "Searching the codebase...",
+  Read: "Reading files...",
+  Edit: "Making changes...",
+  Write: "Making changes...",
+  Bash: "Running a command...",
+  Agent: "Thinking deeper...",
+  WebSearch: "Searching the web...",
+  WebFetch: "Fetching a page...",
+};

--- a/apps/web/src/components/chat/tool-renderers/index.ts
+++ b/apps/web/src/components/chat/tool-renderers/index.ts
@@ -1,0 +1,30 @@
+import type { ComponentType } from "react";
+import type { ToolRendererProps } from "./types";
+
+import { GlobRenderer } from "./GlobRenderer";
+import { ReadRenderer } from "./ReadRenderer";
+import { EditRenderer } from "./EditRenderer";
+import { WriteRenderer } from "./WriteRenderer";
+import { BashRenderer } from "./BashRenderer";
+import { GrepRenderer } from "./GrepRenderer";
+import { AgentRenderer } from "./AgentRenderer";
+import { WebRenderer } from "./WebRenderer";
+import { GenericRenderer } from "./GenericRenderer";
+
+const RENDERERS: Record<string, ComponentType<ToolRendererProps>> = {
+  Glob: GlobRenderer,
+  Read: ReadRenderer,
+  Edit: EditRenderer,
+  Write: WriteRenderer,
+  Bash: BashRenderer,
+  Grep: GrepRenderer,
+  Agent: AgentRenderer,
+  WebSearch: WebRenderer,
+  WebFetch: WebRenderer,
+};
+
+export function getRenderer(toolName: string): ComponentType<ToolRendererProps> {
+  return RENDERERS[toolName] ?? GenericRenderer;
+}
+
+export { TOOL_LABELS, TOOL_ICONS, DEFAULT_ICON } from "./constants";

--- a/apps/web/src/components/chat/tool-renderers/types.ts
+++ b/apps/web/src/components/chat/tool-renderers/types.ts
@@ -1,0 +1,6 @@
+import type { ToolCall } from "@/transport/types";
+
+export interface ToolRendererProps {
+  toolCall: ToolCall;
+  isActive?: boolean;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -117,6 +117,48 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+@keyframes tool-pulse {
+  0%, 100% { border-color: oklch(0.62 0.19 264 / 0.3); }
+  50% { border-color: oklch(0.62 0.19 264 / 0.08); }
+}
+
+.animate-tool-pulse {
+  animation: tool-pulse 2s ease-in-out infinite;
+}
+
+/* max-height must match the max-h-[400px] on ToolCallCard's container */
+@keyframes fade-out {
+  0% { opacity: 1; max-height: 400px; margin-bottom: 0; }
+  50% { opacity: 0; max-height: 400px; margin-bottom: 0; }
+  100% { opacity: 0; max-height: 0; margin-bottom: -16px; }
+}
+
+.animate-fade-out {
+  animation: fade-out 2.7s ease-out forwards;
+  overflow: hidden;
+}
+
+@keyframes shimmer-text {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.animate-shimmer-text {
+  background-image: linear-gradient(
+    90deg,
+    oklch(0.55 0.01 260) 0%,
+    oklch(0.75 0.15 264) 40%,
+    oklch(0.85 0.12 264) 50%,
+    oklch(0.75 0.15 264) 60%,
+    oklch(0.55 0.01 260) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer-text 2.5s ease-in-out infinite;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/apps/web/src/lib/diff.ts
+++ b/apps/web/src/lib/diff.ts
@@ -1,0 +1,23 @@
+export interface DiffLine {
+  type: "remove" | "add";
+  content: string;
+}
+
+/**
+ * Build a simple unified diff from old and new strings.
+ * Shows all old lines as removals followed by all new lines as additions.
+ */
+export function buildSimpleDiff(oldStr: string, newStr: string): DiffLine[] {
+  const oldLines = oldStr.split("\n");
+  const newLines = newStr.split("\n");
+  const result: DiffLine[] = [];
+
+  for (const line of oldLines) {
+    result.push({ type: "remove", content: line });
+  }
+  for (const line of newLines) {
+    result.push({ type: "add", content: line });
+  }
+
+  return result;
+}

--- a/apps/web/src/lib/path.ts
+++ b/apps/web/src/lib/path.ts
@@ -1,0 +1,5 @@
+/** Extract the file name from a path (browser-safe, handles both / and \). */
+export function basename(filePath: string): string {
+  const parts = filePath.replace(/\\/g, "/").split("/");
+  return parts[parts.length - 1] || filePath;
+}

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -16,6 +16,8 @@ interface ThreadState {
   currentThreadId: string | null;
   streamingByThread: Record<string, string>;
   toolCallsByThread: Record<string, ToolCall[]>;
+  /** Tool calls kept briefly after turn complete so the user can see the final state. */
+  fadingToolCallsByThread: Record<string, ToolCall[]>;
   agentStartTimes: Record<string, number>;
   /** Per-thread permission mode and interaction mode. */
   settingsByThread: Record<string, ThreadSettings>;
@@ -34,6 +36,17 @@ interface ThreadState {
   setThreadSettings: (threadId: string, settings: Partial<ThreadSettings>) => void;
 }
 
+/** Pending fade-out timers per thread, so we can cancel on new turns. */
+const fadingTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
+
+function clearFadingTimers(threadId: string) {
+  const timers = fadingTimers.get(threadId);
+  if (timers) {
+    timers.forEach(clearTimeout);
+    fadingTimers.delete(threadId);
+  }
+}
+
 const DEFAULT_THREAD_SETTINGS: ThreadSettings = {
   permissionMode: PERMISSION_MODES.FULL,
   interactionMode: INTERACTION_MODES.CHAT,
@@ -47,6 +60,7 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
   currentThreadId: null,
   streamingByThread: {},
   toolCallsByThread: {},
+  fadingToolCallsByThread: {},
   agentStartTimes: {},
   settingsByThread: {},
 
@@ -155,6 +169,25 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
     const eventType = (event.type as string) || "";
     const params = (event.params as Record<string, unknown>) || event;
 
+    // Helper: mark all prior incomplete tool calls as complete.
+    // The Claude Agent SDK handles tool execution internally and does not
+    // emit standalone "session.toolResult" events. So when a new event
+    // arrives that implies previous tools finished (new toolUse, message,
+    // delta, or turnComplete), we mark prior calls as done.
+    const markPriorToolCallsComplete = () => {
+      const calls = get().toolCallsByThread[threadId];
+      if (!calls || !calls.some((tc) => !tc.isComplete)) return;
+      set((state) => {
+        const current = state.toolCallsByThread[threadId] ?? [];
+        const updated = current.map((tc) =>
+          tc.isComplete ? tc : { ...tc, isComplete: true }
+        );
+        return {
+          toolCallsByThread: { ...state.toolCallsByThread, [threadId]: updated },
+        };
+      });
+    };
+
     // -- Sidecar events (new format) --
 
     if (method === "bridge.crashed") {
@@ -192,6 +225,7 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
     }
 
     if (method === "session.message" || (eventType === "session.message")) {
+      markPriorToolCallsComplete();
       const content = (params.content as string) || "";
       if (content) {
         const message: Message = {
@@ -217,6 +251,10 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
     }
 
     if (method === "session.toolUse") {
+      // New tool call arriving means any previous ones have finished
+      markPriorToolCallsComplete();
+      // Cancel any pending fade-out from a previous turn on this thread
+      clearFadingTimers(threadId);
       const toolCall: ToolCall = {
         id: (params.toolCallId as string) || crypto.randomUUID(),
         toolName: (params.toolName as string) || "unknown",
@@ -267,8 +305,11 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
       const tokensIn = (params.totalTokensIn as number) ?? 0;
       const tokensOut = (params.totalTokensOut as number) ?? 0;
 
-      // Commit any remaining streaming content
+      // Commit any remaining streaming content and stop the agent,
+      // but keep tool calls in their active slot briefly before fading out.
       const streamContent = get().streamingByThread[threadId] ?? "";
+
+      // First: mark all tool calls as complete (in place) and commit the message
       if (streamContent) {
         const message: Message = {
           id: crypto.randomUUID(),
@@ -290,8 +331,11 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
           nextRunning.delete(threadId);
           const nextStartTimes = { ...state.agentStartTimes };
           delete nextStartTimes[threadId];
-          const nextToolCalls = { ...state.toolCallsByThread };
-          delete nextToolCalls[threadId];
+          // Mark all tool calls as complete and keep in active slot briefly
+          const currentCalls = state.toolCallsByThread[threadId] ?? [];
+          const completedCalls = currentCalls.map((tc) =>
+            tc.isComplete ? tc : { ...tc, isComplete: true }
+          );
           return {
             messages: state.currentThreadId === threadId
               ? [...state.messages, message]
@@ -299,7 +343,9 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
             streamingByThread: nextStreaming,
             runningThreadIds: nextRunning,
             agentStartTimes: nextStartTimes,
-            toolCallsByThread: nextToolCalls,
+            toolCallsByThread: completedCalls.length > 0
+              ? { ...state.toolCallsByThread, [threadId]: completedCalls }
+              : state.toolCallsByThread,
           };
         });
       } else {
@@ -310,16 +356,46 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
           delete nextStreaming[threadId];
           const nextStartTimes = { ...state.agentStartTimes };
           delete nextStartTimes[threadId];
-          const nextToolCalls = { ...state.toolCallsByThread };
-          delete nextToolCalls[threadId];
+          const currentCalls = state.toolCallsByThread[threadId] ?? [];
+          const completedCalls = currentCalls.map((tc) =>
+            tc.isComplete ? tc : { ...tc, isComplete: true }
+          );
           return {
             runningThreadIds: nextRunning,
             streamingByThread: nextStreaming,
             agentStartTimes: nextStartTimes,
-            toolCallsByThread: nextToolCalls,
+            toolCallsByThread: completedCalls.length > 0
+              ? { ...state.toolCallsByThread, [threadId]: completedCalls }
+              : state.toolCallsByThread,
           };
         });
       }
+
+      // After a brief pause, move tool calls to fading state for exit animation.
+      // Store timer IDs so they can be cancelled if a new turn starts.
+      clearFadingTimers(threadId);
+      const timers: ReturnType<typeof setTimeout>[] = [];
+      timers.push(setTimeout(() => {
+        set((state) => {
+          const calls = state.toolCallsByThread[threadId];
+          if (!calls || calls.length === 0) return {};
+          const nextToolCalls = { ...state.toolCallsByThread };
+          delete nextToolCalls[threadId];
+          return {
+            toolCallsByThread: nextToolCalls,
+            fadingToolCallsByThread: { ...state.fadingToolCallsByThread, [threadId]: calls },
+          };
+        });
+      }, 800));
+      timers.push(setTimeout(() => {
+        set((state) => {
+          const next = { ...state.fadingToolCallsByThread };
+          delete next[threadId];
+          return { fadingToolCallsByThread: next };
+        });
+        fadingTimers.delete(threadId);
+      }, 3500));
+      fadingTimers.set(threadId, timers);
 
       // Sync the thread's status in workspaceStore so the sidebar shows
       // the green "Completed" badge without waiting for a full thread reload.
@@ -362,6 +438,7 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
     }
 
     if (method === "session.delta") {
+      markPriorToolCallsComplete();
       const text = (params.text as string) || "";
       if (text) {
         set((state) => ({


### PR DESCRIPTION
## Summary
- **Per-tool-type renderers**: 9 specialized renderers (Read, Edit, Write, Bash, Glob, Grep, Agent, Web, Generic) with semantic labels and rich previews (inline diffs, terminal blocks, file trees)
- **Polished UX**: Consecutive same-type grouping, pulse animation on latest tool call, shimmer streaming indicator with phase labels, smooth fade-out with height collapse, inline positioning between messages
- **Robustness**: Error boundary per renderer, cancellable fade timers to prevent race conditions, throttled scroll-to-bottom during streaming

## Test plan
- [ ] Send a message that triggers multiple tool types (Read, Edit, Bash) — verify each shows its semantic renderer
- [ ] Verify consecutive same-type calls (e.g., multiple Reads) collapse into a group with expand/collapse
- [ ] Confirm only the latest tool call pulses; previous ones are static
- [ ] Watch the streaming indicator — should show phase labels ("Reading files...", "Running a command...") with shimmer effect
- [ ] When the agent finishes, tool calls should fade out smoothly (no layout jump) and the response appears below them
- [ ] Send a follow-up message before fade completes — verify no stale tool calls appear
- [ ] Expand an Edit tool call — verify inline diff renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)