### PR TITLE
fix: add path filter to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,8 @@ name: Release Please
 on:
   push:
     branches: [main]
+    paths:
+      - '.release-please-manifest.json'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What
Add path filter to release-please workflow to only trigger on changes to the release-please manifest file.

## Why
The workflow was running on every push to main, which causes unnecessary release-please checks. By filtering to only the manifest file, we reduce noise and allow the workflow to run only when needed.

## Key Changes
- Added `paths: ['.release-please-manifest.json']` filter to the push trigger in release-please workflow

Closes #<issue>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the Release Please workflow trigger to run only when manifest configuration changes, improving workflow efficiency and reducing unnecessary executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->