### PR TITLE
feat: implement complete() on CopilotProvider for PR draft generation

### DIFF
--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -448,3 +448,52 @@ describe("CopilotProvider.complete()", () => {
     expect(mockSession.disconnect).toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// listModels() — TTL cache
+// ---------------------------------------------------------------------------
+
+describe("CopilotProvider.listModels() cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.getState.mockReturnValue("connected");
+    mockClient.start.mockResolvedValue(undefined);
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, result?: { stdout: string }) => void) => {
+        cb(null, { stdout: "gho_faketoken\n" });
+      },
+    );
+  });
+
+  it("returns cached models on the second call within TTL", async () => {
+    mockClient.listModels.mockResolvedValue([
+      { id: "gpt-4.1", name: "GPT-4.1", capabilities: {}, billing: {} },
+    ]);
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+
+    const first = await provider.listModels();
+    const second = await provider.listModels();
+
+    expect(first).toEqual(second);
+    // SDK listModels called only once — second call served from cache
+    expect(mockClient.listModels).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after cache expires", async () => {
+    vi.useFakeTimers();
+    mockClient.listModels.mockResolvedValue([
+      { id: "gpt-4.1", name: "GPT-4.1", capabilities: {}, billing: {} },
+    ]);
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+
+    await provider.listModels();
+    // Advance past the 10-minute TTL
+    vi.advanceTimersByTime(11 * 60 * 1000);
+    await provider.listModels();
+
+    expect(mockClient.listModels).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+});

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -465,6 +465,10 @@ describe("CopilotProvider.listModels() cache", () => {
     );
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns cached models on the second call within TTL", async () => {
     mockClient.listModels.mockResolvedValue([
       { id: "gpt-4.1", name: "GPT-4.1", capabilities: {}, billing: {} },
@@ -494,6 +498,5 @@ describe("CopilotProvider.listModels() cache", () => {
     await provider.listModels();
 
     expect(mockClient.listModels).toHaveBeenCalledTimes(2);
-    vi.useRealTimers();
   });
 });

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -349,7 +349,7 @@ describe("CopilotProvider session.usage_info", () => {
 });
 
 // ---------------------------------------------------------------------------
-// complete() — one-shot text completion
+// complete() - one-shot text completion
 // ---------------------------------------------------------------------------
 
 describe("CopilotProvider.complete()", () => {
@@ -450,7 +450,7 @@ describe("CopilotProvider.complete()", () => {
 });
 
 // ---------------------------------------------------------------------------
-// listModels() — TTL cache
+// listModels() - TTL cache
 // ---------------------------------------------------------------------------
 
 describe("CopilotProvider.listModels() cache", () => {
@@ -476,7 +476,7 @@ describe("CopilotProvider.listModels() cache", () => {
     const second = await provider.listModels();
 
     expect(first).toEqual(second);
-    // SDK listModels called only once — second call served from cache
+    // SDK listModels called only once - second call served from cache
     expect(mockClient.listModels).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -347,3 +347,104 @@ describe("CopilotProvider session.usage_info", () => {
     expect(events.find((e) => e.type === "contextEstimate")).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// complete() — one-shot text completion
+// ---------------------------------------------------------------------------
+
+describe("CopilotProvider.complete()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.getState.mockReturnValue("connected");
+    mockClient.start.mockResolvedValue(undefined);
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, result?: { stdout: string }) => void) => {
+        cb(null, { stdout: "gho_faketoken\n" });
+      },
+    );
+  });
+
+  it("returns collected text from assistant.message event", async () => {
+    const mockSession = makeMockSession();
+    mockClient.createSession.mockResolvedValue(mockSession);
+
+    const jsonResponse = JSON.stringify({
+      title: "feat: add widget",
+      body: "## What\nAdded widget",
+    });
+
+    mockSession.send.mockImplementation(async () => {
+      mockSession.fire("assistant.message", { content: jsonResponse, outputTokens: 42 });
+      mockSession.fire("session.idle");
+    });
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+    const result = await provider.complete("Generate PR draft", "gpt-4.1", "/tmp");
+
+    expect(result).toBe(jsonResponse);
+    expect(mockSession.disconnect).toHaveBeenCalled();
+  });
+
+  it("falls back to accumulated deltas when assistant.message has no content", async () => {
+    const mockSession = makeMockSession();
+    mockClient.createSession.mockResolvedValue(mockSession);
+
+    mockSession.send.mockImplementation(async () => {
+      mockSession.fire("assistant.message_delta", { deltaContent: '{"title":' });
+      mockSession.fire("assistant.message_delta", { deltaContent: '"feat: x","body":"b"}' });
+      mockSession.fire("assistant.message", { content: "", outputTokens: 10 });
+      mockSession.fire("session.idle");
+    });
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+    const result = await provider.complete("Generate PR draft", "gpt-4.1", "/tmp");
+
+    expect(result).toBe('{"title":"feat: x","body":"b"}');
+    expect(mockSession.disconnect).toHaveBeenCalled();
+  });
+
+  it("throws when session.error fires", async () => {
+    const mockSession = makeMockSession();
+    mockClient.createSession.mockResolvedValue(mockSession);
+
+    mockSession.send.mockImplementation(async () => {
+      mockSession.fire("session.error", { message: "Model not available" });
+    });
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+
+    await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
+      "Model not available",
+    );
+    expect(mockSession.disconnect).toHaveBeenCalled();
+  });
+
+  it("throws when no text is returned", async () => {
+    const mockSession = makeMockSession();
+    mockClient.createSession.mockResolvedValue(mockSession);
+
+    mockSession.send.mockImplementation(async () => {
+      mockSession.fire("session.idle");
+    });
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+
+    await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
+      "no text content",
+    );
+    expect(mockSession.disconnect).toHaveBeenCalled();
+  });
+
+  it("disconnects the session even when send() throws", async () => {
+    const mockSession = makeMockSession();
+    mockClient.createSession.mockResolvedValue(mockSession);
+    mockSession.send.mockRejectedValue(new Error("network error"));
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+
+    await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
+      "network error",
+    );
+    expect(mockSession.disconnect).toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/__tests__/pr-draft-service.test.ts
+++ b/apps/server/src/__tests__/pr-draft-service.test.ts
@@ -263,6 +263,50 @@ describe("PrDraftService", () => {
     );
   });
 
+  it("uses Copilot provider with gpt-4.1 default when configured", async () => {
+    mockSettingsService.get.mockResolvedValue({
+      model: { defaults: { provider: "claude" } },
+      prDraft: { provider: "copilot", model: "" },
+    });
+    mockProviderRegistry.resolve.mockReturnValue({ complete: mockComplete, supportsCompletion: true });
+    mockWorkspaceRepo.findById.mockReturnValue({ path: "/repo" });
+    mockGitService.log.mockResolvedValue([{ message: "feat: thing", sha: "aaa" }]);
+    mockGitService.diffStat.mockResolvedValue("1 file changed");
+    mockMessageRepo.listByThread.mockReturnValue({ messages: [], hasMore: false });
+    mockComplete.mockResolvedValue(JSON.stringify({ title: "feat: thing", body: "body" }));
+
+    await service.generateDraft("ws-1", "thread-1", "main");
+
+    expect(mockProviderRegistry.resolve).toHaveBeenCalledWith("copilot");
+    expect(mockComplete).toHaveBeenCalledWith(
+      expect.any(String),
+      "gpt-4.1",
+      "/repo",
+    );
+  });
+
+  it("auto-delegates to Copilot when it is the default provider and supports completion", async () => {
+    mockSettingsService.get.mockResolvedValue({
+      model: { defaults: { provider: "copilot" } },
+      prDraft: { provider: "", model: "" },
+    });
+    mockProviderRegistry.resolve.mockReturnValue({ complete: mockComplete, supportsCompletion: true });
+    mockWorkspaceRepo.findById.mockReturnValue({ path: "/repo" });
+    mockGitService.log.mockResolvedValue([{ message: "feat: thing", sha: "aaa" }]);
+    mockGitService.diffStat.mockResolvedValue("1 file changed");
+    mockMessageRepo.listByThread.mockReturnValue({ messages: [], hasMore: false });
+    mockComplete.mockResolvedValue(JSON.stringify({ title: "feat: thing", body: "body" }));
+
+    await service.generateDraft("ws-1", "thread-1", "main");
+
+    expect(mockProviderRegistry.resolve).toHaveBeenCalledWith("copilot");
+    expect(mockComplete).toHaveBeenCalledWith(
+      expect.any(String),
+      "gpt-4.1",
+      "/repo",
+    );
+  });
+
   describe("parseCompletionDraft (via generateWithAI)", () => {
     beforeEach(() => {
       mockWorkspaceRepo.findById.mockReturnValue({ path: "/repo" });

--- a/apps/server/src/__tests__/pr-draft-service.test.ts
+++ b/apps/server/src/__tests__/pr-draft-service.test.ts
@@ -42,7 +42,7 @@ describe("PrDraftService", () => {
   const mockSettingsService = {
     get: vi.fn().mockResolvedValue({
       model: { defaults: { provider: "claude" } },
-      prDraft: { model: "" },
+      prDraft: { provider: "", model: "" },
     }),
   };
   const mockProviderRegistry = {
@@ -53,7 +53,7 @@ describe("PrDraftService", () => {
     vi.clearAllMocks();
     mockSettingsService.get.mockResolvedValue({
       model: { defaults: { provider: "claude" } },
-      prDraft: { model: "" },
+      prDraft: { provider: "", model: "" },
     });
     mockProviderRegistry.resolve.mockReturnValue({ complete: mockComplete, supportsCompletion: true });
     // Default: direct thread in workspace ws-1

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -121,6 +121,11 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   /** Serialises concurrent refreshClient() calls so only one rebuild runs at a time. */
   private clientStartLock: Promise<void> = Promise.resolve();
 
+  private modelCache: ProviderModelInfo[] | null = null;
+  private modelCacheTimestamp = 0;
+  /** Avoid hammering the Copilot SDK on every call — results are stable within a session. */
+  private static readonly MODEL_CACHE_TTL_MS = 10 * 60 * 1000;
+
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
   ) {
@@ -194,8 +199,13 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Fetch available models from the Copilot SDK. */
+  /** Fetch available models from the Copilot SDK, with a 10-minute TTL cache. */
   async listModels(): Promise<ProviderModelInfo[]> {
+    const now = Date.now();
+    if (this.modelCache && (now - this.modelCacheTimestamp) < CopilotProvider.MODEL_CACHE_TTL_MS) {
+      return this.modelCache;
+    }
+
     await this.refreshClient();
     const client = this.client;
     if (!client) {
@@ -223,7 +233,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       }
     }
 
-    return sdkModels.map((m) => ({
+    const result = sdkModels.map((m) => ({
       id: m.id,
       name: m.name,
       group: inferModelGroup(m.id),
@@ -235,6 +245,9 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       policy: m.policy ? { state: m.policy.state as "enabled" | "disabled" | "unconfigured" } : undefined,
       multiplier: m.billing?.multiplier,
     }));
+    this.modelCache = result;
+    this.modelCacheTimestamp = Date.now();
+    return result;
   }
 
   /** Return current usage/quota state by fetching from account.getQuota(). */

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -109,7 +109,7 @@ interface SessionEntry {
 @injectable()
 export class CopilotProvider extends EventEmitter implements IAgentProvider {
   readonly id: ProviderId = "copilot";
-  readonly supportsCompletion = false;
+  readonly supportsCompletion = true;
 
   private client: CopilotClient | null = null;
   private lastCliPath: string | undefined;
@@ -125,6 +125,73 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     @inject(SettingsService) private readonly settingsService: SettingsService,
   ) {
     super();
+  }
+
+  /**
+   * One-shot text completion using an ephemeral Copilot session.
+   * Creates a temporary session, sends the prompt, collects the response
+   * text from SDK callbacks, then tears down the session.
+   */
+  async complete(prompt: string, model: string, cwd: string): Promise<string> {
+    await this.refreshClient();
+    const client = this.client;
+    if (!client) {
+      throw new Error("Copilot client not available");
+    }
+
+    const session = await client.createSession({
+      onPermissionRequest: approveAll,
+      model: model || undefined,
+      workingDirectory: cwd,
+    });
+
+    try {
+      let messageText = "";
+      let deltaText = "";
+
+      const turnPromise = new Promise<void>((resolve, reject) => {
+        const unsubscribers: Array<() => void> = [];
+
+        unsubscribers.push(
+          session.on("assistant.message_delta", (event: { data: { deltaContent: string } }) => {
+            deltaText += event.data.deltaContent;
+          }),
+        );
+
+        unsubscribers.push(
+          session.on("assistant.message", (event: { data: { content: string } }) => {
+            if (event.data.content) messageText = event.data.content;
+          }),
+        );
+
+        unsubscribers.push(
+          session.on("session.error", (event: { data: { message: string } }) => {
+            for (const unsub of unsubscribers) unsub();
+            reject(new Error(event.data.message));
+          }),
+        );
+
+        unsubscribers.push(
+          session.on("session.idle", () => {
+            for (const unsub of unsubscribers) unsub();
+            resolve();
+          }),
+        );
+      });
+
+      await session.send({ prompt });
+      await turnPromise;
+
+      const text = messageText || deltaText;
+      if (!text) throw new Error("Copilot returned no text content");
+      return text.trim();
+    } finally {
+      await session.disconnect().catch((err: unknown) =>
+        logger.debug("CopilotProvider: error disconnecting ephemeral session", {
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
   }
 
   /** Fetch available models from the Copilot SDK. */

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -123,7 +123,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
 
   private modelCache: ProviderModelInfo[] | null = null;
   private modelCacheTimestamp = 0;
-  /** Avoid hammering the Copilot SDK on every call — results are stable within a session. */
+  /** Avoid hammering the Copilot SDK on every call - results are stable within a session. */
   private static readonly MODEL_CACHE_TTL_MS = 10 * 60 * 1000;
 
   constructor(
@@ -150,13 +150,13 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       workingDirectory: cwd,
     });
 
+    const unsubscribers: Array<() => void> = [];
+
     try {
       let messageText = "";
       let deltaText = "";
 
       const turnPromise = new Promise<void>((resolve, reject) => {
-        const unsubscribers: Array<() => void> = [];
-
         unsubscribers.push(
           session.on("assistant.message_delta", (event: { data: { deltaContent: string } }) => {
             deltaText += event.data.deltaContent;
@@ -171,26 +171,40 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
 
         unsubscribers.push(
           session.on("session.error", (event: { data: { message: string } }) => {
-            for (const unsub of unsubscribers) unsub();
             reject(new Error(event.data.message));
           }),
         );
 
         unsubscribers.push(
           session.on("session.idle", () => {
-            for (const unsub of unsubscribers) unsub();
             resolve();
           }),
         );
       });
 
+      const COMPLETE_TIMEOUT_MS = 60_000;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("Copilot complete() timed out after 60 seconds")),
+          COMPLETE_TIMEOUT_MS,
+        );
+      });
+
       await session.send({ prompt });
-      await turnPromise;
+
+      try {
+        await Promise.race([turnPromise, timeoutPromise]);
+      } finally {
+        clearTimeout(timeoutId);
+      }
 
       const text = messageText || deltaText;
       if (!text) throw new Error("Copilot returned no text content");
       return text.trim();
     } finally {
+      for (const unsub of unsubscribers) unsub();
       await session.disconnect().catch((err: unknown) =>
         logger.debug("CopilotProvider: error disconnecting ephemeral session", {
           error: err instanceof Error ? err.message : String(err),
@@ -222,6 +236,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       if (msg.includes("not connected")) {
         logger.warn("CopilotProvider: listModels connection lost, reconnecting", { error: msg });
         this.client = null;
+        this.modelCache = null;
+        this.modelCacheTimestamp = 0;
         await this.refreshClient();
         const freshClient = this.client as CopilotClient | null;
         if (!freshClient) {
@@ -300,6 +316,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         logger.warn("CopilotProvider: error stopping old client", { error: String(err) }),
       );
       this.client = null;
+      this.modelCache = null;
+      this.modelCacheTimestamp = 0;
     }
 
     const opts: {
@@ -410,9 +428,11 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       const threadId = this.toThreadId(params.sessionId);
 
       if (msg.includes("CLI server exited")) {
-        // The @github/copilot process died — discard the dead client so
+        // The @github/copilot process died - discard the dead client so
         // refreshClient() rebuilds it on the next attempt.
         this.client = null;
+        this.modelCache = null;
+        this.modelCacheTimestamp = 0;
         const userMsg =
           "GitHub Copilot CLI exited unexpectedly.\n\n" +
           "Ensure you are authenticated: run `gh auth login` and confirm you have an active GitHub Copilot subscription.";
@@ -550,7 +570,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
 
     try {
       const turnPromise = new Promise<void>((resolve) => {
-        // assistant.message_delta — streaming text chunk
+        // assistant.message_delta - streaming text chunk
         unsubscribers.push(
           session.on("assistant.message_delta", (event) => {
             const entry = this.sessions.get(sessionId);
@@ -564,7 +584,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // assistant.message — final complete assistant response
+        // assistant.message - final complete assistant response
         unsubscribers.push(
           session.on("assistant.message", (event) => {
             this.emit("event", {
@@ -576,7 +596,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // tool.execution_start — assistant is invoking a tool
+        // tool.execution_start - assistant is invoking a tool
         unsubscribers.push(
           session.on("tool.execution_start", (event) => {
             const { toolCallId, toolName, arguments: toolArgs } = event.data;
@@ -591,7 +611,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // tool.execution_complete — tool has finished
+        // tool.execution_complete - tool has finished
         unsubscribers.push(
           session.on("tool.execution_complete", (event) => {
             const { toolCallId, success, result } = event.data;
@@ -606,7 +626,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // tool.execution_progress — heartbeat while a tool runs
+        // tool.execution_progress - heartbeat while a tool runs
         unsubscribers.push(
           session.on("tool.execution_progress", (event) => {
             const { toolCallId } = event.data;
@@ -630,7 +650,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // session.usage_info — live context window metrics emitted each turn
+        // session.usage_info - live context window metrics emitted each turn
         unsubscribers.push(
           session.on("session.usage_info", (event) => {
             const { tokenLimit, currentTokens } = event.data as {
@@ -647,7 +667,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // assistant.usage — token counts after a model call
+        // assistant.usage - token counts after a model call
         unsubscribers.push(
           session.on("assistant.usage", (event) => {
             const {
@@ -687,7 +707,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // session.error — provider-level error; resolve so cleanup runs.
+        // session.error - provider-level error; resolve so cleanup runs.
         // Also evict the session entry so the next sendMessage creates a fresh
         // session rather than reusing a potentially dead one.
         unsubscribers.push(
@@ -703,7 +723,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // session.compaction_start — context window compaction beginning
+        // session.compaction_start - context window compaction beginning
         unsubscribers.push(
           session.on("session.compaction_start", () => {
             this.emit("event", {
@@ -714,7 +734,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // session.compaction_complete — compaction finished; emit summary if present
+        // session.compaction_complete - compaction finished; emit summary if present
         unsubscribers.push(
           session.on("session.compaction_complete", (event) => {
             if (event.data.summaryContent) {
@@ -732,7 +752,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // session.idle — turn is complete; resolve and clean up handlers
+        // session.idle - turn is complete; resolve and clean up handlers
         unsubscribers.push(
           session.on("session.idle", () => {
             resolve();
@@ -826,6 +846,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         }),
       );
       this.client = null;
+      this.modelCache = null;
+      this.modelCacheTimestamp = 0;
     }
 
     logger.info("CopilotProvider shutdown complete");

--- a/apps/server/src/services/pr-draft-service.ts
+++ b/apps/server/src/services/pr-draft-service.ts
@@ -128,8 +128,11 @@ export class PrDraftService {
 
     const modelDefaults: Record<string, string> = {
       claude: "claude-haiku-4-5-20251001",
+      // gpt-4.1 is the recommended fast model on the Copilot backend
+      copilot: "gpt-4.1",
     };
-    const model = settings.prDraft.model || modelDefaults[provider] || "claude-haiku-4-5-20251001";
+    // Fall back to gpt-4.1 so Copilot users in Auto mode get a valid model instead of a Claude ID
+    const model = settings.prDraft.model || modelDefaults[provider] || "gpt-4.1";
 
     const repoTemplate = this.detectPrTemplate(repoPath);
     const conversationSummary = this.buildConversationSummary(

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -55,7 +55,7 @@ export async function mockWebSocketServer(
       }
       // Default responses
       let result: unknown;
-      if (method?.endsWith(".list")) result = [];
+      if (method?.endsWith(".list") || method === "provider.listModels") result = [];
       else if (method === "git.currentBranch") result = "main";
       else if (method === "agent.activeCount") result = 0;
       else if (method === "app.version") result = "0.0.1-test";

--- a/apps/web/e2e/qa-codex-reasoning.spec.ts
+++ b/apps/web/e2e/qa-codex-reasoning.spec.ts
@@ -19,7 +19,8 @@ function makeDefaultSettings(provider: string, modelId: string, reasoning: strin
     notifications: { enabled: false },
     worktree: { naming: { mode: "auto", aiConfirmation: true } },
     server: { memory: { heapMb: 96 } },
-    provider: { cli: { codex: "", claude: "" } },
+    provider: { cli: { codex: "", claude: "", copilot: "" } },
+    prDraft: { provider: "", model: "" },
   };
 }
 
@@ -128,8 +129,9 @@ test.describe("Codex reasoning selector QA", () => {
     await expect(xhighRadio).toHaveAttribute("aria-checked", "true");
     await page.screenshot({ path: path.join(SCREENSHOT_DIR, "qa-03-xhigh-selected.png") });
 
-    // Switch back to Claude
-    const claudeRadio = page.getByRole("radio", { name: "Claude" });
+    // Switch back to Claude (scoped to the first Provider radiogroup to avoid
+    // ambiguity with the PR Draft provider row which also contains "Claude")
+    const claudeRadio = page.locator('[role="radiogroup"]').first().getByRole("radio", { name: "Claude" });
     await claudeRadio.click();
     await page.waitForTimeout(1000);
 

--- a/apps/web/e2e/settings-visual.spec.ts
+++ b/apps/web/e2e/settings-visual.spec.ts
@@ -17,6 +17,8 @@ const DEFAULT_SETTINGS = {
       reasoning: "high",
     },
   },
+  provider: { cli: { codex: "", claude: "", copilot: "" } },
+  prDraft: { provider: "", model: "" },
   terminal: { scrollback: 1000 },
   notifications: { enabled: false },
   worktree: { naming: { mode: "auto", aiConfirmation: true } },
@@ -69,7 +71,7 @@ test.describe("Settings visual review", () => {
     const modelNav = page.getByRole("button", { name: "Model", exact: true });
     await modelNav.click();
     await page.waitForTimeout(300);
-    const codexBtn = page.getByRole("button", { name: /Codex/ });
+    const codexBtn = page.getByRole("radio", { name: /Codex/ });
     await codexBtn.hover();
     await page.waitForTimeout(500);
     await page.screenshot({

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, type ReactNode } from "react";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useProviderModelsStore } from "@/stores/providerModelsStore";
 import {
   MODEL_PROVIDERS,
   isMaxEffortModel,
@@ -104,6 +105,9 @@ export function ModelSection() {
     (p) => p.id === (prDraftProvider || provider),
   );
 
+  const prDraftEffectiveId = prDraftProvider || provider;
+  const dynamicPrDraftModels = useProviderModelsStore((s) => s.models[prDraftEffectiveId]);
+
   const modelOptions = useMemo(
     () => (activeProvider?.models ?? []).map((m) => ({
       value: m.id,
@@ -118,13 +122,18 @@ export function ModelSection() {
     [modelOptions],
   );
 
-  // PR draft model options: "Auto" (provider default) + all models for the effective provider
+  // PR draft model options: "Auto" (provider default) + all models for the effective provider.
+  // Dynamic models from the store take priority; static registry is the fallback when the
+  // store hasn't fetched yet (e.g. Copilot not connected).
   const prDraftModelOptions = useMemo(
     () => [
       { value: "", label: "Auto" },
-      ...(prDraftEffectiveProvider?.models ?? []).map((m) => ({ value: m.id, label: m.label })),
+      ...(dynamicPrDraftModels ?? prDraftEffectiveProvider?.models ?? []).map((m) => ({
+        value: m.id,
+        label: m.label,
+      })),
     ],
-    [prDraftEffectiveProvider],
+    [dynamicPrDraftModels, prDraftEffectiveProvider],
   );
 
   const codexLevels = useMemo(() => getCodexReasoningLevels(modelId), [modelId]);

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -81,7 +81,9 @@ const CODEX_REASONING_LABELS: Record<string, string> = {
 };
 
 /**
- * Model settings section: provider, default model, fallback model, and reasoning effort.
+ * Model settings section: provider, default model, fallback model, reasoning effort,
+ * PR draft provider/model, and CLI paths.
+ *
  * Model options update when the provider changes. Switching provider resets the default
  * model to the new provider's first model and clears the fallback. Switching to a
  * non-Opus model clamps the reasoning level from "max" to "high".

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -99,6 +99,7 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     id: "copilot",
     name: "GitHub Copilot",
     comingSoon: false,
+    supportsCompletion: true,
     supportsModelListing: true,
     // Minimal static fallback — the live list from listProviderModels() is the
     // source of truth. These are shown only while the spinner is loading or if

--- a/apps/web/src/stores/providerModelsStore.ts
+++ b/apps/web/src/stores/providerModelsStore.ts
@@ -1,0 +1,68 @@
+import { create } from "zustand";
+import { MODEL_PROVIDERS, type ModelDefinition } from "@/lib/model-registry";
+import { getTransport } from "@/transport";
+
+/** How long cached models remain valid before a background refresh. */
+const MODEL_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+/** State and actions for the provider models Zustand store. */
+interface ProviderModelsState {
+  /** Dynamically fetched models keyed by provider ID. */
+  models: Record<string, ModelDefinition[]>;
+  /** Timestamp of last successful fetch per provider. */
+  lastFetched: Record<string, number>;
+  /** Providers currently being fetched. */
+  loading: Record<string, boolean>;
+  /**
+   * Fetch models for a single provider.
+   * No-ops if a fetch is in-flight or the cache is still fresh.
+   */
+  fetchModels: (providerId: string) => Promise<void>;
+  /**
+   * Eagerly fetch models for all providers that support dynamic listing.
+   * Called on WS connection and reconnection.
+   */
+  initialize: () => void;
+}
+
+/** Zustand store for dynamically fetched provider models with TTL caching. */
+export const useProviderModelsStore = create<ProviderModelsState>((set, get) => ({
+  models: {},
+  lastFetched: {},
+  loading: {},
+
+  fetchModels: async (providerId: string) => {
+    const state = get();
+    const lastFetch = state.lastFetched[providerId] ?? 0;
+    if (state.loading[providerId]) return;
+    if (Date.now() - lastFetch < MODEL_CACHE_TTL_MS) return;
+
+    set((s) => ({ loading: { ...s.loading, [providerId]: true } }));
+    try {
+      const info = await getTransport().listProviderModels(providerId);
+      const mapped: ModelDefinition[] = info.map((m) => ({
+        id: m.id,
+        label: m.name,
+        providerId,
+        group: m.group,
+        multiplier: m.multiplier,
+      }));
+      set((s) => ({
+        models: { ...s.models, [providerId]: mapped },
+        lastFetched: { ...s.lastFetched, [providerId]: Date.now() },
+        loading: { ...s.loading, [providerId]: false },
+      }));
+    } catch {
+      set((s) => ({ loading: { ...s.loading, [providerId]: false } }));
+    }
+  },
+
+  initialize: () => {
+    const providers = MODEL_PROVIDERS.filter(
+      (p) => p.supportsModelListing && !p.comingSoon,
+    );
+    for (const p of providers) {
+      void get().fetchModels(p.id);
+    }
+  },
+}));

--- a/apps/web/src/stores/providerModelsStore.ts
+++ b/apps/web/src/stores/providerModelsStore.ts
@@ -32,12 +32,17 @@ export const useProviderModelsStore = create<ProviderModelsState>((set, get) => 
   loading: {},
 
   fetchModels: async (providerId: string) => {
-    const state = get();
-    const lastFetch = state.lastFetched[providerId] ?? 0;
-    if (state.loading[providerId]) return;
-    if (Date.now() - lastFetch < MODEL_CACHE_TTL_MS) return;
-
-    set((s) => ({ loading: { ...s.loading, [providerId]: true } }));
+    // Atomic check-and-set: read loading + TTL inside the updater to avoid a
+    // TOCTOU race where two concurrent callers both pass the guard.
+    let shouldFetch = false;
+    set((s) => {
+      if (s.loading[providerId]) return s;
+      const lastFetch = s.lastFetched[providerId] ?? 0;
+      if (Date.now() - lastFetch < MODEL_CACHE_TTL_MS) return s;
+      shouldFetch = true;
+      return { loading: { ...s.loading, [providerId]: true } };
+    });
+    if (!shouldFetch) return;
     try {
       const info = await getTransport().listProviderModels(providerId);
       const mapped: ModelDefinition[] = info.map((m) => ({

--- a/apps/web/src/stores/providerModelsStore.ts
+++ b/apps/web/src/stores/providerModelsStore.ts
@@ -52,7 +52,8 @@ export const useProviderModelsStore = create<ProviderModelsState>((set, get) => 
         lastFetched: { ...s.lastFetched, [providerId]: Date.now() },
         loading: { ...s.loading, [providerId]: false },
       }));
-    } catch {
+    } catch (err) {
+      console.warn(`[providerModelsStore] Failed to fetch models for "${providerId}":`, err);
       set((s) => ({ loading: { ...s.loading, [providerId]: false } }));
     }
   },

--- a/apps/web/src/transport/index.ts
+++ b/apps/web/src/transport/index.ts
@@ -3,6 +3,7 @@ import { createWsTransport } from "./ws-transport";
 import { ipcPushClient } from "./ipc-push-client";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useProviderModelsStore } from "@/stores/providerModelsStore";
 
 /** Re-exported transport and domain types for use across the web app. */
 export type { McodeTransport, Workspace, Thread, Message, ToolCall, GitBranch, WorktreeInfo, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, SkillInfo, PrInfo, PrDetail, ToolCallRecord, Settings, PartialSettings, PlanAnswer } from "./types";
@@ -110,6 +111,7 @@ export async function initTransport(): Promise<McodeTransport> {
         // is replaced with the latest values.
         if (status === "connected") {
           void useSettingsStore.getState().fetch();
+          useProviderModelsStore.getState().initialize();
         }
       },
       discoverServerUrl: async () => {

--- a/apps/web/src/transport/index.ts
+++ b/apps/web/src/transport/index.ts
@@ -111,7 +111,7 @@ export async function initTransport(): Promise<McodeTransport> {
         // is replaced with the latest values.
         if (status === "connected") {
           void useSettingsStore.getState().fetch();
-          useProviderModelsStore.getState().initialize();
+          void useProviderModelsStore.getState().initialize();
         }
       },
       discoverServerUrl: async () => {


### PR DESCRIPTION
## What

Implement `ICompletionCapable.complete()` on `CopilotProvider` and add Copilot as a selectable PR draft provider in the settings UI with dynamic model listing.

## Why

Copilot users need PR draft generation support. Previously only Claude supported one-shot completions for PR drafts. This extends the capability to Copilot, allowing users to choose their preferred provider for AI-generated PR titles and descriptions.

## Key Changes

- **CopilotProvider.complete()**: Ephemeral session pattern (create, send, collect, disconnect) with 60s timeout and proper cleanup
- **Server TTL cache**: 10-min cache on `CopilotProvider.listModels()` to avoid hammering the SDK; cache invalidated on client rebuild
- **Frontend providerModelsStore**: New Zustand store that eagerly fetches models on WS connect with 10-min TTL and atomic loading guards
- **Settings UI**: Copilot appears in the PR Draft provider SegControl; model dropdown prefers dynamic models with static fallback
- **Model registry**: Copilot marked `supportsCompletion: true` with static fallback models
- **PR draft defaults**: `gpt-4.1` as Copilot's default model; explicit `modelDefaults` map for provider-aware fallback
- **E2E fixes**: Updated mock settings to include `provider.cli` and `prDraft` fields; fixed selector for SegControl radios; added `provider.listModels` to mock handler

Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copilot now supports completion for PR draft generation.
  * Dynamic provider model fetching with per-provider caching and TTL; refresh on reconnect.

* **Behavior Changes**
  * PR draft model selection now prefers provider-specific defaults (Copilot -> GPT-4.1) when unspecified.
  * UI/provider selection tests and interactions refined to avoid ambiguous selectors.

* **Tests**
  * Added/extended tests covering Copilot completions, session error/timeout cases, and model-listing cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->