### PR TITLE
fix: reduce GitHub API rate limit exposure in CI watcher

### DIFF
--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -37,12 +37,12 @@ describe("CiWatcherService", () => {
   });
 
   it("watch() adds entry and starts passive timer", () => {
-    watcher.watch("t1", 42, "/repo");
+    watcher.watch("t1", 42, "main", "/repo");
     expect(watcher.isWatching("t1")).toBe(true);
   });
 
   it("unwatch() removes entry", () => {
-    watcher.watch("t1", 42, "/repo");
+    watcher.watch("t1", 42, "main", "/repo");
     watcher.unwatch("t1");
     expect(watcher.isWatching("t1")).toBe(false);
   });
@@ -51,7 +51,7 @@ describe("CiWatcherService", () => {
     const pending = makeChecks("pending");
     mockGithubService.getCheckRuns.mockResolvedValue(pending);
     // skipInitialFetch so the assertion exercises the scheduled passive tick, not the eager fetch.
-    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
 
     await vi.advanceTimersByTimeAsync(30_000);
 
@@ -64,7 +64,7 @@ describe("CiWatcherService", () => {
   it("does NOT broadcast when state is unchanged", async () => {
     const passing = makeChecks("passing");
     mockGithubService.getCheckRuns.mockResolvedValue(passing);
-    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
 
     await vi.advanceTimersByTimeAsync(30_000);
     mockBroadcast.mockClear();
@@ -77,7 +77,7 @@ describe("CiWatcherService", () => {
   it("promotes to active set when checks are pending", async () => {
     const pending = makeChecks("pending");
     mockGithubService.getCheckRuns.mockResolvedValue(pending);
-    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
 
     // Passive tick promotes to active when aggregate is pending.
     await vi.advanceTimersByTimeAsync(30_000);
@@ -96,7 +96,7 @@ describe("CiWatcherService", () => {
 
   it("refresh() does not broadcast when state is unchanged", () => {
     const passing = makeChecks("passing");
-    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
     // First call: cache is null → always broadcasts.
     watcher.refresh("t1", passing);
     mockBroadcast.mockClear();
@@ -106,7 +106,7 @@ describe("CiWatcherService", () => {
   });
 
   it("refresh() broadcasts when aggregate changes", () => {
-    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
     watcher.refresh("t1", makeChecks("passing"));
     mockBroadcast.mockClear();
     const failing = makeChecks("failing");
@@ -120,7 +120,7 @@ describe("CiWatcherService", () => {
   it("getEntry returns cached status", async () => {
     const passing = makeChecks("passing");
     mockGithubService.getCheckRuns.mockResolvedValue(passing);
-    watcher.watch("t1", 42, "/repo", { skipInitialFetch: true });
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
 
     await vi.advanceTimersByTimeAsync(30_000);
 

--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -82,12 +82,12 @@ describe("CiWatcherService", () => {
     // Passive tick promotes to active when aggregate is pending.
     await vi.advanceTimersByTimeAsync(30_000);
 
-    // Active set ticks at 10s
+    // Active set ticks at 15s
     mockBroadcast.mockClear();
     const passing = makeChecks("passing");
     mockGithubService.getCheckRuns.mockResolvedValue(passing);
 
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(15_000);
     expect(mockBroadcast).toHaveBeenCalledWith("thread.checksUpdated", {
       threadId: "t1",
       checks: passing,

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -153,3 +153,41 @@ describe("GithubService.getCheckRuns", () => {
     expect(result.runs).toHaveLength(0);
   });
 });
+
+type CallbackFn = (error: Error | null, stdout: string, stderr: string) => void;
+
+describe("GithubService.resolveRepoSlug", () => {
+  let ghService: GithubService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ghService = new GithubService({} as WorkspaceRepo);
+  });
+
+  it("returns owner/repo from gh repo view", async () => {
+    mockExecFile.mockImplementationOnce((_cmd: string, args: string[], _opts: unknown, cb: CallbackFn) => {
+      expect(args).toContain("repo");
+      expect(args).toContain("view");
+      cb(null, "owner/my-repo\n", "");
+    });
+    const slug = await ghService.resolveRepoSlug("/some/repo");
+    expect(slug).toBe("owner/my-repo");
+  });
+
+  it("caches the slug per repoPath", async () => {
+    mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+      cb(null, "owner/cached-repo\n", "");
+    });
+    await ghService.resolveRepoSlug("/cached");
+    const slug = await ghService.resolveRepoSlug("/cached");
+    expect(slug).toBe("owner/cached-repo");
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when gh repo view fails", async () => {
+    mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+      cb(new Error("not a git repo"), "", "");
+    });
+    await expect(ghService.resolveRepoSlug("/bad")).rejects.toThrow();
+  });
+});

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -23,19 +23,20 @@ describe("GithubService.getCheckRuns", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     ghService = new GithubService({} as WorkspaceRepo);
+    vi.spyOn(ghService, "resolveRepoSlug").mockResolvedValue("owner/test-repo");
   });
 
   it("returns passing status when all checks succeed", async () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
         cb(null, JSON.stringify([
-          { name: "build", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
-          { name: "lint", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:08Z" },
+          { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          { name: "lint", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:08Z" },
         ]));
       },
     );
 
-    const result = await ghService.getCheckRuns(42, "/repo");
+    const result = await ghService.getCheckRuns("main", "/repo");
 
     expect(result.aggregate).toBe("passing");
     expect(result.runs).toHaveLength(2);
@@ -48,13 +49,13 @@ describe("GithubService.getCheckRuns", () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
         cb(null, JSON.stringify([
-          { name: "build", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
-          { name: "test", state: "FAILURE", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:45Z" },
+          { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          { name: "test", status: "completed", conclusion: "failure", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:45Z" },
         ]));
       },
     );
 
-    const result = await ghService.getCheckRuns(42, "/repo");
+    const result = await ghService.getCheckRuns("main", "/repo");
 
     expect(result.aggregate).toBe("failing");
     expect(result.runs[1].conclusion).toBe("failure");
@@ -64,13 +65,13 @@ describe("GithubService.getCheckRuns", () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
         cb(null, JSON.stringify([
-          { name: "build", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
-          { name: "test", state: "PENDING", startedAt: "2026-04-14T10:00:00Z", completedAt: null },
+          { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          { name: "test", status: "in_progress", conclusion: null, startedAt: "2026-04-14T10:00:00Z", completedAt: null },
         ]));
       },
     );
 
-    const result = await ghService.getCheckRuns(42, "/repo");
+    const result = await ghService.getCheckRuns("main", "/repo");
 
     expect(result.aggregate).toBe("pending");
     expect(result.runs[1].status).toBe("in_progress");
@@ -81,12 +82,12 @@ describe("GithubService.getCheckRuns", () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
         cb(null, JSON.stringify([
-          { name: "deploy", state: "QUEUED", startedAt: null, completedAt: null },
+          { name: "deploy", status: "queued", conclusion: null, startedAt: null, completedAt: null },
         ]));
       },
     );
 
-    const result = await ghService.getCheckRuns(42, "/repo");
+    const result = await ghService.getCheckRuns("main", "/repo");
 
     expect(result.aggregate).toBe("pending");
     expect(result.runs[0].status).toBe("queued");
@@ -101,39 +102,39 @@ describe("GithubService.getCheckRuns", () => {
       },
     );
 
-    const result = await ghService.getCheckRuns(42, "/repo");
+    const result = await ghService.getCheckRuns("main", "/repo");
 
     expect(result.aggregate).toBe("no_checks");
     expect(result.runs).toHaveLength(0);
   });
 
-  it("maps ACTION_REQUIRED state to failing aggregate and failure conclusion", async () => {
+  it("maps action_required conclusion to failing aggregate and failure conclusion", async () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
         cb(null, JSON.stringify([
-          { name: "security-check", state: "ACTION_REQUIRED", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:10Z" },
+          { name: "security-check", status: "completed", conclusion: "action_required", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:10Z" },
         ]));
       },
     );
 
-    const result = await ghService.getCheckRuns(42, "/repo");
+    const result = await ghService.getCheckRuns("main", "/repo");
 
     expect(result.aggregate).toBe("failing");
     expect(result.runs[0].conclusion).toBe("failure");
     expect(result.runs[0].status).toBe("completed");
   });
 
-  it("maps STALE state to cancelled conclusion without affecting passing aggregate", async () => {
+  it("maps cancelled conclusion without affecting passing aggregate", async () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
         cb(null, JSON.stringify([
-          { name: "build", state: "SUCCESS", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
-          { name: "old-check", state: "STALE", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:05Z" },
+          { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          { name: "old-check", status: "completed", conclusion: "cancelled", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:05Z" },
         ]));
       },
     );
 
-    const result = await ghService.getCheckRuns(42, "/repo");
+    const result = await ghService.getCheckRuns("main", "/repo");
 
     expect(result.aggregate).toBe("passing");
     expect(result.runs[1].conclusion).toBe("cancelled");
@@ -147,7 +148,7 @@ describe("GithubService.getCheckRuns", () => {
       },
     );
 
-    const result = await ghService.getCheckRuns(42, "/repo");
+    const result = await ghService.getCheckRuns("main", "/repo");
 
     expect(result.aggregate).toBe("no_checks");
     expect(result.runs).toHaveLength(0);

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 
 const { mockExecFile } = vi.hoisted(() => ({
@@ -180,6 +180,105 @@ describe("GithubService.getCheckRuns", () => {
 
     expect(peakActive).toBeLessThanOrEqual(3);
   });
+
+  // C1: Empty branch guard
+  it("resolves to no_checks when branch is empty string", async () => {
+    const result = await ghService.getCheckRuns("", "/repo");
+
+    expect(result.aggregate).toBe("no_checks");
+    expect(result.runs).toHaveLength(0);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  // H1: Unknown conclusion treated conservatively as failure
+  it("treats unknown conclusion as failure to be conservative", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        cb(null, JSON.stringify([
+          { name: "ci", status: "completed", conclusion: "startup_failure", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:05Z" },
+        ]), "");
+      },
+    );
+
+    const result = await ghService.getCheckRuns("main", "/repo");
+
+    expect(result.aggregate).toBe("failing");
+    expect(result.runs[0].conclusion).toBe("failure");
+  });
+
+  // M1: Missing status defaults to in_progress
+  it("treats missing status as in_progress to avoid false passing aggregate", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        cb(null, JSON.stringify([
+          { name: "ci", conclusion: null, startedAt: null, completedAt: null },
+        ]), "");
+      },
+    );
+
+    const result = await ghService.getCheckRuns("main", "/repo");
+
+    expect(result.runs[0].status).toBe("in_progress");
+    expect(result.aggregate).toBe("pending");
+  });
+
+  // M3: Concurrency gate not stuck after failure
+  it("releases concurrency slot even after a failed getCheckRuns call", async () => {
+    // First 3 calls fail (simulating errors)
+    let callCount = 0;
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        callCount++;
+        setImmediate(() => {
+          cb(new Error("gh error"), "", "");
+        });
+      },
+    );
+
+    // Fire 3 failing calls
+    await Promise.all([
+      ghService.getCheckRuns("main", "/repo"),
+      ghService.getCheckRuns("main", "/repo2"),
+      ghService.getCheckRuns("main", "/repo3"),
+    ]);
+
+    // 4th call should succeed - gate not stuck
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        cb(null, JSON.stringify([
+          { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+        ]), "");
+      },
+    );
+
+    const result = await ghService.getCheckRuns("main", "/repo4");
+    expect(result.aggregate).toBe("passing");
+  });
+
+  // M6: In-flight deduplication for identical branch+repo pairs
+  it("deduplicates concurrent getCheckRuns for same branch+repo", async () => {
+    let execFileCallCount = 0;
+
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        execFileCallCount++;
+        setImmediate(() => {
+          cb(null, JSON.stringify([
+            { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          ]), "");
+        });
+      },
+    );
+
+    const [result1, result2] = await Promise.all([
+      ghService.getCheckRuns("main", "/repo"),
+      ghService.getCheckRuns("main", "/repo"),
+    ]);
+
+    expect(execFileCallCount).toBe(1);
+    expect(result1.aggregate).toBe("passing");
+    expect(result2.aggregate).toBe("passing");
+  });
 });
 
 describe("GithubService.resolveRepoSlug", () => {
@@ -230,5 +329,35 @@ describe("GithubService.resolveRepoSlug", () => {
     expect(slug1).toBe("owner/dedup-repo");
     expect(slug2).toBe("owner/dedup-repo");
     expect(callCount).toBe(1);
+  });
+
+  // H2: Slug cache TTL - re-fetches after expiry
+  it("re-fetches slug after TTL expires", async () => {
+    vi.useFakeTimers();
+
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+      cb(null, "owner/ttl-repo\n", "");
+    });
+
+    // First call populates cache
+    await ghService.resolveRepoSlug("/ttl-repo");
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+
+    // Advance past 30-minute TTL
+    vi.advanceTimersByTime(31 * 60 * 1000);
+
+    // Second call after TTL should re-fetch
+    await ghService.resolveRepoSlug("/ttl-repo");
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  // M2: Malformed slug rejected
+  it("throws when gh repo view returns malformed output", async () => {
+    mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+      cb(null, "not-a-slug\n", "");
+    });
+    await expect(ghService.resolveRepoSlug("/malformed")).rejects.toThrow("Unexpected slug format");
   });
 });

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -190,4 +190,19 @@ describe("GithubService.resolveRepoSlug", () => {
     });
     await expect(ghService.resolveRepoSlug("/bad")).rejects.toThrow();
   });
+
+  it("deduplicates concurrent calls for the same path", async () => {
+    let callCount = 0;
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+      callCount++;
+      setImmediate(() => cb(null, "owner/dedup-repo\n", ""));
+    });
+    const [slug1, slug2] = await Promise.all([
+      ghService.resolveRepoSlug("/dedup"),
+      ghService.resolveRepoSlug("/dedup"),
+    ]);
+    expect(slug1).toBe("owner/dedup-repo");
+    expect(slug2).toBe("owner/dedup-repo");
+    expect(callCount).toBe(1);
+  });
 });

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -17,6 +17,8 @@ vi.mock("@mcode/shared", () => ({
 
 import { GithubService } from "../services/github-service";
 
+type CallbackFn = (error: Error | null, stdout: string, stderr: string) => void;
+
 describe("GithubService.getCheckRuns", () => {
   let ghService: GithubService;
 
@@ -153,9 +155,32 @@ describe("GithubService.getCheckRuns", () => {
     expect(result.aggregate).toBe("no_checks");
     expect(result.runs).toHaveLength(0);
   });
-});
 
-type CallbackFn = (error: Error | null, stdout: string, stderr: string) => void;
+  it("limits concurrent gh subprocesses to 3", async () => {
+    let activeCount = 0;
+    let peakActive = 0;
+
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        activeCount++;
+        peakActive = Math.max(peakActive, activeCount);
+        setImmediate(() => {
+          activeCount--;
+          cb(null, JSON.stringify([
+            { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
+          ]), "");
+        });
+      },
+    );
+
+    // 5 concurrent calls - only 3 should run at once
+    await Promise.all(
+      Array.from({ length: 5 }, () => ghService.getCheckRuns("main", "/repo")),
+    );
+
+    expect(peakActive).toBeLessThanOrEqual(3);
+  });
+});
 
 describe("GithubService.resolveRepoSlug", () => {
   let ghService: GithubService;

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -159,12 +159,15 @@ describe("GithubService.getCheckRuns", () => {
   it("limits concurrent gh subprocesses to 3", async () => {
     let activeCount = 0;
     let peakActive = 0;
+    const resolvers: Array<() => void> = [];
 
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
         activeCount++;
         peakActive = Math.max(peakActive, activeCount);
-        setImmediate(() => {
+        // Push a resolver instead of using setImmediate so the test controls exactly when each
+        // subprocess "completes". This removes timing non-determinism from the assertion.
+        resolvers.push(() => {
           activeCount--;
           cb(null, JSON.stringify([
             { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-14T10:00:00Z", completedAt: "2026-04-14T10:00:23Z" },
@@ -173,12 +176,25 @@ describe("GithubService.getCheckRuns", () => {
       },
     );
 
-    // 5 concurrent calls - only 3 should run at once
-    await Promise.all(
-      Array.from({ length: 5 }, () => ghService.getCheckRuns("main", "/repo")),
-    );
+    // Start 5 concurrent calls with distinct branches so the in-flight dedup does not
+    // collapse them - each needs its own execFile slot to exercise the gate properly.
+    const promises = Array.from({ length: 5 }, (_, i) => ghService.getCheckRuns(`branch-${i}`, "/repo"));
 
-    expect(peakActive).toBeLessThanOrEqual(3);
+    // Drain the microtask queue until the gate is saturated (3 execFile calls in-flight).
+    while (resolvers.length < 3) {
+      await Promise.resolve();
+    }
+    expect(peakActive).toBe(3);
+
+    // Complete each in-flight call one at a time; each release lets a queued call start.
+    while (resolvers.length > 0) {
+      resolvers.shift()!();
+      await Promise.resolve(); // allow the next queued caller to acquire the slot
+    }
+
+    await Promise.all(promises);
+    // Peak never exceeded the gate limit throughout the entire run.
+    expect(peakActive).toBe(3);
   });
 
   // C1: Empty branch guard

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -298,7 +298,7 @@ for (const provider of providerRegistry.resolveAll()) {
             // Start CI watching if PR is open/active; stop watching if it became terminal.
             const prState = pr.state.toLowerCase();
             if (prState !== "merged" && prState !== "closed") {
-              ciWatcherService.watch(thread.id, pr.number, workspace.path);
+              ciWatcherService.watch(thread.id, pr.number, thread.branch, workspace.path);
             } else {
               ciWatcherService.unwatch(thread.id);
             }

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -6,6 +6,7 @@ import type { ChecksStatus } from "@mcode/contracts";
 export interface WatchEntry {
   threadId: string;
   prNumber: number;
+  branch: string;
   repoPath: string;
   cache: ChecksStatus | null;
 }
@@ -49,15 +50,15 @@ export class CiWatcherService {
    * Pass `skipInitialFetch: true` when the caller will fetch and broadcast the result itself,
    * to avoid spawning a redundant concurrent subprocess.
    */
-  watch(threadId: string, prNumber: number, repoPath: string, opts?: { skipInitialFetch?: boolean }): void {
+  watch(threadId: string, prNumber: number, branch: string, repoPath: string, opts?: { skipInitialFetch?: boolean }): void {
     if (this.active.has(threadId) || this.passive.has(threadId)) return;
-    this.passive.set(threadId, { threadId, prNumber, repoPath, cache: null });
+    this.passive.set(threadId, { threadId, prNumber, branch, repoPath, cache: null });
     this.startPassiveTimer();
 
     if (opts?.skipInitialFetch) return;
 
     // Fetch immediately so the client gets data without waiting for the passive tick.
-    this.githubService.getCheckRuns(prNumber, repoPath).then((checks) => {
+    this.githubService.getCheckRuns(branch, repoPath).then((checks) => {
       const entry = this.passive.get(threadId) ?? this.active.get(threadId);
       if (!entry) return; // unwatched during fetch
       entry.cache = checks;
@@ -131,7 +132,7 @@ export class CiWatcherService {
     const entry = this.active.get(threadId) ?? this.passive.get(threadId);
     if (!entry) return;
     try {
-      const checks = await this.githubService.getCheckRuns(entry.prNumber, entry.repoPath);
+      const checks = await this.githubService.getCheckRuns(entry.branch, entry.repoPath);
       this.refresh(threadId, checks);
     } catch (err) {
       logger.debug("CiWatcher bump failed", { threadId, error: String(err) });
@@ -191,11 +192,11 @@ export class CiWatcherService {
       // Insert placeholder synchronously so concurrent watch() calls see this threadId
       // and skip re-insertion during the async fetch window.
       if (!this.active.has(t.id) && !this.passive.has(t.id)) {
-        this.passive.set(t.id, { threadId: t.id, prNumber: t.pr_number, repoPath, cache: null });
+        this.passive.set(t.id, { threadId: t.id, prNumber: t.pr_number, branch: t.branch, repoPath, cache: null });
       }
 
       try {
-        const checks = await this.githubService.getCheckRuns(t.pr_number, repoPath);
+        const checks = await this.githubService.getCheckRuns(t.branch, repoPath);
         const entry = this.passive.get(t.id) ?? this.active.get(t.id);
         if (!entry) return; // was unwatched during fetch
         entry.cache = checks;
@@ -271,7 +272,7 @@ export class CiWatcherService {
     const entries = [...set.values()];
     const results = await Promise.allSettled(
       entries.map(async (entry) => {
-        const checks = await this.githubService.getCheckRuns(entry.prNumber, entry.repoPath);
+        const checks = await this.githubService.getCheckRuns(entry.branch, entry.repoPath);
         return { entry, checks };
       }),
     );

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -14,20 +14,20 @@ export interface WatchEntry {
 /** Broadcast function signature matching the server push system. */
 type BroadcastFn = (channel: string, data: unknown) => void;
 
-// 10s for in-progress checks: responsive enough to catch completion within a PR review window.
-// Worst case: 5 active threads × 6 calls/min = 30 calls/min, well within GitHub's 5000/hr limit.
-const ACTIVE_INTERVAL_MS = 10_000;
-// 15s for terminal checks: catches externally-triggered CI runs (push from terminal / another
+// 15s for in-progress checks: responsive enough to catch completion within a PR review window.
+// Worst case: 5 active threads × 4 calls/min = 20 calls/min, well within GitHub's 5000/hr limit.
+const ACTIVE_INTERVAL_MS = 15_000;
+// 20s for terminal checks: catches externally-triggered CI runs (push from terminal / another
 // machine) within the window where they'd be most noticeable to the user.
-// Worst case: 5 passive threads × 4 calls/min = 20 calls/min, well within GitHub's 5000/hr limit.
-const PASSIVE_INTERVAL_MS = 15_000;
+// Worst case: 5 passive threads × 3 calls/min = 15 calls/min, well within GitHub's 5000/hr limit.
+const PASSIVE_INTERVAL_MS = 20_000;
 // When the user just pushed, GitHub Actions take a few seconds to register the new run.
 // Bump the cache on this curve so "pending" appears within ~3s of push completion.
 const POST_PUSH_BUMP_DELAYS_MS = [3_000, 8_000, 20_000];
 
 /**
  * Server-side CI check watcher with adaptive dual-interval polling.
- * Threads with in-progress checks poll at 10s; terminal checks poll at 15s.
+ * Threads with in-progress checks poll at 15s; terminal checks poll at 20s.
  * Broadcasts `thread.checksUpdated` only when state changes.
  */
 export class CiWatcherService {

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -12,6 +12,8 @@ import { WorkspaceRepo } from "../repositories/workspace-repo";
 /** Handles GitHub PR lookups and listing via the gh CLI. */
 @injectable()
 export class GithubService {
+  private readonly slugCache = new Map<string, string>();
+
   constructor(
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
   ) {}
@@ -246,6 +248,29 @@ export class GithubService {
           } catch {
             resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });
           }
+        },
+      );
+    });
+  }
+
+  /** Resolve the GitHub owner/repo slug for a local repository path. Cached per path. */
+  resolveRepoSlug(repoPath: string): Promise<string> {
+    const cached = this.slugCache.get(repoPath);
+    if (cached) return Promise.resolve(cached);
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        "gh",
+        ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        { cwd: repoPath, encoding: "utf-8", timeout: 10_000 },
+        (error, stdout) => {
+          if (error || !stdout.trim()) {
+            reject(error ?? new Error("Failed to resolve repo slug"));
+            return;
+          }
+          const slug = stdout.trim();
+          this.slugCache.set(repoPath, slug);
+          resolve(slug);
         },
       );
     });

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -12,7 +12,7 @@ import { WorkspaceRepo } from "../repositories/workspace-repo";
 /** Handles GitHub PR lookups and listing via the gh CLI. */
 @injectable()
 export class GithubService {
-  private readonly slugCache = new Map<string, string>();
+  private readonly slugCache = new Map<string, Promise<string>>();
 
   constructor(
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
@@ -256,24 +256,26 @@ export class GithubService {
   /** Resolve the GitHub owner/repo slug for a local repository path. Cached per path. */
   resolveRepoSlug(repoPath: string): Promise<string> {
     const cached = this.slugCache.get(repoPath);
-    if (cached) return Promise.resolve(cached);
+    if (cached) return cached;
 
-    return new Promise((resolve, reject) => {
+    const pending = new Promise<string>((resolve, reject) => {
       execFile(
         "gh",
         ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
         { cwd: repoPath, encoding: "utf-8", timeout: 10_000 },
         (error, stdout) => {
           if (error || !stdout.trim()) {
+            this.slugCache.delete(repoPath); // evict so next call can retry
             reject(error ?? new Error("Failed to resolve repo slug"));
             return;
           }
-          const slug = stdout.trim();
-          this.slugCache.set(repoPath, slug);
-          resolve(slug);
+          resolve(stdout.trim());
         },
       );
     });
+
+    this.slugCache.set(repoPath, pending);
+    return pending;
   }
 
   /** Look up a PR by its GitHub URL. */

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -14,9 +14,39 @@ import { WorkspaceRepo } from "../repositories/workspace-repo";
 export class GithubService {
   private readonly slugCache = new Map<string, Promise<string>>();
 
+  /** Maximum number of gh subprocesses that may run concurrently. */
+  private readonly maxConcurrent = 3;
+  private activeCount = 0;
+  private readonly waitQueue: Array<() => void> = [];
+
   constructor(
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
   ) {}
+
+  /**
+   * Acquire a slot in the concurrency gate.
+   * Resolves immediately when a slot is free, otherwise queues until one is released.
+   */
+  private acquire(): Promise<void> {
+    if (this.activeCount < this.maxConcurrent) {
+      this.activeCount++;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.waitQueue.push(resolve));
+  }
+
+  /**
+   * Release a concurrency slot.
+   * Wakes the next queued waiter if one exists, otherwise decrements the active count.
+   */
+  private release(): void {
+    const next = this.waitQueue.shift();
+    if (next) {
+      next();
+    } else {
+      this.activeCount--;
+    }
+  }
 
   /** Look up the PR associated with a branch in the given working directory. */
   getBranchPr(branch: string, cwd: string): Promise<PrInfo | null> {
@@ -170,6 +200,7 @@ export class GithubService {
    */
   async getCheckRuns(branch: string, repoPath: string): Promise<ChecksStatus> {
     const slug = await this.resolveRepoSlug(repoPath);
+    await this.acquire();
     return new Promise((resolve) => {
       execFile(
         "gh",
@@ -182,6 +213,7 @@ export class GithubService {
         ],
         { cwd: repoPath, encoding: "utf-8", timeout: 15_000 },
         (error, stdout) => {
+          this.release();
           const now = Date.now();
           if (error || !stdout) {
             resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -12,7 +12,12 @@ import { WorkspaceRepo } from "../repositories/workspace-repo";
 /** Handles GitHub PR lookups and listing via the gh CLI. */
 @injectable()
 export class GithubService {
-  private readonly slugCache = new Map<string, Promise<string>>();
+  /** Slug cache TTL in milliseconds (30 minutes). Evicted on expiry to handle repo renames. */
+  private static readonly SLUG_TTL_MS = 30 * 60 * 1000;
+  private readonly slugCache = new Map<string, { promise: Promise<string>; expiresAt: number }>();
+
+  /** In-flight deduplication map for getCheckRuns to avoid redundant concurrent fetches. */
+  private readonly checkRunsInflight = new Map<string, Promise<ChecksStatus>>();
 
   /** Maximum number of gh subprocesses that may run concurrently. */
   private readonly maxConcurrent = 3;
@@ -197,11 +202,57 @@ export class GithubService {
    * Uses `gh api --cache 5s` so ETag conditional requests are sent automatically -
    * 304 Not Modified responses do not count against the 5,000/hr rate limit.
    * Returns aggregate status and individual check details.
+   *
+   * Guards:
+   * - Empty branch returns no_checks immediately without a network call (avoids malformed URL).
+   * - Concurrent calls for the same branch+repo are deduplicated (single in-flight request).
+   * - Unknown conclusion values are treated conservatively as failure.
    */
   async getCheckRuns(branch: string, repoPath: string): Promise<ChecksStatus> {
+    // C1: Empty branch would produce a malformed API URL - short-circuit immediately.
+    if (!branch) {
+      return { aggregate: "no_checks", runs: [], fetchedAt: Date.now() };
+    }
+
+    const inflightKey = `${repoPath}\0${branch}`;
+
+    // M6: Return an existing in-flight promise if one exists for this branch+repo pair.
+    const inflight = this.checkRunsInflight.get(inflightKey);
+    if (inflight) return inflight;
+
     const slug = await this.resolveRepoSlug(repoPath);
+
+    // Check again after async slug resolution - another caller may have already started the fetch.
+    const inflight2 = this.checkRunsInflight.get(inflightKey);
+    if (inflight2) return inflight2;
+
     await this.acquire();
-    return new Promise((resolve) => {
+
+    // Check once more after acquiring the semaphore slot.
+    const inflight3 = this.checkRunsInflight.get(inflightKey);
+    if (inflight3) { this.release(); return inflight3; }
+
+    let released = false;
+    /** Releases the concurrency slot at most once, guarding against double-release. */
+    const releaseOnce = (): void => {
+      if (!released) {
+        released = true;
+        this.release();
+      }
+    };
+
+    /** Explicit conclusion mapping - unknown values default to failure (conservative). */
+    const conclusionMap: Record<string, CheckRun["conclusion"]> = {
+      success: "success",
+      failure: "failure",
+      cancelled: "cancelled",
+      skipped: "skipped",
+      timed_out: "timed_out",
+      neutral: "neutral",
+      action_required: "failure", // blocks merge like a failure
+    };
+
+    const promise = new Promise<ChecksStatus>((resolve) => {
       execFile(
         "gh",
         [
@@ -211,9 +262,10 @@ export class GithubService {
           "-H", "Accept: application/vnd.github+json",
           "--jq", ".check_runs | map({name: .name, status: .status, conclusion: .conclusion, startedAt: .started_at, completedAt: .completed_at})",
         ],
-        { cwd: repoPath, encoding: "utf-8", timeout: 15_000 },
+        { cwd: repoPath, encoding: "utf-8", timeout: 15_000, maxBuffer: 2 * 1024 * 1024 },
         (error, stdout) => {
-          this.release();
+          releaseOnce();
+          this.checkRunsInflight.delete(inflightKey);
           const now = Date.now();
           if (error || !stdout) {
             resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });
@@ -234,12 +286,13 @@ export class GithubService {
             }
 
             const runs = items.map((item) => {
-              const status = (item.status ?? "completed") as CheckRun["status"];
-              // action_required blocks merge like a failure; map it accordingly.
+              // M1: Missing status defaults to in_progress (not completed) to avoid false-green aggregate.
+              const status = (item.status ?? "in_progress") as CheckRun["status"];
+              // H1: Unknown conclusion values are mapped conservatively to failure.
               const rawConclusion = item.conclusion ?? null;
-              const conclusion: CheckRun["conclusion"] = rawConclusion === "action_required"
-                ? "failure"
-                : rawConclusion as CheckRun["conclusion"];
+              const conclusion: CheckRun["conclusion"] = rawConclusion === null
+                ? null
+                : (conclusionMap[rawConclusion] ?? "failure");
 
               let durationMs: number | null = null;
               if (status === "completed" && item.startedAt && item.completedAt) {
@@ -277,12 +330,28 @@ export class GithubService {
         },
       );
     });
+
+    this.checkRunsInflight.set(inflightKey, promise);
+
+    try {
+      return await promise;
+    } finally {
+      // M3: Guard covers the synchronous-throw path; the callback path already called releaseOnce().
+      releaseOnce();
+      this.checkRunsInflight.delete(inflightKey);
+    }
   }
 
-  /** Resolve the GitHub owner/repo slug for a local repository path. Cached per path. */
+  /**
+   * Resolve the GitHub owner/repo slug for a local repository path.
+   * Results are cached for 30 minutes (SLUG_TTL_MS) to handle repo renames gracefully.
+   * Validates the returned value matches `owner/repo` format before caching.
+   */
   resolveRepoSlug(repoPath: string): Promise<string> {
     const cached = this.slugCache.get(repoPath);
-    if (cached) return cached;
+    // H2: Honour TTL - evict expired entries so renamed repos get fresh slugs.
+    if (cached && Date.now() < cached.expiresAt) return cached.promise;
+    if (cached) this.slugCache.delete(repoPath);
 
     const pending = new Promise<string>((resolve, reject) => {
       execFile(
@@ -295,12 +364,19 @@ export class GithubService {
             reject(error ?? new Error("Failed to resolve repo slug"));
             return;
           }
-          resolve(stdout.trim());
+          const trimmed = stdout.trim();
+          // M2: Validate slug format before using it in API URLs.
+          if (!/^[^/]+\/[^/]+$/.test(trimmed)) {
+            this.slugCache.delete(repoPath);
+            reject(new Error(`Unexpected slug format: ${trimmed}`));
+            return;
+          }
+          resolve(trimmed);
         },
       );
     });
 
-    this.slugCache.set(repoPath, pending);
+    this.slugCache.set(repoPath, { promise: pending, expiresAt: Date.now() + GithubService.SLUG_TTL_MS });
     return pending;
   }
 

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -163,14 +163,23 @@ export class GithubService {
   }
 
   /**
-   * Fetch CI check runs for a PR. Uses `gh pr checks` for simplicity.
+   * Fetch CI check runs for a branch via the GitHub REST API.
+   * Uses `gh api --cache 5s` so ETag conditional requests are sent automatically -
+   * 304 Not Modified responses do not count against the 5,000/hr rate limit.
    * Returns aggregate status and individual check details.
    */
-  getCheckRuns(prNumber: number, repoPath: string): Promise<ChecksStatus> {
+  async getCheckRuns(branch: string, repoPath: string): Promise<ChecksStatus> {
+    const slug = await this.resolveRepoSlug(repoPath);
     return new Promise((resolve) => {
       execFile(
         "gh",
-        ["pr", "checks", String(prNumber), "--json", "name,state,startedAt,completedAt"],
+        [
+          "api",
+          `repos/${slug}/commits/${encodeURIComponent(branch)}/check-runs`,
+          "--cache", "5s",
+          "-H", "Accept: application/vnd.github+json",
+          "--jq", ".check_runs | map({name: .name, status: .status, conclusion: .conclusion, startedAt: .started_at, completedAt: .completed_at})",
+        ],
         { cwd: repoPath, encoding: "utf-8", timeout: 15_000 },
         (error, stdout) => {
           const now = Date.now();
@@ -181,7 +190,8 @@ export class GithubService {
           try {
             const items = JSON.parse(stdout) as Array<{
               name?: string;
-              state?: string;
+              status?: string;
+              conclusion?: string | null;
               startedAt?: string | null;
               completedAt?: string | null;
             }>;
@@ -192,31 +202,15 @@ export class GithubService {
             }
 
             const runs = items.map((item) => {
-              const ghState = (item.state ?? "").toUpperCase();
-              const completed = ghState === "SUCCESS" || ghState === "FAILURE"
-                || ghState === "CANCELLED" || ghState === "SKIPPED"
-                || ghState === "TIMED_OUT" || ghState === "NEUTRAL"
-                || ghState === "ACTION_REQUIRED" || ghState === "STALE";
-
-              const status = completed ? "completed" as const
-                : ghState === "QUEUED" ? "queued" as const
-                : "in_progress" as const;
-
-              // ACTION_REQUIRED blocks merge like a failure; STALE is abandoned (terminal like cancelled).
-              const conclusionMap: Record<string, CheckRun["conclusion"]> = {
-                SUCCESS: "success",
-                FAILURE: "failure",
-                CANCELLED: "cancelled",
-                SKIPPED: "skipped",
-                TIMED_OUT: "timed_out",
-                NEUTRAL: "neutral",
-                ACTION_REQUIRED: "failure",
-                STALE: "cancelled",
-              };
-              const conclusion = completed ? (conclusionMap[ghState] ?? "cancelled") : null;
+              const status = (item.status ?? "completed") as CheckRun["status"];
+              // action_required blocks merge like a failure; map it accordingly.
+              const rawConclusion = item.conclusion ?? null;
+              const conclusion: CheckRun["conclusion"] = rawConclusion === "action_required"
+                ? "failure"
+                : rawConclusion as CheckRun["conclusion"];
 
               let durationMs: number | null = null;
-              if (completed && item.startedAt && item.completedAt) {
+              if (status === "completed" && item.startedAt && item.completedAt) {
                 durationMs = new Date(item.completedAt).getTime() - new Date(item.startedAt).getTime();
               }
 

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -9,7 +9,16 @@ import { execFile } from "child_process";
 import type { PrInfo, PrDetail, ChecksStatus, CheckRun } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 
-/** Handles GitHub PR lookups and listing via the gh CLI. */
+/**
+ * Handles GitHub PR lookups and listing via the `gh` CLI.
+ *
+ * Rate-limit strategy:
+ * - `getCheckRuns` uses `gh api --cache 5s` so ETag conditional requests are sent on every poll;
+ *   GitHub 304 Not Modified responses do not count against the 5,000 req/hr limit.
+ * - Concurrent `getCheckRuns` calls for the same branch+repo are deduplicated via `checkRunsInflight`.
+ * - `resolveRepoSlug` results are cached per path with a 30-minute TTL.
+ * - A semaphore (`maxConcurrent = 3`) caps the number of live `gh` subprocesses at any time.
+ */
 @injectable()
 export class GithubService {
   /** Slug cache TTL in milliseconds (30 minutes). Evicted on expiry to handle repo renames. */
@@ -252,86 +261,91 @@ export class GithubService {
       action_required: "failure", // blocks merge like a failure
     };
 
-    const promise = new Promise<ChecksStatus>((resolve) => {
-      execFile(
-        "gh",
-        [
-          "api",
-          `repos/${slug}/commits/${encodeURIComponent(branch)}/check-runs`,
-          "--cache", "5s",
-          "-H", "Accept: application/vnd.github+json",
-          "--jq", ".check_runs | map({name: .name, status: .status, conclusion: .conclusion, startedAt: .started_at, completedAt: .completed_at})",
-        ],
-        { cwd: repoPath, encoding: "utf-8", timeout: 15_000, maxBuffer: 2 * 1024 * 1024 },
-        (error, stdout) => {
-          releaseOnce();
-          this.checkRunsInflight.delete(inflightKey);
-          const now = Date.now();
-          if (error || !stdout) {
-            resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });
+    // Capture resolve externally so the inflight map can be set BEFORE execFile is called,
+    // preventing a race where a synchronous mock callback fires inside the Promise constructor
+    // and sees the map entry missing.
+    let resolvePromise!: (value: ChecksStatus) => void;
+    const promise = new Promise<ChecksStatus>((res) => { resolvePromise = res; });
+
+    // Register before spawning - any concurrent caller arriving now will reuse this promise.
+    this.checkRunsInflight.set(inflightKey, promise);
+
+    execFile(
+      "gh",
+      [
+        "api",
+        `repos/${slug}/commits/${encodeURIComponent(branch)}/check-runs`,
+        "--cache", "5s",
+        "-H", "Accept: application/vnd.github+json",
+        "--jq", ".check_runs | map({name: .name, status: .status, conclusion: .conclusion, startedAt: .started_at, completedAt: .completed_at})",
+      ],
+      { cwd: repoPath, encoding: "utf-8", timeout: 15_000, maxBuffer: 2 * 1024 * 1024 },
+      (error, stdout) => {
+        releaseOnce();
+        this.checkRunsInflight.delete(inflightKey);
+        const now = Date.now();
+        if (error || !stdout) {
+          resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
+          return;
+        }
+        try {
+          const items = JSON.parse(stdout) as Array<{
+            name?: string;
+            status?: string;
+            conclusion?: string | null;
+            startedAt?: string | null;
+            completedAt?: string | null;
+          }>;
+
+          if (items.length === 0) {
+            resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
             return;
           }
-          try {
-            const items = JSON.parse(stdout) as Array<{
-              name?: string;
-              status?: string;
-              conclusion?: string | null;
-              startedAt?: string | null;
-              completedAt?: string | null;
-            }>;
 
-            if (items.length === 0) {
-              resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });
-              return;
+          const runs = items.map((item) => {
+            // M1: Missing status defaults to in_progress (not completed) to avoid false-green aggregate.
+            const status = (item.status ?? "in_progress") as CheckRun["status"];
+            // H1: Unknown conclusion values are mapped conservatively to failure.
+            const rawConclusion = item.conclusion ?? null;
+            const conclusion: CheckRun["conclusion"] = rawConclusion === null
+              ? null
+              : (conclusionMap[rawConclusion] ?? "failure");
+
+            let durationMs: number | null = null;
+            if (status === "completed" && item.startedAt && item.completedAt) {
+              durationMs = new Date(item.completedAt).getTime() - new Date(item.startedAt).getTime();
             }
 
-            const runs = items.map((item) => {
-              // M1: Missing status defaults to in_progress (not completed) to avoid false-green aggregate.
-              const status = (item.status ?? "in_progress") as CheckRun["status"];
-              // H1: Unknown conclusion values are mapped conservatively to failure.
-              const rawConclusion = item.conclusion ?? null;
-              const conclusion: CheckRun["conclusion"] = rawConclusion === null
-                ? null
-                : (conclusionMap[rawConclusion] ?? "failure");
+            return {
+              name: item.name ?? "unknown",
+              status,
+              conclusion,
+              durationMs,
+              startedAt: item.startedAt ?? null,
+            };
+          });
 
-              let durationMs: number | null = null;
-              if (status === "completed" && item.startedAt && item.completedAt) {
-                durationMs = new Date(item.completedAt).getTime() - new Date(item.startedAt).getTime();
-              }
-
-              return {
-                name: item.name ?? "unknown",
-                status,
-                conclusion,
-                durationMs,
-                startedAt: item.startedAt ?? null,
-              };
-            });
-
-            let aggregate: "passing" | "failing" | "pending" | "no_checks";
-            if (runs.some((r) => r.conclusion === "failure" || r.conclusion === "timed_out")) {
-              aggregate = "failing";
-            } else if (runs.some((r) => r.status !== "completed")) {
-              aggregate = "pending";
-            } else {
-              aggregate = "passing";
-            }
-
-            // If all runs completed but none succeeded (all skipped/cancelled/neutral),
-            // treat as no_checks to avoid a misleading green badge.
-            if (aggregate === "passing" && !runs.some((r) => r.conclusion === "success")) {
-              aggregate = "no_checks";
-            }
-
-            resolve({ aggregate, runs, fetchedAt: now });
-          } catch {
-            resolve({ aggregate: "no_checks", runs: [], fetchedAt: now });
+          let aggregate: "passing" | "failing" | "pending" | "no_checks";
+          if (runs.some((r) => r.conclusion === "failure" || r.conclusion === "timed_out")) {
+            aggregate = "failing";
+          } else if (runs.some((r) => r.status !== "completed")) {
+            aggregate = "pending";
+          } else {
+            aggregate = "passing";
           }
-        },
-      );
-    });
 
-    this.checkRunsInflight.set(inflightKey, promise);
+          // If all runs completed but none succeeded (all skipped/cancelled/neutral),
+          // treat as no_checks to avoid a misleading green badge.
+          if (aggregate === "passing" && !runs.some((r) => r.conclusion === "success")) {
+            aggregate = "no_checks";
+          }
+
+          resolvePromise({ aggregate, runs, fetchedAt: now });
+        } catch {
+          resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
+        }
+      },
+    );
 
     try {
       return await promise;

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -273,7 +273,7 @@ async function dispatch(
             const prState = pr.state.toLowerCase();
             if (prState !== "merged" && prState !== "closed") {
               if (numberChanged) deps.ciWatcherService.unwatch(t.id);
-              deps.ciWatcherService.watch(t.id, pr.number, workspace.path);
+              deps.ciWatcherService.watch(t.id, pr.number, t.branch, workspace.path);
             } else {
               deps.ciWatcherService.unwatch(t.id);
             }
@@ -434,10 +434,10 @@ async function dispatch(
           if (workspace) {
             if (isTerminal) {
               // Terminal PR: one-shot fetch without registering in the watcher — no need to poll.
-              return deps.githubService.getCheckRuns(thread.pr_number, workspace.path);
+              return deps.githubService.getCheckRuns(thread.branch, workspace.path);
             }
             // skipInitialFetch: checkStatus will fetch and broadcast below, no need for a second subprocess.
-            deps.ciWatcherService.watch(params.threadId, thread.pr_number, workspace.path, { skipInitialFetch: true });
+            deps.ciWatcherService.watch(params.threadId, thread.pr_number, thread.branch, workspace.path, { skipInitialFetch: true });
             entry = deps.ciWatcherService.getEntry(params.threadId);
           }
         }
@@ -445,7 +445,7 @@ async function dispatch(
       if (!entry) {
         return { aggregate: "no_checks" as const, runs: [], fetchedAt: Date.now() };
       }
-      const checks = await deps.githubService.getCheckRuns(entry.prNumber, entry.repoPath);
+      const checks = await deps.githubService.getCheckRuns(entry.branch, entry.repoPath);
       deps.ciWatcherService.refresh(params.threadId, checks);
       return checks;
     }
@@ -707,7 +707,7 @@ async function dispatch(
 
       // Replace any stale watcher (e.g. previous PR on this thread) before registering the new one.
       deps.ciWatcherService.unwatch(params.threadId);
-      deps.ciWatcherService.watch(params.threadId, result.number, repoPath);
+      deps.ciWatcherService.watch(params.threadId, result.number, branch, repoPath);
       // PR creation implicitly pushes, so schedule the same post-push bump burst.
       deps.ciWatcherService.scheduleBumpAfterPush(params.threadId);
 


### PR DESCRIPTION
## What

Replaces `gh pr checks` with `gh api --cache 5s` (ETag conditional requests) in `GithubService.getCheckRuns`, threads branch ref through the polling stack, adds a concurrency gate, and increases poll intervals.

## Why

The CI watcher was exhausting the 5,000 req/hr GitHub rate limit under moderate load. With 10+ threads polling every 10s, worst-case call volume exceeded 6,000 req/hr. Two clients sharing the same GitHub account compounded this further.

## Key changes

- **ETag caching** - switched from `gh pr checks <prNumber>` to `gh api repos/{owner}/{repo}/commits/{branch}/check-runs --cache 5s`. The `--cache 5s` flag sends `If-None-Match` headers automatically; GitHub 304 responses are free against the rate limit
- **Branch-based polling** - `getCheckRuns` now takes `branch: string` instead of `prNumber: number`, matching the REST endpoint. `branch` is threaded through `WatchEntry`, `CiWatcherService.watch()`, and all four call sites in `ws-router.ts` and `index.ts`
- **Slug cache with TTL** - `resolveRepoSlug` resolves the `owner/repo` slug via `gh repo view`, caches it per repo path with a 30-minute TTL, and deduplicates concurrent cold-path calls with promise memoization
- **Concurrency gate** - semaphore capping parallel `gh` subprocesses at 3, with `releaseOnce` guard ensuring the slot is always freed even on unexpected throws
- **In-flight deduplication** - `checkRunsInflight` map deduplicates concurrent `getCheckRuns` calls for the same branch+repo pair within a single tick
- **Poll interval increase** - active 10s → 15s, passive 15s → 20s (50% reduction in poll attempts on top of ETag savings)
- **Robustness fixes** (post-review): empty branch guard, conservative unknown-conclusion fallback (`?? "failure"`), slug format validation, `maxBuffer: 2 MB` cap

## Configuration changes

None - no new environment variables or settings keys.

## Related issues/PRs

Closes #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * CI status polling cadence adjusted: in-progress checks ~15s, terminal checks ~20s
  * Check retrieval switched to branch-based lookups for more accurate status
  * Repository metadata cached with a 30-minute TTL to reduce repeated calls
  * Concurrency limiting (max 3) and deduplication for simultaneous check/status requests
  * More conservative handling of unknown check conclusions and improved error handling

* **Tests**
  * Expanded and hardened tests around check-run handling, caching, concurrency, and slug resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->