### PR TITLE
fix: deduplicate check runs to show only latest per workflow

### DIFF
--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -271,16 +271,16 @@ describe("GithubService.getCheckRuns", () => {
     expect(result.aggregate).toBe("passing");
   });
 
-  // D1: Duplicate check run names (re-run or multi-suite) — keep most recent per name
-  it("deduplicates check runs with the same name, keeping the most recently started run", async () => {
+  // D1: Duplicate check run names (re-run or multi-suite) — keep most recent per (name, appId)
+  it("deduplicates check runs with the same name and appId, keeping the most recently started run", async () => {
     // Simulates a re-triggered validate-pr: old passing run (earlier startedAt) and
     // new failing run (later startedAt) both returned by the GitHub API.
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
         cb(null, JSON.stringify([
-          { name: "validate-pr", status: "completed", conclusion: "success",  startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:04Z" },
-          { name: "validate-pr", status: "completed", conclusion: "failure",  startedAt: "2026-04-23T10:00:05Z", completedAt: "2026-04-23T10:00:10Z" },
-          { name: "build",       status: "completed", conclusion: "success",  startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:23Z" },
+          { name: "validate-pr", status: "completed", conclusion: "success",  startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:04Z", appId: 15368 },
+          { name: "validate-pr", status: "completed", conclusion: "failure",  startedAt: "2026-04-23T10:00:05Z", completedAt: "2026-04-23T10:00:10Z", appId: 15368 },
+          { name: "build",       status: "completed", conclusion: "success",  startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:23Z", appId: 15368 },
         ]), "");
       },
     );
@@ -300,8 +300,8 @@ describe("GithubService.getCheckRuns", () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
         cb(null, JSON.stringify([
-          { name: "validate-pr", status: "completed", conclusion: "failure", startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:05Z" },
-          { name: "validate-pr", status: "completed", conclusion: "success", startedAt: "2026-04-23T10:00:10Z", completedAt: "2026-04-23T10:00:14Z" },
+          { name: "validate-pr", status: "completed", conclusion: "failure", startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:05Z", appId: 15368 },
+          { name: "validate-pr", status: "completed", conclusion: "success", startedAt: "2026-04-23T10:00:10Z", completedAt: "2026-04-23T10:00:14Z", appId: 15368 },
         ]), "");
       },
     );
@@ -313,13 +313,31 @@ describe("GithubService.getCheckRuns", () => {
     expect(result.aggregate).toBe("passing");
   });
 
+  // D1: Different apps, same name — must NOT be collapsed (e.g. GH Actions + Greptile)
+  it("does not deduplicate same-named runs from different apps", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        cb(null, JSON.stringify([
+          { name: "validate-pr", status: "completed", conclusion: "success", startedAt: "2026-04-23T10:00:10Z", completedAt: "2026-04-23T10:00:14Z", appId: 15368 },
+          { name: "validate-pr", status: "completed", conclusion: "failure", startedAt: "2026-04-23T10:00:08Z", completedAt: "2026-04-23T10:00:12Z", appId: 99999 },
+        ]), "");
+      },
+    );
+
+    const result = await ghService.getCheckRuns("main", "/repo");
+
+    // Both are kept — they belong to different apps and must not be collapsed.
+    expect(result.runs).toHaveLength(2);
+    expect(result.aggregate).toBe("failing");
+  });
+
   // D1: null startedAt — a run with a known timestamp beats a null-startedAt duplicate
   it("keeps the run with a known startedAt over a null-startedAt duplicate", async () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
         cb(null, JSON.stringify([
-          { name: "build", status: "in_progress", conclusion: null, startedAt: null, completedAt: null },
-          { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-23T10:00:05Z", completedAt: "2026-04-23T10:00:10Z" },
+          { name: "build", status: "in_progress", conclusion: null, startedAt: null, completedAt: null, appId: 15368 },
+          { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-23T10:00:05Z", completedAt: "2026-04-23T10:00:10Z", appId: 15368 },
         ]), "");
       },
     );

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -313,6 +313,25 @@ describe("GithubService.getCheckRuns", () => {
     expect(result.aggregate).toBe("passing");
   });
 
+  // D1: null startedAt — a run with a known timestamp beats a null-startedAt duplicate
+  it("keeps the run with a known startedAt over a null-startedAt duplicate", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        cb(null, JSON.stringify([
+          { name: "build", status: "in_progress", conclusion: null, startedAt: null, completedAt: null },
+          { name: "build", status: "completed", conclusion: "success", startedAt: "2026-04-23T10:00:05Z", completedAt: "2026-04-23T10:00:10Z" },
+        ]), "");
+      },
+    );
+
+    const result = await ghService.getCheckRuns("main", "/repo");
+
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0].startedAt).toBe("2026-04-23T10:00:05Z");
+    // The completed success run wins; in_progress null-timestamp run is dropped.
+    expect(result.aggregate).toBe("passing");
+  });
+
   // M6: In-flight deduplication for identical branch+repo pairs
   it("deduplicates concurrent getCheckRuns for same branch+repo", async () => {
     let execFileCallCount = 0;

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -271,6 +271,48 @@ describe("GithubService.getCheckRuns", () => {
     expect(result.aggregate).toBe("passing");
   });
 
+  // D1: Duplicate check run names (re-run or multi-suite) — keep most recent per name
+  it("deduplicates check runs with the same name, keeping the most recently started run", async () => {
+    // Simulates a re-triggered validate-pr: old passing run (earlier startedAt) and
+    // new failing run (later startedAt) both returned by the GitHub API.
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        cb(null, JSON.stringify([
+          { name: "validate-pr", status: "completed", conclusion: "success",  startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:04Z" },
+          { name: "validate-pr", status: "completed", conclusion: "failure",  startedAt: "2026-04-23T10:00:05Z", completedAt: "2026-04-23T10:00:10Z" },
+          { name: "build",       status: "completed", conclusion: "success",  startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:23Z" },
+        ]), "");
+      },
+    );
+
+    const result = await ghService.getCheckRuns("main", "/repo");
+
+    // Only the newest validate-pr (failure) is kept; the old passing duplicate is dropped.
+    expect(result.runs).toHaveLength(2);
+    const validatePr = result.runs.find((r) => r.name === "validate-pr");
+    expect(validatePr?.conclusion).toBe("failure");
+    // Aggregate reflects the deduped set — the failure is present, so failing.
+    expect(result.aggregate).toBe("failing");
+  });
+
+  it("keeps the passing run when it started after an earlier failing run for the same check", async () => {
+    // Re-run succeeded: old failing (earlier) + new passing (later) — keep the passing one.
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: CallbackFn) => {
+        cb(null, JSON.stringify([
+          { name: "validate-pr", status: "completed", conclusion: "failure", startedAt: "2026-04-23T10:00:00Z", completedAt: "2026-04-23T10:00:05Z" },
+          { name: "validate-pr", status: "completed", conclusion: "success", startedAt: "2026-04-23T10:00:10Z", completedAt: "2026-04-23T10:00:14Z" },
+        ]), "");
+      },
+    );
+
+    const result = await ghService.getCheckRuns("main", "/repo");
+
+    expect(result.runs).toHaveLength(1);
+    expect(result.runs[0].conclusion).toBe("success");
+    expect(result.aggregate).toBe("passing");
+  });
+
   // M6: In-flight deduplication for identical branch+repo pairs
   it("deduplicates concurrent getCheckRuns for same branch+repo", async () => {
     let execFileCallCount = 0;

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -330,12 +330,17 @@ export class GithubService {
           // workflows triggered by multiple events produce duplicate entries (e.g., a passing
           // run from suite A alongside a failing run from the newly-triggered suite B).
           // Without dedup the aggregate can be stale and the list shows ghost duplicates.
+          // Tie-breaking: null startedAt maps to "" which is lexicographically less than any
+          // ISO string, so a run with a known timestamp always wins over one without. When
+          // two runs share the same timestamp (or both are null), the first in API response
+          // order is kept — GitHub does not guarantee ordering between suite siblings, so
+          // either choice is equivalent.
           const dedupMap = new Map<string, CheckRun>();
           for (const run of rawRuns) {
             const existing = dedupMap.get(run.name);
             const existingTs = existing?.startedAt ?? "";
             const runTs = run.startedAt ?? "";
-            if (!existing || runTs >= existingTs) {
+            if (!existing || runTs > existingTs) {
               dedupMap.set(run.name, run);
             }
           }

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -277,7 +277,7 @@ export class GithubService {
         `repos/${slug}/commits/${encodeURIComponent(branch)}/check-runs`,
         "--cache", "5s",
         "-H", "Accept: application/vnd.github+json",
-        "--jq", ".check_runs | map({name: .name, status: .status, conclusion: .conclusion, startedAt: .started_at, completedAt: .completed_at})",
+        "--jq", ".check_runs | map({name: .name, status: .status, conclusion: .conclusion, startedAt: .started_at, completedAt: .completed_at, appId: .app.id})",
       ],
       { cwd: repoPath, encoding: "utf-8", timeout: 15_000, maxBuffer: 2 * 1024 * 1024 },
       (error, stdout) => {
@@ -295,6 +295,7 @@ export class GithubService {
             conclusion?: string | null;
             startedAt?: string | null;
             completedAt?: string | null;
+            appId?: number | null;
           }>;
 
           if (items.length === 0) {
@@ -322,29 +323,38 @@ export class GithubService {
               conclusion,
               durationMs,
               startedAt: item.startedAt ?? null,
+              // appId is used only for dedup scoping — it is stripped before the result is returned.
+              appId: typeof item.appId === "number" ? item.appId : 0,
             };
           });
 
-          // D1: Deduplicate runs with the same name, keeping the most recently started one.
+          // D1: Deduplicate runs with the same (name, appId), keeping the most recently started one.
           // GitHub returns check runs from every check suite on a commit, so re-runs or
           // workflows triggered by multiple events produce duplicate entries (e.g., a passing
           // run from suite A alongside a failing run from the newly-triggered suite B).
           // Without dedup the aggregate can be stale and the list shows ghost duplicates.
+          //
+          // The dedup key includes appId so that two different GitHub Apps that both create a
+          // check named "validate-pr" (e.g., GitHub Actions + Greptile) are NOT collapsed —
+          // only runs from the same app are candidates for deduplication.
+          //
           // Tie-breaking: null startedAt maps to "" which is lexicographically less than any
           // ISO string, so a run with a known timestamp always wins over one without. When
           // two runs share the same timestamp (or both are null), the first in API response
           // order is kept — GitHub does not guarantee ordering between suite siblings, so
           // either choice is equivalent.
-          const dedupMap = new Map<string, CheckRun>();
+          const dedupMap = new Map<string, typeof rawRuns[0]>();
           for (const run of rawRuns) {
-            const existing = dedupMap.get(run.name);
+            const key = `${run.name}\0${run.appId}`;
+            const existing = dedupMap.get(key);
             const existingTs = existing?.startedAt ?? "";
             const runTs = run.startedAt ?? "";
             if (!existing || runTs > existingTs) {
-              dedupMap.set(run.name, run);
+              dedupMap.set(key, run);
             }
           }
-          const runs = [...dedupMap.values()];
+          // Strip the internal appId field before passing runs to the caller.
+          const runs: CheckRun[] = [...dedupMap.values()].map(({ appId: _appId, ...run }) => run);
 
           let aggregate: "passing" | "failing" | "pending" | "no_checks";
           if (runs.some((r) => r.conclusion === "failure" || r.conclusion === "timed_out")) {

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -302,7 +302,7 @@ export class GithubService {
             return;
           }
 
-          const runs = items.map((item) => {
+          const rawRuns = items.map((item) => {
             // M1: Missing status defaults to in_progress (not completed) to avoid false-green aggregate.
             const status = (item.status ?? "in_progress") as CheckRun["status"];
             // H1: Unknown conclusion values are mapped conservatively to failure.
@@ -324,6 +324,22 @@ export class GithubService {
               startedAt: item.startedAt ?? null,
             };
           });
+
+          // D1: Deduplicate runs with the same name, keeping the most recently started one.
+          // GitHub returns check runs from every check suite on a commit, so re-runs or
+          // workflows triggered by multiple events produce duplicate entries (e.g., a passing
+          // run from suite A alongside a failing run from the newly-triggered suite B).
+          // Without dedup the aggregate can be stale and the list shows ghost duplicates.
+          const dedupMap = new Map<string, CheckRun>();
+          for (const run of rawRuns) {
+            const existing = dedupMap.get(run.name);
+            const existingTs = existing?.startedAt ?? "";
+            const runTs = run.startedAt ?? "";
+            if (!existing || runTs >= existingTs) {
+              dedupMap.set(run.name, run);
+            }
+          }
+          const runs = [...dedupMap.values()];
 
           let aggregate: "passing" | "failing" | "pending" | "no_checks";
           if (runs.some((r) => r.conclusion === "failure" || r.conclusion === "timed_out")) {


### PR DESCRIPTION
## What

Deduplicate CI check runs by name in `getCheckRuns`, keeping only the most recently started run per workflow.

## Why

GitHub returns check runs from every check suite on a commit. When a workflow is re-run or triggered by multiple events (PR + push), the same check name appears multiple times. Without deduplication:

- The checks popover shows ghost duplicates (e.g. `validate-pr` in both Passing and Failing lanes simultaneously)
- The aggregate can reflect stale state from an older run

## Key changes

- `github-service.ts`: After mapping the raw API response, deduplicate runs by name keeping the one with the latest `startedAt`. ISO 8601 timestamps compare correctly as strings, so `>=` gives chronological ordering.
- `github-service-checks.test.ts`: Two new tests covering the dedup cases — old passing + new failing keeps the failing one; old failing + new passing keeps the passing one.

## Related issues/PRs

Relates to #361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering deduplication of GitHub check runs with identical names, including cases with differing conclusions and null timestamps.

* **Bug Fixes**
  * Check runs with the same name are deduplicated so only the most recent run is kept (null timestamps deprioritized), and aggregate statuses now reflect the deduped set correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->