### PR TITLE
feat(sidebar): differentiate action-required threads with hollow amber ring

### DIFF
--- a/apps/web/e2e/sidebar-action-required.spec.ts
+++ b/apps/web/e2e/sidebar-action-required.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Mock the WebSocket server with optional pending permission injection.
+ *
+ * The app connects to ws://localhost:19400 by default. Permissions arrive
+ * exclusively via the `permission.request` push channel — there is no
+ * initial-fetch RPC. The push is sent in the same message-handler tick as
+ * the `thread.list` reply so the thread already exists in the workspace store
+ * when `addPermissionRequest` runs.
+ */
+async function mockWebSocketServer(
+  page: Page,
+  opts: { pendingPermission: boolean },
+): Promise<void> {
+  const now = new Date().toISOString();
+  const workspace = {
+    id: "ws-1",
+    name: "Test Workspace",
+    path: "/test/path",
+    provider_config: {},
+    created_at: now,
+    updated_at: now,
+  };
+  const thread = {
+    id: "thread-1",
+    workspace_id: "ws-1",
+    title: "Pending Thread",
+    status: "active" as const,
+    mode: "direct" as const,
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+  };
+
+  // Minimal valid settings object matching the server's SettingsSchema defaults.
+  // Required because App.tsx reads settings.appearance.theme on first render;
+  // returning null from settings.get causes an immediate crash.
+  const defaultSettings = {
+    appearance: { theme: "system" },
+    agent: { maxConcurrent: 5, defaults: { mode: "chat", permission: "full" }, guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
+    model: { defaults: { provider: "claude", id: "claude-opus-4-7", reasoning: "high", fallbackId: "claude-sonnet-4-6" } },
+    terminal: { scrollback: 250 },
+    notifications: { enabled: true },
+    worktree: { naming: { mode: "auto", aiConfirmation: true } },
+    server: { memory: { heapMb: 96 } },
+    provider: { cli: { codex: "", claude: "", copilot: "" } },
+    prDraft: { provider: "", model: "" },
+  };
+
+  await page.routeWebSocket(/ws:\/\/localhost:19400/, (ws) => {
+    ws.onMessage((data) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+      const method = msg.method as string;
+      let result: unknown = null;
+      if (method === "workspace.list") result = [workspace];
+      else if (method === "thread.list") result = [thread];
+      else if (method === "settings.get") result = defaultSettings;
+      else if (method?.endsWith(".list")) result = [];
+      else if (method === "git.currentBranch") result = "main";
+      else if (method === "agent.activeCount") result = 0;
+      else if (method === "app.version") result = "0.0.1-test";
+      else if (method === "config.discover") result = {};
+      ws.send(JSON.stringify({ id: msg.id, result }));
+
+      // After confirming the thread exists in the store, push the permission
+      // request so `pendingPermissionThreadIds` resolves for that thread.
+      // PermissionRequest fields: requestId, threadId, toolName, input (no `settled` — store adds it).
+      if (method === "thread.list" && opts.pendingPermission) {
+        ws.send(
+          JSON.stringify({
+            type: "push",
+            channel: "permission.request",
+            data: {
+              requestId: "perm-1",
+              threadId: "thread-1",
+              toolName: "bash",
+              input: { command: "ls" },
+            },
+          }),
+        );
+      }
+    });
+  });
+}
+
+test.describe("sidebar action-required indicator", () => {
+  test("shows a ring indicator with aria-label when a permission is pending", async ({
+    page,
+  }) => {
+    await mockWebSocketServer(page, { pendingPermission: true });
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-list']");
+
+    // Expand the workspace so threads become visible.
+    // Use `.first()` because Playwright also matches the adjacent "Delete" button
+    // which has "Test Workspace" in its aria-label.
+    await page.getByRole("button", { name: /Test Workspace/ }).first().click();
+
+    const indicator = page.getByLabel("Action required");
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toHaveClass(/ring-amber-500/);
+    await expect(indicator).toHaveClass(/bg-transparent/);
+    await expect(indicator).toHaveClass(/animate-pulse/);
+  });
+
+  test("does not show the ring indicator when no permission is pending", async ({
+    page,
+  }) => {
+    await mockWebSocketServer(page, { pendingPermission: false });
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-list']");
+
+    // Expand the workspace so threads become visible.
+    // Use `.first()` because Playwright also matches the adjacent "Delete" button
+    // which has "Test Workspace" in its aria-label.
+    await page.getByRole("button", { name: /Test Workspace/ }).first().click();
+
+    await expect(page.getByLabel("Action required")).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/sidebar-action-required.spec.ts
+++ b/apps/web/e2e/sidebar-action-required.spec.ts
@@ -47,6 +47,8 @@ async function mockWebSocketServer(
     permission_mode: null,
     parent_thread_id: null,
     forked_from_message_id: null,
+    copilot_agent: null,
+    last_compact_summary: null,
   };
 
   // Minimal valid settings object matching the server's SettingsSchema defaults.
@@ -113,10 +115,13 @@ test.describe("sidebar action-required indicator", () => {
     await page.goto("/");
     await page.waitForSelector("[data-testid='thread-list']");
 
-    // Expand the workspace so threads become visible.
-    // Use `.first()` because Playwright also matches the adjacent "Delete" button
-    // which has "Test Workspace" in its aria-label.
-    await page.getByRole("button", { name: /Test Workspace/ }).first().click();
+    // The workspace row is the only button with aria-expanded. Filtering by that
+    // avoids the nested "Delete Test Workspace" button, whose text bleeds into
+    // the parent row's accessible name.
+    await page
+      .locator('[role="button"][aria-expanded]')
+      .filter({ hasText: "Test Workspace" })
+      .click();
 
     const indicator = page.getByLabel("Action required");
     await expect(indicator).toBeVisible();
@@ -132,10 +137,13 @@ test.describe("sidebar action-required indicator", () => {
     await page.goto("/");
     await page.waitForSelector("[data-testid='thread-list']");
 
-    // Expand the workspace so threads become visible.
-    // Use `.first()` because Playwright also matches the adjacent "Delete" button
-    // which has "Test Workspace" in its aria-label.
-    await page.getByRole("button", { name: /Test Workspace/ }).first().click();
+    // The workspace row is the only button with aria-expanded. Filtering by that
+    // avoids the nested "Delete Test Workspace" button, whose text bleeds into
+    // the parent row's accessible name.
+    await page
+      .locator('[role="button"][aria-expanded]')
+      .filter({ hasText: "Test Workspace" })
+      .click();
 
     await expect(page.getByLabel("Action required")).toHaveCount(0);
   });

--- a/apps/web/src/__tests__/thread-status.test.ts
+++ b/apps/web/src/__tests__/thread-status.test.ts
@@ -60,15 +60,39 @@ describe("getStatusDisplay", () => {
     expect(result.label).toBe("");
   });
 
-  it("shows amber pulsing dot when thread has a pending permission and is running", () => {
+  it("shows amber ring with pulse when thread has a pending permission and is running", () => {
     const result = getStatusDisplay(makeThread(), true, true);
-    expect(result.dotClass).toBe("bg-amber-500 animate-pulse");
+    expect(result.shape).toBe("ring");
+    expect(result.dotClass).toContain("ring-amber-500");
+    expect(result.dotClass).toContain("animate-pulse");
+    expect(result.dotClass).toContain("bg-transparent");
     expect(result.color).toBe("text-amber-500");
   });
 
-  it("shows amber dot when thread has pending permission even if not running", () => {
+  it("returns ring shape when thread has pending permission even if not running", () => {
     const result = getStatusDisplay(makeThread({ status: "active" }), false, true);
-    expect(result.dotClass).toContain("amber");
+    expect(result.shape).toBe("ring");
+    expect(result.dotClass).toContain("ring-amber-500");
+  });
+
+  it("returns solid shape when running without a pending permission", () => {
+    const result = getStatusDisplay(makeThread(), true, false);
+    expect(result.shape).toBe("solid");
+  });
+
+  it("returns solid shape for completed threads", () => {
+    const result = getStatusDisplay(makeThread({ status: "completed" }), false);
+    expect(result.shape).toBe("solid");
+  });
+
+  it("returns solid shape for errored threads", () => {
+    const result = getStatusDisplay(makeThread({ status: "errored" }), false);
+    expect(result.shape).toBe("solid");
+  });
+
+  it("returns solid shape for idle threads", () => {
+    const result = getStatusDisplay(makeThread({ status: "active" }), false);
+    expect(result.shape).toBe("solid");
   });
 });
 
@@ -104,10 +128,24 @@ describe("getNotificationDot", () => {
     expect(result).toBeNull();
   });
 
-  it("returns amber dot when thread has pending permission and is running", () => {
+  it("returns ring shape with amber for thread with pending permission", () => {
     const result = getNotificationDot(makeThread(), true, true);
     expect(result).not.toBeNull();
-    expect(result!.dotClass).toBe("bg-amber-500");
+    expect(result!.shape).toBe("ring");
+    expect(result!.dotClass).toContain("ring-amber-500");
+    expect(result!.dotClass).toContain("bg-transparent");
     expect(result!.animate).toBe(true);
+  });
+
+  it("returns solid shape for running PR thread without pending permission", () => {
+    const result = getNotificationDot(makeThread(), true, false);
+    expect(result).not.toBeNull();
+    expect(result!.shape).toBe("solid");
+  });
+
+  it("returns solid shape for completed PR thread", () => {
+    const result = getNotificationDot(makeThread({ status: "completed" }), false);
+    expect(result).not.toBeNull();
+    expect(result!.shape).toBe("solid");
   });
 });

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -31,13 +31,17 @@ vi.mock("@/stores/workspaceStore", () => ({
 }));
 
 // Mutable holder so individual tests can inject unsettled permission requests
-// into the mocked thread store without re-registering the mock.
-const threadStoreOverrides: { permissionsByThread?: Record<string, Array<{ settled: boolean }>> } = {};
+// and running-thread state into the mocked thread store without re-registering
+// the mock.
+const threadStoreOverrides: {
+  permissionsByThread?: Record<string, Array<{ settled: boolean }>>;
+  runningThreadIds?: Set<string>;
+} = {};
 
 vi.mock("@/stores/threadStore", () => ({
   useThreadStore: vi.fn((selector: (s: unknown) => unknown) =>
     selector({
-      runningThreadIds: new Set(),
+      runningThreadIds: threadStoreOverrides.runningThreadIds ?? new Set(),
       permissionsByThread: threadStoreOverrides.permissionsByThread ?? {},
     })
   ),
@@ -261,9 +265,12 @@ describe("ProjectTree thread interactions", () => {
 });
 
 describe("ProjectTree action-required indicator", () => {
-  beforeEach(() => {
-    threadStoreOverrides.permissionsByThread = undefined;
-    const thread = makeThread({ id: "thread-pending", status: "active" });
+  // Holder the tests mutate before calling installWorkspaceMock so they can
+  // swap the rendered thread (e.g. attach a pr_number) and the CI check map.
+  let currentThread: Thread;
+  let currentChecks: Record<string, { aggregate: string }>;
+
+  function installWorkspaceMock() {
     // WorkspaceState is not exported; cast through any so the fixture object
     // satisfies the mock without importing the internal type.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -272,7 +279,8 @@ describe("ProjectTree action-required indicator", () => {
         workspaces: [{ id: "ws-1", name: "Test", path: "/test", provider_config: {}, created_at: "", updated_at: "" }],
         activeWorkspaceId: "ws-1",
         activeThreadId: null,
-        threads: [thread],
+        threads: [currentThread],
+        checksById: currentChecks,
         loadWorkspaces: vi.fn(),
         loadThreads: vi.fn(),
         setActiveWorkspace: vi.fn(),
@@ -288,6 +296,14 @@ describe("ProjectTree action-required indicator", () => {
         error: null,
       })) as any
     );
+  }
+
+  beforeEach(() => {
+    threadStoreOverrides.permissionsByThread = undefined;
+    threadStoreOverrides.runningThreadIds = undefined;
+    currentThread = makeThread({ id: "thread-pending", status: "active" });
+    currentChecks = {};
+    installWorkspaceMock();
     // Pre-expand the workspace so its threads render.
     window.localStorage.setItem("mcode-expanded-projects", JSON.stringify({ "ws-1": true }));
   });
@@ -337,5 +353,65 @@ describe("ProjectTree action-required indicator", () => {
     threadStoreOverrides.permissionsByThread = {};
     render(<ProjectTree />);
     expect(screen.queryByLabelText("Action required")).toBeNull();
+  });
+
+  it("clears the ring when the permission is resolved (settled=true)", () => {
+    threadStoreOverrides.permissionsByThread = {
+      "thread-pending": [{ settled: true }],
+    };
+    render(<ProjectTree />);
+    expect(screen.queryByLabelText("Action required")).toBeNull();
+  });
+
+  it("renders the ring even when the thread is actively running", () => {
+    // The amber ring must outrank the running-state primary pulse — otherwise
+    // a user who is mid-run with a pending permission wouldn't see the affordance.
+    threadStoreOverrides.permissionsByThread = {
+      "thread-pending": [{ settled: false }],
+    };
+    threadStoreOverrides.runningThreadIds = new Set(["thread-pending"]);
+    render(<ProjectTree />);
+    const indicator = screen.getByLabelText("Action required");
+    expect(indicator.className).toContain("ring-amber-500");
+    expect(indicator.className).not.toContain("bg-primary");
+  });
+
+  it("renders the ring on the PR overlay when the thread has a pr_number", () => {
+    currentThread = makeThread({
+      id: "thread-pending",
+      status: "active",
+      pr_number: 42,
+      pr_status: "open",
+    });
+    installWorkspaceMock();
+    threadStoreOverrides.permissionsByThread = {
+      "thread-pending": [{ settled: false }],
+    };
+    render(<ProjectTree />);
+    const indicator = screen.getByLabelText("Action required");
+    expect(indicator.className).toContain("ring-amber-500");
+    // PR overlay uses absolute positioning; the non-PR dot does not.
+    expect(indicator.className).toContain("absolute");
+  });
+
+  it("prefers the ring over a CI status dot on the PR overlay", () => {
+    // Pending permission must win over any CI-check indicator: the user's
+    // attention is required and CI state is merely informational.
+    currentThread = makeThread({
+      id: "thread-pending",
+      status: "active",
+      pr_number: 42,
+      pr_status: "open",
+    });
+    currentChecks = { "thread-pending": { aggregate: "failing" } };
+    installWorkspaceMock();
+    threadStoreOverrides.permissionsByThread = {
+      "thread-pending": [{ settled: false }],
+    };
+    render(<ProjectTree />);
+    const indicator = screen.getByLabelText("Action required");
+    expect(indicator.className).toContain("ring-amber-500");
+    // CI "failing" would normally paint bg-red-500; the ring must suppress it.
+    expect(indicator.className).not.toContain("bg-red-500");
   });
 });

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -278,7 +278,6 @@ describe("ProjectTree action-required indicator", () => {
   function installWorkspaceMock() {
     // WorkspaceState is not exported; cast through any so the fixture object
     // satisfies the mock without importing the internal type.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(useWorkspaceStore).mockImplementation(
       ((selector: (s: unknown) => unknown) => selector({
         workspaces: [{ id: "ws-1", name: "Test", path: "/test", provider_config: {}, created_at: "", updated_at: "" }],
@@ -299,6 +298,7 @@ describe("ProjectTree action-required indicator", () => {
         worktrees: [],
         worktreesLoadedForWorkspace: null,
         error: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       })) as any
     );
   }
@@ -316,7 +316,6 @@ describe("ProjectTree action-required indicator", () => {
   afterEach(() => {
     // Restore the default empty-state implementation so this override does not
     // leak into other describes when test order shifts.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(useWorkspaceStore).mockImplementation(
       ((selector: (s: unknown) => unknown) =>
         selector({
@@ -337,6 +336,7 @@ describe("ProjectTree action-required indicator", () => {
           worktrees: [],
           worktreesLoadedForWorkspace: null,
           error: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
         })) as any
     );
     vi.clearAllMocks();

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -30,9 +30,16 @@ vi.mock("@/stores/workspaceStore", () => ({
   ),
 }));
 
+// Mutable holder so individual tests can inject unsettled permission requests
+// into the mocked thread store without re-registering the mock.
+const threadStoreOverrides: { permissionsByThread?: Record<string, Array<{ settled: boolean }>> } = {};
+
 vi.mock("@/stores/threadStore", () => ({
   useThreadStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ runningThreadIds: new Set(), permissionsByThread: {} })
+    selector({
+      runningThreadIds: new Set(),
+      permissionsByThread: threadStoreOverrides.permissionsByThread ?? {},
+    })
   ),
 }));
 
@@ -250,5 +257,56 @@ describe("ProjectTree thread interactions", () => {
     // Navigation must fire immediately (no timer advance needed).
     expect(setActiveThread).toHaveBeenCalledWith("thread-1");
     expect(setActiveThread).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ProjectTree action-required indicator", () => {
+  beforeEach(() => {
+    threadStoreOverrides.permissionsByThread = undefined;
+    const thread = makeThread({ id: "thread-pending", status: "active" });
+    (useWorkspaceStore as unknown as { mockImplementation: (fn: (selector: (s: unknown) => unknown) => unknown) => void }).mockImplementation(
+      (selector) => selector({
+        workspaces: [{ id: "ws-1", name: "Test", path: "/test", provider_config: {}, created_at: "", updated_at: "" }],
+        activeWorkspaceId: "ws-1",
+        activeThreadId: null,
+        threads: [thread],
+        loadWorkspaces: vi.fn(),
+        loadThreads: vi.fn(),
+        setActiveWorkspace: vi.fn(),
+        setActiveThread: vi.fn(),
+        createWorkspace: vi.fn(),
+        deleteWorkspace: vi.fn(),
+        deleteThread: vi.fn(),
+        setPendingNewThread: vi.fn(),
+        updateThreadTitle: vi.fn(),
+        loadWorktrees: vi.fn(),
+        worktrees: [],
+        worktreesLoadedForWorkspace: null,
+        error: null,
+      })
+    );
+    // Pre-expand the workspace so its threads render.
+    window.localStorage.setItem("mcode-expanded-projects", JSON.stringify({ "ws-1": true }));
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders a ring indicator when the thread has an unsettled permission request", () => {
+    threadStoreOverrides.permissionsByThread = {
+      "thread-pending": [{ settled: false }],
+    };
+    render(<ProjectTree />);
+    const indicator = screen.getByLabelText("Action required");
+    expect(indicator.className).toContain("ring-amber-500");
+    expect(indicator.className).toContain("bg-transparent");
+    expect(indicator.className).toContain("animate-pulse");
+  });
+
+  it("renders a solid dot (no action-required label) when there is no pending permission", () => {
+    threadStoreOverrides.permissionsByThread = {};
+    render(<ProjectTree />);
+    expect(screen.queryByLabelText("Action required")).toBeNull();
   });
 });

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -264,8 +264,11 @@ describe("ProjectTree action-required indicator", () => {
   beforeEach(() => {
     threadStoreOverrides.permissionsByThread = undefined;
     const thread = makeThread({ id: "thread-pending", status: "active" });
-    (useWorkspaceStore as unknown as { mockImplementation: (fn: (selector: (s: unknown) => unknown) => unknown) => void }).mockImplementation(
-      (selector) => selector({
+    // WorkspaceState is not exported; cast through any so the fixture object
+    // satisfies the mock without importing the internal type.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useWorkspaceStore).mockImplementation(
+      ((selector: (s: unknown) => unknown) => selector({
         workspaces: [{ id: "ws-1", name: "Test", path: "/test", provider_config: {}, created_at: "", updated_at: "" }],
         activeWorkspaceId: "ws-1",
         activeThreadId: null,
@@ -283,13 +286,39 @@ describe("ProjectTree action-required indicator", () => {
         worktrees: [],
         worktreesLoadedForWorkspace: null,
         error: null,
-      })
+      })) as any
     );
     // Pre-expand the workspace so its threads render.
     window.localStorage.setItem("mcode-expanded-projects", JSON.stringify({ "ws-1": true }));
   });
 
   afterEach(() => {
+    // Restore the default empty-state implementation so this override does not
+    // leak into other describes when test order shifts.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(useWorkspaceStore).mockImplementation(
+      ((selector: (s: unknown) => unknown) =>
+        selector({
+          workspaces: [],
+          activeWorkspaceId: null,
+          activeThreadId: null,
+          threads: [],
+          loadWorkspaces: vi.fn(),
+          loadThreads: vi.fn(),
+          setActiveWorkspace: vi.fn(),
+          setActiveThread: vi.fn(),
+          createWorkspace: vi.fn(),
+          deleteWorkspace: vi.fn(),
+          deleteThread: vi.fn(),
+          setPendingNewThread: vi.fn(),
+          updateThreadTitle: vi.fn(),
+          loadWorktrees: vi.fn(),
+          worktrees: [],
+          worktreesLoadedForWorkspace: null,
+          error: null,
+        })) as any
+    );
+    vi.clearAllMocks();
     window.localStorage.clear();
   });
 

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -751,7 +751,7 @@ function VirtualizedThreadList({
                   const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
                   // CI dot takes priority when present; fall back to agent notification dot
                   const dot = ciDotClass
-                    ? { dotClass: ciDotClass, animate: ciChecks!.aggregate === "pending" }
+                    ? { dotClass: ciDotClass, animate: ciChecks!.aggregate === "pending", shape: "solid" as const }
                     : agentDot;
                   return (
                     <span
@@ -771,7 +771,14 @@ function VirtualizedThreadList({
                     </span>
                   );
                 })() : (
-                  <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", status.dotClass)} />
+                  <span
+                    aria-label={status.shape === "ring" ? "Action required" : undefined}
+                    className={cn(
+                      "shrink-0 rounded-full",
+                      status.shape === "ring" ? "h-2 w-2" : "h-1.5 w-1.5",
+                      status.dotClass,
+                    )}
+                  />
                 )}
                 {!thread.pr_number && status.label && (
                   <span className={cn("shrink-0 font-mono text-[9.5px] uppercase tracking-[0.12em]", status.color)}>

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -748,11 +748,16 @@ function VirtualizedThreadList({
                   const { Icon: PrIcon, color: prColor } = getPrVisual(thread.pr_status);
                   const ciChecks = checksById[thread.id];
                   const ciDotClass = ciChecks ? getCiDotClass(ciChecks.aggregate) : null;
-                  const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
-                  // CI dot takes priority when present; fall back to agent notification dot
-                  const dot = ciDotClass
-                    ? { dotClass: ciDotClass, animate: ciChecks!.aggregate === "pending", shape: "solid" as const }
-                    : agentDot;
+                  const hasPendingPermission = pendingPermissionThreadIds.has(thread.id);
+                  const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id), hasPendingPermission);
+                  // Pending permission always wins — the user's attention is required,
+                  // and CI status is merely informational. Otherwise CI takes priority
+                  // when present; fall back to the agent notification dot.
+                  const dot = hasPendingPermission
+                    ? agentDot
+                    : ciDotClass
+                      ? { dotClass: ciDotClass, animate: ciChecks!.aggregate === "pending", shape: "solid" as const }
+                      : agentDot;
                   return (
                     <span
                       title={`PR #${thread.pr_number} \u2013 ${thread.pr_status ?? "open"}`}

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -761,8 +761,14 @@ function VirtualizedThreadList({
                       <PrIcon size={12} className={prColor} />
                       {dot && (
                         <span
+                          aria-label={dot.shape === "ring" ? "Action required" : undefined}
                           className={cn(
-                            "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-background",
+                            "absolute rounded-full",
+                            // Ring variant sizes up slightly and drops the background ring so the
+                            // amber ring isn't confused with the 1px separator ring used on dots.
+                            dot.shape === "ring"
+                              ? "-top-1 -right-1 h-2 w-2"
+                              : "-top-0.5 -right-0.5 h-1.5 w-1.5 ring-1 ring-background",
                             dot.dotClass,
                             dot.animate && "animate-pulse",
                           )}

--- a/apps/web/src/lib/thread-status.ts
+++ b/apps/web/src/lib/thread-status.ts
@@ -1,16 +1,21 @@
 import type { Thread } from "@/transport/types";
 
+/** Visual shape of a status indicator. "solid" renders as a filled dot; "ring" renders as a hollow circle. */
+export type StatusShape = "solid" | "ring";
+
 /** Visual properties for rendering a thread's current status. */
 export interface StatusDisplay {
   label: string;
   color: string;
   dotClass: string;
+  shape: StatusShape;
 }
 
 /** Notification dot overlay for PR threads with an actionable status. */
 export interface NotificationDot {
   dotClass: string;
   animate: boolean;
+  shape: StatusShape;
 }
 
 /**
@@ -18,7 +23,7 @@ export interface NotificationDot {
  * Used to overlay a small colored dot on the PR icon in the sidebar.
  * @param thread - The thread whose PR notification dot is being computed.
  * @param isActuallyRunning - True when the agent process is currently live.
- * @param hasPendingPermission - True when the thread has at least one unsettled permission request; renders an amber dot.
+ * @param hasPendingPermission - True when the thread has at least one unsettled permission request; renders an amber ring.
  */
 export function getNotificationDot(
   thread: Thread,
@@ -26,18 +31,23 @@ export function getNotificationDot(
   hasPendingPermission = false,
 ): NotificationDot | null {
   // Amber takes top priority — show even if the thread has temporarily dropped
-  // from runningThreadIds (reconnect race, another tab, etc.).
+  // from runningThreadIds (reconnect race, another tab, etc.). Uses a ring
+  // instead of a dot so it reads distinctly from the running-state amber dot.
   if (hasPendingPermission) {
-    return { dotClass: "bg-amber-500", animate: true };
+    return {
+      dotClass: "ring-2 ring-inset ring-amber-500 bg-transparent",
+      animate: true,
+      shape: "ring",
+    };
   }
   if (isActuallyRunning) {
-    return { dotClass: "bg-primary", animate: true };
+    return { dotClass: "bg-primary", animate: true, shape: "solid" };
   }
   switch (thread.status) {
     case "completed":
-      return { dotClass: "bg-[var(--diff-add-strong)]/85", animate: false };
+      return { dotClass: "bg-[var(--diff-add-strong)]/85", animate: false, shape: "solid" };
     case "errored":
-      return { dotClass: "bg-[var(--diff-remove-strong)]/90", animate: false };
+      return { dotClass: "bg-[var(--diff-remove-strong)]/90", animate: false, shape: "solid" };
     default:
       return null;
   }
@@ -47,7 +57,7 @@ export function getNotificationDot(
  * Returns the display label, text color, and dot class for a thread's status.
  * @param thread - The thread whose status display is being computed.
  * @param isActuallyRunning - True when the agent process is currently live.
- * @param hasPendingPermission - True when the thread has at least one unsettled permission request; renders an amber pulsing dot.
+ * @param hasPendingPermission - True when the thread has at least one unsettled permission request; renders an amber pulsing ring.
  */
 export function getStatusDisplay(
   thread: Thread,
@@ -55,12 +65,14 @@ export function getStatusDisplay(
   hasPendingPermission = false,
 ): StatusDisplay {
   // Pending permission is top priority — show amber even if the thread has
-  // temporarily dropped from runningThreadIds (reconnect race, another tab).
+  // temporarily dropped from runningThreadIds. Uses a hollow ring so it does
+  // NOT visually collide with the running-state amber dot.
   if (hasPendingPermission) {
     return {
       label: "",
       color: "text-amber-500",
-      dotClass: "bg-amber-500 animate-pulse",
+      dotClass: "ring-2 ring-inset ring-amber-500 bg-transparent animate-pulse",
+      shape: "ring",
     };
   }
   // Live process state takes priority over DB status
@@ -69,6 +81,7 @@ export function getStatusDisplay(
       label: "",
       color: "text-primary/90",
       dotClass: "bg-primary animate-pulse",
+      shape: "solid",
     };
   }
 
@@ -79,15 +92,22 @@ export function getStatusDisplay(
         label: "Errored",
         color: "text-[var(--diff-remove-strong)]/80",
         dotClass: "bg-[var(--diff-remove-strong)]/85",
+        shape: "solid",
       };
     case "completed":
       return {
         label: "",
         color: "text-[var(--diff-add-strong)]/80",
         dotClass: "bg-[var(--diff-add-strong)]/80",
+        shape: "solid",
       };
     default:
       // No agent running, not completed, not errored = idle / ready for input
-      return { label: "", color: "text-muted-foreground", dotClass: "bg-muted-foreground/35" };
+      return {
+        label: "",
+        color: "text-muted-foreground",
+        dotClass: "bg-muted-foreground/35",
+        shape: "solid",
+      };
   }
 }


### PR DESCRIPTION
## What

Render a hollow amber ring (instead of a filled amber dot) next to threads that are awaiting a user permission decision, so action-required threads are visually distinct from threads that are merely running.

## Why

Action-required threads and running threads currently share the amber color, so they look identical in the sidebar. Users cannot tell at a glance whether a thread is actively making progress or blocked waiting for their input.

Per the design guide, amber is reserved for active/running states and must stay rare; introducing a new color would dilute that. Encoding severity in **shape** (hollow ring = needs input, filled dot = running) keeps the palette disciplined while creating a clear visual affordance.

Scope is intentionally narrow: dot-level differentiation only. No workspace-row propagation and no tab-title changes.

## Key Changes

- `thread-status.ts`: add `StatusShape = "solid" | "ring"` discriminant to `getStatusDisplay` and `getNotificationDot`; return `shape: "ring"` with `ring-2 ring-inset ring-amber-500 bg-transparent animate-pulse` when `hasPendingPermission` is true
- `ProjectTree.tsx`: both the non-PR dot site and the PR overlay branch on `shape`, size up by 0.5 (h-2 w-2) and set `aria-label="Action required"` for the ring variant
- Tests: 18 unit tests for `thread-status`, 2 component tests for `ProjectTree`, 2 Playwright e2e tests (positive + negative) mocking `permission.request` push delivery

## Verification

- Unit tests: **720/720** passing (74 files)
- E2E tests: **72/72** passing (9m)
- Typecheck: clean across `apps/server`, `apps/web`, `apps/desktop`
- Visual: screenshots of both states included in the branch under `screenshots-action-required/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Action required" sidebar indicator: amber ring with pulse, larger sizing, and accessible label; appears on PR overlay.

* **Behavior Changes**
  * Indicator now uses a ring shape for pending permissions and suppresses CI-failure visuals when action is required.
  * Status/notification representations distinguish "ring" vs "solid" shapes.

* **Tests**
  * Added E2E and unit tests covering presence, styling, accessibility, PR-overlay positioning, precedence, and absence when no pending permission exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->