### PR TITLE
fix: apply permission mode toggle to existing Claude threads

### DIFF
--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -121,7 +121,7 @@ describe("ClaudeProvider permission mode changes", () => {
       permissionMode: "full",
     });
 
-    // Two sdk subprocesses -- the mode change forced a tear-down + recreate.
+    // Two sdk subprocesses. The mode change forced a tear-down + recreate.
     expect(sdkCalls.length).toBe(2);
 
     // First call: supervised → SDK permissionMode "default", no bypass flag.

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -4,19 +4,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 /**
  * Minimal SDK mock returning an async generator that yields one "result"
  * message per user message pushed to the prompt queue. The generator also
- * exposes `setModel` / `close` so the provider's existing-session logic
- * can call them without blowing up.
- *
- * When `throwOnCloseFor` matches the 0-based index of a query() call, that
- * session's next read after `close()` will throw to simulate the real SDK:
- * closing stdin causes the Claude CLI subprocess to exit and, on Windows,
- * an exit code of 1 propagates through `readMessages` as a thrown error.
+ * exposes `setModel`, `setPermissionMode`, and `close` so the provider's
+ * existing-session logic can call them without blowing up.
  */
 function makeFakeSdkQuery(
   pushCalls: Array<{ options: Record<string, unknown> }>,
-  throwOnCloseFor: number | null = null,
 ) {
-  let sessionIndex = 0;
   return ({
     prompt,
     options,
@@ -24,18 +17,13 @@ function makeFakeSdkQuery(
     prompt: AsyncIterable<unknown>;
     options: Record<string, unknown>;
   }) => {
-    const myIndex = sessionIndex++;
     pushCalls.push({ options });
     const iterator = prompt[Symbol.asyncIterator]();
-    let closed = false;
 
     const generator: AsyncGenerator<Record<string, unknown>, void> = {
       async next() {
         const userMsg = await iterator.next();
         if (userMsg.done) {
-          if (closed && throwOnCloseFor === myIndex) {
-            throw new Error("Claude Code process exited with code 1");
-          }
           return { value: undefined as unknown as Record<string, unknown>, done: true };
         }
         return {
@@ -62,19 +50,21 @@ function makeFakeSdkQuery(
 
     Object.assign(generator, {
       setModel: vi.fn(async () => {}),
+      setPermissionMode: vi.fn(async () => {}),
       interrupt: vi.fn(async () => {}),
-      close: vi.fn(() => {
-        closed = true;
-      }),
+      close: vi.fn(() => {}),
     });
+
+    createdQueries.push(generator as unknown as { setPermissionMode: ReturnType<typeof vi.fn> });
 
     return generator;
   };
 }
 
-const { sdkCalls, mockQuery } = vi.hoisted(() => {
+const { sdkCalls, createdQueries, mockQuery } = vi.hoisted(() => {
   const sdkCalls: Array<{ options: Record<string, unknown> }> = [];
-  return { sdkCalls, mockQuery: vi.fn() };
+  const createdQueries: Array<{ setPermissionMode: ReturnType<typeof vi.fn> }> = [];
+  return { sdkCalls, createdQueries, mockQuery: vi.fn() };
 });
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -93,6 +83,7 @@ describe("ClaudeProvider permission mode changes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sdkCalls.length = 0;
+    createdQueries.length = 0;
     mockQuery.mockImplementation(makeFakeSdkQuery(sdkCalls));
     provider = new ClaudeProvider();
   });
@@ -119,7 +110,7 @@ describe("ClaudeProvider permission mode changes", () => {
     expect(sdkCalls.length).toBe(1);
   });
 
-  it("tears down and recreates the session when permissionMode changes", async () => {
+  it("calls setPermissionMode on the existing session when permissionMode changes", async () => {
     await provider.sendMessage({
       sessionId: "mcode-thread-b",
       message: "first",
@@ -137,54 +128,16 @@ describe("ClaudeProvider permission mode changes", () => {
       permissionMode: "full",
     });
 
-    // Two sdk subprocesses. The mode change forced a tear-down + recreate.
-    expect(sdkCalls.length).toBe(2);
+    // Same subprocess is reused. The mode change does NOT force recreate.
+    expect(sdkCalls.length).toBe(1);
 
-    // First call: supervised → SDK permissionMode "default", no bypass flag.
+    // The SDK's setPermissionMode is called once with the new SDK-mode string.
+    expect(createdQueries[0]!.setPermissionMode).toHaveBeenCalledTimes(1);
+    expect(createdQueries[0]!.setPermissionMode).toHaveBeenCalledWith("bypassPermissions");
+
+    // The one sdk subprocess was spawned in supervised mode and stayed that way
+    // at startup. The live mode switch is via setPermissionMode, not options.
     expect(sdkCalls[0]!.options.permissionMode).toBe("default");
     expect(sdkCalls[0]!.options.allowDangerouslySkipPermissions).toBeUndefined();
-
-    // Second call: full → SDK permissionMode "bypassPermissions", bypass flag set.
-    expect(sdkCalls[1]!.options.permissionMode).toBe("bypassPermissions");
-    expect(sdkCalls[1]!.options.allowDangerouslySkipPermissions).toBe(true);
-  });
-
-  it("does not emit an Error event when the torn-down subprocess exits after mode change", async () => {
-    // Arm the first (supervised) session's mock so that after close() is
-    // called its next read throws with the real SDK's exit-code-1 message.
-    // That mirrors what happens on Windows when close() SIGTERMs the CLI.
-    mockQuery.mockImplementation(makeFakeSdkQuery(sdkCalls, /* throwOnCloseFor */ 0));
-
-    const errorEvents: Array<{ type: string; error?: string }> = [];
-    provider.on("event", (ev: { type: string; error?: string }) => {
-      if (ev.type === "error") errorEvents.push(ev);
-    });
-
-    await provider.sendMessage({
-      sessionId: "mcode-thread-c",
-      message: "first",
-      cwd: process.cwd(),
-      model: "claude-sonnet-4-6",
-      resume: false,
-      permissionMode: "supervised",
-    });
-    await provider.sendMessage({
-      sessionId: "mcode-thread-c",
-      message: "second",
-      cwd: process.cwd(),
-      model: "claude-sonnet-4-6",
-      resume: false,
-      permissionMode: "full",
-    });
-
-    // Give the torn-down session's for-await a chance to observe the
-    // close, iterate once more, and throw. The throw runs inside the
-    // async IIFE that drives startStreamLoop.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    // The old subprocess's exit is an intentional supersession, not a
-    // user-visible crash. The fresh session (full-access) owns the thread
-    // now, so no Error event should reach consumers.
-    expect(errorEvents).toEqual([]);
   });
 });

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -1,0 +1,135 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Minimal SDK mock returning an async generator that yields one "result"
+ * message per user message pushed to the prompt queue. The generator also
+ * exposes `setModel` / `close` so the provider's existing-session logic
+ * can call them without blowing up.
+ */
+function makeFakeSdkQuery(pushCalls: Array<{ options: Record<string, unknown> }>) {
+  return ({
+    prompt,
+    options,
+  }: {
+    prompt: AsyncIterable<unknown>;
+    options: Record<string, unknown>;
+  }) => {
+    pushCalls.push({ options });
+    const iterator = prompt[Symbol.asyncIterator]();
+
+    const generator: AsyncGenerator<Record<string, unknown>, void> = {
+      async next() {
+        const userMsg = await iterator.next();
+        if (userMsg.done) {
+          return { value: undefined as unknown as Record<string, unknown>, done: true };
+        }
+        return {
+          value: {
+            type: "result",
+            is_error: false,
+            result: "ok",
+            usage: { input_tokens: 1, output_tokens: 1 },
+            modelUsage: {},
+          },
+          done: false,
+        };
+      },
+      async return() {
+        return { value: undefined as unknown as Record<string, unknown>, done: true };
+      },
+      async throw(e: unknown) {
+        throw e;
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+
+    Object.assign(generator, {
+      setModel: vi.fn(async () => {}),
+      interrupt: vi.fn(async () => {}),
+      close: vi.fn(),
+    });
+
+    return generator;
+  };
+}
+
+const { sdkCalls, mockQuery } = vi.hoisted(() => {
+  const sdkCalls: Array<{ options: Record<string, unknown> }> = [];
+  return { sdkCalls, mockQuery: vi.fn() };
+});
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mockQuery,
+}));
+
+vi.mock("@mcode/shared", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { ClaudeProvider } from "../providers/claude/claude-provider";
+
+describe("ClaudeProvider permission mode changes", () => {
+  let provider: ClaudeProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sdkCalls.length = 0;
+    mockQuery.mockImplementation(makeFakeSdkQuery(sdkCalls));
+    provider = new ClaudeProvider();
+  });
+
+  it("reuses the session when permissionMode is unchanged", async () => {
+    await provider.sendMessage({
+      sessionId: "mcode-thread-a",
+      message: "first",
+      cwd: process.cwd(),
+      model: "claude-sonnet-4-6",
+      resume: false,
+      permissionMode: "supervised",
+    });
+    await provider.sendMessage({
+      sessionId: "mcode-thread-a",
+      message: "second",
+      cwd: process.cwd(),
+      model: "claude-sonnet-4-6",
+      resume: false,
+      permissionMode: "supervised",
+    });
+
+    // One underlying sdk subprocess for both messages.
+    expect(sdkCalls.length).toBe(1);
+  });
+
+  it("tears down and recreates the session when permissionMode changes", async () => {
+    await provider.sendMessage({
+      sessionId: "mcode-thread-b",
+      message: "first",
+      cwd: process.cwd(),
+      model: "claude-sonnet-4-6",
+      resume: false,
+      permissionMode: "supervised",
+    });
+    await provider.sendMessage({
+      sessionId: "mcode-thread-b",
+      message: "second",
+      cwd: process.cwd(),
+      model: "claude-sonnet-4-6",
+      resume: false,
+      permissionMode: "full",
+    });
+
+    // Two sdk subprocesses -- the mode change forced a tear-down + recreate.
+    expect(sdkCalls.length).toBe(2);
+
+    // First call: supervised → SDK permissionMode "default", no bypass flag.
+    expect(sdkCalls[0]!.options.permissionMode).toBe("default");
+    expect(sdkCalls[0]!.options.allowDangerouslySkipPermissions).toBeUndefined();
+
+    // Second call: full → SDK permissionMode "bypassPermissions", bypass flag set.
+    expect(sdkCalls[1]!.options.permissionMode).toBe("bypassPermissions");
+    expect(sdkCalls[1]!.options.allowDangerouslySkipPermissions).toBe(true);
+  });
+});

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -4,8 +4,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 /**
  * Minimal SDK mock returning an async generator that yields one "result"
  * message per user message pushed to the prompt queue. The generator also
- * exposes `setModel`, `setPermissionMode`, and `close` so the provider's
- * existing-session logic can call them without blowing up.
+ * exposes `setModel`, `interrupt`, and `close` so the provider's existing-session
+ * logic (including teardown on permissionMode change) can call them without blowing up.
  */
 function makeFakeSdkQuery(
   pushCalls: Array<{ options: Record<string, unknown> }>,
@@ -50,21 +50,17 @@ function makeFakeSdkQuery(
 
     Object.assign(generator, {
       setModel: vi.fn(async () => {}),
-      setPermissionMode: vi.fn(async () => {}),
       interrupt: vi.fn(async () => {}),
       close: vi.fn(() => {}),
     });
-
-    createdQueries.push(generator as unknown as { setPermissionMode: ReturnType<typeof vi.fn> });
 
     return generator;
   };
 }
 
-const { sdkCalls, createdQueries, mockQuery } = vi.hoisted(() => {
+const { sdkCalls, mockQuery } = vi.hoisted(() => {
   const sdkCalls: Array<{ options: Record<string, unknown> }> = [];
-  const createdQueries: Array<{ setPermissionMode: ReturnType<typeof vi.fn> }> = [];
-  return { sdkCalls, createdQueries, mockQuery: vi.fn() };
+  return { sdkCalls, mockQuery: vi.fn() };
 });
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
@@ -83,7 +79,6 @@ describe("ClaudeProvider permission mode changes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sdkCalls.length = 0;
-    createdQueries.length = 0;
     mockQuery.mockImplementation(makeFakeSdkQuery(sdkCalls));
     provider = new ClaudeProvider();
   });
@@ -110,7 +105,7 @@ describe("ClaudeProvider permission mode changes", () => {
     expect(sdkCalls.length).toBe(1);
   });
 
-  it("calls setPermissionMode on the existing session when permissionMode changes", async () => {
+  it("tears down and respawns the session when permissionMode changes", async () => {
     await provider.sendMessage({
       sessionId: "mcode-thread-b",
       message: "first",
@@ -128,16 +123,15 @@ describe("ClaudeProvider permission mode changes", () => {
       permissionMode: "full",
     });
 
-    // Same subprocess is reused. The mode change does NOT force recreate.
-    expect(sdkCalls.length).toBe(1);
+    // The SDK subprocess is respawned because permissionMode is fixed at spawn.
+    expect(sdkCalls.length).toBe(2);
 
-    // The SDK's setPermissionMode is called once with the new SDK-mode string.
-    expect(createdQueries[0]!.setPermissionMode).toHaveBeenCalledTimes(1);
-    expect(createdQueries[0]!.setPermissionMode).toHaveBeenCalledWith("bypassPermissions");
-
-    // The one sdk subprocess was spawned in supervised mode and stayed that way
-    // at startup. The live mode switch is via setPermissionMode, not options.
+    // First spawn was in supervised (SDK "default") mode with no bypass flag.
     expect(sdkCalls[0]!.options.permissionMode).toBe("default");
     expect(sdkCalls[0]!.options.allowDangerouslySkipPermissions).toBeUndefined();
+
+    // Second spawn is in full (SDK "bypassPermissions") mode, still no CLI bypass flag.
+    expect(sdkCalls[1]!.options.permissionMode).toBe("bypassPermissions");
+    expect(sdkCalls[1]!.options.allowDangerouslySkipPermissions).toBeUndefined();
   });
 });

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -6,8 +6,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
  * message per user message pushed to the prompt queue. The generator also
  * exposes `setModel` / `close` so the provider's existing-session logic
  * can call them without blowing up.
+ *
+ * When `throwOnCloseFor` matches the 0-based index of a query() call, that
+ * session's next read after `close()` will throw to simulate the real SDK:
+ * closing stdin causes the Claude CLI subprocess to exit and, on Windows,
+ * an exit code of 1 propagates through `readMessages` as a thrown error.
  */
-function makeFakeSdkQuery(pushCalls: Array<{ options: Record<string, unknown> }>) {
+function makeFakeSdkQuery(
+  pushCalls: Array<{ options: Record<string, unknown> }>,
+  throwOnCloseFor: number | null = null,
+) {
+  let sessionIndex = 0;
   return ({
     prompt,
     options,
@@ -15,13 +24,18 @@ function makeFakeSdkQuery(pushCalls: Array<{ options: Record<string, unknown> }>
     prompt: AsyncIterable<unknown>;
     options: Record<string, unknown>;
   }) => {
+    const myIndex = sessionIndex++;
     pushCalls.push({ options });
     const iterator = prompt[Symbol.asyncIterator]();
+    let closed = false;
 
     const generator: AsyncGenerator<Record<string, unknown>, void> = {
       async next() {
         const userMsg = await iterator.next();
         if (userMsg.done) {
+          if (closed && throwOnCloseFor === myIndex) {
+            throw new Error("Claude Code process exited with code 1");
+          }
           return { value: undefined as unknown as Record<string, unknown>, done: true };
         }
         return {
@@ -49,7 +63,9 @@ function makeFakeSdkQuery(pushCalls: Array<{ options: Record<string, unknown> }>
     Object.assign(generator, {
       setModel: vi.fn(async () => {}),
       interrupt: vi.fn(async () => {}),
-      close: vi.fn(),
+      close: vi.fn(() => {
+        closed = true;
+      }),
     });
 
     return generator;
@@ -131,5 +147,44 @@ describe("ClaudeProvider permission mode changes", () => {
     // Second call: full → SDK permissionMode "bypassPermissions", bypass flag set.
     expect(sdkCalls[1]!.options.permissionMode).toBe("bypassPermissions");
     expect(sdkCalls[1]!.options.allowDangerouslySkipPermissions).toBe(true);
+  });
+
+  it("does not emit an Error event when the torn-down subprocess exits after mode change", async () => {
+    // Arm the first (supervised) session's mock so that after close() is
+    // called its next read throws with the real SDK's exit-code-1 message.
+    // That mirrors what happens on Windows when close() SIGTERMs the CLI.
+    mockQuery.mockImplementation(makeFakeSdkQuery(sdkCalls, /* throwOnCloseFor */ 0));
+
+    const errorEvents: Array<{ type: string; error?: string }> = [];
+    provider.on("event", (ev: { type: string; error?: string }) => {
+      if (ev.type === "error") errorEvents.push(ev);
+    });
+
+    await provider.sendMessage({
+      sessionId: "mcode-thread-c",
+      message: "first",
+      cwd: process.cwd(),
+      model: "claude-sonnet-4-6",
+      resume: false,
+      permissionMode: "supervised",
+    });
+    await provider.sendMessage({
+      sessionId: "mcode-thread-c",
+      message: "second",
+      cwd: process.cwd(),
+      model: "claude-sonnet-4-6",
+      resume: false,
+      permissionMode: "full",
+    });
+
+    // Give the torn-down session's for-await a chance to observe the
+    // close, iterate once more, and throw. The throw runs inside the
+    // async IIFE that drives startStreamLoop.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // The old subprocess's exit is an intentional supersession, not a
+    // user-visible crash. The fresh session (full-access) owns the thread
+    // now, so no Error event should reach consumers.
+    expect(errorEvents).toEqual([]);
   });
 });

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -36,10 +36,10 @@ interface SessionEntry {
   closeQueue: () => void;
   model: string;
   /**
-   * Permission mode the SDK subprocess is currently running with
-   * ("full" or "supervised"). Compared against incoming requests so we can
-   * live-switch via `query.setPermissionMode()` when it differs, without
-   * tearing down the subprocess.
+   * Permission mode the SDK subprocess was spawned with ("full" or "supervised").
+   * Compared against incoming requests; when it differs, the subprocess is torn
+   * down and a new one is spawned with the new mode because permissionMode is
+   * fixed at spawn in the Claude Agent SDK CLI.
    */
   permissionMode: string;
   lastUsedAt: number;
@@ -350,20 +350,25 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         : toUserMessage(message, sessionId);
 
     if (existing) {
-      existing.lastUsedAt = Date.now();
-
-      // Live-switch permission mode on the running subprocess via the SDK's
-      // control-request IPC. This matches how the Claude CLI itself toggles
-      // modes: no teardown, no lost context, same session.
+      // Permission mode is fixed at SDK subprocess spawn. setPermissionMode()
+      // cannot enter bypassPermissions without the --dangerously-skip-permissions
+      // flag at spawn time (mutually exclusive with canUseTool), so we match
+      // the codex provider's teardown-and-respawn pattern here. The new session
+      // resumes the same conversation via the persisted sdkSessionIds entry.
       if (existing.permissionMode !== permissionMode) {
-        logger.info("permissionMode changed, calling setPermissionMode()", {
+        logger.info("permissionMode changed, recreating session", {
           sessionId,
           from: existing.permissionMode,
           to: permissionMode,
         });
-        await existing.query.setPermissionMode(sdkPermissionMode);
-        existing.permissionMode = permissionMode;
+        existing.suppressEnded = true;
+        existing.closeQueue();
+        existing.query.close();
+        this.sessions.delete(sessionId);
+        return this.doSendMessage(params);
       }
+
+      existing.lastUsedAt = Date.now();
 
       if (existing.model !== resolvedModel) {
         logger.info("Model changed, calling setModel()", {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -356,6 +356,25 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     if (existing) {
       existing.lastUsedAt = Date.now();
 
+      // Permission mode is baked in at session creation (canUseTool callback
+      // and allowDangerouslySkipPermissions flag are set once). If the caller
+      // requests a different mode, tear down the subprocess and recurse. The
+      // fresh spawn below will be configured with the new mode. The thread's
+      // conversation history lives in mcode's DB, not the SDK, so the user
+      // only pays one extra subprocess startup, not any loss of context.
+      if (existing.permissionMode !== permissionMode) {
+        logger.info("permissionMode changed, closing session for recreation", {
+          sessionId,
+          from: existing.permissionMode,
+          to: permissionMode,
+        });
+        existing.suppressEnded = true;
+        existing.closeQueue();
+        existing.query.close();
+        this.sessions.delete(sessionId);
+        return this.doSendMessage({ ...params, resume: false });
+      }
+
       if (existing.model !== resolvedModel) {
         logger.info("Model changed, calling setModel()", {
           sessionId,

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -35,6 +35,13 @@ interface SessionEntry {
   pushMessage: (msg: SDKUserMessage) => void;
   closeQueue: () => void;
   model: string;
+  /**
+   * Permission mode the SDK subprocess was spawned with ("full" or "supervised").
+   * The SDK's canUseTool callback and allowDangerouslySkipPermissions flag are
+   * set at session creation and cannot be changed post-hoc, so if the caller
+   * requests a different mode the session must be torn down and recreated.
+   */
+  permissionMode: string;
   lastUsedAt: number;
   /** When true, the finally block in startStreamLoop should not emit an "ended" event. */
   suppressEnded?: boolean;
@@ -575,6 +582,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       pushMessage: queue.push,
       closeQueue: queue.close,
       model: resolvedModel,
+      permissionMode,
       lastUsedAt: Date.now(),
       pendingToolUses: new Set<string>(),
     };
@@ -625,6 +633,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
           pushMessage: freshQueue.push,
           closeQueue: freshQueue.close,
           model: resolvedModel,
+          permissionMode,
           lastUsedAt: Date.now(),
           pendingToolUses: new Set<string>(),
         };

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -36,10 +36,10 @@ interface SessionEntry {
   closeQueue: () => void;
   model: string;
   /**
-   * Permission mode the SDK subprocess was spawned with ("full" or "supervised").
-   * The SDK's canUseTool callback and allowDangerouslySkipPermissions flag are
-   * set at session creation and cannot be changed post-hoc, so if the caller
-   * requests a different mode the session must be torn down and recreated.
+   * Permission mode the SDK subprocess is currently running with
+   * ("full" or "supervised"). Compared against incoming requests so we can
+   * live-switch via `query.setPermissionMode()` when it differs, without
+   * tearing down the subprocess.
    */
   permissionMode: string;
   lastUsedAt: number;
@@ -352,23 +352,17 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     if (existing) {
       existing.lastUsedAt = Date.now();
 
-      // Permission mode is baked in at session creation (canUseTool callback
-      // and allowDangerouslySkipPermissions flag are set once). If the caller
-      // requests a different mode, tear down the subprocess and recurse. The
-      // fresh spawn below will be configured with the new mode. The thread's
-      // conversation history lives in mcode's DB, not the SDK, so the user
-      // only pays one extra subprocess startup, not any loss of context.
+      // Live-switch permission mode on the running subprocess via the SDK's
+      // control-request IPC. This matches how the Claude CLI itself toggles
+      // modes: no teardown, no lost context, same session.
       if (existing.permissionMode !== permissionMode) {
-        logger.info("permissionMode changed, closing session for recreation", {
+        logger.info("permissionMode changed, calling setPermissionMode()", {
           sessionId,
           from: existing.permissionMode,
           to: permissionMode,
         });
-        existing.suppressEnded = true;
-        existing.closeQueue();
-        existing.query.close();
-        this.sessions.delete(sessionId);
-        return this.doSendMessage({ ...params, resume: false });
+        await existing.query.setPermissionMode(sdkPermissionMode);
+        existing.permissionMode = permissionMode;
       }
 
       if (existing.model !== resolvedModel) {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1115,15 +1115,32 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       } catch (e: unknown) {
         const errorMessage =
           e instanceof Error ? e.message : String(e);
-        logger.error("SDK stream error", {
-          sessionId,
-          error: errorMessage,
-        });
-        this.emit("event", {
-          type: AgentEventType.Error,
-          threadId,
-          error: errorMessage,
-        } satisfies AgentEvent);
+        // Gate the Error event with the same "still the active stream" check
+        // as the Ended event below. When a session is intentionally torn down
+        // (mode change, setModel failure) the Claude CLI subprocess exits
+        // non-zero after its stdin is closed, which propagates here as a
+        // thrown exit error. That exit is expected, not a user-visible crash,
+        // because a fresh session has already taken over the sessionId.
+        const current = this.sessions.get(sessionId);
+        const superseded =
+          (current !== undefined && current.query !== q) ||
+          current?.suppressEnded === true;
+        if (superseded) {
+          logger.debug("SDK stream error suppressed (session superseded)", {
+            sessionId,
+            error: errorMessage,
+          });
+        } else {
+          logger.error("SDK stream error", {
+            sessionId,
+            error: errorMessage,
+          });
+          this.emit("event", {
+            type: AgentEventType.Error,
+            threadId,
+            error: errorMessage,
+          } satisfies AgentEvent);
+        }
       } finally {
         const current = this.sessions.get(sessionId);
         if (current?.query === q) {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -502,12 +502,16 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
           let result;
           switch (decision) {
             case "allow":
+              // updatedInput is required by the CLI's runtime Zod schema (not optional
+              // despite the SDK TypeScript type). Pass the original input unchanged.
               result = {
                 behavior: "allow" as const,
                 updatedInput: input,
               };
               break;
             case "allow-session":
+              // Use the SDK-provided suggestions — they encode the correct
+              // PermissionUpdate shape for the specific tool being allowed.
               result = {
                 behavior: "allow" as const,
                 updatedInput: input,

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -488,6 +488,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
               title: options?.title,
             } satisfies PermissionRequest);
 
+            // Auto-cancel if the SDK aborts the tool call (e.g. timeout).
             if (options?.signal) {
               const onAbort = () => {
                 if (this.pendingPermissions.delete(requestId)) {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -344,10 +344,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     const resolvedCwd = cwd || process.cwd();
     const resolvedModel = model || "claude-sonnet-4-6";
 
-    if (isBypass) {
-      logger.warn("Using bypassPermissions for session", { sessionId });
-    }
-
     const prompt =
       attachments && attachments.length > 0
         ? await this.buildMultimodalMessage(message, attachments, sessionId)
@@ -468,92 +464,82 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       // get stuck.
       disallowedTools: ["EnterPlanMode", "ExitPlanMode"],
       permissionMode: sdkPermissionMode,
-      ...(isBypass && { allowDangerouslySkipPermissions: true }),
-      ...(isBypass
-        ? {}
-        : {
-            canUseTool: (async (
-              toolName: string,
-              input: Record<string, unknown>,
-              options: Parameters<CanUseTool>[2],
-            ) => {
-              try {
-                const requestId = crypto.randomUUID();
-                logger.debug("canUseTool called", { toolName, requestId, threadId: tid });
-                const decision = await new Promise<PermissionDecision>((resolve) => {
-                  this.pendingPermissions.set(requestId, {
-                    threadId: tid,
-                    toolName,
-                    input,
-                    title: options?.title,
-                    resolve,
-                  });
-                  this.emit("permission_request", {
-                    requestId,
-                    threadId: tid,
-                    toolName,
-                    input,
-                    title: options?.title,
-                  } satisfies PermissionRequest);
+      canUseTool: (async (
+        toolName: string,
+        input: Record<string, unknown>,
+        options: Parameters<CanUseTool>[2],
+      ) => {
+        try {
+          const requestId = crypto.randomUUID();
+          logger.debug("canUseTool called", { toolName, requestId, threadId: tid });
+          const decision = await new Promise<PermissionDecision>((resolve) => {
+            this.pendingPermissions.set(requestId, {
+              threadId: tid,
+              toolName,
+              input,
+              title: options?.title,
+              resolve,
+            });
+            this.emit("permission_request", {
+              requestId,
+              threadId: tid,
+              toolName,
+              input,
+              title: options?.title,
+            } satisfies PermissionRequest);
 
-                  // Auto-cancel if the SDK aborts the tool call (e.g. timeout).
-                  if (options?.signal) {
-                    const onAbort = () => {
-                      if (this.pendingPermissions.delete(requestId)) {
-                        resolve("cancelled");
-                        this.emit("permission_resolved", { requestId, decision: "cancelled" as const });
-                      }
-                    };
-                    options.signal.addEventListener("abort", onAbort, { once: true });
-                  }
-                });
-                logger.debug("canUseTool decision", { toolName, requestId, decision });
-                let result;
-                switch (decision) {
-                  case "allow":
-                    // updatedInput is required by the CLI's runtime Zod schema (not optional
-                    // despite the SDK TypeScript type). Pass the original input unchanged.
-                    result = {
-                      behavior: "allow" as const,
-                      updatedInput: input,
-                    };
-                    break;
-                  case "allow-session":
-                    // Use the SDK-provided suggestions — they encode the correct
-                    // PermissionUpdate shape for the specific tool being allowed.
-                    result = {
-                      behavior: "allow" as const,
-                      updatedInput: input,
-                      updatedPermissions: options?.suggestions,
-                    };
-                    break;
-                  case "deny":
-                  case "cancelled":
-                    result = {
-                      behavior: "deny" as const,
-                      message: decision === "cancelled"
-                        ? "Session stopped by user"
-                        : "User denied",
-                    };
-                    break;
-                  default:
-                    logger.error("canUseTool received unexpected decision", { toolName, requestId, decision });
-                    result = {
-                      behavior: "deny" as const,
-                      message: "Unexpected permission decision value",
-                    };
+            if (options?.signal) {
+              const onAbort = () => {
+                if (this.pendingPermissions.delete(requestId)) {
+                  resolve("cancelled");
+                  this.emit("permission_resolved", { requestId, decision: "cancelled" as const });
                 }
-                logger.debug("canUseTool returning", { toolName, requestId, behavior: result.behavior });
-                return result;
-              } catch (err) {
-                logger.error("canUseTool callback threw unexpectedly", { toolName, err });
-                return {
-                  behavior: "deny" as const,
-                  message: "Permission check encountered an internal error",
-                };
-              }
-            }) satisfies CanUseTool,
-          }),
+              };
+              options.signal.addEventListener("abort", onAbort, { once: true });
+            }
+          });
+          logger.debug("canUseTool decision", { toolName, requestId, decision });
+          let result;
+          switch (decision) {
+            case "allow":
+              result = {
+                behavior: "allow" as const,
+                updatedInput: input,
+              };
+              break;
+            case "allow-session":
+              result = {
+                behavior: "allow" as const,
+                updatedInput: input,
+                updatedPermissions: options?.suggestions,
+              };
+              break;
+            case "deny":
+            case "cancelled":
+              result = {
+                behavior: "deny" as const,
+                message: decision === "cancelled"
+                  ? "Session stopped by user"
+                  : "User denied",
+              };
+              break;
+            default:
+              logger.error("canUseTool received unexpected decision", { toolName, requestId, decision });
+              result = {
+                behavior: "deny" as const,
+                message: "Unexpected permission decision value",
+              };
+          }
+          logger.debug("canUseTool returning", { toolName, requestId, behavior: result.behavior });
+          return result;
+        } catch (err) {
+          logger.error("canUseTool callback threw unexpectedly", { toolName, err });
+          return {
+            behavior: "deny" as const,
+            message: "Permission check encountered an internal error",
+          };
+        }
+      }) satisfies CanUseTool,
       ...buildReasoningOptions(reasoningLevel, resolvedModel),
       ...(fallbackModel && { fallbackModel }),
       includePartialMessages: true,

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -510,7 +510,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
               };
               break;
             case "allow-session":
-              // Use the SDK-provided suggestions — they encode the correct
+              // Use the SDK-provided suggestions. They encode the correct
               // PermissionUpdate shape for the specific tool being allowed.
               result = {
                 behavior: "allow" as const,

--- a/apps/web/src/__tests__/per-thread-settings.test.ts
+++ b/apps/web/src/__tests__/per-thread-settings.test.ts
@@ -129,4 +129,64 @@ describe("per-thread settings", () => {
     expect(settings.reasoningLevel).toBe("high");
     expect(settings.permissionMode).toBe("supervised");
   });
+
+  it("setThreadSettings mirrors the patch into workspaceStore.threads", async () => {
+    const thread = createMockThread({
+      id: "thread-sync",
+      reasoning_level: null,
+      interaction_mode: "chat",
+      permission_mode: "supervised",
+    });
+    useWorkspaceStore.setState({ threads: [thread] });
+
+    await useThreadStore
+      .getState()
+      .setThreadSettings("thread-sync", { permissionMode: "full" });
+
+    const updated = useWorkspaceStore
+      .getState()
+      .threads.find((t) => t.id === "thread-sync");
+    expect(updated?.permission_mode).toBe("full");
+  });
+
+  it("setThreadSettings mirrors all provided fields, leaving others untouched", async () => {
+    const thread = createMockThread({
+      id: "thread-sync-2",
+      reasoning_level: "max",
+      interaction_mode: "chat",
+      permission_mode: "supervised",
+      copilot_agent: "code",
+    });
+    useWorkspaceStore.setState({ threads: [thread] });
+
+    await useThreadStore.getState().setThreadSettings("thread-sync-2", {
+      permissionMode: "full",
+      interactionMode: "plan",
+    });
+
+    const updated = useWorkspaceStore
+      .getState()
+      .threads.find((t) => t.id === "thread-sync-2");
+    expect(updated?.permission_mode).toBe("full");
+    expect(updated?.interaction_mode).toBe("plan");
+    expect(updated?.reasoning_level).toBe("max");
+    expect(updated?.copilot_agent).toBe("code");
+  });
+
+  it("setThreadSettings with copilotAgent: null clears the cached value", async () => {
+    const thread = createMockThread({
+      id: "thread-sync-3",
+      copilot_agent: "code",
+    });
+    useWorkspaceStore.setState({ threads: [thread] });
+
+    await useThreadStore
+      .getState()
+      .setThreadSettings("thread-sync-3", { copilotAgent: null });
+
+    const updated = useWorkspaceStore
+      .getState()
+      .threads.find((t) => t.id === "thread-sync-3");
+    expect(updated?.copilot_agent).toBeNull();
+  });
 });

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -696,6 +696,25 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       },
     }));
 
+    // Also mirror the patch into workspaceStore.threads so the cached
+    // thread object stays in sync. Composer's no-draft hydration path
+    // reads from that cache directly (permission_mode, interaction_mode,
+    // reasoning_level, copilot_agent), so failing to sync here causes
+    // the UI to revert to stale DB values on thread re-entry.
+    useWorkspaceStore.setState((state) => ({
+      threads: state.threads.map((t) =>
+        t.id === threadId
+          ? {
+              ...t,
+              ...(patch.permissionMode !== undefined && { permission_mode: patch.permissionMode }),
+              ...(patch.interactionMode !== undefined && { interaction_mode: patch.interactionMode }),
+              ...(patch.reasoningLevel !== undefined && { reasoning_level: patch.reasoningLevel }),
+              ...("copilotAgent" in patch && { copilot_agent: patch.copilotAgent ?? null }),
+            }
+          : t,
+      ),
+    }));
+
     // copilotAgent: null clears the persisted agent; undefined means don't change.
     const transportPatch: {
       reasoningLevel?: ReturnType<typeof get>["settingsByThread"][string]["reasoningLevel"];


### PR DESCRIPTION
## What
Permission-mode toggle (Supervised ↔ Full access) now takes effect on existing threads. Previously the toggle was persisted to the DB but the running SDK session continued with the original mode, so Full access still prompted and Supervised still bypassed.

## Why
Two bugs combined to make the toggle a no-op on live threads:

1. The web store patched the thread's settings in the DB but didn't mirror the change into `workspaceStore.threads`, so the cached object sent to the server on the next turn still held the stale mode.
2. The Claude provider didn't reconcile a differing `permissionMode` against its cached `SessionEntry`, so the running subprocess (launched with the old mode) kept running.

Live-switching via `query.setPermissionMode()` looked viable but the Claude Agent SDK CLI rejects switching into `bypassPermissions` unless the subprocess was spawned with `--dangerously-skip-permissions`, which is mutually exclusive with `canUseTool`. The codex provider already solves the same "mode fixed at spawn" constraint via teardown + respawn, so Claude now matches that pattern.

## Key Changes
- `apps/web/src/stores/threadStore.ts` — `setThreadSettings` now mirrors the patch into `useWorkspaceStore.threads` so the cached thread matches the DB.
- `apps/server/src/providers/claude/claude-provider.ts` — `SessionEntry` tracks the active `permissionMode`; when an incoming request differs, the subprocess is closed and respawned with the new mode. `sdkSessionIds` is preserved so the respawned session resumes the same conversation.
- `canUseTool` is now registered unconditionally; `allowDangerouslySkipPermissions` is no longer set at spawn.
- `apps/server/src/providers/claude/claude-provider.ts` — stream loop suppresses the `ended` event on intentional teardowns so the UI doesn't flash an error on mode change.
- Test coverage for the respawn path and the `workspaceStore` cache sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission mode changes now properly trigger session recreation, ensuring updated permissions are applied consistently.
  * Thread settings updates now fully synchronize with the application, maintaining all configuration changes correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->