### PR TITLE
feat: expose Copilot sub-agents as selectable modes in the Composer

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "*",
-"@mcode/contracts": "workspace:*",
+    "@mcode/contracts": "workspace:*",
     "@mcode/shared": "workspace:*",
     "better-sqlite3": "^12.0.0",
     "node-pty": "^1.0.0",
@@ -22,6 +22,7 @@
     "uuid": "^11.1.0",
     "which": "^5.0.0",
     "ws": "^8.18.0",
+    "yaml": "^2.8.3",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/apps/server/src/providers/copilot/copilot-agent-discovery.test.ts
+++ b/apps/server/src/providers/copilot/copilot-agent-discovery.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { discoverCopilotAgents, COPILOT_DEFAULT_AGENTS } from "./copilot-agent-discovery.js";
+
+describe("discoverCopilotAgents", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-agents-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns only defaults when no YAML files exist", () => {
+    const result = discoverCopilotAgents(tmpDir);
+    expect(result).toHaveLength(3);
+    expect(result.every((a) => a.source === "default")).toBe(true);
+  });
+
+  it("includes project-level agents from .github/agents/", () => {
+    const agentsDir = path.join(tmpDir, ".github", "agents");
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, "reviewer.yml"),
+      "name: reviewer\ndisplayName: Code Reviewer\ndescription: Reviews code changes\n",
+    );
+    const result = discoverCopilotAgents(tmpDir);
+    const custom = result.filter((a) => a.source === "project");
+    expect(custom).toHaveLength(1);
+    expect(custom[0]).toMatchObject({
+      name: "reviewer",
+      displayName: "Code Reviewer",
+      description: "Reviews code changes",
+      source: "project",
+    });
+  });
+
+  it("includes project-level agents from .copilot/agents/", () => {
+    const agentsDir = path.join(tmpDir, ".copilot", "agents");
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, "tester.yaml"),
+      "name: tester\ndescription: Writes tests\n",
+    );
+    const result = discoverCopilotAgents(tmpDir);
+    const custom = result.filter((a) => a.source === "project");
+    expect(custom[0]).toMatchObject({ name: "tester", displayName: "tester", source: "project" });
+  });
+
+  it("skips YAML files missing a name field", () => {
+    const agentsDir = path.join(tmpDir, ".github", "agents");
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, "bad.yml"), "displayName: Missing Name\n");
+    const result = discoverCopilotAgents(tmpDir);
+    expect(result.filter((a) => a.source === "project")).toHaveLength(0);
+  });
+
+  it("skips malformed YAML without crashing", () => {
+    const agentsDir = path.join(tmpDir, ".github", "agents");
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, "broken.yml"), ": : invalid:\n");
+    expect(() => discoverCopilotAgents(tmpDir)).not.toThrow();
+    expect(discoverCopilotAgents(tmpDir)).toHaveLength(3);
+  });
+
+  it("returns defaults first, then user, then project agents", () => {
+    const agentsDir = path.join(tmpDir, ".github", "agents");
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(path.join(agentsDir, "proj.yml"), "name: proj\n");
+    const result = discoverCopilotAgents(tmpDir);
+    expect(result[0]!.source).toBe("default");
+    expect(result[result.length - 1]!.source).toBe("project");
+  });
+});

--- a/apps/server/src/providers/copilot/copilot-agent-discovery.test.ts
+++ b/apps/server/src/providers/copilot/copilot-agent-discovery.test.ts
@@ -16,7 +16,7 @@ describe("discoverCopilotAgents", () => {
   });
 
   it("returns only defaults when no YAML files exist", () => {
-    const result = discoverCopilotAgents(tmpDir);
+    const result = discoverCopilotAgents(tmpDir, path.join(tmpDir, "no-user-agents"));
     expect(result).toHaveLength(3);
     expect(result.every((a) => a.source === "default")).toBe(true);
   });
@@ -28,7 +28,7 @@ describe("discoverCopilotAgents", () => {
       path.join(agentsDir, "reviewer.yml"),
       "name: reviewer\ndisplayName: Code Reviewer\ndescription: Reviews code changes\n",
     );
-    const result = discoverCopilotAgents(tmpDir);
+    const result = discoverCopilotAgents(tmpDir, path.join(tmpDir, "no-user-agents"));
     const custom = result.filter((a) => a.source === "project");
     expect(custom).toHaveLength(1);
     expect(custom[0]).toMatchObject({
@@ -46,7 +46,7 @@ describe("discoverCopilotAgents", () => {
       path.join(agentsDir, "tester.yaml"),
       "name: tester\ndescription: Writes tests\n",
     );
-    const result = discoverCopilotAgents(tmpDir);
+    const result = discoverCopilotAgents(tmpDir, path.join(tmpDir, "no-user-agents"));
     const custom = result.filter((a) => a.source === "project");
     expect(custom[0]).toMatchObject({ name: "tester", displayName: "tester", source: "project" });
   });
@@ -55,7 +55,7 @@ describe("discoverCopilotAgents", () => {
     const agentsDir = path.join(tmpDir, ".github", "agents");
     fs.mkdirSync(agentsDir, { recursive: true });
     fs.writeFileSync(path.join(agentsDir, "bad.yml"), "displayName: Missing Name\n");
-    const result = discoverCopilotAgents(tmpDir);
+    const result = discoverCopilotAgents(tmpDir, path.join(tmpDir, "no-user-agents"));
     expect(result.filter((a) => a.source === "project")).toHaveLength(0);
   });
 
@@ -63,16 +63,34 @@ describe("discoverCopilotAgents", () => {
     const agentsDir = path.join(tmpDir, ".github", "agents");
     fs.mkdirSync(agentsDir, { recursive: true });
     fs.writeFileSync(path.join(agentsDir, "broken.yml"), ": : invalid:\n");
-    expect(() => discoverCopilotAgents(tmpDir)).not.toThrow();
-    expect(discoverCopilotAgents(tmpDir)).toHaveLength(3);
+    expect(() => discoverCopilotAgents(tmpDir, path.join(tmpDir, "no-user-agents"))).not.toThrow();
+    expect(discoverCopilotAgents(tmpDir, path.join(tmpDir, "no-user-agents"))).toHaveLength(3);
   });
 
   it("returns defaults first, then user, then project agents", () => {
     const agentsDir = path.join(tmpDir, ".github", "agents");
     fs.mkdirSync(agentsDir, { recursive: true });
     fs.writeFileSync(path.join(agentsDir, "proj.yml"), "name: proj\n");
-    const result = discoverCopilotAgents(tmpDir);
+    const result = discoverCopilotAgents(tmpDir, path.join(tmpDir, "no-user-agents"));
     expect(result[0]!.source).toBe("default");
     expect(result[result.length - 1]!.source).toBe("project");
+  });
+
+  it("includes user-level agents from the provided userDir", () => {
+    const userDir = path.join(tmpDir, "user-agents");
+    fs.mkdirSync(userDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(userDir, "assistant.yml"),
+      "name: assistant\ndisplayName: Assistant\ndescription: My user agent\n",
+    );
+    const result = discoverCopilotAgents(tmpDir, userDir);
+    const userAgents = result.filter((a) => a.source === "user");
+    expect(userAgents).toHaveLength(1);
+    expect(userAgents[0]).toMatchObject({
+      name: "assistant",
+      displayName: "Assistant",
+      description: "My user agent",
+      source: "user",
+    });
   });
 });

--- a/apps/server/src/providers/copilot/copilot-agent-discovery.test.ts
+++ b/apps/server/src/providers/copilot/copilot-agent-discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { discoverCopilotAgents, COPILOT_DEFAULT_AGENTS } from "./copilot-agent-discovery.js";
+import { discoverCopilotAgents } from "./copilot-agent-discovery.js";
 
 describe("discoverCopilotAgents", () => {
   let tmpDir: string;

--- a/apps/server/src/providers/copilot/copilot-agent-discovery.ts
+++ b/apps/server/src/providers/copilot/copilot-agent-discovery.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { parse as parseYaml } from "yaml";
+import type { CopilotSubagent } from "@mcode/contracts";
+
+/**
+ * Built-in Copilot session modes, always shown regardless of user config.
+ * These map to `session.rpc.mode.set()` mode values.
+ */
+export const COPILOT_DEFAULT_AGENTS: CopilotSubagent[] = [
+  {
+    name: "interactive",
+    displayName: "Ask",
+    description: "Interactive Q&A — answers questions without running tools autonomously.",
+    source: "default",
+  },
+  {
+    name: "plan",
+    displayName: "Plan",
+    description: "Proposes a step-by-step plan and waits for approval before executing.",
+    source: "default",
+  },
+  {
+    name: "autopilot",
+    displayName: "Agent",
+    description: "Fully autonomous — runs tools and makes changes without step-by-step approval.",
+    source: "default",
+  },
+];
+
+/** Minimal shape we expect from a parsed agent YAML file. */
+interface AgentYaml {
+  name?: string;
+  displayName?: string;
+  description?: string;
+}
+
+/** Scans a directory for `*.yml`/`*.yaml` files and parses each as a CopilotSubagent. */
+function scanAgentDir(dir: string, source: "user" | "project"): CopilotSubagent[] {
+  if (!fs.existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .flatMap((f) => {
+      try {
+        const raw = fs.readFileSync(path.join(dir, f), "utf-8");
+        const parsed = parseYaml(raw) as AgentYaml;
+        if (!parsed?.name) return [];
+        return [
+          {
+            name: parsed.name,
+            displayName: parsed.displayName ?? parsed.name,
+            description: parsed.description ?? "",
+            source,
+          } satisfies CopilotSubagent,
+        ];
+      } catch {
+        // Silently skip malformed YAML — don't crash discovery for one bad file.
+        return [];
+      }
+    });
+}
+
+/**
+ * Returns the user-level agents directory for the Copilot CLI on the current OS.
+ * Windows: %APPDATA%\GitHub Copilot\agents
+ * Linux/macOS: ~/.config/github-copilot/agents
+ */
+function userAgentsDir(): string {
+  if (process.platform === "win32") {
+    const appData =
+      process.env["APPDATA"] ?? path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(appData, "GitHub Copilot", "agents");
+  }
+  return path.join(os.homedir(), ".config", "github-copilot", "agents");
+}
+
+/**
+ * Discovers all available Copilot sub-agents across three tiers:
+ * - Default: hardcoded built-in session modes (always present)
+ * - User: YAML files in the OS-level GitHub Copilot config dir
+ * - Project: YAML files in `.github/agents/` or `.copilot/agents/` within `workingDirectory`
+ *
+ * Always returns at least the three built-in defaults.
+ */
+export function discoverCopilotAgents(workingDirectory: string): CopilotSubagent[] {
+  const user = scanAgentDir(userAgentsDir(), "user");
+  const project = [
+    ...scanAgentDir(path.join(workingDirectory, ".github", "agents"), "project"),
+    ...scanAgentDir(path.join(workingDirectory, ".copilot", "agents"), "project"),
+  ];
+  return [...COPILOT_DEFAULT_AGENTS, ...user, ...project];
+}

--- a/apps/server/src/providers/copilot/copilot-agent-discovery.ts
+++ b/apps/server/src/providers/copilot/copilot-agent-discovery.ts
@@ -51,7 +51,9 @@ function scanAgentDir(dir: string, source: "user" | "project"): CopilotSubagent[
       try {
         const raw = fs.readFileSync(path.join(dir, f), "utf-8");
         const parsed = parseYaml(raw) as AgentYaml;
-        if (!parsed?.name) return [];
+        if (typeof parsed?.name !== "string" || !parsed.name.trim()) return [];
+        if (parsed.displayName !== undefined && typeof parsed.displayName !== "string") return [];
+        if (parsed.description !== undefined && typeof parsed.description !== "string") return [];
         return [
           {
             name: parsed.name,
@@ -89,8 +91,8 @@ function userAgentsDir(): string {
  *
  * Always returns at least the three built-in defaults.
  */
-export function discoverCopilotAgents(workingDirectory: string): CopilotSubagent[] {
-  const user = scanAgentDir(userAgentsDir(), "user");
+export function discoverCopilotAgents(workingDirectory: string, userDir?: string): CopilotSubagent[] {
+  const user = scanAgentDir(userDir ?? userAgentsDir(), "user");
   const project = [
     ...scanAgentDir(path.join(workingDirectory, ".github", "agents"), "project"),
     ...scanAgentDir(path.join(workingDirectory, ".copilot", "agents"), "project"),

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -102,7 +102,9 @@ const IDLE_TTL_MS = 10 * 60 * 1000;
 const EVICTION_INTERVAL_MS = 60 * 1000;
 
 /** Names of built-in Copilot session modes, derived from COPILOT_DEFAULT_AGENTS. */
-const BUILTIN_MODE_NAMES = new Set(COPILOT_DEFAULT_AGENTS.map((a) => a.name));
+const BUILTIN_MODE_NAMES = new Set<"interactive" | "plan" | "autopilot">(
+  COPILOT_DEFAULT_AGENTS.map((a) => a.name as "interactive" | "plan" | "autopilot"),
+);
 
 interface SessionEntry {
   session: CopilotSession;
@@ -493,6 +495,16 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     const existing = this.sessions.get(sessionId);
     if (existing) {
       existing.lastUsedAt = Date.now();
+      // Apply agent routing so mid-thread agent changes take effect on cached sessions.
+      if (copilotAgent) {
+        if (BUILTIN_MODE_NAMES.has(copilotAgent as "interactive" | "plan" | "autopilot")) {
+          await existing.session.rpc.mode.set({ mode: copilotAgent as "interactive" | "plan" | "autopilot" });
+          logger.info("CopilotProvider: set built-in mode on cached session", { sessionId, mode: copilotAgent });
+        } else {
+          await existing.session.rpc.agent.select({ name: copilotAgent });
+          logger.info("CopilotProvider: selected custom agent on cached session", { sessionId, agent: copilotAgent });
+        }
+      }
       // Abort in-flight turn by sending a new message on the existing session.
       // The previous runTurn promise will resolve when session.idle fires.
       void this.runTurn(sessionId, threadId, existing.session, message);
@@ -510,6 +522,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     // Discover custom YAML agents so the SDK knows about them before agent.select() is called.
     // Only non-default agents are passed; built-in modes ("interactive", "plan", "autopilot")
     // are handled via mode.set() and do not need to be in customAgents.
+    // Discovery runs only here (new session path) to avoid sync FS calls on every message.
     const discoveredAgents = discoverCopilotAgents(cwd);
     const customAgents = discoveredAgents
       .filter((a) => a.source !== "default")
@@ -559,7 +572,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     // Route to the appropriate Copilot SDK API based on the selected sub-agent.
     // Built-in modes use session.rpc.mode.set(); custom YAML agents use session.rpc.agent.select().
     if (copilotAgent) {
-      if (BUILTIN_MODE_NAMES.has(copilotAgent)) {
+      if (BUILTIN_MODE_NAMES.has(copilotAgent as "interactive" | "plan" | "autopilot")) {
         await session.rpc.mode.set({ mode: copilotAgent as "interactive" | "plan" | "autopilot" });
         logger.info("CopilotProvider: set built-in mode", { sessionId, mode: copilotAgent });
       } else {

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -17,6 +17,7 @@ import which from "which";
 import { EventEmitter } from "events";
 import { CopilotClient, approveAll } from "@github/copilot-sdk";
 import type { CopilotSession, ModelInfo } from "@github/copilot-sdk";
+import { discoverCopilotAgents, COPILOT_DEFAULT_AGENTS } from "./copilot-agent-discovery.js";
 import { logger } from "@mcode/shared";
 import { SettingsService } from "../../services/settings-service.js";
 import type {
@@ -99,6 +100,9 @@ function inferModelGroup(modelId: string): string | undefined {
 const IDLE_TTL_MS = 10 * 60 * 1000;
 /** How often to check for idle sessions (1 minute). */
 const EVICTION_INTERVAL_MS = 60 * 1000;
+
+/** Names of built-in Copilot session modes, derived from COPILOT_DEFAULT_AGENTS. */
+const BUILTIN_MODE_NAMES = new Set(COPILOT_DEFAULT_AGENTS.map((a) => a.name));
 
 interface SessionEntry {
   session: CopilotSession;
@@ -403,7 +407,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   /** Cached context window limit from the last session.usage_info event, keyed by sessionId. */
   private contextWindowBySession = new Map<string, number>();
 
-  /** Start or continue a session by sending a message via the Copilot SDK. */
+  /** Start or continue a session by sending a message via the Copilot SDK. When `copilotAgent` is provided, routes the session to the appropriate built-in mode or custom agent before sending. */
   async sendMessage(params: {
     sessionId: string;
     message: string;
@@ -414,6 +418,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     permissionMode: string;
     attachments?: AttachmentMeta[];
     reasoningLevel?: ReasoningLevel;
+    /** Copilot sub-agent name. Built-in modes: "interactive" | "plan" | "autopilot". Custom: any YAML agent name. */
+    copilotAgent?: string;
   }): Promise<void> {
     try {
       await this.doSendMessage(params);
@@ -465,10 +471,12 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     permissionMode: string;
     attachments?: AttachmentMeta[];
     reasoningLevel?: ReasoningLevel;
+    /** Copilot sub-agent name. Built-in modes: "interactive" | "plan" | "autopilot". Custom: any YAML agent name. */
+    copilotAgent?: string;
   }): Promise<void> {
     await this.refreshClient();
 
-    const { sessionId, message, cwd, model, resume } = params;
+    const { sessionId, message, cwd, model, resume, copilotAgent } = params;
 
     if (!this.evictionTimer) {
       this.evictionTimer = setInterval(
@@ -499,6 +507,20 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
 
     let session: CopilotSession;
 
+    // Discover custom YAML agents so the SDK knows about them before agent.select() is called.
+    // Only non-default agents are passed; built-in modes ("interactive", "plan", "autopilot")
+    // are handled via mode.set() and do not need to be in customAgents.
+    const discoveredAgents = discoverCopilotAgents(cwd);
+    const customAgents = discoveredAgents
+      .filter((a) => a.source !== "default")
+      .map((a) => ({
+        name: a.name,
+        displayName: a.displayName,
+        description: a.description,
+        // SDK uses its own YAML-loaded prompt; empty string defers to CLI config.
+        prompt: "",
+      }));
+
     // TODO(#258): respect params.permissionMode. Currently approveAll is used
     // unconditionally because the Copilot SDK does not expose per-action gating.
     // Until the SDK adds granular permission control, all tool actions are
@@ -509,6 +531,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           onPermissionRequest: approveAll,
           model: model || undefined,
           workingDirectory: cwd,
+          ...(customAgents.length > 0 && { customAgents }),
         });
         logger.info("Resumed Copilot session", { sessionId, sdkSessionId });
       } catch (err) {
@@ -521,6 +544,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           onPermissionRequest: approveAll,
           model: model || undefined,
           workingDirectory: cwd,
+          ...(customAgents.length > 0 && { customAgents }),
         });
       }
     } else {
@@ -528,7 +552,20 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         onPermissionRequest: approveAll,
         model: model || undefined,
         workingDirectory: cwd,
+        ...(customAgents.length > 0 && { customAgents }),
       });
+    }
+
+    // Route to the appropriate Copilot SDK API based on the selected sub-agent.
+    // Built-in modes use session.rpc.mode.set(); custom YAML agents use session.rpc.agent.select().
+    if (copilotAgent) {
+      if (BUILTIN_MODE_NAMES.has(copilotAgent)) {
+        await session.rpc.mode.set({ mode: copilotAgent as "interactive" | "plan" | "autopilot" });
+        logger.info("CopilotProvider: set built-in mode", { sessionId, mode: copilotAgent });
+      } else {
+        await session.rpc.agent.select({ name: copilotAgent });
+        logger.info("CopilotProvider: selected custom agent", { sessionId, agent: copilotAgent });
+      }
     }
 
     // Capture the SDK session ID for future resume and notify the service layer

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -31,6 +31,7 @@ interface ThreadRow {
   reasoning_level: string | null;
   interaction_mode: string | null;
   permission_mode: string | null;
+  copilot_agent: string | null;
   parent_thread_id: string | null;
   forked_from_message_id: string | null;
   last_compact_summary: string | null;
@@ -60,6 +61,7 @@ function rowToThread(row: ThreadRow): Thread {
     reasoning_level: (row.reasoning_level ?? null) as ReasoningLevel | null,
     interaction_mode: (row.interaction_mode ?? null) as InteractionMode | null,
     permission_mode: (row.permission_mode ?? null) as PermissionMode | null,
+    copilot_agent: (row.copilot_agent ?? null) as string | null,
     parent_thread_id: row.parent_thread_id,
     forked_from_message_id: row.forked_from_message_id,
     last_compact_summary: row.last_compact_summary,
@@ -67,7 +69,7 @@ function rowToThread(row: ThreadRow): Thread {
 }
 
 const THREAD_COLUMNS =
-  "id, workspace_id, title, status, mode, worktree_path, branch, worktree_managed, issue_number, pr_number, pr_status, sdk_session_id, model, provider, created_at, updated_at, deleted_at, last_context_tokens, context_window, reasoning_level, interaction_mode, permission_mode, parent_thread_id, forked_from_message_id, last_compact_summary";
+  "id, workspace_id, title, status, mode, worktree_path, branch, worktree_managed, issue_number, pr_number, pr_status, sdk_session_id, model, provider, created_at, updated_at, deleted_at, last_context_tokens, context_window, reasoning_level, interaction_mode, permission_mode, copilot_agent, parent_thread_id, forked_from_message_id, last_compact_summary";
 
 /** Repository for thread lifecycle operations against SQLite. */
 @injectable()
@@ -133,6 +135,7 @@ export class ThreadRepo {
       reasoning_level: null,
       interaction_mode: null,
       permission_mode: null,
+      copilot_agent: null,
       parent_thread_id: lineage?.parentThreadId ?? null,
       forked_from_message_id: lineage?.forkedFromMessageId ?? null,
       last_compact_summary: null,
@@ -280,13 +283,14 @@ export class ThreadRepo {
     return result.changes > 0;
   }
 
-  /** Persist per-thread composer settings (reasoning, mode, permission). */
+  /** Persist per-thread composer settings (reasoning, mode, permission, copilot agent). */
   updateSettings(
     id: string,
     settings: {
       reasoning_level?: string;
       interaction_mode?: string;
       permission_mode?: string;
+      copilot_agent?: string | null;
     },
   ): boolean {
     const fields: string[] = [];
@@ -302,6 +306,10 @@ export class ThreadRepo {
     if (settings.permission_mode !== undefined) {
       fields.push("permission_mode = ?");
       values.push(settings.permission_mode);
+    }
+    if (settings.copilot_agent !== undefined) {
+      fields.push("copilot_agent = ?");
+      values.push(settings.copilot_agent);
     }
     if (fields.length === 0) return false;
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -143,6 +143,9 @@ export class AgentService {
     // Use the thread's stored provider as authoritative fallback; only override
     // when the caller explicitly supplies a provider (new thread or explicit switch).
     const effectiveProvider: ProviderId = provider ?? (thread.provider as ProviderId) ?? "claude";
+    // Fall back to the thread's persisted Copilot agent when the caller doesn't supply one.
+    // Converts null (DB "cleared") to undefined (provider ignores it) so the SDK defaults.
+    const effectiveCopilotAgent = copilotAgent ?? (thread.copilot_agent ?? undefined);
     if (thread.status === "deleted" || thread.deleted_at != null) {
       throw new Error(`Cannot send message to deleted thread: ${threadId}`);
     }
@@ -277,7 +280,7 @@ export class AgentService {
         reasoningLevel,
         ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
         ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
-        copilotAgent,
+        copilotAgent: effectiveCopilotAgent,
       });
       logger.info("Message sent via provider", {
         threadId,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -136,6 +136,7 @@ export class AgentService {
     interactionMode?: InteractionMode,
     maxBudgetUsd?: number,
     maxTurns?: number,
+    copilotAgent?: string,
   ): Promise<void> {
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
@@ -241,6 +242,7 @@ export class AgentService {
       ...(reasoningLevel !== undefined && { reasoning_level: reasoningLevel }),
       ...(interactionMode !== undefined && { interaction_mode: interactionMode }),
       ...(permissionMode !== undefined && permissionMode !== "default" && { permission_mode: permissionMode }),
+      ...(copilotAgent !== undefined && { copilot_agent: copilotAgent }),
     });
 
     const sessionName = `mcode-${threadId}`;
@@ -275,6 +277,7 @@ export class AgentService {
         reasoningLevel,
         ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
         ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
+        copilotAgent,
       });
       logger.info("Message sent via provider", {
         threadId,
@@ -383,6 +386,7 @@ export class AgentService {
     forkedFromMessageId?: string,
     maxBudgetUsd?: number,
     maxTurns?: number,
+    copilotAgent?: string,
   ): Promise<Thread> {
     const title = truncateTitle(content);
 
@@ -392,6 +396,7 @@ export class AgentService {
         existingWorktreePath, attachments, reasoningLevel, provider,
         interactionMode, parentThreadId, forkedFromMessageId, title,
         maxBudgetUsd, maxTurns,
+        copilotAgent,
       });
     }
 
@@ -452,6 +457,7 @@ export class AgentService {
       interactionMode,
       maxBudgetUsd,
       maxTurns,
+      copilotAgent,
     );
 
     // Re-read from DB to pick up model update applied by sendMessage
@@ -482,12 +488,14 @@ export class AgentService {
     title: string;
     maxBudgetUsd?: number;
     maxTurns?: number;
+    copilotAgent?: string;
   }): Promise<Thread> {
     const {
       workspaceId, content, model, permissionMode, mode, branch,
       existingWorktreePath, attachments, reasoningLevel, provider,
       interactionMode, parentThreadId, forkedFromMessageId, title,
       maxBudgetUsd, maxTurns,
+      copilotAgent,
     } = params;
 
     // Validate parent
@@ -652,6 +660,7 @@ export class AgentService {
         interactionMode,
         maxBudgetUsd,
         maxTurns,
+        copilotAgent,
       );
     } finally {
       // Ensure override is cleaned up even if sendMessage throws before consuming it.

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -161,16 +161,22 @@ export class ThreadService {
     return this.threadRepo.updateTitle(threadId, title);
   }
 
-  /** Persist per-thread composer settings (reasoning, mode, permission). */
+  /** Persist per-thread composer settings (reasoning, mode, permission, copilot agent). */
   updateSettings(
     threadId: string,
     settings: {
       reasoning_level?: string;
       interaction_mode?: string;
       permission_mode?: string;
+      copilotAgent?: string;
     },
   ): boolean {
-    return this.threadRepo.updateSettings(threadId, settings);
+    return this.threadRepo.updateSettings(threadId, {
+      ...(settings.reasoning_level !== undefined && { reasoning_level: settings.reasoning_level }),
+      ...(settings.interaction_mode !== undefined && { interaction_mode: settings.interaction_mode }),
+      ...(settings.permission_mode !== undefined && { permission_mode: settings.permission_mode }),
+      ...(settings.copilotAgent !== undefined && { copilot_agent: settings.copilotAgent }),
+    });
   }
 
   /** Link a GitHub PR to a thread by updating pr_number and pr_status. Throws on failure. */

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -168,14 +168,14 @@ export class ThreadService {
       reasoning_level?: string;
       interaction_mode?: string;
       permission_mode?: string;
-      copilotAgent?: string;
+      copilot_agent?: string | null;
     },
   ): boolean {
     return this.threadRepo.updateSettings(threadId, {
       ...(settings.reasoning_level !== undefined && { reasoning_level: settings.reasoning_level }),
       ...(settings.interaction_mode !== undefined && { interaction_mode: settings.interaction_mode }),
       ...(settings.permission_mode !== undefined && { permission_mode: settings.permission_mode }),
-      ...(settings.copilotAgent !== undefined && { copilot_agent: settings.copilotAgent }),
+      ...("copilot_agent" in settings && { copilot_agent: settings.copilot_agent }),
     });
   }
 

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -25,6 +25,7 @@ import * as m012 from "./migrations/012_thread_reasoning_interaction_permission.
 import * as m013 from "./migrations/013_clear_non_claude_context_window.js";
 import * as m014 from "./migrations/014_thread_branching.js";
 import * as m015 from "./migrations/015_thread_compact_summary.js";
+import * as m016 from "./migrations/016_copilot_agent.js";
 
 /**
  * Resolve the correct native binding for better-sqlite3 based on runtime.
@@ -81,6 +82,7 @@ export function loadMigrations(): Map<number, MigrationModule> {
   migrations.set(13, m013);
   migrations.set(14, m014);
   migrations.set(15, m015);
+  migrations.set(16, m016);
   return migrations;
 }
 

--- a/apps/server/src/store/migrations/016_copilot_agent.ts
+++ b/apps/server/src/store/migrations/016_copilot_agent.ts
@@ -1,0 +1,17 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description = "Add copilot_agent to threads";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  db.exec("ALTER TABLE threads ADD COLUMN copilot_agent TEXT DEFAULT NULL");
+}
+
+/**
+ * Reverse this migration.
+ * Throw if rollback is not possible (e.g., irreversible data migration).
+ */
+export function down(db: Database.Database): void {
+  db.exec("ALTER TABLE threads DROP COLUMN copilot_agent");
+}

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -20,6 +20,7 @@ import {
   getExtension,
 } from "@mcode/contracts";
 import { logger, validateBranchName } from "@mcode/shared";
+import { discoverCopilotAgents } from "../providers/copilot/copilot-agent-discovery.js";
 import type { WorkspaceService } from "../services/workspace-service";
 import type { ThreadService } from "../services/thread-service";
 import type { AgentService } from "../services/agent-service";
@@ -211,6 +212,7 @@ async function dispatch(
         reasoning_level: params.reasoningLevel,
         interaction_mode: params.interactionMode,
         permission_mode: params.permissionMode,
+        copilotAgent: params.copilotAgent,
       });
     case "thread.markViewed":
       deps.threadService.markViewed(params.threadId);
@@ -290,6 +292,7 @@ async function dispatch(
         params.interactionMode,
         params.maxBudgetUsd,
         params.maxTurns,
+        params.copilotAgent,
       );
       return;
     case "agent.createAndSend":
@@ -309,6 +312,7 @@ async function dispatch(
         params.forkedFromMessageId,
         params.maxBudgetUsd,
         params.maxTurns,
+        params.copilotAgent,
       );
     case "agent.stop":
       await deps.agentService.stopSession(params.threadId);
@@ -497,6 +501,11 @@ async function dispatch(
         return { providerId: provider.id, quotaCategories: [] } satisfies ProviderUsageInfo;
       }
       return provider.getUsage();
+    }
+    case "provider.copilotAgents": {
+      const workspace = deps.workspaceService.findById(params.workspaceId);
+      if (!workspace) throw new Error(`Workspace not found: ${params.workspaceId}`);
+      return discoverCopilotAgents(workspace.path);
     }
 
     // Memory pressure

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -212,7 +212,7 @@ async function dispatch(
         reasoning_level: params.reasoningLevel,
         interaction_mode: params.interactionMode,
         permission_mode: params.permissionMode,
-        copilotAgent: params.copilotAgent,
+        copilot_agent: params.copilotAgent,
       });
     case "thread.markViewed":
       deps.threadService.markViewed(params.threadId);

--- a/apps/web/e2e/copilot-agent-selector.spec.ts
+++ b/apps/web/e2e/copilot-agent-selector.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Mock Copilot sub-agents for RPC interception.
+ * Includes the three built-in modes plus a user-level custom agent.
+ */
+const MOCK_DEFAULT_AGENTS = [
+  { name: "interactive", displayName: "Ask",   description: "Answers questions.", source: "default" },
+  { name: "plan",        displayName: "Plan",  description: "Proposes a plan.",   source: "default" },
+  { name: "autopilot",  displayName: "Agent", description: "Fully autonomous.",  source: "default" },
+];
+
+const MOCK_DEFAULT_AGENTS_WITH_USER = [
+  ...MOCK_DEFAULT_AGENTS,
+  { name: "my-reviewer", displayName: "My Reviewer", description: "Code review.", source: "user" },
+];
+
+/**
+ * Intercepts the WS server (whichever port it's on) and handles
+ * `provider.copilotAgents` calls with mock data.
+ * Passes all other messages through to the real server.
+ *
+ * We use a broad URL regex to catch any localhost WS port since the server
+ * does dynamic port scanning (19400-19800 range).
+ */
+async function interceptCopilotAgents(
+  page: Page,
+  agents = MOCK_DEFAULT_AGENTS,
+): Promise<void> {
+  await page.routeWebSocket(/ws:\/\/localhost:\d+/, (ws) => {
+    const server = ws.connectToServer();
+    ws.onMessage((data) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        server.send(data);
+        return;
+      }
+      if ((msg.method as string) === "provider.copilotAgents") {
+        ws.send(JSON.stringify({ id: msg.id, result: agents }));
+      } else {
+        server.send(data);
+      }
+    });
+    server.onMessage((data) => ws.send(data));
+  });
+}
+
+/** Wait for the main app UI to be ready (sidebar visible). */
+async function waitForAppReady(page: Page): Promise<boolean> {
+  try {
+    await page.waitForSelector("text=Mcode", { timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test.describe("CopilotAgentSelector — component structure", () => {
+  test("CopilotAgentSelector component renders correct DOM structure", async ({ page }) => {
+    // Test the selector's rendering in isolation by evaluating the component tree.
+    // This avoids needing to mock a full Copilot workspace flow.
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const ready = await waitForAppReady(page);
+    if (!ready) {
+      test.info().annotations.push({ type: "skip-reason", description: "App not ready (WS not connected)" });
+      return;
+    }
+
+    await page.screenshot({ path: "e2e/screenshots/copilot-baseline-ui.png", fullPage: true });
+
+    // The sidebar should always be present
+    await expect(page.locator("text=Mcode")).toBeVisible();
+  });
+});
+
+test.describe("CopilotAgentSelector — WS interception", () => {
+  test("provider.copilotAgents RPC returns agents and selector renders Ask by default", async ({ page }) => {
+    await interceptCopilotAgents(page, MOCK_DEFAULT_AGENTS);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const ready = await waitForAppReady(page);
+    if (!ready) {
+      await page.screenshot({ path: "e2e/screenshots/copilot-ws-not-connected.png", fullPage: true });
+      test.info().annotations.push({ type: "skip-reason", description: "App not connected to WS server" });
+      return;
+    }
+
+    await page.screenshot({ path: "e2e/screenshots/copilot-app-ready.png", fullPage: true });
+
+    // When Copilot is the active provider and a thread is active, the Composer
+    // shows the CopilotAgentSelector with "Ask" as the default label.
+    // Without an active Copilot thread, the selector won't be mounted —
+    // so we verify its trigger via aria-label which is set by the component.
+    const selector = page.locator('[aria-label="Select Copilot agent"]');
+    const isVisible = await selector.isVisible().catch(() => false);
+
+    if (isVisible) {
+      await expect(selector).toBeVisible();
+      await expect(selector).toContainText("Ask");
+    } else {
+      // No Copilot thread active — acceptable. Take screenshot for evidence.
+      await page.screenshot({ path: "e2e/screenshots/copilot-no-active-thread.png", fullPage: true });
+    }
+  });
+
+  test("dropdown shows Default group with Ask, Plan, Agent when opened", async ({ page }) => {
+    await interceptCopilotAgents(page, MOCK_DEFAULT_AGENTS);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const ready = await waitForAppReady(page);
+    if (!ready) { return; }
+
+    const selector = page.locator('[aria-label="Select Copilot agent"]');
+    const isVisible = await selector.isVisible().catch(() => false);
+
+    if (!isVisible) {
+      // No active Copilot thread — cannot test dropdown. Screenshot for evidence.
+      await page.screenshot({ path: "e2e/screenshots/copilot-dropdown-no-thread.png", fullPage: true });
+      return;
+    }
+
+    await selector.click();
+    await page.waitForTimeout(150);
+
+    // "Default" group label must be present
+    await expect(page.locator("text=Default").first()).toBeVisible();
+
+    // All three built-in agents must appear as menu items
+    const menuItems = page.locator('[role="menuitem"]');
+    await expect(menuItems.filter({ hasText: "Ask" })).toBeVisible();
+    await expect(menuItems.filter({ hasText: "Plan" })).toBeVisible();
+    await expect(menuItems.filter({ hasText: "Agent" })).toBeVisible();
+
+    await page.screenshot({ path: "e2e/screenshots/copilot-dropdown-open.png", fullPage: true });
+  });
+
+  test("dropdown shows User group when user-level agents are present", async ({ page }) => {
+    await interceptCopilotAgents(page, MOCK_DEFAULT_AGENTS_WITH_USER);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const ready = await waitForAppReady(page);
+    if (!ready) { return; }
+
+    const selector = page.locator('[aria-label="Select Copilot agent"]');
+    const isVisible = await selector.isVisible().catch(() => false);
+
+    if (!isVisible) {
+      await page.screenshot({ path: "e2e/screenshots/copilot-user-agents-no-thread.png", fullPage: true });
+      return;
+    }
+
+    await selector.click();
+    await page.waitForTimeout(150);
+
+    // Both Default and User sections must appear when user agents are present
+    await expect(page.locator("text=Default").first()).toBeVisible();
+    await expect(page.locator("text=User").first()).toBeVisible();
+    await expect(page.locator('[role="menuitem"]').filter({ hasText: "My Reviewer" })).toBeVisible();
+
+    await page.screenshot({ path: "e2e/screenshots/copilot-user-agents-dropdown.png", fullPage: true });
+  });
+
+  test("CopilotAgentSelector is NOT present when provider is not Copilot", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const ready = await waitForAppReady(page);
+    if (!ready) { return; }
+
+    // The aria-label is only rendered by CopilotAgentSelector.
+    // If the active thread uses Claude/Codex, this element must not be visible.
+    const selector = page.locator('[aria-label="Select Copilot agent"]');
+
+    // We cannot know whether the current app state has a Copilot thread or not,
+    // so we verify the selector's behavior: if present, it must be because
+    // provider=copilot. We just check no unexpected element appears and take a screenshot.
+    await page.screenshot({ path: "e2e/screenshots/non-copilot-provider-state.png", fullPage: true });
+
+    // If the selector IS visible, this test is checking the wrong state — note it.
+    const visible = await selector.isVisible().catch(() => false);
+    if (visible) {
+      test.info().annotations.push({
+        type: "note",
+        description: "Copilot thread is currently active — provider guard test is not exercised",
+      });
+    }
+  });
+});

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -47,6 +47,7 @@ export function createMockThread(overrides?: Partial<Thread>): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,
     last_compact_summary: null,
@@ -133,4 +134,5 @@ export const mockTransport: McodeTransport = {
     providerId: "claude",
     quotaCategories: [],
   }),
+  listCopilotAgents: vi.fn().mockResolvedValue([]),
 };

--- a/apps/web/src/__tests__/thread-status.test.ts
+++ b/apps/web/src/__tests__/thread-status.test.ts
@@ -26,6 +26,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,
     last_compact_summary: null,

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -79,6 +79,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,
     last_compact_summary: null,

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -28,6 +28,7 @@ import { NamingModeSelector } from "./NamingModeSelector";
 import type { NamingMode } from "@mcode/contracts";
 import { BranchNameInput } from "./BranchNameInput";
 const LazyWorktreePicker = lazy(() => import("./WorktreePicker"));
+import { CopilotAgentSelector } from "./CopilotAgentSelector";
 import { AttachmentPreview } from "./AttachmentPreview";
 import type { PendingAttachment } from "./AttachmentPreview";
 import { useFileAutocomplete, clearFileListCache } from "./useFileAutocomplete";
@@ -135,6 +136,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const [provider, setProvider] = useState<string>(getDefaultProviderId());
   const [reasoning, setReasoning] = useState<ReasoningLevel>(getDefaultReasoningLevel());
   const [mode, setMode] = useState<InteractionMode>(INTERACTION_MODES.CHAT);
+  const [copilotAgent, setCopilotAgent] = useState<string | null>(null);
   const [access, setAccess] = useState<AccessMode>(PERMISSION_MODES.FULL);
   const [showReasoningPicker, setShowReasoningPicker] = useState(false);
   const [composerMode, setComposerModeLocal] = useState<ComposerMode>("direct");
@@ -249,10 +251,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             }
           });
         }
-        // Restore mode and permission from thread settings (drafts don't save these)
+        // Restore mode, permission, and copilot agent from thread settings (drafts don't save these)
         const threadSettings = useThreadStore.getState().getThreadSettings(threadId);
         setMode(threadSettings.interactionMode);
         setAccess(threadSettings.permissionMode);
+        setCopilotAgent(threadSettings.copilotAgent ?? null);
       } else {
         // No saved draft: use thread's persisted settings as-is
         setInput("");
@@ -284,6 +287,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             ? (nextThread.permission_mode as PermissionMode)
             : globalSettings.agent.defaults.permission,
         );
+        setCopilotAgent(nextThread?.copilot_agent ?? null);
 
         // Reset Lexical editor
         if (editorRef.current) {
@@ -306,6 +310,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       const { settings } = useSettingsStore.getState();
       setMode(settings.agent.defaults.mode === "plan" ? INTERACTION_MODES.PLAN : INTERACTION_MODES.CHAT);
       setAccess(settings.agent.defaults.permission);
+      setCopilotAgent(null);
       if (editorRef.current) {
         editorRef.current.update(() => {
           const root = $getRoot();
@@ -887,7 +892,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         setPreparingWorktree(true);
       }
       try {
-        await useWorkspaceStore.getState().createAndSendMessage(messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, reasoning, provider, mode);
+        await useWorkspaceStore.getState().createAndSendMessage(messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, reasoning, provider, mode, copilotAgent ?? undefined);
       } finally {
         setPreparingWorktree(false);
       }
@@ -920,10 +925,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         branch: branchBranch,
         existingWorktreePath: branchWorktree,
         forkedFromMessageId: branchFromMessageId,
+        copilotAgent: copilotAgent ?? undefined,
       });
       onBranchModeExit?.();
     } else if (threadId) {
-      await sendMessage(threadId, messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, displayContent, reasoning, provider);
+      await sendMessage(threadId, messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, displayContent, reasoning, provider, copilotAgent ?? undefined);
     }
 
     // Auto-save last-used mode and access as defaults (model defaults are managed in Settings)
@@ -940,7 +946,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
 
     editorRef.current?.focus();
-  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, reasoning, mode, access, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, autoPreviewBranch, onBranchModeExit]);
+  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, reasoning, mode, access, copilotAgent, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, autoPreviewBranch, onBranchModeExit]);
 
   const handleEditorChange = useCallback((text: string) => {
     setInput(text);
@@ -1172,28 +1178,40 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             )}
           </div>
 
-          {/* Chat / Plan toggle */}
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => {
-                    const next = mode === INTERACTION_MODES.CHAT ? INTERACTION_MODES.PLAN : INTERACTION_MODES.CHAT;
-                    setMode(next);
-                    agentSettingsTouchedRef.current = true;
-                    if (threadId) void setThreadSettings(threadId, { interactionMode: next });
-                  }}
-                  className="gap-1.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors"
-                >
-                  {mode === INTERACTION_MODES.CHAT ? <MessageSquare size={14} /> : <FileEdit size={14} />}
-                  <span className="text-sm">{mode === INTERACTION_MODES.CHAT ? "Chat" : "Plan"}</span>
-                </Button>
-              }
+          {/* Chat / Plan toggle — replaced by CopilotAgentSelector when Copilot is active */}
+          {provider === "copilot" ? (
+            <CopilotAgentSelector
+              selected={copilotAgent}
+              workspaceId={workspaceId ?? ""}
+              disabled={isModelFullyLocked}
+              onChange={(agentName) => {
+                setCopilotAgent(agentName);
+                if (threadId) void setThreadSettings(threadId, { copilotAgent: agentName });
+              }}
             />
-            <TooltipContent>{mode === INTERACTION_MODES.CHAT ? "Chat mode" : "Plan mode"}</TooltipContent>
-          </Tooltip>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => {
+                      const next = mode === INTERACTION_MODES.CHAT ? INTERACTION_MODES.PLAN : INTERACTION_MODES.CHAT;
+                      setMode(next);
+                      agentSettingsTouchedRef.current = true;
+                      if (threadId) void setThreadSettings(threadId, { interactionMode: next });
+                    }}
+                    className="gap-1.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors"
+                  >
+                    {mode === INTERACTION_MODES.CHAT ? <MessageSquare size={14} /> : <FileEdit size={14} />}
+                    <span className="text-sm">{mode === INTERACTION_MODES.CHAT ? "Chat" : "Plan"}</span>
+                  </Button>
+                }
+              />
+              <TooltipContent>{mode === INTERACTION_MODES.CHAT ? "Chat mode" : "Plan mode"}</TooltipContent>
+            </Tooltip>
+          )}
 
           {/* Full access / Supervised toggle */}
           <Tooltip>

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -892,7 +892,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         setPreparingWorktree(true);
       }
       try {
-        await useWorkspaceStore.getState().createAndSendMessage(messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, reasoning, provider, mode, copilotAgent ?? undefined);
+        await useWorkspaceStore.getState().createAndSendMessage(messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, reasoning, provider, mode, provider === "copilot" ? (copilotAgent ?? undefined) : undefined);
       } finally {
         setPreparingWorktree(false);
       }
@@ -925,11 +925,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         branch: branchBranch,
         existingWorktreePath: branchWorktree,
         forkedFromMessageId: branchFromMessageId,
-        copilotAgent: copilotAgent ?? undefined,
+        copilotAgent: provider === "copilot" ? (copilotAgent ?? undefined) : undefined,
       });
       onBranchModeExit?.();
     } else if (threadId) {
-      await sendMessage(threadId, messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, displayContent, reasoning, provider, copilotAgent ?? undefined);
+      await sendMessage(threadId, messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, displayContent, reasoning, provider, provider === "copilot" ? (copilotAgent ?? undefined) : undefined);
     }
 
     // Auto-save last-used mode and access as defaults (model defaults are managed in Settings)

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -946,7 +946,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
 
     editorRef.current?.focus();
-  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, reasoning, mode, access, copilotAgent, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, autoPreviewBranch, onBranchModeExit]);
+  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, autoPreviewBranch, onBranchModeExit]);
 
   const handleEditorChange = useCallback((text: string) => {
     setInput(text);

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -826,7 +826,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       const { content, display } = await injectFileContent(trimmed);
       const currentAttachments = collectAndClearAttachments();
 
-      const queueProvider = provider;
       useQueueStore.getState().enqueue(threadId, {
         content,
         displayContent: display,
@@ -834,7 +833,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         model: modelId,
         permissionMode: access,
         reasoningLevel: reasoning,
-        provider: queueProvider,
+        provider,
+        copilotAgent: provider === "copilot" ? (copilotAgent ?? undefined) : undefined,
       });
 
       setInput("");
@@ -1186,7 +1186,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
               disabled={isModelFullyLocked}
               onChange={(agentName) => {
                 setCopilotAgent(agentName);
-                if (threadId) void setThreadSettings(threadId, { copilotAgent: agentName });
+                // Don't persist to parent thread when in branch mode — the
+                // selection only applies to the branch being created.
+                if (threadId && !branchFromMessageId) void setThreadSettings(threadId, { copilotAgent: agentName });
               }}
             />
           ) : (

--- a/apps/web/src/components/chat/CopilotAgentSelector.tsx
+++ b/apps/web/src/components/chat/CopilotAgentSelector.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuGroup,
 } from "@/components/ui/dropdown-menu";
+import { CopilotIcon } from "./ProviderIcons";
 
 /** Built-in agents always available regardless of workspace config. */
 const DEFAULT_AGENTS: CopilotSubagent[] = [
@@ -60,21 +61,32 @@ function AgentItem({
     <DropdownMenuItem
       onClick={onSelect}
       className={cn(
-        "flex cursor-pointer items-start gap-2 px-2 py-1.5 text-xs",
+        "flex cursor-pointer items-start gap-2 px-2 py-1.5 text-sm",
         isSelected ? "text-foreground" : "text-popover-foreground",
       )}
     >
       {/* Fixed-width slot keeps text aligned regardless of selection state. */}
-      <span className="mt-0.5 flex w-3 shrink-0 items-center justify-center">
-        {isSelected && <Check size={10} className="text-muted-foreground" />}
+      <span className="mt-[3px] flex w-3 shrink-0 items-center justify-center">
+        {isSelected && (
+          <Check size={10} className="text-violet-400 dark:text-violet-300" />
+        )}
       </span>
       <span className="flex flex-col gap-0.5">
         <span className="font-medium leading-none">{agent.displayName}</span>
-        <span className="text-[10px] leading-snug text-muted-foreground">
+        <span className="text-[11px] leading-snug text-muted-foreground">
           {agent.description}
         </span>
       </span>
     </DropdownMenuItem>
+  );
+}
+
+/** Section label rendered as all-caps category header with a separator line. */
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <DropdownMenuLabel className="px-2 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+      {children}
+    </DropdownMenuLabel>
   );
 }
 
@@ -112,10 +124,11 @@ export function CopilotAgentSelector({
     return (
       <span
         aria-label={`Copilot agent: ${activeAgent.displayName} (locked)`}
-        className="flex h-6 items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground/70"
+        className="flex h-6 items-center gap-1.5 rounded px-1.5 text-sm text-muted-foreground/50"
       >
+        <CopilotIcon size={12} className="shrink-0" />
         {activeAgent.displayName}
-        <ChevronDown size={10} />
+        <ChevronDown size={11} />
       </span>
     );
   }
@@ -124,15 +137,16 @@ export function CopilotAgentSelector({
     <DropdownMenu>
       <DropdownMenuTrigger
         aria-label="Select Copilot agent"
-        className="flex h-6 items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+        className="flex h-6 items-center gap-1.5 rounded px-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground data-[state=open]:bg-muted/40 data-[state=open]:text-foreground"
       >
+        <CopilotIcon size={12} className="shrink-0 text-violet-400 dark:text-violet-300" />
         {activeAgent.displayName}
-        <ChevronDown size={10} />
+        <ChevronDown size={11} />
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="start" sideOffset={4} className="min-w-[200px]">
+      <DropdownMenuContent align="start" sideOffset={4} className="min-w-[210px]">
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Default</DropdownMenuLabel>
+          <SectionLabel>Default</SectionLabel>
           {DEFAULT_AGENTS.map((agent) => (
             <AgentItem
               key={agent.name}
@@ -147,7 +161,7 @@ export function CopilotAgentSelector({
           <>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuLabel>User</DropdownMenuLabel>
+              <SectionLabel>User</SectionLabel>
               {userAgents.map((agent) => (
                 <AgentItem
                   key={agent.name}
@@ -164,7 +178,7 @@ export function CopilotAgentSelector({
           <>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuLabel>Project</DropdownMenuLabel>
+              <SectionLabel>Project</SectionLabel>
               {projectAgents.map((agent) => (
                 <AgentItem
                   key={agent.name}

--- a/apps/web/src/components/chat/CopilotAgentSelector.tsx
+++ b/apps/web/src/components/chat/CopilotAgentSelector.tsx
@@ -115,7 +115,9 @@ export function CopilotAgentSelector({
         setProjectAgents(agents.filter((a) => a.source === "project"));
       })
       .catch(() => {
-        // Defaults are always shown; remote failures are non-fatal.
+        // Clear stale user/project agents so they don't desync from the workspace.
+        setUserAgents([]);
+        setProjectAgents([]);
       });
   }, [workspaceId]);
 

--- a/apps/web/src/components/chat/CopilotAgentSelector.tsx
+++ b/apps/web/src/components/chat/CopilotAgentSelector.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuGroup,
 } from "@/components/ui/dropdown-menu";
-import { CopilotIcon } from "./ProviderIcons";
 
 /** Built-in agents always available regardless of workspace config. */
 const DEFAULT_AGENTS: CopilotSubagent[] = [
@@ -126,7 +125,6 @@ export function CopilotAgentSelector({
         aria-label={`Copilot agent: ${activeAgent.displayName} (locked)`}
         className="flex h-6 items-center gap-1.5 rounded px-1.5 text-sm text-muted-foreground/50"
       >
-        <CopilotIcon size={12} className="shrink-0" />
         {activeAgent.displayName}
         <ChevronDown size={11} />
       </span>
@@ -139,7 +137,6 @@ export function CopilotAgentSelector({
         aria-label="Select Copilot agent"
         className="flex h-6 items-center gap-1.5 rounded px-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground data-[state=open]:bg-muted/40 data-[state=open]:text-foreground"
       >
-        <CopilotIcon size={12} className="shrink-0 text-violet-400 dark:text-violet-300" />
         {activeAgent.displayName}
         <ChevronDown size={11} />
       </DropdownMenuTrigger>

--- a/apps/web/src/components/chat/CopilotAgentSelector.tsx
+++ b/apps/web/src/components/chat/CopilotAgentSelector.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect } from "react";
+import { ChevronDown, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getTransport } from "@/transport";
+import type { CopilotSubagent } from "@mcode/contracts";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+} from "@/components/ui/dropdown-menu";
+
+/** Built-in agents always available regardless of workspace config. */
+const DEFAULT_AGENTS: CopilotSubagent[] = [
+  {
+    name: "interactive",
+    displayName: "Ask",
+    description: "Answers questions without autonomous tool use.",
+    source: "default",
+  },
+  {
+    name: "plan",
+    displayName: "Plan",
+    description: "Proposes a plan for approval before executing.",
+    source: "default",
+  },
+  {
+    name: "autopilot",
+    displayName: "Agent",
+    description: "Fully autonomous — runs tools without step-by-step approval.",
+    source: "default",
+  },
+];
+
+interface CopilotAgentSelectorProps {
+  /** Currently selected agent name. Defaults to "interactive" if null/undefined. */
+  selected: string | null | undefined;
+  /** Workspace ID for fetching user/project agents. */
+  workspaceId: string;
+  /** Prevents selection changes (e.g., locked thread). */
+  disabled?: boolean;
+  /** Called when the user picks a different agent. */
+  onChange: (agentName: string) => void;
+}
+
+/** Renders a single agent row with an active indicator and description. */
+function AgentItem({
+  agent,
+  isSelected,
+  onSelect,
+}: {
+  agent: CopilotSubagent;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <DropdownMenuItem
+      onClick={onSelect}
+      className={cn(
+        "flex cursor-pointer items-start gap-2 px-2 py-1.5 text-xs",
+        isSelected ? "text-foreground" : "text-popover-foreground",
+      )}
+    >
+      {/* Fixed-width slot keeps text aligned regardless of selection state. */}
+      <span className="mt-0.5 flex w-3 shrink-0 items-center justify-center">
+        {isSelected && <Check size={10} className="text-muted-foreground" />}
+      </span>
+      <span className="flex flex-col gap-0.5">
+        <span className="font-medium leading-none">{agent.displayName}</span>
+        <span className="text-[10px] leading-snug text-muted-foreground">
+          {agent.description}
+        </span>
+      </span>
+    </DropdownMenuItem>
+  );
+}
+
+/**
+ * Compact inline dropdown for picking a Copilot sub-agent in the Composer toolbar.
+ * Replaces the Chat/Plan toggle when Copilot is the active provider.
+ */
+export function CopilotAgentSelector({
+  selected,
+  workspaceId,
+  disabled,
+  onChange,
+}: CopilotAgentSelectorProps) {
+  const [userAgents, setUserAgents] = useState<CopilotSubagent[]>([]);
+  const [projectAgents, setProjectAgents] = useState<CopilotSubagent[]>([]);
+
+  const effectiveName = selected ?? "interactive";
+  const allAgents = [...DEFAULT_AGENTS, ...userAgents, ...projectAgents];
+  const activeAgent =
+    allAgents.find((a) => a.name === effectiveName) ?? DEFAULT_AGENTS[0];
+
+  useEffect(() => {
+    getTransport()
+      .listCopilotAgents(workspaceId)
+      .then((agents) => {
+        setUserAgents(agents.filter((a) => a.source === "user"));
+        setProjectAgents(agents.filter((a) => a.source === "project"));
+      })
+      .catch(() => {
+        // Defaults are always shown; remote failures are non-fatal.
+      });
+  }, [workspaceId]);
+
+  if (disabled) {
+    return (
+      <span
+        aria-label={`Copilot agent: ${activeAgent.displayName} (locked)`}
+        className="flex h-6 items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground/70"
+      >
+        {activeAgent.displayName}
+        <ChevronDown size={10} />
+      </span>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Select Copilot agent"
+        className="flex h-6 items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+      >
+        {activeAgent.displayName}
+        <ChevronDown size={10} />
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" sideOffset={4} className="min-w-[200px]">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Default</DropdownMenuLabel>
+          {DEFAULT_AGENTS.map((agent) => (
+            <AgentItem
+              key={agent.name}
+              agent={agent}
+              isSelected={agent.name === effectiveName}
+              onSelect={() => onChange(agent.name)}
+            />
+          ))}
+        </DropdownMenuGroup>
+
+        {userAgents.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>User</DropdownMenuLabel>
+              {userAgents.map((agent) => (
+                <AgentItem
+                  key={agent.name}
+                  agent={agent}
+                  isSelected={agent.name === effectiveName}
+                  onSelect={() => onChange(agent.name)}
+                />
+              ))}
+            </DropdownMenuGroup>
+          </>
+        )}
+
+        {projectAgents.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Project</DropdownMenuLabel>
+              {projectAgents.map((agent) => (
+                <AgentItem
+                  key={agent.name}
+                  agent={agent}
+                  isSelected={agent.name === effectiveName}
+                  onSelect={() => onChange(agent.name)}
+                />
+              ))}
+            </DropdownMenuGroup>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -86,6 +86,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,
     last_compact_summary: null,

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -81,6 +81,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,
     last_compact_summary: null,

--- a/apps/web/src/stores/queueStore.ts
+++ b/apps/web/src/stores/queueStore.ts
@@ -15,6 +15,8 @@ export interface QueuedMessage {
   reasoningLevel?: ReasoningLevel;
   /** Provider to use; undefined means inherit the thread's stored provider. */
   provider?: string;
+  /** Copilot sub-agent to use; undefined means inherit the thread's stored agent. */
+  copilotAgent?: string;
   /** Unix timestamp (ms) when this message was enqueued. */
   queuedAt: number;
 }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -19,6 +19,8 @@ export interface ThreadSettings {
   interactionMode: InteractionMode;
   /** Reasoning level selected for this thread, forwarded on the post-wizard answer turn. */
   reasoningLevel?: ReasoningLevel;
+  /** Selected Copilot sub-agent name. Null means provider default. Only relevant when provider is "copilot". */
+  copilotAgent?: string | null;
 }
 
 interface ThreadState {
@@ -85,7 +87,7 @@ interface ThreadState {
   // Message actions
   loadMessages: (threadId: string) => Promise<void>;
   loadOlderMessages: (threadId: string) => Promise<void>;
-  sendMessage: (threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], displayContent?: string, reasoningLevel?: ReasoningLevel, provider?: string) => Promise<void>;
+  sendMessage: (threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], displayContent?: string, reasoningLevel?: ReasoningLevel, provider?: string, copilotAgent?: string) => Promise<void>;
   stopAgent: (threadId: string) => Promise<void>;
   addMessage: (message: Message) => void;
   clearMessages: () => void;
@@ -478,7 +480,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * message to local state, marks the thread as running, then dispatches
    * to the transport layer. On failure, rolls back the running state.
    */
-  sendMessage: async (threadId, content, model, permissionMode, attachments, displayContent, reasoningLevel, provider) => {
+  sendMessage: async (threadId, content, model, permissionMode, attachments, displayContent, reasoningLevel, provider, copilotAgent) => {
     // Add user message to local state immediately (optimistic)
     // Use displayContent for the UI (without injected file blocks) if provided
     const userMessage: Message = {
@@ -528,7 +530,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
     try {
       const { interactionMode } = get().getThreadSettings(threadId);
-      await getTransport().sendMessage(threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode);
+      await getTransport().sendMessage(threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent);
     } catch (e) {
       set((state) => {
         const next = new Set(state.runningThreadIds);
@@ -630,6 +632,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         reasoningLevel: thread.reasoning_level !== null
           ? (thread.reasoning_level as ReasoningLevel)
           : undefined,
+        copilotAgent: thread.copilot_agent,
       };
     }
 
@@ -650,6 +653,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (settings.permissionMode !== undefined) patch.permissionMode = settings.permissionMode;
     if (settings.interactionMode !== undefined) patch.interactionMode = settings.interactionMode;
     if (settings.reasoningLevel !== undefined) patch.reasoningLevel = settings.reasoningLevel;
+    // Use `in` check so explicit null clears the agent (null !== undefined).
+    if ("copilotAgent" in settings) patch.copilotAgent = settings.copilotAgent;
 
     if (Object.keys(patch).length === 0) return Promise.resolve(false);
 
@@ -660,7 +665,20 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       },
     }));
 
-    return getTransport().updateThreadSettings(threadId, patch).catch(() => false);
+    // Strip null copilotAgent before transport: the RPC accepts undefined (omit) but not null.
+    const transportPatch: {
+      reasoningLevel?: ReturnType<typeof get>["settingsByThread"][string]["reasoningLevel"];
+      interactionMode?: ReturnType<typeof get>["settingsByThread"][string]["interactionMode"];
+      permissionMode?: ReturnType<typeof get>["settingsByThread"][string]["permissionMode"];
+      copilotAgent?: string;
+    } = {
+      ...(patch.permissionMode !== undefined ? { permissionMode: patch.permissionMode } : {}),
+      ...(patch.interactionMode !== undefined ? { interactionMode: patch.interactionMode } : {}),
+      ...(patch.reasoningLevel !== undefined ? { reasoningLevel: patch.reasoningLevel } : {}),
+      // Convert null → undefined: the RPC uses undefined to mean "omit field", null is not accepted.
+      ...(patch.copilotAgent != null ? { copilotAgent: patch.copilotAgent } : {}),
+    };
+    return getTransport().updateThreadSettings(threadId, transportPatch).catch(() => false);
   },
 
   clearThreadState: (threadId) => {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -665,18 +665,17 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       },
     }));
 
-    // Strip null copilotAgent before transport: the RPC accepts undefined (omit) but not null.
+    // copilotAgent: null clears the persisted agent; undefined means don't change.
     const transportPatch: {
       reasoningLevel?: ReturnType<typeof get>["settingsByThread"][string]["reasoningLevel"];
       interactionMode?: ReturnType<typeof get>["settingsByThread"][string]["interactionMode"];
       permissionMode?: ReturnType<typeof get>["settingsByThread"][string]["permissionMode"];
-      copilotAgent?: string;
+      copilotAgent?: string | null;
     } = {
       ...(patch.permissionMode !== undefined ? { permissionMode: patch.permissionMode } : {}),
       ...(patch.interactionMode !== undefined ? { interactionMode: patch.interactionMode } : {}),
       ...(patch.reasoningLevel !== undefined ? { reasoningLevel: patch.reasoningLevel } : {}),
-      // Convert null → undefined: the RPC uses undefined to mean "omit field", null is not accepted.
-      ...(patch.copilotAgent != null ? { copilotAgent: patch.copilotAgent } : {}),
+      ...("copilotAgent" in patch ? { copilotAgent: patch.copilotAgent } : {}),
     };
     return getTransport().updateThreadSettings(threadId, transportPatch).catch(() => false);
   },

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1365,6 +1365,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               next.displayContent,
               next.reasoningLevel,
               next.provider,
+              next.copilotAgent,
             );
           }
         }, 400);

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -63,7 +63,7 @@ interface WorkspaceState {
     mode: "direct" | "worktree",
     branch: string,
   ) => Promise<Thread>;
-  createAndSendMessage: (content: string, model: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?: InteractionMode) => Promise<Thread>;
+  createAndSendMessage: (content: string, model: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?: InteractionMode, copilotAgent?: string) => Promise<Thread>;
   /** Branch an existing thread into a new child with handoff context. */
   branchThread: (params: {
     sourceThreadId: string;
@@ -78,6 +78,7 @@ interface WorkspaceState {
     reasoningLevel?: ReasoningLevel;
     attachments?: AttachmentMeta[];
     interactionMode?: InteractionMode;
+    copilotAgent?: string;
   }) => Promise<Thread>;
   deleteThread: (threadId: string, cleanupWorktree: boolean) => Promise<void>;
   setActiveThread: (id: string | null) => void;
@@ -282,7 +283,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
   },
 
-  createAndSendMessage: async (content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode) => {
+  createAndSendMessage: async (content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent) => {
     const workspaceId = get().activeWorkspaceId;
     if (!workspaceId) throw new Error("No workspace selected");
 
@@ -315,7 +316,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set({ error: null });
     try {
       const thread = await getTransport().createAndSendMessage(
-        workspaceId, content, model, permissionMode, mode, branch, existingWorktreePath, attachments, reasoningLevel, provider, interactionMode,
+        workspaceId, content, model, permissionMode, mode, branch, existingWorktreePath, attachments, reasoningLevel, provider, interactionMode, undefined, undefined, copilotAgent,
       );
       set((state) => ({
         threads: [thread, ...state.threads],
@@ -375,6 +376,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         params.interactionMode,
         params.sourceThreadId,
         params.forkedFromMessageId,
+        params.copilotAgent,
       );
 
       set((state) => ({

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -22,6 +22,7 @@ import type {
   ProviderUsageInfo,
   PrDraft,
   CreatePrResult,
+  CopilotSubagent,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
@@ -45,7 +46,7 @@ export type {
   ProviderModelInfo,
 } from "@mcode/contracts";
 
-export type { PaginatedMessages, ToolCallRecord, TurnSnapshot } from "@mcode/contracts";
+export type { PaginatedMessages, ToolCallRecord, TurnSnapshot, CopilotSubagent } from "@mcode/contracts";
 
 export { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
 
@@ -87,7 +88,7 @@ export interface McodeTransport {
   listWorktrees(workspaceId: string): Promise<WorktreeInfo[]>;
 
   // Agent commands
-  sendMessage(threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?: InteractionMode): Promise<void>;
+  sendMessage(threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?: InteractionMode, copilotAgent?: string): Promise<void>;
   createAndSendMessage(
     workspaceId: string,
     content: string,
@@ -102,6 +103,7 @@ export interface McodeTransport {
     interactionMode?: InteractionMode,
     parentThreadId?: string,
     forkedFromMessageId?: string,
+    copilotAgent?: string,
   ): Promise<Thread>;
   stopAgent(threadId: string): Promise<void>;
   /** Submit answers to a plan-mode question batch and resume the agent session. */
@@ -238,6 +240,8 @@ export interface McodeTransport {
   listProviderModels(providerId: string): Promise<ProviderModelInfo[]>;
   /** Fetch current usage/quota state for a provider. */
   getProviderUsage(providerId: string): Promise<ProviderUsageInfo>;
+  /** Fetches Copilot sub-agents available for the given workspace. */
+  listCopilotAgents(workspaceId: string): Promise<CopilotSubagent[]>;
 
   // Memory pressure
   /** Notify server of window background/foreground state for memory management. */

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -120,13 +120,14 @@ export interface McodeTransport {
 
   // Thread mutations
   updateThreadTitle(threadId: string, title: string): Promise<boolean>;
-  /** Persist per-thread composer settings (reasoning, mode, permission). */
+  /** Persist per-thread composer settings (reasoning, mode, permission, copilot agent). */
   updateThreadSettings(
     threadId: string,
     settings: {
       reasoningLevel?: ReasoningLevel;
       interactionMode?: InteractionMode;
       permissionMode?: PermissionMode;
+      copilotAgent?: string;
     },
   ): Promise<boolean>;
   /** Clear the "completed" badge for a thread. Transitions completed -> paused in the DB. */

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -127,7 +127,7 @@ export interface McodeTransport {
       reasoningLevel?: ReasoningLevel;
       interactionMode?: InteractionMode;
       permissionMode?: PermissionMode;
-      copilotAgent?: string;
+      copilotAgent?: string | null;
     },
   ): Promise<boolean>;
   /** Clear the "completed" badge for a thread. Transitions completed -> paused in the DB. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -309,18 +309,16 @@ export function createWsTransport(
     listWorktrees: (workspaceId) => rpc<WorktreeInfo[]>("git.listWorktrees", { workspaceId }),
 
     // Agent
-    sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?) => {
+    sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?, copilotAgent?: string) => {
       const state = useSettingsStore.getState();
       const guardrails = state.loaded
         ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
         : {};
       return rpc<void>("agent.send", {
-        threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode,
+        threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent,
         ...guardrails,
       });
     },
-    sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?, copilotAgent?: string) =>
-      rpc<void>("agent.send", { threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent }),
     createAndSendMessage: (
       workspaceId,
       content,
@@ -335,15 +333,13 @@ export function createWsTransport(
       interactionMode?,
       parentThreadId?,
       forkedFromMessageId?,
+      copilotAgent?,
     ) => {
       const state = useSettingsStore.getState();
       const guardrails = state.loaded
         ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
         : {};
       return rpc<Thread>("agent.createAndSend", {
-      copilotAgent?,
-    ) =>
-      rpc<Thread>("agent.createAndSend", {
         workspaceId,
         content,
         model,
@@ -357,11 +353,10 @@ export function createWsTransport(
         interactionMode,
         parentThreadId,
         forkedFromMessageId,
+        copilotAgent,
         ...guardrails,
       });
     },
-        copilotAgent,
-      }),
     stopAgent: (threadId) => rpc<void>("agent.stop", { threadId }),
     answerPlanQuestions: (threadId, answers, permissionMode?, reasoningLevel?) =>
       rpc<void>("agent.answerQuestions", { threadId, answers, permissionMode, reasoningLevel }),

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -13,6 +13,7 @@ import type {
   Settings,
   GitCommit,
   ProviderModelInfo,
+  CopilotSubagent,
 } from "./types";
 import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
@@ -317,6 +318,8 @@ export function createWsTransport(
         ...guardrails,
       });
     },
+    sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?, copilotAgent?: string) =>
+      rpc<void>("agent.send", { threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent }),
     createAndSendMessage: (
       workspaceId,
       content,
@@ -337,6 +340,9 @@ export function createWsTransport(
         ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
         : {};
       return rpc<Thread>("agent.createAndSend", {
+      copilotAgent?,
+    ) =>
+      rpc<Thread>("agent.createAndSend", {
         workspaceId,
         content,
         model,
@@ -353,6 +359,8 @@ export function createWsTransport(
         ...guardrails,
       });
     },
+        copilotAgent,
+      }),
     stopAgent: (threadId) => rpc<void>("agent.stop", { threadId }),
     answerPlanQuestions: (threadId, answers, permissionMode?, reasoningLevel?) =>
       rpc<void>("agent.answerQuestions", { threadId, answers, permissionMode, reasoningLevel }),
@@ -467,6 +475,9 @@ export function createWsTransport(
       rpc<ProviderModelInfo[]>("provider.listModels", { providerId }),
     getProviderUsage: (providerId) =>
       rpc<ProviderUsageInfo>("provider.getUsage", { providerId }),
+    /** Fetches all available Copilot sub-agents for the given workspace (built-in + user + project). */
+    listCopilotAgents: (workspaceId) =>
+      rpc<CopilotSubagent[]>("provider.copilotAgents", { workspaceId }),
 
     // Memory pressure
     setBackground: (background) => rpc<void>("memory.setBackground", { background }),

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -295,6 +295,7 @@ export function createWsTransport(
         reasoningLevel: settings.reasoningLevel,
         interactionMode: settings.interactionMode,
         permissionMode: settings.permissionMode,
+        copilotAgent: settings.copilotAgent,
       }),
     markThreadViewed: (threadId) => rpc<void>("thread.markViewed", { threadId }),
     syncThreadPrs: (workspaceId) =>

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "uuid": "^11.1.0",
         "which": "^5.0.0",
         "ws": "^8.18.0",
+        "yaml": "^2.8.3",
         "zod": "^3.24.2",
       },
       "devDependencies": {
@@ -2529,6 +2530,8 @@
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7,6 +7,8 @@ export {
   PERMISSION_MODES,
   InteractionModeSchema,
   INTERACTION_MODES,
+  CopilotSubagentSourceSchema,
+  COPILOT_SUBAGENT_SOURCES,
 } from "./models/enums.js";
 export type {
   ThreadStatus,
@@ -14,6 +16,7 @@ export type {
   MessageRole,
   PermissionMode,
   InteractionMode,
+  CopilotSubagentSource,
 } from "./models/enums.js";
 
 export {
@@ -160,3 +163,6 @@ export type {
   QuotaCategory,
   ProviderUsageInfo,
 } from "./providers/usage.js";
+
+export { CopilotSubagentSchema } from "./providers/copilot-agent.js";
+export type { CopilotSubagent } from "./providers/copilot-agent.js";

--- a/packages/contracts/src/models/enums.ts
+++ b/packages/contracts/src/models/enums.ts
@@ -52,3 +52,14 @@ export const INTERACTION_MODES = {
   CHAT: "chat" as const,
   PLAN: "plan" as const,
 } satisfies Record<string, InteractionMode>;
+
+/** Discriminates where a Copilot sub-agent was discovered from. */
+export const CopilotSubagentSourceSchema = z.enum(["default", "user", "project"]);
+/** Copilot sub-agent source value. */
+export type CopilotSubagentSource = z.infer<typeof CopilotSubagentSourceSchema>;
+/** Constant lookup for Copilot sub-agent sources. */
+export const COPILOT_SUBAGENT_SOURCES = {
+  DEFAULT: "default" as const,
+  USER: "user" as const,
+  PROJECT: "project" as const,
+} satisfies Record<string, CopilotSubagentSource>;

--- a/packages/contracts/src/models/thread.ts
+++ b/packages/contracts/src/models/thread.ts
@@ -34,6 +34,8 @@ export const ThreadSchema = z.object({
   interaction_mode: InteractionModeSchema.nullable(),
   /** Permission mode last used (full or supervised). */
   permission_mode: PermissionModeSchema.nullable(),
+  /** Selected Copilot sub-agent name. Null means provider default (interactive). */
+  copilot_agent: z.string().nullable(),
   /** ID of the parent thread this was branched from. Null for root threads. */
   parent_thread_id: z.string().nullable(),
   /** ID of the message in the parent thread that marks the fork point. */

--- a/packages/contracts/src/models/thread.ts
+++ b/packages/contracts/src/models/thread.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
 import { ThreadStatusSchema, ThreadModeSchema, InteractionModeSchema, PermissionModeSchema } from "./enums.js";
 import { ReasoningLevelSchema } from "./settings.js";
 
 /** Thread schema matching the SQLite row shape. */
-export const ThreadSchema = z.object({
+export const ThreadSchema = lazySchema(() =>
+  z.object({
   id: z.string(),
   workspace_id: z.string(),
   title: z.string(),
@@ -42,6 +44,7 @@ export const ThreadSchema = z.object({
   forked_from_message_id: z.string().nullable(),
   /** Most recent compaction summary from the AI provider. Used to seed branched thread replays. */
   last_compact_summary: z.string().nullable(),
-});
+  }),
+);
 /** Thread record from the database. */
-export type Thread = z.infer<typeof ThreadSchema>;
+export type Thread = z.infer<ReturnType<typeof ThreadSchema>>;

--- a/packages/contracts/src/providers/copilot-agent.ts
+++ b/packages/contracts/src/providers/copilot-agent.ts
@@ -9,7 +9,7 @@ import { CopilotSubagentSourceSchema } from "../models/enums.js";
 export const CopilotSubagentSchema = lazySchema(() =>
   z.object({
     /** Unique identifier passed to the SDK (mode name or custom agent name). */
-    name: z.string(),
+    name: z.string().min(1),
     /** Human-readable label shown in the UI. */
     displayName: z.string(),
     /** Brief description of the agent's purpose. */

--- a/packages/contracts/src/providers/copilot-agent.ts
+++ b/packages/contracts/src/providers/copilot-agent.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+import { CopilotSubagentSourceSchema } from "../models/enums.js";
+
+/**
+ * A Copilot sub-agent available for selection in the Composer.
+ * Source distinguishes built-ins from user/project YAML-defined agents.
+ */
+export const CopilotSubagentSchema = lazySchema(() =>
+  z.object({
+    /** Unique identifier passed to the SDK (mode name or custom agent name). */
+    name: z.string(),
+    /** Human-readable label shown in the UI. */
+    displayName: z.string(),
+    /** Brief description of the agent's purpose. */
+    description: z.string(),
+    /** Where this agent was discovered from. */
+    source: CopilotSubagentSourceSchema,
+  }),
+);
+
+/** A Copilot sub-agent available for selection in the Composer. */
+export type CopilotSubagent = z.infer<ReturnType<typeof CopilotSubagentSchema>>;

--- a/packages/contracts/src/providers/copilot-agent.ts
+++ b/packages/contracts/src/providers/copilot-agent.ts
@@ -3,13 +3,24 @@ import { lazySchema } from "../utils/lazySchema.js";
 import { CopilotSubagentSourceSchema } from "../models/enums.js";
 
 /**
+ * Shared validation for Copilot agent names.
+ * Applied consistently across discovery, send, and update schemas so a name
+ * that passes discovery cannot be rejected on write.
+ */
+export const CopilotAgentNameSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[\w.-]+$/, "Agent name must contain only word chars, dots, and dashes");
+
+/**
  * A Copilot sub-agent available for selection in the Composer.
  * Source distinguishes built-ins from user/project YAML-defined agents.
  */
 export const CopilotSubagentSchema = lazySchema(() =>
   z.object({
     /** Unique identifier passed to the SDK (mode name or custom agent name). */
-    name: z.string().min(1),
+    name: CopilotAgentNameSchema,
     /** Human-readable label shown in the UI. */
     displayName: z.string(),
     /** Brief description of the agent's purpose. */

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -37,6 +37,13 @@ export interface IAgentProvider {
     maxBudgetUsd?: number;
     /** Maximum agent turns for this session. Provider stops after this count. Undefined or 0 disables. */
     maxTurns?: number;
+    /**
+     * Copilot-specific: name of the sub-agent to activate for this session.
+     * Built-in modes: "interactive" | "plan" | "autopilot".
+     * Custom agents: any name defined in user/project YAML config.
+     * Ignored by non-Copilot providers.
+     */
+    copilotAgent?: string;
   }): void | Promise<void>;
 
   /** Abort a running session. */

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -101,11 +101,11 @@ export const WS_METHODS = lazySchema(() => ({
   },
   "thread.list": {
     params: z.object({ workspaceId: z.string() }),
-    result: z.array(ThreadSchema),
+    result: z.array(ThreadSchema()),
   },
   "thread.create": {
     params: CreateThreadSchema(),
-    result: ThreadSchema,
+    result: ThreadSchema(),
   },
   "thread.delete": {
     params: z.object({
@@ -205,7 +205,7 @@ export const WS_METHODS = lazySchema(() => ({
   },
   "agent.createAndSend": {
     params: CreateAndSendSchema(),
-    result: ThreadSchema,
+    result: ThreadSchema(),
   },
   "agent.stop": {
     params: z.object({ threadId: z.string() }),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -21,6 +21,7 @@ import {
 import { lazySchema } from "../utils/lazySchema.js";
 import { ProviderModelInfoSchema } from "../providers/models.js";
 import { ProviderUsageInfoSchema } from "../providers/usage.js";
+import { CopilotSubagentSchema } from "../providers/copilot-agent.js";
 
 /** Schema for creating a new thread. */
 export const CreateThreadSchema = lazySchema(() =>
@@ -48,6 +49,8 @@ export const SendMessageSchema = lazySchema(() =>
     maxBudgetUsd: z.number().nonnegative().finite().optional(),
     /** Maximum agent turns. 0 or absent disables. */
     maxTurns: z.number().int().nonnegative().optional(),
+    /** Copilot sub-agent to activate for this message. Ignored by other providers. */
+    copilotAgent: z.string().max(128).regex(/^[\w.-]+$/).optional(),
   }),
 );
 
@@ -70,13 +73,15 @@ export const CreateAndSendSchema = lazySchema(() =>
     maxBudgetUsd: z.number().nonnegative().finite().optional(),
     /** Maximum agent turns. 0 or absent disables. */
     maxTurns: z.number().int().nonnegative().optional(),
+    /** Copilot sub-agent to activate for this thread. Ignored by other providers. */
+    copilotAgent: z.string().max(128).regex(/^[\w.-]+$/).optional(),
     /** Source thread ID when branching from an existing thread. */
-    parentThreadId: z.string().optional(),
-    /** Fork-point message ID in the parent thread. Defaults to last persisted message. */
-    forkedFromMessageId: z.string().optional(),
-  }).refine(
-    (d) => !d.forkedFromMessageId || d.parentThreadId,
-    { message: "forkedFromMessageId requires parentThreadId", path: ["forkedFromMessageId"] },
+  parentThreadId: z.string().optional(),
+  /** Fork-point message ID in the parent thread. Defaults to last persisted message. */
+  forkedFromMessageId: z.string().optional(),
+}).refine(
+  (d) => !d.forkedFromMessageId || d.parentThreadId,
+  { message: "forkedFromMessageId requires parentThreadId", path: ["forkedFromMessageId"] },
   ),
 );
 
@@ -119,8 +124,14 @@ export const WS_METHODS = lazySchema(() => ({
       reasoningLevel: ReasoningLevelSchema.optional(),
       interactionMode: InteractionModeSchema.optional(),
       permissionMode: PermissionModeSchema.optional(),
+      /** Copilot-specific: name of the selected sub-agent. */
+      copilotAgent: z.string().optional(),
     }).refine(
-      (data) => data.reasoningLevel !== undefined || data.interactionMode !== undefined || data.permissionMode !== undefined,
+      (data) =>
+        data.reasoningLevel !== undefined ||
+        data.interactionMode !== undefined ||
+        data.permissionMode !== undefined ||
+        data.copilotAgent !== undefined,
       { message: "Must provide at least one setting to update" },
     ),
     result: z.boolean(),
@@ -398,6 +409,12 @@ export const WS_METHODS = lazySchema(() => ({
   "memory.setBackground": {
     params: z.object({ background: z.boolean() }),
     result: z.void(),
+  },
+  "provider.copilotAgents": {
+    params: z.object({
+      workspaceId: z.string(),
+    }),
+    result: z.array(CopilotSubagentSchema()),
   },
 } as const));
 

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -124,8 +124,8 @@ export const WS_METHODS = lazySchema(() => ({
       reasoningLevel: ReasoningLevelSchema.optional(),
       interactionMode: InteractionModeSchema.optional(),
       permissionMode: PermissionModeSchema.optional(),
-      /** Copilot-specific: name of the selected sub-agent. */
-      copilotAgent: z.string().optional(),
+      /** Copilot-specific: name of the selected sub-agent. Pass null to clear back to provider default. */
+      copilotAgent: z.string().max(128).regex(/^[\w.-]+$/).nullable().optional(),
     }).refine(
       (data) =>
         data.reasoningLevel !== undefined ||

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -21,7 +21,7 @@ import {
 import { lazySchema } from "../utils/lazySchema.js";
 import { ProviderModelInfoSchema } from "../providers/models.js";
 import { ProviderUsageInfoSchema } from "../providers/usage.js";
-import { CopilotSubagentSchema } from "../providers/copilot-agent.js";
+import { CopilotSubagentSchema, CopilotAgentNameSchema } from "../providers/copilot-agent.js";
 
 /** Schema for creating a new thread. */
 export const CreateThreadSchema = lazySchema(() =>
@@ -50,7 +50,7 @@ export const SendMessageSchema = lazySchema(() =>
     /** Maximum agent turns. 0 or absent disables. */
     maxTurns: z.number().int().nonnegative().optional(),
     /** Copilot sub-agent to activate for this message. Ignored by other providers. */
-    copilotAgent: z.string().max(128).regex(/^[\w.-]+$/).optional(),
+    copilotAgent: CopilotAgentNameSchema.optional(),
   }),
 );
 
@@ -74,7 +74,7 @@ export const CreateAndSendSchema = lazySchema(() =>
     /** Maximum agent turns. 0 or absent disables. */
     maxTurns: z.number().int().nonnegative().optional(),
     /** Copilot sub-agent to activate for this thread. Ignored by other providers. */
-    copilotAgent: z.string().max(128).regex(/^[\w.-]+$/).optional(),
+    copilotAgent: CopilotAgentNameSchema.optional(),
     /** Source thread ID when branching from an existing thread. */
   parentThreadId: z.string().optional(),
   /** Fork-point message ID in the parent thread. Defaults to last persisted message. */
@@ -125,7 +125,7 @@ export const WS_METHODS = lazySchema(() => ({
       interactionMode: InteractionModeSchema.optional(),
       permissionMode: PermissionModeSchema.optional(),
       /** Copilot-specific: name of the selected sub-agent. Pass null to clear back to provider default. */
-      copilotAgent: z.string().max(128).regex(/^[\w.-]+$/).nullable().optional(),
+      copilotAgent: CopilotAgentNameSchema.nullable().optional(),
     }).refine(
       (data) =>
         data.reasoningLevel !== undefined ||


### PR DESCRIPTION
## What

Replaces the generic Chat/Plan toggle in the Composer with a three-tier Copilot sub-agent selector when Copilot is the active provider. Built-in agents appear instantly from hardcoded defaults; user-level and project-level YAML-defined agents are discovered async and shown in labelled groups.

## Why

The Copilot SDK exposes distinct sub-agents (`interactive`, `plan`, `autopilot`, and custom YAML agents) with different system prompts and tool-use behaviours. Routing every message through the same session without selecting an agent meant users lost access to the richer capabilities the SDK provides. This surfaces those capabilities in the UI with the minimal latency possible.

## Key Changes

- **Contracts:** `CopilotSubagent` schema, `provider.copilotAgents` WS method, `copilotAgent` field on Thread and all send/update paths
- **DB:** Migration 016 adds `copilot_agent TEXT DEFAULT NULL` to `threads`
- **Discovery:** `CopilotAgentDiscovery` scans three tiers — hardcoded defaults, OS user dir (`~/.config/github-copilot/agents/` or `%APPDATA%\GitHub Copilot\agents\`), and project dirs (`.github/agents/`, `.copilot/agents/`) — with full unit test coverage (6 tests)
- **Routing:** `CopilotProvider.sendMessage` calls `session.rpc.mode.set()` for built-ins and `session.rpc.agent.select()` for custom agents; `customAgents` passed at session creation
- **Persistence:** selected agent stored per-thread in SQLite, restored on thread switch
- **UI:** `CopilotAgentSelector` dropdown with Default / User / Project subheadings, matching the Composer toolbar style exactly; defaults render instantly, custom agents load async without blocking

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select Copilot agents (Interactive, Plan, Autopilot) and custom agents from user/project YAML
  * Inline Copilot Agent selector UI with Default/User/Project groupings
  * Selected agent is persisted on threads and included when sending messages

* **Tests**
  * Added unit and end-to-end tests covering agent discovery, selector UI, and various agent scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->