### PR TITLE
feat(terminal): Stream C — binary frames, flow control, pause on hide (#310 #309 #312)

### DIFF
--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -209,6 +209,9 @@ export function setupContainer(): typeof container {
     { useClass: SettingsService },
     { lifecycle: Lifecycle.Singleton },
   );
+  container.register("SettingsService", {
+    useFactory: (c) => c.resolve(SettingsService),
+  });
   container.register(
     GitWatcherService,
     { useClass: GitWatcherService },

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,7 +5,7 @@
 
 import { setupContainer } from "./container";
 import { createWsServer } from "./transport/ws-server";
-import { broadcast, onSessionChange, sessionCount } from "./transport/push";
+import { broadcast, broadcastTerminalData, onSessionChange, sessionCount } from "./transport/push";
 import { PortPush } from "./transport/port-push";
 import { IpcPushServer, generateIpcPath } from "./transport/ipc-push-server";
 import { logger, getMcodeDir } from "@mcode/shared";
@@ -153,14 +153,18 @@ const ciWatcherService = new CiWatcherService(githubService, (channel, data) => 
 });
 
 // Wire up PTY sender to broadcast push events
-terminalService.setSender((channel, data) => {
-  if (channel === "terminal.data") {
-    broadcast("terminal.data", data);
-    portPush.send("terminal.data", data);
-  } else if (channel === "terminal.exit") {
-    broadcast("terminal.exit", data);
-    portPush.send("terminal.exit", data);
-  }
+terminalService.setSender({
+  json: (channel, data) => {
+    broadcast(channel as Parameters<typeof broadcast>[0], data as Parameters<typeof broadcast>[1]);
+    portPush.send(channel, data);
+  },
+  data: (ptyId, seq, bytes) => {
+    broadcastTerminalData(ptyId, seq, bytes);
+    // portPush uses JSON serialization over a socket, so re-encode bytes to a
+    // UTF-8 string for the IPC path. This only runs in Electron mode where a
+    // port is attached, so the performance cost is negligible.
+    portPush.send("terminal.data", { ptyId, data: Buffer.from(bytes).toString("utf8"), seq });
+  },
 });
 
 // AgentService self-wires persistence and session tracking against providers

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -160,11 +160,11 @@ terminalService.setSender({
   },
   data: (ptyId, seq, bytes) => {
     broadcastTerminalData(ptyId, seq, bytes);
-    // PortPush uses MessagePort.postMessage (structured clone), which
-    // transfers Uint8Array losslessly without any UTF-8 re-encoding.
-    // The web-side ws-events.ts handler checks `payload instanceof Uint8Array`
-    // and routes this correctly.
-    portPush.send("terminal.data", { ptyId, payload: bytes, seq });
+    // The IPC socket adapter (ipc-push-server.ts) serializes via JSON.stringify,
+    // so a Uint8Array would arrive as {"0":72,"1":101,...} on the client. Converting
+    // to a plain number[] survives the JSON round-trip; the client reconstructs it
+    // with new Uint8Array(arr).
+    portPush.send("terminal.data", { ptyId, payload: Array.from(bytes), seq });
   },
 });
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,7 +5,7 @@
 
 import { setupContainer } from "./container";
 import { createWsServer } from "./transport/ws-server";
-import { broadcast, broadcastTerminalData, onSessionChange, sessionCount } from "./transport/push";
+import { broadcast, broadcastTerminalData, maxBufferedAmount, onSessionChange, sessionCount } from "./transport/push";
 import { PortPush } from "./transport/port-push";
 import { IpcPushServer, generateIpcPath } from "./transport/ipc-push-server";
 import { logger, getMcodeDir } from "@mcode/shared";
@@ -166,6 +166,13 @@ terminalService.setSender({
     portPush.send("terminal.data", { ptyId, data: Buffer.from(bytes).toString("utf8"), seq });
   },
 });
+
+// Poll ws.bufferedAmount every 50ms and drive server-side flow control.
+// unref() prevents this timer from keeping the process alive if everything
+// else has shut down.
+setInterval(() => {
+  terminalService.onBufferedAmountTick(maxBufferedAmount());
+}, 50).unref();
 
 // AgentService self-wires persistence and session tracking against providers
 agentService.init();

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -160,10 +160,11 @@ terminalService.setSender({
   },
   data: (ptyId, seq, bytes) => {
     broadcastTerminalData(ptyId, seq, bytes);
-    // portPush uses JSON serialization over a socket, so re-encode bytes to a
-    // UTF-8 string for the IPC path. This only runs in Electron mode where a
-    // port is attached, so the performance cost is negligible.
-    portPush.send("terminal.data", { ptyId, data: Buffer.from(bytes).toString("utf8"), seq });
+    // PortPush uses MessagePort.postMessage (structured clone), which
+    // transfers Uint8Array losslessly without any UTF-8 re-encoding.
+    // The web-side ws-events.ts handler checks `payload instanceof Uint8Array`
+    // and routes this correctly.
+    portPush.send("terminal.data", { ptyId, payload: bytes, seq });
   },
 });
 

--- a/apps/server/src/services/__tests__/terminal-flow-control.test.ts
+++ b/apps/server/src/services/__tests__/terminal-flow-control.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { TerminalFlowControl } from "../terminal-flow-control.js";
+
+describe("TerminalFlowControl", () => {
+  it("starts un-paused and forwards bytes through the sink", () => {
+    const sink = vi.fn();
+    const fc = new TerminalFlowControl({ sink, highBytes: 100, lowBytes: 40 });
+    fc.push(new Uint8Array([1, 2, 3]));
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0][0]).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("buffers bytes while paused and drains them on resume", () => {
+    const sink = vi.fn();
+    const fc = new TerminalFlowControl({ sink, highBytes: 100, lowBytes: 40 });
+    fc.pause("client-request");
+    fc.push(new Uint8Array([1, 2]));
+    fc.push(new Uint8Array([3, 4]));
+    expect(sink).not.toHaveBeenCalled();
+    fc.resume();
+    // One drain call per buffered chunk, in order.
+    expect(sink.mock.calls.map((c) => Array.from(c[0] as Uint8Array))).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it("drops oldest buffered chunks only after cap is exceeded and records dropped bytes", () => {
+    const sink = vi.fn();
+    const fc = new TerminalFlowControl({ sink, highBytes: 10, lowBytes: 5, bufferCapBytes: 8 });
+    fc.pause("socket-buffered");
+    fc.push(new Uint8Array([1, 2, 3, 4, 5])); // 5 bytes, fits in cap
+    fc.push(new Uint8Array([6, 7, 8, 9]));   // would bring total to 9 > 8 → drop oldest
+    expect(fc.droppedBytes).toBeGreaterThan(0);
+    fc.resume();
+    const drained = sink.mock.calls.flatMap((c) => Array.from(c[0] as Uint8Array));
+    expect(drained.length).toBeLessThanOrEqual(8);
+  });
+
+  it("is idempotent for pause/resume", () => {
+    const sink = vi.fn();
+    const fc = new TerminalFlowControl({ sink, highBytes: 100, lowBytes: 40 });
+    fc.pause("client-request");
+    fc.pause("socket-buffered"); // second pause is fine
+    fc.resume(); // clears both
+    fc.resume(); // no-op
+    fc.push(new Uint8Array([1]));
+    expect(sink).toHaveBeenCalledOnce();
+  });
+
+  it("release() removes one source and drains only when both are clear", () => {
+    const sink = vi.fn();
+    const fc = new TerminalFlowControl({ sink, highBytes: 100, lowBytes: 40 });
+    fc.pause("client-request");
+    fc.pause("socket-buffered");
+    fc.push(new Uint8Array([42]));
+    fc.release("client-request"); // still held by socket-buffered
+    expect(sink).not.toHaveBeenCalled();
+    fc.release("socket-buffered"); // now clear → drain
+    expect(sink).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/server/src/services/__tests__/terminal-flow-control.test.ts
+++ b/apps/server/src/services/__tests__/terminal-flow-control.test.ts
@@ -5,23 +5,25 @@ describe("TerminalFlowControl", () => {
   it("starts un-paused and forwards bytes through the sink", () => {
     const sink = vi.fn();
     const fc = new TerminalFlowControl({ sink, highBytes: 100, lowBytes: 40 });
-    fc.push(new Uint8Array([1, 2, 3]));
+    fc.push(0, new Uint8Array([1, 2, 3]));
     expect(sink).toHaveBeenCalledTimes(1);
-    expect(sink.mock.calls[0][0]).toEqual(new Uint8Array([1, 2, 3]));
+    // sink receives (seq, bytes)
+    expect(sink.mock.calls[0][0]).toBe(0);
+    expect(sink.mock.calls[0][1]).toEqual(new Uint8Array([1, 2, 3]));
   });
 
   it("buffers bytes while paused and drains them on resume", () => {
     const sink = vi.fn();
     const fc = new TerminalFlowControl({ sink, highBytes: 100, lowBytes: 40 });
     fc.pause("client-request");
-    fc.push(new Uint8Array([1, 2]));
-    fc.push(new Uint8Array([3, 4]));
+    fc.push(0, new Uint8Array([1, 2]));
+    fc.push(1, new Uint8Array([3, 4]));
     expect(sink).not.toHaveBeenCalled();
     fc.resume();
-    // One drain call per buffered chunk, in order.
-    expect(sink.mock.calls.map((c) => Array.from(c[0] as Uint8Array))).toEqual([
-      [1, 2],
-      [3, 4],
+    // Seq numbers preserved through the ring; bytes arrive in order.
+    expect(sink.mock.calls.map((c) => [c[0], Array.from(c[1] as Uint8Array)])).toEqual([
+      [0, [1, 2]],
+      [1, [3, 4]],
     ]);
   });
 
@@ -29,12 +31,26 @@ describe("TerminalFlowControl", () => {
     const sink = vi.fn();
     const fc = new TerminalFlowControl({ sink, highBytes: 10, lowBytes: 5, bufferCapBytes: 8 });
     fc.pause("socket-buffered");
-    fc.push(new Uint8Array([1, 2, 3, 4, 5])); // 5 bytes, fits in cap
-    fc.push(new Uint8Array([6, 7, 8, 9]));   // would bring total to 9 > 8 → drop oldest
+    fc.push(0, new Uint8Array([1, 2, 3, 4, 5])); // 5 bytes, fits in cap
+    fc.push(1, new Uint8Array([6, 7, 8, 9]));   // would bring total to 9 > 8 → drop oldest
     expect(fc.droppedBytes).toBeGreaterThan(0);
     fc.resume();
-    const drained = sink.mock.calls.flatMap((c) => Array.from(c[0] as Uint8Array));
+    const drained = sink.mock.calls.flatMap((c) => Array.from(c[1] as Uint8Array));
     expect(drained.length).toBeLessThanOrEqual(8);
+  });
+
+  it("seq is assigned at push time so evicted chunks leave visible gaps", () => {
+    // The surviving chunk should carry seq=1 even though seq=0 was evicted.
+    const sink = vi.fn();
+    const fc = new TerminalFlowControl({ sink, highBytes: 10, lowBytes: 5, bufferCapBytes: 4 });
+    fc.pause("socket-buffered");
+    fc.push(0, new Uint8Array([1, 2, 3, 4, 5])); // 5 bytes > cap=4 → evicted immediately
+    fc.push(1, new Uint8Array([1, 2, 3]));        // 3 bytes, fits
+    fc.resume();
+    // seq=0 was evicted; only seq=1 arrives at the sink
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0][0]).toBe(1);
+    expect(fc.droppedBytes).toBeGreaterThan(0);
   });
 
   it("is idempotent for pause/resume", () => {
@@ -44,7 +60,7 @@ describe("TerminalFlowControl", () => {
     fc.pause("socket-buffered"); // second pause is fine
     fc.resume(); // clears both
     fc.resume(); // no-op
-    fc.push(new Uint8Array([1]));
+    fc.push(0, new Uint8Array([1]));
     expect(sink).toHaveBeenCalledOnce();
   });
 
@@ -53,7 +69,7 @@ describe("TerminalFlowControl", () => {
     const fc = new TerminalFlowControl({ sink, highBytes: 100, lowBytes: 40 });
     fc.pause("client-request");
     fc.pause("socket-buffered");
-    fc.push(new Uint8Array([42]));
+    fc.push(0, new Uint8Array([42]));
     fc.release("client-request"); // still held by socket-buffered
     expect(sink).not.toHaveBeenCalled();
     fc.release("socket-buffered"); // now clear → drain

--- a/apps/server/src/services/terminal-flow-control.ts
+++ b/apps/server/src/services/terminal-flow-control.ts
@@ -16,8 +16,12 @@ export type PauseSource = "client-request" | "socket-buffered";
 
 /** Options for constructing a {@link TerminalFlowControl} instance. */
 export interface TerminalFlowControlOptions {
-  /** Called with each chunk when the channel is open. */
-  sink: (chunk: Uint8Array) => void;
+  /**
+   * Called with each chunk when the channel is open.
+   * Receives the monotonic per-PTY sequence number assigned at push time so
+   * the caller can detect gaps caused by ring-buffer eviction.
+   */
+  sink: (seq: number, chunk: Uint8Array) => void;
   /** High-water mark used by the socket-level coordinator. */
   highBytes: number;
   /** Low-water mark used by the socket-level coordinator. */
@@ -28,12 +32,13 @@ export interface TerminalFlowControlOptions {
 
 /** Per-PTY backpressure buffer with multi-source pause semantics. */
 export class TerminalFlowControl {
-  private readonly sink: (chunk: Uint8Array) => void;
+  private readonly sink: (seq: number, chunk: Uint8Array) => void;
   private readonly highBytes: number;
   private readonly lowBytes: number;
   private readonly bufferCap: number;
   private readonly pauseReasons = new Set<PauseSource>();
-  private buffer: Uint8Array[] = [];
+  /** Buffered (seq, bytes) pairs queued while paused. */
+  private buffer: Array<{ seq: number; bytes: Uint8Array }> = [];
   private bufferedBytes = 0;
   /** Running count of bytes dropped because the ring was full. */
   public droppedBytes = 0;
@@ -85,27 +90,36 @@ export class TerminalFlowControl {
     }
   }
 
-  /** Push a chunk. Forwards to sink when open; buffers when paused. */
-  push(chunk: Uint8Array): void {
+  /**
+   * Push a chunk with its pre-assigned sequence number.
+   *
+   * Seq is assigned by the caller at PTY data arrival time — before any
+   * buffering or eviction decision. This ensures that if a chunk is later
+   * evicted from the ring, the gap is visible on the wire (the seq
+   * counter advances past the evicted seq numbers).
+   *
+   * Forwards directly to sink when open; queues when paused.
+   */
+  push(seq: number, chunk: Uint8Array): void {
     if (!this.paused) {
-      this.sink(chunk);
+      this.sink(seq, chunk);
       return;
     }
-    this.buffer.push(chunk);
+    this.buffer.push({ seq, bytes: chunk });
     this.bufferedBytes += chunk.length;
     // Evict oldest chunks until we're within the cap.
     while (this.bufferedBytes > this.bufferCap && this.buffer.length > 0) {
       const dropped = this.buffer.shift()!;
-      this.bufferedBytes -= dropped.length;
-      this.droppedBytes += dropped.length;
+      this.bufferedBytes -= dropped.bytes.length;
+      this.droppedBytes += dropped.bytes.length;
     }
   }
 
   private _drain(): void {
     while (this.buffer.length > 0) {
-      const chunk = this.buffer.shift()!;
-      this.bufferedBytes -= chunk.length;
-      this.sink(chunk);
+      const item = this.buffer.shift()!;
+      this.bufferedBytes -= item.bytes.length;
+      this.sink(item.seq, item.bytes);
     }
   }
 }

--- a/apps/server/src/services/terminal-flow-control.ts
+++ b/apps/server/src/services/terminal-flow-control.ts
@@ -12,6 +12,7 @@
  * the kernel buffer is insufficient.
  */
 
+/** Identifies why PTY output is currently paused. */
 export type PauseSource = "client-request" | "socket-buffered";
 
 /** Options for constructing a {@link TerminalFlowControl} instance. */

--- a/apps/server/src/services/terminal-flow-control.ts
+++ b/apps/server/src/services/terminal-flow-control.ts
@@ -121,6 +121,12 @@ export class TerminalFlowControl {
       this.bufferedBytes -= dropped.bytes.length;
       this.droppedBytes += dropped.bytes.length;
     }
+    // Compact the backing array so evicted slots don't retain memory
+    // indefinitely during long pauses.
+    if (this.head > 1024 && this.head * 2 >= this.buffer.length) {
+      this.buffer = this.buffer.slice(this.head);
+      this.head = 0;
+    }
   }
 
   private _drain(): void {

--- a/apps/server/src/services/terminal-flow-control.ts
+++ b/apps/server/src/services/terminal-flow-control.ts
@@ -1,0 +1,111 @@
+/**
+ * Per-PTY flow-control buffer for the server side.
+ *
+ * Two pause sources can hold the PTY:
+ *   - "client-request": the client sent terminal.pause
+ *   - "socket-buffered": ws.bufferedAmount crossed the server high-water mark
+ *
+ * While paused from either source, pushed chunks accumulate in a bounded
+ * ring. When both sources release, the ring drains to the sink in FIFO order.
+ * If the ring cap is exceeded, the oldest bytes are dropped — the kernel PTY
+ * buffer is the primary backpressure mechanism, so this only fires when
+ * the kernel buffer is insufficient.
+ */
+
+export type PauseSource = "client-request" | "socket-buffered";
+
+/** Options for constructing a {@link TerminalFlowControl} instance. */
+export interface TerminalFlowControlOptions {
+  /** Called with each chunk when the channel is open. */
+  sink: (chunk: Uint8Array) => void;
+  /** High-water mark used by the socket-level coordinator. */
+  highBytes: number;
+  /** Low-water mark used by the socket-level coordinator. */
+  lowBytes: number;
+  /** Max bytes to buffer during a pause before dropping oldest. Defaults to highBytes * 4. */
+  bufferCapBytes?: number;
+}
+
+/** Per-PTY backpressure buffer with multi-source pause semantics. */
+export class TerminalFlowControl {
+  private readonly sink: (chunk: Uint8Array) => void;
+  private readonly highBytes: number;
+  private readonly lowBytes: number;
+  private readonly bufferCap: number;
+  private readonly pauseReasons = new Set<PauseSource>();
+  private buffer: Uint8Array[] = [];
+  private bufferedBytes = 0;
+  /** Running count of bytes dropped because the ring was full. */
+  public droppedBytes = 0;
+
+  constructor(opts: TerminalFlowControlOptions) {
+    this.sink = opts.sink;
+    this.highBytes = opts.highBytes;
+    this.lowBytes = opts.lowBytes;
+    this.bufferCap = opts.bufferCapBytes ?? opts.highBytes * 4;
+  }
+
+  /** True while any pause source is held. */
+  get paused(): boolean {
+    return this.pauseReasons.size > 0;
+  }
+
+  /** Bytes currently queued waiting for resume. */
+  get pending(): number {
+    return this.bufferedBytes;
+  }
+
+  /** Low/high water marks (exposed so the coordinator can threshold on them). */
+  get marks(): { high: number; low: number } {
+    return { high: this.highBytes, low: this.lowBytes };
+  }
+
+  /** Hold the PTY under a named source. Idempotent. */
+  pause(source: PauseSource): void {
+    this.pauseReasons.add(source);
+  }
+
+  /**
+   * Release all pause sources and drain the buffer synchronously to the sink.
+   * Idempotent — safe to call when already un-paused.
+   */
+  resume(): void {
+    this.pauseReasons.clear();
+    this._drain();
+  }
+
+  /**
+   * Release a single pause source. Drains only when no sources remain.
+   * Idempotent — safe to call when this source is not held.
+   */
+  release(source: PauseSource): void {
+    this.pauseReasons.delete(source);
+    if (this.pauseReasons.size === 0) {
+      this._drain();
+    }
+  }
+
+  /** Push a chunk. Forwards to sink when open; buffers when paused. */
+  push(chunk: Uint8Array): void {
+    if (!this.paused) {
+      this.sink(chunk);
+      return;
+    }
+    this.buffer.push(chunk);
+    this.bufferedBytes += chunk.length;
+    // Evict oldest chunks until we're within the cap.
+    while (this.bufferedBytes > this.bufferCap && this.buffer.length > 0) {
+      const dropped = this.buffer.shift()!;
+      this.bufferedBytes -= dropped.length;
+      this.droppedBytes += dropped.length;
+    }
+  }
+
+  private _drain(): void {
+    while (this.buffer.length > 0) {
+      const chunk = this.buffer.shift()!;
+      this.bufferedBytes -= chunk.length;
+      this.sink(chunk);
+    }
+  }
+}

--- a/apps/server/src/services/terminal-flow-control.ts
+++ b/apps/server/src/services/terminal-flow-control.ts
@@ -39,6 +39,13 @@ export class TerminalFlowControl {
   private readonly pauseReasons = new Set<PauseSource>();
   /** Buffered (seq, bytes) pairs queued while paused. */
   private buffer: Array<{ seq: number; bytes: Uint8Array }> = [];
+  /**
+   * Index of the oldest unconsumed entry in `buffer`.
+   * Advancing this instead of calling `Array.shift()` keeps eviction and
+   * drain at O(1) per chunk. The array is replaced with a fresh slice on
+   * each full drain, reclaiming memory from the evicted head entries.
+   */
+  private head = 0;
   private bufferedBytes = 0;
   /** Running count of bytes dropped because the ring was full. */
   public droppedBytes = 0;
@@ -107,19 +114,23 @@ export class TerminalFlowControl {
     }
     this.buffer.push({ seq, bytes: chunk });
     this.bufferedBytes += chunk.length;
-    // Evict oldest chunks until we're within the cap.
-    while (this.bufferedBytes > this.bufferCap && this.buffer.length > 0) {
-      const dropped = this.buffer.shift()!;
+    // Evict oldest chunks until we're within the cap.  Advancing `head` is
+    // O(1) vs Array.shift() which is O(n) because it reindexes every entry.
+    while (this.bufferedBytes > this.bufferCap && this.head < this.buffer.length) {
+      const dropped = this.buffer[this.head++]!;
       this.bufferedBytes -= dropped.bytes.length;
       this.droppedBytes += dropped.bytes.length;
     }
   }
 
   private _drain(): void {
-    while (this.buffer.length > 0) {
-      const item = this.buffer.shift()!;
+    while (this.head < this.buffer.length) {
+      const item = this.buffer[this.head++]!;
       this.bufferedBytes -= item.bytes.length;
       this.sink(item.seq, item.bytes);
     }
+    // Reset to reclaim memory from both evicted and drained entries.
+    this.buffer = [];
+    this.head = 0;
   }
 }

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -142,6 +142,11 @@ export class TerminalService {
       highBytes: fcSettings.serverHighBytes,
       lowBytes: fcSettings.serverLowBytes,
     });
+    // Hold the PTY until the client-side TerminalView has mounted and attached
+    // its mcode:pty-data listener. Without this, the shell can emit its first
+    // prompt before the view exists, leaving a newly-opened terminal blank
+    // until some later output happens to arrive.
+    fc.pause("client-request");
     this.flowControls.set(id, fc);
 
     const dataDisposable = pty.onData((data: string) => {

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -138,8 +138,7 @@ export class TerminalService {
 
     const fcSettings = this.settingsService.get().terminal.flowControl;
     const fc = new TerminalFlowControl({
-      // seq++ only when bytes actually leave the buffer — correct when paused
-      sink: (bytes) => this.sender?.data(id, seq++, bytes),
+      sink: (s, bytes) => this.sender?.data(id, s, bytes),
       highBytes: fcSettings.serverHighBytes,
       lowBytes: fcSettings.serverLowBytes,
     });
@@ -147,8 +146,10 @@ export class TerminalService {
 
     const dataDisposable = pty.onData((data: string) => {
       // Re-encode to bytes so multi-byte sequences that straddle a node-pty
-      // read boundary remain intact on the wire.
-      fc.push(Buffer.from(data, "utf8"));
+      // read boundary remain intact on the wire. Seq is assigned here, before
+      // the ring-buffer decides whether to buffer or drop the chunk, so
+      // evicted bytes leave a gap in the client's seq stream.
+      fc.push(seq++, Buffer.from(data, "utf8"));
     });
 
     const exitDisposable = pty.onExit(({ exitCode }) => {

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -12,9 +12,11 @@ import type { IPty, IDisposable } from "node-pty";
 import { v4 as uuid } from "uuid";
 import { logger } from "@mcode/shared";
 import { killProcessTree } from "./process-kill.js";
+import { TerminalFlowControl } from "./terminal-flow-control.js";
 import type { ThreadRepo } from "../repositories/thread-repo";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { GitService } from "./git-service";
+import type { SettingsService } from "./settings-service";
 
 // createRequire lets us load native CJS modules (node-pty) from both ESM
 // (dev mode via entry.mjs + tsx) and the CJS production bundle.
@@ -69,11 +71,13 @@ export class TerminalService {
   private sessions = new Map<string, PtySession>();
   private threadIndex = new Map<string, Set<string>>();
   private sender: PtySender | null = null;
+  private flowControls = new Map<string, TerminalFlowControl>();
 
   constructor(
     @inject("ThreadRepo") private readonly threadRepo: ThreadRepo,
     @inject("WorkspaceRepo") private readonly workspaceRepo: WorkspaceRepo,
     @inject("GitService") private readonly gitService: GitService,
+    @inject("SettingsService") private readonly settingsService: SettingsService,
   ) {}
 
   /** Set the sender used to stream PTY data to connected clients. */
@@ -132,10 +136,19 @@ export class TerminalService {
 
     let seq = 0;
 
+    const fcSettings = this.settingsService.get().terminal.flowControl;
+    const fc = new TerminalFlowControl({
+      // seq++ only when bytes actually leave the buffer — correct when paused
+      sink: (bytes) => this.sender?.data(id, seq++, bytes),
+      highBytes: fcSettings.serverHighBytes,
+      lowBytes: fcSettings.serverLowBytes,
+    });
+    this.flowControls.set(id, fc);
+
     const dataDisposable = pty.onData((data: string) => {
       // Re-encode to bytes so multi-byte sequences that straddle a node-pty
       // read boundary remain intact on the wire.
-      this.sender?.data(id, seq++, Buffer.from(data, "utf8"));
+      fc.push(Buffer.from(data, "utf8"));
     });
 
     const exitDisposable = pty.onExit(({ exitCode }) => {
@@ -160,6 +173,40 @@ export class TerminalService {
     ]);
 
     return id;
+  }
+
+  /**
+   * Hold a PTY under the client-request pause source. Idempotent.
+   * Throws if the PTY ID is not found.
+   */
+  pause(ptyId: string): void {
+    const fc = this.flowControls.get(ptyId);
+    if (!fc) throw new Error(`PTY not found: ${ptyId}`);
+    fc.pause("client-request");
+  }
+
+  /**
+   * Release the client-request pause source for a PTY. Idempotent.
+   * Throws if the PTY ID is not found.
+   */
+  resume(ptyId: string): void {
+    const fc = this.flowControls.get(ptyId);
+    if (!fc) throw new Error(`PTY not found: ${ptyId}`);
+    fc.release("client-request");
+  }
+
+  /**
+   * Invoked by the socket coordinator with the current worst-case
+   * ws.bufferedAmount across all connected clients.
+   */
+  onBufferedAmountTick(bufferedAmount: number): void {
+    for (const [, fc] of this.flowControls) {
+      if (bufferedAmount > fc.marks.high) {
+        fc.pause("socket-buffered");
+      } else if (bufferedAmount < fc.marks.low) {
+        fc.release("socket-buffered");
+      }
+    }
   }
 
   /** Forward keystrokes to a PTY session. */
@@ -253,5 +300,7 @@ export class TerminalService {
       }
       this.threadIndex = newIndex;
     }
+
+    this.flowControls.delete(ptyId);
   }
 }

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -47,11 +47,13 @@ interface PtySession {
   readonly exitDisposable: IDisposable;
 }
 
-/** Callback for sending PTY data and exit events to connected clients. */
-type PtySender = (
-  channel: string,
-  data: Record<string, unknown>,
-) => void;
+/** Callbacks for streaming PTY output and exit events to connected clients. */
+export interface PtySender {
+  /** Send a JSON push event (used for terminal.exit and any future JSON events). */
+  json: (channel: string, data: Record<string, unknown>) => void;
+  /** Send a PTY data chunk as a binary frame (tag 0x01 envelope). */
+  data: (ptyId: string, seq: number, bytes: Uint8Array) => void;
+}
 
 /** Determine the default shell for the current platform. */
 function defaultShell(): string {
@@ -74,9 +76,9 @@ export class TerminalService {
     @inject("GitService") private readonly gitService: GitService,
   ) {}
 
-  /** Set the sender function used to stream PTY data to connected clients. */
-  setSender(fn: PtySender): void {
-    this.sender = fn;
+  /** Set the sender used to stream PTY data to connected clients. */
+  setSender(sender: PtySender): void {
+    this.sender = sender;
   }
 
   /**
@@ -128,12 +130,16 @@ export class TerminalService {
       cwd,
     });
 
+    let seq = 0;
+
     const dataDisposable = pty.onData((data: string) => {
-      this.sender?.("terminal.data", { ptyId: id, data });
+      // Re-encode to bytes so multi-byte sequences that straddle a node-pty
+      // read boundary remain intact on the wire.
+      this.sender?.data(id, seq++, Buffer.from(data, "utf8"));
     });
 
     const exitDisposable = pty.onExit(({ exitCode }) => {
-      this.sender?.("terminal.exit", { ptyId: id, code: exitCode });
+      this.sender?.json("terminal.exit", { ptyId: id, code: exitCode });
       this.removePty(id);
     });
 

--- a/apps/server/src/transport/push.test.ts
+++ b/apps/server/src/transport/push.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { WebSocket } from "ws";
+import {
+  addClient,
+  broadcastTerminalData,
+  _resetForTest,
+} from "./push.js";
+import { decodeTerminalDataFrame } from "@mcode/contracts";
+
+function fakeOpenSocket(received: Array<{ buf: Buffer; binary: boolean }>): WebSocket {
+  const ws: Partial<WebSocket> = {
+    readyState: 1, // OPEN
+    OPEN: 1,
+    send: ((data: unknown, opts?: { binary?: boolean }) => {
+      const buf = Buffer.isBuffer(data)
+        ? data
+        : Buffer.from(data as Uint8Array);
+      received.push({ buf, binary: !!opts?.binary });
+    }) as WebSocket["send"],
+  };
+  return ws as WebSocket;
+}
+
+describe("broadcastTerminalData", () => {
+  beforeEach(() => _resetForTest());
+  afterEach(() => _resetForTest());
+
+  it("sends a binary frame to every connected client", () => {
+    const a: Array<{ buf: Buffer; binary: boolean }> = [];
+    const b: Array<{ buf: Buffer; binary: boolean }> = [];
+    addClient(fakeOpenSocket(a));
+    addClient(fakeOpenSocket(b));
+
+    const payload = new Uint8Array([0x41, 0x42, 0x43]); // ABC
+    broadcastTerminalData("pty-1", 42, payload);
+
+    expect(a).toHaveLength(1);
+    expect(a[0].binary).toBe(true);
+    const decoded = decodeTerminalDataFrame(new Uint8Array(a[0].buf));
+    expect(decoded).toEqual({ ptyId: "pty-1", seq: 42, payload });
+    expect(b).toHaveLength(1);
+    expect(b[0].binary).toBe(true);
+  });
+
+  it("preserves byte boundaries for multi-byte UTF-8", () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    addClient(fakeOpenSocket(received));
+    const payload = new Uint8Array([0xe4, 0xbd, 0xa0]); // "你" in UTF-8
+    broadcastTerminalData("pty-1", 0, payload);
+    const decoded = decodeTerminalDataFrame(new Uint8Array(received[0].buf));
+    expect(decoded.payload).toEqual(payload);
+  });
+});

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -119,7 +119,15 @@ export function broadcastTerminalData(
   const frame = encodeTerminalDataFrame(ptyId, seq, payload);
   for (const ws of clients) {
     if (ws.readyState === ws.OPEN) {
-      ws.send(frame, { binary: true });
+      try {
+        ws.send(frame, { binary: true });
+      } catch (err) {
+        // One bad socket must not interrupt delivery to the remaining clients.
+        // Log and continue — the client will reconnect and re-request state.
+        logger.warn("broadcastTerminalData: ws.send failed for a client", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 }

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -4,7 +4,7 @@
  */
 
 import type { WebSocket } from "ws";
-import { WS_CHANNELS, type WsChannelName } from "@mcode/contracts";
+import { WS_CHANNELS, type WsChannelName, encodeTerminalDataFrame } from "@mcode/contracts";
 import { logger } from "@mcode/shared";
 
 const clients = new Set<WebSocket>();
@@ -87,6 +87,25 @@ export function broadcast(
   for (const ws of clients) {
     if (ws.readyState === ws.OPEN) {
       ws.send(payload);
+    }
+  }
+}
+
+/**
+ * Broadcast a PTY data chunk as a binary WebSocket frame.
+ *
+ * Uses the terminal-binary envelope so clients can decode ptyId + seq without
+ * a preceding text header. Non-PTY channels continue to use JSON `broadcast`.
+ */
+export function broadcastTerminalData(
+  ptyId: string,
+  seq: number,
+  payload: Uint8Array,
+): void {
+  const frame = encodeTerminalDataFrame(ptyId, seq, payload);
+  for (const ws of clients) {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(frame, { binary: true });
     }
   }
 }

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -56,6 +56,20 @@ export function clientCount(): number {
 }
 
 /**
+ * Returns the maximum ws.bufferedAmount across all currently-open clients.
+ * Used by the socket coordinator to drive server-side flow control.
+ */
+export function maxBufferedAmount(): number {
+  let max = 0;
+  for (const ws of clients) {
+    if (ws.readyState === ws.OPEN) {
+      if (ws.bufferedAmount > max) max = ws.bufferedAmount;
+    }
+  }
+  return max;
+}
+
+/**
  * Broadcast a push event to all connected WebSocket clients.
  * Validates the data against the channel's Zod schema before sending.
  */

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -444,6 +444,16 @@ async function dispatch(
     case "terminal.kill":
       await deps.terminalService.kill(params.ptyId);
       return;
+    case "terminal.pause": {
+      const { ptyId } = params as { ptyId: string };
+      deps.terminalService.pause(ptyId);
+      return;
+    }
+    case "terminal.resume": {
+      const { ptyId } = params as { ptyId: string };
+      deps.terminalService.resume(ptyId);
+      return;
+    }
     case "terminal.killByThread":
       await deps.terminalService.killByThread(params.threadId);
       return;

--- a/apps/web/src/__tests__/TerminalStatusIndicator.test.tsx
+++ b/apps/web/src/__tests__/TerminalStatusIndicator.test.tsx
@@ -1,8 +1,17 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { TerminalStatusIndicator } from "@/components/chat/TerminalStatusIndicator";
+
+// toggleTerminalPanel now calls getTransport() to pause/resume PTYs.
+// Provide a no-op mock so these UI-focused tests don't throw on transport access.
+vi.mock("@/transport", () => ({
+  getTransport: () => ({
+    terminalPause: vi.fn().mockResolvedValue(undefined),
+    terminalResume: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
 
 describe("TerminalStatusIndicator", () => {
   beforeEach(() => {

--- a/apps/web/src/__tests__/TerminalView.focus.test.tsx
+++ b/apps/web/src/__tests__/TerminalView.focus.test.tsx
@@ -114,4 +114,16 @@ describe("TerminalView focus behaviour (regression)", () => {
 
     expect(transport.terminalResume).toHaveBeenCalledWith("pty-1");
   });
+
+  it("does NOT resume when mounted hidden", async () => {
+    await act(async () => {
+      render(<TerminalView ptyId="pty-1" visible={false} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(transport.terminalResume).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/__tests__/TerminalView.focus.test.tsx
+++ b/apps/web/src/__tests__/TerminalView.focus.test.tsx
@@ -32,6 +32,12 @@ const term = {
   rows: 24,
 };
 
+const transport = {
+  terminalWrite: vi.fn(() => Promise.resolve()),
+  terminalResize: vi.fn(() => Promise.resolve()),
+  terminalResume: vi.fn(() => Promise.resolve()),
+};
+
 vi.mock("@xterm/xterm", () => {
   class Terminal {
     constructor() {
@@ -53,10 +59,7 @@ vi.mock("@/transport", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/transport")>();
   return {
     ...actual,
-    getTransport: () => ({
-      terminalWrite: vi.fn(() => Promise.resolve()),
-      terminalResize: vi.fn(() => Promise.resolve()),
-    }),
+    getTransport: () => transport,
   };
 });
 
@@ -66,6 +69,7 @@ describe("TerminalView focus behaviour (regression)", () => {
   beforeEach(() => {
     term.focus.mockClear();
     term.refresh.mockClear();
+    transport.terminalResume.mockClear();
   });
 
   // Regression guard: term.focus() must NOT fire when the window/tab
@@ -97,5 +101,17 @@ describe("TerminalView focus behaviour (regression)", () => {
     expect(term.focus.mock.calls.length).toBe(focusCallsBefore);
     // Repaint still happens so half-painted output recovers.
     expect(term.refresh).toHaveBeenCalled();
+  });
+
+  it("resumes a newly-created PTY after the view mounts", async () => {
+    await act(async () => {
+      render(<TerminalView ptyId="pty-1" visible={true} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(transport.terminalResume).toHaveBeenCalledWith("pty-1");
   });
 });

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -116,6 +116,8 @@ export const mockTransport: McodeTransport = {
   terminalWrite: vi.fn().mockResolvedValue(undefined),
   terminalResize: vi.fn().mockResolvedValue(undefined),
   terminalKill: vi.fn().mockResolvedValue(undefined),
+  terminalPause: vi.fn().mockResolvedValue(undefined),
+  terminalResume: vi.fn().mockResolvedValue(undefined),
   terminalKillByThread: vi.fn().mockResolvedValue(undefined),
   listToolCallRecords: vi.fn().mockResolvedValue([]),
   listToolCallRecordsByParent: vi.fn().mockResolvedValue([]),

--- a/apps/web/src/__tests__/terminal-scrollback.test.ts
+++ b/apps/web/src/__tests__/terminal-scrollback.test.ts
@@ -52,9 +52,11 @@ describe("Terminal scrollback from settings", () => {
     useSettingsStore.setState({
       settings: {
         ...defaults,
-        terminal: { ...defaults.terminal, scrollback: 1000 },
+        terminal: { ...defaults.terminal, scrollback: 2500 },
       },
     });
-    expect(useSettingsStore.getState().settings.terminal.scrollback).toBe(1000);
+    // 2500 is intentionally different from the 1000 default so this test
+    // catches a regression where the override is silently ignored.
+    expect(useSettingsStore.getState().settings.terminal.scrollback).toBe(2500);
   });
 });

--- a/apps/web/src/__tests__/terminal-scrollback.test.ts
+++ b/apps/web/src/__tests__/terminal-scrollback.test.ts
@@ -48,10 +48,11 @@ describe("Terminal scrollback from settings", () => {
   });
 
   it("settings store accepts custom scrollback value", () => {
+    const defaults = getDefaultSettings();
     useSettingsStore.setState({
       settings: {
-        ...getDefaultSettings(),
-        terminal: { scrollback: 1000 },
+        ...defaults,
+        terminal: { ...defaults.terminal, scrollback: 1000 },
       },
     });
     expect(useSettingsStore.getState().settings.terminal.scrollback).toBe(1000);

--- a/apps/web/src/__tests__/terminalFlowControl.test.ts
+++ b/apps/web/src/__tests__/terminalFlowControl.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { ClientTerminalFlowControl } from "@/components/terminal/terminalFlowControl";
+
+describe("ClientTerminalFlowControl", () => {
+  it("requests pause when pending bytes cross the high-water mark", () => {
+    const onPause = vi.fn();
+    const onResume = vi.fn();
+    const fc = new ClientTerminalFlowControl({
+      onPause,
+      onResume,
+      highBytes: 100,
+      lowBytes: 40,
+    });
+    fc.written(80);
+    expect(onPause).not.toHaveBeenCalled();
+    fc.written(50); // pending = 130 > 100
+    expect(onPause).toHaveBeenCalledOnce();
+  });
+
+  it("requests resume when pending drops below the low-water mark", () => {
+    const onPause = vi.fn();
+    const onResume = vi.fn();
+    const fc = new ClientTerminalFlowControl({
+      onPause,
+      onResume,
+      highBytes: 100,
+      lowBytes: 40,
+    });
+    fc.written(150); // trips pause
+    expect(onPause).toHaveBeenCalledOnce();
+    fc.acked(120); // pending = 30 < 40
+    expect(onResume).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-pause while already paused", () => {
+    const onPause = vi.fn();
+    const onResume = vi.fn();
+    const fc = new ClientTerminalFlowControl({
+      onPause,
+      onResume,
+      highBytes: 100,
+      lowBytes: 40,
+    });
+    fc.written(150);
+    fc.written(50); // still paused — should not fire again
+    expect(onPause).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-resume while already un-paused", () => {
+    const onPause = vi.fn();
+    const onResume = vi.fn();
+    const fc = new ClientTerminalFlowControl({
+      onPause,
+      onResume,
+      highBytes: 100,
+      lowBytes: 40,
+    });
+    fc.written(150);
+    fc.acked(120); // un-pauses
+    fc.acked(10); // still un-paused — should not fire again
+    expect(onResume).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/terminal/TerminalView.tsx
+++ b/apps/web/src/components/terminal/TerminalView.tsx
@@ -284,11 +284,14 @@ export function TerminalView({ ptyId, visible }: TerminalViewProps) {
       const handlePtyData = (e: Event) => {
         const detail = (e as CustomEvent).detail as {
           ptyId: string;
-          data: string;
+          payload: Uint8Array;
+          seq: number;
         };
-        if (detail.ptyId === ptyId && typeof detail.data === "string") {
-          term.write(detail.data);
-        }
+        if (detail.ptyId !== ptyId) return;
+        // xterm accepts Uint8Array and decodes UTF-8 with stateful buffering
+        // across successive writes, so multi-byte sequences split across
+        // frames render correctly.
+        term.write(detail.payload);
       };
       window.addEventListener("mcode:pty-data", handlePtyData);
 

--- a/apps/web/src/components/terminal/TerminalView.tsx
+++ b/apps/web/src/components/terminal/TerminalView.tsx
@@ -4,6 +4,7 @@ import type { FitAddon } from "@xterm/addon-fit";
 import { getTransport } from "@/transport";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { shouldInterceptKeyEvent } from "./terminalKeyHandler";
+import { ClientTerminalFlowControl } from "./terminalFlowControl";
 // Static import so bundler deduplicates the stylesheet
 import "@xterm/xterm/css/xterm.css";
 
@@ -255,6 +256,15 @@ export function TerminalView({ ptyId, visible }: TerminalViewProps) {
 
       const transport = getTransport();
 
+      const flowSettings =
+        useSettingsStore.getState().settings.terminal.flowControl;
+      const fc = new ClientTerminalFlowControl({
+        onPause: () => transport.terminalPause(ptyId).catch(() => {}),
+        onResume: () => transport.terminalResume(ptyId).catch(() => {}),
+        highBytes: flowSettings.clientHighBytes,
+        lowBytes: flowSettings.clientLowBytes,
+      });
+
       // Right-click pastes clipboard text into the PTY (native terminal convention — no context menu).
       // term.paste() is used instead of transport.terminalWrite() so that xterm applies bracketed
       // paste mode when the shell requests it, preventing embedded newlines from auto-executing commands.
@@ -288,10 +298,11 @@ export function TerminalView({ ptyId, visible }: TerminalViewProps) {
           seq: number;
         };
         if (detail.ptyId !== ptyId) return;
-        // xterm accepts Uint8Array and decodes UTF-8 with stateful buffering
-        // across successive writes, so multi-byte sequences split across
-        // frames render correctly.
-        term.write(detail.payload);
+        const n = detail.payload.length;
+        fc.written(n);
+        // Use xterm's callback form so acked() fires only after the bytes
+        // are committed to the terminal buffer — not just queued.
+        term.write(detail.payload, () => fc.acked(n));
       };
       window.addEventListener("mcode:pty-data", handlePtyData);
 

--- a/apps/web/src/components/terminal/TerminalView.tsx
+++ b/apps/web/src/components/terminal/TerminalView.tsx
@@ -405,6 +405,12 @@ export function TerminalView({ ptyId, visible }: TerminalViewProps) {
         return;
       }
 
+      // New PTYs are created paused server-side so their initial shell prompt
+      // is buffered until this view is ready to consume it. Resume only after
+      // the PTY listeners above are attached; term.write queues bytes even
+      // before the renderer addon finishes loading.
+      transport.terminalResume(ptyId).catch(() => {});
+
       await loadRenderer(term, rendererRef, () => disposed);
       // If `disposed` flipped during the await, React's effect teardown
       // already invoked cleanupRef.current, and loadRenderer's own

--- a/apps/web/src/components/terminal/TerminalView.tsx
+++ b/apps/web/src/components/terminal/TerminalView.tsx
@@ -199,6 +199,9 @@ export function TerminalView({ ptyId, visible }: TerminalViewProps) {
   const flushResizeRpcRef = useRef<(() => void) | null>(null);
   const rendererRef = useRef<IDisposable | null>(null);
 
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
+
   const scrollback = useSettingsStore((s) => s.settings.terminal.scrollback);
   const scrollbackRef = useRef(scrollback);
   scrollbackRef.current = scrollback;
@@ -408,8 +411,11 @@ export function TerminalView({ ptyId, visible }: TerminalViewProps) {
       // New PTYs are created paused server-side so their initial shell prompt
       // is buffered until this view is ready to consume it. Resume only after
       // the PTY listeners above are attached; term.write queues bytes even
-      // before the renderer addon finishes loading.
-      transport.terminalResume(ptyId).catch(() => {});
+      // before the renderer addon finishes loading. Guard with the current
+      // visibility state so a late init doesn't race with pause-on-hide.
+      if (visibleRef.current) {
+        transport.terminalResume(ptyId).catch(() => {});
+      }
 
       await loadRenderer(term, rendererRef, () => disposed);
       // If `disposed` flipped during the await, React's effect teardown

--- a/apps/web/src/components/terminal/terminalFlowControl.ts
+++ b/apps/web/src/components/terminal/terminalFlowControl.ts
@@ -1,0 +1,56 @@
+/**
+ * Client-side flow-control state machine for a single PTY.
+ *
+ * Call `written(n)` each time xterm.write is called with `n` bytes.
+ * Call `acked(n)` when xterm's write callback fires, indicating `n` bytes
+ * have been processed. The machine requests server pause when
+ * `pending = written - acked` crosses highBytes, and requests resume when
+ * pending drops below lowBytes.
+ *
+ * Both callbacks (onPause / onResume) are idempotent at the transport layer,
+ * so duplicate calls are safe if they occur.
+ */
+
+/** Options for constructing a {@link ClientTerminalFlowControl} instance. */
+export interface ClientFlowControlOptions {
+  /** Called when pending bytes cross highBytes. Idempotent. */
+  onPause: () => void;
+  /** Called when pending bytes drop below lowBytes. Idempotent. */
+  onResume: () => void;
+  /** Pending-bytes threshold that triggers a pause request. */
+  highBytes: number;
+  /** Pending-bytes threshold that triggers a resume request. */
+  lowBytes: number;
+}
+
+/** Client-side per-PTY backpressure state machine. */
+export class ClientTerminalFlowControl {
+  private pending = 0;
+  private paused = false;
+
+  constructor(private readonly opts: ClientFlowControlOptions) {}
+
+  /**
+   * Record that `n` bytes have been dispatched to xterm.write.
+   * May trigger an onPause callback if the backlog crosses highBytes.
+   */
+  written(n: number): void {
+    this.pending += n;
+    if (!this.paused && this.pending > this.opts.highBytes) {
+      this.paused = true;
+      this.opts.onPause();
+    }
+  }
+
+  /**
+   * Record that xterm has processed `n` bytes (write callback fired).
+   * May trigger an onResume callback if the backlog drops below lowBytes.
+   */
+  acked(n: number): void {
+    this.pending = Math.max(0, this.pending - n);
+    if (this.paused && this.pending < this.opts.lowBytes) {
+      this.paused = false;
+      this.opts.onResume();
+    }
+  }
+}

--- a/apps/web/src/stores/terminalStore.test.ts
+++ b/apps/web/src/stores/terminalStore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const terminalPause = vi.fn().mockResolvedValue(undefined);
+const terminalResume = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/transport", () => ({
+  getTransport: () => ({ terminalPause, terminalResume }),
+}));
+
+// Import AFTER vi.mock — vitest hoists vi.mock to the top automatically,
+// so the store sees the mocked transport when the module initializes.
+import { useTerminalStore } from "./terminalStore";
+
+describe("terminalStore pause/resume wiring", () => {
+  beforeEach(() => {
+    terminalPause.mockClear();
+    terminalResume.mockClear();
+    useTerminalStore.setState({
+      terminals: {},
+      terminalPanelByThread: {},
+      splitMode: false,
+    });
+  });
+
+  it("pauses all PTYs on hide and resumes on show", () => {
+    const store = useTerminalStore.getState();
+    store.addTerminal("thread-1", "pty-a");
+    store.addTerminal("thread-1", "pty-b");
+    // addTerminal makes the panel visible; no pause/resume should have fired yet.
+    expect(terminalPause).not.toHaveBeenCalled();
+    expect(terminalResume).not.toHaveBeenCalled();
+
+    store.hideTerminalPanel("thread-1");
+    expect(terminalPause).toHaveBeenCalledTimes(2);
+    expect(terminalResume).not.toHaveBeenCalled();
+
+    store.showTerminalPanel("thread-1");
+    expect(terminalResume).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-ops when hiding an already-hidden panel", () => {
+    useTerminalStore.getState().hideTerminalPanel("unknown-thread");
+    expect(terminalPause).not.toHaveBeenCalled();
+  });
+
+  it("toggleTerminalPanel pauses when visible, resumes when hidden", () => {
+    const store = useTerminalStore.getState();
+    store.addTerminal("thread-2", "pty-c");
+    // Panel is visible after addTerminal. Toggle → hide → pause.
+    store.toggleTerminalPanel("thread-2");
+    expect(terminalPause).toHaveBeenCalledOnce();
+    // Toggle again → show → resume.
+    store.toggleTerminalPanel("thread-2");
+    expect(terminalResume).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/stores/terminalStore.ts
+++ b/apps/web/src/stores/terminalStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { getTransport } from "@/transport";
 
 /** A single PTY-backed terminal instance displayed in the terminal panel. */
 export interface TerminalInstance {
@@ -39,6 +40,27 @@ interface TerminalState {
   toggleSplit: () => void;
 }
 
+/**
+ * Pause or resume every PTY bound to a thread.
+ * Fire-and-forget: the server treats pause/resume as idempotent, so
+ * reconnect races are benign. Only acts when the thread has terminals.
+ */
+function setPtyPaused(
+  state: Pick<TerminalState, "terminals">,
+  threadId: string,
+  paused: boolean,
+): void {
+  const ptys = state.terminals[threadId];
+  if (!ptys || ptys.length === 0) return;
+  const transport = getTransport();
+  for (const t of ptys) {
+    const call = paused ? transport.terminalPause(t.id) : transport.terminalResume(t.id);
+    call.catch(() => {
+      // Best-effort. The next visibility toggle will reconcile state.
+    });
+  }
+}
+
 function generateLabel(existing: readonly TerminalInstance[]): string {
   const numbers = existing.map((t) => {
     const match = t.label.match(/^Terminal (\d+)$/);
@@ -60,10 +82,12 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   toggleTerminalPanel: (threadId) =>
     set((state) => {
       const current = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
+      const nextVisible = !current.visible;
+      setPtyPaused(state, threadId, !nextVisible); // pause when hiding, resume when showing
       return {
         terminalPanelByThread: {
           ...state.terminalPanelByThread,
-          [threadId]: { ...current, visible: !current.visible },
+          [threadId]: { ...current, visible: nextVisible },
         },
       };
     }),
@@ -71,6 +95,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   showTerminalPanel: (threadId) =>
     set((state) => {
       const current = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
+      if (!current.visible) setPtyPaused(state, threadId, false);
       return {
         terminalPanelByThread: {
           ...state.terminalPanelByThread,
@@ -82,6 +107,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   hideTerminalPanel: (threadId) =>
     set((state) => {
       const current = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;
+      if (current.visible) setPtyPaused(state, threadId, true);
       return {
         terminalPanelByThread: {
           ...state.terminalPanelByThread,

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -203,6 +203,10 @@ export interface McodeTransport {
   terminalResize(ptyId: string, cols: number, rows: number): Promise<void>;
   /** Kill a single PTY by ID. */
   terminalKill(ptyId: string): Promise<void>;
+  /** Request the server to stop draining a PTY. Idempotent. */
+  terminalPause(ptyId: string): Promise<void>;
+  /** Request the server to resume a paused PTY. Idempotent. */
+  terminalResume(ptyId: string): Promise<void>;
   /** Kill all PTYs attached to a thread. */
   terminalKillByThread(threadId: string): Promise<void>;
 

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -11,6 +11,9 @@ import { clearFileListCache } from "@/components/chat/useFileAutocomplete";
 /** Unsubscribe handles for all push listeners. */
 let unsubs: (() => void)[] = [];
 
+/** Encoder reused across all legacy JSON terminal.data frames. */
+const _legacyEncoder = new TextEncoder();
+
 /**
  * Wire up push channel listeners that forward server events to the
  * appropriate Zustand stores. Call once at app startup.
@@ -53,9 +56,6 @@ export function startPushListeners(): void {
     }),
   );
 
-// Module-level singleton reused across all legacy JSON terminal.data frames.
-const _legacyEncoder = new TextEncoder();
-
   // terminal.data: broadcast to TerminalView instances via CustomEvent
   unsubs.push(
     pushEmitter.on("terminal.data", (data) => {
@@ -69,7 +69,16 @@ const _legacyEncoder = new TextEncoder();
           seq: d["seq"] as number,
           payload: d["payload"] as Uint8Array,
         };
+      } else if (Array.isArray(d["payload"])) {
+        // IPC path: the socket adapter serializes via JSON.stringify, so Uint8Array
+        // arrives as a plain number[]. Reconstruct it here.
+        detail = {
+          ptyId: d["ptyId"] as string,
+          seq: d["seq"] as number,
+          payload: new Uint8Array(d["payload"] as number[]),
+        };
       } else {
+        // Legacy JSON fallback: older servers send { ptyId, data: string, seq? }.
         // Guard: skip malformed frames where data is not a string.
         if (typeof d["data"] !== "string") return;
         detail = {

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -70,12 +70,21 @@ export function startPushListeners(): void {
           payload: d["payload"] as Uint8Array,
         };
       } else if (Array.isArray(d["payload"])) {
-        // IPC path: the socket adapter serializes via JSON.stringify, so Uint8Array
-        // arrives as a plain number[]. Reconstruct it here.
+        // IPC path (current): the socket adapter serializes via JSON.stringify;
+        // the server converts to number[] so it survives the round-trip.
         detail = {
           ptyId: d["ptyId"] as string,
           seq: d["seq"] as number,
           payload: new Uint8Array(d["payload"] as number[]),
+        };
+      } else if (d["payload"] && typeof d["payload"] === "object") {
+        // IPC fallback for older servers that sent a raw Uint8Array through
+        // JSON.stringify — it arrives as an indexed object {"0":72,"1":101,...}.
+        // Object.values gives us the bytes in ascending-key order.
+        detail = {
+          ptyId: d["ptyId"] as string,
+          seq: d["seq"] as number,
+          payload: new Uint8Array(Object.values(d["payload"] as Record<string, number>)),
         };
       } else {
         // Legacy JSON fallback: older servers send { ptyId, data: string, seq? }.

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -53,6 +53,9 @@ export function startPushListeners(): void {
     }),
   );
 
+// Module-level singleton reused across all legacy JSON terminal.data frames.
+const _legacyEncoder = new TextEncoder();
+
   // terminal.data: broadcast to TerminalView instances via CustomEvent
   unsubs.push(
     pushEmitter.on("terminal.data", (data) => {
@@ -67,9 +70,11 @@ export function startPushListeners(): void {
           payload: d["payload"] as Uint8Array,
         };
       } else {
+        // Guard: skip malformed frames where data is not a string.
+        if (typeof d["data"] !== "string") return;
         detail = {
           ptyId: d["ptyId"] as string,
-          payload: new TextEncoder().encode(d["data"] as string),
+          payload: _legacyEncoder.encode(d["data"]),
           seq: (d["seq"] as number | undefined) ?? 0,
         };
       }

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -56,10 +56,24 @@ export function startPushListeners(): void {
   // terminal.data: broadcast to TerminalView instances via CustomEvent
   unsubs.push(
     pushEmitter.on("terminal.data", (data) => {
-      const payload = data as { ptyId: string; data: string };
-      window.dispatchEvent(
-        new CustomEvent("mcode:pty-data", { detail: payload }),
-      );
+      // Binary path (preferred): { ptyId, seq, payload: Uint8Array }
+      // Legacy JSON fallback: { ptyId, data: string, seq?: number }
+      let detail: { ptyId: string; payload: Uint8Array; seq: number };
+      const d = data as Record<string, unknown>;
+      if (d["payload"] instanceof Uint8Array) {
+        detail = {
+          ptyId: d["ptyId"] as string,
+          seq: d["seq"] as number,
+          payload: d["payload"] as Uint8Array,
+        };
+      } else {
+        detail = {
+          ptyId: d["ptyId"] as string,
+          payload: new TextEncoder().encode(d["data"] as string),
+          seq: (d["seq"] as number | undefined) ?? 0,
+        };
+      }
+      window.dispatchEvent(new CustomEvent("mcode:pty-data", { detail }));
     }),
   );
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -551,6 +551,8 @@ export function createWsTransport(
     terminalResize: (ptyId, cols, rows) =>
       rpc<void>("terminal.resize", { ptyId, cols, rows }),
     terminalKill: (ptyId) => rpc<void>("terminal.kill", { ptyId }),
+    terminalPause: (ptyId) => rpc<void>("terminal.pause", { ptyId }),
+    terminalResume: (ptyId) => rpc<void>("terminal.resume", { ptyId }),
     terminalKillByThread: (threadId) =>
       rpc<void>("terminal.killByThread", { threadId }),
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -18,6 +18,10 @@ import type {
 } from "./types";
 import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
+import {
+  TERMINAL_DATA_TAG,
+  decodeTerminalDataFrame,
+} from "@mcode/contracts";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useThreadStore } from "@/stores/threadStore";
 import type { PermissionRequest } from "@mcode/contracts";
@@ -166,6 +170,7 @@ export function createWsTransport(
   function connect(targetUrl?: string) {
     resetReady();
     ws = new WebSocket(targetUrl ?? url);
+    ws.binaryType = "arraybuffer";
 
     ws.onopen = () => {
       reconnectDelay = MIN_RECONNECT_MS;
@@ -238,6 +243,25 @@ export function createWsTransport(
     };
 
     ws.onmessage = (event) => {
+      // Binary frame: only terminal.data uses binary frames. The tag byte
+      // identifies the frame type so future binary channels can coexist.
+      if (event.data instanceof ArrayBuffer) {
+        const view = new Uint8Array(event.data);
+        if (view[0] === TERMINAL_DATA_TAG) {
+          try {
+            const decoded = decodeTerminalDataFrame(view);
+            if (!suppressedPushChannels.has("terminal.data")) {
+              pushEmitter.emit("terminal.data", decoded);
+            }
+          } catch (err) {
+            console.warn("[ws] failed to decode terminal.data frame", err);
+          }
+        } else {
+          console.warn("[ws] unknown binary tag 0x" + view[0]?.toString(16));
+        }
+        return;
+      }
+
       let msg: Record<string, unknown>;
       try {
         msg = JSON.parse(event.data as string);

--- a/packages/contracts/src/globals.d.ts
+++ b/packages/contracts/src/globals.d.ts
@@ -1,0 +1,5 @@
+// TextEncoder/TextDecoder are available in both Node.js (>=11) and browsers.
+// Declaring them here avoids pulling the full DOM lib into a package that
+// must remain environment-agnostic.
+declare const TextEncoder: typeof globalThis.TextEncoder;
+declare const TextDecoder: typeof globalThis.TextDecoder;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -151,6 +151,13 @@ export type { WsMethodName } from "./ws/methods.js";
 export { WS_CHANNELS } from "./ws/channels.js";
 export type { WsChannelName } from "./ws/channels.js";
 
+export {
+  TERMINAL_DATA_TAG,
+  encodeTerminalDataFrame,
+  decodeTerminalDataFrame,
+} from "./ws/terminal-binary.js";
+export type { TerminalDataFrame } from "./ws/terminal-binary.js";
+
 // Utilities
 export { lazySchema } from "./utils/lazySchema.js";
 

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -132,6 +132,12 @@ export const SettingsSchema = lazySchema(() =>
             /** Client-side low-water mark in bytes. Send terminal.resume when xterm write backlog drops below this. */
             clientLowBytes: z.number().int().positive(),
           })
+          .refine((v) => v.serverLowBytes < v.serverHighBytes, {
+            message: "serverLowBytes must be less than serverHighBytes",
+          })
+          .refine((v) => v.clientLowBytes < v.clientHighBytes, {
+            message: "clientLowBytes must be less than clientHighBytes",
+          })
           .default({
             serverHighBytes: 1_048_576,
             serverLowBytes: 262_144,

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -120,6 +120,24 @@ export const SettingsSchema = lazySchema(() =>
           .nonnegative()
           .transform((n) => Math.min(n, 5000))
           .default(1000),
+        /** Flow control settings for PTY backpressure handling. */
+        flowControl: z
+          .object({
+            /** Server-side high-water mark in bytes. Pause PTY drain when ws.bufferedAmount exceeds this. */
+            serverHighBytes: z.number().int().positive(),
+            /** Server-side low-water mark in bytes. Resume PTY drain when ws.bufferedAmount drops below this. */
+            serverLowBytes: z.number().int().positive(),
+            /** Client-side high-water mark in bytes. Send terminal.pause when xterm write backlog exceeds this. */
+            clientHighBytes: z.number().int().positive(),
+            /** Client-side low-water mark in bytes. Send terminal.resume when xterm write backlog drops below this. */
+            clientLowBytes: z.number().int().positive(),
+          })
+          .default({
+            serverHighBytes: 1_048_576,
+            serverLowBytes: 262_144,
+            clientHighBytes: 262_144,
+            clientLowBytes: 65_536,
+          }),
       })
       .default({}),
 
@@ -270,6 +288,14 @@ export const PartialSettingsSchema = lazySchema(() =>
           .int()
           .nonnegative()
           .transform((n) => Math.min(n, 5000))
+          .optional(),
+        flowControl: z
+          .object({
+            serverHighBytes: z.number().int().positive().optional(),
+            serverLowBytes: z.number().int().positive().optional(),
+            clientHighBytes: z.number().int().positive().optional(),
+            clientLowBytes: z.number().int().positive().optional(),
+          })
           .optional(),
       })
       .optional(),

--- a/packages/contracts/src/ws/__tests__/terminal-binary.test.ts
+++ b/packages/contracts/src/ws/__tests__/terminal-binary.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeTerminalDataFrame,
+  decodeTerminalDataFrame,
+  TERMINAL_DATA_TAG,
+} from "../terminal-binary.js";
+
+describe("encodeTerminalDataFrame / decodeTerminalDataFrame", () => {
+  it("round-trips a short ASCII payload", () => {
+    const ptyId = "11111111-1111-4111-8111-111111111111";
+    const payload = new Uint8Array([0x68, 0x69]); // "hi"
+    const frame = encodeTerminalDataFrame(ptyId, 7, payload);
+    expect(frame[0]).toBe(TERMINAL_DATA_TAG);
+    const decoded = decodeTerminalDataFrame(frame);
+    expect(decoded).toEqual({ ptyId, seq: 7, payload });
+  });
+
+  it("round-trips a multi-byte UTF-8 sequence split at an arbitrary index", () => {
+    // U+1F600 grinning face = F0 9F 98 80
+    const ptyId = "abcdabcd-abcd-4abc-8abc-abcdabcdabcd";
+    const payload = new Uint8Array([0xf0, 0x9f, 0x98, 0x80]);
+    const decoded = decodeTerminalDataFrame(
+      encodeTerminalDataFrame(ptyId, 0, payload),
+    );
+    expect(decoded.payload).toEqual(payload);
+  });
+
+  it("rejects frames with a wrong tag", () => {
+    const buf = new Uint8Array([0x00, 0x00]);
+    expect(() => decodeTerminalDataFrame(buf)).toThrow(/tag/i);
+  });
+
+  it("rejects truncated frames", () => {
+    // tag + ptyIdLen=36 but buffer is too short
+    const buf = new Uint8Array([0x01, 36, 0]);
+    expect(() => decodeTerminalDataFrame(buf)).toThrow(/truncat/i);
+  });
+});

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -6,6 +6,7 @@ import { PlanQuestionSchema } from "../models/plan-questions.js";
 import { ChecksStatusSchema } from "../github.js";
 import { PermissionRequestSchema, PermissionDecisionSchema } from "../models/permission.js";
 import { ProviderAvailabilitySchema } from "../providers/availability.js";
+import { lazySchema } from "../utils/lazySchema.js";
 
 /** All push channel definitions keyed by channel name. */
 export const WS_CHANNELS = {
@@ -17,12 +18,14 @@ export const WS_CHANNELS = {
    * is never called for this channel. This schema only applies when a
    * client connects to an older server that still sends JSON terminal.data.
    */
-  "terminal.data": z.object({
-    ptyId: z.string(),
-    data: z.string(),
-    /** Monotonic per-PTY sequence number. Absent from legacy clients/servers. */
-    seq: z.number().int().nonnegative().optional(),
-  }),
+  "terminal.data": lazySchema(() =>
+    z.object({
+      ptyId: z.string(),
+      data: z.string(),
+      /** Monotonic per-PTY sequence number. Absent from legacy clients/servers. */
+      seq: z.number().int().nonnegative().optional(),
+    }),
+  )(),
   "terminal.exit": z.object({ ptyId: z.string(), code: z.number() }),
   "thread.status": z.object({
     threadId: z.string(),

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -10,7 +10,12 @@ import { ProviderAvailabilitySchema } from "../providers/availability.js";
 /** All push channel definitions keyed by channel name. */
 export const WS_CHANNELS = {
   "agent.event": AgentEventSchema(),
-  "terminal.data": z.object({ ptyId: z.string(), data: z.string() }),
+  "terminal.data": z.object({
+    ptyId: z.string(),
+    data: z.string(),
+    /** Monotonic per-PTY sequence number. Absent from legacy clients/servers. */
+    seq: z.number().int().nonnegative().optional(),
+  }),
   "terminal.exit": z.object({ ptyId: z.string(), code: z.number() }),
   "thread.status": z.object({
     threadId: z.string(),

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -10,6 +10,13 @@ import { ProviderAvailabilitySchema } from "../providers/availability.js";
 /** All push channel definitions keyed by channel name. */
 export const WS_CHANNELS = {
   "agent.event": AgentEventSchema(),
+  /**
+   * @deprecated Legacy JSON format retained for backward compatibility.
+   * Current servers send PTY output exclusively as binary WebSocket frames
+   * using the `encodeTerminalDataFrame` envelope (tag 0x01); `broadcast()`
+   * is never called for this channel. This schema only applies when a
+   * client connects to an older server that still sends JSON terminal.data.
+   */
   "terminal.data": z.object({
     ptyId: z.string(),
     data: z.string(),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -339,6 +339,14 @@ export const WS_METHODS = lazySchema(() => ({
     params: z.object({ ptyId: z.string() }),
     result: z.void(),
   },
+  "terminal.pause": {
+    params: z.object({ ptyId: z.string() }),
+    result: z.void(),
+  },
+  "terminal.resume": {
+    params: z.object({ ptyId: z.string() }),
+    result: z.void(),
+  },
   "terminal.killByThread": {
     params: z.object({ threadId: z.string() }),
     result: z.void(),

--- a/packages/contracts/src/ws/terminal-binary.ts
+++ b/packages/contracts/src/ws/terminal-binary.ts
@@ -1,0 +1,81 @@
+/**
+ * Binary envelope format for PTY output pushed from server to client.
+ *
+ * Layout (big-endian for multi-byte integers):
+ *   byte 0        : tag (0x01 = TERMINAL_DATA)
+ *   byte 1        : ptyIdLen (u8)
+ *   bytes 2..1+L  : ptyId (UTF-8)
+ *   bytes 2+L..5+L: seq (u32 BE)
+ *   bytes 6+L..   : payload
+ *
+ * The tag byte disambiguates this frame type from the binary-upload protocol,
+ * which sends an untagged binary frame preceded by a JSON header text frame.
+ */
+
+/** Tag byte identifying a terminal.data binary push frame. */
+export const TERMINAL_DATA_TAG = 0x01;
+
+/** Decoded view of a terminal.data binary frame. */
+export interface TerminalDataFrame {
+  readonly ptyId: string;
+  readonly seq: number;
+  readonly payload: Uint8Array;
+}
+
+const HEADER_FIXED_BYTES = 1 /* tag */ + 1 /* ptyIdLen */ + 4 /* seq */;
+
+/** Encode a PTY data chunk into a binary frame. */
+export function encodeTerminalDataFrame(
+  ptyId: string,
+  seq: number,
+  payload: Uint8Array,
+): Uint8Array {
+  const ptyIdBytes = new TextEncoder().encode(ptyId);
+  if (ptyIdBytes.length > 0xff) {
+    throw new Error(`ptyId too long: ${ptyIdBytes.length} bytes`);
+  }
+  if (!Number.isInteger(seq) || seq < 0 || seq > 0xffffffff) {
+    throw new Error(`seq out of range: ${seq}`);
+  }
+  const out = new Uint8Array(HEADER_FIXED_BYTES + ptyIdBytes.length + payload.length);
+  let off = 0;
+  out[off++] = TERMINAL_DATA_TAG;
+  out[off++] = ptyIdBytes.length;
+  out.set(ptyIdBytes, off);
+  off += ptyIdBytes.length;
+  // u32 BE
+  out[off++] = (seq >>> 24) & 0xff;
+  out[off++] = (seq >>> 16) & 0xff;
+  out[off++] = (seq >>> 8) & 0xff;
+  out[off++] = seq & 0xff;
+  out.set(payload, off);
+  return out;
+}
+
+/** Decode a binary frame into its fields. Throws on tag mismatch or truncation. */
+export function decodeTerminalDataFrame(buf: Uint8Array): TerminalDataFrame {
+  if (buf.length < 1 || buf[0] !== TERMINAL_DATA_TAG) {
+    throw new Error(
+      `terminal.data frame: unexpected tag 0x${buf.length > 0 ? buf[0].toString(16) : "?"}`,
+    );
+  }
+  if (buf.length < HEADER_FIXED_BYTES) {
+    throw new Error("terminal.data frame truncated (header)");
+  }
+  const ptyIdLen = buf[1];
+  const ptyIdEnd = 2 + ptyIdLen;
+  const seqEnd = ptyIdEnd + 4;
+  if (buf.length < seqEnd) {
+    throw new Error("terminal.data frame truncated (ptyId/seq)");
+  }
+  const ptyId = new TextDecoder().decode(buf.subarray(2, ptyIdEnd));
+  const seq =
+    ((buf[ptyIdEnd] << 24) |
+      (buf[ptyIdEnd + 1] << 16) |
+      (buf[ptyIdEnd + 2] << 8) |
+      buf[ptyIdEnd + 3]) >>>
+    0;
+  const payload = buf.subarray(seqEnd);
+  // Return a fresh Uint8Array view so the caller can persist it without aliasing the WS buffer.
+  return { ptyId, seq, payload: new Uint8Array(payload) };
+}

--- a/packages/contracts/src/ws/terminal-binary.ts
+++ b/packages/contracts/src/ws/terminal-binary.ts
@@ -24,13 +24,17 @@ export interface TerminalDataFrame {
 
 const HEADER_FIXED_BYTES = 1 /* tag */ + 1 /* ptyIdLen */ + 4 /* seq */;
 
+// Stateless singletons — safe to reuse across calls, avoids per-call allocation.
+const _encoder = new TextEncoder();
+const _decoder = new TextDecoder();
+
 /** Encode a PTY data chunk into a binary frame. */
 export function encodeTerminalDataFrame(
   ptyId: string,
   seq: number,
   payload: Uint8Array,
 ): Uint8Array {
-  const ptyIdBytes = new TextEncoder().encode(ptyId);
+  const ptyIdBytes = _encoder.encode(ptyId);
   if (ptyIdBytes.length > 0xff) {
     throw new Error(`ptyId too long: ${ptyIdBytes.length} bytes`);
   }
@@ -68,7 +72,7 @@ export function decodeTerminalDataFrame(buf: Uint8Array): TerminalDataFrame {
   if (buf.length < seqEnd) {
     throw new Error("terminal.data frame truncated (ptyId/seq)");
   }
-  const ptyId = new TextDecoder().decode(buf.subarray(2, ptyIdEnd));
+  const ptyId = _decoder.decode(buf.subarray(2, ptyIdEnd));
   const seq =
     ((buf[ptyIdEnd] << 24) |
       (buf[ptyIdEnd + 1] << 16) |

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## What
Ship the three issues of Stream C from the terminal stabilization epic (#302): binary PTY wire format, end-to-end backpressure, and pause-while-hidden.

## Why
Three compounding problems:
- **Multi-byte corruption (#310):** PTY bytes travel as JSON strings; a 4-byte UTF-8 codepoint split across two node-pty read chunks garbles on the wire.
- **Unbounded memory (#309):** Under sustained PTY output the WebSocket send buffer grows without limit, eventually starving the UI.
- **Wasted streaming (#312):** A hidden terminal panel keeps receiving PTY output into a detached xterm instance — burning CPU and contributing to post-backgrounding corruption.

## Key Changes

### PR 1 — Binary frames (#310)
- `packages/contracts/src/ws/terminal-binary.ts` — tag-0x01 envelope (encode/decode); `globals.d.ts` provides TextEncoder/TextDecoder without poisoning the contracts package with the full DOM lib
- `packages/contracts/src/ws/channels.ts` — optional `seq` on the JSON `terminal.data` schema (forward-compat)
- `apps/server/src/transport/push.ts` — `broadcastTerminalData(ptyId, seq, bytes)` sends binary frames; JSON `broadcast` unchanged for all other channels
- `apps/server/src/services/terminal-service.ts` — `PtySender` split into `{ json, data }`; per-PTY `seq` counter
- `apps/web/src/transport/ws-transport.ts` — `binaryType = "arraybuffer"`; binary branch in `onmessage` decodes tag-0x01 frames before JSON parse
- `apps/web/src/transport/ws-events.ts` — shape-aware `terminal.data` listener handles both `Uint8Array` (binary) and string (legacy) payloads
- `apps/web/src/components/terminal/TerminalView.tsx` — `term.write(Uint8Array)` directly; xterm's stateful UTF-8 decoder handles split sequences

### PR 2 — Flow control (#309)
- `terminal.pause` / `terminal.resume` RPCs in contracts and router
- `settings.terminal.flowControl` group (server/client high/low byte watermarks, all with defaults)
- `apps/server/src/services/terminal-flow-control.ts` — per-PTY `TerminalFlowControl` with two-source pause semantics (`client-request`, `socket-buffered`); bounded ring buffer; drains FIFO on resume
- `TerminalService` now owns a `TerminalFlowControl` per PTY; `onBufferedAmountTick()` drives socket-level pause; `pause()`/`resume()` handle client requests
- 50ms `setInterval` in `index.ts` polls `maxBufferedAmount()` and ticks all PTYs
- `apps/web/src/components/terminal/terminalFlowControl.ts` — `ClientTerminalFlowControl` tracks `written`/`acked` bytes; requests pause when xterm backlog crosses watermark
- `TerminalView` uses `term.write(bytes, callback)` to ack into the client state machine

### PR 3 — Pause on hide (#312)
- `terminalStore` `hideTerminalPanel`/`showTerminalPanel`/`toggleTerminalPanel` fire `terminal.pause`/`terminal.resume` for every PTY on the thread, guarded to only act on visibility transitions

Closes #310
Closes #309
Closes #312
Related to #302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal pause/resume controls (UI + transport API) and per-PTY client/server flow-control.
  * New settings: terminal.flowControl thresholds for server & client.

* **Improvements**
  * Binary-framed terminal data for reliable raw-byte delivery and safe decoding (includes sequence handling).
  * Server buffering/backpressure with periodic buffered-amount tick and per-client error isolation.
  * Terminal panels auto-pause when hidden and resume when shown.

* **Tests**
  * Added tests for client/server flow control, binary framing, and broadcast behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->