### PR TITLE
ci: add V8 snapshot check and post-packaging smoke test

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Package with electron-builder
         run: node apps/desktop/scripts/ci-package.mjs
 
+      - name: Smoke test packaged server
+        run: node apps/desktop/scripts/smoke-test.mjs
+
       - name: Collect release artifacts
         if: github.event.release.tag_name || inputs.tag
         id: artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,6 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run --cwd apps/web build
       - run: bun run --cwd apps/desktop build
+
+      - name: Generate V8 snapshot
+        run: bun apps/desktop/scripts/generate-snapshot.mjs

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -1,0 +1,216 @@
+/**
+ * Post-packaging smoke test for the Mcode server bundle.
+ *
+ * Launches server.cjs from the electron-builder unpacked directory using
+ * the packaged Electron binary with ELECTRON_RUN_AS_NODE=1 (mirroring how
+ * server-manager.ts spawns the server in production). Polls /health and
+ * exits 0 on success, 1 on failure.
+ *
+ * This catches:
+ * - Missing native modules (better-sqlite3, node-pty)
+ * - Broken asarUnpack configuration
+ * - Server startup crashes invisible in the packaged app
+ * - Import/require resolution failures in the CJS bundle
+ *
+ * Usage:
+ *   node apps/desktop/scripts/smoke-test.mjs             # auto-detect unpacked dir
+ *   node apps/desktop/scripts/smoke-test.mjs --bundle    # test pre-packaging bundle (requires native deps on PATH)
+ */
+
+import { spawn } from "child_process";
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { tmpdir } from "os";
+import { randomUUID } from "crypto";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const desktopRoot = resolve(__dirname, "..");
+const releaseDir = resolve(desktopRoot, "release");
+
+const SMOKE_PORT = 19899;
+const TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 300;
+
+// ---------------------------------------------------------------------------
+// Locate the unpacked server bundle and Electron binary
+// ---------------------------------------------------------------------------
+
+/** Find the server.cjs and runtime binary from the unpacked directory. */
+function findUnpackedServer() {
+  const candidates = [
+    // Windows
+    {
+      server: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/dist/server/server.cjs"),
+      electron: resolve(releaseDir, "win-unpacked/Mcode.exe"),
+      sqlite: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
+    },
+    // Linux
+    {
+      server: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/dist/server/server.cjs"),
+      electron: resolve(releaseDir, "linux-unpacked/mcode"),
+      sqlite: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
+    },
+    // macOS Intel
+    {
+      server: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/dist/server/server.cjs"),
+      electron: resolve(releaseDir, "mac/Mcode.app/Contents/MacOS/Mcode"),
+      sqlite: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
+    },
+    // macOS ARM
+    {
+      server: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/dist/server/server.cjs"),
+      electron: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/MacOS/Mcode"),
+      sqlite: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
+    },
+  ];
+
+  for (const c of candidates) {
+    if (existsSync(c.server) && existsSync(c.electron)) {
+      // Find the actual .node binding
+      const electronBinding = resolve(c.sqlite, "better_sqlite3.electron.node");
+      const nodeBinding = resolve(c.sqlite, "better_sqlite3.node");
+      const binding = existsSync(electronBinding) ? electronBinding : existsSync(nodeBinding) ? nodeBinding : undefined;
+      return { server: c.server, electron: c.electron, binding };
+    }
+  }
+  return null;
+}
+
+/**
+ * --bundle mode: test the pre-packaging bundle with the system node/bun.
+ * Skips native module verification but catches JS bundle errors.
+ */
+function findBundleServer() {
+  const server = resolve(desktopRoot, "dist/server/server.cjs");
+  if (!existsSync(server)) {
+    return null;
+  }
+  return { server, electron: process.execPath, binding: undefined };
+}
+
+const bundleOnly = process.argv.includes("--bundle");
+const found = bundleOnly ? findBundleServer() : findUnpackedServer();
+
+if (!found) {
+  const target = bundleOnly ? "dist/server/server.cjs" : "unpacked release directory";
+  console.error(`[smoke-test] ERROR: Could not find ${target}.`);
+  console.error(bundleOnly
+    ? "  Run: bun run --cwd apps/desktop build"
+    : "  Run: node apps/desktop/scripts/ci-package.mjs");
+  process.exit(1);
+}
+
+console.log(`[smoke-test] Server: ${found.server}`);
+console.log(`[smoke-test] Runtime: ${found.electron}`);
+if (found.binding) {
+  console.log(`[smoke-test] SQLite binding: ${found.binding}`);
+}
+
+// ---------------------------------------------------------------------------
+// Create a temporary data directory so the smoke test is isolated
+// ---------------------------------------------------------------------------
+
+const dataDir = resolve(tmpdir(), `mcode-smoke-${randomUUID().slice(0, 8)}`);
+mkdirSync(dataDir, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// Spawn the server
+// ---------------------------------------------------------------------------
+
+const env = {
+  ...process.env,
+  ELECTRON_RUN_AS_NODE: "1",
+  MCODE_PORT: String(SMOKE_PORT),
+  MCODE_DATA_DIR: dataDir,
+  MCODE_MODE: "desktop",
+  MCODE_VERSION: "0.0.0-smoke",
+  NODE_ENV: "production",
+};
+
+if (found.binding) {
+  env.BETTER_SQLITE3_BINDING = found.binding;
+}
+
+console.log(`[smoke-test] Starting server on port ${SMOKE_PORT}...`);
+
+const child = spawn(found.electron, [
+  "--max-old-space-size=96",
+  found.server,
+], {
+  cwd: dirname(found.server),
+  env,
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let serverStderr = "";
+child.stderr.on("data", (chunk) => { serverStderr += chunk.toString(); });
+child.stdout.on("data", (chunk) => { process.stdout.write(chunk); });
+
+// ---------------------------------------------------------------------------
+// Poll /health
+// ---------------------------------------------------------------------------
+
+let exited = false;
+/** Resolves when the child process exits. */
+const exitPromise = new Promise((resolve) => {
+  child.on("exit", (code) => {
+    exited = true;
+    if (code !== null && code !== 0) {
+      console.error(`[smoke-test] Server exited with code ${code}`);
+      if (serverStderr) {
+        console.error("[smoke-test] stderr:\n" + serverStderr.slice(-2000));
+      }
+    }
+    resolve(code);
+  });
+});
+
+const deadline = Date.now() + TIMEOUT_MS;
+let healthy = false;
+
+while (Date.now() < deadline && !exited) {
+  try {
+    const res = await fetch(`http://localhost:${SMOKE_PORT}/health`);
+    if (res.ok) {
+      healthy = true;
+      break;
+    }
+  } catch {
+    // not ready yet
+  }
+  await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+}
+
+// ---------------------------------------------------------------------------
+// Report and cleanup
+// ---------------------------------------------------------------------------
+
+// Kill the server (graceful then force)
+try { process.kill(child.pid, "SIGTERM"); } catch { /* already dead */ }
+setTimeout(() => {
+  try { process.kill(child.pid, "SIGKILL"); } catch { /* ok */ }
+}, 3000);
+
+// Wait for exit
+await exitPromise;
+
+// Clean up temp data directory
+try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* ok */ }
+
+if (healthy) {
+  console.log("[smoke-test] PASS: Server started and /health returned 200.");
+  process.exit(0);
+} else if (exited) {
+  console.error("[smoke-test] FAIL: Server crashed before becoming ready.");
+  if (serverStderr) {
+    console.error("[smoke-test] Last stderr output:\n" + serverStderr.slice(-2000));
+  }
+  process.exit(1);
+} else {
+  console.error(`[smoke-test] FAIL: Server did not respond within ${TIMEOUT_MS / 1000}s.`);
+  if (serverStderr) {
+    console.error("[smoke-test] Last stderr output:\n" + serverStderr.slice(-2000));
+  }
+  process.exit(1);
+}

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -9,7 +9,7 @@
 
 import { app } from "electron";
 import { spawn, type ChildProcess } from "child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { createWriteStream, existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { createServer, type AddressInfo } from "net";
 import { resolve, join, dirname } from "path";
@@ -64,6 +64,17 @@ const PORT_MAX = app.isPackaged ? 19800 : isDev ? 19600 : 19700;
 
 /** Interval (ms) between health-check polls during startup. */
 const HEALTH_POLL_INTERVAL = 200;
+
+/**
+ * Maximum time (ms) to wait for the server's /health endpoint.
+ * Cold starts include DB migrations, workspace enumeration, git watcher init,
+ * and IPC socket binding - all before httpServer.listen() runs. 30 seconds
+ * accommodates slow disks and large workspace counts.
+ */
+const STARTUP_TIMEOUT_MS = 30_000;
+
+/** Server stderr log file path. Rotated on each spawn to keep size bounded. */
+const SERVER_LOG_PATH = join(getMcodeDir(), "server-stderr.log");
 
 /** Default V8 max old space size in MB. Tuned for the < 100MB idle target. */
 const DEFAULT_HEAP_MB = 96;
@@ -329,24 +340,36 @@ export class ServerManager {
         : ["--import", "tsx", entry];
       const args = [...v8Flags, ...entryArgs];
 
+      // In production, route stderr to a log file so crashes are diagnosable.
+      // Dev mode inherits stdio for immediate console visibility.
+      const stderrStream = isDev
+        ? undefined
+        : createWriteStream(SERVER_LOG_PATH, { flags: "w" });
+
       const child = spawn(process.execPath, args, {
         cwd,
         env,
         detached: true,
-        stdio: isDev ? "inherit" : "ignore",
+        stdio: isDev ? "inherit" : ["ignore", "ignore", stderrStream ? "pipe" : "ignore"],
       });
       child.unref();
       this.serverProcess = child;
 
+      // Pipe stderr to the log file when running packaged
+      if (!isDev && stderrStream && child.stderr) {
+        child.stderr.pipe(stderrStream);
+      }
+
       child.on("exit", (code) => {
         console.error(`Server process exited with code ${code}`);
+        stderrStream?.end();
         if (this.serverProcess === child) {
           this.serverProcess = null;
           this.onUnexpectedExit?.(code);
         }
       });
 
-      await this.waitForReady(10_000);
+      await this.waitForReady(STARTUP_TIMEOUT_MS);
 
       // Read auth token from lock file (server writes it on startup).
       // Retry briefly in case the lock file write races the health endpoint.
@@ -458,13 +481,23 @@ export class ServerManager {
   }
 
   /**
-   * Poll the server's /health endpoint until it responds 200
-   * or the timeout expires.
+   * Poll the server's /health endpoint until it responds 200,
+   * the timeout expires, or the child process exits early.
    */
   private async waitForReady(timeoutMs: number): Promise<void> {
     const deadline = Date.now() + timeoutMs;
 
     while (Date.now() < deadline) {
+      // Fail fast if the server process already exited (crash, missing native
+      // module, etc.) instead of polling for the full timeout duration.
+      if (!this.serverProcess) {
+        const logExcerpt = this.readServerLogTail();
+        throw new Error(
+          "Server process exited before becoming ready." +
+            (logExcerpt ? `\n\nServer log:\n${logExcerpt}` : "\nNo server log available."),
+        );
+      }
+
       try {
         const res = await fetch(`http://localhost:${this._port}/health`);
         if (res.ok) return;
@@ -474,8 +507,22 @@ export class ServerManager {
       await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL));
     }
 
+    const logExcerpt = this.readServerLogTail();
     throw new Error(
-      `Server did not become ready within ${timeoutMs}ms on port ${this._port}`,
+      `Server did not become ready within ${timeoutMs / 1000}s on port ${this._port}.` +
+        (logExcerpt ? `\n\nServer log:\n${logExcerpt}` : ""),
     );
+  }
+
+  /** Read the last ~40 lines of the server stderr log for diagnostics. */
+  private readServerLogTail(): string {
+    try {
+      if (!existsSync(SERVER_LOG_PATH)) return "";
+      const content = readFileSync(SERVER_LOG_PATH, "utf-8");
+      const lines = content.split("\n");
+      return lines.slice(-40).join("\n").trim();
+    } catch {
+      return "";
+    }
   }
 }

--- a/apps/desktop/src/main/snapshot-entry.ts
+++ b/apps/desktop/src/main/snapshot-entry.ts
@@ -11,7 +11,7 @@
  * - Only pure JavaScript that runs in a bare V8 context
  */
 
-import { SettingsSchema, getExtension } from "@mcode/contracts";
+import { SettingsSchema, getExtension } from "@mcode/contracts/snapshot";
 
 const snapshot = Object.freeze({
   contracts: Object.freeze({ SettingsSchema, getExtension }),

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./snapshot": "./src/snapshot.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -1,0 +1,15 @@
+/**
+ * Snapshot-safe subset of @mcode/contracts.
+ *
+ * Only re-exports symbols that are safe to evaluate in a bare V8 isolate
+ * (no Node.js builtins, no side-effecting module-level calls).
+ *
+ * Used by `apps/desktop/src/main/snapshot-entry.ts` via the
+ * `@mcode/contracts/snapshot` subpath export. Do NOT add re-exports from
+ * modules that call schema factories at module scope (e.g. ws/channels.ts)
+ * or that reference platform globals like TextEncoder.
+ */
+
+export { SettingsSchema } from "./models/settings.js";
+export type { Settings } from "./models/settings.js";
+export { getExtension } from "./models/file-types.js";


### PR DESCRIPTION
## What

Add two CI checks that would have caught both v0.6.0 release failures before artifacts shipped.

## Why

The last two releases hit issues that were invisible until the packaged app ran:
- V8 snapshot broke because a barrel import pulled in non-snapshot-safe modules
- Server startup timed out because of silent crash + short timeout

Both passed the existing PR CI (typecheck + esbuild bundle) and were only caught at release time.

## Key changes

**PR CI (`ci.yml`)**:
- Add V8 snapshot generation to `build-check` job (catches snapshot-breaking contract changes)

**Release CI (`build-release.yml`)**:
- Add `smoke-test.mjs` step after `electron-builder` packaging
- Launches `server.cjs` from the unpacked directory with `ELECTRON_RUN_AS_NODE=1`
- Polls `/health` with 30s timeout
- Fails the build with server stderr output if the server crashes or times out
- Runs before artifact upload, so broken builds are never published

**New script (`apps/desktop/scripts/smoke-test.mjs`)**:
- Auto-detects unpacked directory across Windows/Linux/macOS
- Isolated temp data directory (no side effects on CI state)
- `--bundle` flag for local pre-packaging testing
- Reports last 2KB of stderr on failure for immediate diagnosis

## Test plan

- [ ] PR CI `build-check` job runs snapshot generation
- [ ] Release CI runs smoke test after packaging
- [ ] Smoke test PASSES when server starts correctly
- [ ] Smoke test FAILS with stderr output when server crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated smoke testing to validate the packaged server and Electron runtime functionality.
  * Integrated snapshot generation into the continuous integration pipeline.

* **Bug Fixes**
  * Server startup errors now include detailed diagnostic information and logging for easier troubleshooting.
  * Extended server startup timeout window for improved reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->