### PR TITLE
fix(web): prevent user chat bubble from overflowing horizontally

### DIFF
--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -190,7 +190,7 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch }: 
 
     return (
       <div className="group/msg flex justify-end">
-        <div className="max-w-[75%] space-y-1.5">
+        <div className="min-w-0 max-w-[75%] space-y-1.5">
           {/* Image attachments — standalone thumbnails above the bubble */}
           {imageAttachments.length > 0 && (
             <div className={cn(
@@ -210,7 +210,7 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch }: 
 
           {/* Text bubble — only if there's text or file attachments */}
           {(textContent.trim() || fileAttachments.length > 0) && (
-            <div className="rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
+            <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
               {fileAttachments.length > 0 && (
                 <div className="mb-2 space-y-1">
                   {fileAttachments.map((file) => (


### PR DESCRIPTION
## What
Prevent the user chat bubble from horizontally overflowing its container.

## Why
Long unbreakable content (URLs, inline code, wide code blocks) could push the user message bubble past its `max-w-[75%]` boundary because the flex child had no `min-w-0` and the bubble div lacked overflow/word-break handling.

## Key Changes
- Add `min-w-0` to the bubble wrapper so the flex child respects `max-w-[75%]` even when content is wider
- Add `overflow-hidden` and `break-words` to the bubble div so long text wraps and overflowing content is clipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved text wrapping in chat messages to prevent content from overflowing message bubbles
* Long text now displays properly constrained within message containers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->