### PR TITLE
feat: improve diff view UX

### DIFF
--- a/apps/web/src/components/diff/CommitEntry.tsx
+++ b/apps/web/src/components/diff/CommitEntry.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { Plus, Minus } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { getTransport } from "@/transport";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import type { GitCommit } from "@mcode/contracts";
@@ -102,9 +103,9 @@ export function CommitEntry({ commit }: CommitEntryProps) {
         {/* File count badge (shown once files have loaded) + SHA + time */}
         <span className="flex shrink-0 items-center gap-1.5">
           {files !== null && files.length > 0 && (
-            <span className="rounded bg-muted/50 px-1 font-mono text-[9px] text-muted-foreground/60">
+            <Badge variant="ghost" size="sm" className="font-mono text-muted-foreground/60">
               {files.length} {files.length === 1 ? "file" : "files"}
-            </span>
+            </Badge>
           )}
           <span className="font-mono text-[9px] text-muted-foreground/80">{commit.shortSha}</span>
           <span className="text-[9px] text-muted-foreground/70">{relativeTime(commit.date)}</span>

--- a/apps/web/src/components/diff/CommitEntry.tsx
+++ b/apps/web/src/components/diff/CommitEntry.tsx
@@ -99,8 +99,13 @@ export function CommitEntry({ commit }: CommitEntryProps) {
           {commit.message}
         </span>
 
-        {/* SHA + time */}
+        {/* File count badge (shown once files have loaded) + SHA + time */}
         <span className="flex shrink-0 items-center gap-1.5">
+          {files !== null && files.length > 0 && (
+            <span className="rounded bg-muted/50 px-1 font-mono text-[9px] text-muted-foreground/60">
+              {files.length} {files.length === 1 ? "file" : "files"}
+            </span>
+          )}
           <span className="font-mono text-[9px] text-muted-foreground/80">{commit.shortSha}</span>
           <span className="text-[9px] text-muted-foreground/70">{relativeTime(commit.date)}</span>
         </span>

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -1,4 +1,4 @@
-import { Columns2, AlignJustify } from "lucide-react";
+import { Columns2, AlignJustify, WrapText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDiffStore, type DiffViewMode } from "@/stores/diffStore";
@@ -15,8 +15,10 @@ const ALL_VIEW_MODES: { value: DiffViewMode; label: string; worktreeOnly: boolea
 export function DiffToolbar() {
   const viewMode = useDiffStore((s) => s.viewMode);
   const renderMode = useDiffStore((s) => s.renderMode);
+  const lineWrap = useDiffStore((s) => s.lineWrap);
   const setViewMode = useDiffStore((s) => s.setViewMode);
   const setRenderMode = useDiffStore((s) => s.setRenderMode);
+  const toggleLineWrap = useDiffStore((s) => s.toggleLineWrap);
 
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const isWorktree = useWorkspaceStore((s) => {
@@ -45,24 +47,45 @@ export function DiffToolbar() {
         ))}
       </div>
 
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              onClick={() => setRenderMode(renderMode === "unified" ? "side-by-side" : "unified")}
-              className="h-6 w-6 text-muted-foreground/50 hover:text-foreground/70"
-              aria-label={`Switch to ${renderMode === "unified" ? "side-by-side" : "unified"} view`}
-            >
-              {renderMode === "unified" ? <Columns2 size={13} /> : <AlignJustify size={13} />}
-            </Button>
-          }
-        />
-        <TooltipContent side="left" className="text-xs">
-          {renderMode === "unified" ? "Side-by-side view" : "Unified view"}
-        </TooltipContent>
-      </Tooltip>
+      <div className="flex items-center gap-0.5">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={toggleLineWrap}
+                className={`h-6 w-6 transition-colors ${lineWrap ? "text-foreground/70" : "text-muted-foreground/40 hover:text-foreground/60"}`}
+                aria-label={lineWrap ? "Disable line wrap" : "Wrap long lines"}
+              >
+                <WrapText size={13} />
+              </Button>
+            }
+          />
+          <TooltipContent side="left" className="text-xs">
+            {lineWrap ? "Disable line wrap" : "Wrap long lines"}
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setRenderMode(renderMode === "unified" ? "side-by-side" : "unified")}
+                className="h-6 w-6 text-muted-foreground/50 hover:text-foreground/70"
+                aria-label={`Switch to ${renderMode === "unified" ? "side-by-side" : "unified"} view`}
+              >
+                {renderMode === "unified" ? <Columns2 size={13} /> : <AlignJustify size={13} />}
+              </Button>
+            }
+          />
+          <TooltipContent side="left" className="text-xs">
+            {renderMode === "unified" ? "Side-by-side view" : "Unified view"}
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from "react";
-import { Plus, Minus } from "lucide-react";
+import { Plus, Minus, ChevronsDownUp } from "lucide-react";
 import { useDiffStore, type SelectedFile } from "@/stores/diffStore";
 import { getTransport } from "@/transport";
 import { parseDiffLines } from "@/lib/diff-parser";
@@ -54,6 +54,12 @@ const EXT_COLORS: Record<string, string> = {
   toml: "text-amber-700 dark:text-amber-400",
 };
 
+/**
+ * Number of lines shown initially for large diffs before truncation.
+ * Diffs with more than LARGE_DIFF_THRESHOLD lines start truncated.
+ */
+const LARGE_DIFF_THRESHOLD = 200;
+const INITIAL_LINES_SHOWN = 100;
 
 /**
  * Diff loading state.
@@ -65,9 +71,11 @@ type DiffState = null | { loading: true } | { loading: false; data: string };
  * Single file row with an inline expandable diff.
  * Clicking toggles the diff open/closed directly below the filename.
  * Diff is loaded lazily on the first expand.
+ * Large diffs (>200 lines) are truncated with a "Show all N lines" button.
  */
 export function FileEntry({ filePath, source, id }: FileEntryProps) {
   const [expanded, setExpanded] = useState(false);
+  const [showAllLines, setShowAllLines] = useState(false);
   const [diffState, setDiffState] = useState<DiffState>(null);
   const renderMode = useDiffStore((s) => s.renderMode);
   // Tracks whether a load has been kicked off so the effect doesn't cancel itself
@@ -140,14 +148,31 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
   );
 
   const isLoaded = diffState !== null && !diffState.loading;
+  const isLargeDiff = lines.length > LARGE_DIFF_THRESHOLD;
+  const { visibleLines, hiddenLineCount } = useMemo(() => {
+    if (isLargeDiff && !showAllLines) {
+      return {
+        visibleLines: lines.slice(0, INITIAL_LINES_SHOWN),
+        hiddenLineCount: lines.length - INITIAL_LINES_SHOWN,
+      };
+    }
+    return { visibleLines: lines, hiddenLineCount: 0 };
+  }, [lines, isLargeDiff, showAllLines]);
 
   return (
     <div className={`border-b border-border/30 ${expanded ? "bg-muted/5" : ""}`}>
-      {/* File header row */}
+      {/* File header row — sticky when expanded so filename stays visible while scrolling the diff */}
       <button
         type="button"
-        onClick={() => setExpanded((prev) => !prev)}
-        className="group flex w-full items-center gap-2 py-[5px] pl-7 pr-3 text-left transition-colors hover:bg-muted/20"
+        onClick={() => setExpanded((prev) => {
+          if (prev) setShowAllLines(false); // reset truncation on collapse
+          return !prev;
+        })}
+        className={`group flex w-full items-center gap-2 py-[5px] pl-7 pr-3 text-left transition-colors hover:bg-muted/20 ${
+          expanded
+            ? "sticky top-0 z-10 bg-background/95 backdrop-blur-sm border-b border-border/20"
+            : ""
+        }`}
         title={filePath}
       >
         {expanded ? (
@@ -159,16 +184,21 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
         {/* Status dot */}
         <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500/60" />
 
-        {/* Filename + parent dir */}
+        {/* Filename + path */}
         <span className="flex-1 min-w-0">
           <span className="block truncate font-mono text-[11px] text-foreground/80">
             {basename}
           </span>
-          {parent && (
+          {expanded ? (
+            /* Show full path when expanded for clarity */
+            <span className="block truncate font-mono text-[9px] text-muted-foreground/60">
+              {filePath}
+            </span>
+          ) : parent ? (
             <span className="block truncate font-mono text-[9px] text-muted-foreground/70">
               {parent}/
             </span>
-          )}
+          ) : null}
         </span>
 
         {/* +/- stats once loaded */}
@@ -191,7 +221,7 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
         )}
       </button>
 
-      {/* Inline diff */}
+      {/* Inline diff — no height cap; outer ScrollArea owns vertical scroll */}
       {expanded && (
         <div className="border-t border-border/30">
           {!isLoaded ? (
@@ -205,13 +235,25 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
               ))}
             </div>
           ) : lines.length > 0 ? (
-            <div className="max-h-[360px] overflow-auto">
+            <>
               {renderMode === "unified" ? (
-                <UnifiedDiff lines={lines} language={language} />
+                <UnifiedDiff lines={visibleLines} language={language} />
               ) : (
-                <SideBySideDiff lines={lines} language={language} />
+                <SideBySideDiff lines={visibleLines} language={language} />
               )}
-            </div>
+
+              {/* Large diff expansion button */}
+              {hiddenLineCount > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setShowAllLines(true)}
+                  className="flex w-full items-center justify-center gap-1.5 border-t border-border/20 bg-muted/10 py-2 text-[10px] text-muted-foreground/70 transition-colors hover:bg-muted/20 hover:text-foreground/70"
+                >
+                  <ChevronsDownUp size={11} />
+                  Show {hiddenLineCount} more lines
+                </button>
+              )}
+            </>
           ) : (
             <div className="flex items-center justify-center py-4">
               <p className="text-[10px] text-muted-foreground">No changes</p>

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { Plus, Minus, ChevronsDownUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { useDiffStore, type SelectedFile } from "@/stores/diffStore";
 import { getTransport } from "@/transport";
 import { parseDiffLines } from "@/lib/diff-parser";
@@ -190,8 +191,8 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
             {basename}
           </span>
           {expanded ? (
-            /* Show full path when expanded for clarity */
-            <span className="block truncate font-mono text-[9px] text-muted-foreground/60">
+            /* Show full path when expanded - no truncation so the full path is always readable */
+            <span className="block break-all font-mono text-[9px] text-muted-foreground/60">
               {filePath}
             </span>
           ) : parent ? (
@@ -244,14 +245,15 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
 
               {/* Large diff expansion button */}
               {hiddenLineCount > 0 && (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => setShowAllLines(true)}
-                  className="flex w-full items-center justify-center gap-1.5 border-t border-border/20 bg-muted/10 py-2 text-[10px] text-muted-foreground/70 transition-colors hover:bg-muted/20 hover:text-foreground/70"
+                  className="flex w-full items-center justify-center gap-1.5 rounded-none border-t border-border/20 py-2 text-[10px] text-muted-foreground/70 hover:text-foreground/70"
                 >
                   <ChevronsDownUp size={11} />
                   Show {hiddenLineCount} more lines
-                </button>
+                </Button>
               )}
             </>
           ) : (

--- a/apps/web/src/components/diff/SideBySideDiff.tsx
+++ b/apps/web/src/components/diff/SideBySideDiff.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { ParsedDiffLine } from "@/lib/diff-parser";
 import { useDiffHighlighter } from "@/hooks/useDiffHighlighter";
 import { useShikiTheme } from "@/hooks/useTheme";
+import { useDiffStore } from "@/stores/diffStore";
 import { HunkSeparator } from "./HunkSeparator";
 
 /** Props for SideBySideDiff. */
@@ -100,6 +101,7 @@ const RIGHT_BG: Record<string, string> = {
 export function SideBySideDiff({ lines, language = "text" }: SideBySideDiffProps) {
   const rows = useMemo(() => buildRows(lines), [lines]);
   const theme = useShikiTheme();
+  const lineWrap = useDiffStore((s) => s.lineWrap);
   const { getLineTokens } = useDiffHighlighter(lines, language, theme, language !== "text");
 
   // Vertical scrolling is handled by the parent FileEntry wrapper (overflow-auto),
@@ -107,10 +109,10 @@ export function SideBySideDiff({ lines, language = "text" }: SideBySideDiffProps
   // independent horizontal overflow.
 
   return (
-    <div className="flex select-text text-[11px] font-mono leading-relaxed">
+    <div className="flex select-text text-[12px] font-mono leading-5">
       {/* Left (removed) */}
-      <div className="flex-1 overflow-x-auto border-r border-border/20">
-        <div className="w-fit min-w-full">
+      <div className={`flex-1 border-r border-border/20 ${lineWrap ? "overflow-x-hidden" : "overflow-x-auto"}`}>
+        <div className={lineWrap ? "w-full" : "w-fit min-w-full"}>
         {rows.map((row, i) => {
           // Hunk separator bar
           if (row.left.type === "header") {
@@ -126,7 +128,7 @@ export function SideBySideDiff({ lines, language = "text" }: SideBySideDiffProps
               <span className="inline-flex w-9 shrink-0 select-none items-center justify-end border-r border-border/10 pr-2 text-[10px] text-muted-foreground/20">
                 {row.left.lineNo ?? ""}
               </span>
-              <span className="flex-1 whitespace-pre px-1">
+              <span className={`flex-1 px-1 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
                 {tokens ? (
                   tokens.map((token, j) => (
                     <span key={j} style={{ color: token.color }}>
@@ -154,8 +156,8 @@ export function SideBySideDiff({ lines, language = "text" }: SideBySideDiffProps
       </div>
 
       {/* Right (added) */}
-      <div className="flex-1 overflow-x-auto">
-        <div className="w-fit min-w-full">
+      <div className={`flex-1 ${lineWrap ? "overflow-x-hidden" : "overflow-x-auto"}`}>
+        <div className={lineWrap ? "w-full" : "w-fit min-w-full"}>
         {rows.map((row, i) => {
           // Hunk separator bar
           if (row.right.type === "header") {
@@ -171,7 +173,7 @@ export function SideBySideDiff({ lines, language = "text" }: SideBySideDiffProps
               <span className="inline-flex w-9 shrink-0 select-none items-center justify-end border-r border-border/10 pr-2 text-[10px] text-muted-foreground/20">
                 {row.right.lineNo ?? ""}
               </span>
-              <span className="flex-1 whitespace-pre px-1">
+              <span className={`flex-1 px-1 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
                 {tokens ? (
                   tokens.map((token, j) => (
                     <span key={j} style={{ color: token.color }}>

--- a/apps/web/src/components/diff/UnifiedDiff.tsx
+++ b/apps/web/src/components/diff/UnifiedDiff.tsx
@@ -1,6 +1,7 @@
 import type { ParsedDiffLine } from "@/lib/diff-parser";
 import { useDiffHighlighter } from "@/hooks/useDiffHighlighter";
 import { useShikiTheme } from "@/hooks/useTheme";
+import { useDiffStore } from "@/stores/diffStore";
 import { HunkSeparator } from "./HunkSeparator";
 
 /** Props for UnifiedDiff. */
@@ -13,11 +14,12 @@ interface UnifiedDiffProps {
 /** Unified diff renderer: line numbers, +/- prefix, syntax highlighting, hunk separator bars. */
 export function UnifiedDiff({ lines, language = "text" }: UnifiedDiffProps) {
   const theme = useShikiTheme();
+  const lineWrap = useDiffStore((s) => s.lineWrap);
   const { getLineTokens } = useDiffHighlighter(lines, language, theme, language !== "text");
 
   return (
-    <div className="select-text overflow-x-auto text-[11px] font-mono leading-relaxed">
-      <div className="w-fit min-w-full">
+    <div className={`select-text text-[12px] font-mono leading-5 ${lineWrap ? "overflow-x-hidden" : "overflow-x-auto"}`}>
+      <div className={lineWrap ? "w-full" : "w-fit min-w-full"}>
       {lines.map((line, i) => {
         if (line.type === "header") {
           // Only render @@ hunk headers; skip git metadata lines
@@ -63,7 +65,7 @@ export function UnifiedDiff({ lines, language = "text" }: UnifiedDiffProps) {
               {isAdd ? "+" : isRemove ? "-" : " "}
             </span>
             {/* Content: syntax-highlighted tokens when available, plain text fallback */}
-            <span className="flex-1 whitespace-pre px-1">
+            <span className={`flex-1 px-1 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
               {tokens ? (
                 tokens.map((token, j) => (
                   <span key={j} style={{ color: token.color }}>

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -34,13 +34,17 @@ export function RightPanel() {
   // Registered once on mount; reads panelWidthRef to avoid a stale closure.
   // Throttled with rAF so rapid resize events only trigger one recalculation per frame.
   useEffect(() => {
+    // Clamp immediately on mount in case the stored width already exceeds the viewport.
+    const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
+    if (panelWidthRef.current > maxAllowed) setPanelWidth(maxAllowed);
+
     let rafId: number | null = null;
     const onResize = () => {
       if (rafId !== null) return;
       rafId = requestAnimationFrame(() => {
         rafId = null;
-        const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
-        if (panelWidthRef.current > maxAllowed) setPanelWidth(maxAllowed);
+        const max = window.innerWidth - PANEL_MIN_WIDTH;
+        if (panelWidthRef.current > max) setPanelWidth(max);
       });
     };
     window.addEventListener("resize", onResize);
@@ -99,8 +103,11 @@ export function RightPanel() {
     >
       {/* Drag handle (left edge) — double-click snaps between default and wide */}
       <div
+        role="separator"
+        aria-orientation="vertical"
+        tabIndex={0}
         className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10
-                   hover:bg-primary/25 active:bg-primary/40 transition-colors duration-150"
+                   hover:bg-primary/25 active:bg-primary/40 focus-visible:bg-primary/25 transition-colors duration-150"
         onMouseDown={onDragStart}
         onDoubleClick={() => {
           const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
@@ -108,6 +115,16 @@ export function RightPanel() {
             ? PANEL_DEFAULT_WIDTH
             : Math.min(PANEL_WIDE_WIDTH, viewportCap);
           setPanelWidth(Math.max(PANEL_MIN_WIDTH, target));
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
+            const target = panelWidth >= PANEL_WIDE_WIDTH
+              ? PANEL_DEFAULT_WIDTH
+              : Math.min(PANEL_WIDE_WIDTH, viewportCap);
+            setPanelWidth(Math.max(PANEL_MIN_WIDTH, target));
+          }
         }}
       />
 

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -34,7 +34,7 @@ export function RightPanel() {
   // Registered once on mount; reads panelWidthRef to avoid a stale closure.
   useEffect(() => {
     const onResize = () => {
-      const maxAllowed = window.innerWidth - 300;
+      const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
       if (panelWidthRef.current > maxAllowed) setPanelWidth(maxAllowed);
     };
     window.addEventListener("resize", onResize);
@@ -51,8 +51,8 @@ export function RightPanel() {
       const onMouseMove = (moveEvent: globalThis.MouseEvent) => {
         if (!draggingRef.current) return;
         const delta = startX - moveEvent.clientX;
-        // Always leave at least 300px for the chat area
-        const viewportCap = window.innerWidth - 300;
+        // Always leave at least PANEL_MIN_WIDTH px for the chat area
+        const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
         setPanelWidth(Math.min(startWidth + delta, viewportCap));
       };
 
@@ -85,7 +85,7 @@ export function RightPanel() {
 
   return (
     <div
-      style={{ width: panelWidth, minWidth: PANEL_MIN_WIDTH, maxWidth: "calc(100vw - 300px)" }}
+      style={{ width: panelWidth, minWidth: PANEL_MIN_WIDTH, maxWidth: `calc(100vw - ${PANEL_MIN_WIDTH}px)` }}
       className="relative flex flex-col border-l border-border bg-background/95"
     >
       {/* Drag handle (left edge) — double-click snaps between default and wide */}

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -4,7 +4,7 @@ import { ListChecks, Diff, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTaskStore } from "@/stores/taskStore";
-import { useDiffStore, PANEL_MIN_WIDTH, PANEL_MAX_WIDTH } from "@/stores/diffStore";
+import { useDiffStore, PANEL_MIN_WIDTH, PANEL_DEFAULT_WIDTH, PANEL_WIDE_WIDTH } from "@/stores/diffStore";
 import { TaskPanel } from "@/components/tasks/TaskPanel";
 import { TaskPanelHeader } from "@/components/tasks/TaskPanelHeader";
 import { DiffPanel } from "@/components/diff";
@@ -24,6 +24,22 @@ export function RightPanel() {
 
   const draggingRef = useRef(false);
   const dragListenersRef = useRef<{ move: (e: globalThis.MouseEvent) => void; up: () => void } | null>(null);
+  // Ref keeps the latest panelWidth readable inside the resize handler without
+  // the handler needing to be re-registered on every width change.
+  const panelWidthRef = useRef(panelWidth);
+  useEffect(() => { panelWidthRef.current = panelWidth; }, [panelWidth]);
+
+  // Re-clamp stored width when the window is resized so the panel never
+  // exceeds the available space after the user shrinks the browser.
+  // Registered once on mount; reads panelWidthRef to avoid a stale closure.
+  useEffect(() => {
+    const onResize = () => {
+      const maxAllowed = window.innerWidth - 300;
+      if (panelWidthRef.current > maxAllowed) setPanelWidth(maxAllowed);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [setPanelWidth]);
 
   const onDragStart = useCallback(
     (e: ReactMouseEvent) => {
@@ -35,7 +51,9 @@ export function RightPanel() {
       const onMouseMove = (moveEvent: globalThis.MouseEvent) => {
         if (!draggingRef.current) return;
         const delta = startX - moveEvent.clientX;
-        setPanelWidth(startWidth + delta);
+        // Always leave at least 300px for the chat area
+        const viewportCap = window.innerWidth - 300;
+        setPanelWidth(Math.min(startWidth + delta, viewportCap));
       };
 
       const onMouseUp = () => {
@@ -67,13 +85,17 @@ export function RightPanel() {
 
   return (
     <div
-      style={{ width: panelWidth, minWidth: PANEL_MIN_WIDTH, maxWidth: PANEL_MAX_WIDTH }}
+      style={{ width: panelWidth, minWidth: PANEL_MIN_WIDTH, maxWidth: "calc(100vw - 300px)" }}
       className="relative flex flex-col border-l border-border bg-background/95"
     >
-      {/* Drag handle (left edge) */}
+      {/* Drag handle (left edge) — double-click snaps between default and wide */}
       <div
-        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-muted-foreground/30 z-10"
+        className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10
+                   hover:bg-primary/25 active:bg-primary/40 transition-colors duration-150"
         onMouseDown={onDragStart}
+        onDoubleClick={() =>
+          setPanelWidth(panelWidth >= PANEL_WIDE_WIDTH ? PANEL_DEFAULT_WIDTH : PANEL_WIDE_WIDTH)
+        }
       />
 
       {/* Tab header */}

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -32,13 +32,22 @@ export function RightPanel() {
   // Re-clamp stored width when the window is resized so the panel never
   // exceeds the available space after the user shrinks the browser.
   // Registered once on mount; reads panelWidthRef to avoid a stale closure.
+  // Throttled with rAF so rapid resize events only trigger one recalculation per frame.
   useEffect(() => {
+    let rafId: number | null = null;
     const onResize = () => {
-      const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
-      if (panelWidthRef.current > maxAllowed) setPanelWidth(maxAllowed);
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
+        if (panelWidthRef.current > maxAllowed) setPanelWidth(maxAllowed);
+      });
     };
     window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
   }, [setPanelWidth]);
 
   const onDragStart = useCallback(
@@ -93,9 +102,13 @@ export function RightPanel() {
         className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10
                    hover:bg-primary/25 active:bg-primary/40 transition-colors duration-150"
         onMouseDown={onDragStart}
-        onDoubleClick={() =>
-          setPanelWidth(panelWidth >= PANEL_WIDE_WIDTH ? PANEL_DEFAULT_WIDTH : PANEL_WIDE_WIDTH)
-        }
+        onDoubleClick={() => {
+          const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
+          const target = panelWidth >= PANEL_WIDE_WIDTH
+            ? PANEL_DEFAULT_WIDTH
+            : Math.min(PANEL_WIDE_WIDTH, viewportCap);
+          setPanelWidth(Math.max(PANEL_MIN_WIDTH, target));
+        }}
       />
 
       {/* Tab header */}

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -32,6 +32,8 @@ interface DiffState {
   viewMode: DiffViewMode;
   /** Diff rendering mode. */
   renderMode: DiffRenderMode;
+  /** Whether long lines wrap instead of scrolling horizontally. */
+  lineWrap: boolean;
   /** Turn snapshots keyed by thread ID. */
   snapshotsByThread: Record<string, TurnSnapshot[]>;
   /** Whether snapshots are currently loading, keyed by thread ID. */
@@ -54,6 +56,7 @@ interface DiffState {
   setActiveTab: (tab: RightPanelTab) => void;
   setViewMode: (mode: DiffViewMode) => void;
   setRenderMode: (mode: DiffRenderMode) => void;
+  toggleLineWrap: () => void;
   setSnapshots: (threadId: string, snapshots: TurnSnapshot[]) => void;
   setSnapshotsLoading: (threadId: string, loading: boolean) => void;
   setCommits: (threadId: string, commits: GitCommit[]) => void;
@@ -65,13 +68,15 @@ interface DiffState {
 }
 
 /** Minimum right panel width in pixels. */
-export const PANEL_MIN_WIDTH = 280;
-/** Maximum right panel width in pixels. */
-export const PANEL_MAX_WIDTH = 600;
-const DEFAULT_WIDTH = 320;
+export const PANEL_MIN_WIDTH = 300;
+/** Default right panel width in pixels. */
+export const PANEL_DEFAULT_WIDTH = 380;
+/** Wide snap target for the right panel (double-click drag handle). */
+export const PANEL_WIDE_WIDTH = 680;
+const DEFAULT_WIDTH = PANEL_DEFAULT_WIDTH;
 
 function clampWidth(w: number): number {
-  return Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, w));
+  return Math.max(PANEL_MIN_WIDTH, w);
 }
 
 /** Zustand store for diff panel and right panel tab state. */
@@ -81,6 +86,7 @@ export const useDiffStore = create<DiffState>((set) => ({
   panelWidth: DEFAULT_WIDTH,
   viewMode: "by-turn",
   renderMode: "unified",
+  lineWrap: false,
   snapshotsByThread: {},
   snapshotsLoadingByThread: {},
   commitsByThread: {},
@@ -96,6 +102,7 @@ export const useDiffStore = create<DiffState>((set) => ({
   setActiveTab: (tab) => set({ activeTab: tab }),
   setViewMode: (mode) => set({ viewMode: mode, selectedFile: null, diffContent: null }),
   setRenderMode: (mode) => set({ renderMode: mode }),
+  toggleLineWrap: () => set((s) => ({ lineWrap: !s.lineWrap })),
   setSnapshots: (threadId, snapshots) =>
     set((s) => ({ snapshotsByThread: { ...s.snapshotsByThread, [threadId]: snapshots } })),
   setSnapshotsLoading: (threadId, loading) =>


### PR DESCRIPTION
## What

Polish pass on the diff view panel - addressing width constraints, line wrapping, scroll ergonomics, and responsiveness.

## Why

The diff view was graded C- for UX. Key pain points: hard pixel cap on panel width made diffs unreadable, no line wrap option forced horizontal scrolling on long lines, per-file height caps created scroll-within-scroll, and the panel could overflow the viewport on resize.

## Key changes

- **Line wrap toggle** - `WrapText` button in `DiffToolbar` switches between `whitespace-pre` (scroll) and `whitespace-pre-wrap break-words` (wrap). State lives in `diffStore`.
- **No height cap** - Removed `max-h-[360px]` from `FileEntry`. Outer `ScrollArea` in `DiffPanel` is now the sole vertical scroll owner, eliminating the scroll-within-scroll anti-pattern.
- **Large diff truncation** - Diffs >200 lines show first 100 with a "Show N more lines" button. State resets on collapse.
- **Sticky file header** - Expanded file entries get `sticky top-0` so the filename stays visible while scrolling the diff body.
- **Full path on expand** - Secondary line under the basename shows the full file path when expanded.
- **File count badge** - `CommitEntry` shows `N files` next to the SHA once files load.
- **Responsive panel width** - Hard `600px` cap replaced with `calc(100vw - 300px)`. Drag is capped at `window.innerWidth - 300` at runtime. Resize listener re-clamps stored width when the browser window shrinks (uses ref pattern to avoid stale closure).
- **Double-click snap** - Drag handle snaps between 380px (default) and 680px (wide) on double-click.
- **Font** - Bumped from `text-[11px] leading-relaxed` to `text-[12px] leading-5` in both diff renderers.

## Related issues/PRs

Relates to diff view UX improvements tracked on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File count badge appears in commit headers once file data loads
  * Line-wrap toggle added to diff toolbar (affects unified and side-by-side views)
  * Large diffs truncated with a "Show N more lines" expand button; filename display updates when expanded
  * Double-click or keyboard on diff panel handle toggles between default and wide widths

* **Improvements**
  * Panel resizing better respects viewport and clamps width to avoid overlapping main content
  * Expanded file headers become sticky for easier navigation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->