### PR TITLE
fix(web): sanitize custom branch names in worktree creation

### DIFF
--- a/apps/web/src/__tests__/branch-name.test.ts
+++ b/apps/web/src/__tests__/branch-name.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   sanitizeBranchName,
   sanitizeCustomBranchInput,
+  trimTrailingBranchChars,
   finalizeCustomBranchName,
   generateBranchNameFromMessage,
   generateFallbackBranchName,
@@ -115,19 +116,49 @@ describe("sanitizeCustomBranchInput", () => {
   it("returns empty string for empty input", () => {
     expect(sanitizeCustomBranchInput("")).toBe("");
   });
+
+  it("strips reflog @{...} syntax", () => {
+    expect(sanitizeCustomBranchInput("branch@{0}")).toBe("branch-0");
+  });
+
+  it("replaces control characters with hyphens", () => {
+    expect(sanitizeCustomBranchInput("foo\tbar")).toBe("foo-bar");
+  });
+
+  it("collapses multiple dot-prefixed path components", () => {
+    expect(sanitizeCustomBranchInput("feat/..hidden")).toBe("feat/hidden");
+  });
+
+  it("strips leading slash from dot-prefixed input", () => {
+    expect(sanitizeCustomBranchInput("./foo")).toBe("foo");
+  });
 });
 
-describe("finalizeCustomBranchName", () => {
+describe("trimTrailingBranchChars", () => {
   it("strips trailing dot", () => {
-    expect(finalizeCustomBranchName("branch.")).toBe("branch");
+    expect(trimTrailingBranchChars("branch.")).toBe("branch");
   });
 
   it("strips trailing slash", () => {
-    expect(finalizeCustomBranchName("feat/")).toBe("feat");
+    expect(trimTrailingBranchChars("feat/")).toBe("feat");
   });
 
-  it("strips multiple trailing dots and slashes", () => {
-    expect(finalizeCustomBranchName("feat/bar./..")).toBe("feat/bar");
+  it("strips trailing hyphen", () => {
+    expect(trimTrailingBranchChars("feat-")).toBe("feat");
+  });
+
+  it("strips mixed trailing chars", () => {
+    expect(trimTrailingBranchChars("feat/bar./..")).toBe("feat/bar");
+  });
+
+  it("passes through valid names unchanged", () => {
+    expect(trimTrailingBranchChars("feat/my-branch")).toBe("feat/my-branch");
+  });
+});
+
+describe("finalizeCustomBranchName", () => {
+  it("sanitizes and trims in one pass", () => {
+    expect(finalizeCustomBranchName("feat?bar.")).toBe("feat-bar");
   });
 
   it("passes through valid names unchanged", () => {

--- a/apps/web/src/lib/branch-name.ts
+++ b/apps/web/src/lib/branch-name.ts
@@ -10,6 +10,7 @@ const STOP_WORDS = new Set([
   "hey", "hi", "hello", "please", "thanks", "need", "want", "like",
 ]);
 
+/** Sanitize an auto-generated branch name (lowercase, alphanumeric + hyphens only). */
 export function sanitizeBranchName(raw: string): string {
   return raw
     .toLowerCase()
@@ -24,7 +25,7 @@ export function sanitizeBranchName(raw: string): string {
  * Sanitize a custom branch name as the user types.
  * Replaces git-invalid characters with hyphens and collapses sequences
  * that git-check-ref-format rejects (`..`, `//`, consecutive hyphens).
- * Also strips structural patterns like leading `-`, `.lock` suffix,
+ * Also strips structural patterns like leading `-`/`/`, `.lock` suffix,
  * and dot-prefixed path components (e.g. `feat/.hidden`).
  */
 export function sanitizeCustomBranchInput(raw: string): string {
@@ -35,19 +36,29 @@ export function sanitizeCustomBranchInput(raw: string): string {
     .replace(/\/{2,}/g, "/")
     .replace(/-{2,}/g, "-")
     .replace(/(?:^|\/)\.+/g, (m) => m.startsWith("/") ? "/" : "")
-    .replace(/^-+/, "")
+    .replace(/^[-/]+/, "")
+    .replace(/-+$/, "")
     .slice(0, 100);
 }
 
 /**
- * Final cleanup for a custom branch name before submission.
- * Strips trailing dots and slashes that cannot be removed during
- * typing without interfering with the user's input flow.
+ * Strip trailing dots, slashes, and hyphens from a branch name.
+ * Used at submission time to clean up artifacts that the onChange
+ * sanitizer intentionally preserves while the user is still typing.
  */
-export function finalizeCustomBranchName(raw: string): string {
-  return sanitizeCustomBranchInput(raw).replace(/[./]+$/, "");
+export function trimTrailingBranchChars(name: string): string {
+  return name.replace(/[./-]+$/, "");
 }
 
+/**
+ * Full sanitize + trailing cleanup for a raw custom branch name.
+ * Useful for inputs that did not go through the store setter.
+ */
+export function finalizeCustomBranchName(raw: string): string {
+  return trimTrailingBranchChars(sanitizeCustomBranchInput(raw));
+}
+
+/** Extract meaningful words from a message and join them into a branch name slug. */
 export function generateBranchNameFromMessage(message: string): string {
   const words = message
     .split(/\s+/)
@@ -61,6 +72,7 @@ export function generateBranchNameFromMessage(message: string): string {
   return sanitizeBranchName(meaningful.join("-"));
 }
 
+/** Generate a timestamped fallback branch name (e.g. `thread-k5f2g`). */
 export function generateFallbackBranchName(): string {
   return `thread-${Date.now().toString(36)}`;
 }

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -7,7 +7,7 @@ import { useQueueStore } from "./queueStore";
 import { useComposerDraftStore } from "./composerDraftStore";
 import type { NamingMode, ReasoningLevel } from "@mcode/contracts";
 import { useSettingsStore } from "./settingsStore";
-import { sanitizeCustomBranchInput, finalizeCustomBranchName } from "@/lib/branch-name";
+import { sanitizeCustomBranchInput, trimTrailingBranchChars } from "@/lib/branch-name";
 
 /** Generate a short random branch name for auto-mode worktrees (e.g. `mcode-a1b2c3d4`). */
 function generateBranchId(): string {
@@ -232,7 +232,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           branch = autoPreviewBranch;
           set({ namingMode: "auto" as NamingMode });
         } else {
-          branch = finalizeCustomBranchName(customBranchName);
+          branch = trimTrailingBranchChars(customBranchName);
         }
       } else {
         branch = autoPreviewBranch;


### PR DESCRIPTION
## What
Sanitize custom branch name input to strip git-invalid characters before they reach the server's `validateBranchName`.

## Why
Typing characters like `?`, `*`, `.`, spaces, etc. in the custom branch name field caused server-side validation errors when creating worktrees. Users got unhelpful error messages instead of the input being cleaned up automatically.

## Key Changes
- Added `sanitizeCustomBranchInput()` to replace git-invalid chars with hyphens and collapse sequences git rejects (`..`, `//`, `--`, leading `-`, `.lock` suffix, dot-prefixed components)
- Added `finalizeCustomBranchName()` for submission-time cleanup of trailing `.`/`/` (can't strip during typing without fighting input flow)
- Moved sanitization to the store setter (`setCustomBranchName`) so all code paths are covered, including PR review and branch fetch flows in Composer
- Added 19 test cases covering character replacement, structural rules, and finalization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom branch names are now sanitized as you type and finalized on submit: invalid characters normalized to hyphens, repeated separators collapsed, trailing dots/slashes/hyphens removed, and names truncated for git compatibility.
* **Tests**
  * Added thorough test coverage for input sanitization, trimming behavior, and finalization of custom branch names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->