### PR TITLE
feat: remove client-side CI check fan-out on reconnect

### DIFF
--- a/apps/web/e2e/ci-reconnect-no-fanout.spec.ts
+++ b/apps/web/e2e/ci-reconnect-no-fanout.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect, type Page, type WebSocketRoute } from "@playwright/test";
+import { getDefaultSettings } from "@mcode/contracts";
+
+interface CiMockController {
+  /** RPC method name -> invocation count, accumulated across reconnects. */
+  methodCalls: Map<string, number>;
+  /** Close the latest connection to force the client's reconnect loop. */
+  forceReconnect: () => Promise<void>;
+  /** Emit a thread.checksUpdated push on the latest connection. */
+  pushChecks: (threadId: string, checks: unknown) => Promise<void>;
+}
+
+async function mockCiServer(page: Page): Promise<CiMockController> {
+  const now = new Date().toISOString();
+  const workspace = {
+    id: "ws-1",
+    name: "Test Workspace",
+    path: "/test/path",
+    provider_config: {},
+    created_at: now,
+    updated_at: now,
+  };
+  const thread = {
+    id: "thread-1",
+    workspace_id: "ws-1",
+    title: "PR Thread",
+    status: "active" as const,
+    mode: "direct" as const,
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: 42,
+    pr_status: "open",
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    copilot_agent: null,
+    last_compact_summary: null,
+  };
+
+  const methodCalls = new Map<string, number>();
+  let activeWs: WebSocketRoute | null = null;
+
+  await page.routeWebSocket(/ws:\/\/localhost:\d{5}/, (ws) => {
+    activeWs = ws;
+    ws.onMessage((data) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+      const method = msg.method as string;
+      methodCalls.set(method, (methodCalls.get(method) ?? 0) + 1);
+
+      let result: unknown = null;
+      if (method === "workspace.list") result = [workspace];
+      else if (method === "thread.list") result = [thread];
+      else if (method === "settings.get") result = getDefaultSettings();
+      else if (method === "provider.listAvailable") {
+        // Minimal provider availability structure for sidebar to not crash
+        result = [{ id: "claude", enabled: true, cli: { status: "ok" } }];
+      }
+      else if (method?.endsWith(".list") || method === "provider.listModels") result = [];
+      else if (method === "git.currentBranch") result = "main";
+      else if (method === "agent.activeCount") result = 0;
+      else if (method === "agent.listRunning") result = [];
+      else if (method === "app.version") result = "0.0.1-test";
+      else if (method === "config.discover") result = {};
+      else if (method === "github.checkStatus") {
+        // Surface any unexpected fan-out as a populated reply rather than an
+        // error, so the assertion on methodCalls is the failure signal.
+        result = { aggregate: "no_checks", runs: [], fetchedAt: Date.now() };
+      }
+      ws.send(JSON.stringify({ id: msg.id, result }));
+    });
+  });
+
+  return {
+    methodCalls,
+    forceReconnect: async () => {
+      // Closing from the route side terminates the client's WebSocket and
+      // triggers the exponential backoff reconnect loop in ws-transport.
+      activeWs?.close();
+    },
+    pushChecks: async (threadId, checks) => {
+      if (!activeWs) throw new Error("No active WS connection");
+      activeWs.send(
+        JSON.stringify({
+          type: "push",
+          channel: "thread.checksUpdated",
+          data: { threadId, checks },
+        }),
+      );
+    },
+  };
+}
+
+async function waitForHydration(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete === true,
+  );
+}
+
+test.describe("ci reconnect no fan-out", () => {
+  test("reconnect does not fire github.checkStatus", async ({ page }) => {
+    const ctrl = await mockCiServer(page);
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-list']");
+    await waitForHydration(page);
+
+    // Let any deferred async chains settle (dynamic imports, store subscriptions).
+    await page.waitForTimeout(1000);
+
+    const beforeReconnect = ctrl.methodCalls.get("github.checkStatus") ?? 0;
+
+    // Reset the hydration sentinel so we can wait for the next reconnect cycle.
+    await page.evaluate(() => {
+      (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete = false;
+    });
+
+    await ctrl.forceReconnect();
+    await waitForHydration(page);
+    await page.waitForTimeout(1000);
+
+    const afterReconnect = ctrl.methodCalls.get("github.checkStatus") ?? 0;
+
+    // After removing the client-side CI fan-out, no reconnect should trigger
+    // github.checkStatus. This is a regression guard.
+    expect(afterReconnect).toBe(beforeReconnect);
+  });

--- a/apps/web/e2e/ci-reconnect-no-fanout.spec.ts
+++ b/apps/web/e2e/ci-reconnect-no-fanout.spec.ts
@@ -140,3 +140,4 @@ test.describe("ci reconnect no fan-out", () => {
     // github.checkStatus. This is a regression guard.
     expect(afterReconnect).toBe(beforeReconnect);
   });
+});

--- a/apps/web/e2e/ci-reconnect-no-fanout.spec.ts
+++ b/apps/web/e2e/ci-reconnect-no-fanout.spec.ts
@@ -52,7 +52,7 @@ async function mockCiServer(page: Page): Promise<CiMockController> {
   const methodCalls = new Map<string, number>();
   let activeWs: WebSocketRoute | null = null;
 
-  await page.routeWebSocket(/ws:\/\/localhost:\d{5}/, (ws) => {
+  await page.routeWebSocket(/ws:\/\/localhost:\d+/, (ws) => {
     activeWs = ws;
     ws.onMessage((data) => {
       let msg: Record<string, unknown>;
@@ -125,6 +125,16 @@ test.describe("ci reconnect no fan-out", () => {
 
     const beforeReconnect = ctrl.methodCalls.get("github.checkStatus") ?? 0;
 
+    // Verify push path works before reconnect
+    await ctrl.pushChecks("thread-1", {
+      aggregate: "failing",
+      runs: [
+        { name: "test-job", status: "completed", conclusion: "failure", durationMs: 5000, startedAt: new Date().toISOString() },
+      ],
+      fetchedAt: Date.now(),
+    });
+    await page.waitForTimeout(500); // Let store update
+
     // Reset the hydration sentinel so we can wait for the next reconnect cycle.
     await page.evaluate(() => {
       (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete = false;
@@ -133,6 +143,16 @@ test.describe("ci reconnect no fan-out", () => {
     await ctrl.forceReconnect();
     await waitForHydration(page);
     await page.waitForTimeout(1000);
+
+    // Verify push path still works after reconnect
+    await ctrl.pushChecks("thread-1", {
+      aggregate: "passing",
+      runs: [
+        { name: "test-job", status: "completed", conclusion: "success", durationMs: 3000, startedAt: new Date().toISOString() },
+      ],
+      fetchedAt: Date.now(),
+    });
+    await page.waitForTimeout(500); // Let store update
 
     const afterReconnect = ctrl.methodCalls.get("github.checkStatus") ?? 0;
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -33,11 +33,6 @@ const MAX_RECONNECT_MS = 30_000;
 /** Number of immediate (delay=0) retries on auth failure before falling back to exponential backoff. */
 const MAX_IMMEDIATE_AUTH_RETRIES = 3;
 
-/** Timestamp of the last github.checkStatus fetch triggered on connect/reconnect. */
-let lastCheckStatusFetchAt = 0;
-/** Minimum interval between reconnect-triggered checkStatus fetches to avoid subprocess storms. */
-const CHECK_STATUS_RECONNECT_COOLDOWN_MS = 30_000;
-
 /** Last thread-list refresh timestamp per workspace, triggered on WS reconnect. */
 const lastLoadThreadsAtByWorkspace = new Map<string, number>();
 /** Minimum interval between reconnect-triggered thread-list fetches to avoid rapid-reconnect storms. */
@@ -261,51 +256,6 @@ export function createWsTransport(
           // Best-effort; terminal output from the gap window is already lost.
         }
       });
-
-      // On connect/reconnect, refresh CI checks for all visible PR threads (best-effort).
-      // Cooldown prevents subprocess storms during rapid reconnect loops.
-      // Deferred import avoids a circular dependency at module evaluation time.
-      const now = Date.now();
-      if (now - lastCheckStatusFetchAt > CHECK_STATUS_RECONNECT_COOLDOWN_MS) {
-        lastCheckStatusFetchAt = now;
-        import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-          const state = useWorkspaceStore.getState();
-
-          // Refresh all PR threads visible in the sidebar (including terminal ones — server
-          // handles merged/closed with a one-shot fetch rather than registering a watcher).
-          const prThreads = state.threads.filter((t) => t.pr_number != null);
-
-          for (const thread of prThreads) {
-            rpc<ChecksStatus>("github.checkStatus", { threadId: thread.id }).then((checks) => {
-              useWorkspaceStore.setState((ws) => {
-                const existing = ws.checksById[thread.id];
-                // Ignore stale in-flight responses that arrived after a newer update.
-                if (existing && existing.fetchedAt >= checks.fetchedAt) return ws;
-                return { checksById: { ...ws.checksById, [thread.id]: checks } };
-              });
-            }).catch(() => { /* best-effort */ });
-          }
-
-          // On initial connect, threads haven't loaded yet; subscribe to backfill all PR
-          // threads' CI status once the store is populated.
-          if (state.threads.length === 0) {
-            const unsub = useWorkspaceStore.subscribe((s) => {
-              if (s.threads.length === 0) return;
-              unsub();
-              for (const t of s.threads) {
-                if (t.pr_number == null) continue;
-                rpc<ChecksStatus>("github.checkStatus", { threadId: t.id }).then((checks) => {
-                  useWorkspaceStore.setState((ws) => {
-                    const existing = ws.checksById[t.id];
-                    if (existing && existing.fetchedAt >= checks.fetchedAt) return ws;
-                    return { checksById: { ...ws.checksById, [t.id]: checks } };
-                  });
-                }).catch(() => { /* best-effort */ });
-              }
-            });
-          }
-        });
-      }
     };
 
     ws.onmessage = (event) => {


### PR DESCRIPTION
## What
Delete the WebSocket transport's onopen `github.checkStatus` fan-out (and its 30s cooldown guard / cold-start subscription). The server's `CiWatcherService` already pushes `thread.checksUpdated` and is the single source of truth for CI status.

## Why
Every WS reconnect spawned one `gh pr checks` subprocess per PR thread, plus a second wave from the cold-start subscription. The work duplicates what the watcher already does on its polling loop, and a flaky network produced repeated subprocess storms gated only by a 30s cooldown.

## Key changes
- `apps/web/src/transport/ws-transport.ts` — deleted `lastCheckStatusFetchAt`, `CHECK_STATUS_RECONNECT_COOLDOWN_MS`, and the onopen CI block.
- `apps/web/e2e/ci-reconnect-no-fanout.spec.ts` — new regression spec.

## Related
Closes #334
Relates to #330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket reconnects no longer trigger unnecessary CI status refreshes for PR threads, reducing duplicate network calls and flicker.

* **Tests**
  * Added an end-to-end test that simulates WebSocket reconnects and verifies CI status checks are not re-requested across reconnect cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->