### PR TITLE
feat: add Claude Opus 4.7 with xhigh reasoning effort

### DIFF
--- a/apps/server/src/__tests__/build-reasoning-options.test.ts
+++ b/apps/server/src/__tests__/build-reasoning-options.test.ts
@@ -101,4 +101,14 @@ describe("buildReasoningOptions", () => {
   it("returns empty object when reasoning level is undefined", () => {
     expect(buildReasoningOptions(undefined, OPUS)).toEqual({});
   });
+
+  it("passes xhigh through for a dated Opus 4.7 variant", () => {
+    const result = buildReasoningOptions("xhigh", "claude-opus-4-7-20260401");
+    expect(result.effort).toBe("xhigh");
+  });
+
+  it("passes max through for a dated Opus 4.7 variant", () => {
+    const result = buildReasoningOptions("max", "claude-opus-4-7-20260401");
+    expect(result.effort).toBe("max");
+  });
 });

--- a/apps/server/src/__tests__/build-reasoning-options.test.ts
+++ b/apps/server/src/__tests__/build-reasoning-options.test.ts
@@ -13,6 +13,7 @@ vi.mock("@mcode/shared", () => ({
 import { logger } from "@mcode/shared";
 
 const OPUS = "claude-opus-4-6";
+const OPUS_47 = "claude-opus-4-7";
 const HAIKU = "claude-haiku-4-5";
 const SONNET = "claude-sonnet-4-6";
 
@@ -69,6 +70,32 @@ describe("buildReasoningOptions", () => {
       "Max reasoning effort not supported for model, clamping to high",
       { modelId: SONNET },
     );
+  });
+
+  it("passes xhigh through for claude-opus-4-7", () => {
+    const result = buildReasoningOptions("xhigh", OPUS_47);
+    expect(result.effort).toBe("xhigh");
+    expect(result.thinking).toEqual({ type: "adaptive" });
+  });
+
+  it("clamps xhigh to high for claude-opus-4-6 with warning", () => {
+    const result = buildReasoningOptions("xhigh", OPUS);
+    expect(result.effort).toBe("high");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("xhigh"),
+      expect.objectContaining({ modelId: OPUS }),
+    );
+  });
+
+  it("clamps xhigh to high for claude-sonnet-4-6", () => {
+    const result = buildReasoningOptions("xhigh", SONNET);
+    expect(result.effort).toBe("high");
+  });
+
+  it("passes max through for claude-opus-4-7", () => {
+    const result = buildReasoningOptions("max", OPUS_47);
+    expect(result.effort).toBe("max");
+    expect(result.thinking).toEqual({ type: "adaptive" });
   });
 
   it("returns empty object when reasoning level is undefined", () => {

--- a/apps/server/src/providers/claude/build-reasoning-options.ts
+++ b/apps/server/src/providers/claude/build-reasoning-options.ts
@@ -47,8 +47,8 @@ export function buildReasoningOptions(
   }
 
   return {
-    // SDK EffortLevel doesn't include "xhigh" yet; the API accepts it
-    effort: level as Exclude<ReasoningLevel, "xhigh">,
+    // @ts-expect-error: SDK EffortLevel type doesn't include "xhigh" yet; remove when it does
+    effort: level,
     thinking: { type: "adaptive" },
   };
 }

--- a/apps/server/src/providers/claude/build-reasoning-options.ts
+++ b/apps/server/src/providers/claude/build-reasoning-options.ts
@@ -9,6 +9,16 @@ const MAX_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-7", "claude-opus
 const XHIGH_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-7"];
 
 /**
+ * Strips a dated suffix from a Claude model ID, returning the base ID.
+ * The Claude SDK returns dated variants (e.g. "claude-opus-4-7-20260401")
+ * in session metadata; normalize these before capability checks.
+ */
+function normalizeModelId(modelId: string): string {
+  const allIds = [...MAX_EFFORT_MODEL_IDS, ...XHIGH_EFFORT_MODEL_IDS];
+  return allIds.find((base) => modelId.startsWith(`${base}-`)) ?? modelId;
+}
+
+/**
  * Build the SDK reasoning options from a reasoning level and model ID.
  * Clamps unsupported levels down to "high", emitting a warning when this
  * normalization occurs. Returns an empty object when reasoning is disabled.
@@ -19,16 +29,17 @@ export function buildReasoningOptions(
 ): Pick<Options, "effort" | "thinking"> {
   if (reasoningLevel === undefined) return {};
 
+  const baseModelId = normalizeModelId(modelId);
   let level: ReasoningLevel = reasoningLevel;
 
-  if (level === "xhigh" && !XHIGH_EFFORT_MODEL_IDS.includes(modelId)) {
+  if (level === "xhigh" && !XHIGH_EFFORT_MODEL_IDS.includes(baseModelId)) {
     logger.warn("xhigh reasoning effort not supported for model, clamping to high", {
       modelId,
     });
     level = "high";
   }
 
-  if (level === "max" && !MAX_EFFORT_MODEL_IDS.includes(modelId)) {
+  if (level === "max" && !MAX_EFFORT_MODEL_IDS.includes(baseModelId)) {
     logger.warn("Max reasoning effort not supported for model, clamping to high", {
       modelId,
     });

--- a/apps/server/src/providers/claude/build-reasoning-options.ts
+++ b/apps/server/src/providers/claude/build-reasoning-options.ts
@@ -3,13 +3,15 @@ import type { ReasoningLevel } from "@mcode/contracts";
 import { logger } from "@mcode/shared";
 
 /** Model IDs that support the "max" reasoning effort level. */
-const MAX_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-6"];
+const MAX_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-7", "claude-opus-4-6"];
+
+/** Model IDs that support the "xhigh" reasoning effort level. */
+const XHIGH_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-7"];
 
 /**
  * Build the SDK reasoning options from a reasoning level and model ID.
- * Clamps "max" to "high" for models that do not support the max effort tier,
- * emitting a warning when this normalization occurs.
- * Returns an empty object when reasoning is disabled (level is undefined).
+ * Clamps unsupported levels down to "high", emitting a warning when this
+ * normalization occurs. Returns an empty object when reasoning is disabled.
  */
 export function buildReasoningOptions(
   reasoningLevel: ReasoningLevel | undefined,
@@ -18,18 +20,23 @@ export function buildReasoningOptions(
   if (reasoningLevel === undefined) return {};
 
   let level: ReasoningLevel = reasoningLevel;
+
+  if (level === "xhigh" && !XHIGH_EFFORT_MODEL_IDS.includes(modelId)) {
+    logger.warn("xhigh reasoning effort not supported for model, clamping to high", {
+      modelId,
+    });
+    level = "high";
+  }
+
   if (level === "max" && !MAX_EFFORT_MODEL_IDS.includes(modelId)) {
     logger.warn("Max reasoning effort not supported for model, clamping to high", {
       modelId,
     });
     level = "high";
   }
-  // "xhigh" is a Codex-only level; Claude SDK does not accept it
-  if (level === "xhigh") {
-    level = "high";
-  }
 
   return {
+    // SDK EffortLevel doesn't include "xhigh" yet; the API accepts it
     effort: level as Exclude<ReasoningLevel, "xhigh">,
     thinking: { type: "adaptive" },
   };

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -244,6 +244,10 @@ describe("isXhighEffortModel", () => {
   it("returns false for unknown model", () => {
     expect(isXhighEffortModel("nonexistent")).toBe(false);
   });
+
+  it("returns false for dated Opus 4.6 variant", () => {
+    expect(isXhighEffortModel("claude-opus-4-6-20251001")).toBe(false);
+  });
 });
 
 describe("normalizeReasoningLevelForModel", () => {
@@ -291,6 +295,10 @@ describe("normalizeReasoningLevelForModel", () => {
 
   it("clamps xhigh to high for Sonnet", () => {
     expect(normalizeReasoningLevelForModel("claude-sonnet-4-6", "xhigh")).toBe("high");
+  });
+
+  it("clamps xhigh to high for Haiku", () => {
+    expect(normalizeReasoningLevelForModel("claude-haiku-4-5", "xhigh")).toBe("high");
   });
 });
 

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -232,6 +232,10 @@ describe("normalizeReasoningLevelForModel", () => {
     expect(normalizeReasoningLevelForModel("claude-opus-4-6-20251001", "max")).toBe("max");
   });
 
+  it("returns max unchanged for Opus 4.7", () => {
+    expect(normalizeReasoningLevelForModel("claude-opus-4-7", "max")).toBe("max");
+  });
+
   it("clamps max to high for Sonnet", () => {
     expect(normalizeReasoningLevelForModel("claude-sonnet-4-6", "max")).toBe("high");
   });

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -9,6 +9,7 @@ import {
   getDefaultModelId,
   getDefaultReasoningLevel,
   isMaxEffortModel,
+  isXhighEffortModel,
   normalizeReasoningLevelForModel,
   resolveThreadModelId,
 } from "@/lib/model-registry";
@@ -223,6 +224,28 @@ describe("isMaxEffortModel", () => {
   });
 });
 
+describe("isXhighEffortModel", () => {
+  it("returns true for claude-opus-4-7", () => {
+    expect(isXhighEffortModel("claude-opus-4-7")).toBe(true);
+  });
+
+  it("returns true for dated Opus 4.7 variant", () => {
+    expect(isXhighEffortModel("claude-opus-4-7-20260401")).toBe(true);
+  });
+
+  it("returns false for claude-opus-4-6", () => {
+    expect(isXhighEffortModel("claude-opus-4-6")).toBe(false);
+  });
+
+  it("returns false for claude-sonnet-4-6", () => {
+    expect(isXhighEffortModel("claude-sonnet-4-6")).toBe(false);
+  });
+
+  it("returns false for unknown model", () => {
+    expect(isXhighEffortModel("nonexistent")).toBe(false);
+  });
+});
+
 describe("normalizeReasoningLevelForModel", () => {
   it("returns max unchanged for Opus 4.6", () => {
     expect(normalizeReasoningLevelForModel("claude-opus-4-6", "max")).toBe("max");
@@ -252,6 +275,22 @@ describe("normalizeReasoningLevelForModel", () => {
     expect(normalizeReasoningLevelForModel("claude-sonnet-4-6", "high")).toBe("high");
     expect(normalizeReasoningLevelForModel("claude-sonnet-4-6", "medium")).toBe("medium");
     expect(normalizeReasoningLevelForModel("claude-sonnet-4-6", "low")).toBe("low");
+  });
+
+  it("returns xhigh unchanged for Opus 4.7", () => {
+    expect(normalizeReasoningLevelForModel("claude-opus-4-7", "xhigh")).toBe("xhigh");
+  });
+
+  it("returns xhigh unchanged for dated Opus 4.7 variant", () => {
+    expect(normalizeReasoningLevelForModel("claude-opus-4-7-20260401", "xhigh")).toBe("xhigh");
+  });
+
+  it("clamps xhigh to high for Opus 4.6", () => {
+    expect(normalizeReasoningLevelForModel("claude-opus-4-6", "xhigh")).toBe("high");
+  });
+
+  it("clamps xhigh to high for Sonnet", () => {
+    expect(normalizeReasoningLevelForModel("claude-sonnet-4-6", "xhigh")).toBe("high");
   });
 });
 

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -14,11 +14,17 @@ import {
 } from "@/lib/model-registry";
 
 describe("ModelRegistry", () => {
-  it("MODEL_PROVIDERS contains Claude with 3 models", () => {
+  it("MODEL_PROVIDERS contains Claude with 4 models", () => {
     const claude = MODEL_PROVIDERS.find((p) => p.id === "claude");
     expect(claude).toBeTruthy();
-    expect(claude?.models).toHaveLength(3);
+    expect(claude?.models).toHaveLength(4);
     expect(claude?.comingSoon).toBe(false);
+  });
+
+  it("findModelById returns Opus 4.7", () => {
+    const model = findModelById("claude-opus-4-7");
+    expect(model?.label).toBe("Claude Opus 4.7");
+    expect(model?.providerId).toBe("claude");
   });
 
   it("findModelById returns correct model", () => {
@@ -145,6 +151,11 @@ describe("findModelById dated variants", () => {
     expect(model?.id).toBe("claude-opus-4-6");
   });
 
+  it("resolves claude-opus-4-7-20260401 to claude-opus-4-7", () => {
+    const model = findModelById("claude-opus-4-7-20260401");
+    expect(model?.id).toBe("claude-opus-4-7");
+  });
+
   it("returns undefined for a totally unknown dated-style string", () => {
     expect(findModelById("claude-unknown-99-9-20251001")).toBeUndefined();
   });
@@ -160,6 +171,10 @@ describe("findModelById dated variants", () => {
 describe("findProviderForModel dated variants", () => {
   it("resolves claude-haiku-4-5-20251001 to claude provider", () => {
     expect(findProviderForModel("claude-haiku-4-5-20251001")?.id).toBe("claude");
+  });
+
+  it("resolves claude-opus-4-7-20260401 to claude provider", () => {
+    expect(findProviderForModel("claude-opus-4-7-20260401")?.id).toBe("claude");
   });
 
   it("returns undefined for a totally unknown dated-style string", () => {
@@ -193,6 +208,14 @@ describe("isMaxEffortModel", () => {
 
   it("returns false for claude-haiku-4-5", () => {
     expect(isMaxEffortModel("claude-haiku-4-5")).toBe(false);
+  });
+
+  it("returns true for claude-opus-4-7", () => {
+    expect(isMaxEffortModel("claude-opus-4-7")).toBe(true);
+  });
+
+  it("returns true for dated Opus 4.7 variant", () => {
+    expect(isMaxEffortModel("claude-opus-4-7-20260401")).toBe(true);
   });
 
   it("returns false for unknown model", () => {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1002,14 +1002,13 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const reasoningLabel = (level: string) =>
     level === "xhigh" ? "X-High" : level.charAt(0).toUpperCase() + level.slice(1);
 
-  const codexLevels = getCodexReasoningLevels(modelId);
-  const reasoningLevels: ReasoningLevel[] = codexLevels
-    ? (codexLevels as unknown as ReasoningLevel[])
-    : isXhighEffortModel(modelId)
-      ? ["low", "medium", "high", "max", "xhigh"]
-      : isMaxEffortModel(modelId)
-        ? ["low", "medium", "high", "max"]
-        : ["low", "medium", "high"];
+  const reasoningLevels = useMemo<ReasoningLevel[]>(() => {
+    const codexLevels = getCodexReasoningLevels(modelId);
+    if (codexLevels) return codexLevels as unknown as ReasoningLevel[];
+    if (isXhighEffortModel(modelId)) return ["low", "medium", "high", "max", "xhigh"];
+    if (isMaxEffortModel(modelId)) return ["low", "medium", "high", "max"];
+    return ["low", "medium", "high"];
+  }, [modelId]);
 
   return (
     <div className="relative px-8 py-4">

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -19,7 +19,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, findModelById, isMaxEffortModel, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels } from "@/lib/model-registry";
+import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, findModelById, isMaxEffortModel, isXhighEffortModel, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels } from "@/lib/model-registry";
 import { ModelSelector } from "./ModelSelector";
 import { ModeSelector } from "./ModeSelector";
 import type { ComposerMode } from "./ModeSelector";
@@ -1005,9 +1005,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const codexLevels = getCodexReasoningLevels(modelId);
   const reasoningLevels: ReasoningLevel[] = codexLevels
     ? (codexLevels as unknown as ReasoningLevel[])
-    : isMaxEffortModel(modelId)
-      ? ["low", "medium", "high", "max"]
-      : ["low", "medium", "high"];
+    : isXhighEffortModel(modelId)
+      ? ["low", "medium", "high", "max", "xhigh"]
+      : isMaxEffortModel(modelId)
+        ? ["low", "medium", "high", "max"]
+        : ["low", "medium", "high"];
 
   return (
     <div className="relative px-8 py-4">

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -3,6 +3,7 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import {
   MODEL_PROVIDERS,
   isMaxEffortModel,
+  isXhighEffortModel,
   normalizeReasoningLevelForModel,
   getCodexReasoningLevels,
 } from "@/lib/model-registry";
@@ -141,6 +142,7 @@ export function ModelSection() {
     return [
       ...REASONING_OPTIONS_BASE,
       { value: "max", label: "Max", disabled: !isMaxEffortModel(modelId) },
+      { value: "xhigh", label: "X-High", disabled: !isXhighEffortModel(modelId) },
     ];
   }, [modelId, codexLevels]);
 
@@ -153,7 +155,7 @@ export function ModelSection() {
     if (provider === "copilot") {
       return "Reasoning effort passed to the Copilot model. Not all models support all levels.";
     }
-    return "Default reasoning level. Max requires Opus 4.6.";
+    return "Default reasoning level. Max requires Opus. X-High requires Opus 4.7.";
   }, [codexLevels, provider]);
 
   const handleProviderChange = (v: string) => {

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -46,6 +46,7 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     comingSoon: false,
     supportsCompletion: true,
     models: [
+      { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude" },
       { id: "claude-opus-4-6", label: "Claude Opus 4.6", providerId: "claude" },
       { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providerId: "claude" },
       { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providerId: "claude" },
@@ -186,7 +187,7 @@ export function findProviderForModel(modelId: string): ModelProvider | undefined
 
 /** @deprecated Use `getDefaultModelId()` for settings-aware defaults. */
 export function getDefaultModel(): ModelDefinition {
-  return MODEL_PROVIDERS[0].models[1]; // Claude Sonnet 4.6
+  return MODEL_PROVIDERS[0].models[2]; // Claude Sonnet 4.6
 }
 
 /**
@@ -221,7 +222,7 @@ export function getDefaultReasoningLevel(): ReasoningLevel {
 }
 
 /** Opus model IDs that support the "max" effort level. */
-const MAX_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-6"];
+const MAX_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-7", "claude-opus-4-6"];
 
 /**
  * Returns true when the given model supports "max" reasoning effort.

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -226,7 +226,7 @@ const MAX_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-7", "claude-opus
 
 /**
  * Returns true when the given model supports "max" reasoning effort.
- * Only Opus 4.6 exposes the max effort tier. Accepts dated SDK variants
+ * Opus 4.6 and 4.7 expose the max effort tier. Accepts dated SDK variants
  * (e.g. `claude-opus-4-6-20251001`) by normalizing through `findModelById`.
  */
 export function isMaxEffortModel(modelId: string): boolean {

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -224,6 +224,9 @@ export function getDefaultReasoningLevel(): ReasoningLevel {
 /** Opus model IDs that support the "max" effort level. */
 const MAX_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-7", "claude-opus-4-6"];
 
+/** Claude model IDs that support the "xhigh" effort level. */
+const XHIGH_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-7"];
+
 /**
  * Returns true when the given model supports "max" reasoning effort.
  * Opus 4.6 and 4.7 expose the max effort tier. Accepts dated SDK variants
@@ -235,9 +238,19 @@ export function isMaxEffortModel(modelId: string): boolean {
 }
 
 /**
+ * Returns true when the given Claude model supports "xhigh" reasoning effort.
+ * Only Opus 4.7+ exposes the xhigh effort tier. Accepts dated SDK variants
+ * by normalizing through `findModelById`.
+ */
+export function isXhighEffortModel(modelId: string): boolean {
+  const baseId = findModelById(modelId)?.id ?? modelId;
+  return XHIGH_EFFORT_MODEL_IDS.includes(baseId);
+}
+
+/**
  * Normalizes a reasoning level for the given model.
  * - Clamps "max" to "high" for non-Opus Claude models.
- * - Clamps "xhigh" to "high" for Claude models (xhigh is Codex-only).
+ * - Clamps "xhigh" to "high" for Claude models below Opus 4.7.
  */
 export function normalizeReasoningLevelForModel(
   modelId: string,
@@ -251,8 +264,8 @@ export function normalizeReasoningLevelForModel(
     if (level === "max") return codexLevels.includes("xhigh") ? "xhigh" : "high";
     return level;
   }
-  // Claude: xhigh is not valid, clamp to high
-  if (level === "xhigh") return "high";
+  // Claude: xhigh requires Opus 4.7+
+  if (level === "xhigh" && !isXhighEffortModel(modelId)) return "high";
   if (level === "max" && !isMaxEffortModel(modelId)) return "high";
   return level;
 }

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -26,7 +26,7 @@ export type AgentDefaultMode = z.infer<typeof AgentDefaultModeSchema>;
 
 /**
  * Reasoning effort level for model inference.
- * "max" maps to Claude's extended thinking; "xhigh" maps to Codex's xhigh effort tier.
+ * "max" maps to Claude's extended thinking; "xhigh" maps to Codex's xhigh effort tier and Claude Opus 4.7+.
  */
 export const ReasoningLevelSchema = z.enum(["low", "medium", "high", "max", "xhigh"]);
 /** Reasoning effort level value. */


### PR DESCRIPTION
## What
Adds Claude Opus 4.7 as a selectable model across the provider stack, with support for the new `xhigh` reasoning effort level introduced in this release.

## Why
Opus 4.7 is now GA with stronger performance on advanced software engineering tasks and a new `xhigh` effort tier for finer reasoning control. Without this change, the model does not appear in the picker and the new effort level is unavailable.

## Key Changes
- **Model registry** (`apps/web/src/lib/model-registry.ts`): adds `claude-opus-4-7` as the first Claude model entry; adds `isXhighEffortModel()` alongside the existing `isMaxEffortModel()` pattern; updates `normalizeReasoningLevelForModel` to pass `xhigh` through for Opus 4.7 instead of clamping
- **Backend SDK options** (`apps/server/src/providers/claude/build-reasoning-options.ts`): mirrors the capability gating for `xhigh`; adds `normalizeModelId()` to strip dated SDK variant suffixes before allowlist checks; adds `claude-opus-4-7` to `MAX_EFFORT_MODEL_IDS`
- **Composer** (`apps/web/src/components/chat/Composer.tsx`): exposes `xhigh` in the per-thread reasoning picker for Opus 4.7; wraps computation in `useMemo([modelId])`
- **Settings** (`apps/web/src/components/settings/sections/ModelSection.tsx`): adds an X-High option (disabled for non-Opus-4.7 models) and updates hint text
- **Contracts** (`packages/contracts/src/models/settings.ts`): fixes `ReasoningLevelSchema` docstring to reflect that `xhigh` now applies to both Codex and Claude Opus 4.7+

Settings defaults remain `claude-sonnet-4-6`.

Closes #<issue>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.7.
  * Introduced an X-High reasoning effort level for supported models (Opus 4.7).

* **Improvements**
  * UI now shows the X-High option when available.
  * Max reasoning effort now applies to Opus 4.7.
  * Better handling of dated model variant identifiers.

* **Documentation**
  * Updated reasoning level docs to include Opus 4.7 X-High mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->