### PR TITLE
fix(terminal): four stability fixes for the embedded terminal

### DIFF
--- a/apps/web/src/__tests__/TerminalPanel.test.tsx
+++ b/apps/web/src/__tests__/TerminalPanel.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Stub the transport before TerminalPanel imports it. Storing on globalThis
+// keeps the mock observable from the test body without tripping hoisting.
+const terminalKillByThread = vi.fn().mockResolvedValue(undefined);
+const terminalKill = vi.fn().mockResolvedValue(undefined);
+const terminalCreate = vi.fn().mockResolvedValue("pty-new");
+
+vi.mock("@/transport", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/transport")>();
+  return {
+    ...actual,
+    getTransport: () => ({
+      terminalKillByThread,
+      terminalKill,
+      terminalCreate,
+    }),
+  };
+});
+
+// TerminalView pulls in xterm and dynamic addon imports. We don't need its
+// behaviour here — the toolbar action is what we're verifying.
+vi.mock("@/components/terminal/TerminalView", () => ({
+  TerminalView: () => null,
+}));
+
+import { useTerminalStore } from "@/stores/terminalStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { TerminalPanel } from "@/components/terminal/TerminalPanel";
+
+describe("TerminalPanel", () => {
+  beforeEach(() => {
+    terminalKillByThread.mockClear();
+    terminalKill.mockClear();
+    terminalCreate.mockClear();
+    useTerminalStore.setState({
+      terminals: {},
+      terminalPanelByThread: {},
+      splitMode: false,
+    });
+    useWorkspaceStore.setState({ activeThreadId: "thread-1" });
+  });
+
+  // Regression guard for issue #303: clicking the bin button must kill the
+  // PTY processes AND collapse the panel (previously left an empty panel open).
+  it("hides the panel after closing all terminals via the bin button", () => {
+    useTerminalStore.setState({
+      terminals: {
+        "thread-1": [{ id: "pty-1", threadId: "thread-1", label: "Terminal 1" }],
+      },
+      terminalPanelByThread: {
+        "thread-1": { visible: true, height: 300, activeTerminalId: "pty-1" },
+      },
+    });
+
+    render(<TerminalPanel />);
+
+    const bin = screen.getByRole("button", { name: /delete all terminals/i });
+    fireEvent.click(bin);
+
+    expect(terminalKillByThread).toHaveBeenCalledWith("thread-1");
+
+    const panel = useTerminalStore.getState().terminalPanelByThread["thread-1"];
+    expect(panel?.visible).toBe(false);
+    // Height is preserved so the next open restores the previous size.
+    expect(panel?.height).toBe(300);
+  });
+});

--- a/apps/web/src/__tests__/TerminalView.focus.test.tsx
+++ b/apps/web/src/__tests__/TerminalView.focus.test.tsx
@@ -1,0 +1,101 @@
+import { render } from "@testing-library/react";
+import { act } from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// jsdom doesn't implement ResizeObserver; TerminalView instantiates one in
+// its mount effect. A no-op stub is enough — fit is exercised via the
+// visibility effects, not the observer.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as typeof ResizeObserver;
+}
+
+// Shared xterm term instance observable from the tests. We focus on the
+// .focus() call because that's the one that can steal input from the
+// composer — fit and refresh are idempotent repaints.
+const term = {
+  options: { scrollback: 0 },
+  loadAddon: vi.fn(),
+  open: vi.fn(),
+  attachCustomKeyEventHandler: vi.fn(),
+  getSelection: vi.fn(() => ""),
+  onData: vi.fn(() => ({ dispose: vi.fn() })),
+  write: vi.fn(),
+  paste: vi.fn(),
+  clear: vi.fn(),
+  refresh: vi.fn(),
+  focus: vi.fn(),
+  dispose: vi.fn(),
+  rows: 24,
+};
+
+vi.mock("@xterm/xterm", () => {
+  class Terminal {
+    constructor() {
+      return term as unknown as Terminal;
+    }
+  }
+  return { Terminal };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class FitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+  }
+  return { FitAddon };
+});
+
+vi.mock("@/transport", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/transport")>();
+  return {
+    ...actual,
+    getTransport: () => ({
+      terminalWrite: vi.fn(() => Promise.resolve()),
+      terminalResize: vi.fn(() => Promise.resolve()),
+    }),
+  };
+});
+
+import { TerminalView } from "@/components/terminal/TerminalView";
+
+describe("TerminalView focus behaviour (regression)", () => {
+  beforeEach(() => {
+    term.focus.mockClear();
+    term.refresh.mockClear();
+  });
+
+  // Regression guard: term.focus() must NOT fire when the window/tab
+  // regains visibility. The user may be typing in the composer when the
+  // app returns to the foreground — stealing focus into xterm would
+  // contradict commit 09e0a3e (Ctrl+J from composer).
+  it("does not call term.focus() on document visibilitychange", async () => {
+    await act(async () => {
+      render(<TerminalView ptyId="pty-1" visible={true} />);
+    });
+    // Let the async dynamic imports in init() settle.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const focusCallsBefore = term.focus.mock.calls.length;
+
+    // Simulate return-from-background.
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(term.focus.mock.calls.length).toBe(focusCallsBefore);
+    // Repaint still happens so half-painted output recovers.
+    expect(term.refresh).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/TerminalView.keyhandler.test.ts
+++ b/apps/web/src/__tests__/TerminalView.keyhandler.test.ts
@@ -64,4 +64,29 @@ describe("shouldInterceptKeyEvent", () => {
       expect(shouldInterceptKeyEvent(event, false)).toBe(false);
     });
   });
+
+  // Regression guard for issue #316: after backgrounding the app, users reported
+  // the spacebar no longer reaching the shell. Any key interception on " " would
+  // break normal typing — this test pins the behaviour.
+  describe("space key (regression #316)", () => {
+    it("does not intercept plain space", () => {
+      const event = makeEvent({ key: " " });
+      expect(shouldInterceptKeyEvent(event, false)).toBe(false);
+    });
+
+    it("does not intercept space with a selection present", () => {
+      const event = makeEvent({ key: " " });
+      expect(shouldInterceptKeyEvent(event, true)).toBe(false);
+    });
+
+    it("does not intercept Ctrl+Space", () => {
+      const event = makeEvent({ key: " ", ctrlKey: true });
+      expect(shouldInterceptKeyEvent(event, false)).toBe(false);
+    });
+
+    it("does not intercept Shift+Space", () => {
+      const event = makeEvent({ key: " ", shiftKey: true });
+      expect(shouldInterceptKeyEvent(event, false)).toBe(false);
+    });
+  });
 });

--- a/apps/web/src/__tests__/shortcuts.test.ts
+++ b/apps/web/src/__tests__/shortcuts.test.ts
@@ -78,3 +78,53 @@ describe("shortcuts integration", () => {
     expect(getKeybindings().length).toBe(1);
   });
 });
+
+// Regression guard for issue #304: terminal.toggle must fire even when an
+// input is focused. Users invoke Ctrl/Cmd+J from the composer to toggle the
+// terminal; the previous `when: !inputFocused` gate broke that workflow.
+describe("terminal.toggle keybinding (regression #304)", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    clearKeybindings();
+    clearCommands();
+    resetContext();
+  });
+
+  afterEach(() => {
+    cleanup?.();
+  });
+
+  it("default keybindings bind terminal.toggle to mod+j without a when clause", async () => {
+    const defaults = (await import("@/config/default-keybindings.json")).default as Array<{
+      key: string;
+      command: string;
+      when?: string;
+    }>;
+    const terminalToggle = defaults.find((b) => b.command === "terminal.toggle");
+    expect(terminalToggle).toBeDefined();
+    expect(terminalToggle!.key).toBe("mod+j");
+    expect(terminalToggle!.when).toBeUndefined();
+  });
+
+  it("fires terminal.toggle even when a text input is focused", () => {
+    const handler = vi.fn();
+    registerCommand({
+      id: "terminal.toggle",
+      title: "Toggle Terminal",
+      category: "Terminal",
+      handler,
+    });
+    loadKeybindings([{ key: "mod+j", command: "terminal.toggle" }]);
+    cleanup = initShortcuts();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    document.dispatchEvent(createKeyEvent({ key: "j", ctrlKey: true }));
+    expect(handler).toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+});

--- a/apps/web/src/__tests__/useIdleReclamation.test.tsx
+++ b/apps/web/src/__tests__/useIdleReclamation.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const setBackground = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/transport", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/transport")>();
+  return {
+    ...actual,
+    getTransport: () => ({ setBackground }),
+  };
+});
+
+// threadStore.clearToolCallRecordCache is called during idle — stub the module
+// so we don't pull in its ambient dependencies.
+vi.mock("@/stores/threadStore", () => ({
+  useThreadStore: {
+    getState: () => ({ clearToolCallRecordCache: vi.fn() }),
+  },
+}));
+
+import {
+  useIdleReclamation,
+  CLEAR_TERMINAL_BUFFERS_EVENT,
+} from "@/hooks/useIdleReclamation";
+
+describe("useIdleReclamation (regression #305)", () => {
+  beforeEach(() => {
+    setBackground.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Previously, after 60s of background idle the hook dispatched
+  // CLEAR_TERMINAL_BUFFERS_EVENT, which wiped xterm scrollback. Users reported
+  // their terminal content vanishing after leaving the app for a minute —
+  // that's the bug. Server-side idle reclamation still runs; only the
+  // destructive frontend buffer wipe must be gone.
+  it("does not dispatch CLEAR_TERMINAL_BUFFERS_EVENT on background idle", () => {
+    const listener = vi.fn();
+    window.addEventListener(CLEAR_TERMINAL_BUFFERS_EVENT, listener);
+
+    renderHook(() => useIdleReclamation());
+
+    window.dispatchEvent(new Event("blur"));
+    vi.advanceTimersByTime(61_000);
+
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(CLEAR_TERMINAL_BUFFERS_EVENT, listener);
+  });
+
+  it("still notifies the server to enter background idle", () => {
+    renderHook(() => useIdleReclamation());
+
+    window.dispatchEvent(new Event("blur"));
+    vi.advanceTimersByTime(61_000);
+
+    expect(setBackground).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/web/src/__tests__/useIdleReclamation.test.tsx
+++ b/apps/web/src/__tests__/useIdleReclamation.test.tsx
@@ -19,10 +19,12 @@ vi.mock("@/stores/threadStore", () => ({
   },
 }));
 
-import {
-  useIdleReclamation,
-  CLEAR_TERMINAL_BUFFERS_EVENT,
-} from "@/hooks/useIdleReclamation";
+import { useIdleReclamation } from "@/hooks/useIdleReclamation";
+
+// Inlined literal: the hook previously dispatched this event to wipe xterm
+// scrollback after 60s of blur. The symbol is gone from the module — this
+// test asserts the dispatch is gone by name, not by import.
+const LEGACY_CLEAR_EVENT = "mcode:clear-terminal-buffers";
 
 describe("useIdleReclamation (regression #305)", () => {
   beforeEach(() => {
@@ -35,13 +37,13 @@ describe("useIdleReclamation (regression #305)", () => {
   });
 
   // Previously, after 60s of background idle the hook dispatched
-  // CLEAR_TERMINAL_BUFFERS_EVENT, which wiped xterm scrollback. Users reported
+  // LEGACY_CLEAR_EVENT, which wiped xterm scrollback. Users reported
   // their terminal content vanishing after leaving the app for a minute —
   // that's the bug. Server-side idle reclamation still runs; only the
   // destructive frontend buffer wipe must be gone.
-  it("does not dispatch CLEAR_TERMINAL_BUFFERS_EVENT on background idle", () => {
+  it("does not dispatch LEGACY_CLEAR_EVENT on background idle", () => {
     const listener = vi.fn();
-    window.addEventListener(CLEAR_TERMINAL_BUFFERS_EVENT, listener);
+    window.addEventListener(LEGACY_CLEAR_EVENT, listener);
 
     renderHook(() => useIdleReclamation());
 
@@ -49,7 +51,7 @@ describe("useIdleReclamation (regression #305)", () => {
     vi.advanceTimersByTime(61_000);
 
     expect(listener).not.toHaveBeenCalled();
-    window.removeEventListener(CLEAR_TERMINAL_BUFFERS_EVENT, listener);
+    window.removeEventListener(LEGACY_CLEAR_EVENT, listener);
   });
 
   it("still notifies the server to enter background idle", () => {

--- a/apps/web/src/components/terminal/TerminalPanel.tsx
+++ b/apps/web/src/components/terminal/TerminalPanel.tsx
@@ -97,7 +97,18 @@ export function TerminalPanel() {
    */
   const closeAllTerminals = useCallback(() => {
     if (!activeThreadId) return;
-    getTransport().terminalKillByThread(activeThreadId).catch(() => {});
+    // Optimistically collapse the UI so the bin button feels instant; log
+    // kill failures (rather than swallowing) so leaked PTYs surface in the
+    // console for diagnosis.
+    getTransport()
+      .terminalKillByThread(activeThreadId)
+      .catch((err) => {
+        console.error(
+          "Failed to kill terminals for thread",
+          activeThreadId,
+          err,
+        );
+      });
     removeAllTerminals(activeThreadId);
     hideTerminalPanel(activeThreadId);
   }, [activeThreadId]);

--- a/apps/web/src/components/terminal/TerminalPanel.tsx
+++ b/apps/web/src/components/terminal/TerminalPanel.tsx
@@ -18,6 +18,7 @@ const {
   addTerminal: storeAddTerminal,
   removeTerminal: storeRemoveTerminal,
   removeAllTerminals,
+  hideTerminalPanel,
   setTerminalPanelHeight,
 } = useTerminalStore.getState();
 
@@ -89,11 +90,16 @@ export function TerminalPanel() {
     [],
   );
 
-  /** Kills and removes all terminals for the active thread. */
+  /**
+   * Kills and removes all terminals for the active thread, then collapses the
+   * panel. Leaving the empty panel open after hitting the bin was confusing —
+   * users had to toggle it shut manually (issue #303).
+   */
   const closeAllTerminals = useCallback(() => {
     if (!activeThreadId) return;
     getTransport().terminalKillByThread(activeThreadId).catch(() => {});
     removeAllTerminals(activeThreadId);
+    hideTerminalPanel(activeThreadId);
   }, [activeThreadId]);
 
   if (!panelVisible || !activeThreadId) {

--- a/apps/web/src/components/terminal/TerminalView.tsx
+++ b/apps/web/src/components/terminal/TerminalView.tsx
@@ -4,7 +4,6 @@ import type { FitAddon } from "@xterm/addon-fit";
 import { getTransport } from "@/transport";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { shouldInterceptKeyEvent } from "./terminalKeyHandler";
-import { CLEAR_TERMINAL_BUFFERS_EVENT } from "@/hooks/useIdleReclamation";
 // Static import so bundler deduplicates the stylesheet
 import "@xterm/xterm/css/xterm.css";
 
@@ -170,23 +169,36 @@ export function TerminalView({ ptyId, visible }: TerminalViewProps) {
     };
   }, [ptyId]);
 
-  // Re-fit when visibility changes (ResizeObserver handles the rest)
+  // Restore the terminal whenever it becomes visible again — either because
+  // the panel was toggled open or the window/tab regained focus. xterm's DOM
+  // renderer can miss repaints after long background stints, and the helper
+  // textarea sometimes loses focus so typing (spacebar especially) silently
+  // stops reaching the PTY. Fit -> refresh -> focus covers all three symptoms
+  // reported in issue #305.
   useEffect(() => {
-    if (visible && fitAddonRef.current) {
-      fitAddonRef.current.fit();
-    }
-  }, [visible]);
+    const restore = () => {
+      if (!visible) return;
+      const term = termRef.current;
+      if (!term) return;
+      fitAddonRef.current?.fit();
+      term.refresh(0, term.rows - 1);
+      term.focus();
+    };
 
-  // Clear scrollback buffer during background idle to release memory
-  useEffect(() => {
-    const handleClearBuffers = () => {
-      termRef.current?.clear();
+    restore();
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        restore();
+      }
     };
-    window.addEventListener(CLEAR_TERMINAL_BUFFERS_EVENT, handleClearBuffers);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("focus", restore);
     return () => {
-      window.removeEventListener(CLEAR_TERMINAL_BUFFERS_EVENT, handleClearBuffers);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("focus", restore);
     };
-  }, []);
+  }, [visible]);
 
   // Sync scrollback setting to live terminal without remounting
   useEffect(() => {

--- a/apps/web/src/components/terminal/TerminalView.tsx
+++ b/apps/web/src/components/terminal/TerminalView.tsx
@@ -169,34 +169,41 @@ export function TerminalView({ ptyId, visible }: TerminalViewProps) {
     };
   }, [ptyId]);
 
-  // Restore the terminal whenever it becomes visible again — either because
-  // the panel was toggled open or the window/tab regained focus. xterm's DOM
-  // renderer can miss repaints after long background stints, and the helper
-  // textarea sometimes loses focus so typing (spacebar especially) silently
-  // stops reaching the PTY. Fit -> refresh -> focus covers all three symptoms
-  // reported in issue #305.
+  // When the panel is toggled open (visible: false -> true) we refit and
+  // intentionally pull focus into xterm so the user can start typing
+  // immediately. Focus is deliberately NOT moved on window/tab return —
+  // doing so would steal focus from the composer whenever the user
+  // alt-tabs back, contradicting the Ctrl+J-from-composer workflow.
   useEffect(() => {
-    const restore = () => {
+    if (!visible) return;
+    const term = termRef.current;
+    if (!term) return;
+    fitAddonRef.current?.fit();
+    term.refresh(0, term.rows - 1);
+    term.focus();
+  }, [visible]);
+
+  // Repaint xterm's DOM renderer when the window/tab regains visibility.
+  // Long background stints leave the canvas half-painted; fit + refresh is
+  // idempotent and cheap, and crucially skips term.focus() so we don't
+  // yank focus out of whatever the user was typing in (issue #305).
+  useEffect(() => {
+    const repaint = () => {
       if (!visible) return;
       const term = termRef.current;
       if (!term) return;
       fitAddonRef.current?.fit();
       term.refresh(0, term.rows - 1);
-      term.focus();
     };
-
-    restore();
 
     const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        restore();
-      }
+      if (document.visibilityState === "visible") repaint();
     };
     document.addEventListener("visibilitychange", onVisibilityChange);
-    window.addEventListener("focus", restore);
+    window.addEventListener("focus", repaint);
     return () => {
       document.removeEventListener("visibilitychange", onVisibilityChange);
-      window.removeEventListener("focus", restore);
+      window.removeEventListener("focus", repaint);
     };
   }, [visible]);
 

--- a/apps/web/src/config/default-keybindings.json
+++ b/apps/web/src/config/default-keybindings.json
@@ -3,7 +3,7 @@
   { "key": "mod+n", "command": "thread.new", "when": "!inputFocused" },
   { "key": "mod+shift+n", "command": "workspace.new", "when": "!inputFocused" },
   { "key": "mod+\\", "command": "sidebar.toggle", "when": "!inputFocused" },
-  { "key": "mod+j", "command": "terminal.toggle", "when": "!inputFocused" },
+  { "key": "mod+j", "command": "terminal.toggle" },
   { "key": "mod+,", "command": "settings.open", "when": "!inputFocused" },
   { "key": "mod+shift+?", "command": "shortcuts.help", "when": "!inputFocused" },
   { "key": "mod+o", "command": "explorer.open", "when": "!inputFocused" },

--- a/apps/web/src/hooks/useIdleReclamation.ts
+++ b/apps/web/src/hooks/useIdleReclamation.ts
@@ -13,14 +13,6 @@ import { useThreadStore } from "@/stores/threadStore";
 const BACKGROUND_IDLE_DELAY_MS = 60_000;
 
 /**
- * Historical custom event name. Kept exported so any lingering listeners can
- * be cleaned up safely, but the hook no longer dispatches it — clearing xterm
- * scrollback during background idle destroyed terminal content users expected
- * to find when returning to the app (issue #305).
- */
-export const CLEAR_TERMINAL_BUFFERS_EVENT = "mcode:clear-terminal-buffers";
-
-/**
  * Hook that manages frontend idle reclamation.
  * Mount once in the root App component.
  */

--- a/apps/web/src/hooks/useIdleReclamation.ts
+++ b/apps/web/src/hooks/useIdleReclamation.ts
@@ -1,8 +1,7 @@
 /**
  * Coordinates client-side memory reclamation during background idle.
- * After 60 seconds of window blur: evicts the tool call record cache,
- * dispatches a terminal buffer clear event, and notifies the server
- * to enter background idle mode.
+ * After 60 seconds of window blur: evicts the tool call record cache and
+ * notifies the server to enter background idle mode.
  * On focus: notifies the server to restore normal operation.
  */
 
@@ -13,7 +12,12 @@ import { useThreadStore } from "@/stores/threadStore";
 /** Delay before entering background idle after window blur (ms). */
 const BACKGROUND_IDLE_DELAY_MS = 60_000;
 
-/** Custom event name dispatched to clear all terminal scrollback buffers. */
+/**
+ * Historical custom event name. Kept exported so any lingering listeners can
+ * be cleaned up safely, but the hook no longer dispatches it — clearing xterm
+ * scrollback during background idle destroyed terminal content users expected
+ * to find when returning to the app (issue #305).
+ */
 export const CLEAR_TERMINAL_BUFFERS_EVENT = "mcode:clear-terminal-buffers";
 
 /**
@@ -44,9 +48,6 @@ export function useIdleReclamation(): void {
 
         // Evict client-side caches
         useThreadStore.getState().clearToolCallRecordCache();
-
-        // Clear terminal scrollback buffers
-        window.dispatchEvent(new CustomEvent(CLEAR_TERMINAL_BUFFERS_EVENT));
       }, BACKGROUND_IDLE_DELAY_MS);
     };
 


### PR DESCRIPTION
## What
Four targeted fixes that stabilise the embedded xterm.js terminal: keyboard ergonomics, panel state, and recovery from app backgrounding.

## Why
Reported by the user during a deep-research session on terminal stability. The bottom panel was hard to dismiss, Ctrl+J was unusable from the chat composer, and the terminal silently lost content (or stopped accepting space) after the app sat in the background for a minute.

## Key Changes
- **#304 — Ctrl+J anywhere** Drop the `!inputFocused` gate from the `terminal.toggle` keybinding so the panel toggles even when the composer has focus. The shortcut layer already calls `preventDefault()` on match, so no stray linefeed reaches the input.
- **#303 — Bin button collapses the panel** `closeAllTerminals` now hides the panel after killing the PTY processes. Height is preserved so the next open restores the previous size.
- **#305 — Survive backgrounding** Stop dispatching `CLEAR_TERMINAL_BUFFERS_EVENT` on idle (it was wiping xterm scrollback after 60 s and erasing what users came back to). Add a `visibilitychange` / `window.focus` repaint that runs `fit + refresh` to recover xterm's DOM renderer. Server-side idle reclamation still runs.
- **#316 — Space key regression guard** Audit confirmed nothing intercepts space; pinned with regression tests in `terminalKeyHandler` to prevent reintroduction.
- **Code-review follow-up** Split focus from repaint in the visibility handler. `term.focus()` only fires on the panel-toggle transition; window/tab refocus does the idempotent repaint without stealing focus from the composer (would have contradicted #304). Removed the dead `CLEAR_TERMINAL_BUFFERS_EVENT` export.

Verified: 752 tests passing, typecheck clean across web + server + desktop.

Closes #303
Closes #304
Closes #305
Closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal panel now automatically collapses when deleting all terminals.
  * Terminal toggle shortcut (Ctrl/Cmd+J) now works even when text inputs are focused.

* **Bug Fixes**
  * Improved terminal repaint/refresh when returning to foreground without stealing keyboard focus.
  * Removed legacy automatic terminal buffer clearing on idle.
  * Terminal kill failures are now surfaced to console instead of being silently ignored.

* **Tests**
  * Added tests covering terminal UI, focus/visibility behavior, shortcuts, and idle reclamation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->