### PR TITLE
feat: markdown preview toggle for .md/.mdx diffs

### DIFF
--- a/apps/web/src/__tests__/diff-parser.test.ts
+++ b/apps/web/src/__tests__/diff-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseDiffLines } from "../lib/diff-parser";
+import { parseDiffLines, isMarkdownFile, reconstructNewContent } from "../lib/diff-parser";
 
 describe("parseDiffLines", () => {
   describe("hiddenLineCount on hunk headers", () => {
@@ -161,5 +161,93 @@ diff --git a/b.ts b/b.ts
       const lines = parseDiffLines(diff);
       expect(lines.find((l) => l.type === "context")?.content).toBe("unchanged");
     });
+  });
+});
+
+describe("isMarkdownFile", () => {
+  it("returns true for .md extension", () => {
+    expect(isMarkdownFile("README.md")).toBe(true);
+  });
+
+  it("returns true for .mdx extension", () => {
+    expect(isMarkdownFile("docs/guide.mdx")).toBe(true);
+  });
+
+  it("returns true for uppercase .MD extension", () => {
+    expect(isMarkdownFile("README.MD")).toBe(true);
+  });
+
+  it("returns false for .ts file", () => {
+    expect(isMarkdownFile("index.ts")).toBe(false);
+  });
+
+  it("returns false for .txt file", () => {
+    expect(isMarkdownFile("notes.txt")).toBe(false);
+  });
+
+  it("returns false for a file with no extension", () => {
+    expect(isMarkdownFile("Makefile")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isMarkdownFile("")).toBe(false);
+  });
+
+  it("handles path with directories", () => {
+    expect(isMarkdownFile("docs/guides/architecture.md")).toBe(true);
+  });
+});
+
+describe("reconstructNewContent", () => {
+  it("returns empty string for empty lines array", () => {
+    expect(reconstructNewContent([])).toBe("");
+  });
+
+  it("includes context lines", () => {
+    const lines = parseDiffLines(`@@ -1,2 +1,2 @@
+ first
+ second`);
+    expect(reconstructNewContent(lines)).toBe("first\nsecond");
+  });
+
+  it("includes added lines", () => {
+    const lines = parseDiffLines(`@@ -1,1 +1,2 @@
+ context
++added`);
+    expect(reconstructNewContent(lines)).toBe("context\nadded");
+  });
+
+  it("excludes removed lines", () => {
+    const lines = parseDiffLines(`@@ -1,2 +1,1 @@
+-removed
+ kept`);
+    expect(reconstructNewContent(lines)).toBe("kept");
+  });
+
+  it("excludes header lines", () => {
+    const lines = parseDiffLines(`diff --git a/foo.md b/foo.md
+--- a/foo.md
++++ b/foo.md
+@@ -1,1 +1,1 @@
+-old
++new`);
+    expect(reconstructNewContent(lines)).toBe("new");
+  });
+
+  it("reconstructs correct order: context before add", () => {
+    const lines = parseDiffLines(`@@ -1,2 +1,3 @@
+ line1
+-old
++new
+ line3`);
+    expect(reconstructNewContent(lines)).toBe("line1\nnew\nline3");
+  });
+
+  it("preserves empty lines from context", () => {
+    const lines = parseDiffLines(`@@ -1,3 +1,3 @@
+ first
+
+ last`);
+    expect(reconstructNewContent(lines)).toBe("first\n\nlast");
   });
 });

--- a/apps/web/src/__tests__/diff-parser.test.ts
+++ b/apps/web/src/__tests__/diff-parser.test.ts
@@ -250,4 +250,12 @@ describe("reconstructNewContent", () => {
  last`);
     expect(reconstructNewContent(lines)).toBe("first\n\nlast");
   });
+
+  it("excludes the no-newline sentinel", () => {
+    const lines = parseDiffLines(`@@ -1,1 +1,1 @@
+-old
++new
+\\ No newline at end of file`);
+    expect(reconstructNewContent(lines)).toBe("new");
+  });
 });

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -165,4 +165,5 @@ describe("diffStore", () => {
       expect(state.diffContent).toBe("other diff");
     });
   });
+
 });

--- a/apps/web/src/components/diff/DiffPreview.tsx
+++ b/apps/web/src/components/diff/DiffPreview.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import { reconstructNewContent, type ParsedDiffLine } from "@/lib/diff-parser";
+import { MarkdownContent } from "@/components/chat/MarkdownContent";
+
+/** Props for {@link DiffPreview}. */
+interface DiffPreviewProps {
+  /** Pre-parsed diff lines from the parent (avoids re-parsing the raw diff string). */
+  lines: ParsedDiffLine[];
+}
+
+/**
+ * Renders a markdown preview of the new (post-change) file content reconstructed
+ * from parsed diff lines. Reuses the existing {@link MarkdownContent} renderer so
+ * GFM tables, headings, code blocks, and Mermaid diagrams all work out of the box.
+ */
+export function DiffPreview({ lines }: DiffPreviewProps) {
+  const markdown = useMemo(() => reconstructNewContent(lines), [lines]);
+
+  return (
+    <div className="p-4 text-sm leading-relaxed text-foreground/80">
+      <MarkdownContent content={markdown} />
+    </div>
+  );
+}

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from "react";
-import { Plus, Minus, ChevronsDownUp } from "lucide-react";
+import { Plus, Minus, ChevronsDownUp, Eye, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useDiffStore, type SelectedFile } from "@/stores/diffStore";
 import { getTransport } from "@/transport";
@@ -7,6 +7,7 @@ import { parseDiffLines } from "@/lib/diff-parser";
 import { langFromPath } from "@/lib/lang-from-path";
 import { UnifiedDiff } from "./UnifiedDiff";
 import { SideBySideDiff } from "./SideBySideDiff";
+import { DiffPreview } from "./DiffPreview";
 
 /** Props for FileEntry. */
 interface FileEntryProps {
@@ -77,17 +78,18 @@ type DiffState = null | { loading: true } | { loading: false; data: string };
 export function FileEntry({ filePath, source, id }: FileEntryProps) {
   const [expanded, setExpanded] = useState(false);
   const [showAllLines, setShowAllLines] = useState(false);
+  const [previewMode, setPreviewMode] = useState(false);
   const [diffState, setDiffState] = useState<DiffState>(null);
   const renderMode = useDiffStore((s) => s.renderMode);
   // Tracks whether a load has been kicked off so the effect doesn't cancel itself
   // when diffState transitions from null → {loading:true}
   const loadStartedRef = useRef(false);
 
-  const { basename, parent, ext, language } = useMemo(() => {
+  const { basename, parent, ext, language, isMarkdown } = useMemo(() => {
     const bn = getFileBasename(filePath);
     const pr = getParentDir(filePath);
     const ex = getExtension(filePath);
-    return { basename: bn, parent: pr, ext: ex, language: langFromPath(filePath) };
+    return { basename: bn, parent: pr, ext: ex, language: langFromPath(filePath), isMarkdown: ex === "md" || ex === "mdx" };
   }, [filePath]);
   const extColor = EXT_COLORS[ext] ?? "text-muted-foreground";
 
@@ -166,7 +168,10 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
       <button
         type="button"
         onClick={() => setExpanded((prev) => {
-          if (prev) setShowAllLines(false); // reset truncation on collapse
+          if (prev) {
+            setShowAllLines(false);
+            setPreviewMode(false);
+          }
           return !prev;
         })}
         className={`group flex w-full items-center gap-2 py-[5px] pl-7 pr-3 text-left transition-colors hover:bg-muted/20 ${
@@ -214,6 +219,33 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
           </span>
         )}
 
+        {/* Markdown preview toggle — only shown when expanded */}
+        {expanded && isMarkdown && (
+          // span+role avoids invalid nested <button> while still being accessible
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label={previewMode ? "Show raw diff" : "Preview rendered markdown"}
+            onClick={(e) => {
+              e.stopPropagation();
+              setPreviewMode((prev) => !prev);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.stopPropagation();
+                setPreviewMode((prev) => !prev);
+              }
+            }}
+            className={`shrink-0 rounded p-0.5 transition-colors ${
+              previewMode
+                ? "text-foreground/70 hover:text-foreground"
+                : "text-muted-foreground/40 hover:text-foreground/60"
+            }`}
+          >
+            {previewMode ? <EyeOff size={11} /> : <Eye size={11} />}
+          </span>
+        )}
+
         {/* Extension badge (hidden while expanded to save space) */}
         {!expanded && ext && (
           <span className={`shrink-0 font-mono text-[9px] uppercase tracking-wide ${extColor}`}>
@@ -235,6 +267,8 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
                 />
               ))}
             </div>
+          ) : previewMode && isMarkdown ? (
+            <DiffPreview lines={lines} />
           ) : lines.length > 0 ? (
             <>
               {renderMode === "unified" ? (

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -3,7 +3,7 @@ import { Plus, Minus, ChevronsDownUp, Eye, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useDiffStore, type SelectedFile } from "@/stores/diffStore";
 import { getTransport } from "@/transport";
-import { parseDiffLines } from "@/lib/diff-parser";
+import { parseDiffLines, isMarkdownFile } from "@/lib/diff-parser";
 import { langFromPath } from "@/lib/lang-from-path";
 import { UnifiedDiff } from "./UnifiedDiff";
 import { SideBySideDiff } from "./SideBySideDiff";
@@ -89,7 +89,7 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
     const bn = getFileBasename(filePath);
     const pr = getParentDir(filePath);
     const ex = getExtension(filePath);
-    return { basename: bn, parent: pr, ext: ex, language: langFromPath(filePath), isMarkdown: ex === "md" || ex === "mdx" };
+    return { basename: bn, parent: pr, ext: ex, language: langFromPath(filePath), isMarkdown: isMarkdownFile(filePath) };
   }, [filePath]);
   const extColor = EXT_COLORS[ext] ?? "text-muted-foreground";
 
@@ -226,12 +226,14 @@ export function FileEntry({ filePath, source, id }: FileEntryProps) {
             role="button"
             tabIndex={0}
             aria-label={previewMode ? "Show raw diff" : "Preview rendered markdown"}
+            aria-pressed={previewMode}
             onClick={(e) => {
               e.stopPropagation();
               setPreviewMode((prev) => !prev);
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault(); // prevent Space from scrolling the page
                 e.stopPropagation();
                 setPreviewMode((prev) => !prev);
               }

--- a/apps/web/src/lib/diff-parser.ts
+++ b/apps/web/src/lib/diff-parser.ts
@@ -1,3 +1,32 @@
+/**
+ * Returns true when the file path has a `.md` or `.mdx` extension (case-insensitive).
+ * Used to decide whether to show the markdown preview toggle in the diff toolbar.
+ */
+export function isMarkdownFile(filePath: string): boolean {
+  const dot = filePath.lastIndexOf(".");
+  if (dot < 0) return false;
+  const ext = filePath.slice(dot + 1).toLowerCase();
+  return ext === "md" || ext === "mdx";
+}
+
+/**
+ * Reconstructs the new (post-change) content of a file from its parsed diff lines.
+ *
+ * Only `add` and `context` lines contribute to the result; `remove` and `header` lines
+ * are omitted. Lines are joined with `\n`.
+ *
+ * Limitation: when a diff only covers hunks (not the full file), lines outside the hunks
+ * are not included. The reconstructed content is therefore hunk-only and may be incomplete
+ * for large files with changes in the middle. This is acceptable for the Phase 1 preview,
+ * which is intended for markdown files where diffs typically cover most of the file.
+ */
+export function reconstructNewContent(lines: ParsedDiffLine[]): string {
+  return lines
+    .filter((l) => l.type === "add" || l.type === "context")
+    .map((l) => l.content)
+    .join("\n");
+}
+
 /** Parsed diff line with type classification. */
 export interface ParsedDiffLine {
   type: "add" | "remove" | "context" | "header";

--- a/apps/web/src/lib/diff-parser.ts
+++ b/apps/web/src/lib/diff-parser.ts
@@ -23,6 +23,7 @@ export function isMarkdownFile(filePath: string): boolean {
 export function reconstructNewContent(lines: ParsedDiffLine[]): string {
   return lines
     .filter((l) => l.type === "add" || l.type === "context")
+    .filter((l) => l.content !== "\\ No newline at end of file")
     .map((l) => l.content)
     .join("\n");
 }

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -71,7 +71,6 @@ interface DiffState {
   diffContent: string | null;
   /** Whether diff content is currently loading. */
   diffLoading: boolean;
-
   getRightPanel: (threadId: string) => RightPanelState;
   toggleRightPanel: (threadId: string) => void;
   showRightPanel: (threadId: string) => void;


### PR DESCRIPTION
## What

Adds an Eye/EyeOff toggle to the diff viewer for `.md` and `.mdx` files. When active, it renders the post-change file content as formatted GFM markdown instead of the raw unified diff.

## Why

Raw diff output is hard to read for documentation and changelog files. This lets users quickly see what the rendered result looks like without leaving the diff panel.

## Key Changes

- `diff-parser.ts` -- new `isMarkdownFile` and `reconstructNewContent` exports; the latter filters parsed lines to `add`/`context` types and joins them to reconstruct the new file state
- `DiffPreview.tsx` -- new component; accepts pre-parsed `lines` (avoids re-parsing) and delegates to the existing `MarkdownContent` renderer (GFM, tables, Mermaid all work)
- `FileEntry.tsx` -- local `previewMode` boolean state; Eye/EyeOff toggle in the file header row (only for markdown files, only when expanded); resets on collapse; `isMarkdown` derived inside the existing `useMemo` to avoid repeated extension checks

Preview mode is entirely local to `FileEntry` -- no store changes required.

Closes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown preview mode for the diff viewer: toggle between traditional diff and a live rendered preview for markdown files (tables, code blocks, Mermaid, etc.). Preview shows the post-change content as it will appear, excluding removed lines and diff metadata.
* **Tests**
  * Added unit tests covering markdown detection and reconstruction of post-change content from diffs.
* **Chores**
  * Minor formatting/whitespace cleanups in tests and store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->