### PR TITLE
fix(web): cold-start landing add-project shortcuts and footer hints

### DIFF
--- a/apps/web/e2e/project-selector.spec.ts
+++ b/apps/web/e2e/project-selector.spec.ts
@@ -158,6 +158,62 @@ test.describe("Project selector — cold-start landing", () => {
     await expect(page.getByTestId("palette-add-folder")).toBeVisible();
     await expect(page.locator('[data-slot="palette-input"]')).toHaveValue("~/");
   });
+
+  test("Ctrl+Enter on landing opens add-project palette (browse mode)", async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [],
+      "workspace.enrich": { items: [] },
+      "settings.get": MOCK_SETTINGS,
+      "filesystem.browse": {
+        path: "/home/user",
+        parent: "/home",
+        entries: [{ name: "my-app", isDir: true }],
+      },
+    });
+    await page.goto("/");
+    await expect(page.getByText("No projects yet").first()).toBeVisible({ timeout: 15000 });
+    await page.waitForTimeout(200);
+    // New keyboard-hint row — fails fast if Playwright hits a stale dev server (reuseExistingServer).
+    await expect(page.getByText("Add project", { exact: true })).toBeVisible({ timeout: 5000 });
+    await page.keyboard.press("Control+Enter");
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+    await expect(page.getByTestId("palette-add-folder")).toBeVisible();
+    await expect(page.locator('[data-slot="palette-input"]')).toHaveValue("~/");
+  });
+
+  test("Add project button does not emit dragstart when mouse-dragged", async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [],
+      "workspace.enrich": { items: [] },
+      "settings.get": MOCK_SETTINGS,
+    });
+    await page.goto("/");
+    await expect(page.getByText("No projects yet").first()).toBeVisible({ timeout: 15000 });
+    await page.waitForTimeout(200);
+    await page.evaluate(() => {
+      (window as unknown as { __landingDragStarts?: number }).__landingDragStarts = 0;
+      document.addEventListener(
+        "dragstart",
+        () => {
+          const w = window as unknown as { __landingDragStarts?: number };
+          w.__landingDragStarts = (w.__landingDragStarts ?? 0) + 1;
+        },
+        true,
+      );
+    });
+    const btn = page.getByTestId("landing-add-project");
+    const box = await btn.boundingBox();
+    expect(box).not.toBeNull();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2 + 60, box!.y + box!.height / 2 + 40);
+    await page.mouse.up();
+    const dragStarts = await page.evaluate(
+      () => (window as unknown as { __landingDragStarts?: number }).__landingDragStarts ?? 0,
+    );
+    expect(dragStarts).toBe(0);
+  });
 });
 
 test.describe("Project selector — palette projects view", () => {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,6 +2,14 @@ import { defineConfig } from "@playwright/test";
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
 
+/**
+ * Attach to an already-running dev server on `BASE_URL` instead of starting one.
+ * Only honored locally — CI always boots a fresh server so runs stay reproducible.
+ * Useful when you intentionally keep `bun run dev` open and want faster test iteration.
+ */
+const reuseExistingServer =
+  !process.env.CI && process.env.PLAYWRIGHT_REUSE_WEB_SERVER === "1";
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -21,7 +29,7 @@ export default defineConfig({
   webServer: {
     command: "bun run dev",
     url: BASE_URL,
-    reuseExistingServer: true,
+    reuseExistingServer,
     timeout: 30000,
   },
 });

--- a/apps/web/src/components/projects/ProjectSelectorLanding.tsx
+++ b/apps/web/src/components/projects/ProjectSelectorLanding.tsx
@@ -14,6 +14,8 @@ import type { RecentThread } from "@/transport/types";
  * Renders the app wordmark, then pinned and recent projects.
  * Opening a project calls setActiveWorkspace (same as the palette flow).
  * The "+ Add project" button opens the palette in browse mode (input seeded to `~/`).
+ * While this screen is mounted, Ctrl/Cmd+Enter runs the same action (mirrors browse
+ * mode's confirm shortcut) and is suppressed when an input or contenteditable is focused.
  */
 export function ProjectSelectorLanding() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -22,8 +24,6 @@ export function ProjectSelectorLanding() {
   const setPendingNewThread = useWorkspaceStore((s) => s.setPendingNewThread);
   const pinWorkspace = useWorkspaceStore((s) => s.pinWorkspace);
   const removeRecent = useWorkspaceStore((s) => s.removeRecent);
-  const openPalette = useCommandPaletteStore((s) => s.open);
-
   const pinned = useMemo(() => workspaces.filter((w) => w.pinned), [workspaces]);
   const recent = useMemo(
     () => workspaces.filter((w) => !w.pinned && w.last_opened_at != null),
@@ -82,7 +82,30 @@ export function ProjectSelectorLanding() {
   const handleRemove = (id: string) => {
     void removeRecent(id).catch(() => {});
   };
-  const handleAdd = () => openPalette({ intent: "addProject" });
+  const handleAdd = () =>
+    useCommandPaletteStore.getState().open({ intent: "addProject" });
+
+  useEffect(() => {
+    function isInputFocused(): boolean {
+      const el = document.activeElement;
+      if (!el) return false;
+      const tag = el.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return true;
+      if (el instanceof HTMLElement && el.isContentEditable) return true;
+      return false;
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      const isEnter =
+        e.key === "Enter" || e.code === "Enter" || e.code === "NumpadEnter";
+      if (!(e.ctrlKey || e.metaKey) || !isEnter) return;
+      if (e.shiftKey || e.altKey) return;
+      if (isInputFocused()) return;
+      e.preventDefault();
+      useCommandPaletteStore.getState().open({ intent: "addProject" });
+    }
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, []);
   /**
    * Open a thread from the recent-threads list. Activate the parent workspace
    * first so downstream selectors (sidebar highlight, breadcrumb, settings) see
@@ -98,17 +121,14 @@ export function ProjectSelectorLanding() {
   const modKey = isMac ? "⌘" : "Ctrl";
 
   return (
-    // `flex-1 min-h-0` (instead of `h-full`) so when this is nested in a flex
-    // column with a sibling — e.g. the sidebar-reveal strip rendered by App.tsx
-    // when the sidebar is collapsed — we claim only our allotted slot rather
-    // than overflowing the parent and pushing the absolute keyboard hint
-    // (`bottom-6`) below the viewport.
-    <div className="relative flex min-h-0 flex-1 flex-col">
+    // `flex-1 min-h-0` nests correctly under App's flex column (e.g. beside a
+    // sidebar-reveal strip). Scroll lives only in the middle pane; shortcut hints
+    // sit in a normal-flow footer so they never paint over list rows or the CTA.
+    <div className="flex min-h-0 flex-1 flex-col">
       {/* Scrollable column — `my-auto` on the inner stack centers content when it
           fits and falls back to natural top-alignment when it overflows, so the
-          wordmark never gets pushed offscreen on short viewports.
-          `pb-16` keeps the bottom keyboard hint from overlapping list items. */}
-      <div className="flex min-h-0 flex-1 flex-col items-center overflow-y-auto px-4 pb-16">
+          wordmark never gets pushed offscreen on short viewports. */}
+      <div className="flex min-h-0 flex-1 flex-col items-center overflow-y-auto px-4">
         <div className="my-auto flex w-full flex-col items-center py-8">
           {/* Wordmark — generous size + a small caret accent give the cold-start a moment of personality */}
           <div className="mb-12 flex items-baseline gap-1 select-none font-mono text-[34px] font-semibold leading-none tracking-tight text-foreground">
@@ -169,6 +189,8 @@ export function ProjectSelectorLanding() {
           <Button
             data-testid="landing-add-project"
             variant="outline"
+            draggable={false}
+            onDragStart={(e) => e.preventDefault()}
             onClick={handleAdd}
             className="group mt-2 w-full gap-2 py-2.5 text-[12.5px] text-foreground/80"
           >
@@ -184,6 +206,8 @@ export function ProjectSelectorLanding() {
           </p>
           <Button
             data-testid="landing-add-project"
+            draggable={false}
+            onDragStart={(e) => e.preventDefault()}
             onClick={handleAdd}
             className="gap-2 px-4 py-2 text-[13px]"
           >
@@ -195,13 +219,19 @@ export function ProjectSelectorLanding() {
         </div>
       </div>
 
-      {/* Keyboard hint — surfaces the palette so power users know it exists.
-          Pinned to the bottom so it doesn't compete with the wordmark/list.
-          Sits outside the scroll container so it stays anchored as the list scrolls. */}
-      <div className="pointer-events-none absolute bottom-6 left-1/2 flex -translate-x-1/2 items-center gap-1.5 font-mono text-[10.5px] tracking-[0.06em] text-muted-foreground/55">
-        <Kbd>{modKey}</Kbd>
-        <Kbd>P</Kbd>
-        <span className="ml-1">Command palette</span>
+      {/* Shortcut cheatsheet — fixed footer row below the scroller so it stays
+          readable and never overlaps scrolled content (unlike an overlay). */}
+      <div className="pointer-events-none flex shrink-0 flex-col items-center gap-2 border-t border-border/30 bg-background px-4 pb-5 pt-3 font-mono text-[10.5px] tracking-[0.06em] text-muted-foreground/55">
+        <div className="flex items-center gap-1.5">
+          <Kbd>{modKey}</Kbd>
+          <Kbd>P</Kbd>
+          <span className="ml-1">Command palette</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Kbd>{modKey}</Kbd>
+          <Kbd>Enter</Kbd>
+          <span className="ml-1">Add project</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Ctrl/Cmd+Enter** on the cold-start landing opens the same add-project flow as the CTA (palette seeded with \~/\), with guards matching palette semantics (skipped when an input or contenteditable is focused).
- **Drag**: landing CTAs set \draggable={false}\ and cancel \dragstart\ so text/icon pulls do not show a drag ghost.
- **Layout**: shortcut cheatsheet moved from an **absolute** bottom overlay into a **normal-flow footer** below the scroll region so hints never paint over project rows or **Add project** when scrolling.
- **Tests**: Playwright covers Ctrl+Enter and dragstart; asserts the new footer hint text first to catch stale dev-server bundles.

## Playwright

\euseExistingServer\ is now opt-in via \PLAYWRIGHT_REUSE_WEB_SERVER=1\ when not in CI, so local runs default to a fresh server (CI unchanged: always fresh).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ctrl/Cmd+Enter keyboard shortcut to open the add-project dialog from the project selector.

* **Bug Fixes**
  * Fixed unintended drag behavior on project action buttons.
  * Improved keyboard hint layout to prevent content overlap on the project selector screen.
  * Enhanced keyboard shortcut handling to avoid conflicts when typing in input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->