### PR TITLE
fix: branch-from-chat reads naming settings and sanitizes on submit

### DIFF
--- a/apps/web/e2e/branch-from-chat-naming.spec.ts
+++ b/apps/web/e2e/branch-from-chat-naming.spec.ts
@@ -60,6 +60,7 @@ const FAKE_THREAD: Thread = {
   permission_mode: null,
   parent_thread_id: null,
   forked_from_message_id: null,
+  copilot_agent: null,
 };
 
 const FAKE_THREAD_WORKTREE: Thread = {

--- a/apps/web/e2e/branch-from-chat-naming.spec.ts
+++ b/apps/web/e2e/branch-from-chat-naming.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import type { Thread } from "@mcode/contracts";
 import { getDefaultSettings } from "@mcode/contracts";
 import {
@@ -66,6 +67,7 @@ const FAKE_THREAD_WORKTREE: Thread = {
   mode: "worktree" as const,
   branch: "feat/parent-branch",
   worktree_path: "/tmp/branch-test/.worktrees/feat-parent-branch",
+  worktree_managed: true,
 };
 
 const FAKE_MESSAGE = {
@@ -82,21 +84,41 @@ const FAKE_MESSAGE = {
   attachments: null,
 };
 
+/**
+ * Inject store-finder helpers into the page so evaluate/waitForFunction calls
+ * share a single predicate definition instead of duplicating it.
+ *
+ * Must be called before page.goto() so addInitScript registers before load.
+ */
+async function injectStoreHelpers(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__findWorkspaceStore = () =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ((window as any).__mcodeStores ?? []).find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__findThreadStore = () =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ((window as any).__mcodeStores ?? []).find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (s: any) => "messages" in s.getState() && "loadMessages" in s.getState()
+      );
+  });
+}
+
 /** Activate a thread, wait for messages to load, then inject messages. */
 async function activateThreadAndInjectMessages(
-  page: import("@playwright/test").Page,
+  page: Page,
   thread: Thread,
   messages: typeof FAKE_MESSAGE[]
 ): Promise<void> {
   await page.evaluate(
     ({ workspace, thread, threadId }) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const stores: any[] = (window as any).__mcodeStores ?? [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const wsStore = stores.find((s: any) => {
-        const st = s.getState();
-        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
-      });
+      const wsStore = (window as any).__findWorkspaceStore?.();
       if (!wsStore) { console.error("[E2E] workspace store not found"); return; }
       wsStore.setState({
         workspaces: [workspace],
@@ -112,9 +134,7 @@ async function activateThreadAndInjectMessages(
   await page.waitForFunction(
     () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const stores: any[] = (window as any).__mcodeStores ?? [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const ts = stores.find((s: any) => "messages" in s.getState() && "loadMessages" in s.getState());
+      const ts = (window as any).__findThreadStore?.();
       return ts && ts.getState().loading === false && ts.getState().currentThreadId !== null;
     },
     { timeout: 5000 }
@@ -124,9 +144,7 @@ async function activateThreadAndInjectMessages(
   await page.evaluate(
     ({ messages }) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const stores: any[] = (window as any).__mcodeStores ?? [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const ts = stores.find((s: any) => "messages" in s.getState() && "loadMessages" in s.getState());
+      const ts = (window as any).__findThreadStore?.();
       if (!ts) { console.error("[E2E] thread store not found"); return; }
       ts.setState({ messages, loading: false, error: null });
     },
@@ -135,15 +153,10 @@ async function activateThreadAndInjectMessages(
 }
 
 /** Read the workspaceStore state from the injected registry. */
-async function getWorkspaceStoreState(page: import("@playwright/test").Page): Promise<Record<string, unknown>> {
+async function getWorkspaceStoreState(page: Page): Promise<Record<string, unknown>> {
   return page.evaluate(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stores: any[] = (window as any).__mcodeStores ?? [];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const wsStore = stores.find((s: any) => {
-      const st = s.getState();
-      return "activeThreadId" in st && "threads" in st && "workspaces" in st;
-    });
+    const wsStore = (window as any).__findWorkspaceStore?.();
     if (!wsStore) return {};
     const st = wsStore.getState();
     return {
@@ -171,6 +184,7 @@ test.describe("Branch-from-chat naming fix (#339)", () => {
 
     await mockWebSocketServer(page, { "settings.get": customSettings });
     await interceptZustandStores(page);
+    await injectStoreHelpers(page);
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
@@ -228,6 +242,7 @@ test.describe("Branch-from-chat naming fix (#339)", () => {
     // Default settings have mode: "auto"
     await mockWebSocketServer(page);
     await interceptZustandStores(page);
+    await injectStoreHelpers(page);
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
@@ -264,6 +279,7 @@ test.describe("Branch-from-chat naming fix (#339)", () => {
   test("branchAutoPreview is independent from autoPreviewBranch", async ({ page }) => {
     await mockWebSocketServer(page);
     await interceptZustandStores(page);
+    await injectStoreHelpers(page);
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
@@ -311,6 +327,7 @@ test.describe("Branch-from-chat naming fix (#339)", () => {
   test("initBranchMode defaults to existing-worktree when parent thread is in worktree mode", async ({ page }) => {
     await mockWebSocketServer(page);
     await interceptZustandStores(page);
+    await injectStoreHelpers(page);
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
@@ -330,16 +347,8 @@ test.describe("Branch-from-chat naming fix (#339)", () => {
     // Wait for the useEffect([branchFromMessageId]) to fire and initBranchMode to complete.
     // The effect runs after the React render cycle, so poll until the store reflects it.
     await page.waitForFunction(
-      () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const stores: any[] = (window as any).__mcodeStores ?? [];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const wsStore = stores.find((s: any) => {
-          const st = s.getState();
-          return "activeThreadId" in st && "threads" in st && "workspaces" in st;
-        });
-        return wsStore && wsStore.getState().branchExecMode === "existing-worktree";
-      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (window as any).__findWorkspaceStore?.()?.getState().branchExecMode === "existing-worktree",
       { timeout: 3000 }
     );
 

--- a/apps/web/e2e/branch-from-chat-naming.spec.ts
+++ b/apps/web/e2e/branch-from-chat-naming.spec.ts
@@ -1,0 +1,354 @@
+import { test, expect } from "@playwright/test";
+import type { Thread } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+
+/**
+ * E2E verification for the branch-from-chat naming fix (issue #339).
+ *
+ * Tests three specific behaviors that were broken before the fix:
+ * 1. branchNamingMode initializes from settings.worktree.naming.mode (was hardcoded "auto")
+ * 2. branchAutoPreview is independent from autoPreviewBranch (was shared)
+ * 3. resolveBranchName is used at submit time (strips trailing -/.//)
+ *
+ * Strategy: Use interceptZustandStores to read store state directly, bypassing
+ * the need to submit real forms or hit a live server. The store state reflects
+ * what initBranchMode set, which is exactly what the bug was about.
+ */
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const THREAD_ID = "test-thread-branch-naming";
+
+const FAKE_WORKSPACE = {
+  id: "ws-branch-test",
+  name: "Branch Test Workspace",
+  path: "/tmp/branch-test",
+  provider_config: {},
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const FAKE_THREAD: Thread = {
+  id: THREAD_ID,
+  workspace_id: "ws-branch-test",
+  title: "Branch Naming Test",
+  status: "paused" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: null,
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const FAKE_THREAD_WORKTREE: Thread = {
+  ...FAKE_THREAD,
+  id: "test-thread-worktree",
+  title: "Worktree Thread",
+  mode: "worktree" as const,
+  branch: "feat/parent-branch",
+  worktree_path: "/tmp/branch-test/.worktrees/feat-parent-branch",
+};
+
+const FAKE_MESSAGE = {
+  id: "msg-1",
+  thread_id: THREAD_ID,
+  role: "assistant" as const,
+  content: "I can help you with that feature.",
+  tool_calls: null,
+  files_changed: null,
+  cost_usd: null,
+  tokens_used: 42,
+  timestamp: new Date().toISOString(),
+  sequence: 1,
+  attachments: null,
+};
+
+/** Activate a thread, wait for messages to load, then inject messages. */
+async function activateThreadAndInjectMessages(
+  page: import("@playwright/test").Page,
+  thread: Thread,
+  messages: typeof FAKE_MESSAGE[]
+): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread, threadId }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) { console.error("[E2E] workspace store not found"); return; }
+      wsStore.setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: [thread],
+        activeThreadId: threadId,
+      });
+    },
+    { workspace: FAKE_WORKSPACE, thread, threadId: thread.id }
+  );
+
+  // Wait for loadMessages to complete
+  await page.waitForFunction(
+    () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ts = stores.find((s: any) => "messages" in s.getState() && "loadMessages" in s.getState());
+      return ts && ts.getState().loading === false && ts.getState().currentThreadId !== null;
+    },
+    { timeout: 5000 }
+  );
+
+  // Inject messages after load
+  await page.evaluate(
+    ({ messages }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ts = stores.find((s: any) => "messages" in s.getState() && "loadMessages" in s.getState());
+      if (!ts) { console.error("[E2E] thread store not found"); return; }
+      ts.setState({ messages, loading: false, error: null });
+    },
+    { messages }
+  );
+}
+
+/** Read the workspaceStore state from the injected registry. */
+async function getWorkspaceStoreState(page: import("@playwright/test").Page): Promise<Record<string, unknown>> {
+  return page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stores: any[] = (window as any).__mcodeStores ?? [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wsStore = stores.find((s: any) => {
+      const st = s.getState();
+      return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+    });
+    if (!wsStore) return {};
+    const st = wsStore.getState();
+    return {
+      branchNamingMode: st.branchNamingMode,
+      branchAutoPreview: st.branchAutoPreview,
+      branchExecMode: st.branchExecMode,
+      branchTargetBranch: st.branchTargetBranch,
+      branchWorktreePath: st.branchWorktreePath,
+      autoPreviewBranch: st.autoPreviewBranch,
+    };
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("Branch-from-chat naming fix (#339)", () => {
+  test.setTimeout(30000);
+
+  test("branchNamingMode initializes from settings when mode is 'custom'", async ({ page }) => {
+    // Override settings so worktree.naming.mode is "custom"
+    const customSettings = {
+      ...getDefaultSettings(),
+      worktree: { naming: { mode: "custom" as const, aiConfirmation: true } },
+    };
+
+    await mockWebSocketServer(page, { "settings.get": customSettings });
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // The settingsStore.fetch() is async (WS RPC). Rather than racing against it,
+    // inject the custom settings directly so initBranchMode reads "custom" reliably.
+    await page.evaluate(
+      ({ settings }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const stores: any[] = (window as any).__mcodeStores ?? [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const settingsStore = stores.find((s: any) => {
+          const st = s.getState();
+          return "loaded" in st && "settings" in st && !("threads" in st);
+        });
+        if (!settingsStore) { console.error("[E2E] settings store not found"); return; }
+        settingsStore.setState({ settings, loaded: true });
+      },
+      { settings: customSettings }
+    );
+
+    await activateThreadAndInjectMessages(page, FAKE_THREAD, [FAKE_MESSAGE]);
+
+    // Wait for message to be visible
+    await page.waitForFunction(
+      () => document.body.innerText.includes("I can help you with that feature."),
+      { timeout: 5000 }
+    );
+
+    // Trigger branch mode via the branch button on the message
+    const branchBtn = page.getByRole("button", { name: "Branch from this message" });
+    await expect(branchBtn).toBeVisible({ timeout: 5000 });
+    await branchBtn.click();
+
+    // Switch exec mode to "New worktree" via ModeSelector
+    const modeSelector = page.getByRole("button", { name: /Local|New worktree|Existing worktree/i }).first();
+    await expect(modeSelector).toBeVisible({ timeout: 3000 });
+    await modeSelector.click();
+    const newWorktreeOption = page.getByRole("menuitem", { name: "New worktree" });
+    await expect(newWorktreeOption).toBeVisible({ timeout: 3000 });
+    await newWorktreeOption.click();
+
+    // Verify the NamingModeSelector shows "Custom" (not "Auto")
+    const namingSelector = page.getByRole("button", { name: "Branch naming mode" });
+    await expect(namingSelector).toBeVisible({ timeout: 3000 });
+    await expect(namingSelector).toContainText("Custom");
+
+    // Also verify via store state
+    const storeState = await getWorkspaceStoreState(page);
+    expect(storeState.branchNamingMode).toBe("custom");
+
+    await page.screenshot({ path: "e2e/screenshots/branch-from-chat-naming-custom.png" });
+  });
+
+  test("branchNamingMode initializes to 'auto' when settings mode is 'auto'", async ({ page }) => {
+    // Default settings have mode: "auto"
+    await mockWebSocketServer(page);
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await activateThreadAndInjectMessages(page, FAKE_THREAD, [FAKE_MESSAGE]);
+
+    await page.waitForFunction(
+      () => document.body.innerText.includes("I can help you with that feature."),
+      { timeout: 5000 }
+    );
+
+    const branchBtn = page.getByRole("button", { name: "Branch from this message" });
+    await expect(branchBtn).toBeVisible({ timeout: 5000 });
+    await branchBtn.click();
+
+    // Switch to new worktree mode
+    const modeSelector = page.getByRole("button", { name: /Local|New worktree|Existing worktree/i }).first();
+    await expect(modeSelector).toBeVisible({ timeout: 3000 });
+    await modeSelector.click();
+    const newWorktreeOption = page.getByRole("menuitem", { name: "New worktree" });
+    await expect(newWorktreeOption).toBeVisible({ timeout: 3000 });
+    await newWorktreeOption.click();
+
+    // Verify the NamingModeSelector shows "Auto"
+    const namingSelector = page.getByRole("button", { name: "Branch naming mode" });
+    await expect(namingSelector).toBeVisible({ timeout: 3000 });
+    await expect(namingSelector).toContainText("Auto");
+
+    const storeState = await getWorkspaceStoreState(page);
+    expect(storeState.branchNamingMode).toBe("auto");
+
+    await page.screenshot({ path: "e2e/screenshots/branch-from-chat-naming-auto.png" });
+  });
+
+  test("branchAutoPreview is independent from autoPreviewBranch", async ({ page }) => {
+    await mockWebSocketServer(page);
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Read the initial autoPreviewBranch (new-thread flow) from store
+    const initialState = await getWorkspaceStoreState(page);
+    const initialAutoPreview = initialState.autoPreviewBranch as string;
+    expect(initialAutoPreview).toMatch(/^mcode-/);
+
+    await activateThreadAndInjectMessages(page, FAKE_THREAD, [FAKE_MESSAGE]);
+
+    await page.waitForFunction(
+      () => document.body.innerText.includes("I can help you with that feature."),
+      { timeout: 5000 }
+    );
+
+    // Enter branch mode
+    const branchBtn = page.getByRole("button", { name: "Branch from this message" });
+    await expect(branchBtn).toBeVisible({ timeout: 5000 });
+    await branchBtn.click();
+
+    // Switch to worktree mode to trigger initBranchMode auto preview generation
+    const modeSelector = page.getByRole("button", { name: /Local|New worktree|Existing worktree/i }).first();
+    await modeSelector.click();
+    const newWorktreeOption = page.getByRole("menuitem", { name: "New worktree" });
+    await newWorktreeOption.click();
+
+    // Read store state after branch mode activated
+    const afterState = await getWorkspaceStoreState(page);
+    const branchAutoPreview = afterState.branchAutoPreview as string;
+    const autoPreviewBranch = afterState.autoPreviewBranch as string;
+
+    // Both should be valid mcode-* names
+    expect(branchAutoPreview).toMatch(/^mcode-/);
+    expect(autoPreviewBranch).toMatch(/^mcode-/);
+
+    // They must be different — isolated auto previews
+    expect(branchAutoPreview).not.toBe(autoPreviewBranch);
+
+    // The new-thread auto preview should be unchanged (initBranchMode doesn't touch it)
+    expect(autoPreviewBranch).toBe(initialAutoPreview);
+
+    await page.screenshot({ path: "e2e/screenshots/branch-from-chat-auto-preview-isolated.png" });
+  });
+
+  test("initBranchMode defaults to existing-worktree when parent thread is in worktree mode", async ({ page }) => {
+    await mockWebSocketServer(page);
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Use the worktree thread
+    const worktreeMessage = { ...FAKE_MESSAGE, thread_id: FAKE_THREAD_WORKTREE.id };
+    await activateThreadAndInjectMessages(page, FAKE_THREAD_WORKTREE, [worktreeMessage]);
+
+    await page.waitForFunction(
+      () => document.body.innerText.includes("I can help you with that feature."),
+      { timeout: 5000 }
+    );
+
+    const branchBtn = page.getByRole("button", { name: "Branch from this message" });
+    await expect(branchBtn).toBeVisible({ timeout: 5000 });
+    await branchBtn.click();
+
+    // Wait for the useEffect([branchFromMessageId]) to fire and initBranchMode to complete.
+    // The effect runs after the React render cycle, so poll until the store reflects it.
+    await page.waitForFunction(
+      () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const stores: any[] = (window as any).__mcodeStores ?? [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const wsStore = stores.find((s: any) => {
+          const st = s.getState();
+          return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+        });
+        return wsStore && wsStore.getState().branchExecMode === "existing-worktree";
+      },
+      { timeout: 3000 }
+    );
+
+    // After entering branch mode from a worktree thread, exec mode should be "existing-worktree"
+    const storeState = await getWorkspaceStoreState(page);
+    expect(storeState.branchExecMode).toBe("existing-worktree");
+    // Target branch should reflect parent branch
+    expect(storeState.branchTargetBranch).toBe("feat/parent-branch");
+
+    await page.screenshot({ path: "e2e/screenshots/branch-from-chat-worktree-parent.png" });
+  });
+});

--- a/apps/web/e2e/branch-from-chat-naming.spec.ts
+++ b/apps/web/e2e/branch-from-chat-naming.spec.ts
@@ -10,14 +10,16 @@ import {
 /**
  * E2E verification for the branch-from-chat naming fix (issue #339).
  *
- * Tests three specific behaviors that were broken before the fix:
- * 1. branchNamingMode initializes from settings.worktree.naming.mode (was hardcoded "auto")
- * 2. branchAutoPreview is independent from autoPreviewBranch (was shared)
- * 3. resolveBranchName is used at submit time (strips trailing -/.//)
+ * Tests four behaviors that were broken before the fix:
+ * 1. branchNamingMode initializes from settings.worktree.naming.mode
+ * 2. branchNamingMode defaults to "auto" when settings mode is "auto"
+ * 3. branchAutoPreview is independent from autoPreviewBranch
+ * 4. initBranchMode defaults to "existing-worktree" for worktree parent threads
  *
  * Strategy: Use interceptZustandStores to read store state directly, bypassing
  * the need to submit real forms or hit a live server. The store state reflects
- * what initBranchMode set, which is exactly what the bug was about.
+ * what initBranchMode sets, which is the target of this regression suite.
+ * Note: resolveBranchName submit-time behavior is covered by unit tests.
  */
 
 // ─── Test data ────────────────────────────────────────────────────────────────

--- a/apps/web/src/__tests__/branch-name.test.ts
+++ b/apps/web/src/__tests__/branch-name.test.ts
@@ -230,4 +230,12 @@ describe("resolveBranchName", () => {
       autoPreview: "mcode-abc123",
     })).toBe("mcode-abc123");
   });
+
+  it("returns autoPreview in ai mode", () => {
+    expect(resolveBranchName({
+      namingMode: "ai",
+      customName: "ignored",
+      autoPreview: "mcode-abc123",
+    })).toBe("mcode-abc123");
+  });
 });

--- a/apps/web/src/__tests__/branch-name.test.ts
+++ b/apps/web/src/__tests__/branch-name.test.ts
@@ -6,6 +6,7 @@ import {
   finalizeCustomBranchName,
   generateBranchNameFromMessage,
   generateFallbackBranchName,
+  resolveBranchName,
 } from "../lib/branch-name";
 
 describe("sanitizeBranchName", () => {
@@ -174,5 +175,59 @@ describe("finalizeCustomBranchName", () => {
 describe("generateFallbackBranchName", () => {
   it("returns a thread-prefixed name", () => {
     expect(generateFallbackBranchName()).toMatch(/^thread-[a-z0-9]+$/);
+  });
+});
+
+describe("resolveBranchName", () => {
+  it("returns autoPreview in auto mode", () => {
+    expect(resolveBranchName({
+      namingMode: "auto",
+      customName: "ignored",
+      autoPreview: "mcode-abc123",
+    })).toBe("mcode-abc123");
+  });
+
+  it("returns cleaned custom name in custom mode", () => {
+    expect(resolveBranchName({
+      namingMode: "custom",
+      customName: "feat/my-branch",
+      autoPreview: "mcode-abc123",
+    })).toBe("feat/my-branch");
+  });
+
+  it("strips trailing hyphens, dots, and slashes from custom name", () => {
+    expect(resolveBranchName({
+      namingMode: "custom",
+      customName: "feat/bar-",
+      autoPreview: "mcode-abc123",
+    })).toBe("feat/bar");
+
+    expect(resolveBranchName({
+      namingMode: "custom",
+      customName: "feat.",
+      autoPreview: "mcode-abc123",
+    })).toBe("feat");
+
+    expect(resolveBranchName({
+      namingMode: "custom",
+      customName: "feat/",
+      autoPreview: "mcode-abc123",
+    })).toBe("feat");
+  });
+
+  it("falls back to autoPreview when custom name is empty", () => {
+    expect(resolveBranchName({
+      namingMode: "custom",
+      customName: "",
+      autoPreview: "mcode-abc123",
+    })).toBe("mcode-abc123");
+  });
+
+  it("falls back to autoPreview when custom name is only trailing chars", () => {
+    expect(resolveBranchName({
+      namingMode: "custom",
+      customName: "---",
+      autoPreview: "mcode-abc123",
+    })).toBe("mcode-abc123");
   });
 });

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -558,6 +558,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       loadBranches(workspaceId);
       loadWorktrees(workspaceId);
     }
+  // activeThread is intentionally read at call time, not as a dependency.
+  // Branch mode only activates via a user gesture on a fully-loaded thread,
+  // so activeThread is always current when branchFromMessageId is set.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [branchFromMessageId]);
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -25,7 +25,6 @@ import { ModeSelector } from "./ModeSelector";
 import type { ComposerMode } from "./ModeSelector";
 import { BranchPicker } from "./BranchPicker";
 import { NamingModeSelector } from "./NamingModeSelector";
-import type { NamingMode } from "@mcode/contracts";
 import { BranchNameInput } from "./BranchNameInput";
 const LazyWorktreePicker = lazy(() => import("./WorktreePicker"));
 import { CopilotAgentSelector } from "./CopilotAgentSelector";
@@ -40,6 +39,7 @@ import { TerminalStatusIndicator } from "./TerminalStatusIndicator";
 import { useTaskStore } from "@/stores/taskStore";
 import { useDiffStore } from "@/stores/diffStore";
 import { extractFileRefs, buildInjectedMessage } from "@/lib/file-tags";
+import { resolveBranchName } from "@/lib/branch-name";
 import { useSlashCommand } from "./useSlashCommand";
 import type { Command } from "./useSlashCommand";
 import { SlashCommandPopup } from "./SlashCommandPopup";
@@ -374,13 +374,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const [access, setAccess] = useState<AccessMode>(PERMISSION_MODES.FULL);
   const [showReasoningPicker, setShowReasoningPicker] = useState(false);
   const [composerMode, setComposerModeLocal] = useState<ComposerMode>("direct");
-  // Separate exec mode/branch state used only while in branch mode so the
-  // main new-thread mode state is not disturbed.
-  const [branchExecMode, setBranchExecMode] = useState<ComposerMode>("direct");
-  const [branchTargetBranch, setBranchTargetBranch] = useState("");
-  const [branchWorktreePath, setBranchWorktreePath] = useState("");
-  const [branchNamingMode, setBranchNamingMode] = useState<NamingMode>("auto");
-  const [branchCustomName, setBranchCustomName] = useState("");
   const [preparingWorktree, setPreparingWorktree] = useState(false);
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -561,19 +554,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   // Reset branch-specific exec state and load branch/worktree data when branch mode activates.
   useEffect(() => {
     if (branchFromMessageId && workspaceId) {
-      // Default to the same execution mode as the parent thread so the child
-      // stays in the same context by default (worktree → existing-worktree, local → direct).
-      const defaultExecMode: ComposerMode =
-        activeThread?.mode === "worktree" ? "existing-worktree" : "direct";
-      setBranchExecMode(defaultExecMode);
-      setBranchTargetBranch(activeThread?.branch ?? "");
-      // Pre-select the parent's worktree so the user doesn't have to pick it manually.
-      setBranchWorktreePath(activeThread?.worktree_path ?? "");
-      setBranchNamingMode("auto");
-      setBranchCustomName("");
+      initBranchMode(activeThread);
       loadBranches(workspaceId);
       loadWorktrees(workspaceId);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [branchFromMessageId]);
 
   // Consume pending prefill set by empty-state prompt chips
@@ -683,6 +668,18 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const setNamingMode = useWorkspaceStore((s) => s.setNamingMode);
   const setCustomBranchName = useWorkspaceStore((s) => s.setCustomBranchName);
   const setSelectedWorktree = useWorkspaceStore((s) => s.setSelectedWorktree);
+  const branchExecMode = useWorkspaceStore((s) => s.branchExecMode);
+  const branchTargetBranch = useWorkspaceStore((s) => s.branchTargetBranch);
+  const branchWorktreePath = useWorkspaceStore((s) => s.branchWorktreePath);
+  const branchNamingMode = useWorkspaceStore((s) => s.branchNamingMode);
+  const branchCustomName = useWorkspaceStore((s) => s.branchCustomName);
+  const branchAutoPreview = useWorkspaceStore((s) => s.branchAutoPreview);
+  const initBranchMode = useWorkspaceStore((s) => s.initBranchMode);
+  const setBranchExecMode = useWorkspaceStore((s) => s.setBranchExecMode);
+  const setBranchTargetBranch = useWorkspaceStore((s) => s.setBranchTargetBranch);
+  const setBranchWorktreePath = useWorkspaceStore((s) => s.setBranchWorktreePath);
+  const setBranchNamingMode = useWorkspaceStore((s) => s.setBranchNamingMode);
+  const setBranchCustomName = useWorkspaceStore((s) => s.setBranchCustomName);
   const openPrs = useWorkspaceStore((s) => s.openPrs);
   const openPrsLoading = useWorkspaceStore((s) => s.openPrsLoading);
   const fetchingBranch = useWorkspaceStore((s) => s.fetchingBranch);
@@ -1149,9 +1146,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
       if (branchExecMode === "worktree") {
         branchMode = "worktree";
-        branchBranch = branchNamingMode === "custom" && branchCustomName.trim()
-          ? branchCustomName.trim()
-          : autoPreviewBranch;
+        branchBranch = resolveBranchName({
+          namingMode: branchNamingMode,
+          customName: branchCustomName,
+          autoPreview: branchAutoPreview,
+        });
       } else if (branchExecMode === "existing-worktree") {
         branchMode = "existing-worktree";
         branchWorktree = branchWorktreePath;
@@ -1191,7 +1190,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
 
     editorRef.current?.focus();
-  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, autoPreviewBranch, onBranchModeExit]);
+  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, branchAutoPreview, onBranchModeExit]);
 
   const handleEditorChange = useCallback((text: string) => {
     setInput(text);
@@ -1692,7 +1691,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 <NamingModeSelector mode={branchNamingMode} onModeChange={setBranchNamingMode} />
                 <BranchNameInput
                   namingMode={branchNamingMode}
-                  autoPreview={autoPreviewBranch}
+                  autoPreview={branchAutoPreview}
                   customValue={branchCustomName}
                   onCustomChange={setBranchCustomName}
                 />

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -561,7 +561,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   // activeThread is intentionally read at call time, not as a dependency.
   // Branch mode only activates via a user gesture on a fully-loaded thread,
   // so activeThread is always current when branchFromMessageId is set.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [branchFromMessageId]);
 
   // Consume pending prefill set by empty-state prompt chips

--- a/apps/web/src/lib/branch-name.ts
+++ b/apps/web/src/lib/branch-name.ts
@@ -78,8 +78,10 @@ export function generateFallbackBranchName(): string {
   return `thread-${Date.now().toString(36)}`;
 }
 
-/** Resolve the final branch name from naming mode, custom input, and auto preview.
- *  Used at submission time by both new-worktree and branch-from-chat flows. */
+/**
+ * Resolve the final branch name from naming mode, custom input, and auto preview.
+ * Used at submission time by both new-worktree and branch-from-chat flows.
+ */
 export function resolveBranchName(opts: {
   namingMode: NamingMode;
   customName: string;

--- a/apps/web/src/lib/branch-name.ts
+++ b/apps/web/src/lib/branch-name.ts
@@ -1,3 +1,5 @@
+import type { NamingMode } from "@mcode/contracts";
+
 const STOP_WORDS = new Set([
   "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
   "have", "has", "had", "do", "does", "did", "will", "would", "could",
@@ -74,4 +76,18 @@ export function generateBranchNameFromMessage(message: string): string {
 /** Generate a timestamped fallback branch name (e.g. `thread-k5f2g`). */
 export function generateFallbackBranchName(): string {
   return `thread-${Date.now().toString(36)}`;
+}
+
+/** Resolve the final branch name from naming mode, custom input, and auto preview.
+ *  Used at submission time by both new-worktree and branch-from-chat flows. */
+export function resolveBranchName(opts: {
+  namingMode: NamingMode;
+  customName: string;
+  autoPreview: string;
+}): string {
+  if (opts.namingMode === "custom") {
+    const cleaned = trimTrailingBranchChars(opts.customName);
+    return cleaned || opts.autoPreview;
+  }
+  return opts.autoPreview;
 }

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -105,20 +105,31 @@ interface WorkspaceState {
   regenerateAutoPreview: () => void;
 
   // Branch-from-chat state (mirrors new-thread naming fields)
+  /** Execution mode chosen for the branched thread (direct, new worktree, existing worktree). */
   branchExecMode: "direct" | "worktree" | "existing-worktree";
+  /** Base branch selected in the branch-from-chat branch picker. */
   branchTargetBranch: string;
+  /** Path of the existing worktree to attach to when branchExecMode is "existing-worktree". */
   branchWorktreePath: string;
+  /** Naming mode for the branch-from-chat worktree branch (auto or custom). */
   branchNamingMode: NamingMode;
+  /** Custom branch name entered by the user in branch-from-chat mode. */
   branchCustomName: string;
+  /** Auto-generated preview branch name for branch-from-chat mode. Independent of autoPreviewBranch. */
   branchAutoPreview: string;
 
   // Branch-from-chat actions
   /** Initialize branch-mode state from the parent thread and user settings. */
   initBranchMode: (parentThread: Thread | undefined) => void;
+  /** Set the execution mode for the branched thread. */
   setBranchExecMode: (mode: "direct" | "worktree" | "existing-worktree") => void;
+  /** Set the base branch for the branched thread. */
   setBranchTargetBranch: (branch: string) => void;
+  /** Set the existing worktree path for the branched thread. */
   setBranchWorktreePath: (path: string) => void;
+  /** Set the naming mode for the branch-from-chat worktree branch. */
   setBranchNamingMode: (mode: NamingMode) => void;
+  /** Set and sanitize the custom branch name for the branch-from-chat flow. */
   setBranchCustomName: (name: string) => void;
 
   loadOpenPrs: (workspaceId: string) => Promise<void>;

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -10,7 +10,7 @@ import { useComposerDraftStore } from "./composerDraftStore";
 import { useDiffStore } from "./diffStore";
 import type { NamingMode, ReasoningLevel, InteractionMode } from "@mcode/contracts";
 import { useSettingsStore } from "./settingsStore";
-import { sanitizeCustomBranchInput, trimTrailingBranchChars } from "@/lib/branch-name";
+import { sanitizeCustomBranchInput, resolveBranchName } from "@/lib/branch-name";
 
 /** Generate a short random branch name for auto-mode worktrees (e.g. `mcode-a1b2c3d4`). */
 function generateBranchId(): string {
@@ -104,6 +104,23 @@ interface WorkspaceState {
   setSelectedWorktree: (worktree: WorktreeInfo | null) => void;
   regenerateAutoPreview: () => void;
 
+  // Branch-from-chat state (mirrors new-thread naming fields)
+  branchExecMode: "direct" | "worktree" | "existing-worktree";
+  branchTargetBranch: string;
+  branchWorktreePath: string;
+  branchNamingMode: NamingMode;
+  branchCustomName: string;
+  branchAutoPreview: string;
+
+  // Branch-from-chat actions
+  /** Initialize branch-mode state from the parent thread and user settings. */
+  initBranchMode: (parentThread: Thread | undefined) => void;
+  setBranchExecMode: (mode: "direct" | "worktree" | "existing-worktree") => void;
+  setBranchTargetBranch: (branch: string) => void;
+  setBranchWorktreePath: (path: string) => void;
+  setBranchNamingMode: (mode: NamingMode) => void;
+  setBranchCustomName: (name: string) => void;
+
   loadOpenPrs: (workspaceId: string) => Promise<void>;
   fetchBranch: (workspaceId: string, branch: string, prNumber?: number) => Promise<void>;
   /**
@@ -138,6 +155,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   openPrsLoading: false,
   fetchingBranch: null,
   branchManuallySelected: false,
+  branchExecMode: "direct" as const,
+  branchTargetBranch: "",
+  branchWorktreePath: "",
+  branchNamingMode: "auto" as NamingMode,
+  branchCustomName: "",
+  branchAutoPreview: generateBranchId(),
   prUrlsByThreadId: {},
   checksById: {},
 
@@ -303,17 +326,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
     if (newThreadMode === "worktree") {
       mode = "worktree";
-      if (namingMode === "custom") {
-        if (!customBranchName.trim()) {
-          // Fallback to auto if custom name is empty
-          branch = autoPreviewBranch;
-          set({ namingMode: "auto" as NamingMode });
-        } else {
-          branch = trimTrailingBranchChars(customBranchName);
-        }
-      } else {
-        branch = autoPreviewBranch;
-      }
+      branch = resolveBranchName({ namingMode, customName: customBranchName, autoPreview: autoPreviewBranch });
     } else if (newThreadMode === "existing-worktree") {
       mode = "worktree";
       if (!selectedWorktree) throw new Error("No worktree selected");
@@ -549,6 +562,23 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   setCustomBranchName: (name) => set({ customBranchName: sanitizeCustomBranchInput(name) }),
   setSelectedWorktree: (worktree) => set({ selectedWorktree: worktree }),
   regenerateAutoPreview: () => set({ autoPreviewBranch: generateBranchId() }),
+  initBranchMode: (parentThread) => {
+    const defaultExecMode: "direct" | "worktree" | "existing-worktree" =
+      parentThread?.mode === "worktree" ? "existing-worktree" : "direct";
+    set({
+      branchExecMode: defaultExecMode,
+      branchTargetBranch: parentThread?.branch ?? "",
+      branchWorktreePath: parentThread?.worktree_path ?? "",
+      branchNamingMode: useSettingsStore.getState().settings.worktree.naming.mode,
+      branchCustomName: "",
+      branchAutoPreview: generateBranchId(),
+    });
+  },
+  setBranchExecMode: (mode) => set({ branchExecMode: mode }),
+  setBranchTargetBranch: (branch) => set({ branchTargetBranch: branch }),
+  setBranchWorktreePath: (path) => set({ branchWorktreePath: path }),
+  setBranchNamingMode: (mode) => set({ branchNamingMode: mode }),
+  setBranchCustomName: (name) => set({ branchCustomName: sanitizeCustomBranchInput(name) }),
 
   loadOpenPrs: async (workspaceId) => {
     set({ openPrsLoading: true });

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -166,6 +166,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   openPrsLoading: false,
   fetchingBranch: null,
   branchManuallySelected: false,
+  // Branch-from-chat fields — safe defaults; always reset by initBranchMode before use.
   branchExecMode: "direct" as const,
   branchTargetBranch: "",
   branchWorktreePath: "",
@@ -580,6 +581,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       branchExecMode: defaultExecMode,
       branchTargetBranch: parentThread?.branch ?? "",
       branchWorktreePath: parentThread?.worktree_path ?? "",
+      // Intentional snapshot: reads the current setting at activation time.
+      // If settings load after the user opens branch mode, they'll see "auto"
+      // until the next activation — acceptable given the narrow timing window.
       branchNamingMode: useSettingsStore.getState().settings.worktree.naming.mode,
       branchCustomName: "",
       branchAutoPreview: generateBranchId(),


### PR DESCRIPTION
## What
Fix three bugs in the branch-from-chat flow where it ignored worktree naming settings, shared state with the new-thread flow, and skipped submission sanitization.

## Why
The branch-from-chat path used local `useState` instead of reading from `workspaceStore`, causing it to always default to `"auto"` mode regardless of `settings.worktree.naming.mode`, share the `autoPreviewBranch` value with the new-thread composer (so clicking branch-from-chat would corrupt the new-thread preview), and call `.trim()` instead of `trimTrailingBranchChars()` at submit time.

## Key Changes
- Add `resolveBranchName()` utility in `branch-name.ts` — shared submission logic that strips trailing `- / .` chars in custom mode and falls back to auto-preview when the result is empty
- Add 6 new state fields (`branchExecMode`, `branchNamingMode`, `branchAutoPreview`, etc.) and `initBranchMode` action to `workspaceStore` — reads `settings.worktree.naming.mode` and generates an isolated auto-preview
- Migrate `Composer` branch-from-chat path from local `useState` to store selectors, eliminating state divergence between the two flows
- Add 4 Playwright E2E tests covering: settings-initialized naming mode, auto mode default, isolated auto-preview, and existing-worktree default for worktree parent threads

Closes #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end and unit tests covering branching-from-chat flows: naming modes (Auto/AI/Custom), preview generation, custom-name sanitization/fallbacks, new-worktree and existing-worktree flows, and UI branching actions.

* **Refactor**
  * Centralized branch-name resolution and moved branch-mode state to shared workspace state so branch previews, naming selection, and branching actions behave consistently across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->