### PR TITLE
fix: open links in external browser instead of in-app

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -223,6 +223,43 @@ function createWindow(): void {
 
   mainWindow.setMenuBarVisibility(false);
 
+  // Intercept target="_blank" and window.open() calls.
+  // Deny the new window and open the URL in the system browser instead.
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    try {
+      const parsed = new URL(url);
+      if (["https:", "http:", "mailto:"].includes(parsed.protocol)) {
+        shell.openExternal(url);
+      }
+    } catch {
+      // Invalid URL, ignore
+    }
+    return { action: "deny" };
+  });
+
+  // Prevent the main window from navigating away from the app.
+  // Only allow the initial load URL (dev server or file://).
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    const currentUrl = mainWindow!.webContents.getURL();
+    // Allow same-origin navigation (SPA router)
+    try {
+      const current = new URL(currentUrl);
+      const target = new URL(url);
+      if (current.origin === target.origin) return;
+    } catch {
+      // Parse error, block navigation
+    }
+    event.preventDefault();
+    try {
+      const parsed = new URL(url);
+      if (["https:", "http:", "mailto:"].includes(parsed.protocol)) {
+        shell.openExternal(url);
+      }
+    } catch {
+      // Invalid URL, ignore
+    }
+  });
+
   // Show the window as soon as the first frame is painted.
   // Fallback timeout ensures the window becomes visible even if the
   // ready-to-show event never fires (e.g. renderer crash before first paint).
@@ -301,11 +338,11 @@ function registerIpcHandlers(): void {
     return shell.openPath(dirPath);
   });
 
-  // Open external URL (https only)
+  // Open external URL (https, http, mailto)
   ipcMain.handle("open-external-url", (_event, url: string) => {
     try {
       const parsed = new URL(url);
-      if (parsed.protocol === "https:") {
+      if (["https:", "http:", "mailto:"].includes(parsed.protocol)) {
         shell.openExternal(url);
       }
     } catch {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -191,6 +191,24 @@ const MIME_MAP: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// External URL helper
+// ---------------------------------------------------------------------------
+
+/** Protocols that may be opened in the user's default browser. */
+const EXTERNAL_PROTOCOLS = new Set(["https:", "http:", "mailto:"]);
+
+/** Open a URL in the system browser if its protocol is allowed. */
+function openIfAllowed(url: string): void {
+  try {
+    if (EXTERNAL_PROTOCOLS.has(new URL(url).protocol)) {
+      void shell.openExternal(url);
+    }
+  } catch {
+    // Invalid URL, ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Application state
 // ---------------------------------------------------------------------------
 
@@ -226,38 +244,25 @@ function createWindow(): void {
   // Intercept target="_blank" and window.open() calls.
   // Deny the new window and open the URL in the system browser instead.
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    try {
-      const parsed = new URL(url);
-      if (["https:", "http:", "mailto:"].includes(parsed.protocol)) {
-        shell.openExternal(url);
-      }
-    } catch {
-      // Invalid URL, ignore
-    }
+    openIfAllowed(url);
     return { action: "deny" };
   });
 
   // Prevent the main window from navigating away from the app.
-  // Only allow the initial load URL (dev server or file://).
   mainWindow.webContents.on("will-navigate", (event, url) => {
     const currentUrl = mainWindow!.webContents.getURL();
-    // Allow same-origin navigation (SPA router)
+    // Allow same-origin navigation for the SPA router (dev mode http://localhost).
+    // In production (file://), origin is "null" so all navigation is blocked,
+    // which is correct since the SPA uses pushState routing.
     try {
       const current = new URL(currentUrl);
       const target = new URL(url);
-      if (current.origin === target.origin) return;
+      if (current.origin !== "null" && current.origin === target.origin) return;
     } catch {
-      // Parse error, block navigation
+      // Parse error, fall through to block
     }
     event.preventDefault();
-    try {
-      const parsed = new URL(url);
-      if (["https:", "http:", "mailto:"].includes(parsed.protocol)) {
-        shell.openExternal(url);
-      }
-    } catch {
-      // Invalid URL, ignore
-    }
+    openIfAllowed(url);
   });
 
   // Show the window as soon as the first frame is painted.
@@ -340,14 +345,7 @@ function registerIpcHandlers(): void {
 
   // Open external URL (https, http, mailto)
   ipcMain.handle("open-external-url", (_event, url: string) => {
-    try {
-      const parsed = new URL(url);
-      if (["https:", "http:", "mailto:"].includes(parsed.protocol)) {
-        shell.openExternal(url);
-      }
-    } catch {
-      // Invalid URL, ignore
-    }
+    openIfAllowed(url);
   });
 
   // Read clipboard image and save to temp JPEG

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -200,8 +200,9 @@ const EXTERNAL_PROTOCOLS = new Set(["https:", "http:", "mailto:"]);
 /** Open a URL in the system browser if its protocol is allowed. */
 function openIfAllowed(url: string): void {
   try {
-    if (EXTERNAL_PROTOCOLS.has(new URL(url).protocol)) {
-      void shell.openExternal(url);
+    const parsed = new URL(url);
+    if (EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
+      shell.openExternal(parsed.href).catch(() => {});
     }
   } catch {
     // Invalid URL, ignore

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -202,7 +202,9 @@ function openIfAllowed(url: string): void {
   try {
     const parsed = new URL(url);
     if (EXTERNAL_PROTOCOLS.has(parsed.protocol)) {
-      shell.openExternal(parsed.href).catch(() => {});
+      shell.openExternal(parsed.href).catch((err: unknown) => {
+        console.error(`[openIfAllowed] Failed to open ${parsed.protocol} URL: ${parsed.href}`, err);
+      });
     }
   } catch {
     // Invalid URL, ignore

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -48,7 +48,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   openInExplorer: (path: string): Promise<void> =>
     ipcRenderer.invoke("open-in-explorer", path),
 
-  /** Open a URL in the default browser (https only). */
+  /** Open a URL in the default browser (https, http, mailto). */
   openExternalUrl: (url: string): Promise<void> =>
     ipcRenderer.invoke("open-external-url", url),
 

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MarkdownContent } from "../components/chat/MarkdownContent";
+
+// Mock CodeBlock to avoid shiki/worker dependencies
+vi.mock("../components/chat/CodeBlock", () => ({
+  CodeBlock: ({ code }: { code: string }) => <pre>{code}</pre>,
+}));
+
+describe("MarkdownContent link handling", () => {
+  let mockOpenExternalUrl: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockOpenExternalUrl = vi.fn();
+    window.desktopBridge = {
+      openExternalUrl: mockOpenExternalUrl,
+    } as unknown as typeof window.desktopBridge;
+  });
+
+  it("calls desktopBridge.openExternalUrl for https links", () => {
+    render(<MarkdownContent content="[click me](https://example.com)" />);
+    const link = screen.getByText("click me");
+    fireEvent.click(link);
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("calls desktopBridge.openExternalUrl for http links", () => {
+    render(<MarkdownContent content="[click](http://example.com)" />);
+    const link = screen.getByText("click");
+    fireEvent.click(link);
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith("http://example.com");
+  });
+
+  it("calls desktopBridge.openExternalUrl for mailto links", () => {
+    render(<MarkdownContent content="[email](mailto:test@example.com)" />);
+    const link = screen.getByText("email");
+    fireEvent.click(link);
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith("mailto:test@example.com");
+  });
+
+  it("does not call desktopBridge for javascript: links", () => {
+    render(<MarkdownContent content='[xss](javascript:alert(1))' />);
+    const link = screen.getByText("xss");
+    fireEvent.click(link);
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("falls back to window.open when desktopBridge is unavailable", () => {
+    delete (window as Record<string, unknown>).desktopBridge;
+    const mockOpen = vi.fn();
+    vi.stubGlobal("open", mockOpen);
+
+    render(<MarkdownContent content="[link](https://example.com)" />);
+    fireEvent.click(screen.getByText("link"));
+    expect(mockOpen).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -46,7 +46,7 @@ describe("MarkdownContent link handling", () => {
   });
 
   it("falls back to window.open when desktopBridge is unavailable", () => {
-    delete (window as Record<string, unknown>).desktopBridge;
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
     const mockOpen = vi.fn();
     vi.stubGlobal("open", mockOpen);
 

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MarkdownContent } from "../components/chat/MarkdownContent";
 
@@ -15,6 +15,10 @@ describe("MarkdownContent link handling", () => {
     window.desktopBridge = {
       openExternalUrl: mockOpenExternalUrl,
     } as unknown as typeof window.desktopBridge;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
   });
 
   it("calls desktopBridge.openExternalUrl for https links", () => {
@@ -41,6 +45,13 @@ describe("MarkdownContent link handling", () => {
   it("does not call desktopBridge for javascript: links", () => {
     render(<MarkdownContent content='[xss](javascript:alert(1))' />);
     const link = screen.getByText("xss");
+    fireEvent.click(link);
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("does not call desktopBridge for data: URI links", () => {
+    render(<MarkdownContent content='[data](data:text/html,<h1>hi</h1>)' />);
+    const link = screen.getByText("data");
     fireEvent.click(link);
     expect(mockOpenExternalUrl).not.toHaveBeenCalled();
   });

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -19,6 +19,7 @@ describe("MarkdownContent link handling", () => {
 
   afterEach(() => {
     delete (window as unknown as Record<string, unknown>).desktopBridge;
+    vi.unstubAllGlobals();
   });
 
   it("calls desktopBridge.openExternalUrl for https links", () => {
@@ -64,7 +65,5 @@ describe("MarkdownContent link handling", () => {
     render(<MarkdownContent content="[link](https://example.com)" />);
     fireEvent.click(screen.getByText("link"));
     expect(mockOpen).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
-
-    vi.unstubAllGlobals();
   });
 });

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -33,6 +33,15 @@ const staticComponents = {
         className="text-primary underline hover:text-primary"
         target="_blank"
         rel="noopener noreferrer"
+        onClick={(e) => {
+          if (!safeHref) return;
+          e.preventDefault();
+          if (window.desktopBridge?.openExternalUrl) {
+            window.desktopBridge.openExternalUrl(safeHref);
+          } else {
+            window.open(safeHref, "_blank", "noopener,noreferrer");
+          }
+        }}
       >
         {children}
       </a>


### PR DESCRIPTION
## What

External links clicked inside the Electron app (markdown chat messages, `target="_blank"` anchors) now open in the system default browser instead of navigating within the app window.

## Why

Electron's default behavior for `<a target="_blank">` is to open a new BrowserWindow, causing links to render inside the app rather than the user's browser. This was confusing and broke the expected UX.

## Key Changes

- **Renderer (MarkdownContent.tsx):** Added `onClick` handler to markdown `<a>` elements that routes through `desktopBridge.openExternalUrl()` with a `window.open()` fallback for web mode
- **Main process (main.ts):** Added `setWindowOpenHandler` (denies all new windows, opens URL externally) and `will-navigate` listener (blocks cross-origin navigation) as defense-in-depth safety nets
- **IPC handler:** Expanded `open-external-url` protocol allowlist from `https:` only to `https:`, `http:`, and `mailto:`
- **Shared helper:** Extracted `openIfAllowed()` to deduplicate protocol validation across all three call sites; uses canonicalized `parsed.href` to avoid parser-differential risk
- **Tests:** 6 test cases covering https, http, mailto, javascript: blocking, data: URI blocking, and window.open fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External URL handling now supports https, http, and mailto with a safer click/fallback flow.

* **Security Improvements**
  * Added a protocol allowlist and tightened window/navigation handling to block unsafe or renderer-initiated navigations.

* **Tests**
  * Added tests verifying secure link handling and fallbacks for desktop/web environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->