### PR TITLE
feat: per-provider enable/disable with CLI verification

### DIFF
--- a/apps/server/src/__tests__/pr-draft-service.test.ts
+++ b/apps/server/src/__tests__/pr-draft-service.test.ts
@@ -48,6 +48,11 @@ describe("PrDraftService", () => {
   const mockProviderRegistry = {
     resolve: vi.fn().mockReturnValue({ complete: mockComplete, supportsCompletion: true }),
   };
+  // assertUsable throws ProviderDisabledError / ProviderCliMissingError in prod; here we
+  // default to a no-op so existing tests that don't care about availability stay green.
+  const mockProviderAvailability = {
+    assertUsable: vi.fn(),
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,6 +77,7 @@ describe("PrDraftService", () => {
       mockThreadRepo as any,
       mockSettingsService as any,
       mockProviderRegistry as any,
+      mockProviderAvailability as any,
     );
   });
 

--- a/apps/server/src/__tests__/providers-availability-rpc.test.ts
+++ b/apps/server/src/__tests__/providers-availability-rpc.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration tests for the providers.listAvailability and provider.listModels RPC methods.
+ *
+ * Boots an in-process HTTP + WebSocket server using the same approach as
+ * ws-server-health.test.ts: minimal RouterDeps stubs, no DI container, no SQLite.
+ */
+
+import "reflect-metadata";
+import { describe, it, expect, afterEach } from "vitest";
+import http from "http";
+import WebSocket from "ws";
+import { createWsServer } from "../transport/ws-server.js";
+import type { RouterDeps } from "../transport/ws-router.js";
+import type { ProviderAvailability } from "@mcode/contracts";
+import { ProviderDisabledError } from "../services/provider-availability-errors.js";
+
+const AUTH_TOKEN = "test-token-providers";
+
+/**
+ * Minimal RouterDeps stub.
+ * Only providerAvailability is exercised by the routes under test.
+ */
+function makeMinimalDeps(
+  overrides: Partial<RouterDeps> = {},
+): RouterDeps & { authToken: string } {
+  return {
+    authToken: AUTH_TOKEN,
+    agentService: { activeCount: () => 0 } as unknown as RouterDeps["agentService"],
+    workspaceService: undefined as unknown as RouterDeps["workspaceService"],
+    threadService: undefined as unknown as RouterDeps["threadService"],
+    gitService: undefined as unknown as RouterDeps["gitService"],
+    githubService: undefined as unknown as RouterDeps["githubService"],
+    fileService: undefined as unknown as RouterDeps["fileService"],
+    configService: undefined as unknown as RouterDeps["configService"],
+    skillService: undefined as unknown as RouterDeps["skillService"],
+    terminalService: undefined as unknown as RouterDeps["terminalService"],
+    messageRepo: undefined as unknown as RouterDeps["messageRepo"],
+    toolCallRecordRepo: undefined as unknown as RouterDeps["toolCallRecordRepo"],
+    turnSnapshotRepo: undefined as unknown as RouterDeps["turnSnapshotRepo"],
+    snapshotService: undefined as unknown as RouterDeps["snapshotService"],
+    settingsService: undefined as unknown as RouterDeps["settingsService"],
+    gitWatcherService: undefined as unknown as RouterDeps["gitWatcherService"],
+    memoryPressureService: undefined as unknown as RouterDeps["memoryPressureService"],
+    taskRepo: undefined as unknown as RouterDeps["taskRepo"],
+    providerRegistry: undefined as unknown as RouterDeps["providerRegistry"],
+    prDraftService: undefined as unknown as RouterDeps["prDraftService"],
+    threadRepo: undefined as unknown as RouterDeps["threadRepo"],
+    workspaceRepo: undefined as unknown as RouterDeps["workspaceRepo"],
+    ciWatcherService: undefined as unknown as RouterDeps["ciWatcherService"],
+    providerAvailability: undefined as unknown as RouterDeps["providerAvailability"],
+    ...overrides,
+  };
+}
+
+/** Build a WebSocket URL with the auth token as a query param. */
+function wsUrl(server: http.Server): string {
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("Not bound to TCP");
+  return `ws://127.0.0.1:${addr.port}/?token=${AUTH_TOKEN}`;
+}
+
+/**
+ * Send one RPC call over WebSocket and resolve with the parsed response.
+ * Rejects if the socket emits an error before a message arrives.
+ */
+function rpcCall(
+  server: http.Server,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<{ id: string; result?: unknown; error?: { code: string; message: string; data?: unknown } }> {
+  return new Promise((resolve, reject) => {
+    const client = new WebSocket(wsUrl(server));
+    client.on("open", () => {
+      client.send(JSON.stringify({ id: "req-1", method, params }));
+    });
+    client.on("message", (raw) => {
+      client.close();
+      try {
+        resolve(JSON.parse(raw.toString()) as ReturnType<typeof rpcCall> extends Promise<infer T> ? T : never);
+      } catch (err) {
+        reject(err);
+      }
+    });
+    client.on("error", reject);
+  });
+}
+
+describe("providers.listAvailability RPC", () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("returns six entries in catalog order", async () => {
+    /** Canned response that mirrors PROVIDER_CATALOG order. */
+    const fakeAvailability: ProviderAvailability[] = [
+      { id: "claude",   enabled: true,  hasAdapter: true,  beta: false, comingSoon: false, cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+      { id: "codex",    enabled: true,  hasAdapter: true,  beta: false, comingSoon: false, cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+      { id: "copilot",  enabled: false, hasAdapter: true,  beta: true,  comingSoon: false, cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+      { id: "gemini",   enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+      { id: "cursor",   enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+      { id: "opencode", enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+    ];
+
+    const deps = makeMinimalDeps({
+      providerAvailability: {
+        listAvailability: () => fakeAvailability,
+      } as unknown as RouterDeps["providerAvailability"],
+    });
+
+    ({ httpServer: server } = createWsServer(deps));
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    const response = await rpcCall(server, "providers.listAvailability");
+
+    expect(response.error).toBeUndefined();
+    const result = response.result as ProviderAvailability[];
+    expect(result.map((e) => e.id)).toEqual([
+      "claude",
+      "codex",
+      "copilot",
+      "gemini",
+      "cursor",
+      "opencode",
+    ]);
+  });
+
+  it("returns PROVIDER_DISABLED when calling listModels on a disabled provider", async () => {
+    // Stub assertUsable to throw ProviderDisabledError for "codex".
+    // This simulates settings.provider.enabled.codex = false without needing
+    // a real SettingsService or disk I/O.
+    const deps = makeMinimalDeps({
+      providerAvailability: {
+        assertUsable: (id: string) => {
+          if (id === "codex") throw new ProviderDisabledError("codex");
+        },
+        listAvailability: () => [],
+      } as unknown as RouterDeps["providerAvailability"],
+    });
+
+    ({ httpServer: server } = createWsServer(deps));
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    const response = await rpcCall(server, "provider.listModels", { providerId: "codex" });
+
+    expect(response.result).toBeUndefined();
+    expect(response.error?.code).toBe("PROVIDER_DISABLED");
+  });
+});

--- a/apps/server/src/__tests__/providers-availability-rpc.test.ts
+++ b/apps/server/src/__tests__/providers-availability-rpc.test.ts
@@ -69,15 +69,21 @@ function rpcCall(
   params: Record<string, unknown> = {},
 ): Promise<{ id: string; result?: unknown; error?: { code: string; message: string; data?: unknown } }> {
   return new Promise((resolve, reject) => {
+    const requestId = "req-1";
     const client = new WebSocket(wsUrl(server));
     client.on("open", () => {
-      client.send(JSON.stringify({ id: "req-1", method, params }));
+      client.send(JSON.stringify({ id: requestId, method, params }));
     });
     client.on("message", (raw) => {
-      client.close();
+      // Filter by id: server-initiated pushes have no id / a different id and
+      // must not be mistaken for the RPC response we're awaiting.
       try {
-        resolve(JSON.parse(raw.toString()) as ReturnType<typeof rpcCall> extends Promise<infer T> ? T : never);
+        const msg = JSON.parse(raw.toString()) as { id?: string };
+        if (msg.id !== requestId) return;
+        client.close();
+        resolve(msg as ReturnType<typeof rpcCall> extends Promise<infer T> ? T : never);
       } catch (err) {
+        client.close();
         reject(err);
       }
     });

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -40,6 +40,7 @@ import { GitWatcherService } from "./services/git-watcher-service";
 import { MemoryPressureService } from "./services/memory-pressure-service";
 import { CleanupWorker } from "./services/cleanup-worker";
 import { PrDraftService } from "./services/pr-draft-service";
+import { ProviderAvailabilityService } from "./services/provider-availability-service";
 
 /** Initialize the DI container with all server dependencies. */
 export function setupContainer(): typeof container {
@@ -230,6 +231,11 @@ export function setupContainer(): typeof container {
   container.register("PrDraftService", {
     useFactory: (c) => c.resolve(PrDraftService),
   });
+  container.register(
+    ProviderAvailabilityService,
+    { useClass: ProviderAvailabilityService },
+    { lifecycle: Lifecycle.Singleton },
+  );
 
   return container;
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -307,6 +307,7 @@ const { httpServer, wss } = createWsServer({
   memoryPressureService,
   taskRepo,
   providerRegistry,
+  providerAvailability,
   prDraftService,
   ciWatcherService,
   threadRepo,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -37,6 +37,7 @@ import { WorkspaceRepo } from "./repositories/workspace-repo";
 import { CleanupWorker } from "./services/cleanup-worker";
 import { PrDraftService } from "./services/pr-draft-service";
 import { CiWatcherService } from "./services/ci-watcher";
+import { ProviderAvailabilityService } from "./services/provider-availability-service";
 import { ProviderRegistry } from "./providers/provider-registry";
 import { WebSocket } from "ws";
 import { AgentEventType } from "@mcode/contracts";
@@ -117,6 +118,7 @@ const terminalService = container.resolve(TerminalService);
 const messageRepo = container.resolve(MessageRepo);
 const threadRepo = container.resolve(ThreadRepo);
 const providerRegistry = container.resolve(ProviderRegistry);
+const providerAvailability = container.resolve(ProviderAvailabilityService);
 const toolCallRecordRepo = container.resolve(ToolCallRecordRepo);
 const turnSnapshotRepo = container.resolve(TurnSnapshotRepo);
 const snapshotService = container.resolve(SnapshotService);
@@ -161,6 +163,14 @@ terminalService.setSender((channel, data) => {
 
 // AgentService self-wires persistence and session tracking against providers
 agentService.init();
+
+// Register broadcast callback so settings changes propagate to clients
+providerAvailability.onChange((list) => {
+  broadcast("providers.availability", list);
+});
+// Run startup CLI verification and emit initial availability snapshot
+await providerAvailability.verifyAllEnabled();
+broadcast("providers.availability", providerAvailability.listAvailability());
 
 // Start background worktree cleanup worker
 cleanupWorker.start();

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -170,9 +170,19 @@ agentService.init();
 providerAvailability.onChange((list) => {
   broadcast("providers.availability", list);
 });
-// Run startup CLI verification and emit initial availability snapshot
-await providerAvailability.verifyAllEnabled();
-broadcast("providers.availability", providerAvailability.listAvailability());
+// Run startup CLI verification and emit initial availability snapshot.
+// Wrapped in .then() rather than top-level await: the desktop bundle emits
+// CJS via esbuild, which does not support top-level await. Fire-and-forget
+// is safe here — onChange broadcasts during verify, and the final snapshot
+// is broadcast after verifyAllEnabled resolves.
+providerAvailability
+  .verifyAllEnabled()
+  .then(() => {
+    broadcast("providers.availability", providerAvailability.listAvailability());
+  })
+  .catch((err: unknown) => {
+    logger.error("Provider availability startup verification failed", err);
+  });
 
 // Start background worktree cleanup worker
 cleanupWorker.start();

--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -1,0 +1,206 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Thread, IProviderRegistry } from "@mcode/contracts";
+import { AgentService } from "../agent-service.js";
+import { ProviderAvailabilityService } from "../provider-availability-service.js";
+import { ProviderDisabledError } from "../provider-availability-errors.js";
+import type { ThreadRepo } from "../../repositories/thread-repo.js";
+import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import type { MessageRepo } from "../../repositories/message-repo.js";
+import type { GitService } from "../git-service.js";
+import type { AttachmentService } from "../attachment-service.js";
+import type { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
+import type { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo.js";
+import type { SnapshotService } from "../snapshot-service.js";
+import type { MemoryPressureService } from "../memory-pressure-service.js";
+import type { TaskRepo } from "../../repositories/task-repo.js";
+import type { SettingsService } from "../settings-service.js";
+import type { ThreadService } from "../thread-service.js";
+
+// Mock the broadcast transport so we can assert agent.event emissions
+// without a real WebSocket server.
+vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
+import { broadcast } from "../../transport/push.js";
+
+const THREAD_ID = "thread-abc";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: THREAD_ID,
+    workspace_id: "ws-1",
+    title: "Test thread",
+    status: "idle",
+    mode: "direct",
+    branch: "main",
+    worktree_path: null,
+    model: "claude-sonnet-4-6",
+    provider: "codex",
+    sdk_session_id: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    copilot_agent: null,
+    last_compact_summary: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    deleted_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as Thread;
+}
+
+/**
+ * Build a minimal AgentService with only the dependencies needed to test
+ * the provider availability gate. All other deps are no-op stubs.
+ */
+function buildService({
+  assertUsable = vi.fn(),
+  resolveProvider = vi.fn(),
+}: {
+  assertUsable?: ReturnType<typeof vi.fn>;
+  resolveProvider?: ReturnType<typeof vi.fn>;
+} = {}): AgentService {
+  const thread = makeThread();
+
+  const threadRepo = {
+    findById: vi.fn(() => thread),
+    updateStatus: vi.fn(),
+    updateModel: vi.fn(),
+    updateProvider: vi.fn(),
+    updateSettings: vi.fn(),
+    create: vi.fn(),
+    softDelete: vi.fn(),
+    updateWorktreePath: vi.fn(),
+    updateContextUsage: vi.fn(),
+    updateSdkSessionId: vi.fn(),
+    updateCompactSummary: vi.fn(),
+    updateLineage: vi.fn(),
+  } as unknown as ThreadRepo;
+
+  const workspaceRepo = {
+    findById: vi.fn(() => ({ id: "ws-1", path: "/workspace" })),
+  } as unknown as WorkspaceRepo;
+
+  const messageRepo = {
+    listByThread: vi.fn(() => ({ messages: [] })),
+    create: vi.fn(() => ({ id: "msg-1", sequence: 1 })),
+    findByIdInThread: vi.fn(),
+    listByThreadUpToSequence: vi.fn(() => []),
+  } as unknown as MessageRepo;
+
+  const gitService = {
+    resolveWorkingDir: vi.fn(() => "/workspace"),
+    listWorktrees: vi.fn(() => []),
+  } as unknown as GitService;
+
+  const attachmentService = {
+    persist: vi.fn(() => Promise.resolve({ stored: [], persisted: [] })),
+  } as unknown as AttachmentService;
+
+  const providerRegistry = {
+    resolve: resolveProvider,
+    resolveAll: vi.fn(() => []),
+    shutdown: vi.fn(),
+  } as unknown as IProviderRegistry;
+
+  const threadService = {
+    create: vi.fn(),
+  } as unknown as ThreadService;
+
+  const toolCallRecordRepo = {
+    bulkCreate: vi.fn(),
+  } as unknown as ToolCallRecordRepo;
+
+  const turnSnapshotRepo = {
+    listByThread: vi.fn(() => []),
+  } as unknown as TurnSnapshotRepo;
+
+  const snapshotService = {
+    captureRef: vi.fn(() => Promise.resolve("abc123")),
+    getFilesChanged: vi.fn(() => Promise.resolve([])),
+  } as unknown as SnapshotService;
+
+  const memoryPressureService = {
+    markActive: vi.fn(),
+    markIdle: vi.fn(),
+  } as unknown as MemoryPressureService;
+
+  const taskRepo = {
+    get: vi.fn(() => []),
+    upsert: vi.fn(),
+  } as unknown as TaskRepo;
+
+  const settingsService = {
+    get: vi.fn(() => ({
+      model: { defaults: { fallbackId: undefined } },
+      agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
+      provider: { enabled: {}, cli: {} },
+    })),
+    on: vi.fn(),
+  } as unknown as SettingsService;
+
+  const availability = {
+    assertUsable,
+  } as unknown as ProviderAvailabilityService;
+
+  // AgentService constructor (14 params):
+  //   threadRepo, workspaceRepo, messageRepo, gitService, attachmentService,
+  //   providerRegistry, threadService, toolCallRecordRepo, turnSnapshotRepo,
+  //   snapshotService, memoryPressureService, taskRepo, settingsService, availability
+  return new AgentService(
+    threadRepo,
+    workspaceRepo,
+    messageRepo,
+    gitService,
+    attachmentService,
+    providerRegistry,
+    threadService,
+    toolCallRecordRepo,
+    turnSnapshotRepo,
+    snapshotService,
+    memoryPressureService,
+    taskRepo,
+    settingsService,
+    availability,
+  );
+}
+
+describe("AgentService.sendMessage — provider availability gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits providerUnavailable and returns early when assertUsable throws ProviderDisabledError", async () => {
+    const resolveProvider = vi.fn();
+    const assertUsable = vi.fn(() => {
+      throw new ProviderDisabledError("codex");
+    });
+
+    const svc = buildService({ assertUsable, resolveProvider });
+
+    await svc.sendMessage(
+      THREAD_ID,
+      "Hello",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "codex",
+    );
+
+    // Provider must NOT be resolved — no agent session started
+    expect(resolveProvider).not.toHaveBeenCalled();
+
+    // A providerUnavailable event must have been broadcast on the agent.event channel
+    expect(broadcast).toHaveBeenCalledWith("agent.event", {
+      type: "providerUnavailable",
+      threadId: THREAD_ID,
+      providerId: "codex",
+      reason: "disabled",
+      configuredPath: undefined,
+    });
+  });
+});

--- a/apps/server/src/services/__tests__/provider-availability-service.test.ts
+++ b/apps/server/src/services/__tests__/provider-availability-service.test.ts
@@ -1,0 +1,63 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ProviderAvailabilityService } from "../provider-availability-service.js";
+import type { SettingsService } from "../settings-service.js";
+import type { IProviderRegistry, IAgentProvider } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+
+function stubSettings(overrides: Partial<ReturnType<typeof getDefaultSettings>> = {}): SettingsService {
+  const settings = { ...getDefaultSettings(), ...overrides };
+  return {
+    get: vi.fn(() => settings),
+    on: vi.fn(),
+  } as unknown as SettingsService;
+}
+
+function stubRegistry(ids: string[]): IProviderRegistry {
+  const providers = ids.map((id) => ({ id } as IAgentProvider));
+  return {
+    resolve: vi.fn((id) => providers.find((p) => p.id === id)!),
+    resolveAll: vi.fn(() => providers),
+    shutdown: vi.fn(),
+  };
+}
+
+describe("ProviderAvailabilityService.listAvailability", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reflects settings.provider.enabled flags in output", () => {
+    const s = getDefaultSettings();
+    s.provider.enabled.codex = false;
+    const svc = new ProviderAvailabilityService(
+      { get: () => s, on: () => {} } as unknown as SettingsService,
+      stubRegistry(["claude", "codex", "copilot"]),
+    );
+    const list = svc.listAvailability();
+    expect(list.find((p) => p.id === "codex")?.enabled).toBe(false);
+    expect(list.find((p) => p.id === "claude")?.enabled).toBe(true);
+  });
+
+  it("marks hasAdapter=false for providers missing from the registry", () => {
+    const svc = new ProviderAvailabilityService(
+      stubSettings(),
+      stubRegistry(["claude"]),
+    );
+    const list = svc.listAvailability();
+    expect(list.find((p) => p.id === "claude")?.hasAdapter).toBe(true);
+    expect(list.find((p) => p.id === "gemini")?.hasAdapter).toBe(false);
+  });
+
+  it("returns catalog order: claude, codex, copilot, gemini, cursor, opencode", () => {
+    const svc = new ProviderAvailabilityService(stubSettings(), stubRegistry([]));
+    expect(svc.listAvailability().map((p) => p.id)).toEqual([
+      "claude", "codex", "copilot", "gemini", "cursor", "opencode",
+    ]);
+  });
+
+  it("initial cli.status for every entry is 'unchecked'", () => {
+    const svc = new ProviderAvailabilityService(stubSettings(), stubRegistry(["claude"]));
+    for (const row of svc.listAvailability()) {
+      expect(row.cli.status).toBe("unchecked");
+    }
+  });
+});

--- a/apps/server/src/services/__tests__/provider-availability-service.test.ts
+++ b/apps/server/src/services/__tests__/provider-availability-service.test.ts
@@ -61,3 +61,60 @@ describe("ProviderAvailabilityService.listAvailability", () => {
     }
   });
 });
+
+describe("ProviderAvailabilityService.verifyCli", () => {
+  it("reports 'found' when which resolves the binary", async () => {
+    const svc = new ProviderAvailabilityService(
+      stubSettings(),
+      stubRegistry(["claude"]),
+      {
+        which: vi.fn(async () => "/usr/local/bin/claude"),
+        statExecutable: vi.fn(async () => true),
+      },
+    );
+    const result = await svc.verifyCli("claude");
+    expect(result).toEqual({ status: "found", resolvedPath: "/usr/local/bin/claude" });
+  });
+
+  it("reports 'not_found' when which throws", async () => {
+    const svc = new ProviderAvailabilityService(
+      stubSettings(),
+      stubRegistry(["claude"]),
+      {
+        which: vi.fn(async () => { throw new Error("not on PATH"); }),
+        statExecutable: vi.fn(async () => false),
+      },
+    );
+    const result = await svc.verifyCli("claude");
+    expect(result.status).toBe("not_found");
+    expect(result.resolvedPath).toBeNull();
+  });
+
+  it("prefers a configured path over PATH lookup and validates it with statExecutable", async () => {
+    const s = getDefaultSettings();
+    s.provider.cli.codex = "/custom/codex";
+    const stat = vi.fn(async () => true);
+    const which = vi.fn();
+    const svc = new ProviderAvailabilityService(
+      { get: () => s, on: () => {} } as unknown as SettingsService,
+      stubRegistry(["codex"]),
+      { which, statExecutable: stat },
+    );
+    const result = await svc.verifyCli("codex");
+    expect(which).not.toHaveBeenCalled();
+    expect(stat).toHaveBeenCalledWith("/custom/codex");
+    expect(result).toEqual({ status: "found", resolvedPath: "/custom/codex" });
+  });
+
+  it("caches result and reflects it in listAvailability", async () => {
+    const svc = new ProviderAvailabilityService(
+      stubSettings(),
+      stubRegistry(["claude"]),
+      { which: vi.fn(async () => "/usr/local/bin/claude"), statExecutable: vi.fn() },
+    );
+    await svc.verifyCli("claude");
+    const row = svc.listAvailability().find((p) => p.id === "claude")!;
+    expect(row.cli.status).toBe("found");
+    expect(row.cli.resolvedPath).toBe("/usr/local/bin/claude");
+  });
+});

--- a/apps/server/src/services/__tests__/provider-availability-service.test.ts
+++ b/apps/server/src/services/__tests__/provider-availability-service.test.ts
@@ -4,6 +4,7 @@ import { ProviderAvailabilityService } from "../provider-availability-service.js
 import type { SettingsService } from "../settings-service.js";
 import type { IProviderRegistry, IAgentProvider } from "@mcode/contracts";
 import { getDefaultSettings } from "@mcode/contracts";
+import { ProviderDisabledError, ProviderCliMissingError } from "../provider-availability-errors.js";
 
 function stubSettings(overrides: Partial<ReturnType<typeof getDefaultSettings>> = {}): SettingsService {
   const settings = { ...getDefaultSettings(), ...overrides };
@@ -116,5 +117,69 @@ describe("ProviderAvailabilityService.verifyCli", () => {
     const row = svc.listAvailability().find((p) => p.id === "claude")!;
     expect(row.cli.status).toBe("found");
     expect(row.cli.resolvedPath).toBe("/usr/local/bin/claude");
+  });
+});
+
+describe("ProviderAvailabilityService.assertUsable", () => {
+  it("throws ProviderDisabledError when the toggle is off", async () => {
+    const s = getDefaultSettings();
+    s.provider.enabled.codex = false;
+    const svc = new ProviderAvailabilityService(
+      { get: () => s, on: () => {} } as unknown as SettingsService,
+      stubRegistry(["claude", "codex"]),
+    );
+    expect(() => svc.assertUsable("codex")).toThrow(ProviderDisabledError);
+  });
+
+  it("throws ProviderDisabledError for coming-soon providers regardless of settings", () => {
+    const s = getDefaultSettings();
+    s.provider.enabled.gemini = true;
+    const svc = new ProviderAvailabilityService(
+      { get: () => s, on: () => {} } as unknown as SettingsService,
+      stubRegistry([]),
+    );
+    expect(() => svc.assertUsable("gemini")).toThrow(ProviderDisabledError);
+  });
+
+  it("throws ProviderCliMissingError when enabled but CLI not_found", async () => {
+    const svc = new ProviderAvailabilityService(
+      stubSettings(),
+      stubRegistry(["claude"]),
+      { which: vi.fn(async () => { throw new Error("nope"); }), statExecutable: vi.fn() },
+    );
+    await svc.verifyCli("claude");
+    expect(() => svc.assertUsable("claude")).toThrow(ProviderCliMissingError);
+  });
+
+  it("does not throw when enabled and CLI found", async () => {
+    const svc = new ProviderAvailabilityService(
+      stubSettings(),
+      stubRegistry(["claude"]),
+      { which: vi.fn(async () => "/usr/local/bin/claude"), statExecutable: vi.fn() },
+    );
+    await svc.verifyCli("claude");
+    expect(() => svc.assertUsable("claude")).not.toThrow();
+  });
+
+  it("does not throw when enabled + adapter present but CLI unchecked (startup race)", () => {
+    const svc = new ProviderAvailabilityService(stubSettings(), stubRegistry(["claude"]));
+    expect(() => svc.assertUsable("claude")).not.toThrow();
+  });
+});
+
+describe("ProviderAvailabilityService.verifyAllEnabled", () => {
+  it("verifies only providers with enabled=true and hasAdapter=true", async () => {
+    const s = getDefaultSettings();
+    s.provider.enabled.copilot = false;
+    const which = vi.fn(async (bin: string) => `/usr/local/bin/${bin}`);
+    const svc = new ProviderAvailabilityService(
+      { get: () => s, on: () => {} } as unknown as SettingsService,
+      stubRegistry(["claude", "codex", "copilot"]),
+      { which, statExecutable: vi.fn() },
+    );
+    await svc.verifyAllEnabled();
+    expect(which).toHaveBeenCalledWith("claude");
+    expect(which).toHaveBeenCalledWith("codex");
+    expect(which).not.toHaveBeenCalledWith("copilot");
   });
 });

--- a/apps/server/src/services/__tests__/provider-availability-service.test.ts
+++ b/apps/server/src/services/__tests__/provider-availability-service.test.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ProviderAvailabilityService } from "../provider-availability-service.js";
 import type { SettingsService } from "../settings-service.js";
-import type { IProviderRegistry, IAgentProvider } from "@mcode/contracts";
+import type { IProviderRegistry, IAgentProvider, ProviderAvailability } from "@mcode/contracts";
 import { getDefaultSettings } from "@mcode/contracts";
 import { ProviderDisabledError, ProviderCliMissingError } from "../provider-availability-errors.js";
 
@@ -181,5 +181,40 @@ describe("ProviderAvailabilityService.verifyAllEnabled", () => {
     expect(which).toHaveBeenCalledWith("claude");
     expect(which).toHaveBeenCalledWith("codex");
     expect(which).not.toHaveBeenCalledWith("copilot");
+  });
+});
+
+describe("ProviderAvailabilityService change handling", () => {
+  it("re-verifies when provider.enabled changes and calls the broadcast hook", async () => {
+    const listeners: Array<(s: ReturnType<typeof getDefaultSettings>) => void> = [];
+    const settingsStore = { current: getDefaultSettings() };
+    const settings = {
+      get: () => settingsStore.current,
+      on: (_: string, cb: (s: ReturnType<typeof getDefaultSettings>) => void) => listeners.push(cb),
+    } as unknown as SettingsService;
+
+    const broadcastSpy = vi.fn();
+    const which = vi.fn(async (bin: string) => `/usr/local/bin/${bin}`);
+    const svc = new ProviderAvailabilityService(
+      settings,
+      stubRegistry(["claude", "codex"]),
+      { which, statExecutable: vi.fn() },
+    );
+    svc.onChange(broadcastSpy);
+
+    // Flip codex off.
+    settingsStore.current = {
+      ...settingsStore.current,
+      provider: {
+        ...settingsStore.current.provider,
+        enabled: { ...settingsStore.current.provider.enabled, codex: false },
+      },
+    };
+    for (const cb of listeners) cb(settingsStore.current);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(broadcastSpy).toHaveBeenCalled();
+    const lastList = broadcastSpy.mock.calls.at(-1)![0];
+    expect(lastList.find((p: ProviderAvailability) => p.id === "codex").enabled).toBe(false);
   });
 });

--- a/apps/server/src/services/__tests__/settings-service.test.ts
+++ b/apps/server/src/services/__tests__/settings-service.test.ts
@@ -1,0 +1,56 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock fs before importing SettingsService so the constructor's existsSync / watch
+// calls don't hit the real filesystem.
+vi.mock("fs", () => ({
+  readFileSync: vi.fn(() => { throw new Error("ENOENT"); }),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+  watch: vi.fn(() => ({ close: vi.fn() })),
+}));
+
+vi.mock("@mcode/shared", () => ({
+  getMcodeDir: vi.fn(() => "/fake/mcode"),
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../transport/push.js", () => ({
+  broadcast: vi.fn(),
+}));
+
+import { SettingsService } from "../settings-service.js";
+import { broadcast } from "../../transport/push.js";
+
+describe("SettingsService in-process change listener", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("on('change', cb) fires cb with the validated settings when update() is called", () => {
+    const svc = new SettingsService();
+    const listener = vi.fn();
+    svc.on("change", listener);
+
+    svc.update({});
+
+    expect(listener).toHaveBeenCalledOnce();
+    // The argument should be a Settings object — it will have the provider key.
+    const received = listener.mock.calls[0]![0];
+    expect(received).toHaveProperty("provider");
+    // broadcast must also have been called (existing behaviour is intact)
+    expect(broadcast).toHaveBeenCalled();
+  });
+
+  it("on('change', cb) returns an unsubscribe function that removes the listener", () => {
+    const svc = new SettingsService();
+    const listener = vi.fn();
+    const unsub = svc.on("change", listener);
+
+    unsub();
+    svc.update({});
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -37,6 +37,11 @@ import { broadcast } from "../transport/push";
 // not at AgentService construction time.
 import { ThreadService } from "./thread-service";
 import { SettingsService } from "./settings-service.js";
+import { ProviderAvailabilityService } from "./provider-availability-service.js";
+import {
+  ProviderDisabledError,
+  ProviderCliMissingError,
+} from "./provider-availability-errors.js";
 import { PlanQuestionParser } from "./plan-question-parser.js";
 import { buildHandoffContent, buildConversationReplay, replayBudgetChars, resolveForkSnapshot } from "./handoff-builder.js";
 import { PlanQuestionSchema } from "@mcode/contracts";
@@ -120,6 +125,8 @@ export class AgentService {
     private readonly memoryPressureService: MemoryPressureService,
     @inject(TaskRepo) private readonly taskRepo: TaskRepo,
     @inject(SettingsService) private readonly settingsService: SettingsService,
+    @inject(ProviderAvailabilityService)
+    private readonly availability: ProviderAvailabilityService,
   ) {}
 
   /**
@@ -148,6 +155,25 @@ export class AgentService {
     // Fall back to the thread's persisted Copilot agent when the caller doesn't supply one.
     // Converts null (DB "cleared") to undefined (provider ignores it) so the SDK defaults.
     const effectiveCopilotAgent = copilotAgent ?? (thread.copilot_agent ?? undefined);
+
+    // Gate: reject disabled or CLI-missing providers before any side effects
+    // (message persistence, status changes) so the thread stays in a clean state.
+    try {
+      this.availability.assertUsable(effectiveProvider);
+    } catch (err) {
+      if (err instanceof ProviderDisabledError || err instanceof ProviderCliMissingError) {
+        broadcast("agent.event", {
+          type: "providerUnavailable",
+          threadId,
+          providerId: effectiveProvider,
+          reason: err instanceof ProviderDisabledError ? "disabled" : "cli_missing",
+          configuredPath: err instanceof ProviderCliMissingError ? err.configuredPath : undefined,
+        });
+        return;
+      }
+      throw err;
+    }
+
     if (thread.status === "deleted" || thread.deleted_at != null) {
       throw new Error(`Cannot send message to deleted thread: ${threadId}`);
     }

--- a/apps/server/src/services/pr-draft-service.ts
+++ b/apps/server/src/services/pr-draft-service.ts
@@ -13,6 +13,7 @@ import type { MessageRepo } from "../repositories/message-repo.js";
 import type { WorkspaceRepo } from "../repositories/workspace-repo.js";
 import type { ThreadRepo } from "../repositories/thread-repo.js";
 import { SettingsService } from "./settings-service.js";
+import { ProviderAvailabilityService } from "./provider-availability-service.js";
 import { isCompletionCapable } from "@mcode/contracts";
 import type { IProviderRegistry, ProviderId, PrDraft } from "@mcode/contracts";
 import { parseCompletionDraft } from "./pr-draft-parser.js";
@@ -50,6 +51,7 @@ export class PrDraftService {
     @inject("ThreadRepo") private readonly threadRepo: ThreadRepo,
     @inject(SettingsService) private readonly settingsService: SettingsService,
     @inject("IProviderRegistry") private readonly providerRegistry: IProviderRegistry,
+    @inject(ProviderAvailabilityService) private readonly availability: ProviderAvailabilityService,
   ) {}
 
   /**
@@ -108,6 +110,7 @@ export class PrDraftService {
     const configuredProvider = settings.prDraft.provider as ProviderId | "";
     const defaultProvider = settings.model.defaults.provider as ProviderId;
     const resolvedProvider = configuredProvider || defaultProvider;
+    this.availability.assertUsable(resolvedProvider);
     const resolvedAgent = this.providerRegistry.resolve(resolvedProvider);
 
     let provider: ProviderId;
@@ -149,6 +152,7 @@ export class PrDraftService {
 
     const aiContext = { commitLog, diffStat, conversationSummary, repoTemplate, headBranch, baseBranch, repoPath };
 
+    this.availability.assertUsable(provider);
     try {
       return await this.generateWithAI({ ...aiContext, provider, model });
     } catch (error) {

--- a/apps/server/src/services/provider-availability-errors.ts
+++ b/apps/server/src/services/provider-availability-errors.ts
@@ -1,0 +1,29 @@
+import type { ProviderId } from "@mcode/contracts";
+
+/** Thrown when a caller requests a provider whose enabled flag is false (or comingSoon). */
+export class ProviderDisabledError extends Error {
+  readonly code = "PROVIDER_DISABLED" as const;
+  constructor(public readonly providerId: ProviderId) {
+    super(`Provider "${providerId}" is disabled`);
+    this.name = "ProviderDisabledError";
+  }
+}
+
+/** Thrown when a provider is enabled but its CLI binary could not be resolved. */
+export class ProviderCliMissingError extends Error {
+  readonly code = "PROVIDER_CLI_MISSING" as const;
+  constructor(
+    public readonly providerId: ProviderId,
+    public readonly configuredPath: string,
+  ) {
+    super(`Provider "${providerId}" CLI not found (configuredPath="${configuredPath}")`);
+    this.name = "ProviderCliMissingError";
+  }
+}
+
+/** Type guard for either availability-related error. */
+export function isProviderAvailabilityError(
+  err: unknown,
+): err is ProviderDisabledError | ProviderCliMissingError {
+  return err instanceof ProviderDisabledError || err instanceof ProviderCliMissingError;
+}

--- a/apps/server/src/services/provider-availability-service.ts
+++ b/apps/server/src/services/provider-availability-service.ts
@@ -7,6 +7,10 @@ import {
   type IProviderRegistry,
 } from "@mcode/contracts";
 import { SettingsService } from "./settings-service.js";
+import {
+  ProviderDisabledError,
+  ProviderCliMissingError,
+} from "./provider-availability-errors.js";
 import whichModule from "which";
 import { promises as fsp, constants as fsConst } from "node:fs";
 
@@ -105,5 +109,36 @@ export class ProviderAvailabilityService {
     }
     this.cliCache.set(id, result);
     return result;
+  }
+
+  /**
+   * Throw a typed error if the provider is unusable. Returns normally otherwise.
+   * CLI `unchecked` state is treated as "probably ok" — the first send will
+   * re-verify and surface the real error if the binary is missing.
+   */
+  assertUsable(id: ProviderId): void {
+    const s = this.settings.get();
+    const entry = getCatalogEntry(id);
+    if (entry.comingSoon || !s.provider.enabled[id]) {
+      throw new ProviderDisabledError(id);
+    }
+    const cached = this.cliCache.get(id);
+    if (cached?.status === "not_found") {
+      const configuredPath =
+        id === "codex" || id === "claude" || id === "copilot"
+          ? s.provider.cli[id]
+          : "";
+      throw new ProviderCliMissingError(id, configuredPath);
+    }
+  }
+
+  /** Run verification for every provider whose enabled flag is true and that has an adapter. */
+  async verifyAllEnabled(): Promise<void> {
+    const s = this.settings.get();
+    const registered = new Set(this.registry.resolveAll().map((p) => p.id));
+    const targets = PROVIDER_CATALOG.filter(
+      (entry) => s.provider.enabled[entry.id] && registered.has(entry.id),
+    );
+    await Promise.all(targets.map((entry) => this.verifyCli(entry.id)));
   }
 }

--- a/apps/server/src/services/provider-availability-service.ts
+++ b/apps/server/src/services/provider-availability-service.ts
@@ -19,6 +19,14 @@ type CliRuntime = {
   resolvedPath: string | null;
 };
 
+/** Provider IDs whose CLI path is user-configurable via `settings.provider.cli`. */
+type CliProvider = "codex" | "claude" | "copilot";
+
+/** Narrows a ProviderId to those that carry a configurable CLI path setting. */
+function hasCliPath(id: ProviderId): id is CliProvider {
+  return id === "codex" || id === "claude" || id === "copilot";
+}
+
 /** Thin shim over `which` + fs so tests can inject stubs. */
 export interface CliResolver {
   which(binary: string): Promise<string>;
@@ -61,10 +69,7 @@ export class ProviderAvailabilityService {
         status: "unchecked",
         resolvedPath: null,
       };
-      const configuredPath =
-        entry.id === "codex" || entry.id === "claude" || entry.id === "copilot"
-          ? s.provider.cli[entry.id]
-          : "";
+      const configuredPath = hasCliPath(entry.id) ? s.provider.cli[entry.id] : "";
       return {
         id: entry.id,
         enabled: s.provider.enabled[entry.id],
@@ -88,10 +93,7 @@ export class ProviderAvailabilityService {
    */
   async verifyCli(id: ProviderId): Promise<CliRuntime> {
     const s = this.settings.get();
-    const configured =
-      id === "codex" || id === "claude" || id === "copilot"
-        ? s.provider.cli[id]
-        : "";
+    const configured = hasCliPath(id) ? s.provider.cli[id] : "";
 
     let result: CliRuntime;
     if (configured) {
@@ -124,10 +126,7 @@ export class ProviderAvailabilityService {
     }
     const cached = this.cliCache.get(id);
     if (cached?.status === "not_found") {
-      const configuredPath =
-        id === "codex" || id === "claude" || id === "copilot"
-          ? s.provider.cli[id]
-          : "";
+      const configuredPath = hasCliPath(id) ? s.provider.cli[id] : "";
       throw new ProviderCliMissingError(id, configuredPath);
     }
   }
@@ -144,6 +143,8 @@ export class ProviderAvailabilityService {
 
   private broadcastListeners: Array<(list: ProviderAvailability[]) => void> = [];
   private settingsSubscribed = false;
+  /** Snapshot of `settings.provider` from the last broadcast — used to skip no-op re-verifies. */
+  private lastProviderSnapshot: string | null = null;
 
   /** Register a broadcast callback invoked whenever availability changes due to a settings update. */
   onChange(cb: (list: ProviderAvailability[]) => void): void {
@@ -151,6 +152,7 @@ export class ProviderAvailabilityService {
     // Subscribe to SettingsService once, no matter how many onChange callers there are.
     if (!this.settingsSubscribed) {
       this.settingsSubscribed = true;
+      this.lastProviderSnapshot = JSON.stringify(this.settings.get().provider);
       this.settings.on("change", (s) => {
         void this.handleSettingsChange(s);
       });
@@ -158,8 +160,14 @@ export class ProviderAvailabilityService {
   }
 
   private async handleSettingsChange(
-    _next: ReturnType<SettingsService["get"]>,
+    next: ReturnType<SettingsService["get"]>,
   ): Promise<void> {
+    // Settings emits on every update — skip when the provider slice didn't change
+    // to avoid respawning `which`/`fs.access` probes on unrelated edits (theme, terminal, etc.).
+    const snapshot = JSON.stringify(next.provider);
+    if (snapshot === this.lastProviderSnapshot) return;
+    this.lastProviderSnapshot = snapshot;
+
     await this.verifyAllEnabled();
     const list = this.listAvailability();
     for (const cb of this.broadcastListeners) cb(list);

--- a/apps/server/src/services/provider-availability-service.ts
+++ b/apps/server/src/services/provider-availability-service.ts
@@ -6,6 +6,7 @@ import {
   type ProviderId,
   type IProviderRegistry,
 } from "@mcode/contracts";
+import { logger } from "@mcode/shared";
 import { SettingsService } from "./settings-service.js";
 import {
   ProviderDisabledError,
@@ -168,8 +169,25 @@ export class ProviderAvailabilityService {
     if (snapshot === this.lastProviderSnapshot) return;
     this.lastProviderSnapshot = snapshot;
 
-    await this.verifyAllEnabled();
+    try {
+      await this.verifyAllEnabled();
+    } catch (err) {
+      // Log and continue — listeners still need to receive the updated availability
+      // snapshot. Per-provider CLI entries will stay at their prior cached status.
+      logger.warn("verifyAllEnabled failed during settings change", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     const list = this.listAvailability();
-    for (const cb of this.broadcastListeners) cb(list);
+    for (const cb of this.broadcastListeners) {
+      try {
+        cb(list);
+      } catch (err) {
+        // Isolate listeners: one throwing callback must not prevent others from firing.
+        logger.warn("provider availability onChange listener threw", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 }

--- a/apps/server/src/services/provider-availability-service.ts
+++ b/apps/server/src/services/provider-availability-service.ts
@@ -141,4 +141,27 @@ export class ProviderAvailabilityService {
     );
     await Promise.all(targets.map((entry) => this.verifyCli(entry.id)));
   }
+
+  private broadcastListeners: Array<(list: ProviderAvailability[]) => void> = [];
+  private settingsSubscribed = false;
+
+  /** Register a broadcast callback invoked whenever availability changes due to a settings update. */
+  onChange(cb: (list: ProviderAvailability[]) => void): void {
+    this.broadcastListeners.push(cb);
+    // Subscribe to SettingsService once, no matter how many onChange callers there are.
+    if (!this.settingsSubscribed) {
+      this.settingsSubscribed = true;
+      this.settings.on("change", (s) => {
+        void this.handleSettingsChange(s);
+      });
+    }
+  }
+
+  private async handleSettingsChange(
+    _next: ReturnType<SettingsService["get"]>,
+  ): Promise<void> {
+    await this.verifyAllEnabled();
+    const list = this.listAvailability();
+    for (const cb of this.broadcastListeners) cb(list);
+  }
 }

--- a/apps/server/src/services/provider-availability-service.ts
+++ b/apps/server/src/services/provider-availability-service.ts
@@ -1,0 +1,56 @@
+import { inject, injectable } from "tsyringe";
+import {
+  PROVIDER_CATALOG,
+  type ProviderAvailability,
+  type ProviderId,
+  type IProviderRegistry,
+} from "@mcode/contracts";
+import { SettingsService } from "./settings-service.js";
+
+type CliRuntime = {
+  status: "found" | "not_found" | "unchecked";
+  resolvedPath: string | null;
+};
+
+/**
+ * Tracks per-provider enabled flag + CLI verification state. Call sites use
+ * `assertUsable` before resolving a provider from the registry.
+ */
+@injectable()
+export class ProviderAvailabilityService {
+  private cliCache = new Map<ProviderId, CliRuntime>();
+
+  constructor(
+    @inject(SettingsService) private readonly settings: SettingsService,
+    @inject("IProviderRegistry") private readonly registry: IProviderRegistry,
+  ) {}
+
+  /** Build the full availability list from catalog + settings + cached CLI state. */
+  listAvailability(): ProviderAvailability[] {
+    const s = this.settings.get();
+    const registered = new Set(this.registry.resolveAll().map((p) => p.id));
+
+    return PROVIDER_CATALOG.map((entry): ProviderAvailability => {
+      const cliRuntime: CliRuntime = this.cliCache.get(entry.id) ?? {
+        status: "unchecked",
+        resolvedPath: null,
+      };
+      const configuredPath =
+        entry.id === "codex" || entry.id === "claude" || entry.id === "copilot"
+          ? s.provider.cli[entry.id]
+          : "";
+      return {
+        id: entry.id,
+        enabled: s.provider.enabled[entry.id],
+        hasAdapter: registered.has(entry.id),
+        beta: entry.beta,
+        comingSoon: entry.comingSoon,
+        cli: {
+          status: cliRuntime.status,
+          resolvedPath: cliRuntime.resolvedPath,
+          configuredPath,
+        },
+      };
+    });
+  }
+}

--- a/apps/server/src/services/provider-availability-service.ts
+++ b/apps/server/src/services/provider-availability-service.ts
@@ -1,15 +1,36 @@
 import { inject, injectable } from "tsyringe";
 import {
   PROVIDER_CATALOG,
+  getCatalogEntry,
   type ProviderAvailability,
   type ProviderId,
   type IProviderRegistry,
 } from "@mcode/contracts";
 import { SettingsService } from "./settings-service.js";
+import whichModule from "which";
+import { promises as fsp, constants as fsConst } from "node:fs";
 
 type CliRuntime = {
   status: "found" | "not_found" | "unchecked";
   resolvedPath: string | null;
+};
+
+/** Thin shim over `which` + fs so tests can inject stubs. */
+export interface CliResolver {
+  which(binary: string): Promise<string>;
+  statExecutable(path: string): Promise<boolean>;
+}
+
+const defaultResolver: CliResolver = {
+  which: (binary) => whichModule(binary),
+  statExecutable: async (path) => {
+    try {
+      await fsp.access(path, fsConst.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  },
 };
 
 /**
@@ -23,6 +44,7 @@ export class ProviderAvailabilityService {
   constructor(
     @inject(SettingsService) private readonly settings: SettingsService,
     @inject("IProviderRegistry") private readonly registry: IProviderRegistry,
+    private readonly resolver: CliResolver = defaultResolver,
   ) {}
 
   /** Build the full availability list from catalog + settings + cached CLI state. */
@@ -52,5 +74,36 @@ export class ProviderAvailabilityService {
         },
       };
     });
+  }
+
+  /**
+   * Resolve and validate the CLI binary for the given provider.
+   * When `settings.provider.cli[id]` is set, checks that exact path for execute
+   * permissions; otherwise falls back to PATH lookup via `which`.
+   * Caches the result for subsequent `listAvailability` calls.
+   */
+  async verifyCli(id: ProviderId): Promise<CliRuntime> {
+    const s = this.settings.get();
+    const configured =
+      id === "codex" || id === "claude" || id === "copilot"
+        ? s.provider.cli[id]
+        : "";
+
+    let result: CliRuntime;
+    if (configured) {
+      const ok = await this.resolver.statExecutable(configured);
+      result = ok
+        ? { status: "found", resolvedPath: configured }
+        : { status: "not_found", resolvedPath: null };
+    } else {
+      try {
+        const resolved = await this.resolver.which(getCatalogEntry(id).cliBinary);
+        result = { status: "found", resolvedPath: resolved };
+      } catch {
+        result = { status: "not_found", resolvedPath: null };
+      }
+    }
+    this.cliCache.set(id, result);
+    return result;
   }
 }

--- a/apps/server/src/services/settings-service.ts
+++ b/apps/server/src/services/settings-service.ts
@@ -124,6 +124,14 @@ export class SettingsService {
     // Validate and strip unknown keys before writing to disk
     const validated = SettingsSchema().parse(merged);
 
+    // Refuse updates that would disable every provider, which would render the app
+    // unusable (every sendMessage would throw ProviderDisabledError). The UI enforces
+    // this too, but a direct RPC call would otherwise bypass it.
+    const anyEnabled = Object.values(validated.provider.enabled).some(Boolean);
+    if (!anyEnabled) {
+      throw new Error("At least one provider must remain enabled");
+    }
+
     // Ensure parent directory exists (only on first write)
     if (!this.dirEnsured) {
       mkdirSync(dirname(this.filePath), { recursive: true });

--- a/apps/server/src/services/settings-service.ts
+++ b/apps/server/src/services/settings-service.ts
@@ -72,6 +72,9 @@ export class SettingsService {
   /** Whether the parent directory has already been created, to avoid redundant mkdirSync calls. */
   private dirEnsured = false;
 
+  /** In-process change listeners registered via `on("change", cb)`. */
+  private changeListeners: Array<(next: Settings) => void> = [];
+
   constructor() {
     this.filePath = join(getMcodeDir(), "settings.json");
     this.startWatching();
@@ -152,8 +155,34 @@ export class SettingsService {
     this.cache = validated;
 
     broadcast("settings.changed", validated);
+    this.emitChange(validated);
 
     return validated;
+  }
+
+  /**
+   * Subscribe to in-process settings changes. Called whenever settings are
+   * updated via `update()` or reloaded after an external file edit. Returns
+   * an unsubscribe function.
+   */
+  on(event: "change", cb: (next: Settings) => void): () => void {
+    void event;
+    this.changeListeners.push(cb);
+    return () => {
+      this.changeListeners = this.changeListeners.filter((l) => l !== cb);
+    };
+  }
+
+  private emitChange(next: Settings): void {
+    for (const cb of this.changeListeners) {
+      try {
+        cb(next);
+      } catch (err) {
+        logger.warn("SettingsService change listener threw", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   /** Stop watching the settings file and clean up timers. */
@@ -215,6 +244,7 @@ export class SettingsService {
           this.cache = null;
           const settings = this.get();
           broadcast("settings.changed", settings);
+          this.emitChange(settings);
 
           // If we started watching the directory and the file now exists,
           // switch to watching the file directly for more precise events.

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -43,6 +43,11 @@ import type { CiWatcherService } from "../services/ci-watcher";
 import type { ThreadRepo } from "../repositories/thread-repo";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import { broadcast } from "./push";
+import {
+  ProviderCliMissingError,
+  isProviderAvailabilityError,
+} from "../services/provider-availability-errors.js";
+import type { ProviderAvailabilityService } from "../services/provider-availability-service.js";
 
 /** Service dependencies for the router. */
 export interface RouterDeps {
@@ -67,6 +72,8 @@ export interface RouterDeps {
   taskRepo: TaskRepo;
   /** Registry of AI provider adapters for model discovery. */
   providerRegistry: IProviderRegistry;
+  /** Tracks per-provider enabled flag and CLI verification state. */
+  providerAvailability: ProviderAvailabilityService;
   /** Generates AI-powered PR draft titles and bodies. */
   prDraftService: PrDraftService;
   /** CI check watcher for adaptive polling and manual refresh. */
@@ -148,16 +155,23 @@ export async function routeMessage(
 
     return { id: request.id, result };
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : String(err);
-    logger.error("RPC handler error", {
-      method: request.method,
-      error: message,
-    });
-    return {
-      id: request.id,
-      error: { code: "INTERNAL_ERROR", message },
-    };
+    const message = err instanceof Error ? err.message : String(err);
+    if (isProviderAvailabilityError(err)) {
+      logger.info("Provider unavailable in RPC", { method: request.method, providerId: err.providerId, code: err.code });
+      return {
+        id: request.id,
+        error: {
+          code: err.code,
+          message,
+          data:
+            err instanceof ProviderCliMissingError
+              ? { providerId: err.providerId, configuredPath: err.configuredPath, resolvedPath: null }
+              : { providerId: err.providerId },
+        },
+      };
+    }
+    logger.error("RPC handler error", { method: request.method, error: message });
+    return { id: request.id, error: { code: "INTERNAL_ERROR", message } };
   }
 }
 
@@ -531,6 +545,7 @@ async function dispatch(
 
     // Provider
     case "provider.listModels": {
+      deps.providerAvailability.assertUsable(params.providerId);
       const provider = deps.providerRegistry.resolve(params.providerId);
       if (!provider.listModels) {
         throw new Error(`Provider "${params.providerId}" does not support model listing`);
@@ -538,11 +553,15 @@ async function dispatch(
       return provider.listModels();
     }
     case "provider.getUsage": {
+      deps.providerAvailability.assertUsable(params.providerId);
       const provider = deps.providerRegistry.resolve(params.providerId);
       if (!provider.getUsage) {
         return { providerId: provider.id, quotaCategories: [] } satisfies ProviderUsageInfo;
       }
       return provider.getUsage();
+    }
+    case "providers.listAvailability": {
+      return deps.providerAvailability.listAvailability();
     }
     case "provider.copilotAgents": {
       const workspace = deps.workspaceService.findById(params.workspaceId);

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -14,6 +14,12 @@ export type RpcOverrides = Record<string, unknown>;
 export interface WsController {
   /** Send a JSON-RPC notification (no `id`) to the connected client. */
   sendNotification(method: string, params?: unknown): Promise<void>;
+  /**
+   * Send a server-initiated push event using the transport's
+   * `{ type: "push", channel, data }` wire shape so that `pushEmitter`
+   * listeners in ws-events.ts receive the event correctly.
+   */
+  sendPush(channel: string, data: unknown): Promise<void>;
 }
 
 /**
@@ -83,6 +89,10 @@ export async function mockWebSocketServer(
     async sendNotification(method: string, params?: unknown): Promise<void> {
       const ws = await wsReady;
       ws.send(JSON.stringify({ jsonrpc: "2.0", method, params }));
+    },
+    async sendPush(channel: string, data: unknown): Promise<void> {
+      const ws = await wsReady;
+      ws.send(JSON.stringify({ type: "push", channel, data }));
     },
   };
 }

--- a/apps/web/e2e/provider-toggle.spec.ts
+++ b/apps/web/e2e/provider-toggle.spec.ts
@@ -298,8 +298,9 @@ test.describe("provider toggle", () => {
 
     const controller = await mockWebSocketServer(page, {
       "providers.listAvailability": initialAvailability,
-      // Return empty list for messages so loadMessages resolves immediately.
-      "thread.listMessages": { items: [], cursor: null },
+      // Return empty list so loadMessages resolves immediately. Shape must match
+      // PaginatedMessagesSchema: { messages, hasMore }.
+      "message.list": { messages: [], hasMore: false },
     });
 
     await interceptZustandStores(page);

--- a/apps/web/e2e/provider-toggle.spec.ts
+++ b/apps/web/e2e/provider-toggle.spec.ts
@@ -1,0 +1,330 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+import { getDefaultSettings } from "@mcode/contracts";
+import type { ProviderAvailability } from "@mcode/contracts";
+
+// ── Screenshot path ───────────────────────────────────────────────────────────
+
+const SS = (name: string) => `e2e/screenshots/provider-toggle/${name}`;
+
+// ── Provider availability fixture ────────────────────────────────────────────
+
+/**
+ * Default CLI info for a provider with a known binary path.
+ * Overridden per-provider in the factory when needed.
+ */
+function defaultCli(): ProviderAvailability["cli"] {
+  return { status: "found", resolvedPath: "/usr/local/bin/cli", configuredPath: "" };
+}
+
+/** Per-provider overrides applied on top of the defaults below. */
+type ProviderOverride = Partial<Omit<ProviderAvailability, "id"> & { cli: Partial<ProviderAvailability["cli"]> }>;
+type AvailabilityOverrides = Partial<Record<ProviderAvailability["id"], ProviderOverride>>;
+
+/**
+ * Build a full 6-provider availability list that matches PROVIDER_CATALOG order.
+ * Pass per-provider overrides to change specific fields for a test scenario.
+ */
+function makeAvailabilityFixture(overrides: AvailabilityOverrides = {}): ProviderAvailability[] {
+  function make(
+    id: ProviderAvailability["id"],
+    base: Omit<ProviderAvailability, "id">,
+  ): ProviderAvailability {
+    const o = overrides[id];
+    if (!o) return { id, ...base };
+    const cli = o.cli ? { ...base.cli, ...o.cli } : base.cli;
+    return { id, ...base, ...o, cli } as ProviderAvailability;
+  }
+
+  return [
+    make("claude",   { enabled: true,  hasAdapter: true,  beta: false, comingSoon: false, cli: defaultCli() }),
+    make("codex",    { enabled: true,  hasAdapter: true,  beta: false, comingSoon: false, cli: defaultCli() }),
+    make("copilot",  { enabled: true,  hasAdapter: true,  beta: true,  comingSoon: false, cli: defaultCli() }),
+    make("gemini",   { enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } }),
+    make("cursor",   { enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } }),
+    make("opencode", { enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } }),
+  ];
+}
+
+// ── Thread fixture (used for test 6) ────────────────────────────────────────
+
+const WORKSPACE_PT = {
+  id: "ws-pt-1",
+  name: "Provider Toggle Test",
+  path: "/tmp/pt-test",
+  provider_config: {},
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const THREAD_CLAUDE = {
+  id: "thread-pt-1",
+  workspace_id: "ws-pt-1",
+  title: "Claude Thread",
+  status: "active" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: "claude-sonnet-4-6",
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+// ── Shared helper: navigate to Settings → Provider ───────────────────────────
+
+/**
+ * Click the Settings button then click the "Provider" nav item.
+ * Assumes the app is already loaded and at networkidle.
+ */
+async function openProviderSettings(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Settings" }).click();
+  await page.getByRole("button", { name: "Provider", exact: true }).click();
+  // Wait for the ProviderSection heading to confirm the section rendered.
+  await expect(page.getByRole("heading", { name: "Provider" })).toBeVisible();
+}
+
+/**
+ * Inject workspace + thread state and activate the given thread.
+ * Mirrors the pattern from architecture.spec.ts setupWorkspaceState.
+ */
+async function setupWorkspaceState(
+  page: Page,
+  opts: {
+    workspaces: typeof WORKSPACE_PT[];
+    threads: typeof THREAD_CLAUDE[];
+    activeWorkspaceId: string;
+    activeThreadId?: string | null;
+  },
+): Promise<void> {
+  await page.evaluate(
+    ({ workspaces, threads, activeWorkspaceId, activeThreadId }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({
+        workspaces,
+        activeWorkspaceId,
+        threads,
+        activeThreadId: activeThreadId ?? null,
+        loading: false,
+        error: null,
+      });
+    },
+    opts,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("provider toggle", () => {
+  test.setTimeout(30000);
+
+  // ── Test 1: six switches + key badges visible ──────────────────────────────
+
+  test("renders six switches with badges", async ({ page }) => {
+    const availability = makeAvailabilityFixture();
+
+    await mockWebSocketServer(page, {
+      "providers.listAvailability": availability,
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await openProviderSettings(page);
+
+    // Each provider should have a switch
+    const switchIds: ProviderAvailability["id"][] = [
+      "claude", "codex", "copilot", "gemini", "cursor", "opencode",
+    ];
+    for (const id of switchIds) {
+      await expect(page.getByTestId(`provider-switch-${id}`)).toBeVisible();
+    }
+
+    // Claude switch should be present and visible (already checked above, but explicit)
+    await expect(page.getByTestId("provider-switch-claude")).toBeVisible();
+
+    // Copilot should have a Beta badge
+    await expect(page.getByTestId("provider-badge-copilot-beta")).toBeVisible();
+
+    // Gemini should have a Coming soon badge
+    await expect(page.getByTestId("provider-badge-gemini-comingsoon")).toBeVisible();
+
+    await page.screenshot({ path: SS("01-settings-default.png"), fullPage: false });
+  });
+
+  // ── Test 2: toggle non-default provider off — no dialog ───────────────────
+
+  test("toggling a non-default provider off does not show a dialog", async ({ page }) => {
+    const availability = makeAvailabilityFixture();
+    const settings = getDefaultSettings(); // default provider is "claude"
+
+    await mockWebSocketServer(page, {
+      "providers.listAvailability": availability,
+      "settings.get": settings,
+      "settings.update": settings,
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await openProviderSettings(page);
+
+    // Copilot is enabled but NOT the default provider (claude is).
+    // Clicking its switch should toggle off without showing a confirm dialog.
+    const copilotSwitch = page.getByTestId("provider-switch-copilot");
+    await expect(copilotSwitch).toBeVisible();
+    await expect(copilotSwitch).not.toBeDisabled();
+    await copilotSwitch.click();
+
+    // No dialog should appear
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+
+    await page.screenshot({ path: SS("02-toggle-non-default.png"), fullPage: false });
+  });
+
+  // ── Test 3: toggling the default provider shows the confirm dialog ─────────
+
+  test("toggling the default provider off shows the confirm dialog", async ({ page }) => {
+    const availability = makeAvailabilityFixture();
+    // Override default provider to "codex" so clicking codex triggers the dialog.
+    const settings = {
+      ...getDefaultSettings(),
+      model: {
+        ...getDefaultSettings().model,
+        defaults: {
+          ...getDefaultSettings().model.defaults,
+          provider: "codex" as const,
+        },
+      },
+    };
+
+    await mockWebSocketServer(page, {
+      "providers.listAvailability": availability,
+      "settings.get": settings,
+      "settings.update": settings,
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await openProviderSettings(page);
+
+    // Click codex switch (it is the current default provider)
+    const codexSwitch = page.getByTestId("provider-switch-codex");
+    await expect(codexSwitch).toBeVisible();
+    await expect(codexSwitch).not.toBeDisabled();
+    await codexSwitch.click();
+
+    // Confirm dialog should appear
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Dialog title should mention "Disable Codex"
+    await expect(dialog.getByRole("heading", { name: /Disable Codex/i })).toBeVisible();
+
+    // Dialog body should mention the replacement (Claude, first in catalog)
+    await expect(dialog.getByText(/Claude/i)).toBeVisible();
+
+    await page.screenshot({ path: SS("03-confirm-dialog.png"), fullPage: false });
+  });
+
+  // ── Test 4: CLI missing shows the red badge ───────────────────────────────
+
+  test("CLI missing shows the red badge", async ({ page }) => {
+    const availability = makeAvailabilityFixture({
+      codex: { cli: { status: "not_found", resolvedPath: null, configuredPath: "" } },
+    });
+
+    await mockWebSocketServer(page, {
+      "providers.listAvailability": availability,
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await openProviderSettings(page);
+
+    // The CLI missing badge for codex should be visible
+    await expect(page.getByTestId("provider-badge-codex-cli-missing")).toBeVisible();
+
+    await page.screenshot({ path: SS("04-cli-missing-badge.png"), fullPage: false });
+  });
+
+  // ── Test 5: coming-soon provider switch is disabled ───────────────────────
+
+  test("coming-soon provider switch is disabled", async ({ page }) => {
+    const availability = makeAvailabilityFixture();
+
+    await mockWebSocketServer(page, {
+      "providers.listAvailability": availability,
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await openProviderSettings(page);
+
+    // gemini is comingSoon=true, so its switch must be disabled
+    const geminiSwitch = page.getByTestId("provider-switch-gemini");
+    await expect(geminiSwitch).toBeVisible();
+    await expect(geminiSwitch).toBeDisabled();
+
+    await page.screenshot({ path: SS("05-coming-soon-disabled.png"), fullPage: false });
+  });
+
+  // ── Test 6: composer banner when thread provider is disabled ──────────────
+
+  test("composer shows unavailable banner when thread provider is disabled", async ({ page }) => {
+    // Start with claude enabled so the app boots cleanly.
+    const initialAvailability = makeAvailabilityFixture();
+
+    const controller = await mockWebSocketServer(page, {
+      "providers.listAvailability": initialAvailability,
+      // Return empty list for messages so loadMessages resolves immediately.
+      "thread.listMessages": { items: [], cursor: null },
+    });
+
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Inject workspace + thread into the store, then activate the thread.
+    await setupWorkspaceState(page, {
+      workspaces: [WORKSPACE_PT],
+      threads: [THREAD_CLAUDE],
+      activeWorkspaceId: WORKSPACE_PT.id,
+      activeThreadId: THREAD_CLAUDE.id,
+    });
+
+    // Wait for the composer to appear (confirms the thread is active).
+    await expect(page.locator('[contenteditable="true"]')).toBeVisible({ timeout: 5000 });
+
+    // Push an availability update with claude disabled.
+    await controller.sendPush("providers.availability", makeAvailabilityFixture({
+      claude: { enabled: false },
+    }));
+
+    // The unavailable banner should appear.
+    await expect(page.getByTestId("provider-unavailable-banner")).toBeVisible({ timeout: 5000 });
+
+    await page.screenshot({ path: SS("06-composer-banner.png"), fullPage: false });
+  });
+});

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -132,6 +132,7 @@ export const mockTransport: McodeTransport = {
   getSettings: vi.fn().mockImplementation(() => Promise.resolve(structuredClone(getDefaultSettings()))),
   updateSettings: vi.fn().mockImplementation(() => Promise.resolve(structuredClone(getDefaultSettings()))),
   listProviderModels: vi.fn().mockResolvedValue([]),
+  listProviderAvailability: vi.fn().mockResolvedValue([]),
   setBackground: vi.fn().mockResolvedValue(undefined),
   getProviderUsage: vi.fn().mockResolvedValue({
     providerId: "claude",

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1321,8 +1321,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
         {/* Provider unavailable banner — shown when the thread's active provider is
             disabled by the user or its CLI binary is missing. Branch initiation is
-            owned by ChatView (it controls branchFromMessageId), so that callback is
-            a no-op here; the user can still act via Open Settings. */}
+            owned by ChatView (it controls branchFromMessageId), so we omit onBranch
+            here and the banner renders only the "Open Settings" CTA. */}
         {providerReason && (
           <ProviderUnavailableBanner
             providerId={activeProviderId as ProviderId}
@@ -1330,7 +1330,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             onOpenSettings={() =>
               window.dispatchEvent(new CustomEvent("mcode:open-settings", { detail: { section: "provider" } }))
             }
-            onBranch={() => {}}
           />
         )}
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -639,7 +639,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const usageInfo = useThreadStore((s) => s.usageByProvider[activeProviderId]);
   const hasLowQuota = usageInfo?.quotaCategories.some((c) => !c.isUnlimited && c.remainingPercent < 0.2) ?? false;
 
-  const availability = useProviderAvailabilityStore((s) => s.getAvailability(activeProviderId as ProviderId));
+  // For new threads (no active thread yet), fall back to the composer-selected
+  // provider so the availability banner tracks what the user is about to submit.
+  const effectiveProviderId = (activeThread?.provider ?? provider) as ProviderId;
+  const availability = useProviderAvailabilityStore((s) => s.getAvailability(effectiveProviderId));
   const providerUnusable = !!availability && (
     !availability.enabled || availability.cli.status === "not_found"
   );
@@ -1325,10 +1328,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             here and the banner renders only the "Open Settings" CTA. */}
         {providerReason && (
           <ProviderUnavailableBanner
-            providerId={activeProviderId as ProviderId}
+            providerId={effectiveProviderId}
             reason={providerReason}
             onOpenSettings={() =>
-              window.dispatchEvent(new CustomEvent("mcode:open-settings", { detail: { section: "provider" } }))
+              window.dispatchEvent(new CustomEvent("mcode:open-settings", { detail: { section: "model" } }))
             }
           />
         )}

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -59,9 +59,12 @@ import {
   MAX_ATTACHMENTS,
 } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
+import type { ProviderId } from "@mcode/contracts";
 import { useComposerDraftStore } from "@/stores/composerDraftStore";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { useElementWidth } from "@/hooks/useElementWidth";
+import { ProviderUnavailableBanner } from "./ProviderUnavailableBanner";
 
 /** ReasoningLevel values as a Set for O(1) membership checks in the Codex level filter. */
 const VALID_REASONING_LEVELS_SET = new Set<string>(["low", "medium", "high", "xhigh", "max"]);
@@ -635,6 +638,14 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const activeProviderId = activeThread?.provider ?? "claude";
   const usageInfo = useThreadStore((s) => s.usageByProvider[activeProviderId]);
   const hasLowQuota = usageInfo?.quotaCategories.some((c) => !c.isUnlimited && c.remainingPercent < 0.2) ?? false;
+
+  const availability = useProviderAvailabilityStore((s) => s.getAvailability(activeProviderId as ProviderId));
+  const providerUnusable = !!availability && (
+    !availability.enabled || availability.cli.status === "not_found"
+  );
+  const providerReason: "disabled" | "cli_missing" | null = providerUnusable
+    ? (!availability!.enabled ? "disabled" : "cli_missing")
+    : null;
 
   const branches = useWorkspaceStore((s) => s.branches);
   const branchesLoading = useWorkspaceStore((s) => s.branchesLoading);
@@ -1308,6 +1319,21 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           />
         )}
 
+        {/* Provider unavailable banner — shown when the thread's active provider is
+            disabled by the user or its CLI binary is missing. Branch initiation is
+            owned by ChatView (it controls branchFromMessageId), so that callback is
+            a no-op here; the user can still act via Open Settings. */}
+        {providerReason && (
+          <ProviderUnavailableBanner
+            providerId={activeProviderId as ProviderId}
+            reason={providerReason}
+            onOpenSettings={() =>
+              window.dispatchEvent(new CustomEvent("mcode:open-settings", { detail: { section: "model" } }))
+            }
+            onBranch={() => {}}
+          />
+        )}
+
         {/* Lexical editor with file tag popup */}
         <div className="relative" ref={editorContainerRef} onPaste={handlePaste}>
           <ComposerEditor
@@ -1320,7 +1346,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             onSlashDismiss={slashCommand.onDismiss}
             isSlashPopupOpen={slashCommand.isOpen}
             editorRef={editorRef}
-            disabled={planPending || isStaleWorktree}
+            disabled={planPending || isStaleWorktree || !!providerReason}
             isPopupOpen={isAnyPopupOpen}
             onPopupKeyDown={handlePopupKeyDown}
             placeholder={isStaleWorktree ? "Worktree directory no longer exists. This thread is read-only." : planPending ? "Answer the planning questions above" : branchFromMessageId ? "What should the branch work on?" : isAgentRunning ? "Queue a follow-up..." : "Message Mcode..."}
@@ -1546,6 +1572,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                     : handleSend
             }
             disabled={
+              !!providerReason ||
               isStaleWorktree ||
               planPending ||
               preparingWorktree ||

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1328,7 +1328,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             providerId={activeProviderId as ProviderId}
             reason={providerReason}
             onOpenSettings={() =>
-              window.dispatchEvent(new CustomEvent("mcode:open-settings", { detail: { section: "model" } }))
+              window.dispatchEvent(new CustomEvent("mcode:open-settings", { detail: { section: "provider" } }))
             }
             onBranch={() => {}}
           />

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -9,6 +9,7 @@ import {
   type ModelProvider,
 } from "@/lib/model-registry";
 import { getTransport } from "@/transport";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import {
   ClaudeIcon,
   CodexIcon,
@@ -52,6 +53,9 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   const [hoveredProvider, setHoveredProvider] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Read the full list once at the top level -- hooks cannot be called inside .map().
+  const availabilityList = useProviderAvailabilityStore((s) => s.providers);
 
   // Dynamically fetched model lists, keyed by provider ID.
   const [dynamicModels, setDynamicModels] = useState<Map<string, ModelProvider["models"]>>(new Map());
@@ -284,12 +288,20 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
             const provIconClass = pm?.color ?? "";
             const hasModels = p.models.length > 0;
 
+            // Derive disabled state from the availability store. An absent record is treated
+            // as enabled so newly-registered providers don't appear broken before the server
+            // has had a chance to push their availability.
+            const providerRecord = availabilityList.find((x) => x.id === p.id);
+            const providerDisabled = providerRecord ? !providerRecord.enabled : false;
+
             return (
               <div
                 key={p.id}
-                className="relative"
+                data-testid={`model-group-${p.id}`}
+                data-disabled={providerDisabled ? "true" : "false"}
+                className={cn("relative", providerDisabled && "opacity-50 pointer-events-none")}
                 onMouseEnter={() => {
-                    if (!p.comingSoon && hasModels) {
+                    if (!p.comingSoon && !providerDisabled && hasModels) {
                       setHoveredWithDelay(p.id);
                       if (p.supportsModelListing) fetchProviderModels(p.id);
                     }
@@ -297,8 +309,11 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
                 onMouseLeave={() => setHoveredWithDelay(null)}
               >
                 <button
-                  disabled={p.comingSoon}
+                  disabled={p.comingSoon || providerDisabled}
                   onClick={() => {
+                    // Guard against disabled providers in case pointer-events-none is overridden
+                    // by a theme or browser extension.
+                    if (providerDisabled) return;
                     if (hasModels && p.models.length === 1) {
                       handleSelectModel(p.models[0].id, p.id);
                     }
@@ -315,7 +330,10 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
                   {p.comingSoon && (
                     <Badge variant="secondary" size="sm">SOON</Badge>
                   )}
-                  {!p.comingSoon && hasModels && p.models.length > 1 && (
+                  {providerDisabled && (
+                    <Badge variant="outline" size="sm">Disabled</Badge>
+                  )}
+                  {!p.comingSoon && !providerDisabled && hasModels && p.models.length > 1 && (
                     <ChevronRight size={10} className="text-muted-foreground" />
                   )}
                 </button>

--- a/apps/web/src/components/chat/ProviderUnavailableBanner.tsx
+++ b/apps/web/src/components/chat/ProviderUnavailableBanner.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@/components/ui/button";
+import type { ProviderId } from "@mcode/contracts";
+
+/** Human-readable display names for each provider ID. */
+const NAMES: Record<ProviderId, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  copilot: "GitHub Copilot",
+  gemini: "Gemini",
+  cursor: "Cursor",
+  opencode: "OpenCode",
+};
+
+/** Props for the ProviderUnavailableBanner component. */
+export interface ProviderUnavailableBannerProps {
+  /** The provider that is currently unusable. */
+  providerId: ProviderId;
+  /** Why the provider is unavailable: user-disabled or CLI binary not found. */
+  reason: "disabled" | "cli_missing";
+  /** Called when the user clicks "Open Settings". */
+  onOpenSettings: () => void;
+  /** Called when the user clicks "Branch to another provider". Only shown for reason=disabled. */
+  onBranch: () => void;
+}
+
+/**
+ * Inline banner rendered above the Composer when the thread's active provider
+ * is unusable (disabled in settings or CLI binary not found on disk).
+ */
+export function ProviderUnavailableBanner({
+  providerId,
+  reason,
+  onOpenSettings,
+  onBranch,
+}: ProviderUnavailableBannerProps) {
+  const name = NAMES[providerId];
+  const copy =
+    reason === "disabled"
+      ? `${name} is disabled. Enable it in Settings, or branch this thread to another provider.`
+      : `${name} CLI was not found. Install it or set the path in Settings.`;
+
+  return (
+    <div
+      data-testid="provider-unavailable-banner"
+      className="mb-2 flex flex-wrap items-center gap-3 rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm"
+    >
+      <span className="flex-1">{copy}</span>
+      <Button size="sm" variant="outline" onClick={onOpenSettings}>Open Settings</Button>
+      {reason === "disabled" && (
+        <Button size="sm" variant="ghost" onClick={onBranch}>Branch to another provider</Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ProviderUnavailableBanner.tsx
+++ b/apps/web/src/components/chat/ProviderUnavailableBanner.tsx
@@ -19,8 +19,12 @@ export interface ProviderUnavailableBannerProps {
   reason: "disabled" | "cli_missing";
   /** Called when the user clicks "Open Settings". */
   onOpenSettings: () => void;
-  /** Called when the user clicks "Branch to another provider". Only shown for reason=disabled. */
-  onBranch: () => void;
+  /**
+   * Called when the user clicks "Branch to another provider". The button only renders
+   * when both `reason === "disabled"` and `onBranch` is supplied, so callers that do
+   * not own branch mode can omit it rather than passing a no-op.
+   */
+  onBranch?: () => void;
 }
 
 /**
@@ -46,7 +50,7 @@ export function ProviderUnavailableBanner({
     >
       <span className="flex-1">{copy}</span>
       <Button size="sm" variant="outline" onClick={onOpenSettings}>Open Settings</Button>
-      {reason === "disabled" && (
+      {reason === "disabled" && onBranch && (
         <Button size="sm" variant="ghost" onClick={onBranch}>Branch to another provider</Button>
       )}
     </div>

--- a/apps/web/src/components/chat/__tests__/ModelSelector.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ModelSelector.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
+import React from "react";
+
+// @base-ui/react (used by Button) does not work in jsdom; stub with a native button.
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    ...rest
+  }: {
+    children?: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    disabled?: boolean;
+    [key: string]: unknown;
+  }) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+// @base-ui/react (used by Badge) does not work in jsdom; stub as a plain span.
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({
+    children,
+    "data-testid": testId,
+    ...rest
+  }: {
+    children?: React.ReactNode;
+    "data-testid"?: string;
+    [key: string]: unknown;
+  }) => (
+    <span data-testid={testId} {...rest}>
+      {children}
+    </span>
+  ),
+}));
+
+// Prevent real RPC calls triggered by fetchProviderModels on hover.
+vi.mock("@/transport", () => ({
+  getTransport: () => ({
+    listProviderModels: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+import { ModelSelector } from "../ModelSelector";
+
+beforeEach(() => {
+  useProviderAvailabilityStore.setState({
+    providers: [
+      {
+        id: "claude",
+        enabled: true,
+        hasAdapter: true,
+        beta: false,
+        comingSoon: false,
+        cli: { status: "found", resolvedPath: "/a", configuredPath: "" },
+      },
+      {
+        id: "codex",
+        enabled: false,
+        hasAdapter: true,
+        beta: false,
+        comingSoon: false,
+        cli: { status: "found", resolvedPath: "/b", configuredPath: "" },
+      },
+    ] as never,
+  });
+});
+
+describe("ModelSelector", () => {
+  it("marks disabled providers with data-disabled='true' on their group container", async () => {
+    render(
+      <ModelSelector
+        selectedModelId="claude-sonnet-4-6"
+        selectedProviderId="claude"
+        onSelect={vi.fn()}
+        locked={false}
+      />,
+    );
+
+    // Open the dropdown by clicking the trigger button.
+    const trigger = screen.getAllByRole("button")[0];
+    await userEvent.click(trigger);
+
+    const codexGroup = document.querySelector("[data-testid='model-group-codex']");
+    expect(codexGroup).not.toBeNull();
+    expect(codexGroup).toHaveAttribute("data-disabled", "true");
+  });
+
+  it("shows a 'Disabled' badge for the disabled provider", async () => {
+    render(
+      <ModelSelector
+        selectedModelId="claude-sonnet-4-6"
+        selectedProviderId="claude"
+        onSelect={vi.fn()}
+        locked={false}
+      />,
+    );
+
+    const trigger = screen.getAllByRole("button")[0];
+    await userEvent.click(trigger);
+
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+  });
+
+  it("does not mark enabled providers as disabled", async () => {
+    render(
+      <ModelSelector
+        selectedModelId="claude-sonnet-4-6"
+        selectedProviderId="claude"
+        onSelect={vi.fn()}
+        locked={false}
+      />,
+    );
+
+    const trigger = screen.getAllByRole("button")[0];
+    await userEvent.click(trigger);
+
+    const claudeGroup = document.querySelector("[data-testid='model-group-claude']");
+    expect(claudeGroup).toHaveAttribute("data-disabled", "false");
+  });
+});

--- a/apps/web/src/components/chat/__tests__/ProviderUnavailableBanner.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ProviderUnavailableBanner.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProviderUnavailableBanner } from "../ProviderUnavailableBanner";
+
+describe("ProviderUnavailableBanner", () => {
+  it("renders disabled copy and both action buttons when reason=disabled", () => {
+    render(<ProviderUnavailableBanner providerId="claude" reason="disabled" onOpenSettings={() => {}} onBranch={() => {}} />);
+    expect(screen.getByText(/Claude is disabled/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /open settings/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /branch to another provider/i })).toBeInTheDocument();
+  });
+
+  it("renders cli_missing copy and only the settings button when reason=cli_missing", () => {
+    render(<ProviderUnavailableBanner providerId="codex" reason="cli_missing" onOpenSettings={() => {}} onBranch={() => {}} />);
+    expect(screen.getByText(/Codex CLI was not found/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /branch to another provider/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/sections/ConfirmDisableDialog.tsx
+++ b/apps/web/src/components/settings/sections/ConfirmDisableDialog.tsx
@@ -1,0 +1,20 @@
+import type { ProviderId } from "@mcode/contracts";
+
+/** Props for the dialog shown when disabling a provider that is set as default. */
+export interface ConfirmDisableDialogProps {
+  /** The provider the user is attempting to disable. */
+  providerId: ProviderId;
+  /** Called when the user cancels the dialog. */
+  onCancel: () => void;
+  /** Called when the user confirms disabling the provider. */
+  onConfirm: () => void | Promise<void>;
+}
+
+/**
+ * Confirmation dialog shown before disabling a provider that is currently
+ * referenced by other settings (e.g. the default model provider).
+ * Full implementation is in Task 20. Renders nothing for now.
+ */
+export function ConfirmDisableDialog(_props: ConfirmDisableDialogProps) {
+  return null;
+}

--- a/apps/web/src/components/settings/sections/ConfirmDisableDialog.tsx
+++ b/apps/web/src/components/settings/sections/ConfirmDisableDialog.tsx
@@ -46,11 +46,14 @@ export function ConfirmDisableDialog({
   const affectedPrDraft =
     settings.prDraft.provider !== "" && settings.prDraft.provider === providerId;
 
-  const description = [
-    `${disablingName} is currently your default provider for new threads`,
-    affectedPrDraft ? " and for PR draft generation" : "",
-    `. Disabling it will switch your default to ${replacementName}.`,
-  ].join("");
+  // Default case is only for new threads; PR-draft-only uses a different phrasing.
+  const scope =
+    affectedModel && affectedPrDraft
+      ? "your default provider for new threads and PR draft generation"
+      : affectedModel
+        ? "your default provider for new threads"
+        : "your PR draft generation provider";
+  const description = `${disablingName} is currently ${scope}. Disabling it will switch your default to ${replacementName}.`;
 
   async function handleConfirm() {
     // Batch the toggle-off and default rewrite into a single update call so the
@@ -94,8 +97,9 @@ export function ConfirmDisableDialog({
 
 /**
  * Picks the best replacement provider when `disabling` is turned off.
- * Iterates PROVIDER_CATALOG order (canonical) and returns the first provider
- * that is currently enabled and has an adapter, skipping the one being disabled.
+ * Iterates PROVIDER_CATALOG order (canonical) and returns the first provider that
+ * is enabled, has an adapter, and whose CLI is not known-missing — so we don't
+ * rewrite the default to a provider that cannot actually be used.
  * Falls back to "claude" if no other usable provider is found.
  */
 function pickReplacement(
@@ -105,7 +109,9 @@ function pickReplacement(
   for (const entry of PROVIDER_CATALOG) {
     if (entry.id === disabling) continue;
     const row = providers.find((p) => p.id === entry.id);
-    if (row?.enabled && row.hasAdapter) return entry.id;
+    if (row?.enabled && row.hasAdapter && row.cli.status !== "not_found") {
+      return entry.id;
+    }
   }
   return "claude";
 }

--- a/apps/web/src/components/settings/sections/ConfirmDisableDialog.tsx
+++ b/apps/web/src/components/settings/sections/ConfirmDisableDialog.tsx
@@ -1,4 +1,16 @@
-import type { ProviderId } from "@mcode/contracts";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
+import { PROVIDER_CATALOG } from "@mcode/contracts";
+import type { PartialSettings, ProviderId, SettingsProviderId } from "@mcode/contracts";
 
 /** Props for the dialog shown when disabling a provider that is set as default. */
 export interface ConfirmDisableDialogProps {
@@ -11,10 +23,89 @@ export interface ConfirmDisableDialogProps {
 }
 
 /**
- * Confirmation dialog shown before disabling a provider that is currently
- * referenced by other settings (e.g. the default model provider).
- * Full implementation is in Task 20. Renders nothing for now.
+ * Confirms disabling a provider currently used as a default (model and/or prDraft).
+ * On confirm, performs a single settings.update that flips the toggle AND rewrites
+ * the affected defaults to the deterministic replacement, keeping the settings
+ * consistent in one atomic RPC call.
  */
-export function ConfirmDisableDialog(_props: ConfirmDisableDialogProps) {
-  return null;
+export function ConfirmDisableDialog({
+  providerId,
+  onCancel,
+  onConfirm,
+}: ConfirmDisableDialogProps) {
+  const settings = useSettingsStore((s) => s.settings);
+  const update = useSettingsStore((s) => s.update);
+  const providers = useProviderAvailabilityStore((s) => s.providers);
+
+  const disablingName = PROVIDER_CATALOG.find((e) => e.id === providerId)?.name ?? providerId;
+  const replacement = pickReplacement(providerId, providers);
+  const replacementName = PROVIDER_CATALOG.find((e) => e.id === replacement)?.name ?? replacement;
+
+  const affectedModel = settings.model.defaults.provider === providerId;
+  // prDraft.provider defaults to "" (inherit), so only flag it when explicitly set.
+  const affectedPrDraft =
+    settings.prDraft.provider !== "" && settings.prDraft.provider === providerId;
+
+  const description = [
+    `${disablingName} is currently your default provider for new threads`,
+    affectedPrDraft ? " and for PR draft generation" : "",
+    `. Disabling it will switch your default to ${replacementName}.`,
+  ].join("");
+
+  async function handleConfirm() {
+    // Batch the toggle-off and default rewrite into a single update call so the
+    // server applies both atomically rather than leaving a transient inconsistent state.
+    // Cast through unknown because PartialSettings.provider.enabled expects named keys
+    // (e.g. `{ codex?: boolean }`), but we build the key dynamically at runtime.
+    // The cast is safe: providerId is always a valid key of that object.
+    const enabledPatch = { [providerId]: false } as unknown as NonNullable<
+      NonNullable<PartialSettings["provider"]>["enabled"]
+    >;
+    const patch: PartialSettings = {
+      provider: { enabled: enabledPatch },
+    };
+    if (affectedModel) {
+      patch.model = { defaults: { provider: replacement as SettingsProviderId } };
+    }
+    if (affectedPrDraft) {
+      patch.prDraft = { provider: replacement as SettingsProviderId };
+    }
+    await update(patch);
+    await onConfirm();
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disable {disablingName}?</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm}>Disable and switch default</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Picks the best replacement provider when `disabling` is turned off.
+ * Iterates PROVIDER_CATALOG order (canonical) and returns the first provider
+ * that is currently enabled and has an adapter, skipping the one being disabled.
+ * Falls back to "claude" if no other usable provider is found.
+ */
+function pickReplacement(
+  disabling: ProviderId,
+  providers: ReturnType<typeof useProviderAvailabilityStore.getState>["providers"],
+): ProviderId {
+  for (const entry of PROVIDER_CATALOG) {
+    if (entry.id === disabling) continue;
+    const row = providers.find((p) => p.id === entry.id);
+    if (row?.enabled && row.hasAdapter) return entry.id;
+  }
+  return "claude";
 }

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -14,7 +14,7 @@ import {
 import { SettingRow } from "../SettingRow";
 import { SegControl } from "../SegControl";
 import { SectionHeading } from "../SectionHeading";
-import type { SettingsProviderId, ReasoningLevel } from "@mcode/contracts";
+import type { ProviderAvailability, SettingsProviderId, ReasoningLevel } from "@mcode/contracts";
 import { ChevronDown } from "lucide-react";
 import {
   ClaudeIcon,
@@ -64,6 +64,40 @@ const CODEX_REASONING_LABELS: Record<string, string> = {
 };
 
 /**
+ * Builds a provider option for the Model / PR Draft pickers. A provider is only
+ * rendered as disabled once its availability row has loaded and indicates it is
+ * unusable (disabled by user, no adapter, or CLI missing). While availability is
+ * still loading, the option stays selectable to avoid falsely blanking every
+ * entry on first paint.
+ */
+function buildProviderOption(
+  p: (typeof MODEL_PROVIDERS)[number],
+  avail: ProviderAvailability | undefined,
+): { value: string; label: string; disabled: boolean; icon: ReactNode; title: string | undefined } {
+  const unavailable =
+    avail != null &&
+    (!avail.enabled || !avail.hasAdapter || avail.cli.status === "not_found");
+  const title = p.comingSoon
+    ? "Coming soon"
+    : avail == null
+      ? undefined
+      : !avail.enabled
+        ? "Not enabled"
+        : !avail.hasAdapter
+          ? "Unavailable"
+          : avail.cli.status === "not_found"
+            ? "CLI not found"
+            : undefined;
+  return {
+    value: p.id,
+    label: p.name,
+    disabled: p.comingSoon || unavailable,
+    icon: PROVIDER_ICONS[p.id],
+    title,
+  };
+}
+
+/**
  * Model settings section: provider, default model, fallback model, reasoning effort,
  * PR draft provider/model, and CLI paths.
  *
@@ -80,36 +114,24 @@ export function ModelSection() {
   const prDraftModel = useSettingsStore((s) => s.settings.prDraft.model);
   const update = useSettingsStore((s) => s.update);
   const availabilityProviders = useProviderAvailabilityStore((s) => s.providers);
+  const availabilityById = useMemo(
+    () => new Map<string, ProviderAvailability>(availabilityProviders.map((row) => [row.id, row])),
+    [availabilityProviders],
+  );
 
   const providerOptions = useMemo(
-    () => MODEL_PROVIDERS.map((p) => {
-      const avail = availabilityProviders.find((a) => a.id === p.id);
-      return {
-        value: p.id,
-        label: p.name,
-        disabled: p.comingSoon || !avail?.enabled,
-        icon: PROVIDER_ICONS[p.id],
-        title: p.comingSoon ? "Coming soon" : !avail?.enabled ? "Not enabled" : undefined,
-      };
-    }),
-    [availabilityProviders],
+    () => MODEL_PROVIDERS.map((p) => buildProviderOption(p, availabilityById.get(p.id))),
+    [availabilityById],
   );
 
   const prDraftProviderOptions = useMemo(
     () => [
       { value: "", label: "Auto" },
-      ...MODEL_PROVIDERS.filter((p) => p.supportsCompletion).map((p) => {
-        const avail = availabilityProviders.find((a) => a.id === p.id);
-        return {
-          value: p.id,
-          label: p.name,
-          disabled: p.comingSoon || !avail?.enabled,
-          icon: PROVIDER_ICONS[p.id],
-          title: p.comingSoon ? "Coming soon" : !avail?.enabled ? "Not enabled" : undefined,
-        };
-      }),
+      ...MODEL_PROVIDERS.filter((p) => p.supportsCompletion).map((p) =>
+        buildProviderOption(p, availabilityById.get(p.id)),
+      ),
     ],
-    [availabilityProviders],
+    [availabilityById],
   );
 
   const activeProvider = MODEL_PROVIDERS.find((p) => p.id === provider);

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -1,5 +1,7 @@
 import { useMemo, type ReactNode } from "react";
+import { ProviderSection } from "./ProviderSection";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { useProviderModelsStore } from "@/stores/providerModelsStore";
 import {
   MODEL_PROVIDERS,
@@ -13,7 +15,6 @@ import { SettingRow } from "../SettingRow";
 import { SegControl } from "../SegControl";
 import { SectionHeading } from "../SectionHeading";
 import type { SettingsProviderId, ReasoningLevel } from "@mcode/contracts";
-import { Input } from "@/components/ui/input";
 import { ChevronDown } from "lucide-react";
 import {
   ClaudeIcon,
@@ -46,26 +47,6 @@ const PROVIDER_ICONS: Record<string, ReactNode> = {
   gemini: <GeminiIcon size={12} />,
 };
 
-/** All provider options with icons. Coming-soon providers show a tooltip. */
-const PROVIDER_OPTIONS = MODEL_PROVIDERS.map((p) => ({
-  value: p.id,
-  label: p.name,
-  disabled: p.comingSoon,
-  icon: PROVIDER_ICONS[p.id],
-  title: p.comingSoon ? "Coming soon" : undefined,
-}));
-
-/** Provider options for PR draft: "Auto" plus providers that support one-shot completion. */
-const PR_DRAFT_PROVIDER_OPTIONS = [
-  { value: "", label: "Auto" },
-  ...MODEL_PROVIDERS.filter((p) => p.supportsCompletion).map((p) => ({
-    value: p.id,
-    label: p.name,
-    disabled: p.comingSoon,
-    icon: PROVIDER_ICONS[p.id],
-    title: p.comingSoon ? "Coming soon" : undefined,
-  })),
-];
 
 const REASONING_OPTIONS_BASE = [
   { value: "low", label: "Low" },
@@ -95,12 +76,41 @@ export function ModelSection() {
   const modelId = useSettingsStore((s) => s.settings.model.defaults.id);
   const fallbackId = useSettingsStore((s) => s.settings.model.defaults.fallbackId);
   const reasoning = useSettingsStore((s) => s.settings.model.defaults.reasoning);
-  const codexCliPath = useSettingsStore((s) => s.settings.provider.cli.codex);
-  const claudeCliPath = useSettingsStore((s) => s.settings.provider.cli.claude);
-  const copilotCliPath = useSettingsStore((s) => s.settings.provider.cli.copilot);
   const prDraftProvider = useSettingsStore((s) => s.settings.prDraft.provider);
   const prDraftModel = useSettingsStore((s) => s.settings.prDraft.model);
   const update = useSettingsStore((s) => s.update);
+  const availabilityProviders = useProviderAvailabilityStore((s) => s.providers);
+
+  const providerOptions = useMemo(
+    () => MODEL_PROVIDERS.map((p) => {
+      const avail = availabilityProviders.find((a) => a.id === p.id);
+      return {
+        value: p.id,
+        label: p.name,
+        disabled: p.comingSoon || !avail?.enabled,
+        icon: PROVIDER_ICONS[p.id],
+        title: p.comingSoon ? "Coming soon" : !avail?.enabled ? "Not enabled" : undefined,
+      };
+    }),
+    [availabilityProviders],
+  );
+
+  const prDraftProviderOptions = useMemo(
+    () => [
+      { value: "", label: "Auto" },
+      ...MODEL_PROVIDERS.filter((p) => p.supportsCompletion).map((p) => {
+        const avail = availabilityProviders.find((a) => a.id === p.id);
+        return {
+          value: p.id,
+          label: p.name,
+          disabled: p.comingSoon || !avail?.enabled,
+          icon: PROVIDER_ICONS[p.id],
+          title: p.comingSoon ? "Coming soon" : !avail?.enabled ? "Not enabled" : undefined,
+        };
+      }),
+    ],
+    [availabilityProviders],
+  );
 
   const activeProvider = MODEL_PROVIDERS.find((p) => p.id === provider);
 
@@ -225,6 +235,9 @@ export function ModelSection() {
 
   return (
     <div>
+      <ProviderSection />
+
+      <div className="mt-8">
       <SectionHeading>Model</SectionHeading>
       <div>
       <SettingRow
@@ -232,7 +245,7 @@ export function ModelSection() {
         configKey="model.defaults.provider"
         hint="AI provider for new threads."
       >
-        <SegControl options={PROVIDER_OPTIONS} value={provider} onChange={handleProviderChange} />
+        <SegControl options={providerOptions} value={provider} onChange={handleProviderChange} />
       </SettingRow>
 
       <SettingRow
@@ -342,6 +355,7 @@ export function ModelSection() {
         </SettingRow>
       )}
       </div>
+      </div>
 
       <div className="mt-8">
         <SectionHeading>PR Draft</SectionHeading>
@@ -352,7 +366,7 @@ export function ModelSection() {
             hint="AI provider for PR draft generation. Auto inherits from the default provider above."
           >
             <SegControl
-              options={PR_DRAFT_PROVIDER_OPTIONS}
+              options={prDraftProviderOptions}
               value={prDraftProvider}
               onChange={(v) => void update({ prDraft: { provider: v as SettingsProviderId | "", model: "" } })}
             />
@@ -389,47 +403,6 @@ export function ModelSection() {
         </div>
       </div>
 
-      <div className="mt-8">
-        <SectionHeading>CLI Paths</SectionHeading>
-        <div>
-          <SettingRow
-            label="Codex CLI path"
-            configKey="provider.cli.codex"
-            hint="Path to the Codex CLI binary. Leave empty to auto-discover from PATH."
-          >
-            <Input
-              value={codexCliPath}
-              onChange={(e) => void update({ provider: { cli: { codex: e.target.value } } })}
-              placeholder="codex"
-              className="h-7 w-56 text-xs"
-            />
-          </SettingRow>
-          <SettingRow
-            label="Claude CLI path"
-            configKey="provider.cli.claude"
-            hint="Path to the Claude Code CLI binary. Leave empty to auto-discover from PATH."
-          >
-            <Input
-              value={claudeCliPath}
-              onChange={(e) => void update({ provider: { cli: { claude: e.target.value } } })}
-              placeholder="claude"
-              className="h-7 w-56 text-xs"
-            />
-          </SettingRow>
-          <SettingRow
-            label="Copilot CLI path"
-            configKey="provider.cli.copilot"
-            hint="Path to the Copilot CLI binary. Leave empty to auto-discover from PATH."
-          >
-            <Input
-              value={copilotCliPath}
-              onChange={(e) => void update({ provider: { cli: { copilot: e.target.value } } })}
-              placeholder="copilot"
-              className="h-7 w-56 text-xs"
-            />
-          </SettingRow>
-        </div>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/components/settings/sections/ProviderSection.tsx
+++ b/apps/web/src/components/settings/sections/ProviderSection.tsx
@@ -1,50 +1,183 @@
+import { useState } from "react";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { SettingRow } from "../SettingRow";
 import { SectionHeading } from "../SectionHeading";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { ProviderAvailability, ProviderId } from "@mcode/contracts";
+import { ConfirmDisableDialog } from "./ConfirmDisableDialog";
+
+/** Provider IDs that expose a CLI path input field. */
+type CliProvider = "claude" | "codex" | "copilot";
+const HAS_CLI_INPUT: readonly CliProvider[] = ["claude", "codex", "copilot"];
+
+/** Narrows a ProviderId to those that have an editable CLI path setting. */
+function hasCliInput(id: ProviderId): id is CliProvider {
+  return (HAS_CLI_INPUT as readonly string[]).includes(id);
+}
 
 /**
- * Provider settings section: CLI binary paths for each AI provider.
- * Empty values use auto-discovery from PATH.
+ * Settings section for enabling AI providers and configuring their CLI paths.
+ * Renders one toggle row per provider. When a provider is enabled, a CLI path
+ * input is shown below it (for providers that have CLI binaries).
  */
 export function ProviderSection() {
-  const codexPath = useSettingsStore((s) => s.settings.provider.cli.codex);
-  const claudePath = useSettingsStore((s) => s.settings.provider.cli.claude);
+  const providers = useProviderAvailabilityStore((s) => s.providers);
+  const settings = useSettingsStore((s) => s.settings);
   const update = useSettingsStore((s) => s.update);
+  const [pendingDisable, setPendingDisable] = useState<ProviderId | null>(null);
+
+  // Count how many adapter-backed providers are currently enabled, so we can
+  // prevent the user from disabling the last one.
+  const enabledCount = providers.filter((p) => p.enabled && p.hasAdapter).length;
+
+  async function flipEnabled(id: ProviderId, next: boolean) {
+    if (!next) {
+      // Block turning off the last enabled adapter-backed provider.
+      const isLastEnabled = enabledCount === 1 && providers.find((p) => p.id === id)?.enabled;
+      if (isLastEnabled) return;
+
+      // Warn before disabling a provider that is currently set as the default.
+      const isDefault =
+        settings.model.defaults.provider === id || settings.prDraft.provider === id;
+      if (isDefault) {
+        setPendingDisable(id);
+        return;
+      }
+    }
+    await update({ provider: { enabled: { [id]: next } } });
+  }
 
   return (
     <div>
       <SectionHeading>Provider</SectionHeading>
       <div>
-        <SettingRow
-          label="Codex CLI path"
-          configKey="provider.cli.codex"
-          hint="Path to the Codex CLI binary. Leave empty to auto-discover from PATH."
-        >
-          <Input
-            value={codexPath}
-            onChange={(e) =>
-              void update({ provider: { cli: { codex: e.target.value } } })
+        {providers.map((p) => (
+          <ProviderRow
+            key={p.id}
+            row={p}
+            isLastEnabled={enabledCount === 1 && p.enabled && p.hasAdapter}
+            onToggle={(next) => flipEnabled(p.id, next)}
+            cliPath={hasCliInput(p.id) ? settings.provider.cli[p.id] : undefined}
+            onCliPathChange={
+              hasCliInput(p.id)
+                ? (val: string) => void update({ provider: { cli: { [p.id]: val } } })
+                : undefined
             }
-            placeholder="codex"
-            className="h-7 w-56 text-xs"
           />
-        </SettingRow>
-        <SettingRow
-          label="Claude CLI path"
-          configKey="provider.cli.claude"
-          hint="Path to the Claude Code CLI binary. Leave empty to auto-discover from PATH."
-        >
-          <Input
-            value={claudePath}
-            onChange={(e) =>
-              void update({ provider: { cli: { claude: e.target.value } } })
-            }
-            placeholder="claude"
-            className="h-7 w-56 text-xs"
-          />
-        </SettingRow>
+        ))}
       </div>
+      {pendingDisable && (
+        <ConfirmDisableDialog
+          providerId={pendingDisable}
+          onCancel={() => setPendingDisable(null)}
+          onConfirm={async () => {
+            setPendingDisable(null);
+          }}
+        />
+      )}
     </div>
   );
+}
+
+interface ProviderRowProps {
+  /** Availability and configuration snapshot for this provider. */
+  row: ProviderAvailability;
+  /** True when this is the only enabled adapter-backed provider. */
+  isLastEnabled: boolean;
+  /** Called when the user flips the enable toggle. */
+  onToggle: (next: boolean) => void | Promise<void>;
+  /** Current CLI path setting value; undefined for providers without CLI path config. */
+  cliPath: string | undefined;
+  /** Called when the user edits the CLI path; undefined when no CLI path config exists. */
+  onCliPathChange?: (v: string) => void;
+}
+
+/**
+ * Single provider row: label, status badges, enable switch, and optional CLI path input.
+ * The CLI path input is rendered only when the provider is enabled and has a configurable path.
+ */
+function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }: ProviderRowProps) {
+  // Coming-soon and adapter-less providers cannot be toggled; the last enabled
+  // provider also blocks toggling to prevent an unusable state.
+  const switchDisabled = row.comingSoon || !row.hasAdapter || isLastEnabled;
+
+  return (
+    <>
+      <SettingRow
+        label={labelFor(row.id)}
+        hint={hintFor(row, isLastEnabled)}
+      >
+        <div className="flex items-center gap-2">
+          {row.beta && (
+            <Tooltip>
+              <TooltipTrigger>
+                <Badge variant="secondary" data-testid={`provider-badge-${row.id}-beta`}>
+                  Beta
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                This provider is in early phase. Expect bugs or incomplete features.
+              </TooltipContent>
+            </Tooltip>
+          )}
+          {row.comingSoon && (
+            <Badge variant="outline" data-testid={`provider-badge-${row.id}-comingsoon`}>
+              Coming soon
+            </Badge>
+          )}
+          {row.enabled && row.cli.status === "not_found" && (
+            <Tooltip>
+              <TooltipTrigger>
+                <Badge variant="destructive" data-testid={`provider-badge-${row.id}-cli-missing`}>
+                  CLI not found
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                Tried:{" "}
+                {row.cli.configuredPath ? row.cli.configuredPath : "PATH lookup"}. Install
+                the CLI or set the path below.
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Switch
+            data-testid={`provider-switch-${row.id}`}
+            checked={row.enabled && row.hasAdapter}
+            disabled={switchDisabled}
+            onCheckedChange={onToggle}
+          />
+        </div>
+      </SettingRow>
+      {row.enabled && onCliPathChange && (
+        <SettingRow label={`${labelFor(row.id)} CLI path`} className="pl-6">
+          <Input
+            data-testid={`provider-cli-path-${row.id}`}
+            value={cliPath ?? ""}
+            onChange={(e) => onCliPathChange(e.target.value)}
+            placeholder={row.id}
+            className="h-7 w-56 text-xs"
+          />
+        </SettingRow>
+      )}
+    </>
+  );
+}
+
+/** Returns the human-readable display name for a provider ID. */
+function labelFor(id: ProviderId): string {
+  if (id === "copilot") return "GitHub Copilot";
+  return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+/** Returns the hint text shown below the provider label. */
+function hintFor(row: ProviderAvailability, isLastEnabled: boolean): string {
+  if (isLastEnabled) return "At least one provider must be enabled.";
+  if (row.comingSoon) return "Adapter not available yet.";
+  if (row.enabled && row.cli.status === "not_found") {
+    return `CLI not found${row.cli.configuredPath ? ` at ${row.cli.configuredPath}` : ""}.`;
+  }
+  return "";
 }

--- a/apps/web/src/components/settings/sections/__tests__/ConfirmDisableDialog.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ConfirmDisableDialog.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
+import { getDefaultSettings, type PartialSettings } from "@mcode/contracts";
+
+// @base-ui/react (used by Dialog primitives) does not work in jsdom; stub with plain HTML.
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open !== false ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { ConfirmDisableDialog } from "../ConfirmDisableDialog";
+
+beforeEach(() => {
+  const s = getDefaultSettings();
+  s.model.defaults.provider = "codex";
+  useSettingsStore.setState({ settings: s, update: vi.fn(async () => {}) });
+  useProviderAvailabilityStore.setState({
+    providers: [
+      { id: "claude", enabled: true, hasAdapter: true, beta: false, comingSoon: false, cli: { status: "found", resolvedPath: "/a", configuredPath: "" } },
+      { id: "codex",  enabled: true, hasAdapter: true, beta: false, comingSoon: false, cli: { status: "found", resolvedPath: "/b", configuredPath: "" } },
+    ] as never,
+  });
+});
+
+describe("ConfirmDisableDialog", () => {
+  it("names the replacement provider (first enabled after exclusion, catalog order)", () => {
+    render(<ConfirmDisableDialog providerId="codex" onCancel={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText(/Claude/)).toBeInTheDocument();
+  });
+
+  it("batches toggle-off + default rewrite in a single settings.update on confirm", async () => {
+    const update: Mock<(partial: PartialSettings) => Promise<void>> = vi.fn(async () => {});
+    useSettingsStore.setState({ settings: useSettingsStore.getState().settings, update });
+    render(<ConfirmDisableDialog providerId="codex" onCancel={() => {}} onConfirm={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /disable and switch default/i }));
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0][0]).toMatchObject({
+      provider: { enabled: { codex: false } },
+      model: { defaults: { provider: "claude" } },
+    });
+  });
+
+  it("calls onCancel when cancel is clicked and does not call update", async () => {
+    const update: Mock<(partial: PartialSettings) => Promise<void>> = vi.fn(async () => {});
+    useSettingsStore.setState({ settings: useSettingsStore.getState().settings, update });
+    const onCancel = vi.fn();
+    render(<ConfirmDisableDialog providerId="codex" onCancel={onCancel} onConfirm={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/settings/sections/__tests__/ProviderSection.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ProviderSection.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { getDefaultSettings } from "@mcode/contracts";
+
+// @base-ui/react (used by Switch) does not work in jsdom; stub it with a native button.
+vi.mock("@/components/ui/switch", () => ({
+  Switch: ({
+    checked,
+    disabled,
+    onCheckedChange,
+    "data-testid": testId,
+    ...rest
+  }: {
+    checked?: boolean;
+    disabled?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+    "data-testid"?: string;
+    [key: string]: unknown;
+  }) => (
+    <button
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      data-testid={testId}
+      onClick={() => onCheckedChange?.(!checked)}
+      {...rest}
+    />
+  ),
+}));
+
+// @base-ui/react (used by Badge) does not work in jsdom; stub as a plain span.
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({
+    children,
+    "data-testid": testId,
+    ...rest
+  }: {
+    children?: React.ReactNode;
+    "data-testid"?: string;
+    [key: string]: unknown;
+  }) => (
+    <span data-testid={testId} {...rest}>
+      {children}
+    </span>
+  ),
+}));
+
+// @base-ui/react (used by Tooltip) does not work in jsdom; stub it out.
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { ProviderSection } from "../ProviderSection";
+
+beforeEach(() => {
+  useSettingsStore.setState({ settings: getDefaultSettings(), update: async () => {} });
+  useProviderAvailabilityStore.setState({
+    providers: [
+      { id: "claude",   enabled: true,  hasAdapter: true,  beta: false, comingSoon: false, cli: { status: "found",     resolvedPath: "/a", configuredPath: "" } },
+      { id: "codex",    enabled: true,  hasAdapter: true,  beta: false, comingSoon: false, cli: { status: "not_found", resolvedPath: null, configuredPath: "" } },
+      { id: "copilot",  enabled: false, hasAdapter: true,  beta: true,  comingSoon: false, cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+      { id: "gemini",   enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+      { id: "cursor",   enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+      { id: "opencode", enabled: false, hasAdapter: false, beta: false, comingSoon: true,  cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } },
+    ],
+  });
+});
+
+describe("ProviderSection", () => {
+  it("renders one switch per provider", () => {
+    render(<ProviderSection />);
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(6);
+  });
+
+  it("renders the Beta badge for copilot and Coming soon for gemini/cursor/opencode", () => {
+    render(<ProviderSection />);
+    expect(screen.getByTestId("provider-badge-copilot-beta")).toBeInTheDocument();
+    expect(screen.getByTestId("provider-badge-gemini-comingsoon")).toBeInTheDocument();
+  });
+
+  it("renders a CLI-not-found badge when enabled and status='not_found'", () => {
+    render(<ProviderSection />);
+    expect(screen.getByTestId("provider-badge-codex-cli-missing")).toBeInTheDocument();
+  });
+
+  it("disables the switch for coming-soon providers", () => {
+    render(<ProviderSection />);
+    expect(screen.getByTestId("provider-switch-gemini")).toBeDisabled();
+  });
+
+  it("shows CLI path input only for enabled providers with an adapter", async () => {
+    render(<ProviderSection />);
+    expect(screen.getByTestId("provider-cli-path-claude")).toBeInTheDocument();
+    expect(screen.queryByTestId("provider-cli-path-copilot")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("provider-cli-path-gemini")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/settings-nav.ts
+++ b/apps/web/src/components/settings/settings-nav.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "react";
 import { ModelSection } from "./sections/ModelSection";
 import { AgentSection } from "./sections/AgentSection";
+import { ProviderSection } from "./sections/ProviderSection";
 import { WorktreeSection } from "./sections/WorktreeSection";
 import { AppearanceSection } from "./sections/AppearanceSection";
 import { NotificationsSection } from "./sections/NotificationsSection";
@@ -10,6 +11,7 @@ import { KeyboardShortcutsSection } from "./sections/KeyboardShortcutsSection";
 
 export type SettingsSection =
   | "model"
+  | "provider"
   | "agent"
   | "worktree"
   | "appearance"
@@ -29,6 +31,7 @@ export const NAV_GROUPS: NavGroup[] = [
     label: "AI",
     items: [
       { id: "model", label: "Model" },
+      { id: "provider", label: "Provider" },
       { id: "agent", label: "Agent" },
       { id: "worktree", label: "Worktrees" },
     ],
@@ -51,6 +54,7 @@ export const NAV_GROUPS: NavGroup[] = [
 /** Maps each settings section to its component. */
 export const SECTION_MAP: Record<SettingsSection, ComponentType> = {
   model: ModelSection,
+  provider: ProviderSection,
   agent: AgentSection,
   worktree: WorktreeSection,
   appearance: AppearanceSection,

--- a/apps/web/src/components/settings/settings-nav.ts
+++ b/apps/web/src/components/settings/settings-nav.ts
@@ -1,7 +1,6 @@
 import type { ComponentType } from "react";
 import { ModelSection } from "./sections/ModelSection";
 import { AgentSection } from "./sections/AgentSection";
-import { ProviderSection } from "./sections/ProviderSection";
 import { WorktreeSection } from "./sections/WorktreeSection";
 import { AppearanceSection } from "./sections/AppearanceSection";
 import { NotificationsSection } from "./sections/NotificationsSection";
@@ -11,7 +10,6 @@ import { KeyboardShortcutsSection } from "./sections/KeyboardShortcutsSection";
 
 export type SettingsSection =
   | "model"
-  | "provider"
   | "agent"
   | "worktree"
   | "appearance"
@@ -31,7 +29,6 @@ export const NAV_GROUPS: NavGroup[] = [
     label: "AI",
     items: [
       { id: "model", label: "Model" },
-      { id: "provider", label: "Provider" },
       { id: "agent", label: "Agent" },
       { id: "worktree", label: "Worktrees" },
     ],
@@ -54,7 +51,6 @@ export const NAV_GROUPS: NavGroup[] = [
 /** Maps each settings section to its component. */
 export const SECTION_MAP: Record<SettingsSection, ComponentType> = {
   model: ModelSection,
-  provider: ProviderSection,
   agent: AgentSection,
   worktree: WorktreeSection,
   appearance: AppearanceSection,

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -831,7 +831,13 @@ function VirtualizedThreadList({
         const unusable = providerRow
           ? !providerRow.enabled || providerRow.cli.status === "not_found"
           : false;
-        const unusableReason = !providerRow?.enabled ? "Provider disabled" : "CLI not found";
+        // Only compute a reason when the thread is actually unusable. A missing
+        // providerRow means availability hasn't arrived yet — don't label those as "disabled".
+        const unusableReason = !providerRow
+          ? ""
+          : !providerRow.enabled
+            ? "Provider disabled"
+            : "CLI not found";
         return (
           <div
             key={thread.id}

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -3,6 +3,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { useShallow } from "zustand/shallow";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { Plus, Trash2, ChevronRight, ChevronDown, GitBranch, Loader2, AlertTriangle, FolderPlus } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { getPrVisual } from "@/lib/pr-status";
@@ -756,6 +757,9 @@ function VirtualizedThreadList({
   const worktrees = useWorkspaceStore((s) => s.worktrees);
   const worktreesLoadedFor = useWorkspaceStore((s) => s.worktreesLoadedForWorkspace);
   const checksById = useWorkspaceStore(useShallow((s) => s.checksById));
+  // Subscribe once at the list level so we can derive unusable state per-thread
+  // inside the map without violating Rules of Hooks.
+  const availableProviders = useProviderAvailabilityStore((s) => s.providers);
   const validWorktreePaths = useMemo(() => {
     const set = new Set<string>();
     for (const wt of worktrees) {
@@ -821,6 +825,13 @@ function VirtualizedThreadList({
         const isStaleWorktree = worktreesLoadedFor === thread.workspace_id
           && thread.mode === "worktree" && !!thread.worktree_path
           && !validWorktreePaths.has(thread.worktree_path.replace(/\\/g, "/").replace(/\/$/, "").toLowerCase());
+        // Unusable when the provider is disabled or its CLI binary is missing.
+        // "unchecked" is not treated as unusable — the server may not have verified yet.
+        const providerRow = availableProviders.find((p) => p.id === thread.provider);
+        const unusable = providerRow
+          ? !providerRow.enabled || providerRow.cli.status === "not_found"
+          : false;
+        const unusableReason = !providerRow?.enabled ? "Provider disabled" : "CLI not found";
         return (
           <div
             key={thread.id}
@@ -929,6 +940,20 @@ function VirtualizedThreadList({
                     )}
                     {thread.title}
                   </span>
+                )}
+                {!isEditing && unusable && (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <span
+                          data-testid={`sidebar-unusable-${thread.id}`}
+                          className="ml-1 shrink-0 inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/60"
+                          aria-label={unusableReason}
+                        />
+                      }
+                    />
+                    <TooltipContent side="right" className="text-xs">{unusableReason}</TooltipContent>
+                  </Tooltip>
                 )}
                 {!isEditing && thread.pr_number != null && checksById[thread.id] && (
                   <CiChip checks={checksById[thread.id]} />

--- a/apps/web/src/stores/__tests__/providerAvailabilityStore.test.ts
+++ b/apps/web/src/stores/__tests__/providerAvailabilityStore.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { ProviderAvailability } from "@mcode/contracts";
+import { useProviderAvailabilityStore } from "../providerAvailabilityStore";
+
+function row(partial: Partial<ProviderAvailability>): ProviderAvailability {
+  return {
+    id: "claude",
+    enabled: true,
+    hasAdapter: true,
+    beta: false,
+    comingSoon: false,
+    cli: { status: "found", resolvedPath: "/usr/local/bin/claude", configuredPath: "" },
+    ...partial,
+  };
+}
+
+describe("providerAvailabilityStore", () => {
+  beforeEach(() => useProviderAvailabilityStore.setState({ providers: [] }));
+
+  it("exposes isEnabled", () => {
+    useProviderAvailabilityStore.getState().replace([
+      row({ id: "claude", enabled: true }),
+      row({ id: "codex", enabled: false }),
+    ]);
+    expect(useProviderAvailabilityStore.getState().isEnabled("claude")).toBe(true);
+    expect(useProviderAvailabilityStore.getState().isEnabled("codex")).toBe(false);
+  });
+
+  it("isUsable requires enabled AND cli.status !== 'not_found'", () => {
+    useProviderAvailabilityStore.getState().replace([
+      row({ id: "claude", enabled: true, cli: { status: "found", resolvedPath: "/a", configuredPath: "" } }),
+      row({ id: "codex",  enabled: true, cli: { status: "not_found", resolvedPath: null, configuredPath: "" } }),
+      row({ id: "copilot", enabled: false, cli: { status: "found", resolvedPath: "/b", configuredPath: "" } }),
+    ]);
+    const s = useProviderAvailabilityStore.getState();
+    expect(s.isUsable("claude")).toBe(true);
+    expect(s.isUsable("codex")).toBe(false);
+    expect(s.isUsable("copilot")).toBe(false);
+  });
+
+  it("returns 'unchecked' CLI as usable so the startup race doesn't false-alarm", () => {
+    useProviderAvailabilityStore.getState().replace([
+      row({ id: "claude", enabled: true, cli: { status: "unchecked", resolvedPath: null, configuredPath: "" } }),
+    ]);
+    expect(useProviderAvailabilityStore.getState().isUsable("claude")).toBe(true);
+  });
+});

--- a/apps/web/src/stores/providerAvailabilityStore.ts
+++ b/apps/web/src/stores/providerAvailabilityStore.ts
@@ -1,11 +1,17 @@
 import { create } from "zustand";
 import type { ProviderAvailability, ProviderId } from "@mcode/contracts";
+import { getTransport } from "@/transport";
 
 /** Zustand state shape for the provider availability store. */
 interface State {
   providers: ProviderAvailability[];
   /** Replace the full provider list with a new snapshot from the server. */
   replace: (list: ProviderAvailability[]) => void;
+  /**
+   * Fetch the current provider availability snapshot from the server via RPC
+   * and populate the store. Called on WS connect and reconnect.
+   */
+  fetch: () => Promise<void>;
   /** Return the full availability record for a provider, or undefined if not in the list. */
   getAvailability: (id: ProviderId) => ProviderAvailability | undefined;
   /** Return true when the provider is marked enabled in settings. */
@@ -24,6 +30,14 @@ interface State {
 export const useProviderAvailabilityStore = create<State>((set, get) => ({
   providers: [],
   replace: (list) => set({ providers: list }),
+  fetch: async () => {
+    try {
+      const list = await getTransport().listProviderAvailability();
+      set({ providers: list });
+    } catch (err) {
+      console.error("[providerAvailabilityStore] Failed to load provider availability", err);
+    }
+  },
   getAvailability: (id) => get().providers.find((p) => p.id === id),
   isEnabled: (id) => get().providers.find((p) => p.id === id)?.enabled ?? false,
   isUsable: (id) => {

--- a/apps/web/src/stores/providerAvailabilityStore.ts
+++ b/apps/web/src/stores/providerAvailabilityStore.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+import type { ProviderAvailability, ProviderId } from "@mcode/contracts";
+
+/** Zustand state shape for the provider availability store. */
+interface State {
+  providers: ProviderAvailability[];
+  /** Replace the full provider list with a new snapshot from the server. */
+  replace: (list: ProviderAvailability[]) => void;
+  /** Return the full availability record for a provider, or undefined if not in the list. */
+  getAvailability: (id: ProviderId) => ProviderAvailability | undefined;
+  /** Return true when the provider is marked enabled in settings. */
+  isEnabled: (id: ProviderId) => boolean;
+  /**
+   * Return true when the provider is safe to use for a new thread.
+   *
+   * Requires: enabled, hasAdapter, and cli.status !== "not_found".
+   * "unchecked" is treated as usable to avoid false alarms during startup
+   * before the server has had a chance to verify the CLI.
+   */
+  isUsable: (id: ProviderId) => boolean;
+}
+
+/** Mirrors the server's ProviderAvailability[] list. Populated on WS connect, replaced on push. */
+export const useProviderAvailabilityStore = create<State>((set, get) => ({
+  providers: [],
+  replace: (list) => set({ providers: list }),
+  getAvailability: (id) => get().providers.find((p) => p.id === id),
+  isEnabled: (id) => get().providers.find((p) => p.id === id)?.enabled ?? false,
+  isUsable: (id) => {
+    const row = get().providers.find((p) => p.id === id);
+    if (!row) return false;
+    if (!row.enabled) return false;
+    if (!row.hasAdapter) return false;
+    // "unchecked" means the server hasn't verified the CLI yet; don't block the user.
+    if (row.cli.status === "not_found") return false;
+    return true;
+  },
+}));

--- a/apps/web/src/transport/index.ts
+++ b/apps/web/src/transport/index.ts
@@ -5,6 +5,7 @@ import { useConnectionStore } from "@/stores/connectionStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { scanPortRange, AUTH_TOKEN_STORAGE_KEY } from "./scan-port-range";
 import { useProviderModelsStore } from "@/stores/providerModelsStore";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 
 /** Re-exported transport and domain types for use across the web app. */
 export type { McodeTransport, Workspace, Thread, Message, ToolCall, GitBranch, WorktreeInfo, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, SkillInfo, PrInfo, PrDetail, ToolCallRecord, Settings, PartialSettings, PlanAnswer } from "./types";
@@ -69,6 +70,7 @@ export async function initTransport(): Promise<McodeTransport> {
         if (status === "connected") {
           void useSettingsStore.getState().fetch();
           void useProviderModelsStore.getState().initialize();
+          void useProviderAvailabilityStore.getState().fetch();
         }
       },
       discoverServerUrl: async () => {

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -20,6 +20,7 @@ import type {
   InteractionMode,
   ProviderModelInfo,
   ProviderUsageInfo,
+  ProviderAvailability,
   PrDraft,
   CreatePrResult,
   ChecksStatus,
@@ -252,6 +253,8 @@ export interface McodeTransport {
   getProviderUsage(providerId: string): Promise<ProviderUsageInfo>;
   /** Fetches Copilot sub-agents available for the given workspace. */
   listCopilotAgents(workspaceId: string): Promise<CopilotSubagent[]>;
+  /** Fetch the current availability snapshot for all registered providers. */
+  listProviderAvailability(): Promise<ProviderAvailability[]>;
 
   // Memory pressure
   /** Notify server of window background/foreground state for memory management. */

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -257,8 +257,9 @@ export function startPushListeners(): void {
   // providers.availability: server-pushed snapshot of all provider availability records
   unsubs.push(
     pushEmitter.on("providers.availability", (data) => {
-      const list = data as ProviderAvailability[];
-      useProviderAvailabilityStore.getState().replace(list);
+      // Reject malformed payloads rather than overwriting the store with garbage.
+      if (!Array.isArray(data)) return;
+      useProviderAvailabilityStore.getState().replace(data as ProviderAvailability[]);
     }),
   );
 

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -1,9 +1,10 @@
-import type { Settings } from "@mcode/contracts";
+import type { Settings, ProviderAvailability } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { pushEmitter } from "./ws-transport";
 import { useThreadStore } from "@/stores/threadStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { clearFileListCache } from "@/components/chat/useFileAutocomplete";
 
 /** Unsubscribe handles for all push listeners. */
@@ -28,6 +29,7 @@ let unsubs: (() => void)[] = [];
  * - `plan.questions` -- model-proposed plan questions forwarded to threadStore wizard
  * - `permission.request` -- tool permission awaiting user decision
  * - `permission.resolved` -- a permission was settled (by user or session stop)
+ * - `providers.availability` -- server-pushed provider availability snapshot forwarded to providerAvailabilityStore
  */
 export function startPushListeners(): void {
   // Guard against double-init
@@ -249,6 +251,14 @@ export function startPushListeners(): void {
       };
       if (!requestId) return;
       useThreadStore.getState().resolvePermissionRequest(requestId, decision);
+    }),
+  );
+
+  // providers.availability: server-pushed snapshot of all provider availability records
+  unsubs.push(
+    pushEmitter.on("providers.availability", (data) => {
+      const list = data as ProviderAvailability[];
+      useProviderAvailabilityStore.getState().replace(list);
     }),
   );
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -15,7 +15,7 @@ import type {
   ProviderModelInfo,
   CopilotSubagent,
 } from "./types";
-import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus } from "@mcode/contracts";
+import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 import { useSettingsStore } from "@/stores/settingsStore";
 import type { PermissionRequest } from "@mcode/contracts";
@@ -548,6 +548,8 @@ export function createWsTransport(
     /** Fetches all available Copilot sub-agents for the given workspace (built-in + user + project). */
     listCopilotAgents: (workspaceId) =>
       rpc<CopilotSubagent[]>("provider.copilotAgents", { workspaceId }),
+    listProviderAvailability: () =>
+      rpc<ProviderAvailability[]>("providers.listAvailability", {}),
 
     // Memory pressure
     setBackground: (background) => rpc<void>("memory.setBackground", { background }),

--- a/packages/contracts/src/events/__tests__/agent-event.test.ts
+++ b/packages/contracts/src/events/__tests__/agent-event.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { AgentEventSchema, AgentEventType } from "../agent-event.js";
+
+describe("AgentEvent provider_unavailable", () => {
+  it("parses a disabled-provider event", () => {
+    const parsed = AgentEventSchema().parse({
+      type: "providerUnavailable",
+      threadId: "t-1",
+      providerId: "codex",
+      reason: "disabled",
+    });
+    expect(parsed.type).toBe(AgentEventType.ProviderUnavailable);
+  });
+
+  it("parses a cli_missing event with configuredPath", () => {
+    const parsed = AgentEventSchema().parse({
+      type: "providerUnavailable",
+      threadId: "t-1",
+      providerId: "claude",
+      reason: "cli_missing",
+      configuredPath: "/custom/claude",
+    });
+    if (parsed.type !== "providerUnavailable") throw new Error("unreachable");
+    expect(parsed.configuredPath).toBe("/custom/claude");
+  });
+});

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -165,7 +165,13 @@ export const AgentEventSchema = lazySchema(() =>
       threadId: z.string(),
       providerId: z.enum(["claude", "codex", "gemini", "copilot", "cursor", "opencode"]),
       reason: z.enum(["disabled", "cli_missing"]),
-      /** Configured CLI path the server tried to resolve, when reason === "cli_missing". */
+      /**
+       * Configured CLI path the server tried to resolve. Only populated when
+       * `reason === "cli_missing"`; emitters must leave this undefined when
+       * `reason === "disabled"`. The shape cannot be expressed with superRefine
+       * because discriminatedUnion rejects ZodEffects wrappers — the server
+       * enforces this at emission, and consumers can rely on the invariant.
+       */
       configuredPath: z.string().optional(),
     }),
   ]),

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -26,6 +26,7 @@ export const AgentEventType = {
   ToolProgress: "toolProgress",
   ContextEstimate: "contextEstimate",
   QuotaUpdate: "quotaUpdate",
+  ProviderUnavailable: "providerUnavailable",
 } as const;
 
 /** Union of all valid `AgentEvent` type discriminants. */
@@ -157,6 +158,15 @@ export const AgentEventSchema = lazySchema(() =>
       serviceTier: z.enum(["standard", "priority", "batch"]).optional(),
       numTurns: z.number().int().optional(),
       durationMs: z.number().optional(),
+    }),
+    z.object({
+      /** Emitted when sendMessage is gated because the provider is disabled or its CLI is missing. */
+      type: z.literal(AgentEventType.ProviderUnavailable),
+      threadId: z.string(),
+      providerId: z.enum(["claude", "codex", "gemini", "copilot", "cursor", "opencode"]),
+      reason: z.enum(["disabled", "cli_missing"]),
+      /** Configured CLI path the server tried to resolve, when reason === "cli_missing". */
+      configuredPath: z.string().optional(),
     }),
   ]),
 );

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -156,6 +156,8 @@ export type {
   IProviderRegistry,
 } from "./providers/interfaces.js";
 
+export * from "./providers/catalog.js";
+
 export {
   ProviderModelInfoSchema,
   ModelPolicyStateSchema,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -157,6 +157,7 @@ export type {
 } from "./providers/interfaces.js";
 
 export * from "./providers/catalog.js";
+export * from "./providers/availability.js";
 
 export {
   ProviderModelInfoSchema,

--- a/packages/contracts/src/models/__tests__/settings.test.ts
+++ b/packages/contracts/src/models/__tests__/settings.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { getDefaultSettings, PartialSettingsSchema } from "../settings.js";
+
+describe("settings.provider.enabled", () => {
+  it("defaults claude/codex/copilot to true and others to false", () => {
+    const s = getDefaultSettings();
+    expect(s.provider.enabled).toEqual({
+      claude: true, codex: true, copilot: true,
+      gemini: false, cursor: false, opencode: false,
+    });
+  });
+
+  it("accepts partial updates that flip individual providers", () => {
+    const parsed = PartialSettingsSchema().parse({
+      provider: { enabled: { codex: false } },
+    });
+    expect(parsed.provider?.enabled?.codex).toBe(false);
+  });
+});

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -149,6 +149,17 @@ export const SettingsSchema = lazySchema(() =>
     /** Provider-specific configuration. */
     provider: z
       .object({
+        /** Per-provider enable flag. Disabled providers cannot start new sessions. */
+        enabled: z
+          .object({
+            claude: z.boolean().default(true),
+            codex: z.boolean().default(true),
+            copilot: z.boolean().default(true),
+            gemini: z.boolean().default(false),
+            cursor: z.boolean().default(false),
+            opencode: z.boolean().default(false),
+          })
+          .default({}),
         /** CLI binary paths. Empty string means auto-discover from PATH. */
         cli: z
           .object({
@@ -270,6 +281,16 @@ export const PartialSettingsSchema = lazySchema(() =>
       .optional(),
     provider: z
       .object({
+        enabled: z
+          .object({
+            claude: z.boolean().optional(),
+            codex: z.boolean().optional(),
+            copilot: z.boolean().optional(),
+            gemini: z.boolean().optional(),
+            cursor: z.boolean().optional(),
+            opencode: z.boolean().optional(),
+          })
+          .optional(),
         cli: z
           .object({
             codex: z.string().optional(),

--- a/packages/contracts/src/providers/__tests__/availability.test.ts
+++ b/packages/contracts/src/providers/__tests__/availability.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { ProviderAvailabilitySchema, CliStatusSchema } from "../availability.js";
+
+describe("ProviderAvailabilitySchema", () => {
+  it("accepts a fully populated availability record", () => {
+    const parsed = ProviderAvailabilitySchema().parse({
+      id: "claude",
+      enabled: true,
+      hasAdapter: true,
+      beta: false,
+      comingSoon: false,
+      cli: { status: "found", resolvedPath: "/usr/local/bin/claude", configuredPath: "" },
+    });
+    expect(parsed.id).toBe("claude");
+  });
+
+  it("rejects unknown cli.status values", () => {
+    expect(() => CliStatusSchema().parse("sideways")).toThrow();
+  });
+});

--- a/packages/contracts/src/providers/__tests__/catalog.test.ts
+++ b/packages/contracts/src/providers/__tests__/catalog.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { PROVIDER_CATALOG, getCatalogEntry } from "../catalog.js";
+
+describe("PROVIDER_CATALOG", () => {
+  it("contains all six providers in canonical order", () => {
+    expect(PROVIDER_CATALOG.map((p) => p.id)).toEqual([
+      "claude", "codex", "copilot", "gemini", "cursor", "opencode",
+    ]);
+  });
+
+  it("flags copilot as beta and gemini/cursor/opencode as comingSoon", () => {
+    expect(getCatalogEntry("copilot").beta).toBe(true);
+    expect(getCatalogEntry("gemini").comingSoon).toBe(true);
+    expect(getCatalogEntry("cursor").comingSoon).toBe(true);
+    expect(getCatalogEntry("opencode").comingSoon).toBe(true);
+  });
+
+  it("maps each provider to its CLI binary name", () => {
+    expect(getCatalogEntry("claude").cliBinary).toBe("claude");
+    expect(getCatalogEntry("codex").cliBinary).toBe("codex");
+    expect(getCatalogEntry("copilot").cliBinary).toBe("copilot");
+  });
+});

--- a/packages/contracts/src/providers/availability.ts
+++ b/packages/contracts/src/providers/availability.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+
+/** CLI verification status for a provider binary. */
+export const CliStatusSchema = lazySchema(() =>
+  z.enum(["found", "not_found", "unchecked"]),
+);
+/** CLI verification status for a provider binary. */
+export type CliStatus = z.infer<ReturnType<typeof CliStatusSchema>>;
+
+/** CLI resolution detail attached to a ProviderAvailability record. */
+export const ProviderCliInfoSchema = lazySchema(() =>
+  z.object({
+    status: CliStatusSchema(),
+    /** Path that `which` or `fs.stat` resolved, or null when not_found/unchecked. */
+    resolvedPath: z.string().nullable(),
+    /** The configured path from settings.provider.cli[id]. Empty string means "auto via PATH". */
+    configuredPath: z.string(),
+  }),
+);
+
+/** Runtime availability snapshot for a single provider, broadcast to the frontend. */
+export const ProviderAvailabilitySchema = lazySchema(() =>
+  z.object({
+    id: z.enum(["claude", "codex", "gemini", "copilot", "cursor", "opencode"]),
+    enabled: z.boolean(),
+    /** True when a runtime adapter is registered for this provider. */
+    hasAdapter: z.boolean(),
+    beta: z.boolean(),
+    comingSoon: z.boolean(),
+    cli: ProviderCliInfoSchema(),
+  }),
+);
+
+/** Runtime availability snapshot for a single provider. */
+export type ProviderAvailability = z.infer<ReturnType<typeof ProviderAvailabilitySchema>>;

--- a/packages/contracts/src/providers/catalog.ts
+++ b/packages/contracts/src/providers/catalog.ts
@@ -1,0 +1,36 @@
+import type { ProviderId } from "./interfaces.js";
+
+/**
+ * Static per-provider metadata. Single source of truth for the server.
+ * Frontend mirrors this in `apps/web/src/lib/model-registry.ts` (tech-debt
+ * consolidation tracked separately).
+ */
+export interface ProviderCatalogEntry {
+  /** Stable provider identifier. */
+  id: ProviderId;
+  /** Human-readable display name. */
+  name: string;
+  /** When true, renders a "Beta" badge with an "expect bugs" tooltip. */
+  beta: boolean;
+  /** When true, no adapter ships yet; the Settings switch is fixed off and non-interactive. */
+  comingSoon: boolean;
+  /** Executable name looked up on PATH when `settings.provider.cli[id]` is empty. */
+  cliBinary: string;
+}
+
+/** Canonical ordered list of all providers known to the app. */
+export const PROVIDER_CATALOG: readonly ProviderCatalogEntry[] = [
+  { id: "claude",   name: "Claude",         beta: false, comingSoon: false, cliBinary: "claude"   },
+  { id: "codex",    name: "Codex",          beta: false, comingSoon: false, cliBinary: "codex"    },
+  { id: "copilot",  name: "GitHub Copilot", beta: true,  comingSoon: false, cliBinary: "copilot"  },
+  { id: "gemini",   name: "Gemini",         beta: false, comingSoon: true,  cliBinary: "gemini"   },
+  { id: "cursor",   name: "Cursor",         beta: false, comingSoon: true,  cliBinary: "cursor"   },
+  { id: "opencode", name: "OpenCode",       beta: false, comingSoon: true,  cliBinary: "opencode" },
+] as const;
+
+/** Look up a catalog entry by provider id. Throws if the id is not in the catalog. */
+export function getCatalogEntry(id: ProviderId): ProviderCatalogEntry {
+  const entry = PROVIDER_CATALOG.find((p) => p.id === id);
+  if (!entry) throw new Error(`Unknown provider id: ${id}`);
+  return entry;
+}

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -5,6 +5,7 @@ import { SettingsSchema } from "../models/settings.js";
 import { PlanQuestionSchema } from "../models/plan-questions.js";
 import { ChecksStatusSchema } from "../github.js";
 import { PermissionRequestSchema, PermissionDecisionSchema } from "../models/permission.js";
+import { ProviderAvailabilitySchema } from "../providers/availability.js";
 
 /** All push channel definitions keyed by channel name. */
 export const WS_CHANNELS = {
@@ -30,6 +31,8 @@ export const WS_CHANNELS = {
   }),
   "settings.changed": SettingsSchema(),
   "skills.changed": z.object({}),
+  /** Full-list broadcast of provider availability. Replaces the client cache. */
+  "providers.availability": z.array(ProviderAvailabilitySchema()),
   "branch.changed": z.object({ workspaceId: z.string(), branch: z.string() }),
   "turn.persisted": z.object({
     threadId: z.string(),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -21,6 +21,7 @@ import {
 import { lazySchema } from "../utils/lazySchema.js";
 import { ProviderModelInfoSchema } from "../providers/models.js";
 import { ProviderUsageInfoSchema } from "../providers/usage.js";
+import { ProviderAvailabilitySchema } from "../providers/availability.js";
 import { CopilotSubagentSchema, CopilotAgentNameSchema } from "../providers/copilot-agent.js";
 import { PermissionDecisionSchema, PermissionRequestSchema } from "../models/permission.js";
 
@@ -432,6 +433,10 @@ export const WS_METHODS = lazySchema(() => ({
       workspaceId: z.string(),
     }),
     result: z.array(CopilotSubagentSchema()),
+  },
+  "providers.listAvailability": {
+    params: z.object({}),
+    result: z.array(ProviderAvailabilitySchema()),
   },
 } as const));
 

--- a/packages/contracts/src/ws/protocol.ts
+++ b/packages/contracts/src/ws/protocol.ts
@@ -17,6 +17,8 @@ export const WebSocketResponseSchema = z.object({
     .object({
       code: z.string(),
       message: z.string(),
+      /** Optional structured payload for typed errors (e.g. provider availability errors). */
+      data: z.record(z.unknown()).optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## What

Adds per-provider enable/disable controls to Settings, backed by a runtime `ProviderAvailabilityService` that tracks each provider's adapter registration, user enable flag, and CLI binary discovery. Disabled or CLI-missing providers are gated at RPC boundaries and surfaced in the UI via a Composer banner, greyed ModelSelector groups, and a sidebar dot on affected threads.

## Why

Users need a way to turn off providers they don't use (removes noise from pickers, stops background verification) and to see at a glance which providers are usable without having to attempt a send. The system must fail loudly at the edge rather than silently routing to a dead provider, so RPCs return typed `PROVIDER_DISABLED` / `PROVIDER_CLI_MISSING` error codes with structured data for the client to render actionable copy.

## Key Changes

**Contracts (`packages/contracts`)**
- `ProviderAvailability` and `CliStatus` schemas, static provider catalog with `beta` / `comingSoon` flags
- `provider.enabled` and `provider.cli` nested fields on `SettingsSchema` and `PartialSettingsSchema`
- `providers.listAvailability` RPC method, `providers.availability` push channel, `providerUnavailable` agent event variant
- Optional `data` field on WS error responses for typed error payloads

**Server (`apps/server`)**
- `ProviderAvailabilityService` with `listAvailability`, `verifyCli` (injectable resolver), `assertUsable`, `verifyAllEnabled`, and settings-change re-verification
- `SettingsService` in-process `on("change")` event emitter
- Typed `ProviderDisabledError` and `ProviderCliMissingError`
- `AgentService.sendMessage` and `PrDraftService.generateDraft` gated through `assertUsable`
- `ws-router` central mapper for typed errors to `code` + `data` responses; `providers.listAvailability` handler
- Startup verification runs once, then broadcasts

**Web (`apps/web`)**
- `providerAvailabilityStore` (Zustand) with `isUsable` helper; fetched on WS connect, refreshed on push
- Rebuilt `ProviderSection` with enable switches, CLI path inputs, Beta / Coming soon / CLI not found badges
- `ConfirmDisableDialog` rewrites `model.defaults.provider` and `prDraft.provider` atomically when disabling the active default
- `ProviderUnavailableBanner` above the Composer, disables the editor and send button when the active provider is unusable
- `ModelSelector` greys out disabled provider groups with a `Disabled` badge
- Sidebar dot indicator with tooltip on threads locked to an unusable provider
- `provider` section registered in `settings-nav`

**E2E (`apps/web/e2e`)**
- `provider-toggle.spec.ts` with 6 tests + screenshots covering: switch rendering, non-default toggle, default-toggle confirm dialog, CLI missing badge, coming-soon disable state, and push-driven composer banner
- `WsController.sendPush(channel, data)` helper for push-shape notifications

## Test Plan

- [x] Unit tests across `packages/contracts`, `apps/server`, `apps/web` — 417 pass on this branch (2 pre-existing Windows cleanup-worker flakes identical on main)
- [x] Typecheck clean on all three packages (`apps/server`, `apps/web`, `apps/desktop`)
- [x] Playwright `provider toggle` suite — 6/6 pass with screenshots
- [x] Manual: toggle Codex off while Claude is default — no dialog, switch flips
- [x] Manual: toggle Claude off as default — dialog appears, confirm, default becomes Codex
- [x] Manual: set `settings.provider.cli.claude` to a bogus path — CLI-not-found badge appears
- [x] Manual: open a thread on a disabled provider — banner visible, send disabled; re-enable → banner clears

Closes docs/superpowers/plans/2026-04-20-provider-toggle.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real‑time provider availability sync and a provider availability RPC so clients receive live updates.
  * Provider unavailable banner in the composer with actions to open settings or branch to another provider.
  * Dynamic provider rows in Settings with per-provider CLI path inputs and enable/disable switches.

* **Improvements**
  * Confirmation dialog when disabling a default provider that offers an automatic replacement.
  * Badges for beta/coming‑soon/CLI‑missing states throughout provider selector, settings, and sidebar.
  * UI now disables composer inputs and provider actions when a provider is unusable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->