### PR TITLE
docs: add settings.json schema conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,10 @@ Types: feat, fix, refactor, docs, test, chore, perf, ci
 
 Keep commits atomic. Each commit represents one logical change.
 
+## Settings
+
+When adding or modifying user-facing settings, follow the schema conventions in **[docs/SETTINGS_SCHEMA.md](docs/SETTINGS_SCHEMA.md)**. All settings use nested JSON with a max depth of 3 levels.
+
 ## Key Documentation
 
 - **Architecture:** [ARCHITECTURE.md](ARCHITECTURE.md)

--- a/docs/SETTINGS_SCHEMA.md
+++ b/docs/SETTINGS_SCHEMA.md
@@ -1,0 +1,138 @@
+# Settings Schema Conventions
+
+Mcode uses a `settings.json` file as the single source of truth for user preferences. This document defines the schema structure, naming rules, and conventions that all settings must follow.
+
+**Location:** `~/.mcode/settings.json` (resolved via `getMcodeDataDir()`)
+
+## Structure Rules
+
+### 1. Every setting lives inside a category object
+
+No bare top-level keys. Even a single setting gets a category.
+
+```jsonc
+// Good
+{ "notifications": { "enabled": true } }
+
+// Bad
+{ "notificationsEnabled": true }
+```
+
+**Why:** Categories group related settings and keep the door open for future siblings (e.g., `notifications.sound`) without restructuring.
+
+### 2. Nest when 2+ settings share a qualifier
+
+If a category has multiple settings that share a common qualifier, group them under a nested object.
+
+```jsonc
+// Good: "mode" and "permission" both qualify as "defaults"
+{
+  "agent": {
+    "maxConcurrent": 5,
+    "defaults": {
+      "mode": "chat",
+      "permission": "full"
+    }
+  }
+}
+
+// Bad: flat siblings with repeated prefix
+{
+  "agent": {
+    "maxConcurrent": 5,
+    "defaultMode": "chat",
+    "defaultPermission": "full"
+  }
+}
+```
+
+**The test:** "Do I have 2+ settings that share a common qualifier?" If yes, nest under that qualifier. If no, keep flat within the category.
+
+### 3. Max depth: 3 levels
+
+Settings must not exceed 3 levels of nesting: `category.qualifier.setting`. If you find yourself at 4 levels, flatten.
+
+```jsonc
+// Good: 3 levels
+{ "model": { "defaults": { "reasoning": "high" } } }
+
+// Bad: 4 levels
+{ "model": { "defaults": { "reasoning": { "level": "high" } } } }
+```
+
+### 4. Single settings stay flat within their category
+
+When a category has only one setting or settings that don't share a qualifier, keep them as direct properties.
+
+```jsonc
+// Good: standalone settings within a category
+{
+  "appearance": { "theme": "system" },
+  "terminal": { "scrollback": 500 }
+}
+```
+
+### 5. Use camelCase for property names
+
+All property names use camelCase, matching the TypeScript codebase convention.
+
+```jsonc
+// Good
+{ "agent": { "maxConcurrent": 5 } }
+
+// Bad
+{ "agent": { "max_concurrent": 5 } }
+{ "agent": { "max-concurrent": 5 } }
+```
+
+## Decision Checklist
+
+When adding a new setting, ask these questions in order:
+
+1. **Which category does it belong to?** Pick an existing category or create a new one if no existing category fits.
+2. **Does it share a qualifier with sibling settings?** If 2+ settings share a prefix (e.g., "default"), nest them under that qualifier.
+3. **Am I at 3 levels or fewer?** If the nesting would exceed 3, flatten by removing the least meaningful level.
+4. **Does the single-setting category still make sense?** Even one setting gets a category, but the category name should be broad enough to accept future siblings.
+
+## Current Schema
+
+```jsonc
+{
+  "appearance": {
+    "theme": "system"                  // "system" | "dark" | "light"
+  },
+  "agent": {
+    "maxConcurrent": 5,
+    "defaults": {
+      "mode": "chat",                  // "plan" | "chat" | "agent"
+      "permission": "full"             // "full" | "supervised"
+    }
+  },
+  "model": {
+    "defaults": {
+      "id": "claude-sonnet-4-6",
+      "reasoning": "high"              // "low" | "medium" | "high"
+    }
+  },
+  "terminal": {
+    "scrollback": 500
+  },
+  "notifications": {
+    "enabled": true
+  },
+  "worktree": {
+    "naming": {
+      "mode": "auto",                  // "auto" | "custom" | "ai"
+      "aiConfirmation": true
+    }
+  }
+}
+```
+
+## Adding New Settings
+
+1. Follow the rules above.
+2. Add the setting to the "Current Schema" section in this document.
+3. Add a Zod schema for the new setting in `packages/contracts/`.
+4. Provide a sensible default so the app works without a `settings.json` file.
+5. Settings must be optional and merge over defaults. A missing key means "use default", never an error.


### PR DESCRIPTION
## What
Add `docs/SETTINGS_SCHEMA.md` defining the structure rules for Mcode's `settings.json` file, and reference it from `AGENTS.md`.

## Why
We are moving from scattered localStorage-based settings to a single `settings.json` source of truth (VSCode/Zed-style). Before implementing the settings service, we need agreed-upon conventions so every setting added follows the same structure. This prevents the mixed flat/nested ambiguity that plagues other tools.

## Key Changes
- `docs/SETTINGS_SCHEMA.md`: 5 structure rules, decision checklist, current schema snapshot
  - Every setting lives inside a category object
  - Nest when 2+ settings share a qualifier
  - Max depth: 3 levels
  - Single settings stay flat within their category
  - camelCase property names
- `AGENTS.md`: Two-line reference to the schema doc

Related to #95, #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation defining conventions for user settings structure, including schema rules, naming conventions (camelCase), and nesting requirements (maximum 3 levels deep).
  * Updated contributor guidelines with mandatory settings modification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->