### PR TITLE
feat: auto-updater with user controls, notifications, and release notes

### DIFF
--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -29,19 +29,34 @@ const INTERVAL_MS_MAP: Record<string, number> = {
   "never": Infinity,
 };
 
-/** Get the configured check interval from settings, or 4 hours if settings cannot be read. */
-function getCheckIntervalMs(): number {
+interface UpdaterSettings {
+  autoDownload: boolean;
+  autoInstallOnQuit: boolean;
+  checkInterval: string;
+}
+
+/** Read updater settings from settings.json; falls back to safe defaults if the file is missing or invalid. */
+function loadUpdaterSettings(): UpdaterSettings {
   try {
     const raw = readFileSync(join(getMcodeDir(), "settings.json"), "utf-8");
     const result = SettingsSchema().safeParse(JSON.parse(raw));
     if (result.success) {
-      const interval = result.data.updates?.checkInterval ?? "4hours";
-      return INTERVAL_MS_MAP[interval] ?? (4 * 60 * 60 * 1000);
+      return {
+        autoDownload: result.data.updates?.autoDownload ?? true,
+        autoInstallOnQuit: result.data.updates?.autoInstallOnQuit ?? true,
+        checkInterval: result.data.updates?.checkInterval ?? "4hours",
+      };
     }
   } catch {
-    // File missing or unreadable; use default
+    // File missing or unreadable; use defaults
   }
-  return 4 * 60 * 60 * 1000; // Default: 4 hours
+  return { autoDownload: true, autoInstallOnQuit: true, checkInterval: "4hours" };
+}
+
+/** Get the configured check interval from settings, or 4 hours if settings cannot be read. */
+function getCheckIntervalMs(): number {
+  const { checkInterval } = loadUpdaterSettings();
+  return INTERVAL_MS_MAP[checkInterval] ?? (4 * 60 * 60 * 1000);
 }
 
 /** IPC push channel used to broadcast update status to the renderer. */
@@ -61,6 +76,8 @@ let lastStatus: UpdateStatus = { state: "idle" };
 let initialized = false;
 let checkIntervalId: NodeJS.Timeout | null = null;
 let initialCheckTimeoutId: NodeJS.Timeout | null = null;
+/** Guards against promptRestart being invoked twice concurrently (notification click + direct call). */
+let isPrompting = false;
 
 /** Returns the most recently observed update status (for renderer hydration). */
 export function getUpdateStatus(): UpdateStatus {
@@ -116,22 +133,9 @@ export function initAutoUpdater(): void {
   if (!app.isPackaged) return;
   initialized = true;
 
-  // Read settings to determine auto-update behavior
-  let autoDownload = true;
-  let autoInstallOnAppQuit = true;
-  try {
-    const raw = readFileSync(join(getMcodeDir(), "settings.json"), "utf-8");
-    const result = SettingsSchema().safeParse(JSON.parse(raw));
-    if (result.success) {
-      autoDownload = result.data.updates?.autoDownload ?? true;
-      autoInstallOnAppQuit = result.data.updates?.autoInstallOnQuit ?? true;
-    }
-  } catch {
-    // File missing or unreadable; use defaults
-  }
-
+  const { autoDownload, autoInstallOnQuit } = loadUpdaterSettings();
   autoUpdater.autoDownload = autoDownload;
-  autoUpdater.autoInstallOnAppQuit = autoInstallOnAppQuit;
+  autoUpdater.autoInstallOnAppQuit = autoInstallOnQuit;
 
   autoUpdater.on("checking-for-update", () => {
     broadcastStatus({ state: "checking" });
@@ -175,13 +179,22 @@ export function initAutoUpdater(): void {
         title: "Mcode update ready",
         body: `Version ${info.version} has been downloaded. Restart to install.`,
       });
-      notification.on("click", () => promptRestart(info.version));
+      notification.on("click", () => {
+        if (!isPrompting) void promptRestart(info.version);
+      });
       notification.show();
     }
 
     // Also keep the existing modal as a hard prompt so users who only
     // see the chrome get a clear restart affordance.
-    await promptRestart(info.version);
+    if (!isPrompting) {
+      isPrompting = true;
+      try {
+        await promptRestart(info.version);
+      } finally {
+        isPrompting = false;
+      }
+    }
   });
 
   autoUpdater.on("error", (err) => {

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -1,56 +1,254 @@
 /**
  * Configures electron-updater to check GitHub Releases for new versions.
- * Checks once on launch, then every 4 hours while running.
- * Downloads silently; notifies the user when an update is ready to install.
+ * Checks once on launch, then on a configurable interval while running.
+ *
+ * Surfaces update lifecycle events to the renderer over IPC so the UI can
+ * render an in-app banner and an "About" panel showing current state.
+ * Also fires a native OS Notification when an update finishes downloading.
+ *
+ * Update behavior (auto-download, auto-install, check interval) is controlled
+ * via user settings read from settings.json. Changes take effect on next app launch.
  */
 
 import { autoUpdater } from "electron-updater";
-import { app, dialog, BrowserWindow } from "electron";
+import { app, BrowserWindow, dialog, Notification } from "electron";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { getMcodeDir } from "@mcode/shared";
+import { SettingsSchema as BundledSettingsSchema } from "@mcode/contracts";
 
-/** Interval between update checks (4 hours). */
-const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+/** Use snapshot-provided schema when available (V8 snapshot pre-initializes Zod). */
+const SettingsSchema = globalThis.__v8Snapshot?.contracts?.SettingsSchema ?? BundledSettingsSchema;
 
-/** Initializes auto-update checks. Call once after app "ready" fires. */
+/** Map from user-friendly interval names to milliseconds. */
+const INTERVAL_MS_MAP: Record<string, number> = {
+  "15min": 15 * 60 * 1000,
+  "1hour": 60 * 60 * 1000,
+  "4hours": 4 * 60 * 60 * 1000,
+  "1day": 24 * 60 * 60 * 1000,
+  "never": Infinity,
+};
+
+/** Get the configured check interval from settings, or 4 hours if settings cannot be read. */
+function getCheckIntervalMs(): number {
+  try {
+    const raw = readFileSync(join(getMcodeDir(), "settings.json"), "utf-8");
+    const result = SettingsSchema().safeParse(JSON.parse(raw));
+    if (result.success) {
+      const interval = result.data.updates?.checkInterval ?? "4hours";
+      return INTERVAL_MS_MAP[interval] ?? (4 * 60 * 60 * 1000);
+    }
+  } catch {
+    // File missing or unreadable; use default
+  }
+  return 4 * 60 * 60 * 1000; // Default: 4 hours
+}
+
+/** IPC push channel used to broadcast update status to the renderer. */
+export const UPDATE_STATUS_CHANNEL = "app:update-status";
+
+/** Discriminated union describing the current state of the update workflow. */
+export type UpdateStatus =
+  | { state: "idle" }
+  | { state: "checking" }
+  | { state: "available"; version: string; releaseNotes?: string }
+  | { state: "not-available"; version: string }
+  | { state: "downloading"; percent: number; bytesPerSecond?: number }
+  | { state: "downloaded"; version: string; releaseNotes?: string }
+  | { state: "error"; message: string };
+
+let lastStatus: UpdateStatus = { state: "idle" };
+let initialized = false;
+let checkIntervalId: NodeJS.Timeout | null = null;
+let initialCheckTimeoutId: NodeJS.Timeout | null = null;
+
+/** Returns the most recently observed update status (for renderer hydration). */
+export function getUpdateStatus(): UpdateStatus {
+  return lastStatus;
+}
+
+/** Returns true once initAutoUpdater has run (and therefore in a packaged build). */
+export function isUpdaterEnabled(): boolean {
+  return initialized;
+}
+
+/** Broadcast a status change to all open windows. */
+function broadcastStatus(status: UpdateStatus): void {
+  lastStatus = status;
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(UPDATE_STATUS_CHANNEL, status);
+    }
+  }
+}
+
+/**
+ * Manually trigger a check for updates.
+ * Safe to call from the renderer; resolves once the check completes.
+ */
+export async function checkForUpdatesNow(): Promise<UpdateStatus> {
+  if (!initialized) {
+    // In dev mode there is nothing to check against.
+    return { state: "not-available", version: app.getVersion() };
+  }
+  try {
+    broadcastStatus({ state: "checking" });
+    await autoUpdater.checkForUpdates();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    broadcastStatus({ state: "error", message });
+  }
+  return lastStatus;
+}
+
+/** Quit and install a downloaded update. No-op if nothing is downloaded. */
+export function installUpdate(): void {
+  if (!initialized) return;
+  if (lastStatus.state !== "downloaded") return;
+  autoUpdater.quitAndInstall();
+}
+
+/**
+ * Initializes auto-update checks. Call once after app "ready" fires.
+ * No-op in dev (no packaged app to update).
+ */
 export function initAutoUpdater(): void {
-  // In dev, there's no packaged app to update
   if (!app.isPackaged) return;
+  initialized = true;
 
-  autoUpdater.autoDownload = true;
-  autoUpdater.autoInstallOnAppQuit = true;
+  // Read settings to determine auto-update behavior
+  let autoDownload = true;
+  let autoInstallOnAppQuit = true;
+  try {
+    const raw = readFileSync(join(getMcodeDir(), "settings.json"), "utf-8");
+    const result = SettingsSchema().safeParse(JSON.parse(raw));
+    if (result.success) {
+      autoDownload = result.data.updates?.autoDownload ?? true;
+      autoInstallOnAppQuit = result.data.updates?.autoInstallOnQuit ?? true;
+    }
+  } catch {
+    // File missing or unreadable; use defaults
+  }
+
+  autoUpdater.autoDownload = autoDownload;
+  autoUpdater.autoInstallOnAppQuit = autoInstallOnAppQuit;
+
+  autoUpdater.on("checking-for-update", () => {
+    broadcastStatus({ state: "checking" });
+  });
+
+  autoUpdater.on("update-available", (info) => {
+    broadcastStatus({
+      state: "available",
+      version: info.version,
+      releaseNotes: stringifyReleaseNotes(info.releaseNotes),
+    });
+  });
+
+  autoUpdater.on("update-not-available", (info) => {
+    broadcastStatus({
+      state: "not-available",
+      version: info?.version ?? app.getVersion(),
+    });
+  });
+
+  autoUpdater.on("download-progress", (progress) => {
+    broadcastStatus({
+      state: "downloading",
+      percent: Math.round(progress.percent ?? 0),
+      bytesPerSecond: progress.bytesPerSecond,
+    });
+  });
 
   autoUpdater.on("update-downloaded", async (info) => {
-    const window =
-      BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
-    if (!window) return;
-
-    const { response } = await dialog.showMessageBox(window, {
-      type: "info",
-      title: "Update Ready",
-      message: `Version ${info.version} has been downloaded. Restart to apply.`,
-      buttons: ["Restart Now", "Later"],
-      defaultId: 0,
+    const releaseNotes = stringifyReleaseNotes(info.releaseNotes);
+    broadcastStatus({
+      state: "downloaded",
+      version: info.version,
+      releaseNotes,
     });
 
-    if (response === 0) {
-      autoUpdater.quitAndInstall();
+    // Fire a native OS notification so the user is aware even if Mcode
+    // is in the background. Falls back to the in-app banner via IPC.
+    if (Notification.isSupported()) {
+      const notification = new Notification({
+        title: "Mcode update ready",
+        body: `Version ${info.version} has been downloaded. Restart to install.`,
+      });
+      notification.on("click", () => promptRestart(info.version));
+      notification.show();
     }
+
+    // Also keep the existing modal as a hard prompt so users who only
+    // see the chrome get a clear restart affordance.
+    await promptRestart(info.version);
   });
 
   autoUpdater.on("error", (err) => {
-    console.error("[auto-updater] Error checking for updates:", err.message);
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[auto-updater] Error checking for updates:", message);
+    broadcastStatus({ state: "error", message });
   });
 
-  const checkForUpdates = async (): Promise<void> => {
-    try {
-      await autoUpdater.checkForUpdates();
-    } catch (err) {
-      console.error("[auto-updater] checkForUpdates failed:", err);
-    }
-  };
-
   // Initial check shortly after launch (give the window time to load)
-  setTimeout(checkForUpdates, 10_000);
+  initialCheckTimeoutId = setTimeout(() => {
+    void checkForUpdatesNow();
+  }, 10_000);
 
-  // Periodic checks
-  setInterval(checkForUpdates, CHECK_INTERVAL_MS);
+  // Periodic checks using the configured interval
+  const intervalMs = getCheckIntervalMs();
+  if (isFinite(intervalMs)) {
+    checkIntervalId = setInterval(() => {
+      void checkForUpdatesNow();
+    }, intervalMs);
+  }
+}
+
+/**
+ * Clean up timers and listeners when the app is shutting down.
+ * Call from app "quit" or "will-quit" event.
+ */
+export function cleanupAutoUpdater(): void {
+  if (initialCheckTimeoutId) {
+    clearTimeout(initialCheckTimeoutId);
+    initialCheckTimeoutId = null;
+  }
+  if (checkIntervalId) {
+    clearInterval(checkIntervalId);
+    checkIntervalId = null;
+  }
+  autoUpdater.removeAllListeners();
+}
+
+/** Prompt the user to restart and install a downloaded update. */
+async function promptRestart(version: string): Promise<void> {
+  const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+  if (!win) return;
+
+  const { response } = await dialog.showMessageBox(win, {
+    type: "info",
+    title: "Update Ready",
+    message: `Version ${version} has been downloaded. Restart to apply.`,
+    buttons: ["Restart Now", "Later"],
+    defaultId: 0,
+  });
+
+  if (response === 0) {
+    autoUpdater.quitAndInstall();
+  }
+}
+
+/**
+ * Normalize release notes into a plain string. electron-updater can return
+ * either a string, an array of {version, note} entries, or null.
+ */
+function stringifyReleaseNotes(
+  notes: string | Array<{ version: string; note: string | null }> | null | undefined,
+): string | undefined {
+  if (!notes) return undefined;
+  if (typeof notes === "string") return notes;
+  return notes
+    .map((entry) => entry.note?.trim())
+    .filter((note): note is string => Boolean(note))
+    .join("\n\n");
 }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -30,7 +30,13 @@ import { getExtension as bundledGetExtension } from "@mcode/contracts";
 const getExtension = globalThis.__v8Snapshot?.contracts?.getExtension ?? bundledGetExtension;
 import { ServerManager } from "./server-manager.js";
 import { startIpcRelay } from "./ipc-relay.js";
-import { initAutoUpdater } from "./auto-updater.js";
+import {
+  checkForUpdatesNow,
+  getUpdateStatus,
+  initAutoUpdater,
+  installUpdate,
+  cleanupAutoUpdater,
+} from "./auto-updater.js";
 import { setupSpellcheck } from "./spellcheck.js";
 
 // Isolate dev's Electron userData (cache, cookies, localStorage, IndexedDB)
@@ -468,6 +474,14 @@ function registerIpcHandlers(): void {
       mainWindow.webContents.paste();
     }
   });
+
+  // App version + auto-update controls
+  ipcMain.handle("app:get-version", () => app.getVersion());
+  ipcMain.handle("app:get-update-status", () => getUpdateStatus());
+  ipcMain.handle("app:check-for-updates", () => checkForUpdatesNow());
+  ipcMain.handle("app:install-update", () => {
+    installUpdate();
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -676,6 +690,10 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     app.quit();
   }
+});
+
+app.on("will-quit", () => {
+  cleanupAutoUpdater();
 });
 
 export { mainWindow };

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -96,6 +96,36 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     },
   },
 
+  /** App version and auto-update controls. */
+  app: {
+    /** Read the running app version (from package.json at build time). */
+    getVersion(): Promise<string> {
+      return ipcRenderer.invoke("app:get-version");
+    },
+    /** Get the most recent update status without triggering a new check. */
+    getUpdateStatus(): Promise<unknown> {
+      return ipcRenderer.invoke("app:get-update-status");
+    },
+    /** Manually trigger a check for updates. Resolves with the resulting status. */
+    checkForUpdates(): Promise<unknown> {
+      return ipcRenderer.invoke("app:check-for-updates");
+    },
+    /** Quit and install a downloaded update. No-op if nothing is downloaded. */
+    installUpdate(): Promise<void> {
+      return ipcRenderer.invoke("app:install-update");
+    },
+    /** Subscribe to push updates of update-status. Returns the listener for cleanup. */
+    onUpdateStatus(callback: (status: unknown) => void) {
+      const listener = (_event: unknown, status: unknown) => callback(status);
+      ipcRenderer.on("app:update-status", listener);
+      return listener;
+    },
+    /** Remove a previously registered update-status listener. */
+    offUpdateStatus(listener: (...args: unknown[]) => void) {
+      ipcRenderer.removeListener("app:update-status", listener);
+    },
+  },
+
   /** IPC push transport relayed from the main process. */
   ipc: {
     /** Listen for push messages forwarded by the main process IPC relay. */

--- a/apps/web/e2e/about-visual.spec.ts
+++ b/apps/web/e2e/about-visual.spec.ts
@@ -1,0 +1,48 @@
+import { test } from "@playwright/test";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const SCREENSHOT_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "screenshots");
+
+const MOCK_SETTINGS = {
+  appearance: { theme: "dark" },
+  agent: { maxConcurrent: 3, defaults: { mode: "chat", permission: "supervised" } },
+  model: { defaults: { provider: "claude", id: "claude-sonnet-4-6", fallbackId: "claude-sonnet-4-6", reasoning: "high" } },
+  provider: { cli: { codex: "", claude: "", copilot: "" } },
+  prDraft: { provider: "", model: "" },
+  terminal: { scrollback: 1000 },
+  notifications: { enabled: false },
+  worktree: { naming: { mode: "auto", aiConfirmation: true } },
+  server: { memory: { heapMb: 96 } },
+  updates: { autoDownload: true, autoInstallOnQuit: true, checkInterval: "4hours" },
+};
+
+test.describe("About section visual", () => {
+  test.setTimeout(30000);
+
+  test("about settings section screenshot", async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "settings.get": MOCK_SETTINGS,
+      "settings.update": MOCK_SETTINGS,
+    });
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/");
+    await page.waitForTimeout(1000);
+
+    const settingsBtn = page.getByRole("button", { name: "Settings" });
+    await settingsBtn.click();
+    await page.waitForTimeout(800);
+
+    const aboutBtn = page.getByRole("button", { name: "About", exact: true });
+    await aboutBtn.scrollIntoViewIfNeeded();
+    await aboutBtn.click();
+    await page.waitForTimeout(400);
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, "settings-about.png"),
+      fullPage: false,
+    });
+  });
+});

--- a/apps/web/e2e/settings-visual.spec.ts
+++ b/apps/web/e2e/settings-visual.spec.ts
@@ -23,9 +23,10 @@ const DEFAULT_SETTINGS = {
   notifications: { enabled: false },
   worktree: { naming: { mode: "auto", aiConfirmation: true } },
   server: { memory: { heapMb: 96 } },
+  updates: { autoDownload: true, autoInstallOnQuit: true, checkInterval: "4hours" },
 };
 
-const SECTIONS = ["Model", "Agent", "Worktrees", "Appearance", "Notifications", "Terminal", "Server"];
+const SECTIONS = ["Model", "Agent", "Worktrees", "Appearance", "Notifications", "Terminal", "Server", "About"];
 
 test.describe("Settings visual review", () => {
   test.beforeEach(async ({ page }) => {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -52,7 +52,9 @@ export function App() {
 
     void bridge.getVersion().then((v) => useUpdateStore.getState().setVersion(v));
     void bridge.getUpdateStatus().then((s) => {
-      if (s) useUpdateStore.getState().setStatus(s as UpdateStatus);
+      if (s && useUpdateStore.getState().status.state === "idle") {
+        useUpdateStore.getState().setStatus(s as UpdateStatus);
+      }
     });
 
     const listener = bridge.onUpdateStatus((status) => {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -3,6 +3,9 @@ import { Sidebar } from "@/components/sidebar/Sidebar";
 import { ChatView } from "@/components/chat/ChatView";
 import { SettingsView } from "@/components/settings/SettingsView";
 import { ConnectionBanner } from "@/components/ConnectionBanner";
+import { UpdateBanner } from "@/components/UpdateBanner";
+import { useUpdateStore } from "@/stores/updateStore";
+import type { UpdateStatus } from "@/transport/desktop-bridge";
 import { TerminalPanel } from "@/components/terminal";
 import { RightPanel } from "@/components/panels/RightPanel";
 import { CommandPalette } from "@/components/CommandPalette";
@@ -40,6 +43,22 @@ export function App() {
     startPushListeners();
     useSettingsStore.getState().fetch();
     return () => stopPushListeners();
+  }, []);
+
+  // Hydrate app version + auto-updater status from the Electron preload bridge.
+  useEffect(() => {
+    const bridge = window.desktopBridge?.app;
+    if (!bridge) return;
+
+    void bridge.getVersion().then((v) => useUpdateStore.getState().setVersion(v));
+    void bridge.getUpdateStatus().then((s) => {
+      if (s) useUpdateStore.getState().setStatus(s as UpdateStatus);
+    });
+
+    const listener = bridge.onUpdateStatus((status) => {
+      useUpdateStore.getState().setStatus(status);
+    });
+    return () => bridge.offUpdateStatus(listener);
   }, []);
 
   // Listen for deep-link requests to open a specific settings section
@@ -261,6 +280,7 @@ export function App() {
           appears lifted off the chrome — no inter-panel divider lines required. */}
       <div className="flex h-screen flex-col overflow-hidden bg-page text-foreground">
         <ConnectionBanner />
+        <UpdateBanner />
         <div className="flex flex-1 gap-1.5 overflow-hidden p-1.5">
           {/* Settings view force-expands the sidebar so the settings nav is reachable.
               When the sidebar is hidden, the chat panel claims the full width and the

--- a/apps/web/src/components/UpdateBanner.tsx
+++ b/apps/web/src/components/UpdateBanner.tsx
@@ -41,7 +41,7 @@ export function UpdateBanner() {
       <div className="space-y-1.5 bg-blue-600/90 px-4 py-2 text-white">
         <div className="flex items-center justify-between">
           <span className="flex-1 text-xs font-medium">
-            Update available — version {status.version} is downloading.
+            Update available — version {status.version} is ready to install.
           </span>
           {status.releaseNotes && (
             <button

--- a/apps/web/src/components/UpdateBanner.tsx
+++ b/apps/web/src/components/UpdateBanner.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import { useUpdateStore } from "@/stores/updateStore";
+
+/**
+ * Banner shown across the top of the app when an update is downloading or
+ * ready to install. Hidden in non-Electron environments and when the user
+ * has dismissed the current state. Includes expandable release notes.
+ */
+export function UpdateBanner() {
+  const status = useUpdateStore((s) => s.status);
+  const dismissed = useUpdateStore((s) => s.bannerDismissed);
+  const dismiss = useUpdateStore((s) => s.dismissBanner);
+  const [showReleaseNotes, setShowReleaseNotes] = useState(false);
+
+  if (dismissed) return null;
+  if (!window.desktopBridge) return null;
+
+  if (status.state === "downloading") {
+    return (
+      <div className="space-y-1.5 bg-blue-600/90 px-4 py-2 text-white">
+        <div className="flex items-center justify-center gap-2">
+          <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+          <span className="flex-1 text-xs font-medium">
+            Downloading update… {status.percent}%
+          </span>
+          <button
+            onClick={dismiss}
+            className="rounded px-2 py-0.5 text-xs hover:bg-white/15"
+            aria-label="Dismiss banner"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (status.state === "available") {
+    return (
+      <div className="space-y-1.5 bg-blue-600/90 px-4 py-2 text-white">
+        <div className="flex items-center justify-between">
+          <span className="flex-1 text-xs font-medium">
+            Update available — version {status.version} is downloading.
+          </span>
+          {status.releaseNotes && (
+            <button
+              onClick={() => setShowReleaseNotes(!showReleaseNotes)}
+              className="mx-1 rounded px-2 py-0.5 text-xs hover:bg-white/15"
+            >
+              {showReleaseNotes ? "Hide" : "Show"} notes
+            </button>
+          )}
+          <button
+            onClick={dismiss}
+            className="rounded px-2 py-0.5 text-xs hover:bg-white/15"
+            aria-label="Dismiss banner"
+          >
+            ×
+          </button>
+        </div>
+        {showReleaseNotes && status.releaseNotes && (
+          <div className="max-h-32 overflow-y-auto rounded bg-white/10 px-2 py-1.5 text-xs font-normal leading-relaxed">
+            {status.releaseNotes}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (status.state === "downloaded") {
+    return (
+      <div className="space-y-1.5 bg-emerald-600/95 px-4 py-2 text-white">
+        <div className="flex items-center justify-between">
+          <span className="flex-1 text-xs font-medium">
+            Update {status.version} is ready. Restart Mcode to apply.
+          </span>
+          {status.releaseNotes && (
+            <button
+              onClick={() => setShowReleaseNotes(!showReleaseNotes)}
+              className="mx-1 rounded px-2 py-0.5 text-xs hover:bg-white/15"
+            >
+              {showReleaseNotes ? "Hide" : "Show"} notes
+            </button>
+          )}
+          <button
+            onClick={() => void window.desktopBridge?.app.installUpdate()}
+            className="rounded bg-white/15 px-2 py-0.5 text-xs hover:bg-white/25"
+          >
+            Restart now
+          </button>
+          <button
+            onClick={dismiss}
+            className="rounded px-2 py-0.5 text-xs hover:bg-white/15"
+            aria-label="Dismiss banner"
+          >
+            ×
+          </button>
+        </div>
+        {showReleaseNotes && status.releaseNotes && (
+          <div className="max-h-32 overflow-y-auto rounded bg-white/10 px-2 py-1.5 text-xs font-normal leading-relaxed">
+            {status.releaseNotes}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/apps/web/src/components/UpdateBanner.tsx
+++ b/apps/web/src/components/UpdateBanner.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Loader2 } from "lucide-react";
 import { useUpdateStore } from "@/stores/updateStore";
 
 /**
@@ -19,21 +20,7 @@ export function UpdateBanner() {
     return (
       <div className="space-y-1.5 bg-blue-600/90 px-4 py-2 text-white">
         <div className="flex items-center justify-center gap-2">
-          <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            />
-          </svg>
+          <Loader2 size={14} className="animate-spin" aria-hidden="true" />
           <span className="flex-1 text-xs font-medium">
             Downloading update… {status.percent}%
           </span>
@@ -72,11 +59,7 @@ export function UpdateBanner() {
             ×
           </button>
         </div>
-        {showReleaseNotes && status.releaseNotes && (
-          <div className="max-h-32 overflow-y-auto rounded bg-white/10 px-2 py-1.5 text-xs font-normal leading-relaxed">
-            {status.releaseNotes}
-          </div>
-        )}
+        <ReleaseNotesSection notes={status.releaseNotes} visible={showReleaseNotes} />
       </div>
     );
   }
@@ -110,14 +93,20 @@ export function UpdateBanner() {
             ×
           </button>
         </div>
-        {showReleaseNotes && status.releaseNotes && (
-          <div className="max-h-32 overflow-y-auto rounded bg-white/10 px-2 py-1.5 text-xs font-normal leading-relaxed">
-            {status.releaseNotes}
-          </div>
-        )}
+        <ReleaseNotesSection notes={status.releaseNotes} visible={showReleaseNotes} />
       </div>
     );
   }
 
   return null;
+}
+
+/** Collapsible release-notes panel rendered beneath the banner action row. */
+function ReleaseNotesSection({ notes, visible }: { notes?: string; visible: boolean }) {
+  if (!visible || !notes) return null;
+  return (
+    <div className="max-h-32 overflow-y-auto rounded bg-white/10 px-2 py-1.5 text-xs font-normal leading-relaxed">
+      {notes}
+    </div>
+  );
 }

--- a/apps/web/src/components/settings/sections/AboutSection.tsx
+++ b/apps/web/src/components/settings/sections/AboutSection.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import { Loader2 } from "lucide-react";
 import { useUpdateStore } from "@/stores/updateStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { SettingRow } from "../SettingRow";
@@ -17,6 +18,9 @@ const INTERVAL_OPTIONS = [
   { value: "never", label: "Off" },
 ];
 
+/** How long to hold the "Up to date" label after a check resolves with no update (ms). */
+const UP_TO_DATE_HOLD_MS = 4_000;
+
 /**
  * About settings section: shows the running app version, the current
  * auto-updater state, and controls for update behavior.
@@ -29,12 +33,49 @@ export function AboutSection() {
   const status = useUpdateStore((s) => s.status);
   const settings = useSettingsStore((s) => s.settings);
   const updateSettings = useSettingsStore((s) => s.update);
+
+  /** True while a manually-triggered check is in flight. */
   const [checking, setChecking] = useState(false);
+  /** Transient label shown for UP_TO_DATE_HOLD_MS after "no update" resolves. */
+  const [upToDateLabel, setUpToDateLabel] = useState(false);
+  const upToDateTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const bridge = typeof window !== "undefined" ? window.desktopBridge?.app : undefined;
 
+  // When the status transitions to "not-available" after we were checking,
+  // briefly show "Up to date" so the user sees the result of their click.
+  const prevStatusRef = useRef(status.state);
+  useEffect(() => {
+    if (
+      prevStatusRef.current === "checking" &&
+      status.state === "not-available"
+    ) {
+      setUpToDateLabel(true);
+      if (upToDateTimer.current) clearTimeout(upToDateTimer.current);
+      upToDateTimer.current = setTimeout(() => {
+        setUpToDateLabel(false);
+      }, UP_TO_DATE_HOLD_MS);
+    }
+    // Any active update state clears the transient label.
+    if (
+      status.state === "available" ||
+      status.state === "downloading" ||
+      status.state === "downloaded"
+    ) {
+      setUpToDateLabel(false);
+      if (upToDateTimer.current) clearTimeout(upToDateTimer.current);
+    }
+    prevStatusRef.current = status.state;
+  }, [status.state]);
+
+  // Clean up timer on unmount.
+  useEffect(() => () => {
+    if (upToDateTimer.current) clearTimeout(upToDateTimer.current);
+  }, []);
+
   const handleCheck = async (): Promise<void> => {
     if (!bridge) return;
+    setUpToDateLabel(false);
     setChecking(true);
     try {
       await bridge.checkForUpdates();
@@ -51,17 +92,16 @@ export function AboutSection() {
   const autoInstallOnQuit = settings.updates?.autoInstallOnQuit ?? true;
   const checkInterval = settings.updates?.checkInterval ?? "4hours";
 
-  const statusLabel = describeStatus(status);
   const isBusy = checking || status.state === "checking" || status.state === "downloading";
+
+  // Derive the inline status label shown beside the button.
+  const statusLabel = upToDateLabel ? "Up to date" : describeStatus(status);
 
   return (
     <div>
       <SectionHeading>About</SectionHeading>
       <div>
-        <SettingRow
-          label="Version"
-          hint="Currently installed build."
-        >
+        <SettingRow label="Version" hint="Currently installed build.">
           <span className="font-mono text-xs text-muted-foreground tabular-nums">
             {version || "—"}
           </span>
@@ -69,14 +109,22 @@ export function AboutSection() {
 
         <SettingRow
           label="Updates"
-          hint={checkInterval === "never" ? "Automatic checks disabled." : "Checks for new releases on the configured interval."}
+          hint={
+            checkInterval === "never"
+              ? "Automatic checks disabled."
+              : "Checks for new releases on the configured interval."
+          }
         >
           <div className="flex items-center gap-3">
             {statusLabel && (
-              <span className="font-mono text-xs text-muted-foreground">
+              <span
+                className="font-mono text-xs text-muted-foreground transition-opacity duration-300"
+                aria-live="polite"
+              >
                 {statusLabel}
               </span>
             )}
+
             {status.state === "downloaded" ? (
               <button
                 onClick={handleInstall}
@@ -88,8 +136,16 @@ export function AboutSection() {
               <button
                 onClick={() => void handleCheck()}
                 disabled={!bridge || isBusy}
-                className="rounded bg-muted px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex items-center gap-1.5 rounded bg-muted px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-40"
+                aria-label={isBusy ? "Checking for updates…" : "Check for updates now"}
               >
+                {isBusy && (
+                  <Loader2
+                    size={11}
+                    className="animate-spin"
+                    aria-hidden="true"
+                  />
+                )}
                 {isBusy ? "Checking…" : "Check now"}
               </button>
             )}
@@ -103,7 +159,11 @@ export function AboutSection() {
           <SegControl
             options={INTERVAL_OPTIONS}
             value={checkInterval}
-            onChange={(v) => void updateSettings({ updates: { checkInterval: v as UpdateCheckInterval } })}
+            onChange={(v) =>
+              void updateSettings({
+                updates: { checkInterval: v as UpdateCheckInterval },
+              })
+            }
           />
         </SettingRow>
 
@@ -113,7 +173,9 @@ export function AboutSection() {
         >
           <Switch
             checked={autoDownload}
-            onCheckedChange={(v) => void updateSettings({ updates: { autoDownload: v } })}
+            onCheckedChange={(v) =>
+              void updateSettings({ updates: { autoDownload: v } })
+            }
           />
         </SettingRow>
 
@@ -123,7 +185,9 @@ export function AboutSection() {
         >
           <Switch
             checked={autoInstallOnQuit}
-            onCheckedChange={(v) => void updateSettings({ updates: { autoInstallOnQuit: v } })}
+            onCheckedChange={(v) =>
+              void updateSettings({ updates: { autoInstallOnQuit: v } })
+            }
           />
         </SettingRow>
       </div>
@@ -131,7 +195,7 @@ export function AboutSection() {
   );
 }
 
-/** Render the auto-updater status as a short monospace label, or empty string when idle/up-to-date. */
+/** Short status label shown beside the button. Returns empty string when nothing noteworthy is happening. */
 function describeStatus(status: UpdateStatus): string {
   switch (status.state) {
     case "idle":

--- a/apps/web/src/components/settings/sections/AboutSection.tsx
+++ b/apps/web/src/components/settings/sections/AboutSection.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import { useUpdateStore } from "@/stores/updateStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { SettingRow } from "../SettingRow";
+import { SectionHeading } from "../SectionHeading";
+import type { UpdateStatus } from "@/transport/desktop-bridge";
+import type { UpdateCheckInterval } from "@mcode/contracts";
+
+/**
+ * About settings section: shows the running app version, the current
+ * auto-updater state, and a manual "Check for updates" button.
+ *
+ * The version is read from the Electron main process at startup, so it
+ * always reflects the installed build without manual maintenance.
+ */
+export function AboutSection() {
+  const version = useUpdateStore((s) => s.version);
+  const status = useUpdateStore((s) => s.status);
+  const settings = useSettingsStore((s) => s.settings);
+  const updateSettings = useSettingsStore((s) => s.update);
+  const [checking, setChecking] = useState(false);
+
+  const bridge = typeof window !== "undefined" ? window.desktopBridge?.app : undefined;
+
+  const handleCheck = async (): Promise<void> => {
+    if (!bridge) return;
+    setChecking(true);
+    try {
+      await bridge.checkForUpdates();
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleInstall = (): void => {
+    void bridge?.installUpdate();
+  };
+
+  const handleAutoDownloadChange = (enabled: boolean): void => {
+    void updateSettings({ updates: { autoDownload: enabled } });
+  };
+
+  const handleAutoInstallChange = (enabled: boolean): void => {
+    void updateSettings({ updates: { autoInstallOnQuit: enabled } });
+  };
+
+  const handleCheckIntervalChange = (interval: UpdateCheckInterval): void => {
+    void updateSettings({ updates: { checkInterval: interval } });
+  };
+
+  const autoDownload = settings.updates?.autoDownload ?? true;
+  const autoInstallOnQuit = settings.updates?.autoInstallOnQuit ?? true;
+  const checkInterval = settings.updates?.checkInterval ?? "4hours";
+
+  return (
+    <div>
+      <SectionHeading>About</SectionHeading>
+      <div>
+        <SettingRow
+          label="Version"
+          hint="The currently installed version of Mcode."
+        >
+          <span className="rounded bg-muted px-2 py-1 font-mono text-xs text-foreground">
+            {version || "—"}
+          </span>
+        </SettingRow>
+
+        <SettingRow
+          label="Updates"
+          hint="Check for new versions of Mcode."
+        >
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">
+              {describeStatus(status)}
+            </span>
+            {status.state === "downloaded" ? (
+              <button
+                onClick={handleInstall}
+                className="rounded bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700"
+              >
+                Restart to install
+              </button>
+            ) : (
+              <button
+                onClick={() => void handleCheck()}
+                disabled={!bridge || checking || status.state === "checking" || status.state === "downloading"}
+                className="rounded bg-foreground/10 px-3 py-1.5 text-xs font-medium text-foreground hover:bg-foreground/15 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {checking || status.state === "checking" ? "Checking…" : "Check now"}
+              </button>
+            )}
+          </div>
+        </SettingRow>
+
+        <SettingRow
+          label="Auto-download"
+          hint="Automatically download updates when they become available."
+        >
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={autoDownload}
+              onChange={(e) => handleAutoDownloadChange(e.target.checked)}
+              className="h-4 w-4 rounded border border-input bg-background"
+            />
+            <span className="text-xs text-muted-foreground">
+              {autoDownload ? "Enabled" : "Disabled"}
+            </span>
+          </label>
+        </SettingRow>
+
+        <SettingRow
+          label="Auto-install"
+          hint="Automatically install updates when the app closes."
+        >
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={autoInstallOnQuit}
+              onChange={(e) => handleAutoInstallChange(e.target.checked)}
+              className="h-4 w-4 rounded border border-input bg-background"
+            />
+            <span className="text-xs text-muted-foreground">
+              {autoInstallOnQuit ? "Enabled" : "Disabled"}
+            </span>
+          </label>
+        </SettingRow>
+
+        <SettingRow
+          label="Check interval"
+          hint="How often to check for updates (takes effect on next app launch)."
+        >
+          <select
+            value={checkInterval}
+            onChange={(e) => handleCheckIntervalChange(e.target.value as UpdateCheckInterval)}
+            className="rounded border border-input bg-background px-2 py-1.5 text-xs text-foreground"
+          >
+            <option value="15min">Every 15 minutes</option>
+            <option value="1hour">Every hour</option>
+            <option value="4hours">Every 4 hours</option>
+            <option value="1day">Every day</option>
+            <option value="never">Never</option>
+          </select>
+        </SettingRow>
+      </div>
+    </div>
+  );
+}
+
+/** Render the auto-updater status as a short, user-facing string. */
+function describeStatus(status: UpdateStatus): string {
+  switch (status.state) {
+    case "idle":
+      return "Idle";
+    case "checking":
+      return "Checking for updates…";
+    case "available":
+      return `Version ${status.version} is available — downloading…`;
+    case "not-available":
+      return "You're on the latest version.";
+    case "downloading":
+      return `Downloading update… ${status.percent}%`;
+    case "downloaded":
+      return `Version ${status.version} is downloaded.`;
+    case "error":
+      return `Update check failed: ${status.message}`;
+  }
+}

--- a/apps/web/src/components/settings/sections/AboutSection.tsx
+++ b/apps/web/src/components/settings/sections/AboutSection.tsx
@@ -79,13 +79,21 @@ export function AboutSection() {
     setChecking(true);
     try {
       await bridge.checkForUpdates();
+    } catch {
+      // The main process broadcasts an error status via IPC, which surfaces as
+      // status.state === "error" and renders "Check failed" in the status label.
     } finally {
       setChecking(false);
     }
   };
 
-  const handleInstall = (): void => {
-    void bridge?.installUpdate();
+  const handleInstall = async (): Promise<void> => {
+    if (!bridge) return;
+    try {
+      await bridge.installUpdate();
+    } catch {
+      // installUpdate triggers a quit-and-restart; rejections here are unexpected.
+    }
   };
 
   const autoDownload = settings.updates?.autoDownload ?? true;

--- a/apps/web/src/components/settings/sections/AboutSection.tsx
+++ b/apps/web/src/components/settings/sections/AboutSection.tsx
@@ -195,7 +195,11 @@ export function AboutSection() {
   );
 }
 
-/** Short status label shown beside the button. Returns empty string when nothing noteworthy is happening. */
+/**
+ * Short status label shown beside the button.
+ * @param status - Current update status from the Electron main process.
+ * @returns Human-readable label, or empty string when nothing noteworthy is happening.
+ */
 function describeStatus(status: UpdateStatus): string {
   switch (status.state) {
     case "idle":

--- a/apps/web/src/components/settings/sections/AboutSection.tsx
+++ b/apps/web/src/components/settings/sections/AboutSection.tsx
@@ -3,12 +3,23 @@ import { useUpdateStore } from "@/stores/updateStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { SettingRow } from "../SettingRow";
 import { SectionHeading } from "../SectionHeading";
+import { Switch } from "@/components/ui/switch";
+import { SegControl } from "../SegControl";
 import type { UpdateStatus } from "@/transport/desktop-bridge";
 import type { UpdateCheckInterval } from "@mcode/contracts";
 
+/** Segmented control options for update check frequency. */
+const INTERVAL_OPTIONS = [
+  { value: "15min", label: "15m" },
+  { value: "1hour", label: "1h" },
+  { value: "4hours", label: "4h" },
+  { value: "1day", label: "1d" },
+  { value: "never", label: "Off" },
+];
+
 /**
  * About settings section: shows the running app version, the current
- * auto-updater state, and a manual "Check for updates" button.
+ * auto-updater state, and controls for update behavior.
  *
  * The version is read from the Electron main process at startup, so it
  * always reflects the installed build without manual maintenance.
@@ -36,21 +47,12 @@ export function AboutSection() {
     void bridge?.installUpdate();
   };
 
-  const handleAutoDownloadChange = (enabled: boolean): void => {
-    void updateSettings({ updates: { autoDownload: enabled } });
-  };
-
-  const handleAutoInstallChange = (enabled: boolean): void => {
-    void updateSettings({ updates: { autoInstallOnQuit: enabled } });
-  };
-
-  const handleCheckIntervalChange = (interval: UpdateCheckInterval): void => {
-    void updateSettings({ updates: { checkInterval: interval } });
-  };
-
   const autoDownload = settings.updates?.autoDownload ?? true;
   const autoInstallOnQuit = settings.updates?.autoInstallOnQuit ?? true;
   const checkInterval = settings.updates?.checkInterval ?? "4hours";
+
+  const statusLabel = describeStatus(status);
+  const isBusy = checking || status.state === "checking" || status.state === "downloading";
 
   return (
     <div>
@@ -58,111 +60,92 @@ export function AboutSection() {
       <div>
         <SettingRow
           label="Version"
-          hint="The currently installed version of Mcode."
+          hint="Currently installed build."
         >
-          <span className="rounded bg-muted px-2 py-1 font-mono text-xs text-foreground">
+          <span className="font-mono text-xs text-muted-foreground tabular-nums">
             {version || "—"}
           </span>
         </SettingRow>
 
         <SettingRow
           label="Updates"
-          hint="Check for new versions of Mcode."
+          hint={checkInterval === "never" ? "Automatic checks disabled." : "Checks for new releases on the configured interval."}
         >
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">
-              {describeStatus(status)}
-            </span>
+          <div className="flex items-center gap-3">
+            {statusLabel && (
+              <span className="font-mono text-xs text-muted-foreground">
+                {statusLabel}
+              </span>
+            )}
             {status.state === "downloaded" ? (
               <button
                 onClick={handleInstall}
-                className="rounded bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700"
+                className="rounded bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
               >
                 Restart to install
               </button>
             ) : (
               <button
                 onClick={() => void handleCheck()}
-                disabled={!bridge || checking || status.state === "checking" || status.state === "downloading"}
-                className="rounded bg-foreground/10 px-3 py-1.5 text-xs font-medium text-foreground hover:bg-foreground/15 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={!bridge || isBusy}
+                className="rounded bg-muted px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-40"
               >
-                {checking || status.state === "checking" ? "Checking…" : "Check now"}
+                {isBusy ? "Checking…" : "Check now"}
               </button>
             )}
           </div>
         </SettingRow>
 
         <SettingRow
-          label="Auto-download"
-          hint="Automatically download updates when they become available."
-        >
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={autoDownload}
-              onChange={(e) => handleAutoDownloadChange(e.target.checked)}
-              className="h-4 w-4 rounded border border-input bg-background"
-            />
-            <span className="text-xs text-muted-foreground">
-              {autoDownload ? "Enabled" : "Disabled"}
-            </span>
-          </label>
-        </SettingRow>
-
-        <SettingRow
-          label="Auto-install"
-          hint="Automatically install updates when the app closes."
-        >
-          <label className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={autoInstallOnQuit}
-              onChange={(e) => handleAutoInstallChange(e.target.checked)}
-              className="h-4 w-4 rounded border border-input bg-background"
-            />
-            <span className="text-xs text-muted-foreground">
-              {autoInstallOnQuit ? "Enabled" : "Disabled"}
-            </span>
-          </label>
-        </SettingRow>
-
-        <SettingRow
           label="Check interval"
-          hint="How often to check for updates (takes effect on next app launch)."
+          hint="How often to poll for new releases. Takes effect on next launch."
         >
-          <select
+          <SegControl
+            options={INTERVAL_OPTIONS}
             value={checkInterval}
-            onChange={(e) => handleCheckIntervalChange(e.target.value as UpdateCheckInterval)}
-            className="rounded border border-input bg-background px-2 py-1.5 text-xs text-foreground"
-          >
-            <option value="15min">Every 15 minutes</option>
-            <option value="1hour">Every hour</option>
-            <option value="4hours">Every 4 hours</option>
-            <option value="1day">Every day</option>
-            <option value="never">Never</option>
-          </select>
+            onChange={(v) => void updateSettings({ updates: { checkInterval: v as UpdateCheckInterval } })}
+          />
+        </SettingRow>
+
+        <SettingRow
+          label="Auto-download"
+          hint="Download updates in the background as soon as they are available."
+        >
+          <Switch
+            checked={autoDownload}
+            onCheckedChange={(v) => void updateSettings({ updates: { autoDownload: v } })}
+          />
+        </SettingRow>
+
+        <SettingRow
+          label="Auto-install on quit"
+          hint="Apply downloaded updates automatically when the app closes."
+        >
+          <Switch
+            checked={autoInstallOnQuit}
+            onCheckedChange={(v) => void updateSettings({ updates: { autoInstallOnQuit: v } })}
+          />
         </SettingRow>
       </div>
     </div>
   );
 }
 
-/** Render the auto-updater status as a short, user-facing string. */
+/** Render the auto-updater status as a short monospace label, or empty string when idle/up-to-date. */
 function describeStatus(status: UpdateStatus): string {
   switch (status.state) {
     case "idle":
-      return "Idle";
-    case "checking":
-      return "Checking for updates…";
-    case "available":
-      return `Version ${status.version} is available — downloading…`;
     case "not-available":
-      return "You're on the latest version.";
+      return "";
+    case "checking":
+      return "Checking…";
+    case "available":
+      return `v${status.version} available`;
     case "downloading":
-      return `Downloading update… ${status.percent}%`;
+      return `${status.percent}%`;
     case "downloaded":
-      return `Version ${status.version} is downloaded.`;
+      return `v${status.version} ready`;
     case "error":
-      return `Update check failed: ${status.message}`;
+      return "Check failed";
   }
 }

--- a/apps/web/src/components/settings/settings-nav.ts
+++ b/apps/web/src/components/settings/settings-nav.ts
@@ -21,6 +21,7 @@ export type SettingsSection =
   | "server"
   | "about";
 
+/** Represents a navigation group in the settings sidebar. */
 export interface NavGroup {
   label: string;
   items: { id: SettingsSection; label: string }[];

--- a/apps/web/src/components/settings/settings-nav.ts
+++ b/apps/web/src/components/settings/settings-nav.ts
@@ -7,6 +7,7 @@ import { NotificationsSection } from "./sections/NotificationsSection";
 import { TerminalSection } from "./sections/TerminalSection";
 import { ServerSection } from "./sections/ServerSection";
 import { KeyboardShortcutsSection } from "./sections/KeyboardShortcutsSection";
+import { AboutSection } from "./sections/AboutSection";
 
 export type SettingsSection =
   | "model"
@@ -16,7 +17,8 @@ export type SettingsSection =
   | "notifications"
   | "terminal"
   | "keyboard"
-  | "server";
+  | "server"
+  | "about";
 
 export interface NavGroup {
   label: string;
@@ -44,7 +46,10 @@ export const NAV_GROUPS: NavGroup[] = [
   },
   {
     label: "System",
-    items: [{ id: "server", label: "Server" }],
+    items: [
+      { id: "server", label: "Server" },
+      { id: "about", label: "About" },
+    ],
   },
 ];
 
@@ -58,4 +63,5 @@ export const SECTION_MAP: Record<SettingsSection, ComponentType> = {
   terminal: TerminalSection,
   keyboard: KeyboardShortcutsSection,
   server: ServerSection,
+  about: AboutSection,
 };

--- a/apps/web/src/components/settings/settings-nav.ts
+++ b/apps/web/src/components/settings/settings-nav.ts
@@ -9,6 +9,7 @@ import { ServerSection } from "./sections/ServerSection";
 import { KeyboardShortcutsSection } from "./sections/KeyboardShortcutsSection";
 import { AboutSection } from "./sections/AboutSection";
 
+/** Available settings pages/sections in the app. */
 export type SettingsSection =
   | "model"
   | "agent"

--- a/apps/web/src/stores/updateStore.ts
+++ b/apps/web/src/stores/updateStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import type { UpdateStatus } from "@/transport/desktop-bridge";
+
+interface UpdateState {
+  /** App version reported by the Electron main process. Empty until hydrated. */
+  version: string;
+  /** Whether the user has dismissed the in-app update banner for this session. */
+  bannerDismissed: boolean;
+  /** Most recent auto-updater status pushed from the main process. */
+  status: UpdateStatus;
+  /** Replace the version string. Called once at startup. */
+  setVersion: (version: string) => void;
+  /** Replace the current update status. Called by the IPC listener. */
+  setStatus: (status: UpdateStatus) => void;
+  /** Hide the banner for the rest of this session (resets when a new state arrives). */
+  dismissBanner: () => void;
+}
+
+/**
+ * Zustand store tracking the running app version and the auto-updater
+ * lifecycle. Hydrated from the Electron preload bridge on startup; updated
+ * via push events on the `app:update-status` IPC channel.
+ */
+export const useUpdateStore = create<UpdateState>((set) => ({
+  version: "",
+  bannerDismissed: false,
+  status: { state: "idle" },
+  setVersion: (version) => set({ version }),
+  setStatus: (status) => set({ status, bannerDismissed: false }),
+  dismissBanner: () => set({ bannerDismissed: true }),
+}));

--- a/apps/web/src/stores/updateStore.ts
+++ b/apps/web/src/stores/updateStore.ts
@@ -26,6 +26,6 @@ export const useUpdateStore = create<UpdateState>((set) => ({
   bannerDismissed: false,
   status: { state: "idle" },
   setVersion: (version) => set({ version }),
-  setStatus: (status) => set({ status, bannerDismissed: false }),
+  setStatus: (status) => set({ status }),
   dismissBanner: () => set({ bannerDismissed: true }),
 }));

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -1,5 +1,31 @@
 import type { AttachmentMeta } from "./types";
 
+/** Discriminated union describing the auto-updater lifecycle state. */
+export type UpdateStatus =
+  | { state: "idle" }
+  | { state: "checking" }
+  | { state: "available"; version: string; releaseNotes?: string }
+  | { state: "not-available"; version: string }
+  | { state: "downloading"; percent: number; bytesPerSecond?: number }
+  | { state: "downloaded"; version: string; releaseNotes?: string }
+  | { state: "error"; message: string };
+
+/** App version and auto-update controls exposed by the main process. */
+interface AppBridge {
+  /** Read the running app version (from package.json at build time). */
+  getVersion(): Promise<string>;
+  /** Get the most recent update status without triggering a new check. */
+  getUpdateStatus(): Promise<UpdateStatus>;
+  /** Manually trigger a check for updates. Resolves with the resulting status. */
+  checkForUpdates(): Promise<UpdateStatus>;
+  /** Quit and install a downloaded update. No-op if nothing is downloaded. */
+  installUpdate(): Promise<void>;
+  /** Subscribe to push updates of update-status. Returns the listener for cleanup. */
+  onUpdateStatus(callback: (status: UpdateStatus) => void): (...args: unknown[]) => void;
+  /** Remove a previously registered update-status listener. */
+  offUpdateStatus(listener: (...args: unknown[]) => void): void;
+}
+
 /** IPC push transport relayed from the Electron main process. */
 interface IpcBridge {
   /** Register a callback for push messages forwarded by the main process. */
@@ -79,6 +105,8 @@ interface DesktopBridge {
   openKeybindingsFile(): Promise<string>;
   /** Spellcheck context menu and dictionary management. */
   spellcheck: SpellcheckBridge;
+  /** App version and auto-update controls. */
+  app: AppBridge;
   /** IPC push transport relayed from the main process. */
   ipc: IpcBridge;
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -55,6 +55,7 @@ export {
   ReasoningLevelSchema,
   ProviderIdSchema,
   NamingModeSchema,
+  UpdateCheckIntervalSchema,
 } from "./models/settings.js";
 export type {
   Settings,
@@ -64,6 +65,7 @@ export type {
   ReasoningLevel,
   SettingsProviderId,
   NamingMode,
+  UpdateCheckInterval,
 } from "./models/settings.js";
 
 export {

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -42,6 +42,11 @@ export const NamingModeSchema = z.enum(["auto", "custom", "ai"]);
 /** Worktree branch naming strategy value. */
 export type NamingMode = z.infer<typeof NamingModeSchema>;
 
+/** Auto-update check interval. */
+export const UpdateCheckIntervalSchema = z.enum(["15min", "1hour", "4hours", "1day", "never"]);
+/** Auto-update check interval value. */
+export type UpdateCheckInterval = z.infer<typeof UpdateCheckIntervalSchema>;
+
 // ---------------------------------------------------------------------------
 // Settings schema
 // ---------------------------------------------------------------------------
@@ -239,6 +244,18 @@ export const SettingsSchema = lazySchema(() =>
         model: z.string().default(""),
       })
       .default({}),
+
+    /** App auto-update settings. */
+    updates: z
+      .object({
+        /** Whether to automatically download available updates. */
+        autoDownload: z.boolean().default(true),
+        /** Whether to automatically install updates when the app quits. */
+        autoInstallOnQuit: z.boolean().default(true),
+        /** How often to check for updates. */
+        checkInterval: UpdateCheckIntervalSchema.default("4hours"),
+      })
+      .default({}),
   }),
 );
 
@@ -367,6 +384,13 @@ export const PartialSettingsSchema = lazySchema(() =>
       .object({
         provider: ProviderIdSchema.or(z.literal("")).optional(),
         model: z.string().optional(),
+      })
+      .optional(),
+    updates: z
+      .object({
+        autoDownload: z.boolean().optional(),
+        autoInstallOnQuit: z.boolean().optional(),
+        checkInterval: UpdateCheckIntervalSchema.optional(),
       })
       .optional(),
   }),


### PR DESCRIPTION
## What

Adds a full auto-updater integration for the Mcode desktop app: in-app banner, About settings section with version display and manual check button, and configurable update behavior.

## Why

Users had no way to know a new version was available, see the running version, or control update behavior. The Electron app was using `electron-updater` but none of the update lifecycle was surfaced to the UI.

## Key changes

- **`auto-updater.ts`** - Initializes `electron-updater`, broadcasts status via `app:update-status` IPC channel, fires OS notification on download complete, schedules periodic checks using user-configured interval; `cleanupAutoUpdater()` clears timers on quit. `loadUpdaterSettings()` consolidates the single settings.json read. `isPrompting` guard prevents the restart dialog opening twice if the user clicks the OS notification while the dialog is already open.
- **`updateStore.ts`** - Zustand store tracking `version`, `status`, and `bannerDismissed`; `setStatus` no longer resets `bannerDismissed` on every download-progress tick.
- **`UpdateBanner.tsx`** - Sticky banner for `downloading` / `available` / `downloaded` states with dismiss, expandable release notes, and "Restart now" CTA. Uses `Loader2` (lucide-react) for the download spinner; `ReleaseNotesSection` extracted to eliminate duplication.
- **`AboutSection.tsx`** - Settings panel: installed version, manual "Check now" button with `Loader2` spinner and transient "Up to date" feedback, check-interval `SegControl`, auto-download `Switch`, auto-install-on-quit `Switch`.
- **`App.tsx`** - Hydrates version and update status from the preload bridge on mount; gates the `getUpdateStatus()` snapshot write so a resolved Promise cannot overwrite a newer push event that arrived first.
- **`preload.ts`** - Exposes `getVersion`, `getUpdateStatus`, `checkForUpdates`, `installUpdate`, `onUpdateStatus`, `offUpdateStatus` on `window.desktopBridge.app`.
- **`settings-nav.ts`** - Added `about` section to nav groups and `SettingsSection` union; TSDoc added to type.
- **`contracts/settings.ts`** - Added `UpdateCheckIntervalSchema` enum and `updates` block to `SettingsSchema`.

## Configuration changes

New settings keys under `updates` (all optional, defaults shown):

| Key | Default | Description |
|-----|---------|-------------|
| `updates.autoDownload` | `true` | Download updates in the background |
| `updates.autoInstallOnQuit` | `true` | Apply on next quit |
| `updates.checkInterval` | `"4hours"` | `"15min"` / `"1hour"` / `"4hours"` / `"1day"` / `"never"` |

## Related issues/PRs

Relates to the roadmap auto-updater milestone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable update check interval (including Off), auto-download and auto-install-on-quit preferences
  * Manual "Check for updates" and "Restart to install" controls exposed to the UI
  * Dismissible Update banner with download progress, release notes, and restart action
  * About section in Settings showing app version and update controls; settings persisted
  * Native OS notifications when updates finish and live update-status syncing between processes

* **Tests**
  * Added visual tests for About and Settings UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->