### PR TITLE
feat(web): eliminate MessageList unmount/remount on thread switch

### DIFF
--- a/apps/web/e2e/thread-switch-no-remount.spec.ts
+++ b/apps/web/e2e/thread-switch-no-remount.spec.ts
@@ -107,8 +107,6 @@ async function mockWebSocketServer(page: Page): Promise<void> {
     updated_at: new Date(Date.now() + i * 1000).toISOString(),
   }));
 
-  let currentThreadId = "thread-a";
-
   await page.routeWebSocket(/ws:\/\/localhost/, (ws) => {
     ws.onMessage((data) => {
       let msg: Record<string, unknown>;
@@ -122,17 +120,22 @@ async function mockWebSocketServer(page: Page): Promise<void> {
       if (method === "workspace.list") result = [workspace];
       else if (method === "thread.list") result = [threadA, threadB];
       else if (method === "message.list") {
-        // Extract thread_id from params if available, otherwise use current context
+        // Derive the response from the request payload so reordered or
+        // concurrent requests can't cross-contaminate replies.
         const params = msg.params as Record<string, unknown> | undefined;
-        if (params?.thread_id === "thread-b") {
-          currentThreadId = "thread-b";
+        const threadId = params?.thread_id;
+        if (threadId === "thread-b") {
           result = messageB;
-        } else if (params?.thread_id === "thread-a") {
-          currentThreadId = "thread-a";
+        } else if (threadId === "thread-a") {
           result = messages;
         } else {
-          // Fallback to current thread
-          result = currentThreadId === "thread-b" ? messageB : messages;
+          ws.send(
+            JSON.stringify({
+              id: msg.id,
+              error: { code: -32602, message: `Unknown thread_id: ${String(threadId)}` },
+            }),
+          );
+          return;
         }
       } else if (method?.endsWith(".list")) result = [];
       else if (method === "git.currentBranch") result = "main";

--- a/apps/web/e2e/thread-switch-no-remount.spec.ts
+++ b/apps/web/e2e/thread-switch-no-remount.spec.ts
@@ -107,7 +107,9 @@ async function mockWebSocketServer(page: Page): Promise<void> {
     updated_at: new Date(Date.now() + i * 1000).toISOString(),
   }));
 
-  await page.routeWebSocket(/ws:\/\/localhost:\d{5}/, (ws) => {
+  let currentThreadId = "thread-a";
+
+  await page.routeWebSocket(/ws:\/\/localhost/, (ws) => {
     ws.onMessage((data) => {
       let msg: Record<string, unknown>;
       try {
@@ -120,8 +122,18 @@ async function mockWebSocketServer(page: Page): Promise<void> {
       if (method === "workspace.list") result = [workspace];
       else if (method === "thread.list") result = [threadA, threadB];
       else if (method === "message.list") {
-        // Return messages based on thread context from the previous call
-        result = messages;
+        // Extract thread_id from params if available, otherwise use current context
+        const params = msg.params as Record<string, unknown> | undefined;
+        if (params?.thread_id === "thread-b") {
+          currentThreadId = "thread-b";
+          result = messageB;
+        } else if (params?.thread_id === "thread-a") {
+          currentThreadId = "thread-a";
+          result = messages;
+        } else {
+          // Fallback to current thread
+          result = currentThreadId === "thread-b" ? messageB : messages;
+        }
       } else if (method?.endsWith(".list")) result = [];
       else if (method === "git.currentBranch") result = "main";
       else if (method === "agent.activeCount") result = 0;
@@ -173,14 +185,20 @@ test.describe("Thread switch — no MessageList remount", () => {
     const threadItems = page.locator("[data-testid='thread-item']");
     await threadItems.nth(1).click();
 
-    // Wait for the message list to update (give layout time)
-    await page.waitForTimeout(100);
+    // Wait for thread B's content to load
+    await page.waitForFunction(() => {
+      const text = document.querySelector("[data-testid=message-list]")?.textContent || "";
+      return text.includes("Thread B Message") && text.length > 0;
+    }, { timeout: 5000 });
 
     // Switch back to thread A
     await threadItems.nth(0).click();
 
-    // Wait for the message list to update back to thread A
-    await page.waitForTimeout(100);
+    // Wait for thread A's content to load back
+    await page.waitForFunction(() => {
+      const text = document.querySelector("[data-testid=message-list]")?.textContent || "";
+      return text.includes("Message") && !text.includes("Thread B");
+    }, { timeout: 5000 });
 
     // Check that scroll position was restored
     const restored = await scrollEl.evaluate(
@@ -202,19 +220,27 @@ test.describe("Thread switch — no MessageList remount", () => {
     const threadItems = page.locator("[data-testid='thread-item']");
     await threadItems.nth(1).click();
 
-    // Wait for thread B to load
-    await page.waitForTimeout(100);
+    // Wait for thread B's content to load
+    await page.waitForFunction(() => {
+      const text = document.querySelector("[data-testid=message-list]")?.textContent || "";
+      return text.includes("Thread B Message") && text.length > 0;
+    }, { timeout: 5000 });
 
     // Switch back to thread A — cached return must skip the opacity flash
     await threadItems.nth(0).click();
 
-    // Wait a brief moment for the DOM update
-    await page.waitForTimeout(50);
-
-    // Sample opacity immediately — should be 1 (no flash)
-    const opacity = await scrollEl.evaluate((el) =>
-      Number(getComputedStyle(el as Element).opacity),
-    );
-    expect(opacity).toBe(1);
+    // Sample opacity multiple times over 100ms to ensure no flash occurs
+    let hasFlash = false;
+    for (let i = 0; i < 5; i++) {
+      const opacity = await scrollEl.evaluate((el) =>
+        Number(getComputedStyle(el as Element).opacity),
+      );
+      if (opacity < 1) {
+        hasFlash = true;
+        break;
+      }
+      await page.waitForTimeout(20);
+    }
+    expect(hasFlash).toBe(false);
   });
 });

--- a/apps/web/e2e/thread-switch-no-remount.spec.ts
+++ b/apps/web/e2e/thread-switch-no-remount.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect, type Page } from "@playwright/test";
+import { getDefaultSettings } from "@mcode/contracts";
+
+/**
+ * Regression: thread switching must not unmount/remount MessageList.
+ * Verifies cached row heights survive (instant render, no opacity flash)
+ * and scroll position is restored on cached thread return.
+ *
+ * Requires two seeded threads with messages — relies on mocking the
+ * WebSocket server to respond with thread and message lists.
+ */
+
+/**
+ * Mock the WebSocket server with workspace, threads, and messages.
+ */
+async function mockWebSocketServer(page: Page): Promise<void> {
+  const now = new Date().toISOString();
+  const workspace = {
+    id: "ws-switch-test",
+    name: "Test Workspace",
+    path: "/test/path",
+    provider_config: {},
+    created_at: now,
+    updated_at: now,
+  };
+  const threadA = {
+    id: "thread-a",
+    workspace_id: "ws-switch-test",
+    title: "Thread A",
+    status: "paused" as const,
+    mode: "direct" as const,
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+  };
+  const threadB = {
+    id: "thread-b",
+    workspace_id: "ws-switch-test",
+    title: "Thread B",
+    status: "paused" as const,
+    mode: "direct" as const,
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+  };
+
+  // Generate 20 messages for scrollable content
+  const messages = Array.from({ length: 20 }, (_, i) => ({
+    id: `msg-a-${i}`,
+    thread_id: "thread-a",
+    type: "text" as const,
+    role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
+    content: `Message ${i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit. `,
+    sequence: i,
+    attachment_ids: [],
+    tool_calls: [],
+    tool_results: [],
+    reasoning: null,
+    created_at: new Date(Date.now() + i * 1000).toISOString(),
+    updated_at: new Date(Date.now() + i * 1000).toISOString(),
+  }));
+
+  const messageB = Array.from({ length: 20 }, (_, i) => ({
+    id: `msg-b-${i}`,
+    thread_id: "thread-b",
+    type: "text" as const,
+    role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
+    content: `Thread B Message ${i + 1}: Sed do eiusmod tempor incididunt. `,
+    sequence: i,
+    attachment_ids: [],
+    tool_calls: [],
+    tool_results: [],
+    reasoning: null,
+    created_at: new Date(Date.now() + i * 1000).toISOString(),
+    updated_at: new Date(Date.now() + i * 1000).toISOString(),
+  }));
+
+  await page.routeWebSocket(/ws:\/\/localhost:\d{5}/, (ws) => {
+    ws.onMessage((data) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+      const method = msg.method as string;
+      let result: unknown = null;
+      if (method === "workspace.list") result = [workspace];
+      else if (method === "thread.list") result = [threadA, threadB];
+      else if (method === "message.list") {
+        // Return messages based on thread context from the previous call
+        result = messages;
+      } else if (method?.endsWith(".list")) result = [];
+      else if (method === "git.currentBranch") result = "main";
+      else if (method === "agent.activeCount") result = 0;
+      else if (method === "app.version") result = "0.0.1-test";
+      else if (method === "config.discover") result = {};
+      else if (method === "settings.get") result = getDefaultSettings();
+      ws.send(JSON.stringify({ id: msg.id, result }));
+    });
+  });
+}
+
+test.describe("Thread switch — no MessageList remount", () => {
+  test.beforeEach(async ({ page }) => {
+    // Set up WebSocket mock with workspace and threads
+    await mockWebSocketServer(page);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Wait for thread items to appear in sidebar
+    await page.waitForSelector("[data-testid='thread-item']");
+
+    // Click on the first thread to select it
+    await page.locator("[data-testid='thread-item']").first().click();
+
+    // Wait for the message list to be visible
+    await page.waitForSelector("[data-testid=message-list]");
+  });
+
+  test("scroll position restores on return to a cached thread", async ({
+    page,
+  }) => {
+    // Find the scrollable container in the message list
+    const scrollEl = page
+      .locator("[data-testid=message-list] >> css=.overflow-y-auto")
+      .first();
+    await expect(scrollEl).toBeVisible();
+
+    // Scroll to a non-bottom position (200px from top)
+    await scrollEl.evaluate((el) => {
+      (el as HTMLDivElement).scrollTop = 200;
+    });
+    const savedScrollTop = await scrollEl.evaluate(
+      (el) => (el as HTMLDivElement).scrollTop,
+    );
+    expect(savedScrollTop).toBeGreaterThan(100);
+
+    // Switch to thread B by clicking the second thread in sidebar
+    const threadItems = page.locator("[data-testid='thread-item']");
+    await threadItems.nth(1).click();
+
+    // Wait for the message list to update (give layout time)
+    await page.waitForTimeout(100);
+
+    // Switch back to thread A
+    await threadItems.nth(0).click();
+
+    // Wait for the message list to update back to thread A
+    await page.waitForTimeout(100);
+
+    // Check that scroll position was restored
+    const restored = await scrollEl.evaluate(
+      (el) => (el as HTMLDivElement).scrollTop,
+    );
+    expect(Math.abs(restored - savedScrollTop)).toBeLessThan(20);
+  });
+
+  test("no opacity-0 flash when returning to a cached thread", async ({
+    page,
+  }) => {
+    // Find the scrollable container
+    const scrollEl = page
+      .locator("[data-testid=message-list] >> css=.overflow-y-auto")
+      .first();
+    await expect(scrollEl).toBeVisible();
+
+    // Switch to thread B by clicking the second thread in sidebar
+    const threadItems = page.locator("[data-testid='thread-item']");
+    await threadItems.nth(1).click();
+
+    // Wait for thread B to load
+    await page.waitForTimeout(100);
+
+    // Switch back to thread A — cached return must skip the opacity flash
+    await threadItems.nth(0).click();
+
+    // Wait a brief moment for the DOM update
+    await page.waitForTimeout(50);
+
+    // Sample opacity immediately — should be 1 (no flash)
+    const opacity = await scrollEl.evaluate((el) =>
+      Number(getComputedStyle(el as Element).opacity),
+    );
+    expect(opacity).toBe(1);
+  });
+});

--- a/apps/web/src/__tests__/messageCache.test.ts
+++ b/apps/web/src/__tests__/messageCache.test.ts
@@ -103,9 +103,13 @@ describe("messageCache", () => {
       (MESSAGE_CACHE_SIZE - 1) * 100
     );
 
+    // Seed the new thread's scroll position before the eviction-triggering
+    // insert so this test exercises cleanup at the moment of eviction rather
+    // than just verifying that a value can be written afterward.
+    rememberScrollTop("new", 9999);
+
     // Trigger eviction by adding one more thread.
     cacheSnapshot("new", makeSnapshot("new"));
-    rememberScrollTop("new", 9999);
 
     // t0 should be evicted and its scroll position forgotten.
     expect(getCachedSnapshot("t0")).toBeUndefined();

--- a/apps/web/src/__tests__/messageCache.test.ts
+++ b/apps/web/src/__tests__/messageCache.test.ts
@@ -7,6 +7,11 @@ import {
   MESSAGE_CACHE_SIZE,
   type MessageCacheSnapshot,
 } from "@/stores/messageCache";
+import {
+  rememberScrollTop,
+  recallScrollTop,
+  clearScrollMemory,
+} from "@/components/chat/scrollPositionMemory";
 import { LruCache } from "@/lib/lru-cache";
 
 function makeSnapshot(id: string): MessageCacheSnapshot {
@@ -35,7 +40,10 @@ function makeSnapshot(id: string): MessageCacheSnapshot {
 }
 
 describe("messageCache", () => {
-  beforeEach(() => clearMessageCache());
+  beforeEach(() => {
+    clearMessageCache();
+    clearScrollMemory();
+  });
 
   it("returns undefined for a thread that was never cached", () => {
     expect(getCachedSnapshot("missing")).toBeUndefined();
@@ -82,6 +90,33 @@ describe("messageCache", () => {
     cacheSnapshot("t1", makeSnapshot("t1"));
     clearMessageCache();
     expect(getCachedSnapshot("t1")).toBeUndefined();
+  });
+
+  it("cleans up scroll memory when evicting via LRU capacity", () => {
+    for (let i = 0; i < MESSAGE_CACHE_SIZE; i++) {
+      cacheSnapshot(`t${i}`, makeSnapshot(`t${i}`));
+      rememberScrollTop(`t${i}`, i * 100);
+    }
+    // Verify scroll positions are stored.
+    expect(recallScrollTop("t0")).toBe(0);
+    expect(recallScrollTop(`t${MESSAGE_CACHE_SIZE - 1}`)).toBe(
+      (MESSAGE_CACHE_SIZE - 1) * 100
+    );
+
+    // Trigger eviction by adding one more thread.
+    cacheSnapshot("new", makeSnapshot("new"));
+    rememberScrollTop("new", 9999);
+
+    // t0 should be evicted and its scroll position forgotten.
+    expect(getCachedSnapshot("t0")).toBeUndefined();
+    expect(recallScrollTop("t0")).toBeUndefined();
+
+    // Other threads should still be cached and have scroll positions.
+    expect(getCachedSnapshot("t1")).toBeDefined();
+    expect(recallScrollTop("t1")).toBe(100);
+
+    // New thread should have its scroll position intact.
+    expect(recallScrollTop("new")).toBe(9999);
   });
 });
 

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -337,8 +337,11 @@ export function ChatView() {
         </div>
       )}
 
-      {/* Messages, tool calls, and streaming - all in one scrollable area */}
-      <div key={activeThread.id} className="animate-fade-up-in flex-1 min-h-0">
+      {/* Messages, tool calls, and streaming — all in one scrollable area.
+          No `key` here: forcing remount on thread switch would destroy the
+          virtualizer and discard cached row heights. MessageList resets its
+          own per-thread state imperatively in a useEffect on activeThreadId. */}
+      <div className="animate-fade-up-in flex-1 min-h-0">
         {showEmptyState ? (
           <div className="flex h-full items-center justify-center">
             <EmptyState onPromptSelect={setPendingPrefill} />

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -401,9 +401,14 @@ export function MessageList({ onBranch }: MessageListProps) {
     if (target == null) return;
     const el = containerRef.current;
     if (!el) return;
+    // Only restore if items are actually loaded. On cache misses, this prevents
+    // restoring before items have arrived, which would cause the wrong scroll position
+    // to be briefly visible. When items load, items.length will change and trigger
+    // another effect pass where loading is false.
+    if (loading) return;
     el.scrollTop = target;
     pendingScrollRestoreRef.current = null;
-  }, [activeThreadId, items.length]);
+  }, [activeThreadId, items.length, loading]);
 
   // Discrete events (new message, tool call) -> scroll if at bottom, else highlight button
   useEffect(() => {

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -431,7 +431,7 @@ export function MessageList({ onBranch }: MessageListProps) {
   }, [streamingText, scrollToBottom]);
 
   return (
-    <div className="relative h-full">
+    <div className="relative h-full" data-testid="message-list">
       <div
         ref={containerRef}
         onScroll={handleScroll}

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -301,7 +301,8 @@ export function MessageList({ onBranch }: MessageListProps) {
   // restoration useLayoutEffect reads it.
   useLayoutEffect(() => {
     const prevId = prevActiveThreadIdRef.current;
-    if (prevId && prevId !== activeThreadId) {
+    const isThreadSwitch = !!prevId && prevId !== activeThreadId;
+    if (isThreadSwitch && prevId) {
       const el = containerRef.current;
       if (el) rememberScrollTop(prevId, el.scrollTop);
     }
@@ -309,7 +310,18 @@ export function MessageList({ onBranch }: MessageListProps) {
 
     if (!activeThreadId) return;
 
-    turnExpandRef.current.clear();
+    if (isThreadSwitch) {
+      // Reset thread-scoped refs and affordance state so the prepend-detection
+      // effect, scroll-affordance UI, and turn-expand map don't carry stale
+      // measurements from the previous thread into the new one.
+      turnExpandRef.current.clear();
+      prevMessageCountRef.current = 0;
+      firstMessageIdRef.current = null;
+      prevScrollHeightRef.current = 0;
+      isScrolledUpRef.current = false;
+      setShowScrollBtn(false);
+      setHasNewContent(false);
+    }
 
     if (loading) {
       // Cache miss: full reset path. Hide until messages are positioned at bottom,
@@ -324,10 +336,16 @@ export function MessageList({ onBranch }: MessageListProps) {
     // Cache hit: keep the virtualizer's measurement cache (those rows have the
     // same item keys and dimensions — re-estimating would defeat the optimization).
     // Skip the opacity flash; mark initial-load done so the bottom-scroll effect
-    // does not retrigger.
-    isInitialLoadRef.current = false;
-    setIsPositioned(true);
-    pendingScrollRestoreRef.current = recallScrollTop(activeThreadId) ?? null;
+    // does not retrigger. Only enter this branch when there's a remembered
+    // scroll position; otherwise this also fires when `loading` flips
+    // true→false after a fresh fetch and would prematurely clear
+    // `isInitialLoadRef`, blocking the bottom-positioning effect.
+    const rememberedScrollTop = recallScrollTop(activeThreadId);
+    if (rememberedScrollTop != null) {
+      isInitialLoadRef.current = false;
+      setIsPositioned(true);
+      pendingScrollRestoreRef.current = rememberedScrollTop;
+    }
   }, [activeThreadId, loading, virtualizer]);
 
   // Stabilize scroll position when older messages are prepended.

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -20,6 +20,7 @@ import {
 } from "./virtual-items";
 import type { ChatVirtualItem } from "./virtual-items";
 import type { ToolCall } from "@/transport/types";
+import { rememberScrollTop, recallScrollTop } from "./scrollPositionMemory";
 
 const EMPTY_TOOL_CALLS: ToolCall[] = [];
 const AUTO_SCROLL_THRESHOLD = 64;
@@ -136,6 +137,10 @@ export function MessageList({ onBranch }: MessageListProps) {
   const firstMessageIdRef = useRef<string | null>(null);
   /** True until initial messages are positioned at the bottom after a thread switch. */
   const isInitialLoadRef = useRef(true);
+  /** Tracks the previous activeThreadId so we can save its scrollTop before switching. */
+  const prevActiveThreadIdRef = useRef<string | null>(null);
+  /** Holds the scrollTop value to restore on the next layout effect. */
+  const pendingScrollRestoreRef = useRef<number | null>(null);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
   /** True when new content arrived while the user was scrolled up. */
   const [hasNewContent, setHasNewContent] = useState(false);
@@ -145,6 +150,7 @@ export function MessageList({ onBranch }: MessageListProps) {
   const [isPositioned, setIsPositioned] = useState(false);
 
   const messages = useThreadStore((s) => s.messages);
+  const loading = useThreadStore((s) => s.loading);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const isAgentRunning = useThreadStore((s) =>
     activeThreadId ? s.runningThreadIds.has(activeThreadId) : false,
@@ -288,16 +294,41 @@ export function MessageList({ onBranch }: MessageListProps) {
     };
   }, []);
 
-  // On thread switch, invalidate the virtualizer's cached sizes so
-  // stale heights from the previous thread don't cause overlap.
-  // Also reset positioning state so the container stays hidden until
-  // new messages are scrolled to the bottom.
-  useEffect(() => {
-    isInitialLoadRef.current = true;
-    setIsPositioned(false);
+  // Save the outgoing thread's scrollTop, then reset per-thread UI state.
+  // Cache-miss vs cache-hit is inferred from `loading`: the threadStore sets
+  // loading=true synchronously on miss and false synchronously on hit.
+  // Uses useLayoutEffect so pendingScrollRestoreRef is set before the scroll
+  // restoration useLayoutEffect reads it.
+  useLayoutEffect(() => {
+    const prevId = prevActiveThreadIdRef.current;
+    if (prevId && prevId !== activeThreadId) {
+      const el = containerRef.current;
+      if (el) rememberScrollTop(prevId, el.scrollTop);
+    }
+    prevActiveThreadIdRef.current = activeThreadId ?? null;
+
+    if (!activeThreadId) return;
+
     turnExpandRef.current.clear();
-    virtualizer.measure();
-  }, [activeThreadId, virtualizer]);
+
+    if (loading) {
+      // Cache miss: full reset path. Hide until messages are positioned at bottom,
+      // and clear stale measurements so previous-thread heights don't bleed in.
+      isInitialLoadRef.current = true;
+      setIsPositioned(false);
+      pendingScrollRestoreRef.current = null;
+      virtualizer.measure();
+      return;
+    }
+
+    // Cache hit: keep the virtualizer's measurement cache (those rows have the
+    // same item keys and dimensions — re-estimating would defeat the optimization).
+    // Skip the opacity flash; mark initial-load done so the bottom-scroll effect
+    // does not retrigger.
+    isInitialLoadRef.current = false;
+    setIsPositioned(true);
+    pendingScrollRestoreRef.current = recallScrollTop(activeThreadId) ?? null;
+  }, [activeThreadId, loading, virtualizer]);
 
   // Stabilize scroll position when older messages are prepended.
   // Detects real prepends by comparing the first message ID before and after
@@ -333,7 +364,6 @@ export function MessageList({ onBranch }: MessageListProps) {
 
   // Initial load: position at the bottom before paint to avoid top-to-bottom flash.
   // useLayoutEffect fires after DOM mutations but before the browser paints.
-  const loading = useThreadStore((s) => s.loading);
   useLayoutEffect(() => {
     if (!isInitialLoadRef.current) return;
 
@@ -362,6 +392,18 @@ export function MessageList({ onBranch }: MessageListProps) {
       setIsPositioned(true);
     });
   }, [items.length, loading, virtualizer]);
+
+  // Apply the remembered scrollTop after the virtualizer has rendered the
+  // restored items. useLayoutEffect runs before paint, so the user never sees
+  // the bottom of the list flash before the restore.
+  useLayoutEffect(() => {
+    const target = pendingScrollRestoreRef.current;
+    if (target == null) return;
+    const el = containerRef.current;
+    if (!el) return;
+    el.scrollTop = target;
+    pendingScrollRestoreRef.current = null;
+  }, [activeThreadId, items.length]);
 
   // Discrete events (new message, tool call) -> scroll if at bottom, else highlight button
   useEffect(() => {

--- a/apps/web/src/components/chat/__tests__/ChatView.no-remount.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ChatView.no-remount.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * This test verifies that the wrapper div containing MessageList does not
+ * have a `key` prop bound to the active thread id. A key like `key={activeThread.id}`
+ * would cause React to destroy and remount the entire MessageList subtree on every
+ * thread switch, destroying cached virtualizer state and forcing full re-renders.
+ *
+ * The fix is to remove the key entirely and let MessageList manage its own
+ * per-thread state via useEffect on activeThreadId.
+ *
+ * We use a code-reader test that imports the source and checks for the absence
+ * of the force-remount key pattern, which is a valid approach for structural tests.
+ */
+describe("ChatView — MessageList container", () => {
+  it("does not have key={activeThread.id} on the wrapper div", async () => {
+    // Import the source file as a string to verify the key is not present
+    // We use import.meta.glob with raw imports to read the file content
+    const module = import.meta.glob<string>("../ChatView.tsx", {
+      query: "?raw",
+      import: "default",
+    });
+    const files = await module["../ChatView.tsx"]?.();
+
+    if (!files) {
+      throw new Error("Unable to load ChatView.tsx for inspection");
+    }
+
+    // The wrapper should look like:
+    // <div className="animate-fade-up-in flex-1 min-h-0">
+    // And NOT:
+    // <div key={activeThread.id} className="animate-fade-up-in flex-1 min-h-0">
+
+    const hasForceRemountKey = /key\s*=\s*\{\s*activeThread\.id\s*\}.*className="animate-fade-up-in/.test(
+      files
+    );
+
+    expect(hasForceRemountKey).toBe(false);
+
+    // Also verify the comment explaining why is present
+    const hasExplanationComment = /No `key` here[\s\S]*remount[\s\S]*virtualizer/.test(
+      files
+    );
+    expect(hasExplanationComment).toBe(true);
+  });
+});

--- a/apps/web/src/components/chat/__tests__/ChatView.no-remount.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ChatView.no-remount.test.tsx
@@ -31,7 +31,9 @@ describe("ChatView — MessageList container", () => {
     // And NOT:
     // <div key={activeThread.id} className="animate-fade-up-in flex-1 min-h-0">
 
-    const hasForceRemountKey = /key\s*=\s*\{\s*activeThread\.id\s*\}.*className="animate-fade-up-in/.test(
+    // Use [\s\S]* so a future multiline `key={activeThread.id}` wrapper
+    // can't slip through this guard.
+    const hasForceRemountKey = /key\s*=\s*\{\s*activeThread\.id\s*\}[\s\S]*className="animate-fade-up-in/.test(
       files
     );
 

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for MessageList thread-switch behavior: cache-hit detection,
+ * virtualizer measurement optimization, and scroll position restoration.
+ *
+ * A cache hit occurs when threadStore has messages already loaded (loading: false
+ * synchronously after activeThreadId changes). On cache hit, we skip virtualizer.measure()
+ * to preserve cached row heights and avoid opacity flash by keeping isPositioned=true.
+ */
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const measureSpy = vi.fn();
+const scrollToIndexSpy = vi.fn();
+
+const mockVirtualizer = {
+  getVirtualItems: () => [],
+  getTotalSize: () => 0,
+  measure: measureSpy,
+  scrollToIndex: scrollToIndexSpy,
+  measureElement: () => {},
+  shouldAdjustScrollPositionOnItemSizeChange: undefined,
+};
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: vi.fn(() => mockVirtualizer),
+}));
+
+// Minimal store mocks; control `loading` and `activeThreadId` between renders.
+let loadingValue = false;
+let activeThreadIdValue = "thread-A";
+let messagesValue: { id: string; sequence: number }[] = [{ id: "m1", sequence: 1 }];
+
+vi.mock("@/stores/threadStore", () => ({
+  useThreadStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      messages: messagesValue,
+      loading: loadingValue,
+      runningThreadIds: new Set(),
+      agentStartTimes: {},
+      streamingPreviewByThread: {},
+      toolCallsByThread: {},
+      persistedToolCallCounts: {},
+      serverMessageIds: {},
+      persistedFilesChanged: {},
+      latestTurnWithChanges: null,
+      hasMoreMessages: {},
+      isLoadingMore: {},
+      loadOlderMessages: vi.fn(),
+      permissionsByThread: {},
+    }),
+  ),
+}));
+
+vi.mock("@/stores/workspaceStore", () => ({
+  useWorkspaceStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ activeThreadId: activeThreadIdValue }),
+  ),
+}));
+
+// Stub heavy children.
+vi.mock("../MessageBubble", () => ({ MessageBubble: () => null }));
+vi.mock("../ToolCallCard", () => ({ ToolCallCard: () => null }));
+vi.mock("../StreamingIndicator", () => ({ StreamingIndicator: () => null }));
+vi.mock("../StreamingCard", () => ({ StreamingCard: () => null }));
+vi.mock("../ToolCallSummary", () => ({ ToolCallSummary: () => null }));
+vi.mock("../TurnChangeSummary", () => ({ TurnChangeSummary: () => null }));
+vi.mock("../PermissionRequestCard", () => ({ PermissionRequestCard: () => null }));
+
+import { MessageList } from "../MessageList";
+import { rememberScrollTop, recallScrollTop, clearScrollMemory } from "../scrollPositionMemory";
+
+beforeEach(() => {
+  measureSpy.mockClear();
+  scrollToIndexSpy.mockClear();
+  clearScrollMemory();
+});
+
+describe("MessageList thread switch", () => {
+  it("does not call virtualizer.measure() on a cache-hit switch", () => {
+    loadingValue = false;            // cache hit ⇒ loading is false synchronously
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    activeThreadIdValue = "thread-A";
+    const { rerender } = render(<MessageList />);
+
+    measureSpy.mockClear();          // ignore the first-mount call (allowed)
+    activeThreadIdValue = "thread-B";
+    rerender(<MessageList />);
+
+    expect(measureSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls virtualizer.measure() on a cache-miss switch", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    const { rerender } = render(<MessageList />);
+
+    measureSpy.mockClear();
+    loadingValue = true;             // cache miss ⇒ loading flips to true
+    activeThreadIdValue = "thread-B";
+    rerender(<MessageList />);
+
+    expect(measureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores remembered scrollTop on a cache-hit switch", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    const { rerender, container } = render(<MessageList />);
+
+    // Pretend the user scrolled and we returned to thread B which has memory.
+    rememberScrollTop("thread-B", 1500);
+    expect(recallScrollTop("thread-B")).toBe(1500); // verify memory works
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement | null;
+    expect(scrollEl).not.toBeNull();
+
+    // Mock scrollTop setter to track if it's called with the right value
+    let setScrollTopValue: number | null = null;
+    Object.defineProperty(scrollEl!, "scrollTop", {
+      set: (value: number) => {
+        setScrollTopValue = value;
+      },
+      get: () => setScrollTopValue ?? 0,
+      configurable: true,
+    });
+
+    activeThreadIdValue = "thread-B";
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    // The scroll restoration effect should have called scrollTop setter with 1500
+    expect(setScrollTopValue).toBe(1500);
+  });
+});

--- a/apps/web/src/components/chat/__tests__/scrollPositionMemory.test.ts
+++ b/apps/web/src/components/chat/__tests__/scrollPositionMemory.test.ts
@@ -1,0 +1,48 @@
+// apps/web/src/components/chat/__tests__/scrollPositionMemory.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  rememberScrollTop,
+  recallScrollTop,
+  forgetScrollTop,
+  clearScrollMemory,
+} from "../scrollPositionMemory";
+
+describe("scrollPositionMemory", () => {
+  beforeEach(() => clearScrollMemory());
+
+  it("returns undefined for unknown thread", () => {
+    expect(recallScrollTop("thread-x")).toBeUndefined();
+  });
+
+  it("stores and recalls a scroll position", () => {
+    rememberScrollTop("thread-a", 1234);
+    expect(recallScrollTop("thread-a")).toBe(1234);
+  });
+
+  it("ignores non-finite or negative values", () => {
+    rememberScrollTop("thread-a", Number.NaN);
+    rememberScrollTop("thread-a", -10);
+    rememberScrollTop("thread-a", Number.POSITIVE_INFINITY);
+    expect(recallScrollTop("thread-a")).toBeUndefined();
+  });
+
+  it("overwrites prior value", () => {
+    rememberScrollTop("thread-a", 100);
+    rememberScrollTop("thread-a", 200);
+    expect(recallScrollTop("thread-a")).toBe(200);
+  });
+
+  it("forgets a single thread", () => {
+    rememberScrollTop("thread-a", 1);
+    rememberScrollTop("thread-b", 2);
+    forgetScrollTop("thread-a");
+    expect(recallScrollTop("thread-a")).toBeUndefined();
+    expect(recallScrollTop("thread-b")).toBe(2);
+  });
+
+  it("clearScrollMemory drops everything", () => {
+    rememberScrollTop("thread-a", 1);
+    clearScrollMemory();
+    expect(recallScrollTop("thread-a")).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/chat/__tests__/scrollPositionMemory.test.ts
+++ b/apps/web/src/components/chat/__tests__/scrollPositionMemory.test.ts
@@ -46,3 +46,13 @@ describe("scrollPositionMemory", () => {
     expect(recallScrollTop("thread-a")).toBeUndefined();
   });
 });
+
+describe("scrollPositionMemory — store integration", () => {
+  beforeEach(() => clearScrollMemory());
+
+  it("integrates with thread deletion (sanity)", () => {
+    rememberScrollTop("thread-deleted", 99);
+    forgetScrollTop("thread-deleted");
+    expect(recallScrollTop("thread-deleted")).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/chat/scrollPositionMemory.ts
+++ b/apps/web/src/components/chat/scrollPositionMemory.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-scoped per-thread scrollTop memory used by MessageList to restore
+ * scroll position when returning to a thread. Lives outside React so it
+ * survives MessageList re-renders without coupling to component state.
+ *
+ * Entries are not bounded — the message LRU cache governs lifecycle of
+ * cached threads, and {@link forgetScrollTop} is called when a thread is
+ * deleted or evicted.
+ */
+const positions = new Map<string, number>();
+
+/** Persist the latest scrollTop for a thread. Ignores non-finite/negative values. */
+export function rememberScrollTop(threadId: string, scrollTop: number): void {
+  if (!Number.isFinite(scrollTop) || scrollTop < 0) return;
+  positions.set(threadId, scrollTop);
+}
+
+/** Recall the most recently saved scrollTop for a thread, or undefined. */
+export function recallScrollTop(threadId: string): number | undefined {
+  return positions.get(threadId);
+}
+
+/** Drop the saved scroll position for a thread. */
+export function forgetScrollTop(threadId: string): void {
+  positions.delete(threadId);
+}
+
+/** Drop all saved scroll positions. Used by tests and on full reset. */
+export function clearScrollMemory(): void {
+  positions.clear();
+}

--- a/apps/web/src/lib/lru-cache.ts
+++ b/apps/web/src/lib/lru-cache.ts
@@ -24,15 +24,17 @@ export class LruCache<K, V> {
   }
 
   /** Insert or update a key. Evicts the least recently used entry if at capacity. */
-  set(key: K, value: V): void {
+  set(key: K, value: V): K | null {
+    let evicted: K | null = null;
     if (this.map.has(key)) {
       this.map.delete(key);
     } else if (this.map.size >= this.capacity) {
       // Map.keys().next() returns the oldest (least recently used) key
-      const oldest = this.map.keys().next().value!;
-      this.map.delete(oldest);
+      evicted = this.map.keys().next().value as K;
+      this.map.delete(evicted);
     }
     this.map.set(key, value);
+    return evicted;
   }
 
   /** Remove all entries. */

--- a/apps/web/src/stores/messageCache.ts
+++ b/apps/web/src/stores/messageCache.ts
@@ -1,5 +1,6 @@
 import type { Message } from "@/transport";
 import { LruCache } from "@/lib/lru-cache";
+import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
 
 /**
  * Snapshot of the message-loading state for one thread, stored in the
@@ -30,7 +31,10 @@ export function getCachedSnapshot(threadId: string): MessageCacheSnapshot | unde
 
 /** Store a snapshot for the given thread, evicting the LRU entry if at capacity. */
 export function cacheSnapshot(threadId: string, snapshot: MessageCacheSnapshot): void {
-  cache.set(threadId, snapshot);
+  const evicted = cache.set(threadId, snapshot);
+  if (evicted) {
+    forgetScrollTop(evicted);
+  }
 }
 
 /** Remove a single thread's snapshot. No-op when absent. */

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -18,6 +18,7 @@ import {
   evictThread as evictMessageCache,
   getCachedSnapshot,
 } from "./messageCache";
+import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
 
 /** A permission request with its current resolution state. */
 interface StoredPermission extends PermissionRequest {
@@ -903,6 +904,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   clearThreadState: (threadId) => {
     evictMessageCache(threadId);
     clearDequeueTimer(threadId);
+    forgetScrollTop(threadId);
 
     // Capture before set() to avoid relying on the post-mutation state value.
     const isCurrentThread = get().currentThreadId === threadId;
@@ -971,6 +973,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     for (const threadId of threadIds) {
       evictMessageCache(threadId);
       clearDequeueTimer(threadId);
+      forgetScrollTop(threadId);
     }
 
     // Capture before set() to avoid relying on post-mutation state.


### PR DESCRIPTION
## What

Eliminate the forced remount of `MessageList` when switching threads, preserving the virtualizer's row height cache and restoring scroll positions instantly for cached threads.

## Why

Thread switching in mcode was sluggish due to:
1. Full virtualizer remount on every thread switch (lost cached row heights)
2. Opacity flash while repositioning (hiding → bottom-scroll → show)
3. Every switch required a full WebSocket RPC, even for recently-visited threads
4. Rapid thread flipping paid the full latency penalty every time

This fix keeps the virtualizer mounted across thread switches, preserves measurements for cached threads, and restores scroll positions instantly.

## Key Changes

- **Remove force-remount key** — Dropped `key={activeThread.id}` from ChatView wrapper (line 341)
- **Per-thread scroll memory** — Module-scoped `Map<threadId, scrollTop>` survives React re-renders
- **Cache-hit aware switching** — Detect cache hits via `loading` state; skip virtualizer.measure() and opacity animation on hits
- **Automatic cleanup** — Forget scroll positions when threads are deleted or evicted from the message LRU cache
- **Comprehensive tests** — Unit tests for scroll memory, thread-switch behavior; E2E test for visual regression

## Acceptance Criteria

- [x] Switching between two threads does not trigger a full React unmount/remount of the message list
- [x] Virtualizer row height measurements are preserved for cached threads
- [x] The opacity flash / `isPositioned` delay is eliminated for cached thread switches
- [x] Scroll position restores to where the user left off when returning to a cached thread
- [x] New (uncached) thread switches still render correctly with fresh virtualizer state

## Testing

- ✅ 874+ unit tests pass (6 new tests for scroll memory, 3 for MessageList switching, 1 for ChatView)
- ✅ E2E test verifies scroll restoration and no opacity flash on cached returns
- ✅ TypeScript checks pass across all packages (web, server, desktop)
- ✅ No regressions in existing tests

Depends on #331 (already merged in `cbe53c6`)

Closes #332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thread switching now reliably preserves per-thread scroll position and avoids visibility/opacity flashes when returning to a thread.

* **Performance**
  * Smoother, faster thread navigation by avoiding unnecessary remounts during switches.

* **Tests**
  * Added end-to-end and unit tests to verify scroll restoration, no-remount behavior, and cache/eviction interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->