### PR TITLE
feat: support non-git folders with graceful feature degradation

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -208,10 +208,15 @@ if (removed > 0) {
 }
 
 // Initialize HEAD file watchers for all existing workspaces so branch changes
-// are detected after a server restart.
+// are detected after a server restart. Also correct any stale is_git_repo = false
+// values (can occur when git was unavailable at workspace creation time).
 const allWorkspaces = workspaceRepo.listAll();
 for (const ws of allWorkspaces) {
   gitWatcherService.watchWorkspace(ws.id, ws.path);
+  if (!ws.is_git_repo && existsSync(join(ws.path, ".git"))) {
+    workspaceRepo.setIsGitRepo(ws.id, true);
+    logger.info("Corrected stale is_git_repo=false at startup", { workspaceId: ws.id, path: ws.path });
+  }
 }
 
 // Begin watching the user's Claude skills/commands/plugins directories so the

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -13,6 +13,7 @@ interface WorkspaceRow {
   name: string;
   path: string;
   provider_config: string;
+  is_git_repo: number;
   created_at: string;
   updated_at: string;
 }
@@ -26,6 +27,7 @@ function rowToWorkspace(row: WorkspaceRow): Workspace {
       string,
       unknown
     >,
+    is_git_repo: row.is_git_repo === 1,
     created_at: row.created_at,
     updated_at: row.updated_at,
   };
@@ -37,21 +39,22 @@ export class WorkspaceRepo {
   constructor(@inject("Database") private readonly db: Database.Database) {}
 
   /** Create a new workspace and return the fully-populated record. */
-  create(name: string, path: string): Workspace {
+  create(name: string, path: string, isGitRepo: boolean): Workspace {
     const id = randomUUID();
     const now = new Date().toISOString();
 
     this.db
       .prepare(
-        "INSERT INTO workspaces (id, name, path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO workspaces (id, name, path, is_git_repo, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
       )
-      .run(id, name, path, now, now);
+      .run(id, name, path, isGitRepo ? 1 : 0, now, now);
 
     return {
       id,
       name,
       path,
       provider_config: {},
+      is_git_repo: isGitRepo,
       created_at: now,
       updated_at: now,
     };
@@ -61,7 +64,7 @@ export class WorkspaceRepo {
   findById(id: string): Workspace | null {
     const row = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, created_at, updated_at FROM workspaces WHERE id = ?",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at FROM workspaces WHERE id = ?",
       )
       .get(id) as WorkspaceRow | undefined;
 
@@ -72,7 +75,7 @@ export class WorkspaceRepo {
   findByPath(path: string): Workspace | null {
     const row = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, created_at, updated_at FROM workspaces WHERE path = ?",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at FROM workspaces WHERE path = ?",
       )
       .get(path) as WorkspaceRow | undefined;
 
@@ -83,7 +86,7 @@ export class WorkspaceRepo {
   listAll(): Workspace[] {
     const rows = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, created_at, updated_at FROM workspaces ORDER BY updated_at DESC",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at FROM workspaces ORDER BY updated_at DESC",
       )
       .all() as WorkspaceRow[];
 
@@ -97,5 +100,19 @@ export class WorkspaceRepo {
       .run(id);
 
     return result.changes > 0;
+  }
+
+  /** Bump updated_at to the current time so the workspace sorts to the top of the recent list. */
+  touch(id: string): void {
+    this.db
+      .prepare("UPDATE workspaces SET updated_at = ? WHERE id = ?")
+      .run(new Date().toISOString(), id);
+  }
+
+  /** Update the is_git_repo flag (e.g. after the user runs `git init`). */
+  setIsGitRepo(id: string, isGitRepo: boolean): void {
+    this.db
+      .prepare("UPDATE workspaces SET is_git_repo = ? WHERE id = ?")
+      .run(isGitRepo ? 1 : 0, id);
   }
 }

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -153,8 +153,8 @@ export class GitService {
     return listBranchesForPath(workspace.path);
   }
 
-  /** Get the current branch name for a workspace. */
-  getCurrentBranch(workspaceId: string): string {
+  /** Get the current branch name for a workspace. Returns null for non-git workspaces. */
+  getCurrentBranch(workspaceId: string): string | null {
     const workspace = this.requireWorkspace(workspaceId);
     return getCurrentBranchForPath(workspace.path);
   }
@@ -164,7 +164,7 @@ export class GitService {
    * Use this instead of getCurrentBranch when you already have the resolved path
    * (e.g. a worktree directory that may differ from the workspace root).
    */
-  getCurrentBranchAt(repoPath: string): string {
+  getCurrentBranchAt(repoPath: string): string | null {
     return getCurrentBranchForPath(repoPath);
   }
 
@@ -421,7 +421,13 @@ export class GitService {
       args.push(branch);
     }
 
-    const { stdout } = await execFile("git", args, { timeout: 10_000 });
+    let stdout: string;
+    try {
+      const result = await execFile("git", args, { timeout: 10_000 });
+      stdout = result.stdout;
+    } catch {
+      return [];
+    }
 
     const commits: GitCommit[] = [];
     // Each block starts with MCODE_SEP; split on that separator
@@ -603,17 +609,22 @@ export class GitService {
 
 /** List all branches (local, remote, worktree-attached) for a repository path. */
 function listBranchesForPath(repoPath: string): GitBranch[] {
-  const output = execFileSync(
-    "git",
-    [
-      "-C",
-      repoPath,
-      "branch",
-      "-a",
-      "--format=%(refname)|||%(refname:short)|||%(objectname:short)|||%(HEAD)|||%(worktreepath)",
-    ],
-    { stdio: "pipe", encoding: "utf-8" },
-  );
+  let output: string;
+  try {
+    output = execFileSync(
+      "git",
+      [
+        "-C",
+        repoPath,
+        "branch",
+        "-a",
+        "--format=%(refname)|||%(refname:short)|||%(objectname:short)|||%(HEAD)|||%(worktreepath)",
+      ],
+      { stdio: "pipe", encoding: "utf-8" },
+    );
+  } catch {
+    return [];
+  }
 
   const branches: GitBranch[] = [];
 
@@ -656,17 +667,17 @@ function listBranchesForPath(repoPath: string): GitBranch[] {
   });
 }
 
-/** Get the current branch name for a repository path. */
-export function getCurrentBranchForPath(repoPath: string): string {
+/** Get the current branch name for a repository path. Returns null for non-git paths. */
+export function getCurrentBranchForPath(repoPath: string): string | null {
   try {
     const output = execFileSync(
       "git",
       ["-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD"],
       { stdio: "pipe", encoding: "utf-8" },
     );
-    return output.trim() || "main";
+    return output.trim() || null;
   } catch {
-    return "main";
+    return null;
   }
 }
 

--- a/apps/server/src/services/git-watcher-service.ts
+++ b/apps/server/src/services/git-watcher-service.ts
@@ -4,13 +4,14 @@
  * `branch.changed` push event when the active branch switches.
  */
 
-import { injectable } from "tsyringe";
+import { injectable, inject } from "tsyringe";
 import { watch, existsSync, type FSWatcher } from "fs";
 import { execFileSync } from "child_process";
 import { join, dirname, basename } from "path";
 import { logger } from "@mcode/shared";
 import { broadcast } from "../transport/push";
 import { getCurrentBranchForPath } from "./git-service";
+import { WorkspaceRepo } from "../repositories/workspace-repo";
 
 /** Debounce delay in milliseconds to batch rapid HEAD file writes (e.g., during rebase). */
 const DEBOUNCE_MS = 200;
@@ -30,6 +31,10 @@ interface WatcherEntry {
 @injectable()
 export class GitWatcherService {
   private readonly watchers = new Map<string, WatcherEntry>();
+
+  constructor(
+    @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
+  ) {}
 
   /**
    * Resolve the absolute path to the HEAD file for the given workspace path.
@@ -132,6 +137,33 @@ export class GitWatcherService {
 
     this.watchers.set(workspaceId, { watcher: fsWatcher, timer: null });
     logger.info("GitWatcherService: watching HEAD", { workspaceId, headDir, headName });
+  }
+
+  /**
+   * Attempt to start watching a workspace that was previously detected as non-git.
+   * Called on thread.list to catch `git init` within a session.
+   * Returns true if the workspace is now a git repo and the watcher was started.
+   */
+  retryWatch(workspaceId: string, workspacePath: string): boolean {
+    if (this.watchers.has(workspaceId)) return true;
+
+    const headFile = this.resolveHeadFile(workspacePath);
+    if (!headFile) return false;
+
+    // The folder is now a git repo — update the DB, start watching, notify clients.
+    this.workspaceRepo.setIsGitRepo(workspaceId, true);
+    this.watchWorkspace(workspaceId, workspacePath);
+
+    logger.info("GitWatcherService: non-git workspace became a git repo", {
+      workspaceId,
+    });
+
+    broadcast("workspace.gitStatusChanged", {
+      workspaceId,
+      isGitRepo: true,
+    });
+
+    return true;
   }
 
   /**

--- a/apps/server/src/services/pr-draft-service.ts
+++ b/apps/server/src/services/pr-draft-service.ts
@@ -78,8 +78,8 @@ export class PrDraftService {
       thread.worktree_path,
     );
     const headBranch = this.gitService.getCurrentBranchAt(repoPath);
-    if (headBranch === "HEAD") {
-      throw new Error("Cannot generate PR draft: repository is in detached HEAD state");
+    if (!headBranch || headBranch === "HEAD") {
+      throw new Error("Cannot generate PR draft: repository is in detached HEAD state or not a git repo");
     }
 
     const [commits, diffStat, messagesResult, settings] = await Promise.all([

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -1,11 +1,13 @@
 /**
  * Workspace CRUD service.
- * Thin orchestration layer over WorkspaceRepo.
+ * Thin orchestration layer over WorkspaceRepo with git detection.
  */
 
+import { execFileSync } from "child_process";
 import { injectable, inject } from "tsyringe";
 import type { Workspace } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
+import { logger } from "@mcode/shared";
 
 /** Handles workspace creation, listing, and deletion. */
 @injectable()
@@ -16,14 +18,18 @@ export class WorkspaceService {
 
   /**
    * Create a new workspace, or return the existing one if the path is already registered.
+   * Detects whether the path is a git repository and stores the result.
    * Handles the case where the workspace still exists in the DB (e.g., after a failed
    * delete or stale client state) to prevent UNIQUE constraint errors on re-add.
    */
   create(name: string, path: string): Workspace {
     const existing = this.workspaceRepo.findByPath(path);
-    // Intentionally returns the existing record without updating its name.
-    if (existing) return existing;
-    return this.workspaceRepo.create(name, path);
+    if (existing) {
+      this.workspaceRepo.touch(existing.id);
+      return existing;
+    }
+    const isGitRepo = this.detectGitRepo(path);
+    return this.workspaceRepo.create(name, path, isGitRepo);
   }
 
   /** List all workspaces ordered by most recently updated. */
@@ -39,5 +45,28 @@ export class WorkspaceService {
   /** Find a workspace by its primary key. Returns null if not found. */
   findById(id: string): Workspace | null {
     return this.workspaceRepo.findById(id);
+  }
+
+  /** Bump updated_at for a workspace so it sorts to the top of the recent list. */
+  touch(id: string): void {
+    this.workspaceRepo.touch(id);
+  }
+
+  /** Update the is_git_repo flag on a workspace record. */
+  setIsGitRepo(id: string, isGitRepo: boolean): void {
+    this.workspaceRepo.setIsGitRepo(id, isGitRepo);
+  }
+
+  /** Check whether a filesystem path is inside a git repository. */
+  private detectGitRepo(path: string): boolean {
+    try {
+      execFileSync("git", ["-C", path, "rev-parse", "--git-dir"], {
+        stdio: "pipe",
+      });
+      return true;
+    } catch {
+      logger.info("WorkspaceService: path is not a git repo", { path });
+      return false;
+    }
   }
 }

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -4,6 +4,8 @@
  */
 
 import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
 import { injectable, inject } from "tsyringe";
 import type { Workspace } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
@@ -65,6 +67,11 @@ export class WorkspaceService {
       });
       return true;
     } catch {
+      // Fall back to filesystem check when git is unavailable or fails to run
+      // (e.g. git not in PATH in the server process on some platforms).
+      if (existsSync(join(path, ".git"))) {
+        return true;
+      }
       logger.info("WorkspaceService: path is not a git repo", { path });
       return false;
     }

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -26,6 +26,7 @@ import * as m013 from "./migrations/013_clear_non_claude_context_window.js";
 import * as m014 from "./migrations/014_thread_branching.js";
 import * as m015 from "./migrations/015_thread_compact_summary.js";
 import * as m016 from "./migrations/016_copilot_agent.js";
+import * as m017 from "./migrations/017_workspace_is_git_repo.js";
 
 /**
  * Resolve the correct native binding for better-sqlite3 based on runtime.
@@ -83,6 +84,7 @@ export function loadMigrations(): Map<number, MigrationModule> {
   migrations.set(14, m014);
   migrations.set(15, m015);
   migrations.set(16, m016);
+  migrations.set(17, m017);
   return migrations;
 }
 

--- a/apps/server/src/store/migrations/017_workspace_is_git_repo.ts
+++ b/apps/server/src/store/migrations/017_workspace_is_git_repo.ts
@@ -8,12 +8,14 @@ import type Database from "better-sqlite3";
 
 export const description = "Add is_git_repo column to workspaces";
 
+/** Apply migration: add is_git_repo column to workspaces table. */
 export function up(db: Database.Database): void {
   db.prepare(
     "ALTER TABLE workspaces ADD COLUMN is_git_repo INTEGER NOT NULL DEFAULT 1",
   ).run();
 }
 
+/** Revert migration: remove is_git_repo column from workspaces table. */
 export function down(db: Database.Database): void {
   db.prepare(
     "ALTER TABLE workspaces DROP COLUMN is_git_repo",

--- a/apps/server/src/store/migrations/017_workspace_is_git_repo.ts
+++ b/apps/server/src/store/migrations/017_workspace_is_git_repo.ts
@@ -1,0 +1,21 @@
+/**
+ * Add is_git_repo flag to the workspaces table.
+ * DEFAULT 1 because all existing workspaces were created from git repos
+ * (non-git support did not exist before this migration).
+ */
+
+import type Database from "better-sqlite3";
+
+export const description = "Add is_git_repo column to workspaces";
+
+export function up(db: Database.Database): void {
+  db.prepare(
+    "ALTER TABLE workspaces ADD COLUMN is_git_repo INTEGER NOT NULL DEFAULT 1",
+  ).run();
+}
+
+export function down(db: Database.Database): void {
+  db.prepare(
+    "ALTER TABLE workspaces DROP COLUMN is_git_repo",
+  ).run();
+}

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -205,8 +205,15 @@ async function dispatch(
     }
 
     // Thread
-    case "thread.list":
+    case "thread.list": {
+      deps.workspaceService.touch(params.workspaceId);
+      // Re-detect git status for non-git workspaces (catches `git init` within a session)
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (ws && !ws.is_git_repo) {
+        deps.gitWatcherService.retryWatch(ws.id, ws.path);
+      }
       return deps.threadService.list(params.workspaceId);
+    }
     case "thread.create":
       return deps.threadService.create(
         params.workspaceId,
@@ -237,6 +244,8 @@ async function dispatch(
       deps.threadService.markViewed(params.threadId);
       return;
     case "thread.syncPrs": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return [];
       const threads = deps.threadService.list(params.workspaceId);
       /** Returns true if the thread has no linked PR, missing status, or a non-terminal PR state. */
       const needsPrCheck = (t: { pr_number: number | null; pr_status: string | null }) => {
@@ -275,22 +284,37 @@ async function dispatch(
     }
 
     // Git
-    case "git.listBranches":
+    case "git.listBranches": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return [];
       return deps.gitService.listBranches(params.workspaceId);
-    case "git.currentBranch":
+    }
+    case "git.currentBranch": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return null;
       return deps.gitService.getCurrentBranch(params.workspaceId);
-    case "git.checkout":
+    }
+    case "git.checkout": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return;
       deps.gitService.checkout(params.workspaceId, params.branch);
       return;
-    case "git.listWorktrees":
+    }
+    case "git.listWorktrees": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return [];
       return deps.gitService.listWorktrees(params.workspaceId);
-    case "git.fetchBranch":
+    }
+    case "git.fetchBranch": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return;
       deps.gitService.fetchBranch(
         params.workspaceId,
         params.branch,
         params.prNumber,
       );
       return;
+    }
     case "git.log": {
       let repoPath: string | undefined;
       if (params.threadId) {

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -244,8 +244,8 @@ async function dispatch(
       deps.threadService.markViewed(params.threadId);
       return;
     case "thread.syncPrs": {
-      const ws = deps.workspaceService.findById(params.workspaceId);
-      if (!ws?.is_git_repo) return [];
+      const syncWs = deps.workspaceService.findById(params.workspaceId);
+      if (!syncWs?.is_git_repo) return [];
       const threads = deps.threadService.list(params.workspaceId);
       /** Returns true if the thread has no linked PR, missing status, or a non-terminal PR state. */
       const needsPrCheck = (t: { pr_number: number | null; pr_status: string | null }) => {

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -316,20 +316,28 @@ async function dispatch(
       return;
     }
     case "git.log": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return [];
       let repoPath: string | undefined;
       if (params.threadId) {
         const t = deps.threadRepo.findById(params.threadId);
-        const ws = t ? deps.workspaceRepo.findById(t.workspace_id) : null;
-        if (t && ws) {
-          repoPath = deps.gitService.resolveWorkingDir(ws.path, t.mode, t.worktree_path);
+        const wsForThread = t ? deps.workspaceRepo.findById(t.workspace_id) : null;
+        if (t && wsForThread) {
+          repoPath = deps.gitService.resolveWorkingDir(wsForThread.path, t.mode, t.worktree_path);
         }
       }
       return deps.gitService.log(params.workspaceId, params.branch, params.limit, params.baseBranch, repoPath);
     }
-    case "git.commitDiff":
+    case "git.commitDiff": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return "";
       return deps.gitService.commitDiff(params.workspaceId, params.sha, params.filePath, params.maxLines);
-    case "git.commitFiles":
+    }
+    case "git.commitFiles": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return [];
       return deps.gitService.commitFiles(params.workspaceId, params.sha);
+    }
 
     // Agent
     case "agent.send":
@@ -626,6 +634,7 @@ async function dispatch(
     case "git.push": {
       const workspace = deps.workspaceService.findById(params.workspaceId);
       if (!workspace) throw new Error(`Workspace ${params.workspaceId} not found`);
+      if (!workspace.is_git_repo) return;
       await deps.gitService.push(workspace.path, params.branch);
       // Fresh CI runs appear 3-15s after push. Schedule bumps so the UI surfaces
       // "pending" without waiting a full passive poll cycle.

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -16,6 +16,7 @@ export function createMockWorkspace(
     name: "test-project",
     path: "/tmp/test-project",
     provider_config: {},
+    is_git_repo: true,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -21,8 +21,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { cn } from "@/lib/utils";
 import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, findModelById, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels } from "@/lib/model-registry";
 import { ModelSelector } from "./ModelSelector";
-import { ModeSelector } from "./ModeSelector";
-import type { ComposerMode } from "./ModeSelector";
+import { ModeSelector, ALL_MODE_OPTIONS } from "./ModeSelector";
+import type { ComposerMode, ModeOption } from "./ModeSelector";
 import { BranchPicker } from "./BranchPicker";
 import { NamingModeSelector } from "./NamingModeSelector";
 import type { NamingMode } from "@mcode/contracts";
@@ -571,8 +571,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       setBranchWorktreePath(activeThread?.worktree_path ?? "");
       setBranchNamingMode("auto");
       setBranchCustomName("");
-      loadBranches(workspaceId);
-      loadWorktrees(workspaceId);
+      if (isGitRepo) {
+        loadBranches(workspaceId);
+        loadWorktrees(workspaceId);
+      }
     }
   }, [branchFromMessageId]);
 
@@ -658,6 +660,16 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const setNewThreadMode = useWorkspaceStore((s) => s.setNewThreadMode);
   const setNewThreadBranch = useWorkspaceStore((s) => s.setNewThreadBranch);
 
+  const activeWorkspace = useWorkspaceStore((s) =>
+    s.workspaces.find((w) => w.id === s.activeWorkspaceId),
+  );
+  const isGitRepo = activeWorkspace?.is_git_repo ?? true;
+
+  const modeOptions = useMemo<ModeOption[]>(
+    () => isGitRepo ? ALL_MODE_OPTIONS : ALL_MODE_OPTIONS.filter((o) => o.value === "direct"),
+    [isGitRepo],
+  );
+
   const slashCommand = useSlashCommand({
     anchorRef: editorContainerRef,
     cwd: workspacePath,
@@ -724,12 +736,20 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     setNewThreadMode(mode);
   }, [activeThread?.mode, setNewThreadMode]);
 
+  // Force direct mode for non-git workspaces — worktree modes are not available without git
+  useEffect(() => {
+    if (!isGitRepo && composerMode !== "direct") {
+      setComposerModeLocal("direct");
+      setNewThreadMode("direct");
+    }
+  }, [isGitRepo, composerMode, setNewThreadMode]);
+
   // Load branches when entering new thread mode (always refresh to pick up live changes)
   useEffect(() => {
-    if (isNewThread && workspaceId) {
+    if (isNewThread && workspaceId && isGitRepo) {
       loadBranches(workspaceId);
     }
-  }, [isNewThread, workspaceId, loadBranches]);
+  }, [isNewThread, workspaceId, isGitRepo, loadBranches]);
 
   // Auto-select current branch if none selected
   useEffect(() => {
@@ -752,7 +772,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       clearTimeout(prDetectTimeoutRef.current);
     }
 
-    if (prDismissed || !isNewThread) {
+    if (prDismissed || !isNewThread || !isGitRepo) {
       return;
     }
 
@@ -1107,9 +1127,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
 
     // Checkout confirmation for local mode when a different branch is selected
-    if (isNewThread && newThreadMode === "direct" && newThreadBranch && workspaceId) {
+    if (isNewThread && isGitRepo && newThreadMode === "direct" && newThreadBranch && workspaceId) {
       const currentBranch = await useWorkspaceStore.getState().getCurrentBranch(workspaceId);
-      if (newThreadBranch !== currentBranch) {
+      if (currentBranch && newThreadBranch !== currentBranch) {
         const confirmed = window.confirm(
           `You're on "${currentBranch}" but selected "${newThreadBranch}". Switch to "${newThreadBranch}"? This will checkout the branch.`,
         );
@@ -1626,6 +1646,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           mode={branchFromMessageId ? branchExecMode : composerMode}
           onModeChange={branchFromMessageId ? setBranchExecMode : setComposerMode}
           locked={!isNewThread && !branchFromMessageId}
+          options={modeOptions}
         />
         <div className="flex items-center gap-3">
           <AgentStatusBar />
@@ -1633,6 +1654,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         </div>
         <div className="ml-auto flex items-center gap-1">
           {isNewThread ? (
+            !isGitRepo ? null :
             composerMode === "direct" ? (
               <BranchPicker
                 branches={branches}
@@ -1672,6 +1694,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             ) : null
           ) : branchFromMessageId ? (
             // Branch mode: show execution controls for the child thread
+            !isGitRepo ? null :
             branchExecMode === "direct" ? (
               <BranchPicker
                 branches={branches}
@@ -1705,7 +1728,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 loading={worktreesLoading}
               /></Suspense>
             )
-          ) : activeThread?.branch ? (
+          ) : activeThread?.branch && isGitRepo ? (
             <BranchPicker
               branches={[]}
               selectedBranch={activeThread.branch}

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -559,6 +559,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   }, [threadId, saveDraft, getDraft]);
 
   // Reset branch-specific exec state and load branch/worktree data when branch mode activates.
+  // loadBranches/loadWorktrees are safe to call unconditionally — the server
+  // returns empty results for non-git workspaces via ws-router guards.
   useEffect(() => {
     if (branchFromMessageId && workspaceId) {
       // Default to the same execution mode as the parent thread so the child
@@ -571,12 +573,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       setBranchWorktreePath(activeThread?.worktree_path ?? "");
       setBranchNamingMode("auto");
       setBranchCustomName("");
-      if (isGitRepo) {
-        loadBranches(workspaceId);
-        loadWorktrees(workspaceId);
-      }
+      loadBranches(workspaceId);
+      loadWorktrees(workspaceId);
     }
-  }, [branchFromMessageId, isGitRepo, workspaceId, loadBranches, loadWorktrees]);
+  }, [branchFromMessageId, workspaceId, loadBranches, loadWorktrees]);
 
   // Consume pending prefill set by empty-state prompt chips
   useEffect(() => {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1642,12 +1642,18 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
       {/* Status bar - below the container */}
       <div className="flex items-center justify-between px-1 pt-1.5">
-        <ModeSelector
-          mode={branchFromMessageId ? branchExecMode : composerMode}
-          onModeChange={branchFromMessageId ? setBranchExecMode : setComposerMode}
-          locked={!isNewThread && !branchFromMessageId}
-          options={modeOptions}
-        />
+        {!isGitRepo && isNewThread ? (
+          <span className="flex h-6 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground/40">
+            No git repo
+          </span>
+        ) : (
+          <ModeSelector
+            mode={branchFromMessageId ? branchExecMode : composerMode}
+            onModeChange={branchFromMessageId ? setBranchExecMode : setComposerMode}
+            locked={!isNewThread && !branchFromMessageId}
+            options={modeOptions}
+          />
+        )}
         <div className="flex items-center gap-3">
           <AgentStatusBar />
           <TerminalStatusIndicator />

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -551,6 +551,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     prevThreadIdRef.current = threadId;
   }, [threadId, saveDraft, getDraft]);
 
+  // Selectors needed by the branch-mode effect below — must be declared before the effect
+  // to avoid temporal dead zone errors in the dependency array.
+  const loadBranches = useWorkspaceStore((s) => s.loadBranches);
+  const loadWorktrees = useWorkspaceStore((s) => s.loadWorktrees);
+  const initBranchMode = useWorkspaceStore((s) => s.initBranchMode);
+
   // Reset branch-specific exec state and load branch/worktree data when branch mode activates.
   // loadBranches/loadWorktrees are safe to call unconditionally — the server
   // returns empty results for non-git workspaces via ws-router guards.
@@ -643,7 +649,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const branchesLoading = useWorkspaceStore((s) => s.branchesLoading);
   const newThreadMode = useWorkspaceStore((s) => s.newThreadMode);
   const newThreadBranch = useWorkspaceStore((s) => s.newThreadBranch);
-  const loadBranches = useWorkspaceStore((s) => s.loadBranches);
   const setNewThreadMode = useWorkspaceStore((s) => s.setNewThreadMode);
   const setNewThreadBranch = useWorkspaceStore((s) => s.setNewThreadBranch);
 
@@ -678,7 +683,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const customBranchName = useWorkspaceStore((s) => s.customBranchName);
   const autoPreviewBranch = useWorkspaceStore((s) => s.autoPreviewBranch);
   const selectedWorktree = useWorkspaceStore((s) => s.selectedWorktree);
-  const loadWorktrees = useWorkspaceStore((s) => s.loadWorktrees);
   const setNamingMode = useWorkspaceStore((s) => s.setNamingMode);
   const setCustomBranchName = useWorkspaceStore((s) => s.setCustomBranchName);
   const setSelectedWorktree = useWorkspaceStore((s) => s.setSelectedWorktree);
@@ -688,7 +692,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const branchNamingMode = useWorkspaceStore((s) => s.branchNamingMode);
   const branchCustomName = useWorkspaceStore((s) => s.branchCustomName);
   const branchAutoPreview = useWorkspaceStore((s) => s.branchAutoPreview);
-  const initBranchMode = useWorkspaceStore((s) => s.initBranchMode);
   const setBranchExecMode = useWorkspaceStore((s) => s.setBranchExecMode);
   const setBranchTargetBranch = useWorkspaceStore((s) => s.setBranchTargetBranch);
   const setBranchWorktreePath = useWorkspaceStore((s) => s.setBranchWorktreePath);

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -576,7 +576,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         loadWorktrees(workspaceId);
       }
     }
-  }, [branchFromMessageId]);
+  }, [branchFromMessageId, isGitRepo, workspaceId, loadBranches, loadWorktrees]);
 
   // Consume pending prefill set by empty-state prompt chips
   useEffect(() => {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1643,8 +1643,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       {/* Status bar - below the container */}
       <div className="flex items-center justify-between px-1 pt-1.5">
         {!isGitRepo && isNewThread ? (
-          <span className="flex h-6 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground/40">
-            No git repo
+          <span className="flex h-6 items-center rounded-md px-1.5 py-0.5 text-[10px] text-muted-foreground/40">
+            Not a git repo
           </span>
         ) : (
           <ModeSelector

--- a/apps/web/src/components/chat/ModeSelector.tsx
+++ b/apps/web/src/components/chat/ModeSelector.tsx
@@ -15,21 +15,31 @@ import {
  */
 export type ComposerMode = "direct" | "worktree" | "existing-worktree";
 
-interface ModeSelectorProps {
-  mode: ComposerMode;
-  onModeChange: (mode: ComposerMode) => void;
-  locked: boolean;
+/** Configuration for a single mode option in the dropdown. */
+export interface ModeOption {
+  value: ComposerMode;
+  label: string;
+  icon: typeof FolderOpen;
 }
 
-const MODE_OPTIONS: Array<{ value: ComposerMode; label: string; icon: typeof FolderOpen }> = [
+/** All available mode options. Consumers can filter this list before passing to ModeSelector. */
+export const ALL_MODE_OPTIONS: ModeOption[] = [
   { value: "direct", label: "Local", icon: FolderOpen },
   { value: "worktree", label: "New worktree", icon: GitBranch },
   { value: "existing-worktree", label: "Existing worktree", icon: GitFork },
 ];
 
+interface ModeSelectorProps {
+  mode: ComposerMode;
+  onModeChange: (mode: ComposerMode) => void;
+  locked: boolean;
+  /** Subset of modes to show. Defaults to ALL_MODE_OPTIONS. */
+  options?: ModeOption[];
+}
+
 /** Dropdown for choosing how a new thread runs (local, new worktree, existing worktree). */
-export function ModeSelector({ mode, onModeChange, locked }: ModeSelectorProps) {
-  const selected = MODE_OPTIONS.find((o) => o.value === mode) ?? MODE_OPTIONS[0];
+export function ModeSelector({ mode, onModeChange, locked, options = ALL_MODE_OPTIONS }: ModeSelectorProps) {
+  const selected = options.find((o) => o.value === mode) ?? options[0];
   const Icon = selected.icon;
 
   if (locked) {
@@ -54,7 +64,7 @@ export function ModeSelector({ mode, onModeChange, locked }: ModeSelectorProps) 
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="start" sideOffset={4} className="min-w-[160px]">
-        {MODE_OPTIONS.map((option) => {
+        {options.map((option) => {
           const OptionIcon = option.icon;
           return (
             <DropdownMenuItem

--- a/apps/web/src/components/chat/ModeSelector.tsx
+++ b/apps/web/src/components/chat/ModeSelector.tsx
@@ -39,6 +39,10 @@ interface ModeSelectorProps {
 
 /** Dropdown for choosing how a new thread runs (local, new worktree, existing worktree). */
 export function ModeSelector({ mode, onModeChange, locked, options = ALL_MODE_OPTIONS }: ModeSelectorProps) {
+  if (options.length === 0) {
+    return null;
+  }
+
   const selected = options.find((o) => o.value === mode) ?? options[0];
   const Icon = selected.icon;
 

--- a/apps/web/src/components/diff/CommitsView.tsx
+++ b/apps/web/src/components/diff/CommitsView.tsx
@@ -26,15 +26,9 @@ export function CommitsView() {
 
   // Defense-in-depth: DiffToolbar already hides the "Commits" tab for non-worktree threads.
   // This prevents a crash if the component is somehow rendered for a non-git workspace.
-  if (!activeWorkspace?.is_git_repo) {
-    return (
-      <div className="flex h-full items-center justify-center text-xs text-muted-foreground/50">
-        No git history
-      </div>
-    );
-  }
-
+  // The guard lives inside the effect so all hooks are called unconditionally (Rules of Hooks).
   useEffect(() => {
+    if (!activeWorkspace?.is_git_repo) return;
     if (!activeThreadId || !activeWorkspaceId || !threadBranch) return;
     if (commits !== undefined) return;
 
@@ -60,7 +54,15 @@ export function CommitsView() {
     return () => {
       cancelled = true;
     };
-  }, [activeThreadId, activeWorkspaceId, threadBranch, commits, setCommits, setCommitsLoading]);
+  }, [activeWorkspace?.is_git_repo, activeThreadId, activeWorkspaceId, threadBranch, commits, setCommits, setCommitsLoading]);
+
+  if (!activeWorkspace?.is_git_repo) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-muted-foreground/50">
+        No git history
+      </div>
+    );
+  }
 
   if (commitsLoading) {
     return (

--- a/apps/web/src/components/diff/CommitsView.tsx
+++ b/apps/web/src/components/diff/CommitsView.tsx
@@ -8,6 +8,9 @@ import { CommitEntry } from "./CommitEntry";
 export function CommitsView() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const activeWorkspace = useWorkspaceStore((s) =>
+    s.workspaces.find((w) => w.id === s.activeWorkspaceId),
+  );
   const threadBranch = useWorkspaceStore((s) => {
     const thread = s.threads.find((t) => t.id === activeThreadId);
     return thread?.branch ?? undefined;
@@ -20,6 +23,16 @@ export function CommitsView() {
   );
   const setCommits = useDiffStore((s) => s.setCommits);
   const setCommitsLoading = useDiffStore((s) => s.setCommitsLoading);
+
+  // Defense-in-depth: DiffToolbar already hides the "Commits" tab for non-worktree threads.
+  // This prevents a crash if the component is somehow rendered for a non-git workspace.
+  if (!activeWorkspace?.is_git_repo) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-muted-foreground/50">
+        No git history
+      </div>
+    );
+  }
 
   useEffect(() => {
     if (!activeThreadId || !activeWorkspaceId || !threadBranch) return;

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -4,7 +4,7 @@ import { useShallow } from "zustand/shallow";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
-import { Plus, Trash2, ChevronRight, ChevronDown, GitBranch, GitBranchX, Loader2, AlertTriangle, FolderPlus } from "lucide-react";
+import { Plus, Trash2, ChevronRight, ChevronDown, GitBranch, GitBranchMinus, Loader2, AlertTriangle, FolderPlus } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { getPrVisual } from "@/lib/pr-status";
 import { cn } from "@/lib/utils";
@@ -1086,7 +1086,7 @@ function ProjectNode({
           <Tooltip>
             <TooltipTrigger
               render={
-                <GitBranchX
+                <GitBranchMinus
                   size={10}
                   className="shrink-0 text-muted-foreground/35"
                   aria-label="Not a git repository"

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -4,7 +4,7 @@ import { useShallow } from "zustand/shallow";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
-import { Plus, Trash2, ChevronRight, ChevronDown, GitBranch, Loader2, AlertTriangle, FolderPlus } from "lucide-react";
+import { Plus, Trash2, ChevronRight, ChevronDown, GitBranch, GitBranchX, Loader2, AlertTriangle, FolderPlus } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { getPrVisual } from "@/lib/pr-status";
 import { cn } from "@/lib/utils";
@@ -1081,6 +1081,23 @@ function ProjectNode({
         )}
 
         <span className="truncate font-medium tracking-tight">{workspace.name}</span>
+
+        {!workspace.is_git_repo && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <GitBranchX
+                  size={10}
+                  className="shrink-0 text-muted-foreground/35"
+                  aria-label="Not a git repository"
+                />
+              }
+            />
+            <TooltipContent side="right" className="text-xs">
+              Not a git repository
+            </TooltipContent>
+          </Tooltip>
+        )}
 
         {parentDir && (
           <span

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -90,7 +90,7 @@ interface WorkspaceState {
 
   // Branch actions
   loadBranches: (workspaceId: string) => Promise<void>;
-  getCurrentBranch: (workspaceId: string) => Promise<string>;
+  getCurrentBranch: (workspaceId: string) => Promise<string | null>;
   checkoutBranch: (workspaceId: string, branch: string) => Promise<void>;
   setNewThreadMode: (mode: "direct" | "worktree" | "existing-worktree") => void;
   setNewThreadBranch: (branch: string) => void;

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -89,7 +89,7 @@ export interface McodeTransport {
 
   // Git branch commands
   listBranches(workspaceId: string): Promise<GitBranch[]>;
-  getCurrentBranch(workspaceId: string): Promise<string>;
+  getCurrentBranch(workspaceId: string): Promise<string | null>;
   checkoutBranch(workspaceId: string, branch: string): Promise<void>;
   listWorktrees(workspaceId: string): Promise<WorktreeInfo[]>;
 

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -34,6 +34,7 @@ const _legacyEncoder = new TextEncoder();
  * - `permission.request` -- tool permission awaiting user decision
  * - `permission.resolved` -- a permission was settled (by user or session stop)
  * - `providers.availability` -- server-pushed provider availability snapshot forwarded to providerAvailabilityStore
+ * - `workspace.gitStatusChanged` -- workspace git status changed (e.g. non-git folder became a repo), updates is_git_repo flag
  */
 export function startPushListeners(): void {
   // Guard against double-init
@@ -245,16 +246,30 @@ export function startPushListeners(): void {
   // branch.changed: refresh branch list and update current branch if not manually overridden
   unsubs.push(
     pushEmitter.on("branch.changed", (data) => {
-      const { workspaceId, branch } = data as { workspaceId: string; branch: string };
+      const { workspaceId, branch } = data as { workspaceId: string; branch: string | null };
       import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
         const state = useWorkspaceStore.getState();
         // Only refresh if this event is for the active workspace
         if (state.activeWorkspaceId === workspaceId) {
           state.loadBranches(workspaceId);
-          if (!state.branchManuallySelected) {
+          if (!state.branchManuallySelected && branch) {
             state.setNewThreadBranch(branch);
           }
         }
+      });
+    }),
+  );
+
+  // workspace.gitStatusChanged: update is_git_repo flag when a non-git workspace becomes a git repo
+  unsubs.push(
+    pushEmitter.on("workspace.gitStatusChanged", (data) => {
+      const { workspaceId, isGitRepo } = data as { workspaceId: string; isGitRepo: boolean };
+      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
+        useWorkspaceStore.setState((state) => ({
+          workspaces: state.workspaces.map((w) =>
+            w.id === workspaceId ? { ...w, is_git_repo: isGitRepo } : w,
+          ),
+        }));
       });
     }),
   );

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -486,7 +486,7 @@ export function createWsTransport(
 
     // Git
     listBranches: (workspaceId) => rpc<GitBranch[]>("git.listBranches", { workspaceId }),
-    getCurrentBranch: (workspaceId) => rpc<string>("git.currentBranch", { workspaceId }),
+    getCurrentBranch: (workspaceId) => rpc<string | null>("git.currentBranch", { workspaceId }),
     checkoutBranch: (workspaceId, branch) =>
       rpc<void>("git.checkout", { workspaceId, branch }),
     listWorktrees: (workspaceId) => rpc<WorktreeInfo[]>("git.listWorktrees", { workspaceId }),

--- a/packages/contracts/src/models/workspace.ts
+++ b/packages/contracts/src/models/workspace.ts
@@ -1,14 +1,17 @@
 import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
 
 /** Workspace schema matching the SQLite row shape. */
-export const WorkspaceSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  path: z.string(),
-  provider_config: z.record(z.unknown()),
-  is_git_repo: z.boolean(),
-  created_at: z.string(),
-  updated_at: z.string(),
-});
+export const WorkspaceSchema = lazySchema(() =>
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    path: z.string(),
+    provider_config: z.record(z.unknown()),
+    is_git_repo: z.boolean(),
+    created_at: z.string(),
+    updated_at: z.string(),
+  }),
+);
 /** Workspace record from the database. */
-export type Workspace = z.infer<typeof WorkspaceSchema>;
+export type Workspace = z.infer<ReturnType<typeof WorkspaceSchema>>;

--- a/packages/contracts/src/models/workspace.ts
+++ b/packages/contracts/src/models/workspace.ts
@@ -6,6 +6,7 @@ export const WorkspaceSchema = z.object({
   name: z.string(),
   path: z.string(),
   provider_config: z.record(z.unknown()),
+  is_git_repo: z.boolean(),
   created_at: z.string(),
   updated_at: z.string(),
 });

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -48,8 +48,12 @@ export const WS_CHANNELS = {
   "skills.changed": z.object({}),
   /** Full-list broadcast of provider availability. Replaces the client cache. */
   "providers.availability": z.array(ProviderAvailabilitySchema()),
-  "branch.changed": z.object({ workspaceId: z.string(), branch: z.string().nullable() }),
-  "workspace.gitStatusChanged": z.object({ workspaceId: z.string(), isGitRepo: z.boolean() }),
+  "branch.changed": lazySchema(() =>
+    z.object({ workspaceId: z.string(), branch: z.string().nullable() }),
+  )(),
+  "workspace.gitStatusChanged": lazySchema(() =>
+    z.object({ workspaceId: z.string(), isGitRepo: z.boolean() }),
+  )(),
   "turn.persisted": z.object({
     threadId: z.string(),
     messageId: z.string(),

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -48,7 +48,8 @@ export const WS_CHANNELS = {
   "skills.changed": z.object({}),
   /** Full-list broadcast of provider availability. Replaces the client cache. */
   "providers.availability": z.array(ProviderAvailabilitySchema()),
-  "branch.changed": z.object({ workspaceId: z.string(), branch: z.string() }),
+  "branch.changed": z.object({ workspaceId: z.string(), branch: z.string().nullable() }),
+  "workspace.gitStatusChanged": z.object({ workspaceId: z.string(), isGitRepo: z.boolean() }),
   "turn.persisted": z.object({
     threadId: z.string(),
     messageId: z.string(),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -91,11 +91,11 @@ export const CreateAndSendSchema = lazySchema(() =>
 export const WS_METHODS = lazySchema(() => ({
   "workspace.list": {
     params: z.object({}),
-    result: z.array(WorkspaceSchema),
+    result: z.array(WorkspaceSchema()),
   },
   "workspace.create": {
     params: z.object({ name: z.string(), path: z.string() }),
-    result: WorkspaceSchema,
+    result: WorkspaceSchema(),
   },
   "workspace.delete": {
     params: z.object({ id: z.string() }),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -157,7 +157,7 @@ export const WS_METHODS = lazySchema(() => ({
   },
   "git.currentBranch": {
     params: z.object({ workspaceId: z.string() }),
-    result: z.string(),
+    result: z.string().nullable(),
   },
   "git.checkout": {
     params: z.object({ workspaceId: z.string(), branch: z.string() }),


### PR DESCRIPTION
## Summary
Allow users to open any folder as a workspace, not just git repositories. Git-dependent features (branches, commits, PR detection, worktrees) are hidden/disabled rather than erroring. When users run `git init` mid-session, git features automatically re-enable.

## Key Changes
- Add `is_git_repo: boolean` column to workspaces table (migration 017, DEFAULT 1 for backward compatibility)
- Detect git status at workspace creation via `git rev-parse --git-dir`
- Harden all git service methods with try/catch returning safe empty values
- Guard all git RPC handlers with `is_git_repo` checks
- Re-detect git status on `thread.list` (enables `git init` mid-session path)
- Update frontend to hide git features and show "Not a git repository" indicator
- Fix React hooks violation in CommitsView during git status re-detection

## Testing
- Server tests: `migration-runner.test.ts` (18/18 ✓), `git-service.test.ts` (15/15 ✓)
- Manual verification: non-git folders open without errors, git features hidden
- Git init mid-session: re-detection broadcasts `workspace.gitStatusChanged`, React app updates UI

## Closes
#346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-detect per-workspace git status on create; UI hides/disables git controls and shows a “Not a git repository” indicator. Retry detection to enable git features and broadcast status changes. Expose touch and set-git-status workspace actions.

* **Bug Fixes**
  * Git operations now fail gracefully for non-git workspaces (no-ops/empty results). Current branch may be null when unavailable.

* **Chores**
  * Added DB migration and updated transport/event schemas to track and propagate per-workspace git status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->