### PR TITLE
feat: add provider usage tracking panel

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -17,6 +17,7 @@ import type {
   ReasoningLevel,
   AgentEvent,
   AttachmentMeta,
+  ProviderUsageInfo,
 } from "@mcode/contracts";
 import { buildReasoningOptions } from "./build-reasoning-options.js";
 
@@ -161,6 +162,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
   private sessions = new Map<string, SessionEntry>();
   private sdkSessionIds = new Map<string, string>();
   private evictionTimer: ReturnType<typeof setInterval> | null = null;
+  private lastSessionCostUsd?: number;
 
   constructor() {
     super();
@@ -659,6 +661,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                 (usage.cache_creation_input_tokens ?? 0)
               );
 
+              this.lastSessionCostUsd = (anyMsg.total_cost_usd as number) ?? undefined;
+
               this.emit("event", {
                 type: AgentEventType.TurnComplete,
                 threadId,
@@ -672,6 +676,17 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                 tokensOut: usage.output_tokens ?? 0,
                 contextWindow: sdkContextWindow,
                 totalProcessedTokens,
+                cacheReadTokens: usage.cache_read_input_tokens ?? undefined,
+                cacheWriteTokens: usage.cache_creation_input_tokens ?? undefined,
+                providerId: "claude",
+              } satisfies AgentEvent);
+
+              this.emit("event", {
+                type: AgentEventType.QuotaUpdate,
+                threadId,
+                providerId: "claude",
+                categories: [],
+                sessionCostUsd: this.lastSessionCostUsd,
               } satisfies AgentEvent);
 
               lastContextWindow = sdkContextWindow;
@@ -1004,6 +1019,15 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       entry.closeQueue();
       entry.query.close();
     });
+  }
+
+  /** Return accumulated session cost. Claude has no quota API via the SDK. */
+  async getUsage(): Promise<ProviderUsageInfo> {
+    return {
+      providerId: "claude",
+      quotaCategories: [],
+      sessionCostUsd: this.lastSessionCostUsd,
+    };
   }
 
   /** Tear down all sessions and release resources. */

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -163,6 +163,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
   private sdkSessionIds = new Map<string, string>();
   private evictionTimer: ReturnType<typeof setInterval> | null = null;
   private lastSessionCostUsd?: number;
+  private lastServiceTier?: "standard" | "priority" | "batch";
+  private lastNumTurns?: number;
+  private lastDurationMs?: number;
 
   constructor() {
     super();
@@ -662,6 +665,13 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
               );
 
               this.lastSessionCostUsd = (anyMsg.total_cost_usd as number) ?? undefined;
+              this.lastNumTurns = (anyMsg.num_turns as number) ?? undefined;
+              this.lastDurationMs = (anyMsg.duration_ms as number) ?? undefined;
+              const resultUsage = (anyMsg.usage ?? {}) as { service_tier?: string };
+              const rawTier = resultUsage.service_tier;
+              this.lastServiceTier = (rawTier === "standard" || rawTier === "priority" || rawTier === "batch")
+                ? rawTier
+                : undefined;
 
               this.emit("event", {
                 type: AgentEventType.TurnComplete,
@@ -687,6 +697,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                 providerId: "claude",
                 categories: [],
                 sessionCostUsd: this.lastSessionCostUsd,
+                serviceTier: this.lastServiceTier,
+                numTurns: this.lastNumTurns,
+                durationMs: this.lastDurationMs,
               } satisfies AgentEvent);
 
               lastContextWindow = sdkContextWindow;
@@ -1021,12 +1034,15 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     });
   }
 
-  /** Return accumulated session cost. Claude has no quota API via the SDK. */
+  /** Return accumulated session data. Claude has no quota API via the SDK. */
   async getUsage(): Promise<ProviderUsageInfo> {
     return {
       providerId: "claude",
       quotaCategories: [],
       sessionCostUsd: this.lastSessionCostUsd,
+      serviceTier: this.lastServiceTier,
+      numTurns: this.lastNumTurns,
+      durationMs: this.lastDurationMs,
     };
   }
 

--- a/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
@@ -313,8 +313,10 @@ describe("CodexEventMapper", () => {
       threadId: "test-thread",
       reason: "end_turn",
       costUsd: null,
-      tokensIn: 15,
+      tokensIn: 10,
       tokensOut: 20,
+      cacheReadTokens: 5,
+      providerId: "codex",
       contextWindow: undefined,
       totalProcessedTokens: 35,
     });

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -90,9 +90,11 @@ export class CodexEventMapper {
 
       const text = this.lastAssistantText;
       const usage = turn?.usage ?? {};
-      const tokensIn = (usage.input_tokens ?? 0) + (usage.cached_input_tokens ?? 0);
+      const inputTokens = usage.input_tokens ?? 0;
+      const cachedInputTokens = usage.cached_input_tokens ?? 0;
+      const tokensIn = inputTokens;
       const tokensOut = usage.output_tokens ?? 0;
-      const totalProcessedTokens = tokensIn + tokensOut;
+      const totalProcessedTokens = inputTokens + cachedInputTokens + tokensOut;
 
       const events: AgentEvent[] = [];
       if (text) {
@@ -107,6 +109,8 @@ export class CodexEventMapper {
         tokensOut,
         contextWindow: undefined,
         totalProcessedTokens,
+        cacheReadTokens: cachedInputTokens || undefined,
+        providerId: "codex",
       });
       this.reset();
       return events;

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -26,10 +26,48 @@ import type {
   AgentEvent,
   AttachmentMeta,
   ProviderModelInfo,
+  QuotaCategory,
 } from "@mcode/contracts";
+import { AgentEventType } from "@mcode/contracts";
 
 /** Promisified execFile used to retrieve the gh auth token. */
 const execFileAsync = promisify(execFile);
+
+/** Maps raw Copilot quota snapshot keys to human-readable labels. */
+const QUOTA_LABELS: Record<string, string> = {
+  premium_interactions: "Premium requests",
+  chat: "Chat",
+  completions: "Completions",
+};
+
+/** Shape of a single quota snapshot entry from the Copilot SDK assistant.usage event. */
+interface QuotaSnapshot {
+  isUnlimitedEntitlement?: boolean;
+  entitlementRequests?: number;
+  usedRequests?: number;
+  remainingPercentage?: number;
+  resetDate?: string;
+  overage?: number;
+  overageAllowedWithExhaustedQuota?: boolean;
+  usageAllowedWithExhaustedQuota?: boolean;
+}
+
+/**
+ * Converts a raw Copilot quota snapshot map into an array of normalized QuotaCategory objects
+ * suitable for the QuotaUpdate AgentEvent.
+ */
+function normalizeQuotaSnapshots(
+  snapshots: Record<string, QuotaSnapshot>,
+): QuotaCategory[] {
+  return Object.entries(snapshots).map(([key, snap]) => ({
+    label: QUOTA_LABELS[key] ?? key,
+    used: snap.usedRequests ?? 0,
+    total: snap.isUnlimitedEntitlement ? null : (snap.entitlementRequests ?? 0),
+    remainingPercent: snap.remainingPercentage ?? 1.0,
+    resetDate: snap.resetDate,
+    isUnlimited: snap.isUnlimitedEntitlement ?? false,
+  }));
+}
 
 /** Infer vendor group from model ID prefix for UI section headers. */
 function inferModelGroup(modelId: string): string | undefined {
@@ -508,19 +546,40 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         // assistant.usage — token counts after a model call
         unsubscribers.push(
           session.on("assistant.usage", (event) => {
-            const { inputTokens = 0, outputTokens = 0, cacheReadTokens = 0 } = event.data;
-            const tokensIn = inputTokens + cacheReadTokens;
+            const {
+              inputTokens = 0,
+              outputTokens = 0,
+              cacheReadTokens = 0,
+              cacheWriteTokens = 0,
+              cost,
+              quotaSnapshots,
+            } = event.data;
             const contextWindow = this.contextWindowBySession.get(sessionId);
+
             this.emit("event", {
-              type: "turnComplete",
+              type: AgentEventType.TurnComplete,
               threadId,
               reason: "end_turn",
               costUsd: null,
-              tokensIn,
+              tokensIn: inputTokens,
               tokensOut: outputTokens,
               contextWindow,
-              totalProcessedTokens: tokensIn + outputTokens,
+              totalProcessedTokens: inputTokens + cacheReadTokens + cacheWriteTokens + outputTokens,
+              cacheReadTokens,
+              cacheWriteTokens,
+              costMultiplier: cost,
+              providerId: "copilot",
             } satisfies AgentEvent);
+
+            // Emit quota update if snapshots are present
+            if (quotaSnapshots && typeof quotaSnapshots === "object") {
+              this.emit("event", {
+                type: AgentEventType.QuotaUpdate,
+                threadId,
+                providerId: "copilot",
+                categories: normalizeQuotaSnapshots(quotaSnapshots as Record<string, QuotaSnapshot>),
+              } satisfies AgentEvent);
+            }
           }),
         );
 

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -60,14 +60,22 @@ interface QuotaSnapshot {
 function normalizeQuotaSnapshots(
   snapshots: Record<string, QuotaSnapshot>,
 ): QuotaCategory[] {
-  return Object.entries(snapshots).map(([key, snap]) => ({
-    label: QUOTA_LABELS[key] ?? key,
-    used: snap.usedRequests ?? 0,
-    total: snap.isUnlimitedEntitlement ? null : (snap.entitlementRequests ?? 0),
-    remainingPercent: snap.remainingPercentage ?? 1.0,
-    resetDate: snap.resetDate,
-    isUnlimited: snap.isUnlimitedEntitlement ?? false,
-  }));
+  return Object.entries(snapshots).map(([key, snap]) => {
+    // A category is limited only when the API provides a positive entitlement value
+    // and does not mark it as unlimited. Categories returned with no entitlement
+    // data (entitlementRequests = 0 or absent) default to unlimited so we never
+    // display a misleading 0/0.
+    const hasLimit = (snap.entitlementRequests ?? 0) > 0;
+    const isUnlimited = snap.isUnlimitedEntitlement ?? !hasLimit;
+    return {
+      label: QUOTA_LABELS[key] ?? key,
+      used: snap.usedRequests ?? 0,
+      total: hasLimit ? snap.entitlementRequests! : null,
+      remainingPercent: (snap.remainingPercentage ?? 100) / 100,
+      resetDate: snap.resetDate,
+      isUnlimited,
+    };
+  });
 }
 
 /** Infer vendor group from model ID prefix for UI section headers. */

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -27,6 +27,7 @@ import type {
   AttachmentMeta,
   ProviderModelInfo,
   QuotaCategory,
+  ProviderUsageInfo,
 } from "@mcode/contracts";
 import { AgentEventType } from "@mcode/contracts";
 
@@ -159,6 +160,21 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       policy: m.policy ? { state: m.policy.state as "enabled" | "disabled" | "unconfigured" } : undefined,
       multiplier: m.billing?.multiplier,
     }));
+  }
+
+  /** Return current usage/quota state by fetching from account.getQuota(). */
+  async getUsage(): Promise<ProviderUsageInfo> {
+    try {
+      await this.refreshClient();
+      const result = await this.client!.rpc.account.getQuota();
+      const categories = result?.quotaSnapshots
+        ? normalizeQuotaSnapshots(result.quotaSnapshots)
+        : [];
+      return { providerId: "copilot", quotaCategories: categories };
+    } catch (error) {
+      logger.warn("Failed to fetch Copilot quota", { error });
+      return { providerId: "copilot", quotaCategories: [] };
+    }
   }
 
   /**

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -16,6 +16,7 @@ import {
   type WebSocketResponse,
   type WsMethodName,
   type IProviderRegistry,
+  type ProviderUsageInfo,
   getExtension,
 } from "@mcode/contracts";
 import { logger, validateBranchName } from "@mcode/shared";
@@ -485,6 +486,13 @@ async function dispatch(
         throw new Error(`Provider "${params.providerId}" does not support model listing`);
       }
       return provider.listModels();
+    }
+    case "provider.getUsage": {
+      const provider = deps.providerRegistry.resolve(params.providerId);
+      if (!provider.getUsage) {
+        return { providerId: provider.id, quotaCategories: [] } satisfies ProviderUsageInfo;
+      }
+      return provider.getUsage();
     }
 
     // Memory pressure

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -129,5 +129,8 @@ export const mockTransport: McodeTransport = {
   updateSettings: vi.fn().mockImplementation(() => Promise.resolve(structuredClone(getDefaultSettings()))),
   listProviderModels: vi.fn().mockResolvedValue([]),
   setBackground: vi.fn().mockResolvedValue(undefined),
-  getProviderUsage: vi.fn().mockResolvedValue({ providerId: "claude", quotaCategories: [], sessionCostUsd: undefined }),
+  getProviderUsage: vi.fn().mockResolvedValue({
+    providerId: "claude",
+    quotaCategories: [],
+  }),
 };

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -129,4 +129,5 @@ export const mockTransport: McodeTransport = {
   updateSettings: vi.fn().mockImplementation(() => Promise.resolve(structuredClone(getDefaultSettings()))),
   listProviderModels: vi.fn().mockResolvedValue([]),
   setBackground: vi.fn().mockResolvedValue(undefined),
+  getProviderUsage: vi.fn().mockResolvedValue({ providerId: "claude", quotaCategories: [], sessionCostUsd: undefined }),
 };

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -46,6 +46,7 @@ import { PrDetectedCard } from "./PrDetectedCard";
 import type { PrDetail } from "@/transport/types";
 import { QueuePopover } from "./QueuePopover";
 import { ContextTracker } from "./ContextTracker";
+import { UsagePopover } from "./UsagePopover";
 import { CompactingBanner } from "./CompactingBanner";
 import { useQueueStore } from "@/stores/queueStore";
 import {
@@ -152,6 +153,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const [detectedPr, setDetectedPr] = useState<PrDetail | null>(null);
   const [prDismissed, setPrDismissed] = useState(false);
   const prDetectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [usagePopoverOpen, setUsagePopoverOpen] = useState(false);
 
   const editorRef = useRef<LexicalEditor | null>(null);
   const editorContainerRef = useRef<HTMLDivElement>(null);
@@ -395,6 +397,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
   const threads = useWorkspaceStore((s) => s.threads);
   const activeThread = threadId ? threads.find((t) => t.id === threadId) : undefined;
+
+  const activeProviderId = activeThread?.provider ?? "claude";
+  const usageInfo = useThreadStore((s) => s.usageByProvider[activeProviderId]);
+  const hasLowQuota = usageInfo?.quotaCategories.some((c) => !c.isUnlimited && c.remainingPercent < 0.2) ?? false;
 
   const branches = useWorkspaceStore((s) => s.branches);
   const branchesLoading = useWorkspaceStore((s) => s.branchesLoading);
@@ -1258,11 +1264,15 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
           {/* Context window tracker — live data from turnComplete, fallback to persisted thread record */}
           {threadId && (
-            <ContextTracker
-              tokensIn={contextEntry?.lastTokensIn ?? activeThread?.last_context_tokens ?? 0}
-              contextWindow={contextEntry?.contextWindow ?? activeThread?.context_window ?? undefined}
-              totalProcessedTokens={contextEntry?.totalProcessedTokens}
-            />
+            <UsagePopover threadId={threadId} onOpenChange={setUsagePopoverOpen}>
+              <ContextTracker
+                tokensIn={contextEntry?.lastTokensIn ?? activeThread?.last_context_tokens ?? 0}
+                contextWindow={contextEntry?.contextWindow ?? activeThread?.context_window ?? undefined}
+                totalProcessedTokens={contextEntry?.totalProcessedTokens}
+                hasLowQuota={hasLowQuota}
+                popoverOpen={usagePopoverOpen}
+              />
+            </UsagePopover>
           )}
 
           {/* Send / Queue / Stop button */}

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -46,7 +46,6 @@ import { PrDetectedCard } from "./PrDetectedCard";
 import type { PrDetail } from "@/transport/types";
 import { QueuePopover } from "./QueuePopover";
 import { ContextTracker } from "./ContextTracker";
-import { UsagePopover } from "./UsagePopover";
 import { CompactingBanner } from "./CompactingBanner";
 import { useQueueStore } from "@/stores/queueStore";
 import {
@@ -153,7 +152,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const [detectedPr, setDetectedPr] = useState<PrDetail | null>(null);
   const [prDismissed, setPrDismissed] = useState(false);
   const prDetectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [usagePopoverOpen, setUsagePopoverOpen] = useState(false);
 
   const editorRef = useRef<LexicalEditor | null>(null);
   const editorContainerRef = useRef<HTMLDivElement>(null);
@@ -1264,15 +1262,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
           {/* Context window tracker — live data from turnComplete, fallback to persisted thread record */}
           {threadId && (
-            <UsagePopover threadId={threadId} onOpenChange={setUsagePopoverOpen}>
-              <ContextTracker
-                tokensIn={contextEntry?.lastTokensIn ?? activeThread?.last_context_tokens ?? 0}
-                contextWindow={contextEntry?.contextWindow ?? activeThread?.context_window ?? undefined}
-                totalProcessedTokens={contextEntry?.totalProcessedTokens}
-                hasLowQuota={hasLowQuota}
-                popoverOpen={usagePopoverOpen}
-              />
-            </UsagePopover>
+            <ContextTracker
+              tokensIn={contextEntry?.lastTokensIn ?? activeThread?.last_context_tokens ?? 0}
+              contextWindow={contextEntry?.contextWindow ?? activeThread?.context_window ?? undefined}
+              totalProcessedTokens={contextEntry?.totalProcessedTokens}
+              hasLowQuota={hasLowQuota}
+            />
           )}
 
           {/* Send / Queue / Stop button */}

--- a/apps/web/src/components/chat/ContextTracker.tsx
+++ b/apps/web/src/components/chat/ContextTracker.tsx
@@ -99,7 +99,9 @@ export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, 
             </svg>
 
             {hasLowQuota && (
-              <div className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-background bg-destructive" />
+              <div className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-background bg-destructive">
+                <span className="sr-only">Low quota</span>
+              </div>
             )}
 
             {/* Centre percentage — positioned absolutely so it doesn't rotate */}

--- a/apps/web/src/components/chat/ContextTracker.tsx
+++ b/apps/web/src/components/chat/ContextTracker.tsx
@@ -17,6 +17,10 @@ interface ContextTrackerProps {
   totalProcessedTokens?: number;
   /** Optional additional Tailwind classes for the root element. */
   className?: string;
+  /** Show red dot badge when any quota category is below 20%. */
+  hasLowQuota?: boolean;
+  /** When true, suppress the tooltip (popover is visible). */
+  popoverOpen?: boolean;
 }
 
 /** Returns the color tier class for the fill ring and label. */
@@ -34,7 +38,7 @@ function colorTier(pct: number) {
  * from muted → amber (70%) → red (90%) to signal urgency. When the provider
  * compacts, the ring silently animates backward.
  */
-export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, className }: ContextTrackerProps) {
+export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, className, hasLowQuota, popoverOpen }: ContextTrackerProps) {
   if (tokensIn <= 0 || !contextWindow) return null;
 
   const pct = Math.min(100, contextWindow > 0 ? (tokensIn / contextWindow) * 100 : 0);
@@ -51,12 +55,12 @@ export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, 
   const tooltipLine = `${displayPct}% · ${abbrev(tokensIn)}/${abbrev(contextWindow)} context used`;
 
   return (
-    <Tooltip>
+    <Tooltip open={popoverOpen ? false : undefined}>
       <TooltipTrigger
         render={
           <div
             className={cn(
-              "relative flex items-center justify-center cursor-default",
+              "relative flex items-center justify-center cursor-pointer",
               className,
             )}
             style={{ width: 24, height: 24 }}
@@ -95,6 +99,10 @@ export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, 
                 )}
               />
             </svg>
+
+            {hasLowQuota && (
+              <div className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-background bg-destructive" />
+            )}
 
             {/* Centre percentage — positioned absolutely so it doesn't rotate */}
             <span

--- a/apps/web/src/components/chat/ContextTracker.tsx
+++ b/apps/web/src/components/chat/ContextTracker.tsx
@@ -19,8 +19,6 @@ interface ContextTrackerProps {
   className?: string;
   /** Show red dot badge when any quota category is below 20%. */
   hasLowQuota?: boolean;
-  /** When true, suppress the tooltip (popover is visible). */
-  popoverOpen?: boolean;
 }
 
 /** Returns the color tier class for the fill ring and label. */
@@ -38,7 +36,7 @@ function colorTier(pct: number) {
  * from muted → amber (70%) → red (90%) to signal urgency. When the provider
  * compacts, the ring silently animates backward.
  */
-export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, className, hasLowQuota, popoverOpen }: ContextTrackerProps) {
+export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, className, hasLowQuota }: ContextTrackerProps) {
   if (tokensIn <= 0 || !contextWindow) return null;
 
   const pct = Math.min(100, contextWindow > 0 ? (tokensIn / contextWindow) * 100 : 0);
@@ -55,7 +53,7 @@ export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, 
   const tooltipLine = `${displayPct}% · ${abbrev(tokensIn)}/${abbrev(contextWindow)} context used`;
 
   return (
-    <Tooltip open={popoverOpen ? false : undefined}>
+    <Tooltip>
       <TooltipTrigger
         render={
           <div

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -67,14 +67,15 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
   const contextEntry = useThreadStore((s) => threadId ? s.contextByThread[threadId] : undefined);
   const activeThread = useWorkspaceStore((s) => s.threads.find((t) => t.id === threadId));
   const providerId = (activeThread?.provider ?? "claude") as string;
-  const usageInfo = useThreadStore((s) => s.usageByProvider[providerId]);
+  const usageKey = threadId ? `${threadId}:${providerId}` : null;
+  const usageInfo = useThreadStore((s) => usageKey ? s.usageByProvider[usageKey] : undefined);
   const fetchProviderUsage = useThreadStore((s) => s.fetchProviderUsage);
   const hasFetched = useRef(false);
 
   const handleOpenChange = (open: boolean) => {
-    if (open && !hasFetched.current) {
+    if (open && !hasFetched.current && threadId) {
       hasFetched.current = true;
-      fetchProviderUsage(providerId);
+      fetchProviderUsage(threadId, providerId);
     }
     onOpenChange?.(open);
   };

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -53,7 +53,9 @@ function UsageBar({ percent, className, label }: { percent: number; className?: 
 function QuotaRow({ category }: { category: QuotaCategory }) {
   const usedDisplay = category.isUnlimited
     ? `${category.used}`
-    : `${category.used} / ${category.total}`;
+    : category.total != null
+      ? `${category.used} / ${category.total}`
+      : `${category.used}`;
   const percent = category.isUnlimited ? 0 : (1 - category.remainingPercent);
   return (
     <div className="space-y-1">
@@ -72,7 +74,7 @@ function QuotaRow({ category }: { category: QuotaCategory }) {
 export function UsagePopover({ threadId, children, onOpenChange, side = "top", align = "end" }: UsagePopoverProps) {
   const contextEntry = useThreadStore((s) => threadId ? s.contextByThread[threadId] : undefined);
   const activeThread = useWorkspaceStore((s) => s.threads.find((t) => t.id === threadId));
-  const providerId = (activeThread?.provider ?? "claude") as string;
+  const providerId = activeThread?.provider ?? "claude";
   const usageKey = threadId ? `${threadId}:${providerId}` : null;
   const usageInfo = useThreadStore((s) => usageKey ? s.usageByProvider[usageKey] : undefined);
   const fetchProviderUsage = useThreadStore((s) => s.fetchProviderUsage);
@@ -188,7 +190,7 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
                 <div className="rounded bg-muted/40 px-2 py-1.5">
                   <div className="text-[9px] text-muted-foreground">out</div>
                   <div className="text-xs text-foreground/80">
-                    {formatTokens(contextEntry?.tokensOut ?? 0)}
+                    {formatTokens(tokensOut)}
                   </div>
                 </div>
                 {contextEntry?.cacheReadTokens != null && (

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -86,17 +86,18 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
     onOpenChange?.(open);
   };
 
-  // Reset fetch flag when provider changes
+  // Reset fetch flag when thread or provider changes
   useEffect(() => {
     hasFetched.current = false;
-  }, [providerId]);
+  }, [threadId, providerId]);
 
   const categories = usageInfo?.quotaCategories ?? [];
   const sessionCost = usageInfo?.sessionCostUsd;
   const tokensIn = contextEntry?.lastTokensIn ?? 0;
+  const tokensOut = contextEntry?.tokensOut ?? 0;
   const contextWindow = contextEntry?.contextWindow;
   const hasContext = tokensIn > 0 && contextWindow;
-  const hasTurn = tokensIn > 0;
+  const hasTurn = tokensIn > 0 || tokensOut > 0;
 
   // Earliest reset date across quota categories
   const resetDays = categories
@@ -166,7 +167,10 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
                   {formatTokens(tokensIn)} / {formatTokens(contextWindow)}
                 </span>
               </div>
-              <UsageBar percent={tokensIn / contextWindow} />
+              <UsageBar
+                percent={tokensIn / contextWindow}
+                label={`Context usage: ${formatTokens(tokensIn)} of ${formatTokens(contextWindow)} tokens`}
+              />
             </div>
           )}
 

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -1,0 +1,202 @@
+// apps/web/src/components/chat/UsagePopover.tsx
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { useThreadStore } from "../../stores/threadStore";
+import { useWorkspaceStore } from "../../stores/workspaceStore";
+import type { QuotaCategory } from "@mcode/contracts";
+import { useEffect, useRef, type ReactNode } from "react";
+
+interface UsagePopoverProps {
+  threadId: string | undefined;
+  children: ReactNode;
+  onOpenChange?: (open: boolean) => void;
+}
+
+/** Format token counts for display (e.g., 1500 → "1.5k"). */
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+/** Days until a quota reset date. */
+function daysUntil(iso: string | undefined): number | undefined {
+  if (!iso) return undefined;
+  const diff = new Date(iso).getTime() - Date.now();
+  return diff > 0 ? Math.ceil(diff / 86_400_000) : 0;
+}
+
+/** Horizontal fill bar for usage visualization. */
+function UsageBar({ percent, className }: { percent: number; className?: string }) {
+  const color =
+    percent >= 0.9 ? "bg-destructive" :
+    percent >= 0.7 ? "bg-amber-500" :
+    "bg-emerald-500";
+  return (
+    <div className="h-1 w-full rounded-full bg-muted">
+      <div
+        className={`h-1 rounded-full transition-all ${color} ${className ?? ""}`}
+        style={{ width: `${Math.min(percent * 100, 100)}%` }}
+      />
+    </div>
+  );
+}
+
+/** Single quota category row with label, usage, and progress bar. */
+function QuotaRow({ category }: { category: QuotaCategory }) {
+  const usedDisplay = category.isUnlimited
+    ? `${category.used}`
+    : `${category.used} / ${category.total}`;
+  const percent = category.isUnlimited ? 0 : (1 - category.remainingPercent);
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">{category.label}</span>
+        <span className={percent >= 0.8 ? "text-destructive" : "text-foreground/70"}>
+          {category.isUnlimited ? "unlimited" : usedDisplay}
+        </span>
+      </div>
+      {!category.isUnlimited && <UsageBar percent={percent} />}
+    </div>
+  );
+}
+
+/** Usage popover anchored to the context ring. Shows quota, context window, and last turn data. */
+export function UsagePopover({ threadId, children, onOpenChange }: UsagePopoverProps) {
+  const contextEntry = useThreadStore((s) => threadId ? s.contextByThread[threadId] : undefined);
+  const activeThread = useWorkspaceStore((s) => s.threads.find((t) => t.id === threadId));
+  const providerId = (activeThread?.provider ?? "claude") as string;
+  const usageInfo = useThreadStore((s) => s.usageByProvider[providerId]);
+  const fetchProviderUsage = useThreadStore((s) => s.fetchProviderUsage);
+  const hasFetched = useRef(false);
+
+  const handleOpenChange = (open: boolean) => {
+    if (open && !hasFetched.current) {
+      hasFetched.current = true;
+      fetchProviderUsage(providerId);
+    }
+    onOpenChange?.(open);
+  };
+
+  // Reset fetch flag when provider changes
+  useEffect(() => {
+    hasFetched.current = false;
+  }, [providerId]);
+
+  const categories = usageInfo?.quotaCategories ?? [];
+  const sessionCost = usageInfo?.sessionCostUsd;
+  const tokensIn = contextEntry?.lastTokensIn ?? 0;
+  const contextWindow = contextEntry?.contextWindow;
+  const hasContext = tokensIn > 0 && contextWindow;
+  const hasTurn = tokensIn > 0;
+
+  // Earliest reset date across quota categories
+  const resetDays = categories
+    .map((c) => daysUntil(c.resetDate))
+    .filter((d): d is number => d !== undefined)
+    .sort((a, b) => a - b)[0];
+
+  return (
+    <Popover onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent align="end" className="w-72 p-0">
+        <div className="space-y-3 p-3">
+          {/* Provider header */}
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium capitalize">{providerId}</div>
+              {activeThread?.model && (
+                <div className="text-[10px] text-muted-foreground">
+                  {activeThread.model}
+                  {contextEntry?.costMultiplier != null && ` · ${contextEntry.costMultiplier}×`}
+                </div>
+              )}
+            </div>
+            {resetDays !== undefined && (
+              <div className="text-right">
+                <div className="text-[10px] text-muted-foreground">resets in</div>
+                <div className="text-xs text-foreground/70">{resetDays}d</div>
+              </div>
+            )}
+          </div>
+
+          {/* Quota section */}
+          {categories.length > 0 ? (
+            <div className="space-y-2">
+              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                Quota
+              </div>
+              {categories.map((cat) => (
+                <QuotaRow key={cat.label} category={cat} />
+              ))}
+            </div>
+          ) : (
+            <div className="text-xs text-muted-foreground">
+              Quota data not available for this provider
+            </div>
+          )}
+
+          {/* Session cost (Claude only) */}
+          {sessionCost != null && (
+            <div className="flex items-center justify-between border-t border-border pt-2 text-xs">
+              <span className="text-muted-foreground">Session cost</span>
+              <span className="text-foreground/70">${sessionCost.toFixed(4)}</span>
+            </div>
+          )}
+
+          {/* Context window section */}
+          {hasContext && (
+            <div className="space-y-1 border-t border-border pt-2">
+              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                Context window
+              </div>
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">Used</span>
+                <span className="text-foreground/70">
+                  {formatTokens(tokensIn)} / {formatTokens(contextWindow)}
+                </span>
+              </div>
+              <UsageBar percent={tokensIn / contextWindow} />
+            </div>
+          )}
+
+          {/* Last turn section */}
+          {hasTurn ? (
+            <div className="space-y-2 border-t border-border pt-2">
+              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                Last turn
+              </div>
+              <div className="grid grid-cols-2 gap-1.5">
+                <div className="rounded bg-muted/40 px-2 py-1.5">
+                  <div className="text-[9px] text-muted-foreground">in</div>
+                  <div className="text-xs text-foreground/80">{formatTokens(tokensIn)}</div>
+                </div>
+                <div className="rounded bg-muted/40 px-2 py-1.5">
+                  <div className="text-[9px] text-muted-foreground">out</div>
+                  <div className="text-xs text-foreground/80">
+                    {formatTokens(contextEntry?.tokensOut ?? 0)}
+                  </div>
+                </div>
+                {contextEntry?.cacheReadTokens != null && (
+                  <div className="rounded bg-muted/40 px-2 py-1.5">
+                    <div className="text-[9px] text-muted-foreground">cache read</div>
+                    <div className="text-xs text-foreground/80">{formatTokens(contextEntry.cacheReadTokens)}</div>
+                  </div>
+                )}
+                {contextEntry?.cacheWriteTokens != null && (
+                  <div className="rounded bg-muted/40 px-2 py-1.5">
+                    <div className="text-[9px] text-muted-foreground">cache write</div>
+                    <div className="text-xs text-foreground/80">{formatTokens(contextEntry.cacheWriteTokens)}</div>
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="border-t border-border pt-2 text-xs text-muted-foreground">
+              No turn data yet
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -28,16 +28,22 @@ function daysUntil(iso: string | undefined): number | undefined {
 }
 
 /** Horizontal fill bar for usage visualization. */
-function UsageBar({ percent, className }: { percent: number; className?: string }) {
+function UsageBar({ percent, className, label }: { percent: number; className?: string; label?: string }) {
   const color =
     percent >= 0.9 ? "bg-destructive" :
     percent >= 0.7 ? "bg-amber-500" :
     "bg-emerald-500";
+  const valuenow = Math.round(Math.min(percent * 100, 100));
   return (
     <div className="h-1 w-full rounded-full bg-muted">
       <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={valuenow}
+        aria-label={label}
         className={`h-1 rounded-full transition-all ${color} ${className ?? ""}`}
-        style={{ width: `${Math.min(percent * 100, 100)}%` }}
+        style={{ width: `${valuenow}%` }}
       />
     </div>
   );
@@ -57,7 +63,7 @@ function QuotaRow({ category }: { category: QuotaCategory }) {
           {category.isUnlimited ? "unlimited" : usedDisplay}
         </span>
       </div>
-      {!category.isUnlimited && <UsageBar percent={percent} />}
+      {!category.isUnlimited && <UsageBar percent={percent} label={`${category.label} usage`} />}
     </div>
   );
 }

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -9,6 +9,8 @@ interface UsagePopoverProps {
   threadId: string | undefined;
   children: ReactNode;
   onOpenChange?: (open: boolean) => void;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
 }
 
 /** Format token counts for display (e.g., 1500 → "1.5k"). */
@@ -60,8 +62,8 @@ function QuotaRow({ category }: { category: QuotaCategory }) {
   );
 }
 
-/** Usage popover anchored to the context ring. Shows quota, context window, and last turn data. */
-export function UsagePopover({ threadId, children, onOpenChange }: UsagePopoverProps) {
+/** Usage popover showing quota, context window, and last turn data. */
+export function UsagePopover({ threadId, children, onOpenChange, side = "top", align = "end" }: UsagePopoverProps) {
   const contextEntry = useThreadStore((s) => threadId ? s.contextByThread[threadId] : undefined);
   const activeThread = useWorkspaceStore((s) => s.threads.find((t) => t.id === threadId));
   const providerId = (activeThread?.provider ?? "claude") as string;
@@ -97,8 +99,10 @@ export function UsagePopover({ threadId, children, onOpenChange }: UsagePopoverP
 
   return (
     <Popover onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent align="end" className="w-72 p-0">
+      <PopoverTrigger render={<span style={{ display: "contents" }} />}>
+        {children}
+      </PopoverTrigger>
+      <PopoverContent side={side} align={align} sideOffset={8} className="w-72 p-0">
         <div className="space-y-3 p-3">
           {/* Provider header */}
           <div className="flex items-center justify-between">

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { SettingsNav } from "@/components/settings/SettingsNav";
 import type { SettingsSection } from "@/components/settings/settings-nav";
+import { SidebarUsagePanel } from "./SidebarUsagePanel";
 
 /** True when running inside the Electron shell. */
 const IS_DESKTOP = typeof window !== "undefined" && !!window.desktopBridge;
@@ -34,6 +35,7 @@ export function Sidebar({
 
   // Force-expand sidebar when settings is open
   const isCollapsed = collapsed && !settingsOpen;
+
 
   const handleEditJson = () => {
     if (window.desktopBridge) {
@@ -94,7 +96,8 @@ export function Sidebar({
 
       {/* Footer */}
       {!isCollapsed && (
-        <div className="border-t border-border p-3">
+        <div className="border-t border-border p-3 space-y-1">
+          {!settingsOpen && <SidebarUsagePanel />}
           {settingsOpen ? (
             IS_DESKTOP && (
               <Button

--- a/apps/web/src/components/sidebar/SidebarUsagePanel.tsx
+++ b/apps/web/src/components/sidebar/SidebarUsagePanel.tsx
@@ -1,0 +1,333 @@
+import { useEffect, useRef, useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useThreadStore } from "@/stores/threadStore";
+import { useComposerDraftStore } from "@/stores/composerDraftStore";
+import { cn } from "@/lib/utils";
+import type { QuotaCategory } from "@mcode/contracts";
+
+function abbrev(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
+function daysUntil(iso: string | undefined): number | undefined {
+  if (!iso) return undefined;
+  const diff = new Date(iso).getTime() - Date.now();
+  return diff > 0 ? Math.ceil(diff / 86_400_000) : 0;
+}
+
+function barFill(cat: QuotaCategory): string {
+  const used = 1 - cat.remainingPercent;
+  if (used >= 0.9) return "bg-red-400";
+  if (used >= 0.7) return "bg-amber-400";
+  return "bg-emerald-400";
+}
+
+function compactFill(cat: QuotaCategory): string {
+  const used = 1 - cat.remainingPercent;
+  if (used >= 0.9) return "bg-destructive";
+  if (used >= 0.7) return "bg-amber-500";
+  return "bg-foreground/20";
+}
+
+/** Single quota row — bar for limited, ∞ badge for unlimited. */
+function QuotaRow({ cat }: { cat: QuotaCategory }) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="truncate text-[11px] text-gray-500">{cat.label}</span>
+        {cat.isUnlimited ? (
+          <span className="shrink-0 text-[11px] text-gray-300">∞</span>
+        ) : (
+          <span className="shrink-0 font-mono text-[10px] tabular-nums text-gray-400">
+            {abbrev(cat.used)}&thinsp;/&thinsp;{abbrev(cat.total ?? 0)}
+          </span>
+        )}
+      </div>
+      {!cat.isUnlimited && (
+        <div className="h-[3px] w-full rounded-full bg-gray-100">
+          <div
+            className={cn(
+              "h-[3px] rounded-full transition-[width] duration-700 ease-out",
+              barFill(cat),
+            )}
+            style={{ width: `${Math.min((1 - cat.remainingPercent) * 100, 100)}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Compact always-visible instrument strip in the sidebar footer.
+ * Shows razor-thin bars — no labels. Hovering reveals a white
+ * floating card with full quota, context, and turn breakdown.
+ */
+export function SidebarUsagePanel() {
+  const [open, setOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const activeThread = useWorkspaceStore((s) =>
+    s.threads.find((t) => t.id === s.activeThreadId),
+  );
+  // Prefer the live composer draft model (updates on every dropdown change)
+  // over the thread record which only reflects the last sent message.
+  const draftModel = useComposerDraftStore((s) =>
+    activeThreadId ? s.drafts[activeThreadId]?.modelId : undefined,
+  );
+  const displayModel = draftModel ?? activeThread?.model ?? undefined;
+
+  const providerId = (activeThread?.provider ?? "claude") as string;
+
+  const usageInfo = useThreadStore((s) => s.usageByProvider[providerId]);
+  const contextEntry = useThreadStore((s) =>
+    activeThreadId ? s.contextByThread[activeThreadId] : undefined,
+  );
+  const fetchProviderUsage = useThreadStore((s) => s.fetchProviderUsage);
+
+  // Hydrate immediately — bars appear without waiting for a hover.
+  useEffect(() => {
+    if (activeThreadId && !usageInfo) {
+      void fetchProviderUsage(providerId);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeThreadId, providerId]);
+
+  if (!activeThreadId) return null;
+
+  const categories = usageInfo?.quotaCategories ?? [];
+  const limitedCats = categories.filter((c) => !c.isUnlimited);
+  const sessionCost = usageInfo?.sessionCostUsd;
+  const serviceTier = usageInfo?.serviceTier;
+  const numTurns = usageInfo?.numTurns;
+  const durationMs = usageInfo?.durationMs;
+  // Most constrained limited category — drives the compact strip bar and metric.
+  const mostConstrained = limitedCats.length > 0
+    ? limitedCats.reduce((a, b) => a.remainingPercent < b.remainingPercent ? a : b)
+    : null;
+
+  const ctxTokens = contextEntry?.lastTokensIn ?? 0;
+  const ctxWindow = contextEntry?.contextWindow;
+  const hasContext = ctxTokens > 0 && !!ctxWindow;
+
+  const tokensIn = contextEntry?.lastTokensIn ?? 0;
+  const tokensOut = contextEntry?.tokensOut ?? 0;
+  const cacheRead = contextEntry?.cacheReadTokens ?? 0;
+  const cacheWrite = contextEntry?.cacheWriteTokens ?? 0;
+  const hasTurn = tokensIn > 0 || tokensOut > 0;
+
+  const resetDays = limitedCats
+    .map((c) => daysUntil(c.resetDate))
+    .filter((d): d is number => d !== undefined)
+    .sort((a, b) => a - b)[0];
+
+  const show = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    clearTimeout(closeTimer.current);
+    setOpen(true);
+  };
+
+  const hide = () => {
+    closeTimer.current = setTimeout(() => setOpen(false), 150);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+
+      {/* ── Compact strip ── */}
+      <PopoverTrigger
+        render={
+          <div
+            className="w-full cursor-default py-0.5"
+            onMouseEnter={show}
+            onMouseLeave={hide}
+          />
+        }
+      >
+        <div className="space-y-1.5">
+          {/* Model name + key metric */}
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-[11px] font-medium tracking-tight text-foreground/65">
+              {(displayModel?.split("/").pop() ?? providerId)}
+            </span>
+            <span className="shrink-0 font-mono text-[10px] tabular-nums text-foreground/40">
+              {sessionCost != null
+                ? `$${sessionCost.toFixed(2)}`
+                : mostConstrained
+                  ? `${abbrev(mostConstrained.used)}/${abbrev(mostConstrained.total ?? 0)}`
+                  : null}
+            </span>
+          </div>
+
+          {/* Representative bar */}
+          {mostConstrained ? (
+            <div className="h-[2px] w-full rounded-full bg-border/30">
+              <div
+                className={cn("h-[2px] rounded-full transition-[width] duration-700 ease-out", compactFill(mostConstrained))}
+                style={{ width: `${Math.min((1 - mostConstrained.remainingPercent) * 100, 100)}%` }}
+              />
+            </div>
+          ) : hasContext ? (
+            <div className="h-[2px] w-full rounded-full bg-border/20">
+              <div
+                className="h-[2px] rounded-full bg-foreground/20 transition-[width] duration-700 ease-out"
+                style={{ width: `${Math.min((ctxTokens / ctxWindow!) * 100, 100)}%` }}
+              />
+            </div>
+          ) : (
+            <div className="h-[2px] w-full rounded-full bg-border/15" />
+          )}
+        </div>
+      </PopoverTrigger>
+
+      {/* ── White hover panel ── */}
+      <PopoverContent
+        side="right"
+        align="end"
+        sideOffset={12}
+        className="w-60 p-0 !bg-white !border-black/[0.06] !shadow-[0_16px_48px_rgba(0,0,0,0.14),0_2px_8px_rgba(0,0,0,0.06)] overflow-hidden !rounded-2xl"
+        onMouseEnter={show}
+        onMouseLeave={hide}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between px-4 pt-4 pb-3">
+          <div className="min-w-0">
+            <div className="text-[13px] font-semibold capitalize tracking-tight text-gray-900 leading-none">
+              {providerId}
+            </div>
+            {displayModel && (
+              <div className="mt-0.5 truncate font-mono text-[10px] text-gray-400 leading-tight">
+                {displayModel.split("/").pop()}
+              </div>
+            )}
+          </div>
+          {resetDays !== undefined && (
+            <span className="shrink-0 ml-3 mt-0.5 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] tabular-nums text-gray-500">
+              {resetDays}d left
+            </span>
+          )}
+        </div>
+
+        {/* Quota — all categories */}
+        {categories.length > 0 && (
+          <div className="border-t border-gray-100 px-4 py-3 space-y-3">
+            {categories.map((cat) => (
+              <QuotaRow key={cat.label} cat={cat} />
+            ))}
+          </div>
+        )}
+
+        {/* Session stats — cost, tier, turns, duration */}
+        {(sessionCost != null || serviceTier || numTurns != null || durationMs != null) && (
+          <div className="border-t border-gray-100 px-4 py-3 space-y-2">
+            {sessionCost != null && (
+              <div className="flex items-baseline justify-between">
+                <span className="text-[10px] text-gray-400">session cost</span>
+                <span className="font-mono text-[12px] font-medium tabular-nums text-gray-700">
+                  ${sessionCost.toFixed(4)}
+                </span>
+              </div>
+            )}
+            {(numTurns != null || durationMs != null || serviceTier) && (
+              <div className="flex items-center gap-2 flex-wrap">
+                {numTurns != null && (
+                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] tabular-nums text-gray-500">
+                    {numTurns} {numTurns === 1 ? "turn" : "turns"}
+                  </span>
+                )}
+                {durationMs != null && (
+                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] tabular-nums text-gray-500">
+                    {durationMs >= 60_000
+                      ? `${Math.floor(durationMs / 60_000)}m ${Math.round((durationMs % 60_000) / 1000)}s`
+                      : `${(durationMs / 1000).toFixed(1)}s`}
+                  </span>
+                )}
+                {serviceTier && serviceTier !== "standard" && (
+                  <span className="rounded-full bg-violet-50 px-2 py-0.5 text-[10px] font-medium text-violet-500 capitalize">
+                    {serviceTier}
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Context window */}
+        {hasContext && (
+          <div className="border-t border-gray-100 px-4 py-3 space-y-1.5">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="text-[11px] text-gray-500">context</span>
+              <span className="font-mono text-[10px] tabular-nums text-gray-400">
+                {abbrev(ctxTokens)}&thinsp;/&thinsp;{abbrev(ctxWindow!)}
+              </span>
+            </div>
+            <div className="h-[3px] w-full rounded-full bg-gray-100">
+              <div
+                className="h-[3px] rounded-full bg-gray-300 transition-[width] duration-700 ease-out"
+                style={{ width: `${Math.min((ctxTokens / ctxWindow!) * 100, 100)}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Last turn — clean stat grid */}
+        {hasTurn && (
+          <div className="border-t border-gray-100 px-4 py-3">
+            <div className="text-[9px] font-medium uppercase tracking-wider text-gray-300 mb-2">last turn</div>
+            <div className="flex items-end gap-4">
+              {tokensIn > 0 && (
+                <div>
+                  <span className="font-mono text-[14px] font-semibold leading-none text-gray-800">
+                    {abbrev(tokensIn)}
+                  </span>
+                  <div className="text-[9px] text-gray-400 mt-0.5">in</div>
+                </div>
+              )}
+              {tokensOut > 0 && (
+                <div>
+                  <span className="font-mono text-[14px] font-semibold leading-none text-gray-800">
+                    {abbrev(tokensOut)}
+                  </span>
+                  <div className="text-[9px] text-gray-400 mt-0.5">out</div>
+                </div>
+              )}
+              {cacheRead > 0 && (
+                <div>
+                  <span className="font-mono text-[14px] font-semibold leading-none text-gray-800">
+                    {abbrev(cacheRead)}
+                  </span>
+                  <div className="text-[9px] text-gray-400 mt-0.5">cached</div>
+                </div>
+              )}
+              {cacheWrite > 0 && (
+                <div>
+                  <span className="font-mono text-[14px] font-semibold leading-none text-gray-800">
+                    {abbrev(cacheWrite)}
+                  </span>
+                  <div className="text-[9px] text-gray-400 mt-0.5">written</div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* No data at all yet for this provider */}
+        {usageInfo && categories.length === 0 && sessionCost == null && numTurns == null && !hasTurn && !hasContext && (
+          <div className="border-t border-gray-100 px-4 py-3">
+            <span className="text-[11px] text-gray-400">Send a message to see usage</span>
+          </div>
+        )}
+
+        {!usageInfo && !hasContext && (
+          <div className="border-t border-gray-100 px-4 py-3">
+            <span className="text-[11px] text-gray-400">Loading…</span>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/sidebar/SidebarUsagePanel.tsx
+++ b/apps/web/src/components/sidebar/SidebarUsagePanel.tsx
@@ -83,18 +83,19 @@ export function SidebarUsagePanel() {
 
   const providerId = (activeThread?.provider ?? "claude") as string;
 
-  const usageInfo = useThreadStore((s) => s.usageByProvider[providerId]);
+  const usageKey = activeThreadId ? `${activeThreadId}:${providerId}` : null;
+  const usageInfo = useThreadStore((s) => usageKey ? s.usageByProvider[usageKey] : undefined);
   const contextEntry = useThreadStore((s) =>
     activeThreadId ? s.contextByThread[activeThreadId] : undefined,
   );
   const fetchProviderUsage = useThreadStore((s) => s.fetchProviderUsage);
 
   // Hydrate immediately — bars appear without waiting for a hover.
+  // fetchProviderUsage is a stable Zustand store action.
   useEffect(() => {
     if (activeThreadId && !usageInfo) {
-      void fetchProviderUsage(providerId);
+      void fetchProviderUsage(activeThreadId, providerId);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeThreadId, providerId]);
 
   if (!activeThreadId) return null;

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -16,12 +16,13 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
+  side,
   ...props
 }: PopoverPrimitive.Popup.Props &
-  Pick<PopoverPrimitive.Positioner.Props, "align" | "sideOffset">) {
+  Pick<PopoverPrimitive.Positioner.Props, "align" | "sideOffset" | "side">) {
   return (
     <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Positioner align={align} sideOffset={sideOffset} className="isolate z-50">
+      <PopoverPrimitive.Positioner align={align} sideOffset={sideOffset} side={side} className="isolate z-50">
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1321,17 +1321,26 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const providerId = params.providerId as string;
       const categories = params.categories as QuotaCategory[];
       const sessionCostUsd = params.sessionCostUsd as number | undefined;
+      const serviceTier = params.serviceTier as "standard" | "priority" | "batch" | undefined;
+      const numTurns = params.numTurns as number | undefined;
+      const durationMs = params.durationMs as number | undefined;
       if (providerId) {
-        set((state) => ({
-          usageByProvider: {
-            ...state.usageByProvider,
-            [providerId]: {
-              providerId,
-              quotaCategories: categories ?? [],
-              sessionCostUsd: sessionCostUsd ?? state.usageByProvider[providerId]?.sessionCostUsd,
+        set((state) => {
+          const existing = state.usageByProvider[providerId];
+          return {
+            usageByProvider: {
+              ...state.usageByProvider,
+              [providerId]: {
+                providerId,
+                quotaCategories: categories ?? [],
+                sessionCostUsd: sessionCostUsd ?? existing?.sessionCostUsd,
+                serviceTier: serviceTier ?? existing?.serviceTier,
+                numTurns: numTurns ?? existing?.numTurns,
+                durationMs: durationMs ?? existing?.durationMs,
+              },
             },
-          },
-        }));
+          };
+        });
       }
       return;
     }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1525,7 +1525,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       set((state) => ({
         usageByProvider: {
           ...state.usageByProvider,
-          [key]: usage,
+          [key]: { ...state.usageByProvider[key], ...usage },
         },
       }));
     } catch {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -60,7 +60,7 @@ interface ThreadState {
   loadEpochByThread: Record<string, number>;
   /** Last known token usage and context window size per thread, updated on turn completion. */
   contextByThread: Record<string, { lastTokensIn: number; contextWindow?: number; totalProcessedTokens?: number; tokensOut?: number; cacheReadTokens?: number; cacheWriteTokens?: number; costMultiplier?: number }>;
-  /** Provider-level quota and usage info, keyed by providerId. Updated on session.quotaUpdate events and explicit fetches. */
+  /** Provider-level quota and usage info, keyed by `${threadId}:${providerId}`. Updated on session.quotaUpdate events and explicit fetches. */
   usageByProvider: Record<string, ProviderUsageInfo>;
   /** Whether the SDK is currently compacting the context window for a thread. */
   isCompactingByThread: Record<string, boolean>;
@@ -112,8 +112,8 @@ interface ThreadState {
   /** Merge partial settings and persist to server. Resolves to false if RPC fails or patch is empty. */
   setThreadSettings: (threadId: string, settings: Partial<ThreadSettings>) => Promise<boolean>;
 
-  /** Fetch and refresh provider usage info from the server for the given provider. */
-  fetchProviderUsage: (providerId: string) => Promise<void>;
+  /** Fetch and refresh provider usage info from the server for the given thread and provider. */
+  fetchProviderUsage: (threadId: string, providerId: string) => Promise<void>;
   /** Remove all per-thread state for a deleted thread. Clears visible-thread globals when the deleted thread is the current one. */
   clearThreadState: (threadId: string) => void;
   /** Batch variant of clearThreadState. Prunes all IDs in a single Zustand set() call to avoid N sequential re-renders. Used by deleteWorkspace. */
@@ -1325,12 +1325,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const numTurns = params.numTurns as number | undefined;
       const durationMs = params.durationMs as number | undefined;
       if (providerId) {
+        const key = `${threadId}:${providerId}`;
         set((state) => {
-          const existing = state.usageByProvider[providerId];
+          const existing = state.usageByProvider[key];
           return {
             usageByProvider: {
               ...state.usageByProvider,
-              [providerId]: {
+              [key]: {
                 providerId,
                 quotaCategories: categories ?? [],
                 sessionCostUsd: sessionCostUsd ?? existing?.sessionCostUsd,
@@ -1351,16 +1352,20 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Only apply if not compacting — the compaction-start zero sentinel is
       // authoritative while compaction is in progress.
       if (tokensIn > 0 && !get().isCompactingByThread[threadId]) {
-        set((state) => ({
-          contextByThread: {
-            ...state.contextByThread,
-            [threadId]: {
-              lastTokensIn: tokensIn,
-              contextWindow: ctxWindow ?? state.contextByThread[threadId]?.contextWindow,
-              totalProcessedTokens: state.contextByThread[threadId]?.totalProcessedTokens,
+        set((state) => {
+          const prev = state.contextByThread[threadId];
+          return {
+            contextByThread: {
+              ...state.contextByThread,
+              [threadId]: {
+                ...prev,
+                lastTokensIn: tokensIn,
+                contextWindow: ctxWindow ?? prev?.contextWindow,
+                totalProcessedTokens: prev?.totalProcessedTokens,
+              },
             },
-          },
-        }));
+          };
+        });
       }
       return;
     }
@@ -1402,10 +1407,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         // back to the stale persisted value from the thread record.
         // When active=false, leave contextByThread untouched: the post-compaction
         // turnComplete may have already written fresh data.
+        const prev = state.contextByThread[threadId];
         const nextCtx = active
           ? {
               ...state.contextByThread,
-              [threadId]: { lastTokensIn: 0, contextWindow: state.contextByThread[threadId]?.contextWindow, totalProcessedTokens: state.contextByThread[threadId]?.totalProcessedTokens },
+              [threadId]: { ...prev, lastTokensIn: 0, contextWindow: prev?.contextWindow, totalProcessedTokens: prev?.totalProcessedTokens },
             }
           : state.contextByThread;
         return { isCompactingByThread: next, contextByThread: nextCtx };
@@ -1511,18 +1517,19 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * Fetch provider usage from the server and merge it into usageByProvider.
    * Silently ignores errors so the popover shows stale or empty state rather than crashing.
    */
-  fetchProviderUsage: async (providerId) => {
+  fetchProviderUsage: async (threadId, providerId) => {
     try {
       const { getTransport } = await import("../transport/index.js");
       const usage = await getTransport().getProviderUsage(providerId);
+      const key = `${threadId}:${providerId}`;
       set((state) => ({
         usageByProvider: {
           ...state.usageByProvider,
-          [providerId]: usage,
+          [key]: usage,
         },
       }));
     } catch {
-      // Silently fail - popover shows stale or empty state
+      // Silently fail — popover shows stale or empty state
     }
   },
 

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -694,6 +694,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         planAnswersByThread: omitKey(state.planAnswersByThread, threadId),
         activeQuestionIndexByThread: omitKey(state.activeQuestionIndexByThread, threadId),
         planQuestionsStatusByThread: omitKey(state.planQuestionsStatusByThread, threadId),
+        usageByProvider: Object.fromEntries(
+          Object.entries(state.usageByProvider).filter(([k]) => !k.startsWith(`${threadId}:`)),
+        ),
         // Clear message-keyed globals only when deleting the currently loaded thread.
         // For background threads, message-keyed maps (persistedToolCallCounts, etc.)
         // belong to the active thread's messages and must not be touched.
@@ -768,6 +771,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         planAnswersByThread: pruneAll(state.planAnswersByThread),
         activeQuestionIndexByThread: pruneAll(state.activeQuestionIndexByThread),
         planQuestionsStatusByThread: pruneAll(state.planQuestionsStatusByThread),
+        usageByProvider: Object.fromEntries(
+          Object.entries(state.usageByProvider).filter(([k]) => !threadIds.some((tid) => k.startsWith(`${tid}:`))),
+        ),
         ...(deletingCurrentThread
           ? {
               currentThreadId: null,
@@ -1256,7 +1262,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               lastTokensIn: tokensIn,
               contextWindow,
               totalProcessedTokens,
-              tokensOut: params.tokensOut as number | undefined,
+              tokensOut,
               cacheReadTokens: params.cacheReadTokens as number | undefined,
               cacheWriteTokens: params.cacheWriteTokens as number | undefined,
               costMultiplier: params.costMultiplier as number | undefined,

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { Message, ToolCall, PermissionMode, InteractionMode, AttachmentMeta, ToolCallRecord } from "@/transport";
-import type { ReasoningLevel, PlanQuestion, PlanAnswer } from "@mcode/contracts";
+import type { ReasoningLevel, PlanQuestion, PlanAnswer, ProviderUsageInfo, QuotaCategory } from "@mcode/contracts";
 import { PlanQuestionSchema } from "@mcode/contracts";
 import { getTransport, PERMISSION_MODES, INTERACTION_MODES } from "@/transport";
 import { useWorkspaceStore } from "./workspaceStore";
@@ -59,7 +59,9 @@ interface ThreadState {
   /** Monotonic counter incremented on each loadMessages call, used to discard stale loadOlderMessages responses. */
   loadEpochByThread: Record<string, number>;
   /** Last known token usage and context window size per thread, updated on turn completion. */
-  contextByThread: Record<string, { lastTokensIn: number; contextWindow?: number; totalProcessedTokens?: number }>;
+  contextByThread: Record<string, { lastTokensIn: number; contextWindow?: number; totalProcessedTokens?: number; tokensOut?: number; cacheReadTokens?: number; cacheWriteTokens?: number; costMultiplier?: number }>;
+  /** Provider-level quota and usage info, keyed by providerId. Updated on session.quotaUpdate events and explicit fetches. */
+  usageByProvider: Record<string, ProviderUsageInfo>;
   /** Whether the SDK is currently compacting the context window for a thread. */
   isCompactingByThread: Record<string, boolean>;
   /** Transient fallback state per thread. Cleared when the user sends the next message. */
@@ -110,6 +112,8 @@ interface ThreadState {
   /** Merge partial settings and persist to server. Resolves to false if RPC fails or patch is empty. */
   setThreadSettings: (threadId: string, settings: Partial<ThreadSettings>) => Promise<boolean>;
 
+  /** Fetch and refresh provider usage info from the server for the given provider. */
+  fetchProviderUsage: (providerId: string) => Promise<void>;
   /** Remove all per-thread state for a deleted thread. Clears visible-thread globals when the deleted thread is the current one. */
   clearThreadState: (threadId: string) => void;
   /** Batch variant of clearThreadState. Prunes all IDs in a single Zustand set() call to avoid N sequential re-renders. Used by deleteWorkspace. */
@@ -226,6 +230,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   isLoadingMore: {},
   loadEpochByThread: {},
   contextByThread: {},
+  usageByProvider: {},
   isCompactingByThread: {},
   lastFallbackByThread: {},
   planQuestionsByThread: {},
@@ -1251,6 +1256,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               lastTokensIn: tokensIn,
               contextWindow,
               totalProcessedTokens,
+              tokensOut: params.tokensOut as number | undefined,
+              cacheReadTokens: params.cacheReadTokens as number | undefined,
+              cacheWriteTokens: params.cacheWriteTokens as number | undefined,
+              costMultiplier: params.costMultiplier as number | undefined,
             },
           },
         }));
@@ -1304,6 +1313,25 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           }
         }, 400);
         dequeueTimers.set(threadId, timer);
+      }
+      return;
+    }
+
+    if (method === "session.quotaUpdate") {
+      const providerId = params.providerId as string;
+      const categories = params.categories as QuotaCategory[];
+      const sessionCostUsd = params.sessionCostUsd as number | undefined;
+      if (providerId) {
+        set((state) => ({
+          usageByProvider: {
+            ...state.usageByProvider,
+            [providerId]: {
+              providerId,
+              quotaCategories: categories ?? [],
+              sessionCostUsd: sessionCostUsd ?? state.usageByProvider[providerId]?.sessionCostUsd,
+            },
+          },
+        }));
       }
       return;
     }
@@ -1468,6 +1496,25 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
+  },
+
+  /**
+   * Fetch provider usage from the server and merge it into usageByProvider.
+   * Silently ignores errors so the popover shows stale or empty state rather than crashing.
+   */
+  fetchProviderUsage: async (providerId) => {
+    try {
+      const { getTransport } = await import("../transport/index.js");
+      const usage = await getTransport().getProviderUsage(providerId);
+      set((state) => ({
+        usageByProvider: {
+          ...state.usageByProvider,
+          [providerId]: usage,
+        },
+      }));
+    } catch {
+      // Silently fail - popover shows stale or empty state
+    }
   },
 
   handleTurnPersisted: (payload) => {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1525,7 +1525,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    */
   fetchProviderUsage: async (threadId, providerId) => {
     try {
-      const { getTransport } = await import("../transport/index.js");
       const usage = await getTransport().getProviderUsage(providerId);
       const key = `${threadId}:${providerId}`;
       set((state) => ({

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -19,6 +19,7 @@ import type {
   PlanAnswer,
   InteractionMode,
   ProviderModelInfo,
+  ProviderUsageInfo,
   PrDraft,
   CreatePrResult,
 } from "@mcode/contracts";
@@ -235,6 +236,8 @@ export interface McodeTransport {
   // Provider models
   /** Fetch dynamically discovered models from a provider (e.g. Copilot). */
   listProviderModels(providerId: string): Promise<ProviderModelInfo[]>;
+  /** Fetch current usage/quota state for a provider. */
+  getProviderUsage(providerId: string): Promise<ProviderUsageInfo>;
 
   // Memory pressure
   /** Notify server of window background/foreground state for memory management. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -14,7 +14,7 @@ import type {
   GitCommit,
   ProviderModelInfo,
 } from "./types";
-import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult } from "@mcode/contracts";
+import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 
 /** Minimum reconnect delay in milliseconds. */
@@ -450,6 +450,8 @@ export function createWsTransport(
     // Provider models
     listProviderModels: (providerId) =>
       rpc<ProviderModelInfo[]>("provider.listModels", { providerId }),
+    getProviderUsage: (providerId) =>
+      rpc<ProviderUsageInfo>("provider.getUsage", { providerId }),
 
     // Memory pressure
     setBackground: (background) => rpc<void>("memory.setBackground", { background }),

--- a/docs/specs/2026-04-14-usage-tracking-design.md
+++ b/docs/specs/2026-04-14-usage-tracking-design.md
@@ -59,18 +59,17 @@ interface QuotaCategory {
 
 ### ProviderUsageInfo
 
-Top-level usage state per provider. This is what the popover renders.
+Top-level usage state per provider. This is what the popover renders for quota and cost. Context window data is **not** duplicated here - the popover reads context data from the existing `contextByThread` store (populated by `contextEstimate` and `turnComplete` events).
 
 ```ts
 interface ProviderUsageInfo {
   providerId: ProviderId;
   quotaCategories: QuotaCategory[];  // empty = "quota not available"
   sessionCostUsd?: number;           // Claude only (accumulated)
-  lastTurn?: TurnUsage;
-  contextWindow?: number;
-  contextUsed?: number;
 }
 ```
+
+`lastTurn` is also thread-scoped, not provider-scoped. The popover reads the active thread's most recent turn data from `contextByThread` (extended with token breakdown fields - see Frontend Changes).
 
 ### Provider mapping
 
@@ -78,13 +77,10 @@ interface ProviderUsageInfo {
 |-------|---------|--------|-------|
 | `quotaCategories` | `quotaSnapshots` from `assistant.usage` keyed by "chat", "completions", "premium_interactions" | Empty (no quota API accessible through SDK) | Empty (rate limit notifications exist but have no documented schema) |
 | `sessionCostUsd` | Not available (`null`) | `result.total_cost_usd` (accumulated session total) | Not available (`null`) |
-| `lastTurn.inputTokens` | `assistant.usage.inputTokens` | `stream_event.message_start.usage.input_tokens` | `turn/completed.usage.input_tokens` |
-| `lastTurn.outputTokens` | `assistant.usage.outputTokens` | `result.usage.output_tokens` | `turn/completed.usage.output_tokens` |
-| `lastTurn.cacheReadTokens` | `assistant.usage.cacheReadTokens` | `cache_read_input_tokens` | `cached_input_tokens` |
-| `lastTurn.cacheWriteTokens` | `assistant.usage.cacheWriteTokens` (currently dropped) | `cache_creation_input_tokens` | Not available |
-| `lastTurn.costMultiplier` | `assistant.usage.cost` | Not applicable | Not applicable |
-| `contextWindow` | `session.usage_info.tokenLimit` | `modelUsage[*].contextWindow` | Not available |
-| `contextUsed` | `session.usage_info.currentTokens` | `message_start.usage` sum | Not available |
+| `TurnComplete.cacheReadTokens` | `assistant.usage.cacheReadTokens` (already extracted) | `cache_read_input_tokens` | `cached_input_tokens` |
+| `TurnComplete.cacheWriteTokens` | `assistant.usage.cacheWriteTokens` (present in SDK types, not yet destructured in handler) | `cache_creation_input_tokens` | Not available |
+| `TurnComplete.costMultiplier` | `assistant.usage.cost` | Not applicable | Not applicable |
+| Context (existing path) | `session.usage_info` → `contextEstimate` event → `contextByThread` | `message_start.usage` → `contextEstimate` → `contextByThread` | Not available |
 
 ## Data Flow
 
@@ -109,7 +105,7 @@ This covers the low-quota warning requirement: quota is checked after every turn
 }
 ```
 
-Rides the existing `agent.event` push channel. The `providerId` field lets the frontend aggregate at the provider level despite the event being thread-scoped.
+Rides the existing `agent.event` push channel. The `providerId` field lets the frontend aggregate at the provider level despite the event being thread-scoped. The `agent-service` layer injects `providerId` before broadcasting - it already knows which provider emitted the event because it subscribes to each provider individually.
 
 ### New RPC: `provider.getUsage`
 
@@ -142,7 +138,7 @@ Add optional fields to the existing `TurnComplete` AgentEvent:
 
 1. **`assistant.usage` handler** - Extend to extract `cacheWriteTokens`, `cost` (multiplier), and `quotaSnapshots` from `event.data`. Normalize `quotaSnapshots` into `QuotaCategory[]` and emit `quotaUpdate`.
 2. **Session start** - Call `client.rpc.account.getQuota()` once after session initialization. Emit `quotaUpdate` with the result.
-3. **`session.shutdown` handler** (new) - Extract `totalPremiumRequests` and `modelMetrics` for session summary. Optional enhancement.
+Note: The Copilot SDK also emits a `session.shutdown` event with `totalPremiumRequests` and per-model `modelMetrics`. Handling this is out of scope for this feature but could support a session summary view in future work.
 
 ### Claude provider
 
@@ -154,7 +150,7 @@ Add optional fields to the existing `TurnComplete` AgentEvent:
 
 ### RPC handler
 
-Add `provider.getUsage` case in `ws-router.ts`. Each provider implements a `getUsage(): ProviderUsageInfo` method (or the handler constructs it from available state).
+Add `provider.getUsage` case in `ws-router.ts`. Add an optional `getUsage?(): Promise<ProviderUsageInfo>` method to the `IAgentProvider` interface, following the same pattern as `listModels?()`. Providers that support usage reporting implement it; the RPC handler checks for the method and returns a "not supported" response if absent.
 
 ## Frontend Changes
 
@@ -166,11 +162,25 @@ Add to existing `threadStore`:
 usageByProvider: Record<ProviderId, ProviderUsageInfo>
 ```
 
+Extend the existing `contextByThread` entry type to include the new per-turn fields:
+
+```ts
+contextByThread: Record<string, {
+  lastTokensIn: number;
+  contextWindow?: number;
+  totalProcessedTokens?: number;
+  // New fields:
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  costMultiplier?: number;
+}>
+```
+
 The `handleAgentEvent` dispatcher gets:
 - `quotaUpdate` case: updates `usageByProvider[event.providerId].quotaCategories`
-- `turnComplete` case (extended): updates `usageByProvider[providerId].lastTurn` with token breakdown
+- `turnComplete` case (extended): updates `contextByThread[threadId]` with the new cache/multiplier fields alongside the existing token fields
 
-On first popover open or session start, call `provider.getUsage` RPC to hydrate.
+**Hydration trigger:** The frontend calls `provider.getUsage` RPC when the popover opens for the first time (lazy). The result is cached in `usageByProvider`. Subsequent turns keep it fresh via `quotaUpdate` events. No server-push on session start.
 
 ### New component: `UsagePopover.tsx`
 
@@ -178,9 +188,9 @@ A Radix popover anchored to the context ring. Three sections that show or hide b
 
 **Quota section** - Renders each `QuotaCategory` as a label + progress bar + used/total. Hidden when `quotaCategories` is empty, replaced with "Quota data not available for this provider."
 
-**Context window section** - Shows `contextUsed / contextWindow` as a progress bar. Hidden when `contextWindow` is undefined (Codex).
+**Context window section** - Reads from the existing `contextByThread[activeThreadId]` store. Shows `lastTokensIn / contextWindow` as a progress bar. Hidden when `contextWindow` is undefined (Codex).
 
-**Last turn section** - A 2x2 grid of token counts (in, out, cache read, cache write). Shows after the first turn completes.
+**Last turn section** - Reads from `contextByThread[activeThreadId]`. A 2x2 grid of token counts (in, out, cache read, cache write). Shows after the first turn completes.
 
 **Provider header** - Shows provider name, current model (from thread state), cost multiplier if available, and days until quota reset.
 
@@ -191,7 +201,7 @@ A Radix popover anchored to the context ring. Three sections that show or hide b
 
 ### ContextTracker changes
 
-- Add `onClick` handler to the ring SVG to toggle the popover
+- Add `onClick` handler to the ring SVG to toggle the popover. The existing `TooltipTrigger` wrapper remains for hover - when the popover is closed, hovering shows the tooltip as before. When the popover is open, the tooltip is suppressed (set `Tooltip` `open={false}` while popover is visible).
 - Add a red dot badge (8px circle) when any `QuotaCategory.remainingPercent < 0.20`
 - Ring color continues to reflect context window fill only - the badge is the quota signal
 
@@ -207,7 +217,7 @@ Add popover state management in `Composer.tsx`. The `UsagePopover` renders as a 
 | `provider.getUsage` RPC fails on popover open | Frontend shows last known state with muted "Unable to refresh" text. |
 | Popover opened before first turn | Context data from `contextEstimate` events (already flowing). Quota shows initial hydration. Last turn section shows "No turn data yet." |
 | Provider switched mid-session | `usageByProvider` is keyed by provider ID. Switching renders a different entry. Old provider data persists. |
-| Multiple threads, same provider | Quota is provider-scoped. All threads share the same `usageByProvider[providerId]` entry. Last turn reflects the most recent turn across threads. |
+| Multiple threads, same provider | Quota is provider-scoped - all threads share the same `usageByProvider[providerId]` entry. Last turn and context are thread-scoped - the popover shows data for the active thread. |
 | Provider not configured | `provider.getUsage` returns error. Popover shows "Provider not configured." |
 
 ## What This Does Not Include
@@ -217,6 +227,7 @@ Add popover state management in `Composer.tsx`. The `UsagePopover` renders as a 
 - **Cost estimation for Copilot.** The SDK reports `totalNanoAiu` but there is no USD conversion. The `costMultiplier` is shown as a raw number.
 - **Codex rate limit capture.** The `account/rateLimits/updated` notification exists but has no documented payload schema. We skip it until the schema stabilizes.
 - **Anthropic rate limit headers.** Not accessible through the Claude Agent SDK subprocess.
+- **Copilot `session.shutdown` handling.** The SDK provides session-level aggregates (`totalPremiumRequests`, per-model `modelMetrics`) on shutdown. Useful for a future session summary view but out of scope here.
 
 ## Files Changed
 

--- a/docs/specs/2026-04-14-usage-tracking-design.md
+++ b/docs/specs/2026-04-14-usage-tracking-design.md
@@ -102,6 +102,7 @@ This covers the low-quota warning requirement: quota is checked after every turn
   threadId: string,
   providerId: ProviderId,
   categories: QuotaCategory[],
+  sessionCostUsd?: number,       // Claude: updated from result.total_cost_usd each turn
 }
 ```
 
@@ -150,7 +151,7 @@ Note: The Copilot SDK also emits a `session.shutdown` event with `totalPremiumRe
 
 ### RPC handler
 
-Add `provider.getUsage` case in `ws-router.ts`. Add an optional `getUsage?(): Promise<ProviderUsageInfo>` method to the `IAgentProvider` interface, following the same pattern as `listModels?()`. Providers that support usage reporting implement it; the RPC handler checks for the method and returns a "not supported" response if absent.
+Add `provider.getUsage` case in `ws-router.ts`. Add an optional `getUsage?(): Promise<ProviderUsageInfo>` method to the `IAgentProvider` interface, following the same pattern as `listModels?()`. Providers that support usage reporting implement it; the RPC handler checks for the method and returns a `ProviderUsageInfo` with empty `quotaCategories` and no `sessionCostUsd` if the method is absent. Use `ProviderIdSchema` from `providers/interfaces.ts` (which covers all provider IDs including `cursor` and `opencode`) for the RPC param and contract types.
 
 ## Frontend Changes
 
@@ -178,7 +179,7 @@ contextByThread: Record<string, {
 
 The `handleAgentEvent` dispatcher gets:
 - `quotaUpdate` case: updates `usageByProvider[event.providerId].quotaCategories`
-- `turnComplete` case (extended): updates `contextByThread[threadId]` with the new cache/multiplier fields alongside the existing token fields
+- `turnComplete` case (extended): updates `contextByThread[threadId]` with the new cache/multiplier fields alongside the existing token fields. Note: the Copilot provider currently folds `cacheReadTokens` into `tokensIn` before emitting `TurnComplete`. This changes - `tokensIn` will carry only `inputTokens`, and `cacheReadTokens` becomes a separate field. The same separation applies to Claude and Codex.
 
 **Hydration trigger:** The frontend calls `provider.getUsage` RPC when the popover opens for the first time (lazy). The result is cached in `usageByProvider`. Subsequent turns keep it fresh via `quotaUpdate` events. No server-push on session start.
 

--- a/docs/specs/2026-04-14-usage-tracking-design.md
+++ b/docs/specs/2026-04-14-usage-tracking-design.md
@@ -1,0 +1,235 @@
+# Usage Tracking and Quota Display
+
+**Issue:** #261
+**Date:** 2026-04-14
+**Status:** Design
+
+## Problem
+
+Users juggle multiple AI providers with different billing models. Without visible usage data, they cannot judge when to switch models or providers. Each provider reports usage differently, but the UI should present a unified view.
+
+## Decision: Ring-Anchored Popover (Option I)
+
+The existing context window ring in the Composer becomes the single entry point for all usage information. Click it to open a structured popover with three sections: Quota, Context Window, and Last Turn token breakdown.
+
+**Why this approach:**
+- Zero new UI chrome - reuses the element users already watch
+- One click for full detail, zero clicks for the ambient ring signal
+- Adapts per provider - sections hide when data is unavailable
+- A red dot badge on the ring warns when quota drops below 20%, independent of context fill
+
+**Rejected alternatives:**
+- Right sidebar tab - too much screen real estate for data checked occasionally
+- Inline status bar chips - Composer bar has limited horizontal space, scales poorly to multiple providers
+- Turn receipts in chat stream - adds visual noise to every conversation
+- Dedicated settings page - not visible while working
+
+## Provider-Agnostic Contract
+
+Defined in `packages/contracts/src/providers/`. The frontend renders one shape regardless of provider.
+
+### TurnUsage
+
+Per-turn token breakdown. All providers can populate at least `inputTokens` and `outputTokens`.
+
+```ts
+interface TurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  costMultiplier?: number;       // Copilot billing multiplier (1x, 0.33x, 30x)
+}
+```
+
+### QuotaCategory
+
+A single quota bucket (e.g. "Premium requests", "Chat").
+
+```ts
+interface QuotaCategory {
+  label: string;                 // Display name
+  used: number;
+  total: number | null;          // null = unlimited
+  remainingPercent: number;      // 0.0 to 1.0
+  resetDate?: string;            // ISO 8601
+  isUnlimited: boolean;
+}
+```
+
+### ProviderUsageInfo
+
+Top-level usage state per provider. This is what the popover renders.
+
+```ts
+interface ProviderUsageInfo {
+  providerId: ProviderId;
+  quotaCategories: QuotaCategory[];  // empty = "quota not available"
+  sessionCostUsd?: number;           // Claude only (accumulated)
+  lastTurn?: TurnUsage;
+  contextWindow?: number;
+  contextUsed?: number;
+}
+```
+
+### Provider mapping
+
+| Field | Copilot | Claude | Codex |
+|-------|---------|--------|-------|
+| `quotaCategories` | `quotaSnapshots` from `assistant.usage` keyed by "chat", "completions", "premium_interactions" | Empty (no quota API accessible through SDK) | Empty (rate limit notifications exist but have no documented schema) |
+| `sessionCostUsd` | Not available (`null`) | `result.total_cost_usd` (accumulated session total) | Not available (`null`) |
+| `lastTurn.inputTokens` | `assistant.usage.inputTokens` | `stream_event.message_start.usage.input_tokens` | `turn/completed.usage.input_tokens` |
+| `lastTurn.outputTokens` | `assistant.usage.outputTokens` | `result.usage.output_tokens` | `turn/completed.usage.output_tokens` |
+| `lastTurn.cacheReadTokens` | `assistant.usage.cacheReadTokens` | `cache_read_input_tokens` | `cached_input_tokens` |
+| `lastTurn.cacheWriteTokens` | `assistant.usage.cacheWriteTokens` (currently dropped) | `cache_creation_input_tokens` | Not available |
+| `lastTurn.costMultiplier` | `assistant.usage.cost` | Not applicable | Not applicable |
+| `contextWindow` | `session.usage_info.tokenLimit` | `modelUsage[*].contextWindow` | Not available |
+| `contextUsed` | `session.usage_info.currentTokens` | `message_start.usage` sum | Not available |
+
+## Data Flow
+
+### Fetch strategy: initial hydration + piggybacked updates
+
+Two data paths, no polling:
+
+1. **Initial hydration** - On session start (or first popover open), call `provider.getUsage` RPC. For Copilot this delegates to `client.rpc.account.getQuota()`. For Claude and Codex, it returns whatever accumulated state exists (cost, last turn tokens).
+
+2. **Per-turn updates** - After each assistant reply, the provider emits a `quotaUpdate` AgentEvent with fresh quota data extracted from the response. The Copilot SDK's `assistant.usage` event already includes `quotaSnapshots` - we just need to extract and normalize them. Claude and Codex emit `quotaUpdate` with empty categories but populated turn/cost fields.
+
+This covers the low-quota warning requirement: quota is checked after every turn, so warnings fire without polling.
+
+### New AgentEvent: `quotaUpdate`
+
+```ts
+{
+  type: "quotaUpdate",
+  threadId: string,
+  providerId: ProviderId,
+  categories: QuotaCategory[],
+}
+```
+
+Rides the existing `agent.event` push channel. The `providerId` field lets the frontend aggregate at the provider level despite the event being thread-scoped.
+
+### New RPC: `provider.getUsage`
+
+```ts
+"provider.getUsage": {
+  params: { providerId: ProviderIdSchema },
+  result: ProviderUsageInfoSchema,
+}
+```
+
+Server-side handler delegates to each provider's native API. Copilot calls `account.getQuota()`, Claude returns accumulated session state, Codex returns what it has.
+
+### Extended TurnComplete event
+
+Add optional fields to the existing `TurnComplete` AgentEvent:
+
+```ts
+{
+  // ... existing fields (tokensIn, tokensOut, costUsd, contextWindow, totalProcessedTokens)
+  cacheReadTokens?: number,
+  cacheWriteTokens?: number,
+  costMultiplier?: number,
+  providerId?: ProviderId,
+}
+```
+
+## Server-Side Changes
+
+### Copilot provider
+
+1. **`assistant.usage` handler** - Extend to extract `cacheWriteTokens`, `cost` (multiplier), and `quotaSnapshots` from `event.data`. Normalize `quotaSnapshots` into `QuotaCategory[]` and emit `quotaUpdate`.
+2. **Session start** - Call `client.rpc.account.getQuota()` once after session initialization. Emit `quotaUpdate` with the result.
+3. **`session.shutdown` handler** (new) - Extract `totalPremiumRequests` and `modelMetrics` for session summary. Optional enhancement.
+
+### Claude provider
+
+1. **`result` handler** - Populate `cacheReadTokens` (from `cache_read_input_tokens`) and `cacheWriteTokens` (from `cache_creation_input_tokens`) on the `TurnComplete` event.
+
+### Codex provider
+
+1. **`turn/completed` handler** - Break out `cached_input_tokens` as `cacheReadTokens` on `TurnComplete` instead of folding it into `tokensIn`.
+
+### RPC handler
+
+Add `provider.getUsage` case in `ws-router.ts`. Each provider implements a `getUsage(): ProviderUsageInfo` method (or the handler constructs it from available state).
+
+## Frontend Changes
+
+### Store: `threadStore` extension
+
+Add to existing `threadStore`:
+
+```ts
+usageByProvider: Record<ProviderId, ProviderUsageInfo>
+```
+
+The `handleAgentEvent` dispatcher gets:
+- `quotaUpdate` case: updates `usageByProvider[event.providerId].quotaCategories`
+- `turnComplete` case (extended): updates `usageByProvider[providerId].lastTurn` with token breakdown
+
+On first popover open or session start, call `provider.getUsage` RPC to hydrate.
+
+### New component: `UsagePopover.tsx`
+
+A Radix popover anchored to the context ring. Three sections that show or hide based on available data:
+
+**Quota section** - Renders each `QuotaCategory` as a label + progress bar + used/total. Hidden when `quotaCategories` is empty, replaced with "Quota data not available for this provider."
+
+**Context window section** - Shows `contextUsed / contextWindow` as a progress bar. Hidden when `contextWindow` is undefined (Codex).
+
+**Last turn section** - A 2x2 grid of token counts (in, out, cache read, cache write). Shows after the first turn completes.
+
+**Provider header** - Shows provider name, current model (from thread state), cost multiplier if available, and days until quota reset.
+
+**Per-provider rendering:**
+- Copilot: all sections visible (quota, context, last turn)
+- Claude: no quota section, shows session cost instead, context + last turn
+- Codex: no quota, no context, last turn only + "Usage data limited for this provider"
+
+### ContextTracker changes
+
+- Add `onClick` handler to the ring SVG to toggle the popover
+- Add a red dot badge (8px circle) when any `QuotaCategory.remainingPercent < 0.20`
+- Ring color continues to reflect context window fill only - the badge is the quota signal
+
+### Composer wiring
+
+Add popover state management in `Composer.tsx`. The `UsagePopover` renders as a child of the ring area.
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `account.getQuota()` throws on session start | Log server-side, skip `quotaUpdate` emission. Popover shows empty quota until first turn provides `quotaSnapshots`. |
+| `provider.getUsage` RPC fails on popover open | Frontend shows last known state with muted "Unable to refresh" text. |
+| Popover opened before first turn | Context data from `contextEstimate` events (already flowing). Quota shows initial hydration. Last turn section shows "No turn data yet." |
+| Provider switched mid-session | `usageByProvider` is keyed by provider ID. Switching renders a different entry. Old provider data persists. |
+| Multiple threads, same provider | Quota is provider-scoped. All threads share the same `usageByProvider[providerId]` entry. Last turn reflects the most recent turn across threads. |
+| Provider not configured | `provider.getUsage` returns error. Popover shows "Provider not configured." |
+
+## What This Does Not Include
+
+- **Usage history or trends.** No historical data, no charts. Per-turn data is transient.
+- **New database tables or migrations.** Quota is refreshed every turn. Per-turn tokens flow through events.
+- **Cost estimation for Copilot.** The SDK reports `totalNanoAiu` but there is no USD conversion. The `costMultiplier` is shown as a raw number.
+- **Codex rate limit capture.** The `account/rateLimits/updated` notification exists but has no documented payload schema. We skip it until the schema stabilizes.
+- **Anthropic rate limit headers.** Not accessible through the Claude Agent SDK subprocess.
+
+## Files Changed
+
+| Package | File | Change |
+|---------|------|--------|
+| `packages/contracts` | `providers/usage.ts` (new) | `TurnUsage`, `QuotaCategory`, `ProviderUsageInfo` schemas |
+| `packages/contracts` | `events/agent-event.ts` | Add `quotaUpdate` event type, extend `TurnComplete` with cache/multiplier fields |
+| `packages/contracts` | `ws/methods.ts` | Add `provider.getUsage` RPC |
+| `apps/server` | `providers/copilot/copilot-provider.ts` | Extract `quotaSnapshots`, `cacheWriteTokens`, `cost` from `assistant.usage`; call `account.getQuota()` on session start |
+| `apps/server` | `providers/claude/claude-provider.ts` | Populate cache token fields on `TurnComplete` |
+| `apps/server` | `providers/codex/codex-event-mapper.ts` | Break out `cached_input_tokens` as `cacheReadTokens` |
+| `apps/server` | `transport/ws-router.ts` | Handle `provider.getUsage` RPC |
+| `apps/web` | `stores/threadStore.ts` | Add `usageByProvider`, handle `quotaUpdate` and extended `turnComplete` |
+| `apps/web` | `components/chat/UsagePopover.tsx` (new) | Popover component with quota/context/turn sections |
+| `apps/web` | `components/chat/ContextTracker.tsx` | Add click handler, low-quota badge |
+| `apps/web` | `components/chat/Composer.tsx` | Wire popover state |

--- a/docs/specs/2026-04-14-usage-tracking-plan.md
+++ b/docs/specs/2026-04-14-usage-tracking-plan.md
@@ -1,0 +1,1283 @@
+# Usage Tracking and Quota Display - Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show per-provider usage quota and per-turn token breakdown in a popover anchored to the existing context window ring.
+
+**Architecture:** Extend the existing `agent.event` push pipeline with a new `quotaUpdate` event type and new fields on `TurnComplete`. Add a `provider.getUsage` RPC for initial hydration. Frontend reads quota from a new `usageByProvider` map and turn data from the existing `contextByThread` (extended with cache/multiplier fields).
+
+**Tech Stack:** TypeScript, Zod, tsyringe, Zustand, @base-ui/react/popover, @github/copilot-sdk, @anthropic-ai/claude-agent-sdk
+
+**Spec:** `docs/specs/2026-04-14-usage-tracking-design.md`
+
+**Dependency order:** Chunks must be executed in order. Chunk 2 (server providers) depends on Chunk 1 (contracts) being committed. Chunk 3 depends on Chunk 2. Chunk 4 depends on Chunks 1 and 3. Chunk 5 depends on all prior chunks.
+
+---
+
+## Chunk 1: Contracts
+
+### Task 1: Add usage type schemas
+
+**Files:**
+- Create: `packages/contracts/src/providers/usage.ts`
+- Modify: `packages/contracts/src/providers/models.ts` (imports reference)
+
+- [ ] **Step 1: Create `usage.ts` with Zod schemas**
+
+```ts
+// packages/contracts/src/providers/usage.ts
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+
+/** Per-turn token breakdown. All providers populate at least inputTokens and outputTokens. */
+export const TurnUsageSchema = lazySchema(() =>
+  z.object({
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheReadTokens: z.number().optional(),
+    cacheWriteTokens: z.number().optional(),
+    costMultiplier: z.number().optional(),
+  }),
+);
+
+export type TurnUsage = z.infer<ReturnType<typeof TurnUsageSchema>>;
+
+/** A single quota bucket (e.g. "Premium requests", "Chat"). */
+export const QuotaCategorySchema = lazySchema(() =>
+  z.object({
+    label: z.string(),
+    used: z.number(),
+    total: z.number().nullable(),
+    remainingPercent: z.number().min(0).max(1),
+    resetDate: z.string().optional(),
+    isUnlimited: z.boolean(),
+  }),
+);
+
+export type QuotaCategory = z.infer<ReturnType<typeof QuotaCategorySchema>>;
+
+/** Provider-level usage state. Quota and cost only - context/turn data is thread-scoped. */
+export const ProviderUsageInfoSchema = lazySchema(() =>
+  z.object({
+    providerId: z.string(),
+    quotaCategories: z.array(QuotaCategorySchema()),
+    sessionCostUsd: z.number().optional(),
+  }),
+);
+
+export type ProviderUsageInfo = z.infer<ReturnType<typeof ProviderUsageInfoSchema>>;
+```
+
+- [ ] **Step 2: Verify contracts typecheck**
+
+Run: `cd packages/contracts && npx tsc --noEmit`
+Expected: PASS (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/contracts/src/providers/usage.ts
+git commit -m "feat: add usage tracking type schemas (TurnUsage, QuotaCategory, ProviderUsageInfo)"
+```
+
+---
+
+### Task 2: Extend AgentEvent with quotaUpdate and TurnComplete fields
+
+**Files:**
+- Modify: `packages/contracts/src/events/agent-event.ts:12-69`
+
+- [ ] **Step 1: Add `QuotaUpdate` to `AgentEventType` const**
+
+In `agent-event.ts`, add a new entry inside the `AgentEventType` const object, after `ContextEstimate: "contextEstimate"` and before the closing `} as const`:
+
+```ts
+QuotaUpdate: "quotaUpdate",
+```
+
+- [ ] **Step 2: Add imports for usage schemas**
+
+Add at the top of `agent-event.ts`:
+
+```ts
+import { QuotaCategorySchema } from "../providers/usage.js";
+```
+
+- [ ] **Step 3: Extend `TurnComplete` variant with new optional fields**
+
+In `agent-event.ts`, the `TurnComplete` variant (lines 59-69). Replace with:
+
+```ts
+z.object({
+  type: z.literal(AgentEventType.TurnComplete),
+  threadId: z.string(),
+  reason: z.string(),
+  costUsd: z.number().nullable(),
+  tokensIn: z.number(),
+  tokensOut: z.number(),
+  contextWindow: z.number().optional(),
+  totalProcessedTokens: z.number().optional(),
+  cacheReadTokens: z.number().optional(),
+  cacheWriteTokens: z.number().optional(),
+  costMultiplier: z.number().optional(),
+  providerId: z.string().optional(),
+}),
+```
+
+- [ ] **Step 4: Add `QuotaUpdate` variant to the discriminated union**
+
+Add a new variant inside the `z.discriminatedUnion("type", [...])` array, after the `ContextEstimate` variant:
+
+```ts
+z.object({
+  type: z.literal(AgentEventType.QuotaUpdate),
+  threadId: z.string(),
+  providerId: z.string(),
+  categories: z.array(QuotaCategorySchema()),
+  sessionCostUsd: z.number().optional(),
+}),
+```
+
+- [ ] **Step 5: Verify contracts typecheck**
+
+Run: `cd packages/contracts && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/contracts/src/events/agent-event.ts
+git commit -m "feat: add quotaUpdate event type and extend TurnComplete with cache/multiplier fields"
+```
+
+---
+
+### Task 3: Add `provider.getUsage` RPC method
+
+**Files:**
+- Modify: `packages/contracts/src/ws/methods.ts:375-378`
+
+- [ ] **Step 1: Add import for ProviderUsageInfoSchema**
+
+In `methods.ts`, add to the import block:
+
+```ts
+import { ProviderUsageInfoSchema } from "../providers/usage.js";
+```
+
+- [ ] **Step 2: Add `provider.getUsage` entry to `WS_METHODS`**
+
+Add after the `provider.listModels` entry (line 378):
+
+```ts
+"provider.getUsage": {
+  params: z.object({ providerId: ProviderIdSchema }),
+  result: ProviderUsageInfoSchema(),
+},
+```
+
+- [ ] **Step 3: Verify contracts typecheck**
+
+Run: `cd packages/contracts && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/contracts/src/ws/methods.ts
+git commit -m "feat: add provider.getUsage RPC method to WS_METHODS"
+```
+
+---
+
+## Chunk 2: Server - Provider Changes
+
+### Task 4: Add `getUsage` to `IAgentProvider` interface
+
+**Files:**
+- Modify: `packages/contracts/src/providers/interfaces.ts:47`
+
+- [ ] **Step 1: Add import for ProviderUsageInfo**
+
+```ts
+import type { ProviderUsageInfo } from "./usage.js";
+```
+
+- [ ] **Step 2: Add optional `getUsage` method after `listModels` (line 47)**
+
+```ts
+/** Return current usage/quota state for this provider. */
+getUsage?(): Promise<ProviderUsageInfo>;
+```
+
+- [ ] **Step 3: Verify contracts typecheck**
+
+Run: `cd packages/contracts && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/contracts/src/providers/interfaces.ts
+git commit -m "feat: add optional getUsage method to IAgentProvider interface"
+```
+
+---
+
+### Task 5: Extend Copilot provider - extract quota and cache fields
+
+**Files:**
+- Modify: `apps/server/src/providers/copilot/copilot-provider.ts:508-525`
+- Test: `apps/server/src/providers/copilot/__tests__/copilot-provider.test.ts` (create if needed)
+
+- [ ] **Step 1: Write test for quotaUpdate emission from assistant.usage**
+
+Create or extend the test file. Test that when `assistant.usage` fires with `quotaSnapshots`, the provider emits both a `turnComplete` and a `quotaUpdate` event with normalized `QuotaCategory[]`.
+
+```ts
+it("emits quotaUpdate with normalized categories from assistant.usage quotaSnapshots", () => {
+  // Arrange: mock session that fires assistant.usage with quotaSnapshots
+  const events: AgentEvent[] = [];
+  provider.on("event", (e) => events.push(e));
+
+  // Act: trigger assistant.usage with quotaSnapshots
+  fireAssistantUsage({
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheReadTokens: 20,
+    cacheWriteTokens: 10,
+    cost: 1,
+    quotaSnapshots: {
+      premium_interactions: {
+        isUnlimitedEntitlement: false,
+        entitlementRequests: 300,
+        usedRequests: 142,
+        usageAllowedWithExhaustedQuota: false,
+        overage: 0,
+        overageAllowedWithExhaustedQuota: false,
+        remainingPercentage: 0.527,
+        resetDate: "2026-04-21T00:00:00Z",
+      },
+      chat: {
+        isUnlimitedEntitlement: true,
+        entitlementRequests: 0,
+        usedRequests: 89,
+        usageAllowedWithExhaustedQuota: true,
+        overage: 0,
+        overageAllowedWithExhaustedQuota: false,
+        remainingPercentage: 1.0,
+      },
+    },
+  });
+
+  // Assert: quotaUpdate emitted
+  const quotaEvent = events.find((e) => e.type === "quotaUpdate");
+  expect(quotaEvent).toBeDefined();
+  expect(quotaEvent.providerId).toBe("copilot");
+  expect(quotaEvent.categories).toHaveLength(2);
+  expect(quotaEvent.categories[0]).toMatchObject({
+    label: "Premium requests",
+    used: 142,
+    total: 300,
+    remainingPercent: 0.527,
+    isUnlimited: false,
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && npx vitest run --reporter verbose copilot-provider`
+Expected: FAIL (quotaUpdate event type not yet emitted)
+
+- [ ] **Step 3: Add quota normalization helper**
+
+In `copilot-provider.ts`, add a private method or module-level function:
+
+```ts
+import type { QuotaCategory } from "@mcode/contracts/providers/usage.js";
+import { AgentEventType } from "@mcode/contracts/events/agent-event.js";
+
+const QUOTA_LABELS: Record<string, string> = {
+  premium_interactions: "Premium requests",
+  chat: "Chat",
+  completions: "Completions",
+};
+
+interface QuotaSnapshot {
+  isUnlimitedEntitlement?: boolean;
+  entitlementRequests?: number;
+  usedRequests?: number;
+  remainingPercentage?: number;
+  resetDate?: string;
+  overage?: number;
+  overageAllowedWithExhaustedQuota?: boolean;
+  usageAllowedWithExhaustedQuota?: boolean;
+}
+
+function normalizeQuotaSnapshots(
+  snapshots: Record<string, QuotaSnapshot>,
+): QuotaCategory[] {
+  return Object.entries(snapshots).map(([key, snap]) => ({
+    label: QUOTA_LABELS[key] ?? key,
+    used: snap.usedRequests ?? 0,
+    total: snap.isUnlimitedEntitlement ? null : (snap.entitlementRequests ?? 0),
+    remainingPercent: snap.remainingPercentage ?? 1.0,
+    resetDate: snap.resetDate,
+    isUnlimited: snap.isUnlimitedEntitlement ?? false,
+  }));
+}
+```
+
+- [ ] **Step 4: Extend the `assistant.usage` handler (lines 508-525)**
+
+Replace the existing handler:
+
+```ts
+// assistant.usage — token counts + quota after a model call
+unsubscribers.push(
+  session.on("assistant.usage", (event) => {
+    const {
+      inputTokens = 0,
+      outputTokens = 0,
+      cacheReadTokens = 0,
+      cacheWriteTokens = 0,
+      cost,
+      quotaSnapshots,
+    } = event.data;
+    const contextWindow = this.contextWindowBySession.get(sessionId);
+
+    this.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: inputTokens,
+      tokensOut: outputTokens,
+      contextWindow,
+      totalProcessedTokens: inputTokens + cacheReadTokens + cacheWriteTokens + outputTokens,
+      cacheReadTokens,
+      cacheWriteTokens,
+      costMultiplier: cost,
+      providerId: "copilot",
+    } satisfies AgentEvent);
+
+    // Emit quota update if snapshots present
+    if (quotaSnapshots && typeof quotaSnapshots === "object") {
+      this.emit("event", {
+        type: AgentEventType.QuotaUpdate,
+        threadId,
+        providerId: "copilot",
+        categories: normalizeQuotaSnapshots(quotaSnapshots as Record<string, QuotaSnapshot>),
+      } satisfies AgentEvent);
+    }
+  }),
+);
+```
+
+Note: `tokensIn` now carries only `inputTokens` (not `inputTokens + cacheReadTokens`). `cacheReadTokens` is a separate field. This is a breaking change to the semantics of `tokensIn` for Copilot.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/server && npx vitest run --reporter verbose copilot-provider`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/server/src/providers/copilot/copilot-provider.ts
+git add apps/server/src/providers/copilot/__tests__/
+git commit -m "feat(copilot): extract quotaSnapshots, cacheWriteTokens, costMultiplier from assistant.usage"
+```
+
+---
+
+### Task 6: Copilot provider - implement `getUsage` and initial quota hydration
+
+**Files:**
+- Modify: `apps/server/src/providers/copilot/copilot-provider.ts`
+
+- [ ] **Step 1: Write test for getUsage RPC**
+
+```ts
+it("getUsage returns normalized quota from account.getQuota", async () => {
+  // Mock client.rpc.account.getQuota to return test data
+  const usage = await provider.getUsage();
+  expect(usage.providerId).toBe("copilot");
+  expect(usage.quotaCategories).toHaveLength(2);
+  expect(usage.sessionCostUsd).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && npx vitest run --reporter verbose copilot-provider`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `getUsage` method**
+
+Add to the `CopilotProvider` class:
+
+```ts
+async getUsage(): Promise<ProviderUsageInfo> {
+  try {
+    await this.refreshClient();
+    const result = await this.client!.rpc.account.getQuota();
+    const categories = result?.quotaSnapshots
+      ? normalizeQuotaSnapshots(result.quotaSnapshots)
+      : [];
+    return { providerId: "copilot", quotaCategories: categories };
+  } catch (error) {
+    logger.warn("Failed to fetch Copilot quota", { error });
+    return { providerId: "copilot", quotaCategories: [] };
+  }
+}
+```
+
+Add the import for `ProviderUsageInfo`:
+```ts
+import type { ProviderUsageInfo } from "@mcode/contracts/providers/usage.js";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/server && npx vitest run --reporter verbose copilot-provider`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/providers/copilot/copilot-provider.ts
+git commit -m "feat(copilot): implement getUsage with account.getQuota delegation"
+```
+
+---
+
+### Task 7: Extend Claude provider - populate cache token fields
+
+**Files:**
+- Modify: `apps/server/src/providers/claude/claude-provider.ts:658-670`
+
+- [ ] **Step 1: Write test for cache tokens on TurnComplete**
+
+```ts
+it("includes cacheReadTokens and cacheWriteTokens on TurnComplete", () => {
+  const events: AgentEvent[] = [];
+  provider.on("event", (e) => events.push(e));
+
+  // Fire a result message with cache token fields in usage
+  fireResult({
+    subtype: "success",
+    total_cost_usd: 0.05,
+    usage: {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 200,
+      cache_creation_input_tokens: 30,
+    },
+    modelUsage: {},
+  });
+
+  const tc = events.find((e) => e.type === "turnComplete");
+  expect(tc).toBeDefined();
+  expect(tc!.cacheReadTokens).toBe(200);
+  expect(tc!.cacheWriteTokens).toBe(30);
+  expect(tc!.providerId).toBe("claude");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && npx vitest run --reporter verbose claude-provider`
+Expected: FAIL
+
+- [ ] **Step 3: Extend the `result` handler TurnComplete emission (lines 658-670)**
+
+Replace the `this.emit("event", { ... })` block:
+
+```ts
+this.emit("event", {
+  type: AgentEventType.TurnComplete,
+  threadId,
+  reason:
+    (anyMsg.stop_reason as string) ||
+    (anyMsg.subtype as string) ||
+    "end_turn",
+  costUsd: (anyMsg.total_cost_usd as number) ?? null,
+  tokensIn,
+  tokensOut: usage.output_tokens ?? 0,
+  contextWindow: sdkContextWindow,
+  totalProcessedTokens,
+  cacheReadTokens: usage.cache_read_input_tokens ?? undefined,
+  cacheWriteTokens: usage.cache_creation_input_tokens ?? undefined,
+  providerId: "claude",
+} satisfies AgentEvent);
+```
+
+Also emit a `quotaUpdate` for session cost:
+
+```ts
+this.emit("event", {
+  type: AgentEventType.QuotaUpdate,
+  threadId,
+  providerId: "claude",
+  categories: [],
+  sessionCostUsd: (anyMsg.total_cost_usd as number) ?? undefined,
+} satisfies AgentEvent);
+```
+
+- [ ] **Step 4: Add `lastSessionCostUsd` class field and update it**
+
+Add to the class fields:
+
+```ts
+private lastSessionCostUsd?: number;
+```
+
+In the `result` handler, after the line that reads `total_cost_usd` (line 665: `costUsd: (anyMsg.total_cost_usd as number) ?? null`), add:
+
+```ts
+this.lastSessionCostUsd = (anyMsg.total_cost_usd as number) ?? undefined;
+```
+
+- [ ] **Step 5: Implement `getUsage` on Claude provider**
+
+```ts
+async getUsage(): Promise<ProviderUsageInfo> {
+  return {
+    providerId: "claude",
+    quotaCategories: [],
+    sessionCostUsd: this.lastSessionCostUsd,
+  };
+}
+```
+
+Add the import:
+```ts
+import type { ProviderUsageInfo } from "@mcode/contracts/providers/usage.js";
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd apps/server && npx vitest run --reporter verbose claude-provider`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/server/src/providers/claude/claude-provider.ts
+git commit -m "feat(claude): add cache token fields to TurnComplete and implement getUsage"
+```
+
+---
+
+### Task 8: Extend Codex provider - separate cacheReadTokens
+
+**Files:**
+- Modify: `apps/server/src/providers/codex/codex-event-mapper.ts:91-110`
+
+- [ ] **Step 1: Write test for separated cache tokens**
+
+```ts
+it("reports cached_input_tokens as cacheReadTokens instead of folding into tokensIn", () => {
+  const events = mapper.map({
+    method: "turn/completed",
+    params: {
+      turn: {
+        status: "completed",
+        usage: { input_tokens: 100, cached_input_tokens: 50, output_tokens: 80 },
+      },
+    },
+  });
+  const tc = events.find((e) => e.type === "turnComplete");
+  expect(tc.tokensIn).toBe(100);        // NOT 150
+  expect(tc.cacheReadTokens).toBe(50);
+  expect(tc.tokensOut).toBe(80);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && npx vitest run --reporter verbose codex-event-mapper`
+Expected: FAIL
+
+- [ ] **Step 3: Update the `turn/completed` handler (lines 91-110)**
+
+Replace:
+
+```ts
+const tokensIn = (usage.input_tokens ?? 0) + (usage.cached_input_tokens ?? 0);
+const tokensOut = usage.output_tokens ?? 0;
+const totalProcessedTokens = tokensIn + tokensOut;
+```
+
+With:
+
+```ts
+const inputTokens = usage.input_tokens ?? 0;
+const cachedInputTokens = usage.cached_input_tokens ?? 0;
+const tokensIn = inputTokens;
+const tokensOut = usage.output_tokens ?? 0;
+const totalProcessedTokens = inputTokens + cachedInputTokens + tokensOut;
+```
+
+And update the TurnComplete emission:
+
+```ts
+events.push({
+  type: AgentEventType.TurnComplete,
+  threadId: this.threadId,
+  reason: "end_turn",
+  costUsd: null,
+  tokensIn,
+  tokensOut,
+  contextWindow: undefined,
+  totalProcessedTokens,
+  cacheReadTokens: cachedInputTokens || undefined,
+  providerId: "codex",
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/server && npx vitest run --reporter verbose codex-event-mapper`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/providers/codex/codex-event-mapper.ts
+git commit -m "feat(codex): separate cached_input_tokens into cacheReadTokens field"
+```
+
+---
+
+## Chunk 3: Server - RPC Handler and Broadcasting
+
+### Task 9: Add `provider.getUsage` RPC handler
+
+**Files:**
+- Modify: `apps/server/src/transport/ws-router.ts:482-488`
+
+- [ ] **Step 1: Add the RPC case after `provider.listModels` (line 488)**
+
+```ts
+case "provider.getUsage": {
+  const provider = deps.providerRegistry.resolve(params.providerId);
+  if (!provider.getUsage) {
+    return { providerId: provider.id, quotaCategories: [] } satisfies ProviderUsageInfo;
+  }
+  return provider.getUsage();
+}
+```
+
+- [ ] **Step 2: Verify server typechecks**
+
+Run: `cd apps/server && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/server/src/transport/ws-router.ts
+git commit -m "feat: add provider.getUsage RPC handler in ws-router"
+```
+
+---
+
+## Chunk 4: Frontend - Store and Transport
+
+### Task 10: Add `getProviderUsage` to transport layer
+
+**Files:**
+- Modify: `apps/web/src/transport/types.ts:236-238`
+- Modify: `apps/web/src/transport/ws-transport.ts:451-453`
+
+- [ ] **Step 1: Add to `McodeTransport` interface in `types.ts`**
+
+After `listProviderModels`:
+
+```ts
+/** Fetch current usage/quota state for a provider. */
+getProviderUsage(providerId: string): Promise<ProviderUsageInfo>;
+```
+
+Add the import:
+```ts
+import type { ProviderUsageInfo } from "@mcode/contracts/providers/usage.js";
+```
+
+- [ ] **Step 2: Implement in `ws-transport.ts`**
+
+After `listProviderModels` implementation:
+
+```ts
+getProviderUsage: (providerId) =>
+  rpc<ProviderUsageInfo>("provider.getUsage", { providerId }),
+```
+
+Add the import:
+```ts
+import type { ProviderUsageInfo } from "@mcode/contracts/providers/usage.js";
+```
+
+- [ ] **Step 3: Verify web typechecks**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/transport/types.ts apps/web/src/transport/ws-transport.ts
+git commit -m "feat: add getProviderUsage to transport layer"
+```
+
+---
+
+### Task 11: Extend `threadStore` with `usageByProvider` and new event handlers
+
+**Files:**
+- Modify: `apps/web/src/stores/threadStore.ts`
+
+- [ ] **Step 1: Add `usageByProvider` to store state**
+
+In the `ThreadState` interface (around line 62), add after `contextByThread`:
+
+```ts
+usageByProvider: Record<string, ProviderUsageInfo>;
+```
+
+Add the import:
+```ts
+import type { ProviderUsageInfo } from "@mcode/contracts/providers/usage.js";
+```
+
+In the initial state (around line 228), add after `contextByThread: {}`:
+
+```ts
+usageByProvider: {},
+```
+
+- [ ] **Step 2: Extend the `contextByThread` type**
+
+Change the type at line 62 from:
+
+```ts
+contextByThread: Record<string, { lastTokensIn: number; contextWindow?: number; totalProcessedTokens?: number }>;
+```
+
+To:
+
+```ts
+contextByThread: Record<string, {
+  lastTokensIn: number;
+  contextWindow?: number;
+  totalProcessedTokens?: number;
+  tokensOut?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  costMultiplier?: number;
+}>;
+```
+
+- [ ] **Step 3: Update `session.turnComplete` handler to store new fields**
+
+In the context update block (around lines 1235-1257), extend the `set` call:
+
+```ts
+set((state) => ({
+  contextByThread: {
+    ...state.contextByThread,
+    [threadId]: {
+      lastTokensIn: tokensIn,
+      contextWindow,
+      totalProcessedTokens,
+      tokensOut: params.tokensOut as number | undefined,
+      cacheReadTokens: params.cacheReadTokens as number | undefined,
+      cacheWriteTokens: params.cacheWriteTokens as number | undefined,
+      costMultiplier: params.costMultiplier as number | undefined,
+    },
+  },
+}));
+```
+
+- [ ] **Step 4: Add `session.quotaUpdate` handler**
+
+In `handleAgentEvent`, add a new case before the final return (after the existing `session.contextEstimate` case around line 1329):
+
+```ts
+if (method === "session.quotaUpdate") {
+  const providerId = params.providerId as string;
+  const categories = params.categories as QuotaCategory[];
+  const sessionCostUsd = params.sessionCostUsd as number | undefined;
+  if (providerId) {
+    set((state) => ({
+      usageByProvider: {
+        ...state.usageByProvider,
+        [providerId]: {
+          providerId,
+          quotaCategories: categories ?? [],
+          sessionCostUsd: sessionCostUsd ?? state.usageByProvider[providerId]?.sessionCostUsd,
+        },
+      },
+    }));
+  }
+  return;
+}
+```
+
+Add the import:
+```ts
+import type { QuotaCategory } from "@mcode/contracts/providers/usage.js";
+```
+
+- [ ] **Step 5: Add `fetchProviderUsage` action**
+
+Add a new action to the store for lazy hydration when popover opens:
+
+```ts
+fetchProviderUsage: async (providerId: string) => {
+  try {
+    const { getTransport } = await import("../transport/index.js");
+    const usage = await getTransport().getProviderUsage(providerId);
+    set((state) => ({
+      usageByProvider: {
+        ...state.usageByProvider,
+        [providerId]: usage,
+      },
+    }));
+  } catch {
+    // Silently fail - popover shows stale or empty state
+  }
+},
+```
+
+- [ ] **Step 6: Verify web typechecks**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/stores/threadStore.ts
+git commit -m "feat: add usageByProvider state and quotaUpdate handler to threadStore"
+```
+
+---
+
+## Chunk 5: Frontend - UI Components
+
+### Task 12: Create UsagePopover component
+
+**Files:**
+- Create: `apps/web/src/components/chat/UsagePopover.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// apps/web/src/components/chat/UsagePopover.tsx
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { useThreadStore } from "../../stores/threadStore";
+import { useWorkspaceStore } from "../../stores/workspaceStore";
+import type { ProviderId } from "@mcode/contracts/providers/interfaces.js";
+import type { QuotaCategory } from "@mcode/contracts/providers/usage.js";
+import { useEffect, useRef, type ReactNode } from "react";
+
+interface UsagePopoverProps {
+  threadId: string | undefined;
+  children: ReactNode;
+}
+
+/** Format token counts for display. */
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+/** Days until a date, or undefined if no date. */
+function daysUntil(iso: string | undefined): number | undefined {
+  if (!iso) return undefined;
+  const diff = new Date(iso).getTime() - Date.now();
+  return diff > 0 ? Math.ceil(diff / 86_400_000) : 0;
+}
+
+/** Progress bar component. */
+function UsageBar({ percent, className }: { percent: number; className?: string }) {
+  const color =
+    percent >= 0.9 ? "bg-destructive" :
+    percent >= 0.7 ? "bg-amber-500" :
+    "bg-emerald-500";
+  return (
+    <div className="h-1 w-full rounded-full bg-muted">
+      <div
+        className={`h-1 rounded-full transition-all ${color} ${className ?? ""}`}
+        style={{ width: `${Math.min(percent * 100, 100)}%` }}
+      />
+    </div>
+  );
+}
+
+/** Single quota category row. */
+function QuotaRow({ category }: { category: QuotaCategory }) {
+  const usedDisplay = category.isUnlimited
+    ? `${category.used}`
+    : `${category.used} / ${category.total}`;
+  const percent = category.isUnlimited ? 0 : (1 - category.remainingPercent);
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">{category.label}</span>
+        <span className={percent >= 0.8 ? "text-destructive" : "text-foreground/70"}>
+          {category.isUnlimited ? "unlimited" : usedDisplay}
+        </span>
+      </div>
+      {!category.isUnlimited && <UsageBar percent={percent} />}
+    </div>
+  );
+}
+
+/** The usage popover content. */
+export function UsagePopover({ threadId, children }: UsagePopoverProps) {
+  const contextEntry = useThreadStore((s) => threadId ? s.contextByThread[threadId] : undefined);
+  const activeThread = useWorkspaceStore((s) => s.threads.find((t) => t.id === threadId));
+  const providerId = (activeThread?.provider ?? "claude") as ProviderId;
+  const usageInfo = useThreadStore((s) => s.usageByProvider[providerId]);
+  const fetchProviderUsage = useThreadStore((s) => s.fetchProviderUsage);
+  const hasFetched = useRef(false);
+
+  const handleOpenChange = (open: boolean) => {
+    if (open && !hasFetched.current) {
+      hasFetched.current = true;
+      fetchProviderUsage(providerId);
+    }
+  };
+
+  // Reset fetch flag when provider changes
+  useEffect(() => {
+    hasFetched.current = false;
+  }, [providerId]);
+
+  const categories = usageInfo?.quotaCategories ?? [];
+  const sessionCost = usageInfo?.sessionCostUsd;
+  const tokensIn = contextEntry?.lastTokensIn ?? 0;
+  const contextWindow = contextEntry?.contextWindow;
+  const hasContext = tokensIn > 0 && contextWindow;
+  const hasTurn = tokensIn > 0;
+
+  // Find earliest reset date across categories
+  const resetDays = categories
+    .map((c) => daysUntil(c.resetDate))
+    .filter((d): d is number => d !== undefined)
+    .sort((a, b) => a - b)[0];
+
+  return (
+    <Popover onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent align="end" className="w-72 p-0">
+        <div className="space-y-3 p-3">
+          {/* Header */}
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium capitalize">{providerId}</div>
+              {activeThread?.model && (
+                <div className="text-[10px] text-muted-foreground">
+                  {activeThread.model}
+                  {contextEntry?.costMultiplier != null && ` · ${contextEntry.costMultiplier}×`}
+                </div>
+              )}
+            </div>
+            {resetDays !== undefined && (
+              <div className="text-right">
+                <div className="text-[10px] text-muted-foreground">resets in</div>
+                <div className="text-xs text-foreground/70">{resetDays}d</div>
+              </div>
+            )}
+          </div>
+
+          {/* Quota section */}
+          {categories.length > 0 ? (
+            <div className="space-y-2">
+              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                Quota
+              </div>
+              {categories.map((cat) => (
+                <QuotaRow key={cat.label} category={cat} />
+              ))}
+            </div>
+          ) : (
+            <div className="text-xs text-muted-foreground">
+              Quota data not available for this provider
+            </div>
+          )}
+
+          {/* Session cost (Claude) */}
+          {sessionCost != null && (
+            <div className="flex items-center justify-between border-t border-border pt-2 text-xs">
+              <span className="text-muted-foreground">Session cost</span>
+              <span className="text-foreground/70">${sessionCost.toFixed(4)}</span>
+            </div>
+          )}
+
+          {/* Context window section */}
+          {hasContext && (
+            <div className="space-y-1 border-t border-border pt-2">
+              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                Context window
+              </div>
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">Used</span>
+                <span className="text-foreground/70">
+                  {formatTokens(tokensIn)} / {formatTokens(contextWindow)}
+                </span>
+              </div>
+              <UsageBar percent={tokensIn / contextWindow} />
+            </div>
+          )}
+
+          {/* Last turn section */}
+          {hasTurn ? (
+            <div className="space-y-2 border-t border-border pt-2">
+              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                Last turn
+              </div>
+              <div className="grid grid-cols-2 gap-1.5">
+                <div className="rounded bg-muted/40 px-2 py-1.5">
+                  <div className="text-[9px] text-muted-foreground">in</div>
+                  <div className="text-xs text-foreground/80">{formatTokens(tokensIn)}</div>
+                </div>
+                <div className="rounded bg-muted/40 px-2 py-1.5">
+                  <div className="text-[9px] text-muted-foreground">out</div>
+                  <div className="text-xs text-foreground/80">
+                    {formatTokens(contextEntry?.tokensOut ?? 0)}
+                  </div>
+                </div>
+                {contextEntry?.cacheReadTokens != null && (
+                  <div className="rounded bg-muted/40 px-2 py-1.5">
+                    <div className="text-[9px] text-muted-foreground">cache read</div>
+                    <div className="text-xs text-foreground/80">{formatTokens(contextEntry.cacheReadTokens)}</div>
+                  </div>
+                )}
+                {contextEntry?.cacheWriteTokens != null && (
+                  <div className="rounded bg-muted/40 px-2 py-1.5">
+                    <div className="text-[9px] text-muted-foreground">cache write</div>
+                    <div className="text-xs text-foreground/80">{formatTokens(contextEntry.cacheWriteTokens)}</div>
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="border-t border-border pt-2 text-xs text-muted-foreground">
+              No turn data yet
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 2: Verify web typechecks**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/chat/UsagePopover.tsx
+git commit -m "feat: create UsagePopover component with quota, context, and turn sections"
+```
+
+---
+
+### Task 13: Update ContextTracker - add click handler and low-quota badge
+
+**Files:**
+- Modify: `apps/web/src/components/chat/ContextTracker.tsx`
+
+- [ ] **Step 1: Add `hasLowQuota` and `popoverOpen` props**
+
+Update the props interface:
+
+```ts
+interface ContextTrackerProps {
+  tokensIn: number;
+  contextWindow?: number;
+  totalProcessedTokens?: number;
+  className?: string;
+  hasLowQuota?: boolean;
+  popoverOpen?: boolean;
+}
+```
+
+Note: No `onClick` prop needed - `PopoverTrigger asChild` in `UsagePopover` automatically handles click events on this component.
+
+- [ ] **Step 2: Add low-quota badge and cursor style**
+
+Update the ring wrapper `<div>`:
+
+```tsx
+<div className={`relative cursor-pointer ${className ?? ""}`}>
+  {/* existing SVG */}
+  {hasLowQuota && (
+    <div className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border border-background bg-destructive" />
+  )}
+</div>
+```
+
+- [ ] **Step 3: Suppress tooltip when popover is open**
+
+The existing `Tooltip` wrapper should be suppressed when the popover is open. Update the `Tooltip` component to use controlled `open`:
+
+```tsx
+<Tooltip open={popoverOpen ? false : undefined}>
+```
+
+When `popoverOpen` is `true`, tooltip is forced closed. When `false` or `undefined`, tooltip behaves normally (uncontrolled).
+
+- [ ] **Step 4: Verify web typechecks**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/chat/ContextTracker.tsx
+git commit -m "feat: add click handler and low-quota badge to ContextTracker"
+```
+
+---
+
+### Task 14: Wire UsagePopover into Composer
+
+**Files:**
+- Modify: `apps/web/src/components/chat/Composer.tsx:1259-1266`
+
+- [ ] **Step 1: Add imports**
+
+```ts
+import { UsagePopover } from "./UsagePopover";
+```
+
+- [ ] **Step 2: Add popover state**
+
+Near the other state declarations:
+
+```ts
+const [usagePopoverOpen, setUsagePopoverOpen] = useState(false);
+```
+
+- [ ] **Step 3: Compute `hasLowQuota` and track popover state**
+
+Place these near the other state and selector declarations in Composer, after the existing `contextEntry` selector:
+
+```ts
+const [usagePopoverOpen, setUsagePopoverOpen] = useState(false);
+const activeProviderId = activeThread?.provider ?? "claude";
+const usageInfo = useThreadStore((s) => s.usageByProvider[activeProviderId]);
+const hasLowQuota = usageInfo?.quotaCategories.some((c) => !c.isUnlimited && c.remainingPercent < 0.2) ?? false;
+```
+
+- [ ] **Step 4: Add `onOpenChange` prop to UsagePopover**
+
+In `UsagePopover.tsx`, add an `onOpenChange` callback prop:
+
+```ts
+interface UsagePopoverProps {
+  threadId: string | undefined;
+  children: ReactNode;
+  onOpenChange?: (open: boolean) => void;
+}
+```
+
+Wire it into the `Popover`:
+
+```tsx
+<Popover onOpenChange={(open) => { handleOpenChange(open); onOpenChange?.(open); }}>
+```
+
+- [ ] **Step 5: Wrap ContextTracker with UsagePopover**
+
+Replace the existing ContextTracker render (lines 1259-1266):
+
+```tsx
+{threadId && (
+  <UsagePopover threadId={threadId} onOpenChange={setUsagePopoverOpen}>
+    <ContextTracker
+      tokensIn={contextEntry?.lastTokensIn ?? activeThread?.last_context_tokens ?? 0}
+      contextWindow={contextEntry?.contextWindow ?? activeThread?.context_window ?? undefined}
+      totalProcessedTokens={contextEntry?.totalProcessedTokens}
+      hasLowQuota={hasLowQuota}
+      popoverOpen={usagePopoverOpen}
+    />
+  </UsagePopover>
+)}
+```
+
+- [ ] **Step 5: Verify web typechecks**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 6: Run full typecheck across all packages**
+
+```bash
+(cd packages/contracts && npx tsc --noEmit) && \
+(cd apps/server && npx tsc --noEmit) && \
+(cd apps/web && npx tsc --noEmit)
+```
+
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/chat/Composer.tsx
+git commit -m "feat: wire UsagePopover into Composer around ContextTracker"
+```
+
+---
+
+### Task 15: Manual verification
+
+- [ ] **Step 1: Run dev server**
+
+```bash
+bun run dev
+```
+
+- [ ] **Step 2: Test with Copilot provider**
+
+1. Open the app, select Copilot provider
+2. Send a message
+3. Click the context ring - popover should show quota categories, context window, and last turn tokens
+4. Verify the ring shows a red dot if quota is below 20%
+
+- [ ] **Step 3: Test with Claude provider**
+
+1. Switch to Claude provider
+2. Send a message
+3. Click the ring - popover should show session cost, context window, and last turn tokens
+4. Quota section should show "Quota data not available for this provider"
+
+- [ ] **Step 4: Test with Codex provider**
+
+1. Switch to Codex provider
+2. Send a message
+3. Click the ring - popover should show last turn tokens only
+4. Context window section should be hidden
+
+- [ ] **Step 5: Test edge cases**
+
+1. Open popover before sending any message - shows "No turn data yet"
+2. Dismiss and reopen popover - should still show cached data
+3. Switch providers while popover is open - popover content should update
+
+- [ ] **Step 6: Final commit (if any fixes needed)**
+
+Stage only the specific files that were fixed during verification and commit.

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -154,6 +154,9 @@ export const AgentEventSchema = lazySchema(() =>
       providerId: z.string(),
       categories: z.array(QuotaCategorySchema()),
       sessionCostUsd: z.number().optional(),
+      serviceTier: z.enum(["standard", "priority", "batch"]).optional(),
+      numTurns: z.number().int().optional(),
+      durationMs: z.number().optional(),
     }),
   ]),
 );

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { lazySchema } from "../utils/lazySchema.js";
+import { QuotaCategorySchema } from "../providers/usage.js";
 
 /**
  * All valid `type` discriminants for `AgentEvent`.
@@ -24,6 +25,7 @@ export const AgentEventType = {
   ToolInputDelta: "toolInputDelta",
   ToolProgress: "toolProgress",
   ContextEstimate: "contextEstimate",
+  QuotaUpdate: "quotaUpdate",
 } as const;
 
 /** Union of all valid `AgentEvent` type discriminants. */
@@ -66,6 +68,10 @@ export const AgentEventSchema = lazySchema(() =>
       contextWindow: z.number().optional(),
       /** Accumulated total tokens processed across all API calls in the session. */
       totalProcessedTokens: z.number().optional(),
+      cacheReadTokens: z.number().optional(),
+      cacheWriteTokens: z.number().optional(),
+      costMultiplier: z.number().optional(),
+      providerId: z.string().optional(),
     }),
     z.object({
       type: z.literal(AgentEventType.Error),
@@ -141,6 +147,13 @@ export const AgentEventSchema = lazySchema(() =>
       tokensIn: z.number(),
       /** Model context window size, forwarded from SDK when available. */
       contextWindow: z.number().optional(),
+    }),
+    z.object({
+      type: z.literal(AgentEventType.QuotaUpdate),
+      threadId: z.string(),
+      providerId: z.string(),
+      categories: z.array(QuotaCategorySchema()),
+      sessionCostUsd: z.number().optional(),
     }),
   ]),
 );

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -149,3 +149,14 @@ export {
 } from "./providers/models.js";
 export type { ProviderModelInfo } from "./providers/models.js";
 export { isCompletionCapable } from "./providers/interfaces.js";
+
+export {
+  TurnUsageSchema,
+  QuotaCategorySchema,
+  ProviderUsageInfoSchema,
+} from "./providers/usage.js";
+export type {
+  TurnUsage,
+  QuotaCategory,
+  ProviderUsageInfo,
+} from "./providers/usage.js";

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -2,6 +2,7 @@ import type { AgentEvent } from "../events/agent-event.js";
 import type { AttachmentMeta } from "../models/attachment.js";
 import type { ReasoningLevel } from "../models/settings.js";
 import type { ProviderModelInfo } from "./models.js";
+import type { ProviderUsageInfo } from "./usage.js";
 
 /**
  * Identifier for a supported AI provider.
@@ -45,6 +46,9 @@ export interface IAgentProvider {
 
   /** List models available from this provider. Not all providers support dynamic discovery. */
   listModels?(): Promise<ProviderModelInfo[]>;
+
+  /** Return current usage/quota state for this provider. */
+  getUsage?(): Promise<ProviderUsageInfo>;
 
   /** Subscribe to agent events. */
   on(event: "event", handler: (event: AgentEvent) => void): void;

--- a/packages/contracts/src/providers/usage.ts
+++ b/packages/contracts/src/providers/usage.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+
+/** Per-turn token breakdown. All providers populate at least inputTokens and outputTokens. */
+export const TurnUsageSchema = lazySchema(() =>
+  z.object({
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheReadTokens: z.number().optional(),
+    cacheWriteTokens: z.number().optional(),
+    costMultiplier: z.number().optional(),
+  }),
+);
+
+/** TypeScript type inferred from TurnUsageSchema. */
+export type TurnUsage = z.infer<ReturnType<typeof TurnUsageSchema>>;
+
+/** A single quota bucket (e.g. "Premium requests", "Chat"). */
+export const QuotaCategorySchema = lazySchema(() =>
+  z.object({
+    /** Human-readable label for the quota category. */
+    label: z.string(),
+    /** Number of requests or tokens consumed in this category. */
+    used: z.number(),
+    /** Maximum allowed in this category. Null when the limit is unknown. */
+    total: z.number().nullable(),
+    /** Fraction remaining in [0, 1]. 1 means fully available, 0 means exhausted. */
+    remainingPercent: z.number().min(0).max(1),
+    /** ISO 8601 timestamp when this quota resets. */
+    resetDate: z.string().optional(),
+    /** True when the provider reports no cap on this category. */
+    isUnlimited: z.boolean(),
+  }),
+);
+
+/** TypeScript type inferred from QuotaCategorySchema. */
+export type QuotaCategory = z.infer<ReturnType<typeof QuotaCategorySchema>>;
+
+/** Provider-level usage state. Quota and cost only - context/turn data is thread-scoped. */
+export const ProviderUsageInfoSchema = lazySchema(() =>
+  z.object({
+    /** Identifier matching a registered ProviderId. */
+    providerId: z.string(),
+    /** All quota buckets reported by this provider. */
+    quotaCategories: z.array(QuotaCategorySchema()),
+    /** Accumulated cost for the current session in USD. Absent when the provider does not report cost. */
+    sessionCostUsd: z.number().optional(),
+  }),
+);
+
+/** TypeScript type inferred from ProviderUsageInfoSchema. */
+export type ProviderUsageInfo = z.infer<ReturnType<typeof ProviderUsageInfoSchema>>;

--- a/packages/contracts/src/providers/usage.ts
+++ b/packages/contracts/src/providers/usage.ts
@@ -45,6 +45,12 @@ export const ProviderUsageInfoSchema = lazySchema(() =>
     quotaCategories: z.array(QuotaCategorySchema()),
     /** Accumulated cost for the current session in USD. Absent when the provider does not report cost. */
     sessionCostUsd: z.number().optional(),
+    /** API service tier used for the last turn (Claude only). */
+    serviceTier: z.enum(["standard", "priority", "batch"]).optional(),
+    /** Total number of agent turns in the current session (Claude only). */
+    numTurns: z.number().int().optional(),
+    /** Total wall-clock duration of the current session in ms (Claude only). */
+    durationMs: z.number().optional(),
   }),
 );
 

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -20,6 +20,7 @@ import {
 } from "../models/settings.js";
 import { lazySchema } from "../utils/lazySchema.js";
 import { ProviderModelInfoSchema } from "../providers/models.js";
+import { ProviderUsageInfoSchema } from "../providers/usage.js";
 
 /** Schema for creating a new thread. */
 export const CreateThreadSchema = z.object({
@@ -375,6 +376,10 @@ export const WS_METHODS = lazySchema(() => ({
   "provider.listModels": {
     params: z.object({ providerId: ProviderIdSchema }),
     result: z.array(ProviderModelInfoSchema()),
+  },
+  "provider.getUsage": {
+    params: z.object({ providerId: ProviderIdSchema }),
+    result: ProviderUsageInfoSchema(),
   },
   "memory.setBackground": {
     params: z.object({ background: z.boolean() }),


### PR DESCRIPTION
## What

Add a live usage tracking panel to the sidebar footer. A compact strip sits above the settings button showing the active provider, model name, and a key metric with a fill bar. Hovering reveals a detailed white popover with full quota rows, session cost, turn count, duration, service tier, context window bar, and last-turn token breakdown.

## Why

Users had no visibility into quota consumption, context usage, or cost while working. This surfaces the data inline without requiring any navigation.

## Key changes

- **`SidebarUsagePanel`** - new sidebar footer component with compact strip + hover popover
- **`ProviderUsageInfo` schema** - extended with `serviceTier`, `numTurns`, `durationMs`
- **`AgentEvent` / `TurnComplete`** - added `cacheWriteTokens`, `cacheReadTokens`, `costMultiplier` fields
- **`claude-provider`** - captures `num_turns`, `duration_ms`, `service_tier`, and cache token fields from SDK result; implements `getUsage()`
- **`copilot-provider`** - implements `getUsage()` via `account.getQuota()`; normalizes 0-100 quota percentages to 0-1; treats categories with zero entitlement as unlimited
- **`threadStore`** - adds `usageByProvider` map and `quotaUpdate` push event handler
- **`ws-router`** - adds `provider.getUsage` RPC handler
- **`popover.tsx`** - adds `render` prop support for custom trigger elements

## Related issues/PRs

closes #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time provider usage & quota tracking with per-provider breakdown and session metrics.
  * Usage popover (quota, session cost/tier, context window, last-turn token breakdown including cache read/write).
  * Sidebar usage panel with compact quota bar, progress indicators, and reset estimates.
  * Low-quota red-dot on the context tracker; Composer lazily fetches provider usage when needed.

* **Documentation**
  * Added design/specs detailing usage tracking and UI/API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->