### PR TITLE
fix: inject user-level Copilot instructions, skills, and commands

### DIFF
--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -9,7 +9,9 @@
  */
 
 import { execFile } from "child_process";
-import { dirname } from "path";
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
 import { promisify } from "util";
 
 import { injectable, inject } from "tsyringe";
@@ -34,6 +36,27 @@ import { AgentEventType } from "@mcode/contracts";
 
 /** Promisified execFile used to retrieve the gh auth token. */
 const execFileAsync = promisify(execFile);
+
+/**
+ * Reads user-level Copilot instructions from `~/.copilot/copilot-instructions.md`.
+ * Returns `undefined` if the file does not exist or cannot be read.
+ */
+function readUserInstructions(): string | undefined {
+  try {
+    return readFileSync(join(homedir(), ".copilot", "copilot-instructions.md"), "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns user-level Copilot skill directories to pass to the SDK session.
+ * Currently resolves `~/.copilot/skills` if it exists.
+ */
+function userSkillDirectories(): string[] {
+  const dir = join(homedir(), ".copilot", "skills");
+  return existsSync(dir) ? [dir] : [];
+}
 
 /** Maps raw Copilot quota snapshot keys to human-readable labels. */
 const QUOTA_LABELS: Record<string, string> = {
@@ -150,10 +173,15 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       throw new Error("Copilot client not available");
     }
 
+    const userInstructions = readUserInstructions();
+    const skillDirs = userSkillDirectories();
     const session = await client.createSession({
       onPermissionRequest: approveAll,
       model: model || undefined,
       workingDirectory: cwd,
+      enableConfigDiscovery: true,
+      ...(skillDirs.length > 0 && { skillDirectories: skillDirs }),
+      ...(userInstructions && { systemMessage: { content: userInstructions } }),
     });
 
     const unsubscribers: Array<() => void> = [];
@@ -538,14 +566,21 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     // unconditionally because the Copilot SDK does not expose per-action gating.
     // Until the SDK adds granular permission control, all tool actions are
     // approved automatically regardless of the thread's permissionMode setting.
+    const userInstructions = readUserInstructions();
+    const skillDirs = userSkillDirectories();
+    const sessionBase = {
+      onPermissionRequest: approveAll,
+      model: model || undefined,
+      workingDirectory: cwd,
+      enableConfigDiscovery: true,
+      ...(customAgents.length > 0 && { customAgents }),
+      ...(skillDirs.length > 0 && { skillDirectories: skillDirs }),
+      ...(userInstructions && { systemMessage: { content: userInstructions } }),
+    };
+
     if (resume && sdkSessionId) {
       try {
-        session = await client.resumeSession(sdkSessionId, {
-          onPermissionRequest: approveAll,
-          model: model || undefined,
-          workingDirectory: cwd,
-          ...(customAgents.length > 0 && { customAgents }),
-        });
+        session = await client.resumeSession(sdkSessionId, sessionBase);
         logger.info("Resumed Copilot session", { sessionId, sdkSessionId });
       } catch (err) {
         logger.warn("CopilotProvider: resume failed, starting fresh session", {
@@ -553,20 +588,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           error: err instanceof Error ? err.message : String(err),
         });
         this.sdkSessionIds.delete(sessionId);
-        session = await client.createSession({
-          onPermissionRequest: approveAll,
-          model: model || undefined,
-          workingDirectory: cwd,
-          ...(customAgents.length > 0 && { customAgents }),
-        });
+        session = await client.createSession(sessionBase);
       }
     } else {
-      session = await client.createSession({
-        onPermissionRequest: approveAll,
-        model: model || undefined,
-        workingDirectory: cwd,
-        ...(customAgents.length > 0 && { customAgents }),
-      });
+      session = await client.createSession(sessionBase);
     }
 
     // Route to the appropriate Copilot SDK API based on the selected sub-agent.

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -180,7 +180,7 @@ describe("SkillService", () => {
       expect(skill!.providers).toEqual(["codex"]);
     });
 
-    it("tags skills from ~/.agents/skills with providers=['codex','copilot']", () => {
+    it("tags skills from ~/.agents/skills with providers=['codex'] only", () => {
       const skillDir = join(fakeHome, ".agents", "skills", "shared-skill");
       mkdirSync(skillDir, { recursive: true });
       writeMd(join(skillDir, "SKILL.md"), { description: "Shared skill" });
@@ -192,7 +192,7 @@ describe("SkillService", () => {
 
       svc.invalidate();
       const copilotItems = svc.list(undefined, "copilot");
-      expect(copilotItems.find((i) => i.name === "shared-skill")).toBeDefined();
+      expect(copilotItems.find((i) => i.name === "shared-skill")).toBeUndefined();
 
       svc.invalidate();
       const claudeItems = svc.list(undefined, "claude");

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -206,6 +206,7 @@ interface ScanRoot {
 function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
   const claudeDir = join(home, ".claude");
   const codexDir = join(home, ".codex");
+  const copilotDir = join(home, ".copilot");
   const agentsDir = join(home, ".agents");
 
   const roots: ScanRoot[] = [
@@ -218,11 +219,15 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
     { path: join(codexDir, "skills"), source: "user", providers: ["codex"], kind: "skills" },
     { path: join(codexDir, "commands"), source: "user", providers: ["codex"], kind: "commands" },
 
-    // Cross-provider (.agents at home root — visible to Codex and Copilot but not Claude)
-    { path: join(agentsDir, "skills"), source: "agent", providers: ["codex", "copilot"], kind: "skills" },
-    { path: join(agentsDir, "commands"), source: "agent", providers: ["codex", "copilot"], kind: "commands" },
+    // Copilot ecosystem
+    { path: join(copilotDir, "skills"), source: "user", providers: ["copilot"], kind: "skills" },
+    { path: join(copilotDir, "commands"), source: "user", providers: ["copilot"], kind: "commands" },
 
-    // Copilot user-level agents
+    // Cross-provider (.agents at home root — visible to Codex but not Claude or Copilot)
+    { path: join(agentsDir, "skills"), source: "agent", providers: ["codex"], kind: "skills" },
+    { path: join(agentsDir, "commands"), source: "agent", providers: ["codex"], kind: "commands" },
+
+    // Copilot user-level agents (OS-native config path)
     { path: copilotUserAgentsDir(), source: "user", providers: ["copilot"], kind: "both" },
   ];
 
@@ -237,8 +242,8 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
       { path: join(cwd, ".codex", "commands"), source: "project", providers: ["codex"], kind: "commands" },
 
       // Cross-provider project-level
-      { path: join(cwd, ".agents", "skills"), source: "project", providers: ["codex", "copilot"], kind: "skills" },
-      { path: join(cwd, ".agents", "commands"), source: "project", providers: ["codex", "copilot"], kind: "commands" },
+      { path: join(cwd, ".agents", "skills"), source: "project", providers: ["codex"], kind: "skills" },
+      { path: join(cwd, ".agents", "commands"), source: "project", providers: ["codex"], kind: "commands" },
 
       // Copilot project-level agents
       { path: join(cwd, ".github", "agents"), source: "project", providers: ["copilot"], kind: "both" },


### PR DESCRIPTION
## What

Brings user-level configuration parity to the GitHub Copilot provider. The Copilot SDK spawns a subprocess that does not auto-discover user-level config the way the CLI does when run directly. This PR injects that config explicitly.

## Why

Users with `~/.copilot/copilot-instructions.md` or skills in `~/.copilot/skills/` were being silently ignored when using the Copilot provider in mcode. The SDK only auto-loads instruction files from `workingDirectory` (repo-level), not from the user's home directory.

## Key changes

- **`readUserInstructions()`** - reads `~/.copilot/copilot-instructions.md` and passes it as `systemMessage` (append mode) on every session creation, including `complete()` and all three `createSession`/`resumeSession` paths in `doSendMessage()`
- **`userSkillDirectories()`** - resolves `~/.copilot/skills` when it exists and passes it as `skillDirectories` to the SDK session
- **`enableConfigDiscovery: true`** - added to all session configs so the CLI subprocess auto-discovers repo-level MCP configs and skill directories from `workingDirectory`
- **`skill-service.ts`** - added `~/.copilot/skills` and `~/.copilot/commands` to `buildScanRoots()` so user-level Copilot skills appear in the slash command autocomplete
- **`skill-service.ts`** - removed `"copilot"` from `~/.agents` and `{cwd}/.agents` scan roots (both user-level and project-level); Copilot now uses its own `~/.copilot` ecosystem rather than the shared `.agents` convention

## Configuration changes

No new settings keys. The following paths are now honoured automatically if they exist:

| Path | Effect |
|------|--------|
| `~/.copilot/copilot-instructions.md` | Appended to system prompt on every Copilot session |
| `~/.copilot/skills/` | Skills loaded by CLI subprocess and shown in slash command autocomplete |
| `~/.copilot/commands/` | Commands shown in slash command autocomplete |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copilot now loads custom instructions from a user Copilot instructions file and injects them into sessions.
  * Sessions enable configuration discovery for richer customization.
  * Support for user-defined skills and commands from dedicated user skill/command directories.

* **Bug Fixes / Improvements**
  * Clearer separation of skills across providers so shared skill directories are scoped appropriately (reducing unintended exposure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->