### PR TITLE
fix: pass image attachments to Codex provider

### DIFF
--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -43,9 +43,9 @@ function toCodexReasoningEffort(
 
 /**
  * Build a Codex SDK `Input` from a message string and optional attachments.
- * Images are passed as `local_image` entries referencing the file on disk.
- * Non-image attachments are included as a text note with the file path so the
- * agent can read them if needed.
+ * Images are passed as `local_image` entries referencing the persisted file path on disk.
+ * Non-image attachments are included as a sanitized text note (name and MIME type only)
+ * without exposing local filesystem paths.
  */
 function buildCodexInput(message: string, attachments?: AttachmentMeta[]): CodexInput {
   if (!attachments || attachments.length === 0) return message;

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -144,7 +144,7 @@ export class AgentService {
         ? existingMessages[existingMessages.length - 1].sequence + 1
         : 1;
 
-    const { stored } = await this.attachmentService.persist(
+    const { stored, persisted } = await this.attachmentService.persist(
       threadId,
       attachments,
     );
@@ -203,7 +203,7 @@ export class AgentService {
         fallbackModel,
         resume: isResume,
         permissionMode,
-        attachments: attachments.length > 0 ? attachments : undefined,
+        attachments: persisted.length > 0 ? persisted : undefined,
         reasoningLevel,
       });
       logger.info("Message sent via provider", {


### PR DESCRIPTION
## What
Pass image attachments through to the Codex SDK when sending messages, so Codex can see images the user attaches -- the same way Claude already does.

## Why
The `CodexProvider.sendMessage` accepted `attachments?: AttachmentMeta[]` in its signature but never destructured or used it. Only the plain text `message` was forwarded to `codexThread.runStreamed()`, so Codex never received any attached images.

## Key Changes
- Add `buildCodexInput()` helper that converts `AttachmentMeta[]` to the SDK's `Input` type (`string | UserInput[]`): images become `{ type: "local_image", path }` entries (the SDK reads the file directly -- no base64 encoding required), and non-image files are included as a sanitized text note (name and MIME type only -- no internal paths) so the agent knows a file was attached
- Sanitize `att.name` and `att.mimeType` to strip control characters before interpolation into model-visible text
- Import `Input` and `UserInput` types from `@openai/codex-sdk`
- Update `runTurn` to accept `CodexInput` instead of `string`
- Wire `buildCodexInput` into both `runTurn` call sites (new session and resume path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer attachment handling when sending messages: image files are transmitted as images, other files are included as labeled attachments, and text is appended when present.
  * Persisted attachment data is now used when dispatching messages, ensuring attachments reliably accompany sent messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->