### PR TITLE
fix: align sidebar and chat header heights

### DIFF
--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -5,6 +5,7 @@ import { MessageList } from "./MessageList";
 import { Composer } from "./Composer";
 import { HeaderActions } from "./HeaderActions";
 
+/** Renders the main chat UI for sending and receiving messages within a thread. */
 export function ChatView() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import { PanelLeftClose, PanelLeft } from "lucide-react";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 
+/** Sidebar component that renders app navigation and the project tree. */
 export function Sidebar() {
   const [collapsed, setCollapsed] = useState(false);
 


### PR DESCRIPTION
## What
Standardize header heights across the sidebar and chat view so their bottom borders form a continuous horizontal line.

## Why
The sidebar header used `p-3` (12px all sides) while the chat view header used `py-2` (8px vertical), creating an 8px height mismatch. This caused the `border-b` lines to sit at different vertical positions.

## Key Changes
- Sidebar header: `p-3` replaced with `h-11 px-3` (explicit 44px height)
- ChatView headers (new-thread and active-thread): `px-4 py-2` replaced with `h-11 px-4`
- All headers now use `items-center` for vertical centering within the fixed height

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined header styling in chat and sidebar to use consistent fixed heights and horizontal padding for uniform spacing and alignment.
* **Documentation**
  * Added descriptive JSDoc to the sidebar component for clearer developer-facing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->