### PR TITLE
feat(db): versioned migration framework with rollback and CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,19 @@ Syntax highlighting runs in `apps/web/src/workers/shiki.worker.ts` via `@shikijs
 | App startup to usable | < 2 seconds |
 | Frontend bundle size | < 2MB gzipped |
 
+## Database Migrations
+
+```sh
+cd apps/server
+
+bun run db:migrate status          # Show applied and pending migrations
+bun run db:migrate up              # Apply all pending migrations
+bun run db:migrate down            # Roll back the last migration
+bun run db:migrate new <name>      # Scaffold a new migration file
+```
+
+After scaffolding, implement `up()` and `down()` in the new file, then register it in `loadMigrations()` in `apps/server/src/store/database.ts`.
+
 ## Testing
 
 - **Unit tests:** `bun run test` from root (Vitest, runs in apps/web and apps/desktop)

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node --import tsx src/index.ts",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "db:migrate": "node --import tsx src/store/cli/migrate.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "*",

--- a/apps/server/src/__tests__/migration-runner.test.ts
+++ b/apps/server/src/__tests__/migration-runner.test.ts
@@ -1,0 +1,334 @@
+import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach } from "vitest";
+import { MigrationRunner } from "../store/migrations/runner.js";
+import type { MigrationModule } from "../store/migrations/runner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Open a fresh in-memory SQLite database for each test. */
+function freshDb(): Database.Database {
+  return new Database(":memory:");
+}
+
+/**
+ * Build a simple migration module that adds/drops a single column.
+ * Using a dedicated table per test (not `threads`) keeps tests independent.
+ */
+function makeColumnMigration(
+  description: string,
+  table: string,
+  column: string,
+): MigrationModule {
+  return {
+    description,
+    up(db) {
+      db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} TEXT DEFAULT NULL`);
+    },
+    down(db) {
+      db.exec(`ALTER TABLE ${table} DROP COLUMN ${column}`);
+    },
+  };
+}
+
+/** Create a temporary table so column migrations have something to work with. */
+function createTempTable(db: Database.Database, name: string): void {
+  db.exec(`CREATE TABLE IF NOT EXISTS ${name} (id INTEGER PRIMARY KEY)`);
+}
+
+// A reusable set of three migrations that all operate on table "items".
+function threeItemMigrations(): Map<number, MigrationModule> {
+  return new Map([
+    [1, makeColumnMigration("add col_a", "items", "col_a")],
+    [2, makeColumnMigration("add col_b", "items", "col_b")],
+    [3, makeColumnMigration("add col_c", "items", "col_c")],
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MigrationRunner", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. _migrations table bootstrap
+  // -------------------------------------------------------------------------
+  describe("constructor / table bootstrap", () => {
+    it("creates _migrations table on a fresh DB", () => {
+      new MigrationRunner(db, new Map());
+
+      const tables = (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='_migrations'").all()
+      ) as Array<{ name: string }>;
+
+      expect(tables).toHaveLength(1);
+    });
+
+    it("created table has version, name, and applied_at columns", () => {
+      new MigrationRunner(db, new Map());
+
+      const cols = (db.pragma("table_info(_migrations)")) as Array<{ name: string }>;
+      const colNames = cols.map((c) => c.name);
+
+      expect(colNames).toContain("version");
+      expect(colNames).toContain("name");
+      expect(colNames).toContain("applied_at");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. name column migration for legacy _migrations tables
+  // -------------------------------------------------------------------------
+  describe("legacy _migrations table (no name column)", () => {
+    it("adds name column when _migrations exists without it", () => {
+      // Simulate a pre-existing legacy table (no name column).
+      db.exec(`
+        CREATE TABLE _migrations (
+          version INTEGER PRIMARY KEY,
+          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec("INSERT INTO _migrations (version) VALUES (1)");
+
+      // Constructor should patch the table without throwing.
+      new MigrationRunner(db, new Map());
+
+      const cols = (db.pragma("table_info(_migrations)")) as Array<{ name: string }>;
+      const colNames = cols.map((c) => c.name);
+      expect(colNames).toContain("name");
+
+      // Existing row should have the default empty string for name.
+      const row = db.prepare("SELECT name FROM _migrations WHERE version = 1").get() as {
+        name: string;
+      };
+      expect(row.name).toBe("");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Fresh DB: up() applies all migrations
+  // -------------------------------------------------------------------------
+  describe("up() on fresh DB", () => {
+    it("applies all migrations and applied() returns them all", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+
+      const result = runner.up();
+
+      expect(result.applied).toBe(3);
+      expect(result.migrations).toHaveLength(3);
+      expect(result.migrations.map((m) => m.version)).toEqual([1, 2, 3]);
+
+      const allApplied = runner.applied();
+      expect(allApplied).toHaveLength(3);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Partial DB: up() only applies remaining migrations
+  // -------------------------------------------------------------------------
+  describe("up() with pre-applied migration", () => {
+    it("skips already-applied versions and only runs the rest", () => {
+      createTempTable(db, "items");
+
+      // Pre-apply version 1 via the runner so col_a exists.
+      const runnerA = new MigrationRunner(db, threeItemMigrations());
+      runnerA.up(1);
+
+      // A new runner over the same DB should only apply 2 and 3.
+      const runnerB = new MigrationRunner(db, threeItemMigrations());
+      const result = runnerB.up();
+
+      expect(result.applied).toBe(2);
+      expect(result.migrations.map((m) => m.version)).toEqual([2, 3]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. down() reverts the last migration
+  // -------------------------------------------------------------------------
+  describe("down() with no argument", () => {
+    it("reverts only the last applied migration", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+      runner.up();
+
+      const result = runner.down();
+
+      expect(result.reverted).toBe(1);
+      expect(result.migrations).toHaveLength(1);
+      expect(result.migrations[0].version).toBe(3);
+
+      // col_c should be gone, col_a and col_b should remain.
+      const cols = (db.pragma("table_info(items)")) as Array<{ name: string }>;
+      const colNames = cols.map((c) => c.name);
+      expect(colNames).not.toContain("col_c");
+      expect(colNames).toContain("col_a");
+      expect(colNames).toContain("col_b");
+
+      expect(runner.applied()).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. down(2) reverts the last two migrations
+  // -------------------------------------------------------------------------
+  describe("down(2)", () => {
+    it("reverts the last two applied migrations", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+      runner.up();
+
+      const result = runner.down(2);
+
+      expect(result.reverted).toBe(2);
+      expect(result.migrations.map((m) => m.version)).toEqual([3, 2]);
+
+      const cols = (db.pragma("table_info(items)")) as Array<{ name: string }>;
+      const colNames = cols.map((c) => c.name);
+      expect(colNames).not.toContain("col_c");
+      expect(colNames).not.toContain("col_b");
+      expect(colNames).toContain("col_a");
+
+      expect(runner.applied()).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. down() on empty set returns 0 reverted
+  // -------------------------------------------------------------------------
+  describe("down() on empty applied set", () => {
+    it("returns 0 reverted without throwing when nothing is applied", () => {
+      const runner = new MigrationRunner(db, new Map());
+      const result = runner.down();
+
+      expect(result.reverted).toBe(0);
+      expect(result.migrations).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. pending() returns correct list before and after applying
+  // -------------------------------------------------------------------------
+  describe("pending()", () => {
+    it("returns all migrations as pending before any are applied", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+
+      const pending = runner.pending();
+      expect(pending.map((m) => m.version)).toEqual([1, 2, 3]);
+    });
+
+    it("returns only unapplied migrations after some are applied", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+      runner.up(1);
+
+      const pending = runner.pending();
+      expect(pending.map((m) => m.version)).toEqual([2, 3]);
+    });
+
+    it("returns empty list when all are applied", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+      runner.up();
+
+      expect(runner.pending()).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. applied() returns records sorted ascending
+  // -------------------------------------------------------------------------
+  describe("applied()", () => {
+    it("returns records in ascending version order", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+      runner.up();
+
+      const records = runner.applied();
+      expect(records.map((r) => r.version)).toEqual([1, 2, 3]);
+    });
+
+    it("records include name and appliedAt fields", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+      runner.up(1);
+
+      const [record] = runner.applied();
+      expect(record.version).toBe(1);
+      expect(record.name).toBe("add col_a");
+      expect(typeof record.appliedAt).toBe("string");
+      expect(record.appliedAt.length).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. validate() detects gaps (applied version with no module)
+  // -------------------------------------------------------------------------
+  describe("validate()", () => {
+    it("is valid when all applied versions have a module", () => {
+      createTempTable(db, "items");
+      const runner = new MigrationRunner(db, threeItemMigrations());
+      runner.up();
+
+      expect(runner.validate()).toEqual({ valid: true, gaps: [], missing: [] });
+    });
+
+    it("reports applied version with no file in map as a gap", () => {
+      // Manually insert a version that has no module in the map.
+      const runner = new MigrationRunner(db, new Map());
+      db.exec("INSERT INTO _migrations (version, name) VALUES (99, 'ghost')");
+
+      const result = runner.validate();
+      expect(result.valid).toBe(false);
+      expect(result.gaps).toContain(99);
+      expect(result.missing).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. Transaction rollback: if up() throws, DB is unchanged
+  // -------------------------------------------------------------------------
+  describe("transaction rollback on up() failure", () => {
+    it("leaves DB unchanged when a migration throws", () => {
+      createTempTable(db, "items");
+
+      const failingMigrations: Map<number, MigrationModule> = new Map([
+        [1, makeColumnMigration("add col_a", "items", "col_a")],
+        [
+          2,
+          {
+            description: "intentional failure",
+            up(_db) {
+              throw new Error("migration 2 failed intentionally");
+            },
+            down(_db) {
+              /* no-op */
+            },
+          },
+        ],
+      ]);
+
+      const runner = new MigrationRunner(db, failingMigrations);
+
+      // Apply migration 1 successfully first.
+      runner.up(1);
+      expect(runner.applied()).toHaveLength(1);
+
+      // Migration 2 should throw and leave the DB as-is.
+      expect(() => runner.up(1)).toThrow("migration 2 failed intentionally");
+
+      // Only version 1 should be in _migrations.
+      expect(runner.applied()).toHaveLength(1);
+      expect(runner.applied()[0].version).toBe(1);
+    });
+  });
+});

--- a/apps/server/src/__tests__/migration-runner.test.ts
+++ b/apps/server/src/__tests__/migration-runner.test.ts
@@ -224,7 +224,7 @@ describe("MigrationRunner", () => {
       const runner = new MigrationRunner(db, threeItemMigrations());
       runner.up();
 
-      expect(runner.validate()).toEqual({ valid: true, gaps: [], missing: [] });
+      expect(runner.validate()).toEqual({ valid: true, gaps: [] });
     });
 
     it("reports applied version with no file in map as a gap", () => {
@@ -235,7 +235,6 @@ describe("MigrationRunner", () => {
       const result = runner.validate();
       expect(result.valid).toBe(false);
       expect(result.gaps).toContain(99);
-      expect(result.missing).toEqual([]);
     });
   });
 

--- a/apps/server/src/__tests__/migration-runner.test.ts
+++ b/apps/server/src/__tests__/migration-runner.test.ts
@@ -58,61 +58,6 @@ describe("MigrationRunner", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 10. _migrations table bootstrap
-  // -------------------------------------------------------------------------
-  describe("constructor / table bootstrap", () => {
-    it("creates _migrations table on a fresh DB", () => {
-      new MigrationRunner(db, new Map());
-
-      const tables = (
-        db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='_migrations'").all()
-      ) as Array<{ name: string }>;
-
-      expect(tables).toHaveLength(1);
-    });
-
-    it("created table has version, name, and applied_at columns", () => {
-      new MigrationRunner(db, new Map());
-
-      const cols = (db.pragma("table_info(_migrations)")) as Array<{ name: string }>;
-      const colNames = cols.map((c) => c.name);
-
-      expect(colNames).toContain("version");
-      expect(colNames).toContain("name");
-      expect(colNames).toContain("applied_at");
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // 11. name column migration for legacy _migrations tables
-  // -------------------------------------------------------------------------
-  describe("legacy _migrations table (no name column)", () => {
-    it("adds name column when _migrations exists without it", () => {
-      // Simulate a pre-existing legacy table (no name column).
-      db.exec(`
-        CREATE TABLE _migrations (
-          version INTEGER PRIMARY KEY,
-          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
-        )
-      `);
-      db.exec("INSERT INTO _migrations (version) VALUES (1)");
-
-      // Constructor should patch the table without throwing.
-      new MigrationRunner(db, new Map());
-
-      const cols = (db.pragma("table_info(_migrations)")) as Array<{ name: string }>;
-      const colNames = cols.map((c) => c.name);
-      expect(colNames).toContain("name");
-
-      // Existing row should have the default empty string for name.
-      const row = db.prepare("SELECT name FROM _migrations WHERE version = 1").get() as {
-        name: string;
-      };
-      expect(row.name).toBe("");
-    });
-  });
-
-  // -------------------------------------------------------------------------
   // 1. Fresh DB: up() applies all migrations
   // -------------------------------------------------------------------------
   describe("up() on fresh DB", () => {
@@ -329,6 +274,107 @@ describe("MigrationRunner", () => {
       // Only version 1 should be in _migrations.
       expect(runner.applied()).toHaveLength(1);
       expect(runner.applied()[0].version).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. Transaction rollback: if down() throws, DB is unchanged
+  // -------------------------------------------------------------------------
+  describe("transaction rollback on down() failure", () => {
+    it("reverts down() if the module throws", () => {
+      createTempTable(db, "items");
+
+      const migrations: Map<number, MigrationModule> = new Map([
+        [1, makeColumnMigration("add col_a", "items", "col_a")],
+        [
+          2,
+          {
+            description: "add col_b",
+            up(db) {
+              db.exec("ALTER TABLE items ADD COLUMN col_b TEXT DEFAULT NULL");
+            },
+            down(_db) {
+              // Simulates a buggy rollback so we can verify transaction safety.
+              throw new Error("down migration 2 failed intentionally");
+            },
+          },
+        ],
+      ]);
+
+      const runner = new MigrationRunner(db, migrations);
+      runner.up();
+      expect(runner.applied()).toHaveLength(2);
+
+      // down() on migration 2 throws — the DELETE should be rolled back.
+      expect(() => runner.down()).toThrow("down migration 2 failed intentionally");
+
+      // Both migrations must still be recorded as applied.
+      expect(runner.applied()).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. down(0) throws
+  // -------------------------------------------------------------------------
+  describe("down(0) validation", () => {
+    it("throws when steps is 0", () => {
+      const runner = new MigrationRunner(db, new Map());
+      expect(() => runner.down(0)).toThrow("steps must be a positive integer");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 12. _migrations table bootstrap
+  // -------------------------------------------------------------------------
+  describe("constructor / table bootstrap", () => {
+    it("creates _migrations table on a fresh DB", () => {
+      new MigrationRunner(db, new Map());
+
+      const tables = (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='_migrations'").all()
+      ) as Array<{ name: string }>;
+
+      expect(tables).toHaveLength(1);
+    });
+
+    it("created table has version, name, and applied_at columns", () => {
+      new MigrationRunner(db, new Map());
+
+      const cols = (db.pragma("table_info(_migrations)")) as Array<{ name: string }>;
+      const colNames = cols.map((c) => c.name);
+
+      expect(colNames).toContain("version");
+      expect(colNames).toContain("name");
+      expect(colNames).toContain("applied_at");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 13. name column migration for legacy _migrations tables
+  // -------------------------------------------------------------------------
+  describe("legacy _migrations table (no name column)", () => {
+    it("adds name column when _migrations exists without it", () => {
+      // Simulate a pre-existing legacy table (no name column).
+      db.exec(`
+        CREATE TABLE _migrations (
+          version INTEGER PRIMARY KEY,
+          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec("INSERT INTO _migrations (version) VALUES (1)");
+
+      // Constructor should patch the table without throwing.
+      new MigrationRunner(db, new Map());
+
+      const cols = (db.pragma("table_info(_migrations)")) as Array<{ name: string }>;
+      const colNames = cols.map((c) => c.name);
+      expect(colNames).toContain("name");
+
+      // Existing row should have the default empty string for name.
+      const row = db.prepare("SELECT name FROM _migrations WHERE version = 1").get() as {
+        name: string;
+      };
+      expect(row.name).toBe("");
     });
   });
 });

--- a/apps/server/src/store/cli/migrate.ts
+++ b/apps/server/src/store/cli/migrate.ts
@@ -126,7 +126,7 @@ try {
       console.log(`Rolling back ${actualSteps} migration${actualSteps !== 1 ? "s" : ""}...`);
 
       try {
-        const result = runner.down(steps);
+        const result = runner.down(actualSteps);
         for (const m of result.migrations) {
           console.log(`↩️  V${pad(m.version)} ${m.name}`);
         }

--- a/apps/server/src/store/cli/migrate.ts
+++ b/apps/server/src/store/cli/migrate.ts
@@ -52,128 +52,151 @@ if (!command || command === "--help" || command === "-h") {
   printUsage(0);
 }
 
-switch (command) {
-  case "status": {
-    const db = openDb();
-    const runner = new MigrationRunner(db, loadMigrations());
-    const applied = runner.applied();
-    const pending = runner.pending();
+let db: Database.Database | undefined;
 
-    if (applied.length === 0 && pending.length === 0) {
-      console.log("No migrations found.");
-    }
+try {
+  switch (command) {
+    case "status": {
+      db = openDb();
+      const runner = new MigrationRunner(db, loadMigrations());
+      const applied = runner.applied();
+      const pending = runner.pending();
 
-    for (const m of applied) {
-      console.log(`✅ V${pad(m.version)} ${m.name}  (applied: ${m.appliedAt})`);
-    }
-    for (const m of pending) {
-      console.log(`⏳ V${pad(m.version)} ${m.name}  [not yet applied]`);
-    }
-    break;
-  }
+      if (applied.length === 0 && pending.length === 0) {
+        console.log("No migrations found.");
+      }
 
-  case "up": {
-    const steps = args[0] !== undefined ? parseInt(args[0], 10) : undefined;
-    if (steps !== undefined && (isNaN(steps) || steps <= 0)) {
-      console.error("Error: n must be a positive integer");
-      process.exit(1);
-    }
-
-    const db = openDb();
-    const runner = new MigrationRunner(db, loadMigrations());
-    const pending = runner.pending();
-
-    if (pending.length === 0) {
-      console.log("Already up to date.");
+      for (const m of applied) {
+        console.log(`✅ V${pad(m.version)} ${m.name}  (applied: ${m.appliedAt})`);
+      }
+      for (const m of pending) {
+        console.log(`⏳ V${pad(m.version)} ${m.name}  [not yet applied]`);
+      }
       break;
     }
 
-    const toApply = steps !== undefined ? pending.slice(0, steps) : pending;
-    console.log(`Applying ${toApply.length} pending migration${toApply.length === 1 ? "" : "s"}...`);
-
-    try {
-      const result = runner.up(steps);
-      for (const m of result.migrations) {
-        console.log(`✅ V${pad(m.version)} ${m.name}`);
+    case "up": {
+      const steps = args[0] !== undefined ? parseInt(args[0], 10) : undefined;
+      if (steps !== undefined && (isNaN(steps) || steps <= 0)) {
+        console.error("Error: n must be a positive integer");
+        process.exit(1);
       }
-      console.log(`Done. ${result.applied} migration${result.applied === 1 ? "" : "s"} applied.`);
-    } catch (err) {
-      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
-      process.exit(1);
+
+      db = openDb();
+      const runner = new MigrationRunner(db, loadMigrations());
+      const pending = runner.pending();
+
+      if (pending.length === 0) {
+        console.log("Already up to date.");
+        break;
+      }
+
+      const toApply = steps !== undefined ? pending.slice(0, steps) : pending;
+      console.log(`Applying ${toApply.length} pending migration${toApply.length === 1 ? "" : "s"}...`);
+
+      try {
+        const result = runner.up(steps);
+        for (const m of result.migrations) {
+          console.log(`✅ V${pad(m.version)} ${m.name}`);
+        }
+        console.log(`Done. ${result.applied} migration${result.applied === 1 ? "" : "s"} applied.`);
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+      break;
     }
-    break;
-  }
 
-  case "down": {
-    const steps = args[0] !== undefined ? parseInt(args[0], 10) : 1;
-    if (isNaN(steps) || steps <= 0) {
-      console.error("Error: n must be a positive integer");
-      process.exit(1);
-    }
+    case "down": {
+      const steps = args[0] !== undefined ? parseInt(args[0], 10) : 1;
+      if (isNaN(steps) || steps <= 0) {
+        console.error("Error: n must be a positive integer");
+        process.exit(1);
+      }
 
-    const db = openDb();
-    const runner = new MigrationRunner(db, loadMigrations());
+      db = openDb();
+      const runner = new MigrationRunner(db, loadMigrations());
 
-    console.log(`Rolling back ${steps} migration${steps === 1 ? "" : "s"}...`);
-
-    try {
-      const result = runner.down(steps);
-      if (result.reverted === 0) {
+      const appliedCount = runner.applied().length;
+      const actualSteps = Math.min(steps, appliedCount);
+      if (actualSteps === 0) {
         console.log("Nothing to roll back.");
-      } else {
+        break;
+      }
+      console.log(`Rolling back ${actualSteps} migration${actualSteps !== 1 ? "s" : ""}...`);
+
+      try {
+        const result = runner.down(steps);
         for (const m of result.migrations) {
           console.log(`↩️  V${pad(m.version)} ${m.name}`);
         }
         console.log(`Done. ${result.reverted} migration${result.reverted === 1 ? "" : "s"} reverted.`);
+      } catch (err) {
+        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
       }
-    } catch (err) {
-      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
-      process.exit(1);
-    }
-    break;
-  }
-
-  case "new": {
-    const name = args[0];
-    if (!name) {
-      console.error("Error: missing required argument <name>");
-      process.exit(1);
+      break;
     }
 
-    // Find highest version number from existing migration filenames.
-    const files = existsSync(migrationsDir)
-      ? readdirSync(migrationsDir).filter((f) => /^\d+_/.test(f))
-      : [];
+    case "new": {
+      const name = args[0];
+      if (!name) {
+        console.error("Error: missing required argument <name>");
+        process.exit(1);
+      }
 
-    const highestVersion = files.reduce((max, f) => {
-      const match = f.match(/^(\d+)_/);
-      return match ? Math.max(max, parseInt(match[1], 10)) : max;
-    }, 0);
+      // Find highest version number from existing migration filenames.
+      const files = existsSync(migrationsDir)
+        ? readdirSync(migrationsDir).filter((f) => /^\d+_/.test(f))
+        : [];
 
-    const nextVersion = highestVersion + 1;
-    const slug = name.replace(/\s+/g, "_").toLowerCase();
-    const filename = `${pad(nextVersion)}_${slug}.ts`;
-    const outputPath = join(migrationsDir, filename);
+      const highestVersion = files.reduce((max, f) => {
+        const match = f.match(/^(\d+)_/);
+        return match ? Math.max(max, parseInt(match[1], 10)) : max;
+      }, 0);
 
-    const scaffold = `import type Database from "better-sqlite3";
+      const nextVersion = highestVersion + 1;
+      const slug = name
+        .toLowerCase()
+        .replace(/\s+/g, "_")
+        .replace(/[^a-z0-9_]/g, "");
 
-export const description = "${name}";
+      if (!slug) {
+        console.error("Error: migration name must contain at least one alphanumeric character");
+        process.exit(1);
+      }
 
-export function up(db: Database.Database): void {
+      const filename = `${pad(nextVersion)}_${slug}.ts`;
+      const outputPath = join(migrationsDir, filename);
+
+      if (existsSync(outputPath)) {
+        console.error(`Error: ${filename} already exists`);
+        process.exit(1);
+      }
+
+      const scaffold = `import type Database from "better-sqlite3";
+
+export const description = ${JSON.stringify(name)};
+
+export function up(_db: Database.Database): void {
   // TODO: implement migration
 }
 
-export function down(db: Database.Database): void {
+export function down(_db: Database.Database): void {
   // TODO: implement rollback
 }
 `;
 
-    writeFileSync(outputPath, scaffold);
-    console.log(`Created: apps/server/src/store/migrations/${filename}`);
-    break;
-  }
+      writeFileSync(outputPath, scaffold);
+      console.log(`Created: apps/server/src/store/migrations/${filename}`);
+      console.log(`  Next: register it in apps/server/src/store/database.ts (loadMigrations)`);
+      break;
+    }
 
-  default:
-    console.error(`Unknown command: ${command}`);
-    printUsage(1);
+    default:
+      console.error(`Unknown command: ${command}`);
+      printUsage(1);
+  }
+} finally {
+  db?.close();
 }

--- a/apps/server/src/store/cli/migrate.ts
+++ b/apps/server/src/store/cli/migrate.ts
@@ -12,7 +12,7 @@
 import Database from "better-sqlite3";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { existsSync, readdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "fs";
 import { getMcodeDir } from "@mcode/shared";
 import { MigrationRunner } from "../migrations/runner.js";
 import { loadMigrations } from "../database.js";
@@ -174,14 +174,18 @@ try {
         process.exit(1);
       }
 
+      mkdirSync(migrationsDir, { recursive: true });
+
       const scaffold = `import type Database from "better-sqlite3";
 
 export const description = ${JSON.stringify(name)};
 
+/** Apply this migration. Runner wraps this in a transaction. */
 export function up(_db: Database.Database): void {
   // TODO: implement migration
 }
 
+/** Reverse this migration. Throw if rollback is not possible. */
 export function down(_db: Database.Database): void {
   // TODO: implement rollback
 }

--- a/apps/server/src/store/cli/migrate.ts
+++ b/apps/server/src/store/cli/migrate.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env bun
+/**
+ * CLI entry point for managing SQLite migrations.
+ *
+ * Usage:
+ *   bun run db:migrate status        - Show applied and pending migrations
+ *   bun run db:migrate up [n]        - Apply all (or next n) pending migrations
+ *   bun run db:migrate down [n]      - Roll back last 1 (or n) migrations
+ *   bun run db:migrate new <name>    - Scaffold a new migration file
+ */
+
+import Database from "better-sqlite3";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { existsSync, readdirSync, writeFileSync } from "fs";
+import { getMcodeDir } from "@mcode/shared";
+import { MigrationRunner } from "../migrations/runner.js";
+import { loadMigrations } from "../database.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const migrationsDir = join(__dirname, "..", "migrations");
+
+const dbPath = process.env.MCODE_DB_PATH ?? join(getMcodeDir(), "mcode.db");
+
+/** Pads a version number to 3 digits (e.g. 16 -> "016"). */
+function pad(n: number): string {
+  return String(n).padStart(3, "0");
+}
+
+/** Prints usage instructions and exits with the given code. */
+function printUsage(exitCode = 0): never {
+  console.log(`Usage:
+  bun run db:migrate status          Show applied and pending migrations
+  bun run db:migrate up [n]          Apply all (or next n) pending migrations
+  bun run db:migrate down [n]        Roll back last 1 (or n) migrations
+  bun run db:migrate new <name>      Scaffold a new migration file`);
+  process.exit(exitCode);
+}
+
+/** Opens the database without running migrations (used by CLI to inspect state). */
+function openDb(): Database.Database {
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  return db;
+}
+
+const [, , command, ...args] = process.argv;
+
+if (!command || command === "--help" || command === "-h") {
+  printUsage(0);
+}
+
+switch (command) {
+  case "status": {
+    const db = openDb();
+    const runner = new MigrationRunner(db, loadMigrations());
+    const applied = runner.applied();
+    const pending = runner.pending();
+
+    if (applied.length === 0 && pending.length === 0) {
+      console.log("No migrations found.");
+    }
+
+    for (const m of applied) {
+      console.log(`✅ V${pad(m.version)} ${m.name}  (applied: ${m.appliedAt})`);
+    }
+    for (const m of pending) {
+      console.log(`⏳ V${pad(m.version)} ${m.name}  [not yet applied]`);
+    }
+    break;
+  }
+
+  case "up": {
+    const steps = args[0] !== undefined ? parseInt(args[0], 10) : undefined;
+    if (steps !== undefined && (isNaN(steps) || steps <= 0)) {
+      console.error("Error: n must be a positive integer");
+      process.exit(1);
+    }
+
+    const db = openDb();
+    const runner = new MigrationRunner(db, loadMigrations());
+    const pending = runner.pending();
+
+    if (pending.length === 0) {
+      console.log("Already up to date.");
+      break;
+    }
+
+    const toApply = steps !== undefined ? pending.slice(0, steps) : pending;
+    console.log(`Applying ${toApply.length} pending migration${toApply.length === 1 ? "" : "s"}...`);
+
+    try {
+      const result = runner.up(steps);
+      for (const m of result.migrations) {
+        console.log(`✅ V${pad(m.version)} ${m.name}`);
+      }
+      console.log(`Done. ${result.applied} migration${result.applied === 1 ? "" : "s"} applied.`);
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+    break;
+  }
+
+  case "down": {
+    const steps = args[0] !== undefined ? parseInt(args[0], 10) : 1;
+    if (isNaN(steps) || steps <= 0) {
+      console.error("Error: n must be a positive integer");
+      process.exit(1);
+    }
+
+    const db = openDb();
+    const runner = new MigrationRunner(db, loadMigrations());
+
+    console.log(`Rolling back ${steps} migration${steps === 1 ? "" : "s"}...`);
+
+    try {
+      const result = runner.down(steps);
+      if (result.reverted === 0) {
+        console.log("Nothing to roll back.");
+      } else {
+        for (const m of result.migrations) {
+          console.log(`↩️  V${pad(m.version)} ${m.name}`);
+        }
+        console.log(`Done. ${result.reverted} migration${result.reverted === 1 ? "" : "s"} reverted.`);
+      }
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+    break;
+  }
+
+  case "new": {
+    const name = args[0];
+    if (!name) {
+      console.error("Error: missing required argument <name>");
+      process.exit(1);
+    }
+
+    // Find highest version number from existing migration filenames.
+    const files = existsSync(migrationsDir)
+      ? readdirSync(migrationsDir).filter((f) => /^\d+_/.test(f))
+      : [];
+
+    const highestVersion = files.reduce((max, f) => {
+      const match = f.match(/^(\d+)_/);
+      return match ? Math.max(max, parseInt(match[1], 10)) : max;
+    }, 0);
+
+    const nextVersion = highestVersion + 1;
+    const slug = name.replace(/\s+/g, "_").toLowerCase();
+    const filename = `${pad(nextVersion)}_${slug}.ts`;
+    const outputPath = join(migrationsDir, filename);
+
+    const scaffold = `import type Database from "better-sqlite3";
+
+export const description = "${name}";
+
+export function up(db: Database.Database): void {
+  // TODO: implement migration
+}
+
+export function down(db: Database.Database): void {
+  // TODO: implement rollback
+}
+`;
+
+    writeFileSync(outputPath, scaffold);
+    console.log(`Created: apps/server/src/store/migrations/${filename}`);
+    break;
+  }
+
+  default:
+    console.error(`Unknown command: ${command}`);
+    printUsage(1);
+}

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -86,7 +86,12 @@ export function openDatabase(dbPath?: string): Database.Database {
   db.pragma("foreign_keys = ON");
   db.pragma("cache_size = -2000");  // 2MB page cache (negative = KB)
   db.pragma("mmap_size = 0");       // Disable memory-mapped I/O
-  new MigrationRunner(db, loadMigrations()).up();
+  try {
+    new MigrationRunner(db, loadMigrations()).up();
+  } catch (err) {
+    db.close();
+    throw err;
+  }
   return db;
 }
 
@@ -100,6 +105,11 @@ export function openMemoryDatabase(): Database.Database {
   const nativeBinding = resolveNativeBinding();
   const db = new Database(":memory:", { nativeBinding });
   db.pragma("foreign_keys = ON");
-  new MigrationRunner(db, loadMigrations()).up();
+  try {
+    new MigrationRunner(db, loadMigrations()).up();
+  } catch (err) {
+    db.close();
+    throw err;
+  }
   return db;
 }

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -53,7 +53,7 @@ function resolveNativeBinding(): string | undefined {
 }
 
 /** Builds the ordered map of all migration modules keyed by version number. */
-function loadMigrations(): Map<number, MigrationModule> {
+export function loadMigrations(): Map<number, MigrationModule> {
   const migrations = new Map<number, MigrationModule>();
   migrations.set(1, m001);
   migrations.set(2, m002);

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -8,6 +8,23 @@ import { existsSync } from "fs";
 import { createRequire } from "module";
 import { dirname, join } from "path";
 import { getMcodeDir } from "@mcode/shared";
+import { MigrationRunner } from "./migrations/runner.js";
+import type { MigrationModule } from "./migrations/runner.js";
+import * as m001 from "./migrations/001_initial_schema.js";
+import * as m002 from "./migrations/002_thread_model.js";
+import * as m003 from "./migrations/003_thread_worktree_managed.js";
+import * as m004 from "./migrations/004_message_attachments.js";
+import * as m005 from "./migrations/005_thread_sdk_session_id.js";
+import * as m006 from "./migrations/006_drop_thread_pid_session_name.js";
+import * as m007 from "./migrations/007_tool_call_records_turn_snapshots.js";
+import * as m008 from "./migrations/008_thread_tasks.js";
+import * as m009 from "./migrations/009_thread_context_tracking.js";
+import * as m010 from "./migrations/010_cleanup_jobs.js";
+import * as m011 from "./migrations/011_thread_provider.js";
+import * as m012 from "./migrations/012_thread_reasoning_interaction_permission.js";
+import * as m013 from "./migrations/013_clear_non_claude_context_window.js";
+import * as m014 from "./migrations/014_thread_branching.js";
+import * as m015 from "./migrations/015_thread_compact_summary.js";
 
 /**
  * Resolve the correct native binding for better-sqlite3 based on runtime.
@@ -35,53 +52,26 @@ function resolveNativeBinding(): string | undefined {
   return bindingPath;
 }
 
-const V001_SCHEMA = `
-CREATE TABLE IF NOT EXISTS workspaces (
-    id TEXT PRIMARY KEY NOT NULL,
-    name TEXT NOT NULL,
-    path TEXT NOT NULL UNIQUE,
-    provider_config TEXT NOT NULL DEFAULT '{}',
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-);
-
-CREATE TABLE IF NOT EXISTS threads (
-    id TEXT PRIMARY KEY NOT NULL,
-    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-    title TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'active',
-    mode TEXT NOT NULL DEFAULT 'direct',
-    worktree_path TEXT,
-    branch TEXT NOT NULL,
-    issue_number INTEGER,
-    pr_number INTEGER,
-    pr_status TEXT,
-    session_name TEXT NOT NULL DEFAULT '',
-    pid INTEGER,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    deleted_at TEXT
-);
-
-CREATE INDEX IF NOT EXISTS idx_threads_workspace ON threads(workspace_id);
-CREATE INDEX IF NOT EXISTS idx_threads_status ON threads(status);
-
-CREATE TABLE IF NOT EXISTS messages (
-    id TEXT PRIMARY KEY NOT NULL,
-    thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
-    role TEXT NOT NULL,
-    content TEXT NOT NULL,
-    tool_calls TEXT,
-    files_changed TEXT,
-    cost_usd REAL,
-    tokens_used INTEGER,
-    timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    sequence INTEGER NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id);
-CREATE INDEX IF NOT EXISTS idx_messages_sequence ON messages(thread_id, sequence);
-`;
+/** Builds the ordered map of all migration modules keyed by version number. */
+function loadMigrations(): Map<number, MigrationModule> {
+  const migrations = new Map<number, MigrationModule>();
+  migrations.set(1, m001);
+  migrations.set(2, m002);
+  migrations.set(3, m003);
+  migrations.set(4, m004);
+  migrations.set(5, m005);
+  migrations.set(6, m006);
+  migrations.set(7, m007);
+  migrations.set(8, m008);
+  migrations.set(9, m009);
+  migrations.set(10, m010);
+  migrations.set(11, m011);
+  migrations.set(12, m012);
+  migrations.set(13, m013);
+  migrations.set(14, m014);
+  migrations.set(15, m015);
+  return migrations;
+}
 
 /**
  * Open (or create) a SQLite database with WAL mode and foreign keys enabled,
@@ -96,7 +86,7 @@ export function openDatabase(dbPath?: string): Database.Database {
   db.pragma("foreign_keys = ON");
   db.pragma("cache_size = -2000");  // 2MB page cache (negative = KB)
   db.pragma("mmap_size = 0");       // Disable memory-mapped I/O
-  runMigrations(db);
+  new MigrationRunner(db, loadMigrations()).up();
   return db;
 }
 
@@ -110,171 +100,6 @@ export function openMemoryDatabase(): Database.Database {
   const nativeBinding = resolveNativeBinding();
   const db = new Database(":memory:", { nativeBinding });
   db.pragma("foreign_keys = ON");
-  runMigrations(db);
+  new MigrationRunner(db, loadMigrations()).up();
   return db;
-}
-
-function runMigrations(db: Database.Database): void {
-  db.exec(`CREATE TABLE IF NOT EXISTS _migrations (
-    version INTEGER PRIMARY KEY,
-    applied_at TEXT NOT NULL DEFAULT (datetime('now'))
-  )`);
-
-  const row = db
-    .prepare("SELECT MAX(version) as v FROM _migrations")
-    .get() as { v: number | null } | undefined;
-  const currentVersion = row?.v ?? 0;
-
-  if (currentVersion < 1) {
-    db.exec(V001_SCHEMA);
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(1);
-  }
-
-  if (currentVersion < 2) {
-    db.exec("ALTER TABLE threads ADD COLUMN model TEXT DEFAULT NULL");
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(2);
-  }
-
-  if (currentVersion < 3) {
-    db.exec(
-      "ALTER TABLE threads ADD COLUMN worktree_managed INTEGER NOT NULL DEFAULT 1",
-    );
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(3);
-  }
-
-  if (currentVersion < 4) {
-    db.exec("ALTER TABLE messages ADD COLUMN attachments TEXT DEFAULT NULL");
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(4);
-  }
-
-  if (currentVersion < 5) {
-    db.exec(
-      "ALTER TABLE threads ADD COLUMN sdk_session_id TEXT DEFAULT NULL",
-    );
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(5);
-  }
-
-  if (currentVersion < 6) {
-    db.exec("ALTER TABLE threads DROP COLUMN pid");
-    db.exec("ALTER TABLE threads DROP COLUMN session_name");
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(6);
-  }
-
-  if (currentVersion < 7) {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS tool_call_records (
-        id TEXT PRIMARY KEY NOT NULL,
-        message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
-        parent_tool_call_id TEXT,
-        tool_name TEXT NOT NULL,
-        input_summary TEXT NOT NULL DEFAULT '',
-        output_summary TEXT NOT NULL DEFAULT '',
-        status TEXT NOT NULL DEFAULT 'running',
-        started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-        completed_at TEXT,
-        sort_order INTEGER NOT NULL DEFAULT 0
-      );
-      CREATE INDEX IF NOT EXISTS idx_tool_call_records_message ON tool_call_records(message_id);
-      CREATE INDEX IF NOT EXISTS idx_tool_call_records_parent ON tool_call_records(parent_tool_call_id);
-
-      CREATE TABLE IF NOT EXISTS turn_snapshots (
-        id TEXT PRIMARY KEY NOT NULL,
-        message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
-        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
-        ref_before TEXT NOT NULL,
-        ref_after TEXT NOT NULL,
-        files_changed TEXT NOT NULL DEFAULT '[]',
-        worktree_path TEXT,
-        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-      );
-      CREATE INDEX IF NOT EXISTS idx_turn_snapshots_message ON turn_snapshots(message_id);
-      CREATE INDEX IF NOT EXISTS idx_turn_snapshots_thread ON turn_snapshots(thread_id);
-    `);
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(7);
-  }
-
-  if (currentVersion < 8) {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS thread_tasks (
-        thread_id TEXT PRIMARY KEY NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
-        tasks_json TEXT NOT NULL,
-        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-      );
-    `);
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(8);
-  }
-
-  if (currentVersion < 9) {
-    db.transaction(() => {
-      db.exec(`
-        ALTER TABLE threads ADD COLUMN last_context_tokens INTEGER DEFAULT NULL;
-        ALTER TABLE threads ADD COLUMN context_window INTEGER DEFAULT NULL;
-      `);
-      db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(9);
-    })();
-  }
-
-  if (currentVersion < 10) {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS cleanup_jobs (
-        id TEXT PRIMARY KEY NOT NULL,
-        thread_id TEXT NOT NULL UNIQUE,
-        workspace_path TEXT NOT NULL,
-        worktree_path TEXT NOT NULL,
-        branch TEXT,
-        attempts INTEGER NOT NULL DEFAULT 0,
-        next_retry_at INTEGER NOT NULL DEFAULT 0,
-        last_error TEXT,
-        created_at INTEGER NOT NULL
-      );
-      CREATE INDEX IF NOT EXISTS idx_cleanup_jobs_retry ON cleanup_jobs(next_retry_at, attempts, created_at);
-    `);
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(10);
-  }
-
-  if (currentVersion < 11) {
-    db.exec(
-      "ALTER TABLE threads ADD COLUMN provider TEXT NOT NULL DEFAULT 'claude'",
-    );
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(11);
-  }
-
-  if (currentVersion < 12) {
-    db.transaction(() => {
-      db.exec(`
-        ALTER TABLE threads ADD COLUMN reasoning_level TEXT DEFAULT NULL;
-        ALTER TABLE threads ADD COLUMN interaction_mode TEXT DEFAULT NULL;
-        ALTER TABLE threads ADD COLUMN permission_mode TEXT DEFAULT NULL;
-      `);
-      db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(12);
-    })();
-  }
-
-  if (currentVersion < 13) {
-    // Clear context_window for non-Claude threads. Earlier code wrote a
-    // hardcoded DEFAULT_CONTEXT_WINDOW (200 000) for all providers, including
-    // Codex which does not expose a context window. Those stale rows cause the
-    // context tracker ring to render with an incorrect denominator.
-    db.prepare(
-      "UPDATE threads SET context_window = NULL WHERE provider != 'claude'",
-    ).run();
-    db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(13);
-  }
-
-  if (currentVersion < 14) {
-    db.transaction(() => {
-      db.exec(`
-        ALTER TABLE threads ADD COLUMN parent_thread_id TEXT DEFAULT NULL;
-        ALTER TABLE threads ADD COLUMN forked_from_message_id TEXT DEFAULT NULL;
-      `);
-      db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(14);
-    })();
-  }
-
-  if (currentVersion < 15) {
-    db.transaction(() => {
-      db.exec("ALTER TABLE threads ADD COLUMN last_compact_summary TEXT DEFAULT NULL");
-      db.prepare("INSERT INTO _migrations (version) VALUES (?)").run(15);
-    })();
-  }
 }

--- a/apps/server/src/store/migrations/001_initial_schema.ts
+++ b/apps/server/src/store/migrations/001_initial_schema.ts
@@ -1,0 +1,67 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Initial schema: workspaces, threads, messages";
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS workspaces (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    path TEXT NOT NULL UNIQUE,
+    provider_config TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS threads (
+    id TEXT PRIMARY KEY NOT NULL,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    mode TEXT NOT NULL DEFAULT 'direct',
+    worktree_path TEXT,
+    branch TEXT NOT NULL,
+    issue_number INTEGER,
+    pr_number INTEGER,
+    pr_status TEXT,
+    session_name TEXT NOT NULL DEFAULT '',
+    pid INTEGER,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    deleted_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_threads_workspace ON threads(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_threads_status ON threads(status);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id TEXT PRIMARY KEY NOT NULL,
+    thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    tool_calls TEXT,
+    files_changed TEXT,
+    cost_usd REAL,
+    tokens_used INTEGER,
+    timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    sequence INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_thread ON messages(thread_id);
+CREATE INDEX IF NOT EXISTS idx_messages_sequence ON messages(thread_id, sequence);
+`;
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec(SCHEMA);
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("DROP TABLE IF EXISTS messages;");
+  db.exec("DROP TABLE IF EXISTS threads;");
+  db.exec("DROP TABLE IF EXISTS workspaces;");
+}

--- a/apps/server/src/store/migrations/002_thread_model.ts
+++ b/apps/server/src/store/migrations/002_thread_model.ts
@@ -1,0 +1,17 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add model column to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec("ALTER TABLE threads ADD COLUMN model TEXT DEFAULT NULL");
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN model");
+}

--- a/apps/server/src/store/migrations/003_thread_worktree_managed.ts
+++ b/apps/server/src/store/migrations/003_thread_worktree_managed.ts
@@ -1,0 +1,17 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add worktree_managed column to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec("ALTER TABLE threads ADD COLUMN worktree_managed INTEGER NOT NULL DEFAULT 1");
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN worktree_managed");
+}

--- a/apps/server/src/store/migrations/004_message_attachments.ts
+++ b/apps/server/src/store/migrations/004_message_attachments.ts
@@ -1,0 +1,17 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add attachments column to messages";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec("ALTER TABLE messages ADD COLUMN attachments TEXT DEFAULT NULL");
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE messages DROP COLUMN attachments");
+}

--- a/apps/server/src/store/migrations/005_thread_sdk_session_id.ts
+++ b/apps/server/src/store/migrations/005_thread_sdk_session_id.ts
@@ -1,0 +1,17 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add sdk_session_id column to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec("ALTER TABLE threads ADD COLUMN sdk_session_id TEXT DEFAULT NULL");
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN sdk_session_id");
+}

--- a/apps/server/src/store/migrations/006_drop_thread_pid_session_name.ts
+++ b/apps/server/src/store/migrations/006_drop_thread_pid_session_name.ts
@@ -1,0 +1,19 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Drop pid and session_name columns from threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN pid");
+  db.exec("ALTER TABLE threads DROP COLUMN session_name");
+}
+
+/**
+ * Reverse this migration.
+ * Re-adds the dropped columns with their original defaults.
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads ADD COLUMN session_name TEXT NOT NULL DEFAULT ''");
+  db.exec("ALTER TABLE threads ADD COLUMN pid INTEGER DEFAULT NULL");
+}

--- a/apps/server/src/store/migrations/007_tool_call_records_turn_snapshots.ts
+++ b/apps/server/src/store/migrations/007_tool_call_records_turn_snapshots.ts
@@ -6,7 +6,7 @@ export const description = "Add tool_call_records and turn_snapshots tables";
 /** Apply this migration. Runner wraps this in a transaction. */
 export function up(db: Database.Database): void {
   db.exec(`
-    CREATE TABLE IF NOT EXISTS tool_call_records (
+    CREATE TABLE tool_call_records (
       id TEXT PRIMARY KEY NOT NULL,
       message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
       parent_tool_call_id TEXT,
@@ -18,10 +18,10 @@ export function up(db: Database.Database): void {
       completed_at TEXT,
       sort_order INTEGER NOT NULL DEFAULT 0
     );
-    CREATE INDEX IF NOT EXISTS idx_tool_call_records_message ON tool_call_records(message_id);
-    CREATE INDEX IF NOT EXISTS idx_tool_call_records_parent ON tool_call_records(parent_tool_call_id);
+    CREATE INDEX idx_tool_call_records_message ON tool_call_records(message_id);
+    CREATE INDEX idx_tool_call_records_parent ON tool_call_records(parent_tool_call_id);
 
-    CREATE TABLE IF NOT EXISTS turn_snapshots (
+    CREATE TABLE turn_snapshots (
       id TEXT PRIMARY KEY NOT NULL,
       message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
       thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
@@ -31,16 +31,13 @@ export function up(db: Database.Database): void {
       worktree_path TEXT,
       created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     );
-    CREATE INDEX IF NOT EXISTS idx_turn_snapshots_message ON turn_snapshots(message_id);
-    CREATE INDEX IF NOT EXISTS idx_turn_snapshots_thread ON turn_snapshots(thread_id);
+    CREATE INDEX idx_turn_snapshots_message ON turn_snapshots(message_id);
+    CREATE INDEX idx_turn_snapshots_thread ON turn_snapshots(thread_id);
   `);
 }
 
-/**
- * Reverse this migration.
- * Throw if rollback is not possible (e.g., irreversible data migration).
- */
+/** Reverse this migration. */
 export function down(db: Database.Database): void {
-  db.exec("DROP TABLE IF EXISTS turn_snapshots;");
-  db.exec("DROP TABLE IF EXISTS tool_call_records;");
+  db.exec("DROP TABLE turn_snapshots;");
+  db.exec("DROP TABLE tool_call_records;");
 }

--- a/apps/server/src/store/migrations/007_tool_call_records_turn_snapshots.ts
+++ b/apps/server/src/store/migrations/007_tool_call_records_turn_snapshots.ts
@@ -1,0 +1,46 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add tool_call_records and turn_snapshots tables";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tool_call_records (
+      id TEXT PRIMARY KEY NOT NULL,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      parent_tool_call_id TEXT,
+      tool_name TEXT NOT NULL,
+      input_summary TEXT NOT NULL DEFAULT '',
+      output_summary TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'running',
+      started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      completed_at TEXT,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_tool_call_records_message ON tool_call_records(message_id);
+    CREATE INDEX IF NOT EXISTS idx_tool_call_records_parent ON tool_call_records(parent_tool_call_id);
+
+    CREATE TABLE IF NOT EXISTS turn_snapshots (
+      id TEXT PRIMARY KEY NOT NULL,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+      ref_before TEXT NOT NULL,
+      ref_after TEXT NOT NULL,
+      files_changed TEXT NOT NULL DEFAULT '[]',
+      worktree_path TEXT,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_turn_snapshots_message ON turn_snapshots(message_id);
+    CREATE INDEX IF NOT EXISTS idx_turn_snapshots_thread ON turn_snapshots(thread_id);
+  `);
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("DROP TABLE IF EXISTS turn_snapshots;");
+  db.exec("DROP TABLE IF EXISTS tool_call_records;");
+}

--- a/apps/server/src/store/migrations/008_thread_tasks.ts
+++ b/apps/server/src/store/migrations/008_thread_tasks.ts
@@ -1,0 +1,23 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add thread_tasks table";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS thread_tasks (
+      thread_id TEXT PRIMARY KEY NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+      tasks_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+  `);
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("DROP TABLE IF EXISTS thread_tasks;");
+}

--- a/apps/server/src/store/migrations/009_thread_context_tracking.ts
+++ b/apps/server/src/store/migrations/009_thread_context_tracking.ts
@@ -1,0 +1,21 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add last_context_tokens and context_window to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec(`
+    ALTER TABLE threads ADD COLUMN last_context_tokens INTEGER DEFAULT NULL;
+    ALTER TABLE threads ADD COLUMN context_window INTEGER DEFAULT NULL;
+  `);
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN last_context_tokens");
+  db.exec("ALTER TABLE threads DROP COLUMN context_window");
+}

--- a/apps/server/src/store/migrations/010_cleanup_jobs.ts
+++ b/apps/server/src/store/migrations/010_cleanup_jobs.ts
@@ -6,7 +6,7 @@ export const description = "Add cleanup_jobs table";
 /** Apply this migration. Runner wraps this in a transaction. */
 export function up(db: Database.Database): void {
   db.exec(`
-    CREATE TABLE IF NOT EXISTS cleanup_jobs (
+    CREATE TABLE cleanup_jobs (
       id TEXT PRIMARY KEY NOT NULL,
       thread_id TEXT NOT NULL UNIQUE,
       workspace_path TEXT NOT NULL,
@@ -17,14 +17,11 @@ export function up(db: Database.Database): void {
       last_error TEXT,
       created_at INTEGER NOT NULL
     );
-    CREATE INDEX IF NOT EXISTS idx_cleanup_jobs_retry ON cleanup_jobs(next_retry_at, attempts, created_at);
+    CREATE INDEX idx_cleanup_jobs_retry ON cleanup_jobs(next_retry_at, attempts, created_at);
   `);
 }
 
-/**
- * Reverse this migration.
- * Throw if rollback is not possible (e.g., irreversible data migration).
- */
+/** Reverse this migration. */
 export function down(db: Database.Database): void {
-  db.exec("DROP TABLE IF EXISTS cleanup_jobs;");
+  db.exec("DROP TABLE cleanup_jobs;");
 }

--- a/apps/server/src/store/migrations/010_cleanup_jobs.ts
+++ b/apps/server/src/store/migrations/010_cleanup_jobs.ts
@@ -1,0 +1,30 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add cleanup_jobs table";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cleanup_jobs (
+      id TEXT PRIMARY KEY NOT NULL,
+      thread_id TEXT NOT NULL UNIQUE,
+      workspace_path TEXT NOT NULL,
+      worktree_path TEXT NOT NULL,
+      branch TEXT,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      next_retry_at INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      created_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_cleanup_jobs_retry ON cleanup_jobs(next_retry_at, attempts, created_at);
+  `);
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("DROP TABLE IF EXISTS cleanup_jobs;");
+}

--- a/apps/server/src/store/migrations/011_thread_provider.ts
+++ b/apps/server/src/store/migrations/011_thread_provider.ts
@@ -1,0 +1,17 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add provider column to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec("ALTER TABLE threads ADD COLUMN provider TEXT NOT NULL DEFAULT 'claude'");
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN provider");
+}

--- a/apps/server/src/store/migrations/012_thread_reasoning_interaction_permission.ts
+++ b/apps/server/src/store/migrations/012_thread_reasoning_interaction_permission.ts
@@ -1,0 +1,23 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add reasoning_level, interaction_mode, permission_mode to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec(`
+    ALTER TABLE threads ADD COLUMN reasoning_level TEXT DEFAULT NULL;
+    ALTER TABLE threads ADD COLUMN interaction_mode TEXT DEFAULT NULL;
+    ALTER TABLE threads ADD COLUMN permission_mode TEXT DEFAULT NULL;
+  `);
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN reasoning_level");
+  db.exec("ALTER TABLE threads DROP COLUMN interaction_mode");
+  db.exec("ALTER TABLE threads DROP COLUMN permission_mode");
+}

--- a/apps/server/src/store/migrations/013_clear_non_claude_context_window.ts
+++ b/apps/server/src/store/migrations/013_clear_non_claude_context_window.ts
@@ -5,6 +5,19 @@ export const description = "Clear context_window for non-Claude threads";
 
 /** Apply this migration. Runner wraps this in a transaction. */
 export function up(db: Database.Database): void {
+  // Back up context_window values before clearing so down() can restore them.
+  db.exec(`
+    CREATE TABLE _migration_013_backup (
+      thread_id TEXT NOT NULL PRIMARY KEY,
+      context_window INTEGER NOT NULL
+    )
+  `);
+  db.exec(`
+    INSERT INTO _migration_013_backup (thread_id, context_window)
+    SELECT id, context_window FROM threads
+    WHERE provider != 'claude' AND context_window IS NOT NULL
+  `);
+
   // Clear context_window for non-Claude threads. Earlier code wrote a
   // hardcoded DEFAULT_CONTEXT_WINDOW (200 000) for all providers, including
   // Codex which does not expose a context window. Those stale rows cause the
@@ -12,10 +25,14 @@ export function up(db: Database.Database): void {
   db.prepare("UPDATE threads SET context_window = NULL WHERE provider != 'claude'").run();
 }
 
-/**
- * Reverse this migration.
- * This migration is irreversible: the cleared data cannot be restored.
- */
-export function down(_db: Database.Database): void {
-  throw new Error("Migration 013 is irreversible: cleared data cannot be restored");
+/** Reverse this migration by restoring backed-up context_window values. */
+export function down(db: Database.Database): void {
+  db.exec(`
+    UPDATE threads SET context_window = (
+      SELECT context_window FROM _migration_013_backup
+      WHERE _migration_013_backup.thread_id = threads.id
+    )
+    WHERE id IN (SELECT thread_id FROM _migration_013_backup)
+  `);
+  db.exec("DROP TABLE _migration_013_backup");
 }

--- a/apps/server/src/store/migrations/013_clear_non_claude_context_window.ts
+++ b/apps/server/src/store/migrations/013_clear_non_claude_context_window.ts
@@ -1,0 +1,21 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Clear context_window for non-Claude threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  // Clear context_window for non-Claude threads. Earlier code wrote a
+  // hardcoded DEFAULT_CONTEXT_WINDOW (200 000) for all providers, including
+  // Codex which does not expose a context window. Those stale rows cause the
+  // context tracker ring to render with an incorrect denominator.
+  db.prepare("UPDATE threads SET context_window = NULL WHERE provider != 'claude'").run();
+}
+
+/**
+ * Reverse this migration.
+ * This migration is irreversible: the cleared data cannot be restored.
+ */
+export function down(_db: Database.Database): void {
+  throw new Error("Migration 013 is irreversible: cleared data cannot be restored");
+}

--- a/apps/server/src/store/migrations/014_thread_branching.ts
+++ b/apps/server/src/store/migrations/014_thread_branching.ts
@@ -1,0 +1,21 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add parent_thread_id and forked_from_message_id to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec(`
+    ALTER TABLE threads ADD COLUMN parent_thread_id TEXT DEFAULT NULL;
+    ALTER TABLE threads ADD COLUMN forked_from_message_id TEXT DEFAULT NULL;
+  `);
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN parent_thread_id");
+  db.exec("ALTER TABLE threads DROP COLUMN forked_from_message_id");
+}

--- a/apps/server/src/store/migrations/014_thread_branching.ts
+++ b/apps/server/src/store/migrations/014_thread_branching.ts
@@ -9,13 +9,14 @@ export function up(db: Database.Database): void {
     ALTER TABLE threads ADD COLUMN parent_thread_id TEXT DEFAULT NULL;
     ALTER TABLE threads ADD COLUMN forked_from_message_id TEXT DEFAULT NULL;
   `);
+  db.exec("CREATE INDEX idx_threads_parent_thread_id ON threads(parent_thread_id)");
+  db.exec("CREATE INDEX idx_threads_forked_from_message_id ON threads(forked_from_message_id)");
 }
 
-/**
- * Reverse this migration.
- * Throw if rollback is not possible (e.g., irreversible data migration).
- */
+/** Reverse this migration. */
 export function down(db: Database.Database): void {
-  db.exec("ALTER TABLE threads DROP COLUMN parent_thread_id");
+  db.exec("DROP INDEX idx_threads_forked_from_message_id");
+  db.exec("DROP INDEX idx_threads_parent_thread_id");
   db.exec("ALTER TABLE threads DROP COLUMN forked_from_message_id");
+  db.exec("ALTER TABLE threads DROP COLUMN parent_thread_id");
 }

--- a/apps/server/src/store/migrations/015_thread_compact_summary.ts
+++ b/apps/server/src/store/migrations/015_thread_compact_summary.ts
@@ -1,0 +1,17 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add last_compact_summary to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec("ALTER TABLE threads ADD COLUMN last_compact_summary TEXT DEFAULT NULL");
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN last_compact_summary");
+}

--- a/apps/server/src/store/migrations/runner.ts
+++ b/apps/server/src/store/migrations/runner.ts
@@ -21,8 +21,6 @@ export interface ValidationResult {
   valid: boolean;
   /** Applied DB versions that have no corresponding migration module. */
   gaps: number[];
-  /** Reserved for future file-contiguity checks; always empty for now. */
-  missing: number[];
 }
 
 /**
@@ -90,13 +88,19 @@ export class MigrationRunner {
     }
 
     // Backfill descriptions for rows that were applied before the name column
-    // existed (stored as ''). Uses the in-memory module map, so this is a
-    // no-op for any version not in the map (gaps are left as-is).
-    const updateStmt = this.db.prepare(
-      "UPDATE _migrations SET name = ? WHERE version = ? AND name = ''",
-    );
-    for (const [version, module] of this.migrations) {
-      updateStmt.run(module.description, version);
+    // existed (stored as ''). Guarded by a count check so the prepare and loop
+    // are skipped entirely when there is nothing to backfill.
+    const emptyCount = (
+      this.db.prepare("SELECT COUNT(*) as n FROM _migrations WHERE name = ''").get() as { n: number }
+    ).n;
+
+    if (emptyCount > 0) {
+      const updateStmt = this.db.prepare(
+        "UPDATE _migrations SET name = ? WHERE version = ? AND name = ''",
+      );
+      for (const [version, module] of this.migrations) {
+        updateStmt.run(module.description, version);
+      }
     }
   }
 
@@ -146,7 +150,7 @@ export class MigrationRunner {
    * applied migrations are reverted (no error is thrown for the excess).
    */
   down(steps = 1): { reverted: number; migrations: MigrationRecord[] } {
-    if (steps === 0) {
+    if (steps <= 0) {
       throw new Error("steps must be a positive integer");
     }
 
@@ -225,7 +229,6 @@ export class MigrationRunner {
     return {
       valid: gaps.length === 0,
       gaps,
-      missing: [],
     };
   }
 }

--- a/apps/server/src/store/migrations/runner.ts
+++ b/apps/server/src/store/migrations/runner.ts
@@ -88,6 +88,16 @@ export class MigrationRunner {
     if (!hasNameColumn) {
       this.db.exec("ALTER TABLE _migrations ADD COLUMN name TEXT NOT NULL DEFAULT ''");
     }
+
+    // Backfill descriptions for rows that were applied before the name column
+    // existed (stored as ''). Uses the in-memory module map, so this is a
+    // no-op for any version not in the map (gaps are left as-is).
+    const updateStmt = this.db.prepare(
+      "UPDATE _migrations SET name = ? WHERE version = ? AND name = ''",
+    );
+    for (const [version, module] of this.migrations) {
+      updateStmt.run(module.description, version);
+    }
   }
 
   /**

--- a/apps/server/src/store/migrations/runner.ts
+++ b/apps/server/src/store/migrations/runner.ts
@@ -1,0 +1,205 @@
+/**
+ * MigrationRunner: manages forward and backward SQLite migrations using
+ * pre-loaded migration modules. Takes a Map of version -> module so the
+ * runner is fully testable without filesystem coupling.
+ */
+
+import type Database from "better-sqlite3";
+
+/** A row from the _migrations tracking table. */
+export interface MigrationRecord {
+  version: number;
+  name: string;
+  appliedAt: string;
+}
+
+/**
+ * Result of a schema consistency check between the applied versions in the DB
+ * and the migration modules available in memory.
+ */
+export interface ValidationResult {
+  valid: boolean;
+  /** Applied DB versions that have no corresponding migration module. */
+  gaps: number[];
+  /** Reserved for future file-contiguity checks; always empty for now. */
+  missing: number[];
+}
+
+/**
+ * A single migration module. Each migration must implement both directions so
+ * rollback is always possible.
+ */
+export interface MigrationModule {
+  description: string;
+  up(db: Database.Database): void;
+  down(db: Database.Database): void;
+}
+
+/**
+ * Reads the _migrations table and maps rows to MigrationRecord shape.
+ * Centralises the snake_case -> camelCase mapping in one place.
+ */
+function rowToRecord(row: { version: number; name: string; applied_at: string }): MigrationRecord {
+  return {
+    version: row.version,
+    name: row.name,
+    appliedAt: row.applied_at,
+  };
+}
+
+/**
+ * Orchestrates forward and backward SQLite migrations for a pre-loaded set of
+ * migration modules. Owns the _migrations tracking table lifecycle.
+ */
+export class MigrationRunner {
+  constructor(
+    private db: Database.Database,
+    private migrations: Map<number, MigrationModule>,
+  ) {
+    this.ensureTable();
+  }
+
+  /**
+   * Ensures the _migrations table exists with the expected schema. If the
+   * table already exists but lacks the `name` column (legacy schema), the
+   * column is added via ALTER TABLE so existing data is preserved.
+   */
+  private ensureTable(): void {
+    // Create table with full schema if it does not exist at all.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS _migrations (
+        version INTEGER PRIMARY KEY,
+        name TEXT NOT NULL DEFAULT '',
+        applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
+    // If table existed before (without name column), patch it in.
+    const columns = this.db.pragma("table_info(_migrations)") as Array<{ name: string }>;
+    const hasNameColumn = columns.some((col) => col.name === "name");
+    if (!hasNameColumn) {
+      this.db.exec("ALTER TABLE _migrations ADD COLUMN name TEXT NOT NULL DEFAULT ''");
+    }
+  }
+
+  /**
+   * Applies pending migrations in ascending version order. Stops after
+   * `steps` migrations when provided; applies all pending when omitted.
+   */
+  up(steps?: number): { applied: number; migrations: MigrationRecord[] } {
+    const appliedVersions = new Set(
+      (this.db.prepare("SELECT version FROM _migrations").all() as Array<{ version: number }>).map(
+        (r) => r.version,
+      ),
+    );
+
+    const pending = [...this.migrations.entries()]
+      .filter(([version]) => !appliedVersions.has(version))
+      .sort(([a], [b]) => a - b);
+
+    const toApply = steps !== undefined ? pending.slice(0, steps) : pending;
+    const records: MigrationRecord[] = [];
+
+    const insertStmt = this.db.prepare(
+      "INSERT INTO _migrations (version, name) VALUES (?, ?)",
+    );
+
+    for (const [version, module] of toApply) {
+      this.db.transaction(() => {
+        module.up(this.db);
+        insertStmt.run(version, module.description);
+      })();
+
+      const row = this.db
+        .prepare("SELECT version, name, applied_at FROM _migrations WHERE version = ?")
+        .get(version) as { version: number; name: string; applied_at: string };
+      records.push(rowToRecord(row));
+    }
+
+    return { applied: records.length, migrations: records };
+  }
+
+  /**
+   * Reverts the most-recently applied migrations in descending version order.
+   * Defaults to rolling back 1 migration when `steps` is omitted.
+   */
+  down(steps = 1): { reverted: number; migrations: MigrationRecord[] } {
+    const appliedRows = this.db
+      .prepare("SELECT version, name, applied_at FROM _migrations ORDER BY version DESC")
+      .all() as Array<{ version: number; name: string; applied_at: string }>;
+
+    if (appliedRows.length === 0) {
+      return { reverted: 0, migrations: [] };
+    }
+
+    const toRevert = appliedRows.slice(0, steps);
+    const records: MigrationRecord[] = [];
+
+    const deleteStmt = this.db.prepare("DELETE FROM _migrations WHERE version = ?");
+
+    for (const row of toRevert) {
+      const module = this.migrations.get(row.version);
+      if (!module) {
+        throw new Error(
+          `Cannot revert migration v${row.version}: no migration module loaded for that version`,
+        );
+      }
+
+      const record = rowToRecord(row);
+
+      this.db.transaction(() => {
+        module.down(this.db);
+        deleteStmt.run(row.version);
+      })();
+
+      records.push(record);
+    }
+
+    return { reverted: records.length, migrations: records };
+  }
+
+  /**
+   * Returns all pending migrations (in map but not applied), sorted ascending.
+   */
+  pending(): { version: number; name: string }[] {
+    const appliedVersions = new Set(
+      (this.db.prepare("SELECT version FROM _migrations").all() as Array<{ version: number }>).map(
+        (r) => r.version,
+      ),
+    );
+
+    return [...this.migrations.entries()]
+      .filter(([version]) => !appliedVersions.has(version))
+      .sort(([a], [b]) => a - b)
+      .map(([version, module]) => ({ version, name: module.description }));
+  }
+
+  /**
+   * Returns all applied migrations from _migrations, sorted ascending by
+   * version.
+   */
+  applied(): MigrationRecord[] {
+    const rows = this.db
+      .prepare("SELECT version, name, applied_at FROM _migrations ORDER BY version ASC")
+      .all() as Array<{ version: number; name: string; applied_at: string }>;
+    return rows.map(rowToRecord);
+  }
+
+  /**
+   * Checks that every version recorded in _migrations has a corresponding
+   * migration module loaded. Versions with no module are reported as `gaps`.
+   */
+  validate(): ValidationResult {
+    const appliedVersions = (
+      this.db.prepare("SELECT version FROM _migrations").all() as Array<{ version: number }>
+    ).map((r) => r.version);
+
+    const gaps = appliedVersions.filter((v) => !this.migrations.has(v));
+
+    return {
+      valid: gaps.length === 0,
+      gaps,
+      missing: [],
+    };
+  }
+}

--- a/apps/server/src/store/migrations/runner.ts
+++ b/apps/server/src/store/migrations/runner.ts
@@ -74,8 +74,16 @@ export class MigrationRunner {
       )
     `);
 
+    interface PragmaRow {
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | null;
+      pk: number;
+    }
+
     // If table existed before (without name column), patch it in.
-    const columns = this.db.pragma("table_info(_migrations)") as Array<{ name: string }>;
+    const columns = this.db.pragma("table_info(_migrations)") as PragmaRow[];
     const hasNameColumn = columns.some((col) => col.name === "name");
     if (!hasNameColumn) {
       this.db.exec("ALTER TABLE _migrations ADD COLUMN name TEXT NOT NULL DEFAULT ''");
@@ -101,19 +109,20 @@ export class MigrationRunner {
     const records: MigrationRecord[] = [];
 
     const insertStmt = this.db.prepare(
-      "INSERT INTO _migrations (version, name) VALUES (?, ?)",
+      "INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, ?)",
     );
 
     for (const [version, module] of toApply) {
+      // Capture the timestamp before the transaction so the INSERT and the
+      // returned record agree on the value without a SELECT round-trip.
+      const appliedAt = new Date().toISOString();
+
       this.db.transaction(() => {
         module.up(this.db);
-        insertStmt.run(version, module.description);
+        insertStmt.run(version, module.description, appliedAt);
       })();
 
-      const row = this.db
-        .prepare("SELECT version, name, applied_at FROM _migrations WHERE version = ?")
-        .get(version) as { version: number; name: string; applied_at: string };
-      records.push(rowToRecord(row));
+      records.push({ version, name: module.description, appliedAt });
     }
 
     return { applied: records.length, migrations: records };
@@ -122,8 +131,15 @@ export class MigrationRunner {
   /**
    * Reverts the most-recently applied migrations in descending version order.
    * Defaults to rolling back 1 migration when `steps` is omitted.
+   *
+   * If `steps` exceeds the number of applied migrations, only the available
+   * applied migrations are reverted (no error is thrown for the excess).
    */
   down(steps = 1): { reverted: number; migrations: MigrationRecord[] } {
+    if (steps === 0) {
+      throw new Error("steps must be a positive integer");
+    }
+
     const appliedRows = this.db
       .prepare("SELECT version, name, applied_at FROM _migrations ORDER BY version DESC")
       .all() as Array<{ version: number; name: string; applied_at: string }>;


### PR DESCRIPTION
## What
Replaces the monolithic `runMigrations()` function with a proper versioned migration framework supporting rollbacks, individual migration files, and a CLI.

## Why
The old system was a 280-line function with 15 inline migrations, no rollback support, no CLI, and no way to scaffold new migrations. As the schema grows, this becomes increasingly hard to manage.

## Key Changes
- **`MigrationRunner`** class with `up()`, `down()`, `pending()`, `applied()`, and `validate()` — fully unit-tested with 11 test cases
- **15 individual migration files** (`001_initial_schema.ts` through `015_thread_compact_summary.ts`), each with `up()` and `down()` implementations
- **`bun run db:migrate`** CLI with `status`, `up [n]`, `down [n]`, and `new <name>` commands
- Backfills migration descriptions into existing databases on first startup
- Zero new dependencies

Closes #db-migrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a database migrations system with CLI commands to view status, apply, revert, and scaffold migrations; migration runner supports forward/backward steps and validation.
* **Documentation**
  * Added a "Database Migrations" section documenting CLI usage and scaffolding steps.
* **Tests**
  * Added comprehensive tests for the migration runner covering apply/rollback, reporting, validation, and transaction safety.
* **Chores**
  * Added an npm script to run migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->