### PR TITLE
fix: worktree parent directory cleanup on Windows

### DIFF
--- a/apps/server/src/__tests__/cleanup-worker.test.ts
+++ b/apps/server/src/__tests__/cleanup-worker.test.ts
@@ -84,7 +84,7 @@ describe("CleanupWorker", () => {
   }
 
   describe("poll", () => {
-    it("stops agent session and awaits exit before filesystem operations", async () => {
+    it("runs cleanup steps in correct order: session exit, terminal kill, SDK kill, worktree removal", async () => {
       const callOrder: string[] = [];
       (mockClaudeProvider.waitForSessionExit as ReturnType<typeof vi.fn>).mockImplementation(async () => {
         callOrder.push("waitForSessionExit");
@@ -112,41 +112,6 @@ describe("CleanupWorker", () => {
       await worker.poll();
 
       expect(callOrder).toEqual(["waitForSessionExit", "killByThread", "killDescendants", "removeWorktree"]);
-    });
-
-    it("kills SDK subprocess descendants after terminal kill and before fs operations", async () => {
-      const callOrder: string[] = [];
-      (mockClaudeProvider.waitForSessionExit as ReturnType<typeof vi.fn>).mockImplementation(async () => {
-        callOrder.push("waitForSessionExit");
-      });
-      (mockTerminalService.killByThread as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        callOrder.push("killByThread");
-      });
-      (vi.mocked(killDescendantsByName)).mockImplementation(async () => {
-        callOrder.push("killDescendants");
-      });
-      (mockGitService.removeWorktree as ReturnType<typeof vi.fn>).mockImplementation(async () => {
-        callOrder.push("removeWorktree");
-        return true;
-      });
-
-      const ws = workspaceRepo.create("test", "/repo");
-      insertThread("t-kill", ws.id, "mcode/kill-test", wt("feat-kill"));
-      cleanupJobRepo.insert({
-        thread_id: "t-kill",
-        workspace_path: "/repo",
-        worktree_path: wt("feat-kill"),
-        branch: "mcode/kill-test",
-      });
-
-      await worker.poll();
-
-      expect(callOrder).toEqual([
-        "waitForSessionExit",
-        "killByThread",
-        "killDescendants",
-        "removeWorktree",
-      ]);
       expect(killDescendantsByName).toHaveBeenCalledWith(
         process.pid,
         expect.stringMatching(/claude/i),

--- a/apps/server/src/__tests__/cleanup-worker.test.ts
+++ b/apps/server/src/__tests__/cleanup-worker.test.ts
@@ -10,7 +10,12 @@ import { CleanupWorker } from "../services/cleanup-worker";
 import type { ClaudeProvider } from "../providers/claude/claude-provider";
 import type { TerminalService } from "../services/terminal-service";
 import type { GitService } from "../services/git-service";
+import { killDescendantsByName } from "../services/process-kill";
 import { getMcodeDir } from "@mcode/shared";
+
+vi.mock("../services/process-kill.js", () => ({
+  killDescendantsByName: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Stub filesystem checks - paths in tests are synthetic; we test logic not fs state.
 vi.mock("fs", async (importOriginal) => {
@@ -87,6 +92,9 @@ describe("CleanupWorker", () => {
       (mockTerminalService.killByThread as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callOrder.push("killByThread");
       });
+      (vi.mocked(killDescendantsByName)).mockImplementation(async () => {
+        callOrder.push("killDescendants");
+      });
       (mockGitService.removeWorktree as ReturnType<typeof vi.fn>).mockImplementation(async () => {
         callOrder.push("removeWorktree");
         return true;
@@ -103,7 +111,46 @@ describe("CleanupWorker", () => {
 
       await worker.poll();
 
-      expect(callOrder).toEqual(["waitForSessionExit", "killByThread", "removeWorktree"]);
+      expect(callOrder).toEqual(["waitForSessionExit", "killByThread", "killDescendants", "removeWorktree"]);
+    });
+
+    it("kills SDK subprocess descendants after terminal kill and before fs operations", async () => {
+      const callOrder: string[] = [];
+      (mockClaudeProvider.waitForSessionExit as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        callOrder.push("waitForSessionExit");
+      });
+      (mockTerminalService.killByThread as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callOrder.push("killByThread");
+      });
+      (vi.mocked(killDescendantsByName)).mockImplementation(async () => {
+        callOrder.push("killDescendants");
+      });
+      (mockGitService.removeWorktree as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        callOrder.push("removeWorktree");
+        return true;
+      });
+
+      const ws = workspaceRepo.create("test", "/repo");
+      insertThread("t-kill", ws.id, "mcode/kill-test", wt("feat-kill"));
+      cleanupJobRepo.insert({
+        thread_id: "t-kill",
+        workspace_path: "/repo",
+        worktree_path: wt("feat-kill"),
+        branch: "mcode/kill-test",
+      });
+
+      await worker.poll();
+
+      expect(callOrder).toEqual([
+        "waitForSessionExit",
+        "killByThread",
+        "killDescendants",
+        "removeWorktree",
+      ]);
+      expect(killDescendantsByName).toHaveBeenCalledWith(
+        process.pid,
+        expect.stringMatching(/claude/i),
+      );
     });
 
     it("calls waitForSessionExit with the correct session ID", async () => {

--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -256,4 +256,57 @@ describe("GitService.removeWorktree", () => {
 
     expect(mockRmdir).not.toHaveBeenCalled();
   });
+
+  it("retries EBUSY on parent dir rmdir and succeeds on later attempt", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    mockExistsSync.mockReturnValue(false);
+
+    const ebusyErr = Object.assign(new Error("EBUSY"), { code: "EBUSY" });
+    mockRmdir
+      .mockRejectedValueOnce(ebusyErr)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue(undefined);
+
+    const result = await gitService.removeWorktree("/repo", "my-worktree", { deleteBranch: false });
+
+    expect(result).toBe(true);
+    expect(mockRmdir.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Removed empty managed worktree parent dir",
+      expect.objectContaining({ path: expect.any(String) }),
+    );
+  });
+
+  it("gives up parent dir cleanup after exhausting EBUSY retries", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    mockExistsSync.mockReturnValue(false);
+
+    const ebusyErr = Object.assign(new Error("EBUSY"), { code: "EBUSY" });
+    mockRmdir.mockRejectedValue(ebusyErr);
+
+    const result = await gitService.removeWorktree("/repo", "my-worktree", { deleteBranch: false });
+
+    expect(result).toBe(false);
+    expect(mockRmdir).toHaveBeenCalledTimes(5);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Failed to remove empty managed worktree parent dir",
+      expect.objectContaining({ error: expect.stringContaining("EBUSY") }),
+    );
+  });
+
+  it("retries EPERM on parent dir rmdir the same as EBUSY", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    mockExistsSync.mockReturnValue(false);
+
+    const epermErr = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    mockRmdir
+      .mockRejectedValueOnce(epermErr)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue(undefined);
+
+    const result = await gitService.removeWorktree("/repo", "my-worktree", { deleteBranch: false });
+
+    expect(result).toBe(true);
+    expect(mockRmdir.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -286,7 +286,8 @@ describe("GitService.removeWorktree", () => {
 
     const result = await gitService.removeWorktree("/repo", "my-worktree", { deleteBranch: false });
 
-    expect(result).toBe(false);
+    // Parent cleanup is best-effort; worktree itself was removed so result is true
+    expect(result).toBe(true);
     expect(mockRmdir).toHaveBeenCalledTimes(5);
     expect(mockLogger.warn).toHaveBeenCalledWith(
       "Failed to remove empty managed worktree parent dir",

--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -286,8 +286,8 @@ describe("GitService.removeWorktree", () => {
 
     const result = await gitService.removeWorktree("/repo", "my-worktree", { deleteBranch: false });
 
-    // Parent cleanup is best-effort; worktree itself was removed so result is true
-    expect(result).toBe(true);
+    // Parent cleanup failed with transient lock; returns false so cleanup worker retries
+    expect(result).toBe(false);
     expect(mockRmdir).toHaveBeenCalledTimes(5);
     expect(mockLogger.warn).toHaveBeenCalledWith(
       "Failed to remove empty managed worktree parent dir",

--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -15,10 +15,10 @@ vi.mock("util", async (importOriginal) => {
 });
 
 vi.mock("@mcode/shared", () => ({
-  logger: { warn: vi.fn(), debug: vi.fn() },
+  logger: { warn: vi.fn(), debug: vi.fn(), info: vi.fn() },
 }));
 
-import { killProcessTree } from "../services/process-kill";
+import { killProcessTree, findDescendantsByName, killDescendantsByName } from "../services/process-kill";
 import { logger } from "@mcode/shared";
 
 describe("killProcessTree", () => {
@@ -108,6 +108,130 @@ describe("killProcessTree", () => {
 
       expect(killSpy).not.toHaveBeenCalled();
       killSpy.mockRestore();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+});
+
+describe("findDescendantsByName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns matching PIDs from wmic output on Windows", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      // wmic outputs CSV-like lines: first call for direct children, recursive
+      mockExecFile
+        .mockResolvedValueOnce({
+          stdout: "Name,ProcessId\r\nclaude.exe,5555\r\nnode.exe,6666\r\n",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({
+          stdout: "Name,ProcessId\r\n",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({
+          stdout: "Name,ProcessId\r\nclaude.exe,7777\r\n",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({
+          stdout: "Name,ProcessId\r\n",
+          stderr: "",
+        });
+
+      const pids = await findDescendantsByName(1234, "claude.exe");
+
+      expect(pids).toContain(5555);
+      expect(pids).toContain(7777);
+      expect(pids).not.toContain(6666);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns empty array when no descendants match", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      mockExecFile.mockResolvedValue({
+        stdout: "Name,ProcessId\r\n",
+        stderr: "",
+      });
+
+      const pids = await findDescendantsByName(1234, "claude.exe");
+
+      expect(pids).toEqual([]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("returns empty array when wmic fails", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      mockExecFile.mockRejectedValue(new Error("wmic not found"));
+
+      const pids = await findDescendantsByName(1234, "claude.exe");
+
+      expect(pids).toEqual([]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+});
+
+describe("killDescendantsByName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("finds and kills matching descendants on Windows", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      // First call: findDescendantsByName queries children
+      mockExecFile
+        .mockResolvedValueOnce({
+          stdout: "Name,ProcessId\r\nclaude.exe,5555\r\n",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({
+          stdout: "Name,ProcessId\r\n",
+          stderr: "",
+        })
+        // Second call: taskkill for the found PID
+        .mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+      await killDescendantsByName(1234, "claude.exe");
+
+      // Last call should be taskkill
+      const lastCall = mockExecFile.mock.calls[mockExecFile.mock.calls.length - 1];
+      expect(lastCall?.[0]).toBe("taskkill");
+      expect(lastCall?.[1]).toEqual(["/T", "/F", "/PID", "5555"]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("does nothing when no descendants match", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      mockExecFile.mockResolvedValue({
+        stdout: "Name,ProcessId\r\n",
+        stderr: "",
+      });
+
+      await killDescendantsByName(1234, "claude.exe");
+
+      // Only the wmic query calls, no taskkill
+      for (const call of mockExecFile.mock.calls) {
+        expect(call[0]).not.toBe("taskkill");
+      }
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -16,6 +16,7 @@ import { ThreadRepo } from "../repositories/thread-repo.js";
 import { ClaudeProvider } from "../providers/claude/claude-provider.js";
 import { TerminalService } from "./terminal-service.js";
 import { GitService } from "./git-service.js";
+import { killDescendantsByName } from "./process-kill.js";
 
 /** How often to check for due cleanup jobs (ms). */
 const POLL_INTERVAL_MS = 5_000;
@@ -148,12 +149,18 @@ export class CleanupWorker {
         });
       }
 
-      // 3. Brief delay on Windows so the OS releases directory handles.
+      // 3. Force-kill any lingering SDK subprocess (claude.exe) that is a
+      //    descendant of this server process. waitForSessionExit only confirms
+      //    the stream ended, not that the OS process exited.  Its cwd handle
+      //    locks the worktree directory and ancestors on Windows.
+      await killDescendantsByName(process.pid, "claude.exe");
+
+      // 4. Brief delay on Windows so the OS releases directory handles.
       if (process.platform === "win32") {
         await new Promise<void>((resolve) => setTimeout(resolve, HANDLE_RELEASE_DELAY_MS));
       }
 
-      // 4. Remove the worktree directory and delete the exact thread branch when
+      // 5. Remove the worktree directory and delete the exact thread branch when
       //    the thread record has one. The delete-thread dialog is the user intent
       //    boundary; rollback paths are handled separately in ThreadService.
       const wtName = resolvedWt.replace(/\\/g, "/").split("/").pop() ?? resolvedWt;
@@ -171,7 +178,7 @@ export class CleanupWorker {
         throw new Error(`Worktree directory still exists after removal: ${resolvedWt}`);
       }
 
-      // 5. Hard-delete thread row and cleanup job atomically.
+      // 6. Hard-delete thread row and cleanup job atomically.
       //    Wrapping in a transaction ensures no orphaned job if either statement fails.
       this.db.transaction(() => {
         this.threadRepo.hardDelete(job.thread_id);

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -153,6 +153,12 @@ export class CleanupWorker {
       //    descendant of this server process. waitForSessionExit only confirms
       //    the stream ended, not that the OS process exited.  Its cwd handle
       //    locks the worktree directory and ancestors on Windows.
+      //
+      //    Scope: targets all claude.exe descendants of the server, not just
+      //    this session's subprocess. The SDK does not expose subprocess PIDs,
+      //    so per-session targeting is not possible. This is acceptable because
+      //    cleanup jobs only exist for deleted threads whose sessions have
+      //    already been asked to exit in step 1.
       await killDescendantsByName(process.pid, "claude.exe");
 
       // 4. Brief delay on Windows so the OS releases directory handles.

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -311,6 +311,10 @@ export class GitService {
       try {
         await rename(wtPath, pendingPath);
         logger.info("Renamed stuck worktree for deferred deletion", { wtPath, pendingPath });
+        // Best-effort: .catch() intentionally swallows errors because the
+        // original worktree path is already gone (renamed). If the deferred rm
+        // fails the .deleting-* dir persists but the worktree is effectively
+        // removed, so retrying the entire cleanup job would be pointless.
         deferredRm = rm(pendingPath, RM_RETRY_OPTIONS).catch(
           (err) => {
             logger.warn("Deferred deletion of renamed worktree failed", {

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -351,8 +351,10 @@ export class GitService {
     }
 
     // 7. Best-effort cleanup of any empty managed parent directories left behind.
-    //    Returns false if parent removal failed (triggers cleanup worker retry).
-    const parentCleaned = await removeEmptyManagedParentDirs(wtPath);
+    //    Failure here is cosmetic (empty slug dir left behind) and should not
+    //    cause the cleanup worker to retry the entire pipeline for an already-
+    //    removed worktree.
+    await removeEmptyManagedParentDirs(wtPath);
 
     // 8. Delete the branch when explicitly requested.
     if (branch) {
@@ -368,7 +370,7 @@ export class GitService {
       }
     }
 
-    return parentCleaned;
+    return true;
   }
 
   /**

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -22,6 +22,12 @@ const execFile = promisify(execFileCb);
  */
 const RM_RETRY_OPTIONS = { recursive: true, force: true, maxRetries: 5, retryDelay: 200 } as const;
 
+/** Max retries for rmdir on parent directories (handles transient Windows NTFS/AV locks). */
+const PARENT_RMDIR_MAX_RETRIES = 5;
+
+/** Delay between rmdir retries in milliseconds. */
+const PARENT_RMDIR_RETRY_DELAY_MS = 300;
+
 /**
  * Options for {@link GitService.removeWorktree}.
  * Controls which worktree path is removed and whether the associated branch is deleted.
@@ -60,25 +66,52 @@ function worktreeSlug(repoPath: string): string {
   return basename(repoPath).toLowerCase().replace(/[^a-z0-9-]/g, "-");
 }
 
-/** Best-effort cleanup of empty managed parent directories after a worktree is removed. */
-async function removeEmptyManagedParentDirs(wtPath: string): Promise<void> {
+/**
+ * Retry rmdir for transient EBUSY/EPERM locks on Windows.
+ * After a child directory is removed, NTFS journal updates, antivirus scans,
+ * or the search indexer can briefly hold the parent directory.
+ */
+async function rmdirWithRetry(dirPath: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await rmdir(dirPath);
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code ?? "";
+      if (
+        (code === "EBUSY" || code === "EPERM") &&
+        attempt < PARENT_RMDIR_MAX_RETRIES - 1
+      ) {
+        await new Promise<void>((r) => setTimeout(r, PARENT_RMDIR_RETRY_DELAY_MS));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Best-effort cleanup of empty managed parent directories after a worktree is removed.
+ * Returns true if all empty parents were removed, false if any failed.
+ */
+async function removeEmptyManagedParentDirs(wtPath: string): Promise<boolean> {
   const managedRoot = resolve(getMcodeDir(), "worktrees");
   const rel = relative(managedRoot, resolve(wtPath));
   if (rel.startsWith("..") || isAbsolute(rel)) {
-    return;
+    return true;
   }
 
   let current = dirname(resolve(wtPath));
   while (current !== managedRoot) {
     try {
-      await rmdir(current);
+      await rmdirWithRetry(current);
       logger.info("Removed empty managed worktree parent dir", { path: current });
       current = dirname(current);
     } catch (err) {
       const code = err && typeof err === "object" && "code" in err
         ? String((err as NodeJS.ErrnoException).code)
         : "";
-      if (code === "ENOTEMPTY" || code === "EEXIST" || code === "EBUSY") {
+      if (code === "ENOTEMPTY" || code === "EEXIST") {
         break;
       }
       if (code === "ENOENT") {
@@ -89,9 +122,10 @@ async function removeEmptyManagedParentDirs(wtPath: string): Promise<void> {
         path: current,
         error: err instanceof Error ? err.message : String(err),
       });
-      break;
+      return false;
     }
   }
+  return true;
 }
 
 /** Check whether a branch ref exists in the repository. */
@@ -269,6 +303,7 @@ export class GitService {
     // 3. Rename-then-delete: atomically unblock the path even if deletion is slow.
     // Renaming succeeds even when the directory has open handles, so the original
     // path becomes available immediately while the OS drains remaining handles.
+    let deferredRm: Promise<void> | undefined;
     if (existsSync(wtPath)) {
       // Use a timestamp suffix to avoid collision with stale .deleting directories
       // left by previous crashed cleanup attempts.
@@ -276,8 +311,7 @@ export class GitService {
       try {
         await rename(wtPath, pendingPath);
         logger.info("Renamed stuck worktree for deferred deletion", { wtPath, pendingPath });
-        // Best-effort: fire-and-forget deletion of the renamed directory.
-        rm(pendingPath, RM_RETRY_OPTIONS).catch(
+        deferredRm = rm(pendingPath, RM_RETRY_OPTIONS).catch(
           (err) => {
             logger.warn("Deferred deletion of renamed worktree failed", {
               pendingPath,
@@ -310,26 +344,31 @@ export class GitService {
       });
     }
 
-    // 6. Best-effort cleanup of any empty managed parent directories left behind.
-    await removeEmptyManagedParentDirs(wtPath);
-
-    // 7. Delete the branch when explicitly requested.
-    if (!branch) {
-      return true;
+    // 6. Wait for any deferred deletion to finish so the parent directory is
+    //    actually empty before we try to rmdir it.
+    if (deferredRm) {
+      await deferredRm;
     }
 
-    try {
-      await execFile("git", ["-C", repoPath, "branch", "-d", branch], {
-        timeout: 10_000,
-      });
-    } catch (err) {
-      logger.warn("Branch deletion failed (may not exist)", {
-        branch,
-        error: err instanceof Error ? err.message : String(err),
-      });
+    // 7. Best-effort cleanup of any empty managed parent directories left behind.
+    //    Returns false if parent removal failed (triggers cleanup worker retry).
+    const parentCleaned = await removeEmptyManagedParentDirs(wtPath);
+
+    // 8. Delete the branch when explicitly requested.
+    if (branch) {
+      try {
+        await execFile("git", ["-C", repoPath, "branch", "-d", branch], {
+          timeout: 10_000,
+        });
+      } catch (err) {
+        logger.warn("Branch deletion failed (may not exist)", {
+          branch,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
-    return true;
+    return parentCleaned;
   }
 
   /**

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -354,13 +354,13 @@ export class GitService {
       await deferredRm;
     }
 
-    // 7. Best-effort cleanup of any empty managed parent directories left behind.
-    //    Failure here is cosmetic (empty slug dir left behind) and should not
-    //    cause the cleanup worker to retry the entire pipeline for an already-
-    //    removed worktree.
-    await removeEmptyManagedParentDirs(wtPath);
+    // 7. Remove empty managed parent directories. Returns false on transient
+    //    lock errors (EBUSY/EPERM) so the cleanup worker can retry later when
+    //    the OS releases handles.
+    const parentsCleaned = await removeEmptyManagedParentDirs(wtPath);
 
-    // 8. Delete the branch when explicitly requested.
+    // 8. Delete the branch when explicitly requested (independent of parent
+    //    dir state - always attempt this).
     if (branch) {
       try {
         await execFile("git", ["-C", repoPath, "branch", "-d", branch], {
@@ -374,7 +374,7 @@ export class GitService {
       }
     }
 
-    return true;
+    return parentsCleaned;
   }
 
   /**

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -99,11 +99,18 @@ export async function findDescendantsByName(
  * Find descendant processes matching a name and kill each one.
  * Best-effort: never throws. Used to clean up SDK subprocesses that
  * outlive their stream connection.
+ *
+ * Windows-only: on Unix, process cwd does not hold ancestor directory
+ * handles, so the directory locking problem this solves does not occur.
+ * The wmic-based process tree scan also has no Unix equivalent that
+ * returns process names without additional per-PID lookups.
  */
 export async function killDescendantsByName(
   parentPid: number,
   processName: string,
 ): Promise<void> {
+  if (process.platform !== "win32") return;
+
   const pids = await findDescendantsByName(parentPid, processName);
   if (pids.length === 0) return;
 

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -61,7 +61,10 @@ export async function killProcessTree(pid: number): Promise<void> {
 
 /**
  * Recursively find descendant processes matching a given name.
- * On Windows uses wmic to query the process tree. On Unix uses pgrep.
+ * On Windows uses wmic to query the process tree (returns name + PID).
+ * On Unix uses pgrep (returns PIDs only, without names), so name matching
+ * will never produce results there. Callers that need name-based filtering
+ * should guard with a platform check (see {@link killDescendantsByName}).
  * Best-effort: returns an empty array on failure.
  */
 export async function findDescendantsByName(

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -58,3 +58,102 @@ export async function killProcessTree(pid: number): Promise<void> {
     }
   }
 }
+
+/**
+ * Recursively find descendant processes matching a given name.
+ * On Windows uses wmic to query the process tree. On Unix uses pgrep.
+ * Best-effort: returns an empty array on failure.
+ */
+export async function findDescendantsByName(
+  parentPid: number,
+  processName: string,
+): Promise<number[]> {
+  const matched: number[] = [];
+  const visited = new Set<number>();
+  const queue = [parentPid];
+
+  while (queue.length > 0) {
+    const pid = queue.shift()!;
+    if (visited.has(pid)) continue;
+    visited.add(pid);
+
+    let children: Array<{ name: string; pid: number }>;
+    try {
+      children = await listDirectChildren(pid);
+    } catch {
+      continue;
+    }
+
+    for (const child of children) {
+      if (child.name.toLowerCase() === processName.toLowerCase()) {
+        matched.push(child.pid);
+      }
+      queue.push(child.pid);
+    }
+  }
+
+  return matched;
+}
+
+/**
+ * Find descendant processes matching a name and kill each one.
+ * Best-effort: never throws. Used to clean up SDK subprocesses that
+ * outlive their stream connection.
+ */
+export async function killDescendantsByName(
+  parentPid: number,
+  processName: string,
+): Promise<void> {
+  const pids = await findDescendantsByName(parentPid, processName);
+  if (pids.length === 0) return;
+
+  logger.info("Killing descendant processes", { parentPid, processName, pids });
+  await Promise.all(pids.map((pid) => killProcessTree(pid)));
+}
+
+/**
+ * List direct child processes of a given PID.
+ * Returns name and PID for each child.
+ */
+async function listDirectChildren(
+  pid: number,
+): Promise<Array<{ name: string; pid: number }>> {
+  if (process.platform === "win32") {
+    const { stdout } = await execFile(
+      "wmic",
+      ["process", "where", `ParentProcessId=${pid}`, "get", "Name,ProcessId", "/format:csv"],
+      { timeout: TASKKILL_TIMEOUT_MS },
+    );
+    return parseWmicCsv(stdout);
+  }
+
+  // Unix: pgrep -P returns child PIDs, one per line
+  const { stdout } = await execFile("pgrep", ["-P", String(pid)], {
+    timeout: TASKKILL_TIMEOUT_MS,
+  });
+  return stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => ({ name: "", pid: parseInt(line.trim(), 10) }))
+    .filter((entry) => !isNaN(entry.pid));
+}
+
+/** Parse wmic CSV output into name/pid pairs. */
+function parseWmicCsv(output: string): Array<{ name: string; pid: number }> {
+  const lines = output.split(/\r?\n/).filter((l) => l.trim());
+  if (lines.length < 2) return [];
+
+  const header = lines[0]!.toLowerCase();
+  const nameIdx = header.split(",").findIndex((col) => col.trim() === "name");
+  const pidIdx = header.split(",").findIndex((col) => col.trim() === "processid");
+  if (nameIdx === -1 || pidIdx === -1) return [];
+
+  return lines.slice(1).reduce<Array<{ name: string; pid: number }>>((acc, line) => {
+    const cols = line.split(",");
+    const name = cols[nameIdx]?.trim() ?? "";
+    const pid = parseInt(cols[pidIdx]?.trim() ?? "", 10);
+    if (name && !isNaN(pid)) acc.push({ name, pid });
+    return acc;
+  }, []);
+}


### PR DESCRIPTION
## What
Fix worktree cleanup failing on Windows because the Claude SDK subprocess holds cwd handles on the worktree directory and its parent, preventing deletion. The leftover slug directory blocks future worktree operations for the same repo.

## Why
When a thread is deleted, the cleanup worker signals the SDK subprocess to close and waits for the stream to end. However, `waitForSessionExit` only confirms the async iterator finished, not that the OS process exited. On Windows, a process's cwd holds handles on the directory and all ancestors. The parent directory (`~/.mcode/worktrees/<slug>/`) stays locked until the subprocess fully exits, and the current code gives up immediately on EBUSY.

## Key Changes
- Add `findDescendantsByName()` and `killDescendantsByName()` to `process-kill.ts` for recursive process tree scanning by name (wmic on Windows, pgrep on Unix)
- Insert an explicit SDK subprocess kill step (`claude.exe`) in the cleanup worker between terminal kill and filesystem operations
- Await the previously fire-and-forget `rm(pendingPath)` before parent directory cleanup
- Add `rmdirWithRetry` (5 attempts, 300ms delay) for transient EBUSY/EPERM locks on parent directories
- Surface parent cleanup failure via return value so the cleanup worker's exponential backoff retries the job

Closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown cleanup to force-terminate lingering child processes on Windows and to await pending removals so sessions and filesystem cleanup complete reliably.
  * Added retry handling on Windows for parent-directory removal to tolerate transient filesystem locks and return clear success/failure results.
* **Tests**
  * Added unit tests covering descendant-process termination, retry scenarios, and worktree removal sequencing to validate cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->