### PR TITLE
feat: GitHub Actions check status on threads (#210)

### DIFF
--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -1,0 +1,105 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { GithubService } from "../services/github-service";
+import type { ChecksStatus } from "@mcode/contracts";
+
+vi.mock("@mcode/shared", () => ({
+  getMcodeDir: () => "/mock/mcode",
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { CiWatcherService } from "../services/ci-watcher";
+
+function makeChecks(aggregate: ChecksStatus["aggregate"]): ChecksStatus {
+  return { aggregate, runs: [], fetchedAt: Date.now() };
+}
+
+describe("CiWatcherService", () => {
+  let watcher: CiWatcherService;
+  let mockGithubService: { getCheckRuns: ReturnType<typeof vi.fn> };
+  let mockBroadcast: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGithubService = { getCheckRuns: vi.fn() };
+    mockBroadcast = vi.fn();
+    watcher = new CiWatcherService(
+      mockGithubService as unknown as GithubService,
+      mockBroadcast,
+    );
+  });
+
+  afterEach(() => {
+    watcher.dispose();
+    vi.useRealTimers();
+  });
+
+  it("watch() adds entry and starts passive timer", () => {
+    watcher.watch("t1", 42, "/repo");
+    expect(watcher.isWatching("t1")).toBe(true);
+  });
+
+  it("unwatch() removes entry", () => {
+    watcher.watch("t1", 42, "/repo");
+    watcher.unwatch("t1");
+    expect(watcher.isWatching("t1")).toBe(false);
+  });
+
+  it("broadcasts when check state changes on tick", async () => {
+    const pending = makeChecks("pending");
+    mockGithubService.getCheckRuns.mockResolvedValue(pending);
+    watcher.watch("t1", 42, "/repo");
+
+    // Trigger passive tick (60s)
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockBroadcast).toHaveBeenCalledWith("thread.checksUpdated", {
+      threadId: "t1",
+      checks: pending,
+    });
+  });
+
+  it("does NOT broadcast when state is unchanged", async () => {
+    const passing = makeChecks("passing");
+    mockGithubService.getCheckRuns.mockResolvedValue(passing);
+    watcher.watch("t1", 42, "/repo");
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    mockBroadcast.mockClear();
+
+    // Same state on second tick
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("promotes to active set when checks are pending", async () => {
+    const pending = makeChecks("pending");
+    mockGithubService.getCheckRuns.mockResolvedValue(pending);
+    watcher.watch("t1", 42, "/repo");
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Active set ticks at 10s
+    mockBroadcast.mockClear();
+    const passing = makeChecks("passing");
+    mockGithubService.getCheckRuns.mockResolvedValue(passing);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockBroadcast).toHaveBeenCalledWith("thread.checksUpdated", {
+      threadId: "t1",
+      checks: passing,
+    });
+  });
+
+  it("getEntry returns cached status", async () => {
+    const passing = makeChecks("passing");
+    mockGithubService.getCheckRuns.mockResolvedValue(passing);
+    watcher.watch("t1", 42, "/repo");
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const entry = watcher.getEntry("t1");
+    expect(entry).not.toBeNull();
+    expect(entry!.prNumber).toBe(42);
+  });
+});

--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -127,5 +127,6 @@ describe("CiWatcherService", () => {
     const entry = watcher.getEntry("t1");
     expect(entry).not.toBeNull();
     expect(entry!.prNumber).toBe(42);
+    expect(entry!.cache).toEqual(passing);
   });
 });

--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -94,6 +94,29 @@ describe("CiWatcherService", () => {
     });
   });
 
+  it("refresh() does not broadcast when state is unchanged", () => {
+    const passing = makeChecks("passing");
+    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
+    // First call: cache is null → always broadcasts.
+    watcher.refresh("t1", passing);
+    mockBroadcast.mockClear();
+    // Second call with identical aggregate — no change, no broadcast.
+    watcher.refresh("t1", makeChecks("passing"));
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("refresh() broadcasts when aggregate changes", () => {
+    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
+    watcher.refresh("t1", makeChecks("passing"));
+    mockBroadcast.mockClear();
+    const failing = makeChecks("failing");
+    watcher.refresh("t1", failing);
+    expect(mockBroadcast).toHaveBeenCalledWith("thread.checksUpdated", {
+      threadId: "t1",
+      checks: failing,
+    });
+  });
+
   it("getEntry returns cached status", async () => {
     const passing = makeChecks("passing");
     mockGithubService.getCheckRuns.mockResolvedValue(passing);

--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -52,8 +52,8 @@ describe("CiWatcherService", () => {
     mockGithubService.getCheckRuns.mockResolvedValue(pending);
     watcher.watch("t1", 42, "/repo");
 
-    // Trigger passive tick (60s)
-    await vi.advanceTimersByTimeAsync(60_000);
+    // Trigger passive tick (30s)
+    await vi.advanceTimersByTimeAsync(30_000);
 
     expect(mockBroadcast).toHaveBeenCalledWith("thread.checksUpdated", {
       threadId: "t1",
@@ -66,11 +66,11 @@ describe("CiWatcherService", () => {
     mockGithubService.getCheckRuns.mockResolvedValue(passing);
     watcher.watch("t1", 42, "/repo");
 
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     mockBroadcast.mockClear();
 
     // Same state on second tick
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(mockBroadcast).not.toHaveBeenCalled();
   });
 
@@ -79,7 +79,7 @@ describe("CiWatcherService", () => {
     mockGithubService.getCheckRuns.mockResolvedValue(pending);
     watcher.watch("t1", 42, "/repo");
 
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
 
     // Active set ticks at 10s
     mockBroadcast.mockClear();
@@ -98,7 +98,7 @@ describe("CiWatcherService", () => {
     mockGithubService.getCheckRuns.mockResolvedValue(passing);
     watcher.watch("t1", 42, "/repo");
 
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
 
     const entry = watcher.getEntry("t1");
     expect(entry).not.toBeNull();

--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -22,6 +22,8 @@ describe("CiWatcherService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockGithubService = { getCheckRuns: vi.fn() };
+    // Default: return no_checks so watch() immediate fetch resolves without side effects.
+    mockGithubService.getCheckRuns.mockResolvedValue(makeChecks("no_checks"));
     mockBroadcast = vi.fn();
     watcher = new CiWatcherService(
       mockGithubService as unknown as GithubService,

--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -50,9 +50,9 @@ describe("CiWatcherService", () => {
   it("broadcasts when check state changes on tick", async () => {
     const pending = makeChecks("pending");
     mockGithubService.getCheckRuns.mockResolvedValue(pending);
-    watcher.watch("t1", 42, "/repo");
+    // skipInitialFetch so the assertion exercises the scheduled passive tick, not the eager fetch.
+    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
 
-    // Trigger passive tick (30s)
     await vi.advanceTimersByTimeAsync(30_000);
 
     expect(mockBroadcast).toHaveBeenCalledWith("thread.checksUpdated", {
@@ -64,12 +64,12 @@ describe("CiWatcherService", () => {
   it("does NOT broadcast when state is unchanged", async () => {
     const passing = makeChecks("passing");
     mockGithubService.getCheckRuns.mockResolvedValue(passing);
-    watcher.watch("t1", 42, "/repo");
+    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
 
     await vi.advanceTimersByTimeAsync(30_000);
     mockBroadcast.mockClear();
 
-    // Same state on second tick
+    // Same state on second tick — no change, no broadcast.
     await vi.advanceTimersByTimeAsync(30_000);
     expect(mockBroadcast).not.toHaveBeenCalled();
   });
@@ -77,8 +77,9 @@ describe("CiWatcherService", () => {
   it("promotes to active set when checks are pending", async () => {
     const pending = makeChecks("pending");
     mockGithubService.getCheckRuns.mockResolvedValue(pending);
-    watcher.watch("t1", 42, "/repo");
+    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
 
+    // Passive tick promotes to active when aggregate is pending.
     await vi.advanceTimersByTimeAsync(30_000);
 
     // Active set ticks at 10s
@@ -96,7 +97,7 @@ describe("CiWatcherService", () => {
   it("getEntry returns cached status", async () => {
     const passing = makeChecks("passing");
     mockGithubService.getCheckRuns.mockResolvedValue(passing);
-    watcher.watch("t1", 42, "/repo");
+    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
 
     await vi.advanceTimersByTimeAsync(30_000);
 

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -1,0 +1,105 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { WorkspaceRepo } from "../repositories/workspace-repo";
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  execFile: mockExecFile,
+}));
+
+vi.mock("@mcode/shared", () => ({
+  getMcodeDir: () => "/mock/mcode",
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GithubService } from "../services/github-service";
+
+describe("GithubService.getCheckRuns", () => {
+  let ghService: GithubService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ghService = new GithubService({} as WorkspaceRepo);
+  });
+
+  it("returns passing status when all checks succeed", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, JSON.stringify([
+          { name: "build", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          { name: "lint", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:08Z" },
+        ]));
+      },
+    );
+
+    const result = await ghService.getCheckRuns(42, "/repo");
+
+    expect(result.aggregate).toBe("passing");
+    expect(result.runs).toHaveLength(2);
+    expect(result.runs[0].name).toBe("build");
+    expect(result.runs[0].conclusion).toBe("success");
+    expect(result.runs[0].durationMs).toBe(23000);
+  });
+
+  it("returns failing status when any check fails", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, JSON.stringify([
+          { name: "build", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          { name: "test", state: "FAILURE", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:45Z" },
+        ]));
+      },
+    );
+
+    const result = await ghService.getCheckRuns(42, "/repo");
+
+    expect(result.aggregate).toBe("failing");
+    expect(result.runs[1].conclusion).toBe("failure");
+  });
+
+  it("returns pending status when any check is in progress", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, JSON.stringify([
+          { name: "build", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          { name: "test", state: "PENDING", startedAt: "2026-04-14T10:00:00Z", completedAt: null },
+        ]));
+      },
+    );
+
+    const result = await ghService.getCheckRuns(42, "/repo");
+
+    expect(result.aggregate).toBe("pending");
+    expect(result.runs[1].status).toBe("in_progress");
+    expect(result.runs[1].durationMs).toBeNull();
+  });
+
+  it("returns no_checks when array is empty", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, "[]");
+      },
+    );
+
+    const result = await ghService.getCheckRuns(42, "/repo");
+
+    expect(result.aggregate).toBe("no_checks");
+    expect(result.runs).toHaveLength(0);
+  });
+
+  it("returns no_checks on gh CLI error", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error("gh not found"));
+      },
+    );
+
+    const result = await ghService.getCheckRuns(42, "/repo");
+
+    expect(result.aggregate).toBe("no_checks");
+    expect(result.runs).toHaveLength(0);
+  });
+});

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -107,6 +107,39 @@ describe("GithubService.getCheckRuns", () => {
     expect(result.runs).toHaveLength(0);
   });
 
+  it("maps ACTION_REQUIRED state to failing aggregate and failure conclusion", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, JSON.stringify([
+          { name: "security-check", state: "ACTION_REQUIRED", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:10Z" },
+        ]));
+      },
+    );
+
+    const result = await ghService.getCheckRuns(42, "/repo");
+
+    expect(result.aggregate).toBe("failing");
+    expect(result.runs[0].conclusion).toBe("failure");
+    expect(result.runs[0].status).toBe("completed");
+  });
+
+  it("maps STALE state to cancelled conclusion without affecting passing aggregate", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, JSON.stringify([
+          { name: "build", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          { name: "old-check", state: "STALE", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:05Z" },
+        ]));
+      },
+    );
+
+    const result = await ghService.getCheckRuns(42, "/repo");
+
+    expect(result.aggregate).toBe("passing");
+    expect(result.runs[1].conclusion).toBe("cancelled");
+    expect(result.runs[1].status).toBe("completed");
+  });
+
   it("returns no_checks on gh CLI error", async () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -77,6 +77,23 @@ describe("GithubService.getCheckRuns", () => {
     expect(result.runs[1].durationMs).toBeNull();
   });
 
+  it("returns pending status when a check is queued", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, JSON.stringify([
+          { name: "deploy", state: "QUEUED", startedAt: null, completedAt: null },
+        ]));
+      },
+    );
+
+    const result = await ghService.getCheckRuns(42, "/repo");
+
+    expect(result.aggregate).toBe("pending");
+    expect(result.runs[0].status).toBe("queued");
+    expect(result.runs[0].conclusion).toBeNull();
+    expect(result.runs[0].durationMs).toBeNull();
+  });
+
   it("returns no_checks when array is empty", async () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -35,6 +35,7 @@ import { MemoryPressureService } from "./services/memory-pressure-service";
 import { WorkspaceRepo } from "./repositories/workspace-repo";
 import { CleanupWorker } from "./services/cleanup-worker";
 import { PrDraftService } from "./services/pr-draft-service";
+import { CiWatcherService } from "./services/ci-watcher";
 import { ProviderRegistry } from "./providers/provider-registry";
 import { WebSocket } from "ws";
 import { AgentEventType } from "@mcode/contracts";
@@ -119,6 +120,12 @@ ipcServer.onConnection((port) => {
   portPush.attach(port);
 });
 
+// Construct CI watcher with a combined broadcast that covers both WebSocket and IPC push
+const ciWatcherService = new CiWatcherService(githubService, (channel, data) => {
+  broadcast(channel as Parameters<typeof broadcast>[0], data as Parameters<typeof broadcast>[1]);
+  portPush.send(channel as Parameters<typeof portPush.send>[0], data as Parameters<typeof portPush.send>[1]);
+});
+
 // Wire up PTY sender to broadcast push events
 terminalService.setSender((channel, data) => {
   if (channel === "terminal.data") {
@@ -145,8 +152,26 @@ if (removed > 0) {
 
 // Initialize HEAD file watchers for all existing workspaces so branch changes
 // are detected after a server restart.
-for (const ws of workspaceRepo.listAll()) {
+const allWorkspaces = workspaceRepo.listAll();
+for (const ws of allWorkspaces) {
   gitWatcherService.watchWorkspace(ws.id, ws.path);
+}
+
+// Seed CI check watcher with all threads that have open PRs
+{
+  const workspacePaths = new Map(allWorkspaces.map((ws) => [ws.id, ws.path]));
+  const allThreads: ReturnType<typeof threadService.list> = [];
+  for (const ws of allWorkspaces) {
+    const threads = threadService.list(ws.id);
+    allThreads.push(...threads);
+  }
+  ciWatcherService.seed(
+    allThreads,
+    workspacePaths,
+    (threadId) => allThreads.find((t) => t.id === threadId)?.workspace_id ?? null,
+  ).catch((err) => {
+    logger.warn("CiWatcher seed failed", { error: String(err) });
+  });
 }
 
 // Wire up push broadcasting for agent events and thread status changes.
@@ -234,6 +259,7 @@ const { httpServer, wss } = createWsServer({
   taskRepo,
   providerRegistry,
   prDraftService,
+  ciWatcherService,
   threadRepo,
   workspaceRepo,
   authToken: AUTH_TOKEN,
@@ -365,6 +391,9 @@ async function shutdown(): Promise<void> {
 
   // 8a. Dispose cleanup worker
   cleanupWorker.dispose();
+
+  // 8b. Dispose CI check watcher timers
+  ciWatcherService.dispose();
 
   // 9. Close all WebSocket clients and shut down the WS server
   for (const client of wss.clients) {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -219,6 +219,11 @@ for (const provider of providerRegistry.resolveAll()) {
               broadcast("thread.prLinked", prPayload);
               portPush.send("thread.prLinked", prPayload);
             }
+            // Start CI watching if PR is open/active
+            const prState = pr.state.toLowerCase();
+            if (prState !== "merged" && prState !== "closed") {
+              ciWatcherService.watch(thread.id, pr.number, workspace.path);
+            }
           }).catch((err) => {
             logger.debug("PR lookup failed on turnComplete", {
               threadId: thread.id,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -219,10 +219,12 @@ for (const provider of providerRegistry.resolveAll()) {
               broadcast("thread.prLinked", prPayload);
               portPush.send("thread.prLinked", prPayload);
             }
-            // Start CI watching if PR is open/active
+            // Start CI watching if PR is open/active; stop watching if it became terminal.
             const prState = pr.state.toLowerCase();
             if (prState !== "merged" && prState !== "closed") {
               ciWatcherService.watch(thread.id, pr.number, workspace.path);
+            } else {
+              ciWatcherService.unwatch(thread.id);
             }
           }).catch((err) => {
             logger.debug("PR lookup failed on turnComplete", {

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -91,6 +91,8 @@ export class CiWatcherService {
 
   /**
    * Update the cached status for a thread and broadcast the change.
+   * Mirrors tick()'s promote/demote logic so a manual refresh keeps the
+   * polling cadence correct (e.g. pending → active set, terminal → passive set).
    * Used by the manual-refresh RPC to keep all clients in sync.
    */
   refresh(threadId: string, checks: ChecksStatus): void {
@@ -98,6 +100,19 @@ export class CiWatcherService {
     if (!entry) return;
     entry.cache = checks;
     this.broadcast("thread.checksUpdated", { threadId, checks });
+
+    // Promote to active when checks are running, demote to passive when terminal.
+    if (this.passive.has(threadId) && checks.aggregate === "pending") {
+      this.passive.delete(threadId);
+      this.active.set(threadId, entry);
+      this.startActiveTimer();
+      if (this.passive.size === 0) this.stopPassiveTimer();
+    } else if (this.active.has(threadId) && checks.aggregate !== "pending") {
+      this.active.delete(threadId);
+      this.passive.set(threadId, entry);
+      this.startPassiveTimer();
+      if (this.active.size === 0) this.stopActiveTimer();
+    }
   }
 
   /**

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -1,0 +1,175 @@
+import { logger } from "@mcode/shared";
+import type { GithubService } from "./github-service";
+import type { ChecksStatus } from "@mcode/contracts";
+
+/** Internal tracking entry for a watched thread. */
+export interface WatchEntry {
+  threadId: string;
+  prNumber: number;
+  repoPath: string;
+  cache: ChecksStatus | null;
+}
+
+/** Broadcast function signature matching the server push system. */
+type BroadcastFn = (channel: string, data: unknown) => void;
+
+const ACTIVE_INTERVAL_MS = 10_000;
+const PASSIVE_INTERVAL_MS = 60_000;
+
+/**
+ * Server-side CI check watcher with adaptive dual-interval polling.
+ * Threads with in-progress checks poll at 10s; terminal checks poll at 60s.
+ * Broadcasts `thread.checksUpdated` only when state changes.
+ */
+export class CiWatcherService {
+  private active = new Map<string, WatchEntry>();
+  private passive = new Map<string, WatchEntry>();
+  private activeTimer: ReturnType<typeof setInterval> | null = null;
+  private passiveTimer: ReturnType<typeof setInterval> | null = null;
+  private rateLimitedUntil = 0;
+
+  constructor(
+    private readonly githubService: GithubService,
+    private readonly broadcast: BroadcastFn,
+  ) {
+    this.startPassiveTimer();
+  }
+
+  /** Add a thread to the watcher. Starts in the passive set. */
+  watch(threadId: string, prNumber: number, repoPath: string): void {
+    if (this.active.has(threadId) || this.passive.has(threadId)) return;
+    this.passive.set(threadId, { threadId, prNumber, repoPath, cache: null });
+  }
+
+  /** Remove a thread from the watcher entirely. */
+  unwatch(threadId: string): void {
+    this.active.delete(threadId);
+    this.passive.delete(threadId);
+    if (this.active.size === 0) this.stopActiveTimer();
+  }
+
+  /** Check if a thread is being watched. */
+  isWatching(threadId: string): boolean {
+    return this.active.has(threadId) || this.passive.has(threadId);
+  }
+
+  /** Get the current entry for a thread (for manual refresh). */
+  getEntry(threadId: string): WatchEntry | null {
+    return this.active.get(threadId) ?? this.passive.get(threadId) ?? null;
+  }
+
+  /**
+   * Seed the watcher from existing threads with open PRs.
+   * Called once on server startup.
+   */
+  async seed(
+    threads: Array<{ id: string; pr_number: number | null; pr_status: string | null; branch: string }>,
+    workspacePaths: Map<string, string>,
+    getWorkspaceId: (threadId: string) => string | null,
+  ): Promise<void> {
+    const candidates = threads.filter(
+      (t) => t.pr_number != null && t.pr_status != null
+        && t.pr_status.toLowerCase() !== "merged"
+        && t.pr_status.toLowerCase() !== "closed",
+    );
+
+    const fetches = candidates.map(async (t) => {
+      const wsId = getWorkspaceId(t.id);
+      const repoPath = wsId ? workspacePaths.get(wsId) : undefined;
+      if (!repoPath || t.pr_number == null) return;
+
+      try {
+        const checks = await this.githubService.getCheckRuns(t.pr_number, repoPath);
+        const entry: WatchEntry = { threadId: t.id, prNumber: t.pr_number, repoPath, cache: checks };
+
+        if (checks.aggregate === "pending") {
+          this.active.set(t.id, entry);
+        } else {
+          this.passive.set(t.id, entry);
+        }
+      } catch (err) {
+        logger.debug("CiWatcher seed failed for thread", { threadId: t.id, error: String(err) });
+      }
+    });
+
+    await Promise.allSettled(fetches);
+
+    if (this.active.size > 0) this.startActiveTimer();
+    logger.info(`CiWatcher seeded: ${this.active.size} active, ${this.passive.size} passive`);
+  }
+
+  /** Clean up all timers. Called on server shutdown. */
+  dispose(): void {
+    this.stopActiveTimer();
+    this.stopPassiveTimer();
+  }
+
+  private startActiveTimer(): void {
+    if (this.activeTimer) return;
+    this.activeTimer = setInterval(() => this.tick(this.active), ACTIVE_INTERVAL_MS);
+  }
+
+  private stopActiveTimer(): void {
+    if (this.activeTimer) {
+      clearInterval(this.activeTimer);
+      this.activeTimer = null;
+    }
+  }
+
+  private startPassiveTimer(): void {
+    if (this.passiveTimer) return;
+    this.passiveTimer = setInterval(() => this.tick(this.passive), PASSIVE_INTERVAL_MS);
+  }
+
+  private stopPassiveTimer(): void {
+    if (this.passiveTimer) {
+      clearInterval(this.passiveTimer);
+      this.passiveTimer = null;
+    }
+  }
+
+  private async tick(set: Map<string, WatchEntry>): Promise<void> {
+    if (set.size === 0) return;
+    if (Date.now() < this.rateLimitedUntil) return;
+
+    const entries = [...set.values()];
+    const results = await Promise.allSettled(
+      entries.map(async (entry) => {
+        const checks = await this.githubService.getCheckRuns(entry.prNumber, entry.repoPath);
+        return { entry, checks };
+      }),
+    );
+
+    for (const result of results) {
+      if (result.status === "rejected") continue;
+      const { entry, checks } = result.value;
+
+      const changed = entry.cache == null || entry.cache.aggregate !== checks.aggregate
+        || entry.cache.runs.length !== checks.runs.length
+        || entry.cache.runs.some((r, i) => {
+          const nr = checks.runs[i];
+          return nr && (r.status !== nr.status || r.conclusion !== nr.conclusion);
+        });
+
+      entry.cache = checks;
+
+      if (changed) {
+        this.broadcast("thread.checksUpdated", {
+          threadId: entry.threadId,
+          checks,
+        });
+      }
+
+      // Promote/demote between sets
+      if (set === this.passive && checks.aggregate === "pending") {
+        this.passive.delete(entry.threadId);
+        this.active.set(entry.threadId, entry);
+        this.startActiveTimer();
+      } else if (set === this.active && checks.aggregate !== "pending") {
+        this.active.delete(entry.threadId);
+        this.passive.set(entry.threadId, entry);
+        if (this.active.size === 0) this.stopActiveTimer();
+      }
+    }
+  }
+}

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -13,7 +13,10 @@ export interface WatchEntry {
 /** Broadcast function signature matching the server push system. */
 type BroadcastFn = (channel: string, data: unknown) => void;
 
+// 10s for in-progress checks: responsive enough to catch completion within a PR review window.
+// Worst case: 5 active threads × 6 calls/min = 30 calls/min, well within GitHub's 5000/hr limit.
 const ACTIVE_INTERVAL_MS = 10_000;
+// 60s for terminal checks: keeps open-PR state fresh without burning API quota.
 const PASSIVE_INTERVAL_MS = 60_000;
 
 /**
@@ -62,6 +65,17 @@ export class CiWatcherService {
   }
 
   /**
+   * Update the cached status for a thread and broadcast the change.
+   * Used by the manual-refresh RPC to keep all clients in sync.
+   */
+  refresh(threadId: string, checks: ChecksStatus): void {
+    const entry = this.active.get(threadId) ?? this.passive.get(threadId);
+    if (!entry) return;
+    entry.cache = checks;
+    this.broadcast("thread.checksUpdated", { threadId, checks });
+  }
+
+  /**
    * Seed the watcher from existing threads with open PRs.
    * Called once on server startup.
    */
@@ -81,14 +95,22 @@ export class CiWatcherService {
       const repoPath = wsId ? workspacePaths.get(wsId) : undefined;
       if (!repoPath || t.pr_number == null) return;
 
+      // Insert placeholder synchronously so concurrent watch() calls see this threadId
+      // and skip re-insertion during the async fetch window.
+      if (!this.active.has(t.id) && !this.passive.has(t.id)) {
+        this.passive.set(t.id, { threadId: t.id, prNumber: t.pr_number, repoPath, cache: null });
+      }
+
       try {
         const checks = await this.githubService.getCheckRuns(t.pr_number, repoPath);
-        const entry: WatchEntry = { threadId: t.id, prNumber: t.pr_number, repoPath, cache: checks };
+        const entry = this.passive.get(t.id) ?? this.active.get(t.id);
+        if (!entry) return; // was unwatched during fetch
+        entry.cache = checks;
 
+        // Promote to active if checks are pending; it's already in passive
         if (checks.aggregate === "pending") {
+          this.passive.delete(t.id);
           this.active.set(t.id, entry);
-        } else {
-          this.passive.set(t.id, entry);
         }
       } catch (err) {
         logger.debug("CiWatcher seed failed for thread", { threadId: t.id, error: String(err) });

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -16,12 +16,13 @@ type BroadcastFn = (channel: string, data: unknown) => void;
 // 10s for in-progress checks: responsive enough to catch completion within a PR review window.
 // Worst case: 5 active threads × 6 calls/min = 30 calls/min, well within GitHub's 5000/hr limit.
 const ACTIVE_INTERVAL_MS = 10_000;
-// 60s for terminal checks: keeps open-PR state fresh without burning API quota.
-const PASSIVE_INTERVAL_MS = 60_000;
+// 30s for terminal checks: catches re-triggered CI runs within half a minute.
+// Worst case: 5 passive threads × 2 calls/min = 10 calls/min, well within GitHub's 5000/hr limit.
+const PASSIVE_INTERVAL_MS = 30_000;
 
 /**
  * Server-side CI check watcher with adaptive dual-interval polling.
- * Threads with in-progress checks poll at 10s; terminal checks poll at 60s.
+ * Threads with in-progress checks poll at 10s; terminal checks poll at 30s.
  * Broadcasts `thread.checksUpdated` only when state changes.
  */
 export class CiWatcherService {
@@ -39,13 +40,19 @@ export class CiWatcherService {
     this.startPassiveTimer();
   }
 
-  /** Add a thread to the watcher. Starts in the passive set with an immediate first fetch. */
-  watch(threadId: string, prNumber: number, repoPath: string): void {
+  /**
+   * Add a thread to the watcher. Starts in the passive set with an immediate first fetch.
+   * Pass `skipInitialFetch: true` when the caller will fetch and broadcast the result itself,
+   * to avoid spawning a redundant concurrent subprocess.
+   */
+  watch(threadId: string, prNumber: number, repoPath: string, opts?: { skipInitialFetch?: boolean }): void {
     if (this.active.has(threadId) || this.passive.has(threadId)) return;
     this.passive.set(threadId, { threadId, prNumber, repoPath, cache: null });
     this.startPassiveTimer();
 
-    // Fetch immediately so the client gets data without waiting up to 60s for the passive tick.
+    if (opts?.skipInitialFetch) return;
+
+    // Fetch immediately so the client gets data without waiting for the passive tick.
     this.githubService.getCheckRuns(prNumber, repoPath).then((checks) => {
       const entry = this.passive.get(threadId) ?? this.active.get(threadId);
       if (!entry) return; // unwatched during fetch
@@ -55,8 +62,12 @@ export class CiWatcherService {
         this.passive.delete(threadId);
         this.active.set(threadId, entry);
         this.startActiveTimer();
+        // Passive set just shrank — stop passive timer if it's now empty.
+        if (this.passive.size === 0) this.stopPassiveTimer();
       }
-    }).catch(() => { /* ignore — passive tick will retry */ });
+    }).catch((err) => {
+      logger.debug("CiWatcher initial fetch failed", { threadId, error: String(err) });
+    });
   }
 
   /** Remove a thread from the watcher entirely. */
@@ -64,7 +75,8 @@ export class CiWatcherService {
     this.active.delete(threadId);
     this.passive.delete(threadId);
     if (this.active.size === 0) this.stopActiveTimer();
-    if (this.passive.size === 0 && this.active.size === 0) this.stopPassiveTimer();
+    // Stop the passive timer independently — it's not needed just because active is non-empty.
+    if (this.passive.size === 0) this.stopPassiveTimer();
   }
 
   /** Check if a thread is being watched. */
@@ -213,9 +225,12 @@ export class CiWatcherService {
         this.passive.delete(entry.threadId);
         this.active.set(entry.threadId, entry);
         this.startActiveTimer();
+        // Passive set shrank — stop timer if now empty.
+        if (this.passive.size === 0) this.stopPassiveTimer();
       } else if (set === this.active && checks.aggregate !== "pending") {
         this.active.delete(entry.threadId);
         this.passive.set(entry.threadId, entry);
+        this.startPassiveTimer();
         if (this.active.size === 0) this.stopActiveTimer();
       }
     }

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -90,7 +90,7 @@ export class CiWatcherService {
   }
 
   /**
-   * Update the cached status for a thread and broadcast the change.
+   * Update the cached status for a thread and broadcast if anything changed.
    * Mirrors tick()'s promote/demote logic so a manual refresh keeps the
    * polling cadence correct (e.g. pending → active set, terminal → passive set).
    * Used by the manual-refresh RPC to keep all clients in sync.
@@ -98,8 +98,11 @@ export class CiWatcherService {
   refresh(threadId: string, checks: ChecksStatus): void {
     const entry = this.active.get(threadId) ?? this.passive.get(threadId);
     if (!entry) return;
+    const changed = this.hasChanged(entry.cache, checks);
     entry.cache = checks;
-    this.broadcast("thread.checksUpdated", { threadId, checks });
+    if (changed) {
+      this.broadcast("thread.checksUpdated", { threadId, checks });
+    }
 
     // Promote to active when checks are running, demote to passive when terminal.
     if (this.passive.has(threadId) && checks.aggregate === "pending") {
@@ -201,6 +204,17 @@ export class CiWatcherService {
     }
   }
 
+  /** Returns true when `next` differs semantically from `cached` (aggregate, run count, or per-run status/conclusion). */
+  private hasChanged(cached: ChecksStatus | null, next: ChecksStatus): boolean {
+    return cached == null
+      || cached.aggregate !== next.aggregate
+      || cached.runs.length !== next.runs.length
+      || cached.runs.some((r, i) => {
+        const nr = next.runs[i];
+        return nr && (r.status !== nr.status || r.conclusion !== nr.conclusion);
+      });
+  }
+
   private async tick(set: Map<string, WatchEntry>): Promise<void> {
     if (set.size === 0) return;
 
@@ -219,13 +233,7 @@ export class CiWatcherService {
       // Guard: thread was unwatched while the fetch was in flight
       if (!this.active.has(entry.threadId) && !this.passive.has(entry.threadId)) continue;
 
-      const changed = entry.cache == null || entry.cache.aggregate !== checks.aggregate
-        || entry.cache.runs.length !== checks.runs.length
-        || entry.cache.runs.some((r, i) => {
-          const nr = checks.runs[i];
-          return nr && (r.status !== nr.status || r.conclusion !== nr.conclusion);
-        });
-
+      const changed = this.hasChanged(entry.cache, checks);
       entry.cache = checks;
 
       if (changed) {

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -39,11 +39,24 @@ export class CiWatcherService {
     this.startPassiveTimer();
   }
 
-  /** Add a thread to the watcher. Starts in the passive set. */
+  /** Add a thread to the watcher. Starts in the passive set with an immediate first fetch. */
   watch(threadId: string, prNumber: number, repoPath: string): void {
     if (this.active.has(threadId) || this.passive.has(threadId)) return;
     this.passive.set(threadId, { threadId, prNumber, repoPath, cache: null });
     this.startPassiveTimer();
+
+    // Fetch immediately so the client gets data without waiting up to 60s for the passive tick.
+    this.githubService.getCheckRuns(prNumber, repoPath).then((checks) => {
+      const entry = this.passive.get(threadId) ?? this.active.get(threadId);
+      if (!entry) return; // unwatched during fetch
+      entry.cache = checks;
+      this.broadcast("thread.checksUpdated", { threadId, checks });
+      if (checks.aggregate === "pending") {
+        this.passive.delete(threadId);
+        this.active.set(threadId, entry);
+        this.startActiveTimer();
+      }
+    }).catch(() => { /* ignore — passive tick will retry */ });
   }
 
   /** Remove a thread from the watcher entirely. */

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -26,7 +26,8 @@ export class CiWatcherService {
   private passive = new Map<string, WatchEntry>();
   private activeTimer: ReturnType<typeof setInterval> | null = null;
   private passiveTimer: ReturnType<typeof setInterval> | null = null;
-  private rateLimitedUntil = 0;
+  private activeTicking = false;
+  private passiveTicking = false;
 
   constructor(
     private readonly githubService: GithubService,
@@ -39,6 +40,7 @@ export class CiWatcherService {
   watch(threadId: string, prNumber: number, repoPath: string): void {
     if (this.active.has(threadId) || this.passive.has(threadId)) return;
     this.passive.set(threadId, { threadId, prNumber, repoPath, cache: null });
+    this.startPassiveTimer();
   }
 
   /** Remove a thread from the watcher entirely. */
@@ -46,6 +48,7 @@ export class CiWatcherService {
     this.active.delete(threadId);
     this.passive.delete(threadId);
     if (this.active.size === 0) this.stopActiveTimer();
+    if (this.passive.size === 0 && this.active.size === 0) this.stopPassiveTimer();
   }
 
   /** Check if a thread is being watched. */
@@ -106,7 +109,11 @@ export class CiWatcherService {
 
   private startActiveTimer(): void {
     if (this.activeTimer) return;
-    this.activeTimer = setInterval(() => this.tick(this.active), ACTIVE_INTERVAL_MS);
+    this.activeTimer = setInterval(async () => {
+      if (this.activeTicking) return;
+      this.activeTicking = true;
+      try { await this.tick(this.active); } finally { this.activeTicking = false; }
+    }, ACTIVE_INTERVAL_MS);
   }
 
   private stopActiveTimer(): void {
@@ -118,7 +125,11 @@ export class CiWatcherService {
 
   private startPassiveTimer(): void {
     if (this.passiveTimer) return;
-    this.passiveTimer = setInterval(() => this.tick(this.passive), PASSIVE_INTERVAL_MS);
+    this.passiveTimer = setInterval(async () => {
+      if (this.passiveTicking) return;
+      this.passiveTicking = true;
+      try { await this.tick(this.passive); } finally { this.passiveTicking = false; }
+    }, PASSIVE_INTERVAL_MS);
   }
 
   private stopPassiveTimer(): void {
@@ -130,7 +141,6 @@ export class CiWatcherService {
 
   private async tick(set: Map<string, WatchEntry>): Promise<void> {
     if (set.size === 0) return;
-    if (Date.now() < this.rateLimitedUntil) return;
 
     const entries = [...set.values()];
     const results = await Promise.allSettled(
@@ -143,6 +153,9 @@ export class CiWatcherService {
     for (const result of results) {
       if (result.status === "rejected") continue;
       const { entry, checks } = result.value;
+
+      // Guard: thread was unwatched while the fetch was in flight
+      if (!this.active.has(entry.threadId) && !this.passive.has(entry.threadId)) continue;
 
       const changed = entry.cache == null || entry.cache.aggregate !== checks.aggregate
         || entry.cache.runs.length !== checks.runs.length

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -6,7 +6,7 @@
 
 import { injectable, inject } from "tsyringe";
 import { execFile } from "child_process";
-import type { PrInfo, PrDetail } from "@mcode/contracts";
+import type { PrInfo, PrDetail, ChecksStatus } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 
 /** Handles GitHub PR lookups and listing via the gh CLI. */
@@ -155,6 +155,80 @@ export class GithubService {
           const number = parseInt(prUrlMatch[1], 10);
           const url = prUrlMatch[0];
           resolve({ number, url });
+        },
+      );
+    });
+  }
+
+  /**
+   * Fetch CI check runs for a PR. Uses `gh pr checks` for simplicity.
+   * Returns aggregate status and individual check details.
+   */
+  getCheckRuns(prNumber: number, repoPath: string): Promise<ChecksStatus> {
+    return new Promise((resolve) => {
+      execFile(
+        "gh",
+        ["pr", "checks", String(prNumber), "--json", "name,state,startedAt,completedAt"],
+        { cwd: repoPath, encoding: "utf-8", timeout: 15_000 },
+        (error, stdout) => {
+          const now = Date.now();
+          if (error || !stdout) {
+            resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });
+            return;
+          }
+          try {
+            const items = JSON.parse(stdout) as Array<{
+              name?: string;
+              state?: string;
+              startedAt?: string | null;
+              completedAt?: string | null;
+            }>;
+
+            if (items.length === 0) {
+              resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });
+              return;
+            }
+
+            const runs = items.map((item) => {
+              const ghState = (item.state ?? "").toUpperCase();
+              const completed = ghState === "SUCCESS" || ghState === "FAILURE"
+                || ghState === "CANCELLED" || ghState === "SKIPPED"
+                || ghState === "TIMED_OUT" || ghState === "NEUTRAL";
+
+              const status = completed ? "completed" as const
+                : ghState === "QUEUED" ? "queued" as const
+                : "in_progress" as const;
+
+              const conclusion = completed
+                ? ghState.toLowerCase() as "success" | "failure" | "cancelled" | "skipped" | "timed_out" | "neutral"
+                : null;
+
+              let durationMs: number | null = null;
+              if (completed && item.startedAt && item.completedAt) {
+                durationMs = new Date(item.completedAt).getTime() - new Date(item.startedAt).getTime();
+              }
+
+              return {
+                name: item.name ?? "unknown",
+                status,
+                conclusion,
+                durationMs,
+              };
+            });
+
+            let aggregate: "passing" | "failing" | "pending" | "no_checks";
+            if (runs.some((r) => r.conclusion === "failure" || r.conclusion === "timed_out")) {
+              aggregate = "failing";
+            } else if (runs.some((r) => r.status !== "completed")) {
+              aggregate = "pending";
+            } else {
+              aggregate = "passing";
+            }
+
+            resolve({ aggregate, runs, fetchedAt: now });
+          } catch {
+            resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });
+          }
         },
       );
     });

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -6,7 +6,7 @@
 
 import { injectable, inject } from "tsyringe";
 import { execFile } from "child_process";
-import type { PrInfo, PrDetail, ChecksStatus } from "@mcode/contracts";
+import type { PrInfo, PrDetail, ChecksStatus, CheckRun } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 
 /** Handles GitHub PR lookups and listing via the gh CLI. */
@@ -193,15 +193,25 @@ export class GithubService {
               const ghState = (item.state ?? "").toUpperCase();
               const completed = ghState === "SUCCESS" || ghState === "FAILURE"
                 || ghState === "CANCELLED" || ghState === "SKIPPED"
-                || ghState === "TIMED_OUT" || ghState === "NEUTRAL";
+                || ghState === "TIMED_OUT" || ghState === "NEUTRAL"
+                || ghState === "ACTION_REQUIRED" || ghState === "STALE";
 
               const status = completed ? "completed" as const
                 : ghState === "QUEUED" ? "queued" as const
                 : "in_progress" as const;
 
-              const conclusion = completed
-                ? ghState.toLowerCase() as "success" | "failure" | "cancelled" | "skipped" | "timed_out" | "neutral"
-                : null;
+              // ACTION_REQUIRED blocks merge like a failure; STALE is abandoned (terminal like cancelled).
+              const conclusionMap: Record<string, CheckRun["conclusion"]> = {
+                SUCCESS: "success",
+                FAILURE: "failure",
+                CANCELLED: "cancelled",
+                SKIPPED: "skipped",
+                TIMED_OUT: "timed_out",
+                NEUTRAL: "neutral",
+                ACTION_REQUIRED: "failure",
+                STALE: "cancelled",
+              };
+              const conclusion = completed ? (conclusionMap[ghState] ?? "cancelled") : null;
 
               let durationMs: number | null = null;
               if (completed && item.startedAt && item.completedAt) {
@@ -223,6 +233,12 @@ export class GithubService {
               aggregate = "pending";
             } else {
               aggregate = "passing";
+            }
+
+            // If all runs completed but none succeeded (all skipped/cancelled/neutral),
+            // treat as no_checks to avoid a misleading green badge.
+            if (aggregate === "passing" && !runs.some((r) => r.conclusion === "success")) {
+              aggregate = "no_checks";
             }
 
             resolve({ aggregate, runs, fetchedAt: now });

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -199,11 +199,13 @@ async function dispatch(
         params.mode,
         params.branch,
       );
-    case "thread.delete":
+    case "thread.delete": {
+      deps.ciWatcherService.unwatch(params.threadId);
       return deps.threadService.delete(
         params.threadId,
         params.cleanupWorktree,
       );
+    }
     case "thread.updateTitle":
       return deps.threadService.updateTitle(
         params.threadId,
@@ -240,6 +242,13 @@ async function dispatch(
             if (numberChanged || statusChanged) {
               deps.threadService.linkPr(t.id, pr.number, pr.state);
               results.push({ threadId: t.id, prNumber: pr.number, prStatus: pr.state });
+            }
+            // Start CI watching if PR is not in terminal state
+            const prState = pr.state.toLowerCase();
+            if (prState !== "merged" && prState !== "closed") {
+              deps.ciWatcherService.watch(t.id, pr.number, workspace.path);
+            } else {
+              deps.ciWatcherService.unwatch(t.id);
             }
           }
         }),

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -371,9 +371,13 @@ async function dispatch(
         const thread = deps.threadRepo.findById(params.threadId);
         const prState = thread?.pr_status?.toLowerCase();
         const isTerminal = prState === "merged" || prState === "closed";
-        if (thread?.pr_number && !isTerminal) {
+        if (thread?.pr_number) {
           const workspace = deps.workspaceRepo.findById(thread.workspace_id);
           if (workspace) {
+            if (isTerminal) {
+              // Terminal PR: one-shot fetch without registering in the watcher — no need to poll.
+              return deps.githubService.getCheckRuns(thread.pr_number, workspace.path);
+            }
             // skipInitialFetch: checkStatus will fetch and broadcast below, no need for a second subprocess.
             deps.ciWatcherService.watch(params.threadId, thread.pr_number, workspace.path, { skipInitialFetch: true });
             entry = deps.ciWatcherService.getEntry(params.threadId);

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -372,7 +372,8 @@ async function dispatch(
         if (thread?.pr_number) {
           const workspace = deps.workspaceRepo.findById(thread.workspace_id);
           if (workspace) {
-            deps.ciWatcherService.watch(params.threadId, thread.pr_number, workspace.path);
+            // skipInitialFetch: checkStatus will fetch and broadcast below, no need for a second subprocess.
+            deps.ciWatcherService.watch(params.threadId, thread.pr_number, workspace.path, { skipInitialFetch: true });
             entry = deps.ciWatcherService.getEntry(params.threadId);
           }
         }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -364,7 +364,19 @@ async function dispatch(
     case "github.prByUrl":
       return deps.githubService.getPrByUrl(params.url);
     case "github.checkStatus": {
-      const entry = deps.ciWatcherService.getEntry(params.threadId);
+      let entry = deps.ciWatcherService.getEntry(params.threadId);
+      if (!entry) {
+        // Bootstrap: thread may not be in the watcher yet (e.g. connect race before syncThreadPrs).
+        // Look up the stored PR number and start watching so future polls work automatically.
+        const thread = deps.threadRepo.findById(params.threadId);
+        if (thread?.pr_number) {
+          const workspace = deps.workspaceRepo.findById(thread.workspace_id);
+          if (workspace) {
+            deps.ciWatcherService.watch(params.threadId, thread.pr_number, workspace.path);
+            entry = deps.ciWatcherService.getEntry(params.threadId);
+          }
+        }
+      }
       if (!entry) {
         return { aggregate: "no_checks" as const, runs: [], fetchedAt: Date.now() };
       }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -369,7 +369,9 @@ async function dispatch(
         // Bootstrap: thread may not be in the watcher yet (e.g. connect race before syncThreadPrs).
         // Look up the stored PR number and start watching so future polls work automatically.
         const thread = deps.threadRepo.findById(params.threadId);
-        if (thread?.pr_number) {
+        const prState = thread?.pr_status?.toLowerCase();
+        const isTerminal = prState === "merged" || prState === "closed";
+        if (thread?.pr_number && !isTerminal) {
           const workspace = deps.workspaceRepo.findById(thread.workspace_id);
           if (workspace) {
             // skipInitialFetch: checkStatus will fetch and broadcast below, no need for a second subprocess.

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -38,6 +38,7 @@ import type { SettingsService } from "../services/settings-service";
 import type { GitWatcherService } from "../services/git-watcher-service";
 import type { MemoryPressureService } from "../services/memory-pressure-service";
 import type { PrDraftService } from "../services/pr-draft-service";
+import type { CiWatcherService } from "../services/ci-watcher";
 import type { ThreadRepo } from "../repositories/thread-repo";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import { broadcast } from "./push";
@@ -67,6 +68,8 @@ export interface RouterDeps {
   providerRegistry: IProviderRegistry;
   /** Generates AI-powered PR draft titles and bodies. */
   prDraftService: PrDraftService;
+  /** CI check watcher for adaptive polling and manual refresh. */
+  ciWatcherService: CiWatcherService;
   /** Thread repository for resolving worktree paths in git operations. */
   threadRepo: ThreadRepo;
   /** Workspace repository for resolving repo paths in git operations. */
@@ -351,6 +354,15 @@ async function dispatch(
       return deps.githubService.listOpenPrs(params.workspaceId);
     case "github.prByUrl":
       return deps.githubService.getPrByUrl(params.url);
+    case "github.checkStatus": {
+      const entry = deps.ciWatcherService.getEntry(params.threadId);
+      if (!entry) {
+        return { aggregate: "no_checks" as const, runs: [], fetchedAt: Date.now() };
+      }
+      const checks = await deps.githubService.getCheckRuns(entry.prNumber, entry.repoPath);
+      entry.cache = checks;
+      return checks;
+    }
 
     // Config
     case "config.discover":
@@ -567,6 +579,9 @@ async function dispatch(
         prNumber: result.number,
         prStatus: "OPEN",
       });
+
+      // Start watching CI checks for the newly created PR
+      deps.ciWatcherService.watch(params.threadId, result.number, repoPath);
 
       return result;
     }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -369,7 +369,7 @@ async function dispatch(
         return { aggregate: "no_checks" as const, runs: [], fetchedAt: Date.now() };
       }
       const checks = await deps.githubService.getCheckRuns(entry.prNumber, entry.repoPath);
-      entry.cache = checks;
+      deps.ciWatcherService.refresh(params.threadId, checks);
       return checks;
     }
 

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -105,6 +105,7 @@ export const mockTransport: McodeTransport = {
   listOpenPrs: vi.fn().mockResolvedValue([]),
   fetchBranch: vi.fn().mockResolvedValue(undefined),
   getPrByUrl: vi.fn().mockResolvedValue(null),
+  checkStatus: vi.fn().mockResolvedValue({ aggregate: "no_checks", runs: [], fetchedAt: 0 }),
   listSkills: vi.fn().mockResolvedValue([] as SkillInfo[]),
   terminalCreate: vi.fn().mockResolvedValue("pty-mock-1"),
   terminalWrite: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { CircleCheck, CircleX, Loader2, RefreshCw, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -11,8 +11,6 @@ import type { ChecksStatus, CheckRun } from "@mcode/contracts";
 interface ChecksPopoverProps {
   /** Thread ID used for refresh requests. */
   threadId: string;
-  /** GitHub PR number. */
-  prNumber: number;
   /** GitHub PR URL, used for the "View on GitHub" link. */
   prUrl: string;
   /** Optional PR title shown in the header. */
@@ -75,7 +73,6 @@ function summarise(checks: ChecksStatus): string {
  */
 export function ChecksPopover({
   threadId,
-  prNumber: _prNumber,
   prUrl,
   prTitle,
   prAuthor,
@@ -83,14 +80,25 @@ export function ChecksPopover({
   children,
 }: ChecksPopoverProps) {
   const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+
+  // Keep the staleness label current while the popover is mounted.
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(timer);
+  }, []);
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
+    setRefreshError(false);
     try {
       const fresh = await getTransport().checkStatus(threadId);
       useWorkspaceStore.setState((ws) => ({
         checksById: { ...ws.checksById, [threadId]: fresh },
       }));
+    } catch {
+      setRefreshError(true);
     } finally {
       setRefreshing(false);
     }
@@ -118,7 +126,7 @@ export function ChecksPopover({
     return order(a) - order(b);
   });
 
-  const elapsed = Math.round((Date.now() - checks.fetchedAt) / 1000);
+  const elapsed = Math.round((now - checks.fetchedAt) / 1000);
   const staleLabel =
     elapsed < 5
       ? "just now"
@@ -190,6 +198,9 @@ export function ChecksPopover({
           </button>
           <div className="flex items-center gap-2">
             <span className="text-[10px] text-muted-foreground">{staleLabel}</span>
+            {refreshError && (
+              <span className="text-[10px] text-red-400">Refresh failed</span>
+            )}
             <Button
               variant="ghost"
               size="icon-xs"

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { CircleCheck, CircleX, Loader2, RefreshCw, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -113,8 +113,8 @@ export function ChecksPopover({
   const handleOpenGitHub = useCallback(() => {
     try {
       const parsed = new URL(prUrl);
-      // Only allow https URLs to prevent javascript: or other protocol abuse
-      if (parsed.protocol === "https:") {
+      // Only allow https GitHub URLs to prevent protocol abuse or open-redirect to arbitrary hosts.
+      if (parsed.protocol === "https:" && parsed.hostname === "github.com") {
         window.desktopBridge?.openExternalUrl(prUrl);
       }
     } catch {
@@ -122,15 +122,15 @@ export function ChecksPopover({
     }
   }, [prUrl]);
 
-  // Sort: failing first, then running, then passing/other
-  const sortedRuns = [...checks.runs].sort((a, b) => {
+  // Sort: failing first, then running, then passing/other. Memoized to avoid re-sorting on every render.
+  const sortedRuns = useMemo(() => [...checks.runs].sort((a, b) => {
     const order = (r: CheckRun) => {
       if (r.conclusion === "failure" || r.conclusion === "timed_out") return 0;
       if (r.status !== "completed") return 1;
       return 2;
     };
     return order(a) - order(b);
-  });
+  }), [checks.runs]);
 
   const elapsed = Math.round((now - checks.fetchedAt) / 1000);
   const staleLabel =

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { getTransport } from "@/transport";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { getCiVisual } from "@/lib/ci-status";
 import type { ChecksStatus, CheckRun } from "@mcode/contracts";
 
 /** Props for {@link ChecksPopover}. */
@@ -26,18 +27,18 @@ interface ChecksPopoverProps {
 /** Status icon for an individual check run. */
 function CheckIcon({ run }: { run: CheckRun }) {
   if (run.status === "in_progress" || run.status === "queued") {
-    return <Loader2 size={12} className="text-orange-500 animate-spin" />;
+    return <Loader2 size={12} className="text-amber-500 animate-spin shrink-0" />;
   }
   switch (run.conclusion) {
     case "success":
-      return <CircleCheck size={12} className="text-green-500" />;
+      return <CircleCheck size={12} className="text-green-500 shrink-0" />;
     case "failure":
     case "timed_out":
-      return <CircleX size={12} className="text-red-500" />;
+      return <CircleX size={12} className="text-red-500 shrink-0" />;
     case "cancelled":
-      return <CircleX size={12} className="text-muted-foreground" />;
+      return <CircleX size={12} className="text-muted-foreground/50 shrink-0" />;
     default:
-      return <CircleCheck size={12} className="text-muted-foreground" />;
+      return <CircleCheck size={12} className="text-muted-foreground/50 shrink-0" />;
   }
 }
 
@@ -51,21 +52,33 @@ function formatDuration(ms: number): string {
   return remainSecs > 0 ? `${mins}m ${remainSecs}s` : `${mins}m`;
 }
 
-/** Summarise the check runs as a human-readable string. */
-function summarise(checks: ChecksStatus): string {
+/** Summarise the aggregate CI state as a headline string. */
+function aggregateHeadline(checks: ChecksStatus): string {
   const total = checks.runs.length;
-  const passing = checks.runs.filter((r) => r.conclusion === "success").length;
   const failing = checks.runs.filter(
     (r) => r.conclusion === "failure" || r.conclusion === "timed_out",
   ).length;
   const running = checks.runs.filter((r) => r.status !== "completed").length;
 
-  const parts: string[] = [`${total} check${total !== 1 ? "s" : ""}`];
-  if (passing > 0) parts.push(`${passing} passing`);
-  if (failing > 0) parts.push(`${failing} failing`);
-  if (running > 0) parts.push(`${running} running`);
-  return parts.join(" · ");
+  switch (checks.aggregate) {
+    case "passing":
+      return total === 1 ? "1 check passed" : `All ${total} checks passed`;
+    case "failing":
+      return failing === 1 ? "1 check failed" : `${failing} of ${total} checks failed`;
+    case "pending":
+      return running === 1 ? "1 check running" : `${running} checks running`;
+    case "no_checks":
+      return "No checks configured";
+  }
 }
+
+/** Tailwind bg class for the colored accent strip at the top of the popover. */
+const ACCENT_BG: Record<ChecksStatus["aggregate"], string> = {
+  passing: "bg-green-500",
+  failing: "bg-red-500",
+  pending: "bg-amber-500",
+  no_checks: "bg-border",
+};
 
 /**
  * Popover that shows PR metadata and individual CI check run details.
@@ -134,6 +147,10 @@ export function ChecksPopover({
         ? `${elapsed}s ago`
         : `${Math.floor(elapsed / 60)}m ago`;
 
+  const visual = getCiVisual(checks.aggregate);
+  const StatusIcon = visual.icon;
+  const accentBg = ACCENT_BG[checks.aggregate];
+
   return (
     <Popover>
       <PopoverTrigger
@@ -142,64 +159,85 @@ export function ChecksPopover({
       >
         {children}
       </PopoverTrigger>
-      <PopoverContent side="bottom" align="start" sideOffset={6} className="w-72 p-0">
-        {/* Header: PR title and summary */}
-        {prTitle && (
-          <div className="border-b border-border px-3 py-2">
-            <div className="text-sm font-medium text-foreground truncate">{prTitle}</div>
-            <div className="flex items-center gap-1 text-xs text-muted-foreground">
-              {prAuthor && <span>by {prAuthor}</span>}
-              <span>·</span>
-              <span>{summarise(checks)}</span>
+      <PopoverContent side="bottom" align="start" sideOffset={6} className="w-80 p-0 overflow-hidden">
+        {/* Colored status accent strip */}
+        <div className={cn("h-[2px] w-full", accentBg)} />
+
+        {/* Aggregate status header */}
+        <div className="flex items-center gap-3 px-4 pt-3 pb-2.5">
+          <StatusIcon size={16} className={cn("shrink-0", visual.color)} />
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-foreground leading-tight">
+              {aggregateHeadline(checks)}
             </div>
+            {prTitle && (
+              <div className="text-xs text-muted-foreground truncate mt-0.5">
+                {prTitle}
+                {prAuthor && <span className="opacity-70"> · {prAuthor}</span>}
+              </div>
+            )}
           </div>
-        )}
+        </div>
+
+        {/* Divider */}
+        <div className="h-px bg-border/50 mx-4" />
 
         {/* Check run list */}
-        <div className="px-3 py-2 space-y-1.5 max-h-48 overflow-y-auto">
-          {sortedRuns.map((run) => (
-            <div key={run.name} className="flex items-center justify-between text-xs">
-              <div className="flex items-center gap-2 min-w-0">
+        <div className="py-1.5 max-h-52 overflow-y-auto">
+          {sortedRuns.map((run) => {
+            const isRunning = run.status !== "completed";
+            const isFailing =
+              run.conclusion === "failure" || run.conclusion === "timed_out";
+            return (
+              <div
+                key={run.name}
+                className={cn(
+                  "flex items-center gap-2.5 px-4 py-[5px] text-xs",
+                  isFailing && "bg-red-500/[0.06]",
+                )}
+              >
                 <CheckIcon run={run} />
                 <span
                   className={cn(
-                    "truncate",
-                    run.conclusion === "failure" || run.conclusion === "timed_out"
+                    "truncate flex-1",
+                    isFailing
                       ? "text-red-400 font-medium"
                       : "text-foreground/80",
                   )}
                 >
                   {run.name}
                 </span>
+                <span className="font-mono text-[10px] shrink-0 tabular-nums">
+                  {isRunning ? (
+                    <span className="text-amber-500/80">running</span>
+                  ) : run.durationMs != null ? (
+                    <span className="text-muted-foreground">{formatDuration(run.durationMs)}</span>
+                  ) : null}
+                </span>
               </div>
-              <span className="text-muted-foreground shrink-0 ml-2">
-                {run.status !== "completed"
-                  ? "running…"
-                  : run.durationMs != null
-                    ? formatDuration(run.durationMs)
-                    : ""}
-              </span>
-            </div>
-          ))}
+            );
+          })}
           {sortedRuns.length === 0 && (
-            <div className="text-xs text-muted-foreground text-center py-2">
+            <div className="text-xs text-muted-foreground text-center py-3">
               No checks configured
             </div>
           )}
         </div>
 
-        {/* Footer: GitHub link, staleness label, and refresh button */}
-        <div className="flex items-center justify-between border-t border-border px-3 py-2">
+        {/* Footer */}
+        <div className="h-px bg-border/50 mx-4" />
+        <div className="flex items-center justify-between px-4 py-2">
           <button
             onClick={handleOpenGitHub}
-            className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
-            View on GitHub <ExternalLink size={10} />
+            <ExternalLink size={10} className="opacity-60" />
+            View on GitHub
           </button>
-          <div className="flex items-center gap-2">
-            <span className="text-[10px] text-muted-foreground">{staleLabel}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] text-muted-foreground tabular-nums">{staleLabel}</span>
             {refreshError && (
-              <span className="text-[10px] text-red-400">Refresh failed</span>
+              <span className="text-[10px] text-red-400">failed</span>
             )}
             <Button
               variant="ghost"
@@ -208,7 +246,7 @@ export function ChecksPopover({
               disabled={refreshing}
               aria-label="Refresh checks"
             >
-              <RefreshCw size={10} className={cn(refreshing && "animate-spin")} />
+              <RefreshCw size={9} className={cn(refreshing && "animate-spin")} />
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -1,0 +1,207 @@
+import { useState, useCallback } from "react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { CircleCheck, CircleX, Loader2, RefreshCw, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getTransport } from "@/transport";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import type { ChecksStatus, CheckRun } from "@mcode/contracts";
+
+/** Props for {@link ChecksPopover}. */
+interface ChecksPopoverProps {
+  /** Thread ID used for refresh requests. */
+  threadId: string;
+  /** GitHub PR number. */
+  prNumber: number;
+  /** GitHub PR URL, used for the "View on GitHub" link. */
+  prUrl: string;
+  /** Optional PR title shown in the header. */
+  prTitle?: string;
+  /** Optional PR author shown below the title. */
+  prAuthor?: string;
+  /** Latest CI check status to display. */
+  checks: ChecksStatus;
+  /** Trigger element rendered inside the popover trigger. */
+  children: React.ReactNode;
+}
+
+/** Status icon for an individual check run. */
+function CheckIcon({ run }: { run: CheckRun }) {
+  if (run.status === "in_progress" || run.status === "queued") {
+    return <Loader2 size={12} className="text-orange-500 animate-spin" />;
+  }
+  switch (run.conclusion) {
+    case "success":
+      return <CircleCheck size={12} className="text-green-500" />;
+    case "failure":
+    case "timed_out":
+      return <CircleX size={12} className="text-red-500" />;
+    case "cancelled":
+      return <CircleX size={12} className="text-muted-foreground" />;
+    default:
+      return <CircleCheck size={12} className="text-muted-foreground" />;
+  }
+}
+
+/** Format a duration in milliseconds to a human-readable string. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return "<1s";
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const remainSecs = secs % 60;
+  return remainSecs > 0 ? `${mins}m ${remainSecs}s` : `${mins}m`;
+}
+
+/** Summarise the check runs as a human-readable string. */
+function summarise(checks: ChecksStatus): string {
+  const total = checks.runs.length;
+  const passing = checks.runs.filter((r) => r.conclusion === "success").length;
+  const failing = checks.runs.filter(
+    (r) => r.conclusion === "failure" || r.conclusion === "timed_out",
+  ).length;
+  const running = checks.runs.filter((r) => r.status !== "completed").length;
+
+  const parts: string[] = [`${total} check${total !== 1 ? "s" : ""}`];
+  if (passing > 0) parts.push(`${passing} passing`);
+  if (failing > 0) parts.push(`${failing} failing`);
+  if (running > 0) parts.push(`${running} running`);
+  return parts.join(" · ");
+}
+
+/**
+ * Popover that shows PR metadata and individual CI check run details.
+ * The children prop is rendered as the trigger element.
+ */
+export function ChecksPopover({
+  threadId,
+  prNumber: _prNumber,
+  prUrl,
+  prTitle,
+  prAuthor,
+  checks,
+  children,
+}: ChecksPopoverProps) {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const fresh = await getTransport().checkStatus(threadId);
+      useWorkspaceStore.setState((ws) => ({
+        checksById: { ...ws.checksById, [threadId]: fresh },
+      }));
+    } finally {
+      setRefreshing(false);
+    }
+  }, [threadId]);
+
+  const handleOpenGitHub = useCallback(() => {
+    try {
+      const parsed = new URL(prUrl);
+      // Only allow https URLs to prevent javascript: or other protocol abuse
+      if (parsed.protocol === "https:") {
+        window.desktopBridge?.openExternalUrl(prUrl);
+      }
+    } catch {
+      // Invalid URL - do nothing
+    }
+  }, [prUrl]);
+
+  // Sort: failing first, then running, then passing/other
+  const sortedRuns = [...checks.runs].sort((a, b) => {
+    const order = (r: CheckRun) => {
+      if (r.conclusion === "failure" || r.conclusion === "timed_out") return 0;
+      if (r.status !== "completed") return 1;
+      return 2;
+    };
+    return order(a) - order(b);
+  });
+
+  const elapsed = Math.round((Date.now() - checks.fetchedAt) / 1000);
+  const staleLabel =
+    elapsed < 5
+      ? "just now"
+      : elapsed < 60
+        ? `${elapsed}s ago`
+        : `${Math.floor(elapsed / 60)}m ago`;
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        className="inline-flex cursor-pointer"
+        aria-label="View CI check details"
+      >
+        {children}
+      </PopoverTrigger>
+      <PopoverContent side="bottom" align="start" sideOffset={6} className="w-72 p-0">
+        {/* Header: PR title and summary */}
+        {prTitle && (
+          <div className="border-b border-border px-3 py-2">
+            <div className="text-sm font-medium text-foreground truncate">{prTitle}</div>
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              {prAuthor && <span>by {prAuthor}</span>}
+              <span>·</span>
+              <span>{summarise(checks)}</span>
+            </div>
+          </div>
+        )}
+
+        {/* Check run list */}
+        <div className="px-3 py-2 space-y-1.5 max-h-48 overflow-y-auto">
+          {sortedRuns.map((run) => (
+            <div key={run.name} className="flex items-center justify-between text-xs">
+              <div className="flex items-center gap-2 min-w-0">
+                <CheckIcon run={run} />
+                <span
+                  className={cn(
+                    "truncate",
+                    run.conclusion === "failure" || run.conclusion === "timed_out"
+                      ? "text-red-400 font-medium"
+                      : "text-foreground/80",
+                  )}
+                >
+                  {run.name}
+                </span>
+              </div>
+              <span className="text-muted-foreground shrink-0 ml-2">
+                {run.status !== "completed"
+                  ? "running…"
+                  : run.durationMs != null
+                    ? formatDuration(run.durationMs)
+                    : ""}
+              </span>
+            </div>
+          ))}
+          {sortedRuns.length === 0 && (
+            <div className="text-xs text-muted-foreground text-center py-2">
+              No checks configured
+            </div>
+          )}
+        </div>
+
+        {/* Footer: GitHub link, staleness label, and refresh button */}
+        <div className="flex items-center justify-between border-t border-border px-3 py-2">
+          <button
+            onClick={handleOpenGitHub}
+            className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+          >
+            View on GitHub <ExternalLink size={10} />
+          </button>
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-muted-foreground">{staleLabel}</span>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={handleRefresh}
+              disabled={refreshing}
+              aria-label="Refresh checks"
+            >
+              <RefreshCw size={10} className={cn(refreshing && "animate-spin")} />
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -72,13 +72,6 @@ function aggregateHeadline(checks: ChecksStatus): string {
   }
 }
 
-/** Tailwind bg class for the colored accent strip at the top of the popover. */
-const ACCENT_BG: Record<ChecksStatus["aggregate"], string> = {
-  passing: "bg-green-500",
-  failing: "bg-red-500",
-  pending: "bg-amber-500",
-  no_checks: "bg-border",
-};
 
 /**
  * Popover that shows PR metadata and individual CI check run details.
@@ -149,7 +142,6 @@ export function ChecksPopover({
 
   const visual = getCiVisual(checks.aggregate);
   const StatusIcon = visual.icon;
-  const accentBg = ACCENT_BG[checks.aggregate];
 
   return (
     <Popover>
@@ -160,11 +152,8 @@ export function ChecksPopover({
         {children}
       </PopoverTrigger>
       <PopoverContent side="bottom" align="start" sideOffset={6} className="w-80 p-0 overflow-hidden">
-        {/* Colored status accent strip */}
-        <div className={cn("h-[2px] w-full", accentBg)} />
-
         {/* Aggregate status header */}
-        <div className="flex items-center gap-3 px-4 pt-3 pb-2.5">
+        <div className="flex items-center gap-3 px-4 pt-4 pb-2.5">
           <StatusIcon size={16} className={cn("shrink-0", visual.color)} />
           <div className="min-w-0">
             <div className="text-sm font-semibold text-foreground leading-tight">

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -172,7 +172,7 @@ describe("HeaderActions - Create PR button", () => {
     mockUseBranchPr.mockReturnValue({ number: 42, state: "OPEN", url: "https://github.com/test/pr/42" });
     render(<HeaderActions thread={makeThread()} />);
     expect(screen.queryByRole("button", { name: /create pr/i })).not.toBeInTheDocument();
-    expect(screen.getByText(/View PR #42/)).toBeInTheDocument();
+    expect(screen.getByText("PR #42")).toBeInTheDocument();
   });
 
   it("shows tooltip explaining why button is disabled when no commits", () => {

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -109,6 +109,7 @@ function defaultWorkspaceState() {
     pendingNewThread: false,
     threads: [makeThread()],
     prUrlsByThreadId: {} as Record<string, string>,
+    checksById: {} as Record<string, import("@mcode/contracts").ChecksStatus>,
     loadWorkspaces: vi.fn(),
     loadThreads: vi.fn(),
     setActiveWorkspace: vi.fn(),

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -41,6 +41,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
   // poll resolves. Only use it when cachedPrUrl is present — otherwise we'd produce
   // a PR object with url: "" which breaks the Open-in-browser action.
   const cachedPrUrl = useWorkspaceStore((s) => s.prUrlsByThreadId[thread.id]);
+  const checks = useWorkspaceStore((s) => s.checksById[thread.id]) ?? null;
   const storePr = thread.pr_number != null && cachedPrUrl
     ? { number: thread.pr_number, url: cachedPrUrl, state: thread.pr_status ?? "OPEN" }
     : null;
@@ -126,6 +127,8 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
               hasCommitsAhead={hasCommitsAhead}
               onCreatePr={() => setCreatePrOpen(true)}
               onOpenPr={handleOpenPr}
+              checks={checks}
+              threadId={thread.id}
             />
           )}
           <OpenInEditorMenu dirPath={dirPath} />

--- a/apps/web/src/components/chat/PrSplitButton.test.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.test.tsx
@@ -37,14 +37,14 @@ describe("PrSplitButton", () => {
 
   const openPr = { number: 42, url: "https://github.com/o/r/pull/42", state: "OPEN" };
 
-  it("renders View PR #42 when pr state is OPEN (uppercase — normalised)", () => {
+  it("renders PR #42 when pr state is OPEN (uppercase — normalised)", () => {
     render(<PrSplitButton pr={openPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    expect(screen.getByText(/view pr #42/i)).toBeInTheDocument();
+    expect(screen.getByText("PR #42")).toBeInTheDocument();
   });
 
   it("applies green colour class when pr state is open", () => {
     render(<PrSplitButton pr={openPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    const btn = screen.getByText(/view pr #42/i).closest("button");
+    const btn = screen.getByText("PR #42").closest("button");
     expect(btn?.className).toContain("text-[#3fb950]");
   });
 
@@ -53,10 +53,10 @@ describe("PrSplitButton", () => {
     expect(screen.queryByRole("button", { name: /open pr menu/i })).not.toBeInTheDocument();
   });
 
-  it("calls onOpenPr with the url when View PR is clicked", () => {
+  it("calls onOpenPr with the url when PR badge is clicked", () => {
     const onOpenPr = vi.fn();
     render(<PrSplitButton pr={openPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={onOpenPr} />);
-    fireEvent.click(screen.getByText(/view pr #42/i));
+    fireEvent.click(screen.getByText("PR #42"));
     expect(onOpenPr).toHaveBeenCalledWith("https://github.com/o/r/pull/42");
   });
 

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 import { Github, ChevronDown, GitPullRequest } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ChecksPopover } from "./ChecksPopover";
+import { getCiVisual } from "@/lib/ci-status";
+import type { ChecksStatus } from "@mcode/contracts";
 
 /** Props for {@link PrSplitButton}. */
 interface PrSplitButtonProps {
@@ -12,6 +15,14 @@ interface PrSplitButtonProps {
   onCreatePr: () => void;
   /** Called with the PR URL when the user wants to open it in the browser. */
   onOpenPr: (url: string) => void;
+  /** CI check status for this thread, if available. */
+  checks?: ChecksStatus | null;
+  /** Thread ID for manual refresh via ChecksPopover. */
+  threadId?: string;
+  /** PR title shown in ChecksPopover header. */
+  prTitle?: string;
+  /** PR author shown in ChecksPopover header. */
+  prAuthor?: string;
 }
 
 /**
@@ -19,8 +30,9 @@ interface PrSplitButtonProps {
  * When no PR exists, renders a "Create PR" button (disabled until commits are detected).
  * When a PR exists, renders a primary action button coloured by state plus an optional
  * chevron that opens a dropdown for secondary actions (merged/closed only).
+ * When CI checks are available on an open PR, wraps the primary button in a ChecksPopover.
  */
-export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr }: PrSplitButtonProps) {
+export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, checks, threadId, prTitle, prAuthor }: PrSplitButtonProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -55,15 +67,21 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr }: PrS
 
   const state = pr.state.toLowerCase();
 
-  const stateColour =
-    state === "merged"
+  // When CI checks are active on an open PR, use the CI colour; otherwise use the PR state colour.
+  const hasActiveChecks = checks != null && checks.aggregate !== "no_checks" && state === "open";
+  const ciVisual = hasActiveChecks ? getCiVisual(checks!.aggregate) : null;
+
+  const stateColour = ciVisual
+    ? `${ciVisual.color} hover:opacity-80`
+    : state === "merged"
       ? "text-[#a371f7] hover:text-[#bc8fff]"
       : state === "closed"
         ? "text-[#f85149] hover:text-[#ff6b63]"
         : "text-[#3fb950] hover:text-[#5ee375]";
 
-  const label =
-    state === "merged"
+  const label = ciVisual
+    ? `PR #${pr.number} · ${ciVisual.label}`
+    : state === "merged"
       ? `PR #${pr.number} merged`
       : state === "closed"
         ? `PR #${pr.number} closed`
@@ -71,17 +89,37 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr }: PrS
 
   const showChevron = state === "merged" || state === "closed";
 
+  // Whether to wrap the primary button in ChecksPopover instead of navigating to GitHub
+  const usePopover = hasActiveChecks && threadId != null;
+
+  const primaryButton = (
+    <button
+      className={`inline-flex items-center gap-1.5 px-2 h-6 text-xs bg-muted/10 hover:bg-muted/20 transition-colors ${stateColour}`}
+      onClick={usePopover ? undefined : () => onOpenPr(pr.url)}
+    >
+      <Github size={12} className="opacity-80 flex-shrink-0" />
+      <span>{label}</span>
+    </button>
+  );
+
   return (
     <div ref={containerRef} className="relative inline-flex">
       <div className="inline-flex rounded">
-        {/* Primary action */}
-        <button
-          className={`inline-flex items-center gap-1.5 px-2 h-6 text-xs bg-muted/10 hover:bg-muted/20 transition-colors ${stateColour}`}
-          onClick={() => onOpenPr(pr.url)}
-        >
-          <Github size={12} className="opacity-80 flex-shrink-0" />
-          <span>{label}</span>
-        </button>
+        {/* Primary action — wrapped in ChecksPopover when CI is active on an open PR */}
+        {usePopover ? (
+          <ChecksPopover
+            threadId={threadId!}
+            prNumber={pr.number}
+            prUrl={pr.url}
+            prTitle={prTitle}
+            prAuthor={prAuthor}
+            checks={checks!}
+          >
+            {primaryButton}
+          </ChecksPopover>
+        ) : (
+          primaryButton
+        )}
 
         {/* Chevron — only for merged/closed */}
         {showChevron && (

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Github, ChevronDown, GitPullRequest } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { ChecksPopover } from "./ChecksPopover";
 import { getCiVisual } from "@/lib/ci-status";
 import type { ChecksStatus } from "@mcode/contracts";
@@ -79,26 +80,48 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
         ? "text-[#f85149] hover:text-[#ff6b63]"
         : "text-[#3fb950] hover:text-[#5ee375]";
 
-  const label = ciVisual
-    ? `PR #${pr.number} · ${ciVisual.label}`
-    : state === "merged"
-      ? `PR #${pr.number} merged`
-      : state === "closed"
-        ? `PR #${pr.number} closed`
-        : `View PR #${pr.number}`;
+  // When CI is active, show just the PR number — the status dot carries the state signal.
+  const label = state === "merged"
+    ? `PR #${pr.number} merged`
+    : state === "closed"
+      ? `PR #${pr.number} closed`
+      : `PR #${pr.number}`;
 
   const showChevron = state === "merged" || state === "closed";
 
   // Whether to wrap the primary button in ChecksPopover instead of navigating to GitHub
   const usePopover = hasActiveChecks && threadId != null;
 
+  // Glow dot shown next to the PR number when CI checks are active.
+  const statusDot = hasActiveChecks ? (
+    <span
+      className={cn(
+        "w-1.5 h-1.5 rounded-full shrink-0",
+        checks!.aggregate === "passing" && "bg-green-400",
+        checks!.aggregate === "failing" && "bg-red-400",
+        checks!.aggregate === "pending" && "bg-amber-400 animate-pulse",
+      )}
+      style={
+        checks!.aggregate === "passing"
+          ? { boxShadow: "0 0 5px 1px rgba(74,222,128,0.5)" }
+          : checks!.aggregate === "failing"
+            ? { boxShadow: "0 0 5px 1px rgba(248,113,113,0.5)" }
+            : checks!.aggregate === "pending"
+              ? { boxShadow: "0 0 5px 1px rgba(251,191,36,0.45)" }
+              : undefined
+      }
+    />
+  ) : null;
+
   const primaryButton = (
     <button
       className={`inline-flex items-center gap-1.5 px-2 h-6 text-xs bg-muted/10 hover:bg-muted/20 transition-colors ${stateColour}`}
+      title={ciVisual?.label}
       onClick={usePopover ? undefined : () => onOpenPr(pr.url)}
     >
       <Github size={12} className="opacity-80 flex-shrink-0" />
       <span>{label}</span>
+      {statusDot}
     </button>
   );
 

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -109,7 +109,6 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
         {usePopover ? (
           <ChecksPopover
             threadId={threadId!}
-            prNumber={pr.number}
             prUrl={pr.url}
             prTitle={prTitle}
             prAuthor={prAuthor}

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { relativeTime } from "@/lib/time";
 import { getStatusDisplay, getNotificationDot } from "@/lib/thread-status";
+import { getCiDotClass } from "@/lib/ci-status";
 import type { Workspace, Thread } from "@/transport/types";
 
 // Persist expand/collapse in localStorage
@@ -587,6 +588,7 @@ function VirtualizedThreadList({
   // Normalized set of existing worktree paths for stale detection.
   const worktrees = useWorkspaceStore((s) => s.worktrees);
   const worktreesLoadedFor = useWorkspaceStore((s) => s.worktreesLoadedForWorkspace);
+  const checksById = useWorkspaceStore((s) => s.checksById);
   const validWorktreePaths = useMemo(() => {
     const set = new Set<string>();
     for (const wt of worktrees) {
@@ -706,7 +708,13 @@ function VirtualizedThreadList({
               >
                 {thread.pr_number != null ? (() => {
                   const { Icon: PrIcon, color: prColor } = getPrVisual(thread.pr_status);
-                  const dot = getNotificationDot(thread, runningThreadIds.has(thread.id));
+                  const ciChecks = checksById[thread.id];
+                  const ciDotClass = ciChecks ? getCiDotClass(ciChecks.aggregate) : null;
+                  const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id));
+                  // CI dot takes priority when present; fall back to agent notification dot
+                  const dot = ciDotClass
+                    ? { dotClass: ciDotClass, animate: ciChecks!.aggregate === "pending" }
+                    : agentDot;
                   return (
                     <span
                       title={`PR #${thread.pr_number} \u2013 ${thread.pr_status ?? "open"}`}

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useCallback, useState, useRef, useMemo } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { useShallow } from "zustand/shallow";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { FolderOpen, Plus, Trash2, ChevronRight, ChevronDown, GitBranch, Loader2, AlertTriangle } from "lucide-react";
@@ -588,7 +589,7 @@ function VirtualizedThreadList({
   // Normalized set of existing worktree paths for stale detection.
   const worktrees = useWorkspaceStore((s) => s.worktrees);
   const worktreesLoadedFor = useWorkspaceStore((s) => s.worktreesLoadedForWorkspace);
-  const checksById = useWorkspaceStore((s) => s.checksById);
+  const checksById = useWorkspaceStore(useShallow((s) => s.checksById));
   const validWorktreePaths = useMemo(() => {
     const set = new Set<string>();
     for (const wt of worktrees) {

--- a/apps/web/src/lib/ci-status.ts
+++ b/apps/web/src/lib/ci-status.ts
@@ -1,0 +1,38 @@
+import { CircleCheck, CircleX, Clock, type LucideIcon } from "lucide-react";
+import type { ChecksStatus } from "@mcode/contracts";
+
+/** Visual properties for a CI aggregate state. */
+export interface CiVisual {
+  icon: LucideIcon;
+  color: string;
+  borderColor: string;
+  label: string;
+}
+
+/** Maps an aggregate CI status to icon, color, and label. */
+export function getCiVisual(aggregate: ChecksStatus["aggregate"]): CiVisual {
+  switch (aggregate) {
+    case "passing":
+      return { icon: CircleCheck, color: "text-green-500", borderColor: "border-green-500/50", label: "Checks passing" };
+    case "failing":
+      return { icon: CircleX, color: "text-red-500", borderColor: "border-red-500/50", label: "Checks failing" };
+    case "pending":
+      return { icon: Clock, color: "text-orange-500", borderColor: "border-orange-500/50", label: "Checks running" };
+    case "no_checks":
+      return { icon: CircleCheck, color: "text-muted-foreground", borderColor: "border-border", label: "No checks" };
+  }
+}
+
+/** Returns a Tailwind dot colour class for sidebar CI indicators. Returns null for no_checks. */
+export function getCiDotClass(aggregate: ChecksStatus["aggregate"]): string | null {
+  switch (aggregate) {
+    case "passing":
+      return "bg-green-500";
+    case "failing":
+      return "bg-red-500";
+    case "pending":
+      return "bg-orange-500";
+    case "no_checks":
+      return null;
+  }
+}

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -424,7 +424,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         const remainingUrls = Object.fromEntries(
           Object.entries(state.prUrlsByThreadId).filter(([k]) => k !== threadId),
         ) as Record<string, string>;
-        const { [threadId]: _, ...remainingChecks } = state.checksById;
+        const remainingChecks = Object.fromEntries(
+          Object.entries(state.checksById).filter(([k]) => k !== threadId),
+        ) as typeof state.checksById;
         return {
           threads: state.threads.filter((t) => t.id !== threadId),
           activeThreadId: state.activeThreadId === threadId ? null : state.activeThreadId,

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -420,10 +420,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         const remainingUrls = Object.fromEntries(
           Object.entries(state.prUrlsByThreadId).filter(([k]) => k !== threadId),
         ) as Record<string, string>;
+        const { [threadId]: _, ...remainingChecks } = state.checksById;
         return {
           threads: state.threads.filter((t) => t.id !== threadId),
           activeThreadId: state.activeThreadId === threadId ? null : state.activeThreadId,
           prUrlsByThreadId: remainingUrls,
+          checksById: remainingChecks,
         };
       });
       useThreadStore.getState().clearThreadState(threadId);

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { Workspace, Thread, GitBranch, PermissionMode, WorktreeInfo, AttachmentMeta, PrDetail } from "@/transport";
+import type { ChecksStatus } from "@mcode/contracts";
 import { getTransport } from "@/transport";
 import { useThreadStore } from "./threadStore";
 import { useTerminalStore } from "./terminalStore";
@@ -49,6 +50,8 @@ interface WorkspaceState {
   branchManuallySelected: boolean;
   /** In-memory map of thread ID → PR URL, populated immediately on PR creation so the header can link without waiting for the next poll. */
   prUrlsByThreadId: Record<string, string>;
+  /** In-memory map of thread ID → latest CI check status, updated by the thread.checksUpdated push channel. */
+  checksById: Record<string, ChecksStatus>;
 
   // Workspace actions
   loadWorkspaces: () => Promise<void>;
@@ -135,6 +138,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   fetchingBranch: null,
   branchManuallySelected: false,
   prUrlsByThreadId: {},
+  checksById: {},
 
   loadWorkspaces: async () => {
     set({ loading: true, error: null });

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -181,6 +181,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       }
       // Remove threads from store FIRST (same ordering as deleteThread) so
       // any in-flight timer callbacks see threads as gone before timers are cancelled.
+      const deletedIdSet = new Set(deletedThreadIds);
       set((state) => ({
         workspaces: state.workspaces.filter((w) => w.id !== id),
         activeWorkspaceId:
@@ -191,6 +192,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           deletedThreadIds.includes(state.activeThreadId)
             ? null
             : state.activeThreadId,
+        checksById: Object.fromEntries(
+          Object.entries(state.checksById).filter(([tid]) => !deletedIdSet.has(tid)),
+        ),
       }));
       // One batched Zustand set() for all threads instead of N sequential calls.
       useThreadStore.getState().clearThreadStateMany(deletedThreadIds);

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -22,6 +22,7 @@ import type {
   ProviderUsageInfo,
   PrDraft,
   CreatePrResult,
+  ChecksStatus,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
@@ -167,6 +168,8 @@ export interface McodeTransport {
   listOpenPrs(workspaceId: string): Promise<PrDetail[]>;
   fetchBranch(workspaceId: string, branch: string, prNumber?: number): Promise<void>;
   getPrByUrl(url: string): Promise<PrDetail | null>;
+  /** Fetch fresh CI check status for a thread (manual refresh). */
+  checkStatus(threadId: string): Promise<ChecksStatus>;
 
   // Skills
   listSkills(cwd?: string): Promise<SkillInfo[]>;

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -18,6 +18,7 @@ let unsubs: (() => void)[] = [];
  * - `terminal.exit` -- PTY exit forwarded via custom DOM event
  * - `thread.status` -- thread status changes reflected in threadStore
  * - `thread.prLinked` -- PR detected for a thread, updates pr_number/pr_status
+ * - `thread.checksUpdated` -- CI check status polled for a thread's PR, updates checksById
  * - `files.changed` -- invalidates the file autocomplete cache
  * - `skills.changed` -- reserved for future skill cache invalidation
  * - `turn.persisted` -- tool call persistence confirmation forwarded to threadStore
@@ -105,6 +106,21 @@ export function startPushListeners(): void {
               ? { ...t, pr_number: prNumber, pr_status: prStatus }
               : t,
           ),
+        }));
+      });
+    }),
+  );
+
+  // thread.checksUpdated: CI check status polled for a thread's PR
+  unsubs.push(
+    pushEmitter.on("thread.checksUpdated", (data) => {
+      const { threadId, checks } = data as {
+        threadId: string;
+        checks: import("@mcode/contracts").ChecksStatus;
+      };
+      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
+        useWorkspaceStore.setState((ws) => ({
+          checksById: { ...ws.checksById, [threadId]: checks },
         }));
       });
     }),

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -133,6 +133,19 @@ export function createWsTransport(
 
       // Auth token is conveyed via HttpOnly cookie (Set-Cookie on /health).
       // No need to store it in localStorage - the cookie handles reconnection.
+
+      // On reconnect, refresh CI checks for the active thread (best-effort).
+      // Deferred import avoids a circular dependency at module evaluation time.
+      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
+        const { activeThreadId } = useWorkspaceStore.getState();
+        if (activeThreadId) {
+          rpc<ChecksStatus>("github.checkStatus", { threadId: activeThreadId }).then((checks) => {
+            useWorkspaceStore.setState((ws) => ({
+              checksById: { ...ws.checksById, [activeThreadId]: checks },
+            }));
+          }).catch(() => { /* best-effort */ });
+        }
+      });
     };
 
     ws.onmessage = (event) => {

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -14,7 +14,7 @@ import type {
   GitCommit,
   ProviderModelInfo,
 } from "./types";
-import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo } from "@mcode/contracts";
+import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 
 /** Minimum reconnect delay in milliseconds. */
@@ -376,6 +376,8 @@ export function createWsTransport(
     fetchBranch: (workspaceId, branch, prNumber?) =>
       rpc<void>("git.fetchBranch", { workspaceId, branch, prNumber }),
     getPrByUrl: (url) => rpc<PrDetail | null>("github.prByUrl", { url }),
+    checkStatus: (threadId) =>
+      rpc<ChecksStatus>("github.checkStatus", { threadId }),
 
     // Skills
     listSkills: (cwd?) => rpc<SkillInfo[]>("skill.list", { cwd }),

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -141,20 +141,45 @@ export function createWsTransport(
       // Auth token is conveyed via HttpOnly cookie (Set-Cookie on /health).
       // No need to store it in localStorage - the cookie handles reconnection.
 
-      // On connect/reconnect, refresh CI checks for the active thread (best-effort).
+      // On connect/reconnect, refresh CI checks for all visible PR threads (best-effort).
       // Cooldown prevents subprocess storms during rapid reconnect loops.
       // Deferred import avoids a circular dependency at module evaluation time.
       const now = Date.now();
       if (now - lastCheckStatusFetchAt > CHECK_STATUS_RECONNECT_COOLDOWN_MS) {
         lastCheckStatusFetchAt = now;
         import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-          const { activeThreadId } = useWorkspaceStore.getState();
-          if (activeThreadId) {
-            rpc<ChecksStatus>("github.checkStatus", { threadId: activeThreadId }).then((checks) => {
+          const state = useWorkspaceStore.getState();
+
+          // Refresh all non-terminal PR threads visible in the sidebar.
+          const prThreads = state.threads.filter(
+            (t) => t.pr_number != null
+              && t.pr_status?.toLowerCase() !== "merged"
+              && t.pr_status?.toLowerCase() !== "closed",
+          );
+
+          for (const thread of prThreads) {
+            rpc<ChecksStatus>("github.checkStatus", { threadId: thread.id }).then((checks) => {
               useWorkspaceStore.setState((ws) => ({
-                checksById: { ...ws.checksById, [activeThreadId]: checks },
+                checksById: { ...ws.checksById, [thread.id]: checks },
               }));
             }).catch(() => { /* best-effort */ });
+          }
+
+          // On initial connect, threads haven't loaded yet; subscribe to backfill the active
+          // PR thread's CI status once the store is populated.
+          if (state.threads.length === 0) {
+            const unsub = useWorkspaceStore.subscribe((s) => {
+              if (!s.activeThreadId) return;
+              unsub();
+              const tid = s.activeThreadId;
+              const thread = s.threads.find((t) => t.id === tid);
+              if (thread?.pr_number == null) return;
+              rpc<ChecksStatus>("github.checkStatus", { threadId: tid }).then((checks) => {
+                useWorkspaceStore.setState((ws) => ({
+                  checksById: { ...ws.checksById, [tid]: checks },
+                }));
+              }).catch(() => { /* best-effort */ });
+            });
           }
         });
       }

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -22,6 +22,11 @@ const MIN_RECONNECT_MS = 1000;
 /** Maximum reconnect delay in milliseconds. */
 const MAX_RECONNECT_MS = 30_000;
 
+/** Timestamp of the last github.checkStatus fetch triggered on connect/reconnect. */
+let lastCheckStatusFetchAt = 0;
+/** Minimum interval between reconnect-triggered checkStatus fetches to avoid subprocess storms. */
+const CHECK_STATUS_RECONNECT_COOLDOWN_MS = 30_000;
+
 type Listener = (data: unknown) => void;
 
 /**
@@ -134,18 +139,23 @@ export function createWsTransport(
       // Auth token is conveyed via HttpOnly cookie (Set-Cookie on /health).
       // No need to store it in localStorage - the cookie handles reconnection.
 
-      // On reconnect, refresh CI checks for the active thread (best-effort).
+      // On connect/reconnect, refresh CI checks for the active thread (best-effort).
+      // Cooldown prevents subprocess storms during rapid reconnect loops.
       // Deferred import avoids a circular dependency at module evaluation time.
-      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        const { activeThreadId } = useWorkspaceStore.getState();
-        if (activeThreadId) {
-          rpc<ChecksStatus>("github.checkStatus", { threadId: activeThreadId }).then((checks) => {
-            useWorkspaceStore.setState((ws) => ({
-              checksById: { ...ws.checksById, [activeThreadId]: checks },
-            }));
-          }).catch(() => { /* best-effort */ });
-        }
-      });
+      const now = Date.now();
+      if (now - lastCheckStatusFetchAt > CHECK_STATUS_RECONNECT_COOLDOWN_MS) {
+        lastCheckStatusFetchAt = now;
+        import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
+          const { activeThreadId } = useWorkspaceStore.getState();
+          if (activeThreadId) {
+            rpc<ChecksStatus>("github.checkStatus", { threadId: activeThreadId }).then((checks) => {
+              useWorkspaceStore.setState((ws) => ({
+                checksById: { ...ws.checksById, [activeThreadId]: checks },
+              }));
+            }).catch(() => { /* best-effort */ });
+          }
+        });
+      }
     };
 
     ws.onmessage = (event) => {

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -150,35 +150,37 @@ export function createWsTransport(
         import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
           const state = useWorkspaceStore.getState();
 
-          // Refresh all non-terminal PR threads visible in the sidebar.
-          const prThreads = state.threads.filter(
-            (t) => t.pr_number != null
-              && t.pr_status?.toLowerCase() !== "merged"
-              && t.pr_status?.toLowerCase() !== "closed",
-          );
+          // Refresh all PR threads visible in the sidebar (including terminal ones — server
+          // handles merged/closed with a one-shot fetch rather than registering a watcher).
+          const prThreads = state.threads.filter((t) => t.pr_number != null);
 
           for (const thread of prThreads) {
             rpc<ChecksStatus>("github.checkStatus", { threadId: thread.id }).then((checks) => {
-              useWorkspaceStore.setState((ws) => ({
-                checksById: { ...ws.checksById, [thread.id]: checks },
-              }));
+              useWorkspaceStore.setState((ws) => {
+                const existing = ws.checksById[thread.id];
+                // Ignore stale in-flight responses that arrived after a newer update.
+                if (existing && existing.fetchedAt >= checks.fetchedAt) return ws;
+                return { checksById: { ...ws.checksById, [thread.id]: checks } };
+              });
             }).catch(() => { /* best-effort */ });
           }
 
-          // On initial connect, threads haven't loaded yet; subscribe to backfill the active
-          // PR thread's CI status once the store is populated.
+          // On initial connect, threads haven't loaded yet; subscribe to backfill all PR
+          // threads' CI status once the store is populated.
           if (state.threads.length === 0) {
             const unsub = useWorkspaceStore.subscribe((s) => {
-              if (!s.activeThreadId) return;
+              if (s.threads.length === 0) return;
               unsub();
-              const tid = s.activeThreadId;
-              const thread = s.threads.find((t) => t.id === tid);
-              if (thread?.pr_number == null) return;
-              rpc<ChecksStatus>("github.checkStatus", { threadId: tid }).then((checks) => {
-                useWorkspaceStore.setState((ws) => ({
-                  checksById: { ...ws.checksById, [tid]: checks },
-                }));
-              }).catch(() => { /* best-effort */ });
+              for (const t of s.threads) {
+                if (t.pr_number == null) continue;
+                rpc<ChecksStatus>("github.checkStatus", { threadId: t.id }).then((checks) => {
+                  useWorkspaceStore.setState((ws) => {
+                    const existing = ws.checksById[t.id];
+                    if (existing && existing.fetchedAt >= checks.fetchedAt) return ws;
+                    return { checksById: { ...ws.checksById, [t.id]: checks } };
+                  });
+                }).catch(() => { /* best-effort */ });
+              }
             });
           }
         });

--- a/packages/contracts/src/github.ts
+++ b/packages/contracts/src/github.ts
@@ -59,3 +59,30 @@ export const CreatePrResultSchema = lazySchema(() =>
 );
 
 export type CreatePrResult = z.infer<ReturnType<typeof CreatePrResultSchema>>;
+
+/** Individual CI check run (one job in a GitHub Actions workflow). */
+export const CheckRunSchema = lazySchema(() =>
+  z.object({
+    name: z.string(),
+    status: z.enum(["queued", "in_progress", "completed"]),
+    conclusion: z
+      .enum(["success", "failure", "cancelled", "skipped", "timed_out", "neutral"])
+      .nullable(),
+    durationMs: z.number().nullable(),
+  }),
+);
+
+/** Individual CI check run. */
+export type CheckRun = z.infer<ReturnType<typeof CheckRunSchema>>;
+
+/** Aggregate CI check status for a thread's PR. */
+export const ChecksStatusSchema = lazySchema(() =>
+  z.object({
+    aggregate: z.enum(["passing", "failing", "pending", "no_checks"]),
+    runs: z.array(CheckRunSchema()),
+    fetchedAt: z.number(),
+  }),
+);
+
+/** Aggregate CI check status for a thread's PR. */
+export type ChecksStatus = z.infer<ReturnType<typeof ChecksStatusSchema>>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -96,8 +96,8 @@ export type {
 export { GitBranchSchema, WorktreeSchema, GitCommitSchema } from "./git.js";
 export type { GitBranch, WorktreeInfo, GitCommit } from "./git.js";
 
-export { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrParamsSchema, CreatePrResultSchema } from "./github.js";
-export type { PrInfo, PrDetail, PrDraft, CreatePrParams, CreatePrResult } from "./github.js";
+export { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrParamsSchema, CreatePrResultSchema, CheckRunSchema, ChecksStatusSchema } from "./github.js";
+export type { PrInfo, PrDetail, PrDraft, CreatePrParams, CreatePrResult, CheckRun, ChecksStatus } from "./github.js";
 
 // Skills
 export { SkillInfoSchema } from "./skills.js";

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -3,6 +3,7 @@ import { AgentEventSchema } from "../events/agent-event.js";
 import { ThreadStatusSchema } from "../models/enums.js";
 import { SettingsSchema } from "../models/settings.js";
 import { PlanQuestionSchema } from "../models/plan-questions.js";
+import { ChecksStatusSchema } from "../github.js";
 
 /** All push channel definitions keyed by channel name. */
 export const WS_CHANNELS = {
@@ -17,6 +18,10 @@ export const WS_CHANNELS = {
     threadId: z.string(),
     prNumber: z.number(),
     prStatus: z.string(),
+  }),
+  "thread.checksUpdated": z.object({
+    threadId: z.string(),
+    checks: ChecksStatusSchema(),
   }),
   "files.changed": z.object({
     workspaceId: z.string(),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -7,7 +7,7 @@ import { AttachmentMetaSchema } from "../models/attachment.js";
 import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { GitBranchSchema, WorktreeSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
-import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema } from "../github.js";
+import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema, ChecksStatusSchema } from "../github.js";
 import { SkillInfoSchema } from "../skills.js";
 import { TurnSnapshotSchema } from "../models/turn-snapshot.js";
 import { PlanAnswerSchema } from "../models/plan-questions.js";
@@ -259,6 +259,10 @@ export const WS_METHODS = lazySchema(() => ({
       isDraft: z.boolean().default(false),
     }),
     result: CreatePrResultSchema(),
+  },
+  "github.checkStatus": {
+    params: z.object({ threadId: z.string() }),
+    result: ChecksStatusSchema(),
   },
   "config.discover": {
     params: z.object({ workspacePath: z.string() }),


### PR DESCRIPTION
## What

Surfaces GitHub Actions CI check status on thread PR badges and the sidebar, powered by a server-side adaptive watcher service.

## Why

Users had no visibility into CI state without leaving the app. This closes the loop between opening a PR and knowing whether checks pass, without requiring any client-side polling or manual page refreshes.

## Key Changes

- **`CiWatcherService`** (server): adaptive dual-interval polling via `gh pr checks` -- 10 s when checks are in-progress, 60 s when terminal. Broadcasts `thread.checksUpdated` push events only on state changes. In-flight guards and zombie-re-insertion protection.
- **Contracts**: `CheckRunSchema`, `ChecksStatusSchema`, `github.checkStatus` RPC method, `thread.checksUpdated` push channel.
- **`GithubService.getCheckRuns()`**: maps `gh pr checks --json` output to typed `ChecksStatus` with aggregate derivation (failing > pending > passing > no_checks).
- **Client store**: `checksById` Zustand slice populated reactively by push events. No client-side polling.
- **`ChecksPopover`**: popover showing PR header, individual check rows sorted by severity (failing first), duration, stale timestamp, and a refresh button.
- **`PrSplitButton`**: badge colour and label now reflect CI aggregate (green/red/orange). Clicking opens `ChecksPopover` instead of navigating directly to GitHub.
- **Sidebar dot**: 8 px coloured dot overlaid on PR icon in thread rows. Pulses when pending; CI dot takes priority over agent notification dot.
- **Lifecycle wiring**: `thread.syncPrs`, `TurnComplete`, and `thread.delete` keep the watcher registry in sync. Reconnect refreshes checks for the active thread.

Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI monitoring for PRs with adaptive polling, startup seeding, push updates, and graceful shutdown integration
  * UI: sidebar CI dot, CI-aware PR button with status dot and popover showing runs, durations, refresh, and GitHub link
  * Transport/API & Contracts: github.checkStatus RPC, push channel for check updates, and per-thread CI status in store

* **Tests**
  * Added tests covering CI polling lifecycle, aggregation logic, and check-run parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->