### PR TITLE
fix(web): hide invalid relative time and tidy recent projects landing

### DIFF
--- a/apps/web/src/components/projects/ProjectRow.tsx
+++ b/apps/web/src/components/projects/ProjectRow.tsx
@@ -34,7 +34,9 @@ function relativeTime(ms: number): string | null {
   if (!Number.isFinite(ms)) return null;
   const diff = Date.now() - ms;
   if (!Number.isFinite(diff)) return null;
+  if (diff <= 0) return "just now";
   const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
   const hrs = Math.floor(diff / 3_600_000);
   if (hrs < 24) return `${hrs}h ago`;

--- a/apps/web/src/components/projects/ProjectRow.tsx
+++ b/apps/web/src/components/projects/ProjectRow.tsx
@@ -26,9 +26,14 @@ interface Props {
   home?: string;
 }
 
-/** Format a unix timestamp (ms) as a short relative time string (e.g. "2h ago", "3d ago"). */
-function relativeTime(ms: number): string {
+/**
+ * Format a unix timestamp (ms) as a short relative time string (e.g. "2h ago", "3d ago").
+ * Returns null when the input is not a finite number so callers can skip rendering.
+ */
+function relativeTime(ms: number): string | null {
+  if (!Number.isFinite(ms)) return null;
   const diff = Date.now() - ms;
+  if (!Number.isFinite(diff)) return null;
   const mins = Math.floor(diff / 60_000);
   if (mins < 60) return `${mins}m ago`;
   const hrs = Math.floor(diff / 3_600_000);
@@ -47,6 +52,8 @@ function relativeTime(ms: number): string {
  */
 export function ProjectRow({ workspace, isActive, onSelect, onPin, onRemove, home }: Props) {
   const enrichment = useProjectSelectorStore((s) => s.enrichmentCache.get(workspace.id));
+  const lastOpenedLabel =
+    workspace.last_opened_at != null ? relativeTime(workspace.last_opened_at) : null;
 
   return (
     <div
@@ -140,14 +147,14 @@ export function ProjectRow({ workspace, isActive, onSelect, onPin, onRemove, hom
                 <span className="truncate text-muted-foreground/40">not a git repo</span>
               )}
             </div>
-            {workspace.last_opened_at && (
-              <span className="tabular-nums">{relativeTime(workspace.last_opened_at)}</span>
+            {lastOpenedLabel && (
+              <span className="tabular-nums">{lastOpenedLabel}</span>
             )}
           </>
         ) : (
           // Show timestamp as skeleton while enrichment is loading
-          workspace.last_opened_at && (
-            <span className="tabular-nums">{relativeTime(workspace.last_opened_at)}</span>
+          lastOpenedLabel && (
+            <span className="tabular-nums">{lastOpenedLabel}</span>
           )
         )}
       </div>

--- a/apps/web/src/components/projects/ProjectSelectorLanding.tsx
+++ b/apps/web/src/components/projects/ProjectSelectorLanding.tsx
@@ -26,7 +26,10 @@ export function ProjectSelectorLanding() {
   const removeRecent = useWorkspaceStore((s) => s.removeRecent);
   const pinned = useMemo(() => workspaces.filter((w) => w.pinned), [workspaces]);
   const recent = useMemo(
-    () => workspaces.filter((w) => !w.pinned && w.last_opened_at != null),
+    () =>
+      workspaces
+        .filter((w) => !w.pinned && w.last_opened_at != null)
+        .slice(0, 5),
     [workspaces],
   );
   const hasProjects = pinned.length > 0 || recent.length > 0;
@@ -172,7 +175,7 @@ export function ProjectSelectorLanding() {
           {recent.length > 0 && (
             <section className="mb-6">
               <h2 className="mb-2 px-1 font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/70">
-                Recent
+                Recent Projects
               </h2>
               {recent.map((w) => (
                 <ProjectRow

--- a/apps/web/src/components/projects/RecentThreadRow.tsx
+++ b/apps/web/src/components/projects/RecentThreadRow.tsx
@@ -17,11 +17,16 @@ interface Props {
   home?: string;
 }
 
-/** Format an ISO-8601 timestamp as a short relative time string. */
-function relativeTime(iso: string): string {
+/**
+ * Format an ISO-8601 timestamp as a short relative time string.
+ * Returns null when the input cannot be parsed to a finite millisecond value
+ * so callers can skip rendering.
+ */
+function relativeTime(iso: string): string | null {
   const ms = new Date(iso).getTime();
-  if (!Number.isFinite(ms)) return "";
+  if (!Number.isFinite(ms)) return null;
   const diff = Date.now() - ms;
+  if (!Number.isFinite(diff)) return null;
   const mins = Math.floor(diff / 60_000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
@@ -62,6 +67,7 @@ function statusDot(status: RecentThread["status"]): { className: string; label: 
  */
 export function RecentThreadRow({ thread, isActive, onSelect, onRemove, home }: Props) {
   const dot = statusDot(thread.status);
+  const updatedLabel = relativeTime(thread.updated_at);
 
   return (
     <div
@@ -113,7 +119,9 @@ export function RecentThreadRow({ thread, isActive, onSelect, onRemove, home }: 
             </>
           )}
         </div>
-        <span className="tabular-nums">{relativeTime(thread.updated_at)}</span>
+        {updatedLabel && (
+          <span className="tabular-nums">{updatedLabel}</span>
+        )}
       </div>
 
       {/* Remove from recents — only shown when handler is provided. */}


### PR DESCRIPTION
## What
Fix the cold-start landing's recent-projects and recent-threads lists so they no longer render \"NaNm ago\" when the last-opened timestamp is missing or malformed. Cap the recent-projects list at five entries and rename the section heading.

## Why
Users reported seeing \"NaN ago\" in place of a real relative time when reopening the app. The two row formatters (`ProjectRow.relativeTime` and `RecentThreadRow.relativeTime`) didn't guard against non-finite input, so a missing or unparseable timestamp produced `NaNm ago` instead of being suppressed.

While in the same area:
- The recent-projects list was unbounded, while recent threads were already capped at 5. Five is enough for \"yes, this is where I left off\" without pushing the wordmark or the add-project CTA offscreen.
- The heading read \"Recent\" while the threads heading read \"Recent threads\" — adding \"Projects\" gives the two sections parallel structure.

## Key Changes
- `ProjectRow.relativeTime` and `RecentThreadRow.relativeTime` now return `string | null`, returning `null` for non-finite input so the timestamp span is skipped entirely.
- Cap the recent-projects list to 5 entries on the cold-start landing.
- Rename the section heading from \"Recent\" to \"Recent Projects\".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or missing timestamps no longer render as blank values in recent projects and threads; time labels are shown only when valid.
  * Very recent timestamps now display as "just now" instead of empty or misleading values.

* **Improvements**
  * Recent Projects section now shows up to 5 most recently accessed items for clearer navigation.
  * Section heading updated to "Recent Projects" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->