### PR TITLE
fix(slash-commands): comprehensive fix for intermittent loading failures

### DIFF
--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -37,6 +37,7 @@ import { AttachmentService } from "./services/attachment-service";
 import { SnapshotService } from "./services/snapshot-service";
 import { SettingsService } from "./services/settings-service";
 import { GitWatcherService } from "./services/git-watcher-service";
+import { SkillWatcherService } from "./services/skill-watcher-service";
 import { MemoryPressureService } from "./services/memory-pressure-service";
 import { CleanupWorker } from "./services/cleanup-worker";
 import { PrDraftService } from "./services/pr-draft-service";
@@ -210,6 +211,11 @@ export function setupContainer(): typeof container {
   container.register(
     GitWatcherService,
     { useClass: GitWatcherService },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    SkillWatcherService,
+    { useClass: SkillWatcherService },
     { lifecycle: Lifecycle.Singleton },
   );
   container.register(

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -32,6 +32,7 @@ import { TaskRepo } from "./repositories/task-repo";
 import { SnapshotService } from "./services/snapshot-service";
 import { SettingsService } from "./services/settings-service";
 import { GitWatcherService } from "./services/git-watcher-service";
+import { SkillWatcherService } from "./services/skill-watcher-service";
 import { MemoryPressureService } from "./services/memory-pressure-service";
 import { WorkspaceRepo } from "./repositories/workspace-repo";
 import { CleanupWorker } from "./services/cleanup-worker";
@@ -122,6 +123,7 @@ const turnSnapshotRepo = container.resolve(TurnSnapshotRepo);
 const snapshotService = container.resolve(SnapshotService);
 const settingsService = container.resolve(SettingsService);
 const gitWatcherService = container.resolve(GitWatcherService);
+const skillWatcherService = container.resolve(SkillWatcherService);
 const memoryPressureService = container.resolve(MemoryPressureService);
 const taskRepo = container.resolve(TaskRepo);
 const workspaceRepo = container.resolve(WorkspaceRepo); // Used only for startup watcher initialization
@@ -178,6 +180,10 @@ const allWorkspaces = workspaceRepo.listAll();
 for (const ws of allWorkspaces) {
   gitWatcherService.watchWorkspace(ws.id, ws.path);
 }
+
+// Begin watching the user's Claude skills/commands/plugins directories so the
+// skill registry stays current without a server restart.
+skillWatcherService.start();
 
 // Seed CI check watcher with all threads that have open PRs
 {
@@ -429,6 +435,9 @@ async function shutdown(): Promise<void> {
 
   // 7. Dispose all git HEAD file watchers
   gitWatcherService.dispose();
+
+  // 7a. Stop all skill / plugin directory watchers
+  skillWatcherService.stopAll();
 
   // 8. Dispose memory pressure timers
   memoryPressureService.dispose();

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -1,0 +1,103 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { SkillService } from "./skill-service.js";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "skill-svc-"));
+}
+
+function writeMd(path: string, frontmatter: Record<string, string>, body = "") {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n");
+  writeFileSync(path, `---\n${fm}\n---\n${body}`);
+}
+
+describe("SkillService", () => {
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    fakeHome = tmp();
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome; // Windows
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    if (originalUserProfile !== undefined) process.env.USERPROFILE = originalUserProfile;
+    else delete process.env.USERPROFILE;
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it("scans commands/*.md as command-kind entries", () => {
+    const cmdDir = join(fakeHome, ".claude", "plugins", "cache", "mp", "superpowers", "5.0.7", "commands");
+    mkdirSync(cmdDir, { recursive: true });
+    writeMd(join(cmdDir, "brainstorm.md"), { description: "Brainstorm an idea" });
+
+    const svc = new SkillService();
+    const items = svc.list();
+
+    const brainstorm = items.find((i) => i.name === "superpowers:brainstorm");
+    expect(brainstorm).toBeDefined();
+    expect(brainstorm!.kind).toBe("command");
+    expect(brainstorm!.description).toBe("Brainstorm an idea");
+    expect(brainstorm!.source).toBe("plugin");
+  });
+
+  it("scans plugin skills nested under <version>/.claude/skills", () => {
+    const skillDir = join(fakeHome, ".claude", "plugins", "cache", "mp", "impeccable", "2.1.1", ".claude", "skills", "audit");
+    mkdirSync(skillDir, { recursive: true });
+    writeMd(join(skillDir, "SKILL.md"), { description: "Run audit checks" });
+
+    const items = new SkillService().list();
+    expect(items.find((i) => i.name === "impeccable:audit")).toMatchObject({
+      kind: "skill",
+      description: "Run audit checks",
+    });
+  });
+
+  it("scans project-level <cwd>/.claude/commands/*.md", () => {
+    const cwd = tmp();
+    const cmdDir = join(cwd, ".claude", "commands");
+    mkdirSync(cmdDir, { recursive: true });
+    writeMd(join(cmdDir, "deploy.md"), { description: "Deploy to staging" });
+
+    const items = new SkillService().list(cwd);
+    const deploy = items.find((i) => i.name === "deploy");
+    expect(deploy).toMatchObject({
+      kind: "command",
+      source: "project",
+      description: "Deploy to staging",
+    });
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("dedupes by name with priority user > project > agent > plugin", () => {
+    const userDir = join(fakeHome, ".claude", "skills", "shared");
+    const pluginDir = join(fakeHome, ".claude", "plugins", "cache", "mp", "p", "1.0.0", "skills", "shared");
+    mkdirSync(userDir, { recursive: true });
+    mkdirSync(pluginDir, { recursive: true });
+    writeMd(join(userDir, "SKILL.md"), { description: "User wins" });
+    writeMd(join(pluginDir, "SKILL.md"), { description: "Plugin loses" });
+
+    const items = new SkillService().list();
+    const shared = items.find((i) => i.name === "shared");
+    expect(shared!.description).toBe("User wins");
+    expect(shared!.source).toBe("user");
+  });
+
+  it("returns empty diagnostics with no error when paths are missing", () => {
+    const diag = new SkillService().diagnose();
+    expect(diag.errors).toEqual([]);
+    expect(diag.scanned.every((s) => s.existed === false || s.entries >= 0)).toBe(true);
+  });
+});

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -100,4 +100,36 @@ describe("SkillService", () => {
     expect(diag.errors).toEqual([]);
     expect(diag.scanned.every((s) => s.existed === false || s.entries >= 0)).toBe(true);
   });
+
+  it("invokes subscribers on invalidate() and stops after unsubscribe", () => {
+    const svc = new SkillService();
+    let calls = 0;
+    const unsub = svc.subscribe(() => {
+      calls++;
+    });
+
+    svc.invalidate();
+    expect(calls).toBe(1);
+
+    svc.invalidate();
+    expect(calls).toBe(2);
+
+    unsub();
+    svc.invalidate();
+    expect(calls).toBe(2); // unchanged after unsubscribe
+  });
+
+  it("isolates subscriber errors so later subscribers still fire", () => {
+    const svc = new SkillService();
+    let secondFired = false;
+    svc.subscribe(() => {
+      throw new Error("first subscriber boom");
+    });
+    svc.subscribe(() => {
+      secondFired = true;
+    });
+
+    expect(() => svc.invalidate()).not.toThrow();
+    expect(secondFired).toBe(true);
+  });
 });

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -95,6 +95,23 @@ describe("SkillService", () => {
     expect(shared!.source).toBe("user");
   });
 
+  it("skips skill subdirs that lack SKILL.md", () => {
+    // Two siblings under the user skills root: one is a real skill, the
+    // other is a helper folder (e.g., shared utilities, scaffolding scripts).
+    // Without the SKILL.md guard, the helper would surface as an empty
+    // command in the popup.
+    const realDir = join(fakeHome, ".claude", "skills", "real-skill");
+    const helperDir = join(fakeHome, ".claude", "skills", "_helpers");
+    mkdirSync(realDir, { recursive: true });
+    mkdirSync(helperDir, { recursive: true });
+    writeMd(join(realDir, "SKILL.md"), { description: "A real skill" });
+    // helperDir intentionally has no SKILL.md.
+
+    const items = new SkillService().list();
+    expect(items.find((i) => i.name === "real-skill")).toBeDefined();
+    expect(items.find((i) => i.name === "_helpers")).toBeUndefined();
+  });
+
   it("returns empty diagnostics with no error when paths are missing", () => {
     const diag = new SkillService().diagnose();
     expect(diag.errors).toEqual([]);

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -191,11 +191,18 @@ export class SkillService {
     return result.diag;
   }
 
-  /** Clear the in-memory cache and notify subscribers. */
+  /** Clear the in-memory cache and notify subscribers. Subscriber errors are isolated. */
   invalidate(): void {
     this.cache = null;
     this.cachedCwd = undefined;
-    for (const cb of this.subscribers) cb();
+    for (const cb of this.subscribers) {
+      try {
+        cb();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.debug("SkillService: subscriber threw", { message });
+      }
+    }
   }
 
   /** Register a callback fired whenever the cache is invalidated. Returns an unsubscribe. */

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -124,6 +124,10 @@ function scanPluginVersionDir(
   }
 }
 
+/** Numeric collator orders `2.1.0` before `10.0.0` instead of lexically.
+ *  Avoids pulling in the `semver` dep just for plugin-cache version selection. */
+const VERSION_COLLATOR = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+
 /** Walk plugin cache: cache/<marketplace>/<plugin>/<version>/. */
 function scanPluginCacheDir(ctx: ScanContext, cacheDir: string): void {
   for (const mp of scanDir(ctx, cacheDir)) {
@@ -135,7 +139,7 @@ function scanPluginCacheDir(ctx: ScanContext, cacheDir: string): void {
       const versions = scanDir(ctx, pluginDir)
         .filter((e) => e.isDirectory())
         .map((e) => e.name)
-        .sort();
+        .sort(VERSION_COLLATOR.compare);
       if (versions.length === 0) continue;
       scanPluginVersionDir(ctx, join(pluginDir, versions[versions.length - 1]), plugin.name);
     }

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -1,22 +1,37 @@
 /**
- * Skill scanning service.
- * Discovers skills from user, project, agent, and plugin directories.
- * Extracted from apps/desktop/src/main/skills.ts.
+ * Skill and command scanning service.
+ * Walks user, project, agent, and plugin directories looking for both
+ * `skills/` (each subdirectory is a skill) and `commands/` (each .md file
+ * is a command). Mirrors Claude Code's native discovery.
  */
 
 import { injectable } from "tsyringe";
-import { readdirSync, readFileSync } from "fs";
+import { readdirSync, readFileSync, type Dirent } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import type { SkillInfo } from "@mcode/contracts";
+import { logger } from "@mcode/shared";
+import type { SkillInfo, SkillSource, SkillDiagnostics } from "@mcode/contracts";
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
 const DESC_RE = /^description:\s*(?:"([^"]*)"|'([^']*)'|(.*))$/m;
 
-/** Extract description from a SKILL.md file's frontmatter. */
-function readSkillDescription(skillDir: string): string {
+interface ScanContext {
+  out: Map<string, SkillInfo>;
+  diag: SkillDiagnostics;
+}
+
+/** Source priority: lower number = higher priority (overrides on duplicate name). */
+const SOURCE_PRIORITY: Record<SkillSource, number> = {
+  user: 0,
+  project: 1,
+  agent: 2,
+  plugin: 3,
+};
+
+/** Extract `description:` from the leading YAML frontmatter of a markdown file. */
+function readDescription(filePath: string): string {
   try {
-    const content = readFileSync(join(skillDir, "SKILL.md"), "utf-8");
+    const content = readFileSync(filePath, "utf-8");
     const fm = FRONTMATTER_RE.exec(content);
     if (!fm) return "";
     const desc = DESC_RE.exec(fm[1]);
@@ -27,111 +42,190 @@ function readSkillDescription(skillDir: string): string {
   }
 }
 
-/** Safely read directory entries with file-type info. Returns [] on any error. */
-function safeDirEntries(dir: string): import("fs").Dirent[] {
+/** Read a directory, recording each scan attempt in diagnostics. Never throws. */
+function scanDir(ctx: ScanContext, dir: string): Dirent[] {
+  let entries: Dirent[];
   try {
-    return readdirSync(dir, { withFileTypes: true });
-  } catch {
+    entries = readdirSync(dir, { withFileTypes: true });
+    ctx.diag.scanned.push({ path: dir, existed: true, entries: entries.length });
+    return entries;
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === "ENOENT") {
+      ctx.diag.scanned.push({ path: dir, existed: false, entries: 0 });
+    } else {
+      ctx.diag.errors.push({ path: dir, message: error.message });
+      logger.debug("SkillService: scan error", { dir, message: error.message });
+    }
     return [];
   }
 }
 
-/** Scan a flat skills directory where each subdirectory is a skill. */
-function scanFlatSkillsDir(
+/** Set entry only if absent OR the new source has higher priority than the existing one. */
+function setIfHigherPriority(out: Map<string, SkillInfo>, info: SkillInfo): void {
+  const existing = out.get(info.name);
+  if (!existing || SOURCE_PRIORITY[info.source] < SOURCE_PRIORITY[existing.source]) {
+    out.set(info.name, info);
+  }
+}
+
+/** Walk a flat skills directory: each subdir with `SKILL.md` is a skill. */
+function scanSkillsDir(
+  ctx: ScanContext,
   dir: string,
   prefix: string,
-  out: Map<string, SkillInfo>,
+  source: SkillSource,
 ): void {
-  const entries = safeDirEntries(dir);
-  for (let i = 0; i < entries.length; i++) {
-    const entry = entries[i];
+  for (const entry of scanDir(ctx, dir)) {
     if (!entry.isDirectory()) continue;
-    const displayName = prefix ? `${prefix}:${entry.name}` : entry.name;
-    if (out.has(displayName)) continue;
-    out.set(displayName, {
-      name: displayName,
-      description: readSkillDescription(join(dir, entry.name)),
+    const name = prefix ? `${prefix}:${entry.name}` : entry.name;
+    setIfHigherPriority(ctx.out, {
+      name,
+      description: readDescription(join(dir, entry.name, "SKILL.md")),
+      kind: "skill",
+      source,
     });
+    ctx.diag.totalSkills++;
   }
 }
 
-/** Scan plugin cache directory (versioned, takes latest version per plugin). */
-function scanPluginCacheDir(
-  cacheDir: string,
-  out: Map<string, SkillInfo>,
+/** Walk a flat commands directory: each *.md is a command. */
+function scanCommandsDir(
+  ctx: ScanContext,
+  dir: string,
+  prefix: string,
+  source: SkillSource,
 ): void {
-  const marketplaces = safeDirEntries(cacheDir);
-  for (let m = 0; m < marketplaces.length; m++) {
-    if (!marketplaces[m].isDirectory()) continue;
-    const mDir = join(cacheDir, marketplaces[m].name);
-    const plugins = safeDirEntries(mDir);
-    for (let p = 0; p < plugins.length; p++) {
-      if (!plugins[p].isDirectory()) continue;
-      const pDir = join(mDir, plugins[p].name);
-      const versions: string[] = [];
-      const vEntries = safeDirEntries(pDir);
-      for (let v = 0; v < vEntries.length; v++) {
-        if (vEntries[v].isDirectory()) versions.push(vEntries[v].name);
-      }
+  for (const entry of scanDir(ctx, dir)) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+    const baseName = entry.name.slice(0, -3);
+    const name = prefix ? `${prefix}:${baseName}` : baseName;
+    setIfHigherPriority(ctx.out, {
+      name,
+      description: readDescription(join(dir, entry.name)),
+      kind: "command",
+      source,
+    });
+    ctx.diag.totalCommands++;
+  }
+}
+
+/** Scan every known surface inside one plugin version directory. */
+function scanPluginVersionDir(
+  ctx: ScanContext,
+  versionDir: string,
+  pluginName: string,
+): void {
+  // Both bare and `.claude`-prefixed shapes are observed in the wild.
+  for (const sub of ["", ".claude"]) {
+    const base = sub ? join(versionDir, sub) : versionDir;
+    scanSkillsDir(ctx, join(base, "skills"), pluginName, "plugin");
+    scanCommandsDir(ctx, join(base, "commands"), pluginName, "plugin");
+  }
+}
+
+/** Walk plugin cache: cache/<marketplace>/<plugin>/<version>/. */
+function scanPluginCacheDir(ctx: ScanContext, cacheDir: string): void {
+  for (const mp of scanDir(ctx, cacheDir)) {
+    if (!mp.isDirectory()) continue;
+    const mpDir = join(cacheDir, mp.name);
+    for (const plugin of scanDir(ctx, mpDir)) {
+      if (!plugin.isDirectory()) continue;
+      const pluginDir = join(mpDir, plugin.name);
+      const versions = scanDir(ctx, pluginDir)
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort();
       if (versions.length === 0) continue;
-      versions.sort();
-      const skillsDir = join(
-        pDir,
-        versions[versions.length - 1],
-        "skills",
-      );
-      scanFlatSkillsDir(skillsDir, plugins[p].name, out);
+      scanPluginVersionDir(ctx, join(pluginDir, versions[versions.length - 1]), plugin.name);
     }
   }
 }
 
-/** Scan plugin marketplaces directory (unversioned). */
-function scanPluginMarketplaceDir(
-  marketplacesDir: string,
-  out: Map<string, SkillInfo>,
-): void {
-  const marketplaces = safeDirEntries(marketplacesDir);
-  for (let m = 0; m < marketplaces.length; m++) {
-    if (!marketplaces[m].isDirectory()) continue;
-    const mDir = join(marketplacesDir, marketplaces[m].name);
-    const plugins = safeDirEntries(mDir);
-    for (let p = 0; p < plugins.length; p++) {
-      if (!plugins[p].isDirectory()) continue;
-      const skillsDir = join(mDir, plugins[p].name, "skills");
-      scanFlatSkillsDir(skillsDir, plugins[p].name, out);
+/** Walk plugin marketplaces: marketplaces/<marketplace>/<plugin>/. */
+function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string): void {
+  for (const mp of scanDir(ctx, marketplacesDir)) {
+    if (!mp.isDirectory()) continue;
+    const mpDir = join(marketplacesDir, mp.name);
+    for (const plugin of scanDir(ctx, mpDir)) {
+      if (!plugin.isDirectory()) continue;
+      const pluginDir = join(mpDir, plugin.name);
+      // Marketplaces are unversioned — treat the plugin dir itself as the version dir.
+      scanPluginVersionDir(ctx, pluginDir, plugin.name);
     }
   }
 }
 
-/** Scans the filesystem for available skills from all sources. */
+/** Discovers skills and commands across user, project, agent, and plugin sources. */
 @injectable()
 export class SkillService {
+  /** Cached result; null means cold or invalidated. */
+  private cache: SkillInfo[] | null = null;
+  private cachedCwd: string | undefined = undefined;
+  private subscribers = new Set<() => void>();
+
   /**
-   * List all available skills from every source, in priority order:
-   * 1. Local user skills (~/.claude/skills/)
-   * 2. Project skills (<cwd>/.claude/skills/)
-   * 3. Agent skills (~/.claude/.agents/skills/)
-   * 4. Plugin cache (~/.claude/plugins/cache/)
-   * 5. Plugin marketplaces (~/.claude/plugins/marketplaces/)
+   * List every skill and command discoverable from disk.
+   * Sources, in priority order (higher overrides lower for duplicate names):
+   * 1. `~/.claude/skills/` (user)
+   * 2. `~/.claude/commands/` (user)
+   * 3. `<cwd>/.claude/skills/` (project)
+   * 4. `<cwd>/.claude/commands/` (project)
+   * 5. `~/.claude/.agents/skills/` (agent)
+   * 6. `~/.claude/plugins/cache/...` (plugin)
+   * 7. `~/.claude/plugins/marketplaces/...` (plugin)
    */
   list(cwd?: string): SkillInfo[] {
+    if (this.cache && this.cachedCwd === cwd) return this.cache;
+    const result = this.scan(cwd);
+    this.cache = result.items;
+    this.cachedCwd = cwd;
+    return result.items;
+  }
+
+  /** Force a full rescan and return per-path diagnostics. */
+  diagnose(cwd?: string): SkillDiagnostics {
+    const result = this.scan(cwd);
+    this.cache = result.items;
+    this.cachedCwd = cwd;
+    return result.diag;
+  }
+
+  /** Clear the in-memory cache and notify subscribers. */
+  invalidate(): void {
+    this.cache = null;
+    this.cachedCwd = undefined;
+    for (const cb of this.subscribers) cb();
+  }
+
+  /** Register a callback fired whenever the cache is invalidated. Returns an unsubscribe. */
+  subscribe(cb: () => void): () => void {
+    this.subscribers.add(cb);
+    return () => {
+      this.subscribers.delete(cb);
+    };
+  }
+
+  private scan(cwd?: string): { items: SkillInfo[]; diag: SkillDiagnostics } {
     const home = homedir();
     const claudeDir = join(home, ".claude");
-    const out = new Map<string, SkillInfo>();
+    const ctx: ScanContext = {
+      out: new Map(),
+      diag: { scanned: [], errors: [], totalSkills: 0, totalCommands: 0 },
+    };
 
-    scanFlatSkillsDir(join(claudeDir, "skills"), "", out);
+    scanSkillsDir(ctx, join(claudeDir, "skills"), "", "user");
+    scanCommandsDir(ctx, join(claudeDir, "commands"), "", "user");
 
     if (cwd) {
-      scanFlatSkillsDir(join(cwd, ".claude", "skills"), "", out);
+      scanSkillsDir(ctx, join(cwd, ".claude", "skills"), "", "project");
+      scanCommandsDir(ctx, join(cwd, ".claude", "commands"), "", "project");
     }
 
-    scanFlatSkillsDir(join(claudeDir, ".agents", "skills"), "", out);
-    scanPluginCacheDir(join(claudeDir, "plugins", "cache"), out);
-    scanPluginMarketplaceDir(
-      join(claudeDir, "plugins", "marketplaces"),
-      out,
-    );
+    scanSkillsDir(ctx, join(claudeDir, ".agents", "skills"), "", "agent");
+    scanPluginCacheDir(ctx, join(claudeDir, "plugins", "cache"));
+    scanPluginMarketplaceDir(ctx, join(claudeDir, "plugins", "marketplaces"));
 
-    return Array.from(out.values());
+    return { items: Array.from(ctx.out.values()), diag: ctx.diag };
   }
 }

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable } from "tsyringe";
-import { readdirSync, readFileSync, type Dirent } from "fs";
+import { readdirSync, readFileSync, existsSync, type Dirent } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { logger } from "@mcode/shared";
@@ -78,10 +78,15 @@ function scanSkillsDir(
 ): void {
   for (const entry of scanDir(ctx, dir)) {
     if (!entry.isDirectory()) continue;
+    // Only treat a subdir as a skill if it has SKILL.md. Helper folders
+    // (e.g., `_shared/`, `node_modules/`) and partially installed plugin
+    // dirs would otherwise become empty slash-command entries.
+    const skillFile = join(dir, entry.name, "SKILL.md");
+    if (!existsSync(skillFile)) continue;
     const name = prefix ? `${prefix}:${entry.name}` : entry.name;
     setIfHigherPriority(ctx.out, {
       name,
-      description: readDescription(join(dir, entry.name, "SKILL.md")),
+      description: readDescription(skillFile),
       kind: "skill",
       source,
     });

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -78,6 +78,30 @@ describe("SkillWatcherService", () => {
     expect((watcher as unknown as { watchers: unknown[] }).watchers.length).toBe(1);
   });
 
+  it("auto-registers a root that is created after start()", async () => {
+    // Simulates a fresh-install scenario: ~/.claude exists but the
+    // skills/commands/plugins child dirs don't yet. Without parent-dir
+    // watching, those roots would never be picked up until a process
+    // restart.
+    const root = join(dir, "skills");
+    // dir (parent) exists; root does not.
+
+    watcher.start({ parentDir: dir, roots: [root] });
+
+    // Create the missing root after start() — this should be observed by
+    // the parent watcher and trigger a delayed registration of `root`.
+    mkdirSync(root, { recursive: true });
+    // Allow the parent fs.watch event to flush and onParentChange() to
+    // call watch(root). 150ms is well above OS event coalescing windows.
+    await new Promise((r) => setTimeout(r, 150));
+
+    // Now a change inside the late-registered root should invalidate.
+    const invalidateSpy = vi.spyOn(svc, "invalidate");
+    writeFileSync(join(root, "marker.txt"), "x");
+    await new Promise((r) => setTimeout(r, 400));
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
   it("start() is idempotent: a second call from a clean state does not call watch() again", () => {
     // Spy on watch() so the assertion is independent of which `~/.claude/*`
     // subdirs happen to exist on the host (CI typically has none, in which

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -55,6 +55,29 @@ describe("SkillWatcherService", () => {
     expect(() => watcher.watch(join(dir, "does-not-exist"))).not.toThrow();
   });
 
+  it("watch() dedupes by directory path: a second call for the same dir is a no-op", async () => {
+    mkdirSync(join(dir, "skills"), { recursive: true });
+    const target = join(dir, "skills");
+    const invalidateSpy = vi.spyOn(svc, "invalidate");
+
+    watcher.watch(target);
+    watcher.watch(target);
+
+    // Trigger one fs change. With dedup the debounced invalidate fires once;
+    // without dedup, two FSWatchers would each schedule the timer (the second
+    // resets it), and the eventual single timer fire would still call
+    // invalidate once — so call count alone is insufficient. The real
+    // assertion is that we never registered a second underlying watcher.
+    writeFileSync(join(target, "marker.txt"), "x");
+    await new Promise((r) => setTimeout(r, 350));
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+
+    // stopAll() must close every registered watcher; if dedup leaked a second
+    // watcher into the array, this assertion would still pass but the dir
+    // would remain watched after stopAll(). Verify via internal state.
+    expect((watcher as unknown as { watchers: unknown[] }).watchers.length).toBe(1);
+  });
+
   it("start() is idempotent: a second call from a clean state does not call watch() again", () => {
     // Spy on watch() so the assertion is independent of which `~/.claude/*`
     // subdirs happen to exist on the host (CI typically has none, in which

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -48,10 +48,36 @@ describe("SkillWatcherService", () => {
     }
 
     await new Promise((r) => setTimeout(r, 350));
-    expect(invalidateSpy.mock.calls.length).toBeLessThanOrEqual(1);
+    expect(invalidateSpy.mock.calls.length).toBe(1);
   });
 
   it("watch() on a missing directory does not throw", () => {
     expect(() => watcher.watch(join(dir, "does-not-exist"))).not.toThrow();
+  });
+
+  it("start() is idempotent: a second call does not register duplicate watchers", async () => {
+    mkdirSync(join(dir, "skills"), { recursive: true });
+    const invalidateSpy = vi.spyOn(svc, "invalidate");
+
+    // Seed one watcher manually so start()'s idempotency guard
+    // (`watchers.length > 0` short-circuit) trips on both subsequent calls.
+    // Without the guard, each start() call would push additional FSWatcher
+    // instances rooted at ~/.claude paths, polluting global fs handles.
+    watcher.watch(dir);
+    const countAfterSeed = (watcher as unknown as { watchers: unknown[] }).watchers.length;
+
+    watcher.start();
+    watcher.start();
+
+    const countAfterStarts = (watcher as unknown as { watchers: unknown[] }).watchers.length;
+    expect(countAfterStarts).toBe(countAfterSeed);
+
+    // A single fs change must still result in exactly one invalidation
+    // (regression guard: duplicate watchers would still collapse under the
+    // shared debounce timer, but the watcher-count assertion above catches
+    // the leak directly).
+    writeFileSync(join(dir, "skills", "marker.txt"), "x");
+    await new Promise((r) => setTimeout(r, 350));
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -55,12 +55,12 @@ describe("SkillWatcherService", () => {
     expect(() => watcher.watch(join(dir, "does-not-exist"))).not.toThrow();
   });
 
-  it("start() is idempotent: a second call from a clean state does not register duplicate watchers", () => {
-    // Spy on the per-root watch() call rather than asserting on a snapshot
-    // of watchers.length: this proves the FIRST start() actually ran (its
-    // calls are observable on the spy) and the second start() short-circuited.
-    // Pre-seeding watch(dir) would make both calls hit the fast-path and
-    // leave the regression undetected.
+  it("start() is idempotent: a second call from a clean state does not call watch() again", () => {
+    // Spy on watch() so the assertion is independent of which `~/.claude/*`
+    // subdirs happen to exist on the host (CI typically has none, in which
+    // case watch() short-circuits and never pushes to `watchers`). Counting
+    // watch() invocations directly proves the `started` guard, not the
+    // downstream watcher-registration side effect.
     const watchSpy = vi.spyOn(watcher, "watch");
 
     watcher.start();

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -55,29 +55,19 @@ describe("SkillWatcherService", () => {
     expect(() => watcher.watch(join(dir, "does-not-exist"))).not.toThrow();
   });
 
-  it("start() is idempotent: a second call does not register duplicate watchers", async () => {
-    mkdirSync(join(dir, "skills"), { recursive: true });
-    const invalidateSpy = vi.spyOn(svc, "invalidate");
-
-    // Seed one watcher manually so start()'s idempotency guard
-    // (`watchers.length > 0` short-circuit) trips on both subsequent calls.
-    // Without the guard, each start() call would push additional FSWatcher
-    // instances rooted at ~/.claude paths, polluting global fs handles.
-    watcher.watch(dir);
-    const countAfterSeed = (watcher as unknown as { watchers: unknown[] }).watchers.length;
+  it("start() is idempotent: a second call from a clean state does not register duplicate watchers", () => {
+    // Spy on the per-root watch() call rather than asserting on a snapshot
+    // of watchers.length: this proves the FIRST start() actually ran (its
+    // calls are observable on the spy) and the second start() short-circuited.
+    // Pre-seeding watch(dir) would make both calls hit the fast-path and
+    // leave the regression undetected.
+    const watchSpy = vi.spyOn(watcher, "watch");
 
     watcher.start();
+    const firstCallCount = watchSpy.mock.calls.length;
+    expect(firstCallCount).toBeGreaterThan(0);
+
     watcher.start();
-
-    const countAfterStarts = (watcher as unknown as { watchers: unknown[] }).watchers.length;
-    expect(countAfterStarts).toBe(countAfterSeed);
-
-    // A single fs change must still result in exactly one invalidation
-    // (regression guard: duplicate watchers would still collapse under the
-    // shared debounce timer, but the watcher-count assertion above catches
-    // the leak directly).
-    writeFileSync(join(dir, "skills", "marker.txt"), "x");
-    await new Promise((r) => setTimeout(r, 350));
-    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(watchSpy.mock.calls.length).toBe(firstCallCount);
   });
 });

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -88,18 +88,22 @@ describe("SkillWatcherService", () => {
 
     watcher.start({ parentDir: dir, roots: [root] });
 
+    const invalidateSpy = vi.spyOn(svc, "invalidate");
+
     // Create the missing root after start() — this should be observed by
     // the parent watcher and trigger a delayed registration of `root`.
     mkdirSync(root, { recursive: true });
-    // Allow the parent fs.watch event to flush and onParentChange() to
-    // call watch(root). 150ms is well above OS event coalescing windows.
-    await new Promise((r) => setTimeout(r, 150));
+    // Let the parent-triggered debounce flush; that fires onChange once
+    // for the parent, which alone could satisfy a naive call-count assert.
+    // Clearing the spy after this isolates the next assertion to the
+    // late-registered root's own watcher.
+    await new Promise((r) => setTimeout(r, 350));
+    invalidateSpy.mockClear();
 
-    // Now a change inside the late-registered root should invalidate.
-    const invalidateSpy = vi.spyOn(svc, "invalidate");
+    // A change inside the late-registered root must invalidate exactly once.
     writeFileSync(join(root, "marker.txt"), "x");
-    await new Promise((r) => setTimeout(r, 400));
-    expect(invalidateSpy).toHaveBeenCalled();
+    await new Promise((r) => setTimeout(r, 350));
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 
   it("start() is idempotent: a second call from a clean state does not call watch() again", () => {

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -1,0 +1,57 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { SkillService } from "./skill-service.js";
+import { SkillWatcherService } from "./skill-watcher-service.js";
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), "skill-watch-"));
+}
+
+describe("SkillWatcherService", () => {
+  let dir: string;
+  let svc: SkillService;
+  let watcher: SkillWatcherService;
+
+  beforeEach(() => {
+    dir = tmp();
+    svc = new SkillService();
+    watcher = new SkillWatcherService(svc);
+  });
+
+  afterEach(() => {
+    watcher.stopAll();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("invalidates the SkillService cache when a watched dir changes", async () => {
+    mkdirSync(join(dir, "skills"), { recursive: true });
+    const invalidateSpy = vi.spyOn(svc, "invalidate");
+
+    watcher.watch(dir);
+    // Trigger a change event
+    writeFileSync(join(dir, "skills", "marker.txt"), "x");
+
+    await new Promise((r) => setTimeout(r, 350)); // > debounce window
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it("debounces rapid changes into a single invalidation", async () => {
+    mkdirSync(join(dir, "skills"), { recursive: true });
+    const invalidateSpy = vi.spyOn(svc, "invalidate");
+
+    watcher.watch(dir);
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(join(dir, "skills", `f${i}.txt`), "x");
+    }
+
+    await new Promise((r) => setTimeout(r, 350));
+    expect(invalidateSpy.mock.calls.length).toBeLessThanOrEqual(1);
+  });
+
+  it("watch() on a missing directory does not throw", () => {
+    expect(() => watcher.watch(join(dir, "does-not-exist"))).not.toThrow();
+  });
+});

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -18,6 +18,11 @@ const DEBOUNCE_MS = 200;
 @injectable()
 export class SkillWatcherService {
   private readonly watchers: FSWatcher[] = [];
+  // Tracks which dirs already have a live watcher so repeated `watch(dir)`
+  // calls (e.g. start() running twice across a stopAll(), or future code
+  // paths that add overlapping roots) don't register duplicate FSWatchers
+  // and fire the debounce timer twice per change.
+  private readonly watchedDirs = new Set<string>();
   private timer: ReturnType<typeof setTimeout> | null = null;
   // Tracks whether start() has run, separately from watcher count: a fresh
   // install with no `~/.claude/{skills,commands,plugins}` directories would
@@ -49,16 +54,21 @@ export class SkillWatcherService {
     for (const root of roots) this.watch(root);
   }
 
-  /** Begin watching one directory. No-op when the path is missing. */
+  /** Begin watching one directory. No-op when the path is missing or already watched. */
   watch(dir: string): void {
     if (!existsSync(dir)) {
       logger.debug("SkillWatcherService: skip missing dir", { dir });
+      return;
+    }
+    if (this.watchedDirs.has(dir)) {
+      logger.debug("SkillWatcherService: skip already-watched dir", { dir });
       return;
     }
     try {
       const w = watch(dir, { recursive: true }, () => this.onChange(dir));
       this.attachErrorHandler(w, dir);
       this.watchers.push(w);
+      this.watchedDirs.add(dir);
     } catch (err) {
       // Some platforms (BSD, network FS) reject recursive — fall back.
       const outerMessage = (err as Error).message;
@@ -70,6 +80,7 @@ export class SkillWatcherService {
         const w = watch(dir, () => this.onChange(dir));
         this.attachErrorHandler(w, dir);
         this.watchers.push(w);
+        this.watchedDirs.add(dir);
       } catch (innerErr) {
         const message = (innerErr as Error).message;
         logger.warn("SkillWatcherService: watch failed", { dir, message });
@@ -87,6 +98,7 @@ export class SkillWatcherService {
       }
     }
     this.watchers.length = 0;
+    this.watchedDirs.clear();
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
@@ -111,6 +123,10 @@ export class SkillWatcherService {
       }
       const idx = this.watchers.indexOf(w);
       if (idx !== -1) this.watchers.splice(idx, 1);
+      // Drop the dir from the dedup set too — otherwise a subsequent
+      // watch() for the same path would silently no-op even though the
+      // previous watcher is dead.
+      this.watchedDirs.delete(dir);
     });
   }
 

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -23,6 +23,9 @@ export class SkillWatcherService {
   // paths that add overlapping roots) don't register duplicate FSWatchers
   // and fire the debounce timer twice per change.
   private readonly watchedDirs = new Set<string>();
+  // Roots we want watched. Stored on the instance so the parent-dir watch
+  // can re-attempt registration when one of them is created post-startup.
+  private dynamicRoots: string[] = [];
   private timer: ReturnType<typeof setTimeout> | null = null;
   // Tracks whether start() has run, separately from watcher count: a fresh
   // install with no `~/.claude/{skills,commands,plugins}` directories would
@@ -36,8 +39,14 @@ export class SkillWatcherService {
   /**
    * Begin watching the standard Claude plugin and skill roots.
    * Idempotent: subsequent calls are no-ops until `stopAll()` resets state.
+   *
+   * Also watches the parent `~/.claude` dir so a root that doesn't exist
+   * at startup (fresh install) gets registered automatically when created.
+   *
+   * @param overrides Optional path overrides for testing. Production callers
+   *   should call `start()` with no arguments.
    */
-  start(): void {
+  start(overrides?: { parentDir?: string; roots?: string[] }): void {
     if (this.started) {
       logger.debug("SkillWatcherService: start() ignored, already started", {
         watcherCount: this.watchers.length,
@@ -46,12 +55,53 @@ export class SkillWatcherService {
     }
     this.started = true;
     const home = homedir();
-    const roots = [
-      join(home, ".claude", "skills"),
-      join(home, ".claude", "commands"),
-      join(home, ".claude", "plugins"),
+    const claudeDir = overrides?.parentDir ?? join(home, ".claude");
+    const roots = overrides?.roots ?? [
+      join(claudeDir, "skills"),
+      join(claudeDir, "commands"),
+      join(claudeDir, "plugins"),
     ];
+    this.dynamicRoots = roots;
+    this.watchParent(claudeDir);
     for (const root of roots) this.watch(root);
+  }
+
+  /**
+   * Watch the parent dir non-recursively so creation of any of `dynamicRoots`
+   * post-startup triggers a (re-)registration. Recursive watching here would
+   * fire on every plugin file write — far too noisy. Non-recursive sees only
+   * direct children of the parent, which is exactly the granularity we need.
+   */
+  private watchParent(parentDir: string): void {
+    if (!existsSync(parentDir)) {
+      logger.debug("SkillWatcherService: parent dir missing, dynamic-root detection disabled", {
+        parentDir,
+      });
+      return;
+    }
+    if (this.watchedDirs.has(parentDir)) return;
+    try {
+      const w = watch(parentDir, () => this.onParentChange(parentDir));
+      this.attachErrorHandler(w, parentDir);
+      this.watchers.push(w);
+      this.watchedDirs.add(parentDir);
+    } catch (err) {
+      const message = (err as Error).message;
+      logger.debug("SkillWatcherService: parent watch failed", { parentDir, message });
+    }
+  }
+
+  /**
+   * Re-attempt registration of any dynamic root that's not currently watched
+   * (it may have just been created), then trigger the normal debounced
+   * invalidate. `watch()` is dedup'd and skips missing dirs, so this is safe
+   * to invoke on every parent-dir event.
+   */
+  private onParentChange(parentDir: string): void {
+    for (const root of this.dynamicRoots) {
+      if (!this.watchedDirs.has(root)) this.watch(root);
+    }
+    this.onChange(parentDir);
   }
 
   /** Begin watching one directory. No-op when the path is missing or already watched. */
@@ -99,6 +149,7 @@ export class SkillWatcherService {
     }
     this.watchers.length = 0;
     this.watchedDirs.clear();
+    this.dynamicRoots = [];
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -19,6 +19,10 @@ const DEBOUNCE_MS = 200;
 export class SkillWatcherService {
   private readonly watchers: FSWatcher[] = [];
   private timer: ReturnType<typeof setTimeout> | null = null;
+  // Tracks whether start() has run, separately from watcher count: a fresh
+  // install with no `~/.claude/{skills,commands,plugins}` directories would
+  // otherwise leave `watchers.length === 0`, defeating the idempotency guard.
+  private started = false;
 
   constructor(
     @inject(SkillService) private readonly skills: SkillService,
@@ -26,16 +30,16 @@ export class SkillWatcherService {
 
   /**
    * Begin watching the standard Claude plugin and skill roots.
-   * Idempotent: if any watchers are already registered, this is a no-op.
-   * Call `stopAll()` first if you need to re-bootstrap.
+   * Idempotent: subsequent calls are no-ops until `stopAll()` resets state.
    */
   start(): void {
-    if (this.watchers.length > 0) {
-      logger.debug("SkillWatcherService: start() ignored, watchers active", {
-        count: this.watchers.length,
+    if (this.started) {
+      logger.debug("SkillWatcherService: start() ignored, already started", {
+        watcherCount: this.watchers.length,
       });
       return;
     }
+    this.started = true;
     const home = homedir();
     const roots = [
       join(home, ".claude", "skills"),
@@ -87,6 +91,7 @@ export class SkillWatcherService {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    this.started = false;
   }
 
   /**

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -5,7 +5,7 @@
  * Mirrors the debounce + fs.watch pattern of `GitWatcherService`.
  */
 
-import { injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 import { watch, existsSync, type FSWatcher } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -20,7 +20,9 @@ export class SkillWatcherService {
   private readonly watchers: FSWatcher[] = [];
   private timer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(private readonly skills: SkillService) {}
+  constructor(
+    @inject(SkillService) private readonly skills: SkillService,
+  ) {}
 
   /**
    * Begin watching the standard Claude plugin and skill roots.

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -22,8 +22,18 @@ export class SkillWatcherService {
 
   constructor(private readonly skills: SkillService) {}
 
-  /** Begin watching the standard Claude plugin and skill roots. */
+  /**
+   * Begin watching the standard Claude plugin and skill roots.
+   * Idempotent: if any watchers are already registered, this is a no-op.
+   * Call `stopAll()` first if you need to re-bootstrap.
+   */
   start(): void {
+    if (this.watchers.length > 0) {
+      logger.debug("SkillWatcherService: start() ignored, watchers active", {
+        count: this.watchers.length,
+      });
+      return;
+    }
     const home = homedir();
     const roots = [
       join(home, ".claude", "skills"),
@@ -41,11 +51,18 @@ export class SkillWatcherService {
     }
     try {
       const w = watch(dir, { recursive: true }, () => this.onChange(dir));
+      this.attachErrorHandler(w, dir);
       this.watchers.push(w);
     } catch (err) {
       // Some platforms (BSD, network FS) reject recursive — fall back.
+      const outerMessage = (err as Error).message;
+      logger.debug("SkillWatcherService: recursive watch failed, falling back", {
+        dir,
+        message: outerMessage,
+      });
       try {
         const w = watch(dir, () => this.onChange(dir));
+        this.attachErrorHandler(w, dir);
         this.watchers.push(w);
       } catch (innerErr) {
         const message = (innerErr as Error).message;
@@ -70,13 +87,42 @@ export class SkillWatcherService {
     }
   }
 
+  /**
+   * Wire a `error` handler so a single bad watcher cannot crash the process.
+   * On error, log at debug, close the watcher, and drop it from the registry.
+   */
+  private attachErrorHandler(w: FSWatcher, dir: string): void {
+    w.on("error", (err) => {
+      logger.debug("SkillWatcherService: watcher error, dropping", {
+        dir,
+        message: err.message,
+      });
+      try {
+        w.close();
+      } catch {
+        // ignore
+      }
+      const idx = this.watchers.indexOf(w);
+      if (idx !== -1) this.watchers.splice(idx, 1);
+    });
+  }
+
   private onChange(dir: string): void {
     if (this.timer) clearTimeout(this.timer);
     this.timer = setTimeout(() => {
       this.timer = null;
       logger.debug("SkillWatcherService: debounced change", { dir });
-      this.skills.invalidate();
-      broadcast("skills.changed", {});
+      // A SkillService throw must not poison subsequent debounce cycles.
+      try {
+        this.skills.invalidate();
+        broadcast("skills.changed", {});
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.debug("SkillWatcherService: invalidate/broadcast failed", {
+          dir,
+          message,
+        });
+      }
     }, DEBOUNCE_MS);
   }
 }

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -1,0 +1,82 @@
+/**
+ * Watches Claude plugin and skills directories for changes and triggers
+ * `SkillService` cache invalidation plus a `skills.changed` broadcast.
+ *
+ * Mirrors the debounce + fs.watch pattern of `GitWatcherService`.
+ */
+
+import { injectable } from "tsyringe";
+import { watch, existsSync, type FSWatcher } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { logger } from "@mcode/shared";
+import { broadcast } from "../transport/push";
+import { SkillService } from "./skill-service";
+
+const DEBOUNCE_MS = 200;
+
+@injectable()
+export class SkillWatcherService {
+  private readonly watchers: FSWatcher[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly skills: SkillService) {}
+
+  /** Begin watching the standard Claude plugin and skill roots. */
+  start(): void {
+    const home = homedir();
+    const roots = [
+      join(home, ".claude", "skills"),
+      join(home, ".claude", "commands"),
+      join(home, ".claude", "plugins"),
+    ];
+    for (const root of roots) this.watch(root);
+  }
+
+  /** Begin watching one directory. No-op when the path is missing. */
+  watch(dir: string): void {
+    if (!existsSync(dir)) {
+      logger.debug("SkillWatcherService: skip missing dir", { dir });
+      return;
+    }
+    try {
+      const w = watch(dir, { recursive: true }, () => this.onChange(dir));
+      this.watchers.push(w);
+    } catch (err) {
+      // Some platforms (BSD, network FS) reject recursive — fall back.
+      try {
+        const w = watch(dir, () => this.onChange(dir));
+        this.watchers.push(w);
+      } catch (innerErr) {
+        const message = (innerErr as Error).message;
+        logger.warn("SkillWatcherService: watch failed", { dir, message });
+      }
+    }
+  }
+
+  /** Tear down every watcher (called from shutdown / tests). */
+  stopAll(): void {
+    for (const w of this.watchers) {
+      try {
+        w.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.watchers.length = 0;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private onChange(dir: string): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      logger.debug("SkillWatcherService: debounced change", { dir });
+      this.skills.invalidate();
+      broadcast("skills.changed", {});
+    }, DEBOUNCE_MS);
+  }
+}

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -409,6 +409,8 @@ async function dispatch(
     // Skills
     case "skill.list":
       return deps.skillService.list(params.cwd);
+    case "skill.diagnose":
+      return deps.skillService.diagnose(params.cwd);
 
     // Terminal
     case "terminal.create":

--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -132,7 +132,9 @@ test.describe("Slash command popup", () => {
     // JSON-RPC error. The shared mock helper only supports successful result
     // overrides, so we register a self-contained route that uses
     // `getDefaultSettings()` for bootstrap parity.
-    await page.routeWebSocket(/ws:\/\/localhost:\d{5}/, (ws) => {
+    // Match any host:port (localhost, 127.0.0.1, custom ports) so this test
+    // doesn't break if the dev server's launch shape changes.
+    await page.routeWebSocket(/ws:\/\/[^/]+/, (ws) => {
       ws.onMessage((data) => {
         const msg = JSON.parse(data.toString()) as { id?: string | number; method?: string };
         const method = msg.method;

--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect, type Page } from "@playwright/test";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer, type RpcOverrides } from "./helpers/e2e-helpers";
+
+/**
+ * E2E coverage for the slash-command popup. Verifies the four user-visible
+ * behaviors introduced by the slash-command loading-fixes work:
+ *  - the popup renders the full mixed command list (built-ins + skills + commands)
+ *  - typing further filters the list
+ *  - a server-side error surfaces an ErrorRow with a Retry button
+ *  - a Refresh button is rendered in the popup footer
+ *
+ * Each test captures a full-page screenshot to
+ * `apps/web/e2e/screenshots/slash-command/` for visual verification.
+ */
+
+const NOW = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-1",
+  name: "Test Workspace",
+  path: "/test/path",
+  provider_config: {},
+  created_at: NOW,
+  updated_at: NOW,
+};
+
+const THREAD = {
+  id: "thread-1",
+  workspace_id: "ws-1",
+  title: "Slash Command Test Thread",
+  status: "paused" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  worktree_managed: false,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: NOW,
+  updated_at: NOW,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+/** Varied skills payload covering multiple kinds and sources. */
+const FIXTURE_SKILLS = [
+  { name: "superpowers:brainstorming", description: "Generate ideas creatively", kind: "skill", source: "user" },
+  { name: "superpowers:writing-plans", description: "Plan implementations carefully", kind: "skill", source: "user" },
+  { name: "superpowers:executing-plans", description: "Execute multi-step plans", kind: "skill", source: "user" },
+  { name: "writing-clearly-and-concisely", description: "Polish prose for humans", kind: "command", source: "project" },
+  { name: "review-pr", description: "Review a pull request end-to-end", kind: "command", source: "project" },
+  { name: "hookify:hookify", description: "Configure hookify rules", kind: "skill", source: "plugin" },
+  { name: "claude-code-setup:claude-automation-recommender", description: "Recommend automations", kind: "skill", source: "plugin" },
+  { name: "tdd-workflow", description: "Follow strict TDD discipline", kind: "skill", source: "agent" },
+];
+
+/** Boot the app with one workspace + one thread, plus caller-supplied overrides. */
+async function bootApp(page: Page, extra: RpcOverrides = {}): Promise<void> {
+  await mockWebSocketServer(page, {
+    "workspace.list": [WORKSPACE],
+    "thread.list": [THREAD],
+    "message.list": [],
+    ...extra,
+  });
+}
+
+/** Activate the thread and focus the lexical editor; type prefix; await popup. */
+async function openPopup(page: Page, prefix: string): Promise<void> {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  // Workspaces in the sidebar are collapsed by default; expand to reveal threads.
+  await page
+    .locator('[role="button"][aria-expanded]')
+    .filter({ hasText: "Test Workspace" })
+    .click();
+  await page.waitForSelector("[data-testid='thread-item']");
+  await page.locator("[data-testid='thread-item']").first().click();
+
+  const editor = page.locator("[contenteditable='true']").first();
+  await editor.waitFor({ state: "visible" });
+  await editor.click();
+  await page.keyboard.type(prefix);
+
+  await page.waitForSelector("[data-slash-popup]");
+}
+
+test.describe("Slash command popup", () => {
+  test("01 - popup open shows the full mixed command list", async ({ page }) => {
+    await bootApp(page, { "skill.list": FIXTURE_SKILLS });
+    await openPopup(page, "/");
+
+    const popup = page.locator("[data-slash-popup]");
+    await expect(popup).toBeVisible();
+    await expect(popup.getByText("/compact")).toBeVisible();
+    await expect(popup.getByText("/superpowers:brainstorming")).toBeVisible();
+    await expect(popup.getByText("/hookify:hookify")).toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/screenshots/slash-command/01-popup-open.png",
+      fullPage: true,
+    });
+  });
+
+  test("02 - popup filters as the user keeps typing", async ({ page }) => {
+    await bootApp(page, { "skill.list": FIXTURE_SKILLS });
+    await openPopup(page, "/sup");
+
+    const popup = page.locator("[data-slash-popup]");
+    await expect(popup).toBeVisible();
+    await expect(popup.getByText("/superpowers:brainstorming")).toBeVisible();
+    await expect(popup.getByText("/superpowers:writing-plans")).toBeVisible();
+    await expect(popup.getByText("/compact")).toHaveCount(0);
+
+    await page.screenshot({
+      path: "e2e/screenshots/slash-command/02-popup-filtered.png",
+      fullPage: true,
+    });
+  });
+
+  test("03 - error response surfaces ErrorRow with Retry button", async ({ page }) => {
+    // Mirror the shared helper's defaults but force `skill.list` to return a
+    // JSON-RPC error. The shared mock helper only supports successful result
+    // overrides, so we register a self-contained route that uses
+    // `getDefaultSettings()` for bootstrap parity.
+    await page.routeWebSocket(/ws:\/\/localhost:\d{5}/, (ws) => {
+      ws.onMessage((data) => {
+        const msg = JSON.parse(data.toString()) as { id?: string | number; method?: string };
+        const method = msg.method;
+        if (method === "skill.list") {
+          ws.send(
+            JSON.stringify({
+              id: msg.id,
+              error: { code: -32000, message: "Failed to enumerate skills directory" },
+            }),
+          );
+          return;
+        }
+        let result: unknown = null;
+        if (method === "workspace.list") result = [WORKSPACE];
+        else if (method === "thread.list") result = [THREAD];
+        else if (method?.endsWith(".list") || method === "provider.listModels") result = [];
+        else if (method === "git.currentBranch") result = "main";
+        else if (method === "agent.activeCount") result = 0;
+        else if (method === "app.version") result = "0.0.1-test";
+        else if (method === "config.discover") result = {};
+        else if (method === "settings.get") result = getDefaultSettings();
+        else {
+          ws.send(
+            JSON.stringify({ id: msg.id, error: { code: -32601, message: "Method not found" } }),
+          );
+          return;
+        }
+        ws.send(JSON.stringify({ id: msg.id, result }));
+      });
+    });
+    await openPopup(page, "/");
+
+    const popup = page.locator("[data-slash-popup]");
+    await expect(popup).toBeVisible();
+    await expect(popup.locator("[role='alert']")).toBeVisible();
+    await expect(popup.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(popup).toContainText("Couldn't load commands");
+
+    await page.screenshot({
+      path: "e2e/screenshots/slash-command/03-error-row.png",
+      fullPage: true,
+    });
+  });
+
+  test("04 - footer renders the Refresh button", async ({ page }) => {
+    await bootApp(page, { "skill.list": FIXTURE_SKILLS });
+    await openPopup(page, "/");
+
+    const popup = page.locator("[data-slash-popup]");
+    await expect(popup).toBeVisible();
+    const refresh = popup.getByRole("button", { name: "Refresh commands" });
+    await expect(refresh).toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/screenshots/slash-command/04-refresh-button.png",
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -145,7 +145,7 @@ test.describe("Slash command popup", () => {
           );
           return;
         }
-        let result: unknown = null;
+        let result: unknown;
         if (method === "workspace.list") result = [WORKSPACE];
         else if (method === "thread.list") result = [THREAD];
         else if (method?.endsWith(".list") || method === "provider.listModels") result = [];

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -110,6 +110,7 @@ export const mockTransport: McodeTransport = {
   getPrByUrl: vi.fn().mockResolvedValue(null),
   checkStatus: vi.fn().mockResolvedValue({ aggregate: "no_checks", runs: [], fetchedAt: 0 }),
   listSkills: vi.fn().mockResolvedValue([] as SkillInfo[]),
+  diagnoseSkills: vi.fn().mockResolvedValue({ scanned: [], errors: [], totalSkills: 0, totalCommands: 0 }),
   terminalCreate: vi.fn().mockResolvedValue("pty-mock-1"),
   terminalWrite: vi.fn().mockResolvedValue(undefined),
   terminalResize: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -14,9 +14,13 @@ vi.mock("@/transport", () => ({
 
 import { useSlashCommand } from "@/components/chat/useSlashCommand";
 import { getTransport } from "@/transport";
+import { useSkillsStore } from "@/stores/skillsStore";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Reset store between tests to prevent cross-test cache pollution now that
+  // useSlashCommand delegates caching to the module-scoped skillsStore.
+  useSkillsStore.getState().reset();
 });
 
 function makeAnchor() {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1695,8 +1695,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         items={slashCommand.items}
         selectedIndex={slashCommand.selectedIndex}
         anchorRect={slashCommand.anchorRect}
+        error={slashCommand.error}
         onSelect={handleSlashSelect}
         onDismiss={slashCommand.onDismiss}
+        onRetry={slashCommand.onRetry}
       />
     </div>
   );

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn } from "@/lib/utils";
-import { Terminal, Zap, Puzzle, Sparkles } from "lucide-react";
+import { Terminal, Zap, Puzzle, Sparkles, RefreshCw } from "lucide-react";
 import { NAMESPACE_BADGE_STYLES } from "@/lib/slash-command-styles";
 import type { Command } from "./useSlashCommand";
 
@@ -15,8 +15,10 @@ interface SlashCommandPopupProps {
   items: Command[];
   selectedIndex: number;
   anchorRect: DOMRect | null;
+  error: Error | null;
   onSelect: (cmd: Command) => void;
   onDismiss: () => void;
+  onRetry: () => void;
 }
 
 export function SlashCommandPopup({
@@ -25,8 +27,10 @@ export function SlashCommandPopup({
   items,
   selectedIndex,
   anchorRect,
+  error,
   onSelect,
   onDismiss,
+  onRetry,
 }: SlashCommandPopupProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -93,43 +97,60 @@ export function SlashCommandPopup({
     >
       {isLoading ? (
         <SkeletonRows />
+      ) : error ? (
+        <ErrorRow message={error.message} onRetry={onRetry} />
       ) : items.length === 0 ? (
         <EmptyState />
       ) : (
-        <div
-          ref={scrollRef}
-          role="presentation"
-          style={{ maxHeight, overflowY: "auto" }}
-        >
-          {useVirtual ? (
-            <div role="presentation" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
-              {virtualizer.getVirtualItems().map((vi) => (
-                <div
-                  key={vi.key}
-                  role="presentation"
-                  style={{ position: "absolute", top: vi.start, width: "100%", height: vi.size }}
-                  data-index={vi.index}
-                >
+        <>
+          <div
+            ref={scrollRef}
+            role="presentation"
+            style={{ maxHeight, overflowY: "auto" }}
+          >
+            {useVirtual ? (
+              <div role="presentation" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+                {virtualizer.getVirtualItems().map((vi) => (
+                  <div
+                    key={vi.key}
+                    role="presentation"
+                    style={{ position: "absolute", top: vi.start, width: "100%", height: vi.size }}
+                    data-index={vi.index}
+                  >
+                    <CommandRow
+                      cmd={items[vi.index]}
+                      selected={vi.index === selectedIndex}
+                      onSelect={onSelect}
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              items.map((cmd, i) => (
+                <div key={cmd.name} role="presentation" data-index={i}>
                   <CommandRow
-                    cmd={items[vi.index]}
-                    selected={vi.index === selectedIndex}
+                    cmd={cmd}
+                    selected={i === selectedIndex}
                     onSelect={onSelect}
                   />
                 </div>
-              ))}
-            </div>
-          ) : (
-            items.map((cmd, i) => (
-              <div key={cmd.name} role="presentation" data-index={i}>
-                <CommandRow
-                  cmd={cmd}
-                  selected={i === selectedIndex}
-                  onSelect={onSelect}
-                />
-              </div>
-            ))
-          )}
-        </div>
+              ))
+            )}
+          </div>
+          <div className="flex items-center justify-end border-t border-border px-2 py-1">
+            <button
+              type="button"
+              aria-label="Refresh commands"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onRetry();
+              }}
+              className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <RefreshCw size={12} />
+            </button>
+          </div>
+        </>
       )}
     </div>
   );
@@ -218,6 +239,24 @@ function EmptyState() {
     <div aria-live="polite" role="status" className="flex items-center gap-3 px-3 py-2">
       <span className="flex h-5 w-5 flex-shrink-0" /> {/* icon placeholder */}
       <span className="text-sm text-muted-foreground">No commands match</span>
+    </div>
+  );
+}
+
+function ErrorRow({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div role="alert" className="flex items-center gap-2 px-3 py-2 text-xs text-destructive">
+      <span className="flex-1 truncate">Couldn't load commands: {message}</span>
+      <button
+        type="button"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onRetry();
+        }}
+        className="rounded px-2 py-0.5 text-foreground hover:bg-accent"
+      >
+        Retry
+      </button>
     </div>
   );
 }

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -84,11 +84,12 @@ export function SlashCommandPopup({
   const useVirtual = items.length > VIRTUAL_THRESHOLD;
 
   return (
+    // role="listbox" is intentionally NOT on this outer wrapper: the
+    // Refresh footer button and the ErrorRow's Retry button live inside
+    // and would be invalid descendants of a listbox per WAI-ARIA. The
+    // role is moved down to the options container only.
     <div
       data-slash-popup
-      role="listbox"
-      aria-label="Slash commands"
-      aria-activedescendant={items[selectedIndex] ? `slash-cmd-${items[selectedIndex].name}` : undefined}
       style={style}
       className={cn(
         "z-50 overflow-hidden rounded-lg border border-border bg-card shadow-lg",
@@ -105,7 +106,9 @@ export function SlashCommandPopup({
         <>
           <div
             ref={scrollRef}
-            role="presentation"
+            role="listbox"
+            aria-label="Slash commands"
+            aria-activedescendant={items[selectedIndex] ? `slash-cmd-${items[selectedIndex].name}` : undefined}
             style={{ maxHeight, overflowY: "auto" }}
           >
             {useVirtual ? (

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -141,10 +141,10 @@ export function SlashCommandPopup({
             <button
               type="button"
               aria-label="Refresh commands"
-              onMouseDown={(e) => {
-                e.preventDefault();
-                onRetry();
-              }}
+              // onMouseDown preventDefault keeps editor focus on pointer use;
+              // onClick fires on both pointer and keyboard activation (Enter/Space).
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={onRetry}
               className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
             >
               <RefreshCw size={12} />
@@ -249,10 +249,10 @@ function ErrorRow({ message, onRetry }: { message: string; onRetry: () => void }
       <span className="flex-1 truncate">Couldn't load commands: {message}</span>
       <button
         type="button"
-        onMouseDown={(e) => {
-          e.preventDefault();
-          onRetry();
-        }}
+        // Same pattern as the footer Refresh button: preventDefault on
+        // mousedown to retain editor focus, action on click for keyboard a11y.
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onRetry}
         className="rounded px-2 py-0.5 text-foreground hover:bg-accent"
       >
         Retry

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
@@ -50,8 +50,10 @@ function renderPopup() {
       items={COMMANDS}
       selectedIndex={0}
       anchorRect={makeAnchorRect()}
+      error={null}
       onSelect={() => {}}
       onDismiss={() => {}}
+      onRetry={() => {}}
     />,
   );
 }

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
@@ -67,8 +67,10 @@ function renderPopup(selectedIndex: number) {
       items={COMMANDS}
       selectedIndex={selectedIndex}
       anchorRect={makeAnchorRect()}
+      error={null}
       onSelect={() => {}}
       onDismiss={() => {}}
+      onRetry={() => {}}
     />,
   );
 }

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -1,5 +1,6 @@
-import { useState, useRef, useCallback } from "react";
-import { getTransport, type SkillInfo } from "@/transport";
+import { useState, useRef, useCallback, useEffect } from "react";
+import { useSkillsStore } from "@/stores/skillsStore";
+import type { SkillInfo } from "@/transport";
 import type { SlashCommandNamespace } from "./lexical/SlashCommandNode";
 
 /** A slash command entry shown in the popup. */
@@ -12,23 +13,40 @@ export interface Command {
 }
 
 const BUILTIN_COMMANDS: Command[] = [
-  {
-    name: "m:plan",
-    description: "Toggle plan mode",
-    namespace: "mcode",
-    action: "toggle-plan",
-  },
-  {
-    name: "compact",
-    description: "Summarise conversation history to free up context window",
-    namespace: "command",
-  },
+  { name: "m:plan", description: "Toggle plan mode", namespace: "mcode", action: "toggle-plan" },
+  { name: "compact", description: "Summarise conversation history to free up context window", namespace: "command" },
 ];
 
 /** Regex: matches `/` at start of line or after whitespace, followed by non-space chars. */
 export const SLASH_TRIGGER_RE = /(^|\s)(\/\S*)$/;
 
-const CACHE_TTL_MS = 5 * 60 * 1000;
+/** Map a SkillInfo into a Command. */
+function toCommand(s: SkillInfo): Command {
+  // `kind === "command"` overrides any namespace inference.
+  if (s.kind === "command") {
+    return { name: s.name, description: s.description || `Run /${s.name}`, namespace: "command" };
+  }
+  return {
+    name: s.name,
+    description: s.description || `Run /${s.name}`,
+    namespace: s.name.includes(":") ? "plugin" : "skill",
+  };
+}
+
+/** Sort commands: source group order, then alphabetical within group. */
+const NAMESPACE_ORDER: Record<SlashCommandNamespace, number> = {
+  mcode: 0,
+  command: 1,
+  skill: 2,
+  plugin: 3,
+};
+
+function sortCommands(cmds: Command[]): Command[] {
+  return [...cmds].sort((a, b) => {
+    const order = NAMESPACE_ORDER[a.namespace] - NAMESPACE_ORDER[b.namespace];
+    return order !== 0 ? order : a.name.localeCompare(b.name);
+  });
+}
 
 /** Options for the useSlashCommand hook. */
 interface UseSlashCommandOptions {
@@ -45,58 +63,53 @@ export interface UseSlashCommandReturn {
   allCommands: Command[];
   selectedIndex: number;
   anchorRect: DOMRect | null;
+  error: Error | null;
   onInputChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
   onSelect: (cmd: Command, replaceText: (v: string) => void) => void;
   onDismiss: () => void;
+  onRetry: () => void;
 }
 
-/** Manages slash command detection, skill loading, and popup state. */
+/** Manages slash command detection, skill loading via skillsStore, and popup state. */
 export function useSlashCommand({
   anchorRef,
   onMcodeCommand,
   cwd,
 }: UseSlashCommandOptions): UseSlashCommandReturn {
   const [isOpen, setIsOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [items, setItems] = useState<Command[]>([]);
-  const [allCommands, setAllCommands] = useState<Command[]>(BUILTIN_COMMANDS);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
-
-  // Store the last input text so onSelect can read it without a textarea ref.
   const lastInputRef = useRef("");
+  const lastFilterRef = useRef("");
 
-  // Abort controller for cancelling stale skill-loading requests
-  const abortRef = useRef<AbortController | null>(null);
+  const skills = useSkillsStore((s) => s.skills);
+  const isLoading = useSkillsStore((s) => s.isLoading);
+  const error = useSkillsStore((s) => s.error);
+  const load = useSkillsStore((s) => s.load);
 
-  // Cache: loaded skills + timestamp for TTL.
-  // Also track which cwd the cache was built for — invalidate on workspace switch.
-  const skillsCache = useRef<{ skills: SkillInfo[]; fetchedAt: number; cwd?: string } | null>(null);
+  // Build the full command list (memoize via skills identity).
+  const allCommands = useCallback(() => {
+    const commands: Command[] = [
+      ...BUILTIN_COMMANDS,
+      ...((skills ?? []).map(toCommand)),
+    ];
+    return sortCommands(commands);
+  }, [skills])();
 
-  const buildItems = useCallback((skillInfos: SkillInfo[], filter: string): Command[] => {
-    const f = filter.toLowerCase();
-    const skills: Command[] = skillInfos.map(({ name, description }) => ({
-      name,
-      description: description || `Run /${name}`,
-      namespace: (name.includes(":") ? "plugin" : "skill") as "plugin" | "skill",
-    }));
-    const all = [...BUILTIN_COMMANDS, ...skills];
-    if (!f) return all;
-    return all.filter((cmd) => cmd.name.toLowerCase().includes(f));
-  }, []);
+  const filtered = (() => {
+    const f = lastFilterRef.current.toLowerCase();
+    if (!f) return allCommands;
+    return allCommands.filter((c) => c.name.toLowerCase().includes(f));
+  })();
 
-  const loadSkills = useCallback(async (): Promise<SkillInfo[]> => {
-    const now = Date.now();
-    const cached = skillsCache.current;
-    if (cached && cached.cwd === cwd && now - cached.fetchedAt < CACHE_TTL_MS) {
-      return cached.skills;
+  // Trigger an initial load when the popup first opens.
+  // Retries once on transport failure (handled inside the store after Task 8).
+  useEffect(() => {
+    if (isOpen && skills === null && !isLoading) {
+      load(cwd).catch(() => { /* surfaced via `error` */ });
     }
-    const skills = await getTransport().listSkills(cwd);
-    skillsCache.current = { skills, fetchedAt: now, cwd };
-    setAllCommands(buildItems(skills, ""));
-    return skills;
-  }, [cwd, buildItems]);
+  }, [isOpen, skills, isLoading, load, cwd]);
 
   const onInputChange = useCallback(
     (value: string) => {
@@ -110,64 +123,24 @@ export function useSlashCommand({
         return;
       }
 
-      // Update anchor on every change while popup is open
       const anchor = anchorRef.current;
-      if (anchor) {
-        setAnchorRect(anchor.getBoundingClientRect());
-      }
+      if (anchor) setAnchorRect(anchor.getBoundingClientRect());
 
-      // Filter text is the matched group minus the leading '/'
-      const triggerText = match[2]; // e.g. "/com"
-      const filter = triggerText.slice(1); // e.g. "com"
-
+      lastFilterRef.current = match[2].slice(1);
       setIsOpen(true);
       setSelectedIndex(0);
-
-      // Abort any previous in-flight skill load
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
-
-      if (!skillsCache.current) {
-        setIsLoading(true);
-        loadSkills()
-          .then((skills) => {
-            if (!controller.signal.aborted) {
-              setIsLoading(false);
-              setItems(buildItems(skills, filter));
-            }
-          })
-          .catch(() => {
-            if (!controller.signal.aborted) setIsLoading(false);
-          });
-      } else {
-        setItems(buildItems(skillsCache.current.skills, filter));
-        // Background refresh if TTL expired
-        if (Date.now() - skillsCache.current.fetchedAt >= CACHE_TTL_MS) {
-          loadSkills()
-            .then((skills) => {
-              if (!controller.signal.aborted) setItems(buildItems(skills, filter));
-            })
-            .catch(() => {
-              // Background refresh failed silently; existing cache remains
-            });
-        }
-      }
     },
-    [anchorRef, loadSkills, buildItems],
+    [anchorRef],
   );
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (!isOpen) return;
-
-      // Enter and Tab are handled by the Composer (it calls onSelect directly).
-      // The hook handles only navigation and dismiss.
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
           e.stopPropagation();
-          setSelectedIndex((i) => Math.min(i + 1, items.length - 1));
+          setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
           break;
         case "ArrowUp":
           e.preventDefault();
@@ -181,7 +154,7 @@ export function useSlashCommand({
           break;
       }
     },
-    [isOpen, items],
+    [isOpen, filtered.length],
   );
 
   const onSelect = useCallback(
@@ -196,32 +169,31 @@ export function useSlashCommand({
         // position, rather than lastIndexOf which can pick the wrong occurrence
         // when the same trigger text appears multiple times before the cursor.
         const triggerStart = match.index + match[1].length;
-        const newValue =
-          value.slice(0, triggerStart) + `/${cmd.name} ` + value.slice(cursor);
-        replaceText(newValue);
+        replaceText(value.slice(0, triggerStart) + `/${cmd.name} ` + value.slice(cursor));
       }
-
-      if (cmd.action && onMcodeCommand) {
-        onMcodeCommand(cmd.action);
-      }
-
+      if (cmd.action && onMcodeCommand) onMcodeCommand(cmd.action);
       setIsOpen(false);
     },
     [onMcodeCommand],
   );
 
   const onDismiss = useCallback(() => setIsOpen(false), []);
+  const onRetry = useCallback(() => {
+    load(cwd, true).catch(() => { /* surfaced via `error` */ });
+  }, [load, cwd]);
 
   return {
     isOpen,
     isLoading,
-    items,
+    items: filtered,
     allCommands,
     selectedIndex,
     anchorRect,
+    error,
     onInputChange,
     onKeyDown,
     onSelect,
     onDismiss,
+    onRetry,
   };
 }

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -84,6 +84,7 @@ export function useSlashCommand({
   const lastFilterRef = useRef("");
 
   const skills = useSkillsStore((s) => s.skills);
+  const cachedCwd = useSkillsStore((s) => s.cwd);
   const isLoading = useSkillsStore((s) => s.isLoading);
   const error = useSkillsStore((s) => s.error);
   const load = useSkillsStore((s) => s.load);
@@ -103,15 +104,24 @@ export function useSlashCommand({
     return allCommands.filter((c) => c.name.toLowerCase().includes(f));
   })();
 
-  // Trigger an initial load when the popup first opens.
-  // The `!error` gate is critical: without it, a failed load resets
-  // `isLoading` to false, which would re-trigger this effect immediately
-  // and create an infinite retry loop. Recovery happens via `onRetry`.
+  // Trigger a load when the popup opens AND either (a) we have no skills,
+  // or (b) the current workspace's cwd differs from the cached cwd. The
+  // store now tracks `cwd` for both successful and failed loads, so a
+  // mismatch is the right signal — without this, switching workspaces
+  // would keep showing the previous workspace's commands forever.
+  //
+  // The `!error` gate prevents an infinite retry loop on persistent
+  // failures: when cwd is unchanged, recovery happens via `onRetry`.
+  // When cwd changes, we always load (treating it as a fresh workspace,
+  // ignoring any prior error from the old one).
   useEffect(() => {
-    if (isOpen && skills === null && !isLoading && !error) {
+    if (!isOpen || isLoading) return;
+    const cwdChanged = cachedCwd !== cwd;
+    const noSkills = skills === null;
+    if (cwdChanged || (noSkills && !error)) {
       load(cwd).catch(() => { /* surfaced via `error` */ });
     }
-  }, [isOpen, skills, isLoading, error, load, cwd]);
+  }, [isOpen, skills, cachedCwd, cwd, isLoading, error, load]);
 
   const onInputChange = useCallback(
     (value: string) => {
@@ -142,7 +152,11 @@ export function useSlashCommand({
         case "ArrowDown":
           e.preventDefault();
           e.stopPropagation();
-          setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+          // Clamp to 0 when filtered is empty; otherwise `length - 1` would
+          // be `-1`, leaking an invalid index into ARIA / keyboard handling.
+          setSelectedIndex((i) =>
+            filtered.length === 0 ? 0 : Math.min(i + 1, filtered.length - 1),
+          );
           break;
         case "ArrowUp":
           e.preventDefault();

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -104,12 +104,14 @@ export function useSlashCommand({
   })();
 
   // Trigger an initial load when the popup first opens.
-  // Retries once on transport failure (handled inside the store after Task 8).
+  // The `!error` gate is critical: without it, a failed load resets
+  // `isLoading` to false, which would re-trigger this effect immediately
+  // and create an infinite retry loop. Recovery happens via `onRetry`.
   useEffect(() => {
-    if (isOpen && skills === null && !isLoading) {
+    if (isOpen && skills === null && !isLoading && !error) {
       load(cwd).catch(() => { /* surfaced via `error` */ });
     }
-  }, [isOpen, skills, isLoading, load, cwd]);
+  }, [isOpen, skills, isLoading, error, load, cwd]);
 
   const onInputChange = useCallback(
     (value: string) => {

--- a/apps/web/src/stores/skillsStore.test.ts
+++ b/apps/web/src/stores/skillsStore.test.ts
@@ -5,14 +5,20 @@ const FAKE_SKILLS = [
   { name: "a", description: "A", kind: "skill" as const, source: "user" as const },
 ];
 
+// Hoist the mock so the invalidate-then-reload test can assert call counts.
+// Without a stable reference, every getTransport() call would return a fresh
+// vi.fn() and the second load() would never be observable.
+const listSkillsMock = vi.fn(async () => FAKE_SKILLS);
+
 vi.mock("@/transport", () => ({
   getTransport: () => ({
-    listSkills: vi.fn(async () => FAKE_SKILLS),
+    listSkills: listSkillsMock,
   }),
 }));
 
 describe("skillsStore", () => {
   beforeEach(() => {
+    listSkillsMock.mockClear();
     useSkillsStore.getState().reset();
   });
 
@@ -33,6 +39,15 @@ describe("skillsStore", () => {
     await useSkillsStore.getState().load("/foo");
     useSkillsStore.getState().invalidate();
     expect(useSkillsStore.getState().skills).toBeNull();
+
+    // The visible-state assertion above is necessary but not sufficient: if
+    // invalidate() left the module-scoped TTL or in-flight reference behind,
+    // the next load() could short-circuit to the stale promise without ever
+    // hitting transport. Calling load() again and asserting two transport
+    // hits is what actually proves the cache was cleared.
+    await useSkillsStore.getState().load("/foo");
+    expect(listSkillsMock).toHaveBeenCalledTimes(2);
+    expect(useSkillsStore.getState().skills).toEqual(FAKE_SKILLS);
   });
 
   it("retries once after WebSocket disconnect", async () => {

--- a/apps/web/src/stores/skillsStore.test.ts
+++ b/apps/web/src/stores/skillsStore.test.ts
@@ -34,4 +34,25 @@ describe("skillsStore", () => {
     useSkillsStore.getState().invalidate();
     expect(useSkillsStore.getState().skills).toBeNull();
   });
+
+  it("retries once after WebSocket disconnect", async () => {
+    const calls: number[] = [];
+    vi.doMock("@/transport", () => ({
+      getTransport: () => ({
+        listSkills: vi.fn(async () => {
+          calls.push(Date.now());
+          if (calls.length === 1) throw new Error("WebSocket disconnected");
+          return FAKE_SKILLS;
+        }),
+        waitForConnection: async () => undefined,
+      }),
+    }));
+
+    vi.resetModules();
+    const { useSkillsStore: store } = await import("./skillsStore");
+    store.getState().reset();
+    const result = await store.getState().load("/foo");
+    expect(result).toEqual(FAKE_SKILLS);
+    expect(calls.length).toBe(2);
+  });
 });

--- a/apps/web/src/stores/skillsStore.test.ts
+++ b/apps/web/src/stores/skillsStore.test.ts
@@ -50,6 +50,47 @@ describe("skillsStore", () => {
     expect(useSkillsStore.getState().skills).toEqual(FAKE_SKILLS);
   });
 
+  it("does not single-flight loads for different cwds", async () => {
+    // Two concurrent loads with different cwds must NOT share a promise:
+    // workspace B would receive workspace A's data otherwise.
+    const p1 = useSkillsStore.getState().load("/foo");
+    const p2 = useSkillsStore.getState().load("/bar");
+    expect(p1).not.toBe(p2);
+    await Promise.all([p1, p2]);
+  });
+
+  it("invalidate() fences a load() that's still in flight", async () => {
+    // Slow the next mock response so we can race invalidate() against it.
+    let resolveListSkills!: (v: typeof FAKE_SKILLS) => void;
+    listSkillsMock.mockImplementationOnce(
+      () => new Promise((res) => { resolveListSkills = res; }),
+    );
+
+    const loadPromise = useSkillsStore.getState().load("/foo");
+    // While load is in flight, an external watcher fires invalidate().
+    useSkillsStore.getState().invalidate();
+    // Now resolve the in-flight fetch with data — it must NOT rehydrate
+    // the store, because invalidate() bumped the load epoch.
+    resolveListSkills(FAKE_SKILLS);
+    await loadPromise;
+
+    // Store stays cleared: the late resolution was dropped.
+    expect(useSkillsStore.getState().skills).toBeNull();
+    expect(useSkillsStore.getState().cwd).toBeUndefined();
+  });
+
+  it("tracks cwd on failure so the consumer can detect cwd changes", async () => {
+    listSkillsMock.mockImplementationOnce(async () => {
+      throw new Error("boom");
+    });
+    await expect(useSkillsStore.getState().load("/foo")).rejects.toThrow("boom");
+    // cwd must reflect the *attempted* path even though no skills loaded.
+    // Without this, useSlashCommand cannot distinguish "retry same cwd"
+    // (don't auto-loop) from "user switched workspace" (must reload).
+    expect(useSkillsStore.getState().cwd).toBe("/foo");
+    expect(useSkillsStore.getState().error?.message).toBe("boom");
+  });
+
   it("retries once after WebSocket disconnect", async () => {
     const calls: number[] = [];
     vi.doMock("@/transport", () => ({

--- a/apps/web/src/stores/skillsStore.test.ts
+++ b/apps/web/src/stores/skillsStore.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useSkillsStore } from "./skillsStore";
+
+const FAKE_SKILLS = [
+  { name: "a", description: "A", kind: "skill" as const, source: "user" as const },
+];
+
+vi.mock("@/transport", () => ({
+  getTransport: () => ({
+    listSkills: vi.fn(async () => FAKE_SKILLS),
+  }),
+}));
+
+describe("skillsStore", () => {
+  beforeEach(() => {
+    useSkillsStore.getState().reset();
+  });
+
+  it("loads skills and caches them per cwd", async () => {
+    await useSkillsStore.getState().load("/foo");
+    expect(useSkillsStore.getState().skills).toEqual(FAKE_SKILLS);
+    expect(useSkillsStore.getState().cwd).toBe("/foo");
+  });
+
+  it("single-flights concurrent load() calls", async () => {
+    const p1 = useSkillsStore.getState().load("/foo");
+    const p2 = useSkillsStore.getState().load("/foo");
+    expect(p1).toBe(p2); // same in-flight promise
+    await Promise.all([p1, p2]);
+  });
+
+  it("invalidate() clears cache so next load() re-fetches", async () => {
+    await useSkillsStore.getState().load("/foo");
+    useSkillsStore.getState().invalidate();
+    expect(useSkillsStore.getState().skills).toBeNull();
+  });
+});

--- a/apps/web/src/stores/skillsStore.ts
+++ b/apps/web/src/stores/skillsStore.ts
@@ -1,0 +1,118 @@
+/**
+ * Cache for slash-command skills.
+ *
+ * Module-scoped so the cache survives Composer remounts. Single-flights
+ * concurrent `load()` calls. Reacts to `skills.changed` push events
+ * (wired in `ws-events.ts`) by invalidating.
+ */
+
+import { create } from "zustand";
+import { getTransport, type SkillInfo } from "@/transport";
+
+/** State and actions for the skills Zustand store. */
+interface SkillsState {
+  /** Fetched skill list, or null if not yet loaded or invalidated. */
+  skills: SkillInfo[] | null;
+  /** The cwd used for the last successful fetch. */
+  cwd: string | undefined;
+  /** Whether a fetch is currently in-flight. */
+  isLoading: boolean;
+  /** Error from the last failed fetch, if any. */
+  error: Error | null;
+  /** The in-flight promise, used to enforce single-flight semantics. */
+  inflight: Promise<SkillInfo[]> | null;
+
+  /**
+   * Load skills for the given cwd.
+   *
+   * Returns cached data if still fresh (within TTL) and cwd matches.
+   * Concurrent calls with any cwd while a request is in-flight all
+   * receive the same promise.
+   */
+  load(cwd?: string, force?: boolean): Promise<SkillInfo[]>;
+
+  /**
+   * Invalidate the cached skills so the next `load()` re-fetches from
+   * the server regardless of TTL.
+   */
+  invalidate(): void;
+
+  /**
+   * Reset all store state to initial values, including in-flight tracking.
+   * Used in tests for cleanup between cases.
+   */
+  reset(): void;
+}
+
+/** Skills are considered fresh for 5 minutes after the last successful fetch. */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+// Module-level timestamp so TTL survives store resets in tests but still
+// gets cleared when `reset()` or `invalidate()` is explicitly called.
+let lastFetchedAt = 0;
+
+/** Module-scoped Zustand store for skill caching with single-flight loading. */
+export const useSkillsStore = create<SkillsState>((set, get) => ({
+  skills: null,
+  cwd: undefined,
+  isLoading: false,
+  error: null,
+  inflight: null,
+
+  // Non-async so the return value IS the cached/in-flight promise directly,
+  // enabling identity equality (p1 === p2) for single-flight callers.
+  load(cwd, force = false): Promise<SkillInfo[]> {
+    const state = get();
+
+    // Return cache if fresh and same cwd
+    if (
+      !force &&
+      state.skills &&
+      state.cwd === cwd &&
+      Date.now() - lastFetchedAt < CACHE_TTL_MS
+    ) {
+      return Promise.resolve(state.skills);
+    }
+
+    // Single-flight: return existing in-flight promise for any concurrent caller
+    if (state.inflight) return state.inflight;
+
+    // Create and register the in-flight promise atomically so a second
+    // synchronous caller sees it immediately via get().inflight.
+    let resolveInflight!: (skills: SkillInfo[]) => void;
+    let rejectInflight!: (err: unknown) => void;
+    const promise = new Promise<SkillInfo[]>((res, rej) => {
+      resolveInflight = res;
+      rejectInflight = rej;
+    });
+
+    set({ isLoading: true, error: null, inflight: promise });
+
+    // Kick off the actual fetch outside the synchronous set() block.
+    (async () => {
+      try {
+        const skills = await getTransport().listSkills(cwd);
+        lastFetchedAt = Date.now();
+        set({ skills, cwd, isLoading: false, inflight: null, error: null });
+        resolveInflight(skills);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.warn("[skillsStore] load failed", error);
+        set({ isLoading: false, inflight: null, error });
+        rejectInflight(error);
+      }
+    })();
+
+    return promise;
+  },
+
+  invalidate() {
+    set({ skills: null, cwd: undefined, error: null });
+    lastFetchedAt = 0;
+  },
+
+  reset() {
+    set({ skills: null, cwd: undefined, isLoading: false, error: null, inflight: null });
+    lastFetchedAt = 0;
+  },
+}));

--- a/apps/web/src/stores/skillsStore.ts
+++ b/apps/web/src/stores/skillsStore.ts
@@ -13,14 +13,24 @@ import { getTransport, type SkillInfo } from "@/transport";
 interface SkillsState {
   /** Fetched skill list, or null if not yet loaded or invalidated. */
   skills: SkillInfo[] | null;
-  /** The cwd used for the last successful fetch. */
+  /** The cwd associated with the last load attempt (success OR failure). */
   cwd: string | undefined;
   /** Whether a fetch is currently in-flight. */
   isLoading: boolean;
   /** Error from the last failed fetch, if any. */
   error: Error | null;
-  /** The in-flight promise, used to enforce single-flight semantics. */
+  /** The in-flight promise. Single-flight only deduplicates same-cwd callers. */
   inflight: Promise<SkillInfo[]> | null;
+  /** The cwd of the in-flight promise; used to scope single-flight by cwd. */
+  inflightCwd: string | undefined;
+  /**
+   * Monotonic counter bumped by each new load() call AND by invalidate()/
+   * reset(). The async closure captures the value it incremented to and
+   * checks `get().loadEpoch === myEpoch` before any set(); a mismatch means
+   * a newer load or an invalidate raced ahead, so the stale resolution is
+   * dropped instead of rehydrating the store.
+   */
+  loadEpoch: number;
 
   /**
    * Load skills for the given cwd.
@@ -58,6 +68,8 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   isLoading: false,
   error: null,
   inflight: null,
+  inflightCwd: undefined,
+  loadEpoch: 0,
 
   // Non-async so the return value IS the cached/in-flight promise directly,
   // enabling identity equality (p1 === p2) for single-flight callers.
@@ -74,11 +86,13 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
       return Promise.resolve(state.skills);
     }
 
-    // Single-flight: return existing in-flight promise for any concurrent caller
-    if (state.inflight) return state.inflight;
+    // Single-flight ONLY for the same cwd. A different-cwd request must
+    // not piggyback on an in-flight load for workspace A or it would
+    // receive A's data while expecting B's.
+    if (state.inflight && state.inflightCwd === cwd) return state.inflight;
 
     // Create and register the in-flight promise atomically so a second
-    // synchronous caller sees it immediately via get().inflight.
+    // synchronous caller (same cwd) sees it immediately via get().inflight.
     let resolveInflight!: (skills: SkillInfo[]) => void;
     let rejectInflight!: (err: unknown) => void;
     const promise = new Promise<SkillInfo[]>((res, rej) => {
@@ -86,7 +100,14 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
       rejectInflight = rej;
     });
 
-    set({ isLoading: true, error: null, inflight: promise });
+    const myEpoch = state.loadEpoch + 1;
+    set({
+      isLoading: true,
+      error: null,
+      inflight: promise,
+      inflightCwd: cwd,
+      loadEpoch: myEpoch,
+    });
 
     // Kick off the actual fetch outside the synchronous set() block.
     (async () => {
@@ -111,13 +132,23 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
             throw err;
           }
         }
-        lastFetchedAt = Date.now();
-        set({ skills, cwd, isLoading: false, inflight: null, error: null });
+        // Fence: skip set() if invalidate(), reset(), or a newer load()
+        // bumped the epoch while we were awaiting. Still resolve the promise
+        // so callers don't hang — they'll get the data they asked for, just
+        // without polluting the now-fresher store state.
+        if (get().loadEpoch === myEpoch) {
+          lastFetchedAt = Date.now();
+          set({ skills, cwd, isLoading: false, inflight: null, inflightCwd: undefined, error: null });
+        }
         resolveInflight(skills);
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
         console.warn("[skillsStore] load failed after retry", error);
-        set({ isLoading: false, inflight: null, error });
+        // Track the attempted cwd even on failure so the consumer hook can
+        // detect a cwd change vs. a same-cwd retry and handle each correctly.
+        if (get().loadEpoch === myEpoch) {
+          set({ cwd, isLoading: false, inflight: null, inflightCwd: undefined, error });
+        }
         rejectInflight(error);
       }
     })();
@@ -126,12 +157,31 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   },
 
   invalidate() {
-    set({ skills: null, cwd: undefined, error: null });
+    // Bumping loadEpoch fences any in-flight load() so its eventual set()
+    // is dropped instead of rehydrating the store with pre-invalidation data.
+    const state = get();
+    set({
+      skills: null,
+      cwd: undefined,
+      error: null,
+      inflight: null,
+      inflightCwd: undefined,
+      loadEpoch: state.loadEpoch + 1,
+    });
     lastFetchedAt = 0;
   },
 
   reset() {
-    set({ skills: null, cwd: undefined, isLoading: false, error: null, inflight: null });
+    const state = get();
+    set({
+      skills: null,
+      cwd: undefined,
+      isLoading: false,
+      error: null,
+      inflight: null,
+      inflightCwd: undefined,
+      loadEpoch: state.loadEpoch + 1,
+    });
     lastFetchedAt = 0;
   },
 }));

--- a/apps/web/src/stores/skillsStore.ts
+++ b/apps/web/src/stores/skillsStore.ts
@@ -90,14 +90,33 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
 
     // Kick off the actual fetch outside the synchronous set() block.
     (async () => {
+      const transport = getTransport();
+      const attempt = () => transport.listSkills(cwd);
       try {
-        const skills = await getTransport().listSkills(cwd);
+        let skills: SkillInfo[];
+        try {
+          skills = await attempt();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          // Retry once if the WebSocket was momentarily disconnected. The
+          // transport may expose waitForConnection; use it if available so
+          // the retry doesn't fire before the socket is back up.
+          if (message.includes("disconnected") || message.includes("not initialized")) {
+            const t = transport as unknown as { waitForConnection?: (ms: number) => Promise<void> };
+            if (t.waitForConnection) {
+              await t.waitForConnection(5000).catch(() => undefined);
+            }
+            skills = await attempt();
+          } else {
+            throw err;
+          }
+        }
         lastFetchedAt = Date.now();
         set({ skills, cwd, isLoading: false, inflight: null, error: null });
         resolveInflight(skills);
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
-        console.warn("[skillsStore] load failed", error);
+        console.warn("[skillsStore] load failed after retry", error);
         set({ isLoading: false, inflight: null, error });
         rejectInflight(error);
       }

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -9,6 +9,7 @@ import type {
   PrInfo,
   PrDetail,
   SkillInfo,
+  SkillDiagnostics,
   PermissionMode,
   ReasoningLevel,
   ToolCallRecord,
@@ -40,6 +41,7 @@ export type {
   PrInfo,
   PrDetail,
   SkillInfo,
+  SkillDiagnostics,
   PermissionMode,
   InteractionMode,
   Settings,
@@ -182,6 +184,8 @@ export interface McodeTransport {
 
   // Skills
   listSkills(cwd?: string): Promise<SkillInfo[]>;
+  /** Run a filesystem scan across all skill search paths and return per-path diagnostics. */
+  diagnoseSkills(cwd?: string): Promise<SkillDiagnostics>;
 
   // Terminal (PTY)
   /** Create a new PTY attached to a thread's working directory. Returns the pty ID. */

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -4,6 +4,7 @@ import { pushEmitter } from "./ws-transport";
 import { useThreadStore } from "@/stores/threadStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useSkillsStore } from "@/stores/skillsStore";
 import { clearFileListCache } from "@/components/chat/useFileAutocomplete";
 
 /** Unsubscribe handles for all push listeners. */
@@ -21,7 +22,7 @@ let unsubs: (() => void)[] = [];
  * - `thread.prLinked` -- PR detected for a thread, updates pr_number/pr_status
  * - `thread.checksUpdated` -- CI check status polled for a thread's PR, updates checksById
  * - `files.changed` -- invalidates the file autocomplete cache
- * - `skills.changed` -- reserved for future skill cache invalidation
+ * - `skills.changed` -- invalidates the skill cache; popup re-fetches on next open
  * - `turn.persisted` -- tool call persistence confirmation forwarded to threadStore
  * - `settings.changed` -- server-pushed settings updates forwarded to settingsStore
  * - `branch.changed` -- refreshes branch list and updates current branch if not manually overridden
@@ -140,10 +141,10 @@ export function startPushListeners(): void {
     }),
   );
 
-  // skills.changed: reserved for future skill cache invalidation
+  // skills.changed: invalidate skill cache so the popup re-fetches on next open
   unsubs.push(
     pushEmitter.on("skills.changed", () => {
-      // No-op for now; will invalidate skill cache when implemented.
+      useSkillsStore.getState().invalidate();
     }),
   );
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -6,6 +6,7 @@ import type {
   WorktreeInfo,
   AttachmentMeta,
   SkillInfo,
+  SkillDiagnostics,
   PrInfo,
   PrDetail,
   PermissionMode,
@@ -472,6 +473,7 @@ export function createWsTransport(
 
     // Skills
     listSkills: (cwd?) => rpc<SkillInfo[]>("skill.list", { cwd }),
+    diagnoseSkills: (cwd?) => rpc<SkillDiagnostics>("skill.diagnose", { cwd }),
 
     // Terminal (PTY)
     terminalCreate: (threadId) => rpc<string>("terminal.create", { threadId }),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -113,8 +113,18 @@ export { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrParamsSchema, Crea
 export type { PrInfo, PrDetail, PrDraft, CreatePrParams, CreatePrResult, CheckRun, ChecksStatus } from "./github.js";
 
 // Skills
-export { SkillInfoSchema } from "./skills.js";
-export type { SkillInfo } from "./skills.js";
+export {
+  SkillInfoSchema,
+  SkillKindSchema,
+  SkillSourceSchema,
+  SkillDiagnosticsSchema,
+} from "./skills.js";
+export type {
+  SkillInfo,
+  SkillKind,
+  SkillSource,
+  SkillDiagnostics,
+} from "./skills.js";
 
 // WebSocket protocol
 export {

--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -3,10 +3,12 @@ import { lazySchema } from "./utils/lazySchema.js";
 
 /** Whether the entry comes from a Claude `skills/` dir or a `commands/` dir. */
 export const SkillKindSchema = z.enum(["skill", "command"]);
+/** Whether the entry comes from a Claude `skills/` dir or a `commands/` dir. */
 export type SkillKind = z.infer<typeof SkillKindSchema>;
 
 /** Where the entry was discovered. Used for grouping in the picker. */
 export const SkillSourceSchema = z.enum(["user", "project", "agent", "plugin"]);
+/** Where the entry was discovered. Used for grouping in the picker. */
 export type SkillSource = z.infer<typeof SkillSourceSchema>;
 
 /** Metadata for a discovered skill or command. */
@@ -18,6 +20,7 @@ export const SkillInfoSchema = lazySchema(() =>
     source: SkillSourceSchema.default("plugin"),
   }),
 );
+/** Metadata for a discovered skill or command. */
 export type SkillInfo = z.infer<ReturnType<typeof SkillInfoSchema>>;
 
 /** Per-path diagnostics returned by `skill.diagnose`. */
@@ -35,4 +38,5 @@ export const SkillDiagnosticsSchema = lazySchema(() =>
     totalCommands: z.number(),
   }),
 );
+/** Per-path diagnostics returned by `skill.diagnose`. */
 export type SkillDiagnostics = z.infer<ReturnType<typeof SkillDiagnosticsSchema>>;

--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -1,9 +1,38 @@
 import { z } from "zod";
+import { lazySchema } from "./utils/lazySchema.js";
 
-/** Metadata for a discovered skill. */
-export const SkillInfoSchema = z.object({
-  name: z.string(),
-  description: z.string(),
-});
-/** Metadata for a discovered skill. */
-export type SkillInfo = z.infer<typeof SkillInfoSchema>;
+/** Whether the entry comes from a Claude `skills/` dir or a `commands/` dir. */
+export const SkillKindSchema = z.enum(["skill", "command"]);
+export type SkillKind = z.infer<typeof SkillKindSchema>;
+
+/** Where the entry was discovered. Used for grouping in the picker. */
+export const SkillSourceSchema = z.enum(["user", "project", "agent", "plugin"]);
+export type SkillSource = z.infer<typeof SkillSourceSchema>;
+
+/** Metadata for a discovered skill or command. */
+export const SkillInfoSchema = lazySchema(() =>
+  z.object({
+    name: z.string(),
+    description: z.string(),
+    kind: SkillKindSchema.default("skill"),
+    source: SkillSourceSchema.default("plugin"),
+  }),
+);
+export type SkillInfo = z.infer<ReturnType<typeof SkillInfoSchema>>;
+
+/** Per-path diagnostics returned by `skill.diagnose`. */
+export const SkillDiagnosticsSchema = lazySchema(() =>
+  z.object({
+    scanned: z.array(
+      z.object({
+        path: z.string(),
+        existed: z.boolean(),
+        entries: z.number(),
+      }),
+    ),
+    errors: z.array(z.object({ path: z.string(), message: z.string() })),
+    totalSkills: z.number(),
+    totalCommands: z.number(),
+  }),
+);
+export type SkillDiagnostics = z.infer<ReturnType<typeof SkillDiagnosticsSchema>>;

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -308,7 +308,7 @@ export const WS_METHODS = lazySchema(() => ({
   },
   "skill.list": {
     params: z.object({ cwd: z.string().optional() }),
-    result: z.array(SkillInfoSchema),
+    result: z.array(SkillInfoSchema()),
   },
   "terminal.create": {
     params: z.object({ threadId: z.string() }),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -8,7 +8,7 @@ import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { GitBranchSchema, WorktreeSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
 import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema, ChecksStatusSchema } from "../github.js";
-import { SkillInfoSchema } from "../skills.js";
+import { SkillInfoSchema, SkillDiagnosticsSchema } from "../skills.js";
 import { TurnSnapshotSchema } from "../models/turn-snapshot.js";
 import { PlanAnswerSchema } from "../models/plan-questions.js";
 import { DiffStatsSchema } from "../models/diff-stats.js";
@@ -309,6 +309,10 @@ export const WS_METHODS = lazySchema(() => ({
   "skill.list": {
     params: z.object({ cwd: z.string().optional() }),
     result: z.array(SkillInfoSchema()),
+  },
+  "skill.diagnose": {
+    params: z.object({ cwd: z.string().optional() }),
+    result: SkillDiagnosticsSchema(),
   },
   "terminal.create": {
     params: z.object({ threadId: z.string() }),


### PR DESCRIPTION
## What

Fixes the long-standing bug where slash commands intermittently fail to load in the composer popup. Replaces the in-component, fire-and-forget skill fetch with a module-scoped store, adds a filesystem watcher on the server, surfaces errors with retry, and adds an explicit refresh control.

## Why

Five compounding root causes were producing the symptom users described as "slash commands sometimes do not load":

1. The server only scanned `skills/` directories, missing `commands/` and `.claude`-prefixed plugin shapes.
2. There was no invalidation when files changed on disk, so newly added commands did not appear until the app restarted.
3. The frontend re-fetched per Composer mount with no cache, so race conditions under reconnection produced empty popups.
4. A failed `skill.list` rejected silently and left the popup empty with no recovery path.
5. WebSocket reconnects could land between the popup opening and the request being accepted, causing the load to silently drop.

## Key Changes

- **contracts**: extend `SkillInfo` with `kind` (`skill` / `command`) and `source` (`user` / `project` / `agent` / `plugin`); add `SkillDiagnostics` schema and `skill.diagnose` RPC.
- **server `SkillService`**: rewrite scanner to walk `commands/`, `.claude/`-prefixed shapes, and both plugin-cache and marketplace layouts; isolate subscriber errors; add diagnostics.
- **server `SkillWatcherService`**: new service watching `~/.claude/{skills,commands,plugins}` with 200ms debounce; idempotent `start()`, per-watcher error handler, broadcasts `skills.changed` on disk events; wired into the DI container and boot/shutdown.
- **web `skillsStore`**: new module-scoped Zustand store with single-flight semantics, 5-minute TTL, and a single retry on transient WebSocket disconnect.
- **web `useSlashCommand`**: delegate to the store; expose `error` and `onRetry`; gate the load effect on `!error` to prevent an infinite retry loop after a failed load.
- **web `SlashCommandPopup`**: render `ErrorRow` (role=alert) with Retry, plus a footer Refresh button; add per-namespace icon and badge.
- **web `ws-events`**: subscribe to `skills.changed` push channel and invalidate the store.
- **e2e**: 4 new Playwright tests with screenshots covering the full mixed list, filtering, the error path, and the refresh control.

## Test plan

- [x] Unit tests: `bun run test` (server slash-command tests 11/11, web slash-command tests 31/31; one pre-existing flake in `cleanup-integration.test.ts` unrelated to this branch)
- [x] Typecheck: contracts + server + web + desktop all clean (`tsc --noEmit`)
- [x] E2E: `apps/web && bun run e2e slash-command-popup.spec.ts` (4/4 passing, screenshots in `apps/web/e2e/screenshots/slash-command/`)
- [ ] Manual smoke: open composer, type `/`, confirm full list with icons + badges; touch a file under `~/.claude/commands/`, confirm new entry appears without reload; toggle airplane mode mid-session, confirm Retry button appears and recovers

Closes the slash-command loading regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash popup shows commands and skills, surfaces load errors with an Error row + Retry, and includes a Refresh footer button.

* **Real-time**
  * Filesystem watchers monitor skill/command/plugin roots, debounce updates, auto-register dynamic roots, and reliably start/stop to refresh commands.

* **Diagnostics**
  * Clients can request server-side skill/command scan diagnostics via a new RPC and transport method; server broadcasts skill changes to clients.

* **Quality**
  * Centralized skill caching with single-flight loads, explicit invalidate/subscribe/reset APIs, deterministic dedupe/priorities, and retry/fencing semantics.

* **Tests**
  * New unit and E2E suites covering discovery, watching, caching, RPC, and popup behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->