### PR TITLE
fix(sidebar): copy thread's worktree path, not project path

### DIFF
--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -468,7 +468,11 @@ export function ProjectTree() {
             {
               label: "Copy Path",
               onClick: () => {
-                navigator.clipboard.writeText(contextMenu.workspacePath);
+                // Prefer the worktree path when the thread lives in one,
+                // so the copied path matches the thread's actual checkout.
+                navigator.clipboard.writeText(
+                  contextMenu.worktreePath ?? contextMenu.workspacePath,
+                );
               },
             },
             {


### PR DESCRIPTION
## What
Fix the **Copy Path** action on the thread right-click context menu so it copies the thread's actual associated path — the worktree path for worktree threads, and the project path for direct-mode threads.

## Why
Previously, Copy Path always copied the workspace (project) path regardless of whether the thread was in a worktree. For worktree threads, users expected the worktree checkout path (which is what tools, shells, and editors actually need), not the parent project path.

## Key Changes
- `apps/web/src/components/sidebar/ProjectTree.tsx`: Copy Path now writes `contextMenu.worktreePath ?? contextMenu.workspacePath`. The `worktreePath` was already captured in the context menu state from `thread.worktree_path`, so no new data plumbing was needed.

## Behavior
- Worktree thread → copies the worktree checkout path
- Direct/local thread (`worktree_path` is `null`) → copies the workspace path (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved "Copy Path" context menu action to select the appropriate path based on context (worktree or workspace).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->