### PR TITLE
docs: add UI component registry for consistent shadcn usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ Key components:
 - **`BranchNameInput`** – shows auto-generated or editable branch name
 - **`WorktreePicker`** – searchable dropdown for existing worktrees
 
+## UI Components
+
+When working on frontend code, follow the component registry and rules in **[docs/UI_COMPONENTS.md](docs/UI_COMPONENTS.md)**. Always use existing shadcn primitives from `apps/web/src/components/ui/` before creating custom elements.
+
 ## Code Style
 
 Always add JSDoc/TSDoc docstrings to all exported functions, components, types, and interfaces. AI-powered code reviews depend on these for context. At minimum include a one-line summary of what the symbol does.

--- a/docs/UI_COMPONENTS.md
+++ b/docs/UI_COMPONENTS.md
@@ -1,0 +1,44 @@
+# UI Component Registry
+
+All UI primitives live in `apps/web/src/components/ui/`. **Always use these instead of raw HTML elements with custom Tailwind.** If a component does not exist for your use case, create it in `components/ui/` with proper variants so it can be reused, then use it.
+
+## Available Components
+
+| Component | File | Use Instead Of |
+|-----------|------|----------------|
+| `Button` | `button.tsx` | `<button className="...">` |
+| `Input` | `input.tsx` | `<input className="...">` |
+| `Badge` | `badge.tsx` | `<span className="rounded px-1.5 py-0.5 text-xs ...">` |
+| `Dialog` | `dialog.tsx` | Custom modal divs |
+| `DropdownMenu` | `dropdown-menu.tsx` | Custom dropdown implementations |
+| `Command` | `command.tsx` | Custom search/autocomplete inputs |
+| `ContextMenu` | `context-menu.tsx` | Custom right-click menus |
+| `Popover` | `popover.tsx` | Custom floating panels |
+| `ScrollArea` | `scroll-area.tsx` | `<div className="overflow-auto">` |
+| `Separator` | `separator.tsx` | `<hr>` or `<div className="border-b">` |
+| `Switch` | `switch.tsx` | Custom toggle implementations |
+| `Tooltip` | `tooltip.tsx` | `title` attributes or custom hover text |
+
+## Button Variants
+
+```tsx
+// Variants: default, outline, secondary, ghost, destructive, link
+// Sizes: default (h-8), xs (h-6), sm (h-7), lg (h-9), icon (8x8), icon-xs (6x6), icon-sm (7x7), icon-lg (9x9)
+<Button variant="ghost" size="sm">Click me</Button>
+<Button variant="outline" size="icon-xs"><Icon /></Button>
+```
+
+## Badge Variants
+
+```tsx
+// Variants: default, secondary, destructive, outline, ghost, link
+<Badge variant="secondary">Status</Badge>
+```
+
+## Rules
+
+1. **Never use raw `<button>` with Tailwind classes.** Use `<Button>` with the appropriate variant and size.
+2. **Never use raw `<input>` with Tailwind classes.** Use `<Input>` and override via className if needed.
+3. **Never use styled `<span>` for status labels or counts.** Use `<Badge>` with the appropriate variant.
+4. **If no existing component fits**, create a new one in `components/ui/` with CVA variants following the existing pattern. Then use it wherever needed.
+5. **Stick to the Tailwind text scale** (`text-xs`, `text-sm`, `text-base`). Do not use arbitrary values like `text-[10px]` or `text-[11px]`.


### PR DESCRIPTION
## What
Add a `docs/UI_COMPONENTS.md` registry documenting all available shadcn primitives, their variants, and usage rules. Reference it from `AGENTS.md` so AI models see it when working on frontend code.

## Why
AI models (and contributors) create custom `<button>`, `<input>`, and `<span>` elements with inline Tailwind instead of using existing shadcn components. This causes inconsistent sizing, spacing, and hover states across the UI. The registry makes available components discoverable without bloating AGENTS.md with detail that is irrelevant to non-UI work.

## Key Changes
- `docs/UI_COMPONENTS.md`: Component table, variant cheat sheets, and 5 rules for usage
- `AGENTS.md`: Two-line reference to the registry doc

Related to #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established UI component registry and usage guidelines to promote consistency across application development.
  * Added standards directing contributors to use existing component primitives and discouraging custom implementations of common UI patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->