### PR TITLE
feat: message queuing for sequential delivery

### DIFF
--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -12,6 +12,7 @@ import {
   Unlock,
   ChevronDown,
   Loader2,
+  Check,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getDefaultModel } from "@/lib/model-registry";
@@ -30,6 +31,8 @@ import { TextOverlay } from "./TextOverlay";
 import { extractFileRefs, buildInjectedMessage } from "@/lib/file-tags";
 import { useSlashCommand } from "./useSlashCommand";
 import { SlashCommandPopup } from "./SlashCommandPopup";
+import { QueuePopover } from "./QueuePopover";
+import { useQueueStore } from "@/stores/queueStore";
 
 const SUPPORTED_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
 const SUPPORTED_FILE_TYPES = new Set(["application/pdf", "text/plain"]);
@@ -205,6 +208,8 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
     }
   }, [isNewThread, newThreadBranch, branches, setNewThreadBranch]);
 
+  const hasContent = input.trim().length > 0 || attachments.length > 0;
+
   // Full lock when agent running, provider lock when thread has a model
   const isModelFullyLocked = isAgentRunning;
   const isProviderLocked = !isNewThread && activeThread?.model != null;
@@ -367,13 +372,8 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
     textareaRef.current?.focus();
   }, [addFiles]);
 
-  const handleSend = useCallback(async () => {
-    const trimmed = input.trim();
-    if (!trimmed && attachments.length === 0) return;
-    if (isAgentRunning) return;
-
-    // Content injection: read tagged files and build injected message
-    let messageContent = trimmed;
+  /** Resolve @file tags into injected content. */
+  const injectFileContent = useCallback(async (trimmed: string): Promise<{ content: string; display?: string }> => {
     const refs = extractFileRefs(trimmed);
     if (refs.length > 0 && workspaceId) {
       try {
@@ -383,19 +383,62 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
             try {
               const content = await transport.readFileContent(workspaceId, path, threadId);
               return { path, content };
-            } catch {
-              return null;
-            }
+            } catch { return null; }
           }),
         );
         const validFiles = fileContents.filter(
           (f): f is { path: string; content: string } => f !== null,
         );
-        messageContent = buildInjectedMessage(trimmed, validFiles);
-      } catch {
-        // If file reading fails entirely, send without injection
-      }
+        const injected = buildInjectedMessage(trimmed, validFiles);
+        return { content: injected, display: injected !== trimmed ? trimmed : undefined };
+      } catch { /* fall through */ }
     }
+    return { content: trimmed };
+  }, [workspaceId, threadId]);
+
+  /** Collect attachment metadata and revoke preview URLs. */
+  const collectAndClearAttachments = useCallback((): AttachmentMeta[] => {
+    const metas: AttachmentMeta[] = attachments
+      .filter((a) => a.filePath != null)
+      .map((a) => ({
+        id: a.id,
+        name: a.name,
+        mimeType: a.mimeType,
+        sizeBytes: a.sizeBytes,
+        sourcePath: a.filePath!,
+      }));
+    for (const att of attachments) {
+      if (att.previewUrl) URL.revokeObjectURL(att.previewUrl);
+    }
+    setAttachments([]);
+    return metas;
+  }, [attachments]);
+
+  const handleSend = useCallback(async () => {
+    if (!hasContent) return;
+    const trimmed = input.trim();
+
+    // ---- Queue path: agent is running on this thread ----
+    if (isAgentRunning && threadId) {
+      const { content, display } = await injectFileContent(trimmed);
+      const currentAttachments = collectAndClearAttachments();
+
+      useQueueStore.getState().enqueue(threadId, {
+        content,
+        displayContent: display,
+        attachments: currentAttachments,
+        model: modelId,
+        permissionMode: access,
+      });
+
+      setInput("");
+      setTaggedFiles(new Set());
+      textareaRef.current?.focus();
+      return;
+    }
+
+    // ---- Normal send path ----
+    const { content: messageContent, display: displayContent } = await injectFileContent(trimmed);
 
     // Validate worktree mode requirements
     if (isNewThread && newThreadMode === "worktree" && namingMode === "custom" && !customBranchName.trim()) {
@@ -420,20 +463,7 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
 
     setInput("");
     setTaggedFiles(new Set());
-    const currentAttachments: AttachmentMeta[] = attachments
-      .filter((a) => a.filePath != null)
-      .map((a) => ({
-        id: a.id,
-        name: a.name,
-        mimeType: a.mimeType,
-        sizeBytes: a.sizeBytes,
-        sourcePath: a.filePath!,
-      }));
-
-    for (const att of attachments) {
-      if (att.previewUrl) URL.revokeObjectURL(att.previewUrl);
-    }
-    setAttachments([]);
+    const currentAttachments = collectAndClearAttachments();
 
     if (isNewThread && workspaceId) {
       if (newThreadMode === "worktree" || newThreadMode === "existing-worktree") {
@@ -445,12 +475,11 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
         setPreparingWorktree(false);
       }
     } else if (threadId) {
-      const display = messageContent !== trimmed ? trimmed : undefined;
-      await sendMessage(threadId, messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, display);
+      await sendMessage(threadId, messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, displayContent);
     }
     textareaRef.current?.focus();
   // taggedFiles omitted: handleSend only clears it via setTaggedFiles (stable setter), never reads the value.
-  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, access, namingMode, customBranchName, selectedWorktree]);
+  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, access, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Let the file tag popup handle keys when open
@@ -475,7 +504,6 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
 
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      if (isAgentRunning) return;
       handleSend();
     }
   };
@@ -505,8 +533,18 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
     });
   };
 
+  const toast = useQueueStore((s) => s.toast);
+
   return (
-    <div className="border-t border-border px-4 py-3">
+    <div className="relative border-t border-border px-4 py-3">
+      {/* Queue toast */}
+      {toast && (
+        <div className="pointer-events-none absolute -top-8 right-4 z-20 flex items-center gap-1.5 rounded-full bg-card/90 px-3 py-1 text-[11px] text-muted-foreground shadow-sm ring-1 ring-border/50 backdrop-blur-sm animate-in fade-in-0 slide-in-from-bottom-1 duration-150">
+          <Check size={10} className="text-primary" />
+          {toast}
+        </div>
+      )}
+
       {/* Main composer container - dark bg, rounded */}
       <div
         className={cn(
@@ -532,10 +570,9 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
                 overlayRef.current.scrollTop = e.currentTarget.scrollTop;
               }
             }}
-            placeholder="Ask for follow-up changes or attach images"
+            placeholder={isAgentRunning ? "Queue a follow-up..." : "Ask for follow-up changes or attach images"}
             rows={1}
             className="relative z-10 w-full resize-none bg-transparent px-4 pt-3 pb-1 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
-            disabled={isAgentRunning}
           />
           <FileTagPopup
             files={fileAutocomplete.filteredFiles}
@@ -661,22 +698,76 @@ export function Composer({ threadId, isNewThread, workspaceId }: ComposerProps) 
             </span>
           )}
 
-          {/* Send / Stop toggle */}
+          {/* Inline stop button: visible when agent running AND user has input */}
+          {isAgentRunning && hasContent && (
+            <button
+              onClick={handleStop}
+              className="rounded-md p-1.5 text-destructive/60 transition-colors hover:bg-destructive/10 hover:text-destructive"
+              title="Stop agent"
+            >
+              <Square size={11} />
+            </button>
+          )}
+
+          {/* Queue badge + popover */}
+          {threadId && (
+            <QueuePopover
+              threadId={threadId}
+              isAgentRunning={isAgentRunning}
+              onResume={() => {
+                const next = useQueueStore.getState().dequeueNext(threadId);
+                if (next) {
+                  sendMessage(threadId, next.content, next.model, next.permissionMode,
+                    next.attachments.length > 0 ? next.attachments : undefined, next.displayContent);
+                }
+              }}
+            />
+          )}
+
+          {/* Send / Queue / Stop button */}
           <button
-            onClick={isAgentRunning ? handleStop : handleSend}
-            disabled={preparingWorktree || (!isAgentRunning && !input.trim() && attachments.length === 0)}
+            onClick={
+              preparingWorktree
+                ? undefined
+                : isAgentRunning && hasContent
+                  ? handleSend
+                  : isAgentRunning
+                    ? handleStop
+                    : handleSend
+            }
+            disabled={
+              preparingWorktree ||
+              (!isAgentRunning && !hasContent)
+            }
             className={cn(
               "rounded-full p-2 transition-colors",
               preparingWorktree
                 ? "bg-primary text-primary-foreground animate-spin"
-                : isAgentRunning
-                  ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  : (input.trim() || attachments.length > 0)
-                    ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                    : "bg-muted text-muted-foreground opacity-40"
+                : isAgentRunning && hasContent
+                  ? "bg-primary/60 text-primary-foreground hover:bg-primary/75"
+                  : isAgentRunning
+                    ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    : hasContent
+                      ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                      : "bg-muted text-muted-foreground opacity-40"
             )}
+            title={
+              isAgentRunning && hasContent
+                ? "Queue message"
+                : isAgentRunning
+                  ? "Stop agent"
+                  : "Send message"
+            }
           >
-            {preparingWorktree ? <Loader2 size={14} /> : isAgentRunning ? <Square size={14} /> : <ArrowUp size={14} />}
+            {preparingWorktree ? (
+              <Loader2 size={14} />
+            ) : isAgentRunning && hasContent ? (
+              <ArrowUp size={14} />
+            ) : isAgentRunning ? (
+              <Square size={14} />
+            ) : (
+              <ArrowUp size={14} />
+            )}
           </button>
         </div>
       </div>

--- a/apps/web/src/components/chat/QueuePopover.tsx
+++ b/apps/web/src/components/chat/QueuePopover.tsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useQueueStore, type QueuedMessage } from "@/stores/queueStore";
+import { X, Paperclip, Trash2, Play } from "lucide-react";
+
+const EMPTY_QUEUE: QueuedMessage[] = [];
+
+interface QueuePopoverProps {
+  threadId: string;
+  isAgentRunning: boolean;
+  onResume: () => void;
+}
+
+export function QueuePopover({ threadId, isAgentRunning, onResume }: QueuePopoverProps) {
+  const queue = useQueueStore((s) => s.queues[threadId] ?? EMPTY_QUEUE);
+  const removeFromQueue = useQueueStore((s) => s.removeFromQueue);
+  const clearQueue = useQueueStore((s) => s.clearQueue);
+  const [open, setOpen] = useState(false);
+
+  // Close popover when queue empties
+  useEffect(() => {
+    if (queue.length === 0) setOpen(false);
+  }, [queue.length]);
+
+  if (queue.length === 0) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        aria-label={`${queue.length} queued message${queue.length !== 1 ? "s" : ""}`}
+        className="flex h-5 min-w-5 cursor-pointer items-center justify-center rounded-full bg-primary/15 px-1.5 text-[10px] font-semibold text-primary tabular-nums transition-all hover:bg-primary/25"
+      >
+        {queue.length}
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-64 p-0"
+      >
+        <div className="flex items-center justify-between border-b border-border px-3 py-2">
+          <span className="text-xs font-medium text-muted-foreground">
+            Next up
+          </span>
+          <button
+            onClick={() => clearQueue(threadId)}
+            aria-label="Clear all queued messages"
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+          >
+            <Trash2 size={10} />
+            Clear all
+          </button>
+        </div>
+        <div className="max-h-48 overflow-y-auto p-1">
+          {queue.map((msg, i) => (
+            <div
+              key={msg.id}
+              className="group flex items-start gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-accent/50"
+            >
+              <span className="mt-px text-[10px] font-medium text-muted-foreground/50 tabular-nums">
+                {i + 1}.
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-xs text-foreground">
+                  {msg.displayContent || msg.content}
+                </p>
+                {msg.attachments.length > 0 && (
+                  <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground">
+                    <Paperclip size={8} />
+                    {msg.attachments.length}
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={() => removeFromQueue(threadId, msg.id)}
+                aria-label={`Remove queued message ${i + 1}`}
+                className="mt-px rounded p-0.5 text-muted-foreground/30 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100 focus:opacity-100"
+              >
+                <X size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+        {!isAgentRunning && (
+          <div className="border-t border-border px-3 py-2">
+            <button
+              onClick={() => { setOpen(false); onResume(); }}
+              aria-label="Send next queued message"
+              className="flex w-full items-center justify-center gap-1.5 rounded-md bg-primary/10 px-2 py-1.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/20"
+            >
+              <Play size={10} />
+              Continue
+            </button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/stores/queueStore.ts
+++ b/apps/web/src/stores/queueStore.ts
@@ -1,0 +1,102 @@
+import { create } from "zustand";
+import type { AttachmentMeta, PermissionMode } from "@/transport";
+
+export interface QueuedMessage {
+  id: string;
+  content: string;
+  displayContent?: string;
+  attachments: AttachmentMeta[];
+  model: string;
+  permissionMode: PermissionMode;
+  queuedAt: number;
+}
+
+const MAX_QUEUE_DEPTH = 20;
+
+interface QueueState {
+  /** Per-thread message queues. */
+  queues: Record<string, QueuedMessage[]>;
+  /** Toast text shown briefly after enqueue. Null when hidden. */
+  toast: string | null;
+
+  enqueue: (
+    threadId: string,
+    message: Omit<QueuedMessage, "id" | "queuedAt">,
+  ) => boolean;
+  dequeueNext: (threadId: string) => QueuedMessage | undefined;
+  removeFromQueue: (threadId: string, messageId: string) => void;
+  clearQueue: (threadId: string) => void;
+}
+
+let toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+function showToast(set: (partial: Partial<QueueState>) => void, text: string) {
+  if (toastTimer) clearTimeout(toastTimer);
+  set({ toast: text });
+  toastTimer = setTimeout(() => set({ toast: null }), 1800);
+}
+
+export const useQueueStore = create<QueueState>((set, get) => ({
+  queues: {},
+  toast: null,
+
+  enqueue: (threadId, message) => {
+    const current = get().queues[threadId] ?? [];
+    if (current.length >= MAX_QUEUE_DEPTH) {
+      showToast(set, "Queue full");
+      return false;
+    }
+
+    const entry: QueuedMessage = {
+      ...message,
+      id: crypto.randomUUID(),
+      queuedAt: Date.now(),
+    };
+
+    set((state) => ({
+      queues: {
+        ...state.queues,
+        [threadId]: [...(state.queues[threadId] ?? []), entry],
+      },
+    }));
+
+    const count = (get().queues[threadId] ?? []).length;
+    showToast(set, count > 1 ? `Queued \u00b7 ${count} pending` : "Queued");
+
+    return true;
+  },
+
+  dequeueNext: (threadId) => {
+    const current = get().queues[threadId] ?? [];
+    if (current.length === 0) return undefined;
+
+    const [next, ...rest] = current;
+    set((state) => ({
+      queues: {
+        ...state.queues,
+        [threadId]: rest,
+      },
+    }));
+
+    return next;
+  },
+
+  removeFromQueue: (threadId, messageId) => {
+    set((state) => ({
+      queues: {
+        ...state.queues,
+        [threadId]: (state.queues[threadId] ?? []).filter(
+          (m) => m.id !== messageId,
+        ),
+      },
+    }));
+  },
+
+  clearQueue: (threadId) => {
+    set((state) => {
+      const next = { ...state.queues };
+      delete next[threadId];
+      return { queues: next };
+    });
+  },
+}));

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { Message, ToolCall, PermissionMode, InteractionMode, AttachmentMeta } from "@/transport";
 import { getTransport, PERMISSION_MODES, INTERACTION_MODES } from "@/transport";
 import { useWorkspaceStore } from "./workspaceStore";
+import { useQueueStore } from "./queueStore";
 
 export interface ThreadSettings {
   permissionMode: PermissionMode;
@@ -44,6 +45,17 @@ function clearFadingTimers(threadId: string) {
   if (timers) {
     timers.forEach(clearTimeout);
     fadingTimers.delete(threadId);
+  }
+}
+
+/** Pending dequeue timers per thread, so duplicate turnComplete events don't double-dequeue. */
+const dequeueTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function clearDequeueTimer(threadId: string) {
+  const timer = dequeueTimers.get(threadId);
+  if (timer) {
+    clearTimeout(timer);
+    dequeueTimers.delete(threadId);
   }
 }
 
@@ -191,6 +203,8 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
     // -- Sidecar events (new format) --
 
     if (method === "bridge.crashed") {
+      // Cancel all pending dequeue timers to prevent sends after crash
+      for (const tid of dequeueTimers.keys()) clearDequeueTimer(tid);
       set({
         runningThreadIds: new Set(),
         streamingByThread: {},
@@ -404,6 +418,35 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
           t.id === threadId ? { ...t, status: "completed" as const } : t,
         ),
       }));
+
+      // Auto-dequeue: send next queued message after a brief visual pause.
+      // Only on turnComplete (not session.ended) so explicit stops don't drain the queue.
+      // Uses tracked timers to prevent double-dequeue from duplicate events.
+      if (method === "session.turnComplete") {
+        clearDequeueTimer(threadId);
+        const timer = setTimeout(() => {
+          dequeueTimers.delete(threadId);
+          // Guard: verify the thread still exists and isn't already running
+          const threadExists = useWorkspaceStore.getState().threads.some(
+            (t) => t.id === threadId && t.deleted_at == null,
+          );
+          if (!threadExists) return;
+          if (get().runningThreadIds.has(threadId)) return;
+
+          const next = useQueueStore.getState().dequeueNext(threadId);
+          if (next) {
+            get().sendMessage(
+              threadId,
+              next.content,
+              next.model,
+              next.permissionMode,
+              next.attachments.length > 0 ? next.attachments : undefined,
+              next.displayContent,
+            );
+          }
+        }, 400);
+        dequeueTimers.set(threadId, timer);
+      }
       return;
     }
 
@@ -426,6 +469,10 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
           toolCallsByThread: nextToolCalls,
         };
       });
+
+      // Clear any pending dequeue timer and queue for this thread on error
+      clearDequeueTimer(threadId);
+      useQueueStore.getState().clearQueue(threadId);
 
       // Sync the thread's status in workspaceStore so the sidebar shows
       // the red "Errored" badge without waiting for a full thread reload.

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -3,6 +3,7 @@ import type { Workspace, Thread, GitBranch, PermissionMode, WorktreeInfo, Attach
 import { getTransport } from "@/transport";
 import { useThreadStore } from "./threadStore";
 import { useTerminalStore } from "./terminalStore";
+import { useQueueStore } from "./queueStore";
 import { getSetting, type NamingMode } from "@/lib/settings";
 
 /** Generate a short random branch name for auto-mode worktrees (e.g. `mcode-a1b2c3d4`). */
@@ -249,6 +250,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     try {
       await getTransport().deleteThread(threadId, cleanupWorktree);
       useTerminalStore.getState().removeAllTerminals(threadId);
+      useQueueStore.getState().clearQueue(threadId);
       set((state) => ({
         threads: state.threads.filter((t) => t.id !== threadId),
         activeThreadId: state.activeThreadId === threadId ? null : state.activeThreadId,


### PR DESCRIPTION
## What
Ambient message queue that lets users compose follow-up instructions while the agent is working, with auto-drain on turn completion.

## Why
The composer was disabled during agent runs, forcing users to wait and losing context. This is a frontend-only change since the backend sidecar already has a per-session prompt queue.

## Key Changes
- **queueStore**: Zustand store for per-thread message queues (max 20) with toast feedback
- **QueuePopover**: Count badge + popover for inspecting, removing, and resuming queued messages
- **Composer**: Queue-aware send button (4 states), inline stop button, dynamic placeholder, toast overlay, extracted `injectFileContent`/`collectAndClearAttachments` helpers
- **threadStore**: Auto-dequeue on `session.turnComplete` with 400ms delay, tracked timers to prevent double-dequeue, thread existence + runningThreadIds guards, queue cleanup on `session.error` and `bridge.crashed`
- **workspaceStore**: Queue cleanup on thread deletion

Closes #26