### PR TITLE
feat: show context window usage gauge for Copilot sessions

### DIFF
--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -2,6 +2,37 @@ import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import type { AgentEvent } from "@mcode/contracts";
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal mock CopilotSession whose `on()` stores handlers by event
+ * name and returns a no-op unsubscriber. Call `fire(eventName, data)` to
+ * invoke all registered handlers for that event.
+ */
+function makeMockSession() {
+  const handlers = new Map<string, Array<(event: { data: unknown }) => void>>();
+
+  const session = {
+    sessionId: "sdk-session-123",
+    on: vi.fn((eventName: string, handler: (event: { data: unknown }) => void) => {
+      if (!handlers.has(eventName)) handlers.set(eventName, []);
+      handlers.get(eventName)!.push(handler);
+      return () => {};
+    }),
+    send: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    fire(eventName: string, data?: unknown) {
+      for (const h of handlers.get(eventName) ?? []) {
+        h({ data });
+      }
+    },
+  };
+
+  return session;
+}
+
 // --- Mocks (hoisted to avoid TDZ issues with vi.mock) ---
 
 const { mockExecFile, mockClient, MockCopilotClient } = vi.hoisted(() => {
@@ -201,5 +232,118 @@ describe("CopilotProvider bootstrap", () => {
       expect(errorEvt).toBeDefined();
       expect(errorEvt?.type === "error" && errorEvt.error).toContain("npm install");
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// session.usage_info → ContextEstimate
+// ---------------------------------------------------------------------------
+
+describe("CopilotProvider session.usage_info", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.getState.mockReturnValue("connected");
+    mockClient.start.mockResolvedValue(undefined);
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, result?: { stdout: string }) => void) => {
+        cb(null, { stdout: "gho_faketoken\n" });
+      },
+    );
+  });
+
+  /**
+   * Helper: run sendMessage with a mock session that fires the given events
+   * in sequence after send() resolves, then fires session.idle to end the turn.
+   */
+  async function runWithSession(
+    eventSequence: Array<{ name: string; data?: unknown }>,
+  ): Promise<{ events: AgentEvent[] }> {
+    const mockSession = makeMockSession();
+
+    mockClient.getState.mockReturnValue("connected");
+    mockClient.createSession.mockResolvedValue(mockSession);
+
+    // After send() is called, fire the event sequence then resolve idle.
+    mockSession.send.mockImplementation(async () => {
+      for (const evt of eventSequence) {
+        mockSession.fire(evt.name, evt.data);
+      }
+      mockSession.fire("session.idle");
+    });
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+    const events: AgentEvent[] = [];
+    provider.on("event", (e: AgentEvent) => events.push(e));
+
+    await provider.sendMessage({
+      sessionId: "mcode-ctx-test",
+      message: "hello",
+      cwd: "/tmp",
+      model: "gpt-4o",
+      resume: false,
+      permissionMode: "auto",
+    });
+
+    return { events };
+  }
+
+  it("emits a contextEstimate event when session.usage_info fires", async () => {
+    const { events } = await runWithSession([
+      {
+        name: "session.usage_info",
+        data: {
+          tokenLimit: 128000,
+          currentTokens: 5000,
+          systemTokens: 1000,
+          conversationTokens: 4000,
+        },
+      },
+    ]);
+
+    const ctxEvt = events.find((e) => e.type === "contextEstimate");
+    expect(ctxEvt).toBeDefined();
+    expect(ctxEvt?.type === "contextEstimate" && ctxEvt.tokensIn).toBe(5000);
+    expect(ctxEvt?.type === "contextEstimate" && ctxEvt.contextWindow).toBe(128000);
+  });
+
+  it("populates contextWindow on turnComplete using the cached tokenLimit", async () => {
+    const { events } = await runWithSession([
+      {
+        name: "session.usage_info",
+        data: { tokenLimit: 128000, currentTokens: 5000 },
+      },
+      {
+        name: "assistant.usage",
+        data: { inputTokens: 5000, outputTokens: 200, cacheReadTokens: 0 },
+      },
+    ]);
+
+    const turnEvt = events.find((e) => e.type === "turnComplete");
+    expect(turnEvt).toBeDefined();
+    expect(turnEvt?.type === "turnComplete" && turnEvt.contextWindow).toBe(128000);
+  });
+
+  it("leaves contextWindow undefined on turnComplete when no usage_info fired", async () => {
+    const { events } = await runWithSession([
+      {
+        name: "assistant.usage",
+        data: { inputTokens: 1000, outputTokens: 100, cacheReadTokens: 0 },
+      },
+    ]);
+
+    const turnEvt = events.find((e) => e.type === "turnComplete");
+    expect(turnEvt).toBeDefined();
+    expect(turnEvt?.type === "turnComplete" && turnEvt.contextWindow).toBeUndefined();
+  });
+
+  it("does not emit contextEstimate when session.usage_info is not fired", async () => {
+    const { events } = await runWithSession([
+      {
+        name: "assistant.message",
+        data: { content: "hello", outputTokens: 10 },
+      },
+    ]);
+
+    expect(events.find((e) => e.type === "contextEstimate")).toBeUndefined();
   });
 });

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -535,6 +535,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
               error: event.data.message,
             } satisfies AgentEvent);
             this.sessions.delete(sessionId);
+            this.contextWindowBySession.delete(sessionId);
             resolve();
           }),
         );

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -171,11 +171,11 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       opts.cliPath = configuredCliPath;
     }
 
-    // Electron fix: utilityProcess.fork sets process.execPath to
-    // electron.exe. The SDK's getNodeExecPath() reads process.execPath
-    // to spawn .js CLI files. Rather than mutating the global, we
-    // prepend the real node binary's directory to PATH in the env we
-    // pass to the SDK so `node` resolves correctly in the child process.
+    // Electron fix: resolve the real node binary path once. The SDK's
+    // getNodeExecPath() reads process.execPath to spawn .js CLI files,
+    // but in Electron that returns electron.exe which cannot host the
+    // CLI's server mode. We temporarily override process.execPath during
+    // client.start() and also prepend node's directory to PATH.
     if (process.versions.electron && !configuredCliPath) {
       if (this.cachedNodePath === undefined) {
         this.cachedNodePath = await which("node", { nothrow: true });
@@ -213,7 +213,21 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     const client = new CopilotClient(opts as ConstructorParameters<typeof CopilotClient>[0]);
     // The SDK's createSession() auto-starts the connection, but listModels()
     // does not. Eagerly start the client so both paths work.
-    await client.start();
+    //
+    // Electron fix: the SDK reads process.execPath to spawn the CLI .js file.
+    // In Electron that returns electron.exe, causing the CLI to exit immediately.
+    // Temporarily override process.execPath with the real node binary.
+    if (process.versions.electron && this.cachedNodePath) {
+      const origExecPath = process.execPath;
+      process.execPath = this.cachedNodePath;
+      try {
+        await client.start();
+      } finally {
+        process.execPath = origExecPath;
+      }
+    } else {
+      await client.start();
+    }
     // Assign only after start() succeeds so a failed startup never leaves
     // a stale non-started client on the instance.
     this.client = client;
@@ -225,6 +239,9 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   private toThreadId(sessionId: string): string {
     return sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
   }
+
+  /** Cached context window limit from the last session.usage_info event, keyed by sessionId. */
+  private contextWindowBySession = new Map<string, number>();
 
   /** Start or continue a session by sending a message via the Copilot SDK. */
   async sendMessage(params: {
@@ -471,11 +488,29 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
+        // session.usage_info — live context window metrics emitted each turn
+        unsubscribers.push(
+          session.on("session.usage_info", (event) => {
+            const { tokenLimit, currentTokens } = event.data as {
+              tokenLimit: number;
+              currentTokens: number;
+            };
+            this.contextWindowBySession.set(sessionId, tokenLimit);
+            this.emit("event", {
+              type: "contextEstimate",
+              threadId,
+              tokensIn: currentTokens,
+              contextWindow: tokenLimit,
+            } satisfies AgentEvent);
+          }),
+        );
+
         // assistant.usage — token counts after a model call
         unsubscribers.push(
           session.on("assistant.usage", (event) => {
             const { inputTokens = 0, outputTokens = 0, cacheReadTokens = 0 } = event.data;
             const tokensIn = inputTokens + cacheReadTokens;
+            const contextWindow = this.contextWindowBySession.get(sessionId);
             this.emit("event", {
               type: "turnComplete",
               threadId,
@@ -483,7 +518,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
               costUsd: null,
               tokensIn,
               tokensOut: outputTokens,
-              contextWindow: undefined,
+              contextWindow,
               totalProcessedTokens: tokensIn + outputTokens,
             } satisfies AgentEvent);
           }),
@@ -576,6 +611,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
         this.sessions.delete(sessionId);
+        this.contextWindowBySession.delete(sessionId);
       }
     }
   }
@@ -587,6 +623,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
 
   /** Disconnect and remove an active session. */
   stopSession(sessionId: string): void {
+    this.contextWindowBySession.delete(sessionId);
     const entry = this.sessions.get(sessionId);
     if (entry) {
       entry.session.disconnect().catch((err) =>
@@ -616,6 +653,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     }
     this.sessions.clear();
     this.sdkSessionIds.clear();
+    this.contextWindowBySession.clear();
 
     if (this.client) {
       this.client.stop().catch((err) =>

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -4,6 +4,7 @@
  * Extracted from apps/desktop/src/main/pty-manager.ts.
  */
 
+import { createRequire } from "node:module";
 import { injectable, inject } from "tsyringe";
 import { isAbsolute } from "path";
 import { existsSync, statSync } from "fs";
@@ -15,6 +16,10 @@ import type { ThreadRepo } from "../repositories/thread-repo";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { GitService } from "./git-service";
 
+// createRequire lets us load native CJS modules (node-pty) from both ESM
+// (dev mode via entry.mjs + tsx) and the CJS production bundle.
+const _require = createRequire(import.meta.url);
+
 /**
  * Lazily load node-pty's spawn function. Deferred to avoid crashing the server
  * at startup if the native binding is missing or incompatible - the error is
@@ -23,8 +28,7 @@ import type { GitService } from "./git-service";
 let _spawn: typeof import("node-pty").spawn | undefined;
 function getSpawn(): typeof import("node-pty").spawn {
   if (!_spawn) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    _spawn = (require("node-pty") as typeof import("node-pty")).spawn;
+    _spawn = (_require("node-pty") as typeof import("node-pty")).spawn;
   }
   return _spawn;
 }

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1259,7 +1259,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           {threadId && (
             <ContextTracker
               tokensIn={contextEntry?.lastTokensIn ?? activeThread?.last_context_tokens ?? 0}
-              contextWindow={contextEntry?.contextWindow ?? (activeThread?.provider === "claude" ? activeThread.context_window ?? undefined : undefined)}
+              contextWindow={contextEntry?.contextWindow ?? activeThread?.context_window ?? undefined}
               totalProcessedTokens={contextEntry?.totalProcessedTokens}
             />
           )}


### PR DESCRIPTION
## What

Surface live context window usage for Copilot sessions via the existing `ContextTracker` ring gauge.

## Why

The Copilot SDK emits `session.usage_info` events with `tokenLimit` and `currentTokens` each turn, but this data was not wired through to the UI. Users had no visibility into how much context headroom remained during Copilot sessions.

## Key changes

- **`copilot-provider.ts`**: Add `session.usage_info` event handler that emits `ContextEstimate` events and caches `tokenLimit` per session. Populate `contextWindow` on `TurnComplete` events. Also fix Electron `process.execPath` override so the SDK spawns the CLI with `node` instead of `electron.exe`.
- **`Composer.tsx`**: Remove `provider === "claude"` guard on the `contextWindow` fallback so all providers show the gauge.
- **`terminal-service.ts`**: Replace bare `require("node-pty")` with `createRequire` from `node:module` to fix `require is not defined` in ESM dev mode.
- **`copilot-provider.test.ts`**: Add 4 tests covering `session.usage_info` event handling and `contextWindow` propagation to `TurnComplete`.

## Test plan

- [x] All 303 server tests pass
- [x] All 547 frontend tests pass
- [x] Verify context gauge appears during a Copilot session
- [x] Verify gauge updates after each turn
- [ ] Verify 80%+ threshold triggers amber/red warning color

Closes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-session context window tracking and on-the-fly context estimates for Copilot sessions to surface token capacity.

* **Improvements**
  * More accurate propagation of context window in session/turn events and cleanup of stale context data.
  * Better runtime compatibility for terminal/agent startup and simplified context-fallback logic in the chat composer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->