### PR TITLE
fix(desktop): harden server startup reliability

### DIFF
--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -9,7 +9,7 @@
 
 import { app } from "electron";
 import { spawn, type ChildProcess } from "child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { createWriteStream, existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { createServer, type AddressInfo } from "net";
 import { resolve, join, dirname } from "path";
@@ -64,6 +64,17 @@ const PORT_MAX = app.isPackaged ? 19800 : isDev ? 19600 : 19700;
 
 /** Interval (ms) between health-check polls during startup. */
 const HEALTH_POLL_INTERVAL = 200;
+
+/**
+ * Maximum time (ms) to wait for the server's /health endpoint.
+ * Cold starts include DB migrations, workspace enumeration, git watcher init,
+ * and IPC socket binding - all before httpServer.listen() runs. 30 seconds
+ * accommodates slow disks and large workspace counts.
+ */
+const STARTUP_TIMEOUT_MS = 30_000;
+
+/** Server stderr log file path. Rotated on each spawn to keep size bounded. */
+const SERVER_LOG_PATH = join(getMcodeDir(), "server-stderr.log");
 
 /** Default V8 max old space size in MB. Tuned for the < 100MB idle target. */
 const DEFAULT_HEAP_MB = 96;
@@ -329,24 +340,36 @@ export class ServerManager {
         : ["--import", "tsx", entry];
       const args = [...v8Flags, ...entryArgs];
 
+      // In production, route stderr to a log file so crashes are diagnosable.
+      // Dev mode inherits stdio for immediate console visibility.
+      const stderrStream = isDev
+        ? undefined
+        : createWriteStream(SERVER_LOG_PATH, { flags: "w" });
+
       const child = spawn(process.execPath, args, {
         cwd,
         env,
         detached: true,
-        stdio: isDev ? "inherit" : "ignore",
+        stdio: isDev ? "inherit" : ["ignore", "ignore", stderrStream ? "pipe" : "ignore"],
       });
       child.unref();
       this.serverProcess = child;
 
+      // Pipe stderr to the log file when running packaged
+      if (!isDev && stderrStream && child.stderr) {
+        child.stderr.pipe(stderrStream);
+      }
+
       child.on("exit", (code) => {
         console.error(`Server process exited with code ${code}`);
+        stderrStream?.end();
         if (this.serverProcess === child) {
           this.serverProcess = null;
           this.onUnexpectedExit?.(code);
         }
       });
 
-      await this.waitForReady(10_000);
+      await this.waitForReady(STARTUP_TIMEOUT_MS);
 
       // Read auth token from lock file (server writes it on startup).
       // Retry briefly in case the lock file write races the health endpoint.
@@ -458,13 +481,23 @@ export class ServerManager {
   }
 
   /**
-   * Poll the server's /health endpoint until it responds 200
-   * or the timeout expires.
+   * Poll the server's /health endpoint until it responds 200,
+   * the timeout expires, or the child process exits early.
    */
   private async waitForReady(timeoutMs: number): Promise<void> {
     const deadline = Date.now() + timeoutMs;
 
     while (Date.now() < deadline) {
+      // Fail fast if the server process already exited (crash, missing native
+      // module, etc.) instead of polling for the full timeout duration.
+      if (!this.serverProcess) {
+        const logExcerpt = this.readServerLogTail();
+        throw new Error(
+          "Server process exited before becoming ready." +
+            (logExcerpt ? `\n\nServer log:\n${logExcerpt}` : "\nNo server log available."),
+        );
+      }
+
       try {
         const res = await fetch(`http://localhost:${this._port}/health`);
         if (res.ok) return;
@@ -474,8 +507,22 @@ export class ServerManager {
       await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL));
     }
 
+    const logExcerpt = this.readServerLogTail();
     throw new Error(
-      `Server did not become ready within ${timeoutMs}ms on port ${this._port}`,
+      `Server did not become ready within ${timeoutMs / 1000}s on port ${this._port}.` +
+        (logExcerpt ? `\n\nServer log:\n${logExcerpt}` : ""),
     );
+  }
+
+  /** Read the last ~40 lines of the server stderr log for diagnostics. */
+  private readServerLogTail(): string {
+    try {
+      if (!existsSync(SERVER_LOG_PATH)) return "";
+      const content = readFileSync(SERVER_LOG_PATH, "utf-8");
+      const lines = content.split("\n");
+      return lines.slice(-40).join("\n").trim();
+    } catch {
+      return "";
+    }
   }
 }

--- a/apps/desktop/src/main/snapshot-entry.ts
+++ b/apps/desktop/src/main/snapshot-entry.ts
@@ -11,7 +11,7 @@
  * - Only pure JavaScript that runs in a bare V8 context
  */
 
-import { SettingsSchema, getExtension } from "@mcode/contracts";
+import { SettingsSchema, getExtension } from "@mcode/contracts/snapshot";
 
 const snapshot = Object.freeze({
   contracts: Object.freeze({ SettingsSchema, getExtension }),

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./snapshot": "./src/snapshot.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -1,0 +1,15 @@
+/**
+ * Snapshot-safe subset of @mcode/contracts.
+ *
+ * Only re-exports symbols that are safe to evaluate in a bare V8 isolate
+ * (no Node.js builtins, no side-effecting module-level calls).
+ *
+ * Used by `apps/desktop/src/main/snapshot-entry.ts` via the
+ * `@mcode/contracts/snapshot` subpath export. Do NOT add re-exports from
+ * modules that call schema factories at module scope (e.g. ws/channels.ts)
+ * or that reference platform globals like TextEncoder.
+ */
+
+export { SettingsSchema } from "./models/settings.js";
+export type { Settings } from "./models/settings.js";
+export { getExtension } from "./models/file-types.js";


### PR DESCRIPTION
## What

Fix silent server startup failures in packaged builds that caused the app to show a generic timeout error.

## Why

Three issues combined to make packaged-build startup failures undiagnosable:

1. `waitForReady` polled `/health` for the full 10 seconds even when the server process had already crashed (missing native module, DB error, etc.)
2. Production mode set `stdio: "ignore"`, discarding all server stderr output
3. The 10-second timeout was tight for cold starts where the server runs DB migrations, enumerates all workspaces, initializes git watchers, binds the IPC socket, and kills orphaned servers - all before `httpServer.listen()` runs

## Key changes

- `waitForReady` now checks if the child process exited each iteration and fails fast with the server log tail
- Server stderr is routed to `~/.mcode/server-stderr.log` in production mode (rotated on each spawn)
- Startup timeout increased from 10s to 30s to accommodate cold starts
- Error dialog now includes the last 40 lines of server log for immediate diagnosis

## Test plan

- [ ] Verify packaged app starts on cold install (no prior data dir)
- [ ] Verify app starts when many workspaces exist (slow git watcher init)
- [ ] Kill server mid-startup and verify early exit detection fires within 200ms
- [ ] Verify `~/.mcode/server-stderr.log` contains server output after startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced server startup with improved error diagnostics and timeout configuration.
  * Added server log tail diagnostics to error messages for better troubleshooting.

* **Bug Fixes**
  * Improved handling of server process failures with early detection logic.
  * Better error messages with human-readable timing information.

* **Chores**
  * Extended package exports to support modular import paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->