### PR TITLE
feat(sidebar): reclaim full chat width when collapsed

### DIFF
--- a/apps/web/e2e/app.spec.ts
+++ b/apps/web/e2e/app.spec.ts
@@ -113,27 +113,19 @@ test.describe("Sidebar", () => {
     // Brand name is visible when sidebar is expanded
     await expect(page.locator("text=Mcode")).toBeVisible();
 
-    // Click the collapse/expand icon button (PanelLeftClose icon)
-    const toggleBtn = page.locator(
-      "button:has(svg)",
-      { hasText: "" }
-    ).first();
+    // Collapse the sidebar — the button lives in the sidebar header and is
+    // identified by its aria-label so the test survives class-name churn.
+    await page.getByRole("button", { name: "Collapse sidebar" }).click();
 
-    // Find the collapse button by locating the header area button that is NOT the settings trigger
-    // The sidebar header has exactly one button (the collapse toggle)
-    const sidebarHeader = page.locator(".border-b.border-border.p-3").first();
-    const collapseBtn = sidebarHeader.locator("button");
-    await collapseBtn.click();
-
-    // After collapse, brand name should disappear (sidebar collapses to w-12)
+    // The sidebar unmounts entirely on collapse so the chat panel can claim
+    // the full viewport width. Brand name and project tree should be gone.
     await expect(page.locator("text=Mcode")).not.toBeVisible();
     await expect(page.locator("text=Projects")).not.toBeVisible();
 
-    // Click again to expand
-    await collapseBtn.click();
+    // The reveal control now lives inline in the chat header. Click it to
+    // bring the sidebar back.
+    await page.getByRole("button", { name: "Expand sidebar" }).click();
     await expect(page.locator("text=Mcode")).toBeVisible();
-
-    void toggleBtn; // suppress unused variable warning
   });
 });
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -218,7 +218,10 @@ export function App() {
       <div className="flex h-screen flex-col overflow-hidden bg-page text-foreground">
         <ConnectionBanner />
         <div className="flex flex-1 gap-1.5 overflow-hidden p-1.5">
-          {!sidebarCollapsed && (
+          {/* Settings view force-expands the sidebar so the settings nav is reachable.
+              When the sidebar is hidden, the chat panel claims the full width and the
+              reveal button lives inline in the chat header (see ChatView). */}
+          {(!sidebarCollapsed || settingsOpen) && (
             <div className="flex shrink-0 overflow-hidden rounded-lg shadow-sm">
               <Sidebar
                 settingsOpen={settingsOpen}

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -13,6 +13,8 @@ import { HeaderActions } from "./HeaderActions";
 import { CliErrorBanner, isCliError } from "./CliErrorBanner";
 import { InterruptedSessionsBanner } from "./InterruptedSessionsBanner";
 import { ThreadTitleEditor } from "./ThreadTitleEditor";
+import { SidebarRevealButton } from "@/components/sidebar/SidebarRevealButton";
+import { useUiStore } from "@/stores/uiStore";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -78,6 +80,7 @@ export function ChatView() {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const pendingNewThread = useWorkspaceStore((s) => s.pendingNewThread);
   const threads = useWorkspaceStore((s) => s.threads);
+  const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
   const updateThreadTitle = useWorkspaceStore((s) => s.updateThreadTitle);
   const setActiveThread = useWorkspaceStore((s) => s.setActiveThread);
   const [editingThreadId, setEditingThreadId] = useState<string | null>(null);
@@ -225,8 +228,9 @@ export function ChatView() {
     return (
       <div className="flex h-full flex-col bg-background">
         {/* Header */}
-        <div className="flex h-11 items-center justify-between border-b border-border/40 px-4">
+        <div className="flex h-11 items-center justify-between border-b border-border/40 pr-4 pl-2">
           <div className="flex items-center gap-2">
+            {sidebarCollapsed && <SidebarRevealButton />}
             <span className="text-sm text-muted-foreground">New thread</span>
             {activeWorkspaceId && (
               <Badge variant="secondary">
@@ -249,14 +253,23 @@ export function ChatView() {
 
   if (!activeThread) {
     return (
-      <div className="flex h-full items-center justify-center bg-background">
-        <div className="text-center">
-          <h2 className="text-lg font-medium text-foreground">
-            Select a thread
-          </h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Choose a thread from the sidebar or create a new one.
-          </p>
+      <div className="flex h-full flex-col bg-background">
+        {/* Minimal top bar — only renders the reveal button when the sidebar is
+            collapsed, so the user always has a way back to the project tree. */}
+        {sidebarCollapsed && (
+          <div className="flex h-11 items-center border-b border-border/40 pl-2">
+            <SidebarRevealButton />
+          </div>
+        )}
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <h2 className="text-lg font-medium text-foreground">
+              Select a thread
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Choose a thread from the sidebar or create a new one.
+            </p>
+          </div>
         </div>
       </div>
     );
@@ -268,8 +281,9 @@ export function ChatView() {
   return (
     <div className="flex h-full flex-col bg-background" data-testid="chat-view">
       {/* Header */}
-      <div className="flex h-11 items-center justify-between border-b border-border px-4">
+      <div className="flex h-11 items-center justify-between border-b border-border pr-4 pl-2">
         <div className="flex items-center gap-2">
+          {sidebarCollapsed && <SidebarRevealButton />}
           <div
             data-testid="chat-header-title"
             onDoubleClick={() => setEditingThreadId(activeThread.id)}

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -1,11 +1,11 @@
 import { ProjectTree } from "./ProjectTree";
-import { PanelLeftClose, PanelLeft, Settings, ArrowLeft, ExternalLink, Braces } from "lucide-react";
-import { useState } from "react";
-import { cn } from "@/lib/utils";
+import { Settings, ArrowLeft, ExternalLink, Braces } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SettingsNav } from "@/components/settings/SettingsNav";
 import type { SettingsSection } from "@/components/settings/settings-nav";
 import { SidebarUsagePanel } from "./SidebarUsagePanel";
+import { PanelCollapseIcon } from "./SidebarRevealButton";
+import { useUiStore } from "@/stores/uiStore";
 
 /** True when running inside the Electron shell. */
 const IS_DESKTOP = typeof window !== "undefined" && !!window.desktopBridge;
@@ -31,11 +31,7 @@ export function Sidebar({
   onOpenSettings,
   onCloseSettings,
 }: SidebarProps) {
-  const [collapsed, setCollapsed] = useState(false);
-
-  // Force-expand sidebar when settings is open
-  const isCollapsed = collapsed && !settingsOpen;
-
+  const toggleSidebar = useUiStore((s) => s.toggleSidebar);
 
   const handleEditJson = () => {
     if (window.desktopBridge) {
@@ -44,17 +40,10 @@ export function Sidebar({
   };
 
   return (
-    <div
-      className={cn(
-        "flex h-full flex-col bg-sidebar transition-[width] duration-200",
-        // Clamp expanded width on narrow viewports so the sidebar can't dominate the layout.
-        // Above md (>=768px), the cap is removed and the full w-72 applies.
-        isCollapsed ? "w-12" : "w-72 max-w-[55vw] md:max-w-none",
-      )}
-    >
+    <div className="flex h-full w-72 max-w-[55vw] flex-col bg-sidebar md:max-w-none">
       {/* Header */}
       <div className="flex h-11 items-center justify-between border-b border-border/40 px-3">
-        {settingsOpen && !isCollapsed ? (
+        {settingsOpen ? (
           <div className="flex items-center gap-2">
             <Button
               variant="ghost"
@@ -69,61 +58,55 @@ export function Sidebar({
           </div>
         ) : (
           <>
-            {!isCollapsed && (
-              <span className="text-sm font-semibold tracking-tight text-foreground">Mcode</span>
-            )}
+            <span className="text-sm font-semibold tracking-tight text-foreground">Mcode</span>
             <Button
               variant="ghost"
               size="icon-sm"
-              onClick={() => setCollapsed(!collapsed)}
-              aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              onClick={toggleSidebar}
+              aria-label="Collapse sidebar"
               className="text-muted-foreground"
             >
-              {isCollapsed ? <PanelLeft size={16} /> : <PanelLeftClose size={16} />}
+              <PanelCollapseIcon className="transition-transform duration-200 group-hover/button:-translate-x-px" />
             </Button>
           </>
         )}
       </div>
 
       {/* Body */}
-      {!isCollapsed && (
-        <div className="flex-1 overflow-y-auto">
-          {settingsOpen && settingsSection && onSettingsSection ? (
-            <SettingsNav section={settingsSection} onSection={onSettingsSection} />
-          ) : (
-            <ProjectTree />
-          )}
-        </div>
-      )}
+      <div className="flex-1 overflow-y-auto">
+        {settingsOpen && settingsSection && onSettingsSection ? (
+          <SettingsNav section={settingsSection} onSection={onSettingsSection} />
+        ) : (
+          <ProjectTree />
+        )}
+      </div>
 
       {/* Footer */}
-      {!isCollapsed && (
-        <div className="border-t border-border/40 p-3 space-y-1">
-          {!settingsOpen && <SidebarUsagePanel />}
-          {settingsOpen ? (
-            IS_DESKTOP && (
-              <Button
-                variant="ghost"
-                className="flex w-full items-center gap-2 rounded p-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
-                onClick={handleEditJson}
-              >
-                <Braces size={14} />
-                Edit settings.json
-                <ExternalLink size={11} />
-              </Button>
-            )
-          ) : (
+      <div className="border-t border-border/40 p-3 space-y-1">
+        {!settingsOpen && <SidebarUsagePanel />}
+        {settingsOpen ? (
+          IS_DESKTOP && (
             <Button
               variant="ghost"
               className="flex w-full items-center gap-2 rounded p-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
-              onClick={onOpenSettings}
+              onClick={handleEditJson}
             >
-              <Settings size={16} />
-              Settings
+              <Braces size={14} />
+              Edit settings.json
+              <ExternalLink size={11} />
             </Button>
-          )}
-        </div>
-      )}
+          )
+        ) : (
+          <Button
+            variant="ghost"
+            className="flex w-full items-center gap-2 rounded p-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+            onClick={onOpenSettings}
+          >
+            <Settings size={16} />
+            Settings
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/sidebar/SidebarRevealButton.tsx
+++ b/apps/web/src/components/sidebar/SidebarRevealButton.tsx
@@ -1,0 +1,83 @@
+import { useUiStore } from "@/stores/uiStore";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+/**
+ * Custom icon showing a vertical rail with a chevron pointing right.
+ * Used as the "reveal sidebar" affordance when the sidebar is collapsed.
+ * The chevron direction communicates the action: panel slides out from the left.
+ */
+export function PanelRevealIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M4 3v10" />
+      <path d="M8 5.5l2.5 2.5L8 10.5" />
+    </svg>
+  );
+}
+
+/**
+ * Mirrored companion icon: vertical rail on the right with a chevron pointing left.
+ * Used inside the expanded sidebar header to collapse the panel.
+ */
+export function PanelCollapseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12 3v10" />
+      <path d="M8 5.5L5.5 8 8 10.5" />
+    </svg>
+  );
+}
+
+/**
+ * Compact inline control rendered inside the chat panel's header when the
+ * sidebar is collapsed. Lives as the first child of the header row so it
+ * naturally reserves space without colliding with the thread title. The
+ * chevron slides outward on hover to telegraph the reveal action.
+ */
+export function SidebarRevealButton() {
+  const toggle = useUiStore((s) => s.toggleSidebar);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        onClick={toggle}
+        aria-label="Expand sidebar"
+        className={cn(
+          "group inline-flex size-7 shrink-0 items-center justify-center rounded-md",
+          "text-muted-foreground transition-[color,transform,background-color]",
+          "hover:bg-muted hover:text-foreground",
+          "active:translate-y-px",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        )}
+      >
+        <PanelRevealIcon className="transition-transform duration-200 group-hover:translate-x-px" />
+      </TooltipTrigger>
+      <TooltipContent side="right" className="text-xs">
+        Expand sidebar
+      </TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## What

When the sidebar is collapsed, the chat panel now claims the full viewport width and the reveal control lives inline as the first item of the chat header row. A new custom rail+chevron icon pair replaces Lucide's `PanelLeft` / `PanelLeftClose` glyphs.

## Why

The collapsed sidebar previously left a 48px empty rail on the left, wasting horizontal space for a single icon button. The existing expand glyph also felt out of place against the rest of the click UI.

Settings view still force-expands the sidebar so the settings nav stays reachable.

## Key Changes

- `apps/web/src/app/App.tsx` — sidebar container only renders when `!sidebarCollapsed || settingsOpen`, so the chat panel takes over the full width when collapsed
- `apps/web/src/components/sidebar/Sidebar.tsx` — removes the local `useState` collapse, routes through the global `uiStore.toggleSidebar`, drops the `w-12` collapsed branch, uses the new `PanelCollapseIcon`
- `apps/web/src/components/chat/ChatView.tsx` — inlines `<SidebarRevealButton />` at the start of all three header branches (pending-new-thread, no-active-thread empty state, and active-thread header), adjusted padding so the button nests cleanly beside the title
- `apps/web/src/components/sidebar/SidebarRevealButton.tsx` (new) — exports the mirrored 16px SVG icon pair (`PanelRevealIcon`, `PanelCollapseIcon`) and the inline reveal button with a tooltip and a hover chevron-slide micro-interaction

## Test plan

- [x] Typecheck passes (`npx tsc --noEmit` in `apps/web`)
- [x] Playwright screenshots verify full-width chat and no leftover rail in collapsed state
- [ ] Live-click a populated thread to confirm the inline button sits beside the thread title without collision (not verifiable in the test env, no workspaces seeded)
- [ ] E2E suite (`cd apps/web && bun run e2e`) passes on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar reveal/expand control added for quick access when collapsed
  * Sidebar automatically reveals when opening settings for consistent layout

* **UI Improvements**
  * Chat and empty-thread views show an expand control when sidebar is hidden
  * Sidebar header and footer consistently visible in expanded mode

* **Tests**
  * Sidebar collapse/expand test updated to use accessible role/name selectors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->