### PR TITLE
fix(build): resolve release build failures

### DIFF
--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -45,10 +45,10 @@ function findUnpackedServer() {
       electron: resolve(releaseDir, "win-unpacked/Mcode.exe"),
       sqlite: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
     },
-    // Linux
+    // Linux (electron-builder uses productName as binary name)
     {
       server: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/dist/server/server.cjs"),
-      electron: resolve(releaseDir, "linux-unpacked/mcode"),
+      electron: resolve(releaseDir, "linux-unpacked/Mcode"),
       sqlite: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
     },
     // macOS Intel

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -41,7 +41,10 @@ import { SkillWatcherService } from "./services/skill-watcher-service";
 import { MemoryPressureService } from "./services/memory-pressure-service";
 import { CleanupWorker } from "./services/cleanup-worker";
 import { PrDraftService } from "./services/pr-draft-service";
-import { ProviderAvailabilityService } from "./services/provider-availability-service";
+import {
+  ProviderAvailabilityService,
+  defaultResolver,
+} from "./services/provider-availability-service";
 import { PtyPidRegistry } from "./services/pty-pid-registry";
 
 /** Initialize the DI container with all server dependencies. */
@@ -246,6 +249,7 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register("PrDraftService", {
     useFactory: (c) => c.resolve(PrDraftService),
   });
+  container.register("CliResolver", { useValue: defaultResolver });
   container.register(
     ProviderAvailabilityService,
     { useClass: ProviderAvailabilityService },

--- a/apps/server/src/services/provider-availability-service.ts
+++ b/apps/server/src/services/provider-availability-service.ts
@@ -34,7 +34,7 @@ export interface CliResolver {
   statExecutable(path: string): Promise<boolean>;
 }
 
-const defaultResolver: CliResolver = {
+export const defaultResolver: CliResolver = {
   which: (binary) => whichModule(binary),
   statExecutable: async (path) => {
     try {
@@ -59,7 +59,7 @@ export class ProviderAvailabilityService {
   constructor(
     @inject(SettingsService) private readonly settings: SettingsService,
     @inject("IProviderRegistry") private readonly registry: IProviderRegistry,
-    private readonly resolver: CliResolver = defaultResolver,
+    @inject("CliResolver") private readonly resolver: CliResolver = defaultResolver,
   ) {}
 
   /** Build the full availability list from catalog + settings + cached CLI state. */


### PR DESCRIPTION
## What

Fixes the v0.6.0 release build failures across three root causes discovered incrementally.

## Why

The release workflow failed at multiple stages: V8 snapshot generation, server startup timeout, and tsyringe DI crash. Each fix was validated by the smoke test catching the next failure, proving the layered defense works.

## Key changes

- **V8 snapshot fix**: created `@mcode/contracts/snapshot` subpath export isolating snapshot-safe symbols from the full barrel (which pulls in `TextEncoder`, module-scope schema calls)
- **Server startup hardening**: increased timeout to 30s, piped stderr to log file, added early process exit detection in `waitForReady`
- **Smoke test**: added post-packaging smoke test to release CI that spawns the unpacked server and polls `/health` before uploading artifacts
- **CI snapshot check**: added V8 snapshot generation to PR CI so snapshot regressions are caught before merge
- **tsyringe DI fix**: `ProviderAvailabilityService.resolver` parameter lacked `@inject` decorator and `CliResolver` is an interface erased at compile time - registered `defaultResolver` with a DI token
- **Linux binary path**: corrected smoke test from `linux-unpacked/mcode` to `linux-unpacked/Mcode` (electron-builder uses productName)

## Configuration changes

- New subpath export `@mcode/contracts/snapshot` in `packages/contracts/package.json`
- New DI token `"CliResolver"` registered in `apps/server/src/container.ts`

Closes #343 Closes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linux desktop application runtime path resolution for correct Electron binary detection.

* **Refactor**
  * Improved internal dependency injection setup for resolver service configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->