### PR TITLE
fix(web): align Cursor brand icon in Open menu and model selector

### DIFF
--- a/apps/web/src/components/chat/EditorIcons.tsx
+++ b/apps/web/src/components/chat/EditorIcons.tsx
@@ -91,23 +91,3 @@ export function ZedIcon({ size = 14, className }: IconProps) {
     </svg>
   );
 }
-
-/** Cursor - official Cursor editor brand mark (rounded rect with arrow cutout). */
-export function CursorIcon({ size = 14, className }: IconProps) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 28 28"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-    >
-      <rect width="28" height="28" rx="5" fill="currentColor" />
-      <path
-        d="M22.3 13.5L8 4v20l4.8-6.5L17.5 24l3-1.2-4.7-6.8L22.3 13.5z"
-        fill="var(--popover)"
-      />
-    </svg>
-  );
-}

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -26,7 +26,7 @@ const PROVIDER_META: Record<string, { icon: IconComponent; color: string }> = {
   claude: { icon: ClaudeIcon, color: "text-orange-500 dark:text-orange-400" },
   codex: { icon: CodexIcon, color: "text-emerald-400" },
   copilot: { icon: CopilotIcon, color: "text-violet-400 dark:text-violet-300" },
-  cursor: { icon: CursorProviderIcon, color: "text-blue-400" },
+  cursor: { icon: CursorProviderIcon, color: "" },
   opencode: { icon: OpenCodeIcon, color: "text-violet-400" },
   gemini: { icon: GeminiIcon, color: "text-sky-400" },
 };

--- a/apps/web/src/components/chat/OpenInEditorMenu.tsx
+++ b/apps/web/src/components/chat/OpenInEditorMenu.tsx
@@ -6,7 +6,8 @@ import { registerCommand } from "@/lib/shortcuts";
 import { formatKeybinding } from "@/lib/keybinding-manager";
 import { isMac } from "@/lib/platform";
 import { useToastStore } from "@/stores/toastStore";
-import { VsCodeIcon, ZedIcon, CursorIcon } from "./EditorIcons";
+import { VsCodeIcon, ZedIcon } from "./EditorIcons";
+import { CursorProviderIcon } from "./ProviderIcons";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -24,7 +25,7 @@ interface EditorEntry {
 
 const EDITOR_CONFIG: Record<string, { label: string; icon: (size: number) => React.ReactNode }> = {
   code: { label: "VS Code", icon: (s) => <VsCodeIcon size={s} /> },
-  cursor: { label: "Cursor", icon: (s) => <CursorIcon size={s} /> },
+  cursor: { label: "Cursor", icon: (s) => <CursorProviderIcon size={s} /> },
   zed: { label: "Zed", icon: (s) => <ZedIcon size={s} /> },
 };
 


### PR DESCRIPTION
## Summary

Aligns the Cursor mark with the official split-hexagon icon everywhere and drops the ad-hoc blue tint in the model selector so the icon uses foreground / \currentColor\ like Settings → Models.

## Changes

- **Open in editor menu:** Use \CursorProviderIcon\ from \ProviderIcons.tsx\ instead of the rounded-rect placeholder in \EditorIcons.tsx\.
- **Model selector:** Remove \	ext-blue-400\ from Cursor provider meta so the mark renders monochrome.
- **EditorIcons:** Remove the unused \CursorIcon\ export.

## Verification

- [ ] \cd apps/web && bun run typecheck\
- Manual: model picker Cursor row, project **Open** → Cursor, Settings → Models.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual appearance of the Cursor editor icon, adjusting its color styling to align with UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->