### PR TITLE
fix(desktop): bundle server for dev without tsx loader

### DIFF
--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -89,7 +89,7 @@ await build({
   ...shared,
   entryPoints: [resolve(serverRoot, "dist-tsc/index.js")],
   outfile: "dist/server/server.cjs",
-  external: ["better-sqlite3", "node-pty", "electron"],
+  external: ["better-sqlite3", "node-pty", "electron", "koffi"],
   banner: {
     js: 'var __importMetaUrl = require("url").pathToFileURL(__filename).href;',
   },

--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -2,10 +2,13 @@
  * Dev orchestration script for the Electron desktop app.
  *
  * 1. Starts the web (renderer) dev server and esbuild in parallel.
- * 2. Detects the actual Vite dev server URL (auto-increments port if taken).
- * 3. Spawns Electron with ELECTRON_RENDERER_URL pointing at the dev server.
- * 4. Restarts Electron when dist/main/main.cjs changes (debounced 300ms).
- * 5. Cleans up all child processes on SIGINT/SIGTERM.
+ * 2. Compiles the backend server (`tsc` → `esbuild`, same pipeline as packaged
+ *    builds) so the desktop child runs `server.cjs` without `--import tsx`.
+ * 3. Detects the actual Vite dev server URL (auto-increments port if taken).
+ * 4. Spawns Electron with ELECTRON_RENDERER_URL pointing at the dev server.
+ * 5. Restarts Electron when dist/main/main.cjs or dist/server/server.cjs
+ *    changes (debounced 300ms).
+ * 6. Cleans up all child processes on SIGINT/SIGTERM.
  */
 
 import { context } from "esbuild";
@@ -14,10 +17,20 @@ import { watch } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
+import {
+  rebuildServerDevBundle,
+  resolveServerTscBin,
+} from "../../../scripts/build-server-dev-bundle.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
 const webRoot = resolve(projectRoot, "..", "web");
+const serverRoot = resolve(projectRoot, "..", "server");
+
+/** Paths to Electron main/preload bundles and server bundle (restart triggers). */
+const mainOutFile = resolve(projectRoot, "dist/main/main.cjs");
+const preloadOutFile = resolve(projectRoot, "dist/preload/preload.cjs");
+const serverOutFile = resolve(projectRoot, "dist/server/server.cjs");
 
 /** Shared esbuild options. */
 const shared = {
@@ -28,12 +41,30 @@ const shared = {
   format: "cjs",
 };
 
+/**
+ * Spawn `tsc --watch` so server source edits re-emit apps/server/dist-tsc.
+ *
+ * @returns Detached subprocess handle (caller must `.kill()` on shutdown).
+ */
+function startServerTscWatch() {  const tscBin = resolveServerTscBin(serverRoot);
+  return spawn(process.execPath, [
+    tscBin,
+    "--project",
+    resolve(serverRoot, "tsconfig.build.json"),
+    "--watch",
+    "--preserveWatchOutput",
+  ], {
+    cwd: serverRoot,
+    stdio: "inherit",
+  });
+}
+
 /** esbuild entry point configs. */
 const entries = [
   {
     ...shared,
     entryPoints: [resolve(projectRoot, "src/main/main.ts")],
-    outfile: resolve(projectRoot, "dist/main/main.cjs"),
+    outfile: mainOutFile,
     external: ["electron"],
   },
   {
@@ -43,6 +74,23 @@ const entries = [
     external: ["electron"],
   },
 ];
+
+console.log("[dev] Building bundled server entry (apps/desktop/dist/server/server.cjs)...");
+await rebuildServerDevBundle();
+
+const serverEsbuildCfg = {
+  ...shared,
+  entryPoints: [resolve(serverRoot, "dist-tsc/index.js")],
+  outfile: serverOutFile,
+  external: ["better-sqlite3", "node-pty", "electron", "koffi"],
+  banner: {
+    js: 'var __importMetaUrl = require("url").pathToFileURL(__filename).href;',
+  },
+  define: {
+    "import.meta.url": "__importMetaUrl",
+    // Do not bake NODE_ENV — the server child inherits Electron's runtime env.
+  },
+};
 
 // -------------------------------------------------------------------------
 // Step 1: Start web dev server + esbuild in parallel
@@ -100,11 +148,11 @@ function startViteDevServer() {
   });
 }
 
-// Run Vite startup and esbuild initial build in parallel
+// Run Vite startup and esbuild (main/preload/server) watch in parallel
 const [devServerUrl, watchContexts] = await Promise.all([
   startViteDevServer(),
   Promise.all(
-    entries.map(async (cfg) => {
+    [...entries, serverEsbuildCfg].map(async (cfg) => {
       const ctx = await context(cfg);
       await ctx.rebuild();
       await ctx.watch();
@@ -112,6 +160,9 @@ const [devServerUrl, watchContexts] = await Promise.all([
     }),
   ),
 ]);
+
+/** `tsc --watch` subprocess for apps/server → dist-tsc (killed on cleanup). */
+let serverTscWatch = startServerTscWatch();
 
 if (!devServerUrl) {
   console.error("[dev] Vite dev server failed to start");
@@ -177,19 +228,27 @@ function spawnElectron() {
 spawnElectron();
 
 // -------------------------------------------------------------------------
-// Step 3: Restart Electron on main process rebuild (debounced)
+// Step 3: Restart Electron on main/server bundle rebuild (debounced)
 // -------------------------------------------------------------------------
 
-const mainOutFile = resolve(projectRoot, "dist/main/main.cjs");
 let debounceTimer = null;
 
-watch(mainOutFile, () => {
+/**
+ * Debounce Electron restart so rapid esbuild increments coalesce.
+ *
+ * @param {string} reason Log line fragment after `[dev]`.
+ */
+function scheduleElectronRestart(reason) {
   if (debounceTimer) clearTimeout(debounceTimer);
   debounceTimer = setTimeout(() => {
-    console.log("[dev] main.cjs changed, restarting Electron...");
+    console.log(`[dev] ${reason}, restarting Electron...`);
     spawnElectron();
   }, 300);
-});
+}
+
+watch(mainOutFile, () => scheduleElectronRestart("main bundle updated"));
+watch(preloadOutFile, () => scheduleElectronRestart("preload bundle updated"));
+watch(serverOutFile, () => scheduleElectronRestart("server bundle updated"));
 
 // -------------------------------------------------------------------------
 // Step 4: Cleanup on exit signals
@@ -198,6 +257,11 @@ watch(mainOutFile, () => {
 /** Stop all child processes and esbuild watchers. */
 function cleanup() {
   if (debounceTimer) clearTimeout(debounceTimer);
+
+  if (serverTscWatch) {
+    serverTscWatch.kill();
+    serverTscWatch = null;
+  }
 
   for (const ctx of watchContexts) {
     ctx.dispose().catch(() => {});

--- a/apps/desktop/src/main/__tests__/server-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/server-manager.test.ts
@@ -354,14 +354,14 @@ describe("ServerManager", () => {
   // Packaged vs dev entry path branching
   // -----------------------------------------------------------------------
 
-  it("spawns the dev index.ts with --import tsx when app.isPackaged is false", async () => {
+  it("spawns the bundled server.cjs without ts-loader when app.isPackaged is false", async () => {
     await manager.start();
 
     const spawnCall = vi.mocked(spawn).mock.calls[0];
     const args = spawnCall[1] as string[];
-    expect(args.join(" ")).toContain("index.ts");
-    expect(args).toContain("--import");
-    expect(args).toContain("tsx");
+    expect(args.some((arg) => arg.includes("dist") && arg.includes("server") && arg.endsWith("server.cjs"))).toBe(true);
+    expect(args.join(" ")).not.toContain("tsx");
+    expect(args.join(" ")).not.toContain("--import");
   });
 
   it("sets ELECTRON_RUN_AS_NODE=1 in the server child process env", async () => {

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -22,9 +22,9 @@ const SettingsSchema = globalThis.__v8Snapshot?.contracts?.SettingsSchema ?? Bun
 
 /**
  * Resolve the server entry point and working directory based on whether the
- * app is packaged or running from source. In packaged mode, the server is a
- * single CJS bundle at `dist/server/server.cjs`; in dev mode it uses the
- * tsx bootstrap at `src/entry.mjs`.
+ * app is packaged or running from source. Packaged and dev both run the same
+ * bundled CJS entry (`dist/server/server.cjs`); dev builds it via
+ * `apps/desktop/scripts/dev-electron.mjs` (tsc → esbuild watch).
  *
  * Also returns the native binding path for better-sqlite3 when packaged so
  * the server child process can find it outside the asar archive.
@@ -47,8 +47,9 @@ function getServerPaths(): {
     return { entry: serverBundle, cwd: dirname(serverBundle), nativeBindingPath };
   }
 
-  const serverDir = resolve(__dirname, "../../../server");
-  return { entry: resolve(serverDir, "src/index.ts"), cwd: serverDir };
+  /** Matches both `src/main/` (Vitest) and bundled `dist/main/` (`__dirname`). */
+  const serverBundle = resolve(__dirname, "..", "..", "dist", "server", "server.cjs");
+  return { entry: serverBundle, cwd: dirname(serverBundle) };
 }
 
 /**
@@ -334,12 +335,8 @@ export class ServerManager {
       }
 
       // V8 flags go in the args array for child_process.spawn.
-      // Module loader flags (--import tsx) are supported here, unlike utilityProcess.
       const v8Flags = [`--max-old-space-size=${heapMb}`, "--max-semi-space-size=2", "--expose-gc"];
-      const entryArgs = entry.endsWith(".cjs")
-        ? [entry]
-        : ["--import", "tsx", entry];
-      const args = [...v8Flags, ...entryArgs];
+      const args = [...v8Flags, entry];
 
       // In production, route stderr to a log file so crashes are diagnosable.
       // Dev mode inherits stdio for immediate console visibility.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "start": "node --import tsx src/index.ts",
+    "start": "bun src/index.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "db:migrate": "node --import tsx src/store/cli/migrate.ts"
+    "db:migrate": "bun src/store/cli/migrate.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "*",
@@ -19,7 +19,6 @@
     "koffi": "^2.16.1",
     "node-pty": "^1.0.0",
     "reflect-metadata": "^0.2.2",
-    "tsx": "^4.19.0",
     "tsyringe": "^4.8.0",
     "uuid": "^11.1.0",
     "which": "^5.0.0",
@@ -28,6 +27,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@types/node": "^22.19.17",
     "@types/better-sqlite3": "^7.6.12",
     "@types/uuid": "^10.0.0",
     "@types/which": "^3.0.4",

--- a/apps/server/src/entry.mjs
+++ b/apps/server/src/entry.mjs
@@ -1,13 +1,12 @@
 /**
- * Bootstrap entry for Electron utilityProcess.
+ * @deprecated Legacy bootstrap for running the server as raw TypeScript under
+ * Electron `utilityProcess`. The supported paths are:
+ * - Standalone: `bun src/index.ts` (see `apps/server/package.json` `start`)
+ * - Desktop: bundled `apps/desktop/dist/server/server.cjs` (see `server-manager.ts`)
  *
- * utilityProcess.fork() does not process execArgv as Node.js CLI flags
- * and Electron strips NODE_OPTIONS in utility processes, so --import tsx
- * cannot be used. Instead, we use tsx's programmatic ESM API to register
- * the TypeScript loader, then dynamically import the server entry point.
+ * This module is retained so accidental imports fail with a clear message
+ * instead of a missing `tsx` dependency.
  */
-import { register } from "tsx/esm/api";
-
-register();
-
-await import("./index.ts");
+throw new Error(
+  "apps/server/src/entry.mjs is deprecated. Use `bun src/index.ts` or spawn apps/desktop/dist/server/server.cjs under Electron (ELECTRON_RUN_AS_NODE=1).",
+);

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -21,7 +21,7 @@ import type { GitService } from "./git-service";
 import type { SettingsService } from "./settings-service";
 
 // createRequire lets us load native CJS modules (node-pty) from both ESM
-// (dev mode via entry.mjs + tsx) and the CJS production bundle.
+// (Bun running `src/index.ts`) and the CJS production / dev bundle.
 const _require = createRequire(import.meta.url);
 
 /**

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -23,6 +23,7 @@ import { initShortcuts } from "@/lib/shortcuts";
 import { registerCommand } from "@/lib/command-registry";
 import { setContext } from "@/lib/context-tracker";
 import { startPushListeners, stopPushListeners } from "@/transport/ws-events";
+import { getTransport } from "@/transport";
 import { useIdleReclamation } from "@/hooks/useIdleReclamation";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ToastContainer } from "@/components/Toast";
@@ -190,7 +191,7 @@ export function App() {
             const terminals = store.terminals[tid];
             if (!terminals || terminals.length === 0) {
               terminalCreationInFlight.add(tid);
-              import("@/transport").then(({ getTransport }) => {
+              try {
                 const transport = getTransport();
                 transport
                   .terminalCreate(tid)
@@ -215,7 +216,9 @@ export function App() {
                   .catch(() => {
                     terminalCreationInFlight.delete(tid);
                   });
-              });
+              } catch {
+                terminalCreationInFlight.delete(tid);
+              }
             }
           }
         },

--- a/apps/web/src/components/chat/CreatePrDialog.tsx
+++ b/apps/web/src/components/chat/CreatePrDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from "react";
 import { Loader2, GitPullRequest, GitBranch, ChevronDown, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -20,11 +20,12 @@ import {
 } from "@/components/ui/command";
 import { Switch } from "@/components/ui/switch";
 import { SegControl } from "@/components/settings/SegControl";
-import { MarkdownContent } from "./MarkdownContent";
 import { getTransport } from "@/transport";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useToastStore } from "@/stores/toastStore";
 import type { GitBranch as GitBranchType } from "@mcode/contracts";
+
+const PreviewMarkdown = lazy(() => import("./MarkdownContent"));
 
 // ---------------------------------------------------------------------------
 // BaseBranchSelect — searchable local-branch picker for the PR dialog sidebar
@@ -424,7 +425,9 @@ export function CreatePrDialog({
                     className="flex-1 min-h-0 overflow-y-auto rounded-lg border border-input bg-background px-3 py-2.5 text-sm"
                   >
                     {body.trim() ? (
-                      <MarkdownContent content={body} />
+                    <Suspense fallback={<span className="text-muted-foreground text-sm">Loading preview…</span>}>
+                      <PreviewMarkdown content={body} />
+                    </Suspense>
                     ) : (
                       <span className="text-muted-foreground italic">Nothing to preview.</span>
                     )}

--- a/apps/web/src/components/diff/DiffContent.tsx
+++ b/apps/web/src/components/diff/DiffContent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { getTransport } from "@/transport";
 import { parseDiffLines } from "@/lib/diff-parser";
 import { langFromPath } from "@/lib/lang-from-path";
@@ -31,7 +32,6 @@ export function DiffContent() {
         } else if (selectedFile.source === "cumulative") {
           result = await transport.getCumulativeDiff(selectedFile.id, selectedFile.filePath);
         } else {
-          const { useWorkspaceStore } = await import("@/stores/workspaceStore");
           const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
           result = workspaceId
             ? await transport.getCommitDiff(workspaceId, selectedFile.id, selectedFile.filePath)

--- a/apps/web/src/components/diff/DiffPreview.tsx
+++ b/apps/web/src/components/diff/DiffPreview.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, lazy, Suspense } from "react";
 import { reconstructNewContent, type ParsedDiffLine } from "@/lib/diff-parser";
-import { MarkdownContent } from "@/components/chat/MarkdownContent";
+
+const PreviewMarkdown = lazy(() => import("@/components/chat/MarkdownContent"));
 
 /** Props for {@link DiffPreview}. */
 interface DiffPreviewProps {
@@ -18,7 +19,9 @@ export function DiffPreview({ lines }: DiffPreviewProps) {
 
   return (
     <div className="p-4 text-sm leading-relaxed text-foreground/80">
-      <MarkdownContent content={markdown} />
+      <Suspense fallback={<span className="text-muted-foreground text-sm">Loading preview…</span>}>
+        <PreviewMarkdown content={markdown} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { ChevronsDownUp, Code2, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useDiffStore, type SelectedFile } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { getTransport } from "@/transport";
 import { parseDiffLines, isMarkdownFile } from "@/lib/diff-parser";
 import { langFromPath } from "@/lib/lang-from-path";
@@ -94,7 +95,6 @@ export function FileEntry({ filePath, source, id, depth = 0 }: FileEntryProps) {
         } else if (source === "cumulative") {
           result = await transport.getCumulativeDiff(id, filePath);
         } else {
-          const { useWorkspaceStore } = await import("@/stores/workspaceStore");
           const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
           result = workspaceId
             ? await transport.getCommitDiff(workspaceId, id, filePath)

--- a/apps/web/src/lib/__tests__/is-markdown-file.test.ts
+++ b/apps/web/src/lib/__tests__/is-markdown-file.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { isMarkdownFile } from "@/lib/diff-parser";
+
+describe("isMarkdownFile", () => {
+  it("returns true for .md files", () => {
+    expect(isMarkdownFile("README.md")).toBe(true);
+    expect(isMarkdownFile("docs/guides/foo.md")).toBe(true);
+  });
+
+  it("returns true for .mdx files", () => {
+    expect(isMarkdownFile("apps/web/src/page.mdx")).toBe(true);
+  });
+
+  it("is case insensitive", () => {
+    expect(isMarkdownFile("README.MD")).toBe(true);
+    expect(isMarkdownFile("NOTES.Md")).toBe(true);
+  });
+
+  it("returns false for non-markdown files", () => {
+    expect(isMarkdownFile("src/index.ts")).toBe(false);
+    expect(isMarkdownFile("package.json")).toBe(false);
+    expect(isMarkdownFile("notes.md.bak")).toBe(false);
+  });
+
+  it("returns false for empty or missing paths", () => {
+    expect(isMarkdownFile("")).toBe(false);
+  });
+
+  it("returns false for paths that merely contain 'md'", () => {
+    expect(isMarkdownFile("md")).toBe(false);
+    expect(isMarkdownFile("some/mdirectory/file.ts")).toBe(false);
+  });
+});

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -1,6 +1,9 @@
 import type { Settings, ProviderAvailability } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { pushEmitter } from "./ws-transport";
+import { getTransport } from "@/transport";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useDiffStore } from "@/stores/diffStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -124,15 +127,11 @@ export function startPushListeners(): void {
         threadId: string;
         status: string;
       };
-      // The workspace store mirrors thread status; import lazily to
-      // avoid circular deps at module evaluation time.
-      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        useWorkspaceStore.setState((ws) => ({
-          threads: ws.threads.map((t) =>
-            t.id === threadId ? { ...t, status: status as typeof t.status } : t,
-          ),
-        }));
-      });
+      useWorkspaceStore.setState((ws) => ({
+        threads: ws.threads.map((t) =>
+          t.id === threadId ? { ...t, status: status as typeof t.status } : t,
+        ),
+      }));
     }),
   );
 
@@ -144,15 +143,11 @@ export function startPushListeners(): void {
         prNumber: number;
         prStatus: string;
       };
-      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        useWorkspaceStore.setState((ws) => ({
-          threads: ws.threads.map((t) =>
-            t.id === threadId
-              ? { ...t, pr_number: prNumber, pr_status: prStatus }
-              : t,
-          ),
-        }));
-      });
+      useWorkspaceStore.setState((ws) => ({
+        threads: ws.threads.map((t) =>
+          t.id === threadId ? { ...t, pr_number: prNumber, pr_status: prStatus } : t,
+        ),
+      }));
     }),
   );
 
@@ -163,11 +158,9 @@ export function startPushListeners(): void {
         threadId: string;
         checks: import("@mcode/contracts").ChecksStatus;
       };
-      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        useWorkspaceStore.setState((ws) => ({
-          checksById: { ...ws.checksById, [threadId]: checks },
-        }));
-      });
+      useWorkspaceStore.setState((ws) => ({
+        checksById: { ...ws.checksById, [threadId]: checks },
+      }));
     }),
   );
 
@@ -200,39 +193,45 @@ export function startPushListeners(): void {
       };
       useThreadStore.getState().handleTurnPersisted(payload);
 
-      // Update diff panel snapshots and commits if this thread is already loaded
-      import("@/stores/diffStore").then(({ useDiffStore }) => {
-        const snap = useDiffStore.getState();
-        const hasSnapshots = snap.snapshotsByThread[payload.threadId] !== undefined;
-        const hasCommits = snap.commitsByThread[payload.threadId] !== undefined;
-        // Skip transport import entirely when neither panel has data for this thread
-        if (!hasSnapshots && !hasCommits) return;
+      const snap = useDiffStore.getState();
+      const hasSnapshots = snap.snapshotsByThread[payload.threadId] !== undefined;
+      const hasCommits = snap.commitsByThread[payload.threadId] !== undefined;
+      if (!hasSnapshots && !hasCommits) return;
 
-        import("@/transport").then(({ getTransport }) => {
-          if (hasSnapshots) {
-            getTransport()
-              .listSnapshots(payload.threadId)
-              .then((snapshots) => useDiffStore.getState().setSnapshots(payload.threadId, snapshots))
-              .catch(() => { /* non-critical */ });
-          }
+      try {
+        const transport = getTransport();
+        if (hasSnapshots) {
+          transport
+            .listSnapshots(payload.threadId)
+            .then((snapshots) =>
+              useDiffStore.getState().setSnapshots(payload.threadId, snapshots),
+            )
+            .catch(() => { /* non-critical */ });
+        }
 
-          if (hasCommits) {
-            import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-              const thread = useWorkspaceStore.getState().threads.find((t) => t.id === payload.threadId);
-              if (!thread) return;
-              getTransport()
-                .getGitLog(thread.workspace_id, thread.branch, 100)
-                .then((commits) => {
-                  // Re-read current state at write time to avoid stale-closure races
-                  const current = useDiffStore.getState().commitsByThread[payload.threadId];
-                  if (current && commits.length === current.length && commits.every((c, i) => c.sha === current[i].sha)) return;
-                  useDiffStore.getState().setCommits(payload.threadId, commits);
-                })
-                .catch(() => { /* non-critical */ });
-            });
-          }
-        });
-      });
+        if (hasCommits) {
+          const thread = useWorkspaceStore
+            .getState()
+            .threads.find((t) => t.id === payload.threadId);
+          if (!thread) return;
+          transport
+            .getGitLog(thread.workspace_id, thread.branch, 100)
+            .then((commits) => {
+              const current = useDiffStore.getState().commitsByThread[payload.threadId];
+              if (
+                current &&
+                commits.length === current.length &&
+                commits.every((c, i) => c.sha === current[i].sha)
+              ) {
+                return;
+              }
+              useDiffStore.getState().setCommits(payload.threadId, commits);
+            })
+            .catch(() => { /* non-critical */ });
+        }
+      } catch {
+        // Transport not initialized — ignore (startup race / tests).
+      }
     }),
   );
 
@@ -248,16 +247,14 @@ export function startPushListeners(): void {
   unsubs.push(
     pushEmitter.on("branch.changed", (data) => {
       const { workspaceId, branch } = data as { workspaceId: string; branch: string | null };
-      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        const state = useWorkspaceStore.getState();
-        // Only refresh if this event is for the active workspace
-        if (state.activeWorkspaceId === workspaceId) {
-          state.loadBranches(workspaceId);
-          if (!state.branchManuallySelected && branch) {
-            state.setNewThreadBranch(branch);
-          }
+      const state = useWorkspaceStore.getState();
+      // Only refresh if this event is for the active workspace
+      if (state.activeWorkspaceId === workspaceId) {
+        state.loadBranches(workspaceId);
+        if (!state.branchManuallySelected && branch) {
+          state.setNewThreadBranch(branch);
         }
-      });
+      }
     }),
   );
 
@@ -265,13 +262,11 @@ export function startPushListeners(): void {
   unsubs.push(
     pushEmitter.on("workspace.gitStatusChanged", (data) => {
       const { workspaceId, isGitRepo } = data as { workspaceId: string; isGitRepo: boolean };
-      import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        useWorkspaceStore.setState((state) => ({
-          workspaces: state.workspaces.map((w) =>
-            w.id === workspaceId ? { ...w, is_git_repo: isGitRepo } : w,
-          ),
-        }));
-      });
+      useWorkspaceStore.setState((state) => ({
+        workspaces: state.workspaces.map((w) =>
+          w.id === workspaceId ? { ...w, is_git_repo: isGitRepo } : w,
+        ),
+      }));
     }),
   );
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
     target: "esnext",
     minify: "oxc",
     sourcemap: false,
+    chunkSizeWarningLimit: 1500,
   },
   test: {
     globals: true,

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "mcode",
       "devDependencies": {
+        "@types/node": "^22.19.17",
+        "esbuild": "^0.27.7",
         "turbo": "^2.5.0",
       },
     },
@@ -47,7 +49,6 @@
         "koffi": "^2.16.1",
         "node-pty": "^1.0.0",
         "reflect-metadata": "^0.2.2",
-        "tsx": "^4.19.0",
         "tsyringe": "^4.8.0",
         "uuid": "^11.1.0",
         "which": "^5.0.0",
@@ -57,6 +58,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
+        "@types/node": "^22.19.17",
         "@types/uuid": "^10.0.0",
         "@types/which": "^3.0.4",
         "@types/ws": "^8.5.13",

--- a/docs/agents/runtime.md
+++ b/docs/agents/runtime.md
@@ -9,13 +9,15 @@ Read it before starting any work. Run `bun run doctor` to verify your environmen
 
 | Command | What it starts |
 |---------|---------------|
-| `bun run dev:web` | Vite frontend + backend server (web-only, no Electron needed) |
+| `bun run dev:web` | Vite frontend + bundled backend under Electron's Node (no Electron window) |
 | `bun run dev:desktop` | Full Electron desktop app |
-| `bun run dev:server` | Backend server only (no frontend) |
+| `bun run dev:server` | Backend server only (no frontend): `bun src/index.ts` |
 
-**For most development work, use `bun run dev:web`.** It starts the server under
-Electron's Node.js (required for the `better-sqlite3` native module ABI) and Vite
-together. No Electron binary is needed.
+**For most development work, use `bun run dev:web`.** It builds the server bundle
+into `apps/desktop/dist/server/server.cjs` on startup (`scripts/build-server-dev-bundle.mjs`),
+then runs it under Electron's Node.js (`ELECTRON_RUN_AS_NODE=1`) so `better-sqlite3` matches
+Electron's ABI, and starts Vite. The Electron **package** must be installed (`bun install`);
+no Electron window is opened.
 
 Use `bun run dev:desktop` only when testing Electron-specific behavior (native IPC,
 tray, window management).

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "db:info": "node scripts/db-info.mjs"
   },
   "devDependencies": {
+    "@types/node": "^22.19.17",
+    "esbuild": "^0.27.7",
     "turbo": "^2.5.0"
   },
   "packageManager": "bun@1.2.14",

--- a/scripts/build-server-dev-bundle.mjs
+++ b/scripts/build-server-dev-bundle.mjs
@@ -1,0 +1,95 @@
+/**
+ * One-shot dev server bundle: `apps/server` tsc emit (`emitDecoratorMetadata`)
+ * followed by esbuild CJS bundle to `apps/desktop/dist/server/server.cjs`, plus
+ * Claude SDK cli.js beside it. Shared by desktop dev orchestration and
+ * `scripts/dev-web.mjs` (no `--import tsx` at runtime).
+ */
+
+import { build } from "esbuild";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Monorepo root when this script lives at `<root>/scripts/`. */
+export function repoRootFromScript() {
+  return resolve(__dirname, "..");
+}
+
+/**
+ * Resolve the bundled `typescript` compiler entry for `execFile(process.execPath, [...])`.
+ *
+ * @param serverRoot Usually `apps/server` (passed so worktrees/monorepo roots resolve reliably).
+ */
+export function resolveServerTscBin(serverRoot = resolve(repoRootFromScript(), "apps/server")) {
+  const localTsc = resolve(serverRoot, "node_modules/typescript/bin/tsc");
+  const rootTsc = resolve(serverRoot, "../../node_modules/typescript/bin/tsc");
+  return existsSync(localTsc) ? localTsc : rootTsc;
+}
+
+/**
+ * Compile apps/server → dist-tsc via tsc (same project as packaged builds).
+ *
+ * @param {string} [serverRoot] Root of `apps/server` (directory with `package.json`).
+ */
+export function compileServerWithTsc(serverRoot = resolve(repoRootFromScript(), "apps/server")) {
+  const tscBin = resolveServerTscBin(serverRoot);
+  execFileSync(process.execPath, [tscBin, "--project", resolve(serverRoot, "tsconfig.build.json")], {
+    cwd: serverRoot,
+    stdio: "inherit",
+  });
+}
+
+/**
+ * Copy Claude Agent SDK `cli.js` adjacent to the bundled server entry (the SDK
+ * resolves it relative to dirname(import.meta.url) at runtime).
+ *
+ * @param {string} serverCjsOut Absolute path to `server.cjs`.
+ * @param {string} serverPackageRoot Root of `apps/server` (directory with `package.json`).
+ */
+export function copyClaudeSdkCliNextTo(serverCjsOut, serverPackageRoot) {
+  const serverRequire = createRequire(resolve(serverPackageRoot, "package.json"));
+  const sdkPkgPath = serverRequire.resolve("@anthropic-ai/claude-agent-sdk/package.json");
+  const sdkCliSrc = resolve(dirname(sdkPkgPath), "cli.js");
+  copyFileSync(sdkCliSrc, resolve(dirname(serverCjsOut), "cli.js"));
+}
+
+/**
+ * Produce `apps/desktop/dist/server/server.cjs` from current server sources.
+ *
+ * @param {object} [options]
+ * @param {string} [options.repoRoot] Repository root; defaults to the parent of `scripts/`.
+ */
+export async function rebuildServerDevBundle(options = {}) {
+  const repoRoot = options.repoRoot ?? repoRootFromScript();
+  const desktopRoot = resolve(repoRoot, "apps/desktop");
+  const serverRoot = resolve(repoRoot, "apps/server");
+  const serverOutFile = resolve(desktopRoot, "dist/server/server.cjs");
+
+  console.log("[server-dev-bundle] Running tsc (apps/server tsconfig.build)...");
+  compileServerWithTsc(serverRoot);
+
+  console.log("[server-dev-bundle] Bundling to dist/server/server.cjs...");
+  await build({
+    bundle: true,
+    platform: "node",
+    target: "node20",
+    sourcemap: true,
+    format: "cjs",
+    entryPoints: [resolve(serverRoot, "dist-tsc/index.js")],
+    outfile: serverOutFile,
+    external: ["better-sqlite3", "node-pty", "electron", "koffi"],
+    banner: {
+      js: 'var __importMetaUrl = require("url").pathToFileURL(__filename).href;',
+    },
+    define: {
+      "import.meta.url": "__importMetaUrl",
+    },
+  });
+
+  copyClaudeSdkCliNextTo(serverOutFile, serverRoot);
+  console.log(`[server-dev-bundle] Complete: ${serverOutFile}`);
+}

--- a/scripts/dev-web.mjs
+++ b/scripts/dev-web.mjs
@@ -15,9 +15,12 @@ import { randomUUID } from "node:crypto";
 import { resolve, dirname } from "node:path";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { rebuildServerDevBundle } from "./build-server-dev-bundle.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, "..");
+const desktopRoot = resolve(rootDir, "apps", "desktop");
+const serverCjs = resolve(desktopRoot, "dist", "server", "server.cjs");
 const SERVER_PORT = 19400;
 
 /** Find an available port starting from `preferred`, incrementing on conflict. */
@@ -82,6 +85,15 @@ if (!electronBin) {
   process.exit(1);
 }
 
+console.log(`\x1b[36m[dev:web]\x1b[0m Building server bundle (${serverCjs})...`);
+
+try {
+  await rebuildServerDevBundle();
+} catch (err) {
+  console.error("[dev:web] Server bundle failed:", err);
+  process.exit(1);
+}
+
 console.log(`\x1b[36m[dev:web]\x1b[0m Starting server on port ${port}...`);
 
 let serverFailed = false;
@@ -89,9 +101,9 @@ let serverFailed = false;
 // Start the server using Electron's Node.js (matches better-sqlite3 ABI).
 const server = spawn(
   electronBin,
-  ["--import", "tsx", "src/index.ts"],
+  [serverCjs],
   {
-    cwd: resolve(rootDir, "apps", "server"),
+    cwd: dirname(serverCjs),
     env: {
       ...process.env,
       ELECTRON_RUN_AS_NODE: "1",


### PR DESCRIPTION
## Summary
Fixes desktop dev startup failures when \	sx\ could not resolve \sbuild\ under Bun's isolated \
ode_modules\ on Windows by never using \--import tsx\ for the server child.

## Changes
- **Dev server bundle**: \scripts/build-server-dev-bundle.mjs\ runs \	sc\ (emitDecoratorMetadata) + esbuild → \pps/desktop/dist/server/server.cjs\; used by \dev-electron.mjs\ (with \	sc --watch\) and \scripts/dev-web.mjs\ on startup.
- **Electron**: [\server-manager.ts\](apps/desktop/src/main/server-manager.ts) always spawns the bundled \server.cjs\ when unpackaged.
- **Server CLI**: \un src/index.ts\ / \un\ for migrations; removed \	sx\ dependency; deprecated [\ntry.mjs\](apps/server/src/entry.mjs).
- **Tooling**: Root \sbuild\ so Node can run the bundle script.
- **Types**: \@types/node\ at root + server; \DOM\ lib in server tsconfig.
- **Web**: Static imports in \ws-events\ / \App\ / diff loaders where safe; lazy Markdown in PR/diff preview; \chunkSizeWarningLimit\.
- **Docs**: [\docs/agents/runtime.md\](docs/agents/runtime.md) startup description.

## Verification
- \un run typecheck\ ✓
- \pps/web\ vitest ✓
- \pps/desktop\ server-manager tests ✓