### PR TITLE
feat: provider-scoped slash commands with multi-directory scanning

### DIFF
--- a/apps/desktop/src/main/__tests__/server-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/server-manager.test.ts
@@ -65,6 +65,9 @@ vi.mock("fs", () => ({
   }),
   unlinkSync: vi.fn(),
   writeFileSync: vi.fn(),
+  // createWriteStream is used in non-dev mode to route stderr to a log file.
+  // Return a minimal writable-stream stub so callers like child.stderr.pipe() work.
+  createWriteStream: vi.fn(() => ({ write: vi.fn(), end: vi.fn() })),
 }));
 
 vi.mock("fs/promises", () => ({
@@ -165,10 +168,10 @@ describe("ServerManager", () => {
     const spawnCall = vi.mocked(spawn).mock.calls[0];
     // First arg is process.execPath
     expect(spawnCall[0]).toBe(process.execPath);
-    // Options include detached: true and stdio: "ignore"
+    // Options include detached: true; in non-dev mode stderr is piped to a log file
     const opts = spawnCall[2] as Record<string, unknown>;
     expect(opts.detached).toBe(true);
-    expect(opts.stdio).toBe("ignore");
+    expect(opts.stdio).toEqual(["ignore", "ignore", "pipe"]);
     expect(result.port).toBe(19600);
     expect(result.authToken).toBe("test-auth-token");
   });

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -335,8 +335,9 @@ describe("SkillService", () => {
       expect(copilotItems.find((i) => i.name === "myplugin:codex-task")).toBeUndefined();
     });
 
-    it("marketplace plugin with .agents subdir: copilot sees it, claude does not", () => {
-      // Multi-provider marketplace layout: impeccable/.agents/skills/impeccable/SKILL.md
+    it("marketplace plugin: .agents/skills/ produces <marketplace-name>:* prefix for codex+copilot", () => {
+      // The marketplace dir IS the plugin version root. Skills under .agents/ should be
+      // named "impeccable:impeccable" (marketplace name as prefix), not ".agents:impeccable".
       const skillDir = join(
         fakeHome, ".claude", "plugins", "marketplaces", "impeccable",
         ".agents", "skills", "impeccable",
@@ -346,30 +347,59 @@ describe("SkillService", () => {
 
       const svc = new SkillService();
 
+      // Codex and Copilot see it under the correct marketplace name prefix.
       const copilotItems = svc.list(undefined, "copilot");
-      expect(copilotItems.find((i) => i.name === ".agents:impeccable")).toBeDefined();
+      expect(copilotItems.find((i) => i.name === "impeccable:impeccable")).toBeDefined();
+      expect(copilotItems.find((i) => i.name === ".agents:impeccable")).toBeUndefined();
 
       svc.invalidate();
+      const codexItems = svc.list(undefined, "codex");
+      expect(codexItems.find((i) => i.name === "impeccable:impeccable")).toBeDefined();
+
+      // Claude does NOT see it (tagged codex+copilot only via .agents/).
+      svc.invalidate();
       const claudeItems = svc.list(undefined, "claude");
-      expect(claudeItems.find((i) => i.name === ".agents:impeccable")).toBeUndefined();
+      expect(claudeItems.find((i) => i.name === "impeccable:impeccable")).toBeUndefined();
     });
 
-    it("marketplace plugin with unknown .xxx subdir is invisible to all mcode providers", () => {
-      // .kiro is not a known mcode provider — derived provider ["kiro"] matches nothing.
+    it("marketplace plugin: .claude/skills/ produces <marketplace-name>:* prefix for claude only", () => {
       const skillDir = join(
         fakeHome, ".claude", "plugins", "marketplaces", "impeccable",
-        ".kiro", "skills", "impeccable",
+        ".claude", "skills", "audit",
       );
       mkdirSync(skillDir, { recursive: true });
-      writeMd(join(skillDir, "SKILL.md"), { description: "Kiro skill" });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Claude-only marketplace skill" });
 
       const svc = new SkillService();
 
-      for (const pid of ["claude", "codex", "copilot", "cursor", "gemini", "opencode"]) {
-        svc.invalidate();
-        const items = svc.list(undefined, pid);
-        expect(items.find((i) => i.name === ".kiro:impeccable")).toBeUndefined();
-      }
+      const claudeItems = svc.list(undefined, "claude");
+      expect(claudeItems.find((i) => i.name === "impeccable:audit")).toBeDefined();
+      // No .claude:audit prefix — the marketplace dir IS the version root.
+      expect(claudeItems.find((i) => i.name === ".claude:audit")).toBeUndefined();
+
+      svc.invalidate();
+      const codexItems = svc.list(undefined, "codex");
+      expect(codexItems.find((i) => i.name === "impeccable:audit")).toBeUndefined();
+    });
+
+    it("marketplace plugin: cache and marketplace produce same skill names (dedup collapses them)", () => {
+      // Cache and marketplace both produce "impeccable:adapt" — dedup should keep one.
+      const cacheSkillDir = join(
+        fakeHome, ".claude", "plugins", "cache", "mp", "impeccable", "2.1.1",
+        ".claude", "skills", "adapt",
+      );
+      const marketplaceSkillDir = join(
+        fakeHome, ".claude", "plugins", "marketplaces", "impeccable",
+        ".claude", "skills", "adapt",
+      );
+      mkdirSync(cacheSkillDir, { recursive: true });
+      mkdirSync(marketplaceSkillDir, { recursive: true });
+      writeMd(join(cacheSkillDir, "SKILL.md"), { description: "Cache version" });
+      writeMd(join(marketplaceSkillDir, "SKILL.md"), { description: "Marketplace version" });
+
+      const items = new SkillService().list(undefined, "claude");
+      const matches = items.filter((i) => i.name === "impeccable:adapt");
+      expect(matches).toHaveLength(1);
     });
   });
 });

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -289,5 +289,87 @@ describe("SkillService", () => {
       expect(cmd!.kind).toBe("command");
       expect(cmd!.providers).toEqual(["codex"]);
     });
+
+    it("tags plugin skills from <version>/.agents/skills with providers=['codex','copilot']", () => {
+      // A plugin that ships cross-provider skills under .agents/.
+      const skillDir = join(
+        fakeHome, ".claude", "plugins", "cache", "mp", "impeccable", "2.1.1",
+        ".agents", "skills", "impeccable",
+      );
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Cross-provider skill" });
+
+      const svc = new SkillService();
+
+      const copilotItems = svc.list(undefined, "copilot");
+      expect(copilotItems.find((i) => i.name === "impeccable:impeccable")).toBeDefined();
+
+      svc.invalidate();
+      const codexItems = svc.list(undefined, "codex");
+      expect(codexItems.find((i) => i.name === "impeccable:impeccable")).toBeDefined();
+
+      svc.invalidate();
+      const claudeItems = svc.list(undefined, "claude");
+      expect(claudeItems.find((i) => i.name === "impeccable:impeccable")).toBeUndefined();
+    });
+
+    it("tags plugin skills from <version>/.codex/skills with providers=['codex'] only", () => {
+      const skillDir = join(
+        fakeHome, ".claude", "plugins", "cache", "mp", "myplugin", "1.0.0",
+        ".codex", "skills", "codex-task",
+      );
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Codex-only plugin skill" });
+
+      const svc = new SkillService();
+
+      const codexItems = svc.list(undefined, "codex");
+      expect(codexItems.find((i) => i.name === "myplugin:codex-task")).toBeDefined();
+
+      svc.invalidate();
+      const claudeItems = svc.list(undefined, "claude");
+      expect(claudeItems.find((i) => i.name === "myplugin:codex-task")).toBeUndefined();
+
+      svc.invalidate();
+      const copilotItems = svc.list(undefined, "copilot");
+      expect(copilotItems.find((i) => i.name === "myplugin:codex-task")).toBeUndefined();
+    });
+
+    it("marketplace plugin with .agents subdir: copilot sees it, claude does not", () => {
+      // Multi-provider marketplace layout: impeccable/.agents/skills/impeccable/SKILL.md
+      const skillDir = join(
+        fakeHome, ".claude", "plugins", "marketplaces", "impeccable",
+        ".agents", "skills", "impeccable",
+      );
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Cross-provider marketplace skill" });
+
+      const svc = new SkillService();
+
+      const copilotItems = svc.list(undefined, "copilot");
+      expect(copilotItems.find((i) => i.name === ".agents:impeccable")).toBeDefined();
+
+      svc.invalidate();
+      const claudeItems = svc.list(undefined, "claude");
+      expect(claudeItems.find((i) => i.name === ".agents:impeccable")).toBeUndefined();
+    });
+
+    it("marketplace plugin with unknown .xxx subdir is invisible to all mcode providers", () => {
+      // .kiro is not a known mcode provider — derived provider ["kiro"] matches nothing.
+      const skillDir = join(
+        fakeHome, ".claude", "plugins", "marketplaces", "impeccable",
+        ".kiro", "skills", "impeccable",
+      );
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Kiro skill" });
+
+      const svc = new SkillService();
+
+      for (const pid of ["claude", "codex", "copilot", "cursor", "gemini", "opencode"]) {
+        svc.invalidate();
+        const items = svc.list(undefined, pid);
+        expect(items.find((i) => i.name === ".kiro:impeccable")).toBeUndefined();
+      }
+    });
   });
 });

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -290,8 +290,10 @@ describe("SkillService", () => {
       expect(cmd!.providers).toEqual(["codex"]);
     });
 
-    it("tags plugin skills from <version>/.agents/skills with providers=['codex','copilot']", () => {
-      // A plugin that ships cross-provider skills under .agents/.
+    it("plugin .agents/skills/ is NOT exposed to non-Claude providers", () => {
+      // Plugins live under ~/.claude/plugins/ — Claude's own infrastructure.
+      // Even if a plugin ships .agents/ subdirs, those don't grant cross-provider access.
+      // A user who installed impeccable as a Claude plugin should not see it in Codex/Copilot.
       const skillDir = join(
         fakeHome, ".claude", "plugins", "cache", "mp", "impeccable", "2.1.1",
         ".agents", "skills", "impeccable",
@@ -301,65 +303,51 @@ describe("SkillService", () => {
 
       const svc = new SkillService();
 
+      // Non-Claude providers must not see skills from Claude's plugin cache.
       const copilotItems = svc.list(undefined, "copilot");
-      expect(copilotItems.find((i) => i.name === "impeccable:impeccable")).toBeDefined();
+      expect(copilotItems.find((i) => i.name === "impeccable:impeccable")).toBeUndefined();
 
       svc.invalidate();
       const codexItems = svc.list(undefined, "codex");
-      expect(codexItems.find((i) => i.name === "impeccable:impeccable")).toBeDefined();
-
-      svc.invalidate();
-      const claudeItems = svc.list(undefined, "claude");
-      expect(claudeItems.find((i) => i.name === "impeccable:impeccable")).toBeUndefined();
+      expect(codexItems.find((i) => i.name === "impeccable:impeccable")).toBeUndefined();
     });
 
-    it("tags plugin skills from <version>/.codex/skills with providers=['codex'] only", () => {
+    it("plugin .codex/skills/ is NOT exposed to Codex", () => {
+      // Same rule — .codex/ subdir in a Claude plugin does not make it available to Codex.
       const skillDir = join(
         fakeHome, ".claude", "plugins", "cache", "mp", "myplugin", "1.0.0",
         ".codex", "skills", "codex-task",
       );
       mkdirSync(skillDir, { recursive: true });
-      writeMd(join(skillDir, "SKILL.md"), { description: "Codex-only plugin skill" });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Codex subdir skill" });
 
       const svc = new SkillService();
 
       const codexItems = svc.list(undefined, "codex");
-      expect(codexItems.find((i) => i.name === "myplugin:codex-task")).toBeDefined();
-
-      svc.invalidate();
-      const claudeItems = svc.list(undefined, "claude");
-      expect(claudeItems.find((i) => i.name === "myplugin:codex-task")).toBeUndefined();
-
-      svc.invalidate();
-      const copilotItems = svc.list(undefined, "copilot");
-      expect(copilotItems.find((i) => i.name === "myplugin:codex-task")).toBeUndefined();
+      expect(codexItems.find((i) => i.name === "myplugin:codex-task")).toBeUndefined();
     });
 
-    it("marketplace plugin: .agents/skills/ produces <marketplace-name>:* prefix for codex+copilot", () => {
-      // The marketplace dir IS the plugin version root. Skills under .agents/ should be
-      // named "impeccable:impeccable" (marketplace name as prefix), not ".agents:impeccable".
+    it("marketplace plugin: .agents/skills/ is not exposed to non-Claude providers", () => {
+      // Marketplace plugins are part of Claude's plugin infrastructure — same rule as
+      // the cache. Skills under .agents/ don't grant cross-provider access. The skill
+      // name uses the marketplace name as prefix (not ".agents:"), but it's Claude-only.
       const skillDir = join(
         fakeHome, ".claude", "plugins", "marketplaces", "impeccable",
         ".agents", "skills", "impeccable",
       );
       mkdirSync(skillDir, { recursive: true });
-      writeMd(join(skillDir, "SKILL.md"), { description: "Cross-provider marketplace skill" });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Marketplace skill" });
 
       const svc = new SkillService();
 
-      // Codex and Copilot see it under the correct marketplace name prefix.
+      // Non-Claude providers must not see it.
       const copilotItems = svc.list(undefined, "copilot");
-      expect(copilotItems.find((i) => i.name === "impeccable:impeccable")).toBeDefined();
+      expect(copilotItems.find((i) => i.name === "impeccable:impeccable")).toBeUndefined();
       expect(copilotItems.find((i) => i.name === ".agents:impeccable")).toBeUndefined();
 
       svc.invalidate();
       const codexItems = svc.list(undefined, "codex");
-      expect(codexItems.find((i) => i.name === "impeccable:impeccable")).toBeDefined();
-
-      // Claude does NOT see it (tagged codex+copilot only via .agents/).
-      svc.invalidate();
-      const claudeItems = svc.list(undefined, "claude");
-      expect(claudeItems.find((i) => i.name === "impeccable:impeccable")).toBeUndefined();
+      expect(codexItems.find((i) => i.name === "impeccable:impeccable")).toBeUndefined();
     });
 
     it("marketplace plugin: .claude/skills/ produces <marketplace-name>:* prefix for claude only", () => {

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -19,14 +19,17 @@ function writeMd(path: string, frontmatter: Record<string, string>, body = "") {
 describe("SkillService", () => {
   let originalHome: string | undefined;
   let originalUserProfile: string | undefined;
+  let originalAppData: string | undefined;
   let fakeHome: string;
 
   beforeEach(() => {
     fakeHome = tmp();
     originalHome = process.env.HOME;
     originalUserProfile = process.env.USERPROFILE;
+    originalAppData = process.env.APPDATA;
     process.env.HOME = fakeHome;
     process.env.USERPROFILE = fakeHome; // Windows
+    process.env.APPDATA = join(fakeHome, "AppData", "Roaming"); // Windows Copilot path
   });
 
   afterEach(() => {
@@ -34,6 +37,8 @@ describe("SkillService", () => {
     else delete process.env.HOME;
     if (originalUserProfile !== undefined) process.env.USERPROFILE = originalUserProfile;
     else delete process.env.USERPROFILE;
+    if (originalAppData !== undefined) process.env.APPDATA = originalAppData;
+    else delete process.env.APPDATA;
     rmSync(fakeHome, { recursive: true, force: true });
   });
 
@@ -270,6 +275,19 @@ describe("SkillService", () => {
       const codexItems = svc.list(undefined, "codex");
       const codexDeploy = codexItems.find((i) => i.name === "deploy");
       expect(codexDeploy!.description).toBe("Codex deploy");
+    });
+
+    it("tags commands from ~/.codex/commands with providers=['codex']", () => {
+      const cmdDir = join(fakeHome, ".codex", "commands");
+      mkdirSync(cmdDir, { recursive: true });
+      writeMd(join(cmdDir, "deploy.md"), { description: "Codex deploy command" });
+
+      const items = new SkillService().list(undefined, "codex");
+
+      const cmd = items.find((i) => i.name === "deploy");
+      expect(cmd).toBeDefined();
+      expect(cmd!.kind).toBe("command");
+      expect(cmd!.providers).toEqual(["codex"]);
     });
   });
 });

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -149,4 +149,127 @@ describe("SkillService", () => {
     expect(() => svc.invalidate()).not.toThrow();
     expect(secondFired).toBe(true);
   });
+
+  describe("provider-scoped scanning", () => {
+    it("tags skills from ~/.claude/skills with providers=['claude']", () => {
+      const skillDir = join(fakeHome, ".claude", "skills", "my-skill");
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Claude skill" });
+
+      const items = new SkillService().list(undefined, "claude");
+
+      const skill = items.find((i) => i.name === "my-skill");
+      expect(skill).toBeDefined();
+      expect(skill!.providers).toEqual(["claude"]);
+    });
+
+    it("tags skills from ~/.codex/skills with providers=['codex']", () => {
+      const skillDir = join(fakeHome, ".codex", "skills", "codex-skill");
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Codex skill" });
+
+      const items = new SkillService().list(undefined, "codex");
+
+      const skill = items.find((i) => i.name === "codex-skill");
+      expect(skill).toBeDefined();
+      expect(skill!.providers).toEqual(["codex"]);
+    });
+
+    it("tags skills from ~/.agents/skills with providers=['codex','copilot']", () => {
+      const skillDir = join(fakeHome, ".agents", "skills", "shared-skill");
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Shared skill" });
+
+      const svc = new SkillService();
+
+      const codexItems = svc.list(undefined, "codex");
+      expect(codexItems.find((i) => i.name === "shared-skill")).toBeDefined();
+
+      svc.invalidate();
+      const copilotItems = svc.list(undefined, "copilot");
+      expect(copilotItems.find((i) => i.name === "shared-skill")).toBeDefined();
+
+      svc.invalidate();
+      const claudeItems = svc.list(undefined, "claude");
+      expect(claudeItems.find((i) => i.name === "shared-skill")).toBeUndefined();
+    });
+
+    it("filters by providerId and returns only matching skills", () => {
+      const claudeSkillDir = join(fakeHome, ".claude", "skills", "claude-only");
+      mkdirSync(claudeSkillDir, { recursive: true });
+      writeMd(join(claudeSkillDir, "SKILL.md"), { description: "Claude only" });
+
+      const codexSkillDir = join(fakeHome, ".codex", "skills", "codex-only");
+      mkdirSync(codexSkillDir, { recursive: true });
+      writeMd(join(codexSkillDir, "SKILL.md"), { description: "Codex only" });
+
+      const svc = new SkillService();
+
+      const claudeItems = svc.list(undefined, "claude");
+      expect(claudeItems.find((i) => i.name === "claude-only")).toBeDefined();
+      expect(claudeItems.find((i) => i.name === "codex-only")).toBeUndefined();
+
+      svc.invalidate();
+      const codexItems = svc.list(undefined, "codex");
+      expect(codexItems.find((i) => i.name === "codex-only")).toBeDefined();
+      expect(codexItems.find((i) => i.name === "claude-only")).toBeUndefined();
+    });
+
+    it("returns all skills when no providerId is given", () => {
+      const claudeSkillDir = join(fakeHome, ".claude", "skills", "claude-skill");
+      mkdirSync(claudeSkillDir, { recursive: true });
+      writeMd(join(claudeSkillDir, "SKILL.md"), { description: "Claude" });
+
+      const codexSkillDir = join(fakeHome, ".codex", "skills", "codex-skill");
+      mkdirSync(codexSkillDir, { recursive: true });
+      writeMd(join(codexSkillDir, "SKILL.md"), { description: "Codex" });
+
+      const items = new SkillService().list();
+
+      expect(items.find((i) => i.name === "claude-skill")).toBeDefined();
+      expect(items.find((i) => i.name === "codex-skill")).toBeDefined();
+      expect(items.every((i) => Array.isArray(i.providers))).toBe(true);
+    });
+
+    it("deduplicates by name within same provider using source priority", () => {
+      const cwd = tmp();
+      try {
+        const userSkillDir = join(fakeHome, ".claude", "skills", "shared");
+        mkdirSync(userSkillDir, { recursive: true });
+        writeMd(join(userSkillDir, "SKILL.md"), { description: "User wins" });
+
+        const projectSkillDir = join(cwd, ".claude", "skills", "shared");
+        mkdirSync(projectSkillDir, { recursive: true });
+        writeMd(join(projectSkillDir, "SKILL.md"), { description: "Project loses" });
+
+        const items = new SkillService().list(cwd, "claude");
+        const shared = items.find((i) => i.name === "shared");
+        expect(shared!.description).toBe("User wins");
+        expect(shared!.source).toBe("user");
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it("allows same name across different providers", () => {
+      const claudeSkillDir = join(fakeHome, ".claude", "skills", "deploy");
+      mkdirSync(claudeSkillDir, { recursive: true });
+      writeMd(join(claudeSkillDir, "SKILL.md"), { description: "Claude deploy" });
+
+      const codexSkillDir = join(fakeHome, ".codex", "skills", "deploy");
+      mkdirSync(codexSkillDir, { recursive: true });
+      writeMd(join(codexSkillDir, "SKILL.md"), { description: "Codex deploy" });
+
+      const svc = new SkillService();
+
+      const claudeItems = svc.list(undefined, "claude");
+      const claudeDeploy = claudeItems.find((i) => i.name === "deploy");
+      expect(claudeDeploy!.description).toBe("Claude deploy");
+
+      svc.invalidate();
+      const codexItems = svc.list(undefined, "codex");
+      const codexDeploy = codexItems.find((i) => i.name === "deploy");
+      expect(codexDeploy!.description).toBe("Codex deploy");
+    });
+  });
 });

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -171,25 +171,22 @@ function scanPluginCacheDir(ctx: ScanContext, cacheDir: string, providers: strin
   }
 }
 
-/** Walk plugin marketplaces: marketplaces/<marketplace>/<plugin>/. */
+/**
+ * Walk plugin marketplaces: each marketplace directory IS the plugin version root.
+ *
+ * Marketplace installs are git-checkout style repos where the marketplace dir itself
+ * contains the plugin content (skills/, commands/, .agents/, .claude/, etc.).
+ * They do NOT follow a <marketplace>/<plugin>/<version>/ nesting — the marketplace
+ * name IS the plugin name, and the directory IS the version dir. Treating subdirs
+ * as separate "plugins" would produce wrong prefixes (e.g. ".agents:adapt" instead
+ * of "impeccable:adapt") and duplicate entries alongside the cache scan.
+ */
 function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string, providers: string[]): void {
   for (const mp of scanDir(ctx, marketplacesDir)) {
     if (!mp.isDirectory()) continue;
     const mpDir = join(marketplacesDir, mp.name);
-    for (const plugin of scanDir(ctx, mpDir)) {
-      if (!plugin.isDirectory()) continue;
-      const pluginDir = join(mpDir, plugin.name);
-      // Some marketplace plugins use a multi-provider layout where subdirectories
-      // are named after provider roots (`.agents`, `.claude`, `.codex`, etc.) rather
-      // than being conventional plugin dirs. Map known names to their scoped providers;
-      // for unknown `.xxx` dirs derive the provider from the dir name so they remain
-      // invisible to all mcode-managed providers.
-      const effectiveProviders =
-        PROVIDER_SUBDIR_PROVIDERS[plugin.name] ??
-        (plugin.name.startsWith(".") ? [plugin.name.slice(1)] : providers);
-      // Marketplaces are unversioned — treat the plugin dir itself as the version dir.
-      scanPluginVersionDir(ctx, pluginDir, plugin.name, effectiveProviders);
-    }
+    // Use the marketplace name as the plugin prefix; the dir itself is the version dir.
+    scanPluginVersionDir(ctx, mpDir, mp.name, providers);
   }
 }
 

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -119,13 +119,35 @@ function scanPluginVersionDir(
   pluginName: string,
   providers: string[],
 ): void {
-  // Both bare and `.claude`-prefixed shapes are observed in the wild.
-  for (const sub of ["", ".claude"]) {
-    const base = sub ? join(versionDir, sub) : versionDir;
-    scanSkillsDir(ctx, join(base, "skills"), pluginName, "plugin", providers);
-    scanCommandsDir(ctx, join(base, "commands"), pluginName, "plugin", providers);
+  // Root-level skills/commands inherit the plugin's default providers.
+  scanSkillsDir(ctx, join(versionDir, "skills"), pluginName, "plugin", providers);
+  scanCommandsDir(ctx, join(versionDir, "commands"), pluginName, "plugin", providers);
+
+  // Provider-specific subdirs each carry their own scoped providers so that,
+  // for example, `.agents/skills/` is visible to Codex + Copilot but not Claude.
+  for (const [sub, subProviders] of Object.entries(PROVIDER_SUBDIR_PROVIDERS)) {
+    const base = join(versionDir, sub);
+    scanSkillsDir(ctx, join(base, "skills"), pluginName, "plugin", subProviders);
+    scanCommandsDir(ctx, join(base, "commands"), pluginName, "plugin", subProviders);
   }
 }
+
+/**
+ * Maps known provider-specific plugin subdirectories to the providers that should see them.
+ * Root-level plugin skills/commands retain whatever providers the parent scan root carries.
+ * Entries like `.agents` are cross-provider (Codex + Copilot); `.claude` and `.claude-plugin`
+ * are Claude-only; the rest are single-provider.
+ */
+const PROVIDER_SUBDIR_PROVIDERS: Record<string, string[]> = {
+  ".agents":        ["codex", "copilot"],
+  ".claude":        ["claude"],
+  ".claude-plugin": ["claude"],
+  ".codex":         ["codex"],
+  ".cursor":        ["cursor"],
+  ".gemini":        ["gemini"],
+  ".github":        ["copilot"],
+  ".opencode":      ["opencode"],
+};
 
 /** Numeric collator orders `2.1.0` before `10.0.0` instead of lexically.
  *  Avoids pulling in the `semver` dep just for plugin-cache version selection. */
@@ -157,8 +179,16 @@ function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string, pro
     for (const plugin of scanDir(ctx, mpDir)) {
       if (!plugin.isDirectory()) continue;
       const pluginDir = join(mpDir, plugin.name);
+      // Some marketplace plugins use a multi-provider layout where subdirectories
+      // are named after provider roots (`.agents`, `.claude`, `.codex`, etc.) rather
+      // than being conventional plugin dirs. Map known names to their scoped providers;
+      // for unknown `.xxx` dirs derive the provider from the dir name so they remain
+      // invisible to all mcode-managed providers.
+      const effectiveProviders =
+        PROVIDER_SUBDIR_PROVIDERS[plugin.name] ??
+        (plugin.name.startsWith(".") ? [plugin.name.slice(1)] : providers);
       // Marketplaces are unversioned — treat the plugin dir itself as the version dir.
-      scanPluginVersionDir(ctx, pluginDir, plugin.name, providers);
+      scanPluginVersionDir(ctx, pluginDir, plugin.name, effectiveProviders);
     }
   }
 }

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -168,7 +168,7 @@ function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string, pro
  * On Windows: %APPDATA%\GitHub Copilot\agents.
  * On macOS/Linux: ~/.config/github-copilot/agents.
  */
-function copilotUserAgentsDir(): string {
+export function copilotUserAgentsDir(): string {
   if (platform() === "win32") {
     const appData =
       process.env["APPDATA"] ?? join(homedir(), "AppData", "Roaming");

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -2,13 +2,14 @@
  * Skill and command scanning service.
  * Walks user, project, agent, and plugin directories looking for both
  * `skills/` (each subdirectory is a skill) and `commands/` (each .md file
- * is a command). Mirrors Claude Code's native discovery.
+ * is a command). Mirrors Claude Code's native discovery, extended to cover
+ * Codex and Copilot provider directories.
  */
 
 import { injectable } from "tsyringe";
 import { readdirSync, readFileSync, existsSync, type Dirent } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { homedir, platform } from "os";
 import { logger } from "@mcode/shared";
 import type { SkillInfo, SkillSource, SkillDiagnostics } from "@mcode/contracts";
 
@@ -16,7 +17,7 @@ const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
 const DESC_RE = /^description:\s*(?:"([^"]*)"|'([^']*)'|(.*))$/m;
 
 interface ScanContext {
-  out: Map<string, SkillInfo>;
+  out: SkillInfo[];
   diag: SkillDiagnostics;
 }
 
@@ -61,20 +62,13 @@ function scanDir(ctx: ScanContext, dir: string): Dirent[] {
   }
 }
 
-/** Set entry only if absent OR the new source has higher priority than the existing one. */
-function setIfHigherPriority(out: Map<string, SkillInfo>, info: SkillInfo): void {
-  const existing = out.get(info.name);
-  if (!existing || SOURCE_PRIORITY[info.source] < SOURCE_PRIORITY[existing.source]) {
-    out.set(info.name, info);
-  }
-}
-
 /** Walk a flat skills directory: each subdir with `SKILL.md` is a skill. */
 function scanSkillsDir(
   ctx: ScanContext,
   dir: string,
   prefix: string,
   source: SkillSource,
+  providers: string[],
 ): void {
   for (const entry of scanDir(ctx, dir)) {
     if (!entry.isDirectory()) continue;
@@ -84,11 +78,12 @@ function scanSkillsDir(
     const skillFile = join(dir, entry.name, "SKILL.md");
     if (!existsSync(skillFile)) continue;
     const name = prefix ? `${prefix}:${entry.name}` : entry.name;
-    setIfHigherPriority(ctx.out, {
+    ctx.out.push({
       name,
       description: readDescription(skillFile),
       kind: "skill",
       source,
+      providers,
     });
     ctx.diag.totalSkills++;
   }
@@ -100,16 +95,18 @@ function scanCommandsDir(
   dir: string,
   prefix: string,
   source: SkillSource,
+  providers: string[],
 ): void {
   for (const entry of scanDir(ctx, dir)) {
     if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
     const baseName = entry.name.slice(0, -3);
     const name = prefix ? `${prefix}:${baseName}` : baseName;
-    setIfHigherPriority(ctx.out, {
+    ctx.out.push({
       name,
       description: readDescription(join(dir, entry.name)),
       kind: "command",
       source,
+      providers,
     });
     ctx.diag.totalCommands++;
   }
@@ -120,12 +117,13 @@ function scanPluginVersionDir(
   ctx: ScanContext,
   versionDir: string,
   pluginName: string,
+  providers: string[],
 ): void {
   // Both bare and `.claude`-prefixed shapes are observed in the wild.
   for (const sub of ["", ".claude"]) {
     const base = sub ? join(versionDir, sub) : versionDir;
-    scanSkillsDir(ctx, join(base, "skills"), pluginName, "plugin");
-    scanCommandsDir(ctx, join(base, "commands"), pluginName, "plugin");
+    scanSkillsDir(ctx, join(base, "skills"), pluginName, "plugin", providers);
+    scanCommandsDir(ctx, join(base, "commands"), pluginName, "plugin", providers);
   }
 }
 
@@ -134,7 +132,7 @@ function scanPluginVersionDir(
 const VERSION_COLLATOR = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
 
 /** Walk plugin cache: cache/<marketplace>/<plugin>/<version>/. */
-function scanPluginCacheDir(ctx: ScanContext, cacheDir: string): void {
+function scanPluginCacheDir(ctx: ScanContext, cacheDir: string, providers: string[]): void {
   for (const mp of scanDir(ctx, cacheDir)) {
     if (!mp.isDirectory()) continue;
     const mpDir = join(cacheDir, mp.name);
@@ -146,13 +144,13 @@ function scanPluginCacheDir(ctx: ScanContext, cacheDir: string): void {
         .map((e) => e.name)
         .sort(VERSION_COLLATOR.compare);
       if (versions.length === 0) continue;
-      scanPluginVersionDir(ctx, join(pluginDir, versions[versions.length - 1]), plugin.name);
+      scanPluginVersionDir(ctx, join(pluginDir, versions[versions.length - 1]), plugin.name, providers);
     }
   }
 }
 
 /** Walk plugin marketplaces: marketplaces/<marketplace>/<plugin>/. */
-function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string): void {
+function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string, providers: string[]): void {
   for (const mp of scanDir(ctx, marketplacesDir)) {
     if (!mp.isDirectory()) continue;
     const mpDir = join(marketplacesDir, mp.name);
@@ -160,9 +158,79 @@ function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string): vo
       if (!plugin.isDirectory()) continue;
       const pluginDir = join(mpDir, plugin.name);
       // Marketplaces are unversioned — treat the plugin dir itself as the version dir.
-      scanPluginVersionDir(ctx, pluginDir, plugin.name);
+      scanPluginVersionDir(ctx, pluginDir, plugin.name, providers);
     }
   }
+}
+
+/**
+ * Resolve the Copilot user-level agents directory.
+ * On Windows: %APPDATA%\GitHub Copilot\agents.
+ * On macOS/Linux: ~/.config/github-copilot/agents.
+ */
+function copilotUserAgentsDir(): string {
+  if (platform() === "win32") {
+    const appData =
+      process.env["APPDATA"] ?? join(homedir(), "AppData", "Roaming");
+    return join(appData, "GitHub Copilot", "agents");
+  }
+  return join(homedir(), ".config", "github-copilot", "agents");
+}
+
+/** Drives a single directory scan: which path, what source, which providers, and whether to scan for skills, commands, or both. */
+interface ScanRoot {
+  path: string;
+  source: SkillSource;
+  providers: string[];
+  /** "skills" scans for subdirs with SKILL.md, "commands" scans for *.md files, "both" does both. */
+  kind: "skills" | "commands" | "both";
+}
+
+/** Build the ordered list of directories to scan for skills and commands. */
+function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
+  const claudeDir = join(home, ".claude");
+  const codexDir = join(home, ".codex");
+  const agentsDir = join(home, ".agents");
+
+  const roots: ScanRoot[] = [
+    // Claude ecosystem
+    { path: join(claudeDir, "skills"), source: "user", providers: ["claude"], kind: "skills" },
+    { path: join(claudeDir, "commands"), source: "user", providers: ["claude"], kind: "commands" },
+    { path: join(claudeDir, ".agents", "skills"), source: "agent", providers: ["claude"], kind: "skills" },
+
+    // Codex ecosystem
+    { path: join(codexDir, "skills"), source: "user", providers: ["codex"], kind: "skills" },
+    { path: join(codexDir, "commands"), source: "user", providers: ["codex"], kind: "commands" },
+
+    // Cross-provider (.agents at home root — visible to Codex and Copilot but not Claude)
+    { path: join(agentsDir, "skills"), source: "agent", providers: ["codex", "copilot"], kind: "skills" },
+    { path: join(agentsDir, "commands"), source: "agent", providers: ["codex", "copilot"], kind: "commands" },
+
+    // Copilot user-level agents
+    { path: copilotUserAgentsDir(), source: "user", providers: ["copilot"], kind: "both" },
+  ];
+
+  if (cwd) {
+    roots.push(
+      // Claude project-level
+      { path: join(cwd, ".claude", "skills"), source: "project", providers: ["claude"], kind: "skills" },
+      { path: join(cwd, ".claude", "commands"), source: "project", providers: ["claude"], kind: "commands" },
+
+      // Codex project-level
+      { path: join(cwd, ".codex", "skills"), source: "project", providers: ["codex"], kind: "skills" },
+      { path: join(cwd, ".codex", "commands"), source: "project", providers: ["codex"], kind: "commands" },
+
+      // Cross-provider project-level
+      { path: join(cwd, ".agents", "skills"), source: "project", providers: ["codex", "copilot"], kind: "skills" },
+      { path: join(cwd, ".agents", "commands"), source: "project", providers: ["codex", "copilot"], kind: "commands" },
+
+      // Copilot project-level agents
+      { path: join(cwd, ".github", "agents"), source: "project", providers: ["copilot"], kind: "both" },
+      { path: join(cwd, ".copilot", "agents"), source: "project", providers: ["copilot"], kind: "both" },
+    );
+  }
+
+  return roots;
 }
 
 /** Discovers skills and commands across user, project, agent, and plugin sources. */
@@ -174,25 +242,22 @@ export class SkillService {
   private subscribers = new Set<() => void>();
 
   /**
-   * List every skill and command discoverable from disk.
-   * Sources, in priority order (higher overrides lower for duplicate names):
-   * 1. `~/.claude/skills/` (user)
-   * 2. `~/.claude/commands/` (user)
-   * 3. `<cwd>/.claude/skills/` (project)
-   * 4. `<cwd>/.claude/commands/` (project)
-   * 5. `~/.claude/.agents/skills/` (agent)
-   * 6. `~/.claude/plugins/cache/...` (plugin)
-   * 7. `~/.claude/plugins/marketplaces/...` (plugin)
+   * List discoverable skills and commands from disk.
+   * When `providerId` is given, only entries whose `providers` array includes
+   * that id are returned. Deduplication by name (higher-priority source wins)
+   * is applied per filtered set, so the same name can coexist across providers.
    */
-  list(cwd?: string): SkillInfo[] {
-    if (this.cache && this.cachedCwd === cwd) return this.cache;
+  list(cwd?: string, providerId?: string): SkillInfo[] {
+    if (this.cache && this.cachedCwd === cwd) {
+      return this.filterAndDedup(this.cache, providerId);
+    }
     const result = this.scan(cwd);
     this.cache = result.items;
     this.cachedCwd = cwd;
-    return result.items;
+    return this.filterAndDedup(result.items, providerId);
   }
 
-  /** Force a full rescan and return per-path diagnostics. */
+  /** Force a full rescan and return per-path diagnostics. Provider-agnostic. */
   diagnose(cwd?: string): SkillDiagnostics {
     const result = this.scan(cwd);
     this.cache = result.items;
@@ -222,26 +287,49 @@ export class SkillService {
     };
   }
 
+  /**
+   * Filter entries by provider, then deduplicate by name within the filtered
+   * set using source priority (user > project > agent > plugin).
+   * Deduplication is intentionally scoped to the filtered set so that a skill
+   * named "deploy" can independently exist for both claude and codex.
+   */
+  private filterAndDedup(items: SkillInfo[], providerId?: string): SkillInfo[] {
+    const filtered = providerId
+      ? items.filter((s) => s.providers.includes(providerId))
+      : items;
+
+    const seen = new Map<string, SkillInfo>();
+    for (const item of filtered) {
+      const existing = seen.get(item.name);
+      if (!existing || SOURCE_PRIORITY[item.source] < SOURCE_PRIORITY[existing.source]) {
+        seen.set(item.name, item);
+      }
+    }
+    return Array.from(seen.values());
+  }
+
   private scan(cwd?: string): { items: SkillInfo[]; diag: SkillDiagnostics } {
     const home = homedir();
     const claudeDir = join(home, ".claude");
     const ctx: ScanContext = {
-      out: new Map(),
+      out: [],
       diag: { scanned: [], errors: [], totalSkills: 0, totalCommands: 0 },
     };
 
-    scanSkillsDir(ctx, join(claudeDir, "skills"), "", "user");
-    scanCommandsDir(ctx, join(claudeDir, "commands"), "", "user");
-
-    if (cwd) {
-      scanSkillsDir(ctx, join(cwd, ".claude", "skills"), "", "project");
-      scanCommandsDir(ctx, join(cwd, ".claude", "commands"), "", "project");
+    const roots = buildScanRoots(home, cwd);
+    for (const root of roots) {
+      if (root.kind === "skills" || root.kind === "both") {
+        scanSkillsDir(ctx, root.path, "", root.source, root.providers);
+      }
+      if (root.kind === "commands" || root.kind === "both") {
+        scanCommandsDir(ctx, root.path, "", root.source, root.providers);
+      }
     }
 
-    scanSkillsDir(ctx, join(claudeDir, ".agents", "skills"), "", "agent");
-    scanPluginCacheDir(ctx, join(claudeDir, "plugins", "cache"));
-    scanPluginMarketplaceDir(ctx, join(claudeDir, "plugins", "marketplaces"));
+    // Plugins remain Claude-scoped
+    scanPluginCacheDir(ctx, join(claudeDir, "plugins", "cache"), ["claude"]);
+    scanPluginMarketplaceDir(ctx, join(claudeDir, "plugins", "marketplaces"), ["claude"]);
 
-    return { items: Array.from(ctx.out.values()), diag: ctx.diag };
+    return { items: ctx.out, diag: ctx.diag };
   }
 }

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -112,42 +112,29 @@ function scanCommandsDir(
   }
 }
 
-/** Scan every known surface inside one plugin version directory. */
+/**
+ * Scan every known surface inside one plugin version directory.
+ * Plugins live under `~/.claude/plugins/` — Claude's own infrastructure — so they
+ * are always tagged with whatever `providers` the caller passes (always `["claude"]`).
+ * Provider-specific subdirs authored by the plugin (`.agents/`, `.codex/`, etc.) are
+ * intentionally ignored here: a plugin installed through Claude's system does not
+ * automatically become available to other providers. Cross-provider access requires
+ * the user to place skills in the provider-specific user directories (`~/.codex/`,
+ * `~/.agents/`, etc.) explicitly.
+ */
 function scanPluginVersionDir(
   ctx: ScanContext,
   versionDir: string,
   pluginName: string,
   providers: string[],
 ): void {
-  // Root-level skills/commands inherit the plugin's default providers.
-  scanSkillsDir(ctx, join(versionDir, "skills"), pluginName, "plugin", providers);
-  scanCommandsDir(ctx, join(versionDir, "commands"), pluginName, "plugin", providers);
-
-  // Provider-specific subdirs each carry their own scoped providers so that,
-  // for example, `.agents/skills/` is visible to Codex + Copilot but not Claude.
-  for (const [sub, subProviders] of Object.entries(PROVIDER_SUBDIR_PROVIDERS)) {
-    const base = join(versionDir, sub);
-    scanSkillsDir(ctx, join(base, "skills"), pluginName, "plugin", subProviders);
-    scanCommandsDir(ctx, join(base, "commands"), pluginName, "plugin", subProviders);
+  // Both bare and `.claude`-prefixed shapes are observed in the wild.
+  for (const sub of ["", ".claude"]) {
+    const base = sub ? join(versionDir, sub) : versionDir;
+    scanSkillsDir(ctx, join(base, "skills"), pluginName, "plugin", providers);
+    scanCommandsDir(ctx, join(base, "commands"), pluginName, "plugin", providers);
   }
 }
-
-/**
- * Maps known provider-specific plugin subdirectories to the providers that should see them.
- * Root-level plugin skills/commands retain whatever providers the parent scan root carries.
- * Entries like `.agents` are cross-provider (Codex + Copilot); `.claude` and `.claude-plugin`
- * are Claude-only; the rest are single-provider.
- */
-const PROVIDER_SUBDIR_PROVIDERS: Record<string, string[]> = {
-  ".agents":        ["codex", "copilot"],
-  ".claude":        ["claude"],
-  ".claude-plugin": ["claude"],
-  ".codex":         ["codex"],
-  ".cursor":        ["cursor"],
-  ".gemini":        ["gemini"],
-  ".github":        ["copilot"],
-  ".opencode":      ["opencode"],
-};
 
 /** Numeric collator orders `2.1.0` before `10.0.0` instead of lexically.
  *  Avoids pulling in the `semver` dep just for plugin-cache version selection. */

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -179,8 +179,10 @@ function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string, pro
 
 /**
  * Resolve the Copilot user-level agents directory.
- * On Windows: %APPDATA%\GitHub Copilot\agents.
- * On macOS/Linux: ~/.config/github-copilot/agents.
+ *
+ * @returns The platform-specific path to Copilot's user-level agents directory.
+ *   - Windows: `%APPDATA%\GitHub Copilot\agents`
+ *   - macOS/Linux: `~/.config/github-copilot/agents`
  */
 export function copilotUserAgentsDir(): string {
   if (platform() === "win32") {

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -118,13 +118,14 @@ describe("SkillWatcherService", () => {
   });
 
   it("auto-registers roots from multiple parent directories", async () => {
-    // Simulate ~/.codex/ being created after start()
+    // Simulate two provider parent dirs existing at startup (e.g. ~/.claude and ~/.codex)
     const claudeParent = join(dir, ".claude");
     const codexParent = join(dir, ".codex");
     mkdirSync(claudeParent, { recursive: true });
-    // codexParent does NOT exist at start time
+    mkdirSync(codexParent, { recursive: true });
 
     const codexRoot = join(codexParent, "skills");
+    // codexRoot does NOT exist at start time
 
     watcher.start({
       parentDirs: [claudeParent, codexParent],
@@ -133,12 +134,13 @@ describe("SkillWatcherService", () => {
 
     const invalidateSpy = vi.spyOn(svc, "invalidate");
 
-    // Create the codex parent (and its skills subdir) after start
+    // Create the missing codex root after start() — the codexParent watcher
+    // should detect this and auto-register codexRoot.
     mkdirSync(codexRoot, { recursive: true });
     await new Promise((r) => setTimeout(r, 350));
     invalidateSpy.mockClear();
 
-    // A change inside the late-registered codex root should invalidate
+    // A change inside the late-registered codex root must invalidate
     writeFileSync(join(codexRoot, "marker.txt"), "x");
     await new Promise((r) => setTimeout(r, 350));
     expect(invalidateSpy).toHaveBeenCalledTimes(1);

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -86,7 +86,7 @@ describe("SkillWatcherService", () => {
     const root = join(dir, "skills");
     // dir (parent) exists; root does not.
 
-    watcher.start({ parentDir: dir, roots: [root] });
+    watcher.start({ parentDirs: [dir], roots: [root] });
 
     const invalidateSpy = vi.spyOn(svc, "invalidate");
 
@@ -102,6 +102,44 @@ describe("SkillWatcherService", () => {
 
     // A change inside the late-registered root must invalidate exactly once.
     writeFileSync(join(root, "marker.txt"), "x");
+    await new Promise((r) => setTimeout(r, 350));
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("watches codex and agents roots in addition to claude roots", () => {
+    const watchSpy = vi.spyOn(watcher, "watch");
+
+    watcher.start();
+    const watchedPaths = watchSpy.mock.calls.map((call) => call[0] as string);
+
+    // Should watch all the new provider roots
+    expect(watchedPaths.some((p) => p.includes(".codex"))).toBe(true);
+    expect(watchedPaths.some((p) => p.includes(".agents"))).toBe(true);
+  });
+
+  it("auto-registers roots from multiple parent directories", async () => {
+    // Simulate ~/.codex/ being created after start()
+    const claudeParent = join(dir, ".claude");
+    const codexParent = join(dir, ".codex");
+    mkdirSync(claudeParent, { recursive: true });
+    // codexParent does NOT exist at start time
+
+    const codexRoot = join(codexParent, "skills");
+
+    watcher.start({
+      parentDirs: [claudeParent, codexParent],
+      roots: [join(claudeParent, "skills"), codexRoot],
+    });
+
+    const invalidateSpy = vi.spyOn(svc, "invalidate");
+
+    // Create the codex parent (and its skills subdir) after start
+    mkdirSync(codexRoot, { recursive: true });
+    await new Promise((r) => setTimeout(r, 350));
+    invalidateSpy.mockClear();
+
+    // A change inside the late-registered codex root should invalidate
+    writeFileSync(join(codexRoot, "marker.txt"), "x");
     await new Promise((r) => setTimeout(r, 350));
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -7,7 +7,7 @@
 
 import { inject, injectable } from "tsyringe";
 import { watch, existsSync, type FSWatcher } from "fs";
-import { join, dirname } from "path";
+import { join } from "path";
 import { homedir } from "os";
 import { logger } from "@mcode/shared";
 import { broadcast } from "../transport/push";
@@ -86,41 +86,12 @@ export class SkillWatcherService {
    * post-startup triggers a (re-)registration. Recursive watching here would
    * fire on every plugin file write — far too noisy. Non-recursive sees only
    * direct children of the parent, which is exactly the granularity we need.
-   *
-   * When the parent dir doesn't exist yet (e.g. `~/.codex` on a fresh install),
-   * we watch the grandparent (i.e. `~`) instead. `~` always exists, so when the
-   * provider installs and creates `~/.codex`, the grandparent watcher fires and
-   * bootstraps the real parent watch plus any child roots.
    */
   private watchParent(parentDir: string): void {
     if (!existsSync(parentDir)) {
-      const grandparent = dirname(parentDir);
-      if (!existsSync(grandparent) || this.watchedDirs.has(grandparent)) return;
-      try {
-        const w = watch(grandparent, () => {
-          if (existsSync(parentDir) && !this.watchedDirs.has(parentDir)) {
-            this.watchParent(parentDir);
-            for (const root of this.dynamicRoots) {
-              if (!this.watchedDirs.has(root)) this.watch(root);
-            }
-            this.onChange(parentDir);
-          }
-        });
-        this.attachErrorHandler(w, grandparent);
-        this.watchers.push(w);
-        this.watchedDirs.add(grandparent);
-        logger.debug("SkillWatcherService: parent dir missing, watching grandparent for late creation", {
-          parentDir,
-          grandparent,
-        });
-      } catch (err) {
-        const message = (err as Error).message;
-        logger.debug("SkillWatcherService: grandparent watch failed, late detection disabled", {
-          parentDir,
-          grandparent,
-          message,
-        });
-      }
+      logger.debug("SkillWatcherService: parent dir missing, dynamic-root detection disabled", {
+        parentDir,
+      });
       return;
     }
     if (this.watchedDirs.has(parentDir)) return;

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -7,11 +7,11 @@
 
 import { inject, injectable } from "tsyringe";
 import { watch, existsSync, type FSWatcher } from "fs";
-import { join } from "path";
+import { join, dirname } from "path";
 import { homedir } from "os";
 import { logger } from "@mcode/shared";
 import { broadcast } from "../transport/push";
-import { SkillService } from "./skill-service";
+import { SkillService, copilotUserAgentsDir } from "./skill-service";
 
 const DEBOUNCE_MS = 200;
 
@@ -37,16 +37,17 @@ export class SkillWatcherService {
   ) {}
 
   /**
-   * Begin watching the standard Claude plugin and skill roots.
+   * Begin watching skill and plugin roots across all supported providers.
    * Idempotent: subsequent calls are no-ops until `stopAll()` resets state.
    *
-   * Also watches the parent `~/.claude` dir so a root that doesn't exist
-   * at startup (fresh install) gets registered automatically when created.
+   * Also watches each provider's parent dir (e.g. `~/.claude`, `~/.codex`,
+   * `~/.agents`) so roots that don't exist at startup get registered
+   * automatically when the directory is created later.
    *
    * @param overrides Optional path overrides for testing. Production callers
    *   should call `start()` with no arguments.
    */
-  start(overrides?: { parentDir?: string; roots?: string[] }): void {
+  start(overrides?: { parentDirs?: string[]; roots?: string[] }): void {
     if (this.started) {
       logger.debug("SkillWatcherService: start() ignored, already started", {
         watcherCount: this.watchers.length,
@@ -55,14 +56,28 @@ export class SkillWatcherService {
     }
     this.started = true;
     const home = homedir();
-    const claudeDir = overrides?.parentDir ?? join(home, ".claude");
+    const claudeDir = join(home, ".claude");
+    const codexDir = join(home, ".codex");
+    const agentsDir = join(home, ".agents");
+
+    const parentDirs = overrides?.parentDirs ?? [claudeDir, codexDir, agentsDir];
     const roots = overrides?.roots ?? [
+      // Claude roots
       join(claudeDir, "skills"),
       join(claudeDir, "commands"),
       join(claudeDir, "plugins"),
+      // Codex roots
+      join(codexDir, "skills"),
+      join(codexDir, "commands"),
+      // Cross-provider roots
+      join(agentsDir, "skills"),
+      join(agentsDir, "commands"),
+      // Copilot user-level agents
+      copilotUserAgentsDir(),
     ];
+
     this.dynamicRoots = roots;
-    this.watchParent(claudeDir);
+    for (const parentDir of parentDirs) this.watchParent(parentDir);
     for (const root of roots) this.watch(root);
   }
 
@@ -71,12 +86,41 @@ export class SkillWatcherService {
    * post-startup triggers a (re-)registration. Recursive watching here would
    * fire on every plugin file write — far too noisy. Non-recursive sees only
    * direct children of the parent, which is exactly the granularity we need.
+   *
+   * When the parent dir doesn't exist yet (e.g. `~/.codex` on a fresh install),
+   * we watch the grandparent (i.e. `~`) instead. `~` always exists, so when the
+   * provider installs and creates `~/.codex`, the grandparent watcher fires and
+   * bootstraps the real parent watch plus any child roots.
    */
   private watchParent(parentDir: string): void {
     if (!existsSync(parentDir)) {
-      logger.debug("SkillWatcherService: parent dir missing, dynamic-root detection disabled", {
-        parentDir,
-      });
+      const grandparent = dirname(parentDir);
+      if (!existsSync(grandparent) || this.watchedDirs.has(grandparent)) return;
+      try {
+        const w = watch(grandparent, () => {
+          if (existsSync(parentDir) && !this.watchedDirs.has(parentDir)) {
+            this.watchParent(parentDir);
+            for (const root of this.dynamicRoots) {
+              if (!this.watchedDirs.has(root)) this.watch(root);
+            }
+            this.onChange(parentDir);
+          }
+        });
+        this.attachErrorHandler(w, grandparent);
+        this.watchers.push(w);
+        this.watchedDirs.add(grandparent);
+        logger.debug("SkillWatcherService: parent dir missing, watching grandparent for late creation", {
+          parentDir,
+          grandparent,
+        });
+      } catch (err) {
+        const message = (err as Error).message;
+        logger.debug("SkillWatcherService: grandparent watch failed, late detection disabled", {
+          parentDir,
+          grandparent,
+          message,
+        });
+      }
       return;
     }
     if (this.watchedDirs.has(parentDir)) return;

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -66,6 +66,7 @@ export class SkillWatcherService {
       join(claudeDir, "skills"),
       join(claudeDir, "commands"),
       join(claudeDir, "plugins"),
+      join(claudeDir, ".agents", "skills"),
       // Codex roots
       join(codexDir, "skills"),
       join(codexDir, "commands"),

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -424,7 +424,7 @@ async function dispatch(
 
     // Skills
     case "skill.list":
-      return deps.skillService.list(params.cwd);
+      return deps.skillService.list(params.cwd, params.providerId);
     case "skill.diagnose":
       return deps.skillService.diagnose(params.cwd);
 

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -289,7 +289,77 @@ describe("cwd passthrough", () => {
     await act(async () => { result.current.onInputChange("/"); });
     await act(async () => {});
 
-    expect(mockListSkills).toHaveBeenCalledWith("/my/project");
+    expect(mockListSkills).toHaveBeenCalledWith("/my/project", undefined);
+  });
+});
+
+describe("provider-scoped commands", () => {
+  it("passes providerId through to store load", async () => {
+    const mockListSkills = vi.fn().mockResolvedValue([]);
+    vi.mocked(getTransport).mockReturnValue({ listSkills: mockListSkills } as never);
+
+    const ref = makeAnchor();
+    const { result } = renderHook(() =>
+      useSlashCommand({ anchorRef: ref, cwd: "/my/project", providerId: "codex" })
+    );
+
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    expect(mockListSkills).toHaveBeenCalledWith("/my/project", "codex");
+  });
+
+  it("hides /m:plan for copilot provider", async () => {
+    const ref = makeAnchor();
+    const { result } = renderHook(() =>
+      useSlashCommand({ anchorRef: ref, providerId: "copilot" })
+    );
+
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    const names = result.current.allCommands.map((c) => c.name);
+    expect(names).not.toContain("m:plan");
+    expect(names).toContain("compact");
+  });
+
+  it("shows /m:plan for claude provider", async () => {
+    const ref = makeAnchor();
+    const { result } = renderHook(() =>
+      useSlashCommand({ anchorRef: ref, providerId: "claude" })
+    );
+
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    const names = result.current.allCommands.map((c) => c.name);
+    expect(names).toContain("m:plan");
+  });
+
+  it("shows /m:plan when no provider is specified", async () => {
+    const ref = makeAnchor();
+    const { result } = renderHook(() =>
+      useSlashCommand({ anchorRef: ref })
+    );
+
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    const names = result.current.allCommands.map((c) => c.name);
+    expect(names).toContain("m:plan");
+  });
+
+  it("always shows /compact regardless of provider", async () => {
+    const ref = makeAnchor();
+    const { result } = renderHook(() =>
+      useSlashCommand({ anchorRef: ref, providerId: "copilot" })
+    );
+
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    const names = result.current.allCommands.map((c) => c.name);
+    expect(names).toContain("compact");
   });
 });
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -661,6 +661,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const slashCommand = useSlashCommand({
     anchorRef: editorContainerRef,
     cwd: workspacePath,
+    providerId: effectiveProviderId,
     onMcodeCommand: (action) => {
       if (action === "toggle-plan") {
         const next =

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -53,6 +53,7 @@ interface UseSlashCommandOptions {
   anchorRef: React.RefObject<HTMLElement | null>;
   onMcodeCommand?: (action: string) => void;
   cwd?: string;
+  /** Provider ID used to scope skill loading and filter built-in commands (e.g., hides /m:plan for "copilot"). */
   providerId?: string;
 }
 

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -195,7 +195,7 @@ export function useSlashCommand({
 
   const onDismiss = useCallback(() => setIsOpen(false), []);
   const onRetry = useCallback(() => {
-    load(cwd, true).catch(() => { /* surfaced via `error` */ });
+    load(cwd, undefined, true).catch(() => { /* surfaced via `error` */ });
   }, [load, cwd]);
 
   return {

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -53,6 +53,7 @@ interface UseSlashCommandOptions {
   anchorRef: React.RefObject<HTMLElement | null>;
   onMcodeCommand?: (action: string) => void;
   cwd?: string;
+  providerId?: string;
 }
 
 /** Return value of the useSlashCommand hook. */
@@ -76,6 +77,7 @@ export function useSlashCommand({
   anchorRef,
   onMcodeCommand,
   cwd,
+  providerId,
 }: UseSlashCommandOptions): UseSlashCommandReturn {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -85,18 +87,27 @@ export function useSlashCommand({
 
   const skills = useSkillsStore((s) => s.skills);
   const cachedCwd = useSkillsStore((s) => s.cwd);
+  const cachedProviderId = useSkillsStore((s) => s.providerId);
   const isLoading = useSkillsStore((s) => s.isLoading);
   const error = useSkillsStore((s) => s.error);
   const load = useSkillsStore((s) => s.load);
 
-  // Build the full command list (memoize via skills identity).
+  // Build the full command list (memoize via skills identity and providerId).
+  // The filter is inside the callback so `providerId` (a stable string) is the
+  // dep — if we filtered outside and put the resulting array in deps, every
+  // render would produce a new reference and break memoization.
   const allCommands = useCallback(() => {
+    const builtins = BUILTIN_COMMANDS.filter((cmd) => {
+      // /m:plan is hidden for copilot (uses its own dynamic modes instead)
+      if (cmd.name === "m:plan" && providerId === "copilot") return false;
+      return true;
+    });
     const commands: Command[] = [
-      ...BUILTIN_COMMANDS,
+      ...builtins,
       ...((skills ?? []).map(toCommand)),
     ];
     return sortCommands(commands);
-  }, [skills])();
+  }, [skills, providerId])();
 
   const filtered = (() => {
     const f = lastFilterRef.current.toLowerCase();
@@ -117,11 +128,12 @@ export function useSlashCommand({
   useEffect(() => {
     if (!isOpen || isLoading) return;
     const cwdChanged = cachedCwd !== cwd;
+    const providerChanged = cachedProviderId !== providerId;
     const noSkills = skills === null;
-    if (cwdChanged || (noSkills && !error)) {
-      load(cwd).catch(() => { /* surfaced via `error` */ });
+    if (cwdChanged || providerChanged || (noSkills && !error)) {
+      load(cwd, providerId).catch(() => { /* surfaced via `error` */ });
     }
-  }, [isOpen, skills, cachedCwd, cwd, isLoading, error, load]);
+  }, [isOpen, skills, cachedCwd, cachedProviderId, cwd, providerId, isLoading, error, load]);
 
   const onInputChange = useCallback(
     (value: string) => {
@@ -195,8 +207,8 @@ export function useSlashCommand({
 
   const onDismiss = useCallback(() => setIsOpen(false), []);
   const onRetry = useCallback(() => {
-    load(cwd, undefined, true).catch(() => { /* surfaced via `error` */ });
-  }, [load, cwd]);
+    load(cwd, providerId, true).catch(() => { /* surfaced via `error` */ });
+  }, [load, cwd, providerId]);
 
   return {
     isOpen,

--- a/apps/web/src/stores/skillsStore.test.ts
+++ b/apps/web/src/stores/skillsStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useSkillsStore } from "./skillsStore";
 
 const FAKE_SKILLS = [
-  { name: "a", description: "A", kind: "skill" as const, source: "user" as const },
+  { name: "a", description: "A", kind: "skill" as const, source: "user" as const, providers: ["claude"] },
 ];
 
 // Hoist the mock so the invalidate-then-reload test can assert call counts.

--- a/apps/web/src/stores/skillsStore.test.ts
+++ b/apps/web/src/stores/skillsStore.test.ts
@@ -112,3 +112,36 @@ describe("skillsStore", () => {
     expect(calls.length).toBe(2);
   });
 });
+
+describe("provider-scoped caching", () => {
+  beforeEach(() => {
+    listSkillsMock.mockClear();
+    useSkillsStore.getState().reset();
+  });
+
+  it("re-fetches when providerId changes", async () => {
+    await useSkillsStore.getState().load("/foo", "claude");
+    listSkillsMock.mockClear();
+    await useSkillsStore.getState().load("/foo", "codex");
+    expect(listSkillsMock).toHaveBeenCalledTimes(1); // cache miss — different provider
+  });
+
+  it("returns cached data when cwd and providerId both match", async () => {
+    await useSkillsStore.getState().load("/foo", "claude");
+    listSkillsMock.mockClear();
+    await useSkillsStore.getState().load("/foo", "claude");
+    expect(listSkillsMock).not.toHaveBeenCalled(); // cache hit
+  });
+
+  it("passes providerId through to RPC call", async () => {
+    await useSkillsStore.getState().load("/foo", "codex");
+    expect(listSkillsMock).toHaveBeenCalledWith("/foo", "codex");
+  });
+
+  it("scopes single-flight by cwd + providerId", async () => {
+    const p1 = useSkillsStore.getState().load("/foo", "claude");
+    const p2 = useSkillsStore.getState().load("/foo", "codex");
+    expect(p1).not.toBe(p2); // different providers = different in-flight promises
+    await Promise.all([p1, p2]);
+  });
+});

--- a/apps/web/src/stores/skillsStore.ts
+++ b/apps/web/src/stores/skillsStore.ts
@@ -15,14 +15,18 @@ interface SkillsState {
   skills: SkillInfo[] | null;
   /** The cwd associated with the last load attempt (success OR failure). */
   cwd: string | undefined;
+  /** The providerId associated with the last load attempt. */
+  providerId: string | undefined;
   /** Whether a fetch is currently in-flight. */
   isLoading: boolean;
   /** Error from the last failed fetch, if any. */
   error: Error | null;
-  /** The in-flight promise. Single-flight only deduplicates same-cwd callers. */
+  /** The in-flight promise. Single-flight only deduplicates same-cwd+providerId callers. */
   inflight: Promise<SkillInfo[]> | null;
   /** The cwd of the in-flight promise; used to scope single-flight by cwd. */
   inflightCwd: string | undefined;
+  /** The providerId of the in-flight promise; scopes single-flight to cwd + providerId. */
+  inflightProviderId: string | undefined;
   /**
    * Monotonic counter bumped by each new load() call AND by invalidate()/
    * reset(). The async closure captures the value it incremented to and
@@ -33,13 +37,14 @@ interface SkillsState {
   loadEpoch: number;
 
   /**
-   * Load skills for the given cwd.
+   * Load skills for the given cwd and providerId.
    *
-   * Returns cached data if still fresh (within TTL) and cwd matches.
-   * Concurrent calls with any cwd while a request is in-flight all
-   * receive the same promise.
+   * Returns cached data if still fresh (within TTL) and both cwd and
+   * providerId match. Concurrent calls with the same (cwd, providerId)
+   * while a request is in-flight all receive the same promise. Different
+   * providerId values get separate in-flight promises.
    */
-  load(cwd?: string, force?: boolean): Promise<SkillInfo[]>;
+  load(cwd?: string, providerId?: string, force?: boolean): Promise<SkillInfo[]>;
 
   /**
    * Invalidate the cached skills so the next `load()` re-fetches from
@@ -65,34 +70,42 @@ let lastFetchedAt = 0;
 export const useSkillsStore = create<SkillsState>((set, get) => ({
   skills: null,
   cwd: undefined,
+  providerId: undefined,
   isLoading: false,
   error: null,
   inflight: null,
   inflightCwd: undefined,
+  inflightProviderId: undefined,
   loadEpoch: 0,
 
   // Non-async so the return value IS the cached/in-flight promise directly,
   // enabling identity equality (p1 === p2) for single-flight callers.
-  load(cwd, force = false): Promise<SkillInfo[]> {
+  load(cwd, providerId, force = false): Promise<SkillInfo[]> {
     const state = get();
 
-    // Return cache if fresh and same cwd
+    // Return cache if fresh, same cwd, AND same providerId
     if (
       !force &&
       state.skills &&
       state.cwd === cwd &&
+      state.providerId === providerId &&
       Date.now() - lastFetchedAt < CACHE_TTL_MS
     ) {
       return Promise.resolve(state.skills);
     }
 
-    // Single-flight ONLY for the same cwd. A different-cwd request must
-    // not piggyback on an in-flight load for workspace A or it would
-    // receive A's data while expecting B's.
-    if (state.inflight && state.inflightCwd === cwd) return state.inflight;
+    // Single-flight scoped to cwd + providerId. A different-providerId request
+    // must not piggyback on an in-flight load or it would receive the wrong data.
+    if (
+      state.inflight &&
+      state.inflightCwd === cwd &&
+      state.inflightProviderId === providerId
+    ) {
+      return state.inflight;
+    }
 
     // Create and register the in-flight promise atomically so a second
-    // synchronous caller (same cwd) sees it immediately via get().inflight.
+    // synchronous caller (same cwd + providerId) sees it immediately via get().inflight.
     let resolveInflight!: (skills: SkillInfo[]) => void;
     let rejectInflight!: (err: unknown) => void;
     const promise = new Promise<SkillInfo[]>((res, rej) => {
@@ -106,13 +119,14 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
       error: null,
       inflight: promise,
       inflightCwd: cwd,
+      inflightProviderId: providerId,
       loadEpoch: myEpoch,
     });
 
     // Kick off the actual fetch outside the synchronous set() block.
     (async () => {
       const transport = getTransport();
-      const attempt = () => transport.listSkills(cwd);
+      const attempt = () => transport.listSkills(cwd, providerId);
       try {
         let skills: SkillInfo[];
         try {
@@ -138,7 +152,7 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
         // without polluting the now-fresher store state.
         if (get().loadEpoch === myEpoch) {
           lastFetchedAt = Date.now();
-          set({ skills, cwd, isLoading: false, inflight: null, inflightCwd: undefined, error: null });
+          set({ skills, cwd, providerId, isLoading: false, inflight: null, inflightCwd: undefined, inflightProviderId: undefined, error: null });
         }
         resolveInflight(skills);
       } catch (err) {
@@ -147,7 +161,7 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
         // Track the attempted cwd even on failure so the consumer hook can
         // detect a cwd change vs. a same-cwd retry and handle each correctly.
         if (get().loadEpoch === myEpoch) {
-          set({ cwd, isLoading: false, inflight: null, inflightCwd: undefined, error });
+          set({ cwd, providerId, isLoading: false, inflight: null, inflightCwd: undefined, inflightProviderId: undefined, error });
         }
         rejectInflight(error);
       }
@@ -163,9 +177,11 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
     set({
       skills: null,
       cwd: undefined,
+      providerId: undefined,
       error: null,
       inflight: null,
       inflightCwd: undefined,
+      inflightProviderId: undefined,
       loadEpoch: state.loadEpoch + 1,
     });
     lastFetchedAt = 0;
@@ -176,10 +192,12 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
     set({
       skills: null,
       cwd: undefined,
+      providerId: undefined,
       isLoading: false,
       error: null,
       inflight: null,
       inflightCwd: undefined,
+      inflightProviderId: undefined,
       loadEpoch: state.loadEpoch + 1,
     });
     lastFetchedAt = 0;

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -190,7 +190,7 @@ export interface McodeTransport {
   checkStatus(threadId: string): Promise<ChecksStatus>;
 
   // Skills
-  listSkills(cwd?: string): Promise<SkillInfo[]>;
+  listSkills(cwd?: string, providerId?: string): Promise<SkillInfo[]>;
   /** Run a filesystem scan across all skill search paths and return per-path diagnostics. */
   diagnoseSkills(cwd?: string): Promise<SkillDiagnostics>;
 

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -190,6 +190,7 @@ export interface McodeTransport {
   checkStatus(threadId: string): Promise<ChecksStatus>;
 
   // Skills
+  /** List discoverable skills and commands, optionally scoped to a workspace path and provider. */
   listSkills(cwd?: string, providerId?: string): Promise<SkillInfo[]>;
   /** Run a filesystem scan across all skill search paths and return per-path diagnostics. */
   diagnoseSkills(cwd?: string): Promise<SkillDiagnostics>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -587,7 +587,7 @@ export function createWsTransport(
       rpc<ChecksStatus>("github.checkStatus", { threadId }),
 
     // Skills
-    listSkills: (cwd?) => rpc<SkillInfo[]>("skill.list", { cwd }),
+    listSkills: (cwd?, providerId?) => rpc<SkillInfo[]>("skill.list", { cwd, providerId }),
     diagnoseSkills: (cwd?) => rpc<SkillDiagnostics>("skill.diagnose", { cwd }),
 
     // Terminal (PTY)

--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -18,6 +18,7 @@ export const SkillInfoSchema = lazySchema(() =>
     description: z.string(),
     kind: SkillKindSchema.default("skill"),
     source: SkillSourceSchema.default("plugin"),
+    providers: z.array(z.string()).default([]),
   }),
 );
 /** Metadata for a discovered skill or command. */

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -312,7 +312,10 @@ export const WS_METHODS = lazySchema(() => ({
     result: z.record(z.unknown()),
   },
   "skill.list": {
-    params: z.object({ cwd: z.string().optional() }),
+    params: z.object({
+      cwd: z.string().optional(),
+      providerId: z.string().optional(),
+    }),
     result: z.array(SkillInfoSchema()),
   },
   "skill.diagnose": {


### PR DESCRIPTION
## What
Slash commands are now filtered by provider. Each thread only sees skills and commands relevant to the provider it uses.

## Why
Codex and Copilot threads were showing Claude-specific skills (and vice versa). `SkillService` only scanned `~/.claude/` directories, so non-Claude providers had no slash command support at all. Closes #338.

## Key Changes
- **`packages/contracts`**: Added `providers: string[]` to `SkillInfoSchema`; added optional `providerId` param to `skill.list` RPC
- **`apps/server` - `SkillService`**: Scans all provider directories (`~/.claude/`, `~/.codex/`, `~/.agents/`, Copilot user-agents dir, project-level equivalents), tags each skill with its provider scope, and filters on `list()` by `providerId`. Plugin subdirs (`.agents/`, `.codex/`, etc. inside a plugin version dir) are also scoped correctly via `PROVIDER_SUBDIR_PROVIDERS`
- **`apps/server` - `SkillWatcherService`**: Watches the new directories and invalidates the cache on changes
- **`apps/web` - `skillsStore`**: Added `providerId` to cache key so switching providers triggers a fresh load
- **`apps/web` - `useSlashCommand`**: Accepts `providerId`; hides `/m:plan` for Copilot (which uses its own mode system)
- **`apps/web` - `Composer`**: Passes `effectiveProviderId` to the slash command hook

## Test Plan
- [ ] Open a Claude thread -- see only Claude skills/commands in `/` popup
- [ ] Open a Codex thread -- see only Codex skills/commands (`~/.codex/`, `~/.agents/`)
- [ ] Open a Copilot thread -- see only Copilot skills/commands; `/m:plan` absent
- [ ] Switch provider mid-session -- popup refreshes with correct skills on next open
- [ ] Install a multi-provider plugin (e.g. impeccable) -- each provider sees only its subdirectory's skills
- [ ] `bun run test` in `apps/server` -- all skill-service tests pass (20/20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-provider skill support (Claude, Codex, Copilot) with provider-aware discovery and filtering.
  * Provider metadata on skills so UI can reflect provider scope.
  * Provider-aware command visibility (e.g., /m:plan shown for Claude, hidden for Copilot).

* **Improvements**
  * Caching, loading, and live watches respect provider context for more accurate results and updates.
  * Deduplication and marketplace/plugin entries behave correctly across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->