### PR TITLE
fix: capture untracked files in turn snapshots

### DIFF
--- a/apps/server/src/__tests__/snapshot-service.integration.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.integration.test.ts
@@ -1,0 +1,201 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { SnapshotService } from "../services/snapshot-service";
+
+/**
+ * Integration tests for SnapshotService using real git repositories.
+ * These tests exercise the full git pipeline with no mocks to verify
+ * actual behavior against the filesystem.
+ */
+
+/** Initializes a fresh git repo in a temp directory with one committed file. */
+function createGitRepo(): string {
+  const tmpDir = mkdtempSync(join(tmpdir(), "mcode-snap-test-"));
+
+  execFileSync("git", ["-C", tmpDir, "init", "-b", "main"]);
+  execFileSync("git", ["-C", tmpDir, "config", "user.email", "test@mcode.test"]);
+  execFileSync("git", ["-C", tmpDir, "config", "user.name", "Mcode Test"]);
+
+  // Create an initial file and commit so HEAD exists
+  writeFileSync(join(tmpDir, "existing.txt"), "line one\nline two\nline three\n");
+  execFileSync("git", ["-C", tmpDir, "add", "existing.txt"]);
+  execFileSync("git", ["-C", tmpDir, "commit", "-m", "initial commit"]);
+
+  return tmpDir;
+}
+
+/** Initializes a fresh git repo with no commits (unborn HEAD). */
+function createUnbornRepo(): string {
+  const tmpDir = mkdtempSync(join(tmpdir(), "mcode-snap-unborn-"));
+
+  execFileSync("git", ["-C", tmpDir, "init", "-b", "main"]);
+  execFileSync("git", ["-C", tmpDir, "config", "user.email", "test@mcode.test"]);
+  execFileSync("git", ["-C", tmpDir, "config", "user.name", "Mcode Test"]);
+
+  return tmpDir;
+}
+
+describe("SnapshotService integration", () => {
+  let service: SnapshotService;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    service = new SnapshotService();
+    tmpDir = createGitRepo();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("new untracked files appear in getFilesChanged", async () => {
+    const refBefore = await service.captureRef(tmpDir);
+
+    writeFileSync(join(tmpDir, "newfile.ts"), 'export const x = 1;\n');
+
+    const refAfter = await service.captureRef(tmpDir);
+
+    expect(refBefore).not.toBe(refAfter);
+
+    const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
+    expect(files).toContain("newfile.ts");
+  });
+
+  it("modified tracked files appear in getFilesChanged", async () => {
+    const refBefore = await service.captureRef(tmpDir);
+
+    writeFileSync(join(tmpDir, "existing.txt"), "line one\nline two\nline three\nline four\n");
+
+    const refAfter = await service.captureRef(tmpDir);
+
+    expect(refBefore).not.toBe(refAfter);
+
+    const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
+    expect(files).toContain("existing.txt");
+  });
+
+  it("both new and modified files appear in getFilesChanged", async () => {
+    const refBefore = await service.captureRef(tmpDir);
+
+    writeFileSync(join(tmpDir, "existing.txt"), "line one\nline two\nline three\nmodified\n");
+    writeFileSync(join(tmpDir, "brand-new.ts"), "export const brand = 'new';\n");
+
+    const refAfter = await service.captureRef(tmpDir);
+
+    expect(refBefore).not.toBe(refAfter);
+
+    const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
+    expect(files).toContain("existing.txt");
+    expect(files).toContain("brand-new.ts");
+  });
+
+  it("clean tree returns the same ref for consecutive captureRef calls", async () => {
+    // No changes between the two captures
+    const refA = await service.captureRef(tmpDir);
+    const refB = await service.captureRef(tmpDir);
+
+    expect(refA).toBe(refB);
+
+    const files = await service.getFilesChanged(tmpDir, refA, refB);
+    expect(files).toHaveLength(0);
+  });
+
+  it("getDiff includes new file content", async () => {
+    const refBefore = await service.captureRef(tmpDir);
+
+    writeFileSync(join(tmpDir, "hello.ts"), "export function hello() {\n  return 'world';\n}\n");
+
+    const refAfter = await service.captureRef(tmpDir);
+
+    const diff = await service.getDiff(tmpDir, refBefore, refAfter);
+
+    expect(diff).toContain("hello.ts");
+    // Added lines are prefixed with '+' in unified diff
+    expect(diff).toContain("+export function hello()");
+  });
+
+  it("getDiffStats counts new file additions", async () => {
+    const newFileContent = "line 1\nline 2\nline 3\n";
+    const expectedLineCount = newFileContent.split("\n").filter(Boolean).length; // 3
+
+    const refBefore = await service.captureRef(tmpDir);
+
+    writeFileSync(join(tmpDir, "counted.txt"), newFileContent);
+
+    const refAfter = await service.captureRef(tmpDir);
+
+    const stats = await service.getDiffStats(tmpDir, refBefore, refAfter);
+
+    const fileStat = stats.find((s) => s.filePath === "counted.txt");
+    expect(fileStat).toBeDefined();
+    expect(fileStat!.additions).toBe(expectedLineCount);
+    expect(fileStat!.deletions).toBe(0);
+  });
+
+  it("gitignored files are excluded from getFilesChanged", async () => {
+    const refBefore = await service.captureRef(tmpDir);
+
+    writeFileSync(join(tmpDir, ".gitignore"), "*.log\n");
+    writeFileSync(join(tmpDir, "debug.log"), "some debug output\n");
+    writeFileSync(join(tmpDir, "visible.txt"), "this file should appear\n");
+
+    const refAfter = await service.captureRef(tmpDir);
+
+    const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
+
+    expect(files).not.toContain("debug.log");
+    // The .gitignore itself and visible.txt are tracked changes
+    expect(files).toContain(".gitignore");
+    expect(files).toContain("visible.txt");
+  });
+});
+
+describe("SnapshotService integration - unborn repo", () => {
+  let service: SnapshotService;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    service = new SnapshotService();
+    tmpDir = createUnbornRepo();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("captures files in a repo with no commits", async () => {
+    writeFileSync(join(tmpDir, "first.ts"), "export const first = true;\n");
+
+    const ref = await service.captureRef(tmpDir);
+
+    // Should return a valid 40-char hex tree SHA, not empty
+    expect(ref).toMatch(/^[0-9a-f]{40}$/);
+    expect(ref).not.toBe("4b825dc642cb6eb9a060e54bf899d69f82cf7109"); // not the empty tree
+  });
+
+  it("detects new files between snapshots in unborn repo", async () => {
+    const refBefore = await service.captureRef(tmpDir);
+
+    writeFileSync(join(tmpDir, "hello.ts"), "export const hello = 'world';\n");
+
+    const refAfter = await service.captureRef(tmpDir);
+
+    expect(refBefore).not.toBe(refAfter);
+
+    const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
+    expect(files).toContain("hello.ts");
+  });
+
+  it("clean unborn repo returns the same (empty) tree SHA", async () => {
+    const refA = await service.captureRef(tmpDir);
+    const refB = await service.captureRef(tmpDir);
+
+    expect(refA).toBe(refB);
+    // Should be a valid 40-char hex tree SHA
+    expect(refA).toMatch(/^[0-9a-f]{40}$/);
+  });
+});

--- a/apps/server/src/__tests__/snapshot-service.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.test.ts
@@ -1,0 +1,176 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockExecFile, mockUnlink } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  mockUnlink: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("node:util", () => ({
+  promisify: () => mockExecFile,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  unlink: mockUnlink,
+}));
+
+import { SnapshotService } from "../services/snapshot-service";
+
+describe("SnapshotService.captureRef", () => {
+  let service: SnapshotService;
+  const cwd = "/repo";
+  const treeSha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+  const gitDir = "/repo/.git";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUnlink.mockResolvedValue(undefined);
+    service = new SnapshotService();
+  });
+
+  it("returns the tree SHA from write-tree after read-tree + add -A", async () => {
+    // 1. rev-parse --git-dir
+    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
+    // 2. read-tree HEAD
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    // 3. add -A
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    // 4. write-tree
+    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
+
+    const result = await service.captureRef(cwd);
+
+    expect(result).toBe(treeSha);
+    expect(mockExecFile).toHaveBeenCalledTimes(4);
+
+    // Verify command sequence
+    expect(mockExecFile.mock.calls[0][1]).toEqual(["-C", cwd, "rev-parse", "--git-dir"]);
+    expect(mockExecFile.mock.calls[1][1]).toEqual(["-C", cwd, "read-tree", "HEAD"]);
+    expect(mockExecFile.mock.calls[2][1]).toEqual(["-C", cwd, "add", "-A"]);
+    expect(mockExecFile.mock.calls[3][1]).toEqual(["-C", cwd, "write-tree"]);
+
+    // Verify all index-touching commands use GIT_INDEX_FILE
+    for (const callIdx of [1, 2, 3]) {
+      expect(mockExecFile.mock.calls[callIdx][2]).toEqual(
+        expect.objectContaining({
+          env: expect.objectContaining({ GIT_INDEX_FILE: expect.stringContaining(`${gitDir}/mcode-index-`) }),
+        }),
+      );
+    }
+
+    // No commit-tree call
+    const commitTreeCall = mockExecFile.mock.calls.find(
+      (call) => Array.isArray(call[1]) && call[1].includes("commit-tree"),
+    );
+    expect(commitTreeCall).toBeUndefined();
+  });
+
+  it("unborn repo: skips read-tree failure and proceeds with empty index", async () => {
+    // 1. rev-parse --git-dir
+    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
+    // 2. read-tree HEAD fails (unborn repo)
+    mockExecFile.mockRejectedValueOnce(new Error("fatal: Not a valid object name HEAD"));
+    // 3. add -A (proceeds with empty index)
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    // 4. write-tree
+    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
+
+    const result = await service.captureRef(cwd);
+
+    expect(result).toBe(treeSha);
+    expect(mockExecFile).toHaveBeenCalledTimes(4);
+
+    // add -A was still called after read-tree failed
+    expect(mockExecFile.mock.calls[2][1]).toEqual(["-C", cwd, "add", "-A"]);
+  });
+
+  it("throws when rev-parse --git-dir fails (not a git repo)", async () => {
+    mockExecFile.mockRejectedValueOnce(new Error("not a git repo"));
+
+    await expect(service.captureRef(cwd)).rejects.toThrow("not a git repo");
+  });
+
+  it("throws when add -A fails (disk full, permissions)", async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExecFile.mockRejectedValueOnce(new Error("add failed"));
+
+    await expect(service.captureRef(cwd)).rejects.toThrow("add failed");
+  });
+
+  it("throws when write-tree fails", async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExecFile.mockRejectedValueOnce(new Error("write-tree failed"));
+
+    await expect(service.captureRef(cwd)).rejects.toThrow("write-tree failed");
+  });
+
+  it("resolves relative git-dir path against cwd", async () => {
+    // rev-parse --git-dir returns relative ".git"
+    mockExecFile.mockResolvedValueOnce({ stdout: ".git\n", stderr: "" });
+    // read-tree HEAD
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    // add -A
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    // write-tree
+    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
+
+    const result = await service.captureRef(cwd);
+    expect(result).toBe(treeSha);
+
+    // Verify temp index path contains both the resolved .git dir and mcode-index- prefix.
+    // join() produces backslashes on Windows, so use regex to accept either separator.
+    const indexPath = mockExecFile.mock.calls[1][2].env.GIT_INDEX_FILE as string;
+    expect(indexPath).toMatch(/\.git/);
+    expect(indexPath).toMatch(/mcode-index-/);
+  });
+
+  it("cleans up temp index on success", async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
+
+    await service.captureRef(cwd);
+
+    expect(mockUnlink).toHaveBeenCalledTimes(1);
+    expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining(`${gitDir}/mcode-index-`));
+  });
+
+  it("cleans up temp index even when add -A throws", async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExecFile.mockRejectedValueOnce(new Error("add -A failed"));
+
+    await expect(service.captureRef(cwd)).rejects.toThrow();
+
+    expect(mockUnlink).toHaveBeenCalledTimes(1);
+    expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining(`${gitDir}/mcode-index-`));
+  });
+
+  it("cleans up temp index when read-tree fails (unborn repo path)", async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
+    mockExecFile.mockRejectedValueOnce(new Error("not a valid object name HEAD"));
+    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
+
+    await service.captureRef(cwd);
+
+    expect(mockUnlink).toHaveBeenCalledTimes(1);
+    expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining(`${gitDir}/mcode-index-`));
+  });
+
+  it("does not attempt unlink when rev-parse --git-dir fails (no tmpIndex created)", async () => {
+    mockExecFile.mockRejectedValueOnce(new Error("not a git repo"));
+
+    await expect(service.captureRef(cwd)).rejects.toThrow();
+
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/snapshot-service.ts
+++ b/apps/server/src/services/snapshot-service.ts
@@ -1,12 +1,15 @@
 /**
  * Snapshot service for capturing git working tree state.
- * Creates unreachable commits from the working tree and provides diff utilities
+ * Creates tree objects from the working tree and provides diff utilities
  * for comparing snapshots.
  */
 
 import { injectable } from "tsyringe";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
+import { unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 
 const execFile = promisify(execFileCb);
 
@@ -14,36 +17,64 @@ const execFile = promisify(execFileCb);
 @injectable()
 export class SnapshotService {
   /**
-   * Capture the current working tree state as an unreachable commit.
-   * Returns the SHA of the stash commit, or HEAD if the tree is clean.
+   * Capture the current working tree state as a tree object SHA.
+   *
+   * Uses a temporary git index (via GIT_INDEX_FILE) to stage all working tree
+   * changes including untracked files without touching the real index. Returns
+   * the tree SHA directly - no commit object is created, so no git identity
+   * configuration is required.
+   *
+   * Identical working trees produce identical tree SHAs (content-addressable),
+   * so consecutive calls on a clean tree return the same value.
+   *
+   * For unborn repos (no commits yet), read-tree is skipped and the tree is
+   * built from scratch. Throws on non-recoverable failures (disk full,
+   * permissions, not a git repo) so the caller can skip snapshot creation.
    */
   async captureRef(cwd: string): Promise<string> {
-    let stashSha = "";
-    try {
-      const { stdout: stashOut } = await execFile(
-        "git",
-        ["-C", cwd, "stash", "create", "-u"],
-        { timeout: 10_000 },
-      );
-      stashSha = stashOut.trim();
-    } catch {
-      // stash create can fail in bare repos or with corrupt index
-    }
-    if (stashSha) {
-      return stashSha;
-    }
+    const timeout = 10_000;
+    let tmpIndex = "";
 
-    // Working tree is clean; fall back to HEAD
-    const { stdout: headOut } = await execFile(
+    // Resolve the git dir so the temp index lives on the same volume (Windows compatibility)
+    const { stdout: gitDirOut } = await execFile(
       "git",
-      ["-C", cwd, "rev-parse", "HEAD"],
-      { timeout: 10_000 },
+      ["-C", cwd, "rev-parse", "--git-dir"],
+      { timeout },
     );
+    const gitDirRaw = gitDirOut.trim();
+    // rev-parse --git-dir may return a relative path on some git versions
+    const gitDir = gitDirRaw.startsWith("/") || /^[A-Za-z]:/.test(gitDirRaw)
+      ? gitDirRaw
+      : join(cwd, gitDirRaw);
 
-    return headOut.trim();
+    tmpIndex = `${gitDir}/mcode-index-${randomUUID()}`;
+    const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
+
+    try {
+      // Seed from HEAD tree; swallow failure for unborn repos (no commits yet)
+      try {
+        await execFile("git", ["-C", cwd, "read-tree", "HEAD"], { timeout, env });
+      } catch {
+        // Unborn repo or corrupt HEAD - proceed with empty index
+      }
+
+      // Stage all working tree changes including untracked files
+      await execFile("git", ["-C", cwd, "add", "-A"], { timeout, env });
+
+      // Write the staged index as a tree object and return the SHA
+      const { stdout: treeOut } = await execFile(
+        "git",
+        ["-C", cwd, "write-tree"],
+        { timeout, env },
+      );
+      return treeOut.trim();
+    } finally {
+      // Fire-and-forget cleanup - no await to prevent hangs on locked files
+      unlink(tmpIndex).catch(() => {});
+    }
   }
 
-  /** Get list of files changed between two refs. */
+  /** Get list of files changed between two refs (tree or commit SHAs). */
   async getFilesChanged(cwd: string, refBefore: string, refAfter: string): Promise<string[]> {
     if (refBefore === refAfter) {
       return [];
@@ -68,7 +99,7 @@ export class SnapshotService {
   }
 
   /**
-   * Get a unified diff between two refs.
+   * Get a unified diff between two refs (tree or commit SHAs).
    * Optionally scoped to a single file path.
    * @param maxLines - If provided, truncate output to this many lines.
    */
@@ -79,7 +110,7 @@ export class SnapshotService {
     filePath?: string,
     maxLines?: number,
   ): Promise<string> {
-    const args = ["-C", cwd, "diff", "--find-renames", `${refBefore}..${refAfter}`];
+    const args = ["-C", cwd, "diff", "--find-renames", refBefore, refAfter];
 
     if (filePath) {
       args.push("--", filePath);
@@ -111,7 +142,7 @@ export class SnapshotService {
     }
   }
 
-  /** Get per-file line addition/deletion counts between two refs using git diff --numstat. */
+  /** Get per-file line addition/deletion counts between two refs (tree or commit SHAs). */
   async getDiffStats(
     cwd: string,
     refBefore: string,


### PR DESCRIPTION
## What

New files created by agents were missing from the inline diff summary and the turns view diff viewer.

## Why

`SnapshotService.captureRef` used `git stash create -u` to snapshot the working tree. On clean trees (no staged/unstaged changes to tracked files) `stash create` returns empty even when untracked files exist - those files were silently dropped from snapshots.

## Key changes

- Replaced `git stash create -u` with a temporary-index approach (`read-tree HEAD` + `add -A` + `write-tree`) that returns tree SHAs directly
- No `commit-tree` call - removes git identity (`user.name`/`user.email`) dependency entirely
- No dangling commit objects created - tree objects are lighter weight and content-addressable (identical trees = identical SHA)
- Unborn repos supported - `read-tree HEAD` failure is caught and skipped, building the tree from scratch
- `getDiff` changed from `refBefore..refAfter` (commit-only syntax) to positional `refBefore refAfter` (works with both tree and commit SHAs, backward-compatible with old stored data)
- Temp index uses `GIT_INDEX_FILE` inside `.git/` dir to avoid cross-volume issues on Windows
- Added unit tests (8 cases): tree SHA return, unborn repo, git-dir failure, add -A failure, relative git-dir resolution, cleanup on success/error/unborn
- Added integration tests (10 cases): new files, modified files, mixed changes, clean tree, diff content, diff stats, gitignore exclusion, unborn repo capture/diff/idempotency

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration and unit tests validating snapshot capture, diff generation, diff stats, gitignore behavior, unborn-repo scenarios, and cleanup behavior.

* **Refactor**
  * Snapshot capture now returns a stable content-addressed tree SHA, reliably detects changes (including untracked files), produces unified diffs with added-line markers, computes accurate diff stats, and is more robust across varied repository states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->