### PR TITLE
feat: implement supervised permission mode for Claude provider

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -180,6 +180,16 @@ for (const ws of allWorkspaces) {
 // listener fires. We read the stack via getCurrentParentToolCallId to enrich
 // non-Agent tool calls with their parent ID.
 for (const provider of providerRegistry.resolveAll()) {
+  provider.on("permission_request", (request) => {
+    broadcast("permission.request", request);
+    portPush.send("permission.request", request);
+  });
+
+  provider.on("permission_resolved", (payload) => {
+    broadcast("permission.resolved", payload);
+    portPush.send("permission.resolved", payload);
+  });
+
   provider.on("event", (event: AgentEvent) => {
     let enrichedEvent = event;
 

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -329,8 +329,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     const resolvedCwd = cwd || process.cwd();
     const resolvedModel = model || "claude-sonnet-4-6";
 
-    logger.info("doSendMessage permissionMode", { sessionId, permissionMode, isBypass, hasExisting: !!existing });
-
     if (isBypass) {
       logger.warn("Using bypassPermissions for session", { sessionId });
     }
@@ -408,7 +406,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
             ) => {
               try {
                 const requestId = crypto.randomUUID();
-                logger.info("canUseTool called", { toolName, requestId, threadId: tid, hasSuggestions: !!options?.suggestions?.length });
+                logger.debug("canUseTool called", { toolName, requestId, threadId: tid });
                 const decision = await new Promise<PermissionDecision>((resolve) => {
                   this.pendingPermissions.set(requestId, {
                     threadId: tid,
@@ -424,13 +422,27 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                     input,
                     title: options?.title,
                   } satisfies PermissionRequest);
+
+                  // Auto-cancel if the SDK aborts the tool call (e.g. timeout).
+                  if (options?.signal) {
+                    const onAbort = () => {
+                      if (this.pendingPermissions.delete(requestId)) {
+                        resolve("cancelled");
+                        this.emit("permission_resolved", { requestId, decision: "cancelled" as const });
+                      }
+                    };
+                    options.signal.addEventListener("abort", onAbort, { once: true });
+                  }
                 });
-                logger.info("canUseTool decision received", { toolName, requestId, decision, signalAborted: options?.signal?.aborted });
+                logger.debug("canUseTool decision", { toolName, requestId, decision });
                 let result;
                 switch (decision) {
                   case "allow":
+                    // updatedInput is required by the CLI's runtime Zod schema (not optional
+                    // despite the SDK TypeScript type). Pass the original input unchanged.
                     result = {
                       behavior: "allow" as const,
+                      updatedInput: input,
                     };
                     break;
                   case "allow-session":
@@ -438,6 +450,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                     // PermissionUpdate shape for the specific tool being allowed.
                     result = {
                       behavior: "allow" as const,
+                      updatedInput: input,
                       updatedPermissions: options?.suggestions,
                     };
                     break;
@@ -457,7 +470,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                       message: "Unexpected permission decision value",
                     };
                 }
-                logger.info("canUseTool returning", { toolName, requestId, behavior: result.behavior });
+                logger.debug("canUseTool returning", { toolName, requestId, behavior: result.behavior });
                 return result;
               } catch (err) {
                 logger.error("canUseTool callback threw unexpectedly", { toolName, err });
@@ -1167,7 +1180,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       logger.warn("resolvePermission: requestId not found in pendingPermissions", { requestId, decision, mapSize: this.pendingPermissions.size });
       return false;
     }
-    logger.info("resolvePermission: resolving", { requestId, decision, toolName: entry.toolName, threadId: entry.threadId });
+    logger.debug("resolvePermission", { requestId, decision, toolName: entry.toolName });
     this.pendingPermissions.delete(requestId);
 
     // Reset the session's idle timer so the 10-minute eviction clock starts

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1139,6 +1139,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     if (!entry) return false;
     this.pendingPermissions.delete(requestId);
     entry.resolve(decision);
+    this.emit("permission_resolved", { requestId, decision });
     return true;
   }
 

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -404,48 +404,61 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
               input: Record<string, unknown>,
               options: Parameters<CanUseTool>[2],
             ) => {
-              const requestId = crypto.randomUUID();
-              const decision = await new Promise<PermissionDecision>((resolve) => {
-                this.pendingPermissions.set(requestId, {
-                  threadId: tid,
-                  toolName,
-                  input,
-                  title: options?.title,
-                  resolve,
+              try {
+                const requestId = crypto.randomUUID();
+                const decision = await new Promise<PermissionDecision>((resolve) => {
+                  this.pendingPermissions.set(requestId, {
+                    threadId: tid,
+                    toolName,
+                    input,
+                    title: options?.title,
+                    resolve,
+                  });
+                  this.emit("permission_request", {
+                    requestId,
+                    threadId: tid,
+                    toolName,
+                    input,
+                    title: options?.title,
+                  } satisfies PermissionRequest);
                 });
-                this.emit("permission_request", {
-                  requestId,
-                  threadId: tid,
-                  toolName,
-                  input,
-                  title: options?.title,
-                } satisfies PermissionRequest);
-              });
-              switch (decision) {
-                case "allow":
-                  return { behavior: "allow" as const };
-                case "allow-session": {
-                  // Persist "always allow" for this tool into the session-scoped
-                  // permission rules so subsequent calls are auto-approved.
-                  const sessionUpdate: PermissionUpdate = {
-                    type: "addRules",
-                    rules: [{ toolName }],
-                    behavior: "allow",
-                    destination: "session",
-                  };
-                  return {
-                    behavior: "allow" as const,
-                    updatedPermissions: [sessionUpdate],
-                  };
+                switch (decision) {
+                  case "allow":
+                    return {
+                      behavior: "allow" as const,
+                      decisionClassification: "user_temporary" as const,
+                    };
+                  case "allow-session": {
+                    // Persist "always allow" for this tool into the session-scoped
+                    // permission rules so subsequent calls are auto-approved.
+                    const sessionUpdate: PermissionUpdate = {
+                      type: "addRules",
+                      rules: [{ toolName }],
+                      behavior: "allow",
+                      destination: "session",
+                    };
+                    return {
+                      behavior: "allow" as const,
+                      updatedPermissions: [sessionUpdate],
+                      decisionClassification: "user_permanent" as const,
+                    };
+                  }
+                  case "deny":
+                  case "cancelled":
+                    return {
+                      behavior: "deny" as const,
+                      message: decision === "cancelled"
+                        ? "Session stopped by user"
+                        : "User denied",
+                      decisionClassification: "user_reject" as const,
+                    };
                 }
-                case "deny":
-                case "cancelled":
-                  return {
-                    behavior: "deny" as const,
-                    message: decision === "cancelled"
-                      ? "Session stopped by user"
-                      : "User denied",
-                  };
+              } catch (err) {
+                logger.error("canUseTool callback threw unexpectedly", { toolName, err });
+                return {
+                  behavior: "deny" as const,
+                  message: "Permission check encountered an internal error",
+                };
               }
             }) satisfies CanUseTool,
           }),

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -8,7 +8,7 @@ import { injectable } from "tsyringe";
 import { EventEmitter } from "events";
 import { readFile } from "fs/promises";
 import { query as sdkQuery } from "@anthropic-ai/claude-agent-sdk";
-import type { Query, SDKUserMessage, PostCompactHookInput, CanUseTool, PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
+import type { Query, SDKUserMessage, PostCompactHookInput, CanUseTool } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "@mcode/shared";
 import { AgentEventType } from "@mcode/contracts";
 import type {
@@ -428,21 +428,14 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                       behavior: "allow" as const,
                       decisionClassification: "user_temporary" as const,
                     };
-                  case "allow-session": {
-                    // Persist "always allow" for this tool into the session-scoped
-                    // permission rules so subsequent calls are auto-approved.
-                    const sessionUpdate: PermissionUpdate = {
-                      type: "addRules",
-                      rules: [{ toolName }],
-                      behavior: "allow",
-                      destination: "session",
-                    };
+                  case "allow-session":
+                    // Use the SDK-provided suggestions — they encode the correct
+                    // PermissionUpdate shape for the specific tool being allowed.
                     return {
                       behavior: "allow" as const,
-                      updatedPermissions: [sessionUpdate],
+                      updatedPermissions: options?.suggestions,
                       decisionClassification: "user_permanent" as const,
                     };
-                  }
                   case "deny":
                   case "cancelled":
                     return {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -431,7 +431,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                   case "allow":
                     result = {
                       behavior: "allow" as const,
-                      decisionClassification: "user_temporary" as const,
                     };
                     break;
                   case "allow-session":
@@ -440,7 +439,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                     result = {
                       behavior: "allow" as const,
                       updatedPermissions: options?.suggestions,
-                      decisionClassification: "user_permanent" as const,
                     };
                     break;
                   case "deny":
@@ -450,7 +448,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                       message: decision === "cancelled"
                         ? "Session stopped by user"
                         : "User denied",
-                      decisionClassification: "user_reject" as const,
                     };
                     break;
                   default:

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1051,6 +1051,14 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     const now = Date.now();
     for (const [sessionId, entry] of this.sessions) {
       if (now - entry.lastUsedAt > IDLE_TTL_MS) {
+        // Never evict a session that is actively awaiting a user permission response —
+        // the user may be on another thread and is about to respond.
+        const tid = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
+        const hasPending = [...this.pendingPermissions.values()].some(
+          (p) => p.threadId === tid,
+        );
+        if (hasPending) continue;
+
         logger.info("Evicting idle session", { sessionId });
         this.sessions.delete(sessionId);
         entry.closeQueue();
@@ -1138,6 +1146,13 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     const entry = this.pendingPermissions.get(requestId);
     if (!entry) return false;
     this.pendingPermissions.delete(requestId);
+
+    // Reset the session's idle timer so the 10-minute eviction clock starts
+    // from the moment the user responds, not from when the request was sent.
+    const sessionId = `mcode-${entry.threadId}`;
+    const session = this.sessions.get(sessionId);
+    if (session) session.lastUsedAt = Date.now();
+
     entry.resolve(decision);
     this.emit("permission_resolved", { requestId, decision });
     return true;

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -329,6 +329,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     const resolvedCwd = cwd || process.cwd();
     const resolvedModel = model || "claude-sonnet-4-6";
 
+    logger.info("doSendMessage permissionMode", { sessionId, permissionMode, isBypass, hasExisting: !!existing });
+
     if (isBypass) {
       logger.warn("Using bypassPermissions for session", { sessionId });
     }
@@ -406,6 +408,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
             ) => {
               try {
                 const requestId = crypto.randomUUID();
+                logger.info("canUseTool called", { toolName, requestId, threadId: tid, hasSuggestions: !!options?.suggestions?.length });
                 const decision = await new Promise<PermissionDecision>((resolve) => {
                   this.pendingPermissions.set(requestId, {
                     threadId: tid,
@@ -422,30 +425,43 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                     title: options?.title,
                   } satisfies PermissionRequest);
                 });
+                logger.info("canUseTool decision received", { toolName, requestId, decision, signalAborted: options?.signal?.aborted });
+                let result;
                 switch (decision) {
                   case "allow":
-                    return {
+                    result = {
                       behavior: "allow" as const,
                       decisionClassification: "user_temporary" as const,
                     };
+                    break;
                   case "allow-session":
                     // Use the SDK-provided suggestions — they encode the correct
                     // PermissionUpdate shape for the specific tool being allowed.
-                    return {
+                    result = {
                       behavior: "allow" as const,
                       updatedPermissions: options?.suggestions,
                       decisionClassification: "user_permanent" as const,
                     };
+                    break;
                   case "deny":
                   case "cancelled":
-                    return {
+                    result = {
                       behavior: "deny" as const,
                       message: decision === "cancelled"
                         ? "Session stopped by user"
                         : "User denied",
                       decisionClassification: "user_reject" as const,
                     };
+                    break;
+                  default:
+                    logger.error("canUseTool received unexpected decision", { toolName, requestId, decision });
+                    result = {
+                      behavior: "deny" as const,
+                      message: "Unexpected permission decision value",
+                    };
                 }
+                logger.info("canUseTool returning", { toolName, requestId, behavior: result.behavior });
+                return result;
               } catch (err) {
                 logger.error("canUseTool callback threw unexpectedly", { toolName, err });
                 return {
@@ -1150,7 +1166,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
   /** Resolves a pending permission request by ID. Deletes the entry before calling resolve to prevent re-entrant calls. Returns false if the requestId is unknown. */
   resolvePermission(requestId: string, decision: PermissionDecision): boolean {
     const entry = this.pendingPermissions.get(requestId);
-    if (!entry) return false;
+    if (!entry) {
+      logger.warn("resolvePermission: requestId not found in pendingPermissions", { requestId, decision, mapSize: this.pendingPermissions.size });
+      return false;
+    }
+    logger.info("resolvePermission: resolving", { requestId, decision, toolName: entry.toolName, threadId: entry.threadId });
     this.pendingPermissions.delete(requestId);
 
     // Reset the session's idle timer so the 10-minute eviction clock starts

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1133,7 +1133,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     };
   }
 
-  /** @inheritdoc */
+  /** Resolves a pending permission request by ID. Deletes the entry before calling resolve to prevent re-entrant calls. Returns false if the requestId is unknown. */
   resolvePermission(requestId: string, decision: PermissionDecision): boolean {
     const entry = this.pendingPermissions.get(requestId);
     if (!entry) return false;
@@ -1143,7 +1143,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     return true;
   }
 
-  /** @inheritdoc */
+  /** Returns all pending permission requests for the given thread, including tool input and optional title for display. Used by the frontend to re-hydrate cards after a WebSocket reconnect. */
   listPendingPermissions(threadId: string): PermissionRequest[] {
     const results: PermissionRequest[] = [];
     for (const [requestId, entry] of this.pendingPermissions) {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -8,7 +8,7 @@ import { injectable } from "tsyringe";
 import { EventEmitter } from "events";
 import { readFile } from "fs/promises";
 import { query as sdkQuery } from "@anthropic-ai/claude-agent-sdk";
-import type { Query, SDKUserMessage, PostCompactHookInput } from "@anthropic-ai/claude-agent-sdk";
+import type { Query, SDKUserMessage, PostCompactHookInput, CanUseTool, PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "@mcode/shared";
 import { AgentEventType } from "@mcode/contracts";
 import type {
@@ -18,6 +18,8 @@ import type {
   AgentEvent,
   AttachmentMeta,
   ProviderUsageInfo,
+  PermissionDecision,
+  PermissionRequest,
 } from "@mcode/contracts";
 import { buildReasoningOptions } from "./build-reasoning-options.js";
 
@@ -161,6 +163,17 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
 
   private sessions = new Map<string, SessionEntry>();
   private sdkSessionIds = new Map<string, string>();
+  /** Pending permission requests awaiting user decision, keyed by requestId. */
+  private pendingPermissions = new Map<
+    string,
+    {
+      threadId: string;
+      toolName: string;
+      input: unknown;
+      title?: string;
+      resolve: (decision: PermissionDecision) => void;
+    }
+  >();
   private evictionTimer: ReturnType<typeof setInterval> | null = null;
   private lastSessionCostUsd?: number;
   private lastServiceTier?: "standard" | "priority" | "batch";
@@ -312,6 +325,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     const uuid = sessionId.startsWith("mcode-")
       ? sessionId.slice(6)
       : sessionId;
+    const tid = uuid;
     const resolvedCwd = cwd || process.cwd();
     const resolvedModel = model || "claude-sonnet-4-6";
 
@@ -382,6 +396,59 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       disallowedTools: ["EnterPlanMode", "ExitPlanMode"],
       permissionMode: sdkPermissionMode,
       ...(isBypass && { allowDangerouslySkipPermissions: true }),
+      ...(isBypass
+        ? {}
+        : {
+            canUseTool: (async (
+              toolName: string,
+              input: Record<string, unknown>,
+              options: Parameters<CanUseTool>[2],
+            ) => {
+              const requestId = crypto.randomUUID();
+              const decision = await new Promise<PermissionDecision>((resolve) => {
+                this.pendingPermissions.set(requestId, {
+                  threadId: tid,
+                  toolName,
+                  input,
+                  title: options?.title,
+                  resolve,
+                });
+                this.emit("permission_request", {
+                  requestId,
+                  threadId: tid,
+                  toolName,
+                  input,
+                  title: options?.title,
+                } satisfies PermissionRequest);
+              });
+              switch (decision) {
+                case "allow":
+                  return { behavior: "allow" as const };
+                case "allow-session": {
+                  // Persist "always allow" for this tool into the session-scoped
+                  // permission rules so subsequent calls are auto-approved.
+                  const sessionUpdate: PermissionUpdate = {
+                    type: "addRules",
+                    rules: [{ toolName }],
+                    behavior: "allow",
+                    destination: "session",
+                  };
+                  return {
+                    behavior: "allow" as const,
+                    updatedPermissions: [sessionUpdate],
+                  };
+                }
+                case "deny":
+                case "cancelled":
+                  return {
+                    behavior: "deny" as const,
+                    message: decision === "cancelled"
+                      ? "Session stopped by user"
+                      : "User denied",
+                  };
+              }
+            }) satisfies CanUseTool,
+          }),
       ...buildReasoningOptions(reasoningLevel, resolvedModel),
       ...(fallbackModel && { fallbackModel }),
       includePartialMessages: true,
@@ -999,6 +1066,16 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
 
   /** Abort a running session. */
   stopSession(sessionId: string): void {
+    // Normalize to the raw UUID that canUseTool stores as threadId.
+    const tid = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
+    // Reject all pending permission requests for this session and notify frontend.
+    for (const [requestId, entry] of this.pendingPermissions) {
+      if (entry.threadId === tid) {
+        this.pendingPermissions.delete(requestId);
+        entry.resolve("cancelled");
+        this.emit("permission_resolved", { requestId, decision: "cancelled" });
+      }
+    }
     const entry = this.sessions.get(sessionId);
     if (entry) {
       this.sessions.delete(sessionId);
@@ -1056,11 +1133,43 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     };
   }
 
+  /** @inheritdoc */
+  resolvePermission(requestId: string, decision: PermissionDecision): boolean {
+    const entry = this.pendingPermissions.get(requestId);
+    if (!entry) return false;
+    this.pendingPermissions.delete(requestId);
+    entry.resolve(decision);
+    return true;
+  }
+
+  /** @inheritdoc */
+  listPendingPermissions(threadId: string): PermissionRequest[] {
+    const results: PermissionRequest[] = [];
+    for (const [requestId, entry] of this.pendingPermissions) {
+      if (entry.threadId === threadId) {
+        results.push({
+          requestId,
+          threadId: entry.threadId,
+          toolName: entry.toolName,
+          input: entry.input,
+          title: entry.title,
+        });
+      }
+    }
+    return results;
+  }
+
   /** Tear down all sessions and release resources. */
   shutdown(): void {
     if (this.evictionTimer) {
       clearInterval(this.evictionTimer);
       this.evictionTimer = null;
+    }
+    // Drain all pending permission requests so their promises settle
+    for (const [requestId, entry] of this.pendingPermissions) {
+      this.pendingPermissions.delete(requestId);
+      entry.resolve("cancelled");
+      this.emit("permission_resolved", { requestId, decision: "cancelled" as const });
     }
     for (const [, entry] of this.sessions) {
       entry.closeQueue();

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -18,6 +18,8 @@ import type {
   AgentEvent,
   ProviderId,
   InteractionMode,
+  PermissionDecision,
+  PermissionRequest,
 } from "@mcode/contracts";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
@@ -712,6 +714,30 @@ export class AgentService {
   /** Get all currently active thread IDs. */
   activeThreadIds(): string[] {
     return [...this.activeSessionIds];
+  }
+
+  /**
+   * Forward a user's permission decision to the provider holding the request.
+   * Tries all registered providers; the first one that holds the requestId resolves it.
+   */
+  respondToPermission(requestId: string, decision: PermissionDecision): void {
+    for (const provider of this.providerRegistry.resolveAll()) {
+      if (provider.resolvePermission?.(requestId, decision)) {
+        return;
+      }
+    }
+    logger.warn("permission.respond: no provider holds requestId %s", requestId);
+  }
+
+  /** Collect all pending permission requests for a thread across all providers. */
+  listPendingPermissions(threadId: string): PermissionRequest[] {
+    const results: PermissionRequest[] = [];
+    for (const provider of this.providerRegistry.resolveAll()) {
+      if (provider.listPendingPermissions) {
+        results.push(...provider.listPendingPermissions(threadId));
+      }
+    }
+    return results;
   }
 
   /**

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -636,6 +636,7 @@ async function dispatch(
 
     // Permission
     case "permission.respond": {
+      logger.info("ws-router: permission.respond received", { requestId: params.requestId, decision: params.decision });
       deps.agentService.respondToPermission(params.requestId, params.decision);
       broadcast("permission.resolved", {
         requestId: params.requestId,

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -636,12 +636,8 @@ async function dispatch(
 
     // Permission
     case "permission.respond": {
-      logger.info("ws-router: permission.respond received", { requestId: params.requestId, decision: params.decision });
       deps.agentService.respondToPermission(params.requestId, params.decision);
-      broadcast("permission.resolved", {
-        requestId: params.requestId,
-        decision: params.decision,
-      });
+      // broadcast is handled by the provider's "permission_resolved" event → index.ts listener
       return;
     }
     case "permission.listPending":

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -634,6 +634,14 @@ async function dispatch(
     case "app.version":
       return process.env.MCODE_VERSION ?? "0.0.1";
 
+    // Permission
+    case "permission.respond": {
+      deps.agentService.respondToPermission(params.requestId, params.decision);
+      return;
+    }
+    case "permission.listPending":
+      return deps.agentService.listPendingPermissions(params.threadId);
+
     default:
       throw new Error(`Unhandled method: ${method}`);
   }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -637,6 +637,10 @@ async function dispatch(
     // Permission
     case "permission.respond": {
       deps.agentService.respondToPermission(params.requestId, params.decision);
+      broadcast("permission.resolved", {
+        requestId: params.requestId,
+        decision: params.decision,
+      });
       return;
     }
     case "permission.listPending":

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -85,6 +85,8 @@ export const mockTransport: McodeTransport = {
   listWorktrees: vi.fn().mockResolvedValue([]),
   sendMessage: vi.fn().mockResolvedValue(1),
   stopAgent: vi.fn().mockResolvedValue(undefined),
+  respondToPermission: vi.fn().mockResolvedValue(undefined),
+  listPendingPermissions: vi.fn().mockResolvedValue([]),
   answerPlanQuestions: vi.fn().mockResolvedValue(undefined),
   getActiveAgentCount: vi.fn().mockResolvedValue(0),
   getMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),

--- a/apps/web/src/__tests__/thread-status.test.ts
+++ b/apps/web/src/__tests__/thread-status.test.ts
@@ -58,6 +58,17 @@ describe("getStatusDisplay", () => {
     const result = getStatusDisplay(makeThread({ status: "active" }), false);
     expect(result.label).toBe("");
   });
+
+  it("shows amber pulsing dot when thread has a pending permission and is running", () => {
+    const result = getStatusDisplay(makeThread(), true, true);
+    expect(result.dotClass).toBe("bg-amber-500 animate-pulse");
+    expect(result.color).toBe("text-amber-500");
+  });
+
+  it("does not show amber dot when thread has pending permission but is not running", () => {
+    const result = getStatusDisplay(makeThread({ status: "active" }), false, true);
+    expect(result.dotClass).not.toContain("amber");
+  });
 });
 
 describe("getNotificationDot", () => {
@@ -90,5 +101,12 @@ describe("getNotificationDot", () => {
   it("returns null for paused thread", () => {
     const result = getNotificationDot(makeThread({ status: "paused" }), false);
     expect(result).toBeNull();
+  });
+
+  it("returns amber dot when thread has pending permission and is running", () => {
+    const result = getNotificationDot(makeThread(), true, true);
+    expect(result).not.toBeNull();
+    expect(result!.dotClass).toBe("bg-amber-500");
+    expect(result!.animate).toBe(true);
   });
 });

--- a/apps/web/src/__tests__/thread-status.test.ts
+++ b/apps/web/src/__tests__/thread-status.test.ts
@@ -65,9 +65,9 @@ describe("getStatusDisplay", () => {
     expect(result.color).toBe("text-amber-500");
   });
 
-  it("does not show amber dot when thread has pending permission but is not running", () => {
+  it("shows amber dot when thread has pending permission even if not running", () => {
     const result = getStatusDisplay(makeThread({ status: "active" }), false, true);
-    expect(result.dotClass).not.toContain("amber");
+    expect(result.dotClass).toContain("amber");
   });
 });
 

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -11,6 +11,7 @@ import { StreamingIndicator } from "./StreamingIndicator";
 import { StreamingCard } from "./StreamingCard";
 import { ToolCallSummary } from "./ToolCallSummary";
 import { TurnChangeSummary } from "./TurnChangeSummary";
+import { PermissionRequestCard } from "./PermissionRequestCard";
 import {
   buildStableItems,
   buildVolatileItems,
@@ -64,6 +65,17 @@ const VirtualItemRenderer = memo(function VirtualItemRenderer({
           filesChanged={item.filesChanged}
           isLatestTurn={item.isLatestTurn}
           manualExpandRef={turnExpandRef}
+        />
+      );
+    case "permission-request":
+      return (
+        <PermissionRequestCard
+          requestId={item.requestId}
+          toolName={item.toolName}
+          input={item.input}
+          title={item.title}
+          settled={item.settled}
+          decision={item.decision}
         />
       );
   }
@@ -134,6 +146,10 @@ export function MessageList({ onBranch }: MessageListProps) {
     activeThreadId ? s.isLoadingMore[activeThreadId] ?? false : false,
   );
   const loadOlderMessages = useThreadStore((s) => s.loadOlderMessages);
+  const currentThreadId = activeThreadId;
+  const permissions = useThreadStore(
+    useShallow((s) => currentThreadId ? (s.permissionsByThread[currentThreadId] ?? []) : []),
+  );
 
   const toolCalls = toolCallsRaw ?? EMPTY_TOOL_CALLS;
 
@@ -165,8 +181,8 @@ export function MessageList({ onBranch }: MessageListProps) {
   );
 
   const volatileItems = useMemo(
-    () => buildVolatileItems(toolCalls, isAgentRunning, agentStartTime, streamingText),
-    [toolCalls, isAgentRunning, agentStartTime, streamingText],
+    () => buildVolatileItems(toolCalls, isAgentRunning, agentStartTime, streamingText, permissions),
+    [toolCalls, isAgentRunning, agentStartTime, streamingText, permissions],
   );
 
   const hasToolCalls = toolCalls.length > 0;

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -135,7 +135,7 @@ export function PermissionRequestCard({
               "inline-flex h-6 items-center gap-1 pl-2 pr-2 text-xs font-medium",
               "bg-primary text-primary-foreground",
               "hover:bg-primary/90 transition-colors",
-              "disabled:pointer-events-none disabled:opacity-50",
+              "cursor-pointer disabled:pointer-events-none disabled:opacity-50",
             )}
           >
             <Check size={11} />
@@ -154,7 +154,7 @@ export function PermissionRequestCard({
                 "bg-primary text-primary-foreground",
                 "hover:bg-primary/90 transition-colors",
                 "outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-                "disabled:pointer-events-none disabled:opacity-50",
+                "cursor-pointer disabled:pointer-events-none disabled:opacity-50",
               )}
             >
               <ChevronDown size={11} className="opacity-80" />
@@ -195,7 +195,7 @@ export function PermissionRequestCard({
             "inline-flex h-6 items-center gap-1 px-2 text-xs font-medium rounded-md",
             "text-muted-foreground/70 hover:text-destructive",
             "hover:bg-destructive/10 transition-colors",
-            "disabled:pointer-events-none disabled:opacity-50",
+            "cursor-pointer disabled:pointer-events-none disabled:opacity-50",
           )}
         >
           <X size={11} />

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -1,7 +1,13 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { Shield, ChevronDown, Check, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { getTransport } from "@/transport";
 import { TOOL_ICONS } from "./tool-renderers/constants";
@@ -62,26 +68,11 @@ export function PermissionRequestCard({
   decision,
 }: PermissionRequestCardProps) {
   const [responding, setResponding] = useState(false);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // Close the "Allow in session" dropdown on outside click
-  useEffect(() => {
-    if (!dropdownOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setDropdownOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [dropdownOpen]);
 
   const respond = useCallback(
     async (d: PermissionDecision) => {
       setResponding(true);
-      setDropdownOpen(false);
       try {
         setError(null);
         await getTransport().respondToPermission(requestId, d);
@@ -118,7 +109,7 @@ export function PermissionRequestCard({
     <div className="border-l-2 border-amber-500/60 pl-3 py-2 flex flex-col gap-2">
       {/* Header */}
       <div className="flex items-center gap-2 text-xs font-medium text-amber-600 dark:text-amber-400">
-        <Shield size={13} className="shrink-0" />
+        <Icon size={13} className="shrink-0" />
         <span>Permission requested: {label}</span>
       </div>
 
@@ -137,54 +128,38 @@ export function PermissionRequestCard({
       {/* Controls */}
       <div className="flex items-center gap-2">
         {/* Split Allow button */}
-        <div ref={dropdownRef} className="relative inline-flex">
-          <div className="inline-flex rounded-lg overflow-hidden">
-            {/* Primary: Allow once */}
-            <Button
-              variant="default"
-              size="xs"
-              disabled={responding}
-              onClick={() => respond("allow")}
-              className="rounded-r-none border-r border-primary-foreground/20"
-            >
-              <Check size={11} className="mr-1" />
-              Allow
-            </Button>
-            {/* Chevron: opens "Allow in session" */}
-            <Button
-              variant="default"
-              size="xs"
+        <div className="inline-flex rounded-lg overflow-hidden">
+          {/* Primary: Allow once */}
+          <Button
+            variant="default"
+            size="xs"
+            disabled={responding}
+            onClick={() => respond("allow")}
+            className="rounded-r-none border-r border-primary-foreground/20"
+          >
+            <Check size={11} className="mr-1" />
+            Allow
+          </Button>
+
+          {/* Chevron dropdown: Allow in session */}
+          <DropdownMenu>
+            <DropdownMenuTrigger
               disabled={responding}
               aria-label="More allow options"
-              aria-expanded={dropdownOpen}
-              onClick={() => setDropdownOpen((o) => !o)}
-              className="rounded-l-none px-1"
+              className="inline-flex h-6 items-center justify-center rounded-l-none rounded-r-[min(var(--radius-md),10px)] border border-transparent bg-primary px-1 text-primary-foreground transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 active:translate-y-px"
             >
-              <ChevronDown
-                size={11}
-                className={cn(
-                  "transition-transform duration-150",
-                  dropdownOpen && "rotate-180",
-                )}
-              />
-            </Button>
-          </div>
-
-          {/* Dropdown */}
-          {dropdownOpen && (
-            <div role="menu" className="absolute top-full left-0 mt-1 z-50 min-w-[160px] rounded-md border border-border/50 bg-popover shadow-md py-1">
-              <button
-                type="button"
-                role="menuitem"
+              <ChevronDown size={11} />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" sideOffset={4}>
+              <DropdownMenuItem
                 disabled={responding}
-                className="w-full text-left px-3 py-1.5 text-xs text-foreground/80 hover:text-foreground hover:bg-muted/40 flex items-center gap-2 transition-colors"
-                onClick={() => respond("allow-session")}
+                onSelect={() => respond("allow-session")}
               >
-                <Check size={11} className="opacity-75 shrink-0" />
+                <Check size={11} className="opacity-75" />
                 Allow in session
-              </button>
-            </div>
-          )}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         {/* Deny */}

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback } from "react";
 import { Shield, ChevronDown, Check, X, Zap, Clock } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
@@ -126,63 +125,82 @@ export function PermissionRequestCard({
       </pre>
 
       {/* Controls */}
-      <div className="flex items-center gap-1.5">
-        {/* Allow dropdown — shows both options */}
-        <DropdownMenu>
-          <DropdownMenuTrigger
+      <div className="flex items-center gap-2">
+        {/* Split button: left side fires Allow immediately; right chevron opens more options */}
+        <div className="flex items-stretch rounded-md overflow-hidden ring-1 ring-primary/60">
+          <button
             disabled={responding}
-            aria-label="Allow options"
+            onClick={() => respond("allow")}
             className={cn(
-              "inline-flex h-6 items-center gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs font-medium",
+              "inline-flex h-6 items-center gap-1 pl-2 pr-2 text-xs font-medium",
               "bg-primary text-primary-foreground",
-              "transition-colors hover:bg-primary/90",
-              "outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+              "hover:bg-primary/90 transition-colors",
               "disabled:pointer-events-none disabled:opacity-50",
-              "select-none cursor-default",
             )}
           >
             <Check size={11} />
             Allow
-            <ChevronDown size={10} className="opacity-70 -mr-0.5" />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" sideOffset={4} className="min-w-[170px]">
-            <DropdownMenuItem
-              disabled={responding}
-              onSelect={() => respond("allow")}
-              className="gap-2"
-            >
-              <Zap size={12} className="text-amber-500 shrink-0" />
-              <div className="flex flex-col">
-                <span className="text-xs font-medium">Allow once</span>
-                <span className="text-[10px] text-muted-foreground">Prompt again next time</span>
-              </div>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              disabled={responding}
-              onSelect={() => respond("allow-session")}
-              className="gap-2"
-            >
-              <Clock size={12} className="text-blue-400 shrink-0" />
-              <div className="flex flex-col">
-                <span className="text-xs font-medium">Allow in session</span>
-                <span className="text-[10px] text-muted-foreground">Skip prompts this session</span>
-              </div>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+          </button>
 
-        {/* Deny — quiet by default, destructive on hover */}
-        <Button
-          variant="ghost"
-          size="xs"
+          {/* Divider — the visual demarcator between Allow and the dropdown */}
+          <div className="w-px bg-primary-foreground/20 self-stretch" />
+
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              disabled={responding}
+              aria-label="More allow options"
+              className={cn(
+                "inline-flex h-6 w-6 items-center justify-center",
+                "bg-primary text-primary-foreground",
+                "hover:bg-primary/90 transition-colors",
+                "outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+                "disabled:pointer-events-none disabled:opacity-50",
+              )}
+            >
+              <ChevronDown size={11} className="opacity-80" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" sideOffset={4} className="min-w-[180px]">
+              <DropdownMenuItem
+                disabled={responding}
+                onSelect={() => respond("allow")}
+                className="gap-2"
+              >
+                <Zap size={12} className="text-amber-500 shrink-0" />
+                <div className="flex flex-col">
+                  <span className="text-xs font-medium">Allow once</span>
+                  <span className="text-[10px] text-muted-foreground">Prompt again next time</span>
+                </div>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={responding}
+                onSelect={() => respond("allow-session")}
+                className="gap-2"
+              >
+                <Clock size={12} className="text-blue-400 shrink-0" />
+                <div className="flex flex-col">
+                  <span className="text-xs font-medium">Allow in session</span>
+                  <span className="text-[10px] text-muted-foreground">Skip prompts this session</span>
+                </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {/* Deny — muted ghost, goes red on hover */}
+        <button
           disabled={responding}
           onClick={() => respond("deny")}
-          className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 gap-1"
+          className={cn(
+            "inline-flex h-6 items-center gap-1 px-2 text-xs font-medium rounded-md",
+            "text-muted-foreground/70 hover:text-destructive",
+            "hover:bg-destructive/10 transition-colors",
+            "disabled:pointer-events-none disabled:opacity-50",
+          )}
         >
           <X size={11} />
           Deny
-        </Button>
+        </button>
       </div>
 
       {error && (

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -1,0 +1,205 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { Shield, ChevronDown, Check, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { getTransport } from "@/transport";
+import { TOOL_ICONS } from "./tool-renderers/constants";
+import type { PermissionDecision } from "@mcode/contracts";
+
+/** Props for {@link PermissionRequestCard}. */
+interface PermissionRequestCardProps {
+  /** Unique identifier for the permission request. */
+  requestId: string;
+  /** The tool name that is requesting permission. */
+  toolName: string;
+  /** Raw tool input arguments; shape varies by tool. */
+  input: unknown;
+  /** Optional human-readable title for the permission request. */
+  title?: string;
+  /** Whether this request has already been resolved. */
+  settled: boolean;
+  /** The user's decision, present when settled. */
+  decision?: PermissionDecision;
+}
+
+/** Maps a PermissionDecision to its Badge variant. */
+function badgeVariantFor(
+  decision: PermissionDecision,
+): "default" | "destructive" | "secondary" | "outline" {
+  if (decision === "allow" || decision === "allow-session") return "default";
+  if (decision === "deny") return "destructive";
+  return "outline";
+}
+
+/** Maps a PermissionDecision to its display label. */
+function decisionLabel(decision: PermissionDecision): string {
+  switch (decision) {
+    case "allow":
+      return "Allowed";
+    case "allow-session":
+      return "Allowed this session";
+    case "deny":
+      return "Denied";
+    case "cancelled":
+      return "Cancelled";
+  }
+}
+
+/**
+ * Renders an inline permission request card inside the chat message list.
+ *
+ * In the pending state it shows the tool name, an input preview, and split
+ * Allow / Allow in session / Deny controls. Once resolved it collapses to a
+ * single line showing the tool name and an outcome badge.
+ */
+export function PermissionRequestCard({
+  requestId,
+  toolName,
+  input,
+  title,
+  settled,
+  decision,
+}: PermissionRequestCardProps) {
+  const [responding, setResponding] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close the "Allow in session" dropdown on outside click
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [dropdownOpen]);
+
+  const respond = useCallback(
+    async (d: PermissionDecision) => {
+      setResponding(true);
+      setDropdownOpen(false);
+      try {
+        setError(null);
+        await getTransport().respondToPermission(requestId, d);
+      } catch {
+        setError("Failed to send response. Please try again.");
+        setResponding(false);
+      }
+    },
+    [requestId],
+  );
+
+  const Icon = TOOL_ICONS[toolName] ?? Shield;
+  const label = title ?? toolName;
+  const inputPreview =
+    typeof input === "string" ? input : JSON.stringify(input, null, 2);
+
+  // ── Settled (collapsed) state ──────────────────────────────────────────────
+  if (settled && decision) {
+    const variant = badgeVariantFor(decision);
+    return (
+      <div className="flex items-center gap-2 border-l-2 border-border/30 pl-3 py-1 text-xs text-muted-foreground/70">
+        <Icon size={13} className="shrink-0 text-muted-foreground/50" />
+        <span className="font-medium">{label}</span>
+        <Badge variant={variant} size="sm" className="ml-1">
+          {decisionLabel(decision)}
+        </Badge>
+      </div>
+    );
+  }
+
+  // ── Pending state ──────────────────────────────────────────────────────────
+  return (
+    <div className="border-l-2 border-amber-500/60 pl-3 py-2 flex flex-col gap-2">
+      {/* Header */}
+      <div className="flex items-center gap-2 text-xs font-medium text-amber-600 dark:text-amber-400">
+        <Shield size={13} className="shrink-0" />
+        <span>Permission requested: {label}</span>
+      </div>
+
+      {/* Input preview */}
+      <pre
+        className={cn(
+          "text-[0.7rem] leading-relaxed text-muted-foreground/80",
+          "bg-muted/30 rounded px-2 py-1.5",
+          "max-h-[120px] overflow-y-auto scrollbar-on-hover",
+          "whitespace-pre-wrap break-all font-mono",
+        )}
+      >
+        {inputPreview}
+      </pre>
+
+      {/* Controls */}
+      <div className="flex items-center gap-2">
+        {/* Split Allow button */}
+        <div ref={dropdownRef} className="relative inline-flex">
+          <div className="inline-flex rounded-lg overflow-hidden">
+            {/* Primary: Allow once */}
+            <Button
+              variant="default"
+              size="xs"
+              disabled={responding}
+              onClick={() => respond("allow")}
+              className="rounded-r-none border-r border-primary-foreground/20"
+            >
+              <Check size={11} className="mr-1" />
+              Allow
+            </Button>
+            {/* Chevron: opens "Allow in session" */}
+            <Button
+              variant="default"
+              size="xs"
+              disabled={responding}
+              aria-label="More allow options"
+              aria-expanded={dropdownOpen}
+              onClick={() => setDropdownOpen((o) => !o)}
+              className="rounded-l-none px-1"
+            >
+              <ChevronDown
+                size={11}
+                className={cn(
+                  "transition-transform duration-150",
+                  dropdownOpen && "rotate-180",
+                )}
+              />
+            </Button>
+          </div>
+
+          {/* Dropdown */}
+          {dropdownOpen && (
+            <div role="menu" className="absolute top-full left-0 mt-1 z-50 min-w-[160px] rounded-md border border-border/50 bg-popover shadow-md py-1">
+              <button
+                type="button"
+                role="menuitem"
+                disabled={responding}
+                className="w-full text-left px-3 py-1.5 text-xs text-foreground/80 hover:text-foreground hover:bg-muted/40 flex items-center gap-2 transition-colors"
+                onClick={() => respond("allow-session")}
+              >
+                <Check size={11} className="opacity-75 shrink-0" />
+                Allow in session
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Deny */}
+        <Button
+          variant="destructive"
+          size="xs"
+          disabled={responding}
+          onClick={() => respond("deny")}
+        >
+          <X size={11} className="mr-1" />
+          Deny
+        </Button>
+      </div>
+      {error && (
+        <p className="text-xs text-destructive">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { Shield, ChevronDown, Check, X, Zap, Clock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -97,8 +97,10 @@ export function PermissionRequestCard({
 
   const Icon = TOOL_ICONS[toolName] ?? Shield;
   const label = title ?? toolName;
-  const inputPreview =
-    typeof input === "string" ? input : JSON.stringify(input, null, 2);
+  const inputPreview = useMemo(
+    () => (typeof input === "string" ? input : JSON.stringify(input, null, 2)),
+    [input],
+  );
 
   // ── Settled (collapsed) state ──────────────────────────────────────────────
   if (settled && decision) {

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -127,7 +127,7 @@ export function PermissionRequestCard({
       {/* Controls */}
       <div className="flex items-center gap-2">
         {/* Split button: left side fires Allow immediately; right chevron opens more options */}
-        <div className="flex items-stretch rounded-md overflow-hidden ring-1 ring-primary/60">
+        <div className="flex items-stretch rounded-md overflow-hidden">
           <button
             disabled={responding}
             onClick={() => respond("allow")}

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -163,7 +163,7 @@ export function PermissionRequestCard({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" sideOffset={4} className="min-w-[180px]">
               <DropdownMenuItem
-                onSelect={() => setAllowMode("allow")}
+                onClick={() => setAllowMode("allow")}
                 className="gap-2"
               >
                 <Zap size={12} className="text-amber-500 shrink-0" />
@@ -175,7 +175,7 @@ export function PermissionRequestCard({
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
-                onSelect={() => setAllowMode("allow-session")}
+                onClick={() => setAllowMode("allow-session")}
                 className="gap-2"
               >
                 <Clock size={12} className="text-blue-400 shrink-0" />

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { Shield, ChevronDown, Check, X } from "lucide-react";
+import { Shield, ChevronDown, Check, X, Zap, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { getTransport } from "@/transport";
@@ -42,9 +43,9 @@ function badgeVariantFor(
 function decisionLabel(decision: PermissionDecision): string {
   switch (decision) {
     case "allow":
-      return "Allowed";
+      return "Allowed once";
     case "allow-session":
-      return "Allowed this session";
+      return "Allowed in session";
     case "deny":
       return "Denied";
     case "cancelled":
@@ -55,9 +56,9 @@ function decisionLabel(decision: PermissionDecision): string {
 /**
  * Renders an inline permission request card inside the chat message list.
  *
- * In the pending state it shows the tool name, an input preview, and split
- * Allow / Allow in session / Deny controls. Once resolved it collapses to a
- * single line showing the tool name and an outcome badge.
+ * In the pending state it shows the tool name, an input preview, and an Allow
+ * dropdown (Allow once / Allow in session) plus a Deny button. Once resolved
+ * it collapses to a single line with an outcome badge.
  */
 export function PermissionRequestCard({
   requestId,
@@ -92,12 +93,11 @@ export function PermissionRequestCard({
 
   // ── Settled (collapsed) state ──────────────────────────────────────────────
   if (settled && decision) {
-    const variant = badgeVariantFor(decision);
     return (
       <div className="flex items-center gap-2 border-l-2 border-border/30 pl-3 py-1 text-xs text-muted-foreground/70">
         <Icon size={13} className="shrink-0 text-muted-foreground/50" />
         <span className="font-medium">{label}</span>
-        <Badge variant={variant} size="sm" className="ml-1">
+        <Badge variant={badgeVariantFor(decision)} size="sm" className="ml-1">
           {decisionLabel(decision)}
         </Badge>
       </div>
@@ -126,53 +126,65 @@ export function PermissionRequestCard({
       </pre>
 
       {/* Controls */}
-      <div className="flex items-center gap-2">
-        {/* Split Allow button */}
-        <div className="inline-flex rounded-lg overflow-hidden">
-          {/* Primary: Allow once */}
-          <Button
-            variant="default"
-            size="xs"
+      <div className="flex items-center gap-1.5">
+        {/* Allow dropdown — shows both options */}
+        <DropdownMenu>
+          <DropdownMenuTrigger
             disabled={responding}
-            onClick={() => respond("allow")}
-            className="rounded-r-none border-r border-primary-foreground/20"
+            aria-label="Allow options"
+            className={cn(
+              "inline-flex h-6 items-center gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs font-medium",
+              "bg-primary text-primary-foreground",
+              "transition-colors hover:bg-primary/90",
+              "outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+              "disabled:pointer-events-none disabled:opacity-50",
+              "select-none cursor-default",
+            )}
           >
-            <Check size={11} className="mr-1" />
+            <Check size={11} />
             Allow
-          </Button>
-
-          {/* Chevron dropdown: Allow in session */}
-          <DropdownMenu>
-            <DropdownMenuTrigger
+            <ChevronDown size={10} className="opacity-70 -mr-0.5" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" sideOffset={4} className="min-w-[170px]">
+            <DropdownMenuItem
               disabled={responding}
-              aria-label="More allow options"
-              className="inline-flex h-6 items-center justify-center rounded-l-none rounded-r-[min(var(--radius-md),10px)] border border-transparent bg-primary px-1 text-primary-foreground transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 active:translate-y-px"
+              onSelect={() => respond("allow")}
+              className="gap-2"
             >
-              <ChevronDown size={11} />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" sideOffset={4}>
-              <DropdownMenuItem
-                disabled={responding}
-                onSelect={() => respond("allow-session")}
-              >
-                <Check size={11} className="opacity-75" />
-                Allow in session
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+              <Zap size={12} className="text-amber-500 shrink-0" />
+              <div className="flex flex-col">
+                <span className="text-xs font-medium">Allow once</span>
+                <span className="text-[10px] text-muted-foreground">Prompt again next time</span>
+              </div>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              disabled={responding}
+              onSelect={() => respond("allow-session")}
+              className="gap-2"
+            >
+              <Clock size={12} className="text-blue-400 shrink-0" />
+              <div className="flex flex-col">
+                <span className="text-xs font-medium">Allow in session</span>
+                <span className="text-[10px] text-muted-foreground">Skip prompts this session</span>
+              </div>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
-        {/* Deny */}
+        {/* Deny — quiet by default, destructive on hover */}
         <Button
-          variant="destructive"
+          variant="ghost"
           size="xs"
           disabled={responding}
           onClick={() => respond("deny")}
+          className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 gap-1"
         >
-          <X size={11} className="mr-1" />
+          <X size={11} />
           Deny
         </Button>
       </div>
+
       {error && (
         <p className="text-xs text-destructive">{error}</p>
       )}

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Shield, ChevronDown, Check, X, Zap, Clock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -71,6 +71,14 @@ export function PermissionRequestCard({
   const [error, setError] = useState<string | null>(null);
   // Tracks which allow mode is active — dropdown picks the mode, primary button fires it.
   const [allowMode, setAllowMode] = useState<"allow" | "allow-session">("allow");
+  // Guard against accidental clicks caused by the card appearing under the cursor.
+  // Buttons are disabled for 600ms after the card mounts so layout shifts don't
+  // register as intentional clicks.
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setReady(true), 600);
+    return () => clearTimeout(t);
+  }, []);
 
   const respond = useCallback(
     async (d: PermissionDecision) => {
@@ -131,7 +139,7 @@ export function PermissionRequestCard({
         {/* Split button: left fires the active mode; chevron picks the mode */}
         <div className="flex items-stretch rounded-md overflow-hidden">
           <button
-            disabled={responding}
+            disabled={responding || !ready}
             onClick={() => respond(allowMode)}
             className={cn(
               "inline-flex h-6 items-center gap-1 pl-2 pr-2 text-xs font-medium",
@@ -149,7 +157,7 @@ export function PermissionRequestCard({
 
           <DropdownMenu>
             <DropdownMenuTrigger
-              disabled={responding}
+              disabled={responding || !ready}
               aria-label="Change allow mode"
               className={cn(
                 "inline-flex h-6 w-6 items-center justify-center",
@@ -191,7 +199,7 @@ export function PermissionRequestCard({
 
         {/* Deny — muted ghost, goes red on hover */}
         <button
-          disabled={responding}
+          disabled={responding || !ready}
           onClick={() => respond("deny")}
           className={cn(
             "inline-flex h-6 items-center gap-1 px-2 text-xs font-medium rounded-md",

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -69,6 +69,8 @@ export function PermissionRequestCard({
 }: PermissionRequestCardProps) {
   const [responding, setResponding] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Tracks which allow mode is active — dropdown picks the mode, primary button fires it.
+  const [allowMode, setAllowMode] = useState<"allow" | "allow-session">("allow");
 
   const respond = useCallback(
     async (d: PermissionDecision) => {
@@ -126,11 +128,11 @@ export function PermissionRequestCard({
 
       {/* Controls */}
       <div className="flex items-center gap-2">
-        {/* Split button: left side fires Allow immediately; right chevron opens more options */}
+        {/* Split button: left fires the active mode; chevron picks the mode */}
         <div className="flex items-stretch rounded-md overflow-hidden">
           <button
             disabled={responding}
-            onClick={() => respond("allow")}
+            onClick={() => respond(allowMode)}
             className={cn(
               "inline-flex h-6 items-center gap-1 pl-2 pr-2 text-xs font-medium",
               "bg-primary text-primary-foreground",
@@ -138,17 +140,17 @@ export function PermissionRequestCard({
               "cursor-pointer disabled:pointer-events-none disabled:opacity-50",
             )}
           >
-            <Check size={11} />
-            Allow
+            {allowMode === "allow" ? <Check size={11} /> : <Clock size={11} />}
+            {allowMode === "allow" ? "Allow" : "Allow in session"}
           </button>
 
-          {/* Divider — the visual demarcator between Allow and the dropdown */}
+          {/* Divider — visual demarcator between primary action and mode picker */}
           <div className="w-px bg-primary-foreground/20 self-stretch" />
 
           <DropdownMenu>
             <DropdownMenuTrigger
               disabled={responding}
-              aria-label="More allow options"
+              aria-label="Change allow mode"
               className={cn(
                 "inline-flex h-6 w-6 items-center justify-center",
                 "bg-primary text-primary-foreground",
@@ -161,8 +163,7 @@ export function PermissionRequestCard({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" sideOffset={4} className="min-w-[180px]">
               <DropdownMenuItem
-                disabled={responding}
-                onSelect={() => respond("allow")}
+                onSelect={() => setAllowMode("allow")}
                 className="gap-2"
               >
                 <Zap size={12} className="text-amber-500 shrink-0" />
@@ -170,11 +171,11 @@ export function PermissionRequestCard({
                   <span className="text-xs font-medium">Allow once</span>
                   <span className="text-[10px] text-muted-foreground">Prompt again next time</span>
                 </div>
+                {allowMode === "allow" && <Check size={11} className="ml-auto text-primary" />}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
-                disabled={responding}
-                onSelect={() => respond("allow-session")}
+                onSelect={() => setAllowMode("allow-session")}
                 className="gap-2"
               >
                 <Clock size={12} className="text-blue-400 shrink-0" />
@@ -182,6 +183,7 @@ export function PermissionRequestCard({
                   <span className="text-xs font-medium">Allow in session</span>
                   <span className="text-[10px] text-muted-foreground">Skip prompts this session</span>
                 </div>
+                {allowMode === "allow-session" && <Check size={11} className="ml-auto text-primary" />}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -87,6 +87,7 @@ export function PermissionRequestCard({
         await getTransport().respondToPermission(requestId, d);
       } catch {
         setError("Failed to send response. Please try again.");
+      } finally {
         setResponding(false);
       }
     },

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -109,9 +109,10 @@ export function buildVolatileItems(
     items.push({ key: "active-tools", type: "active-tools", toolCalls });
   }
 
-  // Permission requests follow because they are caused by the tool calls above.
+  // Only show unsettled permission requests — settled cards disappear once the
+  // agent's response arrives so they don't trail below the agent's message.
   if (permissions && permissions.length > 0) {
-    for (const p of permissions) {
+    for (const p of permissions.filter((p) => !p.settled)) {
       items.push({
         key: `permission-${p.requestId}`,
         type: "permission-request" as const,

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -1,3 +1,4 @@
+import type { PermissionDecision } from "@mcode/contracts";
 import type { Message, ToolCall } from "@/transport/types";
 
 /** Compile-time exhaustive check; throws at runtime for unhandled discriminants. */
@@ -26,6 +27,16 @@ export type ChatVirtualItem =
       messageId: string;
       filesChanged: string[];
       isLatestTurn: boolean;
+    }
+  | {
+      key: string;
+      type: "permission-request";
+      requestId: string;
+      toolName: string;
+      input: unknown;
+      title?: string;
+      settled: boolean;
+      decision?: PermissionDecision;
     };
 
 /**
@@ -74,7 +85,7 @@ export function buildStableItems(
 }
 
 /**
- * Build the volatile segment: active tool calls, streaming text, and indicator.
+ * Build the volatile segment: permission requests, active tool calls, streaming text, and indicator.
  * This changes on every tool call event but doesn't depend on messages.
  */
 export function buildVolatileItems(
@@ -82,11 +93,36 @@ export function buildVolatileItems(
   isAgentRunning: boolean,
   agentStartTime: number | undefined,
   streamingText: string | undefined,
+  permissions?: readonly {
+    requestId: string;
+    toolName: string;
+    input?: unknown;
+    title?: string;
+    settled: boolean;
+    decision?: PermissionDecision;
+  }[],
 ): ChatVirtualItem[] {
   const items: ChatVirtualItem[] = [];
 
+  // Tool calls first — the agent invoked a tool before the permission gate fires.
   if (toolCalls.length > 0) {
     items.push({ key: "active-tools", type: "active-tools", toolCalls });
+  }
+
+  // Permission requests follow because they are caused by the tool calls above.
+  if (permissions && permissions.length > 0) {
+    for (const p of permissions) {
+      items.push({
+        key: `permission-${p.requestId}`,
+        type: "permission-request" as const,
+        requestId: p.requestId,
+        toolName: p.toolName,
+        input: p.input,
+        title: p.title,
+        settled: p.settled,
+        decision: p.decision,
+      });
+    }
   }
 
   if (isAgentRunning) {
@@ -257,6 +293,8 @@ export function estimateItemHeight(item: ChatVirtualItem): number {
       const overflowRow = item.filesChanged.length > 50 ? 28 : 0;
       return item.isLatestTurn ? 44 + visibleFiles * 32 + overflowRow : 44;
     }
+    case "permission-request":
+      return item.settled ? 36 : 120;
     default:
       return assertNever(item);
   }

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -109,10 +109,13 @@ export function buildVolatileItems(
     items.push({ key: "active-tools", type: "active-tools", toolCalls });
   }
 
-  // Only show unsettled permission requests — settled cards disappear once the
-  // agent's response arrives so they don't trail below the agent's message.
+  // Show all permission requests (settled and unsettled) so the user gets
+  // visual confirmation of their allow/deny decision. Settled cards collapse
+  // to a single-line badge. The full permissionsByThread entry is cleared
+  // when the agent turn ends, so settled cards never trail below the agent's
+  // persisted message.
   if (permissions && permissions.length > 0) {
-    for (const p of permissions.filter((p) => !p.settled)) {
+    for (const p of permissions) {
       items.push({
         key: `permission-${p.requestId}`,
         type: "permission-request" as const,

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -32,7 +32,7 @@ vi.mock("@/stores/workspaceStore", () => ({
 
 vi.mock("@/stores/threadStore", () => ({
   useThreadStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ runningThreadIds: new Set() })
+    selector({ runningThreadIds: new Set(), permissionsByThread: {} })
   ),
 }));
 

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -149,7 +149,7 @@ export function ProjectTree() {
   const pendingPermissionThreadIds = useMemo(
     () =>
       new Set(
-        Object.entries(permissionsByThread)
+        Object.entries(permissionsByThread ?? {})
           .filter(([, perms]) => perms.some((p) => !p.settled))
           .map(([id]) => id),
       ),

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -143,6 +143,18 @@ export function ProjectTree() {
   const updateThreadTitle = useWorkspaceStore((s) => s.updateThreadTitle);
   const error = useWorkspaceStore((s) => s.error);
   const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
+  const permissionsByThread = useThreadStore((s) => s.permissionsByThread);
+  // Derive a set of thread IDs that have at least one unsettled permission request,
+  // so the sidebar can render the amber pending indicator without per-thread subscriptions.
+  const pendingPermissionThreadIds = useMemo(
+    () =>
+      new Set(
+        Object.entries(permissionsByThread)
+          .filter(([, perms]) => perms.some((p) => !p.settled))
+          .map(([id]) => id),
+      ),
+    [permissionsByThread],
+  );
 
   const [expanded, setExpanded] = useState<Record<string, boolean>>(getExpandedState);
   const [threadListExpanded, setThreadListExpandedState] = useState<Record<string, boolean>>(getThreadListExpanded);
@@ -356,6 +368,7 @@ export function ProjectTree() {
               activeThreadId={activeThreadId}
               threads={threads.filter((t) => t.workspace_id === ws.id)}
               runningThreadIds={runningThreadIds}
+              pendingPermissionThreadIds={pendingPermissionThreadIds}
               isThreadListExpanded={threadListExpanded[ws.id] ?? false}
               onToggleThreadList={() => toggleThreadList(ws.id)}
               scrollElementRef={scrollViewportRef}
@@ -554,6 +567,8 @@ interface VirtualizedThreadListProps {
   maxVisible: number;
   activeThreadId: string | null;
   runningThreadIds: Set<string>;
+  /** Thread IDs with at least one unsettled permission request. */
+  pendingPermissionThreadIds: Set<string>;
   scrollElementRef: React.RefObject<HTMLDivElement | null>;
   inlineEdit: InlineEditState | null;
   onInlineEditChange: (title: string) => void;
@@ -571,6 +586,7 @@ function VirtualizedThreadList({
   maxVisible,
   activeThreadId,
   runningThreadIds,
+  pendingPermissionThreadIds,
   scrollElementRef,
   inlineEdit,
   onInlineEditChange,
@@ -663,7 +679,7 @@ function VirtualizedThreadList({
     >
       {virtualizer.getVirtualItems().map((virtualItem) => {
         const { thread, depth } = treeItems[virtualItem.index];
-        const status = getStatusDisplay(thread, runningThreadIds.has(thread.id));
+        const status = getStatusDisplay(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
         const isEditing = inlineEdit?.threadId === thread.id;
         // Worktree thread whose directory no longer exists on disk.
         // Only check threads from the workspace whose worktrees are loaded — comparing
@@ -711,7 +727,7 @@ function VirtualizedThreadList({
                   const { Icon: PrIcon, color: prColor } = getPrVisual(thread.pr_status);
                   const ciChecks = checksById[thread.id];
                   const ciDotClass = ciChecks ? getCiDotClass(ciChecks.aggregate) : null;
-                  const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id));
+                  const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
                   // CI dot takes priority when present; fall back to agent notification dot
                   const dot = ciDotClass
                     ? { dotClass: ciDotClass, animate: ciChecks!.aggregate === "pending" }
@@ -796,6 +812,8 @@ interface ProjectNodeProps {
   activeThreadId: string | null;
   threads: Thread[];
   runningThreadIds: Set<string>;
+  /** Thread IDs with at least one unsettled permission request. */
+  pendingPermissionThreadIds: Set<string>;
   /** Whether the thread list is fully expanded (persisted by parent). */
   isThreadListExpanded: boolean;
   /** Callback to toggle the thread list expanded state (persisted by parent). */
@@ -822,6 +840,7 @@ function ProjectNode({
   activeThreadId,
   threads,
   runningThreadIds,
+  pendingPermissionThreadIds,
   isThreadListExpanded,
   onToggleThreadList,
   scrollElementRef,
@@ -894,6 +913,7 @@ function ProjectNode({
               maxVisible={maxVisible}
               activeThreadId={activeThreadId}
               runningThreadIds={runningThreadIds}
+              pendingPermissionThreadIds={pendingPermissionThreadIds}
               scrollElementRef={scrollElementRef}
               inlineEdit={inlineEdit}
               onInlineEditChange={onInlineEditChange}

--- a/apps/web/src/lib/thread-status.ts
+++ b/apps/web/src/lib/thread-status.ts
@@ -16,12 +16,19 @@ export interface NotificationDot {
 /**
  * Returns notification dot info for threads with PRs, or null if idle.
  * Used to overlay a small colored dot on the PR icon in the sidebar.
+ * @param thread - The thread whose PR notification dot is being computed.
+ * @param isActuallyRunning - True when the agent process is currently live.
+ * @param hasPendingPermission - True when the thread has at least one unsettled permission request; renders an amber dot.
  */
 export function getNotificationDot(
   thread: Thread,
   isActuallyRunning: boolean,
+  hasPendingPermission = false,
 ): NotificationDot | null {
   if (isActuallyRunning) {
+    if (hasPendingPermission) {
+      return { dotClass: "bg-amber-500", animate: true };
+    }
     return { dotClass: "bg-yellow-500", animate: true };
   }
   switch (thread.status) {
@@ -34,13 +41,27 @@ export function getNotificationDot(
   }
 }
 
-/** Returns the display label, text color, and dot class for a thread's status. */
+/**
+ * Returns the display label, text color, and dot class for a thread's status.
+ * @param thread - The thread whose status display is being computed.
+ * @param isActuallyRunning - True when the agent process is currently live.
+ * @param hasPendingPermission - True when the thread has at least one unsettled permission request; renders an amber pulsing dot.
+ */
 export function getStatusDisplay(
   thread: Thread,
   isActuallyRunning: boolean,
+  hasPendingPermission = false,
 ): StatusDisplay {
   // Live process state takes priority over DB status
   if (isActuallyRunning) {
+    // Permission requests are a sub-state of running — amber overrides the normal yellow.
+    if (hasPendingPermission) {
+      return {
+        label: "",
+        color: "text-amber-500",
+        dotClass: "bg-amber-500 animate-pulse",
+      };
+    }
     return {
       label: "",
       color: "text-yellow-500",

--- a/apps/web/src/lib/thread-status.ts
+++ b/apps/web/src/lib/thread-status.ts
@@ -25,10 +25,12 @@ export function getNotificationDot(
   isActuallyRunning: boolean,
   hasPendingPermission = false,
 ): NotificationDot | null {
+  // Amber takes top priority — show even if the thread has temporarily dropped
+  // from runningThreadIds (reconnect race, another tab, etc.).
+  if (hasPendingPermission) {
+    return { dotClass: "bg-amber-500", animate: true };
+  }
   if (isActuallyRunning) {
-    if (hasPendingPermission) {
-      return { dotClass: "bg-amber-500", animate: true };
-    }
     return { dotClass: "bg-yellow-500", animate: true };
   }
   switch (thread.status) {
@@ -52,16 +54,17 @@ export function getStatusDisplay(
   isActuallyRunning: boolean,
   hasPendingPermission = false,
 ): StatusDisplay {
+  // Pending permission is top priority — show amber even if the thread has
+  // temporarily dropped from runningThreadIds (reconnect race, another tab).
+  if (hasPendingPermission) {
+    return {
+      label: "",
+      color: "text-amber-500",
+      dotClass: "bg-amber-500 animate-pulse",
+    };
+  }
   // Live process state takes priority over DB status
   if (isActuallyRunning) {
-    // Permission requests are a sub-state of running — amber overrides the normal yellow.
-    if (hasPendingPermission) {
-      return {
-        label: "",
-        color: "text-amber-500",
-        dotClass: "bg-amber-500 animate-pulse",
-      };
-    }
     return {
       label: "",
       color: "text-yellow-500",

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1306,6 +1306,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             toolCallsByThread: completedCalls.length > 0
               ? { ...state.toolCallsByThread, [threadId]: completedCalls }
               : state.toolCallsByThread,
+            // Clear permission cards now that the agent has responded.
+            permissionsByThread: (() => {
+              const next = { ...state.permissionsByThread };
+              delete next[threadId];
+              return next;
+            })(),
           };
         });
       } else {
@@ -1342,6 +1348,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             toolCallsByThread: completedCalls.length > 0
               ? { ...state.toolCallsByThread, [threadId]: completedCalls }
               : state.toolCallsByThread,
+            // Clear permission cards now that the agent has responded.
+            permissionsByThread: (() => {
+              const next = { ...state.permissionsByThread };
+              delete next[threadId];
+              return next;
+            })(),
           };
         });
       }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { Message, ToolCall, PermissionMode, InteractionMode, AttachmentMeta, ToolCallRecord } from "@/transport";
 import type { ReasoningLevel, PlanQuestion, PlanAnswer, ProviderUsageInfo, QuotaCategory } from "@mcode/contracts";
+import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { PlanQuestionSchema } from "@mcode/contracts";
 import { getTransport, PERMISSION_MODES, INTERACTION_MODES } from "@/transport";
 import { useWorkspaceStore } from "./workspaceStore";
@@ -10,6 +11,12 @@ import { useTaskStore, coerceTaskStatus } from "./taskStore";
 import type { TaskItem } from "./taskStore";
 import { useToastStore } from "./toastStore";
 import { findModelById, getContextWindow } from "@/lib/model-registry";
+
+/** A permission request with its current resolution state. */
+interface StoredPermission extends PermissionRequest {
+  settled: boolean;
+  decision?: PermissionDecision;
+}
 
 /** Per-thread configuration for permission scope, interaction mode, and optional reasoning level. */
 export interface ThreadSettings {
@@ -76,6 +83,8 @@ interface ThreadState {
   activeQuestionIndexByThread: Record<string, number>;
   /** Plan wizard status per thread. */
   planQuestionsStatusByThread: Record<string, "idle" | "pending" | "answered">;
+  /** Pending and recently-settled permission requests per thread. */
+  permissionsByThread: Record<string, StoredPermission[]>;
 
   /** Store tool call records in the cache. */
   cacheToolCallRecords: (key: string, records: ToolCallRecord[]) => void;
@@ -103,6 +112,10 @@ interface ThreadState {
   submitPlanAnswers: (threadId: string) => Promise<void>;
   /** Reset plan question state for a thread (called on clear/reload). */
   clearPlanQuestions: (threadId: string) => void;
+  /** Add a new pending permission request for a thread. */
+  addPermissionRequest: (request: PermissionRequest) => void;
+  /** Mark a permission request as settled with its decision. */
+  resolvePermissionRequest: (requestId: string, decision: PermissionDecision) => void;
   handleAgentEvent: (threadId: string, event: Record<string, unknown>) => void;
 
   /** Handle server-side tool call persistence confirmation. */
@@ -239,6 +252,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   planAnswersByThread: {},
   activeQuestionIndexByThread: {},
   planQuestionsStatusByThread: {},
+  permissionsByThread: {},
 
   cacheToolCallRecords: (key, records) => {
     get().toolCallRecordCache.set(key, records);
@@ -333,6 +347,23 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           hasMoreMessages: { [threadId]: hasMore },
           isLoadingMore: {},
         });
+
+        // Re-hydrate pending permissions (covers reconnect and thread switch)
+        void getTransport()
+          .listPendingPermissions(threadId)
+          .then((pending) => {
+            if (pending.length > 0) {
+              set((s) => ({
+                permissionsByThread: {
+                  ...s.permissionsByThread,
+                  [threadId]: pending.map((p) => ({ ...p, settled: false })),
+                },
+              }));
+            }
+          })
+          .catch(() => {
+            // non-critical; push events will update state if the server pushes
+          });
 
         // Hydrate task panel from persisted TodoWrite state.
         getTransport()
@@ -711,6 +742,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         planAnswersByThread: omitKey(state.planAnswersByThread, threadId),
         activeQuestionIndexByThread: omitKey(state.activeQuestionIndexByThread, threadId),
         planQuestionsStatusByThread: omitKey(state.planQuestionsStatusByThread, threadId),
+        permissionsByThread: omitKey(state.permissionsByThread, threadId),
         usageByProvider: Object.fromEntries(
           Object.entries(state.usageByProvider).filter(([k]) => !k.startsWith(`${threadId}:`)),
         ),
@@ -788,6 +820,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         planAnswersByThread: pruneAll(state.planAnswersByThread),
         activeQuestionIndexByThread: pruneAll(state.activeQuestionIndexByThread),
         planQuestionsStatusByThread: pruneAll(state.planQuestionsStatusByThread),
+        permissionsByThread: pruneAll(state.permissionsByThread),
         usageByProvider: Object.fromEntries(
           Object.entries(state.usageByProvider).filter(([k]) => !threadIds.some((tid) => k.startsWith(`${tid}:`))),
         ),
@@ -884,6 +917,35 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         activeQuestionIndexByThread: nextIndex,
         planQuestionsStatusByThread: nextStatus,
       };
+    });
+  },
+
+  addPermissionRequest: (request) => {
+    set((s) => ({
+      permissionsByThread: {
+        ...s.permissionsByThread,
+        [request.threadId]: [
+          ...(s.permissionsByThread[request.threadId] ?? []),
+          { ...request, settled: false },
+        ],
+      },
+    }));
+  },
+
+  resolvePermissionRequest: (requestId, decision) => {
+    set((s) => {
+      const updated = { ...s.permissionsByThread };
+      for (const threadId of Object.keys(updated)) {
+        const list = updated[threadId];
+        const idx = list?.findIndex((p) => p.requestId === requestId);
+        if (idx !== undefined && idx >= 0 && list) {
+          updated[threadId] = list.map((p, i) =>
+            i === idx ? { ...p, settled: true, decision } : p,
+          );
+          break;
+        }
+      }
+      return { permissionsByThread: updated };
     });
   },
 
@@ -1643,3 +1705,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   },
   };
 });
+
+/**
+ * Returns true if the given thread has any unsettled permission requests.
+ * Use inside components: `useThreadStore(s => hasPendingPermissions(s, threadId))`.
+ */
+export function hasPendingPermissions(state: ThreadState, threadId: string): boolean {
+  const perms = state.permissionsByThread[threadId];
+  return perms != null && perms.some((p) => !p.settled);
+}

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -921,15 +921,17 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   },
 
   addPermissionRequest: (request) => {
-    set((s) => ({
-      permissionsByThread: {
-        ...s.permissionsByThread,
-        [request.threadId]: [
-          ...(s.permissionsByThread[request.threadId] ?? []),
-          { ...request, settled: false },
-        ],
-      },
-    }));
+    set((s) => {
+      const existing = s.permissionsByThread[request.threadId] ?? [];
+      // Guard against duplicate push events (e.g., IPC + WebSocket double delivery)
+      if (existing.some((p) => p.requestId === request.requestId)) return s;
+      return {
+        permissionsByThread: {
+          ...s.permissionsByThread,
+          [request.threadId]: [...existing, { ...request, settled: false }],
+        },
+      };
+    });
   },
 
   resolvePermissionRequest: (requestId, decision) => {

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -24,6 +24,8 @@ import type {
   CreatePrResult,
   ChecksStatus,
   CopilotSubagent,
+  PermissionDecision,
+  PermissionRequest,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
@@ -107,6 +109,10 @@ export interface McodeTransport {
     copilotAgent?: string,
   ): Promise<Thread>;
   stopAgent(threadId: string): Promise<void>;
+  /** Respond to a tool permission request from the agent. */
+  respondToPermission(requestId: string, decision: PermissionDecision): Promise<void>;
+  /** List pending permission requests for a thread (used to re-hydrate after reconnect). */
+  listPendingPermissions(threadId: string): Promise<PermissionRequest[]>;
   /** Submit answers to a plan-mode question batch and resume the agent session. */
   answerPlanQuestions(
     threadId: string,

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -1,4 +1,5 @@
 import type { Settings } from "@mcode/contracts";
+import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { pushEmitter } from "./ws-transport";
 import { useThreadStore } from "@/stores/threadStore";
 import { useTerminalStore } from "@/stores/terminalStore";
@@ -25,6 +26,8 @@ let unsubs: (() => void)[] = [];
  * - `settings.changed` -- server-pushed settings updates forwarded to settingsStore
  * - `branch.changed` -- refreshes branch list and updates current branch if not manually overridden
  * - `plan.questions` -- model-proposed plan questions forwarded to threadStore wizard
+ * - `permission.request` -- tool permission awaiting user decision
+ * - `permission.resolved` -- a permission was settled (by user or session stop)
  */
 export function startPushListeners(): void {
   // Guard against double-init
@@ -225,6 +228,27 @@ export function startPushListeners(): void {
       };
       if (!threadId || !Array.isArray(questions)) return;
       useThreadStore.getState().setPlanQuestions(threadId, questions);
+    }),
+  );
+
+  // permission.request: tool permission awaiting user decision
+  unsubs.push(
+    pushEmitter.on("permission.request", (data) => {
+      const request = data as PermissionRequest;
+      if (!request.requestId || !request.threadId) return;
+      useThreadStore.getState().addPermissionRequest(request);
+    }),
+  );
+
+  // permission.resolved: a permission was settled (by user or session stop)
+  unsubs.push(
+    pushEmitter.on("permission.resolved", (data) => {
+      const { requestId, decision } = data as {
+        requestId: string;
+        decision: PermissionDecision;
+      };
+      if (!requestId) return;
+      useThreadStore.getState().resolvePermissionRequest(requestId, decision);
     }),
   );
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -18,7 +18,7 @@ import type {
 import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 import { useSettingsStore } from "@/stores/settingsStore";
-import type { PermissionDecision, PermissionRequest } from "@mcode/contracts";
+import type { PermissionRequest } from "@mcode/contracts";
 
 /** Minimum reconnect delay in milliseconds. */
 const MIN_RECONNECT_MS = 1000;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -18,6 +18,7 @@ import type {
 import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 import { useSettingsStore } from "@/stores/settingsStore";
+import type { PermissionDecision, PermissionRequest } from "@mcode/contracts";
 
 /** Minimum reconnect delay in milliseconds. */
 const MIN_RECONNECT_MS = 1000;
@@ -408,6 +409,10 @@ export function createWsTransport(
       });
     },
     stopAgent: (threadId) => rpc<void>("agent.stop", { threadId }),
+    respondToPermission: (requestId, decision) =>
+      rpc<void>("permission.respond", { requestId, decision }),
+    listPendingPermissions: (threadId) =>
+      rpc<PermissionRequest[]>("permission.listPending", { threadId }),
     answerPlanQuestions: (threadId, answers, permissionMode?, reasoningLevel?) =>
       rpc<void>("agent.answerQuestions", { threadId, answers, permissionMode, reasoningLevel }),
     readClipboardImage: () =>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -95,6 +95,16 @@ export type {
   PlanQuestionBatch,
 } from "./models/plan-questions.js";
 
+// Permissions
+export {
+  PermissionDecisionSchema,
+  PermissionRequestSchema,
+} from "./models/permission.js";
+export type {
+  PermissionDecision,
+  PermissionRequest,
+} from "./models/permission.js";
+
 // Git / GitHub
 export { GitBranchSchema, WorktreeSchema, GitCommitSchema } from "./git.js";
 export type { GitBranch, WorktreeInfo, GitCommit } from "./git.js";

--- a/packages/contracts/src/models/permission.ts
+++ b/packages/contracts/src/models/permission.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+/** The set of decisions a user can make on a permission request. */
+export const PermissionDecisionSchema = z.enum([
+  "allow",
+  "allow-session",
+  "deny",
+  "cancelled",
+]);
+/** A user's decision on a pending tool permission request. */
+export type PermissionDecision = z.infer<typeof PermissionDecisionSchema>;
+
+/** A pending permission request pushed to the frontend. */
+export const PermissionRequestSchema = z.object({
+  requestId: z.string(),
+  threadId: z.string(),
+  toolName: z.string(),
+  /** Raw tool input arguments; shape varies by tool. */
+  input: z.unknown(),
+  title: z.string().optional(),
+});
+/** A pending tool permission request awaiting user decision. */
+export type PermissionRequest = z.infer<typeof PermissionRequestSchema>;

--- a/packages/contracts/src/models/permission.ts
+++ b/packages/contracts/src/models/permission.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
 
 /** The set of decisions a user can make on a permission request. */
 export const PermissionDecisionSchema = z.enum([
@@ -11,13 +12,13 @@ export const PermissionDecisionSchema = z.enum([
 export type PermissionDecision = z.infer<typeof PermissionDecisionSchema>;
 
 /** A pending permission request pushed to the frontend. */
-export const PermissionRequestSchema = z.object({
+export const PermissionRequestSchema = lazySchema(() => z.object({
   requestId: z.string(),
   threadId: z.string(),
   toolName: z.string(),
   /** Raw tool input arguments; shape varies by tool. */
   input: z.unknown(),
   title: z.string().optional(),
-});
+}));
 /** A pending tool permission request awaiting user decision. */
-export type PermissionRequest = z.infer<typeof PermissionRequestSchema>;
+export type PermissionRequest = z.infer<ReturnType<typeof PermissionRequestSchema>>;

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent } from "../events/agent-event.js";
 import type { AttachmentMeta } from "../models/attachment.js";
+import type { PermissionDecision, PermissionRequest } from "../models/permission.js";
 import type { ReasoningLevel } from "../models/settings.js";
 import type { ProviderModelInfo } from "./models.js";
 import type { ProviderUsageInfo } from "./usage.js";
@@ -61,10 +62,23 @@ export interface IAgentProvider {
   /** Return current usage/quota state for this provider. */
   getUsage?(): Promise<ProviderUsageInfo>;
 
+  /**
+   * Resolve a pending permission request.
+   * Returns true if the requestId was found and resolved, false otherwise.
+   */
+  resolvePermission?(requestId: string, decision: PermissionDecision): boolean;
+
+  /** Return all pending permission requests for a given thread. */
+  listPendingPermissions?(threadId: string): PermissionRequest[];
+
   /** Subscribe to agent events. */
   on(event: "event", handler: (event: AgentEvent) => void): void;
   /** Subscribe to provider-level errors. */
   on(event: "error", handler: (error: Error) => void): void;
+  /** Subscribe to permission request events (emitted when canUseTool fires). */
+  on(event: "permission_request", handler: (request: PermissionRequest) => void): void;
+  /** Subscribe to permission resolved events (emitted on session stop cancellation). */
+  on(event: "permission_resolved", handler: (payload: { requestId: string; decision: PermissionDecision }) => void): void;
 }
 
 /**

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -4,6 +4,7 @@ import { ThreadStatusSchema } from "../models/enums.js";
 import { SettingsSchema } from "../models/settings.js";
 import { PlanQuestionSchema } from "../models/plan-questions.js";
 import { ChecksStatusSchema } from "../github.js";
+import { PermissionRequestSchema, PermissionDecisionSchema } from "../models/permission.js";
 
 /** All push channel definitions keyed by channel name. */
 export const WS_CHANNELS = {
@@ -40,6 +41,13 @@ export const WS_CHANNELS = {
   "plan.questions": z.object({
     threadId: z.string(),
     questions: z.array(PlanQuestionSchema),
+  }),
+  /** A tool permission request awaiting user decision. */
+  "permission.request": PermissionRequestSchema,
+  /** Notification that a permission request has been settled. */
+  "permission.resolved": z.object({
+    requestId: z.string(),
+    decision: PermissionDecisionSchema,
   }),
 } as const;
 

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -43,7 +43,7 @@ export const WS_CHANNELS = {
     questions: z.array(PlanQuestionSchema),
   }),
   /** A tool permission request awaiting user decision. */
-  "permission.request": PermissionRequestSchema,
+  "permission.request": PermissionRequestSchema(),
   /** Notification that a permission request has been settled. */
   "permission.resolved": z.object({
     requestId: z.string(),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -235,7 +235,7 @@ export const WS_METHODS = lazySchema(() => ({
   /** Returns pending permission requests for a thread; used to re-hydrate the frontend after a WebSocket reconnect. */
   "permission.listPending": {
     params: z.object({ threadId: z.string() }),
-    result: z.array(PermissionRequestSchema),
+    result: z.array(PermissionRequestSchema()),
   },
   "message.list": {
     params: z.object({

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -22,6 +22,7 @@ import { lazySchema } from "../utils/lazySchema.js";
 import { ProviderModelInfoSchema } from "../providers/models.js";
 import { ProviderUsageInfoSchema } from "../providers/usage.js";
 import { CopilotSubagentSchema, CopilotAgentNameSchema } from "../providers/copilot-agent.js";
+import { PermissionDecisionSchema, PermissionRequestSchema } from "../models/permission.js";
 
 /** Schema for creating a new thread. */
 export const CreateThreadSchema = lazySchema(() =>
@@ -223,6 +224,18 @@ export const WS_METHODS = lazySchema(() => ({
       reasoningLevel: ReasoningLevelSchema.optional(),
     }),
     result: z.void(),
+  },
+  "permission.respond": {
+    params: z.object({
+      requestId: z.string(),
+      decision: PermissionDecisionSchema,
+    }),
+    result: z.void(),
+  },
+  /** Returns pending permission requests for a thread; used to re-hydrate the frontend after a WebSocket reconnect. */
+  "permission.listPending": {
+    params: z.object({ threadId: z.string() }),
+    result: z.array(PermissionRequestSchema),
   },
   "message.list": {
     params: z.object({


### PR DESCRIPTION
## What

Replace the binary bypass/default permission model with a proper `canUseTool` callback that routes tool permission requests to the mcode frontend via WebSocket, rendering an inline approval card in the chat UI.

## Why

In the current model, `"default"` mode is unusable in mcode because permission prompts render inside the invisible Claude Code subprocess. Users either run fully bypassed or get stuck. This implements a third mode — supervised — where the user approves or denies each tool call interactively from the chat.

## Key Changes

- **Contracts:** New `PermissionRequest`/`PermissionDecision` schemas, `permission.request`/`permission.resolved` push channels, `permission.respond`/`permission.listPending` RPC methods
- **Claude provider:** `canUseTool` callback with pending promise map; `resolvePermission`, `listPendingPermissions` methods; cleanup on `stopSession` and `shutdown`
- **Server transport:** Push broadcasting for permission events, `AgentService` delegation, `ws-router` dispatch cases
- **Frontend store:** `permissionsByThread` state with add/resolve actions, deduplication guard, re-hydration on thread load/reconnect
- **`PermissionRequestCard`:** Inline chat card with split Allow/Allow-in-session button and Deny; settles to a collapsed badge when resolved
- **Virtual list:** New `permission-request` item type rendered after active tool calls
- **Sidebar:** Amber pulsing dot on threads with pending permission requests

## Design decisions

- No "Always allow" — avoids coupling to CLI settings file formats (deferred to phase 2 issue #276)
- No timeout — agent waits indefinitely; only resolves on user action, session stop, or server restart
- Non-blocking — composer stays open while a permission is pending
- `allow-session` uses SDK's `updatedPermissions` with `destination: "session"` — no mcode-side storage

Closes #156 / Related to #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline permission cards in chat let you view tool name, input preview, and choose Allow once, Allow for session, or Deny.
  * Real-time push notifications surface new permission requests and resolved decisions; chat updates immediately.
  * Sidebar and thread list show amber pending-permission indicators for threads with outstanding requests.
  * Permission decisions persist across reconnects and pending requests are rehydrated on load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->