### PR TITLE
fix: prevent intermittent tool call drops in chat UI

### DIFF
--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -3,7 +3,6 @@ import type { Message, ToolCall, PermissionMode, InteractionMode, AttachmentMeta
 import { getTransport, PERMISSION_MODES, INTERACTION_MODES } from "@/transport";
 import { useWorkspaceStore } from "./workspaceStore";
 import { useQueueStore } from "./queueStore";
-import { createBatchedUpdater } from "./batchMiddleware";
 
 export interface ThreadSettings {
   permissionMode: PermissionMode;
@@ -29,6 +28,8 @@ interface ThreadState {
   activeSubagentsByThread: Record<string, number>;
   /** Cache for tool call records to avoid re-fetching from server. */
   toolCallRecordCache: Record<string, ToolCallRecord[]>;
+  /** Tracks the local message ID for the most recent assistant message per thread, used by handleTurnPersisted to correctly assign tool call counts. */
+  currentTurnMessageIdByThread: Record<string, string>;
 
   /** Store tool call records in the cache. */
   cacheToolCallRecords: (key: string, records: ToolCallRecord[]) => void;
@@ -69,8 +70,6 @@ const DEFAULT_THREAD_SETTINGS: ThreadSettings = {
 };
 
 export const useThreadStore = create<ThreadState>((set, get) => {
-  const batchSet = createBatchedUpdater<ThreadState>(set);
-
   return {
   messages: [],
   runningThreadIds: new Set<string>(),
@@ -85,6 +84,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   serverMessageIds: {},
   activeSubagentsByThread: {},
   toolCallRecordCache: {},
+  currentTurnMessageIdByThread: {},
 
   cacheToolCallRecords: (key, records) => {
     set((state) => ({
@@ -115,6 +115,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         delete nextStreaming[threadId];
         const nextStartTimes = { ...state.agentStartTimes };
         delete nextStartTimes[threadId];
+        const nextTurnMsgIds = { ...state.currentTurnMessageIdByThread };
+        delete nextTurnMsgIds[threadId];
         return {
           loading: true,
           error: null,
@@ -122,6 +124,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           toolCallsByThread: nextToolCalls,
           streamingByThread: nextStreaming,
           agentStartTimes: nextStartTimes,
+          currentTurnMessageIdByThread: nextTurnMsgIds,
           toolCallRecordCache: {},
         };
       });
@@ -228,7 +231,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * Does NOT reset runningThreadIds since agents may still be executing.
    */
   clearMessages: () => {
-    set({ messages: [], error: null, streamingByThread: {}, toolCallsByThread: {}, persistedToolCallCounts: {}, serverMessageIds: {}, toolCallRecordCache: {} });
+    set({ messages: [], error: null, streamingByThread: {}, toolCallsByThread: {}, persistedToolCallCounts: {}, serverMessageIds: {}, toolCallRecordCache: {}, currentTurnMessageIdByThread: {} });
     // Note: does NOT reset runningThreadIds - agents may still be running
   },
 
@@ -329,6 +332,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           messages: state.currentThreadId === threadId
             ? [...state.messages, message]
             : state.messages,
+          currentTurnMessageIdByThread: {
+            ...state.currentTurnMessageIdByThread,
+            [threadId]: message.id,
+          },
         }));
       }
       return;
@@ -362,7 +369,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         isComplete: false,
         parentToolCallId: parentToolCallId || undefined,
       };
-      batchSet((state) => ({
+      set((state) => ({
         toolCallsByThread: {
           ...state.toolCallsByThread,
           [threadId]: [...(state.toolCallsByThread[threadId] ?? []), toolCall],
@@ -375,7 +382,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const toolCallId = (params.toolCallId as string) || "";
       const output = (params.output as string) || "";
       const isError = (params.isError as boolean) || false;
-      batchSet((state) => {
+      set((state) => {
         const calls = state.toolCallsByThread[threadId] ?? [];
         // Try matching by ID first; fall back to the first incomplete tool call
         // when the SDK sends a null or non-matching toolCallId.
@@ -584,16 +591,24 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       delete nextToolCalls[payload.threadId];
 
       // The server's messageId may differ from the client's in-memory UUID
-      // (client generates its own via crypto.randomUUID()). Match by finding
-      // the last assistant message, but only if messages belong to this thread.
+      // (client generates its own via crypto.randomUUID()). Prefer the ID
+      // tracked during the active turn; fall back to the last assistant message
+      // for cases where session.message arrived before tracking was introduced.
       let localMsgId = payload.messageId;
-      if (state.currentThreadId === payload.threadId) {
+      const trackedMsgId = state.currentTurnMessageIdByThread[payload.threadId];
+      if (trackedMsgId) {
+        localMsgId = trackedMsgId;
+      } else if (state.currentThreadId === payload.threadId) {
+        // Fallback: find last assistant message (covers cases where session.message
+        // arrived before we started tracking, e.g. on initial load)
         const lastAssistantMsg = [...state.messages]
           .reverse()
           .find((m) => m.role === "assistant");
         if (lastAssistantMsg) localMsgId = lastAssistantMsg.id;
       }
 
+      const nextTurnMsgIds = { ...state.currentTurnMessageIdByThread };
+      delete nextTurnMsgIds[payload.threadId];
       return {
         toolCallsByThread: nextToolCalls,
         persistedToolCallCounts: {
@@ -604,6 +619,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           ...state.serverMessageIds,
           [localMsgId]: payload.messageId,
         },
+        currentTurnMessageIdByThread: nextTurnMsgIds,
       };
     });
   },


### PR DESCRIPTION
## What
Fixes two race conditions in `threadStore.ts` that caused tool call cards to intermittently disappear or never appear during agent runs.

## Why
Tool calls were stored via a `requestAnimationFrame`-deferred `batchSet`, and the persisted turn handler used a fragile heuristic to match the current turn's assistant message. Together, these could cause tool calls to be cleared before they were ever rendered, or their counts to be attached to the wrong message.

## Key Changes
- Replace `batchSet` (rAF-deferred) with synchronous `set` for `session.toolUse` and `session.toolResult` handlers, eliminating the window where `handleTurnPersisted` could clear `toolCallsByThread` before the batched update fired
- Track `currentTurnMessageIdByThread[threadId]` when `session.message` arrives so `handleTurnPersisted` can reliably identify the current turn's message instead of scanning for "last assistant message" (which resolves to the wrong turn when the agent produces only tool calls)
- Defer cleanup of `currentTurnMessageIdByThread` to `handleTurnPersisted` only (not `session.turnComplete`), since `turn.persisted` always arrives after `turnComplete`
- Clear `currentTurnMessageIdByThread` in `loadMessages` (non-running threads) and `clearMessages` to prevent stale entries

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced message state tracking in threaded conversations to improve reliability and consistency of tool interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->