### PR TITLE
perf: memoize MessageBubble and MarkdownContent components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ Key components:
 - **`BranchNameInput`** – shows auto-generated or editable branch name
 - **`WorktreePicker`** – searchable dropdown for existing worktrees
 
+## Code Style
+
+Always add JSDoc/TSDoc docstrings to all exported functions, components, types, and interfaces. AI-powered code reviews depend on these for context. At minimum include a one-line summary of what the symbol does.
+
 ## Commit Guidelines
 
 Use [Conventional Commits](https://www.conventionalcommits.org/).

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -3,12 +3,16 @@ import type { Element } from "hast";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+/** Props for {@link MarkdownContent}. */
 interface MarkdownContentProps {
+  /** Raw markdown string to render. */
   content: string;
 }
 
+/** Stable remark plugin list, hoisted to avoid re-creating on every render. */
 const plugins = [remarkGfm];
 
+/** Stable custom element renderers for react-markdown, hoisted to module scope. */
 const components = {
   h1: ({ children }: { children?: React.ReactNode }) => <h1 className="text-xl font-bold mt-4 mb-2">{children}</h1>,
   h2: ({ children }: { children?: React.ReactNode }) => <h2 className="text-lg font-semibold mt-3 mb-2">{children}</h2>,
@@ -79,6 +83,7 @@ const components = {
   ),
 };
 
+/** Renders a markdown string with GFM support. Memoized to skip re-renders when content is unchanged. */
 export const MarkdownContent = memo(function MarkdownContent({ content }: MarkdownContentProps) {
   return (
     <ReactMarkdown remarkPlugins={plugins} components={components}>

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -4,10 +4,13 @@ import { Bot, FileText, File, RotateCcw } from "lucide-react";
 import { MarkdownContent } from "./MarkdownContent";
 import { stripInjectedFiles } from "@/lib/file-tags";
 
+/** Props for {@link MessageBubble}. */
 interface MessageBubbleProps {
+  /** The message object to render. */
   message: Message;
 }
 
+/** Maps a MIME type to a file extension for attachment URLs. */
 function extFromMime(mimeType: string): string {
   const map: Record<string, string> = {
     "image/jpeg": ".jpg",
@@ -20,6 +23,7 @@ function extFromMime(mimeType: string): string {
   return map[mimeType] ?? "";
 }
 
+/** Renders image thumbnails and file badges for message attachments. */
 const AttachmentDisplay = memo(function AttachmentDisplay({
   attachments,
   threadId,
@@ -60,6 +64,7 @@ const AttachmentDisplay = memo(function AttachmentDisplay({
   );
 });
 
+/** Renders a single chat message (system, user, or assistant). Memoized to prevent re-renders when the message ref is unchanged. */
 export const MessageBubble = memo(function MessageBubble({ message }: MessageBubbleProps) {
   const formattedTime = useMemo(
     () => new Date(message.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),


### PR DESCRIPTION
## What
Wrap `MessageBubble` and `MarkdownContent` in `React.memo()` to prevent unnecessary re-renders of settled messages during streaming and message appends.

## Why
Every new message or stream update caused all message components to re-render (O(n)). `MarkdownContent` is especially expensive because it re-runs `react-markdown` + `remark-gfm` parsing on every render. With 100+ messages, this causes visible jank.

## Key Changes
- Wrap `MarkdownContent` in `React.memo()` and hoist `remarkPlugins` array and `components` map to module scope for stable references
- Wrap `MessageBubble` in `React.memo()` so settled messages skip re-renders when message ref is unchanged
- Wrap `AttachmentDisplay` in `React.memo()` with `useMemo` for filter arrays
- Memoize `toLocaleTimeString()` via `useMemo` keyed on `message.timestamp`

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved component performance through memoization and caching to reduce unnecessary re-renders.
  * Enhanced TypeScript annotations for greater reliability.

* **Bug Fix / Security**
  * Safer link handling in rendered content: external links are now validated and only allowed protocols are used to prevent unsafe hrefs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->