### PR TITLE
feat: add maxBudgetUsd and maxTurns guardrails (Claude only)

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -385,6 +385,10 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       ...buildReasoningOptions(reasoningLevel, resolvedModel),
       ...(fallbackModel && { fallbackModel }),
       includePartialMessages: true,
+      // Guardrails are fixed at session creation. If the user changes the
+      // setting between turns while the session is still live in memory, the
+      // original values remain in effect until the session is evicted or the
+      // server restarts.
       ...(params.maxBudgetUsd != null && params.maxBudgetUsd > 0 && { maxBudgetUsd: params.maxBudgetUsd }),
       ...(params.maxTurns != null && params.maxTurns > 0 && { maxTurns: params.maxTurns }),
       hooks: {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -182,6 +182,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     permissionMode: string;
     attachments?: AttachmentMeta[];
     reasoningLevel?: ReasoningLevel;
+    maxBudgetUsd?: number;
+    maxTurns?: number;
   }): Promise<void> {
     try {
       await this.doSendMessage(params);
@@ -280,6 +282,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     permissionMode: string;
     attachments?: AttachmentMeta[];
     reasoningLevel?: ReasoningLevel;
+    maxBudgetUsd?: number;
+    maxTurns?: number;
   }): Promise<void> {
     const {
       sessionId,
@@ -381,6 +385,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       ...buildReasoningOptions(reasoningLevel, resolvedModel),
       ...(fallbackModel && { fallbackModel }),
       includePartialMessages: true,
+      ...(params.maxBudgetUsd != null && params.maxBudgetUsd > 0 && { maxBudgetUsd: params.maxBudgetUsd }),
+      ...(params.maxTurns != null && params.maxTurns > 0 && { maxTurns: params.maxTurns }),
       hooks: {
         PostCompact: [{
           // @ts-expect-error: HookCallback accepts 3 params but we only need input

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -134,6 +134,8 @@ export class AgentService {
     reasoningLevel?: ReasoningLevel,
     provider?: ProviderId,
     interactionMode?: InteractionMode,
+    maxBudgetUsd?: number,
+    maxTurns?: number,
   ): Promise<void> {
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
@@ -220,9 +222,15 @@ export class AgentService {
     }
 
     const resolvedModel = model;
-    const { fallbackId } = (await this.settingsService.get()).model.defaults;
+    const settings = await this.settingsService.get();
+    const { fallbackId } = settings.model.defaults;
     const fallbackModel =
       fallbackId && fallbackId !== resolvedModel ? fallbackId : undefined;
+
+    // Resolve guardrails: per-request values override settings defaults.
+    // A value of 0 means "disabled" — do not pass to provider.
+    const effectiveBudget = maxBudgetUsd ?? settings.agent.guardrails.maxBudgetUsd;
+    const effectiveTurns = maxTurns ?? settings.agent.guardrails.maxTurns;
     this.threadRepo.updateModel(threadId, resolvedModel);
     // Only persist provider when the caller explicitly supplied one (new thread or deliberate switch).
     if (provider !== undefined) {
@@ -265,6 +273,8 @@ export class AgentService {
         permissionMode,
         attachments: persisted.length > 0 ? persisted : undefined,
         reasoningLevel,
+        ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
+        ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
       });
       logger.info("Message sent via provider", {
         threadId,
@@ -371,6 +381,8 @@ export class AgentService {
     interactionMode?: InteractionMode,
     parentThreadId?: string,
     forkedFromMessageId?: string,
+    maxBudgetUsd?: number,
+    maxTurns?: number,
   ): Promise<Thread> {
     const title = truncateTitle(content);
 
@@ -379,6 +391,7 @@ export class AgentService {
         workspaceId, content, model, permissionMode, mode, branch,
         existingWorktreePath, attachments, reasoningLevel, provider,
         interactionMode, parentThreadId, forkedFromMessageId, title,
+        maxBudgetUsd, maxTurns,
       });
     }
 
@@ -437,6 +450,8 @@ export class AgentService {
       reasoningLevel,
       provider,
       interactionMode,
+      maxBudgetUsd,
+      maxTurns,
     );
 
     // Re-read from DB to pick up model update applied by sendMessage
@@ -465,11 +480,14 @@ export class AgentService {
     parentThreadId: string;
     forkedFromMessageId?: string;
     title: string;
+    maxBudgetUsd?: number;
+    maxTurns?: number;
   }): Promise<Thread> {
     const {
       workspaceId, content, model, permissionMode, mode, branch,
       existingWorktreePath, attachments, reasoningLevel, provider,
       interactionMode, parentThreadId, forkedFromMessageId, title,
+      maxBudgetUsd, maxTurns,
     } = params;
 
     // Validate parent
@@ -632,6 +650,8 @@ export class AgentService {
         reasoningLevel,
         provider,
         interactionMode,
+        maxBudgetUsd,
+        maxTurns,
       );
     } finally {
       // Ensure override is cleaned up even if sendMessage throws before consuming it.

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -288,6 +288,8 @@ async function dispatch(
         params.reasoningLevel,
         params.provider,
         params.interactionMode,
+        params.maxBudgetUsd,
+        params.maxTurns,
       );
       return;
     case "agent.createAndSend":
@@ -305,6 +307,8 @@ async function dispatch(
         params.interactionMode,
         params.parentThreadId,
         params.forkedFromMessageId,
+        params.maxBudgetUsd,
+        params.maxTurns,
       );
     case "agent.stop":
       await deps.agentService.stopSession(params.threadId);

--- a/apps/web/src/components/settings/sections/AgentSection.tsx
+++ b/apps/web/src/components/settings/sections/AgentSection.tsx
@@ -6,12 +6,14 @@ import { SectionHeading } from "../SectionHeading";
 import type { AgentDefaultMode } from "@mcode/contracts";
 
 /**
- * Agent settings section: max concurrent agents, default interaction mode, and permission level.
+ * Agent settings section: concurrency, defaults, and per-session guardrails.
  */
 export function AgentSection() {
   const maxConcurrent = useSettingsStore((s) => s.settings.agent.maxConcurrent);
   const mode = useSettingsStore((s) => s.settings.agent.defaults.mode);
   const permission = useSettingsStore((s) => s.settings.agent.defaults.permission);
+  const maxBudgetUsd = useSettingsStore((s) => s.settings.agent.guardrails.maxBudgetUsd);
+  const maxTurns = useSettingsStore((s) => s.settings.agent.guardrails.maxTurns);
   const update = useSettingsStore((s) => s.update);
 
   return (
@@ -61,6 +63,38 @@ export function AgentSection() {
           onChange={(v) =>
             update({ agent: { defaults: { permission: v as "full" | "supervised" } } })
           }
+        />
+      </SettingRow>
+
+      <SectionHeading>Guardrails</SectionHeading>
+
+      <SettingRow
+        label="Budget cap"
+        configKey="agent.guardrails.maxBudgetUsd"
+        hint="Stop the agent when session cost exceeds this USD amount. 0 disables. Claude only."
+      >
+        <RangeControl
+          min={0}
+          max={50}
+          step={1}
+          value={maxBudgetUsd}
+          onCommit={(v) => void update({ agent: { guardrails: { maxBudgetUsd: v } } })}
+          formatValue={(v) => v === 0 ? "Off" : `$${v}`}
+        />
+      </SettingRow>
+
+      <SettingRow
+        label="Max turns"
+        configKey="agent.guardrails.maxTurns"
+        hint="Stop the agent after this many turns. 0 disables. Claude only."
+      >
+        <RangeControl
+          min={0}
+          max={100}
+          step={5}
+          value={maxTurns}
+          onCommit={(v) => void update({ agent: { guardrails: { maxTurns: v } } })}
+          formatValue={(v) => v === 0 ? "Off" : `${v}`}
         />
       </SettingRow>
       </div>

--- a/apps/web/src/components/settings/sections/AgentSection.tsx
+++ b/apps/web/src/components/settings/sections/AgentSection.tsx
@@ -91,7 +91,7 @@ export function AgentSection() {
         <RangeControl
           min={0}
           max={100}
-          step={5}
+          step={1}
           value={maxTurns}
           onCommit={(v) => void update({ agent: { guardrails: { maxTurns: v } } })}
           formatValue={(v) => v === 0 ? "Off" : `${v}`}

--- a/apps/web/src/components/settings/sections/AgentSection.tsx
+++ b/apps/web/src/components/settings/sections/AgentSection.tsx
@@ -66,12 +66,19 @@ export function AgentSection() {
         />
       </SettingRow>
 
-      <SectionHeading>Guardrails</SectionHeading>
+      <div className="mt-6 mb-1 flex items-center gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/50">
+          Guardrails
+        </span>
+        <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest text-amber-400/90">
+          Beta
+        </span>
+      </div>
 
       <SettingRow
         label="Budget cap"
         configKey="agent.guardrails.maxBudgetUsd"
-        hint="Stop the agent when session cost exceeds this USD amount. 0 disables. Claude only."
+        hint="Stop the agent when session cost exceeds this USD amount. 0 disables. Claude only. Budget is checked between turns, so actual cost may slightly exceed the cap."
       >
         <RangeControl
           min={0}

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1157,6 +1157,24 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Tool calls remain in-place and collapse into a summary.
       const streamContent = get().streamingByThread[threadId] ?? "";
 
+      // Build an ephemeral system message for guardrail stops (budget/turn limit).
+      // Folded into the same set() call to avoid a double render pass.
+      const reason = method === "session.turnComplete" ? params.reason as string | undefined : undefined;
+      const isGuardrailStop = reason === "error_max_budget_usd" || reason === "max_turns";
+      const guardrailMsg: Message | null = isGuardrailStop ? {
+        id: crypto.randomUUID(),
+        thread_id: threadId,
+        role: "system",
+        content: `Agent stopped: ${reason === "error_max_budget_usd" ? "Budget cap reached" : "Max turns reached"}. You can adjust guardrails in Settings > Agent.`,
+        sequence: 0,
+        tokens_used: null,
+        cost_usd: null,
+        timestamp: new Date().toISOString(),
+        tool_calls: null,
+        files_changed: null,
+        attachments: null,
+      } : null;
+
       // First: mark all tool calls as complete (in place) and commit the message
       if (streamContent) {
         const message: Message = {
@@ -1188,10 +1206,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           const completedCalls = currentCalls.map((tc) =>
             tc.isComplete ? tc : { ...tc, isComplete: true }
           );
+          const pending = [message, ...(guardrailMsg ? [guardrailMsg] : [])];
           return {
             ...(state.currentThreadId === threadId
               ? (() => {
-                  const { messages: capped, evicted } = capMessages([...state.messages, message]);
+                  const { messages: capped, evicted } = capMessages([...state.messages, ...pending]);
                   return { messages: capped, ...(evicted && state.currentThreadId ? { hasMoreMessages: { ...state.hasMoreMessages, [state.currentThreadId]: true } } : {}) };
                 })()
               : {}),
@@ -1222,6 +1241,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             tc.isComplete ? tc : { ...tc, isComplete: true }
           );
           return {
+            ...(guardrailMsg && state.currentThreadId === threadId
+              ? (() => {
+                  const { messages: capped, evicted } = capMessages([...state.messages, guardrailMsg]);
+                  return { messages: capped, ...(evicted ? { hasMoreMessages: { ...state.hasMoreMessages, [threadId]: true } } : {}) };
+                })()
+              : {}),
             runningThreadIds: nextRunning,
             streamingByThread: nextStreaming,
             streamingPreviewByThread: nextPreview,
@@ -1269,39 +1294,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             },
           },
         }));
-      }
-
-      // Surface guardrail stop reasons as a visible system message
-      if (method === "session.turnComplete") {
-        const reason = params.reason as string | undefined;
-        if (reason === "error_max_budget_usd" || reason === "max_turns") {
-          const label = reason === "error_max_budget_usd"
-            ? "Budget cap reached"
-            : "Max turns reached";
-
-          const systemMsg: Message = {
-            id: crypto.randomUUID(),
-            thread_id: threadId,
-            role: "system",
-            content: `Agent stopped: ${label}. You can adjust guardrails in Settings > Agent.`,
-            sequence: 0,
-            tokens_used: null,
-            cost_usd: null,
-            timestamp: new Date().toISOString(),
-            tool_calls: null,
-            files_changed: null,
-            attachments: null,
-          };
-
-          set((state) => {
-            if (state.currentThreadId !== threadId) return {};
-            const { messages: capped, evicted } = capMessages([...state.messages, systemMsg]);
-            return {
-              messages: capped,
-              ...(evicted ? { hasMoreMessages: { ...state.hasMoreMessages, [threadId]: true } } : {}),
-            };
-          });
-        }
       }
 
       // Tool calls remain in state (all marked complete). They render as

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1271,6 +1271,39 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         }));
       }
 
+      // Surface guardrail stop reasons as a visible system message
+      if (method === "session.turnComplete") {
+        const reason = params.reason as string | undefined;
+        if (reason === "error_max_budget_usd" || reason === "max_turns") {
+          const label = reason === "error_max_budget_usd"
+            ? "Budget cap reached"
+            : "Max turns reached";
+
+          const systemMsg: Message = {
+            id: crypto.randomUUID(),
+            thread_id: threadId,
+            role: "system",
+            content: `Agent stopped: ${label}. You can adjust guardrails in Settings > Agent.`,
+            sequence: 0,
+            tokens_used: null,
+            cost_usd: null,
+            timestamp: new Date().toISOString(),
+            tool_calls: null,
+            files_changed: null,
+            attachments: null,
+          };
+
+          set((state) => {
+            if (state.currentThreadId !== threadId) return {};
+            const { messages: capped, evicted } = capMessages([...state.messages, systemMsg]);
+            return {
+              messages: capped,
+              ...(evicted ? { hasMoreMessages: { ...state.hasMoreMessages, [threadId]: true } } : {}),
+            };
+          });
+        }
+      }
+
       // Tool calls remain in state (all marked complete). They render as
       // a collapsed summary in-place. When turn.persisted fires, the DB-backed
       // summary replaces them and tool calls are cleared.

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1318,7 +1318,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Auto-dequeue: send next queued message after a brief visual pause.
       // Only on turnComplete (not session.ended) so explicit stops don't drain the queue.
       // Uses tracked timers to prevent double-dequeue from duplicate events.
-      if (method === "session.turnComplete") {
+      // Skip dequeue when a guardrail stopped the session to avoid restarting
+      // an agent that was intentionally capped by budget or turn limits.
+      if (method === "session.turnComplete" && !isGuardrailStop) {
         clearDequeueTimer(threadId);
         const timer = setTimeout(() => {
           dequeueTimers.delete(threadId);

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1206,7 +1206,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           const completedCalls = currentCalls.map((tc) =>
             tc.isComplete ? tc : { ...tc, isComplete: true }
           );
-          const pending = [message, ...(guardrailMsg ? [guardrailMsg] : [])];
+          const dedupedGuardrail = guardrailMsg && !state.messages.some(
+            (m) => m.role === "system" && m.content.startsWith("Agent stopped:"),
+          ) ? guardrailMsg : null;
+          const pending = [message, ...(dedupedGuardrail ? [dedupedGuardrail] : [])];
           return {
             ...(state.currentThreadId === threadId
               ? (() => {
@@ -1240,10 +1243,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           const completedCalls = currentCalls.map((tc) =>
             tc.isComplete ? tc : { ...tc, isComplete: true }
           );
+          const dedupedGuardrail = guardrailMsg && !state.messages.some(
+            (m) => m.role === "system" && m.content.startsWith("Agent stopped:"),
+          ) ? guardrailMsg : null;
           return {
-            ...(guardrailMsg && state.currentThreadId === threadId
+            ...(dedupedGuardrail && state.currentThreadId === threadId
               ? (() => {
-                  const { messages: capped, evicted } = capMessages([...state.messages, guardrailMsg]);
+                  const { messages: capped, evicted } = capMessages([...state.messages, dedupedGuardrail]);
                   return { messages: capped, ...(evicted ? { hasMoreMessages: { ...state.hasMoreMessages, [threadId]: true } } : {}) };
                 })()
               : {}),

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types";
 import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
+import { useSettingsStore } from "@/stores/settingsStore";
 
 /** Minimum reconnect delay in milliseconds. */
 const MIN_RECONNECT_MS = 1000;
@@ -306,8 +307,14 @@ export function createWsTransport(
     listWorktrees: (workspaceId) => rpc<WorktreeInfo[]>("git.listWorktrees", { workspaceId }),
 
     // Agent
-    sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?) =>
-      rpc<void>("agent.send", { threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode }),
+    sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?) => {
+      const { maxBudgetUsd, maxTurns } = useSettingsStore.getState().settings.agent.guardrails;
+      return rpc<void>("agent.send", {
+        threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode,
+        ...(maxBudgetUsd > 0 && { maxBudgetUsd }),
+        ...(maxTurns > 0 && { maxTurns }),
+      });
+    },
     createAndSendMessage: (
       workspaceId,
       content,
@@ -322,8 +329,9 @@ export function createWsTransport(
       interactionMode?,
       parentThreadId?,
       forkedFromMessageId?,
-    ) =>
-      rpc<Thread>("agent.createAndSend", {
+    ) => {
+      const { maxBudgetUsd, maxTurns } = useSettingsStore.getState().settings.agent.guardrails;
+      return rpc<Thread>("agent.createAndSend", {
         workspaceId,
         content,
         model,
@@ -337,7 +345,10 @@ export function createWsTransport(
         interactionMode,
         parentThreadId,
         forkedFromMessageId,
-      }),
+        ...(maxBudgetUsd > 0 && { maxBudgetUsd }),
+        ...(maxTurns > 0 && { maxTurns }),
+      });
+    },
     stopAgent: (threadId) => rpc<void>("agent.stop", { threadId }),
     answerPlanQuestions: (threadId, answers, permissionMode?, reasoningLevel?) =>
       rpc<void>("agent.answerQuestions", { threadId, answers, permissionMode, reasoningLevel }),

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -308,11 +308,13 @@ export function createWsTransport(
 
     // Agent
     sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?) => {
-      const { maxBudgetUsd, maxTurns } = useSettingsStore.getState().settings.agent.guardrails;
+      const state = useSettingsStore.getState();
+      const guardrails = state.loaded
+        ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
+        : {};
       return rpc<void>("agent.send", {
         threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode,
-        maxBudgetUsd,
-        maxTurns,
+        ...guardrails,
       });
     },
     createAndSendMessage: (
@@ -330,7 +332,10 @@ export function createWsTransport(
       parentThreadId?,
       forkedFromMessageId?,
     ) => {
-      const { maxBudgetUsd, maxTurns } = useSettingsStore.getState().settings.agent.guardrails;
+      const state = useSettingsStore.getState();
+      const guardrails = state.loaded
+        ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
+        : {};
       return rpc<Thread>("agent.createAndSend", {
         workspaceId,
         content,
@@ -345,8 +350,7 @@ export function createWsTransport(
         interactionMode,
         parentThreadId,
         forkedFromMessageId,
-        maxBudgetUsd,
-        maxTurns,
+        ...guardrails,
       });
     },
     stopAgent: (threadId) => rpc<void>("agent.stop", { threadId }),

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -311,8 +311,8 @@ export function createWsTransport(
       const { maxBudgetUsd, maxTurns } = useSettingsStore.getState().settings.agent.guardrails;
       return rpc<void>("agent.send", {
         threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode,
-        ...(maxBudgetUsd > 0 && { maxBudgetUsd }),
-        ...(maxTurns > 0 && { maxTurns }),
+        maxBudgetUsd,
+        maxTurns,
       });
     },
     createAndSendMessage: (
@@ -345,8 +345,8 @@ export function createWsTransport(
         interactionMode,
         parentThreadId,
         forkedFromMessageId,
-        ...(maxBudgetUsd > 0 && { maxBudgetUsd }),
-        ...(maxTurns > 0 && { maxTurns }),
+        maxBudgetUsd,
+        maxTurns,
       });
     },
     stopAgent: (threadId) => rpc<void>("agent.stop", { threadId }),

--- a/docs/guides/settings-schema.md
+++ b/docs/guides/settings-schema.md
@@ -117,6 +117,10 @@ When adding a new setting, ask these questions in order:
     "defaults": {
       "mode": "chat",                  // "plan" | "chat" | "agent"
       "permission": "full"             // "full" | "supervised"
+    },
+    "guardrails": {
+      "maxBudgetUsd": 0,               // 0 disables, USD cap per session (Claude only)
+      "maxTurns": 0                    // 0 disables, turn limit per session (Claude only)
     }
   },
   "model": {

--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -12,6 +12,8 @@ Per-setting reference for Mcode's `settings.json`. For schema conventions and st
 | `agent.maxConcurrent` | integer | `5` | > 0 | - | Maximum concurrent agent sessions |
 | `agent.defaults.mode` | enum | `"chat"` | `"plan"` \| `"chat"` \| `"agent"` | - | Default interaction mode for new agents |
 | `agent.defaults.permission` | enum | `"full"` | `"full"` \| `"supervised"` | - | Default permission mode for new agents |
+| `agent.guardrails.maxBudgetUsd` | number | `0` | >= 0 | - | Stop the agent when session cost exceeds this USD amount. `0` disables. Claude only. |
+| `agent.guardrails.maxTurns` | integer | `0` | >= 0 | - | Stop the agent after this many turns. `0` disables. Claude only. |
 | `model.defaults.provider` | enum | `"claude"` | `"claude"` \| `"codex"` \| `"gemini"` \| `"copilot"` | - | Default AI provider |
 | `model.defaults.id` | string | `"claude-sonnet-4-6"` | - | - | Default model identifier |
 | `model.defaults.reasoning` | enum | `"high"` | `"low"` \| `"medium"` \| `"high"` \| `"xhigh"` \| `"max"` | - | Default reasoning effort level. `"xhigh"` applies to Codex models only. `"max"` is only valid for Opus 4.6; it normalizes to `"high"` at runtime on all other Claude models |

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -71,6 +71,15 @@ export const SettingsSchema = lazySchema(() =>
             permission: PermissionModeSchema.default("full"),
           })
           .default({}),
+        /** Per-session safety limits (Claude provider only). */
+        guardrails: z
+          .object({
+            /** Stop the agent if session cost exceeds this USD amount. 0 disables. */
+            maxBudgetUsd: z.number().nonnegative().default(0),
+            /** Stop the agent after this many turns. 0 disables. */
+            maxTurns: z.number().int().nonnegative().default(0),
+          })
+          .default({}),
       })
       .default({}),
 
@@ -208,6 +217,12 @@ export const PartialSettingsSchema = lazySchema(() =>
           .object({
             mode: AgentDefaultModeSchema.optional(),
             permission: PermissionModeSchema.optional(),
+          })
+          .optional(),
+        guardrails: z
+          .object({
+            maxBudgetUsd: z.number().nonnegative().optional(),
+            maxTurns: z.number().int().nonnegative().optional(),
           })
           .optional(),
       })

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -75,7 +75,7 @@ export const SettingsSchema = lazySchema(() =>
         guardrails: z
           .object({
             /** Stop the agent if session cost exceeds this USD amount. 0 disables. */
-            maxBudgetUsd: z.number().nonnegative().default(0),
+            maxBudgetUsd: z.number().nonnegative().finite().default(0),
             /** Stop the agent after this many turns. 0 disables. */
             maxTurns: z.number().int().nonnegative().default(0),
           })
@@ -221,7 +221,7 @@ export const PartialSettingsSchema = lazySchema(() =>
           .optional(),
         guardrails: z
           .object({
-            maxBudgetUsd: z.number().nonnegative().optional(),
+            maxBudgetUsd: z.number().nonnegative().finite().optional(),
             maxTurns: z.number().int().nonnegative().optional(),
           })
           .optional(),

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -33,6 +33,10 @@ export interface IAgentProvider {
     permissionMode: string;
     attachments?: AttachmentMeta[];
     reasoningLevel?: ReasoningLevel;
+    /** USD budget cap for this session. Provider stops if exceeded. Undefined or 0 disables. */
+    maxBudgetUsd?: number;
+    /** Maximum agent turns for this session. Provider stops after this count. Undefined or 0 disables. */
+    maxTurns?: number;
   }): void | Promise<void>;
 
   /** Abort a running session. */

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -41,6 +41,10 @@ export const SendMessageSchema = z.object({
   provider: ProviderIdSchema.optional(),
   /** When "plan", the server wraps the message with the plan-mode question prompt. */
   interactionMode: InteractionModeSchema.optional(),
+  /** USD budget cap for this session. 0 or absent disables. */
+  maxBudgetUsd: z.number().nonnegative().optional(),
+  /** Maximum agent turns. 0 or absent disables. */
+  maxTurns: z.number().int().nonnegative().optional(),
 });
 
 /** Schema for creating a thread and sending a message in one call. */
@@ -57,6 +61,10 @@ export const CreateAndSendSchema = z.object({
   provider: ProviderIdSchema.optional(),
   /** When "plan", the server wraps the message with the plan-mode question prompt. */
   interactionMode: InteractionModeSchema.optional(),
+  /** USD budget cap for this session. 0 or absent disables. */
+  maxBudgetUsd: z.number().nonnegative().optional(),
+  /** Maximum agent turns. 0 or absent disables. */
+  maxTurns: z.number().int().nonnegative().optional(),
   /** Source thread ID when branching from an existing thread. */
   parentThreadId: z.string().optional(),
   /** Fork-point message ID in the parent thread. Defaults to last persisted message. */

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -23,55 +23,61 @@ import { ProviderModelInfoSchema } from "../providers/models.js";
 import { ProviderUsageInfoSchema } from "../providers/usage.js";
 
 /** Schema for creating a new thread. */
-export const CreateThreadSchema = z.object({
-  workspaceId: z.string(),
-  title: z.string(),
-  mode: ThreadModeSchema,
-  branch: z.string(),
-});
+export const CreateThreadSchema = lazySchema(() =>
+  z.object({
+    workspaceId: z.string(),
+    title: z.string(),
+    mode: ThreadModeSchema,
+    branch: z.string(),
+  }),
+);
 
 /** Schema for sending a message to an existing thread. */
-export const SendMessageSchema = z.object({
-  threadId: z.string(),
-  content: z.string(),
-  model: z.string().optional(),
-  permissionMode: PermissionModeSchema.optional(),
-  attachments: z.array(AttachmentMetaSchema).optional(),
-  reasoningLevel: ReasoningLevelSchema.optional(),
-  provider: ProviderIdSchema.optional(),
-  /** When "plan", the server wraps the message with the plan-mode question prompt. */
-  interactionMode: InteractionModeSchema.optional(),
-  /** USD budget cap for this session. 0 or absent disables. */
-  maxBudgetUsd: z.number().nonnegative().finite().optional(),
-  /** Maximum agent turns. 0 or absent disables. */
-  maxTurns: z.number().int().nonnegative().optional(),
-});
+export const SendMessageSchema = lazySchema(() =>
+  z.object({
+    threadId: z.string(),
+    content: z.string(),
+    model: z.string().optional(),
+    permissionMode: PermissionModeSchema.optional(),
+    attachments: z.array(AttachmentMetaSchema).optional(),
+    reasoningLevel: ReasoningLevelSchema.optional(),
+    provider: ProviderIdSchema.optional(),
+    /** When "plan", the server wraps the message with the plan-mode question prompt. */
+    interactionMode: InteractionModeSchema.optional(),
+    /** USD budget cap for this session. 0 or absent disables. */
+    maxBudgetUsd: z.number().nonnegative().finite().optional(),
+    /** Maximum agent turns. 0 or absent disables. */
+    maxTurns: z.number().int().nonnegative().optional(),
+  }),
+);
 
 /** Schema for creating a thread and sending a message in one call. */
-export const CreateAndSendSchema = z.object({
-  workspaceId: z.string(),
-  content: z.string(),
-  model: z.string(),
-  permissionMode: PermissionModeSchema.optional(),
-  mode: ThreadModeSchema.optional(),
-  branch: z.string().optional(),
-  existingWorktreePath: z.string().optional(),
-  attachments: z.array(AttachmentMetaSchema).optional(),
-  reasoningLevel: ReasoningLevelSchema.optional(),
-  provider: ProviderIdSchema.optional(),
-  /** When "plan", the server wraps the message with the plan-mode question prompt. */
-  interactionMode: InteractionModeSchema.optional(),
-  /** USD budget cap for this session. 0 or absent disables. */
-  maxBudgetUsd: z.number().nonnegative().finite().optional(),
-  /** Maximum agent turns. 0 or absent disables. */
-  maxTurns: z.number().int().nonnegative().optional(),
-  /** Source thread ID when branching from an existing thread. */
-  parentThreadId: z.string().optional(),
-  /** Fork-point message ID in the parent thread. Defaults to last persisted message. */
-  forkedFromMessageId: z.string().optional(),
-}).refine(
-  (d) => !d.forkedFromMessageId || d.parentThreadId,
-  { message: "forkedFromMessageId requires parentThreadId", path: ["forkedFromMessageId"] },
+export const CreateAndSendSchema = lazySchema(() =>
+  z.object({
+    workspaceId: z.string(),
+    content: z.string(),
+    model: z.string(),
+    permissionMode: PermissionModeSchema.optional(),
+    mode: ThreadModeSchema.optional(),
+    branch: z.string().optional(),
+    existingWorktreePath: z.string().optional(),
+    attachments: z.array(AttachmentMetaSchema).optional(),
+    reasoningLevel: ReasoningLevelSchema.optional(),
+    provider: ProviderIdSchema.optional(),
+    /** When "plan", the server wraps the message with the plan-mode question prompt. */
+    interactionMode: InteractionModeSchema.optional(),
+    /** USD budget cap for this session. 0 or absent disables. */
+    maxBudgetUsd: z.number().nonnegative().finite().optional(),
+    /** Maximum agent turns. 0 or absent disables. */
+    maxTurns: z.number().int().nonnegative().optional(),
+    /** Source thread ID when branching from an existing thread. */
+    parentThreadId: z.string().optional(),
+    /** Fork-point message ID in the parent thread. Defaults to last persisted message. */
+    forkedFromMessageId: z.string().optional(),
+  }).refine(
+    (d) => !d.forkedFromMessageId || d.parentThreadId,
+    { message: "forkedFromMessageId requires parentThreadId", path: ["forkedFromMessageId"] },
+  ),
 );
 
 /** All RPC method definitions keyed by method name with params and result schemas. */
@@ -93,7 +99,7 @@ export const WS_METHODS = lazySchema(() => ({
     result: z.array(ThreadSchema),
   },
   "thread.create": {
-    params: CreateThreadSchema,
+    params: CreateThreadSchema(),
     result: ThreadSchema,
   },
   "thread.delete": {
@@ -183,11 +189,11 @@ export const WS_METHODS = lazySchema(() => ({
     result: z.array(z.string()),
   },
   "agent.send": {
-    params: SendMessageSchema,
+    params: SendMessageSchema(),
     result: z.void(),
   },
   "agent.createAndSend": {
-    params: CreateAndSendSchema,
+    params: CreateAndSendSchema(),
     result: ThreadSchema,
   },
   "agent.stop": {

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -42,7 +42,7 @@ export const SendMessageSchema = z.object({
   /** When "plan", the server wraps the message with the plan-mode question prompt. */
   interactionMode: InteractionModeSchema.optional(),
   /** USD budget cap for this session. 0 or absent disables. */
-  maxBudgetUsd: z.number().nonnegative().optional(),
+  maxBudgetUsd: z.number().nonnegative().finite().optional(),
   /** Maximum agent turns. 0 or absent disables. */
   maxTurns: z.number().int().nonnegative().optional(),
 });
@@ -62,7 +62,7 @@ export const CreateAndSendSchema = z.object({
   /** When "plan", the server wraps the message with the plan-mode question prompt. */
   interactionMode: InteractionModeSchema.optional(),
   /** USD budget cap for this session. 0 or absent disables. */
-  maxBudgetUsd: z.number().nonnegative().optional(),
+  maxBudgetUsd: z.number().nonnegative().finite().optional(),
   /** Maximum agent turns. 0 or absent disables. */
   maxTurns: z.number().int().nonnegative().optional(),
   /** Source thread ID when branching from an existing thread. */


### PR DESCRIPTION
## What
Per-session cost and turn guardrails that pass through to the Claude SDK. Users can set a USD budget cap and max turn limit in Settings > Agent > Guardrails. The SDK enforces limits internally and returns distinct stop reasons.

## Why
Without guardrails, a runaway agent (e.g. failing tests in a retry loop) can spend unbounded money and loop indefinitely. The SDK already supports `maxBudgetUsd` and `maxTurns` natively, so mcode just needs to thread the values through.

## Key Changes
- **Settings schema**: `agent.guardrails.maxBudgetUsd` and `agent.guardrails.maxTurns` (default 0 = disabled)
- **Provider interface**: optional `maxBudgetUsd` and `maxTurns` on `IAgentProvider.sendMessage()`
- **WS RPC schemas**: guardrail fields on `SendMessageSchema` and `CreateAndSendSchema`
- **Agent service**: reads settings defaults, allows per-request overrides, passes to provider
- **Claude provider**: conditional spread into SDK `query()` options
- **Settings UI**: RangeControl sliders under Agent > Guardrails (Budget: $0-50, Turns: 0-100)
- **Frontend transport**: reads guardrails from settings store, includes in RPC calls
- **Stop reason display**: system message in chat on `error_max_budget_usd` or `max_turns`
- **Docs**: updated settings schema guide and reference

Claude-only by design. Codex and Copilot ignore the optional params since they lack SDK-level budget/turn enforcement.

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent guardrails to limit per-session budget (USD) and max turns — applies to Claude models; 0 disables each limit.
  * Guardrails can be set globally or overridden per-request/session.
  * New "Guardrails" (Beta) settings panel with Budget cap and Max turns controls.
  * Sessions now emit a system notification when a guardrail stops an agent.

* **Documentation**
  * Settings schema and reference updated with the new guardrail options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->