### PR TITLE
fix: new worktree threads incorrectly shown as read-only

### DIFF
--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -303,6 +303,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         activeThreadId: thread.id,
         pendingNewThread: false,
         branchManuallySelected: false,
+        // Invalidate worktree cache so the new worktree is included in the
+        // stale-worktree check. ProjectTree's effect will reload the list.
+        ...(mode === "worktree" ? { worktreesLoadedForWorkspace: null } : {}),
       }));
 
       // Mark the new thread as running in the threadStore so the
@@ -360,6 +363,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         activeThreadId: thread.id,
         pendingNewThread: false,
         branchManuallySelected: false,
+        // Invalidate worktree cache so the branched worktree is included in
+        // the stale-worktree check. ProjectTree's effect will reload the list.
+        ...(transportMode === "worktree" ? { worktreesLoadedForWorkspace: null } : {}),
       }));
 
       useThreadStore.setState((state) => ({


### PR DESCRIPTION
## What

New worktree threads were incorrectly marked read-only immediately after creation.

## Why

When a worktree thread is created, the server creates the worktree on disk and returns the thread with a `worktree_path`. The client adds the thread to state, but the cached `worktrees` list is stale - it was fetched before the server created the new worktree. The `isStaleWorktree` check in `Composer.tsx` compares the thread's `worktree_path` against this stale list, finds no match, and disables the composer with "Worktree directory no longer exists. This thread is read-only."

The auto-reload in `ProjectTree.tsx` skips re-fetching because `worktreesLoadedForWorkspace` already matches the workspace ID.

## Key changes

- Null out `worktreesLoadedForWorkspace` when creating a worktree thread in `createAndSendMessage` and `branchThread`
- This makes `isStaleWorktree` return `false` immediately (it bails when worktrees aren't loaded for the workspace)
- `ProjectTree`'s useEffect detects the invalidation and reloads the worktree list in the background

## Test plan

- [ ] Create a new worktree thread - composer should remain editable
- [ ] Branch a thread in worktree mode - composer should remain editable
- [ ] Navigate away and back to a worktree thread whose directory was deleted - should still show read-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worktree data inconsistencies during thread creation and branching. The application now properly refreshes and reloads worktree information when creating new threads or branching from existing threads, ensuring users always have access to the most current and accurate worktree data without experiencing stale data issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->