### PR TITLE
perf: lazy-load react-markdown and cmdk

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -60,6 +60,7 @@
     "eslint": "^10.1.0",
     "globals": "^17.4.0",
     "jsdom": "^29.0.1",
+    "rollup-plugin-visualizer": "^7.0.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "typescript-eslint": "^8.57.1",

--- a/apps/web/src/__tests__/lazy-markdown.test.tsx
+++ b/apps/web/src/__tests__/lazy-markdown.test.tsx
@@ -22,8 +22,13 @@ const assistantMsg = {
   thread_id: "t-1",
   role: "assistant" as const,
   content: "Hello world",
+  cost_usd: null,
+  tokens_used: null,
   timestamp: new Date().toISOString(),
+  sequence: 0,
   attachments: [],
+  tool_calls: null,
+  files_changed: null,
 };
 
 describe("MessageBubble lazy MarkdownContent", () => {

--- a/apps/web/src/__tests__/lazy-markdown.test.tsx
+++ b/apps/web/src/__tests__/lazy-markdown.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("react-markdown", () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
+vi.mock("remark-gfm", () => ({ __esModule: true, default: () => {} }));
+vi.mock("../../hooks/useHighlighter", () => ({
+  useHighlighter: vi.fn(() => ({ html: null })),
+}));
+vi.mock("../../hooks/useTheme", () => ({
+  useShikiTheme: vi.fn(() => "github-dark"),
+}));
+
+import { MessageBubble } from "../components/chat/MessageBubble";
+
+const assistantMsg = {
+  id: "msg-1",
+  thread_id: "t-1",
+  role: "assistant" as const,
+  content: "Hello world",
+  timestamp: new Date().toISOString(),
+  attachments: [],
+};
+
+describe("MessageBubble lazy MarkdownContent", () => {
+  it("renders assistant message content via lazy-loaded MarkdownContent", async () => {
+    render(<MessageBubble message={assistantMsg} />);
+    expect(await screen.findByTestId("markdown")).toBeInTheDocument();
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/lazy-worktree-picker.test.tsx
+++ b/apps/web/src/__tests__/lazy-worktree-picker.test.tsx
@@ -1,16 +1,17 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 
 vi.mock("cmdk", () => ({
   Command: Object.assign(
-    ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    ({ children, ...props }: ComponentProps<"div">) => <div {...props}>{children}</div>,
     {
-      Input: (props: any) => <input {...props} />,
-      List: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-      Empty: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-      Group: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-      Item: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-      Separator: (props: any) => <hr {...props} />,
+      Input: (props: ComponentProps<"input">) => <input {...props} />,
+      List: ({ children, ...props }: ComponentProps<"div">) => <div {...props}>{children}</div>,
+      Empty: ({ children, ...props }: ComponentProps<"div">) => <div {...props}>{children}</div>,
+      Group: ({ children, ...props }: ComponentProps<"div">) => <div {...props}>{children}</div>,
+      Item: ({ children, ...props }: ComponentProps<"div">) => <div {...props}>{children}</div>,
+      Separator: (props: ComponentProps<"hr">) => <hr {...props} />,
     },
   ),
 }));

--- a/apps/web/src/__tests__/lazy-worktree-picker.test.tsx
+++ b/apps/web/src/__tests__/lazy-worktree-picker.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { ComponentProps } from "react";
+import { lazy, Suspense, type ComponentProps } from "react";
 
 vi.mock("cmdk", () => ({
   Command: Object.assign(
@@ -33,5 +33,20 @@ describe("WorktreePicker", () => {
       />,
     );
     expect(screen.getByText("feature-a")).toBeInTheDocument();
+  });
+
+  it("renders via React.lazy default export", async () => {
+    const LazyWorktreePicker = lazy(() => import("../components/chat/WorktreePicker"));
+    render(
+      <Suspense fallback={<div data-testid="fallback" />}>
+        <LazyWorktreePicker
+          worktrees={worktrees}
+          selectedPath="/repo/.worktrees/feature-a"
+          onSelect={() => {}}
+          loading={false}
+        />
+      </Suspense>,
+    );
+    expect(await screen.findByText("feature-a")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/__tests__/lazy-worktree-picker.test.tsx
+++ b/apps/web/src/__tests__/lazy-worktree-picker.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("cmdk", () => ({
+  Command: Object.assign(
+    ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    {
+      Input: (props: any) => <input {...props} />,
+      List: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      Empty: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      Group: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      Item: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      Separator: (props: any) => <hr {...props} />,
+    },
+  ),
+}));
+
+import { WorktreePicker } from "../components/chat/WorktreePicker";
+
+const worktrees = [
+  { name: "feature-a", branch: "feature/a", path: "/repo/.worktrees/feature-a", managed: true },
+];
+
+describe("WorktreePicker", () => {
+  it("renders the selected worktree name", () => {
+    render(
+      <WorktreePicker
+        worktrees={worktrees}
+        selectedPath="/repo/.worktrees/feature-a"
+        onSelect={() => {}}
+        loading={false}
+      />,
+    );
+    expect(screen.getByText("feature-a")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo, lazy, Suspense } from "react";
 import { useThreadStore } from "@/stores/threadStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import type { PermissionMode, InteractionMode, AttachmentMeta } from "@/transport";
@@ -27,7 +27,7 @@ import { BranchPicker } from "./BranchPicker";
 import { NamingModeSelector } from "./NamingModeSelector";
 import type { NamingMode } from "@mcode/contracts";
 import { BranchNameInput } from "./BranchNameInput";
-import { WorktreePicker } from "./WorktreePicker";
+const LazyWorktreePicker = lazy(() => import("./WorktreePicker"));
 import { AttachmentPreview } from "./AttachmentPreview";
 import type { PendingAttachment } from "./AttachmentPreview";
 import { useFileAutocomplete, clearFileListCache } from "./useFileAutocomplete";
@@ -1355,12 +1355,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 />
               </>
             ) : composerMode === "existing-worktree" ? (
-              <WorktreePicker
+              <Suspense fallback={null}><LazyWorktreePicker
                 worktrees={worktrees}
                 selectedPath={selectedWorktree?.path ?? ""}
                 onSelect={setSelectedWorktree}
                 loading={worktreesLoading}
-              />
+              /></Suspense>
             ) : null
           ) : branchFromMessageId ? (
             // Branch mode: show execution controls for the child thread
@@ -1390,12 +1390,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 />
               </>
             ) : (
-              <WorktreePicker
+              <Suspense fallback={null}><LazyWorktreePicker
                 worktrees={worktrees}
                 selectedPath={branchWorktreePath}
                 onSelect={(wt) => setBranchWorktreePath(wt.path)}
                 loading={worktreesLoading}
-              />
+              /></Suspense>
             )
           ) : activeThread?.branch ? (
             <BranchPicker

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1355,7 +1355,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 />
               </>
             ) : composerMode === "existing-worktree" ? (
-              <Suspense fallback={null}><LazyWorktreePicker
+              <Suspense fallback={<div className="h-7" />}><LazyWorktreePicker
                 worktrees={worktrees}
                 selectedPath={selectedWorktree?.path ?? ""}
                 onSelect={setSelectedWorktree}
@@ -1390,7 +1390,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 />
               </>
             ) : (
-              <Suspense fallback={null}><LazyWorktreePicker
+              <Suspense fallback={<div className="h-7" />}><LazyWorktreePicker
                 worktrees={worktrees}
                 selectedPath={branchWorktreePath}
                 onSelect={(wt) => setBranchWorktreePath(wt.path)}

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -111,3 +111,5 @@ export const MarkdownContent = memo(function MarkdownContent({
     </ReactMarkdown>
   );
 });
+
+export default MarkdownContent;

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -1,8 +1,8 @@
-import { memo, useMemo, useState, useCallback, useRef, useEffect } from "react";
+import { memo, useMemo, useState, useCallback, useRef, useEffect, lazy, Suspense } from "react";
 import type { Message } from "@/transport";
 import { FileText, File, ImageIcon, RotateCcw, Copy, Check, GitBranch } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { MarkdownContent } from "./MarkdownContent";
+const LazyMarkdownContent = lazy(() => import("./MarkdownContent"));
 import { stripInjectedFiles } from "@/lib/file-tags";
 import { isHandoffMessage, parseHandoffJson } from "./handoff-utils";
 import { HandoffCard } from "./HandoffCard";
@@ -210,7 +210,9 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch }: 
   return (
     <div className="group/msg space-y-2">
       <div className="text-sm text-foreground">
-        <MarkdownContent content={message.content} isStreaming={false} />
+        <Suspense>
+          <LazyMarkdownContent content={message.content} isStreaming={false} />
+        </Suspense>
       </div>
       <div className="flex items-center gap-3 px-1">
         {onBranch && <BranchButton onClick={() => onBranch(message.id)} />}

--- a/apps/web/src/components/chat/WorktreePicker.tsx
+++ b/apps/web/src/components/chat/WorktreePicker.tsx
@@ -109,3 +109,5 @@ function truncatePath(path: string): string {
   if (parts.length <= 4) return path;
   return ".../" + parts.slice(-3).join("/");
 }
+
+export default WorktreePicker;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,18 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
 
+const analyze = process.env.ANALYZE === "true" || process.env.ANALYZE === "1";
+
 export default defineConfig({
-  base: process.env.ELECTRON_BUILD ? "./" : "/",
   plugins: [
     react(),
     tailwindcss(),
-    ...(process.env.ANALYZE
-      ? [visualizer({ open: true, gzipSize: true, filename: "dist/bundle-stats.html" })]
+    ...(analyze
+      ? [(await import("rollup-plugin-visualizer")).visualizer({ open: true, gzipSize: true, filename: "dist/bundle-stats.html" })]
       : []),
   ],
+  base: process.env.ELECTRON_BUILD ? "./" : "/",
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,11 +1,18 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
 
 export default defineConfig({
   base: process.env.ELECTRON_BUILD ? "./" : "/",
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    ...(process.env.ANALYZE
+      ? [visualizer({ open: true, gzipSize: true, filename: "dist/bundle-stats.html" })]
+      : []),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "apps/desktop": {
       "name": "mcode-desktop",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@electron/rebuild": "^3.7.1",
         "@mcode/contracts": "workspace:*",
@@ -108,6 +108,7 @@
         "eslint": "^10.1.0",
         "globals": "^17.4.0",
         "jsdom": "^29.0.1",
+        "rollup-plugin-visualizer": "^7.0.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
         "typescript-eslint": "^8.57.1",
@@ -1958,6 +1959,8 @@
 
     "rolldown": ["rolldown@1.0.0-rc.10", "", { "dependencies": { "@oxc-project/types": "=0.120.0", "@rolldown/pluginutils": "1.0.0-rc.10" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.10", "@rolldown/binding-darwin-arm64": "1.0.0-rc.10", "@rolldown/binding-darwin-x64": "1.0.0-rc.10", "@rolldown/binding-freebsd-x64": "1.0.0-rc.10", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA=="],
 
+    "rollup-plugin-visualizer": ["rollup-plugin-visualizer@7.0.1", "", { "dependencies": { "open": "^11.0.0", "picomatch": "^4.0.2", "source-map": "^0.7.4", "yargs": "^18.0.0" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -2032,7 +2035,7 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@7.0.0", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww=="],
 
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -2510,6 +2513,8 @@
 
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
+    "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "recast/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
@@ -2517,6 +2522,8 @@
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.10", "", {}, "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg=="],
+
+    "rollup-plugin-visualizer/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
@@ -2529,6 +2536,8 @@
     "shadcn/ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
     "socks-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -2626,6 +2635,12 @@
 
     "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "rollup-plugin-visualizer/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "rollup-plugin-visualizer/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "rollup-plugin-visualizer/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "shadcn/ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -2670,6 +2685,14 @@
 
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
+    "rollup-plugin-visualizer/yargs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "rollup-plugin-visualizer/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "rollup-plugin-visualizer/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "rollup-plugin-visualizer/yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
     "shadcn/ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "shadcn/ora/log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
@@ -2691,6 +2714,12 @@
     "node-gyp/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "rollup-plugin-visualizer/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "rollup-plugin-visualizer/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "rollup-plugin-visualizer/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "shadcn/ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 


### PR DESCRIPTION
## What
Defer loading of `react-markdown` + `remark-gfm` and `cmdk` using `React.lazy()` + `Suspense`, so they are excluded from the initial bundle.

## Why
These libraries (~200KB raw) were eagerly imported at module load time but are only needed after the first assistant message renders (markdown) or when the worktree picker is opened (cmdk). Removing them from the critical path reduces startup parse cost.

## Key Changes
- `MarkdownContent` is now lazy-loaded in `MessageBubble` via `React.lazy()` — defers `react-markdown` + `remark-gfm` (157 KB chunk)
- `WorktreePicker` is now lazy-loaded in `Composer` — defers `cmdk` (42 KB chunk)
- Added `rollup-plugin-visualizer` behind `ANALYZE=1` env var for ongoing bundle inspection

**Bundle impact (gzip):** main chunk 329 KB → 269 KB (-18%)

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Markdown rendering and worktree selection components are now lazy-loaded to reduce initial bundle size and improve page load responsiveness.

* **Tests**
  * Added tests validating rendering and behavior of the lazy-loaded components.

* **Chores**
  * Added bundle analysis tooling to the development setup to aid inspection of build size metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->