### PR TITLE
fix(copilot): preserve running state during agentic tool-use loops

### DIFF
--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -346,6 +346,35 @@ describe("CopilotProvider session.usage_info", () => {
 
     expect(events.find((e) => e.type === "contextEstimate")).toBeUndefined();
   });
+
+  it("emits exactly one turnComplete per turn even with multiple assistant.usage events", async () => {
+    const { events } = await runWithSession([
+      // First model call: agent decides to use a tool
+      { name: "assistant.usage", data: { inputTokens: 3000, outputTokens: 100, cacheReadTokens: 0, cacheWriteTokens: 0 } },
+      // Tool executes, results sent back, second model call
+      { name: "assistant.usage", data: { inputTokens: 5000, outputTokens: 200, cacheReadTokens: 100, cacheWriteTokens: 0 } },
+      // Third model call: agent produces final response
+      { name: "assistant.usage", data: { inputTokens: 7000, outputTokens: 150, cacheReadTokens: 200, cacheWriteTokens: 0 } },
+    ]);
+
+    const turnEvts = events.filter((e) => e.type === "turnComplete");
+    expect(turnEvts).toHaveLength(1);
+
+    // tokensIn uses the latest value (context grows)
+    const tc = turnEvts[0]!;
+    expect(tc.type === "turnComplete" && tc.tokensIn).toBe(7000);
+    // tokensOut accumulates across all calls
+    expect(tc.type === "turnComplete" && tc.tokensOut).toBe(450);
+  });
+
+  it("emits exactly one turnComplete when only one assistant.usage fires", async () => {
+    const { events } = await runWithSession([
+      { name: "assistant.usage", data: { inputTokens: 5000, outputTokens: 200, cacheReadTokens: 0, cacheWriteTokens: 0 } },
+    ]);
+
+    // One usage event → still exactly one turnComplete (on session.idle, not on usage)
+    expect(events.filter((e) => e.type === "turnComplete")).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -450,6 +450,113 @@ describe("CopilotProvider.complete()", () => {
 });
 
 // ---------------------------------------------------------------------------
+// assistant.message phase filtering - thinking content must not reach the UI
+// ---------------------------------------------------------------------------
+
+describe("CopilotProvider assistant.message phase filtering", () => {
+  /** Fires events via a fresh mock session and captures all emitted AgentEvents. */
+  async function runWithSession(
+    eventSequence: Array<{ name: string; data?: unknown }>,
+  ): Promise<{ events: AgentEvent[] }> {
+    vi.clearAllMocks();
+    mockClient.getState.mockReturnValue("connected");
+    mockClient.start.mockResolvedValue(undefined);
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, result?: { stdout: string }) => void) => {
+        cb(null, { stdout: "gho_faketoken\n" });
+      },
+    );
+
+    const mockSession = makeMockSession();
+    mockClient.createSession.mockResolvedValue(mockSession);
+    mockSession.send.mockImplementation(async () => {
+      for (const evt of eventSequence) {
+        mockSession.fire(evt.name, evt.data);
+      }
+      mockSession.fire("session.idle");
+    });
+
+    const provider = new CopilotProvider(makeSettingsService() as any);
+    const events: AgentEvent[] = [];
+    provider.on("event", (e: AgentEvent) => events.push(e));
+
+    await provider.sendMessage({
+      sessionId: "mcode-phase-test",
+      message: "hello",
+      cwd: "/tmp",
+      model: "gpt-4o",
+      resume: false,
+      permissionMode: "auto",
+    });
+
+    return { events };
+  }
+
+  it("emits a message event for a normal (no phase) assistant.message", async () => {
+    const { events } = await runWithSession([
+      { name: "assistant.message", data: { content: "Hello, world!", outputTokens: 5 } },
+    ]);
+
+    const msgEvts = events.filter((e) => e.type === "message");
+    expect(msgEvts).toHaveLength(1);
+    expect(msgEvts[0]?.type === "message" && msgEvts[0].content).toBe("Hello, world!");
+  });
+
+  it("emits a message event for a response-phase assistant.message", async () => {
+    const { events } = await runWithSession([
+      { name: "assistant.message", data: { content: "Final answer.", outputTokens: 10, phase: "response" } },
+    ]);
+
+    const msgEvts = events.filter((e) => e.type === "message");
+    expect(msgEvts).toHaveLength(1);
+    expect(msgEvts[0]?.type === "message" && msgEvts[0].content).toBe("Final answer.");
+  });
+
+  it("does NOT emit a message event for a thinking-phase assistant.message", async () => {
+    const { events } = await runWithSession([
+      { name: "assistant.message", data: { content: "I am reasoning internally...", outputTokens: 20, phase: "thinking" } },
+    ]);
+
+    const msgEvts = events.filter((e) => e.type === "message");
+    expect(msgEvts).toHaveLength(0);
+  });
+
+  it("only emits the response-phase message when both phases fire in the same turn", async () => {
+    const { events } = await runWithSession([
+      { name: "assistant.message", data: { content: "Internal thoughts here.", outputTokens: 15, phase: "thinking" } },
+      { name: "assistant.message", data: { content: "Here is my answer.", outputTokens: 8, phase: "response" } },
+    ]);
+
+    const msgEvts = events.filter((e) => e.type === "message");
+    expect(msgEvts).toHaveLength(1);
+    expect(msgEvts[0]?.type === "message" && msgEvts[0].content).toBe("Here is my answer.");
+  });
+
+  it("does NOT emit a message event when content is empty", async () => {
+    const { events } = await runWithSession([
+      { name: "assistant.message", data: { content: "", outputTokens: 0 } },
+    ]);
+
+    const msgEvts = events.filter((e) => e.type === "message");
+    expect(msgEvts).toHaveLength(0);
+  });
+
+  it("does NOT emit textDelta events for assistant.reasoning_delta (no handler registered)", async () => {
+    const { events } = await runWithSession([
+      { name: "assistant.reasoning_delta", data: { reasoningId: "r-1", deltaContent: "thinking chunk" } },
+      { name: "assistant.message", data: { content: "Actual response.", outputTokens: 5 } },
+    ]);
+
+    const deltaEvts = events.filter((e) => e.type === "textDelta");
+    // No textDelta from reasoning events - only from assistant.message_delta
+    expect(deltaEvts).toHaveLength(0);
+    // Response message is still emitted
+    const msgEvts = events.filter((e) => e.type === "message");
+    expect(msgEvts).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // listModels() - TTL cache
 // ---------------------------------------------------------------------------
 

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -236,59 +236,60 @@ describe("CopilotProvider bootstrap", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Shared helper for event-sequence tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Run sendMessage with a fresh mock session that fires the given events
+ * in sequence after send() resolves, then fires session.idle to end the turn.
+ * Fully resets mock state on each call for isolation.
+ */
+async function runWithMockSession(
+  eventSequence: Array<{ name: string; data?: unknown }>,
+  sessionId = "mcode-shared-test",
+): Promise<{ events: AgentEvent[] }> {
+  vi.clearAllMocks();
+  mockClient.getState.mockReturnValue("connected");
+  mockClient.start.mockResolvedValue(undefined);
+  mockExecFile.mockImplementation(
+    (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, result?: { stdout: string }) => void) => {
+      cb(null, { stdout: "gho_faketoken\n" });
+    },
+  );
+
+  const mockSession = makeMockSession();
+  mockClient.createSession.mockResolvedValue(mockSession);
+  mockSession.send.mockImplementation(async () => {
+    for (const evt of eventSequence) {
+      mockSession.fire(evt.name, evt.data);
+    }
+    mockSession.fire("session.idle");
+  });
+
+  const provider = new CopilotProvider(makeSettingsService() as any);
+  const events: AgentEvent[] = [];
+  provider.on("event", (e: AgentEvent) => events.push(e));
+
+  await provider.sendMessage({
+    sessionId,
+    message: "hello",
+    cwd: "/tmp",
+    model: "gpt-4o",
+    resume: false,
+    permissionMode: "auto",
+  });
+
+  return { events };
+}
+
+// ---------------------------------------------------------------------------
 // session.usage_info → ContextEstimate
 // ---------------------------------------------------------------------------
 
 describe("CopilotProvider session.usage_info", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockClient.getState.mockReturnValue("connected");
-    mockClient.start.mockResolvedValue(undefined);
-    mockExecFile.mockImplementation(
-      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, result?: { stdout: string }) => void) => {
-        cb(null, { stdout: "gho_faketoken\n" });
-      },
-    );
-  });
-
-  /**
-   * Helper: run sendMessage with a mock session that fires the given events
-   * in sequence after send() resolves, then fires session.idle to end the turn.
-   */
-  async function runWithSession(
-    eventSequence: Array<{ name: string; data?: unknown }>,
-  ): Promise<{ events: AgentEvent[] }> {
-    const mockSession = makeMockSession();
-
-    mockClient.getState.mockReturnValue("connected");
-    mockClient.createSession.mockResolvedValue(mockSession);
-
-    // After send() is called, fire the event sequence then resolve idle.
-    mockSession.send.mockImplementation(async () => {
-      for (const evt of eventSequence) {
-        mockSession.fire(evt.name, evt.data);
-      }
-      mockSession.fire("session.idle");
-    });
-
-    const provider = new CopilotProvider(makeSettingsService() as any);
-    const events: AgentEvent[] = [];
-    provider.on("event", (e: AgentEvent) => events.push(e));
-
-    await provider.sendMessage({
-      sessionId: "mcode-ctx-test",
-      message: "hello",
-      cwd: "/tmp",
-      model: "gpt-4o",
-      resume: false,
-      permissionMode: "auto",
-    });
-
-    return { events };
-  }
 
   it("emits a contextEstimate event when session.usage_info fires", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       {
         name: "session.usage_info",
         data: {
@@ -307,7 +308,7 @@ describe("CopilotProvider session.usage_info", () => {
   });
 
   it("populates contextWindow on turnComplete using the cached tokenLimit", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       {
         name: "session.usage_info",
         data: { tokenLimit: 128000, currentTokens: 5000 },
@@ -324,7 +325,7 @@ describe("CopilotProvider session.usage_info", () => {
   });
 
   it("leaves contextWindow undefined on turnComplete when no usage_info fired", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       {
         name: "assistant.usage",
         data: { inputTokens: 1000, outputTokens: 100, cacheReadTokens: 0 },
@@ -337,7 +338,7 @@ describe("CopilotProvider session.usage_info", () => {
   });
 
   it("does not emit contextEstimate when session.usage_info is not fired", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       {
         name: "assistant.message",
         data: { content: "hello", outputTokens: 10 },
@@ -348,7 +349,7 @@ describe("CopilotProvider session.usage_info", () => {
   });
 
   it("emits exactly one turnComplete per turn even with multiple assistant.usage events", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       // First model call: agent decides to use a tool
       { name: "assistant.usage", data: { inputTokens: 3000, outputTokens: 100, cacheReadTokens: 0, cacheWriteTokens: 0 } },
       // Tool executes, results sent back, second model call
@@ -368,7 +369,7 @@ describe("CopilotProvider session.usage_info", () => {
   });
 
   it("emits exactly one turnComplete when only one assistant.usage fires", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       { name: "assistant.usage", data: { inputTokens: 5000, outputTokens: 200, cacheReadTokens: 0, cacheWriteTokens: 0 } },
     ]);
 
@@ -483,46 +484,8 @@ describe("CopilotProvider.complete()", () => {
 // ---------------------------------------------------------------------------
 
 describe("CopilotProvider assistant.message phase filtering", () => {
-  /** Fires events via a fresh mock session and captures all emitted AgentEvents. */
-  async function runWithSession(
-    eventSequence: Array<{ name: string; data?: unknown }>,
-  ): Promise<{ events: AgentEvent[] }> {
-    vi.clearAllMocks();
-    mockClient.getState.mockReturnValue("connected");
-    mockClient.start.mockResolvedValue(undefined);
-    mockExecFile.mockImplementation(
-      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, result?: { stdout: string }) => void) => {
-        cb(null, { stdout: "gho_faketoken\n" });
-      },
-    );
-
-    const mockSession = makeMockSession();
-    mockClient.createSession.mockResolvedValue(mockSession);
-    mockSession.send.mockImplementation(async () => {
-      for (const evt of eventSequence) {
-        mockSession.fire(evt.name, evt.data);
-      }
-      mockSession.fire("session.idle");
-    });
-
-    const provider = new CopilotProvider(makeSettingsService() as any);
-    const events: AgentEvent[] = [];
-    provider.on("event", (e: AgentEvent) => events.push(e));
-
-    await provider.sendMessage({
-      sessionId: "mcode-phase-test",
-      message: "hello",
-      cwd: "/tmp",
-      model: "gpt-4o",
-      resume: false,
-      permissionMode: "auto",
-    });
-
-    return { events };
-  }
-
   it("emits a message event for a normal (no phase) assistant.message", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       { name: "assistant.message", data: { content: "Hello, world!", outputTokens: 5 } },
     ]);
 
@@ -532,7 +495,7 @@ describe("CopilotProvider assistant.message phase filtering", () => {
   });
 
   it("emits a message event for a response-phase assistant.message", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       { name: "assistant.message", data: { content: "Final answer.", outputTokens: 10, phase: "response" } },
     ]);
 
@@ -542,7 +505,7 @@ describe("CopilotProvider assistant.message phase filtering", () => {
   });
 
   it("does NOT emit a message event for a thinking-phase assistant.message", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       { name: "assistant.message", data: { content: "I am reasoning internally...", outputTokens: 20, phase: "thinking" } },
     ]);
 
@@ -551,7 +514,7 @@ describe("CopilotProvider assistant.message phase filtering", () => {
   });
 
   it("only emits the response-phase message when both phases fire in the same turn", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       { name: "assistant.message", data: { content: "Internal thoughts here.", outputTokens: 15, phase: "thinking" } },
       { name: "assistant.message", data: { content: "Here is my answer.", outputTokens: 8, phase: "response" } },
     ]);
@@ -562,7 +525,7 @@ describe("CopilotProvider assistant.message phase filtering", () => {
   });
 
   it("does NOT emit a message event when content is empty", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       { name: "assistant.message", data: { content: "", outputTokens: 0 } },
     ]);
 
@@ -571,7 +534,7 @@ describe("CopilotProvider assistant.message phase filtering", () => {
   });
 
   it("does NOT emit textDelta events for assistant.reasoning_delta (no handler registered)", async () => {
-    const { events } = await runWithSession([
+    const { events } = await runWithMockSession([
       { name: "assistant.reasoning_delta", data: { reasoningId: "r-1", deltaContent: "thinking chunk" } },
       { name: "assistant.message", data: { content: "Actual response.", outputTokens: 5 } },
     ]);

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -641,6 +641,16 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     // Track per-tool start times to derive elapsedSeconds for toolProgress events.
     const toolStartTimes = new Map<string, number>();
 
+    // Accumulate usage data across assistant.usage events for the final TurnComplete.
+    // Copilot SDK fires assistant.usage after each model call in an agentic loop,
+    // but TurnComplete must fire only once (on session.idle) to prevent premature
+    // removal from runningThreadIds in the frontend.
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalCacheRead = 0;
+    let totalCacheWrite = 0;
+    let totalCost: number | undefined;
+
     const unsubscribers: Array<() => void> = [];
 
     try {
@@ -752,7 +762,9 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // assistant.usage - token counts after a model call
+        // assistant.usage - accumulate token counts across model calls.
+        // TurnComplete is deferred to session.idle so the frontend keeps the
+        // thread in runningThreadIds for the entire agentic turn.
         unsubscribers.push(
           session.on("assistant.usage", (event) => {
             const {
@@ -763,24 +775,16 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
               cost,
               quotaSnapshots,
             } = event.data;
-            const contextWindow = this.contextWindowBySession.get(sessionId);
+            // Use latest inputTokens (context grows across calls in a turn)
+            totalInputTokens = inputTokens;
+            // Accumulate output tokens (each call generates new output)
+            totalOutputTokens += outputTokens;
+            totalCacheRead = cacheReadTokens;
+            totalCacheWrite = cacheWriteTokens;
+            if (cost !== undefined) totalCost = (totalCost ?? 0) + cost;
 
-            this.emit("event", {
-              type: AgentEventType.TurnComplete,
-              threadId,
-              reason: "end_turn",
-              costUsd: null,
-              tokensIn: inputTokens,
-              tokensOut: outputTokens,
-              contextWindow,
-              totalProcessedTokens: inputTokens + cacheReadTokens + cacheWriteTokens + outputTokens,
-              cacheReadTokens,
-              cacheWriteTokens,
-              costMultiplier: cost,
-              providerId: "copilot",
-            } satisfies AgentEvent);
-
-            // Emit quota update if snapshots are present
+            // Quota updates are safe to emit immediately (they only update
+            // usage display, not running state).
             if (quotaSnapshots && typeof quotaSnapshots === "object") {
               this.emit("event", {
                 type: AgentEventType.QuotaUpdate,
@@ -837,9 +841,27 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // session.idle - turn is complete; resolve and clean up handlers
+        // session.idle - turn is truly complete; emit TurnComplete with
+        // accumulated usage data and resolve. This is the single point where
+        // the frontend learns the turn ended, preventing premature removal
+        // from runningThreadIds during multi-step agentic turns.
         unsubscribers.push(
           session.on("session.idle", () => {
+            const contextWindow = this.contextWindowBySession.get(sessionId);
+            this.emit("event", {
+              type: AgentEventType.TurnComplete,
+              threadId,
+              reason: "end_turn",
+              costUsd: null,
+              tokensIn: totalInputTokens,
+              tokensOut: totalOutputTokens,
+              contextWindow,
+              totalProcessedTokens: totalInputTokens + totalCacheRead + totalCacheWrite + totalOutputTokens,
+              cacheReadTokens: totalCacheRead,
+              cacheWriteTokens: totalCacheWrite,
+              costMultiplier: totalCost,
+              providerId: "copilot",
+            } satisfies AgentEvent);
             resolve();
           }),
         );

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -153,7 +153,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   private modelCache: ProviderModelInfo[] | null = null;
   private modelCacheTimestamp = 0;
   /** Avoid hammering the Copilot SDK on every call - results are stable within a session. */
-  private static readonly MODEL_CACHE_TTL_MS = 10 * 60 * 1000;
+  private static readonly MODEL_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
@@ -659,13 +659,23 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
           }),
         );
 
-        // assistant.message - final complete assistant response
+        // assistant.message - final complete assistant response.
+        // Phased-output models (e.g. o3, o4-mini, Claude extended thinking) emit
+        // one assistant.message per phase. The "thinking" phase carries internal
+        // reasoning that must not be saved or shown in the chat. Only the response
+        // phase (or messages without an explicit phase) contain user-facing content.
+        // Separate assistant.reasoning / assistant.reasoning_delta events carry
+        // extended thinking for streaming; those have no handler registered here
+        // and are therefore silently ignored.
         unsubscribers.push(
           session.on("assistant.message", (event) => {
+            if (event.data.phase === "thinking") return;
+            const content = event.data.content;
+            if (!content) return;
             this.emit("event", {
               type: "message",
               threadId,
-              content: event.data.content,
+              content,
               tokens: event.data.outputTokens ?? null,
             } satisfies AgentEvent);
           }),

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -779,8 +779,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
             totalInputTokens = inputTokens;
             // Accumulate output tokens (each call generates new output)
             totalOutputTokens += outputTokens;
-            totalCacheRead = cacheReadTokens;
-            totalCacheWrite = cacheWriteTokens;
+            totalCacheRead += cacheReadTokens;
+            totalCacheWrite += cacheWriteTokens;
             if (cost !== undefined) totalCost = (totalCost ?? 0) + cost;
 
             // Quota updates are safe to emit immediately (they only update

--- a/apps/web/e2e/sidebar-interrupted-state.spec.ts
+++ b/apps/web/e2e/sidebar-interrupted-state.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * E2E tests verifying that threads with status "interrupted" render the correct
+ * amber pulsing dot in the sidebar, and that the dot clears to running (primary)
+ * when the thread resumes via session.turnStarted.
+ *
+ * This tests the fix for: "copilot not persisting working state" where threads
+ * showed idle/normal state after a server restart instead of interrupted state.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const WORKSPACE = {
+  id: "ws-interrupted-test",
+  name: "Interrupted Test Workspace",
+  path: "/tmp/interrupted-test",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const THREAD_INTERRUPTED = {
+  id: "thread-interrupted-1",
+  workspace_id: WORKSPACE.id,
+  title: "Was running when server restarted",
+  status: "interrupted" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: null,
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: "sdk-session-xyz",
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Inject workspaces and threads into the Zustand workspace store. */
+async function setupWorkspaceState(
+  page: Page,
+  opts: { workspaces: typeof WORKSPACE[]; threads: typeof THREAD_INTERRUPTED[]; activeWorkspaceId: string },
+): Promise<void> {
+  await page.evaluate(
+    ({ workspaces, threads, activeWorkspaceId }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({ workspaces, threads, activeWorkspaceId, activeThreadId: null, loading: false });
+    },
+    opts,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe("Sidebar: interrupted thread state", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((wsId: string) => {
+      localStorage.setItem("mcode-expanded-projects", JSON.stringify({ [wsId]: true }));
+    }, WORKSPACE.id);
+
+    await mockWebSocketServer(page, {
+      "thread.list": [THREAD_INTERRUPTED],
+    });
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Wait for hydration to complete before injecting state.
+    await page.waitForFunction(
+      () => (window as any).__mcodeHydrationComplete === true, // eslint-disable-line @typescript-eslint/no-explicit-any
+    );
+  });
+
+  test("interrupted thread shows amber pulsing dot in sidebar", async ({ page }) => {
+    await setupWorkspaceState(page, {
+      workspaces: [WORKSPACE],
+      threads: [THREAD_INTERRUPTED],
+      activeWorkspaceId: WORKSPACE.id,
+    });
+
+    const threadRow = page.locator(
+      `[data-testid="thread-item"][data-thread-id="${THREAD_INTERRUPTED.id}"]`,
+    );
+    await expect(threadRow).toBeVisible();
+
+    const statusDot = threadRow.locator("span.rounded-full").first();
+
+    // Must show amber (not idle grey, not primary blue).
+    await expect(statusDot).toHaveClass(/amber/);
+    await expect(statusDot).toHaveClass(/animate-pulse/);
+    // Must NOT look like a running thread.
+    await expect(statusDot).not.toHaveClass(/bg-primary/);
+
+    await page.screenshot({
+      path: "e2e/screenshots/interrupted-amber-dot.png",
+      fullPage: true,
+    });
+  });
+
+  test("interrupted dot switches to primary pulsing when session.turnStarted fires", async ({ page }) => {
+    await setupWorkspaceState(page, {
+      workspaces: [WORKSPACE],
+      threads: [THREAD_INTERRUPTED],
+      activeWorkspaceId: WORKSPACE.id,
+    });
+
+    const threadRow = page.locator(
+      `[data-testid="thread-item"][data-thread-id="${THREAD_INTERRUPTED.id}"]`,
+    );
+    await expect(threadRow).toBeVisible();
+
+    const statusDot = threadRow.locator("span.rounded-full").first();
+
+    // Confirm amber state before resume.
+    await expect(statusDot).toHaveClass(/amber/);
+
+    // Inject session.turnStarted to simulate user resuming the thread.
+    await page.evaluate(
+      ({ threadId }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const stores: any[] = (window as any).__mcodeStores ?? [];
+        const threadStore = stores.find(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (s: any) => "handleAgentEvent" in s.getState() && "runningThreadIds" in s.getState(),
+        );
+        if (!threadStore) throw new Error("[E2E] thread store not found");
+        threadStore.getState().handleAgentEvent(threadId, {
+          method: "session.turnStarted",
+          type: "turnStarted",
+          threadId,
+        });
+      },
+      { threadId: THREAD_INTERRUPTED.id },
+    );
+
+    // After resume the dot must switch to primary running indicator.
+    await expect(statusDot).toHaveClass(/bg-primary/);
+    await expect(statusDot).toHaveClass(/animate-pulse/);
+    await expect(statusDot).not.toHaveClass(/amber/);
+
+    await page.screenshot({
+      path: "e2e/screenshots/interrupted-resumed-running-dot.png",
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/src/__tests__/running-session-signal.test.ts
+++ b/apps/web/src/__tests__/running-session-signal.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useThreadStore } from "@/stores/threadStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { createMockThread } from "./mocks/transport";
 
 describe("running-session signal", () => {
   beforeEach(() => {
@@ -54,5 +56,42 @@ describe("running-session signal", () => {
     expect(ids.has("stale")).toBe(false);
     expect(ids.has("t-1")).toBe(true);
     expect(ids.has("t-2")).toBe(true);
+  });
+});
+
+describe("session.turnStarted clears interrupted status", () => {
+  beforeEach(() => {
+    useThreadStore.setState({ runningThreadIds: new Set(), currentThreadId: null, messages: [] });
+    useWorkspaceStore.setState({
+      threads: [createMockThread({ id: "t-1", status: "interrupted" })],
+      activeThreadId: "t-1",
+    });
+  });
+
+  it("updates workspace store thread status from interrupted to active on turnStarted", () => {
+    useThreadStore.getState().handleAgentEvent("t-1", {
+      method: "session.turnStarted",
+      type: "turnStarted",
+      threadId: "t-1",
+    });
+
+    const thread = useWorkspaceStore.getState().threads.find((t) => t.id === "t-1");
+    expect(thread?.status).toBe("active");
+  });
+
+  it("does not change status for non-interrupted threads on turnStarted", () => {
+    useWorkspaceStore.setState({
+      threads: [createMockThread({ id: "t-1", status: "active" })],
+      activeThreadId: "t-1",
+    });
+
+    useThreadStore.getState().handleAgentEvent("t-1", {
+      method: "session.turnStarted",
+      type: "turnStarted",
+      threadId: "t-1",
+    });
+
+    const thread = useWorkspaceStore.getState().threads.find((t) => t.id === "t-1");
+    expect(thread?.status).toBe("active");
   });
 });

--- a/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
+++ b/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Verifies that the thread list is refreshed after a WebSocket reconnect,
+ * so that statuses updated on the server during a restart (e.g., "interrupted")
+ * are reflected in the client without a full page reload.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { mockTransport, createMockWorkspace, createMockThread } from "./mocks/transport";
+
+vi.mock("@/transport", async () => ({
+  ...(await vi.importActual("@/transport")),
+  getTransport: () => mockTransport,
+}));
+
+describe("thread status refresh after reconnect", () => {
+  const ws = createMockWorkspace();
+
+  beforeEach(() => {
+    useWorkspaceStore.setState({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      threads: [],
+      activeThreadId: null,
+      loading: false,
+      error: null,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("replaces stale 'active' status with 'interrupted' from the server after loadThreads", async () => {
+    // Simulate pre-restart client state: thread is active
+    const thread = createMockThread({ workspace_id: ws.id, status: "active" });
+    useWorkspaceStore.setState({ threads: [thread] });
+
+    // Server returns the same thread marked interrupted (set during graceful shutdown)
+    const interruptedThread = { ...thread, status: "interrupted" as const };
+    (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockResolvedValue([interruptedThread]);
+
+    // This is what ws-transport.ts calls in the ws.onopen handler after reconnect
+    await useWorkspaceStore.getState().loadThreads(ws.id);
+
+    const updated = useWorkspaceStore.getState().threads.find((t) => t.id === thread.id);
+    expect(updated?.status).toBe("interrupted");
+  });
+
+  it("loadThreads on reconnect does not clobber threads from other workspaces", async () => {
+    const otherWs = createMockWorkspace();
+    const myThread = createMockThread({ workspace_id: ws.id, status: "active" });
+    const otherThread = createMockThread({ workspace_id: otherWs.id, status: "active" });
+
+    useWorkspaceStore.setState({ threads: [myThread, otherThread] });
+
+    // Server returns only the active workspace's threads
+    const fresh = { ...myThread, status: "interrupted" as const };
+    (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockResolvedValue([fresh]);
+
+    await useWorkspaceStore.getState().loadThreads(ws.id);
+
+    const threads = useWorkspaceStore.getState().threads;
+    expect(threads.find((t) => t.id === myThread.id)?.status).toBe("interrupted");
+    // Other workspace's thread is preserved unchanged
+    expect(threads.find((t) => t.id === otherThread.id)?.status).toBe("active");
+  });
+});

--- a/apps/web/src/__tests__/thread-status.test.ts
+++ b/apps/web/src/__tests__/thread-status.test.ts
@@ -94,6 +94,19 @@ describe("getStatusDisplay", () => {
     const result = getStatusDisplay(makeThread({ status: "active" }), false);
     expect(result.shape).toBe("solid");
   });
+
+  it("interrupted status returns amber dot with pulse", () => {
+    const result = getStatusDisplay(makeThread({ status: "interrupted" }), false);
+    expect(result.dotClass).toContain("amber");
+    expect(result.dotClass).toContain("animate-pulse");
+    expect(result.shape).toBe("solid");
+  });
+
+  it("interrupted thread shows running indicator when agent is live (resume in progress)", () => {
+    const result = getStatusDisplay(makeThread({ status: "interrupted" }), true);
+    expect(result.dotClass).toContain("bg-primary");
+    expect(result.dotClass).toContain("animate-pulse");
+  });
 });
 
 describe("getNotificationDot", () => {

--- a/apps/web/src/lib/thread-status.ts
+++ b/apps/web/src/lib/thread-status.ts
@@ -101,6 +101,13 @@ export function getStatusDisplay(
         dotClass: "bg-[var(--diff-add-strong)]/80",
         shape: "solid",
       };
+    case "interrupted":
+      return {
+        label: "",
+        color: "text-amber-500/90",
+        dotClass: "bg-amber-500/85 animate-pulse",
+        shape: "solid",
+      };
     default:
       // No agent running, not completed, not errored = idle / ready for input
       return {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1072,11 +1072,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       });
       // Clear interrupted status so the resume banner no longer lists this
       // thread while the agent processes the continuation message.
-      useWorkspaceStore.setState((ws) => ({
-        threads: ws.threads.map((t) =>
-          t.id === threadId && t.status === "interrupted" ? { ...t, status: "active" as const } : t,
-        ),
-      }));
+      useWorkspaceStore.setState((ws) => {
+        const idx = ws.threads.findIndex(
+          (t) => t.id === threadId && t.status === "interrupted",
+        );
+        if (idx < 0) return ws;
+        const threads = [...ws.threads];
+        threads[idx] = { ...threads[idx], status: "active" as const };
+        return { threads };
+      });
       return;
     }
 

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1070,6 +1070,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         next.add(threadId);
         return { runningThreadIds: next, agentStartTimes: { ...state.agentStartTimes, [threadId]: Date.now() } };
       });
+      // Clear interrupted status so the resume banner no longer lists this
+      // thread while the agent processes the continuation message.
+      useWorkspaceStore.setState((ws) => ({
+        threads: ws.threads.map((t) =>
+          t.id === threadId && t.status === "interrupted" ? { ...t, status: "active" as const } : t,
+        ),
+      }));
       return;
     }
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -38,8 +38,8 @@ let lastCheckStatusFetchAt = 0;
 /** Minimum interval between reconnect-triggered checkStatus fetches to avoid subprocess storms. */
 const CHECK_STATUS_RECONNECT_COOLDOWN_MS = 30_000;
 
-/** Timestamp of the last thread-list refresh triggered on WS reconnect. */
-let lastLoadThreadsAt = 0;
+/** Last thread-list refresh timestamp per workspace, triggered on WS reconnect. */
+const lastLoadThreadsAtByWorkspace = new Map<string, number>();
 /** Minimum interval between reconnect-triggered thread-list fetches to avoid rapid-reconnect storms. */
 const LOAD_THREADS_RECONNECT_COOLDOWN_MS = 5_000;
 
@@ -215,15 +215,14 @@ export function createWsTransport(
       // (e.g. flaky networks, server restarts causing multiple reconnect attempts).
       // Deferred import avoids a circular dependency at module evaluation time.
       const nowForThreads = Date.now();
-      if (nowForThreads - lastLoadThreadsAt > LOAD_THREADS_RECONNECT_COOLDOWN_MS) {
-        lastLoadThreadsAt = nowForThreads;
-        import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-          const { activeWorkspaceId, loadThreads } = useWorkspaceStore.getState();
-          if (activeWorkspaceId) {
-            loadThreads(activeWorkspaceId).catch(() => {});
-          }
-        });
-      }
+      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
+        const { activeWorkspaceId, loadThreads } = useWorkspaceStore.getState();
+        if (!activeWorkspaceId) return;
+        const last = lastLoadThreadsAtByWorkspace.get(activeWorkspaceId) ?? 0;
+        if (nowForThreads - last <= LOAD_THREADS_RECONNECT_COOLDOWN_MS) return;
+        lastLoadThreadsAtByWorkspace.set(activeWorkspaceId, nowForThreads);
+        loadThreads(activeWorkspaceId).catch(() => {});
+      });
 
       // Reattach active terminals after reconnect.
       // Deferred import avoids a circular dependency at module evaluation time.

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -38,6 +38,11 @@ let lastCheckStatusFetchAt = 0;
 /** Minimum interval between reconnect-triggered checkStatus fetches to avoid subprocess storms. */
 const CHECK_STATUS_RECONNECT_COOLDOWN_MS = 30_000;
 
+/** Timestamp of the last thread-list refresh triggered on WS reconnect. */
+let lastLoadThreadsAt = 0;
+/** Minimum interval between reconnect-triggered thread-list fetches to avoid rapid-reconnect storms. */
+const LOAD_THREADS_RECONNECT_COOLDOWN_MS = 5_000;
+
 type Listener = (data: unknown) => void;
 
 /**
@@ -205,16 +210,20 @@ export function createWsTransport(
 
       // Re-fetch the thread list after reconnect so thread statuses are not
       // stale. A server restart marks active threads "interrupted" in the DB
-      // but the client still holds the pre-restart status in memory. Without
-      // this refresh, the sidebar continues to show idle state instead of the
-      // amber pulsing interrupted indicator introduced for this fix.
+      // but the client still holds the pre-restart status in memory.
+      // Throttled to avoid hammering the API during rapid reconnect cycles
+      // (e.g. flaky networks, server restarts causing multiple reconnect attempts).
       // Deferred import avoids a circular dependency at module evaluation time.
-      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        const { activeWorkspaceId, loadThreads } = useWorkspaceStore.getState();
-        if (activeWorkspaceId) {
-          loadThreads(activeWorkspaceId).catch(() => {});
-        }
-      });
+      const nowForThreads = Date.now();
+      if (nowForThreads - lastLoadThreadsAt > LOAD_THREADS_RECONNECT_COOLDOWN_MS) {
+        lastLoadThreadsAt = nowForThreads;
+        import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
+          const { activeWorkspaceId, loadThreads } = useWorkspaceStore.getState();
+          if (activeWorkspaceId) {
+            loadThreads(activeWorkspaceId).catch(() => {});
+          }
+        });
+      }
 
       // Reattach active terminals after reconnect.
       // Deferred import avoids a circular dependency at module evaluation time.

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -203,6 +203,19 @@ export function createWsTransport(
         });
       }
 
+      // Re-fetch the thread list after reconnect so thread statuses are not
+      // stale. A server restart marks active threads "interrupted" in the DB
+      // but the client still holds the pre-restart status in memory. Without
+      // this refresh, the sidebar continues to show idle state instead of the
+      // amber pulsing interrupted indicator introduced for this fix.
+      // Deferred import avoids a circular dependency at module evaluation time.
+      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
+        const { activeWorkspaceId, loadThreads } = useWorkspaceStore.getState();
+        if (activeWorkspaceId) {
+          loadThreads(activeWorkspaceId).catch(() => {});
+        }
+      });
+
       // Reattach active terminals after reconnect.
       // Deferred import avoids a circular dependency at module evaluation time.
       import("@/stores/terminalStore").then(async ({ useTerminalStore }) => {


### PR DESCRIPTION
## What

Copilot threads showed idle/normal state in the sidebar and project tree while the Copilot agent was actively executing tool calls.

## Why

The Copilot SDK fires `assistant.usage` after **each model call** in an agentic loop (model → tool calls → model → ...). The previous code emitted `TurnComplete` on every `assistant.usage` event. Each `TurnComplete` caused the frontend to:

1. Remove the thread from `runningThreadIds` - sidebar shows idle
2. Set DB status to `"completed"` - project tree shows normal state

No `TurnStarted` re-fires between model calls, so the thread stayed in idle/completed state while tools were still executing.

## Key changes

- **`copilot-provider.ts`**: Accumulate token usage (`totalInputTokens`, `totalOutputTokens`, `totalCacheRead`, `totalCacheWrite`, `totalCost`) across `assistant.usage` events. Emit a single `TurnComplete` in the `session.idle` handler, which is the SDK's signal that the turn is truly finished.
- **`ws-transport.ts`**: On WebSocket reconnect, refresh the thread list so `"interrupted"` status set during a server restart is surfaced to the client. Added a 5 s cooldown to prevent API hammering during rapid reconnect cycles.
- **`thread-status.ts`**: Amber pulsing dot for `"interrupted"` threads.
- **`threadStore.ts`**: Clear `"interrupted"` status to `"active"` when `session.turnStarted` fires (thread resumed after a server restart).

## Related issues/PRs

Closes #fix-copilot-not-persisting-workign-state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interrupted thread status now displays with amber pulsing indicator
  * Thread list automatically refreshes on WebSocket reconnect
  * Interrupted threads transition to active when resumed

* **Bug Fixes**
  * Corrected token aggregation across multiple model calls
  * Improved message filtering for multi-phase AI responses, excluding internal reasoning phases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->