### PR TITLE
fix: add per-model context window metadata for Claude models

### DIFF
--- a/apps/server/src/__tests__/claude-provider-eviction.test.ts
+++ b/apps/server/src/__tests__/claude-provider-eviction.test.ts
@@ -3,9 +3,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }));
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({ query: mockQuery }));
-vi.mock("@mcode/shared", () => ({
-  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
-}));
+vi.mock("@mcode/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcode/shared")>();
+  return {
+    ...actual,
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+});
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -67,9 +67,13 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: mockQuery,
 }));
 
-vi.mock("@mcode/shared", () => ({
-  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
-}));
+vi.mock("@mcode/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcode/shared")>();
+  return {
+    ...actual,
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+});
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 

--- a/apps/server/src/__tests__/claude-provider-queue.test.ts
+++ b/apps/server/src/__tests__/claude-provider-queue.test.ts
@@ -44,9 +44,13 @@ import { AgentEventType } from "@mcode/contracts";
 
 const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }));
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({ query: mockQuery }));
-vi.mock("@mcode/shared", () => ({
-  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
-}));
+vi.mock("@mcode/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcode/shared")>();
+  return {
+    ...actual,
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+});
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";

--- a/apps/server/src/__tests__/claude-provider-result-error.test.ts
+++ b/apps/server/src/__tests__/claude-provider-result-error.test.ts
@@ -4,9 +4,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({ query: mockQuery }));
-vi.mock("@mcode/shared", () => ({
-  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
-}));
+vi.mock("@mcode/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcode/shared")>();
+  return {
+    ...actual,
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+});
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";

--- a/apps/server/src/__tests__/handoff-builder.test.ts
+++ b/apps/server/src/__tests__/handoff-builder.test.ts
@@ -291,9 +291,22 @@ describe("buildConversationReplay", () => {
 });
 
 describe("replayBudgetChars", () => {
-  it("returns 120000 for claude models", () => {
-    expect(replayBudgetChars("claude-sonnet-4-6")).toBe(120_000);
-    expect(replayBudgetChars("claude-opus-4-6")).toBe(120_000);
+  // 15% of context window, at ~4 chars/token.
+  // Opus 4.7 / Opus 4.6 / Sonnet 4.6 all have 1M context → 600_000 chars.
+  // Haiku 4.5 has 200K context → 120_000 chars.
+  it("returns 600000 for 1M-context Claude models", () => {
+    expect(replayBudgetChars("claude-opus-4-7")).toBe(600_000);
+    expect(replayBudgetChars("claude-opus-4-6")).toBe(600_000);
+    expect(replayBudgetChars("claude-sonnet-4-6")).toBe(600_000);
+  });
+
+  it("returns 120000 for Claude Haiku 4.5 (200K context)", () => {
+    expect(replayBudgetChars("claude-haiku-4-5")).toBe(120_000);
+  });
+
+  it("matches dated SDK variants", () => {
+    expect(replayBudgetChars("claude-haiku-4-5-20251001")).toBe(120_000);
+    expect(replayBudgetChars("claude-sonnet-4-6-20260101")).toBe(600_000);
   });
 
   it("returns 100000 for unknown models", () => {

--- a/apps/server/src/providers/claude/__tests__/build-reasoning-options.test.ts
+++ b/apps/server/src/providers/claude/__tests__/build-reasoning-options.test.ts
@@ -127,4 +127,55 @@ describe("buildReasoningOptions", () => {
     const result = buildReasoningOptions("high", "claude-haiku-4-5");
     expect(result).not.toHaveProperty("thinking");
   });
+
+  // ---------------------------------------------------------------------------
+  // Ultrathink: virtual tier maps to effort "max" at SDK boundary
+  // ---------------------------------------------------------------------------
+
+  it("maps ultrathink to effort 'max' for opus-4-7", () => {
+    const result = buildReasoningOptions("ultrathink", "claude-opus-4-7");
+    expect(result).toMatchObject({ effort: "max", thinking: { type: "adaptive" } });
+  });
+
+  it("maps ultrathink to effort 'max' for opus-4-6", () => {
+    const result = buildReasoningOptions("ultrathink", "claude-opus-4-6");
+    expect(result).toMatchObject({ effort: "max" });
+  });
+
+  it("maps ultrathink to effort 'max' for sonnet-4-6", () => {
+    const result = buildReasoningOptions("ultrathink", "claude-sonnet-4-6");
+    expect(result).toMatchObject({ effort: "max" });
+  });
+
+  it("ignores ultrathink for haiku-4-5 (no effort param emitted)", () => {
+    expect(buildReasoningOptions("ultrathink", "claude-haiku-4-5")).toEqual({});
+  });
+
+  // ---------------------------------------------------------------------------
+  // Haiku thinking toggle: boolean flag → adaptive thinking
+  // ---------------------------------------------------------------------------
+
+  it("emits thinking adaptive for haiku-4-5 when thinking is true", () => {
+    const result = buildReasoningOptions("high", "claude-haiku-4-5", true);
+    expect(result).toEqual({ thinking: { type: "adaptive" } });
+    expect(result).not.toHaveProperty("effort");
+  });
+
+  it("omits thinking field for haiku-4-5 when thinking is false", () => {
+    const result = buildReasoningOptions("high", "claude-haiku-4-5", false);
+    expect(result).toEqual({});
+  });
+
+  it("omits thinking field for haiku-4-5 when thinking is undefined", () => {
+    const result = buildReasoningOptions("high", "claude-haiku-4-5", undefined);
+    expect(result).toEqual({});
+  });
+
+  it("ignores thinking flag for non-haiku models (effort path drives output)", () => {
+    // The thinking flag is a Haiku-specific override. For effort-capable models
+    // the thinking field is already set to adaptive whenever a level is provided,
+    // and the boolean is not consulted.
+    const result = buildReasoningOptions("high", "claude-sonnet-4-6", true);
+    expect(result).toMatchObject({ effort: "high", thinking: { type: "adaptive" } });
+  });
 });

--- a/apps/server/src/providers/claude/__tests__/list-models.test.ts
+++ b/apps/server/src/providers/claude/__tests__/list-models.test.ts
@@ -77,9 +77,11 @@ describe("listClaudeModels", () => {
     );
   });
 
-  it("throws when ANTHROPIC_API_KEY is missing", async () => {
+  it("returns empty array when ANTHROPIC_API_KEY is missing", async () => {
     delete process.env.ANTHROPIC_API_KEY;
-    await expect(listClaudeModels()).rejects.toThrow("ANTHROPIC_API_KEY");
+    const result = await listClaudeModels();
+    expect(result).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("throws on non-OK response", async () => {

--- a/apps/server/src/providers/claude/__tests__/list-models.test.ts
+++ b/apps/server/src/providers/claude/__tests__/list-models.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ProviderModelInfo } from "@mcode/contracts";
+import { listClaudeModels, resetModelCache } from "../list-models.js";
+
+// Minimal shape matching the Anthropic Models API response.
+const MOCK_API_RESPONSE = {
+  data: [
+    {
+      id: "claude-sonnet-4-6-20250514",
+      display_name: "Claude Sonnet 4.6",
+      type: "model",
+      max_input_tokens: 1_000_000,
+      max_tokens: 16_384,
+    },
+    {
+      id: "claude-haiku-4-5-20251001",
+      display_name: "Claude Haiku 4.5",
+      type: "model",
+      max_input_tokens: 200_000,
+      max_tokens: 8_192,
+    },
+    {
+      id: "some-non-claude-model",
+      display_name: "Not Claude",
+      type: "model",
+      max_input_tokens: 128_000,
+      max_tokens: 4_096,
+    },
+  ],
+  has_more: false,
+};
+
+describe("listClaudeModels", () => {
+  const originalEnv = process.env.ANTHROPIC_API_KEY;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = "test-key-123";
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(MOCK_API_RESPONSE),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    process.env.ANTHROPIC_API_KEY = originalEnv;
+    vi.restoreAllMocks();
+    resetModelCache();
+  });
+
+  it("returns ProviderModelInfo[] filtered to claude models", async () => {
+    const result = await listClaudeModels();
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual<ProviderModelInfo>({
+      id: "claude-sonnet-4-6-20250514",
+      name: "Claude Sonnet 4.6",
+      contextWindow: 1_000_000,
+    });
+    expect(result[1]).toEqual<ProviderModelInfo>({
+      id: "claude-haiku-4-5-20251001",
+      name: "Claude Haiku 4.5",
+      contextWindow: 200_000,
+    });
+  });
+
+  it("sends the correct headers", async () => {
+    await listClaudeModels();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/models?limit=100",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-api-key": "test-key-123",
+          "anthropic-version": "2023-06-01",
+        }),
+      }),
+    );
+  });
+
+  it("throws when ANTHROPIC_API_KEY is missing", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    await expect(listClaudeModels()).rejects.toThrow("ANTHROPIC_API_KEY");
+  });
+
+  it("throws on non-OK response", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+    });
+    await expect(listClaudeModels()).rejects.toThrow("401");
+  });
+
+  it("returns cached result on second call without re-fetching", async () => {
+    await listClaudeModels();
+    await listClaudeModels();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after the TTL expires", async () => {
+    await listClaudeModels();
+    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 5 * 60 * 1001);
+    await listClaudeModels();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    dateSpy.mockRestore();
+  });
+});

--- a/apps/server/src/providers/claude/__tests__/list-models.test.ts
+++ b/apps/server/src/providers/claude/__tests__/list-models.test.ts
@@ -44,8 +44,12 @@ describe("listClaudeModels", () => {
   });
 
   afterEach(() => {
-    process.env.ANTHROPIC_API_KEY = originalEnv;
-    vi.restoreAllMocks();
+    if (originalEnv === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalEnv;
+    }
+    vi.unstubAllGlobals();
     resetModelCache();
   });
 

--- a/apps/server/src/providers/claude/__tests__/list-models.test.ts
+++ b/apps/server/src/providers/claude/__tests__/list-models.test.ts
@@ -104,4 +104,10 @@ describe("listClaudeModels", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     dateSpy.mockRestore();
   });
+
+  it("coalesces concurrent cache-miss requests into a single fetch", async () => {
+    const [a, b] = await Promise.all([listClaudeModels(), listClaudeModels()]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b); // same array reference from the shared promise
+  });
 });

--- a/apps/server/src/providers/claude/__tests__/resolve-slug.test.ts
+++ b/apps/server/src/providers/claude/__tests__/resolve-slug.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { resolveSdkModelSlug, applyUltrathinkPrefix } from "../resolve-slug.js";
+
+describe("resolveSdkModelSlug", () => {
+  // ---------------------------------------------------------------------------
+  // 1M opt-in: append [1m] suffix for supported models
+  // ---------------------------------------------------------------------------
+
+  it("appends [1m] for opus-4-7 in 1m mode", () => {
+    expect(resolveSdkModelSlug("claude-opus-4-7", "1m")).toBe("claude-opus-4-7[1m]");
+  });
+
+  it("appends [1m] for opus-4-6 in 1m mode", () => {
+    expect(resolveSdkModelSlug("claude-opus-4-6", "1m")).toBe("claude-opus-4-6[1m]");
+  });
+
+  it("appends [1m] for sonnet-4-6 in 1m mode", () => {
+    expect(resolveSdkModelSlug("claude-sonnet-4-6", "1m")).toBe("claude-sonnet-4-6[1m]");
+  });
+
+  it("appends [1m] for dated sonnet-4-6 variant in 1m mode", () => {
+    expect(resolveSdkModelSlug("claude-sonnet-4-6-20260301", "1m")).toBe(
+      "claude-sonnet-4-6-20260301[1m]",
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // No suffix for unsupported models
+  // ---------------------------------------------------------------------------
+
+  it("returns bare slug for haiku-4-5 in 1m mode (not supported)", () => {
+    expect(resolveSdkModelSlug("claude-haiku-4-5", "1m")).toBe("claude-haiku-4-5");
+  });
+
+  it("returns bare slug for unknown model in 1m mode", () => {
+    expect(resolveSdkModelSlug("claude-future-model", "1m")).toBe("claude-future-model");
+  });
+
+  // ---------------------------------------------------------------------------
+  // 200k mode + undefined: never appends suffix
+  // ---------------------------------------------------------------------------
+
+  it("returns bare slug for sonnet-4-6 in 200k mode", () => {
+    expect(resolveSdkModelSlug("claude-sonnet-4-6", "200k")).toBe("claude-sonnet-4-6");
+  });
+
+  it("returns bare slug for sonnet-4-6 with undefined mode", () => {
+    expect(resolveSdkModelSlug("claude-sonnet-4-6", undefined)).toBe("claude-sonnet-4-6");
+  });
+});
+
+describe("applyUltrathinkPrefix", () => {
+  // ---------------------------------------------------------------------------
+  // Prefix applied for ultrathink + supported model
+  // ---------------------------------------------------------------------------
+
+  it("prepends 'Ultrathink:\\n' for opus-4-7 + ultrathink", () => {
+    expect(applyUltrathinkPrefix("hello", "ultrathink", "claude-opus-4-7")).toBe(
+      "Ultrathink:\nhello",
+    );
+  });
+
+  it("prepends 'Ultrathink:\\n' for sonnet-4-6 + ultrathink", () => {
+    expect(applyUltrathinkPrefix("hello", "ultrathink", "claude-sonnet-4-6")).toBe(
+      "Ultrathink:\nhello",
+    );
+  });
+
+  it("prepends 'Ultrathink:\\n' for opus-4-6 + ultrathink", () => {
+    expect(applyUltrathinkPrefix("hello", "ultrathink", "claude-opus-4-6")).toBe(
+      "Ultrathink:\nhello",
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Prefix skipped for unsupported model (Haiku) or non-ultrathink levels
+  // ---------------------------------------------------------------------------
+
+  it("does not prepend for haiku-4-5 (ultrathink unsupported)", () => {
+    expect(applyUltrathinkPrefix("hello", "ultrathink", "claude-haiku-4-5")).toBe("hello");
+  });
+
+  it("does not prepend when level is 'max'", () => {
+    expect(applyUltrathinkPrefix("hello", "max", "claude-opus-4-7")).toBe("hello");
+  });
+
+  it("does not prepend when level is 'high'", () => {
+    expect(applyUltrathinkPrefix("hello", "high", "claude-sonnet-4-6")).toBe("hello");
+  });
+
+  it("does not prepend when level is undefined", () => {
+    expect(applyUltrathinkPrefix("hello", undefined, "claude-sonnet-4-6")).toBe("hello");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Idempotency: do not double-prefix
+  // ---------------------------------------------------------------------------
+
+  it("does not double-prefix an already-prefixed message", () => {
+    expect(
+      applyUltrathinkPrefix("Ultrathink:\nhello", "ultrathink", "claude-opus-4-7"),
+    ).toBe("Ultrathink:\nhello");
+  });
+});

--- a/apps/server/src/providers/claude/build-reasoning-options.ts
+++ b/apps/server/src/providers/claude/build-reasoning-options.ts
@@ -4,25 +4,38 @@ import {
   logger,
   normalizeReasoningLevelForModel,
   supportsEffortParameter,
+  supportsThinkingToggle,
 } from "@mcode/shared";
 
 /**
- * Build the SDK reasoning options from a reasoning level and model ID.
+ * Build the SDK reasoning options from a reasoning level, model ID, and
+ * optional thinking toggle.
  *
- * Delegates normalization to the shared tier-ladder helper. Haiku 4.5
- * and other effort-unsupported models get an empty return (no `effort` field)
- * because the Claude SDK rejects the effort parameter for those models.
- * Emits a warning when the level is clamped.
+ * - For models with no effort support (Haiku-class), the `effort` field is
+ *   omitted entirely. If `thinking` is true and the model exposes the boolean
+ *   thinking toggle, we still emit `thinking: { type: "adaptive" }` so Haiku
+ *   uses its extended thinking pathway.
+ * - "ultrathink" is a Mcode virtual tier — it is mapped to `effort: "max"` at
+ *   the SDK boundary because the SDK's EffortLevel union does not include it.
+ *   The "Ultrathink:\n" prompt prefix is applied separately by
+ *   `applyUltrathinkPrefix` in the message-building path.
+ * - All other levels are normalized to the highest tier the model accepts via
+ *   the shared tier-ladder helper, with a warning logged on clamp.
  */
 export function buildReasoningOptions(
   reasoningLevel: ReasoningLevel | undefined,
   modelId: string,
+  thinking?: boolean,
 ): Pick<Options, "effort" | "thinking"> {
-  if (reasoningLevel === undefined) return {};
+  // Models that ignore the effort parameter (Haiku 4.5).
+  if (!supportsEffortParameter(modelId)) {
+    if (thinking === true && supportsThinkingToggle(modelId)) {
+      return { thinking: { type: "adaptive" } };
+    }
+    return {};
+  }
 
-  // Haiku and future no-effort models: omit the effort field entirely.
-  // The SDK rejects the field for these models rather than ignoring it.
-  if (!supportsEffortParameter(modelId)) return {};
+  if (reasoningLevel === undefined) return {};
 
   const normalized = normalizeReasoningLevelForModel(modelId, reasoningLevel);
   if (normalized !== reasoningLevel) {
@@ -33,11 +46,15 @@ export function buildReasoningOptions(
     });
   }
 
+  // Ultrathink is a Mcode virtual tier; the SDK only accepts up through "max".
+  // The "Ultrathink:\n" prompt prefix is applied separately by the caller.
+  const sdkEffort = normalized === "ultrathink" ? "max" : normalized;
+
   return {
     // "xhigh" is valid for claude-opus-4-7; the SDK's EffortLevel union does not
     // include "xhigh" yet, so we cast to any to avoid a compile-time rejection.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    effort: normalized as any,
+    effort: sdkEffort as any,
     thinking: { type: "adaptive" },
   };
 }

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -15,6 +15,7 @@ import type {
   IAgentProvider,
   ProviderId,
   ReasoningLevel,
+  ContextWindowMode,
   AgentEvent,
   AttachmentMeta,
   ProviderModelInfo,
@@ -24,6 +25,7 @@ import type {
 } from "@mcode/contracts";
 import { buildReasoningOptions } from "./build-reasoning-options.js";
 import { listClaudeModels } from "./list-models.js";
+import { applyUltrathinkPrefix, resolveSdkModelSlug } from "./resolve-slug.js";
 
 /** Idle TTL before a session is evicted (10 minutes). */
 const IDLE_TTL_MS = 10 * 60 * 1000;
@@ -44,6 +46,13 @@ interface SessionEntry {
    * fixed at spawn in the Claude Agent SDK CLI.
    */
   permissionMode: string;
+  /**
+   * Context window mode the SDK subprocess was spawned with. The 1M window is
+   * encoded into the model slug (`<id>[1m]`), so changing this between turns
+   * requires a fresh subprocess — the same teardown-and-respawn pattern used
+   * for permissionMode.
+   */
+  contextWindowMode: ContextWindowMode | undefined;
   lastUsedAt: number;
   /** When true, the finally block in startStreamLoop should not emit an "ended" event. */
   suppressEnded?: boolean;
@@ -212,6 +221,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     permissionMode: string;
     attachments?: AttachmentMeta[];
     reasoningLevel?: ReasoningLevel;
+    contextWindowMode?: ContextWindowMode;
+    thinking?: boolean;
     maxBudgetUsd?: number;
     maxTurns?: number;
   }): Promise<void> {
@@ -312,6 +323,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     permissionMode: string;
     attachments?: AttachmentMeta[];
     reasoningLevel?: ReasoningLevel;
+    contextWindowMode?: ContextWindowMode;
+    thinking?: boolean;
     maxBudgetUsd?: number;
     maxTurns?: number;
   }): Promise<void> {
@@ -325,6 +338,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       permissionMode,
       attachments,
       reasoningLevel,
+      contextWindowMode,
+      thinking,
     } = params;
 
     if (!this.evictionTimer) {
@@ -345,11 +360,19 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     const tid = uuid;
     const resolvedCwd = cwd || process.cwd();
     const resolvedModel = model || "claude-sonnet-4-6";
+    // The "[1m]" suffix is appended only when the user opted into the 1M context
+    // window AND the model supports it. The SDK translates it into the
+    // `context-1m-2025-08-07` beta header.
+    const sdkModelSlug = resolveSdkModelSlug(resolvedModel, contextWindowMode);
+
+    // Ultrathink prepends "Ultrathink:\n" to the user prompt for models that
+    // support it. The matching `effort: "max"` is emitted by buildReasoningOptions.
+    const finalMessage = applyUltrathinkPrefix(message, reasoningLevel, resolvedModel);
 
     const prompt =
       attachments && attachments.length > 0
-        ? await this.buildMultimodalMessage(message, attachments, sessionId)
-        : toUserMessage(message, sessionId);
+        ? await this.buildMultimodalMessage(finalMessage, attachments, sessionId)
+        : toUserMessage(finalMessage, sessionId);
 
     if (existing) {
       // Permission mode is fixed at SDK subprocess spawn. setPermissionMode()
@@ -370,15 +393,35 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         return this.doSendMessage(params);
       }
 
+      // Context window mode is part of the model slug at spawn time, so the SDK
+      // subprocess must be torn down and respawned when the user toggles 200k/1M.
+      // setModel() can change the model ID but cannot toggle the [1m] suffix beta
+      // header, which is only attached at session creation.
+      if (existing.contextWindowMode !== contextWindowMode) {
+        logger.info("contextWindowMode changed, recreating session", {
+          sessionId,
+          from: existing.contextWindowMode,
+          to: contextWindowMode,
+        });
+        existing.suppressEnded = true;
+        existing.closeQueue();
+        existing.query.close();
+        this.sessions.delete(sessionId);
+        return this.doSendMessage(params);
+      }
+
       existing.lastUsedAt = Date.now();
 
       if (existing.model !== resolvedModel) {
         logger.info("Model changed, calling setModel()", {
           sessionId,
-          model: resolvedModel,
+          model: sdkModelSlug,
         });
         try {
-          await existing.query.setModel(resolvedModel);
+          // Always pass the slug (with optional [1m] suffix) to the SDK; the
+          // entry stores the bare model ID so fallback detection compares
+          // against the base name the SDK reports in modelUsage.
+          await existing.query.setModel(sdkModelSlug);
           existing.model = resolvedModel;
         } catch (err) {
           logger.error(
@@ -444,7 +487,10 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
 
     const baseOptions = {
       cwd: resolvedCwd,
-      model: resolvedModel,
+      // sdkModelSlug appends "[1m]" when the user opted into the 1M context window
+      // and the model supports it. Plain `resolvedModel` is preserved on the
+      // session entry as well so the existing-session branch can detect changes.
+      model: sdkModelSlug,
       settingSources: [
         "user" as const,
         "project" as const,
@@ -546,7 +592,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
           };
         }
       }) satisfies CanUseTool,
-      ...buildReasoningOptions(reasoningLevel, resolvedModel),
+      ...buildReasoningOptions(reasoningLevel, resolvedModel, thinking),
       ...(fallbackModel && { fallbackModel }),
       includePartialMessages: true,
       // Guardrails are fixed at session creation. If the user changes the
@@ -592,8 +638,12 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       query: q,
       pushMessage: queue.push,
       closeQueue: queue.close,
+      // Store the bare model ID; the [1m] suffix is only attached at the SDK
+      // boundary so detectFallbackModel can compare against the dated snapshot
+      // IDs the SDK reports in modelUsage.
       model: resolvedModel,
       permissionMode,
+      contextWindowMode,
       lastUsedAt: Date.now(),
       pendingToolUses: new Set<string>(),
     };
@@ -645,6 +695,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
           closeQueue: freshQueue.close,
           model: resolvedModel,
           permissionMode,
+          contextWindowMode,
           lastUsedAt: Date.now(),
           pendingToolUses: new Set<string>(),
         };

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -17,11 +17,13 @@ import type {
   ReasoningLevel,
   AgentEvent,
   AttachmentMeta,
+  ProviderModelInfo,
   ProviderUsageInfo,
   PermissionDecision,
   PermissionRequest,
 } from "@mcode/contracts";
 import { buildReasoningOptions } from "./build-reasoning-options.js";
+import { listClaudeModels } from "./list-models.js";
 
 /** Idle TTL before a session is evicted (10 minutes). */
 const IDLE_TTL_MS = 10 * 60 * 1000;
@@ -1321,6 +1323,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       numTurns: this.lastNumTurns,
       durationMs: this.lastDurationMs,
     };
+  }
+
+  /** Fetch available Claude models from the Anthropic REST API. */
+  async listModels(): Promise<ProviderModelInfo[]> {
+    return listClaudeModels();
   }
 
   /** Resolves a pending permission request by ID. Deletes the entry before calling resolve to prevent re-entrant calls. Returns false if the requestId is unknown. */

--- a/apps/server/src/providers/claude/list-models.ts
+++ b/apps/server/src/providers/claude/list-models.ts
@@ -1,0 +1,111 @@
+/**
+ * Fetches available Claude models from the Anthropic REST API.
+ *
+ * Returns ProviderModelInfo[] with contextWindow populated from
+ * max_input_tokens. Results are cached in-memory with a 5-minute TTL
+ * to avoid hammering the API on repeated model selector hovers.
+ */
+
+import { logger } from "@mcode/shared";
+import type { ProviderModelInfo } from "@mcode/contracts";
+
+/** Cache TTL: 5 minutes, matching the design spec. */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Shape of a single model from the Anthropic Models API. */
+interface AnthropicModelInfo {
+  id: string;
+  display_name: string;
+  type: string;
+  max_input_tokens: number | null;
+  max_tokens: number | null;
+}
+
+/** Paginated response from GET /v1/models. */
+interface AnthropicModelsResponse {
+  data: AnthropicModelInfo[];
+  has_more: boolean;
+  first_id?: string;
+  last_id?: string;
+}
+
+let cachedModels: ProviderModelInfo[] | null = null;
+let cacheTimestamp = 0;
+let inflight: Promise<ProviderModelInfo[]> | null = null;
+
+/** Reset the in-memory cache. Exposed for testing. */
+export function resetModelCache(): void {
+  cachedModels = null;
+  cacheTimestamp = 0;
+  inflight = null;
+}
+
+/**
+ * Performs the actual network request to the Anthropic Models API.
+ *
+ * Populates the in-memory cache on success. Does not guard against
+ * concurrent callers — use listClaudeModels() which coalesces inflight
+ * requests onto a single promise.
+ */
+async function fetchModels(): Promise<ProviderModelInfo[]> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error("ANTHROPIC_API_KEY environment variable is not set");
+  }
+
+  // limit=100 covers all current Claude models without pagination.
+  // Anthropic has far fewer than 100 Claude models at present, so we
+  // intentionally do not follow has_more / last_id pagination.
+  const res = await fetch("https://api.anthropic.com/v1/models?limit=100", {
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Anthropic Models API returned ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const body = (await res.json()) as AnthropicModelsResponse;
+
+  const models: ProviderModelInfo[] = body.data
+    .filter((m) => m.id.startsWith("claude-"))
+    .map((m) => ({
+      id: m.id,
+      name: m.display_name,
+      contextWindow: m.max_input_tokens ?? undefined,
+    }));
+
+  cachedModels = models;
+  cacheTimestamp = Date.now();
+
+  logger.debug("Fetched Claude models from API", { count: models.length });
+
+  return models;
+}
+
+/**
+ * Fetch Claude models from the Anthropic REST API.
+ *
+ * Reads `ANTHROPIC_API_KEY` from the environment (same var the Claude
+ * Agent SDK uses). Filters to `claude-*` models and maps each to
+ * `ProviderModelInfo` with `contextWindow` from `max_input_tokens`.
+ *
+ * Results are cached for CACHE_TTL_MS. Concurrent callers during a
+ * cache miss share a single inflight promise to prevent stampedes.
+ */
+export async function listClaudeModels(): Promise<ProviderModelInfo[]> {
+  const now = Date.now();
+  if (cachedModels && now - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedModels;
+  }
+  if (inflight) return inflight;
+
+  inflight = fetchModels().finally(() => {
+    inflight = null;
+  });
+  return inflight;
+}

--- a/apps/server/src/providers/claude/list-models.ts
+++ b/apps/server/src/providers/claude/list-models.ts
@@ -33,7 +33,12 @@ let cachedModels: ProviderModelInfo[] | null = null;
 let cacheTimestamp = 0;
 let inflight: Promise<ProviderModelInfo[]> | null = null;
 
-/** Reset the in-memory cache. Exposed for testing. */
+/**
+ * Resets the in-memory model cache and any inflight request.
+ *
+ * Exposed for testing to ensure a clean state between test runs. Not intended
+ * for production use; the TTL-based expiry handles normal cache invalidation.
+ */
 export function resetModelCache(): void {
   cachedModels = null;
   cacheTimestamp = 0;
@@ -61,6 +66,7 @@ async function fetchModels(): Promise<ProviderModelInfo[]> {
   // Anthropic has far fewer than 100 Claude models at present, so we
   // intentionally do not follow has_more / last_id pagination.
   const res = await fetch("https://api.anthropic.com/v1/models?limit=100", {
+    signal: AbortSignal.timeout(10_000),
     headers: {
       "x-api-key": apiKey,
       "anthropic-version": "2023-06-01",

--- a/apps/server/src/providers/claude/list-models.ts
+++ b/apps/server/src/providers/claude/list-models.ts
@@ -50,7 +50,11 @@ export function resetModelCache(): void {
 async function fetchModels(): Promise<ProviderModelInfo[]> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
-    throw new Error("ANTHROPIC_API_KEY environment variable is not set");
+    // The Claude Agent SDK uses its own auth mechanism, so this env var
+    // is often absent. Return empty and let the static registry provide
+    // model data instead of surfacing an error to the user.
+    logger.debug("ANTHROPIC_API_KEY not set, skipping models API fetch");
+    return [];
   }
 
   // limit=100 covers all current Claude models without pagination.

--- a/apps/server/src/providers/claude/resolve-slug.ts
+++ b/apps/server/src/providers/claude/resolve-slug.ts
@@ -1,0 +1,46 @@
+import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
+import { supports1MContextWindow, supportsUltrathink } from "@mcode/shared";
+
+/**
+ * Append the `[1m]` suffix that the Claude Agent SDK uses to enable the
+ * 1,000,000-token context window beta. The SDK translates the suffix into the
+ * `context-1m-2025-08-07` beta header on the wire.
+ *
+ * Falls through to the bare model ID when:
+ *   - the user did not opt into 1M mode (mode !== "1m"), or
+ *   - the model does not support the extended window (e.g. Haiku 4.5).
+ */
+export function resolveSdkModelSlug(
+  modelId: string,
+  mode: ContextWindowMode | undefined,
+): string {
+  if (mode === "1m" && supports1MContextWindow(modelId)) {
+    return `${modelId}[1m]`;
+  }
+  return modelId;
+}
+
+/** Prefix the SDK passes through verbatim to flip the model into ultrathink mode. */
+const ULTRATHINK_PREFIX = "Ultrathink:\n";
+
+/**
+ * Conditionally prepend "Ultrathink:\n" to the user prompt.
+ *
+ * Ultrathink is a Mcode virtual tier on top of "max" effort. The prefix is the
+ * documented signal the model uses to engage the deepest reasoning path; the
+ * matching `effort: "max"` is emitted by `buildReasoningOptions`.
+ *
+ * Returns the original message untouched when:
+ *   - the level is not "ultrathink", or
+ *   - the model does not support ultrathink (e.g. Haiku 4.5).
+ */
+export function applyUltrathinkPrefix(
+  message: string,
+  reasoningLevel: ReasoningLevel | undefined,
+  modelId: string,
+): string {
+  if (reasoningLevel !== "ultrathink") return message;
+  if (!supportsUltrathink(modelId)) return message;
+  if (message.startsWith(ULTRATHINK_PREFIX)) return message;
+  return `${ULTRATHINK_PREFIX}${message}`;
+}

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -6,7 +6,7 @@
 import { randomUUID } from "crypto";
 import { injectable, inject } from "tsyringe";
 import type Database from "better-sqlite3";
-import type { Thread, ThreadMode, ThreadStatus, ReasoningLevel, InteractionMode, PermissionMode } from "@mcode/contracts";
+import type { Thread, ThreadMode, ThreadStatus, ReasoningLevel, InteractionMode, PermissionMode, ContextWindowMode } from "@mcode/contracts";
 
 interface ThreadRow {
   id: string;
@@ -31,6 +31,8 @@ interface ThreadRow {
   reasoning_level: string | null;
   interaction_mode: string | null;
   permission_mode: string | null;
+  context_window_mode: string | null;
+  thinking: number | null;
   copilot_agent: string | null;
   parent_thread_id: string | null;
   forked_from_message_id: string | null;
@@ -61,6 +63,9 @@ function rowToThread(row: ThreadRow): Thread {
     reasoning_level: (row.reasoning_level ?? null) as ReasoningLevel | null,
     interaction_mode: (row.interaction_mode ?? null) as InteractionMode | null,
     permission_mode: (row.permission_mode ?? null) as PermissionMode | null,
+    context_window_mode:
+      (row.context_window_mode ?? null) as ContextWindowMode | null,
+    thinking: row.thinking == null ? null : row.thinking === 1,
     copilot_agent: (row.copilot_agent ?? null) as string | null,
     parent_thread_id: row.parent_thread_id,
     forked_from_message_id: row.forked_from_message_id,
@@ -69,7 +74,7 @@ function rowToThread(row: ThreadRow): Thread {
 }
 
 const THREAD_COLUMNS =
-  "id, workspace_id, title, status, mode, worktree_path, branch, worktree_managed, issue_number, pr_number, pr_status, sdk_session_id, model, provider, created_at, updated_at, deleted_at, last_context_tokens, context_window, reasoning_level, interaction_mode, permission_mode, copilot_agent, parent_thread_id, forked_from_message_id, last_compact_summary";
+  "id, workspace_id, title, status, mode, worktree_path, branch, worktree_managed, issue_number, pr_number, pr_status, sdk_session_id, model, provider, created_at, updated_at, deleted_at, last_context_tokens, context_window, reasoning_level, interaction_mode, permission_mode, context_window_mode, thinking, copilot_agent, parent_thread_id, forked_from_message_id, last_compact_summary";
 
 /** Repository for thread lifecycle operations against SQLite. */
 @injectable()
@@ -135,6 +140,8 @@ export class ThreadRepo {
       reasoning_level: null,
       interaction_mode: null,
       permission_mode: null,
+      context_window_mode: null,
+      thinking: null,
       copilot_agent: null,
       parent_thread_id: lineage?.parentThreadId ?? null,
       forked_from_message_id: lineage?.forkedFromMessageId ?? null,
@@ -290,6 +297,8 @@ export class ThreadRepo {
       reasoning_level?: string;
       interaction_mode?: string;
       permission_mode?: string;
+      context_window_mode?: string | null;
+      thinking?: boolean | null;
       copilot_agent?: string | null;
     },
   ): boolean {
@@ -306,6 +315,17 @@ export class ThreadRepo {
     if (settings.permission_mode !== undefined) {
       fields.push("permission_mode = ?");
       values.push(settings.permission_mode);
+    }
+    if (settings.context_window_mode !== undefined) {
+      fields.push("context_window_mode = ?");
+      // null clears the override so the thread inherits from settings.
+      values.push(settings.context_window_mode);
+    }
+    if (settings.thinking !== undefined) {
+      fields.push("thinking = ?");
+      // SQLite has no native boolean — store 0/1 to match the column convention.
+      // null clears the override so the thread inherits from settings.
+      values.push(settings.thinking == null ? null : settings.thinking ? 1 : 0);
     }
     if (settings.copilot_agent !== undefined) {
       fields.push("copilot_agent = ?");

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -297,7 +297,7 @@ export class ThreadRepo {
       reasoning_level?: string;
       interaction_mode?: string;
       permission_mode?: string;
-      context_window_mode?: string | null;
+      context_window_mode?: ContextWindowMode | null;
       thinking?: boolean | null;
       copilot_agent?: string | null;
     },

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -578,6 +578,14 @@ export class AgentService {
     // Validate parent
     const parentThread = this.threadRepo.findById(parentThreadId);
     if (!parentThread) throw new Error(`Parent thread not found: ${parentThreadId}`);
+
+    // Inherit context window mode and thinking from the parent thread when not
+    // explicitly overridden by the caller — branched threads continue in the same
+    // context tier / thinking mode as the thread they forked from.
+    const effectiveContextWindowMode =
+      contextWindowMode ?? (parentThread.context_window_mode as ContextWindowMode | null | undefined) ?? undefined;
+    const effectiveThinking =
+      thinking !== undefined ? thinking : (parentThread.thinking != null ? Boolean(parentThread.thinking) : undefined);
     if (parentThread.workspace_id !== workspaceId) {
       throw new Error("Cannot branch across workspaces");
     }
@@ -738,8 +746,8 @@ export class AgentService {
         maxBudgetUsd,
         maxTurns,
         copilotAgent,
-        contextWindowMode,
-        thinking,
+        effectiveContextWindowMode,
+        effectiveThinking,
       );
     } finally {
       // Ensure override is cleaned up even if sendMessage throws before consuming it.

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -14,6 +14,7 @@ import type {
   Thread,
   AttachmentMeta,
   ReasoningLevel,
+  ContextWindowMode,
   IProviderRegistry,
   AgentEvent,
   ProviderId,
@@ -146,6 +147,8 @@ export class AgentService {
     maxBudgetUsd?: number,
     maxTurns?: number,
     copilotAgent?: string,
+    contextWindowMode?: ContextWindowMode,
+    thinking?: boolean,
   ): Promise<void> {
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
@@ -263,6 +266,16 @@ export class AgentService {
     // A value of 0 means "disabled" — do not pass to provider.
     const effectiveBudget = maxBudgetUsd ?? settings.agent.guardrails.maxBudgetUsd;
     const effectiveTurns = maxTurns ?? settings.agent.guardrails.maxTurns;
+
+    // Resolve context window mode + thinking via the standard precedence chain:
+    // per-call (composer/RPC override) > thread (persisted from earlier turns)
+    // > settings default. The result is what actually flows to the SDK.
+    const effectiveContextWindowMode: ContextWindowMode =
+      contextWindowMode ??
+      (thread.context_window_mode as ContextWindowMode | null) ??
+      settings.model.defaults.contextWindow;
+    const effectiveThinking: boolean =
+      thinking ?? (thread.thinking ?? settings.model.defaults.thinking);
     this.threadRepo.updateModel(threadId, resolvedModel);
     // Only persist provider when the caller explicitly supplied one (new thread or deliberate switch).
     if (provider !== undefined) {
@@ -273,6 +286,8 @@ export class AgentService {
       ...(reasoningLevel !== undefined && { reasoning_level: reasoningLevel }),
       ...(interactionMode !== undefined && { interaction_mode: interactionMode }),
       ...(permissionMode !== undefined && permissionMode !== "default" && { permission_mode: permissionMode }),
+      ...(contextWindowMode !== undefined && { context_window_mode: contextWindowMode }),
+      ...(thinking !== undefined && { thinking }),
       ...(copilotAgent !== undefined && { copilot_agent: copilotAgent }),
     });
 
@@ -317,6 +332,8 @@ export class AgentService {
         permissionMode,
         attachments: persisted.length > 0 ? persisted : undefined,
         reasoningLevel,
+        contextWindowMode: effectiveContextWindowMode,
+        thinking: effectiveThinking,
         ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
         ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
         copilotAgent: effectiveCopilotAgent,
@@ -372,6 +389,8 @@ export class AgentService {
     answers: Array<{ questionId: string; selectedOptionId: string | null; freeText: string | null }>,
     permissionMode = "default",
     reasoningLevel?: ReasoningLevel,
+    contextWindowMode?: ContextWindowMode,
+    thinking?: boolean,
   ): Promise<void> {
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
@@ -404,6 +423,12 @@ export class AgentService {
       [],
       reasoningLevel,
       (thread.provider as ProviderId) ?? "claude",
+      undefined, // interactionMode
+      undefined, // maxBudgetUsd
+      undefined, // maxTurns
+      undefined, // copilotAgent
+      contextWindowMode,
+      thinking,
     );
   }
 
@@ -429,6 +454,8 @@ export class AgentService {
     maxBudgetUsd?: number,
     maxTurns?: number,
     copilotAgent?: string,
+    contextWindowMode?: ContextWindowMode,
+    thinking?: boolean,
   ): Promise<Thread> {
     const title = truncateTitle(content);
 
@@ -439,6 +466,8 @@ export class AgentService {
         interactionMode, parentThreadId, forkedFromMessageId, title,
         maxBudgetUsd, maxTurns,
         copilotAgent,
+        contextWindowMode,
+        thinking,
       });
     }
 
@@ -500,6 +529,8 @@ export class AgentService {
       maxBudgetUsd,
       maxTurns,
       copilotAgent,
+      contextWindowMode,
+      thinking,
     );
 
     // Re-read from DB to pick up model update applied by sendMessage
@@ -531,6 +562,8 @@ export class AgentService {
     maxBudgetUsd?: number;
     maxTurns?: number;
     copilotAgent?: string;
+    contextWindowMode?: ContextWindowMode;
+    thinking?: boolean;
   }): Promise<Thread> {
     const {
       workspaceId, content, model, permissionMode, mode, branch,
@@ -538,6 +571,8 @@ export class AgentService {
       interactionMode, parentThreadId, forkedFromMessageId, title,
       maxBudgetUsd, maxTurns,
       copilotAgent,
+      contextWindowMode,
+      thinking,
     } = params;
 
     // Validate parent
@@ -703,6 +738,8 @@ export class AgentService {
         maxBudgetUsd,
         maxTurns,
         copilotAgent,
+        contextWindowMode,
+        thinking,
       );
     } finally {
       // Ensure override is cleaned up even if sendMessage throws before consuming it.

--- a/apps/server/src/services/handoff-builder.ts
+++ b/apps/server/src/services/handoff-builder.ts
@@ -25,12 +25,15 @@ const MAX_ASSISTANT_TEXT = 2000;
 
 /**
  * Rough char budget for the conversation replay injected into the provider.
- * Uses 15% of the model's known context window at ~4 chars/token, leaving
- * headroom for the new conversation. Falls back to a conservative 100K chars
- * (~25K tokens) when the model is unknown.
+ * Uses 15% of the model's *maximum* context window at ~4 chars/token, leaving
+ * headroom for the new conversation. We pass `"1m"` here so 1M-capable models
+ * get the larger budget — the per-thread context window is selected at send
+ * time and may differ, but the replay should fit either tier comfortably.
+ * Falls back to a conservative 100K chars (~25K tokens) when the model is
+ * unknown.
  */
 export function replayBudgetChars(modelId: string): number {
-  const contextWindow = getModelContextWindow(modelId);
+  const contextWindow = getModelContextWindow(modelId, "1m");
   if (contextWindow !== undefined) {
     // 15% of the context window, at ~4 chars/token.
     return Math.floor(contextWindow * 0.15 * 4);

--- a/apps/server/src/services/handoff-builder.ts
+++ b/apps/server/src/services/handoff-builder.ts
@@ -9,6 +9,7 @@ import type { Thread, Message, TurnSnapshot, HandoffMetadata } from "@mcode/cont
 import { HANDOFF_MARKER } from "@mcode/contracts";
 export { HANDOFF_MARKER, parseHandoffJson } from "@mcode/contracts";
 export type { HandoffMetadata } from "@mcode/contracts";
+import { getModelContextWindow } from "@mcode/shared/model-context";
 
 /** Input for building handoff content. */
 export interface HandoffInput {
@@ -24,13 +25,16 @@ const MAX_ASSISTANT_TEXT = 2000;
 
 /**
  * Rough char budget for the conversation replay injected into the provider.
- * Uses 15% of the model's known context window at ~4 chars/token,
- * leaving headroom for the new conversation.
+ * Uses 15% of the model's known context window at ~4 chars/token, leaving
+ * headroom for the new conversation. Falls back to a conservative 100K chars
+ * (~25K tokens) when the model is unknown.
  */
 export function replayBudgetChars(modelId: string): number {
-  // Claude models: 200K token context window
-  if (modelId.startsWith("claude")) return 120_000; // 200_000 * 0.15 * 4
-  // Conservative default for other models (~100K chars / ~25K tokens)
+  const contextWindow = getModelContextWindow(modelId);
+  if (contextWindow !== undefined) {
+    // 15% of the context window, at ~4 chars/token.
+    return Math.floor(contextWindow * 0.15 * 4);
+  }
   return 100_000;
 }
 

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -6,7 +6,7 @@
 
 import { injectable, inject } from "tsyringe";
 import { validateBranchName, sanitizeBranchForFolder, logger } from "@mcode/shared";
-import type { Thread, ThreadMode } from "@mcode/contracts";
+import type { Thread, ThreadMode, ContextWindowMode } from "@mcode/contracts";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { GitService } from "./git-service";
@@ -169,7 +169,7 @@ export class ThreadService {
       interaction_mode?: string;
       permission_mode?: string;
       copilot_agent?: string | null;
-      context_window_mode?: string | null;
+      context_window_mode?: ContextWindowMode | null;
       thinking?: boolean | null;
     },
   ): boolean {

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -161,7 +161,7 @@ export class ThreadService {
     return this.threadRepo.updateTitle(threadId, title);
   }
 
-  /** Persist per-thread composer settings (reasoning, mode, permission, copilot agent). */
+  /** Persist per-thread composer settings (reasoning, mode, permission, copilot agent, context window, thinking). */
   updateSettings(
     threadId: string,
     settings: {
@@ -169,6 +169,8 @@ export class ThreadService {
       interaction_mode?: string;
       permission_mode?: string;
       copilot_agent?: string | null;
+      context_window_mode?: string | null;
+      thinking?: boolean | null;
     },
   ): boolean {
     return this.threadRepo.updateSettings(threadId, {
@@ -176,6 +178,8 @@ export class ThreadService {
       ...(settings.interaction_mode !== undefined && { interaction_mode: settings.interaction_mode }),
       ...(settings.permission_mode !== undefined && { permission_mode: settings.permission_mode }),
       ...("copilot_agent" in settings && { copilot_agent: settings.copilot_agent }),
+      ...("context_window_mode" in settings && { context_window_mode: settings.context_window_mode }),
+      ...("thinking" in settings && { thinking: settings.thinking }),
     });
   }
 

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -27,6 +27,7 @@ import * as m014 from "./migrations/014_thread_branching.js";
 import * as m015 from "./migrations/015_thread_compact_summary.js";
 import * as m016 from "./migrations/016_copilot_agent.js";
 import * as m017 from "./migrations/017_workspace_is_git_repo.js";
+import * as m018 from "./migrations/018_thread_context_window_mode_thinking.js";
 
 /**
  * Resolve the correct native binding for better-sqlite3 based on runtime.
@@ -85,6 +86,7 @@ export function loadMigrations(): Map<number, MigrationModule> {
   migrations.set(15, m015);
   migrations.set(16, m016);
   migrations.set(17, m017);
+  migrations.set(18, m018);
   return migrations;
 }
 

--- a/apps/server/src/store/migrations/018_thread_context_window_mode_thinking.ts
+++ b/apps/server/src/store/migrations/018_thread_context_window_mode_thinking.ts
@@ -1,0 +1,29 @@
+import type Database from "better-sqlite3";
+
+/** Human-readable description shown in CLI status. */
+export const description =
+  "Add context_window_mode and thinking columns to threads (per-thread 200k/1M opt-in + Haiku thinking toggle)";
+
+/** Apply this migration. Runner wraps this in a transaction. */
+export function up(db: Database.Database): void {
+  // context_window_mode: '200k' | '1m' | NULL (NULL = inherit from settings).
+  // thinking: 0 | 1 | NULL (NULL = inherit). Stored as INTEGER because SQLite
+  // has no native boolean type; the repo layer converts to TypeScript boolean.
+  const sql = `
+    ALTER TABLE threads ADD COLUMN context_window_mode TEXT DEFAULT NULL;
+    ALTER TABLE threads ADD COLUMN thinking INTEGER DEFAULT NULL;
+  `;
+  db.exec(sql);
+}
+
+/**
+ * Reverse this migration.
+ * Drops both new columns. SQLite supports DROP COLUMN since 3.35 (2021),
+ * which is comfortably below the better-sqlite3 minimum.
+ */
+export function down(db: Database.Database): void {
+  const dropMode = "ALTER TABLE threads DROP COLUMN context_window_mode";
+  const dropThinking = "ALTER TABLE threads DROP COLUMN thinking";
+  db.exec(dropMode);
+  db.exec(dropThinking);
+}

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -239,6 +239,8 @@ async function dispatch(
         interaction_mode: params.interactionMode,
         permission_mode: params.permissionMode,
         copilot_agent: params.copilotAgent,
+        context_window_mode: params.contextWindow,
+        thinking: params.thinking,
       });
     case "thread.markViewed":
       deps.threadService.markViewed(params.threadId);
@@ -353,6 +355,8 @@ async function dispatch(
         params.maxBudgetUsd,
         params.maxTurns,
         params.copilotAgent,
+        params.contextWindow,
+        params.thinking,
       );
       return;
     case "agent.createAndSend":
@@ -373,6 +377,8 @@ async function dispatch(
         params.maxBudgetUsd,
         params.maxTurns,
         params.copilotAgent,
+        params.contextWindow,
+        params.thinking,
       );
     case "agent.stop":
       await deps.agentService.stopSession(params.threadId);
@@ -387,6 +393,8 @@ async function dispatch(
         params.answers,
         params.permissionMode ?? "default",
         params.reasoningLevel,
+        params.contextWindow,
+        params.thinking,
       );
       return;
 

--- a/apps/web/src/__tests__/context-tracker.test.ts
+++ b/apps/web/src/__tests__/context-tracker.test.ts
@@ -49,7 +49,9 @@ describe("context tracker — Fix 2: output tokens included", () => {
 
     const ctx = useThreadStore.getState().contextByThread[THREAD];
     expect(ctx?.lastTokensIn).toBe(5000);
-    expect(ctx?.contextWindow).toBe(200_000);
+    // Registry value (1M) for claude-sonnet-4-6 wins over the SDK-reported 200K
+    // because the registry preference chain now ranks registry above SDK.
+    expect(ctx?.contextWindow).toBe(1_000_000);
   });
 });
 

--- a/apps/web/src/__tests__/context-tracker.test.ts
+++ b/apps/web/src/__tests__/context-tracker.test.ts
@@ -49,9 +49,10 @@ describe("context tracker — Fix 2: output tokens included", () => {
 
     const ctx = useThreadStore.getState().contextByThread[THREAD];
     expect(ctx?.lastTokensIn).toBe(5000);
-    // Registry value (1M) for claude-sonnet-4-6 wins over the SDK-reported 200K
-    // because the registry preference chain now ranks registry above SDK.
-    expect(ctx?.contextWindow).toBe(1_000_000);
+    // SDK runtime value (200K) is truthful and wins over the static map.
+    // The new preference chain ranks SDK > static map > previous, so the
+    // SDK-reported 200K is what gets stored.
+    expect(ctx?.contextWindow).toBe(200_000);
   });
 });
 

--- a/apps/web/src/__tests__/context-window-preference-chain.test.ts
+++ b/apps/web/src/__tests__/context-window-preference-chain.test.ts
@@ -2,66 +2,56 @@ import { describe, it, expect } from "vitest";
 import { resolveContextWindow } from "@/lib/resolve-context-window";
 
 describe("resolveContextWindow preference chain", () => {
-  it("prefers user settings override when model matches default", () => {
+  it("prefers SDK runtime value when present (truthful, post-fallback)", () => {
     expect(
       resolveContextWindow({
         sdkContextWindow: 200_000,
         modelId: "claude-sonnet-4-6",
-        defaultModelId: "claude-sonnet-4-6",
-        settingsContextWindow: 500_000,   // user's override
-        registryContextWindow: 1_000_000, // registry would give this
-        previousContextWindow: undefined,
-      }),
-    ).toBe(500_000); // user's override wins
-  });
-
-  it("ignores user settings override when model differs from default", () => {
-    expect(
-      resolveContextWindow({
-        sdkContextWindow: 200_000,
-        modelId: "claude-haiku-4-5",
-        defaultModelId: "claude-sonnet-4-6",
-        settingsContextWindow: 1_000_000,
-        registryContextWindow: 200_000,
+        contextWindowMode: "1m",
         previousContextWindow: undefined,
       }),
     ).toBe(200_000);
   });
 
-  it("falls back to registry when no user override", () => {
+  it("returns 1M when mode is '1m' and the model supports it", () => {
     expect(
       resolveContextWindow({
-        sdkContextWindow: 200_000,
+        sdkContextWindow: undefined,
         modelId: "claude-sonnet-4-6",
-        defaultModelId: "claude-sonnet-4-6",
-        settingsContextWindow: undefined,
-        registryContextWindow: 1_000_000,
+        contextWindowMode: "1m",
         previousContextWindow: undefined,
       }),
     ).toBe(1_000_000);
   });
 
-  it("falls back to SDK when registry has no value", () => {
+  it("returns the standard window when mode is '200k'", () => {
     expect(
       resolveContextWindow({
-        sdkContextWindow: 200_000,
-        modelId: "unknown-model",
-        defaultModelId: "claude-sonnet-4-6",
-        settingsContextWindow: undefined,
-        registryContextWindow: undefined,
+        sdkContextWindow: undefined,
+        modelId: "claude-sonnet-4-6",
+        contextWindowMode: "200k",
         previousContextWindow: undefined,
       }),
     ).toBe(200_000);
   });
 
-  it("falls back to previously stored value as last resort", () => {
+  it("falls back to default 200k for models that don't support 1M", () => {
+    expect(
+      resolveContextWindow({
+        sdkContextWindow: undefined,
+        modelId: "claude-haiku-4-5",
+        contextWindowMode: "1m",
+        previousContextWindow: undefined,
+      }),
+    ).toBe(200_000);
+  });
+
+  it("falls back to previously stored value when nothing else has a value", () => {
     expect(
       resolveContextWindow({
         sdkContextWindow: undefined,
         modelId: "unknown-model",
-        defaultModelId: "claude-sonnet-4-6",
-        settingsContextWindow: undefined,
-        registryContextWindow: undefined,
+        contextWindowMode: "200k",
         previousContextWindow: 128_000,
       }),
     ).toBe(128_000);
@@ -72,9 +62,7 @@ describe("resolveContextWindow preference chain", () => {
       resolveContextWindow({
         sdkContextWindow: undefined,
         modelId: "unknown-model",
-        defaultModelId: "claude-sonnet-4-6",
-        settingsContextWindow: undefined,
-        registryContextWindow: undefined,
+        contextWindowMode: "200k",
         previousContextWindow: undefined,
       }),
     ).toBeUndefined();

--- a/apps/web/src/__tests__/context-window-preference-chain.test.ts
+++ b/apps/web/src/__tests__/context-window-preference-chain.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { resolveContextWindow } from "@/lib/resolve-context-window";
+
+describe("resolveContextWindow preference chain", () => {
+  it("prefers user settings override when model matches default", () => {
+    expect(
+      resolveContextWindow({
+        sdkContextWindow: 200_000,
+        modelId: "claude-sonnet-4-6",
+        defaultModelId: "claude-sonnet-4-6",
+        settingsContextWindow: 500_000,   // user's override
+        registryContextWindow: 1_000_000, // registry would give this
+        previousContextWindow: undefined,
+      }),
+    ).toBe(500_000); // user's override wins
+  });
+
+  it("ignores user settings override when model differs from default", () => {
+    expect(
+      resolveContextWindow({
+        sdkContextWindow: 200_000,
+        modelId: "claude-haiku-4-5",
+        defaultModelId: "claude-sonnet-4-6",
+        settingsContextWindow: 1_000_000,
+        registryContextWindow: 200_000,
+        previousContextWindow: undefined,
+      }),
+    ).toBe(200_000);
+  });
+
+  it("falls back to registry when no user override", () => {
+    expect(
+      resolveContextWindow({
+        sdkContextWindow: 200_000,
+        modelId: "claude-sonnet-4-6",
+        defaultModelId: "claude-sonnet-4-6",
+        settingsContextWindow: undefined,
+        registryContextWindow: 1_000_000,
+        previousContextWindow: undefined,
+      }),
+    ).toBe(1_000_000);
+  });
+
+  it("falls back to SDK when registry has no value", () => {
+    expect(
+      resolveContextWindow({
+        sdkContextWindow: 200_000,
+        modelId: "unknown-model",
+        defaultModelId: "claude-sonnet-4-6",
+        settingsContextWindow: undefined,
+        registryContextWindow: undefined,
+        previousContextWindow: undefined,
+      }),
+    ).toBe(200_000);
+  });
+
+  it("falls back to previously stored value as last resort", () => {
+    expect(
+      resolveContextWindow({
+        sdkContextWindow: undefined,
+        modelId: "unknown-model",
+        defaultModelId: "claude-sonnet-4-6",
+        settingsContextWindow: undefined,
+        registryContextWindow: undefined,
+        previousContextWindow: 128_000,
+      }),
+    ).toBe(128_000);
+  });
+
+  it("returns undefined when no source has a value", () => {
+    expect(
+      resolveContextWindow({
+        sdkContextWindow: undefined,
+        modelId: "unknown-model",
+        defaultModelId: "claude-sonnet-4-6",
+        settingsContextWindow: undefined,
+        registryContextWindow: undefined,
+        previousContextWindow: undefined,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -48,6 +48,8 @@ export function createMockThread(overrides?: Partial<Thread>): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
     copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,

--- a/apps/web/src/__tests__/model-registry-context-window.test.ts
+++ b/apps/web/src/__tests__/model-registry-context-window.test.ts
@@ -1,23 +1,45 @@
 import { describe, it, expect } from "vitest";
-import { getContextWindow } from "@/lib/model-registry";
+import { getContextWindow, getModelContextWindow } from "@/lib/model-registry";
 
-describe("getContextWindow (Claude static values)", () => {
-  it("returns 1_000_000 for Opus 4.7", () => {
-    expect(getContextWindow("claude-opus-4-7")).toBe(1_000_000);
+describe("getContextWindow (legacy: model's default 200k window)", () => {
+  // The single-arg helper returns the model's *default* window. The 1M tier is
+  // an explicit opt-in via the mode parameter on `getModelContextWindow`.
+  it("returns 200_000 for Opus 4.7", () => {
+    expect(getContextWindow("claude-opus-4-7")).toBe(200_000);
   });
-  it("returns 1_000_000 for Opus 4.6", () => {
-    expect(getContextWindow("claude-opus-4-6")).toBe(1_000_000);
+  it("returns 200_000 for Opus 4.6", () => {
+    expect(getContextWindow("claude-opus-4-6")).toBe(200_000);
   });
-  it("returns 1_000_000 for Sonnet 4.6", () => {
-    expect(getContextWindow("claude-sonnet-4-6")).toBe(1_000_000);
+  it("returns 200_000 for Sonnet 4.6", () => {
+    expect(getContextWindow("claude-sonnet-4-6")).toBe(200_000);
   });
   it("returns 200_000 for Haiku 4.5", () => {
     expect(getContextWindow("claude-haiku-4-5")).toBe(200_000);
   });
-  it("resolves dated SDK variants via prefix match", () => {
-    expect(getContextWindow("claude-haiku-4-5-20251001")).toBe(200_000);
-  });
   it("returns undefined for Codex models (not populated statically)", () => {
     expect(getContextWindow("gpt-5.4")).toBeUndefined();
+  });
+});
+
+describe("getModelContextWindow (mode-aware)", () => {
+  it("returns 1_000_000 for Opus 4.7 in 1m mode", () => {
+    expect(getModelContextWindow("claude-opus-4-7", "1m")).toBe(1_000_000);
+  });
+  it("returns 1_000_000 for Opus 4.6 in 1m mode", () => {
+    expect(getModelContextWindow("claude-opus-4-6", "1m")).toBe(1_000_000);
+  });
+  it("returns 1_000_000 for Sonnet 4.6 in 1m mode", () => {
+    expect(getModelContextWindow("claude-sonnet-4-6", "1m")).toBe(1_000_000);
+  });
+  it("falls back to 200_000 for Haiku 4.5 even in 1m mode (not supported)", () => {
+    expect(getModelContextWindow("claude-haiku-4-5", "1m")).toBe(200_000);
+  });
+  it("returns 200_000 for any supported model in 200k mode", () => {
+    expect(getModelContextWindow("claude-opus-4-7", "200k")).toBe(200_000);
+    expect(getModelContextWindow("claude-sonnet-4-6", "200k")).toBe(200_000);
+  });
+  it("resolves dated SDK variants via prefix match", () => {
+    expect(getModelContextWindow("claude-haiku-4-5-20251001", "200k")).toBe(200_000);
+    expect(getModelContextWindow("claude-sonnet-4-6-20260101", "1m")).toBe(1_000_000);
   });
 });

--- a/apps/web/src/__tests__/model-registry-context-window.test.ts
+++ b/apps/web/src/__tests__/model-registry-context-window.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { getContextWindow } from "@/lib/model-registry";
+
+describe("getContextWindow (Claude static values)", () => {
+  it("returns 1_000_000 for Opus 4.7", () => {
+    expect(getContextWindow("claude-opus-4-7")).toBe(1_000_000);
+  });
+  it("returns 1_000_000 for Opus 4.6", () => {
+    expect(getContextWindow("claude-opus-4-6")).toBe(1_000_000);
+  });
+  it("returns 1_000_000 for Sonnet 4.6", () => {
+    expect(getContextWindow("claude-sonnet-4-6")).toBe(1_000_000);
+  });
+  it("returns 200_000 for Haiku 4.5", () => {
+    expect(getContextWindow("claude-haiku-4-5")).toBe(200_000);
+  });
+  it("resolves dated SDK variants via prefix match", () => {
+    expect(getContextWindow("claude-haiku-4-5-20251001")).toBe(200_000);
+  });
+  it("returns undefined for Codex models (not populated statically)", () => {
+    expect(getContextWindow("gpt-5.4")).toBeUndefined();
+  });
+});

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -67,7 +67,7 @@ describe("Settings-aware defaults", () => {
       settings: {
         ...getDefaultSettings(),
         model: {
-          defaults: { provider: "claude", id: "claude-opus-4-6", reasoning: "high", fallbackId: "" },
+          defaults: { provider: "claude", id: "claude-opus-4-6", reasoning: "high", fallbackId: "", contextWindow: "200k", thinking: false },
         },
       },
     });
@@ -79,7 +79,7 @@ describe("Settings-aware defaults", () => {
       settings: {
         ...getDefaultSettings(),
         model: {
-          defaults: { provider: "claude", id: "nonexistent-model", reasoning: "high", fallbackId: "" },
+          defaults: { provider: "claude", id: "nonexistent-model", reasoning: "high", fallbackId: "", contextWindow: "200k", thinking: false },
         },
       },
     });
@@ -95,7 +95,7 @@ describe("Settings-aware defaults", () => {
       settings: {
         ...getDefaultSettings(),
         model: {
-          defaults: { provider: "claude", id: "claude-sonnet-4-6", reasoning: "low", fallbackId: "" },
+          defaults: { provider: "claude", id: "claude-sonnet-4-6", reasoning: "low", fallbackId: "", contextWindow: "200k", thinking: false },
         },
       },
     });
@@ -111,7 +111,7 @@ describe("Settings-aware defaults", () => {
       settings: {
         ...getDefaultSettings(),
         model: {
-          defaults: { provider: "claude", id: "claude-opus-4-6", reasoning: "max", fallbackId: "" },
+          defaults: { provider: "claude", id: "claude-opus-4-6", reasoning: "max", fallbackId: "", contextWindow: "200k", thinking: false },
         },
       },
     });

--- a/apps/web/src/__tests__/model-selector-context-badge.test.ts
+++ b/apps/web/src/__tests__/model-selector-context-badge.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { formatContextWindow } from "@/components/chat/format-context-window";
+
+describe("formatContextWindow", () => {
+  it("formats 1M tokens", () => {
+    expect(formatContextWindow(1_000_000)).toBe("1M");
+  });
+
+  it("formats 200K tokens", () => {
+    expect(formatContextWindow(200_000)).toBe("200K");
+  });
+
+  it("formats 128K tokens", () => {
+    expect(formatContextWindow(128_000)).toBe("128K");
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(formatContextWindow(undefined)).toBeUndefined();
+  });
+
+  it("formats 2M tokens", () => {
+    expect(formatContextWindow(2_000_000)).toBe("2M");
+  });
+
+  it("formats fractional millions", () => {
+    expect(formatContextWindow(1_500_000)).toBe("1.5M");
+  });
+
+  it("rounds non-round K values", () => {
+    expect(formatContextWindow(8_192)).toBe("8K");
+  });
+});

--- a/apps/web/src/__tests__/thread-status.test.ts
+++ b/apps/web/src/__tests__/thread-status.test.ts
@@ -26,6 +26,8 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
     copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -79,6 +79,8 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
     copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1463,8 +1463,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           */}
           {(() => {
             const hasReasoning = reasoningLevels.length > 0;
-            const has1M = supports1MContextWindow(modelId);
-            const hasThinking = supportsThinkingToggle(modelId);
+            const has1M = provider === "claude" && supports1MContextWindow(modelId);
+            const hasThinking = provider === "claude" && supportsThinkingToggle(modelId);
             if (!hasReasoning && !has1M && !hasThinking) return null;
 
             const ctxMode: ContextWindowMode = contextWindow ?? settingsDefaultContextWindow ?? "200k";
@@ -1568,7 +1568,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                             key={mode}
                             onClick={() => {
                               setContextWindow(mode);
-                              if (threadId) void setThreadSettings(threadId, { contextWindow: mode });
+                              if (threadId && !branchFromMessageId) void setThreadSettings(threadId, { contextWindow: mode });
                             }}
                             className={itemClass(ctxMode === mode)}
                           >
@@ -1591,7 +1591,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                             key={String(value)}
                             onClick={() => {
                               setThinking(value);
-                              if (threadId) void setThreadSettings(threadId, { thinking: value });
+                              if (threadId && !branchFromMessageId) void setThreadSettings(threadId, { thinking: value });
                             }}
                             className={itemClass(thinkingOn === value)}
                           >

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, findModelById, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels } from "@/lib/model-registry";
+import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, findModelById, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, supportsUltrathink, supports1MContextWindow, supportsThinkingToggle, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels } from "@/lib/model-registry";
 import { ModelSelector } from "./ModelSelector";
 import { ModeSelector, ALL_MODE_OPTIONS } from "./ModeSelector";
 import type { ComposerMode, ModeOption } from "./ModeSelector";
@@ -58,7 +58,8 @@ import {
   inferMimeType,
   MAX_ATTACHMENTS,
 } from "@mcode/contracts";
-import type { ReasoningLevel } from "@mcode/contracts";
+import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
+import { getModelContextWindow } from "@mcode/shared/model-context";
 import type { ProviderId } from "@mcode/contracts";
 import { useComposerDraftStore } from "@/stores/composerDraftStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -67,11 +68,13 @@ import { useElementWidth } from "@/hooks/useElementWidth";
 import { ProviderUnavailableBanner } from "./ProviderUnavailableBanner";
 
 /** ReasoningLevel values as a Set for O(1) membership checks in the Codex level filter. */
-const VALID_REASONING_LEVELS_SET = new Set<string>(["low", "medium", "high", "xhigh", "max"]);
+const VALID_REASONING_LEVELS_SET = new Set<string>(["low", "medium", "high", "xhigh", "max", "ultrathink"]);
 
 /** Display label for a reasoning level value. */
 function reasoningLabel(level: string): string {
-  return level === "xhigh" ? "X-High" : level.charAt(0).toUpperCase() + level.slice(1);
+  if (level === "xhigh") return "X-High";
+  if (level === "ultrathink") return "Ultrathink";
+  return level.charAt(0).toUpperCase() + level.slice(1);
 }
 
 interface ComposerProps {
@@ -371,6 +374,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const [reasoning, setReasoning] = useState<ReasoningLevel>(getDefaultReasoningLevel());
   const [mode, setMode] = useState<InteractionMode>(INTERACTION_MODES.CHAT);
   const [copilotAgent, setCopilotAgent] = useState<string | null>(null);
+  // Per-thread overrides; null/undefined means inherit from settings default.
+  const [contextWindow, setContextWindow] = useState<ContextWindowMode | null>(null);
+  const [thinking, setThinking] = useState<boolean | null>(null);
   const [access, setAccess] = useState<AccessMode>(PERMISSION_MODES.FULL);
   const [showReasoningPicker, setShowReasoningPicker] = useState(false);
   const [composerMode, setComposerModeLocal] = useState<ComposerMode>("direct");
@@ -386,7 +392,15 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const editorContainerRef = useRef<HTMLDivElement>(null);
 
   const prevThreadIdRef = useRef<string | undefined>(threadId);
-  const draftRef = useRef({ input, attachments, modelId, provider, reasoning });
+  const draftRef = useRef<{
+    input: string;
+    attachments: PendingAttachment[];
+    modelId: string;
+    provider: string;
+    reasoning: ReasoningLevel;
+    contextWindow?: ContextWindowMode;
+    thinking?: boolean;
+  }>({ input, attachments, modelId, provider, reasoning });
   /** Tracks whether the user toggled mode/access before settings finished loading. */
   const agentSettingsTouchedRef = useRef(false);
   /** Set to true by the thread-switch effect; cleared by the model-sync effect.
@@ -395,7 +409,15 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
   // Keep draft ref in sync so the thread-switch effect reads current values
   useEffect(() => {
-    draftRef.current = { input, attachments, modelId, provider, reasoning };
+    draftRef.current = {
+      input,
+      attachments,
+      modelId,
+      provider,
+      reasoning,
+      contextWindow: contextWindow ?? undefined,
+      thinking: thinking ?? undefined,
+    };
   });
 
   const saveDraft = useComposerDraftStore((s) => s.saveDraft);
@@ -411,6 +433,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const settingsDefaultReasoning = useSettingsStore((s) => s.settings.model.defaults.reasoning);
   const settingsDefaultMode = useSettingsStore((s) => s.settings.agent.defaults.mode);
   const settingsDefaultPermission = useSettingsStore((s) => s.settings.agent.defaults.permission);
+  const settingsDefaultContextWindow = useSettingsStore((s) => s.settings.model.defaults.contextWindow);
+  const settingsDefaultThinking = useSettingsStore((s) => s.settings.model.defaults.thinking);
 
   useEffect(() => {
     if (!settingsLoaded) return;
@@ -483,6 +507,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         setMode(threadSettings.interactionMode);
         setAccess(threadSettings.permissionMode);
         setCopilotAgent(threadSettings.copilotAgent ?? null);
+        setContextWindow(threadSettings.contextWindow ?? null);
+        setThinking(threadSettings.thinking ?? null);
       } else {
         // No saved draft: use thread's persisted settings as-is
         setInput("");
@@ -515,6 +541,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             : globalSettings.agent.defaults.permission,
         );
         setCopilotAgent(nextThread?.copilot_agent ?? null);
+        setContextWindow((nextThread?.context_window_mode as ContextWindowMode | null | undefined) ?? null);
+        setThinking(nextThread?.thinking ?? null);
 
         // Reset Lexical editor
         if (editorRef.current) {
@@ -538,6 +566,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       setMode(settings.agent.defaults.mode === "plan" ? INTERACTION_MODES.PLAN : INTERACTION_MODES.CHAT);
       setAccess(settings.agent.defaults.permission);
       setCopilotAgent(null);
+      setContextWindow(null);
+      setThinking(null);
       if (editorRef.current) {
         editorRef.current.update(() => {
           const root = $getRoot();
@@ -1103,6 +1133,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         reasoningLevel: reasoning,
         provider,
         copilotAgent: provider === "copilot" ? (copilotAgent ?? undefined) : undefined,
+        contextWindow: contextWindow ?? undefined,
+        thinking: thinking ?? undefined,
       });
 
       setInput("");
@@ -1160,7 +1192,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         setPreparingWorktree(true);
       }
       try {
-        await useWorkspaceStore.getState().createAndSendMessage(messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, reasoning, provider, mode, provider === "copilot" ? (copilotAgent ?? undefined) : undefined);
+        await useWorkspaceStore.getState().createAndSendMessage(messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, reasoning, provider, mode, provider === "copilot" ? (copilotAgent ?? undefined) : undefined, contextWindow ?? undefined, thinking ?? undefined);
       } finally {
         setPreparingWorktree(false);
       }
@@ -1196,10 +1228,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         existingWorktreePath: branchWorktree,
         forkedFromMessageId: branchFromMessageId,
         copilotAgent: provider === "copilot" ? (copilotAgent ?? undefined) : undefined,
+        contextWindow: contextWindow ?? undefined,
+        thinking: thinking ?? undefined,
       });
       onBranchModeExit?.();
     } else if (threadId) {
-      await sendMessage(threadId, messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, displayContent, reasoning, provider, provider === "copilot" ? (copilotAgent ?? undefined) : undefined);
+      await sendMessage(threadId, messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, displayContent, reasoning, provider, provider === "copilot" ? (copilotAgent ?? undefined) : undefined, contextWindow ?? undefined, thinking ?? undefined);
     }
 
     // Auto-save last-used mode and access as defaults (model defaults are managed in Settings)
@@ -1216,7 +1250,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
 
     editorRef.current?.focus();
-  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, branchAutoPreview, onBranchModeExit]);
+  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, contextWindow, thinking, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, branchAutoPreview, onBranchModeExit]);
 
   const handleEditorChange = useCallback((text: string) => {
     setInput(text);
@@ -1288,14 +1322,20 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       "high",
       ...(isXhighEffortModel(modelId) ? (["xhigh"] as const) : []),
       ...(isMaxEffortModel(modelId)   ? (["max"]   as const) : []),
+      ...(supportsUltrathink(modelId) ? (["ultrathink"] as const) : []),
     ];
   }, [modelId, provider]);
 
-  // Close the picker when the user switches to a model with no effort tiers (e.g. Haiku).
-  // Without this the popover stays open and points at nothing.
+  // Close the unified preferences picker when the active model exposes no
+  // knobs at all (no reasoning tiers, no 1M opt-in, no thinking toggle).
+  // Without this the popover would stay open pointing at an empty container.
+  const has1MCapability = supports1MContextWindow(modelId);
+  const hasThinkingCapability = supportsThinkingToggle(modelId);
   useEffect(() => {
-    if (reasoningLevels.length === 0) setShowReasoningPicker(false);
-  }, [reasoningLevels.length]);
+    if (reasoningLevels.length === 0 && !has1MCapability && !hasThinkingCapability) {
+      setShowReasoningPicker(false);
+    }
+  }, [reasoningLevels.length, has1MCapability, hasThinkingCapability]);
 
   return (
     <div className="relative px-8 py-4">
@@ -1414,53 +1454,158 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             providerLocked={isProviderLocked}
           />
 
-          {/* Reasoning level — hidden for models that have no effort tiers (e.g. Haiku) */}
-          {reasoningLevels.length > 0 && (
-          <div className="relative">
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowReasoningPicker(!showReasoningPicker);
-                    }}
-                    className="gap-1.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors"
+          {/*
+            Unified model-preferences popover. Combines reasoning effort,
+            context window (1M opt-in), and the Haiku thinking toggle into a
+            single trigger so the composer toolbar stays compact. The trigger
+            is hidden when the active model exposes none of these knobs.
+            Sections render conditionally based on model capability.
+          */}
+          {(() => {
+            const hasReasoning = reasoningLevels.length > 0;
+            const has1M = supports1MContextWindow(modelId);
+            const hasThinking = supportsThinkingToggle(modelId);
+            if (!hasReasoning && !has1M && !hasThinking) return null;
+
+            const ctxMode: ContextWindowMode = contextWindow ?? settingsDefaultContextWindow ?? "200k";
+            const thinkingOn: boolean = thinking ?? settingsDefaultThinking ?? false;
+
+            // Trigger label: reasoning level when present; falls back to a
+            // bare "Thinking" or the active context mode for models that only
+            // expose those knobs. Active state (1M / Thinking on) is conveyed
+            // through a trailing chip rather than rewriting the label, so the
+            // trigger width stays stable as users toggle.
+            const triggerLabel = hasReasoning
+              ? reasoningLabel(reasoning)
+              : hasThinking
+                ? "Thinking"
+                : ctxMode === "1m" ? "1M" : "200K";
+
+            // Show a trailing chip for any active "extension" of the base
+            // model behaviour: 1M context (when reasoning is also visible),
+            // or thinking-on (when thinking is the only knob). When context
+            // is the only knob, the mode is already in the trigger label, so
+            // no chip is needed.
+            const activeChipLabel = hasReasoning && has1M && ctxMode === "1m"
+              ? "1M"
+              : !hasReasoning && hasThinking && thinkingOn
+                ? "ON"
+                : null;
+
+            const tooltipLabel = hasReasoning
+              ? has1M || hasThinking ? "Reasoning, context & thinking" : "Reasoning level"
+              : hasThinking
+                ? "Thinking"
+                : "Context window";
+
+            const sectionHeaderClass = "px-3 pt-1.5 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none";
+            const itemClass = (active: boolean) => cn(
+              "flex w-full items-center justify-between rounded px-3 py-1.5 text-xs",
+              active
+                ? "bg-accent text-foreground"
+                : "text-popover-foreground hover:bg-accent/50 hover:text-foreground",
+            );
+
+            return (
+              <div className="relative">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setShowReasoningPicker(!showReasoningPicker);
+                        }}
+                        className="gap-1.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors"
+                      >
+                        <span className="text-sm">{triggerLabel}</span>
+                        {activeChipLabel && (
+                          <span
+                            data-testid="composer-1m-badge"
+                            className="rounded-sm bg-foreground/5 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-foreground/80 ring-1 ring-inset ring-foreground/10 tabular-nums"
+                          >
+                            {activeChipLabel}
+                          </span>
+                        )}
+                        <ChevronDown size={11} />
+                      </Button>
+                    }
+                  />
+                  <TooltipContent>{tooltipLabel}</TooltipContent>
+                </Tooltip>
+                {showReasoningPicker && (
+                  <div
+                    onClick={(e) => e.stopPropagation()}
+                    className="absolute bottom-full left-0 z-20 mb-1 min-w-[224px] rounded-md border border-border bg-popover p-1 shadow-lg animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150"
                   >
-                    <span className="text-sm">{reasoningLabel(reasoning)}</span>
-                    <ChevronDown size={11} />
-                  </Button>
-                }
-              />
-              <TooltipContent>Reasoning level</TooltipContent>
-            </Tooltip>
-            {showReasoningPicker && (
-              <div className="absolute bottom-full left-0 z-20 mb-1 rounded-md border border-border bg-card p-1 shadow-lg">
-                {reasoningLevels.map((level) => (
-                  <button
-                    key={level}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setReasoning(level);
-                      if (threadId) void setThreadSettings(threadId, { reasoningLevel: level });
-                      setShowReasoningPicker(false);
-                    }}
-                    className={cn(
-                      "flex w-full items-center rounded px-3 py-1.5 text-xs",
-                      reasoning === level
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                    {hasReasoning && (
+                      <>
+                        <div className={sectionHeaderClass}>Reasoning effort</div>
+                        {reasoningLevels.map((level) => (
+                          <button
+                            key={level}
+                            onClick={() => {
+                              setReasoning(level);
+                              if (threadId) void setThreadSettings(threadId, { reasoningLevel: level });
+                            }}
+                            className={itemClass(reasoning === level)}
+                          >
+                            <span>{reasoningLabel(level)}</span>
+                            {reasoning === level && <Check size={10} className="shrink-0 text-foreground" />}
+                          </button>
+                        ))}
+                      </>
                     )}
-                  >
-                    {reasoningLabel(level)}
-                  </button>
-                ))}
+
+                    {has1M && (
+                      <>
+                        {hasReasoning && <div className="my-1 h-px bg-border/60" />}
+                        <div className={sectionHeaderClass}>Context window</div>
+                        {(["200k", "1m"] as const).map((mode) => (
+                          <button
+                            key={mode}
+                            onClick={() => {
+                              setContextWindow(mode);
+                              if (threadId) void setThreadSettings(threadId, { contextWindow: mode });
+                            }}
+                            className={itemClass(ctxMode === mode)}
+                          >
+                            <span className="tabular-nums">{mode === "1m" ? "1M tokens" : "200K tokens"}</span>
+                            {ctxMode === mode && <Check size={10} className="shrink-0 text-foreground" />}
+                          </button>
+                        ))}
+                      </>
+                    )}
+
+                    {hasThinking && (
+                      <>
+                        {(hasReasoning || has1M) && <div className="my-1 h-px bg-border/60" />}
+                        <div className={sectionHeaderClass}>Thinking</div>
+                        {[
+                          { value: false, label: "Off" },
+                          { value: true, label: "On" },
+                        ].map(({ value, label }) => (
+                          <button
+                            key={String(value)}
+                            onClick={() => {
+                              setThinking(value);
+                              if (threadId) void setThreadSettings(threadId, { thinking: value });
+                            }}
+                            className={itemClass(thinkingOn === value)}
+                          >
+                            <span>{label}</span>
+                            {thinkingOn === value && <Check size={10} className="shrink-0 text-foreground" />}
+                          </button>
+                        ))}
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
-          )}
+            );
+          })()}
 
           {/*
             Copilot exposes a per-agent selector inline (replaces Chat/Plan
@@ -1577,15 +1722,25 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             />
           )}
 
-          {/* Context window tracker — live data from turnComplete, fallback to persisted thread record */}
-          {threadId && (
-            <ContextTracker
-              tokensIn={contextEntry?.lastTokensIn ?? activeThread?.last_context_tokens ?? 0}
-              contextWindow={contextEntry?.contextWindow ?? activeThread?.context_window ?? undefined}
-              totalProcessedTokens={contextEntry?.totalProcessedTokens}
-              hasLowQuota={hasLowQuota}
-            />
-          )}
+          {/* Context window tracker — live data from turnComplete, fallback to persisted thread record.
+              Always resolve the denominator against the current model + mode so switching from a 1M model
+              to Haiku immediately reflects 200K rather than the stale SDK-reported 1M value. */}
+          {threadId && (() => {
+            const effectiveCtxMode: ContextWindowMode = contextWindow ?? settingsDefaultContextWindow ?? "200k";
+            const trackerContextWindow =
+              getModelContextWindow(modelId, effectiveCtxMode) ??
+              contextEntry?.contextWindow ??
+              activeThread?.context_window ??
+              undefined;
+            return (
+              <ContextTracker
+                tokensIn={contextEntry?.lastTokensIn ?? activeThread?.last_context_tokens ?? 0}
+                contextWindow={trackerContextWindow}
+                totalProcessedTokens={contextEntry?.totalProcessedTokens}
+                hasLowQuota={hasLowQuota}
+              />
+            );
+          })()}
 
           {/* Send / Queue / Stop button */}
           <button

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -86,6 +86,8 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
     copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -105,9 +105,16 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     }
   }, []);
 
-  /** Returns live models for a provider, falling back to the static registry. */
-  const getModels = (p: ModelProvider): ModelProvider["models"] =>
-    dynamicModels.get(p.id) ?? p.models;
+  /**
+   * Returns live models for a provider, falling back to the static registry.
+   * Empty dynamic lists fall through to the static registry — `listClaudeModels`
+   * returns `[]` when ANTHROPIC_API_KEY is unset, and `??` does not fall
+   * through on a truthy empty array, which would hide all Claude models.
+   */
+  const getModels = (p: ModelProvider): ModelProvider["models"] => {
+    const dynamic = dynamicModels.get(p.id);
+    return dynamic && dynamic.length > 0 ? dynamic : p.models;
+  };
 
   // Delayed hover close so user has time to move to submenu
   const setHoveredWithDelay = (providerId: string | null) => {

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, type ComponentType } from "react";
 import { ChevronDown, ChevronRight, Lock, Check, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { formatContextWindow } from "./format-context-window";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -195,28 +196,36 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     m: ModelProvider["models"][0],
     providerId: string,
     isSelected: (id: string) => boolean
-  ) => (
-    <button
-      key={m.id}
-      onClick={() => handleSelectModel(m.id, providerId)}
-      className={cn(
-        "flex w-full items-center gap-2 rounded px-3 py-1.5 text-xs",
-        isSelected(m.id)
-          ? "bg-accent text-foreground"
-          : "text-popover-foreground hover:bg-accent/50 hover:text-foreground"
-      )}
-    >
-      <span className="flex-1 text-left">{m.label}</span>
-      {m.multiplier != null && (
-        <span className="text-[10px] text-muted-foreground/60 tabular-nums">
-          {m.multiplier}x
-        </span>
-      )}
-      {isSelected(m.id) && (
-        <Check size={10} className="shrink-0 text-foreground" />
-      )}
-    </button>
-  );
+  ) => {
+    const ctxLabel = formatContextWindow(m.contextWindow);
+    return (
+      <button
+        key={m.id}
+        onClick={() => handleSelectModel(m.id, providerId)}
+        className={cn(
+          "flex w-full items-center gap-2 rounded px-3 py-1.5 text-xs",
+          isSelected(m.id)
+            ? "bg-accent text-foreground"
+            : "text-popover-foreground hover:bg-accent/50 hover:text-foreground"
+        )}
+      >
+        <span className="flex-1 text-left">{m.label}</span>
+        {ctxLabel && (
+          <span className="text-[10px] text-muted-foreground/60 tabular-nums">
+            {ctxLabel}
+          </span>
+        )}
+        {m.multiplier != null && (
+          <span className="text-[10px] text-muted-foreground/60 tabular-nums">
+            {m.multiplier}x
+          </span>
+        )}
+        {isSelected(m.id) && (
+          <Check size={10} className="shrink-0 text-foreground" />
+        )}
+      </button>
+    );
+  };
 
   const renderGroupedModels = (
     models: ModelProvider["models"],

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -84,6 +84,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
         label: m.name,
         providerId,
         group: m.group,
+        contextWindow: m.contextWindow,
         multiplier: m.multiplier,
       }));
       const updated = new Map(dynamicModelsRef.current).set(providerId, mapped);

--- a/apps/web/src/components/chat/format-context-window.ts
+++ b/apps/web/src/components/chat/format-context-window.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats a context window token count for compact badge display.
+ *
+ * - >= 1,000,000 tokens: "1M", "1.5M", "2M"
+ * - < 1,000,000 tokens: "200K", "128K"
+ * - undefined input: returns undefined (no badge)
+ */
+export function formatContextWindow(tokens: number | undefined): string | undefined {
+  if (tokens === undefined) return undefined;
+  if (tokens >= 1_000_000) {
+    const millions = tokens / 1_000_000;
+    return `${millions}M`;
+  }
+  return `${Math.round(tokens / 1_000)}K`;
+}

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -10,6 +10,7 @@ import {
   supportsEffortParameter,
   normalizeReasoningLevelForModel,
   getCodexReasoningLevels,
+  getContextWindow,
 } from "@/lib/model-registry";
 import { SettingRow } from "../SettingRow";
 import { SegControl } from "../SegControl";
@@ -110,6 +111,9 @@ export function ModelSection() {
   const modelId = useSettingsStore((s) => s.settings.model.defaults.id);
   const fallbackId = useSettingsStore((s) => s.settings.model.defaults.fallbackId);
   const reasoning = useSettingsStore((s) => s.settings.model.defaults.reasoning);
+  const contextWindowOverride = useSettingsStore(
+    (s) => s.settings.model.defaults.contextWindow,
+  );
   const prDraftProvider = useSettingsStore((s) => s.settings.prDraft.provider);
   const prDraftModel = useSettingsStore((s) => s.settings.prDraft.model);
   const update = useSettingsStore((s) => s.update);
@@ -373,6 +377,39 @@ export function ModelSection() {
             onChange={(v) =>
               update({ model: { defaults: { reasoning: v as ReasoningLevel } } })
             }
+          />
+        </SettingRow>
+      )}
+
+      {provider === "claude" && (
+        <SettingRow
+          label="Context window"
+          configKey="model.defaults.contextWindow"
+          hint="Override the context window (tokens) for the default model. Leave empty to use the API or static value."
+        >
+          <input
+            type="number"
+            min={1}
+            max={2_000_000}
+            step={1000}
+            placeholder={String(getContextWindow(modelId) ?? "")}
+            value={contextWindowOverride ?? ""}
+            onChange={(e) => {
+              const raw = e.target.value.trim();
+              if (raw === "") {
+                void update({ model: { defaults: { contextWindow: undefined } } });
+                return;
+              }
+              const coerced = Math.round(Number(raw));
+              void update({
+                model: {
+                  defaults: {
+                    contextWindow: coerced > 0 ? coerced : undefined,
+                  },
+                },
+              });
+            }}
+            className="h-7 w-36 rounded-[min(var(--radius-md),12px)] border border-input bg-background px-2 py-0.5 text-xs text-foreground tabular-nums placeholder:text-muted-foreground/50 focus-visible:border-ring focus-visible:outline-none"
           />
         </SettingRow>
       )}

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -8,14 +8,16 @@ import {
   isMaxEffortModel,
   isXhighEffortModel,
   supportsEffortParameter,
+  supportsUltrathink,
+  supports1MContextWindow,
+  supportsThinkingToggle,
   normalizeReasoningLevelForModel,
   getCodexReasoningLevels,
-  getContextWindow,
 } from "@/lib/model-registry";
 import { SettingRow } from "../SettingRow";
 import { SegControl } from "../SegControl";
 import { SectionHeading } from "../SectionHeading";
-import type { ProviderAvailability, SettingsProviderId, ReasoningLevel } from "@mcode/contracts";
+import type { ContextWindowMode, ProviderAvailability, SettingsProviderId, ReasoningLevel } from "@mcode/contracts";
 import { ChevronDown } from "lucide-react";
 import {
   ClaudeIcon,
@@ -111,9 +113,10 @@ export function ModelSection() {
   const modelId = useSettingsStore((s) => s.settings.model.defaults.id);
   const fallbackId = useSettingsStore((s) => s.settings.model.defaults.fallbackId);
   const reasoning = useSettingsStore((s) => s.settings.model.defaults.reasoning);
-  const contextWindowOverride = useSettingsStore(
+  const contextWindowMode = useSettingsStore(
     (s) => s.settings.model.defaults.contextWindow,
   );
+  const thinking = useSettingsStore((s) => s.settings.model.defaults.thinking);
   const prDraftProvider = useSettingsStore((s) => s.settings.prDraft.provider);
   const prDraftModel = useSettingsStore((s) => s.settings.prDraft.model);
   const update = useSettingsStore((s) => s.update);
@@ -193,12 +196,13 @@ export function ModelSection() {
     if (provider === "copilot") {
       return REASONING_OPTIONS_BASE;
     }
-    // Claude: correct tier order is Low, Medium, High, X-High, Max.
-    // X-High and Max are disabled unless the selected model supports them.
+    // Claude: correct tier order is Low, Medium, High, X-High, Max, Ultrathink.
+    // Tiers above the model's ceiling are disabled.
     return [
       ...REASONING_OPTIONS_BASE,
-      { value: "xhigh", label: "X-High", disabled: !isXhighEffortModel(modelId) },
-      { value: "max",   label: "Max",    disabled: !isMaxEffortModel(modelId) },
+      { value: "xhigh",      label: "X-High",     disabled: !isXhighEffortModel(modelId) },
+      { value: "max",        label: "Max",        disabled: !isMaxEffortModel(modelId) },
+      { value: "ultrathink", label: "Ultrathink", disabled: !supportsUltrathink(modelId) },
     ];
   }, [modelId, codexLevels, provider]);
 
@@ -211,7 +215,7 @@ export function ModelSection() {
     if (provider === "copilot") {
       return "Reasoning effort passed to the Copilot model. Not all models support all levels.";
     }
-    return "Default reasoning level. Max requires Opus 4.7, Opus 4.6, or Sonnet 4.6. X-High requires Opus 4.7.";
+    return "Default reasoning level. Max and Ultrathink require Opus 4.7/4.6 or Sonnet 4.6. X-High requires Opus 4.7. Ultrathink prepends an explicit instruction to the prompt.";
   }, [codexLevels, provider]);
 
   const handleProviderChange = (v: string) => {
@@ -385,31 +389,36 @@ export function ModelSection() {
         <SettingRow
           label="Context window"
           configKey="model.defaults.contextWindow"
-          hint="Override the context window (tokens) for the default model. Leave empty to use the API or static value."
+          hint="200k is the standard window. 1M unlocks the extended beta window on Opus 4.7/4.6 and Sonnet 4.6."
         >
-          <input
-            type="number"
-            min={1}
-            max={2_000_000}
-            step={1000}
-            placeholder={String(getContextWindow(modelId) ?? "")}
-            value={contextWindowOverride ?? ""}
-            onChange={(e) => {
-              const raw = e.target.value.trim();
-              if (raw === "") {
-                void update({ model: { defaults: { contextWindow: undefined } } });
-                return;
-              }
-              const coerced = Math.round(Number(raw));
-              void update({
-                model: {
-                  defaults: {
-                    contextWindow: coerced > 0 ? coerced : undefined,
-                  },
-                },
-              });
-            }}
-            className="h-7 w-36 rounded-[min(var(--radius-md),12px)] border border-input bg-background px-2 py-0.5 text-xs text-foreground tabular-nums placeholder:text-muted-foreground/50 focus-visible:border-ring focus-visible:outline-none"
+          <SegControl
+            options={[
+              { value: "200k", label: "200K" },
+              { value: "1m",   label: "1M",   disabled: !supports1MContextWindow(modelId) },
+            ]}
+            value={contextWindowMode}
+            onChange={(v) =>
+              update({ model: { defaults: { contextWindow: v as ContextWindowMode } } })
+            }
+          />
+        </SettingRow>
+      )}
+
+      {provider === "claude" && supportsThinkingToggle(modelId) && (
+        <SettingRow
+          label="Thinking"
+          configKey="model.defaults.thinking"
+          hint="Enable extended thinking for Haiku 4.5. Effort-tier models ignore this and use the reasoning level instead."
+        >
+          <SegControl
+            options={[
+              { value: "off", label: "Off" },
+              { value: "on",  label: "On"  },
+            ]}
+            value={thinking ? "on" : "off"}
+            onChange={(v) =>
+              update({ model: { defaults: { thinking: v === "on" } } })
+            }
           />
         </SettingRow>
       )}

--- a/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
@@ -90,14 +90,14 @@ describe("ModelSection reasoning options", () => {
     vi.clearAllMocks();
   });
 
-  it("renders reasoning options in order: Low, Medium, High, X-High, Max for Claude Opus 4.7", () => {
+  it("renders reasoning options in order: Low, Medium, High, X-High, Max, Ultrathink for Claude Opus 4.7", () => {
     renderWithModel("claude", "claude-opus-4-7");
 
     const row = getReasoningRow();
     const radios = within(row).getAllByRole("radio");
     const labels = radios.map((r) => r.textContent?.trim());
 
-    expect(labels).toEqual(["Low", "Medium", "High", "X-High", "Max"]);
+    expect(labels).toEqual(["Low", "Medium", "High", "X-High", "Max", "Ultrathink"]);
   });
 
   it("X-High is enabled for Claude Opus 4.7", () => {

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -93,6 +93,8 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     reasoning_level: null,
     interaction_mode: null,
     permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
     copilot_agent: null,
     parent_thread_id: null,
     forked_from_message_id: null,

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -1,5 +1,6 @@
 import { useSettingsStore } from "@/stores/settingsStore";
 import type { ReasoningLevel } from "@mcode/contracts";
+import { MODEL_CONTEXT_WINDOWS } from "@mcode/shared/model-context";
 
 // Import from the subpath, NOT the barrel. The barrel re-exports
 // winston-bound logging at the top of index.ts, which throws
@@ -57,10 +58,14 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     comingSoon: false,
     supportsCompletion: true,
     models: [
-      { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude" },
-      { id: "claude-opus-4-6", label: "Claude Opus 4.6", providerId: "claude" },
-      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providerId: "claude" },
-      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providerId: "claude" },
+      { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude",
+        contextWindow: MODEL_CONTEXT_WINDOWS["claude-opus-4-7"] },
+      { id: "claude-opus-4-6", label: "Claude Opus 4.6", providerId: "claude",
+        contextWindow: MODEL_CONTEXT_WINDOWS["claude-opus-4-6"] },
+      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providerId: "claude",
+        contextWindow: MODEL_CONTEXT_WINDOWS["claude-sonnet-4-6"] },
+      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providerId: "claude",
+        contextWindow: MODEL_CONTEXT_WINDOWS["claude-haiku-4-5"] },
     ],
   },
   {

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -2,6 +2,7 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
 import {
   MODEL_CONTEXT_WINDOWS_DEFAULT,
+  MODEL_CONTEXT_WINDOWS_EXTENDED,
   getModelContextWindow as sharedGetModelContextWindow,
 } from "@mcode/shared/model-context";
 
@@ -66,11 +67,11 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     supportsModelListing: true,
     models: [
       { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-7"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_EXTENDED["claude-opus-4-7"] },
       { id: "claude-opus-4-6", label: "Claude Opus 4.6", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-6"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_EXTENDED["claude-opus-4-6"] },
       { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-sonnet-4-6"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_EXTENDED["claude-sonnet-4-6"] },
       { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providerId: "claude",
         contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-haiku-4-5"] },
     ],

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -2,7 +2,6 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
 import {
   MODEL_CONTEXT_WINDOWS_DEFAULT,
-  MODEL_CONTEXT_WINDOWS_EXTENDED,
   getModelContextWindow as sharedGetModelContextWindow,
 } from "@mcode/shared/model-context";
 
@@ -67,11 +66,11 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     supportsModelListing: true,
     models: [
       { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_EXTENDED["claude-opus-4-7"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-7"] },
       { id: "claude-opus-4-6", label: "Claude Opus 4.6", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_EXTENDED["claude-opus-4-6"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-6"] },
       { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_EXTENDED["claude-sonnet-4-6"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-sonnet-4-6"] },
       { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providerId: "claude",
         contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-haiku-4-5"] },
     ],

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -57,6 +57,7 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     name: "Claude",
     comingSoon: false,
     supportsCompletion: true,
+    supportsModelListing: true,
     models: [
       { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude",
         contextWindow: MODEL_CONTEXT_WINDOWS["claude-opus-4-7"] },

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -1,6 +1,9 @@
 import { useSettingsStore } from "@/stores/settingsStore";
-import type { ReasoningLevel } from "@mcode/contracts";
-import { MODEL_CONTEXT_WINDOWS } from "@mcode/shared/model-context";
+import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
+import {
+  MODEL_CONTEXT_WINDOWS_DEFAULT,
+  getModelContextWindow as sharedGetModelContextWindow,
+} from "@mcode/shared/model-context";
 
 // Import from the subpath, NOT the barrel. The barrel re-exports
 // winston-bound logging at the top of index.ts, which throws
@@ -10,6 +13,9 @@ export {
   isXhighEffortModel,
   isMaxEffortModel,
   supportsEffortParameter,
+  supportsUltrathink,
+  supports1MContextWindow,
+  supportsThinkingToggle,
   normalizeReasoningLevelForModel,
 } from "@mcode/shared/model-effort";
 
@@ -60,13 +66,13 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     supportsModelListing: true,
     models: [
       { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS["claude-opus-4-7"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-7"] },
       { id: "claude-opus-4-6", label: "Claude Opus 4.6", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS["claude-opus-4-6"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-6"] },
       { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS["claude-sonnet-4-6"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-sonnet-4-6"] },
       { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS["claude-haiku-4-5"] },
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-haiku-4-5"] },
     ],
   },
   {
@@ -228,7 +234,7 @@ export function getDefaultProviderId(): string {
 }
 
 /** Valid reasoning levels for fallback validation. */
-const VALID_REASONING_LEVELS: readonly string[] = ["low", "medium", "high", "max", "xhigh"];
+const VALID_REASONING_LEVELS: readonly string[] = ["low", "medium", "high", "max", "xhigh", "ultrathink"];
 
 /**
  * Return the default reasoning level from user settings, falling back
@@ -242,6 +248,18 @@ export function getDefaultReasoningLevel(): ReasoningLevel {
 /** Returns the context window size for a model, if statically known. */
 export function getContextWindow(modelId: string): number | undefined {
   return findModelById(modelId)?.contextWindow;
+}
+
+/**
+ * Returns the active context window (tokens) for a model and the user's
+ * selected mode. "1m" yields the extended window only when the model supports
+ * it; otherwise falls through to the model's default 200k window.
+ */
+export function getModelContextWindow(
+  modelId: string,
+  mode: ContextWindowMode = "200k",
+): number | undefined {
+  return sharedGetModelContextWindow(modelId, mode);
 }
 
 /**

--- a/apps/web/src/lib/resolve-context-window.ts
+++ b/apps/web/src/lib/resolve-context-window.ts
@@ -1,42 +1,37 @@
+import type { ContextWindowMode } from "@mcode/contracts";
+import { getModelContextWindow } from "@mcode/shared/model-context";
+
 /** Input parameters for context window resolution. */
 export interface ResolveContextWindowParams {
   /** Context window reported by the Claude Agent SDK runtime. */
   sdkContextWindow: number | undefined;
   /** Model ID that actually ran (post-fallback). */
   modelId: string;
-  /** The user's configured default model ID from settings. */
-  defaultModelId: string;
-  /** User's explicit context window override from settings. */
-  settingsContextWindow: number | undefined;
-  /** Context window from the model registry (API-fetched or static). */
-  registryContextWindow: number | undefined;
-  /** Previously stored context window for this thread. */
+  /**
+   * Effective context window mode for this thread.
+   * Per-thread override > settings default > "200k".
+   */
+  contextWindowMode: ContextWindowMode;
+  /** Previously stored numeric context window for this thread, used as final fallback. */
   previousContextWindow: number | undefined;
 }
 
 /**
- * Resolves the context window to display for a thread.
+ * Resolves the numeric context window (tokens) to display for a thread.
  *
  * Preference chain (highest to lowest priority):
- * 1. User settings override (only when the thread's model matches the default)
- * 2. Model registry (API-fetched or static)
- * 3. SDK runtime value
- * 4. Previously stored value
+ * 1. SDK runtime value (truthful — the SDK reports what it actually sent).
+ * 2. Static map keyed on (modelId, mode). Falls back to 200k for unknown models.
+ * 3. Previously stored value (smooths a transient gap during reconnect).
  */
 export function resolveContextWindow(params: ResolveContextWindowParams): number | undefined {
-  const {
-    sdkContextWindow,
-    modelId,
-    defaultModelId,
-    settingsContextWindow,
-    registryContextWindow,
-    previousContextWindow,
-  } = params;
-
-  // User override only applies to the default model.
-  if (settingsContextWindow !== undefined && modelId === defaultModelId) {
-    return settingsContextWindow;
+  const { sdkContextWindow, modelId, contextWindowMode, previousContextWindow } = params;
+  if (sdkContextWindow !== undefined) {
+    return sdkContextWindow;
   }
-
-  return registryContextWindow ?? sdkContextWindow ?? previousContextWindow;
+  const fromMap = getModelContextWindow(modelId, contextWindowMode);
+  if (fromMap !== undefined) {
+    return fromMap;
+  }
+  return previousContextWindow;
 }

--- a/apps/web/src/lib/resolve-context-window.ts
+++ b/apps/web/src/lib/resolve-context-window.ts
@@ -1,0 +1,42 @@
+/** Input parameters for context window resolution. */
+export interface ResolveContextWindowParams {
+  /** Context window reported by the Claude Agent SDK runtime. */
+  sdkContextWindow: number | undefined;
+  /** Model ID that actually ran (post-fallback). */
+  modelId: string;
+  /** The user's configured default model ID from settings. */
+  defaultModelId: string;
+  /** User's explicit context window override from settings. */
+  settingsContextWindow: number | undefined;
+  /** Context window from the model registry (API-fetched or static). */
+  registryContextWindow: number | undefined;
+  /** Previously stored context window for this thread. */
+  previousContextWindow: number | undefined;
+}
+
+/**
+ * Resolves the context window to display for a thread.
+ *
+ * Preference chain (highest to lowest priority):
+ * 1. User settings override (only when the thread's model matches the default)
+ * 2. Model registry (API-fetched or static)
+ * 3. SDK runtime value
+ * 4. Previously stored value
+ */
+export function resolveContextWindow(params: ResolveContextWindowParams): number | undefined {
+  const {
+    sdkContextWindow,
+    modelId,
+    defaultModelId,
+    settingsContextWindow,
+    registryContextWindow,
+    previousContextWindow,
+  } = params;
+
+  // User override only applies to the default model.
+  if (settingsContextWindow !== undefined && modelId === defaultModelId) {
+    return settingsContextWindow;
+  }
+
+  return registryContextWindow ?? sdkContextWindow ?? previousContextWindow;
+}

--- a/apps/web/src/stores/composerDraftStore.ts
+++ b/apps/web/src/stores/composerDraftStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { PendingAttachment } from "@/components/chat/AttachmentPreview";
-import type { ReasoningLevel } from "@mcode/contracts";
+import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
 
 /** Draft state for a single composer instance, keyed by thread ID. */
 export interface ComposerDraft {
@@ -10,6 +10,18 @@ export interface ComposerDraft {
   /** Provider ID stored alongside the model because multiple providers share model IDs. */
   provider?: string;
   reasoning: ReasoningLevel;
+  /**
+   * Per-thread context window override. Undefined falls back to the thread's
+   * persisted mode (or the global settings default). Honored only by Claude
+   * provider for models that support a 1M-context beta header.
+   */
+  contextWindow?: ContextWindowMode;
+  /**
+   * Per-thread thinking toggle override. Undefined falls back to the thread's
+   * persisted toggle (or the global settings default). Honored only by models
+   * that expose a thinking toggle (Haiku 4.5).
+   */
+  thinking?: boolean;
 }
 
 interface ComposerDraftState {

--- a/apps/web/src/stores/providerModelsStore.ts
+++ b/apps/web/src/stores/providerModelsStore.ts
@@ -51,6 +51,7 @@ export const useProviderModelsStore = create<ProviderModelsState>((set, get) => 
         providerId,
         group: m.group,
         multiplier: m.multiplier,
+        contextWindow: m.contextWindow,
       }));
       set((s) => ({
         models: { ...s.models, [providerId]: mapped },

--- a/apps/web/src/stores/queueStore.ts
+++ b/apps/web/src/stores/queueStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { AttachmentMeta, PermissionMode } from "@/transport";
-import type { ReasoningLevel } from "@mcode/contracts";
+import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
 
 /** A message waiting to be sent while the thread is busy with another turn. */
 export interface QueuedMessage {
@@ -17,6 +17,10 @@ export interface QueuedMessage {
   provider?: string;
   /** Copilot sub-agent to use; undefined means inherit the thread's stored agent. */
   copilotAgent?: string;
+  /** Claude context window mode for this turn; undefined means inherit from thread/settings. */
+  contextWindow?: ContextWindowMode;
+  /** Haiku thinking toggle for this turn; undefined means inherit from thread/settings. */
+  thinking?: boolean;
   /** Unix timestamp (ms) when this message was enqueued. */
   queuedAt: number;
 }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { Message, ToolCall, PermissionMode, InteractionMode, AttachmentMeta, ToolCallRecord } from "@/transport";
-import type { ReasoningLevel, PlanQuestion, PlanAnswer, ProviderUsageInfo, QuotaCategory } from "@mcode/contracts";
+import type { ContextWindowMode, ReasoningLevel, PlanQuestion, PlanAnswer, ProviderUsageInfo, QuotaCategory } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { PlanQuestionSchema, PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
 import { getTransport } from "@/transport";
@@ -10,8 +10,8 @@ import { LruCache } from "@/lib/lru-cache";
 import { useTaskStore, coerceTaskStatus } from "./taskStore";
 import type { TaskItem } from "./taskStore";
 import { useToastStore } from "./toastStore";
-import { findModelById, getContextWindow } from "@/lib/model-registry";
-import { resolveContextWindow } from "../lib/resolve-context-window";
+import { findModelById } from "@/lib/model-registry";
+import { resolveContextWindow } from "@/lib/resolve-context-window";
 import { useSettingsStore } from "./settingsStore";
 
 /** A permission request with its current resolution state. */
@@ -30,6 +30,18 @@ export interface ThreadSettings {
   reasoningLevel?: ReasoningLevel;
   /** Selected Copilot sub-agent name. Null means provider default. Only relevant when provider is "copilot". */
   copilotAgent?: string | null;
+  /**
+   * Per-thread context window override. Null clears the override so the thread
+   * inherits from the global settings default. Honored only by Claude provider
+   * for models that support a 1M-context beta header.
+   */
+  contextWindow?: ContextWindowMode | null;
+  /**
+   * Per-thread thinking toggle override. Null clears the override so the thread
+   * inherits from the global settings default. Honored only by models that
+   * expose a thinking toggle (Haiku 4.5).
+   */
+  thinking?: boolean | null;
 }
 
 interface ThreadState {
@@ -98,7 +110,7 @@ interface ThreadState {
   // Message actions
   loadMessages: (threadId: string) => Promise<void>;
   loadOlderMessages: (threadId: string) => Promise<void>;
-  sendMessage: (threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], displayContent?: string, reasoningLevel?: ReasoningLevel, provider?: string, copilotAgent?: string) => Promise<void>;
+  sendMessage: (threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], displayContent?: string, reasoningLevel?: ReasoningLevel, provider?: string, copilotAgent?: string, contextWindow?: ContextWindowMode, thinking?: boolean) => Promise<void>;
   stopAgent: (threadId: string) => Promise<void>;
   /** Replace runningThreadIds with the authoritative server snapshot. Called on WS (re)connect. */
   hydrateRunningThreads: (ids: string[]) => void;
@@ -515,7 +527,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * message to local state, marks the thread as running, then dispatches
    * to the transport layer. On failure, rolls back the running state.
    */
-  sendMessage: async (threadId, content, model, permissionMode, attachments, displayContent, reasoningLevel, provider, copilotAgent) => {
+  sendMessage: async (threadId, content, model, permissionMode, attachments, displayContent, reasoningLevel, provider, copilotAgent, contextWindow, thinking) => {
     // Add user message to local state immediately (optimistic)
     // Use displayContent for the UI (without injected file blocks) if provided
     const userMessage: Message = {
@@ -546,9 +558,17 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         : {}),
       runningThreadIds: new Set([...state.runningThreadIds, threadId]),
       agentStartTimes: { ...state.agentStartTimes, [threadId]: Date.now() },
-      // Persist reasoningLevel so the post-wizard answer turn forwards the same setting
-      settingsByThread: reasoningLevel !== undefined
-        ? { ...state.settingsByThread, [threadId]: { ...state.getThreadSettings(threadId), reasoningLevel } }
+      // Persist composer-side overrides so the post-wizard answer turn forwards them
+      settingsByThread: (reasoningLevel !== undefined || contextWindow !== undefined || thinking !== undefined)
+        ? {
+            ...state.settingsByThread,
+            [threadId]: {
+              ...state.getThreadSettings(threadId),
+              ...(reasoningLevel !== undefined && { reasoningLevel }),
+              ...(contextWindow !== undefined && { contextWindow }),
+              ...(thinking !== undefined && { thinking }),
+            },
+          }
         : state.settingsByThread,
       // Clear any transient fallback from the previous turn so the next message uses the intended model
       lastFallbackByThread: (() => {
@@ -565,7 +585,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
     try {
       const { interactionMode } = get().getThreadSettings(threadId);
-      await getTransport().sendMessage(threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent);
+      await getTransport().sendMessage(threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent, contextWindow, thinking);
     } catch (e) {
       set((state) => {
         const next = new Set(state.runningThreadIds);
@@ -692,6 +712,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           ? (thread.reasoning_level as ReasoningLevel)
           : undefined,
         copilotAgent: thread.copilot_agent,
+        contextWindow: (thread.context_window_mode as ContextWindowMode | null) ?? null,
+        thinking: thread.thinking ?? null,
       };
     }
 
@@ -714,6 +736,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (settings.reasoningLevel !== undefined) patch.reasoningLevel = settings.reasoningLevel;
     // Use `in` check so explicit null clears the agent (null !== undefined).
     if ("copilotAgent" in settings) patch.copilotAgent = settings.copilotAgent;
+    // null clears the override so the thread inherits from the global default.
+    if ("contextWindow" in settings) patch.contextWindow = settings.contextWindow;
+    if ("thinking" in settings) patch.thinking = settings.thinking;
 
     if (Object.keys(patch).length === 0) return Promise.resolve(false);
 
@@ -738,22 +763,28 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               ...(patch.interactionMode !== undefined && { interaction_mode: patch.interactionMode }),
               ...(patch.reasoningLevel !== undefined && { reasoning_level: patch.reasoningLevel }),
               ...("copilotAgent" in patch && { copilot_agent: patch.copilotAgent ?? null }),
+              ...("contextWindow" in patch && { context_window_mode: patch.contextWindow ?? null }),
+              ...("thinking" in patch && { thinking: patch.thinking ?? null }),
             }
           : t,
       ),
     }));
 
-    // copilotAgent: null clears the persisted agent; undefined means don't change.
+    // copilotAgent / contextWindow / thinking: null clears the persisted value; undefined means don't change.
     const transportPatch: {
       reasoningLevel?: ReturnType<typeof get>["settingsByThread"][string]["reasoningLevel"];
       interactionMode?: ReturnType<typeof get>["settingsByThread"][string]["interactionMode"];
       permissionMode?: ReturnType<typeof get>["settingsByThread"][string]["permissionMode"];
       copilotAgent?: string | null;
+      contextWindow?: ContextWindowMode | null;
+      thinking?: boolean | null;
     } = {
       ...(patch.permissionMode !== undefined ? { permissionMode: patch.permissionMode } : {}),
       ...(patch.interactionMode !== undefined ? { interactionMode: patch.interactionMode } : {}),
       ...(patch.reasoningLevel !== undefined ? { reasoningLevel: patch.reasoningLevel } : {}),
       ...("copilotAgent" in patch ? { copilotAgent: patch.copilotAgent } : {}),
+      ...("contextWindow" in patch ? { contextWindow: patch.contextWindow } : {}),
+      ...("thinking" in patch ? { thinking: patch.thinking } : {}),
     };
     return getTransport().updateThreadSettings(threadId, transportPatch).catch(() => false);
   },
@@ -919,7 +950,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     const state = get();
     const answersMap = state.planAnswersByThread[threadId] ?? new Map<string, PlanAnswer>();
     const questions = state.planQuestionsByThread[threadId] ?? [];
-    const { permissionMode, reasoningLevel } = state.getThreadSettings(threadId);
+    const { permissionMode, reasoningLevel, contextWindow, thinking } = state.getThreadSettings(threadId);
 
     // Build an answer for every question; unanswered questions get nulls
     const answers: PlanAnswer[] = questions.map((q) => {
@@ -937,7 +968,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }));
 
     try {
-      await getTransport().answerPlanQuestions(threadId, answers, permissionMode, reasoningLevel);
+      await getTransport().answerPlanQuestions(
+        threadId,
+        answers,
+        permissionMode,
+        reasoningLevel,
+        contextWindow ?? undefined,
+        thinking ?? undefined,
+      );
     } catch (e) {
       // Revert to pending on error so user can retry
       set((s) => ({
@@ -1434,18 +1472,21 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         // Prefer the actual model that ran (post-fallback) so context window
         // sizing reflects Haiku's limits rather than the requested Opus model.
         const fallback = get().lastFallbackByThread[threadId];
+        const thread = useWorkspaceStore.getState().threads.find((t) => t.id === threadId);
         const modelId = fallback?.actualModel
-          ?? useWorkspaceStore.getState().threads.find((t) => t.id === threadId)?.model
+          ?? thread?.model
           ?? "claude-sonnet-4-6";
-        // Preference chain: user settings override (default model only) > registry > SDK > previously stored.
+        // Effective mode chain: thread override > settings default > "200k".
         // Uses get() (not state) because this runs outside the set() callback.
         const settingsDefaults = useSettingsStore.getState().settings.model.defaults;
+        const effectiveMode: ContextWindowMode =
+          (thread?.context_window_mode as ContextWindowMode | null | undefined)
+          ?? settingsDefaults.contextWindow
+          ?? "200k";
         const contextWindow = resolveContextWindow({
           sdkContextWindow,
           modelId,
-          defaultModelId: settingsDefaults.id,
-          settingsContextWindow: settingsDefaults.contextWindow,
-          registryContextWindow: getContextWindow(modelId),
+          contextWindowMode: effectiveMode,
           previousContextWindow: get().contextByThread[threadId]?.contextWindow,
         });
         set((state) => ({
@@ -1511,6 +1552,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               next.reasoningLevel,
               next.provider,
               next.copilotAgent,
+              next.contextWindow,
+              next.thinking,
             );
           }
         }, 400);

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -11,6 +11,8 @@ import { useTaskStore, coerceTaskStatus } from "./taskStore";
 import type { TaskItem } from "./taskStore";
 import { useToastStore } from "./toastStore";
 import { findModelById, getContextWindow } from "@/lib/model-registry";
+import { resolveContextWindow } from "../lib/resolve-context-window";
+import { useSettingsStore } from "./settingsStore";
 
 /** A permission request with its current resolution state. */
 interface StoredPermission extends PermissionRequest {
@@ -1435,9 +1437,17 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         const modelId = fallback?.actualModel
           ?? useWorkspaceStore.getState().threads.find((t) => t.id === threadId)?.model
           ?? "claude-sonnet-4-6";
-        // Prefer SDK value, fall back to static registry, then preserve last known value.
+        // Preference chain: user settings override (default model only) > registry > SDK > previously stored.
         // Uses get() (not state) because this runs outside the set() callback.
-        const contextWindow = sdkContextWindow ?? getContextWindow(modelId) ?? get().contextByThread[threadId]?.contextWindow;
+        const settingsDefaults = useSettingsStore.getState().settings.model.defaults;
+        const contextWindow = resolveContextWindow({
+          sdkContextWindow,
+          modelId,
+          defaultModelId: settingsDefaults.id,
+          settingsContextWindow: settingsDefaults.contextWindow,
+          registryContextWindow: getContextWindow(modelId),
+          previousContextWindow: get().contextByThread[threadId]?.contextWindow,
+        });
         set((state) => ({
           contextByThread: {
             ...state.contextByThread,

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -8,7 +8,7 @@ import { useQueueStore } from "./queueStore";
 import { useTaskStore } from "./taskStore";
 import { useComposerDraftStore } from "./composerDraftStore";
 import { useDiffStore } from "./diffStore";
-import type { NamingMode, ReasoningLevel, InteractionMode } from "@mcode/contracts";
+import type { ContextWindowMode, NamingMode, ReasoningLevel, InteractionMode } from "@mcode/contracts";
 import { useSettingsStore } from "./settingsStore";
 import { sanitizeCustomBranchInput, resolveBranchName } from "@/lib/branch-name";
 
@@ -66,7 +66,7 @@ interface WorkspaceState {
     mode: "direct" | "worktree",
     branch: string,
   ) => Promise<Thread>;
-  createAndSendMessage: (content: string, model: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?: InteractionMode, copilotAgent?: string) => Promise<Thread>;
+  createAndSendMessage: (content: string, model: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?: InteractionMode, copilotAgent?: string, contextWindow?: ContextWindowMode, thinking?: boolean) => Promise<Thread>;
   /** Branch an existing thread into a new child with handoff context. */
   branchThread: (params: {
     sourceThreadId: string;
@@ -82,6 +82,8 @@ interface WorkspaceState {
     attachments?: AttachmentMeta[];
     interactionMode?: InteractionMode;
     copilotAgent?: string;
+    contextWindow?: ContextWindowMode;
+    thinking?: boolean;
   }) => Promise<Thread>;
   deleteThread: (threadId: string, cleanupWorktree: boolean) => Promise<void>;
   setActiveThread: (id: string | null) => void;
@@ -326,7 +328,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
   },
 
-  createAndSendMessage: async (content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent) => {
+  createAndSendMessage: async (content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent, contextWindow, thinking) => {
     const workspaceId = get().activeWorkspaceId;
     if (!workspaceId) throw new Error("No workspace selected");
 
@@ -349,7 +351,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set({ error: null });
     try {
       const thread = await getTransport().createAndSendMessage(
-        workspaceId, content, model, permissionMode, mode, branch, existingWorktreePath, attachments, reasoningLevel, provider, interactionMode, undefined, undefined, copilotAgent,
+        workspaceId, content, model, permissionMode, mode, branch, existingWorktreePath, attachments, reasoningLevel, provider, interactionMode, undefined, undefined, copilotAgent, contextWindow, thinking,
       );
       set((state) => ({
         threads: [thread, ...state.threads],
@@ -410,6 +412,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         params.sourceThreadId,
         params.forkedFromMessageId,
         params.copilotAgent,
+        params.contextWindow,
+        params.thinking,
       );
 
       set((state) => ({

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -12,6 +12,7 @@ import type {
   SkillDiagnostics,
   PermissionMode,
   ReasoningLevel,
+  ContextWindowMode,
   ToolCallRecord,
   TurnSnapshot,
   Settings,
@@ -45,6 +46,7 @@ export type {
   SkillDiagnostics,
   PermissionMode,
   InteractionMode,
+  ContextWindowMode,
   Settings,
   PartialSettings,
   GitCommit,
@@ -94,7 +96,7 @@ export interface McodeTransport {
   listWorktrees(workspaceId: string): Promise<WorktreeInfo[]>;
 
   // Agent commands
-  sendMessage(threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?: InteractionMode, copilotAgent?: string): Promise<void>;
+  sendMessage(threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?: InteractionMode, copilotAgent?: string, contextWindow?: ContextWindowMode, thinking?: boolean): Promise<void>;
   createAndSendMessage(
     workspaceId: string,
     content: string,
@@ -110,6 +112,8 @@ export interface McodeTransport {
     parentThreadId?: string,
     forkedFromMessageId?: string,
     copilotAgent?: string,
+    contextWindow?: ContextWindowMode,
+    thinking?: boolean,
   ): Promise<Thread>;
   stopAgent(threadId: string): Promise<void>;
   /** Respond to a tool permission request from the agent. */
@@ -122,6 +126,8 @@ export interface McodeTransport {
     answers: PlanAnswer[],
     permissionMode?: PermissionMode,
     reasoningLevel?: ReasoningLevel,
+    contextWindow?: ContextWindowMode,
+    thinking?: boolean,
   ): Promise<void>;
   readClipboardImage(): Promise<AttachmentMeta | null>;
   /** Save a clipboard file blob to disk via the server. Returns attachment metadata. */
@@ -136,7 +142,7 @@ export interface McodeTransport {
 
   // Thread mutations
   updateThreadTitle(threadId: string, title: string): Promise<boolean>;
-  /** Persist per-thread composer settings (reasoning, mode, permission, copilot agent). */
+  /** Persist per-thread composer settings (reasoning, mode, permission, copilot agent, context window, thinking). */
   updateThreadSettings(
     threadId: string,
     settings: {
@@ -144,6 +150,8 @@ export interface McodeTransport {
       interactionMode?: InteractionMode;
       permissionMode?: PermissionMode;
       copilotAgent?: string | null;
+      contextWindow?: ContextWindowMode | null;
+      thinking?: boolean | null;
     },
   ): Promise<boolean>;
   /** Clear the "completed" badge for a thread. Transitions completed -> paused in the DB. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -500,6 +500,8 @@ export function createWsTransport(
         interactionMode: settings.interactionMode,
         permissionMode: settings.permissionMode,
         copilotAgent: settings.copilotAgent,
+        contextWindow: settings.contextWindow,
+        thinking: settings.thinking,
       }),
     markThreadViewed: (threadId) => rpc<void>("thread.markViewed", { threadId }),
     syncThreadPrs: (workspaceId) =>
@@ -513,13 +515,14 @@ export function createWsTransport(
     listWorktrees: (workspaceId) => rpc<WorktreeInfo[]>("git.listWorktrees", { workspaceId }),
 
     // Agent
-    sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?, copilotAgent?: string) => {
+    sendMessage: (threadId, content, model?, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], reasoningLevel?: ReasoningLevel, provider?: string, interactionMode?, copilotAgent?: string, contextWindow?, thinking?) => {
       const state = useSettingsStore.getState();
       const guardrails = state.loaded
         ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
         : {};
       return rpc<void>("agent.send", {
         threadId, content, model, permissionMode, attachments, reasoningLevel, provider, interactionMode, copilotAgent,
+        contextWindow, thinking,
         ...guardrails,
       });
     },
@@ -538,6 +541,8 @@ export function createWsTransport(
       parentThreadId?,
       forkedFromMessageId?,
       copilotAgent?,
+      contextWindow?,
+      thinking?,
     ) => {
       const state = useSettingsStore.getState();
       const guardrails = state.loaded
@@ -558,6 +563,8 @@ export function createWsTransport(
         parentThreadId,
         forkedFromMessageId,
         copilotAgent,
+        contextWindow,
+        thinking,
         ...guardrails,
       });
     },
@@ -566,8 +573,8 @@ export function createWsTransport(
       rpc<void>("permission.respond", { requestId, decision }),
     listPendingPermissions: (threadId) =>
       rpc<PermissionRequest[]>("permission.listPending", { threadId }),
-    answerPlanQuestions: (threadId, answers, permissionMode?, reasoningLevel?) =>
-      rpc<void>("agent.answerQuestions", { threadId, answers, permissionMode, reasoningLevel }),
+    answerPlanQuestions: (threadId, answers, permissionMode?, reasoningLevel?, contextWindow?, thinking?) =>
+      rpc<void>("agent.answerQuestions", { threadId, answers, permissionMode, reasoningLevel, contextWindow, thinking }),
     readClipboardImage: () =>
       Promise.resolve(null as AttachmentMeta | null),
     saveClipboardFile: (data, mimeType, fileName) =>

--- a/docs/guides/settings-schema.md
+++ b/docs/guides/settings-schema.md
@@ -128,7 +128,8 @@ When adding a new setting, ask these questions in order:
       "provider": "claude",            // "claude" | "codex" | "gemini" | "copilot"
       "id": "claude-sonnet-4-6",
       "reasoning": "high",             // "low" | "medium" | "high"
-      "fallbackId": "claude-sonnet-4-6" // "" disables fallback
+      "fallbackId": "claude-sonnet-4-6", // "" disables fallback
+      "contextWindow": null             // number or null; overrides API/SDK value
     }
   },
   "terminal": {

--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -18,6 +18,7 @@ Per-setting reference for Mcode's `settings.json`. For schema conventions and st
 | `model.defaults.id` | string | `"claude-opus-4-7"` | - | - | Default model identifier for new installs. Existing users keep their stored value. |
 | `model.defaults.reasoning` | enum | `"high"` | `"low"` \| `"medium"` \| `"high"` \| `"xhigh"` \| `"max"` | - | Default reasoning effort level. Tiers in ascending order: `low < medium < high < xhigh < max`. `"xhigh"` requires Opus 4.7 for Claude (also valid for Codex models). `"max"` requires Opus 4.7, Opus 4.6, or Sonnet 4.6; it normalizes to `"high"` at runtime on other Claude models. Haiku 4.5 ignores this setting entirely -- the effort parameter is not sent for that model. |
 | `model.defaults.fallbackId` | string | `"claude-sonnet-4-6"` | - | - | Fallback model when the primary is unavailable. Set to `""` to disable fallback. |
+| `model.defaults.contextWindow` | integer | - | > 0, ≤ 2,000,000 | - | Override the context window (tokens) for the default model. When set, takes priority over API-fetched and SDK-reported values. Useful when the SDK reports stale data (e.g. 200K instead of 1M). Omit to use the automatically detected value. Claude only. |
 | `terminal.scrollback` | integer | `250` | >= 0 | - | Number of scrollback lines to retain |
 | `notifications.enabled` | boolean | `true` | - | - | Whether desktop notifications are enabled |
 | `worktree.naming.mode` | enum | `"auto"` | `"auto"` \| `"custom"` \| `"ai"` | - | Naming strategy for new worktree branches |

--- a/docs/specs/2026-04-22-dynamic-context-window-design.md
+++ b/docs/specs/2026-04-22-dynamic-context-window-design.md
@@ -1,0 +1,137 @@
+# Dynamic Context Window Discovery and User Override
+
+**Goal:** Surface per-model context window sizes in the model selector, fetch them live from the Anthropic Models API for Claude, and let users override the value in settings when the SDK binary reports stale data.
+
+**Prerequisite:** PR #356 (static `MODEL_CONTEXT_WINDOWS` in `@mcode/shared/model-context`).
+
+---
+
+## Problem
+
+The Claude Agent SDK binary (v2.1.104) reports 200K as the context window for all Claude models, including Sonnet 4.6, Opus 4.6, and Opus 4.7, which Anthropic's docs confirm support 1M. PR #356 added correct static values, but the SDK runtime value overrides them after the first turn. Users have no way to see or correct the context window from within mcode.
+
+## Approach
+
+Follow the same dynamic model listing pattern that Copilot already uses:
+
+1. `ClaudeProvider.listModels()` calls the Anthropic REST API (`GET /v1/models`) for live per-account model metadata, including the real context window.
+2. The model selector shows a context window badge next to each model.
+3. Users can set a `model.defaults.contextWindow` override in settings when the SDK or API value is wrong for their account.
+4. The preference chain is updated so the user override wins over all other sources.
+
+---
+
+## Design
+
+### 1. Server: `ClaudeProvider.listModels()`
+
+**File:** `apps/server/src/providers/claude/claude-provider.ts`
+
+Add a `listModels()` method that:
+
+- Calls `GET https://api.anthropic.com/v1/models` with the `ANTHROPIC_API_KEY` environment variable and the required `anthropic-version` header.
+- Filters the response to `claude-*` models.
+- Maps each model to `ProviderModelInfo`:
+  - `id`: model ID from the API
+  - `name`: display name derived from the model ID
+  - `contextWindow`: `model.max_input_tokens` from the API response (e.g., 1,000,000 for Sonnet 4.6)
+- Caches the result in-memory with a 5-minute TTL. Model lists rarely change and this matches the Copilot provider's fetch-on-hover pattern.
+
+**File:** `apps/web/src/lib/model-registry.ts`
+
+Set `supportsModelListing: true` on the Claude provider entry in `MODEL_PROVIDERS`. This triggers the existing `fetchProviderModels` path in the model selector on hover, identical to Copilot.
+
+No transport changes needed. The existing RPC route at `ws-router.ts:567-574` already dispatches `provider.listModels` to the resolved provider.
+
+### 2. Web: Model selector context window badge
+
+**File:** `apps/web/src/components/chat/ModelSelector.tsx`
+
+**2a. Pass `contextWindow` through from dynamic listings.**
+
+`fetchProviderModels` (line 82-88) currently maps the response to `{ id, label, providerId, group, multiplier }` and drops `contextWindow`. Add `contextWindow: m.contextWindow` to the mapped object so it flows through `ModelDefinition.contextWindow`.
+
+**2b. Render the badge in `renderModelRow`.**
+
+After the model label, render a compact context window badge when `contextWindow` is present:
+
+```
+[Opus 4.7]                [1M]
+[Sonnet 4.6]              [1M]
+[Haiku 4.5]             [200K]
+```
+
+Formatting: `contextWindow >= 1_000_000` displays as "1M", otherwise `${contextWindow / 1000}K`. Styled with `text-[10px] text-muted-foreground/60 tabular-nums`, matching the existing Copilot `multiplier` badge.
+
+The `multiplier` badge is Copilot-specific. Claude models do not show `multiplier`. The two badges never overlap for the same model.
+
+For static-only providers (no `listModels()`), the badge still works because `ModelDefinition.contextWindow` is already populated from the static registry (PR #356).
+
+### 3. Settings: context window override
+
+**File:** `packages/contracts/src/models/settings.ts`
+
+Add `contextWindow` to the `model.defaults` schema:
+
+```typescript
+defaults: z.object({
+  provider: z.string().default("claude"),
+  id: z.string().default("claude-sonnet-4-6"),
+  reasoning: z.string().default("high"),
+  fallbackId: z.string().optional(),
+  contextWindow: z.number().optional(),  // new
+}),
+```
+
+This is a single user-controlled value under `model.defaults`. When set, it overrides whatever the API or SDK reports for the user's default model. It addresses the case where the SDK binary reports 200K but the user knows their account supports 1M.
+
+**Settings UI:** expose the field as a numeric input in the model defaults section of the settings page, pre-filled with the API-fetched or static value when no override is set.
+
+**Docs:** update `docs/guides/settings-schema.md` and `docs/settings/reference.md` with the new field.
+
+### 4. Preference chain
+
+**Current chain** (`threadStore.ts:1429`):
+
+```
+SDK runtime → static registry → prev stored
+```
+
+**New chain:**
+
+```
+user settings override → API-fetched (ModelDefinition.contextWindow) → static registry → SDK runtime → prev stored
+```
+
+**Implementation in `threadStore.ts`:**
+
+When computing the context window for display:
+
+1. Check `useSettingsStore.getState().settings.model.defaults.contextWindow`. If the thread's active model matches the user's default model and the override is set, use it.
+2. Otherwise, fall back to `getContextWindow(modelId)`, which returns the `ModelDefinition.contextWindow` (populated from the API-fetched list or the static registry).
+3. Then the SDK runtime value (`sdkContextWindow`).
+4. Then the previously stored value.
+
+**`handoff-builder.ts`:** continues to use `getModelContextWindow()` from `@mcode/shared/model-context` (the static map). The handoff budget calculation does not need user-override precision since the static values are correct per Anthropic's documentation.
+
+**Behavioral note:** when the user sets `contextWindow: 1_000_000` in settings and the SDK binary reports 200K, the gauge shows 1M. The SDK still handles API-level compaction internally at whatever its actual limit is. The gauge reflects the user's declared truth.
+
+---
+
+## What is NOT in scope
+
+- Per-model context window overrides (only the default model gets an override; switching models uses API-fetched or static values).
+- Auto-compaction on model switch (the SDK handles this autonomously).
+- Modifying the Claude Agent SDK binary or its reported values.
+- Context window for non-Claude providers (Copilot already handles this dynamically; Codex is SDK-sourced).
+
+---
+
+## Testing
+
+- **Unit:** `ClaudeProvider.listModels()` returns correct `ProviderModelInfo[]` with `contextWindow` populated (mock the API call).
+- **Unit:** `fetchProviderModels` in `ModelSelector` correctly passes `contextWindow` through to `ModelDefinition`.
+- **Unit:** Settings schema validates `model.defaults.contextWindow` as optional number.
+- **Unit:** Preference chain in `threadStore` applies the correct priority order.
+- **E2E:** Model selector shows context window badge for Claude models.
+- **E2E:** Setting `model.defaults.contextWindow` overrides the displayed gauge value.

--- a/packages/contracts/src/__tests__/settings.test.ts
+++ b/packages/contracts/src/__tests__/settings.test.ts
@@ -131,5 +131,13 @@ describe("SettingsSchema", () => {
         }),
       ).toThrow();
     });
+
+    it("rejects contextWindow above 2_000_000", () => {
+      expect(() =>
+        SettingsSchema().parse({
+          model: { defaults: { contextWindow: 3_000_000 } },
+        }),
+      ).toThrow();
+    });
   });
 });

--- a/packages/contracts/src/__tests__/settings.test.ts
+++ b/packages/contracts/src/__tests__/settings.test.ts
@@ -110,4 +110,26 @@ describe("SettingsSchema", () => {
       expect(getDefaultSettings().terminal.scrollback).toBe(1000);
     });
   });
+
+  describe("model.defaults.contextWindow", () => {
+    it("accepts contextWindow as a number", () => {
+      const result = SettingsSchema().parse({
+        model: { defaults: { contextWindow: 1_000_000 } },
+      });
+      expect(result.model.defaults.contextWindow).toBe(1_000_000);
+    });
+
+    it("defaults contextWindow to undefined when omitted", () => {
+      const result = SettingsSchema().parse({});
+      expect(result.model.defaults.contextWindow).toBeUndefined();
+    });
+
+    it("rejects non-number contextWindow", () => {
+      expect(() =>
+        SettingsSchema().parse({
+          model: { defaults: { contextWindow: "1M" } },
+        }),
+      ).toThrow();
+    });
+  });
 });

--- a/packages/contracts/src/__tests__/settings.test.ts
+++ b/packages/contracts/src/__tests__/settings.test.ts
@@ -112,30 +112,59 @@ describe("SettingsSchema", () => {
   });
 
   describe("model.defaults.contextWindow", () => {
-    it("accepts contextWindow as a number", () => {
+    it("accepts contextWindow '200k'", () => {
       const result = SettingsSchema().parse({
-        model: { defaults: { contextWindow: 1_000_000 } },
+        model: { defaults: { contextWindow: "200k" } },
       });
-      expect(result.model.defaults.contextWindow).toBe(1_000_000);
+      expect(result.model.defaults.contextWindow).toBe("200k");
     });
 
-    it("defaults contextWindow to undefined when omitted", () => {
+    it("accepts contextWindow '1m'", () => {
+      const result = SettingsSchema().parse({
+        model: { defaults: { contextWindow: "1m" } },
+      });
+      expect(result.model.defaults.contextWindow).toBe("1m");
+    });
+
+    it("defaults contextWindow to '200k' when omitted", () => {
       const result = SettingsSchema().parse({});
-      expect(result.model.defaults.contextWindow).toBeUndefined();
+      expect(result.model.defaults.contextWindow).toBe("200k");
     });
 
-    it("rejects non-number contextWindow", () => {
+    it("rejects numeric contextWindow", () => {
+      expect(() =>
+        SettingsSchema().parse({
+          model: { defaults: { contextWindow: 1_000_000 } },
+        }),
+      ).toThrow();
+    });
+
+    it("rejects unknown contextWindow strings", () => {
       expect(() =>
         SettingsSchema().parse({
           model: { defaults: { contextWindow: "1M" } },
         }),
       ).toThrow();
     });
+  });
 
-    it("rejects contextWindow above 2_000_000", () => {
+  describe("model.defaults.thinking", () => {
+    it("accepts thinking true", () => {
+      const result = SettingsSchema().parse({
+        model: { defaults: { thinking: true } },
+      });
+      expect(result.model.defaults.thinking).toBe(true);
+    });
+
+    it("defaults thinking to false when omitted", () => {
+      const result = SettingsSchema().parse({});
+      expect(result.model.defaults.thinking).toBe(false);
+    });
+
+    it("rejects non-boolean thinking", () => {
       expect(() =>
         SettingsSchema().parse({
-          model: { defaults: { contextWindow: 3_000_000 } },
+          model: { defaults: { thinking: "yes" } },
         }),
       ).toThrow();
     });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -53,6 +53,7 @@ export {
   ThemeSchema,
   AgentDefaultModeSchema,
   ReasoningLevelSchema,
+  ContextWindowModeSchema,
   ProviderIdSchema,
   NamingModeSchema,
 } from "./models/settings.js";
@@ -62,6 +63,7 @@ export type {
   Theme,
   AgentDefaultMode,
   ReasoningLevel,
+  ContextWindowMode,
   SettingsProviderId,
   NamingMode,
 } from "./models/settings.js";

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -97,6 +97,8 @@ export const SettingsSchema = lazySchema(() =>
             reasoning: ReasoningLevelSchema.default("high"),
             /** Fallback model when the primary is unavailable. Empty string disables fallback. */
             fallbackId: z.string().trim().default("claude-sonnet-4-6"),
+            /** User override for the default model's context window (tokens). Overrides API and SDK values when set. */
+            contextWindow: z.number().int().positive().optional(),
           })
           .default({}),
       })
@@ -295,6 +297,7 @@ export const PartialSettingsSchema = lazySchema(() =>
             id: z.string().optional(),
             reasoning: ReasoningLevelSchema.optional(),
             fallbackId: z.string().trim().optional(),
+            contextWindow: z.number().int().positive().optional(),
           })
           .optional(),
       })

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -98,7 +98,7 @@ export const SettingsSchema = lazySchema(() =>
             /** Fallback model when the primary is unavailable. Empty string disables fallback. */
             fallbackId: z.string().trim().default("claude-sonnet-4-6"),
             /** User override for the default model's context window (tokens). Overrides API and SDK values when set. */
-            contextWindow: z.number().int().positive().optional(),
+            contextWindow: z.number().int().positive().max(2_000_000).optional(),
           })
           .default({}),
       })
@@ -297,7 +297,7 @@ export const PartialSettingsSchema = lazySchema(() =>
             id: z.string().optional(),
             reasoning: ReasoningLevelSchema.optional(),
             fallbackId: z.string().trim().optional(),
-            contextWindow: z.number().int().positive().optional(),
+            contextWindow: z.number().int().positive().max(2_000_000).optional(),
           })
           .optional(),
       })

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -26,11 +26,33 @@ export type AgentDefaultMode = z.infer<typeof AgentDefaultModeSchema>;
 
 /**
  * Reasoning effort level for model inference.
- * "max" maps to Claude's extended thinking; "xhigh" maps to Codex's xhigh effort tier and Claude Opus 4.7+.
+ * "max" maps to Claude's extended thinking; "xhigh" maps to Codex's xhigh effort tier and Claude Opus 4.7+;
+ * "ultrathink" is a virtual top-tier that prepends "Ultrathink:\n" to the user prompt and
+ * sends "max" effort to the SDK. Supported only by max-tier Claude models (Opus 4.7/4.6, Sonnet 4.6).
  */
-export const ReasoningLevelSchema = z.enum(["low", "medium", "high", "max", "xhigh"]);
+export const ReasoningLevelSchema = z.enum([
+  "low",
+  "medium",
+  "high",
+  "max",
+  "xhigh",
+  "ultrathink",
+]);
 /** Reasoning effort level value. */
 export type ReasoningLevel = z.infer<typeof ReasoningLevelSchema>;
+
+/**
+ * Context window selection for Claude models that support an extended 1M tier.
+ * "200k" is the default tier every Claude model supports; "1m" requests the
+ * 1,000,000-token tier (only honored for Opus 4.7/4.6 and Sonnet 4.6).
+ *
+ * At send time the server appends a `[1m]` suffix to the model slug to opt
+ * into the extended window via the Claude Agent SDK; the SDK forwards the
+ * appropriate beta header internally.
+ */
+export const ContextWindowModeSchema = z.enum(["200k", "1m"]);
+/** Context window selection value. */
+export type ContextWindowMode = z.infer<typeof ContextWindowModeSchema>;
 
 /** Supported AI provider identifier for settings. */
 export const ProviderIdSchema = z.enum(["claude", "codex", "gemini", "copilot"]);
@@ -97,8 +119,18 @@ export const SettingsSchema = lazySchema(() =>
             reasoning: ReasoningLevelSchema.default("high"),
             /** Fallback model when the primary is unavailable. Empty string disables fallback. */
             fallbackId: z.string().trim().default("claude-sonnet-4-6"),
-            /** User override for the default model's context window (tokens). Overrides API and SDK values when set. */
-            contextWindow: z.number().int().positive().max(2_000_000).optional(),
+            /**
+             * Default context window mode. "200k" is the universally supported tier;
+             * "1m" requests the extended 1M-token window from Opus 4.7/4.6 and Sonnet 4.6.
+             * Models that do not support 1M ignore this and run on 200k.
+             */
+            contextWindow: ContextWindowModeSchema.default("200k"),
+            /**
+             * Default boolean thinking toggle. Honored only by models that expose
+             * thinking as a boolean (Haiku 4.5). Effort-tier models ignore this and
+             * use their reasoning level instead.
+             */
+            thinking: z.boolean().default(false),
           })
           .default({}),
       })
@@ -297,7 +329,8 @@ export const PartialSettingsSchema = lazySchema(() =>
             id: z.string().optional(),
             reasoning: ReasoningLevelSchema.optional(),
             fallbackId: z.string().trim().optional(),
-            contextWindow: z.number().int().positive().max(2_000_000).optional(),
+            contextWindow: ContextWindowModeSchema.optional(),
+            thinking: z.boolean().optional(),
           })
           .optional(),
       })

--- a/packages/contracts/src/models/thread.ts
+++ b/packages/contracts/src/models/thread.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { lazySchema } from "../utils/lazySchema.js";
 import { ThreadStatusSchema, ThreadModeSchema, InteractionModeSchema, PermissionModeSchema } from "./enums.js";
-import { ReasoningLevelSchema } from "./settings.js";
+import { ContextWindowModeSchema, ReasoningLevelSchema } from "./settings.js";
 
 /** Thread schema matching the SQLite row shape. */
 export const ThreadSchema = lazySchema(() =>
@@ -36,6 +36,10 @@ export const ThreadSchema = lazySchema(() =>
   interaction_mode: InteractionModeSchema.nullable(),
   /** Permission mode last used (full or supervised). */
   permission_mode: PermissionModeSchema.nullable(),
+  /** Context window mode last used in this thread ("200k" or "1m"). */
+  context_window_mode: ContextWindowModeSchema.nullable(),
+  /** Boolean thinking toggle last used in this thread. Honored only by models with a thinking toggle (Haiku 4.5). */
+  thinking: z.boolean().nullable(),
   /** Selected Copilot sub-agent name. Null means provider default (interactive). */
   copilot_agent: z.string().nullable(),
   /** ID of the parent thread this was branched from. Null for root threads. */

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -1,7 +1,7 @@
 import type { AgentEvent } from "../events/agent-event.js";
 import type { AttachmentMeta } from "../models/attachment.js";
 import type { PermissionDecision, PermissionRequest } from "../models/permission.js";
-import type { ReasoningLevel } from "../models/settings.js";
+import type { ContextWindowMode, ReasoningLevel } from "../models/settings.js";
 import type { ProviderModelInfo } from "./models.js";
 import type { ProviderUsageInfo } from "./usage.js";
 
@@ -34,6 +34,18 @@ export interface IAgentProvider {
     permissionMode: string;
     attachments?: AttachmentMeta[];
     reasoningLevel?: ReasoningLevel;
+    /**
+     * Per-thread context window selection. "1m" appends `[1m]` to the model
+     * slug at the SDK boundary so the SDK attaches the 1M-context beta header.
+     * Undefined falls back to the model's default 200k window.
+     * Honored only by Claude provider; ignored by Codex/Gemini/Copilot.
+     */
+    contextWindowMode?: ContextWindowMode;
+    /**
+     * Boolean thinking toggle for models that expose it (Haiku 4.5).
+     * Undefined and non-Haiku models ignore this field.
+     */
+    thinking?: boolean;
     /** USD budget cap for this session. Provider stops if exceeded. Undefined or 0 disables. */
     maxBudgetUsd?: number;
     /** Maximum agent turns for this session. Provider stops after this count. Undefined or 0 disables. */

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -17,6 +17,7 @@ import {
   PartialSettingsSchema,
   ReasoningLevelSchema,
   ProviderIdSchema,
+  ContextWindowModeSchema,
 } from "../models/settings.js";
 import { lazySchema } from "../utils/lazySchema.js";
 import { ProviderModelInfoSchema } from "../providers/models.js";
@@ -53,6 +54,10 @@ export const SendMessageSchema = lazySchema(() =>
     maxTurns: z.number().int().nonnegative().optional(),
     /** Copilot sub-agent to activate for this message. Ignored by other providers. */
     copilotAgent: CopilotAgentNameSchema.optional(),
+    /** Context window tier ("200k" default, "1m" extended). Honored only by 1M-capable Claude models. */
+    contextWindow: ContextWindowModeSchema.optional(),
+    /** Boolean thinking toggle. Honored only by models with a thinking toggle (Haiku 4.5). */
+    thinking: z.boolean().optional(),
   }),
 );
 
@@ -77,6 +82,10 @@ export const CreateAndSendSchema = lazySchema(() =>
     maxTurns: z.number().int().nonnegative().optional(),
     /** Copilot sub-agent to activate for this thread. Ignored by other providers. */
     copilotAgent: CopilotAgentNameSchema.optional(),
+    /** Context window tier ("200k" default, "1m" extended). Honored only by 1M-capable Claude models. */
+    contextWindow: ContextWindowModeSchema.optional(),
+    /** Boolean thinking toggle. Honored only by models with a thinking toggle (Haiku 4.5). */
+    thinking: z.boolean().optional(),
     /** Source thread ID when branching from an existing thread. */
   parentThreadId: z.string().optional(),
   /** Fork-point message ID in the parent thread. Defaults to last persisted message. */
@@ -128,12 +137,18 @@ export const WS_METHODS = lazySchema(() => ({
       permissionMode: PermissionModeSchema.optional(),
       /** Copilot-specific: name of the selected sub-agent. Pass null to clear back to provider default. */
       copilotAgent: CopilotAgentNameSchema.nullable().optional(),
+      /** Context window tier persisted on the thread. */
+      contextWindow: ContextWindowModeSchema.optional(),
+      /** Boolean thinking toggle persisted on the thread. Honored only for Haiku-class models. */
+      thinking: z.boolean().optional(),
     }).refine(
       (data) =>
         data.reasoningLevel !== undefined ||
         data.interactionMode !== undefined ||
         data.permissionMode !== undefined ||
-        data.copilotAgent !== undefined,
+        data.copilotAgent !== undefined ||
+        data.contextWindow !== undefined ||
+        data.thinking !== undefined,
       { message: "Must provide at least one setting to update" },
     ),
     result: z.boolean(),
@@ -227,6 +242,8 @@ export const WS_METHODS = lazySchema(() => ({
       answers: z.array(PlanAnswerSchema),
       permissionMode: PermissionModeSchema.optional(),
       reasoningLevel: ReasoningLevelSchema.optional(),
+      contextWindow: ContextWindowModeSchema.optional(),
+      thinking: z.boolean().optional(),
     }),
     result: z.void(),
   },

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -137,10 +137,10 @@ export const WS_METHODS = lazySchema(() => ({
       permissionMode: PermissionModeSchema.optional(),
       /** Copilot-specific: name of the selected sub-agent. Pass null to clear back to provider default. */
       copilotAgent: CopilotAgentNameSchema.nullable().optional(),
-      /** Context window tier persisted on the thread. */
-      contextWindow: ContextWindowModeSchema.optional(),
-      /** Boolean thinking toggle persisted on the thread. Honored only for Haiku-class models. */
-      thinking: z.boolean().optional(),
+      /** Context window tier persisted on the thread. Pass null to clear back to the global default. */
+      contextWindow: ContextWindowModeSchema.nullable().optional(),
+      /** Boolean thinking toggle persisted on the thread. Honored only for Haiku-class models. Pass null to clear. */
+      thinking: z.boolean().nullable().optional(),
     }).refine(
       (data) =>
         data.reasoningLevel !== undefined ||

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./model-effort": "./src/model-effort/index.ts"
+    "./model-effort": "./src/model-effort/index.ts",
+    "./model-context": "./src/model-context/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,5 +16,8 @@ export {
   isXhighEffortModel,
   isMaxEffortModel,
   supportsEffortParameter,
+  supportsUltrathink,
+  supports1MContextWindow,
+  supportsThinkingToggle,
   normalizeReasoningLevelForModel,
 } from "./model-effort/index.js";

--- a/packages/shared/src/model-context/__tests__/model-context.test.ts
+++ b/packages/shared/src/model-context/__tests__/model-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { MODEL_CONTEXT_WINDOWS, getModelContextWindow } from "../index.js";
+
+describe("MODEL_CONTEXT_WINDOWS", () => {
+  it("exposes 1M for Claude Opus 4.7", () => {
+    expect(MODEL_CONTEXT_WINDOWS["claude-opus-4-7"]).toBe(1_000_000);
+  });
+  it("exposes 1M for Claude Opus 4.6", () => {
+    expect(MODEL_CONTEXT_WINDOWS["claude-opus-4-6"]).toBe(1_000_000);
+  });
+  it("exposes 1M for Claude Sonnet 4.6", () => {
+    expect(MODEL_CONTEXT_WINDOWS["claude-sonnet-4-6"]).toBe(1_000_000);
+  });
+  it("exposes 200K for Claude Haiku 4.5", () => {
+    expect(MODEL_CONTEXT_WINDOWS["claude-haiku-4-5"]).toBe(200_000);
+  });
+});
+
+describe("getModelContextWindow", () => {
+  it("returns the value for exact base IDs", () => {
+    expect(getModelContextWindow("claude-sonnet-4-6")).toBe(1_000_000);
+    expect(getModelContextWindow("claude-haiku-4-5")).toBe(200_000);
+  });
+
+  it("matches dated SDK variants by longest-prefix", () => {
+    // Anthropic SDK can return dated variants like claude-haiku-4-5-20251001.
+    expect(getModelContextWindow("claude-haiku-4-5-20251001")).toBe(200_000);
+    expect(getModelContextWindow("claude-sonnet-4-6-20260101")).toBe(1_000_000);
+  });
+
+  it("returns undefined for unknown models", () => {
+    expect(getModelContextWindow("gpt-5.4")).toBeUndefined();
+    expect(getModelContextWindow("")).toBeUndefined();
+    expect(getModelContextWindow("not-a-real-model")).toBeUndefined();
+    expect(getModelContextWindow("claude-haiku-4-5abc")).toBeUndefined();
+  });
+});

--- a/packages/shared/src/model-context/__tests__/model-context.test.ts
+++ b/packages/shared/src/model-context/__tests__/model-context.test.ts
@@ -1,37 +1,94 @@
 import { describe, it, expect } from "vitest";
-import { MODEL_CONTEXT_WINDOWS, getModelContextWindow } from "../index.js";
+import {
+  MODEL_CONTEXT_WINDOWS,
+  MODEL_CONTEXT_WINDOWS_DEFAULT,
+  MODEL_CONTEXT_WINDOWS_EXTENDED,
+  getModelContextWindow,
+} from "../index.js";
 
-describe("MODEL_CONTEXT_WINDOWS", () => {
-  it("exposes 1M for Claude Opus 4.7", () => {
-    expect(MODEL_CONTEXT_WINDOWS["claude-opus-4-7"]).toBe(1_000_000);
+describe("MODEL_CONTEXT_WINDOWS_DEFAULT", () => {
+  it("exposes 200K as the default for every Claude model (no opt-in)", () => {
+    expect(MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-7"]).toBe(200_000);
+    expect(MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-6"]).toBe(200_000);
+    expect(MODEL_CONTEXT_WINDOWS_DEFAULT["claude-sonnet-4-6"]).toBe(200_000);
+    expect(MODEL_CONTEXT_WINDOWS_DEFAULT["claude-haiku-4-5"]).toBe(200_000);
   });
-  it("exposes 1M for Claude Opus 4.6", () => {
-    expect(MODEL_CONTEXT_WINDOWS["claude-opus-4-6"]).toBe(1_000_000);
+
+  it("MODEL_CONTEXT_WINDOWS alias points at the default map (back-compat)", () => {
+    expect(MODEL_CONTEXT_WINDOWS).toBe(MODEL_CONTEXT_WINDOWS_DEFAULT);
   });
-  it("exposes 1M for Claude Sonnet 4.6", () => {
-    expect(MODEL_CONTEXT_WINDOWS["claude-sonnet-4-6"]).toBe(1_000_000);
+});
+
+describe("MODEL_CONTEXT_WINDOWS_EXTENDED", () => {
+  it("exposes 1M for Opus 4.7", () => {
+    expect(MODEL_CONTEXT_WINDOWS_EXTENDED["claude-opus-4-7"]).toBe(1_000_000);
   });
-  it("exposes 200K for Claude Haiku 4.5", () => {
-    expect(MODEL_CONTEXT_WINDOWS["claude-haiku-4-5"]).toBe(200_000);
+  it("exposes 1M for Opus 4.6", () => {
+    expect(MODEL_CONTEXT_WINDOWS_EXTENDED["claude-opus-4-6"]).toBe(1_000_000);
+  });
+  it("exposes 1M for Sonnet 4.6", () => {
+    expect(MODEL_CONTEXT_WINDOWS_EXTENDED["claude-sonnet-4-6"]).toBe(1_000_000);
+  });
+  it("does NOT expose 1M for Haiku 4.5", () => {
+    expect(MODEL_CONTEXT_WINDOWS_EXTENDED["claude-haiku-4-5"]).toBeUndefined();
   });
 });
 
 describe("getModelContextWindow", () => {
-  it("returns the value for exact base IDs", () => {
-    expect(getModelContextWindow("claude-sonnet-4-6")).toBe(1_000_000);
+  // -------------------------------------------------------------------------
+  // Default (200k) mode -- used when no opt-in is selected.
+  // -------------------------------------------------------------------------
+
+  it("returns 200K for every supported Claude model in 200k mode", () => {
+    expect(getModelContextWindow("claude-opus-4-7", "200k")).toBe(200_000);
+    expect(getModelContextWindow("claude-opus-4-6", "200k")).toBe(200_000);
+    expect(getModelContextWindow("claude-sonnet-4-6", "200k")).toBe(200_000);
+    expect(getModelContextWindow("claude-haiku-4-5", "200k")).toBe(200_000);
+  });
+
+  it("defaults to 200k when mode is omitted", () => {
+    expect(getModelContextWindow("claude-sonnet-4-6")).toBe(200_000);
     expect(getModelContextWindow("claude-haiku-4-5")).toBe(200_000);
   });
 
-  it("matches dated SDK variants by longest-prefix", () => {
-    // Anthropic SDK can return dated variants like claude-haiku-4-5-20251001.
-    expect(getModelContextWindow("claude-haiku-4-5-20251001")).toBe(200_000);
-    expect(getModelContextWindow("claude-sonnet-4-6-20260101")).toBe(1_000_000);
+  // -------------------------------------------------------------------------
+  // 1M mode -- only models in the extended map honor the opt-in.
+  // -------------------------------------------------------------------------
+
+  it("returns 1M for opus-4-7/4-6 and sonnet-4-6 in 1m mode", () => {
+    expect(getModelContextWindow("claude-opus-4-7", "1m")).toBe(1_000_000);
+    expect(getModelContextWindow("claude-opus-4-6", "1m")).toBe(1_000_000);
+    expect(getModelContextWindow("claude-sonnet-4-6", "1m")).toBe(1_000_000);
   });
 
-  it("returns undefined for unknown models", () => {
-    expect(getModelContextWindow("gpt-5.4")).toBeUndefined();
-    expect(getModelContextWindow("")).toBeUndefined();
-    expect(getModelContextWindow("not-a-real-model")).toBeUndefined();
-    expect(getModelContextWindow("claude-haiku-4-5abc")).toBeUndefined();
+  it("falls back to 200K for haiku-4-5 even in 1m mode (not supported)", () => {
+    expect(getModelContextWindow("claude-haiku-4-5", "1m")).toBe(200_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Dated SDK variants
+  // -------------------------------------------------------------------------
+
+  it("matches dated SDK variants by longest-prefix in 200k mode", () => {
+    expect(getModelContextWindow("claude-haiku-4-5-20251001", "200k")).toBe(200_000);
+    expect(getModelContextWindow("claude-sonnet-4-6-20260101", "200k")).toBe(200_000);
+  });
+
+  it("matches dated SDK variants in 1m mode", () => {
+    expect(getModelContextWindow("claude-sonnet-4-6-20260101", "1m")).toBe(1_000_000);
+    // Dated Haiku variant should still fall back to 200K.
+    expect(getModelContextWindow("claude-haiku-4-5-20251001", "1m")).toBe(200_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown / invalid inputs
+  // -------------------------------------------------------------------------
+
+  it("returns undefined for unknown models in any mode", () => {
+    expect(getModelContextWindow("gpt-5.4", "200k")).toBeUndefined();
+    expect(getModelContextWindow("gpt-5.4", "1m")).toBeUndefined();
+    expect(getModelContextWindow("", "200k")).toBeUndefined();
+    expect(getModelContextWindow("not-a-real-model", "1m")).toBeUndefined();
+    expect(getModelContextWindow("claude-haiku-4-5abc", "200k")).toBeUndefined();
   });
 });

--- a/packages/shared/src/model-context/index.ts
+++ b/packages/shared/src/model-context/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Static per-model maximum context window (tokens) for models whose limits
+ * are known up-front. This fills the UI gauge and server-side budgeting
+ * before the first turn; the provider-reported live value takes precedence
+ * once a turn completes.
+ *
+ * Source: https://platform.claude.com/docs/en/docs/about-claude/models/overview
+ * (verified 2026-04-22).
+ */
+export const MODEL_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
+  "claude-opus-4-7": 1_000_000,
+  "claude-opus-4-6": 1_000_000,
+  "claude-sonnet-4-6": 1_000_000,
+  "claude-haiku-4-5": 200_000,
+};
+
+/**
+ * Precomputed longest-first key list so dated SDK variants
+ * (e.g. `claude-haiku-4-5-20251001`) resolve to the closest base ID
+ * without being shadowed by a shorter prefix.
+ */
+const SORTED_KEYS: readonly string[] = Object.keys(MODEL_CONTEXT_WINDOWS)
+  .sort((a, b) => b.length - a.length);
+
+/**
+ * Returns the static context window (in tokens) for a model ID, including
+ * prefix matches against dated SDK variants. Returns undefined when the
+ * model is unknown.
+ */
+export function getModelContextWindow(modelId: string): number | undefined {
+  if (!modelId) return undefined;
+  const exact = MODEL_CONTEXT_WINDOWS[modelId];
+  if (exact !== undefined) return exact;
+  const base = SORTED_KEYS.find((k) => modelId.startsWith(`${k}-`));
+  return base ? MODEL_CONTEXT_WINDOWS[base] : undefined;
+}

--- a/packages/shared/src/model-context/index.ts
+++ b/packages/shared/src/model-context/index.ts
@@ -1,36 +1,73 @@
+import type { ContextWindowMode } from "@mcode/contracts";
+
 /**
- * Static per-model maximum context window (tokens) for models whose limits
- * are known up-front. This fills the UI gauge and server-side budgeting
- * before the first turn; the provider-reported live value takes precedence
- * once a turn completes.
+ * Default per-model context window (tokens). Every Claude model supports this
+ * tier without any opt-in. Values are deliberately conservative — the SDK and
+ * Anthropic Models API may return larger numbers for the *capability ceiling*,
+ * but those are only honored when the user explicitly opts into 1M mode.
  *
  * Source: https://platform.claude.com/docs/en/docs/about-claude/models/overview
  * (verified 2026-04-22).
  */
-export const MODEL_CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
+export const MODEL_CONTEXT_WINDOWS_DEFAULT: Readonly<Record<string, number>> = {
+  "claude-opus-4-7": 200_000,
+  "claude-opus-4-6": 200_000,
+  "claude-sonnet-4-6": 200_000,
+  "claude-haiku-4-5": 200_000,
+};
+
+/**
+ * Extended per-model context window (tokens) for models that support the
+ * 1,000,000-token tier. Selected at request time by appending `[1m]` to the
+ * model slug. Models absent from this map ignore the 1M opt-in and run on
+ * their default window.
+ */
+export const MODEL_CONTEXT_WINDOWS_EXTENDED: Readonly<Record<string, number>> = {
   "claude-opus-4-7": 1_000_000,
   "claude-opus-4-6": 1_000_000,
   "claude-sonnet-4-6": 1_000_000,
-  "claude-haiku-4-5": 200_000,
 };
+
+/**
+ * Backwards-compatible alias. Returns the default window for each model.
+ * New call sites should prefer `getModelContextWindow(modelId, mode)` so the
+ * active window matches the request the SDK actually receives.
+ */
+export const MODEL_CONTEXT_WINDOWS = MODEL_CONTEXT_WINDOWS_DEFAULT;
 
 /**
  * Precomputed longest-first key list so dated SDK variants
  * (e.g. `claude-haiku-4-5-20251001`) resolve to the closest base ID
  * without being shadowed by a shorter prefix.
  */
-const SORTED_KEYS: readonly string[] = Object.keys(MODEL_CONTEXT_WINDOWS)
+const SORTED_KEYS: readonly string[] = Object.keys(MODEL_CONTEXT_WINDOWS_DEFAULT)
   .sort((a, b) => b.length - a.length);
 
-/**
- * Returns the static context window (in tokens) for a model ID, including
- * prefix matches against dated SDK variants. Returns undefined when the
- * model is unknown.
- */
-export function getModelContextWindow(modelId: string): number | undefined {
+/** Looks up a model in `map` with prefix matching for dated SDK variants. */
+function lookup(map: Readonly<Record<string, number>>, modelId: string): number | undefined {
   if (!modelId) return undefined;
-  const exact = MODEL_CONTEXT_WINDOWS[modelId];
+  const exact = map[modelId];
   if (exact !== undefined) return exact;
   const base = SORTED_KEYS.find((k) => modelId.startsWith(`${k}-`));
-  return base ? MODEL_CONTEXT_WINDOWS[base] : undefined;
+  return base ? map[base] : undefined;
+}
+
+/**
+ * Returns the active context window (tokens) for a model and mode.
+ *
+ * - "200k" (or unspecified): the model's default window.
+ * - "1m": the extended window if the model supports it, otherwise falls
+ *   through to the default.
+ *
+ * Returns `undefined` for unknown models.
+ */
+export function getModelContextWindow(
+  modelId: string,
+  mode: ContextWindowMode = "200k",
+): number | undefined {
+  if (mode === "1m") {
+    const extended = lookup(MODEL_CONTEXT_WINDOWS_EXTENDED, modelId);
+    if (extended !== undefined) return extended;
+  }
+  return lookup(MODEL_CONTEXT_WINDOWS_DEFAULT, modelId);
 }

--- a/packages/shared/src/model-context/index.ts
+++ b/packages/shared/src/model-context/index.ts
@@ -46,9 +46,11 @@ const SORTED_KEYS: readonly string[] = Object.keys(MODEL_CONTEXT_WINDOWS_DEFAULT
 /** Looks up a model in `map` with prefix matching for dated SDK variants. */
 function lookup(map: Readonly<Record<string, number>>, modelId: string): number | undefined {
   if (!modelId) return undefined;
-  const exact = map[modelId];
+  // Strip [1m] suffix that may be present on slugs returned by resolveSdkModelSlug.
+  const bare = modelId.replace(/\[1m\]$/, "");
+  const exact = map[bare];
   if (exact !== undefined) return exact;
-  const base = SORTED_KEYS.find((k) => modelId.startsWith(`${k}-`));
+  const base = SORTED_KEYS.find((k) => bare.startsWith(`${k}-`));
   return base ? map[base] : undefined;
 }
 

--- a/packages/shared/src/model-effort/index.ts
+++ b/packages/shared/src/model-effort/index.ts
@@ -13,15 +13,16 @@ import type { ReasoningLevel } from "@mcode/contracts";
 //
 // xhigh sits below max because xhigh is exclusive to Opus 4.7, while max is a
 // broader "extended thinking" tier supported by Opus 4.6 and Sonnet 4.6 as well.
-// This ordering means: requesting "max" on Opus 4.6 passes through (max is in its
-// allowed set), but requesting "xhigh" on Opus 4.6 correctly downgrades to "high"
-// by walking down past xhigh (not in allowed) and landing on high (in allowed).
+// "ultrathink" is the virtual top tier: it is mapped to "max" effort at the SDK
+// boundary and additionally prepends "Ultrathink:\n" to the user prompt.
+// Eligibility is identical to the max tier (Opus 4.7/4.6, Sonnet 4.6).
 const TIER_LADDER: readonly ReasoningLevel[] = [
   "low",
   "medium",
   "high",
   "xhigh",
   "max",
+  "ultrathink",
 ];
 
 /** Claude model IDs that support the "xhigh" effort tier. */
@@ -33,6 +34,28 @@ const MAX_EFFORT_MODEL_IDS: readonly string[] = [
   "claude-opus-4-6",
   "claude-sonnet-4-6",
 ];
+
+/**
+ * Claude model IDs that support the "ultrathink" virtual tier.
+ * Identical to the max-tier set — ultrathink is "max + prompt prefix".
+ */
+const ULTRATHINK_MODEL_IDS: readonly string[] = MAX_EFFORT_MODEL_IDS;
+
+/**
+ * Claude model IDs that support the extended 1,000,000-token context window.
+ * The same Opus 4.7/4.6 + Sonnet 4.6 cohort that supports the max effort tier.
+ */
+const ONE_M_CONTEXT_MODEL_IDS: readonly string[] = [
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+];
+
+/**
+ * Claude model IDs that expose a boolean thinking toggle (instead of an effort
+ * dial). Currently only Haiku 4.5 fits this shape.
+ */
+const THINKING_TOGGLE_MODEL_IDS: readonly string[] = ["claude-haiku-4-5"];
 
 /** Claude model IDs that do NOT support the effort parameter at all. */
 const EFFORT_UNSUPPORTED_CLAUDE_IDS: readonly string[] = ["claude-haiku-4-5"];
@@ -47,6 +70,9 @@ const ALL_KNOWN_BASE_IDS: readonly string[] = [
   ...new Set([
     ...XHIGH_EFFORT_MODEL_IDS,
     ...MAX_EFFORT_MODEL_IDS,
+    ...ULTRATHINK_MODEL_IDS,
+    ...ONE_M_CONTEXT_MODEL_IDS,
+    ...THINKING_TOGGLE_MODEL_IDS,
     ...EFFORT_UNSUPPORTED_CLAUDE_IDS,
   ]),
 ].sort((a, b) => b.length - a.length);
@@ -85,6 +111,36 @@ export function isMaxEffortModel(modelId: string): boolean {
 }
 
 /**
+ * Returns true when the model supports the "ultrathink" virtual tier.
+ *
+ * Applies to the opus-4-7, opus-4-6, and sonnet-4-6 families. Ultrathink
+ * resolves to "max" effort at the SDK boundary and additionally prepends
+ * "Ultrathink:\n" to the user prompt.
+ */
+export function supportsUltrathink(modelId: string): boolean {
+  return ULTRATHINK_MODEL_IDS.includes(normalizeModelId(modelId));
+}
+
+/**
+ * Returns true when the model supports the extended 1,000,000-token context
+ * window. Applies to opus-4-7, opus-4-6, and sonnet-4-6.
+ *
+ * The window is opted into by appending `[1m]` to the model slug at send
+ * time; the Claude Agent SDK handles the beta header internally.
+ */
+export function supports1MContextWindow(modelId: string): boolean {
+  return ONE_M_CONTEXT_MODEL_IDS.includes(normalizeModelId(modelId));
+}
+
+/**
+ * Returns true when the model exposes a boolean thinking toggle (instead of
+ * an effort dial). Currently Haiku 4.5 is the only such model.
+ */
+export function supportsThinkingToggle(modelId: string): boolean {
+  return THINKING_TOGGLE_MODEL_IDS.includes(normalizeModelId(modelId));
+}
+
+/**
  * Returns false when the model does not accept the effort parameter at all.
  *
  * Haiku-class models ignore effort; sending it causes API errors.
@@ -120,6 +176,9 @@ export function normalizeReasoningLevelForModel(
   }
   if (isXhighEffortModel(modelId)) {
     allowed.add("xhigh");
+  }
+  if (supportsUltrathink(modelId)) {
+    allowed.add("ultrathink");
   }
 
   if (allowed.has(level)) {


### PR DESCRIPTION
## What

Add per-model context window metadata for Claude models and plumb it end-to-end: UI gauge, model selector badges, handoff budget, and a user-facing default override. Also add dynamic discovery via the Anthropic Models API so newly-released models surface a context window without a static-table edit.

## Why

- `MODEL_PROVIDERS` omitted `contextWindow` for every Claude entry, so the UI gauge was blank until the first SDK turn populated it.
- `handoff-builder.ts` hardcoded 200K for all `claude-*` models, under-budgeting Opus 4.6/4.7 and Sonnet 4.6 (which support 1M tokens per [Anthropic's docs](https://platform.claude.com/docs/en/docs/about-claude/models/overview)).
- Static tables drift. Newly-released models sat without a context window until someone updated the constants by hand.

Verified context window values (2026-04-22):

| Model | Context window |
|-------|----------------|
| `claude-opus-4-7` | 1,000,000 |
| `claude-opus-4-6` | 1,000,000 |
| `claude-sonnet-4-6` | 1,000,000 |
| `claude-haiku-4-5` | 200,000 |

## Key changes

**Static lookup (`@mcode/shared/model-context`)**
- New `MODEL_CONTEXT_WINDOWS` table with prefix-aware lookup so dated SDK variants (e.g. `claude-haiku-4-5-20251001`) resolve to the same value.
- `apps/web/src/lib/model-registry.ts`: every Claude `ModelDefinition` populates `contextWindow` from the shared constant. Gauge shows a value on a fresh thread.
- `apps/server/src/services/handoff-builder.ts`: `replayBudgetChars()` scales to 15% of the per-model context window at ~4 chars/token (600K chars for 1M models, 120K for Haiku). Falls back to 100K for unknown models.

**Dynamic discovery (Anthropic Models API)**
- `apps/server/src/providers/claude/list-models.ts`: TTL-cached fetcher hitting Anthropic's Models API.
- `ClaudeProvider.listModels()` exposes the list to the web client and no-ops gracefully when `ANTHROPIC_API_KEY` is unset.
- `fetchProviderModels` and `providerModelsStore` plumb `contextWindow` through to the UI.

**User override (`model.defaults.contextWindow`)**
- New numeric setting with a schema upper bound, applied to the default model.
- Settings UI input under the Model section.
- Resolution chain: user override (default model only) → registry → SDK → stored value.

**UI**
- `ModelSelector` shows a context-window badge per model row (e.g. `1M`, `200K`).
- Gauge renders correctly before the first turn.

**Tests**
- Cover all four shipped Claude models, dated SDK variants, the unknown-model fallback, the prefix-matching boundary, the resolution chain, dynamic listing, and the schema upper bound.

## Configuration changes

- New setting `model.defaults.contextWindow` (number, optional). Documented in `docs/settings/reference.md`.

## Related

- Closes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selector shows per-model context-window badges; composer model-preferences popover adds 200k/1m picker and a Thinking toggle; "Ultrathink" reasoning tier available where supported.  
* **Behavior Changes**
  * Context-window resolution uses SDK/runtime → model preference → stored fallback with per-thread overrides and dynamic Claude model listing; per-thread contextWindow/thinking persist and travel with queued/branched messages.  
* **Tests**
  * Added extensive tests for context-window maps, preference resolution, reasoning tiers, formatting, and provider listing.  
* **Documentation**
  * New design spec and settings reference entries; settings-schema examples updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
