### PR TITLE
fix(build): correct Linux binary name in smoke test

### DIFF
--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -45,10 +45,10 @@ function findUnpackedServer() {
       electron: resolve(releaseDir, "win-unpacked/Mcode.exe"),
       sqlite: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
     },
-    // Linux (electron-builder uses productName as binary name)
+    // Linux (electron-builder uses package name as binary name)
     {
       server: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/dist/server/server.cjs"),
-      electron: resolve(releaseDir, "linux-unpacked/Mcode"),
+      electron: resolve(releaseDir, "linux-unpacked/mcode-desktop"),
       sqlite: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
     },
     // macOS Intel


### PR DESCRIPTION
## What

Fix smoke test Linux binary detection.

## Why

electron-builder uses the package `name` field (`mcode-desktop`) as the Linux executable, not the `productName` (`Mcode`). The smoke test was looking for the wrong binary and always failing on Ubuntu CI.

## Key changes

- Changed `linux-unpacked/Mcode` to `linux-unpacked/mcode-desktop` in `smoke-test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Linux smoke test discovery to align with current build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->