### PR TITLE
fix: disallow SDK plan mode tools that Mcode cannot handle

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -272,6 +272,12 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         type: "preset" as const,
         preset: "claude_code" as const,
       },
+      // Mcode implements its own plan mode via prompt wrapping and the
+      // PlanQuestionWizard UI.  The SDK's built-in EnterPlanMode /
+      // ExitPlanMode tools conflict because Mcode has no UI to handle
+      // the SDK's "Exit plan mode?" confirmation, causing the model to
+      // get stuck.
+      disallowedTools: ["EnterPlanMode", "ExitPlanMode"],
       permissionMode: sdkPermissionMode,
       ...(isBypass && { allowDangerouslySkipPermissions: true }),
       ...buildReasoningOptions(reasoningLevel, resolvedModel),


### PR DESCRIPTION
## What
Disallow the Claude Agent SDK's `EnterPlanMode` and `ExitPlanMode` tools via the `disallowedTools` option.

## Why
The SDK's `claude_code` system prompt instructs the model to "Prefer using EnterPlanMode for implementation tasks unless they're simple." When the model follows this, it enters SDK plan mode and eventually calls `ExitPlanMode`, which requires user confirmation inside the SDK subprocess. Mcode has no UI to surface this confirmation, so the model gets stuck in a loop telling the user to "approve the Exit plan mode dialog." This happens even with "Full access" permission mode.

Mcode has its own plan mode implementation (prompt wrapping + `PlanQuestionWizard`) that is completely separate from and unaffected by this change.

## Key Changes
- Added `disallowedTools: ["EnterPlanMode", "ExitPlanMode"]` to the SDK options in `ClaudeProvider`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Planning-mode tools (`EnterPlanMode` and `ExitPlanMode`) are now disabled in Claude Agent sessions, restricting the model's ability to invoke these tools during session execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->