### PR TITLE
fix(build): snapshot-safe subpath import for V8 snapshot entry

### DIFF
--- a/apps/desktop/src/main/snapshot-entry.ts
+++ b/apps/desktop/src/main/snapshot-entry.ts
@@ -11,7 +11,7 @@
  * - Only pure JavaScript that runs in a bare V8 context
  */
 
-import { SettingsSchema, getExtension } from "@mcode/contracts";
+import { SettingsSchema, getExtension } from "@mcode/contracts/snapshot";
 
 const snapshot = Object.freeze({
   contracts: Object.freeze({ SettingsSchema, getExtension }),

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./snapshot": "./src/snapshot.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -1,0 +1,15 @@
+/**
+ * Snapshot-safe subset of @mcode/contracts.
+ *
+ * Only re-exports symbols that are safe to evaluate in a bare V8 isolate
+ * (no Node.js builtins, no side-effecting module-level calls).
+ *
+ * Used by `apps/desktop/src/main/snapshot-entry.ts` via the
+ * `@mcode/contracts/snapshot` subpath export. Do NOT add re-exports from
+ * modules that call schema factories at module scope (e.g. ws/channels.ts)
+ * or that reference platform globals like TextEncoder.
+ */
+
+export { SettingsSchema } from "./models/settings.js";
+export type { Settings } from "./models/settings.js";
+export { getExtension } from "./models/file-types.js";


### PR DESCRIPTION
## What

Fix the release build failure in the "Generate V8 snapshot" step that broke both Windows and Linux CI runners.

## Why

The snapshot entry imported from the `@mcode/contracts` barrel, which transitively pulled in 41 modules including:
- `ws/channels.ts` - calls schema factories (`SettingsSchema()`, `AgentEventSchema()`) at module scope, building complex Zod objects with `.refine()`/`.transform()` closures
- `ws/terminal-binary.ts` - instantiates `TextEncoder`/`TextDecoder` at module scope

Both are incompatible with `electron-mksnapshot`'s bare V8 isolate (no Node.js builtins, no Web API globals).

## Key changes

- Add `packages/contracts/src/snapshot.ts` - re-exports only `SettingsSchema` and `getExtension` (both snapshot-safe)
- Add `"./snapshot"` subpath export to contracts `package.json`
- Switch `snapshot-entry.ts` to import from `@mcode/contracts/snapshot`

Bundle drops from 41 to 16 modules. Snapshot generation passes locally on Windows.

## Related issues/PRs

Fixes failed release build: https://github.com/Mzeey-Emipre/mcode/actions/runs/24726352535