### PR TITLE
docs: document OS warnings for unsigned downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ bun run dev:desktop
 - Zustand
 - Bun
 
+## Installing Pre-built Downloads
+
+Mcode builds are currently **unsigned** while the project is in early development. Your OS will warn you before running them. This is expected and the binaries are safe — they are built in CI directly from this public repository (see [`.github/workflows/build-release.yml`](.github/workflows/build-release.yml)).
+
+**Windows:** SmartScreen will show *"Windows protected your PC"*. Click **More info** → **Run anyway**.
+
+**macOS:** Gatekeeper will say the app *"cannot be opened because the developer cannot be verified"*. Right-click the app → **Open** → **Open** in the dialog. Or run:
+
+```bash
+xattr -d com.apple.quarantine /Applications/Mcode.app
+```
+
+**Linux:** No warning. Make the AppImage executable with `chmod +x Mcode-*.AppImage`.
+
+Proper code signing (Azure Trusted Signing for Windows, Apple Developer ID + notarization for macOS) is planned once the project matures.
+
 ## Notes
 
 This project is in very early development. Expect bugs, breaking changes, and incomplete features. Use at your own risk for now.


### PR DESCRIPTION
## What
Add a README section explaining why SmartScreen (Windows) and Gatekeeper (macOS) warn on downloaded Mcode installers, and how users can run them anyway.

## Why
Builds are currently unsigned. Code signing requires paid certs (Azure Trusted Signing, Apple Developer ID) that the project is not ready to invest in yet. Without documentation, users hitting the OS warnings have no way to tell if the download is legitimate or compromised. Pointing them at the public CI workflow gives them a real trust signal in the meantime.

## Key Changes
- New "Installing Pre-built Downloads" section in README
- Per-OS workarounds: SmartScreen "More info → Run anyway", Gatekeeper right-click/Open + xattr one-liner, Linux chmod
- Note that proper signing is planned once the project matures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions for pre-built binaries with platform-specific guidance for Windows, macOS, and Linux.
  * Documented current unsigned binary status and necessary steps to run the application on each OS.
  * Outlined future code signing improvements planned for upcoming releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->