### PR TITLE
fix: clean worktree deletion and parent dir cleanup

### DIFF
--- a/apps/server/src/__tests__/cleanup-integration.test.ts
+++ b/apps/server/src/__tests__/cleanup-integration.test.ts
@@ -116,7 +116,10 @@ describe("Cleanup integration", () => {
     expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
       expect.any(String),
       "feat-wt",
-      "mcode/int-branch",
+      expect.objectContaining({
+        branchName: "mcode/int-branch",
+        worktreePath: expect.stringContaining("feat-wt"),
+      }),
     );
 
     // Verify: thread hard-deleted from database

--- a/apps/server/src/__tests__/cleanup-worker.test.ts
+++ b/apps/server/src/__tests__/cleanup-worker.test.ts
@@ -52,6 +52,7 @@ describe("CleanupWorker", () => {
 
     mockGitService = {
       removeWorktree: vi.fn().mockResolvedValue(true),
+      isRegisteredWorktreePath: vi.fn().mockReturnValue(false),
     } as unknown as GitService;
 
     worker = new CleanupWorker(
@@ -258,7 +259,7 @@ describe("CleanupWorker", () => {
       expect(mockGitService.removeWorktree).not.toHaveBeenCalled();
     });
 
-    it("skips branch deletion for non-mcode branches and still removes worktree", async () => {
+    it("deletes non-mcode thread branches too when cleanup is requested", async () => {
       const ws = workspaceRepo.create("test", "/repo");
       insertThread("t-nobranch", ws.id, "feat/user-branch", wt("user-wt"));
       cleanupJobRepo.insert({
@@ -270,11 +271,42 @@ describe("CleanupWorker", () => {
 
       await worker.poll();
 
-      // removeWorktree called with undefined branch so git branch -d is skipped
+      // removeWorktree receives the stored thread branch, even when it is not mcode/*
       expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
         expect.any(String),
         "user-wt",
-        undefined,
+        expect.objectContaining({
+          branchName: "feat/user-branch",
+          worktreePath: expect.stringContaining("user-wt"),
+        }),
+      );
+    });
+
+    it("allows an attached external worktree when git still registers the path", async () => {
+      const externalWtPath = "/external/worktrees/feat-ext";
+      (mockGitService.isRegisteredWorktreePath as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      const ws = workspaceRepo.create("test", "/repo");
+      insertThread("t-external", ws.id, "feat/external", externalWtPath);
+      cleanupJobRepo.insert({
+        thread_id: "t-external",
+        workspace_path: "/repo",
+        worktree_path: externalWtPath,
+        branch: "feat/external",
+      });
+
+      await worker.poll();
+
+      expect(mockGitService.isRegisteredWorktreePath).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining("feat-ext"),
+      );
+      expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+        expect.any(String),
+        "feat-ext",
+        expect.objectContaining({
+          branchName: "feat/external",
+          worktreePath: expect.stringContaining("feat-ext"),
+        }),
       );
     });
 
@@ -332,7 +364,10 @@ describe("CleanupWorker", () => {
       expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
         expect.any(String),
         "win-wt",
-        "mcode/win",
+        expect.objectContaining({
+          branchName: "mcode/win",
+          worktreePath: expect.stringContaining("win-wt"),
+        }),
       );
     });
 

--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -42,7 +42,7 @@ describe("GitService.removeWorktree", () => {
   let gitService: GitService;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     gitService = new GitService({} as WorkspaceRepo);
   });
 
@@ -53,7 +53,7 @@ describe("GitService.removeWorktree", () => {
     const result = await gitService.removeWorktree(
       "/repo",
       "my-worktree",
-      "feat/test",
+      { branchName: "feat/test" },
     );
 
     expect(result).toBe(true);
@@ -117,7 +117,7 @@ describe("GitService.removeWorktree", () => {
     const result = await gitService.removeWorktree(
       "/repo",
       "my-worktree",
-      "feat/test",
+      { branchName: "feat/test" },
     );
 
     expect(result).toBe(true);
@@ -143,12 +143,29 @@ describe("GitService.removeWorktree", () => {
     mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
 
-    await gitService.removeWorktree("/repo", "my-worktree", "feat/test");
+    await gitService.removeWorktree("/repo", "my-worktree", { branchName: "feat/test" });
 
     expect(mockExecFile).toHaveBeenCalledWith(
       "git",
       ["-C", "/repo", "worktree", "remove", expect.stringContaining("my-worktree"), "--force", "--force"],
       expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it("skips branch deletion when deleteBranch is false", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    mockExistsSync.mockReturnValue(false);
+
+    const result = await gitService.removeWorktree("/repo", "my-worktree", {
+      deleteBranch: false,
+    });
+
+    expect(result).toBe(true);
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+    expect(mockExecFile).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["branch", "-d"]),
+      expect.anything(),
     );
   });
 
@@ -183,5 +200,35 @@ describe("GitService.removeWorktree", () => {
     const result = await gitService.removeWorktree("/repo", "my-worktree");
 
     expect(result).toBe(false);
+  });
+
+  it("prunes stale metadata after manual fallback before deleting the branch", async () => {
+    mockExecFile
+      .mockRejectedValueOnce(new Error("git failed")) // worktree remove
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }) // prune
+      .mockResolvedValueOnce({ stdout: "", stderr: "" }); // branch -d
+    mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    mockRm.mockResolvedValue(undefined);
+
+    await gitService.removeWorktree("/repo", "my-worktree", {
+      branchName: "mcode/my-worktree",
+    });
+
+    const pruneIndex = 1;
+    const branchIndex = 2;
+    expect(mockExecFile.mock.calls[pruneIndex]?.[1]).toEqual(["-C", "/repo", "worktree", "prune"]);
+    expect(mockExecFile.mock.calls[branchIndex]?.[1]).toEqual([
+      "-C",
+      "/repo",
+      "branch",
+      "-d",
+      "mcode/my-worktree",
+    ]);
+    expect(mockRm.mock.invocationCallOrder[0]).toBeLessThan(
+      mockExecFile.mock.invocationCallOrder[pruneIndex],
+    );
+    expect(mockExecFile.mock.invocationCallOrder[pruneIndex]).toBeLessThan(
+      mockExecFile.mock.invocationCallOrder[branchIndex],
+    );
   });
 });

--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -2,10 +2,11 @@ import "reflect-metadata";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 
-const { mockExecFile, mockRm, mockRename, mockExistsSync, mockLogger } = vi.hoisted(() => ({
+const { mockExecFile, mockRm, mockRename, mockRmdir, mockExistsSync, mockLogger } = vi.hoisted(() => ({
   mockExecFile: vi.fn(),
   mockRm: vi.fn(),
   mockRename: vi.fn(),
+  mockRmdir: vi.fn(),
   mockExistsSync: vi.fn(),
   mockLogger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
@@ -27,6 +28,7 @@ vi.mock("fs", () => ({
 vi.mock("fs/promises", () => ({
   rm: mockRm,
   rename: mockRename,
+  rmdir: mockRmdir,
 }));
 
 vi.mock("@mcode/shared", () => ({
@@ -230,5 +232,28 @@ describe("GitService.removeWorktree", () => {
     expect(mockExecFile.mock.invocationCallOrder[pruneIndex]).toBeLessThan(
       mockExecFile.mock.invocationCallOrder[branchIndex],
     );
+  });
+
+  it("removes an empty managed parent directory after worktree cleanup", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    mockExistsSync.mockReturnValue(false);
+    mockRmdir.mockResolvedValue(undefined);
+
+    await gitService.removeWorktree("/repo", "my-worktree");
+
+    expect(mockRmdir).toHaveBeenCalledWith(expect.stringContaining("worktrees"));
+    expect(mockRmdir).toHaveBeenCalledWith(expect.stringContaining("repo"));
+  });
+
+  it("does not remove parent directories for external worktrees", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    mockExistsSync.mockReturnValue(false);
+
+    await gitService.removeWorktree("/repo", "my-worktree", {
+      worktreePath: "/external/worktrees/my-worktree",
+      deleteBranch: false,
+    });
+
+    expect(mockRmdir).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/__tests__/thread-service.test.ts
+++ b/apps/server/src/__tests__/thread-service.test.ts
@@ -124,4 +124,68 @@ describe("ThreadService.delete", () => {
     expect(result).toBe(true);
     expect(cleanupJobRepo.count()).toBe(0);
   });
+
+  it("enqueues a cleanup job for an attached existing worktree when cleanup is requested", () => {
+    const ws = workspaceRepo.create("test", "/tmp/test");
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO threads
+        (id, workspace_id, title, branch, mode, status, worktree_path, worktree_managed, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'worktree', 'active', ?, 0, ?, ?)`,
+    ).run("t-existing", ws.id, "Existing Worktree", "feat/existing", "/tmp/existing-wt", now, now);
+
+    const result = threadService.delete("t-existing", true);
+
+    expect(result).toBe(true);
+    expect(cleanupJobRepo.count()).toBe(1);
+    const job = cleanupJobRepo.findDue(Date.now())[0];
+    expect(job.worktree_path).toBe("/tmp/existing-wt");
+    expect(job.branch).toBe("feat/existing");
+  });
+
+  it("rollback during create does not delete an existing non-mcode branch", async () => {
+    const ws = workspaceRepo.create("test", "/tmp/test");
+    vi.spyOn(threadRepo, "updateWorktreePath").mockReturnValue(false);
+    (mockGitService.createWorktree as ReturnType<typeof vi.fn>).mockReturnValue({
+      name: "feat-custom-rollback",
+      path: "/tmp/wt/feat-custom-rollback",
+      branch: "feat/custom",
+      managed: true,
+      createdBranch: false,
+    });
+
+    await expect(
+      threadService.create(ws.id, "Rollback Thread", "worktree", "feat/custom"),
+    ).rejects.toThrow("Failed to persist worktree path");
+
+    const worktreeName = (mockGitService.createWorktree as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+      "/tmp/test",
+      worktreeName,
+      { deleteBranch: false },
+    );
+  });
+
+  it("rollback during create deletes a newly-created branch", async () => {
+    const ws = workspaceRepo.create("test", "/tmp/test");
+    vi.spyOn(threadRepo, "updateWorktreePath").mockReturnValue(false);
+    (mockGitService.createWorktree as ReturnType<typeof vi.fn>).mockReturnValue({
+      name: "feat-new-rollback",
+      path: "/tmp/wt/feat-new-rollback",
+      branch: "feat/new",
+      managed: true,
+      createdBranch: true,
+    });
+
+    await expect(
+      threadService.create(ws.id, "Rollback Thread", "worktree", "feat/new"),
+    ).rejects.toThrow("Failed to persist worktree path");
+
+    const worktreeName = (mockGitService.createWorktree as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+      "/tmp/test",
+      worktreeName,
+      { branchName: "feat/new" },
+    );
+  });
 });

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -34,9 +34,6 @@ const HANDLE_RELEASE_DELAY_MS = 1_500;
  */
 const SESSION_EXIT_TIMEOUT_MS = 5_000;
 
-/** Expected prefix for all mcode-managed branch names. */
-const MCODE_BRANCH_PREFIX = "mcode/";
-
 /**
  * Drains the cleanup_jobs table with retry logic.
  * Must be started via start() after DI is fully resolved.
@@ -126,9 +123,14 @@ export class CleanupWorker {
       if (!existsSync(resolvedWs)) {
         throw new Error(`workspace_path does not exist: ${resolvedWs}`);
       }
+      if (resolvedWt === resolvedWs) {
+        throw new Error(`worktree_path must not equal workspace_path: ${resolvedWt}`);
+      }
+
       const rel = relative(worktreeBase, resolvedWt);
-      if (rel.startsWith("..") || isAbsolute(rel)) {
-        throw new Error(`worktree_path outside expected base: ${resolvedWt}`);
+      const isManagedPath = !(rel.startsWith("..") || isAbsolute(rel));
+      if (!isManagedPath && !this.gitService.isRegisteredWorktreePath(resolvedWs, resolvedWt)) {
+        throw new Error(`worktree_path is not a registered worktree for repo: ${resolvedWt}`);
       }
 
       // 1. Signal the SDK subprocess to exit and wait for it to actually stop.
@@ -151,25 +153,18 @@ export class CleanupWorker {
         await new Promise<void>((resolve) => setTimeout(resolve, HANDLE_RELEASE_DELAY_MS));
       }
 
-      // 4. Remove the worktree directory. Only pass branch if it uses the
-      //    mcode/ prefix to prevent accidental deletion of user branches.
+      // 4. Remove the worktree directory and delete the exact thread branch when
+      //    the thread record has one. The delete-thread dialog is the user intent
+      //    boundary; rollback paths are handled separately in ThreadService.
       const wtName = resolvedWt.replace(/\\/g, "/").split("/").pop() ?? resolvedWt;
-      const safeBranch =
-        job.branch && job.branch.startsWith(MCODE_BRANCH_PREFIX)
-          ? job.branch
-          : undefined;
-
-      if (job.branch && !safeBranch) {
-        logger.warn("CleanupWorker skipped branch deletion for non-mcode branch", {
-          jobId: job.id,
-          branch: job.branch,
-        });
-      }
+      const removeOptions = job.branch
+        ? { branchName: job.branch, worktreePath: resolvedWt }
+        : { deleteBranch: false, worktreePath: resolvedWt };
 
       const removed = await this.gitService.removeWorktree(
         resolvedWs,
         wtName,
-        safeBranch,
+        removeOptions,
       );
 
       if (!removed) {

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -9,7 +9,7 @@ import { execFileSync, execFile as execFileCb } from "child_process";
 import { promisify } from "util";
 import { rm, rename } from "fs/promises";
 import { existsSync, mkdirSync } from "fs";
-import { join, basename } from "path";
+import { join, basename, resolve } from "path";
 import { getMcodeDir, validateBranchName, validateWorktreeName, logger } from "@mcode/shared";
 import type { GitBranch, WorktreeInfo, GitCommit } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
@@ -21,6 +21,12 @@ const execFile = promisify(execFileCb);
  * maxRetries handles transient EBUSY locks from antivirus/indexers on Windows.
  */
 const RM_RETRY_OPTIONS = { recursive: true, force: true, maxRetries: 5, retryDelay: 200 } as const;
+
+interface RemoveWorktreeOptions {
+  branchName?: string;
+  deleteBranch?: boolean;
+  worktreePath?: string;
+}
 
 /** Resolve the worktree base directory path under the mcode data dir. */
 function getWorktreeBaseDir(repoPath: string): string {
@@ -83,6 +89,14 @@ export class GitService {
     return listWorktreesForPath(workspace.path);
   }
 
+  /** Check whether a filesystem path is a git-registered worktree for a repository. */
+  isRegisteredWorktreePath(repoPath: string, worktreePath: string): boolean {
+    const normalize = (value: string) =>
+      resolve(value).replace(/\\/g, "/").toLowerCase().replace(/\/+$/, "");
+    const target = normalize(worktreePath);
+    return listWorktreesForPath(repoPath).some((worktree) => normalize(worktree.path) === target);
+  }
+
   /**
    * Fetch a remote branch from origin and create a local tracking branch.
    * When prNumber is provided, fetches via `refs/pull/<n>/head` refspec.
@@ -98,13 +112,14 @@ export class GitService {
 
   /**
    * Create a new git worktree in the mcode data directory.
-   * Returns the worktree metadata including the filesystem path.
+   * Returns the worktree metadata including the filesystem path and whether this
+   * call created the branch or attached to an existing one.
    */
   createWorktree(
     repoPath: string,
     name: string,
     branchName?: string,
-  ): WorktreeInfo {
+  ): WorktreeInfo & { createdBranch: boolean } {
     validateWorktreeName(name);
 
     if (!existsSync(repoPath)) {
@@ -119,7 +134,9 @@ export class GitService {
       throw new Error(`Worktree directory already exists: ${wtPath}`);
     }
 
-    if (branchExists(repoPath, branch)) {
+    const createdBranch = !branchExists(repoPath, branch);
+
+    if (!createdBranch) {
       execFileSync(
         "git",
         ["-C", repoPath, "worktree", "add", wtPath, branch],
@@ -133,20 +150,30 @@ export class GitService {
       );
     }
 
-    return { name, path: wtPath, branch, managed: true };
+    return { name, path: wtPath, branch, managed: true, createdBranch };
   }
 
-  /** Remove a git worktree by name. Returns true if the directory was cleaned up. */
+  /**
+   * Remove a git worktree by name.
+   * When deleteBranch is true, deletes options.branchName or the default managed branch.
+   * When worktreePath is set, removes that exact worktree path instead of deriving
+   * one under the managed mcode worktree directory.
+   */
   async removeWorktree(
     repoPath: string,
     name: string,
-    branchName?: string,
+    options: RemoveWorktreeOptions = {},
   ): Promise<boolean> {
     validateWorktreeName(name);
 
-    const wtPath = join(getWorktreeBaseDir(repoPath), name);
-    const branch = branchName ?? `mcode/${name}`;
-    validateBranchName(branch);
+    const wtPath = options.worktreePath ?? join(getWorktreeBaseDir(repoPath), name);
+    const deleteBranch = options.deleteBranch ?? true;
+    const branch = deleteBranch
+      ? (options.branchName ?? `mcode/${name}`)
+      : null;
+    if (branch) {
+      validateBranchName(branch);
+    }
 
     // 1. Try git worktree remove
     try {
@@ -164,18 +191,7 @@ export class GitService {
       });
     }
 
-    // 2. Prune stale worktree metadata
-    try {
-      await execFile("git", ["-C", repoPath, "worktree", "prune"], {
-        timeout: 10_000,
-      });
-    } catch (err) {
-      logger.warn("git worktree prune failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-
-    // 3. Fallback: remove directory manually if git didn't clean it up.
+    // 2. Fallback: remove directory manually if git didn't clean it up.
     if (existsSync(wtPath)) {
       logger.warn(
         "Worktree directory still exists after git remove, falling back to fs.rm",
@@ -191,7 +207,7 @@ export class GitService {
       }
     }
 
-    // 4. Rename-then-delete: atomically unblock the path even if deletion is slow.
+    // 3. Rename-then-delete: atomically unblock the path even if deletion is slow.
     // Renaming succeeds even when the directory has open handles, so the original
     // path becomes available immediately while the OS drains remaining handles.
     if (existsSync(wtPath)) {
@@ -218,13 +234,28 @@ export class GitService {
       }
     }
 
-    // 5. Verify cleanup
+    // 4. Verify cleanup
     if (existsSync(wtPath)) {
       logger.error("Worktree directory could not be removed", { wtPath });
       return false;
     }
 
-    // 6. Delete the branch
+    // 5. Prune stale worktree metadata after any manual fallback removed the path.
+    try {
+      await execFile("git", ["-C", repoPath, "worktree", "prune"], {
+        timeout: 10_000,
+      });
+    } catch (err) {
+      logger.warn("git worktree prune failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    // 6. Delete the branch when explicitly requested.
+    if (!branch) {
+      return true;
+    }
+
     try {
       await execFile("git", ["-C", repoPath, "branch", "-d", branch], {
         timeout: 10_000,

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -7,9 +7,9 @@
 import { injectable, inject } from "tsyringe";
 import { execFileSync, execFile as execFileCb } from "child_process";
 import { promisify } from "util";
-import { rm, rename } from "fs/promises";
+import { rm, rename, rmdir } from "fs/promises";
 import { existsSync, mkdirSync } from "fs";
-import { join, basename, resolve } from "path";
+import { join, basename, dirname, resolve, relative, isAbsolute } from "path";
 import { getMcodeDir, validateBranchName, validateWorktreeName, logger } from "@mcode/shared";
 import type { GitBranch, WorktreeInfo, GitCommit } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
@@ -42,6 +42,40 @@ function ensureWorktreeBaseDir(repoPath: string): string {
 
 function worktreeSlug(repoPath: string): string {
   return basename(repoPath).toLowerCase().replace(/[^a-z0-9-]/g, "-");
+}
+
+/** Best-effort cleanup of empty managed parent directories after a worktree is removed. */
+async function removeEmptyManagedParentDirs(wtPath: string): Promise<void> {
+  const managedRoot = resolve(getMcodeDir(), "worktrees");
+  const rel = relative(managedRoot, resolve(wtPath));
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    return;
+  }
+
+  let current = dirname(resolve(wtPath));
+  while (current !== managedRoot) {
+    try {
+      await rmdir(current);
+      logger.info("Removed empty managed worktree parent dir", { path: current });
+      current = dirname(current);
+    } catch (err) {
+      const code = err && typeof err === "object" && "code" in err
+        ? String((err as NodeJS.ErrnoException).code)
+        : "";
+      if (code === "ENOTEMPTY" || code === "EEXIST" || code === "EBUSY") {
+        break;
+      }
+      if (code === "ENOENT") {
+        current = dirname(current);
+        continue;
+      }
+      logger.warn("Failed to remove empty managed worktree parent dir", {
+        path: current,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      break;
+    }
+  }
 }
 
 /** Check whether a branch ref exists in the repository. */
@@ -251,7 +285,10 @@ export class GitService {
       });
     }
 
-    // 6. Delete the branch when explicitly requested.
+    // 6. Best-effort cleanup of any empty managed parent directories left behind.
+    await removeEmptyManagedParentDirs(wtPath);
+
+    // 7. Delete the branch when explicitly requested.
     if (!branch) {
       return true;
     }

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -22,9 +22,25 @@ const execFile = promisify(execFileCb);
  */
 const RM_RETRY_OPTIONS = { recursive: true, force: true, maxRetries: 5, retryDelay: 200 } as const;
 
+/**
+ * Options for {@link GitService.removeWorktree}.
+ * Controls which worktree path is removed and whether the associated branch is deleted.
+ */
 interface RemoveWorktreeOptions {
+  /**
+   * Exact branch name to delete after the worktree is removed.
+   * When omitted and deleteBranch is true, removeWorktree falls back to `mcode/<worktree-name>`.
+   */
   branchName?: string;
+  /**
+   * Whether removeWorktree should attempt `git branch -d` after cleaning up the worktree.
+   * Defaults to true; when false, branchName is ignored and no branch deletion is attempted.
+   */
   deleteBranch?: boolean;
+  /**
+   * Exact filesystem path of the worktree to remove.
+   * When omitted, removeWorktree derives the managed path under the mcode worktree directory from the worktree name.
+   */
   worktreePath?: string;
 }
 

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -76,10 +76,13 @@ export class ThreadService {
 
         if (!updated) {
           try {
+            const rollbackOptions = info.createdBranch
+              ? { branchName: branch }
+              : { deleteBranch: false };
             const cleaned = await this.gitService.removeWorktree(
               workspace.path,
               worktreeName,
-              branch,
+              rollbackOptions,
             );
             if (!cleaned) {
               logger.warn("Rollback worktree cleanup returned false during thread creation", {
@@ -119,15 +122,15 @@ export class ThreadService {
 
   /**
    * Soft-delete a thread and enqueue a background cleanup job when the thread
-   * has a managed worktree. The cleanup job handles process termination,
+   * has a worktree path. The cleanup job handles process termination,
    * filesystem removal, and hard-deletion of the DB row asynchronously with
-   * exponential backoff retries. The job's branch field is set from
-   * thread.branch; branches prefixed with "mcode/" are deleted by the worker.
+   * exponential backoff retries. The job stores the thread's exact branch so
+   * explicit user cleanup deletes the worktree and its associated thread branch.
    */
   delete(threadId: string, cleanupWorktree: boolean): boolean {
     if (cleanupWorktree) {
       const thread = this.threadRepo.findById(threadId);
-      if (thread?.worktree_path && thread.worktree_managed) {
+      if (thread?.worktree_path) {
         const workspace = this.workspaceRepo.findById(thread.workspace_id);
         if (workspace) {
           this.cleanupJobRepo.insert({


### PR DESCRIPTION
## Summary
- delete the exact stored worktree path and thread branch during explicit thread cleanup
- keep rollback branch deletion conservative by only deleting branches created during setup
- remove empty managed parent directories left behind after worktree cleanup

## Verification
- npx vitest run --maxWorkers 1 src/__tests__/git-service.test.ts src/__tests__/cleanup-worker.test.ts src/__tests__/thread-service.test.ts src/__tests__/cleanup-integration.test.ts
- bun x tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced validation and cleanup of worktree paths
  * Improved support for external worktrees not managed by the application
  * Better directory cleanup after worktree removal
  * More flexible branch management during worktree operations
  * Fixed handling of thread deletion with non-managed worktrees

<!-- end of auto-generated comment: release notes by coderabbit.ai -->