### PR TITLE
fix: prevent fallback model errors and false fallback detection

### DIFF
--- a/apps/server/src/__tests__/fallback-model-detection.test.ts
+++ b/apps/server/src/__tests__/fallback-model-detection.test.ts
@@ -24,4 +24,14 @@ describe("detectFallbackModel", () => {
     };
     expect(detectFallbackModel(usage, "claude-opus-4-6")).toBe("claude-sonnet-4-6");
   });
+
+  it("returns null when SDK resolves alias to dated variant of same model", () => {
+    const usage = { "claude-sonnet-4-6-20250514": { inputTokens: 100, outputTokens: 50 } };
+    expect(detectFallbackModel(usage, "claude-sonnet-4-6")).toBeNull();
+  });
+
+  it("detects real fallback even when both keys are dated variants", () => {
+    const usage = { "claude-haiku-4-5-20251001": { inputTokens: 100, outputTokens: 50 } };
+    expect(detectFallbackModel(usage, "claude-sonnet-4-6")).toBe("claude-haiku-4-5-20251001");
+  });
 });

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -132,7 +132,11 @@ export function detectFallbackModel(
   requestedModel: string,
 ): string | null {
   const usedModels = Object.keys(modelUsage);
-  const actualModel = usedModels.find((m) => m !== requestedModel);
+  // SDK resolves aliases to dated IDs (e.g. "claude-sonnet-4-6" → "claude-sonnet-4-6-20250514").
+  // A dated variant that starts with the requested alias is the same model, not a fallback.
+  const actualModel = usedModels.find(
+    (m) => m !== requestedModel && !m.startsWith(requestedModel),
+  );
   return actualModel ?? null;
 }
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -166,7 +166,8 @@ export class AgentService {
 
     const resolvedModel = model;
     const { fallbackId } = (await this.settingsService.get()).model.defaults;
-    const fallbackModel = fallbackId || undefined; // empty string → no fallback
+    const fallbackModel =
+      fallbackId && fallbackId !== resolvedModel ? fallbackId : undefined;
     this.threadRepo.updateModel(threadId, resolvedModel);
 
     const sessionName = `mcode-${threadId}`;


### PR DESCRIPTION
## What

Fix two related fallback model bugs that cause runtime errors and incorrect model reporting.

## Why

1. When the default fallback model (`claude-sonnet-4-6`) matches the primary model, the SDK rejects the request with "Fallback model cannot be the same as the main model."
2. The SDK resolves short aliases to dated IDs (e.g. `claude-sonnet-4-6` to `claude-sonnet-4-6-20250514`). The detection logic treated these as different models, falsely reporting fallback events - causing users to see haiku or other models when none were used.

## Key changes

- `agent-service.ts`: skip `fallbackModel` when it equals the resolved primary model
- `claude-provider.ts`: use `startsWith` prefix matching so dated variants of the same model are not treated as fallbacks
- Added 2 test cases covering dated-variant detection and real cross-model fallback

Closes #162 follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model fallback detection to correctly distinguish between model variants and actual fallbacks. The system now recognizes dated model variants (e.g., base model vs. timestamped variant) as the same model, preventing false fallback notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->