### PR TITLE
feat: per-thread panel state for terminal and right panel

### DIFF
--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -86,10 +86,12 @@ describe("killProcessTree", () => {
       });
 
       await expect(killProcessTree(5678)).resolves.toBeUndefined();
-      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      // ESRCH means process already gone - expected; logged at debug, not warn.
+      expect(vi.mocked(logger.debug)).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ pid: 5678 }),
       );
+      expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
       killSpy.mockRestore();
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -16,6 +16,21 @@ const execFile = promisify(execFileCb);
 const TASKKILL_TIMEOUT_MS = 5_000;
 
 /**
+ * Returns true when the error indicates the process was already gone.
+ * These are expected when killProcessTree is called after the PTY shell has
+ * already exited (e.g. the cleanup pass after pty.kill()).
+ */
+function isProcessGoneError(err: unknown): boolean {
+  const e = err as NodeJS.ErrnoException & { code?: string | number; stderr?: string };
+  // Unix: ESRCH = no such process
+  if (e.code === "ESRCH") return true;
+  // Windows: taskkill exits with code 128 when the PID is not found
+  if (typeof e.code === "number" && e.code === 128) return true;
+  if (typeof e.stderr === "string" && /not found/i.test(e.stderr)) return true;
+  return false;
+}
+
+/**
  * Kill an entire process tree rooted at the given PID.
  * Best-effort: never throws. The process may already be dead.
  */
@@ -32,9 +47,14 @@ export async function killProcessTree(pid: number): Promise<void> {
       }
     }
   } catch (err) {
-    logger.warn("killProcessTree: process may already be dead", {
-      pid,
-      error: err instanceof Error ? err.message : String(err),
-    });
+    if (isProcessGoneError(err)) {
+      // Expected when the process already exited (e.g. cleanup pass after pty.kill()).
+      logger.debug("killProcessTree: process already gone", { pid });
+    } else {
+      logger.warn("killProcessTree: unexpected error killing process tree", {
+        pid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 }

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -209,10 +209,10 @@ export class TerminalService {
         error: err,
       });
     }
-    // Kill the entire process tree (grandchildren like git, npm) before the PTY
-    // shell itself. On Windows, pty.kill() only kills the direct shell process;
-    // grandchildren survive and keep the worktree directory locked.
-    await killProcessTree(session.pty.pid);
+    // Kill the PTY first so node-pty's conpty cleanup agent (conpty_console_list_agent)
+    // can AttachConsole while the shell process is still alive. If we run
+    // killProcessTree first, the shell is already dead when the agent forks and
+    // AttachConsole fails with "AttachConsole failed".
     try {
       session.pty.kill();
     } catch (err) {
@@ -221,6 +221,10 @@ export class TerminalService {
         error: err,
       });
     }
+    // Kill any grandchildren (git, npm, etc.) that were not attached to the
+    // console and therefore missed by node-pty's process list enumeration.
+    // Best-effort: the shell may already be dead at this point.
+    await killProcessTree(session.pty.pid);
   }
 
   private removePty(ptyId: string): void {

--- a/apps/web/src/__tests__/TerminalStatusIndicator.test.tsx
+++ b/apps/web/src/__tests__/TerminalStatusIndicator.test.tsx
@@ -8,8 +8,7 @@ describe("TerminalStatusIndicator", () => {
   beforeEach(() => {
     useTerminalStore.setState({
       terminals: {},
-      activeTerminalId: null,
-      panelVisible: false,
+      terminalPanelByThread: {},
       splitMode: false,
     });
     useWorkspaceStore.setState({
@@ -77,13 +76,13 @@ describe("TerminalStatusIndicator", () => {
       terminals: {
         "thread-1": [{ id: "pty-1", threadId: "thread-1", label: "Terminal 1" }],
       },
-      panelVisible: false,
+      terminalPanelByThread: { "thread-1": { visible: false, height: 300, activeTerminalId: null } },
     });
 
     render(<TerminalStatusIndicator />);
     fireEvent.click(screen.getByRole("button"));
 
-    expect(useTerminalStore.getState().panelVisible).toBe(true);
+    expect(useTerminalStore.getState().terminalPanelByThread["thread-1"]?.visible).toBe(true);
   });
 
   it("toggles panel off when clicked while panel is visible", () => {
@@ -91,12 +90,12 @@ describe("TerminalStatusIndicator", () => {
       terminals: {
         "thread-1": [{ id: "pty-1", threadId: "thread-1", label: "Terminal 1" }],
       },
-      panelVisible: true,
+      terminalPanelByThread: { "thread-1": { visible: true, height: 300, activeTerminalId: null } },
     });
 
     render(<TerminalStatusIndicator />);
     fireEvent.click(screen.getByRole("button"));
 
-    expect(useTerminalStore.getState().panelVisible).toBe(false);
+    expect(useTerminalStore.getState().terminalPanelByThread["thread-1"]?.visible).toBe(false);
   });
 });

--- a/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
+++ b/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
@@ -171,7 +171,7 @@ describe("Agent event thread isolation", () => {
       await Promise.resolve();
 
       const { useDiffStore } = await import("@/stores/diffStore");
-      expect(useDiffStore.getState().panelVisible).toBe(false);
+      expect(useDiffStore.getState().rightPanelByThread[THREAD_A]?.visible).toBeFalsy();
     });
 
     it("opens task panel when TodoWrite fires on the active thread", async () => {
@@ -190,13 +190,13 @@ describe("Agent event thread isolation", () => {
       await Promise.resolve();
 
       const { useDiffStore } = await import("@/stores/diffStore");
-      expect(useDiffStore.getState().panelVisible).toBe(true);
+      expect(useDiffStore.getState().rightPanelByThread[THREAD_A]?.visible).toBe(true);
     });
 
     it("does not open task panel if user switches threads before the import resolves", async () => {
       // Reset panel state from previous tests
       const { useDiffStore } = await import("@/stores/diffStore");
-      useDiffStore.setState({ panelVisible: false });
+      useDiffStore.setState({ rightPanelByThread: {} });
 
       const { handleAgentEvent } = useThreadStore.getState();
 
@@ -216,7 +216,7 @@ describe("Agent event thread isolation", () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(useDiffStore.getState().panelVisible).toBe(false);
+      expect(useDiffStore.getState().rightPanelByThread[THREAD_A]?.visible).toBeFalsy();
     });
   });
 

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useDiffStore,
+  RIGHT_PANEL_DEFAULTS,
+  PANEL_DEFAULT_WIDTH,
+  PANEL_MIN_WIDTH,
+} from "../stores/diffStore";
+
+describe("diffStore", () => {
+  beforeEach(() => {
+    useDiffStore.setState({
+      rightPanelByThread: {},
+      snapshotsByThread: {},
+      snapshotsLoadingByThread: {},
+      commitsByThread: {},
+      commitsLoadingByThread: {},
+      selectedFile: null,
+      diffContent: null,
+      diffLoading: false,
+      viewMode: "by-turn",
+      renderMode: "unified",
+      lineWrap: false,
+    });
+  });
+
+  describe("getRightPanel", () => {
+    it("should return defaults for unknown thread", () => {
+      const { getRightPanel } = useDiffStore.getState();
+      expect(getRightPanel("unknown")).toEqual(RIGHT_PANEL_DEFAULTS);
+    });
+
+    it("should return stored state for known thread", () => {
+      const { showRightPanel, getRightPanel } = useDiffStore.getState();
+      showRightPanel("thread-1");
+      expect(getRightPanel("thread-1").visible).toBe(true);
+    });
+  });
+
+  describe("toggleRightPanel", () => {
+    it("should flip visibility for one thread", () => {
+      const { toggleRightPanel, getRightPanel } = useDiffStore.getState();
+      toggleRightPanel("thread-1");
+      expect(getRightPanel("thread-1").visible).toBe(true);
+      toggleRightPanel("thread-1");
+      expect(getRightPanel("thread-1").visible).toBe(false);
+    });
+
+    it("should not affect other threads", () => {
+      const { toggleRightPanel, getRightPanel } = useDiffStore.getState();
+      toggleRightPanel("thread-1");
+      expect(getRightPanel("thread-2").visible).toBe(false);
+    });
+  });
+
+  describe("showRightPanel / hideRightPanel", () => {
+    it("showRightPanel sets visible true without affecting width", () => {
+      const { showRightPanel, setRightPanelWidth, getRightPanel } = useDiffStore.getState();
+      setRightPanelWidth("thread-1", 500);
+      showRightPanel("thread-1");
+      const panel = getRightPanel("thread-1");
+      expect(panel.visible).toBe(true);
+      expect(panel.width).toBe(500);
+    });
+
+    it("hideRightPanel sets visible false without affecting tab", () => {
+      const { showRightPanel, hideRightPanel, setRightPanelTab, getRightPanel } = useDiffStore.getState();
+      showRightPanel("thread-1");
+      setRightPanelTab("thread-1", "changes");
+      hideRightPanel("thread-1");
+      const panel = getRightPanel("thread-1");
+      expect(panel.visible).toBe(false);
+      expect(panel.activeTab).toBe("changes");
+    });
+  });
+
+  describe("setRightPanelWidth", () => {
+    it("should update width for one thread", () => {
+      const { setRightPanelWidth, getRightPanel } = useDiffStore.getState();
+      setRightPanelWidth("thread-1", 500);
+      expect(getRightPanel("thread-1").width).toBe(500);
+      expect(getRightPanel("thread-2").width).toBe(PANEL_DEFAULT_WIDTH);
+    });
+
+    it("should clamp width to PANEL_MIN_WIDTH", () => {
+      const { setRightPanelWidth, getRightPanel } = useDiffStore.getState();
+      setRightPanelWidth("thread-1", 100);
+      expect(getRightPanel("thread-1").width).toBe(PANEL_MIN_WIDTH);
+    });
+  });
+
+  describe("setRightPanelTab", () => {
+    it("should update active tab for one thread only", () => {
+      const { setRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("thread-1", "changes");
+      expect(getRightPanel("thread-1").activeTab).toBe("changes");
+      expect(getRightPanel("thread-2").activeTab).toBe("tasks");
+    });
+  });
+
+  describe("clearThread", () => {
+    it("should remove rightPanelByThread entry", () => {
+      const { showRightPanel, clearThread, getRightPanel } = useDiffStore.getState();
+      showRightPanel("thread-1");
+      clearThread("thread-1");
+      expect(useDiffStore.getState().rightPanelByThread["thread-1"]).toBeUndefined();
+      expect(getRightPanel("thread-1")).toEqual(RIGHT_PANEL_DEFAULTS);
+    });
+
+    it("should not affect other threads' panel state", () => {
+      const { showRightPanel, clearThread, getRightPanel } = useDiffStore.getState();
+      showRightPanel("thread-1");
+      showRightPanel("thread-2");
+      clearThread("thread-1");
+      expect(getRightPanel("thread-2").visible).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -113,5 +113,31 @@ describe("diffStore", () => {
       clearThread("thread-1");
       expect(getRightPanel("thread-2").visible).toBe(true);
     });
+
+    it("should clear selectedFile when it belongs to deleted thread", () => {
+      useDiffStore.setState({
+        selectedFile: { source: "snapshot", id: "snap-1", filePath: "a.ts", threadId: "thread-1" },
+        diffContent: "diff text",
+        diffLoading: true,
+      });
+      useDiffStore.getState().clearThread("thread-1");
+      const state = useDiffStore.getState();
+      expect(state.selectedFile).toBeNull();
+      expect(state.diffContent).toBeNull();
+      expect(state.diffLoading).toBe(false);
+    });
+
+    it("should preserve selectedFile when it belongs to a different thread", () => {
+      const file = { source: "commit" as const, id: "abc123", filePath: "b.ts", threadId: "thread-2" };
+      useDiffStore.setState({
+        selectedFile: file,
+        diffContent: "other diff",
+        diffLoading: false,
+      });
+      useDiffStore.getState().clearThread("thread-1");
+      const state = useDiffStore.getState();
+      expect(state.selectedFile).toEqual(file);
+      expect(state.diffContent).toBe("other diff");
+    });
   });
 });

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -98,20 +98,45 @@ describe("diffStore", () => {
   });
 
   describe("clearThread", () => {
-    it("should remove rightPanelByThread entry", () => {
-      const { showRightPanel, clearThread, getRightPanel } = useDiffStore.getState();
+    it("should remove all per-thread entries", () => {
+      const { showRightPanel, setSnapshots, setSnapshotsLoading, setCommits, setCommitsLoading, clearThread, getRightPanel } =
+        useDiffStore.getState();
       showRightPanel("thread-1");
+      setSnapshots("thread-1", [{ id: "s1" } as never]);
+      setSnapshotsLoading("thread-1", true);
+      setCommits("thread-1", [{ sha: "c1" } as never]);
+      setCommitsLoading("thread-1", true);
+
       clearThread("thread-1");
-      expect(useDiffStore.getState().rightPanelByThread["thread-1"]).toBeUndefined();
+
+      const state = useDiffStore.getState();
+      expect(state.rightPanelByThread["thread-1"]).toBeUndefined();
       expect(getRightPanel("thread-1")).toEqual(RIGHT_PANEL_DEFAULTS);
+      expect(state.snapshotsByThread["thread-1"]).toBeUndefined();
+      expect(state.snapshotsLoadingByThread["thread-1"]).toBeUndefined();
+      expect(state.commitsByThread["thread-1"]).toBeUndefined();
+      expect(state.commitsLoadingByThread["thread-1"]).toBeUndefined();
     });
 
-    it("should not affect other threads' panel state", () => {
-      const { showRightPanel, clearThread, getRightPanel } = useDiffStore.getState();
+    it("should not affect other threads", () => {
+      const { showRightPanel, setSnapshots, setSnapshotsLoading, setCommits, setCommitsLoading, clearThread, getRightPanel } =
+        useDiffStore.getState();
       showRightPanel("thread-1");
       showRightPanel("thread-2");
+      setSnapshots("thread-1", [{ id: "s1" } as never]);
+      setSnapshots("thread-2", [{ id: "s2" } as never]);
+      setSnapshotsLoading("thread-2", true);
+      setCommits("thread-2", [{ sha: "c2" } as never]);
+      setCommitsLoading("thread-2", true);
+
       clearThread("thread-1");
+
+      const state = useDiffStore.getState();
       expect(getRightPanel("thread-2").visible).toBe(true);
+      expect(state.snapshotsByThread["thread-2"]).toHaveLength(1);
+      expect(state.snapshotsLoadingByThread["thread-2"]).toBe(true);
+      expect(state.commitsByThread["thread-2"]).toHaveLength(1);
+      expect(state.commitsLoadingByThread["thread-2"]).toBe(true);
     });
 
     it("should clear selectedFile when it belongs to deleted thread", () => {

--- a/apps/web/src/__tests__/terminalStore.test.ts
+++ b/apps/web/src/__tests__/terminalStore.test.ts
@@ -142,15 +142,17 @@ describe("TerminalStore", () => {
   });
 
   describe("removeAllTerminals", () => {
-    it("should remove terminals and panel state for the thread", () => {
+    it("should remove terminals but preserve panel config", () => {
       const { addTerminal, removeAllTerminals, getTerminalPanel } = useTerminalStore.getState();
       addTerminal("thread-1", "pty-1");
       removeAllTerminals("thread-1");
 
       const state = useTerminalStore.getState();
       expect(state.terminals["thread-1"]).toBeUndefined();
-      expect(state.terminalPanelByThread["thread-1"]).toBeUndefined();
-      expect(getTerminalPanel("thread-1")).toEqual(TERMINAL_PANEL_DEFAULTS);
+      // Panel config preserved (height, visibility) but activeTerminalId nulled.
+      const panel = getTerminalPanel("thread-1");
+      expect(panel.visible).toBe(true);
+      expect(panel.activeTerminalId).toBeNull();
     });
 
     it("should not affect other threads", () => {
@@ -180,6 +182,29 @@ describe("TerminalStore", () => {
       useTerminalStore.getState().removeAllTerminals("thread-1");
 
       expect(useTerminalStore.getState().terminals["thread-2"]).toHaveLength(1);
+    });
+  });
+
+  describe("clearThread", () => {
+    it("should remove both terminals and panel state", () => {
+      const { addTerminal, clearThread, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      clearThread("thread-1");
+
+      const state = useTerminalStore.getState();
+      expect(state.terminals["thread-1"]).toBeUndefined();
+      expect(state.terminalPanelByThread["thread-1"]).toBeUndefined();
+      expect(getTerminalPanel("thread-1")).toEqual(TERMINAL_PANEL_DEFAULTS);
+    });
+
+    it("should not affect other threads", () => {
+      const { addTerminal, clearThread, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      addTerminal("thread-2", "pty-2");
+      clearThread("thread-1");
+
+      expect(getTerminalPanel("thread-2").visible).toBe(true);
+      expect(getTerminalPanel("thread-2").activeTerminalId).toBe("pty-2");
     });
   });
 

--- a/apps/web/src/__tests__/terminalStore.test.ts
+++ b/apps/web/src/__tests__/terminalStore.test.ts
@@ -1,36 +1,36 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useTerminalStore } from "@/stores/terminalStore";
+import { useTerminalStore, TerminalPanelState, TERMINAL_PANEL_DEFAULTS } from "@/stores/terminalStore";
 
 describe("TerminalStore", () => {
   beforeEach(() => {
     useTerminalStore.setState({
       terminals: {},
-      activeTerminalId: null,
-      panelVisible: false,
+      terminalPanelByThread: {},
       splitMode: false,
     });
   });
 
   describe("addTerminal", () => {
-    it("adds a terminal to the specified thread", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
+    it("should add a terminal and set per-thread panel state", () => {
+      const { addTerminal, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
 
-      const terminals = useTerminalStore.getState().terminals["thread-1"];
-      expect(terminals).toHaveLength(1);
-      expect(terminals![0].id).toBe("pty-1");
-      expect(terminals![0].threadId).toBe("thread-1");
+      const state = useTerminalStore.getState();
+      expect(state.terminals["thread-1"]).toHaveLength(1);
+      expect(state.terminals["thread-1"]![0]!.id).toBe("pty-1");
+
+      const panel = getTerminalPanel("thread-1");
+      expect(panel.visible).toBe(true);
+      expect(panel.activeTerminalId).toBe("pty-1");
     });
 
-    it("sets added terminal as active", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
+    it("should isolate panel state between threads", () => {
+      const { addTerminal, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      addTerminal("thread-2", "pty-2");
 
-      expect(useTerminalStore.getState().activeTerminalId).toBe("pty-1");
-    });
-
-    it("shows the panel when a terminal is added", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-
-      expect(useTerminalStore.getState().panelVisible).toBe(true);
+      expect(getTerminalPanel("thread-1").activeTerminalId).toBe("pty-1");
+      expect(getTerminalPanel("thread-2").activeTerminalId).toBe("pty-2");
     });
 
     it("adds multiple terminals to the same thread", () => {
@@ -95,22 +95,21 @@ describe("TerminalStore", () => {
       expect(terminals![0].id).toBe("pty-2");
     });
 
-    it("picks next available terminal when active is removed", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-      useTerminalStore.getState().addTerminal("thread-1", "pty-2");
-      useTerminalStore.getState().setActiveTerminal("pty-1");
+    it("should set activeTerminalId to first remaining when active is removed", () => {
+      const { addTerminal, removeTerminal, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      addTerminal("thread-1", "pty-2");
+      removeTerminal("pty-2");
 
-      useTerminalStore.getState().removeTerminal("pty-1");
-
-      expect(useTerminalStore.getState().activeTerminalId).toBe("pty-2");
+      expect(getTerminalPanel("thread-1").activeTerminalId).toBe("pty-1");
     });
 
-    it("sets active to null when last terminal is removed", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
+    it("should set activeTerminalId to null when last terminal removed", () => {
+      const { addTerminal, removeTerminal, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      removeTerminal("pty-1");
 
-      useTerminalStore.getState().removeTerminal("pty-1");
-
-      expect(useTerminalStore.getState().activeTerminalId).toBeNull();
+      expect(getTerminalPanel("thread-1").activeTerminalId).toBeNull();
     });
 
     it("does nothing for unknown ptyId", () => {
@@ -120,6 +119,15 @@ describe("TerminalStore", () => {
 
       const terminals = useTerminalStore.getState().terminals["thread-1"];
       expect(terminals).toHaveLength(1);
+    });
+
+    it("should not affect other threads", () => {
+      const { addTerminal, removeTerminal, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      addTerminal("thread-2", "pty-2");
+      removeTerminal("pty-1");
+
+      expect(getTerminalPanel("thread-2").activeTerminalId).toBe("pty-2");
     });
 
     it("removes terminal from correct thread when multiple threads exist", () => {
@@ -134,6 +142,27 @@ describe("TerminalStore", () => {
   });
 
   describe("removeAllTerminals", () => {
+    it("should remove terminals and panel state for the thread", () => {
+      const { addTerminal, removeAllTerminals, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      removeAllTerminals("thread-1");
+
+      const state = useTerminalStore.getState();
+      expect(state.terminals["thread-1"]).toBeUndefined();
+      expect(state.terminalPanelByThread["thread-1"]).toBeUndefined();
+      expect(getTerminalPanel("thread-1")).toEqual(TERMINAL_PANEL_DEFAULTS);
+    });
+
+    it("should not affect other threads", () => {
+      const { addTerminal, removeAllTerminals, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      addTerminal("thread-2", "pty-2");
+      removeAllTerminals("thread-1");
+
+      expect(getTerminalPanel("thread-2").visible).toBe(true);
+      expect(getTerminalPanel("thread-2").activeTerminalId).toBe("pty-2");
+    });
+
     it("removes all terminals for a thread", () => {
       useTerminalStore.getState().addTerminal("thread-1", "pty-1");
       useTerminalStore.getState().addTerminal("thread-1", "pty-2");
@@ -144,25 +173,7 @@ describe("TerminalStore", () => {
       expect(terminals).toBeUndefined();
     });
 
-    it("hides the panel", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-      expect(useTerminalStore.getState().panelVisible).toBe(true);
-
-      useTerminalStore.getState().removeAllTerminals("thread-1");
-
-      expect(useTerminalStore.getState().panelVisible).toBe(false);
-    });
-
-    it("clears active terminal if it belonged to the removed thread", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-      expect(useTerminalStore.getState().activeTerminalId).toBe("pty-1");
-
-      useTerminalStore.getState().removeAllTerminals("thread-1");
-
-      expect(useTerminalStore.getState().activeTerminalId).toBeNull();
-    });
-
-    it("does not affect other threads", () => {
+    it("does not affect other threads terminals", () => {
       useTerminalStore.getState().addTerminal("thread-1", "pty-1");
       useTerminalStore.getState().addTerminal("thread-2", "pty-2");
 
@@ -172,48 +183,52 @@ describe("TerminalStore", () => {
     });
   });
 
-  describe("setActiveTerminal", () => {
-    it("sets the active terminal id", () => {
-      useTerminalStore.getState().setActiveTerminal("pty-1");
-
-      expect(useTerminalStore.getState().activeTerminalId).toBe("pty-1");
+  describe("per-thread panel actions", () => {
+    it("getTerminalPanel returns defaults for unknown thread", () => {
+      const { getTerminalPanel } = useTerminalStore.getState();
+      expect(getTerminalPanel("unknown")).toEqual(TERMINAL_PANEL_DEFAULTS);
     });
 
-    it("sets active terminal to null", () => {
-      useTerminalStore.getState().setActiveTerminal("pty-1");
-      useTerminalStore.getState().setActiveTerminal(null);
-
-      expect(useTerminalStore.getState().activeTerminalId).toBeNull();
-    });
-  });
-
-  describe("togglePanel", () => {
-    it("toggles panel visibility on", () => {
-      useTerminalStore.getState().togglePanel();
-
-      expect(useTerminalStore.getState().panelVisible).toBe(true);
+    it("toggleTerminalPanel flips visibility for one thread only", () => {
+      const { toggleTerminalPanel, getTerminalPanel } = useTerminalStore.getState();
+      toggleTerminalPanel("thread-1");
+      expect(getTerminalPanel("thread-1").visible).toBe(true);
+      toggleTerminalPanel("thread-1");
+      expect(getTerminalPanel("thread-1").visible).toBe(false);
     });
 
-    it("toggles panel visibility off", () => {
-      useTerminalStore.getState().togglePanel();
-      useTerminalStore.getState().togglePanel();
-
-      expect(useTerminalStore.getState().panelVisible).toBe(false);
-    });
-  });
-
-  describe("showPanel / hidePanel", () => {
-    it("shows the panel", () => {
-      useTerminalStore.getState().showPanel();
-
-      expect(useTerminalStore.getState().panelVisible).toBe(true);
+    it("showTerminalPanel sets visible true without affecting other fields", () => {
+      const { showTerminalPanel, setTerminalPanelHeight, getTerminalPanel } = useTerminalStore.getState();
+      setTerminalPanelHeight("thread-1", 450);
+      showTerminalPanel("thread-1");
+      const panel = getTerminalPanel("thread-1");
+      expect(panel.visible).toBe(true);
+      expect(panel.height).toBe(450);
     });
 
-    it("hides the panel", () => {
-      useTerminalStore.getState().showPanel();
-      useTerminalStore.getState().hidePanel();
+    it("hideTerminalPanel sets visible false without affecting other fields", () => {
+      const { showTerminalPanel, hideTerminalPanel, setTerminalPanelHeight, getTerminalPanel } = useTerminalStore.getState();
+      showTerminalPanel("thread-1");
+      setTerminalPanelHeight("thread-1", 450);
+      hideTerminalPanel("thread-1");
+      const panel = getTerminalPanel("thread-1");
+      expect(panel.visible).toBe(false);
+      expect(panel.height).toBe(450);
+    });
 
-      expect(useTerminalStore.getState().panelVisible).toBe(false);
+    it("setTerminalPanelHeight updates height for one thread only", () => {
+      const { setTerminalPanelHeight, getTerminalPanel } = useTerminalStore.getState();
+      setTerminalPanelHeight("thread-1", 450);
+      expect(getTerminalPanel("thread-1").height).toBe(450);
+      expect(getTerminalPanel("thread-2").height).toBe(300); // default
+    });
+
+    it("setActiveTerminal scoped to thread", () => {
+      const { addTerminal, setActiveTerminal, getTerminalPanel } = useTerminalStore.getState();
+      addTerminal("thread-1", "pty-1");
+      addTerminal("thread-1", "pty-2");
+      setActiveTerminal("thread-1", "pty-1");
+      expect(getTerminalPanel("thread-1").activeTerminalId).toBe("pty-1");
     });
   });
 
@@ -229,54 +244,6 @@ describe("TerminalStore", () => {
       useTerminalStore.getState().toggleSplit();
 
       expect(useTerminalStore.getState().splitMode).toBe(false);
-    });
-  });
-
-  describe("syncToThread", () => {
-    it("selects first terminal when switching to a thread with terminals", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-      useTerminalStore.getState().addTerminal("thread-2", "pty-2");
-      expect(useTerminalStore.getState().activeTerminalId).toBe("pty-2");
-
-      useTerminalStore.getState().syncToThread("thread-1");
-
-      expect(useTerminalStore.getState().activeTerminalId).toBe("pty-1");
-    });
-
-    it("sets null when switching to a thread with no terminals", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-
-      useTerminalStore.getState().syncToThread("thread-2");
-
-      expect(useTerminalStore.getState().activeTerminalId).toBeNull();
-    });
-
-    it("sets null when switching to null thread", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-
-      useTerminalStore.getState().syncToThread(null);
-
-      expect(useTerminalStore.getState().activeTerminalId).toBeNull();
-    });
-
-    it("keeps activeTerminalId if it already belongs to the target thread", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-      useTerminalStore.getState().addTerminal("thread-1", "pty-2");
-      useTerminalStore.getState().setActiveTerminal("pty-2");
-
-      useTerminalStore.getState().syncToThread("thread-1");
-
-      expect(useTerminalStore.getState().activeTerminalId).toBe("pty-2");
-    });
-
-    it("resets when active terminal belongs to a different thread", () => {
-      useTerminalStore.getState().addTerminal("thread-1", "pty-1");
-      useTerminalStore.getState().addTerminal("thread-2", "pty-2");
-      useTerminalStore.getState().setActiveTerminal("pty-1");
-
-      useTerminalStore.getState().syncToThread("thread-2");
-
-      expect(useTerminalStore.getState().activeTerminalId).toBe("pty-2");
     });
   });
 });

--- a/apps/web/src/__tests__/terminalStore.test.ts
+++ b/apps/web/src/__tests__/terminalStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useTerminalStore, TerminalPanelState, TERMINAL_PANEL_DEFAULTS } from "@/stores/terminalStore";
+import { useTerminalStore, TERMINAL_PANEL_DEFAULTS } from "@/stores/terminalStore";
 
 describe("TerminalStore", () => {
   beforeEach(() => {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -106,7 +106,10 @@ export function App() {
         id: "terminal.toggle",
         title: "Toggle Terminal",
         category: "View",
-        handler: () => useTerminalStore.getState().togglePanel(),
+        handler: () => {
+          const tid = useWorkspaceStore.getState().activeThreadId;
+          if (tid) useTerminalStore.getState().toggleTerminalPanel(tid);
+        },
       }),
       registerCommand({
         id: "settings.open",
@@ -134,14 +137,18 @@ export function App() {
         title: "Toggle Tasks Panel",
         category: "View",
         handler: () => {
-          const store = useDiffStore.getState();
-          if (!store.panelVisible) {
-            store.showPanel();
-            store.setActiveTab("tasks");
-          } else if (store.activeTab !== "tasks") {
-            store.setActiveTab("tasks");
+          const tid = useWorkspaceStore.getState().activeThreadId;
+          if (!tid) return;
+          const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
+            useDiffStore.getState();
+          const panel = getRightPanel(tid);
+          if (!panel.visible) {
+            showRightPanel(tid);
+            setRightPanelTab(tid, "tasks");
+          } else if (panel.activeTab !== "tasks") {
+            setRightPanelTab(tid, "tasks");
           } else {
-            store.hidePanel();
+            hideRightPanel(tid);
           }
         },
       }),
@@ -150,14 +157,18 @@ export function App() {
         title: "Toggle Changes Panel",
         category: "View",
         handler: () => {
-          const store = useDiffStore.getState();
-          if (!store.panelVisible) {
-            store.showPanel();
-            store.setActiveTab("changes");
-          } else if (store.activeTab !== "changes") {
-            store.setActiveTab("changes");
+          const tid = useWorkspaceStore.getState().activeThreadId;
+          if (!tid) return;
+          const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
+            useDiffStore.getState();
+          const panel = getRightPanel(tid);
+          if (!panel.visible) {
+            showRightPanel(tid);
+            setRightPanelTab(tid, "changes");
+          } else if (panel.activeTab !== "changes") {
+            setRightPanelTab(tid, "changes");
           } else {
-            store.hidePanel();
+            hideRightPanel(tid);
           }
         },
       }),

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -78,15 +78,16 @@ function TasksToggle({ threadId }: { threadId?: string }) {
   const hasTasks = useTaskStore(
     (s) => !!(threadId && s.tasksByThread[threadId]?.length),
   );
-  const panelVisible = useDiffStore((s) => s.panelVisible);
-  const showPanel = useDiffStore((s) => s.showPanel);
-  const setActiveTab = useDiffStore((s) => s.setActiveTab);
+  const panelVisible = useDiffStore(
+    (s) => !!(threadId && s.rightPanelByThread[threadId]?.visible),
+  );
 
   if (!hasTasks) return null;
 
   const handleClick = () => {
-    showPanel();
-    setActiveTab("tasks");
+    if (!threadId) return;
+    useDiffStore.getState().showRightPanel(threadId);
+    useDiffStore.getState().setRightPanelTab(threadId, "tasks");
   };
 
   return (

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -23,13 +23,13 @@ vi.mock("@/stores/workspaceStore", () => {
 
 vi.mock("@/stores/terminalStore", () => ({
   useTerminalStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ panelVisible: false, togglePanel: vi.fn() }),
+    selector({ terminalPanelByThread: {}, toggleTerminalPanel: vi.fn() }),
   ),
 }));
 
 vi.mock("@/stores/diffStore", () => ({
   useDiffStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ panelVisible: false, activeTab: "changes", showPanel: vi.fn(), hidePanel: vi.fn(), setActiveTab: vi.fn() }),
+    selector({ rightPanelByThread: {}, showRightPanel: vi.fn(), hideRightPanel: vi.fn(), setRightPanelTab: vi.fn() }),
   ),
 }));
 

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -27,11 +27,22 @@ vi.mock("@/stores/terminalStore", () => ({
   ),
 }));
 
-vi.mock("@/stores/diffStore", () => ({
-  useDiffStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ rightPanelByThread: {}, showRightPanel: vi.fn(), hideRightPanel: vi.fn(), setRightPanelTab: vi.fn() }),
-  ),
-}));
+vi.mock("@/stores/diffStore", () => {
+  const getRightPanel = vi.fn().mockReturnValue({ visible: false, width: 380, activeTab: "tasks" });
+  const actions = {
+    getRightPanel,
+    showRightPanel: vi.fn(),
+    hideRightPanel: vi.fn(),
+    setRightPanelTab: vi.fn(),
+  };
+  const store = Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) =>
+      selector({ rightPanelByThread: {}, ...actions }),
+    ),
+    { getState: vi.fn().mockReturnValue(actions) },
+  );
+  return { useDiffStore: store };
+});
 
 vi.mock("./OpenInEditorMenu", () => ({
   OpenInEditorMenu: () => <div data-testid="open-in-editor" />,

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -84,12 +84,11 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
     if (thread?.id) useTerminalStore.getState().toggleTerminalPanel(thread.id);
   }, [thread?.id]);
 
-  const diffActive = useDiffStore((s) =>
-    thread?.id
-      ? (s.rightPanelByThread[thread.id]?.visible ?? false) &&
-        (s.rightPanelByThread[thread.id]?.activeTab ?? "tasks") === "changes"
-      : false,
-  );
+  const diffActive = useDiffStore((s) => {
+    if (!thread?.id) return false;
+    const panel = s.rightPanelByThread[thread.id];
+    return (panel?.visible ?? false) && (panel?.activeTab ?? "tasks") === "changes";
+  });
 
   const toggleDiff = useCallback(() => {
     if (!thread?.id) return;

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -77,22 +77,34 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
     });
   }, [pr, thread.id]);
 
-  const terminalVisible = useTerminalStore((s) => s.panelVisible);
-  const toggleTerminal = useTerminalStore((s) => s.togglePanel);
+  const terminalVisible = useTerminalStore((s) =>
+    thread?.id ? (s.terminalPanelByThread[thread.id]?.visible ?? false) : false,
+  );
+  const toggleTerminal = useCallback(() => {
+    if (thread?.id) useTerminalStore.getState().toggleTerminalPanel(thread.id);
+  }, [thread?.id]);
 
-  const diffActive = useDiffStore(
-    (s) => s.panelVisible && s.activeTab === "changes",
+  const diffActive = useDiffStore((s) =>
+    thread?.id
+      ? (s.rightPanelByThread[thread.id]?.visible ?? false) &&
+        (s.rightPanelByThread[thread.id]?.activeTab ?? "tasks") === "changes"
+      : false,
   );
 
   const toggleDiff = useCallback(() => {
-    const store = useDiffStore.getState();
-    if (!store.panelVisible || store.activeTab !== "changes") {
-      store.showPanel();
-      store.setActiveTab("changes");
+    if (!thread?.id) return;
+    const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
+      useDiffStore.getState();
+    const panel = getRightPanel(thread.id);
+    if (!panel.visible) {
+      showRightPanel(thread.id);
+      setRightPanelTab(thread.id, "changes");
+    } else if (panel.activeTab !== "changes") {
+      setRightPanelTab(thread.id, "changes");
     } else {
-      store.hidePanel();
+      hideRightPanel(thread.id);
     }
-  }, []);
+  }, [thread?.id]);
 
   const handleOpenPr = useCallback((url: string) => {
     try {

--- a/apps/web/src/components/chat/TerminalStatusIndicator.tsx
+++ b/apps/web/src/components/chat/TerminalStatusIndicator.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { TerminalSquare } from "lucide-react";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -10,7 +11,9 @@ export function TerminalStatusIndicator() {
   const count = useTerminalStore((s) =>
     activeThreadId ? (s.terminals[activeThreadId]?.length ?? 0) : 0,
   );
-  const togglePanel = useTerminalStore((s) => s.togglePanel);
+  const togglePanel = useCallback(() => {
+    if (activeThreadId) useTerminalStore.getState().toggleTerminalPanel(activeThreadId);
+  }, [activeThreadId]);
 
   if (count <= 0) return null;
 

--- a/apps/web/src/components/chat/TurnChangeSummary.tsx
+++ b/apps/web/src/components/chat/TurnChangeSummary.tsx
@@ -98,8 +98,8 @@ export function TurnChangeSummary({ messageId, filesChanged, isLatestTurn, manua
     if (!threadId) return;
 
     const store = useDiffStore.getState();
-    store.showPanel();
-    store.setActiveTab("changes");
+    store.showRightPanel(threadId);
+    store.setRightPanelTab(threadId, "changes");
     store.setViewMode("by-turn");
 
     // Ensure snapshots are loaded so the panel can display this turn

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -4,7 +4,7 @@ import { ListChecks, Diff, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTaskStore } from "@/stores/taskStore";
-import { useDiffStore, PANEL_MIN_WIDTH, PANEL_DEFAULT_WIDTH, PANEL_WIDE_WIDTH } from "@/stores/diffStore";
+import { useDiffStore, PANEL_MIN_WIDTH, PANEL_DEFAULT_WIDTH, PANEL_WIDE_WIDTH, RIGHT_PANEL_DEFAULTS } from "@/stores/diffStore";
 import { TaskPanel } from "@/components/tasks/TaskPanel";
 import { TaskPanelHeader } from "@/components/tasks/TaskPanelHeader";
 import { DiffPanel } from "@/components/diff";
@@ -12,12 +12,17 @@ import { DiffPanel } from "@/components/diff";
 /** Right-side panel with tabs for Tasks and Changes. */
 export function RightPanel() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
-  const panelVisible = useDiffStore((s) => s.panelVisible);
-  const activeTab = useDiffStore((s) => s.activeTab);
-  const panelWidth = useDiffStore((s) => s.panelWidth);
-  const setPanelWidth = useDiffStore((s) => s.setPanelWidth);
-  const setActiveTab = useDiffStore((s) => s.setActiveTab);
-  const hidePanel = useDiffStore((s) => s.hidePanel);
+
+  // Per-thread panel state
+  const panelState = useDiffStore((s) =>
+    activeThreadId
+      ? (s.rightPanelByThread[activeThreadId] ?? RIGHT_PANEL_DEFAULTS)
+      : RIGHT_PANEL_DEFAULTS,
+  );
+  const { visible: panelVisible, width: panelWidth, activeTab } = panelState;
+
+  const { setRightPanelWidth, setRightPanelTab, hideRightPanel } = useDiffStore.getState();
+
   const tasks = useTaskStore(
     (s) => (activeThreadId ? s.tasksByThread[activeThreadId] : undefined),
   );
@@ -34,9 +39,10 @@ export function RightPanel() {
   // Registered once on mount; reads panelWidthRef to avoid a stale closure.
   // Throttled with rAF so rapid resize events only trigger one recalculation per frame.
   useEffect(() => {
+    if (!activeThreadId) return;
     // Clamp immediately on mount in case the stored width already exceeds the viewport.
     const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
-    if (panelWidthRef.current > maxAllowed) setPanelWidth(maxAllowed);
+    if (panelWidthRef.current > maxAllowed) setRightPanelWidth(activeThreadId, maxAllowed);
 
     let rafId: number | null = null;
     const onResize = () => {
@@ -44,7 +50,7 @@ export function RightPanel() {
       rafId = requestAnimationFrame(() => {
         rafId = null;
         const max = window.innerWidth - PANEL_MIN_WIDTH;
-        if (panelWidthRef.current > max) setPanelWidth(max);
+        if (panelWidthRef.current > max) setRightPanelWidth(activeThreadId, max);
       });
     };
     window.addEventListener("resize", onResize);
@@ -52,7 +58,7 @@ export function RightPanel() {
       window.removeEventListener("resize", onResize);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [setPanelWidth]);
+  }, [activeThreadId, setRightPanelWidth]);
 
   const onDragStart = useCallback(
     (e: ReactMouseEvent) => {
@@ -66,7 +72,7 @@ export function RightPanel() {
         const delta = startX - moveEvent.clientX;
         // Always leave at least PANEL_MIN_WIDTH px for the chat area
         const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
-        setPanelWidth(Math.min(startWidth + delta, viewportCap));
+        setRightPanelWidth(activeThreadId!, Math.min(startWidth + delta, viewportCap));
       };
 
       const onMouseUp = () => {
@@ -80,7 +86,7 @@ export function RightPanel() {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     },
-    [panelWidth, setPanelWidth],
+    [panelWidth, activeThreadId, setRightPanelWidth],
   );
 
   useEffect(() => {
@@ -114,7 +120,7 @@ export function RightPanel() {
           const target = panelWidth >= PANEL_WIDE_WIDTH
             ? PANEL_DEFAULT_WIDTH
             : Math.min(PANEL_WIDE_WIDTH, viewportCap);
-          setPanelWidth(Math.max(PANEL_MIN_WIDTH, target));
+          setRightPanelWidth(activeThreadId!, Math.max(PANEL_MIN_WIDTH, target));
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
@@ -123,7 +129,7 @@ export function RightPanel() {
             const target = panelWidth >= PANEL_WIDE_WIDTH
               ? PANEL_DEFAULT_WIDTH
               : Math.min(PANEL_WIDE_WIDTH, viewportCap);
-            setPanelWidth(Math.max(PANEL_MIN_WIDTH, target));
+            setRightPanelWidth(activeThreadId!, Math.max(PANEL_MIN_WIDTH, target));
           }
         }}
       />
@@ -134,7 +140,7 @@ export function RightPanel() {
           <div className="flex items-center gap-0.5">
             <button
               type="button"
-              onClick={() => setActiveTab("tasks")}
+              onClick={() => setRightPanelTab(activeThreadId!, "tasks")}
               className={`flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-semibold tracking-[0.1em] uppercase transition-colors ${
                 activeTab === "tasks"
                   ? "text-foreground bg-muted/50"
@@ -146,7 +152,7 @@ export function RightPanel() {
             </button>
             <button
               type="button"
-              onClick={() => setActiveTab("changes")}
+              onClick={() => setRightPanelTab(activeThreadId!, "changes")}
               className={`flex items-center gap-1.5 rounded-md px-2 py-1 text-[10px] font-semibold tracking-[0.1em] uppercase transition-colors ${
                 activeTab === "changes"
                   ? "text-foreground bg-muted/50"
@@ -160,7 +166,7 @@ export function RightPanel() {
           <Button
             variant="ghost"
             size="icon-xs"
-            onClick={hidePanel}
+            onClick={() => hideRightPanel(activeThreadId!)}
             className="h-5 w-5 text-muted-foreground/70 hover:text-foreground hover:bg-transparent transition-colors duration-150"
             aria-label="Close panel"
           >

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -21,6 +21,9 @@ export function RightPanel() {
   );
   const { visible: panelVisible, width: panelWidth, activeTab } = panelState;
 
+  // Zustand action refs are stable (same identity for the store's lifetime),
+  // so destructuring from getState() at render time is safe and avoids
+  // adding actions to useCallback/useEffect dependency arrays.
   const { setRightPanelWidth, setRightPanelTab, hideRightPanel } = useDiffStore.getState();
 
   const tasks = useTaskStore(
@@ -34,13 +37,13 @@ export function RightPanel() {
   const panelWidthRef = useRef(panelWidth);
   useEffect(() => { panelWidthRef.current = panelWidth; }, [panelWidth]);
 
-  // Re-clamp stored width when the window is resized so the panel never
-  // exceeds the available space after the user shrinks the browser.
-  // Registered once on mount; reads panelWidthRef to avoid a stale closure.
+  // Re-clamp stored width when the panel becomes visible or the window is resized
+  // so the panel never exceeds the available space after the user shrinks the browser.
+  // Re-registers when activeThreadId changes (each thread has its own stored width).
   // Throttled with rAF so rapid resize events only trigger one recalculation per frame.
   useEffect(() => {
-    if (!activeThreadId) return;
-    // Clamp immediately on mount in case the stored width already exceeds the viewport.
+    if (!activeThreadId || !panelVisible) return;
+    // Clamp immediately in case the stored width already exceeds the viewport.
     const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
     if (panelWidthRef.current > maxAllowed) setRightPanelWidth(activeThreadId, maxAllowed);
 
@@ -58,7 +61,7 @@ export function RightPanel() {
       window.removeEventListener("resize", onResize);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [activeThreadId, setRightPanelWidth]);
+  }, [activeThreadId, panelVisible]);
 
   const onDragStart = useCallback(
     (e: ReactMouseEvent) => {
@@ -86,7 +89,7 @@ export function RightPanel() {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     },
-    [panelWidth, activeThreadId, setRightPanelWidth],
+    [panelWidth, activeThreadId],
   );
 
   useEffect(() => {

--- a/apps/web/src/components/terminal/TerminalList.tsx
+++ b/apps/web/src/components/terminal/TerminalList.tsx
@@ -12,7 +12,9 @@ export function TerminalList({ threadId, onClose }: TerminalListProps) {
   const terminals = useTerminalStore(
     (s) => s.terminals[threadId] ?? EMPTY_TERMINALS,
   );
-  const activeTerminalId = useTerminalStore((s) => s.activeTerminalId);
+  const activeTerminalId = useTerminalStore(
+    (s) => s.terminalPanelByThread[threadId]?.activeTerminalId ?? null,
+  );
   const setActiveTerminal = useTerminalStore((s) => s.setActiveTerminal);
 
   return (
@@ -24,7 +26,7 @@ export function TerminalList({ threadId, onClose }: TerminalListProps) {
           <div
             key={terminal.id}
             className="group flex cursor-pointer items-center justify-between px-3 py-1.5 hover:bg-muted"
-            onClick={() => setActiveTerminal(terminal.id)}
+            onClick={() => setActiveTerminal(threadId, terminal.id)}
           >
             <div className="flex items-center gap-2">
               <TerminalSquare className="size-3.5 text-muted-foreground" />

--- a/apps/web/src/components/terminal/TerminalList.tsx
+++ b/apps/web/src/components/terminal/TerminalList.tsx
@@ -3,6 +3,7 @@ import { useTerminalStore, type TerminalInstance } from "@/stores/terminalStore"
 
 const EMPTY_TERMINALS: readonly TerminalInstance[] = [];
 
+/** Props for TerminalList: the owning thread and a handler to close a single terminal. */
 interface TerminalListProps {
   readonly threadId: string;
   readonly onClose: (ptyId: string) => void;

--- a/apps/web/src/components/terminal/TerminalPanel.tsx
+++ b/apps/web/src/components/terminal/TerminalPanel.tsx
@@ -1,34 +1,45 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
+import { TerminalSquare } from "lucide-react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useTerminalStore, type TerminalInstance } from "@/stores/terminalStore";
+import { useTerminalStore, TERMINAL_PANEL_DEFAULTS, type TerminalInstance } from "@/stores/terminalStore";
 import { getTransport } from "@/transport";
+import { Button } from "@/components/ui/button";
 import { TerminalToolbar } from "./TerminalToolbar";
 import { TerminalList } from "./TerminalList";
 import { TerminalView } from "./TerminalView";
 
-const DEFAULT_HEIGHT = 300;
 const MIN_HEIGHT = 150;
 const MAX_HEIGHT_RATIO = 0.7;
 const EMPTY_TERMINALS: readonly TerminalInstance[] = [];
 
+/** Terminal panel that renders per-thread terminal instances with drag-to-resize. */
 export function TerminalPanel() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
-  const panelVisible = useTerminalStore((s) => s.panelVisible);
-  const splitMode = useTerminalStore((s) => s.splitMode);
-  const activeTerminalId = useTerminalStore((s) => s.activeTerminalId);
-  const addTerminal = useTerminalStore((s) => s.addTerminal);
-  const removeTerminal = useTerminalStore((s) => s.removeTerminal);
-  const removeAllTerminals = useTerminalStore((s) => s.removeAllTerminals);
-  const syncToThread = useTerminalStore((s) => s.syncToThread);
+
+  // One-time action refs (stable, don't trigger re-renders)
+  const {
+    addTerminal: storeAddTerminal,
+    removeTerminal: storeRemoveTerminal,
+    removeAllTerminals,
+    setTerminalPanelHeight,
+  } = useTerminalStore.getState();
+
+  // Reactive subscriptions
+  const panelState = useTerminalStore((s) =>
+    activeThreadId
+      ? (s.terminalPanelByThread[activeThreadId] ?? TERMINAL_PANEL_DEFAULTS)
+      : TERMINAL_PANEL_DEFAULTS,
+  );
+  const { visible: panelVisible, height: panelHeight, activeTerminalId } = panelState;
 
   const terminals = useTerminalStore(
     (s) => (activeThreadId ? s.terminals[activeThreadId] : undefined) ?? EMPTY_TERMINALS,
   );
+  const splitMode = useTerminalStore((s) => s.splitMode);
 
-  const [panelHeight, setPanelHeight] = useState(DEFAULT_HEIGHT);
   const draggingRef = useRef(false);
 
-  // Drag handle resizing
+  /** Handles drag-to-resize from the top edge of the panel. */
   const onDragStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
@@ -44,7 +55,7 @@ export function TerminalPanel() {
           MIN_HEIGHT,
           Math.min(maxHeight, startHeight + delta),
         );
-        setPanelHeight(newHeight);
+        setTerminalPanelHeight(activeThreadId!, newHeight);
       };
 
       const onMouseUp = () => {
@@ -56,55 +67,32 @@ export function TerminalPanel() {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     },
-    [panelHeight],
+    [panelHeight, activeThreadId, setTerminalPanelHeight],
   );
 
-  // Create a new terminal for the active thread
+  /** Creates a new terminal for the active thread. */
   const createTerminal = useCallback(async () => {
     if (!activeThreadId) return;
     const transport = getTransport();
     const ptyId = await transport.terminalCreate(activeThreadId);
-    addTerminal(activeThreadId, ptyId);
-  }, [activeThreadId, addTerminal]);
+    storeAddTerminal(activeThreadId, ptyId);
+  }, [activeThreadId, storeAddTerminal]);
 
-  // Close a single terminal
+  /** Kills and removes a single terminal. */
   const closeTerminal = useCallback(
     (ptyId: string) => {
       getTransport().terminalKill(ptyId).catch(() => {});
-      removeTerminal(ptyId);
+      storeRemoveTerminal(ptyId);
     },
-    [removeTerminal],
+    [storeRemoveTerminal],
   );
 
-  // Close all terminals for the active thread (single RPC call)
+  /** Kills and removes all terminals for the active thread. */
   const closeAllTerminals = useCallback(() => {
     if (!activeThreadId) return;
     getTransport().terminalKillByThread(activeThreadId).catch(() => {});
     removeAllTerminals(activeThreadId);
   }, [activeThreadId, removeAllTerminals]);
-
-  // Sync activeTerminalId to the current thread on every switch.
-  // Must run before the auto-create effect below so that
-  // activeTerminalId is correct before auto-create checks
-  // whether to spawn a new terminal.
-  useEffect(() => {
-    syncToThread(activeThreadId);
-  }, [activeThreadId, syncToThread]);
-
-  // Auto-create first terminal when panel opens with none
-  const autoCreateFailed = useRef(false);
-  useEffect(() => {
-    // Reset failure flag when thread changes or panel closes
-    if (!panelVisible || !activeThreadId) {
-      autoCreateFailed.current = false;
-      return;
-    }
-    if (terminals.length === 0 && !autoCreateFailed.current) {
-      createTerminal().catch(() => {
-        autoCreateFailed.current = true;
-      });
-    }
-  }, [panelVisible, activeThreadId, terminals.length, createTerminal]);
 
   if (!panelVisible || !activeThreadId) {
     return null;
@@ -130,21 +118,31 @@ export function TerminalPanel() {
       </div>
 
       {/* Terminal views + optional split list */}
-      <div className="flex flex-1 overflow-hidden">
-        <div className="flex-1 overflow-hidden">
-          {terminals.map((term) => (
-            <TerminalView
-              key={term.id}
-              ptyId={term.id}
-              visible={term.id === activeTerminalId}
-            />
-          ))}
+      {terminals.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
+          <TerminalSquare className="h-10 w-10 opacity-40" />
+          <p className="text-sm">No terminals</p>
+          <Button variant="outline" size="sm" onClick={createTerminal}>
+            New terminal
+          </Button>
         </div>
+      ) : (
+        <div className="relative flex flex-1 overflow-hidden">
+          <div className="flex-1 overflow-hidden">
+            {terminals.map((term) => (
+              <TerminalView
+                key={term.id}
+                ptyId={term.id}
+                visible={term.id === activeTerminalId}
+              />
+            ))}
+          </div>
 
-        {splitMode && (
-          <TerminalList threadId={activeThreadId} onClose={closeTerminal} />
-        )}
-      </div>
+          {splitMode && (
+            <TerminalList threadId={activeThreadId} onClose={closeTerminal} />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/terminal/TerminalPanel.tsx
+++ b/apps/web/src/components/terminal/TerminalPanel.tsx
@@ -12,17 +12,18 @@ const MIN_HEIGHT = 150;
 const MAX_HEIGHT_RATIO = 0.7;
 const EMPTY_TERMINALS: readonly TerminalInstance[] = [];
 
+// Zustand action refs are stable (same identity for the store's lifetime).
+// Destructuring at module scope avoids calling getState() on every render.
+const {
+  addTerminal: storeAddTerminal,
+  removeTerminal: storeRemoveTerminal,
+  removeAllTerminals,
+  setTerminalPanelHeight,
+} = useTerminalStore.getState();
+
 /** Terminal panel that renders per-thread terminal instances with drag-to-resize. */
 export function TerminalPanel() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
-
-  // One-time action refs (stable, don't trigger re-renders)
-  const {
-    addTerminal: storeAddTerminal,
-    removeTerminal: storeRemoveTerminal,
-    removeAllTerminals,
-    setTerminalPanelHeight,
-  } = useTerminalStore.getState();
 
   // Reactive subscriptions
   const panelState = useTerminalStore((s) =>
@@ -42,6 +43,7 @@ export function TerminalPanel() {
   /** Handles drag-to-resize from the top edge of the panel. */
   const onDragStart = useCallback(
     (e: React.MouseEvent) => {
+      if (!activeThreadId) return;
       e.preventDefault();
       draggingRef.current = true;
       const startY = e.clientY;
@@ -55,7 +57,7 @@ export function TerminalPanel() {
           MIN_HEIGHT,
           Math.min(maxHeight, startHeight + delta),
         );
-        setTerminalPanelHeight(activeThreadId!, newHeight);
+        setTerminalPanelHeight(activeThreadId, newHeight);
       };
 
       const onMouseUp = () => {
@@ -67,7 +69,7 @@ export function TerminalPanel() {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     },
-    [panelHeight, activeThreadId, setTerminalPanelHeight],
+    [panelHeight, activeThreadId],
   );
 
   /** Creates a new terminal for the active thread. */
@@ -76,7 +78,7 @@ export function TerminalPanel() {
     const transport = getTransport();
     const ptyId = await transport.terminalCreate(activeThreadId);
     storeAddTerminal(activeThreadId, ptyId);
-  }, [activeThreadId, storeAddTerminal]);
+  }, [activeThreadId]);
 
   /** Kills and removes a single terminal. */
   const closeTerminal = useCallback(
@@ -84,7 +86,7 @@ export function TerminalPanel() {
       getTransport().terminalKill(ptyId).catch(() => {});
       storeRemoveTerminal(ptyId);
     },
-    [storeRemoveTerminal],
+    [],
   );
 
   /** Kills and removes all terminals for the active thread. */
@@ -92,7 +94,7 @@ export function TerminalPanel() {
     if (!activeThreadId) return;
     getTransport().terminalKillByThread(activeThreadId).catch(() => {});
     removeAllTerminals(activeThreadId);
-  }, [activeThreadId, removeAllTerminals]);
+  }, [activeThreadId]);
 
   if (!panelVisible || !activeThreadId) {
     return null;

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -177,23 +177,35 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   setDiffLoading: (loading) => set({ diffLoading: loading }),
   clearThread: (threadId) =>
     set((state) => {
-      const { [threadId]: _s, ...snapshots } = state.snapshotsByThread;
-      const { [threadId]: _sl, ...snapshotsLoading } = state.snapshotsLoadingByThread;
-      const { [threadId]: _c, ...commits } = state.commitsByThread;
-      const { [threadId]: _cl, ...commitsLoading } = state.commitsLoadingByThread;
-      const { [threadId]: _rp, ...rightPanels } = state.rightPanelByThread;
-      // selectedFile and diffContent are global (not per-thread), so clearing them
-      // on any thread deletion is intentional: if the user had a diff open for the
-      // deleted thread, it should no longer be displayed. If they had a diff open
-      // for a different thread, that thread's panel will reload its content on next focus.
+      const snapshots = { ...state.snapshotsByThread };
+      delete snapshots[threadId];
+      const snapshotsLoading = { ...state.snapshotsLoadingByThread };
+      delete snapshotsLoading[threadId];
+      const commits = { ...state.commitsByThread };
+      delete commits[threadId];
+      const commitsLoading = { ...state.commitsLoadingByThread };
+      delete commitsLoading[threadId];
+      const rightPanels = { ...state.rightPanelByThread };
+      delete rightPanels[threadId];
+
+      // Only clear the global selectedFile/diffContent when they belong to the
+      // thread being deleted. Threads that have no snapshot/commit data yet (e.g.
+      // newly created) default to false, leaving another thread's open diff intact.
+      const sf = state.selectedFile;
+      const selectionBelongsToThread = sf !== null && (() => {
+        if (sf.source === "snapshot" || sf.source === "cumulative") {
+          return (state.snapshotsByThread[threadId] ?? []).some((s) => s.id === sf.id);
+        }
+        return (state.commitsByThread[threadId] ?? []).some((c) => c.sha === sf.id);
+      })();
+
       return {
         snapshotsByThread: snapshots,
         snapshotsLoadingByThread: snapshotsLoading,
         commitsByThread: commits,
         commitsLoadingByThread: commitsLoading,
         rightPanelByThread: rightPanels,
-        selectedFile: null,
-        diffContent: null,
+        ...(selectionBelongsToThread ? { selectedFile: null, diffContent: null } : {}),
       };
     }),
 }));

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -182,6 +182,10 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       const { [threadId]: _c, ...commits } = state.commitsByThread;
       const { [threadId]: _cl, ...commitsLoading } = state.commitsLoadingByThread;
       const { [threadId]: _rp, ...rightPanels } = state.rightPanelByThread;
+      // selectedFile and diffContent are global (not per-thread), so clearing them
+      // on any thread deletion is intentional: if the user had a diff open for the
+      // deleted thread, it should no longer be displayed. If they had a diff open
+      // for a different thread, that thread's panel will reload its content on next focus.
       return {
         snapshotsByThread: snapshots,
         snapshotsLoadingByThread: snapshotsLoading,

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -29,6 +29,8 @@ export interface SelectedFile {
   /** Snapshot ID or commit SHA depending on source. */
   id: string;
   filePath: string;
+  /** Thread that owns this selection, used to clear on thread deletion. */
+  threadId: string;
 }
 
 /** Per-thread right panel state (visibility, width, active tab). */
@@ -188,16 +190,8 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       const rightPanels = { ...state.rightPanelByThread };
       delete rightPanels[threadId];
 
-      // Only clear the global selectedFile/diffContent when they belong to the
-      // thread being deleted. Threads that have no snapshot/commit data yet (e.g.
-      // newly created) default to false, leaving another thread's open diff intact.
-      const sf = state.selectedFile;
-      const selectionBelongsToThread = sf !== null && (() => {
-        if (sf.source === "snapshot" || sf.source === "cumulative") {
-          return (state.snapshotsByThread[threadId] ?? []).some((s) => s.id === sf.id);
-        }
-        return (state.commitsByThread[threadId] ?? []).some((c) => c.sha === sf.id);
-      })();
+      // Only clear the global selection when it belongs to the deleted thread.
+      const selectionBelongsToThread = state.selectedFile?.threadId === threadId;
 
       return {
         snapshotsByThread: snapshots,
@@ -205,7 +199,9 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         commitsByThread: commits,
         commitsLoadingByThread: commitsLoading,
         rightPanelByThread: rightPanels,
-        ...(selectionBelongsToThread ? { selectedFile: null, diffContent: null } : {}),
+        ...(selectionBelongsToThread
+          ? { selectedFile: null, diffContent: null, diffLoading: false }
+          : {}),
       };
     }),
 }));

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -12,6 +12,17 @@ export type DiffViewMode = "by-turn" | "all" | "commits";
 /** Diff rendering mode. */
 export type DiffRenderMode = "unified" | "side-by-side";
 
+/** Minimum right panel width in pixels. */
+export const PANEL_MIN_WIDTH = 300;
+/** Default right panel width in pixels. */
+export const PANEL_DEFAULT_WIDTH = 380;
+/** Wide snap target for the right panel (double-click drag handle). */
+export const PANEL_WIDE_WIDTH = 680;
+
+function clampWidth(w: number): number {
+  return Math.max(PANEL_MIN_WIDTH, w);
+}
+
 /** Currently selected file for diff viewing. */
 export interface SelectedFile {
   source: "snapshot" | "cumulative" | "commit";
@@ -20,14 +31,24 @@ export interface SelectedFile {
   filePath: string;
 }
 
+/** Per-thread right panel state (visibility, width, active tab). */
+export type RightPanelState = {
+  readonly visible: boolean;
+  readonly width: number;
+  readonly activeTab: RightPanelTab;
+};
+
+/** Default state for threads with no panel record. Panels start closed. */
+export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
+  visible: false,
+  width: PANEL_DEFAULT_WIDTH,
+  activeTab: "tasks",
+} as const;
+
 /** Zustand state shape for the diff panel. */
 interface DiffState {
-  /** Whether the right panel is visible. */
-  panelVisible: boolean;
-  /** Active tab in the right panel. */
-  activeTab: RightPanelTab;
-  /** Width of the right panel in pixels. */
-  panelWidth: number;
+  /** Per-thread right panel state keyed by thread ID. */
+  readonly rightPanelByThread: Record<string, RightPanelState>;
   /** View mode within the Changes tab. */
   viewMode: DiffViewMode;
   /** Diff rendering mode. */
@@ -49,11 +70,12 @@ interface DiffState {
   /** Whether diff content is currently loading. */
   diffLoading: boolean;
 
-  togglePanel: () => void;
-  showPanel: () => void;
-  hidePanel: () => void;
-  setPanelWidth: (width: number) => void;
-  setActiveTab: (tab: RightPanelTab) => void;
+  getRightPanel: (threadId: string) => RightPanelState;
+  toggleRightPanel: (threadId: string) => void;
+  showRightPanel: (threadId: string) => void;
+  hideRightPanel: (threadId: string) => void;
+  setRightPanelWidth: (threadId: string, width: number) => void;
+  setRightPanelTab: (threadId: string, tab: RightPanelTab) => void;
   setViewMode: (mode: DiffViewMode) => void;
   setRenderMode: (mode: DiffRenderMode) => void;
   toggleLineWrap: () => void;
@@ -67,23 +89,9 @@ interface DiffState {
   clearThread: (threadId: string) => void;
 }
 
-/** Minimum right panel width in pixels. */
-export const PANEL_MIN_WIDTH = 300;
-/** Default right panel width in pixels. */
-export const PANEL_DEFAULT_WIDTH = 380;
-/** Wide snap target for the right panel (double-click drag handle). */
-export const PANEL_WIDE_WIDTH = 680;
-const DEFAULT_WIDTH = PANEL_DEFAULT_WIDTH;
-
-function clampWidth(w: number): number {
-  return Math.max(PANEL_MIN_WIDTH, w);
-}
-
 /** Zustand store for diff panel and right panel tab state. */
-export const useDiffStore = create<DiffState>((set) => ({
-  panelVisible: false,
-  activeTab: "tasks",
-  panelWidth: DEFAULT_WIDTH,
+export const useDiffStore = create<DiffState>((set, get) => ({
+  rightPanelByThread: {},
   viewMode: "by-turn",
   renderMode: "unified",
   lineWrap: false,
@@ -95,11 +103,64 @@ export const useDiffStore = create<DiffState>((set) => ({
   diffContent: null,
   diffLoading: false,
 
-  togglePanel: () => set((s) => ({ panelVisible: !s.panelVisible })),
-  showPanel: () => set({ panelVisible: true }),
-  hidePanel: () => set({ panelVisible: false }),
-  setPanelWidth: (width) => set({ panelWidth: clampWidth(width) }),
-  setActiveTab: (tab) => set({ activeTab: tab }),
+  getRightPanel: (threadId) =>
+    get().rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS,
+
+  toggleRightPanel: (threadId) =>
+    set((state) => {
+      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      return {
+        rightPanelByThread: {
+          ...state.rightPanelByThread,
+          [threadId]: { ...current, visible: !current.visible },
+        },
+      };
+    }),
+
+  showRightPanel: (threadId) =>
+    set((state) => {
+      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      return {
+        rightPanelByThread: {
+          ...state.rightPanelByThread,
+          [threadId]: { ...current, visible: true },
+        },
+      };
+    }),
+
+  hideRightPanel: (threadId) =>
+    set((state) => {
+      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      return {
+        rightPanelByThread: {
+          ...state.rightPanelByThread,
+          [threadId]: { ...current, visible: false },
+        },
+      };
+    }),
+
+  setRightPanelWidth: (threadId, width) =>
+    set((state) => {
+      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      return {
+        rightPanelByThread: {
+          ...state.rightPanelByThread,
+          [threadId]: { ...current, width: clampWidth(width) },
+        },
+      };
+    }),
+
+  setRightPanelTab: (threadId, tab) =>
+    set((state) => {
+      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      return {
+        rightPanelByThread: {
+          ...state.rightPanelByThread,
+          [threadId]: { ...current, activeTab: tab },
+        },
+      };
+    }),
+
   setViewMode: (mode) => set({ viewMode: mode, selectedFile: null, diffContent: null }),
   setRenderMode: (mode) => set({ renderMode: mode }),
   toggleLineWrap: () => set((s) => ({ lineWrap: !s.lineWrap })),
@@ -115,20 +176,18 @@ export const useDiffStore = create<DiffState>((set) => ({
   setDiffContent: (content) => set({ diffContent: content, diffLoading: false }),
   setDiffLoading: (loading) => set({ diffLoading: loading }),
   clearThread: (threadId) =>
-    set((s) => {
-      const nextSnapshots = { ...s.snapshotsByThread };
-      delete nextSnapshots[threadId];
-      const nextCommits = { ...s.commitsByThread };
-      delete nextCommits[threadId];
-      const nextSnapshotsLoading = { ...s.snapshotsLoadingByThread };
-      delete nextSnapshotsLoading[threadId];
-      const nextCommitsLoading = { ...s.commitsLoadingByThread };
-      delete nextCommitsLoading[threadId];
+    set((state) => {
+      const { [threadId]: _s, ...snapshots } = state.snapshotsByThread;
+      const { [threadId]: _sl, ...snapshotsLoading } = state.snapshotsLoadingByThread;
+      const { [threadId]: _c, ...commits } = state.commitsByThread;
+      const { [threadId]: _cl, ...commitsLoading } = state.commitsLoadingByThread;
+      const { [threadId]: _rp, ...rightPanels } = state.rightPanelByThread;
       return {
-        snapshotsByThread: nextSnapshots,
-        commitsByThread: nextCommits,
-        snapshotsLoadingByThread: nextSnapshotsLoading,
-        commitsLoadingByThread: nextCommitsLoading,
+        snapshotsByThread: snapshots,
+        snapshotsLoadingByThread: snapshotsLoading,
+        commitsByThread: commits,
+        commitsLoadingByThread: commitsLoading,
+        rightPanelByThread: rightPanels,
         selectedFile: null,
         diffContent: null,
       };

--- a/apps/web/src/stores/terminalStore.ts
+++ b/apps/web/src/stores/terminalStore.ts
@@ -46,141 +46,131 @@ function generateLabel(existing: readonly TerminalInstance[]): string {
   return `Terminal ${max + 1}`;
 }
 
-function findAllTerminals(
-  terminals: Record<string, readonly TerminalInstance[]>,
-): readonly TerminalInstance[] {
-  return Object.values(terminals).flat();
-}
-
-export const useTerminalStore = create<TerminalState>((set) => ({
+export const useTerminalStore = create<TerminalState>((set, get) => ({
   terminals: {},
-  activeTerminalId: null,
-  panelVisible: false,
+  terminalPanelByThread: {},
   splitMode: false,
 
-  addTerminal: (threadId, ptyId) => {
+  getTerminalPanel: (threadId) =>
+    get().terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS,
+
+  toggleTerminalPanel: (threadId) =>
+    set((state) => {
+      const current = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
+      return {
+        terminalPanelByThread: {
+          ...state.terminalPanelByThread,
+          [threadId]: { ...current, visible: !current.visible },
+        },
+      };
+    }),
+
+  showTerminalPanel: (threadId) =>
+    set((state) => {
+      const current = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
+      return {
+        terminalPanelByThread: {
+          ...state.terminalPanelByThread,
+          [threadId]: { ...current, visible: true },
+        },
+      };
+    }),
+
+  hideTerminalPanel: (threadId) =>
+    set((state) => {
+      const current = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
+      return {
+        terminalPanelByThread: {
+          ...state.terminalPanelByThread,
+          [threadId]: { ...current, visible: false },
+        },
+      };
+    }),
+
+  setTerminalPanelHeight: (threadId, height) =>
+    set((state) => {
+      const current = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
+      return {
+        terminalPanelByThread: {
+          ...state.terminalPanelByThread,
+          [threadId]: { ...current, height },
+        },
+      };
+    }),
+
+  setActiveTerminal: (threadId, ptyId) =>
+    set((state) => {
+      const current = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
+      return {
+        terminalPanelByThread: {
+          ...state.terminalPanelByThread,
+          [threadId]: { ...current, activeTerminalId: ptyId },
+        },
+      };
+    }),
+
+  addTerminal: (threadId, ptyId) =>
     set((state) => {
       const existing = state.terminals[threadId] ?? [];
       const label = generateLabel(existing);
-      const instance: TerminalInstance = {
-        id: ptyId,
-        threadId,
-        label,
-      };
+      const instance: TerminalInstance = { id: ptyId, threadId, label };
+      const currentPanel = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
       return {
         terminals: {
           ...state.terminals,
           [threadId]: [...existing, instance],
         },
-        activeTerminalId: ptyId,
-        panelVisible: true,
+        terminalPanelByThread: {
+          ...state.terminalPanelByThread,
+          [threadId]: { ...currentPanel, visible: true, activeTerminalId: ptyId },
+        },
       };
-    });
-  },
+    }),
 
-  removeTerminal: (ptyId) => {
+  removeTerminal: (ptyId) =>
     set((state) => {
+      let ownerThreadId: string | null = null;
       const updatedTerminals: Record<string, readonly TerminalInstance[]> = {};
-      let found = false;
 
-      for (const [threadId, instances] of Object.entries(state.terminals)) {
-        const filtered = instances.filter((t) => t.id !== ptyId);
-        if (filtered.length !== instances.length) {
-          found = true;
-        }
-        // Don't keep empty arrays in the map
+      for (const [tid, instances] of Object.entries(state.terminals)) {
+        const filtered = instances.filter((t) => {
+          if (t.id === ptyId) {
+            ownerThreadId = tid;
+            return false;
+          }
+          return true;
+        });
         if (filtered.length > 0) {
-          updatedTerminals[threadId] = filtered;
+          updatedTerminals[tid] = filtered;
         }
       }
 
-      if (!found) {
-        return state;
-      }
+      if (!ownerThreadId) return state;
 
-      const wasActive = state.activeTerminalId === ptyId;
-      let nextActive = state.activeTerminalId;
-
-      if (wasActive) {
-        const allRemaining = findAllTerminals(updatedTerminals);
-        nextActive = allRemaining.length > 0 ? allRemaining[0].id : null;
-      }
+      const currentPanel = state.terminalPanelByThread[ownerThreadId] ?? TERMINAL_PANEL_DEFAULTS;
+      const needsNewActive = currentPanel.activeTerminalId === ptyId;
+      const remaining = updatedTerminals[ownerThreadId] ?? [];
+      const nextActive = needsNewActive ? (remaining[0]?.id ?? null) : currentPanel.activeTerminalId;
 
       return {
         terminals: updatedTerminals,
-        activeTerminalId: nextActive,
+        terminalPanelByThread: {
+          ...state.terminalPanelByThread,
+          [ownerThreadId]: { ...currentPanel, activeTerminalId: nextActive },
+        },
       };
-    });
-  },
+    }),
 
-  removeAllTerminals: (threadId) => {
+  removeAllTerminals: (threadId) =>
     set((state) => {
-      const removed = state.terminals[threadId] ?? [];
-      const removedIds = new Set(removed.map((t) => t.id));
-      const wasActive =
-        state.activeTerminalId !== null &&
-        removedIds.has(state.activeTerminalId);
-
-      // Remove the key entirely instead of leaving an empty array
-      const updatedTerminals = { ...state.terminals };
-      delete updatedTerminals[threadId];
-
-      // Only hide panel if no terminals remain across all threads
-      const anyRemaining = Object.values(updatedTerminals).some(
-        (list) => list.length > 0,
-      );
-
+      if (!state.terminals[threadId] && !state.terminalPanelByThread[threadId]) return state;
+      const { [threadId]: _, ...remainingTerminals } = state.terminals;
+      const { [threadId]: __, ...remainingPanels } = state.terminalPanelByThread;
       return {
-        terminals: updatedTerminals,
-        activeTerminalId: wasActive ? null : state.activeTerminalId,
-        panelVisible: anyRemaining ? state.panelVisible : false,
+        terminals: remainingTerminals,
+        terminalPanelByThread: remainingPanels,
       };
-    });
-  },
+    }),
 
-  setActiveTerminal: (ptyId) => {
-    set({ activeTerminalId: ptyId });
-  },
-
-  togglePanel: () => {
-    set((state) => ({ panelVisible: !state.panelVisible }));
-  },
-
-  showPanel: () => {
-    set({ panelVisible: true });
-  },
-
-  hidePanel: () => {
-    set({ panelVisible: false });
-  },
-
-  toggleSplit: () => {
-    set((state) => ({ splitMode: !state.splitMode }));
-  },
-
-  /**
-   * Align activeTerminalId to the given thread. Called on every thread
-   * switch so the terminal panel shows a terminal belonging to the
-   * current thread instead of going blank.
-   */
-  syncToThread: (threadId) => {
-    set((state) => {
-      if (!threadId) {
-        return state.activeTerminalId === null ? {} : { activeTerminalId: null };
-      }
-
-      const threadTerminals = state.terminals[threadId] ?? [];
-      const currentActive = state.activeTerminalId;
-
-      // If current active terminal already belongs to this thread, keep it
-      if (currentActive && threadTerminals.some((t) => t.id === currentActive)) {
-        return {};
-      }
-
-      // Pick first terminal in the thread, or null
-      return {
-        activeTerminalId: threadTerminals.length > 0 ? threadTerminals[0].id : null,
-      };
-    });
-  },
+  toggleSplit: () => set((state) => ({ splitMode: !state.splitMode })),
 }));

--- a/apps/web/src/stores/terminalStore.ts
+++ b/apps/web/src/stores/terminalStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 
+/** A single PTY-backed terminal instance displayed in the terminal panel. */
 export interface TerminalInstance {
   readonly id: string;
   readonly threadId: string;
@@ -46,6 +47,7 @@ function generateLabel(existing: readonly TerminalInstance[]): string {
   return `Terminal ${max + 1}`;
 }
 
+/** Zustand store for terminal instances and per-thread panel state. */
 export const useTerminalStore = create<TerminalState>((set, get) => ({
   terminals: {},
   terminalPanelByThread: {},
@@ -129,23 +131,21 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
 
   removeTerminal: (ptyId) =>
     set((state) => {
-      let ownerThreadId: string | null = null;
-      const updatedTerminals: Record<string, readonly TerminalInstance[]> = {};
+      // Find the owning thread before filtering so the predicate stays pure.
+      const ownerEntry = Object.entries(state.terminals).find(([, instances]) =>
+        instances.some((t) => t.id === ptyId),
+      );
+      if (!ownerEntry) return state;
+      const [ownerThreadId] = ownerEntry;
 
+      const updatedTerminals: Record<string, readonly TerminalInstance[]> = {};
       for (const [tid, instances] of Object.entries(state.terminals)) {
-        const filtered = instances.filter((t) => {
-          if (t.id === ptyId) {
-            ownerThreadId = tid;
-            return false;
-          }
-          return true;
-        });
+        const filtered = instances.filter((t) => t.id !== ptyId);
+        // Threads with zero remaining terminals are intentionally pruned from the map.
         if (filtered.length > 0) {
           updatedTerminals[tid] = filtered;
         }
       }
-
-      if (!ownerThreadId) return state;
 
       const currentPanel = state.terminalPanelByThread[ownerThreadId] ?? TERMINAL_PANEL_DEFAULTS;
       const needsNewActive = currentPanel.activeTerminalId === ptyId;

--- a/apps/web/src/stores/terminalStore.ts
+++ b/apps/web/src/stores/terminalStore.ts
@@ -164,8 +164,10 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   removeAllTerminals: (threadId) =>
     set((state) => {
       if (!state.terminals[threadId] && !state.terminalPanelByThread[threadId]) return state;
-      const { [threadId]: _, ...remainingTerminals } = state.terminals;
-      const { [threadId]: __, ...remainingPanels } = state.terminalPanelByThread;
+      const remainingTerminals = { ...state.terminals };
+      delete remainingTerminals[threadId];
+      const remainingPanels = { ...state.terminalPanelByThread };
+      delete remainingPanels[threadId];
       return {
         terminals: remainingTerminals,
         terminalPanelByThread: remainingPanels,

--- a/apps/web/src/stores/terminalStore.ts
+++ b/apps/web/src/stores/terminalStore.ts
@@ -6,21 +6,35 @@ export interface TerminalInstance {
   readonly label: string;
 }
 
-interface TerminalState {
-  terminals: Record<string, readonly TerminalInstance[]>;
-  activeTerminalId: string | null;
-  panelVisible: boolean;
-  splitMode: boolean;
+/** Per-thread terminal panel state (visibility, height, active terminal). */
+export type TerminalPanelState = {
+  readonly visible: boolean;
+  readonly height: number;
+  readonly activeTerminalId: string | null;
+};
 
+/** Default state for threads with no panel record. Panels start closed. */
+export const TERMINAL_PANEL_DEFAULTS: TerminalPanelState = {
+  visible: false,
+  height: 300,
+  activeTerminalId: null,
+} as const;
+
+interface TerminalState {
+  readonly terminals: Record<string, readonly TerminalInstance[]>;
+  readonly terminalPanelByThread: Record<string, TerminalPanelState>;
+  readonly splitMode: boolean;
+
+  getTerminalPanel: (threadId: string) => TerminalPanelState;
+  toggleTerminalPanel: (threadId: string) => void;
+  showTerminalPanel: (threadId: string) => void;
+  hideTerminalPanel: (threadId: string) => void;
+  setTerminalPanelHeight: (threadId: string, height: number) => void;
+  setActiveTerminal: (threadId: string, ptyId: string | null) => void;
   addTerminal: (threadId: string, ptyId: string) => void;
   removeTerminal: (ptyId: string) => void;
   removeAllTerminals: (threadId: string) => void;
-  setActiveTerminal: (ptyId: string | null) => void;
-  togglePanel: () => void;
-  showPanel: () => void;
-  hidePanel: () => void;
   toggleSplit: () => void;
-  syncToThread: (threadId: string | null) => void;
 }
 
 function generateLabel(existing: readonly TerminalInstance[]): string {

--- a/apps/web/src/stores/terminalStore.ts
+++ b/apps/web/src/stores/terminalStore.ts
@@ -35,6 +35,7 @@ interface TerminalState {
   addTerminal: (threadId: string, ptyId: string) => void;
   removeTerminal: (ptyId: string) => void;
   removeAllTerminals: (threadId: string) => void;
+  clearThread: (threadId: string) => void;
   toggleSplit: () => void;
 }
 
@@ -136,21 +137,22 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         instances.some((t) => t.id === ptyId),
       );
       if (!ownerEntry) return state;
-      const [ownerThreadId] = ownerEntry;
+      const [ownerThreadId, ownerInstances] = ownerEntry;
 
-      const updatedTerminals: Record<string, readonly TerminalInstance[]> = {};
-      for (const [tid, instances] of Object.entries(state.terminals)) {
-        const filtered = instances.filter((t) => t.id !== ptyId);
-        // Threads with zero remaining terminals are intentionally pruned from the map.
-        if (filtered.length > 0) {
-          updatedTerminals[tid] = filtered;
-        }
-      }
+      // Only rebuild the owning thread's array; other threads keep their identity.
+      const filtered = ownerInstances.filter((t) => t.id !== ptyId);
+      const updatedTerminals =
+        filtered.length > 0
+          ? { ...state.terminals, [ownerThreadId]: filtered }
+          : (() => {
+              const rest = { ...state.terminals };
+              delete rest[ownerThreadId];
+              return rest;
+            })();
 
       const currentPanel = state.terminalPanelByThread[ownerThreadId] ?? TERMINAL_PANEL_DEFAULTS;
       const needsNewActive = currentPanel.activeTerminalId === ptyId;
-      const remaining = updatedTerminals[ownerThreadId] ?? [];
-      const nextActive = needsNewActive ? (remaining[0]?.id ?? null) : currentPanel.activeTerminalId;
+      const nextActive = needsNewActive ? (filtered[0]?.id ?? null) : currentPanel.activeTerminalId;
 
       return {
         terminals: updatedTerminals,
@@ -162,6 +164,27 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     }),
 
   removeAllTerminals: (threadId) =>
+    set((state) => {
+      if (!state.terminals[threadId]) return state;
+      const remainingTerminals = { ...state.terminals };
+      delete remainingTerminals[threadId];
+      // Preserve panel config (height, visibility) so it persists across "close all".
+      // Only null out activeTerminalId since there are no terminals left.
+      const currentPanel = state.terminalPanelByThread[threadId];
+      return {
+        terminals: remainingTerminals,
+        ...(currentPanel
+          ? {
+              terminalPanelByThread: {
+                ...state.terminalPanelByThread,
+                [threadId]: { ...currentPanel, activeTerminalId: null },
+              },
+            }
+          : {}),
+      };
+    }),
+
+  clearThread: (threadId) =>
     set((state) => {
       if (!state.terminals[threadId] && !state.terminalPanelByThread[threadId]) return state;
       const remainingTerminals = { ...state.terminals };

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1011,8 +1011,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             import("./diffStore").then(({ useDiffStore }) => {
               // Re-check after async import: user may have switched threads.
               if (useWorkspaceStore.getState().activeThreadId !== threadId) return;
-              useDiffStore.getState().showPanel();
-              useDiffStore.getState().setActiveTab("tasks");
+              useDiffStore.getState().showRightPanel(threadId);
+              useDiffStore.getState().setRightPanelTab(threadId, "tasks");
             });
           }
         }

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -6,6 +6,7 @@ import { useTerminalStore } from "./terminalStore";
 import { useQueueStore } from "./queueStore";
 import { useTaskStore } from "./taskStore";
 import { useComposerDraftStore } from "./composerDraftStore";
+import { useDiffStore } from "./diffStore";
 import type { NamingMode, ReasoningLevel, InteractionMode } from "@mcode/contracts";
 import { useSettingsStore } from "./settingsStore";
 import { sanitizeCustomBranchInput, trimTrailingBranchChars } from "@/lib/branch-name";
@@ -402,6 +403,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       useQueueStore.getState().clearQueue(threadId);
       useComposerDraftStore.getState().clearDraft(threadId);
       useTaskStore.getState().clearTasks(threadId);
+      useDiffStore.getState().clearThread(threadId);
       // Remove from threads[] FIRST so any in-flight dequeue timer callback's
       // threadExists guard sees the thread as deleted before clearThreadState
       // cancels the timer. This closes the race window between the timer

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -172,7 +172,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       for (const tid of deletedThreadIds) {
         draftStore.clearDraft(tid);
         taskStore.clearTasks(tid);
-        terminalStore.removeAllTerminals(tid);
+        terminalStore.clearThread(tid);
         diffStore.clearThread(tid);
       }
       // Remove threads from store FIRST (same ordering as deleteThread) so
@@ -403,7 +403,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set({ error: null });
     try {
       await getTransport().deleteThread(threadId, cleanupWorktree);
-      useTerminalStore.getState().removeAllTerminals(threadId);
+      useTerminalStore.getState().clearThread(threadId);
       useQueueStore.getState().clearQueue(threadId);
       useComposerDraftStore.getState().clearDraft(threadId);
       useTaskStore.getState().clearTasks(threadId);

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -167,9 +167,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         .map((t) => t.id);
       const draftStore = useComposerDraftStore.getState();
       const taskStore = useTaskStore.getState();
+      const terminalStore = useTerminalStore.getState();
+      const diffStore = useDiffStore.getState();
       for (const tid of deletedThreadIds) {
         draftStore.clearDraft(tid);
         taskStore.clearTasks(tid);
+        terminalStore.removeAllTerminals(tid);
+        diffStore.clearThread(tid);
       }
       // Remove threads from store FIRST (same ordering as deleteThread) so
       // any in-flight timer callbacks see threads as gone before timers are cancelled.


### PR DESCRIPTION
## What

Make terminal and right panel state (visibility, dimensions, active selection) per-thread, stored in `Record<string, State>` maps keyed by `threadId`. Switching threads is now a pure read operation - no auto-creating PTYs, no stale panel state from a previous thread.

Also fixes a Windows-only crash (`AttachConsole failed`) that occurred every time a terminal was closed.

## Why

Thread switching was triggering side effects: auto-spawning PTYs and carrying over the previous thread's panel visibility. Panel state should belong to the thread, not the app shell.

## Key changes

- **`terminalStore`**: removed global `panelVisible` / `activeTerminalId`; added `terminalPanelByThread: Record<string, TerminalPanelState>` with per-thread `getTerminalPanel`, `toggleTerminalPanel`, `showTerminalPanel`, `hideTerminalPanel`, `setTerminalPanelHeight`, `setActiveTerminal` actions
- **`diffStore`**: removed global `panelVisible` / `panelWidth` / `activeTab`; added `rightPanelByThread: Record<string, RightPanelState>` with matching per-thread actions; `clearThread` now also clears the right panel entry
- **`TerminalPanel`**: removed auto-create-on-open side effect; removed local height state and `syncToThread`; shows an empty state UI with a "New terminal" button when no terminals exist for the thread
- **`RightPanel`**, **`TerminalList`**, **`HeaderActions`**, **`TerminalStatusIndicator`**, **`Composer`**, **`TurnChangeSummary`**, **`threadStore`**, **`App.tsx`**: updated all consumers to use per-thread APIs
- **`workspaceStore.deleteThread`**: wired up `diffStore.clearThread` so right panel state is cleaned up on thread deletion
- **`terminal-service`** (server): swapped `killProcessTree` / `pty.kill()` order to fix `AttachConsole failed` crash on Windows - the conpty cleanup agent must fork before `taskkill` kills the shell process

## Related issues/PRs

Closes #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Right panel (Tasks/Changes) is now per-thread (visibility, width, active tab).
  - Terminal panels are per-thread (visibility, active terminal, height); empty panels show “No terminals” with a “New terminal” button.

* **Bug Fixes**
  - Improved terminal shutdown to better terminate descendant processes and reduce orphans; quieter logs when processes are already gone.
  - Deleting threads/workspaces now clears associated panel and terminal state.

* **Tests**
  - Updated and new tests covering per-thread panel and terminal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->