### PR TITLE
fix(desktop): bundle copilot-sdk to fix server startup in packaged app

### DIFF
--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -69,14 +69,13 @@ try {
     cwd: serverRoot,
     stdio: "inherit",
   });
-} catch {
-  // tsc may report errors (e.g. missing third-party type declarations) yet still
-  // emit JavaScript output. Verify the entry file exists before continuing.
+} catch (err) {
   const tscEntry = resolve(serverRoot, "dist-tsc/index.js");
   if (!existsSync(tscEntry)) {
     throw new Error(`tsc failed and did not emit ${tscEntry}`);
   }
-  console.warn("tsc reported errors but emitted output — continuing with esbuild bundle");
+  console.warn("⚠ tsc reported errors but emitted output — continuing with esbuild bundle");
+  console.warn("  Fix the type errors above to avoid runtime issues in the packaged app");
 }
 
 // Phase 2b: esbuild bundles the tsc output into a single CJS file.
@@ -90,7 +89,7 @@ await build({
   ...shared,
   entryPoints: [resolve(serverRoot, "dist-tsc/index.js")],
   outfile: "dist/server/server.cjs",
-  external: ["better-sqlite3", "node-pty", "electron", "@github/copilot-sdk"],
+  external: ["better-sqlite3", "node-pty", "electron"],
   banner: {
     js: 'var __importMetaUrl = require("url").pathToFileURL(__filename).href;',
   },

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "*",
+    "@github/copilot-sdk": "^0.2.2",
     "@mcode/contracts": "workspace:*",
     "@mcode/shared": "workspace:*",
     "better-sqlite3": "^12.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -4,17 +4,13 @@
   "workspaces": {
     "": {
       "name": "mcode",
-      "dependencies": {
-        "@github/copilot": "^1.0.21",
-        "@github/copilot-sdk": "^0.2.2",
-      },
       "devDependencies": {
         "turbo": "^2.5.0",
       },
     },
     "apps/desktop": {
       "name": "mcode-desktop",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@electron/rebuild": "^3.7.1",
         "@mcode/contracts": "workspace:*",
@@ -43,6 +39,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "*",
+        "@github/copilot-sdk": "^0.2.2",
         "@mcode/contracts": "workspace:*",
         "@mcode/shared": "workspace:*",
         "better-sqlite3": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
     "node-pty",
     "@electron/rebuild"
   ],
-  "dependencies": {
-    "@github/copilot": "^1.0.21",
-    "@github/copilot-sdk": "^0.2.2"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
## What

Fix the server failing to start after installing the v0.3.0 desktop app.

## Why

The server decoupling commit (#265) externalized `@github/copilot-sdk` from the esbuild bundle so the build would pass, but the SDK was never included in the Electron package's `asarUnpack` or `files` list. At runtime, `server.cjs` called `require("@github/copilot-sdk")` which threw `MODULE_NOT_FOUND`, crashing the server before it could listen on any port.

## Key changes

- Remove `@github/copilot-sdk` from esbuild `external` list in `build-main.mjs` - the SDK is pure JS with no native bindings, safe to bundle inline
- Add `@github/copilot-sdk` to `apps/server/package.json` dependencies (was only declared at root)
- Remove stale `@github/copilot` and `@github/copilot-sdk` from root `package.json`
- Improve tsc error handling to warn visibly instead of silently continuing

## Test plan

- [ ] Run `bun run build` in `apps/desktop` - build completes without tsc errors
- [ ] Verify `dist/server/server.cjs` has no `require("@github/copilot-sdk")` external call
- [ ] Run `bun run dist:no-snapshot` and install the resulting exe - server starts successfully

Closes the v0.3.0 server startup regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build script error handling to better capture and report type errors with enhanced warning messages, helping prevent potential runtime issues in packaged applications.

* **Chores**
  * Optimized server bundling configuration by updating external dependencies and reorganized project-level dependencies for improved build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->