### PR TITLE
fix: guard pid <= 0 in killProcessTree on all platforms

### DIFF
--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -64,15 +64,14 @@ describe("killProcessTree", () => {
   it("sends SIGKILL to process group on Unix", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "linux" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     try {
-      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
       await killProcessTree(5678);
 
       expect(killSpy).toHaveBeenCalledWith(-5678, "SIGKILL");
       expect(mockExecFile).not.toHaveBeenCalled();
-      killSpy.mockRestore();
     } finally {
+      killSpy.mockRestore();
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }
   });
@@ -80,18 +79,17 @@ describe("killProcessTree", () => {
   it("does not throw when Unix kill fails (process already exited)", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "linux" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
     try {
-      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
-        throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
-      });
-
       await expect(killProcessTree(5678)).resolves.toBeUndefined();
       expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ pid: 5678 }),
       );
-      killSpy.mockRestore();
     } finally {
+      killSpy.mockRestore();
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }
   });
@@ -99,14 +97,39 @@ describe("killProcessTree", () => {
   it("does nothing when pid is 0 on Unix", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "linux" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     try {
-      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
       await killProcessTree(0);
 
       expect(killSpy).not.toHaveBeenCalled();
-      killSpy.mockRestore();
     } finally {
+      killSpy.mockRestore();
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("does nothing when pid is 0 on Windows", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      await killProcessTree(0);
+
+      expect(mockExecFile).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("does nothing when pid is negative on Unix", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      await killProcessTree(-1);
+
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }
   });

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -20,16 +20,16 @@ const TASKKILL_TIMEOUT_MS = 5_000;
  * Best-effort: never throws. The process may already be dead.
  */
 export async function killProcessTree(pid: number): Promise<void> {
+  // Guard against invalid PIDs on all platforms: taskkill with PID 0 targets the
+  // System Idle Process on Windows; process.kill(0) sends to the server's own group.
+  if (pid <= 0) return;
   try {
     if (process.platform === "win32") {
       await execFile("taskkill", ["/T", "/F", "/PID", String(pid)], {
         timeout: TASKKILL_TIMEOUT_MS,
       });
     } else {
-      // Guard against pid <= 0: process.kill(0) would kill the server's own group.
-      if (pid > 0) {
-        process.kill(-pid, "SIGKILL");
-      }
+      process.kill(-pid, "SIGKILL");
     }
   } catch (err) {
     logger.warn("killProcessTree: process may already be dead", {


### PR DESCRIPTION
## What

Guards against `pid <= 0` at the top of `killProcessTree` before the platform check, and moves `killSpy.mockRestore()` into `finally` blocks in the tests.

## Why

The original guard was Unix-only (`if (pid > 0)` inside the `else` branch). On Windows, `killProcessTree(0)` would call `taskkill /T /F /PID 0`, which targets the System Idle Process. This was caught by the `try/catch` and logged, but it was noisy and technically wrong. Consolidating the guard at the function entry covers both platforms with a single check.

The `mockRestore()` placement in `try` meant a failing assertion would leave the spy active and potentially affect later tests.

## Key Changes

- `process-kill.ts`: Single `if (pid <= 0) return` guard before the platform branch
- `process-kill.test.ts`: `killSpy.mockRestore()` moved to `finally` in all three affected tests; added `pid=0` on Windows and `pid=-1` on Unix coverage tests

Related to #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for process identifiers, now properly handling zero and negative values to prevent unintended operations.

* **Tests**
  * Expanded test coverage to include edge cases for invalid process identifiers across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->