### PR TITLE
fix: set NODE_ENV=production in desktop prod script

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "bun scripts/dev-electron.mjs",
     "build": "bun scripts/build-main.mjs",
-    "prod": "bun run build && npx electron .",
+    "prod": "NODE_ENV=production bun run build && NODE_ENV=production npx electron .",
     "typecheck": "tsc --noEmit",
     "rebuild": "electron-rebuild -f",
     "dist": "bun run build && electron-builder --publish never",


### PR DESCRIPTION
## What
Set `NODE_ENV=production` in the desktop `prod` script.

## Why
The prod script never set `NODE_ENV`, so `getMcodeDir()` always resolved to `~/.mcode-dev` instead of `~/.mcode`, causing prod and dev builds to share the same database.

## Key Changes
- Add `NODE_ENV=production` to both the build and electron launch steps in the `prod` script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration for desktop application builds to ensure the app runs in production mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->