### PR TITLE
fix(server): skip empty text block in attachment-only messages

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -628,7 +628,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       }
     }
 
-    contentBlocks.push({ type: "text", text: message });
+    if (message.trim().length > 0) {
+      contentBlocks.push({ type: "text", text: message });
+    }
 
     return {
       type: "user" as const,


### PR DESCRIPTION
## What
Fix attachment-only messages crashing with API errors, and surface worktree cleanup failures in thread lifecycle methods.

## Why
Sending attachments without text caused `buildMultimodalMessage()` to add `{ type: "text", text: "" }` to the content array. The Claude API rejects empty text blocks, corrupting the SDK session and breaking all subsequent sends in the thread.

Additionally, both thread creation and deletion had rollback/cleanup paths that silently swallowed `removeWorktree` failures, making cleanup issues invisible to logging and observability.

## Key Changes
- Guard the text block push in `buildMultimodalMessage()` with a non-empty check
- Log warnings when worktree rollback returns false or throws during thread creation
- Log warnings when worktree removal returns false or throws during thread deletion

Closes #133