### PR TITLE
fix: close IPC relay socket and stderr stream on teardown

### DIFF
--- a/apps/desktop/src/main/__tests__/ipc-relay.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-relay.test.ts
@@ -24,22 +24,26 @@ import { connect as netConnect } from "net";
 // ---------------------------------------------------------------------------
 
 /** Minimal window stub that satisfies the RelayWindow contract. */
-function makeWindow(destroyed = false) {
+function makeWindow(destroyed = false, webContentsDestroyed = false) {
   return {
     isDestroyed: vi.fn().mockReturnValue(destroyed),
-    webContents: { send: vi.fn() },
+    webContents: {
+      isDestroyed: vi.fn().mockReturnValue(webContentsDestroyed),
+      send: vi.fn(),
+    },
   };
 }
 
 /**
  * Build a length-prefixed frame buffer for a single JSON message.
- * Wire format: 4-byte big-endian frame length followed by the UTF-8 JSON body.
+ * Wire format: 4-byte big-endian length (UTF-8 byte count) followed by the UTF-8 JSON body.
  */
 function encodeFrame(data: unknown): Buffer {
   const json = JSON.stringify(data);
-  const buf = Buffer.alloc(4 + json.length);
-  buf.writeUInt32BE(json.length, 0);
-  buf.write(json, 4, "utf-8");
+  const body = Buffer.from(json, "utf-8");
+  const buf = Buffer.alloc(4 + body.length);
+  buf.writeUInt32BE(body.length, 0);
+  body.copy(buf, 4);
   return buf;
 }
 
@@ -114,6 +118,15 @@ describe("startIpcRelay", () => {
 
       expect(win.webContents.send).not.toHaveBeenCalled();
     });
+
+    it("skips ipc-push-disconnect when webContents is destroyed but window is alive", () => {
+      const win = makeWindow(false, true);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      handlers["close"]?.();
+
+      expect(win.webContents.send).not.toHaveBeenCalled();
+    });
   });
 
   describe("frame parsing", () => {
@@ -178,6 +191,37 @@ describe("startIpcRelay", () => {
       handlers["data"]?.(encodeFrame({ event: "ping" }));
 
       expect(win.webContents.send).not.toHaveBeenCalled();
+    });
+
+    it("does not forward frames when webContents is destroyed but window is alive", () => {
+      const win = makeWindow(false, true);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      handlers["data"]?.(encodeFrame({ event: "ping" }));
+
+      expect(win.webContents.send).not.toHaveBeenCalled();
+    });
+
+    it("destroys socket when frame length exceeds MAX_FRAME_SIZE", () => {
+      startIpcRelay("/tmp/mcode.sock", makeWindow() as never);
+
+      // Write a length prefix of 9 MiB, which exceeds the 8 MiB limit.
+      const buf = Buffer.alloc(4);
+      buf.writeUInt32BE(9 * 1024 * 1024, 0);
+
+      handlers["data"]?.(buf);
+
+      expect(mockSocket.destroy).toHaveBeenCalled();
+    });
+
+    it("encodes and decodes non-ASCII payloads correctly", () => {
+      const win = makeWindow(false);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      const message = { text: "こんにちは 🌍" };
+      handlers["data"]?.(encodeFrame(message));
+
+      expect(win.webContents.send).toHaveBeenCalledWith("ipc-push-message", message);
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/ipc-relay.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-relay.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Socket mock factory - create a fresh mock per test via beforeEach
+// ---------------------------------------------------------------------------
+
+let mockSocket: {
+  on: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+};
+
+/** Per-test handler registry, keyed by event name. */
+let handlers: Record<string, (...args: unknown[]) => void>;
+
+vi.mock("net", () => ({
+  connect: vi.fn(),
+}));
+
+import { startIpcRelay } from "../ipc-relay.js";
+import { connect as netConnect } from "net";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal window stub that satisfies the RelayWindow contract. */
+function makeWindow(destroyed = false) {
+  return {
+    isDestroyed: vi.fn().mockReturnValue(destroyed),
+    webContents: { send: vi.fn() },
+  };
+}
+
+/**
+ * Build a length-prefixed frame buffer for a single JSON message.
+ * Wire format: 4-byte big-endian frame length followed by the UTF-8 JSON body.
+ */
+function encodeFrame(data: unknown): Buffer {
+  const json = JSON.stringify(data);
+  const buf = Buffer.alloc(4 + json.length);
+  buf.writeUInt32BE(json.length, 0);
+  buf.write(json, 4, "utf-8");
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  handlers = {};
+  mockSocket = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers[event] = handler;
+      return mockSocket;
+    }),
+    destroy: vi.fn(),
+  };
+  vi.mocked(netConnect).mockReturnValue(mockSocket as unknown as ReturnType<typeof netConnect>);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startIpcRelay", () => {
+  describe("empty ipcPath", () => {
+    it("returns a no-op cleanup without connecting", () => {
+      const cleanup = startIpcRelay("", makeWindow() as never);
+
+      cleanup(); // must not throw
+
+      expect(netConnect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("socket lifecycle", () => {
+    it("connects to the given ipcPath", () => {
+      startIpcRelay("/tmp/mcode.sock", makeWindow() as never);
+
+      expect(netConnect).toHaveBeenCalledWith("/tmp/mcode.sock");
+    });
+
+    it("cleanup destroys the socket", () => {
+      const cleanup = startIpcRelay("/tmp/mcode.sock", makeWindow() as never);
+
+      cleanup();
+
+      expect(mockSocket.destroy).toHaveBeenCalledOnce();
+    });
+
+    it("destroys socket on error event", () => {
+      startIpcRelay("/tmp/mcode.sock", makeWindow() as never);
+
+      handlers["error"]?.(new Error("ECONNREFUSED"));
+
+      expect(mockSocket.destroy).toHaveBeenCalledOnce();
+    });
+
+    it("sends ipc-push-disconnect on close when window is alive", () => {
+      const win = makeWindow(false);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      handlers["close"]?.();
+
+      expect(win.webContents.send).toHaveBeenCalledWith("ipc-push-disconnect");
+    });
+
+    it("skips ipc-push-disconnect when window is destroyed", () => {
+      const win = makeWindow(true);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      handlers["close"]?.();
+
+      expect(win.webContents.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("frame parsing", () => {
+    it("forwards a single complete frame to the renderer", () => {
+      const win = makeWindow(false);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      const message = { type: "test-event", payload: 42 };
+      handlers["data"]?.(encodeFrame(message));
+
+      expect(win.webContents.send).toHaveBeenCalledWith("ipc-push-message", message);
+    });
+
+    it("forwards multiple frames from a single data chunk", () => {
+      const win = makeWindow(false);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      const a = { id: 1 };
+      const b = { id: 2 };
+      const combined = Buffer.concat([encodeFrame(a), encodeFrame(b)]);
+
+      handlers["data"]?.(combined);
+
+      expect(win.webContents.send).toHaveBeenCalledTimes(2);
+      expect(win.webContents.send).toHaveBeenNthCalledWith(1, "ipc-push-message", a);
+      expect(win.webContents.send).toHaveBeenNthCalledWith(2, "ipc-push-message", b);
+    });
+
+    it("buffers a partial frame and flushes on the next data event", () => {
+      const win = makeWindow(false);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      const message = { hello: "world" };
+      const full = encodeFrame(message);
+      const firstHalf = full.subarray(0, Math.floor(full.length / 2));
+      const secondHalf = full.subarray(Math.floor(full.length / 2));
+
+      handlers["data"]?.(firstHalf);
+      expect(win.webContents.send).not.toHaveBeenCalled();
+
+      handlers["data"]?.(secondHalf);
+      expect(win.webContents.send).toHaveBeenCalledWith("ipc-push-message", message);
+    });
+
+    it("skips malformed JSON frames without throwing", () => {
+      const win = makeWindow(false);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      const garbage = Buffer.from("not-json");
+      const buf = Buffer.alloc(4 + garbage.length);
+      buf.writeUInt32BE(garbage.length, 0);
+      garbage.copy(buf, 4);
+
+      expect(() => handlers["data"]?.(buf)).not.toThrow();
+      expect(win.webContents.send).not.toHaveBeenCalled();
+    });
+
+    it("does not forward frames to a destroyed window", () => {
+      const win = makeWindow(true);
+      startIpcRelay("/tmp/mcode.sock", win as never);
+
+      handlers["data"]?.(encodeFrame({ event: "ping" }));
+
+      expect(win.webContents.send).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/server-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/server-manager.test.ts
@@ -67,7 +67,7 @@ vi.mock("fs", () => ({
   writeFileSync: vi.fn(),
   // createWriteStream is used in non-dev mode to route stderr to a log file.
   // Return a minimal writable-stream stub so callers like child.stderr.pipe() work.
-  createWriteStream: vi.fn(() => ({ write: vi.fn(), end: vi.fn() })),
+  createWriteStream: vi.fn(() => ({ write: vi.fn(), end: vi.fn(), destroy: vi.fn() })),
 }));
 
 vi.mock("fs/promises", () => ({
@@ -115,7 +115,7 @@ const originalFetch = globalThis.fetch;
 
 import { ServerManager } from "../server-manager.js";
 import { spawn } from "child_process";
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, createWriteStream } from "fs";
 import { readFile } from "fs/promises";
 
 // ---------------------------------------------------------------------------
@@ -410,6 +410,30 @@ describe("ServerManager", () => {
     );
 
     killSpy.mockRestore();
+  });
+
+  // -----------------------------------------------------------------------
+  // Reuse existing server from lock file
+  // -----------------------------------------------------------------------
+
+  // -----------------------------------------------------------------------
+  // stderrStream cleanup on spawn failure
+  // -----------------------------------------------------------------------
+
+  it("destroys stderrStream when spawn throws in non-dev mode", async () => {
+    // Capture the stream instance created by createWriteStream so we can
+    // assert that destroy() was called on it after spawn fails.
+    const mockStream = { write: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+    vi.mocked(createWriteStream).mockReturnValueOnce(mockStream as never);
+
+    // Make spawn throw synchronously - simulates a missing executable or
+    // other OS-level failure before any child process is created.
+    vi.mocked(spawn).mockImplementationOnce(() => {
+      throw new Error("spawn ENOENT");
+    });
+
+    await expect(manager.start()).rejects.toThrow("spawn ENOENT");
+    expect(mockStream.destroy).toHaveBeenCalledOnce();
   });
 
   // -----------------------------------------------------------------------

--- a/apps/desktop/src/main/ipc-relay.ts
+++ b/apps/desktop/src/main/ipc-relay.ts
@@ -8,10 +8,15 @@
 
 import { connect as netConnect } from "net";
 
+/** Maximum permitted frame body size (8 MiB). Frames larger than this indicate
+ *  a corrupt or malicious length prefix; the socket is destroyed immediately. */
+const MAX_FRAME_SIZE = 8 * 1024 * 1024;
+
 /** Minimal subset of BrowserWindow required by the relay. */
 interface RelayWindow {
   isDestroyed(): boolean;
   webContents: {
+    isDestroyed(): boolean;
     send(channel: string, ...args: unknown[]): void;
   };
 }
@@ -44,6 +49,10 @@ export function startIpcRelay(ipcPath: string, window: RelayWindow): () => void 
 
     while (buffer.length >= 4) {
       const frameLen = buffer.readUInt32BE(0);
+      if (frameLen > MAX_FRAME_SIZE) {
+        socket.destroy();
+        return;
+      }
       if (buffer.length < 4 + frameLen) break;
 
       const json = buffer.subarray(4, 4 + frameLen).toString("utf-8");
@@ -51,7 +60,7 @@ export function startIpcRelay(ipcPath: string, window: RelayWindow): () => void 
 
       try {
         const data = JSON.parse(json) as unknown;
-        if (!window.isDestroyed()) {
+        if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
           window.webContents.send("ipc-push-message", data);
         }
       } catch { /* malformed frame - skip */ }
@@ -66,7 +75,7 @@ export function startIpcRelay(ipcPath: string, window: RelayWindow): () => void 
 
   socket.on("error", () => socket.destroy());
   socket.on("close", () => {
-    if (!window.isDestroyed()) {
+    if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
       window.webContents.send("ipc-push-disconnect");
     }
   });

--- a/apps/desktop/src/main/ipc-relay.ts
+++ b/apps/desktop/src/main/ipc-relay.ts
@@ -1,0 +1,75 @@
+/**
+ * IPC push relay - connects a Node.js net.Socket to the server's IPC pipe
+ * and forwards length-prefixed frames to the renderer via webContents.send.
+ *
+ * The main process owns the socket because the preload runs in a sandbox
+ * that does not have access to the Node.js `net` module.
+ */
+
+import { connect as netConnect } from "net";
+
+/** Minimal subset of BrowserWindow required by the relay. */
+interface RelayWindow {
+  isDestroyed(): boolean;
+  webContents: {
+    send(channel: string, ...args: unknown[]): void;
+  };
+}
+
+/**
+ * Connect to the server's IPC push endpoint and forward parsed frames
+ * to the renderer via `webContents.send("ipc-push-message", data)`.
+ *
+ * Wire format: each frame is a 4-byte big-endian length prefix followed by
+ * the UTF-8 encoded JSON body.
+ *
+ * @returns A cleanup function. Call it when the window closes to destroy
+ *   the socket and prevent a named-pipe handle leak on Windows.
+ */
+export function startIpcRelay(ipcPath: string, window: RelayWindow): () => void {
+  if (!ipcPath) return () => { /* no-op: no socket was opened */ };
+
+  const socket = netConnect(ipcPath);
+  const chunks: Buffer[] = [];
+  let totalLen = 0;
+
+  socket.on("data", (chunk: Buffer) => {
+    chunks.push(chunk);
+    totalLen += chunk.length;
+
+    // Avoid concat overhead when only one chunk is buffered.
+    let buffer = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks, totalLen);
+    chunks.length = 0;
+    totalLen = 0;
+
+    while (buffer.length >= 4) {
+      const frameLen = buffer.readUInt32BE(0);
+      if (buffer.length < 4 + frameLen) break;
+
+      const json = buffer.subarray(4, 4 + frameLen).toString("utf-8");
+      buffer = buffer.subarray(4 + frameLen);
+
+      try {
+        const data = JSON.parse(json) as unknown;
+        if (!window.isDestroyed()) {
+          window.webContents.send("ipc-push-message", data);
+        }
+      } catch { /* malformed frame - skip */ }
+    }
+
+    // Retain leftover bytes for the next data event.
+    if (buffer.length > 0) {
+      chunks.push(buffer);
+      totalLen = buffer.length;
+    }
+  });
+
+  socket.on("error", () => socket.destroy());
+  socket.on("close", () => {
+    if (!window.isDestroyed()) {
+      window.webContents.send("ipc-push-disconnect");
+    }
+  });
+
+  return () => socket.destroy();
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -20,7 +20,6 @@ import {
 import { execFileSync, spawn, type ChildProcess } from "child_process";
 import { existsSync, createReadStream } from "fs";
 import { mkdir, writeFile } from "fs/promises";
-import { connect as netConnect } from "net";
 import { isAbsolute, join } from "path";
 import { randomUUID } from "crypto";
 import { Readable } from "stream";
@@ -30,6 +29,7 @@ import { getExtension as bundledGetExtension } from "@mcode/contracts";
 /** Use snapshot-provided module when available (V8 snapshot skips re-init). */
 const getExtension = globalThis.__v8Snapshot?.contracts?.getExtension ?? bundledGetExtension;
 import { ServerManager } from "./server-manager.js";
+import { startIpcRelay } from "./ipc-relay.js";
 import { initAutoUpdater } from "./auto-updater.js";
 import { setupSpellcheck } from "./spellcheck.js";
 
@@ -223,62 +223,6 @@ function openIfAllowed(url: string): void {
   } catch {
     // Invalid URL, ignore
   }
-}
-
-// ---------------------------------------------------------------------------
-// IPC push relay (main process → renderer via webContents.send)
-// ---------------------------------------------------------------------------
-
-/**
- * Connect to the server's IPC push endpoint and forward parsed frames
- * to the renderer via webContents.send("ipc-push-message", data).
- * The main process owns the net.Socket because the preload runs in a
- * sandbox that doesn't have access to the Node.js `net` module.
- */
-function startIpcRelay(ipcPath: string, window: BrowserWindow): void {
-  if (!ipcPath) return;
-
-  const socket = netConnect(ipcPath);
-  const chunks: Buffer[] = [];
-  let totalLen = 0;
-
-  socket.on("data", (chunk: Buffer) => {
-    chunks.push(chunk);
-    totalLen += chunk.length;
-
-    // Only concat when we have enough data for at least one frame header
-    let buffer = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks, totalLen);
-    chunks.length = 0;
-    totalLen = 0;
-
-    while (buffer.length >= 4) {
-      const frameLen = buffer.readUInt32BE(0);
-      if (buffer.length < 4 + frameLen) break;
-
-      const json = buffer.subarray(4, 4 + frameLen).toString("utf-8");
-      buffer = buffer.subarray(4 + frameLen);
-
-      try {
-        const data = JSON.parse(json);
-        if (!window.isDestroyed()) {
-          window.webContents.send("ipc-push-message", data);
-        }
-      } catch { /* malformed frame, skip */ }
-    }
-
-    // Retain leftover bytes for the next data event
-    if (buffer.length > 0) {
-      chunks.push(buffer);
-      totalLen = buffer.length;
-    }
-  });
-
-  socket.on("error", () => socket.destroy());
-  socket.on("close", () => {
-    if (!window.isDestroyed()) {
-      window.webContents.send("ipc-push-disconnect");
-    }
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -693,9 +637,11 @@ app.whenReady().then(async () => {
     // Enable spellchecker and attach per-window context-menu handler.
     setupSpellcheck(mainWindow!);
 
-    // Start IPC push relay (main process → renderer via webContents.send)
+    // Start IPC push relay (main process → renderer via webContents.send).
+    // Destroy the socket when the window closes to prevent named-pipe handle leaks.
     if (mainWindow && serverManager.ipcPath) {
-      startIpcRelay(serverManager.ipcPath, mainWindow);
+      const cleanupRelay = startIpcRelay(serverManager.ipcPath, mainWindow);
+      mainWindow.once("closed", cleanupRelay);
     }
 
     // Set up close handler
@@ -708,7 +654,8 @@ app.whenReady().then(async () => {
         setupSpellcheck(mainWindow!);
         setupCloseHandler();
         if (mainWindow && serverManager.ipcPath) {
-          startIpcRelay(serverManager.ipcPath, mainWindow);
+          const cleanupRelay = startIpcRelay(serverManager.ipcPath, mainWindow);
+          mainWindow.once("closed", cleanupRelay);
         }
       }
     });

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -346,12 +346,18 @@ export class ServerManager {
         ? undefined
         : createWriteStream(SERVER_LOG_PATH, { flags: "w" });
 
-      const child = spawn(process.execPath, args, {
-        cwd,
-        env,
-        detached: true,
-        stdio: isDev ? "inherit" : ["ignore", "ignore", stderrStream ? "pipe" : "ignore"],
-      });
+      let child;
+      try {
+        child = spawn(process.execPath, args, {
+          cwd,
+          env,
+          detached: true,
+          stdio: isDev ? "inherit" : ["ignore", "ignore", stderrStream ? "pipe" : "ignore"],
+        });
+      } catch (err) {
+        stderrStream?.destroy();
+        throw err;
+      }
       child.unref();
       this.serverProcess = child;
 


### PR DESCRIPTION
## What

Fixes two kernel-object leaks in the Electron main process that caused handle accumulation in the Windows paged pool and committed memory.

## Why

Each BrowserWindow open/close cycle opened a `net.Socket` to the server's named pipe (`\.\pipe\mcode-<pid>`) but never destroyed it - the handle leaked for the process lifetime. Separately, `ServerManager.start()` created a `WriteStream` for server stderr before calling `spawn()`; if `spawn()` threw synchronously the stream was never closed.

## Key changes

- **`apps/desktop/src/main/ipc-relay.ts`** (new) - Extracted `startIpcRelay` from `main.ts` into its own module. Return type changed from `void` to `() => void`; callers receive a cleanup function that calls `socket.destroy()`.
- **`apps/desktop/src/main/main.ts`** - Both call sites (initial startup + macOS `activate` handler) now register the cleanup on `mainWindow.once("closed", cleanupRelay)`.
- **`apps/desktop/src/main/server-manager.ts`** - Wrapped `spawn()` in try/catch; `stderrStream?.destroy()` is called before re-throwing if spawn fails.
- **`apps/desktop/src/main/__tests__/ipc-relay.test.ts`** (new) - 11 unit tests covering socket connect, cleanup, error/close handlers, single/multi-frame parsing, partial frame buffering, malformed JSON, and destroyed-window guard.
- **`apps/desktop/src/main/__tests__/server-manager.test.ts`** - Added `destroy` to `createWriteStream` stub; added test for the spawn-throw stream cleanup path.

## Configuration changes

None.

## Related issues/PRs

Relates to the paged pool / committed memory investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new IPC relay to reliably receive and forward renderer messages.

* **Bug Fixes**
  * Improved startup error handling to clean up log streams on spawn failure.
  * Ensured socket/relay is cleaned up when windows close or on connection errors.
  * Protects against oversized or malformed messages to avoid crashes.

* **Tests**
  * Added comprehensive tests covering IPC parsing, edge cases, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->