### PR TITLE
fix(cursor): discover .cursor skills/commands/plugins and inject user AGENTS.md

### DIFF
--- a/apps/server/src/providers/cursor/__tests__/cursor-prompt.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-prompt.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { buildCursorPrompt, readCursorUserInstructions } from "../cursor-prompt.js";
+
+describe("cursor-prompt", () => {
+  describe("readCursorUserInstructions", () => {
+    let originalHome: string | undefined;
+    let originalUserProfile: string | undefined;
+    let fakeHome: string;
+
+    beforeEach(() => {
+      fakeHome = mkdtempSync(join(tmpdir(), "cursor-prompt-"));
+      originalHome = process.env.HOME;
+      originalUserProfile = process.env.USERPROFILE;
+      process.env.HOME = fakeHome;
+      process.env.USERPROFILE = fakeHome;
+    });
+
+    afterEach(() => {
+      if (originalHome !== undefined) process.env.HOME = originalHome;
+      else delete process.env.HOME;
+      if (originalUserProfile !== undefined) process.env.USERPROFILE = originalUserProfile;
+      else delete process.env.USERPROFILE;
+      rmSync(fakeHome, { recursive: true, force: true });
+    });
+
+    it("returns undefined when ~/.cursor/AGENTS.md is absent", () => {
+      expect(readCursorUserInstructions()).toBeUndefined();
+    });
+
+    it("returns trimmed contents when ~/.cursor/AGENTS.md exists", () => {
+      const agentsPath = join(fakeHome, ".cursor", "AGENTS.md");
+      mkdirSync(join(fakeHome, ".cursor"), { recursive: true });
+      writeFileSync(agentsPath, "  Stay concise.\n\n", "utf-8");
+
+      expect(readCursorUserInstructions()).toBe("Stay concise.");
+    });
+
+    it("returns undefined when file is whitespace-only", () => {
+      const agentsPath = join(fakeHome, ".cursor", "AGENTS.md");
+      mkdirSync(join(fakeHome, ".cursor"), { recursive: true });
+      writeFileSync(agentsPath, "   \n\t\n", "utf-8");
+
+      expect(readCursorUserInstructions()).toBeUndefined();
+    });
+  });
+
+  describe("buildCursorPrompt", () => {
+    it("concatenates attachments and message without instructions block when omitted", () => {
+      const prompt = buildCursorPrompt("hello", [
+        {
+          id: "a1",
+          name: "x.txt",
+          mimeType: "text/plain",
+          sizeBytes: 1,
+          sourcePath: "/tmp/x.txt",
+        },
+      ]);
+      expect(prompt).toBe("[Attached file: x.txt (text/plain)]\n\nhello");
+      expect(prompt).not.toContain("<user-instructions>");
+    });
+
+    it("prepends user-instructions wrapper when instructions are provided", () => {
+      const prompt = buildCursorPrompt("do work", undefined, "Always cite paths.");
+      expect(prompt.startsWith("<user-instructions>\nAlways cite paths.\n</user-instructions>")).toBe(
+        true,
+      );
+      expect(prompt.endsWith("\n\ndo work")).toBe(true);
+    });
+  });
+});

--- a/apps/server/src/providers/cursor/cursor-prompt.ts
+++ b/apps/server/src/providers/cursor/cursor-prompt.ts
@@ -1,0 +1,58 @@
+/**
+ * Prompt assembly for `cursor-agent --print`. Cursor exposes no `--system` or
+ * `--instructions` flag; user-scope guidance from `~/.cursor/AGENTS.md` is
+ * prepended here so each turn receives it alongside workspace-local discovery.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AttachmentMeta } from "@mcode/contracts";
+
+/**
+ * Reads trimmed contents of `~/.cursor/AGENTS.md` when that file exists.
+ *
+ * @returns File contents or `undefined` when missing or unreadable.
+ */
+export function readCursorUserInstructions(): string | undefined {
+  const path = join(homedir(), ".cursor", "AGENTS.md");
+  if (!existsSync(path)) return undefined;
+  try {
+    const text = readFileSync(path, "utf-8").trim();
+    return text.length > 0 ? text : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Builds prompt text from optional user instructions, attachment references, and the message.
+ *
+ * Images become explicit paths; non-images become labelled mentions without raw FS paths.
+ *
+ * @param message User-visible message body for this turn.
+ * @param attachments Optional attachment metadata from the composer.
+ * @param userInstructions Optional extra instructions (typically from {@link readCursorUserInstructions}).
+ */
+export function buildCursorPrompt(
+  message: string,
+  attachments?: AttachmentMeta[],
+  userInstructions?: string,
+): string {
+  const lines: string[] = [];
+  const trimmedInstructions = userInstructions?.trim();
+  if (trimmedInstructions) {
+    lines.push(`<user-instructions>\n${trimmedInstructions}\n</user-instructions>`);
+  }
+  for (const att of attachments ?? []) {
+    if (att.mimeType.startsWith("image/")) {
+      lines.push(`[Attached image path: ${att.sourcePath}]`);
+    } else {
+      const safeName = att.name.replace(/[\x00-\x1f\x7f]/g, "");
+      const safeMime = att.mimeType.replace(/[\x00-\x1f\x7f]/g, "");
+      lines.push(`[Attached file: ${safeName} (${safeMime})]`);
+    }
+  }
+  lines.push(message);
+  return lines.join("\n\n");
+}

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -51,6 +51,10 @@ import type {
 } from "@mcode/contracts";
 import { runCursorTurn } from "./cursor-turn-runner.js";
 import {
+  buildCursorPrompt,
+  readCursorUserInstructions,
+} from "./cursor-prompt.js";
+import {
   createCursorTodoSnapshot,
   type CursorTodoSnapshot,
 } from "./cursor-todo-snapshot.js";
@@ -64,26 +68,6 @@ interface CursorSessionState {
   todoSnapshot: CursorTodoSnapshot;
   /** AbortController for the in-flight turn (if any), used by stopSession. */
   inFlight: AbortController | null;
-}
-
-/**
- * Builds prompt text from the user message plus safe attachment references.
- * Images become explicit paths; non-images become labelled mentions without
- * raw FS paths to avoid injection-style attacks via filenames.
- */
-function buildCursorPrompt(message: string, attachments?: AttachmentMeta[]): string {
-  const lines: string[] = [];
-  for (const att of attachments ?? []) {
-    if (att.mimeType.startsWith("image/")) {
-      lines.push(`[Attached image path: ${att.sourcePath}]`);
-    } else {
-      const safeName = att.name.replace(/[\x00-\x1f\x7f]/g, "");
-      const safeMime = att.mimeType.replace(/[\x00-\x1f\x7f]/g, "");
-      lines.push(`[Attached file: ${safeName} (${safeMime})]`);
-    }
-  }
-  lines.push(message);
-  return lines.join("\n\n");
 }
 
 /** Executable paths to try for cursor-agent (configured override → catalog → bare name). */
@@ -159,7 +143,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     } = params;
 
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
-    const prompt = buildCursorPrompt(message, attachments);
+    const prompt = buildCursorPrompt(message, attachments, readCursorUserInstructions());
 
     const state = this.getOrCreateState(sessionId);
     const chatId = resume ? state.chatId ?? this.sdkSessionIds.get(sessionId) ?? null : null;

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { SkillService } from "./skill-service.js";
@@ -288,6 +288,136 @@ describe("SkillService", () => {
       expect(cmd).toBeDefined();
       expect(cmd!.kind).toBe("command");
       expect(cmd!.providers).toEqual(["codex"]);
+    });
+
+    it("tags skills from ~/.cursor/skills with providers=['cursor']", () => {
+      const skillDir = join(fakeHome, ".cursor", "skills", "my-cursor-skill");
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Cursor user skill" });
+
+      const items = new SkillService().list(undefined, "cursor");
+      const skill = items.find((i) => i.name === "my-cursor-skill");
+      expect(skill).toMatchObject({
+        kind: "skill",
+        source: "user",
+        description: "Cursor user skill",
+        providers: ["cursor"],
+      });
+    });
+
+    it("tags commands from ~/.cursor/commands with providers=['cursor']", () => {
+      const cmdDir = join(fakeHome, ".cursor", "commands");
+      mkdirSync(cmdDir, { recursive: true });
+      writeMd(join(cmdDir, "lint.md"), { description: "Cursor lint command" });
+
+      const items = new SkillService().list(undefined, "cursor");
+      const cmd = items.find((i) => i.name === "lint");
+      expect(cmd).toMatchObject({
+        kind: "command",
+        source: "user",
+        description: "Cursor lint command",
+        providers: ["cursor"],
+      });
+    });
+
+    it("scans project-level <cwd>/.cursor/skills and commands for cursor", () => {
+      const cwd = tmp();
+      try {
+        const skillDir = join(cwd, ".cursor", "skills", "proj-skill");
+        mkdirSync(skillDir, { recursive: true });
+        writeMd(join(skillDir, "SKILL.md"), { description: "Project cursor skill" });
+
+        const cmdDir = join(cwd, ".cursor", "commands");
+        mkdirSync(cmdDir, { recursive: true });
+        writeMd(join(cmdDir, "ship.md"), { description: "Ship it" });
+
+        const items = new SkillService().list(cwd, "cursor");
+        expect(items.find((i) => i.name === "proj-skill")).toMatchObject({
+          kind: "skill",
+          source: "project",
+          providers: ["cursor"],
+        });
+        expect(items.find((i) => i.name === "ship")).toMatchObject({
+          kind: "command",
+          source: "project",
+          providers: ["cursor"],
+        });
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it("cursor plugin cache: scans newest hash dir by mtime, not lexical order", () => {
+      const pluginRoot = join(fakeHome, ".cursor", "plugins", "cache", "mp", "myplug");
+      /** Lexically last — would win if we wrongly sorted by name instead of mtime. */
+      const dirStaleLexLast = join(pluginRoot, "zebra-hash");
+      /** Lexically first — must win because its mtime is newest. */
+      const dirFreshLexFirst = join(pluginRoot, "apple-hash");
+      mkdirSync(join(dirStaleLexLast, "skills", "deploy"), { recursive: true });
+      mkdirSync(join(dirFreshLexFirst, "skills", "deploy"), { recursive: true });
+      writeMd(join(dirStaleLexLast, "skills", "deploy", "SKILL.md"), {
+        description: "Stale plugin skill",
+      });
+      writeMd(join(dirFreshLexFirst, "skills", "deploy", "SKILL.md"), {
+        description: "Fresh plugin skill",
+      });
+
+      utimesSync(dirStaleLexLast, new Date("2020-06-01"), new Date("2020-06-01"));
+      utimesSync(dirFreshLexFirst, new Date("2025-06-01"), new Date("2025-06-01"));
+
+      const items = new SkillService().list(undefined, "cursor");
+      const deploy = items.find((i) => i.name === "myplug:deploy");
+      expect(deploy).toMatchObject({
+        kind: "skill",
+        source: "plugin",
+        description: "Fresh plugin skill",
+        providers: ["cursor"],
+      });
+    });
+
+    it("cursor plugin cache: scans workflow-skills alongside skills/", () => {
+      const wfDir = join(
+        fakeHome,
+        ".cursor",
+        "plugins",
+        "local",
+        "mp",
+        "wfplug",
+        "hash1",
+        "workflow-skills",
+        "analyze",
+      );
+      mkdirSync(wfDir, { recursive: true });
+      writeMd(join(wfDir, "SKILL.md"), { description: "Workflow skill" });
+
+      const items = new SkillService().list(undefined, "cursor");
+      expect(items.find((i) => i.name === "wfplug:analyze")).toMatchObject({
+        kind: "skill",
+        source: "plugin",
+        providers: ["cursor"],
+      });
+    });
+
+    it("cursor plugin skills under .cursor/skills are tagged for cursor provider", () => {
+      const skillDir = join(
+        fakeHome,
+        ".cursor",
+        "plugins",
+        "cache",
+        "mp",
+        "native",
+        "v1",
+        ".cursor",
+        "skills",
+        "native-skill",
+      );
+      mkdirSync(skillDir, { recursive: true });
+      writeMd(join(skillDir, "SKILL.md"), { description: "Native cursor plugin layout" });
+
+      const items = new SkillService().list(undefined, "cursor");
+      expect(items.find((i) => i.name === "native:native-skill")).toMatchObject({
+        providers: ["cursor"],
+      });
     });
 
     it("plugin .agents/skills/ is NOT exposed to non-Claude providers", () => {

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -3,11 +3,11 @@
  * Walks user, project, agent, and plugin directories looking for both
  * `skills/` (each subdirectory is a skill) and `commands/` (each .md file
  * is a command). Mirrors Claude Code's native discovery, extended to cover
- * Codex and Copilot provider directories.
+ * Codex and Copilot provider directories, plus Cursor `.cursor/skills` and commands.
  */
 
 import { injectable } from "tsyringe";
-import { readdirSync, readFileSync, existsSync, type Dirent } from "fs";
+import { readdirSync, readFileSync, existsSync, statSync, type Dirent } from "fs";
 import { join } from "path";
 import { homedir, platform } from "os";
 import { logger } from "@mcode/shared";
@@ -178,6 +178,58 @@ function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string, pro
 }
 
 /**
+ * Scan one Cursor plugin install directory (hash-named version folder).
+ * Extends Claude-shaped layouts with Cursor-native `.cursor/skills`,
+ * `.cursor/commands`, and peer `workflow-skills/` trees.
+ */
+function scanCursorPluginVersionDir(
+  ctx: ScanContext,
+  versionDir: string,
+  pluginName: string,
+  providers: string[],
+): void {
+  scanPluginVersionDir(ctx, versionDir, pluginName, providers);
+  const cursorBase = join(versionDir, ".cursor");
+  scanSkillsDir(ctx, join(cursorBase, "skills"), pluginName, "plugin", providers);
+  scanCommandsDir(ctx, join(cursorBase, "commands"), pluginName, "plugin", providers);
+  scanSkillsDir(ctx, join(versionDir, "workflow-skills"), pluginName, "plugin", providers);
+  scanSkillsDir(ctx, join(cursorBase, "workflow-skills"), pluginName, "plugin", providers);
+}
+
+/**
+ * Walk Cursor plugin caches (`~/.cursor/plugins/cache`, `local`): cache/<mp>/<plugin>/<hash>/.
+ * Version dirs are opaque hashes (not semver); pick the newest by directory mtime.
+ */
+function scanCursorPluginCacheDir(ctx: ScanContext, cacheDir: string, providers: string[]): void {
+  for (const mp of scanDir(ctx, cacheDir)) {
+    if (!mp.isDirectory()) continue;
+    const mpDir = join(cacheDir, mp.name);
+    for (const plugin of scanDir(ctx, mpDir)) {
+      if (!plugin.isDirectory()) continue;
+      const pluginDir = join(mpDir, plugin.name);
+      const versionDirs = scanDir(ctx, pluginDir).filter((e) => e.isDirectory());
+      if (versionDirs.length === 0) continue;
+      let best: { name: string; mtime: number } | null = null;
+      for (const e of versionDirs) {
+        const p = join(pluginDir, e.name);
+        let mtime = 0;
+        try {
+          mtime = statSync(p).mtimeMs;
+        } catch {
+          /* stale symlink / race — treat as 0 */
+        }
+        if (!best || mtime > best.mtime) {
+          best = { name: e.name, mtime };
+        }
+      }
+      if (best) {
+        scanCursorPluginVersionDir(ctx, join(pluginDir, best.name), plugin.name, providers);
+      }
+    }
+  }
+}
+
+/**
  * Resolve the Copilot user-level agents directory.
  *
  * @returns The platform-specific path to Copilot's user-level agents directory.
@@ -208,6 +260,7 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
   const codexDir = join(home, ".codex");
   const copilotDir = join(home, ".copilot");
   const agentsDir = join(home, ".agents");
+  const cursorDir = join(home, ".cursor");
 
   const roots: ScanRoot[] = [
     // Claude ecosystem
@@ -222,6 +275,10 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
     // Copilot ecosystem
     { path: join(copilotDir, "skills"), source: "user", providers: ["copilot"], kind: "skills" },
     { path: join(copilotDir, "commands"), source: "user", providers: ["copilot"], kind: "commands" },
+
+    // Cursor CLI ecosystem (cursor-agent discovers workspace rules separately; these roots drive Mcode UI listing)
+    { path: join(cursorDir, "skills"), source: "user", providers: ["cursor"], kind: "skills" },
+    { path: join(cursorDir, "commands"), source: "user", providers: ["cursor"], kind: "commands" },
 
     // Cross-provider (.agents at home root — visible to Codex but not Claude or Copilot)
     { path: join(agentsDir, "skills"), source: "agent", providers: ["codex"], kind: "skills" },
@@ -248,6 +305,10 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
       // Copilot project-level agents
       { path: join(cwd, ".github", "agents"), source: "project", providers: ["copilot"], kind: "both" },
       { path: join(cwd, ".copilot", "agents"), source: "project", providers: ["copilot"], kind: "both" },
+
+      // Cursor project-level
+      { path: join(cwd, ".cursor", "skills"), source: "project", providers: ["cursor"], kind: "skills" },
+      { path: join(cwd, ".cursor", "commands"), source: "project", providers: ["cursor"], kind: "commands" },
     );
   }
 
@@ -332,6 +393,7 @@ export class SkillService {
   private scan(cwd?: string): { items: SkillInfo[]; diag: SkillDiagnostics } {
     const home = homedir();
     const claudeDir = join(home, ".claude");
+    const cursorDir = join(home, ".cursor");
     const ctx: ScanContext = {
       out: [],
       diag: { scanned: [], errors: [], totalSkills: 0, totalCommands: 0 },
@@ -347,9 +409,13 @@ export class SkillService {
       }
     }
 
-    // Plugins remain Claude-scoped
+    // Claude plugin infrastructure (semver-sorted cache + marketplace checkouts)
     scanPluginCacheDir(ctx, join(claudeDir, "plugins", "cache"), ["claude"]);
     scanPluginMarketplaceDir(ctx, join(claudeDir, "plugins", "marketplaces"), ["claude"]);
+
+    // Cursor plugin installs (mtime-selected hash dirs under ~/.cursor/plugins)
+    scanCursorPluginCacheDir(ctx, join(cursorDir, "plugins", "cache"), ["cursor"]);
+    scanCursorPluginCacheDir(ctx, join(cursorDir, "plugins", "local"), ["cursor"]);
 
     return { items: ctx.out, diag: ctx.diag };
   }

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -106,7 +106,7 @@ describe("SkillWatcherService", () => {
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("watches codex and agents roots in addition to claude roots", () => {
+  it("watches codex, agents, and cursor roots in addition to claude roots", () => {
     const watchSpy = vi.spyOn(watcher, "watch");
 
     watcher.start();
@@ -115,6 +115,7 @@ describe("SkillWatcherService", () => {
     // Should watch all the new provider roots
     expect(watchedPaths.some((p) => p.includes(".codex"))).toBe(true);
     expect(watchedPaths.some((p) => p.includes(".agents"))).toBe(true);
+    expect(watchedPaths.some((p) => p.replace(/\\/g, "/").includes(".cursor/skills"))).toBe(true);
   });
 
   it("auto-registers roots from multiple parent directories", async () => {

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -1,6 +1,7 @@
 /**
- * Watches Claude plugin and skills directories for changes and triggers
- * `SkillService` cache invalidation plus a `skills.changed` broadcast.
+ * Watches Claude, Cursor, Codex, Copilot-adjacent, and cross-provider skill
+ * directories for changes and triggers `SkillService` cache invalidation plus
+ * a `skills.changed` broadcast.
  *
  * Mirrors the debounce + fs.watch pattern of `GitWatcherService`.
  */
@@ -59,8 +60,10 @@ export class SkillWatcherService {
     const claudeDir = join(home, ".claude");
     const codexDir = join(home, ".codex");
     const agentsDir = join(home, ".agents");
+    const cursorDir = join(home, ".cursor");
 
-    const parentDirs = overrides?.parentDirs ?? [claudeDir, codexDir, agentsDir];
+    const parentDirs =
+      overrides?.parentDirs ?? [claudeDir, codexDir, agentsDir, cursorDir];
     const roots = overrides?.roots ?? [
       // Claude roots
       join(claudeDir, "skills"),
@@ -75,6 +78,10 @@ export class SkillWatcherService {
       join(agentsDir, "commands"),
       // Copilot user-level agents
       copilotUserAgentsDir(),
+      // Cursor CLI roots (skills/commands/plugins mirror Claude-style layout)
+      join(cursorDir, "skills"),
+      join(cursorDir, "commands"),
+      join(cursorDir, "plugins"),
     ];
 
     this.dynamicRoots = roots;

--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -52,6 +52,13 @@ const THREAD = {
   forked_from_message_id: null,
 };
 
+/** Cursor-backed thread — `skill.list` must receive `providerId: "cursor"`. */
+const THREAD_CURSOR = {
+  ...THREAD,
+  provider: "cursor" as const,
+  model: "cursor-auto",
+};
+
 /** Varied skills payload covering multiple kinds and sources. */
 const FIXTURE_SKILLS = [
   { name: "superpowers:brainstorming", description: "Generate ideas creatively", kind: "skill", source: "user" },
@@ -190,6 +197,41 @@ test.describe("Slash command popup", () => {
 
     await page.screenshot({
       path: "e2e/screenshots/slash-command/04-refresh-button.png",
+      fullPage: true,
+    });
+  });
+
+  test("05 - cursor provider thread scopes skill.list to providerId cursor", async ({ page }) => {
+    let listParams: { cwd?: string; providerId?: string } | undefined;
+    const cursorSkills = [
+      {
+        name: "cursor-plugin:deploy",
+        description: "Example Cursor-only skill entry",
+        kind: "skill" as const,
+        source: "plugin" as const,
+        providers: ["cursor"],
+      },
+    ];
+
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [THREAD_CURSOR],
+      "message.list": [],
+      "skill.list": (params) => {
+        listParams = params as { cwd?: string; providerId?: string };
+        return cursorSkills;
+      },
+    });
+
+    await openPopup(page, "/cursor");
+
+    expect(listParams?.providerId).toBe("cursor");
+
+    const popup = page.locator("[data-slash-popup]");
+    await expect(popup.getByText("/cursor-plugin:deploy")).toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/screenshots/slash-command/05-cursor-provider-skills.png",
       fullPage: true,
     });
   });


### PR DESCRIPTION
## Summary

Cursor threads showed empty slash-command lists and skipped user-level guidance because Mcode did not scan Cursor directories or prepend global instructions (unlike Claude and Copilot).

## Changes

- **SkillService**: Scan `~/.cursor/skills`, `commands`, project `.cursor/*`, and `~/.cursor/plugins/cache|local` with mtime-based version selection for hash plugin dirs; scan `.cursor/skills`, `workflow-skills`, etc. inside plugin installs.
- **SkillWatcherService**: Watch `~/.cursor` plus skill/command/plugin roots so cached listings refresh when files change.
- **Cursor provider**: Read `~/.cursor/AGENTS.md` and prepend a `<user-instructions>` block each turn (`cursor-agent` has no system-prompt flag).
- **E2E**: Slash-command popup asserts `skill.list` receives `providerId: "cursor"` for Cursor threads.

## Verification

- Server: Vitest (`skill-service`, `cursor-prompt`, `skill-watcher-service`) and `tsc --noEmit`.
- Web: Playwright `e2e/slash-command-popup.spec.ts` (including new case 05).

## Commits

Four atomic commits: scan → watcher → AGENTS prepend → E2E.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cursor provider now reads and incorporates user instructions into prompts
  * Added skill and command discovery for Cursor provider from user and project directories
  * Cursor provider now monitors file changes for dynamic skill updates

* **Tests**
  * Extended test coverage for Cursor provider prompt building and skill discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->