### PR TITLE
fix(copilot): restore dynamic model listing

### DIFF
--- a/apps/server/src/__tests__/providers-availability-rpc.test.ts
+++ b/apps/server/src/__tests__/providers-availability-rpc.test.ts
@@ -133,14 +133,16 @@ describe("providers.listAvailability RPC", () => {
   });
 
   it("returns PROVIDER_DISABLED when calling listModels on a disabled provider", async () => {
-    // Stub assertUsable to throw ProviderDisabledError for "codex".
-    // This simulates settings.provider.enabled.codex = false without needing
-    // a real SettingsService or disk I/O.
+    // Stub assertEnabled to throw ProviderDisabledError for "codex".
+    // listModels uses assertEnabled (not assertUsable) so it works for SDK-based
+    // providers that don't require a CLI binary. This simulates
+    // settings.provider.enabled.codex = false without needing a real SettingsService.
     const deps = makeMinimalDeps({
       providerAvailability: {
-        assertUsable: (id: string) => {
+        assertEnabled: (id: string) => {
           if (id === "codex") throw new ProviderDisabledError("codex");
         },
+        assertUsable: () => {},
         listAvailability: () => [],
       } as unknown as RouterDeps["providerAvailability"],
     });

--- a/apps/server/src/services/__tests__/provider-availability-service.test.ts
+++ b/apps/server/src/services/__tests__/provider-availability-service.test.ts
@@ -120,6 +120,43 @@ describe("ProviderAvailabilityService.verifyCli", () => {
   });
 });
 
+describe("ProviderAvailabilityService.assertEnabled", () => {
+  it("throws ProviderDisabledError when the toggle is off (regardless of CLI state)", () => {
+    const s = getDefaultSettings();
+    s.provider.enabled.codex = false;
+    const svc = new ProviderAvailabilityService(
+      { get: () => s, on: () => {} } as unknown as SettingsService,
+      stubRegistry(["claude", "codex"]),
+    );
+    expect(() => svc.assertEnabled("codex")).toThrow(ProviderDisabledError);
+  });
+
+  it("throws ProviderDisabledError for coming-soon providers (regardless of CLI state)", () => {
+    const s = getDefaultSettings();
+    s.provider.enabled.gemini = true;
+    const svc = new ProviderAvailabilityService(
+      { get: () => s, on: () => {} } as unknown as SettingsService,
+      stubRegistry([]),
+    );
+    expect(() => svc.assertEnabled("gemini")).toThrow(ProviderDisabledError);
+  });
+
+  it("does not throw when enabled but CLI not_found (SDK-based providers need no CLI binary)", async () => {
+    const svc = new ProviderAvailabilityService(
+      stubSettings(),
+      stubRegistry(["copilot"]),
+      { which: vi.fn(async () => { throw new Error("nope"); }), statExecutable: vi.fn() },
+    );
+    await svc.verifyCli("copilot");
+    expect(() => svc.assertEnabled("copilot")).not.toThrow();
+  });
+
+  it("does not throw when enabled and CLI unchecked", () => {
+    const svc = new ProviderAvailabilityService(stubSettings(), stubRegistry(["copilot"]));
+    expect(() => svc.assertEnabled("copilot")).not.toThrow();
+  });
+});
+
 describe("ProviderAvailabilityService.assertUsable", () => {
   it("throws ProviderDisabledError when the toggle is off", async () => {
     const s = getDefaultSettings();

--- a/apps/server/src/services/provider-availability-service.ts
+++ b/apps/server/src/services/provider-availability-service.ts
@@ -47,8 +47,10 @@ const defaultResolver: CliResolver = {
 };
 
 /**
- * Tracks per-provider enabled flag + CLI verification state. Call sites use
- * `assertUsable` before resolving a provider from the registry.
+ * Tracks per-provider enabled flag + CLI verification state.
+ * Use `assertEnabled` before read-only discovery calls (e.g. `listModels`) —
+ * it checks the enabled flag and `comingSoon` without requiring a CLI binary.
+ * Use `assertUsable` before send/execution calls that require the CLI binary.
  */
 @injectable()
 export class ProviderAvailabilityService {
@@ -115,19 +117,27 @@ export class ProviderAvailabilityService {
   }
 
   /**
+   * Throw if the provider is disabled or coming-soon. Does NOT check CLI
+   * binary status, so read-only discovery calls (e.g. listModels) work even
+   * when the CLI is missing - SDK-based providers don't need the binary.
+   */
+  assertEnabled(id: ProviderId): void {
+    const entry = getCatalogEntry(id);
+    if (entry.comingSoon || !this.settings.get().provider.enabled[id]) {
+      throw new ProviderDisabledError(id);
+    }
+  }
+
+  /**
    * Throw a typed error if the provider is unusable. Returns normally otherwise.
    * CLI `unchecked` state is treated as "probably ok" — the first send will
    * re-verify and surface the real error if the binary is missing.
    */
   assertUsable(id: ProviderId): void {
-    const s = this.settings.get();
-    const entry = getCatalogEntry(id);
-    if (entry.comingSoon || !s.provider.enabled[id]) {
-      throw new ProviderDisabledError(id);
-    }
+    this.assertEnabled(id);
     const cached = this.cliCache.get(id);
     if (cached?.status === "not_found") {
-      const configuredPath = hasCliPath(id) ? s.provider.cli[id] : "";
+      const configuredPath = hasCliPath(id) ? this.settings.get().provider.cli[id] : "";
       throw new ProviderCliMissingError(id, configuredPath);
     }
   }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -559,7 +559,7 @@ async function dispatch(
 
     // Provider
     case "provider.listModels": {
-      deps.providerAvailability.assertUsable(params.providerId);
+      deps.providerAvailability.assertEnabled(params.providerId);
       const provider = deps.providerRegistry.resolve(params.providerId);
       if (!provider.listModels) {
         throw new Error(`Provider "${params.providerId}" does not support model listing`);

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -62,15 +62,18 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   const dynamicModelsRef = useRef<Map<string, ModelProvider["models"]>>(new Map());
   const [loadingProviders, setLoadingProviders] = useState<Set<string>>(new Set());
   const fetchingRef = useRef<Set<string>>(new Set());
-  // Tracks providers whose fetch failed; prevents repeated retries on every hover.
-  const fetchFailedRef = useRef<Set<string>>(new Set());
+  /** Timestamps of the last failed fetch per provider, used to enforce a retry cooldown. */
+  const fetchFailedAtRef = useRef<Map<string, number>>(new Map());
+  /** How long to wait before retrying a provider after a failed fetch. */
+  const FETCH_RETRY_COOLDOWN_MS = 30_000;
 
-  /** Fetches live models for a provider and caches the result. No-ops on repeat calls or after a failure. */
+  /** Fetches live models for a provider and caches the result. No-ops while a fetch is in-flight, the cache is populated, or within the retry cooldown after a failure. */
   const fetchProviderModels = useCallback(async (providerId: string) => {
+    const lastFailedAt = fetchFailedAtRef.current.get(providerId);
     if (
       fetchingRef.current.has(providerId) ||
       dynamicModelsRef.current.has(providerId) ||
-      fetchFailedRef.current.has(providerId)
+      (lastFailedAt !== undefined && Date.now() - lastFailedAt < FETCH_RETRY_COOLDOWN_MS)
     ) return;
     fetchingRef.current.add(providerId);
     setLoadingProviders((prev) => new Set(prev).add(providerId));
@@ -83,13 +86,13 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
         group: m.group,
         multiplier: m.multiplier,
       }));
-      // Reuse the same Map instance for both the ref and state to avoid a double-copy.
       const updated = new Map(dynamicModelsRef.current).set(providerId, mapped);
       dynamicModelsRef.current = updated;
       setDynamicModels(updated);
     } catch {
-      // Mark as failed so repeated hovers don't spam the server while Copilot is unavailable.
-      fetchFailedRef.current.add(providerId);
+      // Record failure time so retries are throttled — leave the cache unpopulated
+      // so a subsequent hover after the cooldown triggers a fresh attempt.
+      fetchFailedAtRef.current.set(providerId, Date.now());
     } finally {
       fetchingRef.current.delete(providerId);
       setLoadingProviders((prev) => {


### PR DESCRIPTION
## What

Restores dynamic Copilot model list loading on app start, broken since `dce716d` (feat: per-provider enable/disable with CLI verification).

## Why

`dce716d` added `assertUsable()` to the `provider.listModels` RPC handler. `assertUsable()` checks for the provider's CLI binary via `which()`, but `CopilotProvider` uses `@github/copilot-sdk` directly — no `copilot` CLI binary is needed for model listing. `which("copilot")` fails on most machines, so the check threw `ProviderCliMissingError` before reaching `client.listModels()`. The `ModelSelector` frontend then permanently blacklisted the provider for the session, preventing any retry.

## Key changes

- **`ProviderAvailabilityService`** — Added `assertEnabled()`: checks the enabled flag and `comingSoon` only, without the CLI binary check. Refactored `assertUsable()` to call `assertEnabled()` internally before adding the CLI check.
- **`ws-router.ts`** — `provider.listModels` now uses `assertEnabled()` instead of `assertUsable()`. Read-only discovery should not require a CLI binary that SDK-based providers don't use.
- **`ModelSelector.tsx`** — Replaced the permanent `fetchFailedRef` blacklist with a 30-second retry cooldown (`fetchFailedAtRef`). Transient failures allow recovery after the cooldown without flooding the server.
- **Tests** — Added 4 test cases for `assertEnabled()`, covering disabled, coming-soon, CLI not_found (must not throw), and CLI unchecked.

## Known follow-up

`verifyAllEnabled()` still calls `verifyCli("copilot")`, which marks copilot's CLI cache as `not_found` since `which("copilot")` fails. This causes `assertUsable()` to block `provider.getUsage` for copilot too. A separate fix is needed — either a `requiresCli` catalog flag or using `assertEnabled()` for `getUsage` on SDK-based providers.

## Test plan

- [x] `bunx vitest run apps/server/src/services/__tests__/provider-availability-service.test.ts` — 19/19 pass
- [x] `bunx tsc --noEmit` in `apps/server`, `apps/web`, `apps/desktop` — all clean
- [ ] Manual: Open model selector → Copilot row should show dynamically fetched models on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Model fetch resilience: provider model list requests that fail now retry after 30s instead of being permanently blocked.

* **Refactor**
  * Provider availability checks separated: enabled/coming-soon enforcement is now distinct from CLI availability verification.

* **Tests**
  * Added tests covering enabled/coming-soon enforcement and its interactions with CLI availability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->