### PR TITLE
fix: add loading state to delete thread dialog

### DIFF
--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -57,6 +57,7 @@ interface InlineEditState {
   originalTitle: string;
 }
 
+/** Sidebar tree listing workspaces and their threads with CRUD actions. */
 export function ProjectTree() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
@@ -386,7 +387,11 @@ export function ProjectTree() {
               </div>
               <Switch
                 checked={deleteWorktree}
-                onCheckedChange={(checked) => setDeleteWorktree(checked)}
+                onCheckedChange={(checked) => {
+                  if (isDeleting) return;
+                  setDeleteWorktree(checked);
+                }}
+                disabled={isDeleting}
                 className="data-[checked]:bg-destructive"
                 aria-label="Delete worktree"
               />


### PR DESCRIPTION
## What
Add loading feedback to the delete thread confirmation dialog.

## Why
Clicking "Delete" gave no visual indication that anything was happening. The UI appeared frozen for several seconds until the async operation completed, making it unclear whether the click registered.

## Key Changes
- Add `isDeleting` state with spinner and "Deleting..." text on the delete button
- Disable both Cancel and Delete buttons during the async operation
- Prevent dialog dismissal (Escape/backdrop) while deletion is in progress
- Add `cursor-pointer` to dialog buttons for correct hover behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve delete confirmation flow: shows a loading indicator and "Deleting..." label during deletion, disables dialog actions and related toggles to prevent changes, and prevents closing the dialog while deletion is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->