### PR TITLE
feat: add staleness guard to github.checkStatus RPC handler

### DIFF
--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -129,4 +129,62 @@ describe("CiWatcherService", () => {
     expect(entry!.prNumber).toBe(42);
     expect(entry!.cache).toEqual(passing);
   });
+
+  describe("getFreshCache", () => {
+    it("returns null when no entry exists", () => {
+      expect(watcher.getFreshCache("missing", 15_000)).toBeNull();
+    });
+
+    it("returns null when entry exists but cache is null", () => {
+      watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
+      expect(watcher.getFreshCache("t1", 15_000)).toBeNull();
+    });
+
+    it("returns cached status when fetchedAt is within maxAgeMs", () => {
+      const fresh: ChecksStatus = {
+        aggregate: "passing",
+        runs: [],
+        fetchedAt: Date.now() - 5_000, // 5s old
+      };
+      watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
+      watcher.refresh("t1", fresh);
+      expect(watcher.getFreshCache("t1", 15_000)).toEqual(fresh);
+    });
+
+    it("returns null when fetchedAt is older than maxAgeMs", () => {
+      const stale: ChecksStatus = {
+        aggregate: "passing",
+        runs: [],
+        fetchedAt: Date.now() - 20_000, // 20s old
+      };
+      watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
+      watcher.refresh("t1", stale);
+      expect(watcher.getFreshCache("t1", 15_000)).toBeNull();
+    });
+
+    it("treats exact boundary (maxAgeMs) as fresh", () => {
+      const boundary: ChecksStatus = {
+        aggregate: "passing",
+        runs: [],
+        fetchedAt: Date.now() - 15_000,
+      };
+      watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
+      watcher.refresh("t1", boundary);
+      expect(watcher.getFreshCache("t1", 15_000)).toEqual(boundary);
+    });
+  });
+
+  it("getFreshCache does not mutate state or broadcast", async () => {
+    const passing = makeChecks("passing");
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
+    watcher.refresh("t1", passing);
+    mockBroadcast.mockClear();
+
+    // Repeated reads must not cause broadcasts or move the entry between sets.
+    watcher.getFreshCache("t1", 15_000);
+    watcher.getFreshCache("t1", 15_000);
+
+    expect(mockBroadcast).not.toHaveBeenCalled();
+    expect(watcher.isWatching("t1")).toBe(true);
+  });
 });

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -95,6 +95,19 @@ export class CiWatcherService {
   }
 
   /**
+   * Return the cached status only if it was fetched within `maxAgeMs`. Returns null
+   * when the thread is not watched, has no cached result, or the cache is older than
+   * `maxAgeMs`. Used by the `github.checkStatus` RPC handler to short-circuit live
+   * fetches when the watcher already has a fresh result.
+   */
+  getFreshCache(threadId: string, maxAgeMs: number): ChecksStatus | null {
+    const entry = this.getEntry(threadId);
+    if (!entry?.cache) return null;
+    if (Date.now() - entry.cache.fetchedAt > maxAgeMs) return null;
+    return entry.cache;
+  }
+
+  /**
    * Update the cached status for a thread and broadcast if anything changed.
    * Mirrors tick()'s promote/demote logic so a manual refresh keeps the
    * polling cadence correct (e.g. pending → active set, terminal → passive set).

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -430,6 +430,15 @@ async function dispatch(
     case "github.prByUrl":
       return deps.githubService.getPrByUrl(params.url);
     case "github.checkStatus": {
+      // 15s window: matches the active-set polling cadence so a fresh tick result
+      // satisfies most reads without spawning a redundant `gh pr checks` subprocess.
+      // `force: true` (used by the manual refresh button) bypasses this guard.
+      const STALENESS_MS = 15_000;
+      if (!params.force) {
+        const fresh = deps.ciWatcherService.getFreshCache(params.threadId, STALENESS_MS);
+        if (fresh) return fresh;
+      }
+
       let entry = deps.ciWatcherService.getEntry(params.threadId);
       if (!entry) {
         // Bootstrap: thread may not be in the watcher yet (e.g. connect race before syncThreadPrs).

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -174,7 +174,7 @@ export function ChecksPopover({
     setRefreshing(true);
     setRefreshError(false);
     try {
-      const fresh = await getTransport().checkStatus(threadId);
+      const fresh = await getTransport().checkStatus(threadId, true);
       useWorkspaceStore.setState((ws) => ({
         checksById: { ...ws.checksById, [threadId]: fresh },
       }));

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -195,7 +195,7 @@ export interface McodeTransport {
   fetchBranch(workspaceId: string, branch: string, prNumber?: number): Promise<void>;
   getPrByUrl(url: string): Promise<PrDetail | null>;
   /** Fetch fresh CI check status for a thread (manual refresh). */
-  checkStatus(threadId: string): Promise<ChecksStatus>;
+  checkStatus(threadId: string, force?: boolean): Promise<ChecksStatus>;
 
   // Skills
   /** List discoverable skills and commands, optionally scoped to a workspace path and provider. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -561,8 +561,8 @@ export function createWsTransport(
     fetchBranch: (workspaceId, branch, prNumber?) =>
       rpc<void>("git.fetchBranch", { workspaceId, branch, prNumber }),
     getPrByUrl: (url) => rpc<PrDetail | null>("github.prByUrl", { url }),
-    checkStatus: (threadId) =>
-      rpc<ChecksStatus>("github.checkStatus", { threadId }),
+    checkStatus: (threadId, force) =>
+      rpc<ChecksStatus>("github.checkStatus", { threadId, force }),
 
     // Skills
     listSkills: (cwd?, providerId?) => rpc<SkillInfo[]>("skill.list", { cwd, providerId }),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -321,7 +321,11 @@ export const WS_METHODS = lazySchema(() => ({
     result: CreatePrResultSchema(),
   },
   "github.checkStatus": {
-    params: z.object({ threadId: z.string() }),
+    params: z.object({
+      threadId: z.string(),
+      /** Bypass the watcher's staleness guard and always perform a live `gh pr checks` fetch. */
+      force: z.boolean().optional(),
+    }),
     result: ChecksStatusSchema(),
   },
   "config.discover": {


### PR DESCRIPTION
## What
Add a 15-second staleness guard to the `github.checkStatus` RPC handler so it returns the `CiWatcherService`'s cached result when fresh, avoiding redundant `gh pr checks` subprocess spawns. A new `force` parameter lets `ChecksPopover`'s manual refresh button always bypass the cache.

## Why
The RPC handler was spawning a live `gh pr checks` subprocess on every call, even when the watcher had polled the same thread seconds ago. This causes unnecessary subprocess load during reconnects and rapid UI interactions. The watcher already maintains a timestamped cache — this change makes the RPC layer use it.

Closes #335. Part of epic #330.

## Key Changes
- `CiWatcherService.getFreshCache(threadId, maxAgeMs)` — pure read helper that returns cached status only if younger than `maxAgeMs`; null otherwise
- `github.checkStatus` RPC handler short-circuits with cached result when `force` is absent and cache is younger than 15s
- `force?: boolean` added to the contract schema, transport interface, and WS client
- `ChecksPopover` manual refresh passes `force: true` to always live-fetch

## Test Plan
- [x] `getFreshCache` unit tests: null when no entry, null when cache is null, returns fresh cache within window, null when stale, boundary treated as fresh
- [x] Invariant test: `getFreshCache` is a pure read (no broadcasts, no set mutations)
- [x] All 14 ci-watcher tests pass
- [x] All 885 web unit tests pass
- [x] Full typecheck across contracts, server, web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI status checks are now cached for up to 15 seconds, reducing redundant background work on frequent reads.
  * Added optional force refresh parameter to bypass the cache when users need current results.

* **Performance**
  * Reduced unnecessary subprocess and CLI calls by serving cached CI check results when fresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->