### PR TITLE
fix(cursor): persistent ACP subprocess and unified tool call handling

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,6 +11,7 @@
     "db:migrate": "bun src/store/cli/migrate.ts"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^0.21.0",
     "@anthropic-ai/claude-agent-sdk": "*",
     "@github/copilot-sdk": "^0.2.2",
     "@mcode/contracts": "workspace:*",

--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
@@ -95,4 +95,52 @@ describe("mapCursorAcpSessionNotification", () => {
       true,
     );
   });
+
+  it("maps plan session update to TodoWrite events", () => {
+    const state = createCursorAcpTurnState();
+    const events = mapCursorAcpSessionNotification(
+      {
+        sessionId: "s",
+        update: {
+          sessionUpdate: "plan",
+          entries: [
+            { content: "Read the file", status: "completed", priority: "high" },
+            { content: "Edit the function", status: "in_progress", priority: "medium" },
+            { content: "Run tests", status: "pending", priority: "low" },
+          ],
+        },
+      } as any,
+      threadId,
+      state,
+    );
+    expect(events.length).toBe(2);
+    expect(events[0]).toMatchObject({
+      type: AgentEventType.ToolUse,
+      threadId,
+      toolName: "TodoWrite",
+    });
+    const todos = (events[0] as any).toolInput.todos;
+    expect(todos).toHaveLength(3);
+    expect(todos[0]).toMatchObject({ content: "Read the file", status: "completed" });
+    expect(todos[1]).toMatchObject({ content: "Edit the function", status: "in_progress" });
+    expect(todos[2]).toMatchObject({ content: "Run tests", status: "pending" });
+    expect(events[1]).toMatchObject({
+      type: AgentEventType.ToolResult,
+      threadId,
+      isError: false,
+    });
+  });
+
+  it("returns empty for plan with no entries", () => {
+    const state = createCursorAcpTurnState();
+    const events = mapCursorAcpSessionNotification(
+      {
+        sessionId: "s",
+        update: { sessionUpdate: "plan", entries: [] },
+      } as any,
+      threadId,
+      state,
+    );
+    expect(events).toEqual([]);
+  });
 });

--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
@@ -39,6 +39,24 @@ describe("mapCursorAcpSessionNotification", () => {
     expect(state.accumulator.assistantText).toBe("Hi there");
   });
 
+  it("maps agent_thought_chunk to TextDelta like message chunks", () => {
+    const state = createCursorAcpTurnState();
+    const ev = mapCursorAcpSessionNotification(
+      {
+        sessionId: "s",
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Thinking out loud..." },
+        },
+      },
+      threadId,
+      state,
+    );
+    expect(ev).toEqual([
+      { type: AgentEventType.TextDelta, threadId, delta: "Thinking out loud..." },
+    ]);
+  });
+
   it("maps tool_call_update to ToolResult", () => {
     const state = createCursorAcpTurnState();
     mapCursorAcpSessionNotification(

--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { AgentEventType } from "@mcode/contracts";
+import {
+  createCursorAcpTurnState,
+  mapCursorAcpSessionNotification,
+} from "../cursor-acp-event-mapper.js";
+
+describe("mapCursorAcpSessionNotification", () => {
+  const threadId = "t1";
+
+  it("maps agent text chunks to TextDelta and accumulates assistant text", () => {
+    const state = createCursorAcpTurnState();
+    const ev1 = mapCursorAcpSessionNotification(
+      {
+        sessionId: "s",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Hi" },
+        },
+      },
+      threadId,
+      state,
+    );
+    expect(ev1).toEqual([
+      { type: AgentEventType.TextDelta, threadId, delta: "Hi" },
+    ]);
+    const ev2 = mapCursorAcpSessionNotification(
+      {
+        sessionId: "s",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: " there" },
+        },
+      },
+      threadId,
+      state,
+    );
+    expect(ev2[0]).toMatchObject({ delta: " there" });
+    expect(state.accumulator.assistantText).toBe("Hi there");
+  });
+
+  it("maps tool_call_update to ToolResult", () => {
+    const state = createCursorAcpTurnState();
+    mapCursorAcpSessionNotification(
+      {
+        sessionId: "s",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "c1",
+          title: "Shell",
+          rawInput: { shellToolCall: { args: { command: "ls" } } },
+          status: "in_progress",
+        },
+      },
+      threadId,
+      state,
+    );
+    const done = mapCursorAcpSessionNotification(
+      {
+        sessionId: "s",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "c1",
+          status: "completed",
+          rawInput: {
+            shellToolCall: {
+              args: { command: "ls" },
+              result: { success: "ok" },
+            },
+          },
+        },
+      },
+      threadId,
+      state,
+    );
+    expect(done.some((e) => e.type === AgentEventType.ToolResult && e.toolCallId === "c1")).toBe(
+      true,
+    );
+  });
+});

--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-permission-mapper.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-permission-mapper.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapDecisionToAcpOutcome,
+  pickFullAccessAllowOption,
+} from "../cursor-acp-permission-mapper.js";
+
+describe("cursor-acp-permission-mapper", () => {
+  const options = [
+    { kind: "reject_once" as const, name: "No", optionId: "r1" },
+    { kind: "allow_once" as const, name: "Yes", optionId: "a1" },
+  ];
+
+  it("pickFullAccessAllowOption prefers allow_always then allow_once", () => {
+    expect(
+      pickFullAccessAllowOption([
+        { kind: "reject_once", name: "n", optionId: "r" },
+        { kind: "allow_once", name: "y", optionId: "a" },
+      ]),
+    ).toBe("a");
+    expect(
+      pickFullAccessAllowOption([
+        { kind: "allow_always", name: "all", optionId: "aa" },
+        { kind: "allow_once", name: "y", optionId: "a" },
+      ]),
+    ).toBe("aa");
+  });
+
+  it("mapDecisionToAcpOutcome selects allow_once for allow", () => {
+    expect(mapDecisionToAcpOutcome("allow", options)).toEqual({
+      outcome: "selected",
+      optionId: "a1",
+    });
+  });
+
+  it("mapDecisionToAcpOutcome yields cancelled", () => {
+    expect(mapDecisionToAcpOutcome("cancelled", options)).toEqual({ outcome: "cancelled" });
+  });
+});

--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-spawn-args.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-spawn-args.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildCursorAcpArgs } from "../cursor-acp-spawn-args.js";
+
+describe("buildCursorAcpArgs", () => {
+  it("uses acp subcommand and full-access flags on full mode", () => {
+    expect(buildCursorAcpArgs({ permissionMode: "full", platform: "linux" })).toEqual([
+      "acp",
+      "--force",
+      "--sandbox",
+      "disabled",
+    ]);
+  });
+
+  it("enables sandbox on macOS for default mode", () => {
+    expect(buildCursorAcpArgs({ permissionMode: "default", platform: "darwin" })).toEqual([
+      "acp",
+      "--trust",
+      "--sandbox",
+      "enabled",
+    ]);
+  });
+
+  it("disables sandbox on Windows for default mode", () => {
+    expect(buildCursorAcpArgs({ permissionMode: "default", platform: "win32" })).toEqual([
+      "acp",
+      "--trust",
+      "--sandbox",
+      "disabled",
+    ]);
+  });
+});

--- a/apps/server/src/providers/cursor/__tests__/cursor-agent-guidance.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-agent-guidance.test.ts
@@ -1,0 +1,55 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  mergeCursorWorkspaceAgentMarkdown,
+  formatCursorSkillsAndCommandsForPrompt,
+} from "../cursor-agent-guidance.js";
+
+describe("mergeCursorWorkspaceAgentMarkdown", () => {
+  let project: string;
+
+  beforeEach(() => {
+    project = mkdtempSync(join(tmpdir(), "cursor-guide-proj-"));
+  });
+
+  it("merges repo root AGENTS.md and .cursor/AGENTS.md in order", () => {
+    writeFileSync(join(project, "AGENTS.md"), "REPO");
+    mkdirSync(join(project, ".cursor"), { recursive: true });
+    writeFileSync(join(project, ".cursor", "AGENTS.md"), "PROJ");
+    const out = mergeCursorWorkspaceAgentMarkdown(project);
+    expect(out).toBe("REPO\n\n---\n\nPROJ");
+  });
+
+  it("returns undefined when no workspace instruction files exist", () => {
+    expect(mergeCursorWorkspaceAgentMarkdown(project)).toBeUndefined();
+  });
+});
+
+describe("formatCursorSkillsAndCommandsForPrompt", () => {
+  it("returns undefined for empty list", () => {
+    expect(formatCursorSkillsAndCommandsForPrompt([])).toBeUndefined();
+  });
+
+  it("lists skills and commands", () => {
+    const text = formatCursorSkillsAndCommandsForPrompt([
+      {
+        name: "deploy",
+        description: "Ship it",
+        kind: "skill",
+        source: "user",
+        providers: ["cursor"],
+      },
+      {
+        name: "lint",
+        description: "Run lint",
+        kind: "command",
+        source: "project",
+        providers: ["cursor"],
+      },
+    ]);
+    expect(text).toContain("[skill] deploy");
+    expect(text).toContain("[command] lint");
+  });
+});

--- a/apps/server/src/providers/cursor/__tests__/cursor-todo-snapshot.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-todo-snapshot.test.ts
@@ -15,6 +15,7 @@ import {
   normalizeCursorTodoEntry,
   isCursorUpdateTodosTool,
   buildTodoWriteEvents,
+  cursorUpdateTodosExtNotificationToAgentEvents,
 } from "../cursor-todo-snapshot.js";
 import type { NormalizedCursorTodo } from "../cursor-todo-snapshot.js";
 import { AgentEventType } from "@mcode/contracts";
@@ -186,5 +187,41 @@ describe("buildTodoWriteEvents", () => {
     const events = buildTodoWriteEvents([{ id: "1", content: "x", status: "pending" }], "t");
     if (events[0].type !== AgentEventType.ToolUse) throw new Error("unreachable");
     expect(events[0].toolCallId.startsWith("cursor-todos-")).toBe(true);
+  });
+});
+
+describe("cursorUpdateTodosExtNotificationToAgentEvents", () => {
+  it("emits TodoWrite + ToolResult and applies merge semantics to snapshot", () => {
+    const snap = createCursorTodoSnapshot();
+    snap.todos.set("a", { id: "a", content: "old", status: "pending" });
+    const events = cursorUpdateTodosExtNotificationToAgentEvents(
+      "t1",
+      {
+        toolCallId: "todo-ext-1",
+        merge: true,
+        todos: [{ id: "a", content: "new", status: "completed" }],
+      },
+      snap,
+    );
+    expect(events).toHaveLength(2);
+    const use = events[0];
+    expect(use?.type).toBe(AgentEventType.ToolUse);
+    if (!use || use.type !== AgentEventType.ToolUse) throw new Error("unreachable");
+    expect(use.toolName).toBe("TodoWrite");
+    expect(use.toolCallId).toBe("todo-ext-1");
+    expect(use.toolInput).toMatchObject({
+      todos: [{ id: "a", content: "new", status: "completed" }],
+    });
+    expect(events[1]?.type).toBe(AgentEventType.ToolResult);
+  });
+
+  it("returns empty array when todos missing", () => {
+    expect(
+      cursorUpdateTodosExtNotificationToAgentEvents(
+        "t",
+        { toolCallId: "x", merge: false, todos: [] },
+        createCursorTodoSnapshot(),
+      ).length,
+    ).toBe(0);
   });
 });

--- a/apps/server/src/providers/cursor/__tests__/cursor-tool-input-normalize.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-tool-input-normalize.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMcodeCursorToolInput } from "../cursor-tool-input-normalize.js";
+
+describe("normalizeMcodeCursorToolInput", () => {
+  it("maps Cursor edit aliases to snake_case render fields", () => {
+    expect(
+      normalizeMcodeCursorToolInput("Edit", {
+        path: "src/foo.ts",
+        search: "// old\n",
+        replace: "// new\n",
+      }),
+    ).toMatchObject({
+      file_path: "src/foo.ts",
+      old_string: "// old\n",
+      new_string: "// new\n",
+    });
+  });
+
+  it("maps Write aliases (path, contents) to renderer fields", () => {
+    expect(
+      normalizeMcodeCursorToolInput("Write", {
+        path: "README.md",
+        contents: "hello",
+      }),
+    ).toMatchObject({
+      file_path: "README.md",
+      content: "hello",
+    });
+  });
+
+  it("passes through unrelated tools untouched", () => {
+    expect(normalizeMcodeCursorToolInput("Read", { file_path: "x" })).toEqual({
+      file_path: "x",
+    });
+  });
+});

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -1,5 +1,13 @@
 /**
  * Maps ACP `session/update` notifications to mcode {@link AgentEvent} values.
+ *
+ * ACP tool calls differ fundamentally from `--print` stream-json:
+ * - `tool_call` is a lifecycle marker with `kind`/`title` but often empty `rawInput`
+ * - `_toolName` tools (e.g. updateTodos) carry no args; data arrives via ext methods
+ * - Actual tool output arrives on `tool_call_update` via:
+ *   - `rawOutput.content` for Read (file content)
+ *   - `content[]` with `type: "diff"` for Edit (path, oldText, newText)
+ *   - `rawOutput.{stdout,stderr,exitCode}` for Terminal/Bash
  */
 
 import type { SessionNotification } from "@agentclientprotocol/sdk";
@@ -15,6 +23,17 @@ import {
 import { normalizeMcodeCursorToolInput } from "./cursor-tool-input-normalize.js";
 import type { CursorStreamAccumulator } from "./cursor-stream-event-mapper.js";
 
+/** Maps ACP `kind` field to Mcode tool names. */
+const TOOL_NAME_BY_ACP_KIND: Record<string, string> = {
+  read: "Read",
+  edit: "Edit",
+  write: "Write",
+  command: "Bash",
+  search: "Grep",
+  other: "Tool",
+};
+
+/** Maps `--print` style discriminator keys to Mcode tool names (legacy compat). */
 const TOOL_NAME_BY_DISCRIMINATOR: Record<string, string> = {
   readToolCall: "Read",
   writeToolCall: "Write",
@@ -30,11 +49,26 @@ const TOOL_NAME_BY_DISCRIMINATOR: Record<string, string> = {
   strReplaceToolCall: "Edit",
 };
 
+/** Maps ACP `title` strings to Mcode tool names as fallback. */
+const TOOL_NAME_BY_TITLE: Record<string, string> = {
+  "Read File": "Read",
+  "Edit File": "Edit",
+  "Write File": "Write",
+  "Terminal": "Bash",
+  "Find": "Glob",
+  "Read Lints": "Read",
+  "Search": "Grep",
+};
+
 /**
  * Accumulator for streaming state during one ACP prompt turn on a thread.
  */
 export interface CursorAcpTurnState {
   accumulator: CursorStreamAccumulator;
+  /** Tool call IDs whose data arrives via ext methods, not session updates. */
+  suppressedToolCallIds: Set<string>;
+  /** Tracks the ACP tool name (kind/title) per tool call ID for enriching updates. */
+  toolNameByCallId: Map<string, string>;
 }
 
 /** Creates a fresh per-turn state bundle (wraps shared stream accumulator shape). */
@@ -45,16 +79,13 @@ export function createCursorAcpTurnState(): CursorAcpTurnState {
       toolStartTimes: new Map(),
       chatId: null,
     },
+    suppressedToolCallIds: new Set(),
+    toolNameByCallId: new Map(),
   };
 }
 
 /**
  * Converts a single `session/update` notification into zero or more agent events.
- *
- * @param notification - ACP session update (already scoped to the active session).
- * @param threadId - Mcode thread UUID.
- * @param state - Mutable per-turn state; reset by the provider at the start of each prompt.
- * @param todoSnapshot - Optional todo merge state for `updateTodosToolCall` parity with stream-json.
  */
 export function mapCursorAcpSessionNotification(
   notification: SessionNotification,
@@ -79,18 +110,18 @@ export function mapCursorAcpSessionNotification(
     case "usage_update":
       return [];
     case "tool_call":
-      return mapAcpToolCallStarted(update, threadId, acc, todoSnapshot);
+      return mapAcpToolCallStarted(update, threadId, state, acc, todoSnapshot);
     case "tool_call_update":
-      return mapAcpToolCallUpdated(update, threadId, acc);
+      return mapAcpToolCallUpdated(update, threadId, state, acc);
     default:
       return [];
   }
 }
 
-/**
- * Normal assistant text uses `agent_message_chunk`, but Cursor streams some models
- * (e.g. composer) as `agent_thought_chunk` only. Map both so the UI receives TextDelta.
- */
+// ---------------------------------------------------------------------------
+// Text chunks
+// ---------------------------------------------------------------------------
+
 function mapAgentLanguageChunk(
   threadId: string,
   acc: CursorStreamAccumulator,
@@ -107,6 +138,115 @@ function mapAgentLanguageChunk(
   acc.assistantText += text;
   return [{ type: AgentEventType.TextDelta, threadId, delta: text }];
 }
+
+// ---------------------------------------------------------------------------
+// Tool call helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve an ACP tool call to a Mcode tool name using kind → title → discriminator. */
+function resolveAcpToolName(update: {
+  kind?: unknown;
+  title?: string | null;
+  rawInput?: unknown;
+}): string {
+  // 1. ACP `kind` field (most reliable for ACP-native calls)
+  if (typeof update.kind === "string" && TOOL_NAME_BY_ACP_KIND[update.kind]) {
+    return TOOL_NAME_BY_ACP_KIND[update.kind];
+  }
+
+  // 2. Title-based lookup
+  const title = typeof update.title === "string" ? update.title : null;
+  if (title && TOOL_NAME_BY_TITLE[title]) {
+    return TOOL_NAME_BY_TITLE[title];
+  }
+
+  // 3. Legacy discriminator in rawInput (--print compat)
+  if (update.rawInput && typeof update.rawInput === "object" && !Array.isArray(update.rawInput)) {
+    const rec = update.rawInput as Record<string, unknown>;
+    for (const key of Object.keys(rec)) {
+      if (key === "result" || key === "args" || key === "_toolName") continue;
+      if (rec[key] && typeof rec[key] === "object" && !Array.isArray(rec[key])) {
+        if (TOOL_NAME_BY_DISCRIMINATOR[key]) return TOOL_NAME_BY_DISCRIMINATOR[key];
+      }
+    }
+  }
+
+  return title || "Tool";
+}
+
+/** Extract `content` blocks from an ACP tool_call or tool_call_update. */
+interface AcpDiffBlock {
+  type: "diff";
+  path: string;
+  oldText: string;
+  newText: string;
+}
+
+function extractContentDiffs(update: Record<string, unknown>): AcpDiffBlock[] {
+  const content = update.content;
+  if (!Array.isArray(content)) return [];
+  return content.filter(
+    (c): c is AcpDiffBlock =>
+      c != null &&
+      typeof c === "object" &&
+      (c as Record<string, unknown>).type === "diff" &&
+      typeof (c as Record<string, unknown>).path === "string",
+  );
+}
+
+/** Extract structured rawOutput fields for different tool types. */
+function extractAcpRawOutput(rawOutput: unknown): {
+  /** File content (Read tool) */
+  fileContent?: string;
+  /** Terminal stdout */
+  stdout?: string;
+  /** Terminal stderr */
+  stderr?: string;
+  /** Terminal exit code */
+  exitCode?: number;
+  /** Raw string output */
+  raw?: string;
+} {
+  if (rawOutput === undefined || rawOutput === null) return {};
+  if (typeof rawOutput === "string") return { raw: rawOutput };
+  if (typeof rawOutput !== "object" || Array.isArray(rawOutput)) return {};
+
+  const r = rawOutput as Record<string, unknown>;
+
+  // Read tool: { content: "file contents..." }
+  if (typeof r.content === "string") {
+    return { fileContent: r.content };
+  }
+
+  // Terminal/Bash: { exitCode, stdout, stderr }
+  if ("stdout" in r || "exitCode" in r) {
+    return {
+      stdout: typeof r.stdout === "string" ? r.stdout : undefined,
+      stderr: typeof r.stderr === "string" ? r.stderr : undefined,
+      exitCode: typeof r.exitCode === "number" ? r.exitCode : undefined,
+    };
+  }
+
+  // Legacy: { success/rejected/failure }
+  const body = r.success ?? r.rejected ?? r.failure;
+  if (body != null) {
+    return { raw: typeof body === "string" ? body : safeStringify(body) };
+  }
+
+  return { raw: safeStringify(rawOutput) };
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy --print helpers (kept for backward compat if mixed transports)
+// ---------------------------------------------------------------------------
 
 function extractToolCallDiscriminator(toolCall: Record<string, unknown> | undefined): {
   discriminator: string | null;
@@ -130,10 +270,6 @@ function extractArgs(payload: Record<string, unknown> | undefined): Record<strin
   return undefined;
 }
 
-/**
- * Resolves tool-call argument fields: prefer nested `args`, else flatten the payload
- * minus `result` so ACP shapes that inline fields still reach the UI extractors.
- */
 function coercePayloadArgs(payload: Record<string, unknown> | undefined): Record<string, unknown> {
   if (!payload) return {};
   const nested = extractArgs(payload);
@@ -142,61 +278,40 @@ function coercePayloadArgs(payload: Record<string, unknown> | undefined): Record
   return { ...rest };
 }
 
-function extractResult(payload: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
-  if (!payload) return undefined;
-  const v = payload.result;
-  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
-  return undefined;
-}
-
-function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function formatResultOutput(result: Record<string, unknown> | undefined): string {
-  if (!result) return "";
-  const body = result.success ?? result.rejected ?? result.failure;
-  if (body == null) return safeStringify(result);
-  if (typeof body === "string") return body;
-  return safeStringify(body);
-}
-
-function coerceRawToolEnvelope(rawInput: unknown): {
-  discriminator: string | null;
-  payload: Record<string, unknown> | undefined;
-} {
-  if (rawInput !== undefined && typeof rawInput === "object" && rawInput !== null && !Array.isArray(rawInput)) {
-    const rec = rawInput as Record<string, unknown>;
-    const extracted = extractToolCallDiscriminator(rec);
-    if (extracted.discriminator) return extracted;
-    return { discriminator: null, payload: rec };
-  }
-  return { discriminator: null, payload: undefined };
-}
+// ---------------------------------------------------------------------------
+// tool_call (initial)
+// ---------------------------------------------------------------------------
 
 function mapAcpToolCallStarted(
   update: {
     rawInput?: unknown;
     toolCallId: string;
     title: string;
+    kind?: unknown;
   },
   threadId: string,
+  state: CursorAcpTurnState,
   acc: CursorStreamAccumulator,
   todoSnapshot: CursorTodoSnapshot | undefined,
 ): AgentEvent[] {
-  const raw = coerceRawToolEnvelope(update.rawInput);
-  const payloadRecord =
-    raw.payload ??
-    (typeof update.rawInput === "object" && update.rawInput !== null && !Array.isArray(update.rawInput)
+  const rawInputRecord =
+    update.rawInput && typeof update.rawInput === "object" && !Array.isArray(update.rawInput)
       ? (update.rawInput as Record<string, unknown>)
-      : undefined);
-  const args = coercePayloadArgs(payloadRecord);
+      : undefined;
 
+  // ACP `_toolName` tools (e.g. updateTodos) carry no args in rawInput;
+  // data arrives via ext methods. Suppress these lifecycle markers.
+  const acpToolName = rawInputRecord?._toolName;
+  if (typeof acpToolName === "string") {
+    acc.toolStartTimes.set(update.toolCallId, Date.now());
+    state.suppressedToolCallIds.add(update.toolCallId);
+    return [];
+  }
+
+  // Legacy --print discriminator (updateTodosToolCall, shellToolCall, etc.)
+  const raw = rawInputRecord ? extractToolCallDiscriminator(rawInputRecord) : { discriminator: null, payload: undefined };
   if (raw.discriminator === "updateTodosToolCall") {
+    const args = coercePayloadArgs(raw.payload);
     const entries = extractCursorTodoEntries(args);
     if (!entries || entries.length === 0) return [];
     const merge = args.merge === true;
@@ -214,20 +329,33 @@ function mapAcpToolCallStarted(
     ];
   }
 
+  // Resolve tool name from ACP kind/title/discriminator
   const toolName = raw.discriminator
     ? (TOOL_NAME_BY_DISCRIMINATOR[raw.discriminator] ?? raw.discriminator)
-    : update.title || "Tool";
+    : resolveAcpToolName(update);
+
+  // Build toolInput from rawInput if available
   let toolInput: Record<string, unknown> =
-    args && Object.keys(args).length > 0
-      ? args
-      : (typeof update.rawInput === "object" && update.rawInput !== null && !Array.isArray(update.rawInput))
-        ? coercePayloadArgs(update.rawInput as Record<string, unknown>)
-        : {};
+    raw.payload ? coercePayloadArgs(raw.payload) : {};
+  if (Object.keys(toolInput).length === 0 && rawInputRecord) {
+    const { _toolName: _, ...rest } = rawInputRecord;
+    if (Object.keys(rest).length > 0) toolInput = rest;
+  }
 
   if (toolName === "Edit" || toolName === "Write") {
     toolInput = normalizeMcodeCursorToolInput(toolName, toolInput);
   }
+
   acc.toolStartTimes.set(update.toolCallId, Date.now());
+  state.toolNameByCallId.set(update.toolCallId, toolName);
+
+  // ACP tool_calls with empty rawInput are lifecycle markers; actual data
+  // arrives on tool_call_update (content blocks or rawOutput). Defer ToolUse
+  // so we emit one event with real data instead of an empty one now + duplicate later.
+  if (Object.keys(toolInput).length === 0) {
+    return [];
+  }
+
   return [
     {
       type: AgentEventType.ToolUse,
@@ -239,79 +367,104 @@ function mapAcpToolCallStarted(
   ];
 }
 
+// ---------------------------------------------------------------------------
+// tool_call_update (progress + completion)
+// ---------------------------------------------------------------------------
+
 function mapAcpToolCallUpdated(
   update: {
     rawInput?: unknown;
     rawOutput?: unknown;
+    content?: unknown;
     status?: unknown;
     toolCallId: string;
     title?: string | null;
+    kind?: unknown;
   },
   threadId: string,
+  state: CursorAcpTurnState,
   acc: CursorStreamAccumulator,
 ): AgentEvent[] {
-  const raw = coerceRawToolEnvelope(update.rawInput);
-  const discriminator = raw.discriminator;
-  const payload = raw.payload;
-
-  let isError = update.status === "failed";
-
-  const resultEnvelope =
-    extractResult(payload) ??
-    (update.rawOutput !== undefined && typeof update.rawOutput === "object" && update.rawOutput !== null
-      ? (update.rawOutput as Record<string, unknown>)
-      : typeof update.rawOutput === "string"
-        ? ({ success: update.rawOutput } as Record<string, unknown>)
-        : undefined);
-
-  if (resultEnvelope) {
-    isError = isError || resultEnvelope.rejected != null || resultEnvelope.failure != null;
+  // Suppress lifecycle-only tool calls (handled by ext methods)
+  if (state.suppressedToolCallIds.has(update.toolCallId)) {
+    acc.toolStartTimes.delete(update.toolCallId);
+    if (update.status === "completed" || update.status === "failed") {
+      state.suppressedToolCallIds.delete(update.toolCallId);
+    }
+    return [];
   }
 
-  const output =
-    typeof update.rawOutput === "string"
-      ? update.rawOutput
-      : formatResultOutput(resultEnvelope);
+  // Skip in-progress updates that carry no data
+  const hasData =
+    update.rawOutput !== undefined ||
+    (Array.isArray(update.content) && (update.content as unknown[]).length > 0) ||
+    update.status === "completed" ||
+    update.status === "failed";
+  if (!hasData) return [];
 
   const events: AgentEvent[] = [];
+  const isError = update.status === "failed";
+  const knownToolName = state.toolNameByCallId.get(update.toolCallId);
 
-  if (!acc.toolStartTimes.has(update.toolCallId)) {
-    const toolName =
-      discriminator != null ? (TOOL_NAME_BY_DISCRIMINATOR[discriminator] ?? discriminator) : update.title ?? "Tool";
-    if (discriminator !== "updateTodosToolCall") {
-      let orphanInput = coercePayloadArgs(payload ?? undefined);
-      if (toolName === "Edit" || toolName === "Write") {
-        orphanInput = normalizeMcodeCursorToolInput(toolName, orphanInput);
-      }
-      events.push({
-        type: AgentEventType.ToolUse,
-        threadId,
-        toolCallId: update.toolCallId,
-        toolName,
-        toolInput: orphanInput,
-      });
+  // Extract structured output from the two ACP channels
+  const diffs = extractContentDiffs(update as Record<string, unknown>);
+  const rawOut = extractAcpRawOutput(update.rawOutput);
+
+  // Determine tool name and build ToolUse input from available data
+  const toolName = knownToolName ?? resolveAcpToolName(update);
+  let toolInput: Record<string, unknown> = {};
+  let output = "";
+
+  if (diffs.length > 0) {
+    const diff = diffs[0];
+    toolInput = {
+      file_path: diff.path,
+      old_string: diff.oldText,
+      new_string: diff.newText,
+    };
+    output = `Applied edit to ${diff.path}`;
+  } else if (rawOut.fileContent !== undefined) {
+    toolInput = { file_path: "" };
+    output = rawOut.fileContent;
+  } else if (rawOut.stdout !== undefined || rawOut.stderr !== undefined) {
+    const parts: string[] = [];
+    if (rawOut.stdout) parts.push(rawOut.stdout);
+    if (rawOut.stderr) parts.push(`stderr: ${rawOut.stderr}`);
+    if (rawOut.exitCode !== undefined && rawOut.exitCode !== 0) {
+      parts.push(`exit code: ${rawOut.exitCode}`);
     }
+    output = parts.join("\n");
+  } else if (rawOut.raw) {
+    output = rawOut.raw;
   }
 
+  // Emit ToolUse with actual data. The initial tool_call deferred ToolUse
+  // when rawInput was empty; this is where the real data arrives.
+  events.push({
+    type: AgentEventType.ToolUse,
+    threadId,
+    toolCallId: update.toolCallId,
+    toolName,
+    toolInput,
+  });
+
   acc.toolStartTimes.delete(update.toolCallId);
+  state.toolNameByCallId.delete(update.toolCallId);
 
   events.push({
     type: AgentEventType.ToolResult,
     threadId,
     toolCallId: update.toolCallId,
-    output: output || (discriminator === "updateTodosToolCall" ? "Updated todos" : ""),
+    output,
     isError,
   });
   return events;
 }
 
-/**
- * Maps an ACP `plan` session update to TodoWrite events.
- *
- * Cursor sends task progress both through `cursor/update_todos` (ext notification)
- * and through `session/update` with `sessionUpdate: "plan"`. Both paths must emit
- * TodoWrite events so the task panel stays in sync regardless of which channel fires.
- */
+// ---------------------------------------------------------------------------
+// Plan session update → TodoWrite
+// ---------------------------------------------------------------------------
+
 function mapAcpPlanUpdate(
   update: { entries: Array<{ content: string; status: string; priority?: string }> },
   threadId: string,
@@ -326,12 +479,10 @@ function mapAcpPlanUpdate(
     priority: entry.priority,
   }));
 
-  // Plan updates are full replacements per ACP spec, so merge=false
   const todos = reconcileCursorTodos(incoming, false, todoSnapshot);
   return buildTodoWriteEvents(todos, threadId);
 }
 
-/** Normalize ACP PlanEntryStatus to our TaskStatus. */
 function normalizePlanStatus(
   status: string,
 ): "pending" | "in_progress" | "completed" | "cancelled" {

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -62,13 +62,9 @@ export function mapCursorAcpSessionNotification(
   const acc = state.accumulator;
 
   switch (update.sessionUpdate) {
-    case "agent_message_chunk": {
-      if (update.content.type !== "text" || !update.content.text) return [];
-      const text = update.content.text;
-      acc.assistantText += text;
-      return [{ type: AgentEventType.TextDelta, threadId, delta: text }];
-    }
+    case "agent_message_chunk":
     case "agent_thought_chunk":
+      return mapAgentLanguageChunk(threadId, acc, update);
     case "user_message_chunk":
     case "plan":
     case "available_commands_update":
@@ -84,6 +80,27 @@ export function mapCursorAcpSessionNotification(
     default:
       return [];
   }
+}
+
+/**
+ * Normal assistant text uses `agent_message_chunk`, but Cursor streams some models
+ * (e.g. composer) as `agent_thought_chunk` only. Map both so the UI receives TextDelta.
+ */
+function mapAgentLanguageChunk(
+  threadId: string,
+  acc: CursorStreamAccumulator,
+  update:
+    | (import("@agentclientprotocol/sdk").ContentChunk & {
+        sessionUpdate: "agent_message_chunk";
+      })
+    | (import("@agentclientprotocol/sdk").ContentChunk & {
+        sessionUpdate: "agent_thought_chunk";
+      }),
+): AgentEvent[] {
+  if (update.content.type !== "text" || !update.content.text) return [];
+  const text = update.content.text;
+  acc.assistantText += text;
+  return [{ type: AgentEventType.TextDelta, threadId, delta: text }];
 }
 
 function extractToolCallDiscriminator(toolCall: Record<string, unknown> | undefined): {

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -438,15 +438,18 @@ function mapAcpToolCallUpdated(
     output = rawOut.raw;
   }
 
-  // Emit ToolUse with actual data. The initial tool_call deferred ToolUse
-  // when rawInput was empty; this is where the real data arrives.
-  events.push({
-    type: AgentEventType.ToolUse,
-    threadId,
-    toolCallId: update.toolCallId,
-    toolName,
-    toolInput,
-  });
+  // Emit ToolUse with actual data only if the initial tool_call deferred it
+  // (rawInput was empty). If tool_call already emitted ToolUse, skip to avoid
+  // duplicate tool-call cards.
+  if (!acc.toolStartTimes.has(update.toolCallId)) {
+    events.push({
+      type: AgentEventType.ToolUse,
+      threadId,
+      toolCallId: update.toolCallId,
+      toolName,
+      toolInput,
+    });
+  }
 
   acc.toolStartTimes.delete(update.toolCallId);
   state.toolNameByCallId.delete(update.toolCallId);
@@ -489,6 +492,9 @@ function normalizePlanStatus(
   switch (status) {
     case "completed":
       return "completed";
+    case "cancelled":
+    case "canceled":
+      return "cancelled";
     case "in_progress":
     case "inProgress":
       return "in_progress";

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -1,0 +1,253 @@
+/**
+ * Maps ACP `session/update` notifications to mcode {@link AgentEvent} values.
+ */
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { AgentEventType } from "@mcode/contracts";
+import type { AgentEvent } from "@mcode/contracts";
+import {
+  extractCursorTodoEntries,
+  normalizeCursorTodoEntry,
+  reconcileCursorTodos,
+  type CursorTodoSnapshot,
+} from "./cursor-todo-snapshot.js";
+import type { CursorStreamAccumulator } from "./cursor-stream-event-mapper.js";
+
+const TOOL_NAME_BY_DISCRIMINATOR: Record<string, string> = {
+  readToolCall: "Read",
+  writeToolCall: "Write",
+  editToolCall: "Edit",
+  shellToolCall: "Bash",
+  grepToolCall: "Grep",
+  globToolCall: "Glob",
+  lsToolCall: "LS",
+  deleteToolCall: "Delete",
+  webSearchToolCall: "WebSearch",
+  fetchToolCall: "WebFetch",
+};
+
+/**
+ * Accumulator for streaming state during one ACP prompt turn on a thread.
+ */
+export interface CursorAcpTurnState {
+  accumulator: CursorStreamAccumulator;
+}
+
+/** Creates a fresh per-turn state bundle (wraps shared stream accumulator shape). */
+export function createCursorAcpTurnState(): CursorAcpTurnState {
+  return {
+    accumulator: {
+      assistantText: "",
+      toolStartTimes: new Map(),
+      chatId: null,
+    },
+  };
+}
+
+/**
+ * Converts a single `session/update` notification into zero or more agent events.
+ *
+ * @param notification - ACP session update (already scoped to the active session).
+ * @param threadId - Mcode thread UUID.
+ * @param state - Mutable per-turn state; reset by the provider at the start of each prompt.
+ * @param todoSnapshot - Optional todo merge state for `updateTodosToolCall` parity with stream-json.
+ */
+export function mapCursorAcpSessionNotification(
+  notification: SessionNotification,
+  threadId: string,
+  state: CursorAcpTurnState,
+  todoSnapshot?: CursorTodoSnapshot,
+): AgentEvent[] {
+  const { update } = notification;
+  const acc = state.accumulator;
+
+  switch (update.sessionUpdate) {
+    case "agent_message_chunk": {
+      if (update.content.type !== "text" || !update.content.text) return [];
+      const text = update.content.text;
+      acc.assistantText += text;
+      return [{ type: AgentEventType.TextDelta, threadId, delta: text }];
+    }
+    case "agent_thought_chunk":
+    case "user_message_chunk":
+    case "plan":
+    case "available_commands_update":
+    case "current_mode_update":
+    case "config_option_update":
+    case "session_info_update":
+    case "usage_update":
+      return [];
+    case "tool_call":
+      return mapAcpToolCallStarted(update, threadId, acc, todoSnapshot);
+    case "tool_call_update":
+      return mapAcpToolCallUpdated(update, threadId, acc);
+    default:
+      return [];
+  }
+}
+
+function extractToolCallDiscriminator(toolCall: Record<string, unknown> | undefined): {
+  discriminator: string | null;
+  payload: Record<string, unknown> | undefined;
+} {
+  if (!toolCall || typeof toolCall !== "object") return { discriminator: null, payload: undefined };
+  for (const key of Object.keys(toolCall)) {
+    if (key === "result" || key === "args") continue;
+    const v = toolCall[key];
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      return { discriminator: key, payload: v as Record<string, unknown> };
+    }
+  }
+  return { discriminator: null, payload: undefined };
+}
+
+function extractArgs(payload: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!payload) return undefined;
+  const v = payload.args;
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return undefined;
+}
+
+function extractResult(payload: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!payload) return undefined;
+  const v = payload.result;
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return undefined;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatResultOutput(result: Record<string, unknown> | undefined): string {
+  if (!result) return "";
+  const body = result.success ?? result.rejected ?? result.failure;
+  if (body == null) return safeStringify(result);
+  if (typeof body === "string") return body;
+  return safeStringify(body);
+}
+
+function coerceRawToolEnvelope(rawInput: unknown): {
+  discriminator: string | null;
+  payload: Record<string, unknown> | undefined;
+} {
+  if (rawInput !== undefined && typeof rawInput === "object" && rawInput !== null && !Array.isArray(rawInput)) {
+    const rec = rawInput as Record<string, unknown>;
+    const extracted = extractToolCallDiscriminator(rec);
+    if (extracted.discriminator) return extracted;
+    return { discriminator: null, payload: rec };
+  }
+  return { discriminator: null, payload: undefined };
+}
+
+function mapAcpToolCallStarted(
+  update: {
+    rawInput?: unknown;
+    toolCallId: string;
+    title: string;
+  },
+  threadId: string,
+  acc: CursorStreamAccumulator,
+  todoSnapshot: CursorTodoSnapshot | undefined,
+): AgentEvent[] {
+  const raw = coerceRawToolEnvelope(update.rawInput);
+  if (raw.discriminator === "updateTodosToolCall") {
+    const args = extractArgs(raw.payload);
+    const entries = extractCursorTodoEntries(args);
+    if (!entries || entries.length === 0) return [];
+    const merge = args?.merge === true;
+    const incoming = entries.map((entry, index) => normalizeCursorTodoEntry(entry, index));
+    const todos = reconcileCursorTodos(incoming, merge, todoSnapshot);
+    acc.toolStartTimes.set(update.toolCallId, Date.now());
+    return [
+      {
+        type: AgentEventType.ToolUse,
+        threadId,
+        toolCallId: update.toolCallId,
+        toolName: "TodoWrite",
+        toolInput: { todos },
+      },
+    ];
+  }
+
+  const toolName = raw.discriminator
+    ? (TOOL_NAME_BY_DISCRIMINATOR[raw.discriminator] ?? raw.discriminator)
+    : update.title || "Tool";
+  const args = extractArgs(raw.payload);
+  acc.toolStartTimes.set(update.toolCallId, Date.now());
+  return [
+    {
+      type: AgentEventType.ToolUse,
+      threadId,
+      toolCallId: update.toolCallId,
+      toolName,
+      toolInput: args ?? (update.rawInput as Record<string, unknown>) ?? {},
+    },
+  ];
+}
+
+function mapAcpToolCallUpdated(
+  update: {
+    rawInput?: unknown;
+    rawOutput?: unknown;
+    status?: unknown;
+    toolCallId: string;
+    title?: string | null;
+  },
+  threadId: string,
+  acc: CursorStreamAccumulator,
+): AgentEvent[] {
+  const raw = coerceRawToolEnvelope(update.rawInput);
+  const discriminator = raw.discriminator;
+  const payload = raw.payload;
+
+  let isError = update.status === "failed";
+
+  const resultEnvelope =
+    extractResult(payload) ??
+    (update.rawOutput !== undefined && typeof update.rawOutput === "object" && update.rawOutput !== null
+      ? (update.rawOutput as Record<string, unknown>)
+      : typeof update.rawOutput === "string"
+        ? ({ success: update.rawOutput } as Record<string, unknown>)
+        : undefined);
+
+  if (resultEnvelope) {
+    isError = isError || resultEnvelope.rejected != null || resultEnvelope.failure != null;
+  }
+
+  const output =
+    typeof update.rawOutput === "string"
+      ? update.rawOutput
+      : formatResultOutput(resultEnvelope);
+
+  const events: AgentEvent[] = [];
+
+  if (!acc.toolStartTimes.has(update.toolCallId)) {
+    const toolName =
+      discriminator != null ? (TOOL_NAME_BY_DISCRIMINATOR[discriminator] ?? discriminator) : update.title ?? "Tool";
+    if (discriminator !== "updateTodosToolCall") {
+      events.push({
+        type: AgentEventType.ToolUse,
+        threadId,
+        toolCallId: update.toolCallId,
+        toolName,
+        toolInput: extractArgs(payload) ?? {},
+      });
+    }
+  }
+
+  acc.toolStartTimes.delete(update.toolCallId);
+
+  events.push({
+    type: AgentEventType.ToolResult,
+    threadId,
+    toolCallId: update.toolCallId,
+    output: output || (discriminator === "updateTodosToolCall" ? "Updated todos" : ""),
+    isError,
+  });
+  return events;
+}

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -9,6 +9,7 @@ import {
   extractCursorTodoEntries,
   normalizeCursorTodoEntry,
   reconcileCursorTodos,
+  buildTodoWriteEvents,
   type CursorTodoSnapshot,
 } from "./cursor-todo-snapshot.js";
 import { normalizeMcodeCursorToolInput } from "./cursor-tool-input-normalize.js";
@@ -68,8 +69,9 @@ export function mapCursorAcpSessionNotification(
     case "agent_message_chunk":
     case "agent_thought_chunk":
       return mapAgentLanguageChunk(threadId, acc, update);
-    case "user_message_chunk":
     case "plan":
+      return mapAcpPlanUpdate(update, threadId, todoSnapshot);
+    case "user_message_chunk":
     case "available_commands_update":
     case "current_mode_update":
     case "config_option_update":
@@ -301,4 +303,45 @@ function mapAcpToolCallUpdated(
     isError,
   });
   return events;
+}
+
+/**
+ * Maps an ACP `plan` session update to TodoWrite events.
+ *
+ * Cursor sends task progress both through `cursor/update_todos` (ext notification)
+ * and through `session/update` with `sessionUpdate: "plan"`. Both paths must emit
+ * TodoWrite events so the task panel stays in sync regardless of which channel fires.
+ */
+function mapAcpPlanUpdate(
+  update: { entries: Array<{ content: string; status: string; priority?: string }> },
+  threadId: string,
+  todoSnapshot: CursorTodoSnapshot | undefined,
+): AgentEvent[] {
+  if (!update.entries || update.entries.length === 0) return [];
+
+  const incoming = update.entries.map((entry, i) => ({
+    id: String(i),
+    content: entry.content?.trim() || `Step ${i + 1}`,
+    status: normalizePlanStatus(entry.status),
+    priority: entry.priority,
+  }));
+
+  // Plan updates are full replacements per ACP spec, so merge=false
+  const todos = reconcileCursorTodos(incoming, false, todoSnapshot);
+  return buildTodoWriteEvents(todos, threadId);
+}
+
+/** Normalize ACP PlanEntryStatus to our TaskStatus. */
+function normalizePlanStatus(
+  status: string,
+): "pending" | "in_progress" | "completed" | "cancelled" {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "in_progress":
+    case "inProgress":
+      return "in_progress";
+    default:
+      return "pending";
+  }
 }

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -11,6 +11,7 @@ import {
   reconcileCursorTodos,
   type CursorTodoSnapshot,
 } from "./cursor-todo-snapshot.js";
+import { normalizeMcodeCursorToolInput } from "./cursor-tool-input-normalize.js";
 import type { CursorStreamAccumulator } from "./cursor-stream-event-mapper.js";
 
 const TOOL_NAME_BY_DISCRIMINATOR: Record<string, string> = {
@@ -24,6 +25,8 @@ const TOOL_NAME_BY_DISCRIMINATOR: Record<string, string> = {
   deleteToolCall: "Delete",
   webSearchToolCall: "WebSearch",
   fetchToolCall: "WebFetch",
+  searchReplaceToolCall: "Edit",
+  strReplaceToolCall: "Edit",
 };
 
 /**
@@ -125,6 +128,18 @@ function extractArgs(payload: Record<string, unknown> | undefined): Record<strin
   return undefined;
 }
 
+/**
+ * Resolves tool-call argument fields: prefer nested `args`, else flatten the payload
+ * minus `result` so ACP shapes that inline fields still reach the UI extractors.
+ */
+function coercePayloadArgs(payload: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!payload) return {};
+  const nested = extractArgs(payload);
+  if (nested && Object.keys(nested).length > 0) return { ...nested };
+  const { result: _omitResult, ...rest } = payload;
+  return { ...rest };
+}
+
 function extractResult(payload: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
   if (!payload) return undefined;
   const v = payload.result;
@@ -172,11 +187,17 @@ function mapAcpToolCallStarted(
   todoSnapshot: CursorTodoSnapshot | undefined,
 ): AgentEvent[] {
   const raw = coerceRawToolEnvelope(update.rawInput);
+  const payloadRecord =
+    raw.payload ??
+    (typeof update.rawInput === "object" && update.rawInput !== null && !Array.isArray(update.rawInput)
+      ? (update.rawInput as Record<string, unknown>)
+      : undefined);
+  const args = coercePayloadArgs(payloadRecord);
+
   if (raw.discriminator === "updateTodosToolCall") {
-    const args = extractArgs(raw.payload);
     const entries = extractCursorTodoEntries(args);
     if (!entries || entries.length === 0) return [];
-    const merge = args?.merge === true;
+    const merge = args.merge === true;
     const incoming = entries.map((entry, index) => normalizeCursorTodoEntry(entry, index));
     const todos = reconcileCursorTodos(incoming, merge, todoSnapshot);
     acc.toolStartTimes.set(update.toolCallId, Date.now());
@@ -194,7 +215,16 @@ function mapAcpToolCallStarted(
   const toolName = raw.discriminator
     ? (TOOL_NAME_BY_DISCRIMINATOR[raw.discriminator] ?? raw.discriminator)
     : update.title || "Tool";
-  const args = extractArgs(raw.payload);
+  let toolInput: Record<string, unknown> =
+    args && Object.keys(args).length > 0
+      ? args
+      : (typeof update.rawInput === "object" && update.rawInput !== null && !Array.isArray(update.rawInput))
+        ? coercePayloadArgs(update.rawInput as Record<string, unknown>)
+        : {};
+
+  if (toolName === "Edit" || toolName === "Write") {
+    toolInput = normalizeMcodeCursorToolInput(toolName, toolInput);
+  }
   acc.toolStartTimes.set(update.toolCallId, Date.now());
   return [
     {
@@ -202,7 +232,7 @@ function mapAcpToolCallStarted(
       threadId,
       toolCallId: update.toolCallId,
       toolName,
-      toolInput: args ?? (update.rawInput as Record<string, unknown>) ?? {},
+      toolInput,
     },
   ];
 }
@@ -247,12 +277,16 @@ function mapAcpToolCallUpdated(
     const toolName =
       discriminator != null ? (TOOL_NAME_BY_DISCRIMINATOR[discriminator] ?? discriminator) : update.title ?? "Tool";
     if (discriminator !== "updateTodosToolCall") {
+      let orphanInput = coercePayloadArgs(payload ?? undefined);
+      if (toolName === "Edit" || toolName === "Write") {
+        orphanInput = normalizeMcodeCursorToolInput(toolName, orphanInput);
+      }
       events.push({
         type: AgentEventType.ToolUse,
         threadId,
         toolCallId: update.toolCallId,
         toolName,
-        toolInput: extractArgs(payload) ?? {},
+        toolInput: orphanInput,
       });
     }
   }

--- a/apps/server/src/providers/cursor/cursor-acp-permission-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-permission-mapper.ts
@@ -1,0 +1,77 @@
+/**
+ * Bridges ACP `requestPermission` payloads to mcode {@link PermissionRequest} and back.
+ */
+
+import type { PermissionOption, RequestPermissionOutcome } from "@agentclientprotocol/sdk";
+import type { PermissionDecision, PermissionRequest } from "@mcode/contracts";
+
+/**
+ * Builds a pending permission card for the web client from an ACP request.
+ *
+ * @param input - Stable `requestId` from the provider plus ACP payload fields.
+ */
+export function synthesizeCursorAcpPermissionRequest(input: {
+  requestId: string;
+  threadId: string;
+  toolTitle: string;
+  rawToolInput: unknown;
+}): PermissionRequest {
+  const { requestId, threadId, toolTitle, rawToolInput } = input;
+  const toolInput =
+    rawToolInput !== undefined && typeof rawToolInput === "object" && !Array.isArray(rawToolInput)
+      ? (rawToolInput as Record<string, unknown>)
+      : {};
+  return {
+    requestId,
+    threadId,
+    toolName: toolTitle || "Tool",
+    input: toolInput,
+    title: toolTitle || undefined,
+  };
+}
+
+/** Picks the first allow-style option Cursor offered (full-access auto-approve). */
+export function pickFullAccessAllowOption(options: PermissionOption[]): string | undefined {
+  const ranked = ["allow_always", "allow_once"] as const;
+  for (const kind of ranked) {
+    const hit = options.find((o) => o.kind === kind);
+    if (hit) return hit.optionId;
+  }
+  return options[0]?.optionId;
+}
+
+/**
+ * Maps an mcode user decision onto an ACP {@link RequestPermissionOutcome}.
+ *
+ * Prefer option kinds that match the intent; fallback to `options[0]` so a host
+ * misconfiguration cannot wedge the prompt turn indefinitely.
+ */
+export function mapDecisionToAcpOutcome(
+  decision: PermissionDecision,
+  options: PermissionOption[],
+): RequestPermissionOutcome {
+  if (decision === "cancelled") {
+    return { outcome: "cancelled" };
+  }
+  const pickKind = (kinds: readonly PermissionOption["kind"][]): string | undefined => {
+    for (const kind of kinds) {
+      const hit = options.find((o) => o.kind === kind);
+      if (hit) return hit.optionId;
+    }
+    return undefined;
+  };
+
+  let optionId: string | undefined;
+  if (decision === "allow") {
+    optionId = pickKind(["allow_once", "allow_always"]);
+  } else if (decision === "allow-session") {
+    optionId = pickKind(["allow_always", "allow_once"]);
+  } else {
+    optionId = pickKind(["reject_once", "reject_always"]);
+  }
+  const resolved = optionId ?? options[0]?.optionId;
+  if (!resolved) {
+    return { outcome: "cancelled" };
+  }
+  return { outcome: "selected", optionId: resolved };
+}

--- a/apps/server/src/providers/cursor/cursor-acp-prompt.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-prompt.ts
@@ -1,0 +1,53 @@
+/**
+ * Builds ACP {@link ContentBlock} arrays for Cursor from composer text, optional
+ * attachments, and user-scope instructions (same sources as {@link buildCursorPrompt}).
+ */
+
+import { readFileSync } from "node:fs";
+import type { AttachmentMeta } from "@mcode/contracts";
+import type { ContentBlock } from "@agentclientprotocol/sdk";
+import {
+  buildCursorPrompt,
+  readCursorUserInstructions,
+} from "./cursor-prompt.js";
+
+/**
+ * Assembles prompt blocks for `session/prompt`, embedding images when readable
+ * from disk; non-image attachments stay as inline text notes without raw paths.
+ *
+ * @param message - User-visible message for this turn (may include branch replay text).
+ * @param attachments - Persisted attachment metadata with `sourcePath` for images.
+ * @param userInstructions - Optional AGENTS.md contents; defaults to {@link readCursorUserInstructions}.
+ */
+export function buildCursorAcpPromptBlocks(
+  message: string,
+  attachments?: AttachmentMeta[],
+  userInstructions?: string,
+): ContentBlock[] {
+  const instructions = userInstructions ?? readCursorUserInstructions();
+  const blocks: ContentBlock[] = [];
+
+  const nonImageAttachments =
+    attachments?.filter((att) => !att.mimeType.startsWith("image/")) ?? [];
+
+  for (const att of attachments ?? []) {
+    if (!att.mimeType.startsWith("image/")) continue;
+    try {
+      const buf = readFileSync(att.sourcePath);
+      blocks.push({
+        type: "image",
+        mimeType: att.mimeType,
+        data: buf.toString("base64"),
+      });
+    } catch {
+      blocks.push({
+        type: "text",
+        text: `[Attached image unreadable: ${att.name.replace(/[\x00-\x1f\x7f]/g, "")}]`,
+      });
+    }
+  }
+
+  const textBody = buildCursorPrompt(message, nonImageAttachments, instructions);
+  blocks.push({ type: "text", text: textBody });
+  return blocks;
+}

--- a/apps/server/src/providers/cursor/cursor-acp-prompt.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-prompt.ts
@@ -17,7 +17,8 @@ import {
  *
  * @param message - User-visible message for this turn (may include branch replay text).
  * @param attachments - Persisted attachment metadata with `sourcePath` for images.
- * @param userInstructions - Optional AGENTS.md contents; defaults to {@link readCursorUserInstructions}.
+ * @param userInstructions - Precomposed instructions string (layered AGENTS files, skill index).
+ * When omitted, falls back to {@link readCursorUserInstructions} (~/.cursor/AGENTS.md only).
  */
 export function buildCursorAcpPromptBlocks(
   message: string,

--- a/apps/server/src/providers/cursor/cursor-acp-prompt.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-prompt.ts
@@ -27,6 +27,7 @@ export function buildCursorAcpPromptBlocks(
 ): ContentBlock[] {
   const instructions = userInstructions ?? readCursorUserInstructions();
   const blocks: ContentBlock[] = [];
+  const unreadableNotes: string[] = [];
 
   const nonImageAttachments =
     attachments?.filter((att) => !att.mimeType.startsWith("image/")) ?? [];
@@ -41,14 +42,19 @@ export function buildCursorAcpPromptBlocks(
         data: buf.toString("base64"),
       });
     } catch {
-      blocks.push({
-        type: "text",
-        text: `[Attached image unreadable: ${att.name.replace(/[\x00-\x1f\x7f]/g, "")}]`,
-      });
+      unreadableNotes.push(
+        `[Attached image unreadable: ${att.name.replace(/[\x00-\x1f\x7f]/g, "")}]`,
+      );
     }
   }
 
   const textBody = buildCursorPrompt(message, nonImageAttachments, instructions);
-  blocks.push({ type: "text", text: textBody });
+  blocks.push({
+    type: "text",
+    text:
+      unreadableNotes.length > 0
+        ? `${unreadableNotes.join("\n\n")}\n\n${textBody}`
+        : textBody,
+  });
   return blocks;
 }

--- a/apps/server/src/providers/cursor/cursor-acp-spawn-args.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-spawn-args.ts
@@ -1,0 +1,23 @@
+/**
+ * Builds argv for `cursor-agent` / `agent acp` subprocesses.
+ * Mirrors the supervised vs full-access flag matrix from {@link buildCursorTurnArgs}
+ * so sandbox and trust semantics stay aligned with the `--print` transport.
+ */
+
+/** Args after the executable: `["acp", ...]` */
+export function buildCursorAcpArgs(opts: {
+  permissionMode: "default" | "full";
+  /** Host platform; defaults to `process.platform` in the provider. */
+  platform?: NodeJS.Platform;
+}): string[] {
+  const platform = opts.platform ?? process.platform;
+  const args: string[] = ["acp"];
+  if (opts.permissionMode === "full") {
+    args.push("--force", "--sandbox", "disabled");
+  } else {
+    args.push("--trust");
+    const supervisedSandboxAvailable = platform === "darwin" || platform === "linux";
+    args.push("--sandbox", supervisedSandboxAvailable ? "enabled" : "disabled");
+  }
+  return args;
+}

--- a/apps/server/src/providers/cursor/cursor-agent-guidance.ts
+++ b/apps/server/src/providers/cursor/cursor-agent-guidance.ts
@@ -1,0 +1,75 @@
+/**
+ * Merges Markdown instruction sources for Cursor ACP turns: user `~/.cursor/AGENTS.md`,
+ * repository `AGENTS.md`, and `.cursor/AGENTS.md` under the session working directory.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { SkillInfo } from "@mcode/contracts";
+
+/** Reads a Markdown file when it exists and is non-empty after trim. */
+function readOptionalMarkdownFile(filePath: string): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+  try {
+    const text = readFileSync(filePath, "utf-8").trim();
+    return text.length > 0 ? text : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Concatenates `AGENTS.md` and `.cursor/AGENTS.md` under the session cwd.
+ *
+ * @param cwd - Session working directory.
+ * @returns Combined Markdown or `undefined` when both files are missing or empty.
+ */
+export function mergeCursorWorkspaceAgentMarkdown(cwd: string): string | undefined {
+  const chunks: string[] = [];
+  const repo = readOptionalMarkdownFile(join(cwd, "AGENTS.md"));
+  if (repo) chunks.push(repo);
+  const project = readOptionalMarkdownFile(join(cwd, ".cursor", "AGENTS.md"));
+  if (project) chunks.push(project);
+  if (chunks.length === 0) return undefined;
+  return chunks.join("\n\n---\n\n");
+}
+
+/**
+ * Builds layered agent instructions for Cursor: global user rules (`~/.cursor/AGENTS.md`),
+ * then workspace {@link mergeCursorWorkspaceAgentMarkdown}.
+ *
+ * @param cwd - Session working directory (composer branch or worktree root).
+ * @returns Combined Markdown or `undefined` when no files are readable.
+ */
+export function buildCursorAgentGuidanceMarkdown(cwd: string): string | undefined {
+  const chunks: string[] = [];
+  const user = readOptionalMarkdownFile(join(homedir(), ".cursor", "AGENTS.md"));
+  if (user) chunks.push(user);
+  const workspace = mergeCursorWorkspaceAgentMarkdown(cwd);
+  if (workspace) chunks.push(workspace);
+  if (chunks.length === 0) return undefined;
+  return chunks.join("\n\n---\n\n");
+}
+
+/**
+ * Formats skill and command metadata into an XML-ish prompt section so the Cursor
+ * agent knows which toolbox entries apply for this workspace.
+ *
+ * @param items - Skills and commands from `SkillService.list(cwd, "cursor")`.
+ */
+export function formatCursorSkillsAndCommandsForPrompt(
+  items: readonly SkillInfo[],
+): string | undefined {
+  if (items.length === 0) return undefined;
+  const lines = items.map((i) => {
+    const tag = i.kind === "command" ? "command" : "skill";
+    return `- [${tag}] ${i.name}: ${i.description}`;
+  });
+  return [
+    "<available-skills-and-commands>",
+    "Discovered Cursor provider skills and commands (user and project .cursor trees).",
+    ...lines,
+    "</available-skills-and-commands>",
+  ].join("\n");
+}

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -43,7 +43,11 @@ import type {
   ReasoningLevel,
   Settings,
 } from "@mcode/contracts";
-import { createCursorTodoSnapshot, type CursorTodoSnapshot } from "./cursor-todo-snapshot.js";
+import {
+  createCursorTodoSnapshot,
+  cursorUpdateTodosExtNotificationToAgentEvents,
+  type CursorTodoSnapshot,
+} from "./cursor-todo-snapshot.js";
 import { fetchCursorCliModels } from "./cursor-cli-models.js";
 import { buildCursorAcpArgs } from "./cursor-acp-spawn-args.js";
 import { buildCursorAcpPromptBlocks } from "./cursor-acp-prompt.js";
@@ -398,6 +402,22 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
         return {};
       },
       extNotification: async (method, params) => {
+        if (
+          method === "cursor/update_todos" &&
+          params !== null &&
+          typeof params === "object" &&
+          !Array.isArray(params)
+        ) {
+          const events = cursorUpdateTodosExtNotificationToAgentEvents(
+            entry.threadId,
+            params as Record<string, unknown>,
+            entry.todoSnapshot,
+          );
+          for (const ev of events) {
+            this.emit("event", ev);
+          }
+          return;
+        }
         void method;
         void params;
       },

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -383,7 +383,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
         return {};
       },
       extMethod: async (method, params) => {
-        void params;
         if (method === "cursor/ask_question") {
           return {
             outcome: {
@@ -394,6 +393,24 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
         }
         if (method === "cursor/create_plan") {
           return { outcome: { outcome: "accepted" } };
+        }
+        // cursor/update_todos arrives as a request (not notification) in the
+        // ACP SDK dispatch. Handle it here so the task panel stays in sync.
+        if (
+          method === "cursor/update_todos" &&
+          params !== null &&
+          typeof params === "object" &&
+          !Array.isArray(params)
+        ) {
+          const events = cursorUpdateTodosExtNotificationToAgentEvents(
+            entry.threadId,
+            params as Record<string, unknown>,
+            entry.todoSnapshot,
+          );
+          for (const ev of events) {
+            this.emit("event", ev);
+          }
+          return {};
         }
         logger.debug("Cursor ACP extMethod unhandled", {
           threadId: entry.threadId,
@@ -468,6 +485,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     if (!entry.acpSessionId || params.sessionId !== entry.acpSessionId) return;
     const state = entry.activeTurnState;
     if (!state) return;
+
     const mapped = mapCursorAcpSessionNotification(
       params,
       entry.threadId,

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -1,43 +1,36 @@
 /**
- * Cursor CLI provider via `cursor-agent --print --output-format stream-json`.
+ * Cursor CLI provider via long-lived `cursor-agent acp` (Agent Client Protocol).
  *
- * Each prompt turn spawns a fresh subprocess that resolves the persistent
- * chat from disk via `--resume <chatId>` and exits when the turn completes.
- * This replaces the prior `cursor-agent acp` long-lived subprocess pool: the
- * ACP transport's `session/load` resume path is broken on Cursor's side
- * (sessionIds are subprocess-scoped and cannot be reattached after a
- * restart), and the chat-id namespace exposed via `--resume` is the only
- * stable persistence handle Cursor offers.
- *
- * Trade-offs vs the ACP transport:
- *   - **Resume across restarts** works: chat ids round-trip through
- *     `setSdkSessionId` and disk persistence.
- *   - **Permissions** are simplified: `cursor-agent --print` has no
- *     interactive permission flow ("Has access to all tools, including write
- *     and shell"), so we cannot route per-tool prompts through the UI like
- *     the ACP transport did. Instead we delegate safety to whatever
- *     cursor-agent supports on the host:
- *       - **full mode** (all platforms): `--force --sandbox disabled`
- *         (tool approval + workspace trust, sandbox off — anything goes)
- *       - **default mode on macOS/Linux**: `--trust --sandbox enabled`
- *         (workspace trust granted; OS sandbox blocks writes outside the
- *         workspace and dangerous shell commands)
- *       - **default mode on Windows**: `--trust --sandbox disabled` — the
- *         OS sandbox is unsupported on Windows ("Sandbox requires macOS or
- *         Linux"), so we fall back to cursor-agent's built-in allowlist
- *         mode. Off-allowlist commands are auto-rejected at the agent
- *         layer; this is weaker than the OS sandbox but better than `--force`.
- *     All flags are passed explicitly so the user's local cursor-agent
- *     config cannot override the intended semantics.
- *   - **No subprocess pool / idle eviction** — every turn is fresh, so the
- *     resource model is "pay per turn" instead of "pay to keep alive".
+ * One subprocess per Mcode thread keeps JSON-RPC on stdio stable across turns.
+ * When `session/load` fails (known Cursor limitations), we fall back to `session/new`
+ * and emit `sdk_session_id` so the DB tracks the active session id.
  */
 
 import { injectable, inject } from "tsyringe";
+import { spawn, execFile, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { Readable, Writable } from "node:stream";
+import { randomUUID } from "node:crypto";
 import { logger } from "@mcode/shared";
+import {
+  ClientSideConnection,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type Client,
+  type PermissionOption,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+
 import { SettingsService } from "../../services/settings-service.js";
-import { AgentEventType, CURSOR_STATIC_MODEL_FALLBACK, getCatalogEntry } from "@mcode/contracts";
+import {
+  AgentEventType,
+  CURSOR_STATIC_MODEL_FALLBACK,
+  getCatalogEntry,
+} from "@mcode/contracts";
 import type {
   AttachmentMeta,
   AgentEvent,
@@ -49,44 +42,60 @@ import type {
   ReasoningLevel,
   Settings,
 } from "@mcode/contracts";
-import { runCursorTurn } from "./cursor-turn-runner.js";
-import {
-  buildCursorPrompt,
-  readCursorUserInstructions,
-} from "./cursor-prompt.js";
-import {
-  createCursorTodoSnapshot,
-  type CursorTodoSnapshot,
-} from "./cursor-todo-snapshot.js";
+import { createCursorTodoSnapshot, type CursorTodoSnapshot } from "./cursor-todo-snapshot.js";
 import { fetchCursorCliModels } from "./cursor-cli-models.js";
+import { buildCursorAcpArgs } from "./cursor-acp-spawn-args.js";
+import { buildCursorAcpPromptBlocks } from "./cursor-acp-prompt.js";
+import {
+  createCursorAcpTurnState,
+  mapCursorAcpSessionNotification,
+  type CursorAcpTurnState,
+} from "./cursor-acp-event-mapper.js";
+import {
+  mapDecisionToAcpOutcome,
+  pickFullAccessAllowOption,
+  synthesizeCursorAcpPermissionRequest,
+} from "./cursor-acp-permission-mapper.js";
 
-/** Per-mcode-session state that survives across prompt turns. */
-interface CursorSessionState {
-  /** Persistent cursor chat id (used with `--resume`). Null until first turn captures it. */
-  chatId: string | null;
-  /** Snapshot for `merge: true` updateTodos reconciliation across turns. */
-  todoSnapshot: CursorTodoSnapshot;
-  /** AbortController for the in-flight turn (if any), used by stopSession. */
-  inFlight: AbortController | null;
-}
+const IDLE_TTL_MS = 10 * 60 * 1000;
+const EVICTION_INTERVAL_MS = 60 * 1000;
 
-/** Executable paths to try for cursor-agent (configured override → catalog → bare name). */
 function cursorCliProbeBinaries(settings: Settings): string[] {
   const configured = settings.provider.cli.cursor?.trim();
   return configured ? [configured] : [getCatalogEntry("cursor").cliBinary, "agent"];
 }
 
-/**
- * Cursor CLI-backed agent provider using the `--print` stream-json transport.
- */
+interface PendingAcpPermission {
+  mcodeSessionId: string;
+  threadId: string;
+  options: PermissionOption[];
+  request: PermissionRequest;
+  resolve: (value: RequestPermissionResponse) => void;
+}
+
+interface CursorAcpSessionEntry {
+  mcodeSessionId: string;
+  threadId: string;
+  child: ChildProcess;
+  connection: ClientSideConnection;
+  acpSessionId: string;
+  cwd: string;
+  permissionMode: "full" | "default";
+  lastUsedAt: number;
+  todoSnapshot: CursorTodoSnapshot;
+  turnChain: Promise<void>;
+  activeTurnState: CursorAcpTurnState | null;
+}
+
 @injectable()
 export class CursorProvider extends EventEmitter implements IAgentProvider {
   readonly id: ProviderId = "cursor";
   readonly supportsCompletion = false;
 
-  private states = new Map<string, CursorSessionState>();
-  /** Mirror of states[*].chatId so `setSdkSessionId` works before first send. */
+  private sessions = new Map<string, CursorAcpSessionEntry>();
   private sdkSessionIds = new Map<string, string>();
+  private pendingPermissions = new Map<string, PendingAcpPermission>();
+  private evictionTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
@@ -109,13 +118,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     return [...CURSOR_STATIC_MODEL_FALLBACK];
   }
 
-  /**
-   * Sends a user message by spawning one cursor-agent --print turn.
-   *
-   * Emits TurnStarted, then streamed deltas/tool events from the runner,
-   * then Message + TurnComplete + Ended for persistence parity. On error,
-   * emits Error + Ended so the UI doesn't show a stuck spinner.
-   */
+  /** Queues an ACP `session/prompt` on the session subprocess (serialized per thread). */
   async sendMessage(params: {
     sessionId: string;
     message: string;
@@ -130,8 +133,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     void params.fallbackModel;
     void params.reasoningLevel;
 
-    const settings = this.settingsService.get();
-
     const {
       sessionId,
       message,
@@ -142,141 +143,468 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       attachments,
     } = params;
 
+    const pm: "full" | "default" = permissionMode === "full" ? "full" : "default";
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
-    const prompt = buildCursorPrompt(message, attachments, readCursorUserInstructions());
 
-    const state = this.getOrCreateState(sessionId);
-    const chatId = resume ? state.chatId ?? this.sdkSessionIds.get(sessionId) ?? null : null;
+    if (!this.evictionTimer) {
+      this.evictionTimer = setInterval(() => this.evictIdleSessions(), EVICTION_INTERVAL_MS);
+    }
 
-    const abort = new AbortController();
-    state.inFlight = abort;
-
-    this.emit("event", { type: AgentEventType.TurnStarted, threadId } satisfies AgentEvent);
-
-    const cliCandidates = cursorCliProbeBinaries(settings);
-    let lastErr: unknown = null;
-    for (const cliPath of cliCandidates) {
-      try {
-        const { chatId: capturedChatId, assistantText } = await runCursorTurn(
-          {
-            cliPath,
-            prompt,
-            cwd,
-            threadId,
-            model: model || undefined,
-            permissionMode: permissionMode === "full" ? "full" : "default",
-            chatId,
-          },
-          (ev) => this.emit("event", ev),
-          state.todoSnapshot,
-          abort.signal,
-        );
-        if (capturedChatId) {
-          state.chatId = capturedChatId;
-          this.sdkSessionIds.set(sessionId, capturedChatId);
-        }
-        state.inFlight = null;
-        this.finishTurn(threadId, assistantText);
-        return;
-      } catch (e) {
-        lastErr = e;
-        // ENOENT / spawn errors → try the next probed binary.
-        const msg = e instanceof Error ? e.message : String(e);
-        if (/Failed to spawn cursor-agent/i.test(msg)) continue;
-        // All other errors are real turn failures — surface immediately.
-        break;
+    const settings = this.settingsService.get();
+    let entry = this.sessions.get(sessionId);
+    if (entry) {
+      const dead =
+        entry.child.exitCode != null ||
+        entry.child.signalCode != null;
+      const mismatch = entry.permissionMode !== pm || entry.cwd !== cwd;
+      if (mismatch || dead) {
+        await this.teardownSessionEntry(sessionId, entry, false);
+        entry = undefined;
       }
     }
 
-    state.inFlight = null;
-    const errMsg = lastErr instanceof Error ? lastErr.message : String(lastErr ?? "cursor-agent failed");
-    logger.error("Cursor turn failed", { sessionId, error: errMsg });
-    this.emit("event", { type: AgentEventType.Error, threadId, error: errMsg } satisfies AgentEvent);
-    this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+    if (!entry) {
+      try {
+        entry = await this.spawnChild(sessionId, threadId, cwd, pm, settings);
+        this.sessions.set(sessionId, entry);
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        logger.error("Cursor ACP spawn failed", { sessionId, error: errMsg });
+        this.emit("event", { type: AgentEventType.Error, threadId, error: errMsg } satisfies AgentEvent);
+        this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+        return;
+      }
+    }
+
+    entry.lastUsedAt = Date.now();
+    const scheduled = entry.turnChain.then(() =>
+      this.runTurn(entry!, { message, model, resume, attachments }),
+    );
+    entry.turnChain = scheduled.then(
+      () => {},
+      () => {},
+    );
+    await scheduled;
   }
 
-  /** Persists chat ids so subsequent turns resume the same cursor chat. */
   setSdkSessionId(sessionId: string, sdkSessionId: string): void {
     this.sdkSessionIds.set(sessionId, sdkSessionId);
-    const state = this.states.get(sessionId);
-    if (state) state.chatId = sdkSessionId;
   }
 
-  /** Aborts the in-flight turn (if any). State is preserved for the next turn. */
   stopSession(sessionId: string): void {
-    const state = this.states.get(sessionId);
-    if (!state?.inFlight) return;
-    try {
-      state.inFlight.abort();
-    } catch {
-      /* ignore */
-    }
-    state.inFlight = null;
+    const entry = this.sessions.get(sessionId);
+    this.cancelPendingForThread(sessionId);
+    if (!entry?.acpSessionId) return;
+    void entry.connection.cancel({ sessionId: entry.acpSessionId }).catch(() => {});
   }
 
-  /** Aborts every in-flight turn and clears bookkeeping. */
   shutdown(): void {
-    for (const state of this.states.values()) {
-      if (state.inFlight) {
-        try {
-          state.inFlight.abort();
-        } catch {
-          /* ignore */
-        }
-      }
+    if (this.evictionTimer) {
+      clearInterval(this.evictionTimer);
+      this.evictionTimer = null;
     }
-    this.states.clear();
+    this.drainAllPendingCancelled();
+    for (const [id, entry] of this.sessions) {
+      void this.teardownSessionEntry(id, entry, false);
+    }
+    this.sessions.clear();
     this.sdkSessionIds.clear();
     logger.info("CursorProvider shutdown complete");
   }
 
-  /**
-   * Stream-json --print mode does not surface interactive permission prompts.
-   * The method is preserved on the interface as a no-op so the WebSocket RPC
-   * router can call it uniformly across providers.
-   */
-  resolvePermission(_requestId: string, _decision: PermissionDecision): boolean {
+  resolvePermission(requestId: string, decision: PermissionDecision): boolean {
+    const pending = this.pendingPermissions.get(requestId);
+    if (!pending) return false;
+    this.pendingPermissions.delete(requestId);
+    try {
+      this.emit("permission_resolved", { requestId, decision });
+    } catch {
+      /* ignore subscriber errors */
+    }
+    pending.resolve({ outcome: mapDecisionToAcpOutcome(decision, pending.options) });
+    return true;
+  }
+
+  listPendingPermissions(threadId: string): PermissionRequest[] {
+    const out: PermissionRequest[] = [];
+    for (const p of this.pendingPermissions.values()) {
+      if (p.threadId === threadId) out.push(p.request);
+    }
+    return out;
+  }
+
+  private cancelPendingForThread(mcodeSessionId: string): void {
+    for (const [requestId, p] of this.pendingPermissions) {
+      if (p.mcodeSessionId !== mcodeSessionId) continue;
+      this.pendingPermissions.delete(requestId);
+      p.resolve({ outcome: { outcome: "cancelled" } });
+      try {
+        this.emit("permission_resolved", { requestId, decision: "cancelled" });
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  private drainAllPendingCancelled(): void {
+    for (const [requestId, p] of this.pendingPermissions) {
+      p.resolve({ outcome: { outcome: "cancelled" } });
+      try {
+        this.emit("permission_resolved", { requestId, decision: "cancelled" });
+      } catch {
+        /* ignore */
+      }
+    }
+    this.pendingPermissions.clear();
+  }
+
+  private async spawnChild(
+    mcodeSessionId: string,
+    threadId: string,
+    cwd: string,
+    permissionMode: "full" | "default",
+    settings: Settings,
+  ): Promise<CursorAcpSessionEntry> {
+    const cliCandidates = cursorCliProbeBinaries(settings);
+    let lastErr: unknown = null;
+    for (const cliPath of cliCandidates) {
+      try {
+        return await this.spawnOneCli(cliPath, mcodeSessionId, threadId, cwd, permissionMode);
+      } catch (e) {
+        lastErr = e;
+        const msg = e instanceof Error ? e.message : String(e);
+        if (/Failed to spawn cursor-agent/i.test(msg)) continue;
+        break;
+      }
+    }
+    throw lastErr instanceof Error
+      ? lastErr
+      : new Error(String(lastErr ?? "Failed to spawn cursor-agent (acp)"));
+  }
+
+  private async spawnOneCli(
+    cliPath: string,
+    mcodeSessionId: string,
+    threadId: string,
+    cwd: string,
+    permissionMode: "full" | "default",
+  ): Promise<CursorAcpSessionEntry> {
+    const args = buildCursorAcpArgs({ permissionMode });
+    const child = spawn(cliPath, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd,
+      shell: process.platform === "win32",
+      env: { ...process.env },
+    });
+
+    if (!child.stdin || !child.stdout) {
+      throw new Error("Failed to spawn cursor-agent: stdio pipes unavailable");
+    }
+
+    const out = Writable.toWeb(child.stdin) as WritableStream<Uint8Array>;
+    const inp = Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>;
+    const stream = ndJsonStream(out, inp);
+
+    const shell: Omit<CursorAcpSessionEntry, "connection"> = {
+      mcodeSessionId,
+      threadId,
+      child,
+      acpSessionId: "",
+      cwd,
+      permissionMode,
+      lastUsedAt: Date.now(),
+      todoSnapshot: createCursorTodoSnapshot(),
+      turnChain: Promise.resolve(),
+      activeTurnState: null,
+    };
+
+    const connection = new ClientSideConnection(
+      () => this.buildAcpClient(shell as CursorAcpSessionEntry),
+      stream,
+    );
+
+    const entry = { ...shell, connection } as CursorAcpSessionEntry;
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString().split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed) logger.debug("cursor-agent acp stderr", { threadId, line: trimmed });
+      }
+    });
+
+    child.on("exit", () => {
+      this.cancelPendingForThread(mcodeSessionId);
+      this.sessions.delete(mcodeSessionId);
+    });
+
+    const initResult = await connection.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientInfo: { name: "mcode", title: "Mcode", version: "0.0.1" },
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+      },
+    });
+
+    const authMethods = initResult.authMethods ?? [];
+    const methodId = authMethods[0]?.id;
+    if (methodId) {
+      await connection.authenticate({ methodId }).catch((err: unknown) => {
+        logger.info("Cursor ACP authenticate noop", {
+          threadId,
+          error: String(err),
+        });
+      });
+    }
+
+    return entry;
+  }
+
+  private buildAcpClient(entry: CursorAcpSessionEntry): Client {
+    return {
+      requestPermission: async (req) => this.bridgePermission(entry, req),
+      sessionUpdate: async (params) => this.deliverSessionUpdate(entry, params),
+      readTextFile: async (r) => ({ content: this.safeReadWorkspaceFile(entry.cwd, r.path) }),
+      writeTextFile: async (r) => {
+        this.safeWriteWorkspaceFile(entry.cwd, r.path, r.content);
+        return {};
+      },
+    };
+  }
+
+  private async bridgePermission(
+    entry: CursorAcpSessionEntry,
+    params: RequestPermissionRequest,
+  ): Promise<RequestPermissionResponse> {
+    if (entry.permissionMode === "full") {
+      const optionId = pickFullAccessAllowOption(params.options);
+      if (!optionId) return { outcome: { outcome: "cancelled" } };
+      return { outcome: { outcome: "selected", optionId } };
+    }
+
+    const requestId = randomUUID();
+    const toolTitle = typeof params.toolCall.title === "string" ? params.toolCall.title : "Tool";
+    const request = synthesizeCursorAcpPermissionRequest({
+      requestId,
+      threadId: entry.threadId,
+      toolTitle,
+      rawToolInput: params.toolCall.rawInput,
+    });
+
+    return await new Promise((resolve) => {
+      this.pendingPermissions.set(requestId, {
+        mcodeSessionId: entry.mcodeSessionId,
+        threadId: entry.threadId,
+        options: params.options,
+        request,
+        resolve,
+      });
+      queueMicrotask(() => {
+        try {
+          this.emit("permission_request", request);
+        } catch {
+          /* ignore */
+        }
+      });
+    });
+  }
+
+  private async deliverSessionUpdate(
+    entry: CursorAcpSessionEntry,
+    params: SessionNotification,
+  ): Promise<void> {
+    if (!entry.acpSessionId || params.sessionId !== entry.acpSessionId) return;
+    const state = entry.activeTurnState;
+    if (!state) return;
+    const mapped = mapCursorAcpSessionNotification(
+      params,
+      entry.threadId,
+      state,
+      entry.todoSnapshot,
+    );
+    for (const ev of mapped) {
+      this.emit("event", ev);
+    }
+  }
+
+  private safeReadWorkspaceFile(cwd: string, filePath: string): string {
+    const resolved = path.resolve(filePath);
+    const root = path.resolve(cwd);
+    if (resolved !== root && !resolved.startsWith(root + path.sep)) return "";
+    try {
+      if (!existsSync(resolved)) return "";
+      return readFileSync(resolved, "utf-8");
+    } catch {
+      return "";
+    }
+  }
+
+  private safeWriteWorkspaceFile(cwd: string, filePath: string, content: string): void {
+    const resolved = path.resolve(filePath);
+    const root = path.resolve(cwd);
+    if (resolved !== root && !resolved.startsWith(root + path.sep)) return;
+    try {
+      mkdirSync(path.dirname(resolved), { recursive: true });
+      writeFileSync(resolved, content, "utf-8");
+    } catch {
+      /* tool layer records failure */
+    }
+  }
+
+  /** Ensures `entry.acpSessionId` is ready (new or load). */
+  private async openLogicalSession(entry: CursorAcpSessionEntry, resume: boolean): Promise<void> {
+    if (entry.acpSessionId) return;
+
+    const stored = this.sdkSessionIds.get(entry.mcodeSessionId);
+    let acpId: string;
+
+    if (resume && stored) {
+      try {
+        await entry.connection.loadSession({
+          cwd: entry.cwd,
+          mcpServers: [],
+          sessionId: stored,
+        });
+        acpId = stored;
+      } catch (err) {
+        logger.info("Cursor ACP loadSession failed; new session", {
+          threadId: entry.threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        const created = await entry.connection.newSession({
+          cwd: entry.cwd,
+          mcpServers: [],
+        });
+        acpId = created.sessionId;
+      }
+    } else {
+      const created = await entry.connection.newSession({
+        cwd: entry.cwd,
+        mcpServers: [],
+      });
+      acpId = created.sessionId;
+    }
+
+    entry.acpSessionId = acpId;
+    this.sdkSessionIds.set(entry.mcodeSessionId, acpId);
+    this.emit("event", {
+      type: AgentEventType.System,
+      threadId: entry.threadId,
+      subtype: `sdk_session_id:${acpId}`,
+    } satisfies AgentEvent);
+  }
+
+  private async applyModel(entry: CursorAcpSessionEntry, model: string): Promise<void> {
+    const trimmed = model.trim();
+    if (!trimmed || !entry.acpSessionId) return;
+    await entry.connection
+      .unstable_setSessionModel({
+        sessionId: entry.acpSessionId,
+        modelId: trimmed,
+      })
+      .catch((err: unknown) => {
+        logger.debug("Cursor ACP setSessionModel noop", {
+          threadId: entry.threadId,
+          error: String(err),
+        });
+      });
+  }
+
+  private async runTurn(
+    entry: CursorAcpSessionEntry,
+    opts: {
+      message: string;
+      model: string;
+      resume: boolean;
+      attachments?: AttachmentMeta[];
+    },
+  ): Promise<void> {
+    const { message, model, resume, attachments } = opts;
+    entry.activeTurnState = createCursorAcpTurnState();
+    try {
+      await this.openLogicalSession(entry, resume);
+      await this.applyModel(entry, model);
+
+      const blocks = buildCursorAcpPromptBlocks(message, attachments);
+      const promptResponse = await entry.connection.prompt({
+        sessionId: entry.acpSessionId,
+        prompt: blocks,
+      });
+
+      const text = entry.activeTurnState.accumulator.assistantText.trim();
+      if (text.length > 0) {
+        this.emit("event", {
+          type: AgentEventType.Message,
+          threadId: entry.threadId,
+          content: text,
+          tokens: null,
+        } satisfies AgentEvent);
+      }
+
+      const usage = promptResponse.usage;
+      this.emit("event", {
+        type: AgentEventType.TurnComplete,
+        threadId: entry.threadId,
+        reason: promptResponse.stopReason,
+        costUsd: null,
+        tokensIn: usage?.inputTokens ?? 0,
+        tokensOut: usage?.outputTokens ?? 0,
+        providerId: "cursor",
+      } satisfies AgentEvent);
+
+      this.emit("event", { type: AgentEventType.Ended, threadId: entry.threadId } satisfies AgentEvent);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      logger.error("Cursor ACP prompt failed", { threadId: entry.threadId, error: errMsg });
+      this.emit("event", {
+        type: AgentEventType.Error,
+        threadId: entry.threadId,
+        error: errMsg,
+      } satisfies AgentEvent);
+      this.emit("event", { type: AgentEventType.Ended, threadId: entry.threadId } satisfies AgentEvent);
+    } finally {
+      entry.activeTurnState = null;
+    }
+  }
+
+  private async teardownSessionEntry(
+    mcodeSessionId: string,
+    entry: CursorAcpSessionEntry,
+    clearStoredSdkId: boolean,
+  ): Promise<void> {
+    this.cancelPendingForThread(mcodeSessionId);
+    try {
+      entry.child.kill();
+    } catch {
+      /* ignore */
+    }
+    if (process.platform === "win32" && entry.child.pid) {
+      await new Promise<void>((resolve) => {
+        execFile(
+          "taskkill",
+          ["/T", "/F", "/PID", String(entry.child.pid)],
+          () => resolve(),
+        );
+      });
+    }
+    if (clearStoredSdkId) {
+      this.sdkSessionIds.delete(mcodeSessionId);
+    }
+  }
+
+  private sessionHasPendingPermissions(mcodeSessionId: string): boolean {
+    for (const p of this.pendingPermissions.values()) {
+      if (p.mcodeSessionId === mcodeSessionId) return true;
+    }
     return false;
   }
 
-  /** Stream-json --print mode never produces pending permissions. */
-  listPendingPermissions(_threadId: string): PermissionRequest[] {
-    return [];
-  }
-
-  private finishTurn(threadId: string, assistantText: string): void {
-    if (assistantText.trim()) {
-      this.emit("event", {
-        type: AgentEventType.Message,
-        threadId,
-        content: assistantText,
-        tokens: null,
-      } satisfies AgentEvent);
+  private evictIdleSessions(): void {
+    const now = Date.now();
+    for (const [id, entry] of this.sessions) {
+      if (now - entry.lastUsedAt <= IDLE_TTL_MS) continue;
+      if (this.sessionHasPendingPermissions(id)) continue;
+      void this.teardownSessionEntry(id, entry, true);
+      this.sessions.delete(id);
     }
-
-    this.emit("event", {
-      type: AgentEventType.TurnComplete,
-      threadId,
-      reason: "end_turn",
-      costUsd: null,
-      tokensIn: 0,
-      tokensOut: 0,
-      providerId: "cursor",
-    } satisfies AgentEvent);
-
-    this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-  }
-
-  private getOrCreateState(sessionId: string): CursorSessionState {
-    let state = this.states.get(sessionId);
-    if (!state) {
-      state = {
-        chatId: this.sdkSessionIds.get(sessionId) ?? null,
-        todoSnapshot: createCursorTodoSnapshot(),
-        inFlight: null,
-      };
-      this.states.set(sessionId, state);
-    }
-    return state;
   }
 }

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -498,8 +498,8 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   }
 
   private safeReadWorkspaceFile(cwd: string, filePath: string): string {
-    const resolved = path.resolve(filePath);
     const root = path.resolve(cwd);
+    const resolved = path.resolve(root, filePath);
     if (resolved !== root && !resolved.startsWith(root + path.sep)) return "";
     try {
       if (!existsSync(resolved)) return "";
@@ -510,15 +510,13 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   }
 
   private safeWriteWorkspaceFile(cwd: string, filePath: string, content: string): void {
-    const resolved = path.resolve(filePath);
     const root = path.resolve(cwd);
-    if (resolved !== root && !resolved.startsWith(root + path.sep)) return;
-    try {
-      mkdirSync(path.dirname(resolved), { recursive: true });
-      writeFileSync(resolved, content, "utf-8");
-    } catch {
-      /* tool layer records failure */
+    const resolved = path.resolve(root, filePath);
+    if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+      throw new Error("Path outside workspace root");
     }
+    mkdirSync(path.dirname(resolved), { recursive: true });
+    writeFileSync(resolved, content, "utf-8");
   }
 
   /** Ensures `entry.acpSessionId` is ready (new or load). */

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -26,6 +26,7 @@ import {
 } from "@agentclientprotocol/sdk";
 
 import { SettingsService } from "../../services/settings-service.js";
+import { SkillService } from "../../services/skill-service.js";
 import {
   AgentEventType,
   CURSOR_STATIC_MODEL_FALLBACK,
@@ -46,6 +47,11 @@ import { createCursorTodoSnapshot, type CursorTodoSnapshot } from "./cursor-todo
 import { fetchCursorCliModels } from "./cursor-cli-models.js";
 import { buildCursorAcpArgs } from "./cursor-acp-spawn-args.js";
 import { buildCursorAcpPromptBlocks } from "./cursor-acp-prompt.js";
+import {
+  buildCursorAgentGuidanceMarkdown,
+  formatCursorSkillsAndCommandsForPrompt,
+} from "./cursor-agent-guidance.js";
+import { readCursorUserInstructions } from "./cursor-prompt.js";
 import {
   createCursorAcpTurnState,
   mapCursorAcpSessionNotification,
@@ -99,6 +105,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
+    @inject(SkillService) private readonly skillService: SkillService,
   ) {
     super();
   }
@@ -305,7 +312,9 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     const inp = Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>;
     const stream = ndJsonStream(out, inp);
 
-    const shell: Omit<CursorAcpSessionEntry, "connection"> = {
+    const entry: Omit<CursorAcpSessionEntry, "connection"> & {
+      connection?: CursorAcpSessionEntry["connection"];
+    } = {
       mcodeSessionId,
       threadId,
       child,
@@ -318,12 +327,12 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       activeTurnState: null,
     };
 
-    const connection = new ClientSideConnection(
-      () => this.buildAcpClient(shell as CursorAcpSessionEntry),
+    entry.connection = new ClientSideConnection(
+      () => this.buildAcpClient(entry as CursorAcpSessionEntry),
       stream,
-    );
+    ) as CursorAcpSessionEntry["connection"];
 
-    const entry = { ...shell, connection } as CursorAcpSessionEntry;
+    const connection = entry.connection;
 
     child.stderr?.on("data", (chunk: Buffer) => {
       for (const line of chunk.toString().split("\n")) {
@@ -346,7 +355,8 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     });
 
     const authMethods = initResult.authMethods ?? [];
-    const methodId = authMethods[0]?.id;
+    const methodId =
+      authMethods.find((m) => m.id === "cursor_login")?.id ?? authMethods[0]?.id;
     if (methodId) {
       await connection.authenticate({ methodId }).catch((err: unknown) => {
         logger.info("Cursor ACP authenticate noop", {
@@ -356,7 +366,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       });
     }
 
-    return entry;
+    return entry as CursorAcpSessionEntry;
   }
 
   private buildAcpClient(entry: CursorAcpSessionEntry): Client {
@@ -367,6 +377,29 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       writeTextFile: async (r) => {
         this.safeWriteWorkspaceFile(entry.cwd, r.path, r.content);
         return {};
+      },
+      extMethod: async (method, params) => {
+        void params;
+        if (method === "cursor/ask_question") {
+          return {
+            outcome: {
+              outcome: "skipped",
+              reason: "Mcode ACP client does not surface interactive questions.",
+            },
+          };
+        }
+        if (method === "cursor/create_plan") {
+          return { outcome: { outcome: "accepted" } };
+        }
+        logger.debug("Cursor ACP extMethod unhandled", {
+          threadId: entry.threadId,
+          method,
+        });
+        return {};
+      },
+      extNotification: async (method, params) => {
+        void method;
+        void params;
       },
     };
   }
@@ -524,7 +557,18 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       await this.openLogicalSession(entry, resume);
       await this.applyModel(entry, model);
 
-      const blocks = buildCursorAcpPromptBlocks(message, attachments);
+      const guidance = buildCursorAgentGuidanceMarkdown(entry.cwd);
+      const skillsBlock = formatCursorSkillsAndCommandsForPrompt(
+        this.skillService.list(entry.cwd, "cursor"),
+      );
+      const instructionParts = [guidance, skillsBlock].filter(
+        (s): s is string => typeof s === "string" && s.length > 0,
+      );
+      const instructions =
+        instructionParts.length > 0
+          ? instructionParts.join("\n\n---\n\n")
+          : readCursorUserInstructions();
+      const blocks = buildCursorAcpPromptBlocks(message, attachments, instructions);
       const promptResponse = await entry.connection.prompt({
         sessionId: entry.acpSessionId,
         prompt: blocks,

--- a/apps/server/src/providers/cursor/cursor-stream-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-stream-event-mapper.ts
@@ -21,6 +21,7 @@ import {
   normalizeCursorTodoEntry,
   reconcileCursorTodos,
 } from "./cursor-todo-snapshot.js";
+import { normalizeMcodeCursorToolInput } from "./cursor-tool-input-normalize.js";
 import type { CursorTodoSnapshot } from "./cursor-todo-snapshot.js";
 import type {
   CursorStreamAssistant,
@@ -74,6 +75,8 @@ const TOOL_NAME_BY_DISCRIMINATOR: Record<string, string> = {
   deleteToolCall: "Delete",
   webSearchToolCall: "WebSearch",
   fetchToolCall: "WebFetch",
+  searchReplaceToolCall: "Edit",
+  strReplaceToolCall: "Edit",
 };
 
 /**
@@ -228,13 +231,18 @@ function mapToolCallStarted(
 
   const toolName = TOOL_NAME_BY_DISCRIMINATOR[discriminator] ?? discriminator;
   acc.toolStartTimes.set(callId, Date.now());
+  const toolInput =
+    toolName === "Edit" || toolName === "Write"
+      ? normalizeMcodeCursorToolInput(toolName, args ?? {})
+      : args ?? {};
+
   return [
     {
       type: AgentEventType.ToolUse,
       threadId,
       toolCallId: callId,
       toolName,
-      toolInput: args ?? {},
+      toolInput,
     },
   ];
 }
@@ -282,12 +290,17 @@ function mapToolCallCompleted(
   if (!acc.toolStartTimes.has(callId)) {
     if (discriminator !== "updateTodosToolCall") {
       const toolName = TOOL_NAME_BY_DISCRIMINATOR[discriminator] ?? discriminator;
+      const orphanArgs = extractArgs(payload) ?? {};
+      const toolInput =
+        toolName === "Edit" || toolName === "Write"
+          ? normalizeMcodeCursorToolInput(toolName, orphanArgs)
+          : orphanArgs;
       events.push({
         type: AgentEventType.ToolUse,
         threadId,
         toolCallId: callId,
         toolName,
-        toolInput: extractArgs(payload) ?? {},
+        toolInput,
       });
     }
   }

--- a/apps/server/src/providers/cursor/cursor-stream-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-stream-event-mapper.ts
@@ -1,18 +1,16 @@
 /**
  * Maps {@link CursorStreamEvent} objects produced by the cursor-agent
  * `--print --output-format stream-json` parser into {@link AgentEvent}
- * objects the rest of mcode consumes.
+ * values.
  *
- * The stream-json transport replaces the broken ACP `session/load` resume
- * path: each turn invokes a fresh `cursor-agent --print --resume <chatId>`
- * subprocess that resolves the persistent chat from disk, then emits a
- * deterministic NDJSON event stream and exits. This mapper is the analogue
- * of {@link mapCursorAcpNotification} for that stream — it preserves the
- * existing UI contract (TextDelta, ToolUse, ToolResult, TodoWrite synthesis
- * for `updateTodosToolCall`) so the transport swap is invisible downstream.
+ * **`--print` only.** The Cursor provider uses `agent acp` for normal chat;
+ * ACP notification mapping lives in `cursor-acp-event-mapper.ts`.
+ *
+ * Preserves the streaming contract (TextDelta, ToolUse, ToolResult, TodoWrite
+ * synthesis for `updateTodosToolCall`) consumed by `AgentService`.
  *
  * The terminal `result` event resolves the runner's per-turn promise out of
- * band; the mapper itself returns `[]` for it so no agent event is emitted.
+ * band; the mapper returns `[]` for it so no agent event is emitted.
  */
 
 import { AgentEventType } from "@mcode/contracts";

--- a/apps/server/src/providers/cursor/cursor-todo-snapshot.ts
+++ b/apps/server/src/providers/cursor/cursor-todo-snapshot.ts
@@ -188,6 +188,57 @@ export function reconcileCursorTodos(
 }
 
 /**
+ * Builds {@link AgentEvent} values from an ACP notification `cursor/update_todos`.
+ *
+ * Parallel to streaming `tool_call` with `updateTodosToolCall`; some Cursor builds emit
+ * only this notification channel, so swallowing it left the tasks panel stale.
+ *
+ * @param threadId - Mcode thread id.
+ * @param notification - JSON-RPC notification params (`toolCallId`, `todos`, `merge`).
+ * @param snapshot - Per-connection todo snapshot for merge semantics.
+ */
+export function cursorUpdateTodosExtNotificationToAgentEvents(
+  threadId: string,
+  notification: Record<string, unknown>,
+  snapshot: CursorTodoSnapshot | undefined,
+): AgentEvent[] {
+  const rawTodos = notification.todos;
+  if (!Array.isArray(rawTodos) || rawTodos.length === 0) return [];
+
+  const toolCallId =
+    typeof notification.toolCallId === "string" && notification.toolCallId.length > 0
+      ? notification.toolCallId
+      : `cursor-todos-${randomUUID()}`;
+
+  const merge = notification.merge === true;
+  const asRecords = rawTodos.filter(
+    (t): t is Record<string, unknown> =>
+      t != null && typeof t === "object" && !Array.isArray(t),
+  );
+  if (asRecords.length === 0) return [];
+
+  const incoming = asRecords.map((e, i) => normalizeCursorTodoEntry(e, i));
+  const todos = reconcileCursorTodos(incoming, merge, snapshot);
+
+  return [
+    {
+      type: AgentEventType.ToolUse,
+      threadId,
+      toolCallId,
+      toolName: "TodoWrite",
+      toolInput: { todos },
+    },
+    {
+      type: AgentEventType.ToolResult,
+      threadId,
+      toolCallId,
+      output: `Updated ${todos.length} todo(s)`,
+      isError: false,
+    },
+  ];
+}
+
+/**
  * Synthesizes a paired TodoWrite `ToolUse` + `ToolResult` from an already-
  * reconciled todo list. Caller is responsible for merge/replace semantics
  * via {@link reconcileCursorTodos}; this just constructs the events.

--- a/apps/server/src/providers/cursor/cursor-tool-input-normalize.ts
+++ b/apps/server/src/providers/cursor/cursor-tool-input-normalize.ts
@@ -1,0 +1,60 @@
+/**
+ * Maps Cursor-agent tool payloads to the snake_case shapes Mcode chat renderers expect.
+ */
+
+/**
+ * Adapts `Edit` and `Write` tool arguments so the web `EditRenderer` / `WriteRenderer`
+ * receive `file_path`, `old_string` / `new_string`, or `content` regardless of Cursor field naming.
+ *
+ * @param toolName - Mcode tool label after discriminator mapping (`Edit`, `Write`, …).
+ * @param raw - Raw arguments object from the Cursor ACP envelope.
+ */
+export function normalizeMcodeCursorToolInput(
+  toolName: string,
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  if (toolName !== "Edit" && toolName !== "Write") return raw;
+
+  const out: Record<string, unknown> = { ...raw };
+
+  if (toolName === "Edit") {
+    copyIfMissing(out, "file_path", pickString(raw, ["file_path", "path", "filePath", "target_file", "filepath"]));
+    copyIfMissing(
+      out,
+      "old_string",
+      pickString(raw, ["old_string", "oldString", "search", "oldText", "textToReplace"]),
+    );
+    copyIfMissing(
+      out,
+      "new_string",
+      pickString(raw, ["new_string", "newString", "replace", "replacement", "replacementText"]),
+    );
+  }
+
+  if (toolName === "Write") {
+    copyIfMissing(out, "file_path", pickString(raw, ["file_path", "path", "filePath", "target_file"]));
+    if (out.content === undefined) {
+      const fromContents =
+        typeof raw.contents === "string"
+          ? raw.contents
+          : pickString(raw, ["content", "text", "body"]);
+      if (fromContents !== undefined) out.content = fromContents;
+    }
+  }
+
+  return out;
+}
+
+function pickString(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === "string") return v;
+  }
+  return undefined;
+}
+
+function copyIfMissing(target: Record<string, unknown>, key: string, value: string | undefined): void {
+  if (value === undefined || value === "") return;
+  const cur = target[key];
+  if (cur === undefined || cur === "") target[key] = value;
+}

--- a/apps/server/src/providers/cursor/cursor-tool-input-normalize.ts
+++ b/apps/server/src/providers/cursor/cursor-tool-input-normalize.ts
@@ -32,8 +32,8 @@ export function normalizeMcodeCursorToolInput(
   }
 
   if (toolName === "Write") {
-    copyIfMissing(out, "file_path", pickString(raw, ["file_path", "path", "filePath", "target_file"]));
-    if (out.content === undefined) {
+    copyIfMissing(out, "file_path", pickString(raw, ["file_path", "path", "filePath", "target_file", "filepath"]));
+    if (out.content === undefined || out.content === "") {
       const fromContents =
         typeof raw.contents === "string"
           ? raw.contents

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -577,6 +577,8 @@ export class AgentService {
       );
     }
 
+    this.threadRepo.updateModel(thread.id, model);
+
     void this.sendMessage(
       thread.id,
       content,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -792,7 +792,7 @@ export class AgentService {
     const providerInput =
       interactionMode === "plan" ? this.buildPlanPrompt(stitchedContent) : stitchedContent;
 
-    await this.sendMessage(
+    void this.sendMessage(
       thread.id,
       content,
       permissionMode,
@@ -808,10 +808,14 @@ export class AgentService {
       effectiveThinking,
       undefined,
       providerInput,
-    );
+    ).catch((err) => {
+      logger.error("createBranchedThread initial send failed", {
+        threadId: thread.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
 
-    const updated = this.threadRepo.findById(thread.id);
-    return updated ?? thread;
+    return thread;
   }
 
   /** Stop the agent for a given thread, persisting any buffered tool calls first. */

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -106,10 +106,6 @@ export class AgentService {
    * Broadcasting from `ended` ensures the session is fully closed before the client
    * can submit answers, preventing overlapping sends on the same thread. */
   private pendingPlanQuestions = new Map<string, z.infer<typeof PlanQuestionSchema>[]>();
-  /** Per-thread override for the content sent to the provider on the next sendMessage call.
-   * Used by branching to stitch handoff prose into the first turn without polluting the DB. */
-  private providerContentOverride = new Map<string, string>();
-
   constructor(
     @inject(ThreadRepo) private readonly threadRepo: ThreadRepo,
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
@@ -161,6 +157,12 @@ export class AgentService {
      * has been satisfied so it does not re-pop on reload.
      */
     markPlanAnswerForMessageId?: string,
+    /**
+     * Provider-only payload for this send (fork continuation, stitched replay).
+     * The persisted user row still uses `content`; this string is forwarded to
+     * the agent without writing it to SQLite.
+     */
+    providerWireOverride?: string,
   ): Promise<void> {
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
@@ -263,7 +265,7 @@ export class AgentService {
     // plain content when there is no override.
     if (interactionMode === "plan") {
       this.planParsers.set(threadId, new PlanQuestionParser());
-      if (!this.providerContentOverride.has(threadId)) {
+      if (providerWireOverride === undefined) {
         content = this.buildPlanPrompt(content);
       }
     }
@@ -354,9 +356,7 @@ export class AgentService {
       threadId,
     } satisfies AgentEvent);
 
-    // Check for branching content override (stitched handoff + user prompt)
-    const providerMessage = this.providerContentOverride.get(threadId) ?? content;
-    this.providerContentOverride.delete(threadId);
+    const providerMessage = providerWireOverride ?? content;
 
     try {
       await resolvedProvider.sendMessage({
@@ -577,7 +577,7 @@ export class AgentService {
       );
     }
 
-    await this.sendMessage(
+    void this.sendMessage(
       thread.id,
       content,
       permissionMode,
@@ -591,9 +591,13 @@ export class AgentService {
       copilotAgent,
       contextWindowMode,
       thinking,
-    );
+    ).catch((err) => {
+      logger.error("createAndSend initial send failed", {
+        threadId: thread.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
 
-    // Re-read from DB to pick up model update applied by sendMessage
     const updated = this.threadRepo.findById(thread.id);
     return updated ?? thread;
   }
@@ -602,7 +606,7 @@ export class AgentService {
    * Create a child thread branched from a parent at a specific message.
    * Injects a conversation replay into the provider's first turn for continuity.
    * The handoff system message (seq 1) is stored in the DB for the UI; the replay
-   * is sent only to the provider via providerContentOverride.
+   * is sent only to the provider via `providerWireOverride` on `sendMessage`.
    */
   private async createBranchedThread(params: {
     workspaceId: string;
@@ -786,33 +790,23 @@ export class AgentService {
     const providerInput =
       interactionMode === "plan" ? this.buildPlanPrompt(stitchedContent) : stitchedContent;
 
-    // Set provider content override so sendMessage uses the prepared content.
-    // IMPORTANT: sendMessage deletes this override before its try block, so the override
-    // is always consumed on the next call. Do not add any await between this set and the
-    // sendMessage call below, or the override could be consumed by an unrelated invocation.
-    this.providerContentOverride.set(thread.id, providerInput);
-
-    // sendMessage will persist the clean user prompt at seq 2 and send stitched content to provider
-    try {
-      await this.sendMessage(
-        thread.id,
-        content,
-        permissionMode,
-        model,
-        attachments,
-        reasoningLevel,
-        provider,
-        interactionMode,
-        maxBudgetUsd,
-        maxTurns,
-        copilotAgent,
-        effectiveContextWindowMode,
-        effectiveThinking,
-      );
-    } finally {
-      // Ensure override is cleaned up even if sendMessage throws before consuming it.
-      this.providerContentOverride.delete(thread.id);
-    }
+    await this.sendMessage(
+      thread.id,
+      content,
+      permissionMode,
+      model,
+      attachments,
+      reasoningLevel,
+      provider,
+      interactionMode,
+      maxBudgetUsd,
+      maxTurns,
+      copilotAgent,
+      effectiveContextWindowMode,
+      effectiveThinking,
+      undefined,
+      providerInput,
+    );
 
     const updated = this.threadRepo.findById(thread.id);
     return updated ?? thread;

--- a/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
+++ b/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
@@ -174,7 +174,7 @@ describe("Agent event thread isolation", () => {
       expect(useDiffStore.getState().rightPanelByThread[THREAD_A]?.visible).toBeFalsy();
     });
 
-    it("opens task panel when TodoWrite fires on the active thread", async () => {
+    it("does not auto-open task panel on TodoWrite", async () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
       handleAgentEvent(THREAD_A, {
@@ -184,38 +184,11 @@ describe("Agent event thread isolation", () => {
         toolInput: { todos: [{ id: "0", content: "Plan", status: "in_progress" }] },
       });
 
-      // Give the dynamic import time to resolve
       await vi.advanceTimersByTime(0);
       await Promise.resolve();
       await Promise.resolve();
 
       const { useDiffStore } = await import("@/stores/diffStore");
-      expect(useDiffStore.getState().rightPanelByThread[THREAD_A]?.visible).toBe(true);
-    });
-
-    it("does not open task panel if user switches threads before the import resolves", async () => {
-      // Reset panel state from previous tests
-      const { useDiffStore } = await import("@/stores/diffStore");
-      useDiffStore.setState({ rightPanelByThread: {} });
-
-      const { handleAgentEvent } = useThreadStore.getState();
-
-      // TodoWrite fires on the active thread (A)
-      handleAgentEvent(THREAD_A, {
-        method: "session.toolUse",
-        toolCallId: "tc-todo-race",
-        toolName: "TodoWrite",
-        toolInput: { todos: [{ id: "0", content: "Plan", status: "in_progress" }] },
-      });
-
-      // User switches to Thread B before the .then() microtask runs
-      useWorkspaceStore.setState({ activeThreadId: THREAD_B });
-
-      // Flush microtasks so the .then() callback executes
-      await vi.advanceTimersByTime(0);
-      await Promise.resolve();
-      await Promise.resolve();
-
       expect(useDiffStore.getState().rightPanelByThread[THREAD_A]?.visible).toBeFalsy();
     });
   });

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useWorkspaceStore, __resetThreadListMutationEpochForTests } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import {
   mockTransport,
@@ -14,6 +14,7 @@ vi.mock("@/transport", async () => ({
 
 describe("Workspace Behavior", () => {
   beforeEach(() => {
+    __resetThreadListMutationEpochForTests();
     useWorkspaceStore.setState({
       workspaces: [],
       activeWorkspaceId: null,
@@ -111,6 +112,54 @@ describe("Workspace Behavior", () => {
     // Both workspaces' threads should be present (merged, not replaced)
     expect(state.threads).toHaveLength(2);
     expect(state.threads.map((t) => t.title).sort()).toEqual(["Thread A", "Thread B"]);
+  });
+
+  it("when branchThread completes while loadThreads is in flight, stale listThreads does not drop the new branch", async () => {
+    const ws = createMockWorkspace({ id: "ws-branch" });
+    const parent = createMockThread({
+      id: "parent-1",
+      workspace_id: ws.id,
+      title: "Parent",
+    });
+    let listResolve!: (value: typeof parent[]) => void;
+    const listPromise = new Promise<typeof parent[]>((resolve) => {
+      listResolve = resolve;
+    });
+
+    useWorkspaceStore.setState({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      threads: [parent],
+    });
+
+    (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockImplementation(() => listPromise);
+
+    void useWorkspaceStore.getState().loadThreads(ws.id);
+
+    const child = createMockThread({
+      id: "child-1",
+      workspace_id: ws.id,
+      title: "Branched",
+      parent_thread_id: "parent-1",
+    });
+    (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(child);
+
+    await useWorkspaceStore.getState().branchThread({
+      sourceThreadId: "parent-1",
+      content: "Continue",
+      model: "gpt-4",
+      mode: "direct",
+      forkedFromMessageId: "msg-1",
+    });
+
+    expect(useWorkspaceStore.getState().threads.some((t) => t.id === "child-1")).toBe(true);
+
+    listResolve([parent]);
+
+    await listPromise;
+    await Promise.resolve();
+
+    expect(useWorkspaceStore.getState().threads.some((t) => t.id === "child-1")).toBe(true);
   });
 
   it("when the user creates a thread, it appears in the list", async () => {

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -162,6 +162,47 @@ describe("Workspace Behavior", () => {
     expect(useWorkspaceStore.getState().threads.some((t) => t.id === "child-1")).toBe(true);
   });
 
+  it("when createAndSendMessage completes while loadThreads is in flight, stale listThreads does not drop the new thread", async () => {
+    const ws = createMockWorkspace({ id: "ws-first-msg" });
+    const existing = createMockThread({
+      id: "existing-1",
+      workspace_id: ws.id,
+      title: "Existing",
+    });
+    let listResolve!: (value: typeof existing[]) => void;
+    const listPromise = new Promise<typeof existing[]>((resolve) => {
+      listResolve = resolve;
+    });
+
+    useWorkspaceStore.setState({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      threads: [existing],
+    });
+
+    (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockImplementation(() => listPromise);
+
+    void useWorkspaceStore.getState().loadThreads(ws.id);
+
+    const created = createMockThread({
+      id: "new-first-send",
+      workspace_id: ws.id,
+      title: "New from first message",
+    });
+    (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+
+    await useWorkspaceStore.getState().createAndSendMessage("Hello", "composer-2-fast");
+
+    expect(useWorkspaceStore.getState().threads.some((t) => t.id === "new-first-send")).toBe(true);
+
+    listResolve([existing]);
+
+    await listPromise;
+    await Promise.resolve();
+
+    expect(useWorkspaceStore.getState().threads.some((t) => t.id === "new-first-send")).toBe(true);
+  });
+
   it("when the user creates a thread, it appears in the list", async () => {
     const ws = createMockWorkspace();
     const thread = createMockThread({

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -917,8 +917,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
   // Full lock when agent running, unless the user is branching (child thread is independent).
   const isModelFullyLocked = isAgentRunning && !branchFromMessageId;
-  // Allow provider switching when creating a new thread or branching (child thread can use any provider).
-  const isProviderLocked = !isNewThread && !branchFromMessageId && activeThread?.model != null;
+  // Lock provider on any persisted thread except the branching composer. Rows always have
+  // `provider`; `model` stays null until the first sendMessage transaction runs, which is easy
+  // to race now that createAndSend returns before sendMessage finishes.
+  const isProviderLocked =
+    Boolean(threadId && !isNewThread && !branchFromMessageId && activeThread?.provider);
 
   // Close dropdowns on click outside
   useEffect(() => {

--- a/apps/web/src/components/chat/tool-renderers/EditRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/EditRenderer.tsx
@@ -7,9 +7,11 @@ import { basename } from "@/lib/path";
 
 /** Renders an inline diff for file edit tool calls. */
 export const EditRenderer = memo(function EditRenderer({ toolCall, isActive }: ToolRendererProps) {
-  const filePath = String(toolCall.toolInput.file_path ?? "");
-  const oldStr = String(toolCall.toolInput.old_string ?? "");
-  const newStr = String(toolCall.toolInput.new_string ?? "");
+  const filePath = String(
+    toolCall.toolInput.file_path ?? toolCall.toolInput.path ?? toolCall.toolInput.filePath ?? "",
+  );
+  const oldStr = String(toolCall.toolInput.old_string ?? toolCall.toolInput.oldString ?? "");
+  const newStr = String(toolCall.toolInput.new_string ?? toolCall.toolInput.newString ?? "");
   const lines = useMemo(() => buildSimpleDiff(oldStr, newStr), [oldStr, newStr]);
 
   return (

--- a/apps/web/src/components/chat/tool-renderers/WriteRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/WriteRenderer.tsx
@@ -9,8 +9,9 @@ const MAX_LINES = 10;
 
 export function WriteRenderer({ toolCall, isActive }: ToolRendererProps) {
   const [showAll, setShowAll] = useState(false);
-  const filePath = String(toolCall.toolInput.file_path ?? "");
-  const content = String(toolCall.toolInput.content ?? "");
+  const filePath = String(toolCall.toolInput.file_path ?? toolCall.toolInput.path ?? "");
+  const rawContent = toolCall.toolInput.content ?? toolCall.toolInput.contents;
+  const content = typeof rawContent === "string" ? rawContent : String(rawContent ?? "");
   const lines = content.split("\n");
   const visible = showAll ? lines : lines.slice(0, MAX_LINES);
 

--- a/apps/web/src/components/chat/tool-renderers/WriteRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/WriteRenderer.tsx
@@ -11,7 +11,14 @@ export function WriteRenderer({ toolCall, isActive }: ToolRendererProps) {
   const [showAll, setShowAll] = useState(false);
   const filePath = String(toolCall.toolInput.file_path ?? toolCall.toolInput.path ?? "");
   const rawContent = toolCall.toolInput.content ?? toolCall.toolInput.contents;
-  const content = typeof rawContent === "string" ? rawContent : String(rawContent ?? "");
+  const content =
+    typeof rawContent === "string"
+      ? rawContent
+      : rawContent == null
+        ? ""
+        : Array.isArray(rawContent)
+          ? rawContent.join("\n")
+          : JSON.stringify(rawContent, null, 2);
   const lines = content.split("\n");
   const visible = showAll ? lines : lines.slice(0, MAX_LINES);
 

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1410,17 +1410,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             group: "Tasks",
           }));
           useTaskStore.getState().setTasks(threadId, taskItems);
-          // Only open the task panel if the user is viewing this thread.
-          // Background threads populate tasksByThread silently.
-          if (useWorkspaceStore.getState().activeThreadId === threadId) {
-            // Imported lazily to avoid circular dependency at module evaluation time.
-            import("./diffStore").then(({ useDiffStore }) => {
-              // Re-check after async import: user may have switched threads.
-              if (useWorkspaceStore.getState().activeThreadId !== threadId) return;
-              useDiffStore.getState().showRightPanel(threadId);
-              useDiffStore.getState().setRightPanelTab(threadId, "tasks");
-            });
-          }
         }
       }
 

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -241,6 +241,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set({ error: null });
     try {
       await getTransport().deleteWorkspace(id);
+      bumpThreadListMutationEpoch(id);
       const deletedThreadIds = get()
         .threads.filter((t) => t.workspace_id === id)
         .map((t) => t.id);

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -23,6 +23,26 @@ const SYNC_THROTTLE_MS = 30_000;
 const lastSyncTime = new Map<string, number>();
 
 /**
+ * Bumped immediately before applying local additions/removals that must win over
+ * in-flight {@link WorkspaceState.loadThreads} responses. Without this, a slow
+ * `thread.list` that started before branching (for example) can finish after the
+ * new thread was merged and overwrite the sidebar with an older snapshot.
+ */
+const threadListMutationEpochByWorkspace = new Map<string, number>();
+
+function bumpThreadListMutationEpoch(workspaceId: string): void {
+  threadListMutationEpochByWorkspace.set(
+    workspaceId,
+    (threadListMutationEpochByWorkspace.get(workspaceId) ?? 0) + 1,
+  );
+}
+
+/** Clears mutation-epoch bookkeeping. Used by Vitest only. */
+export function __resetThreadListMutationEpochForTests(): void {
+  threadListMutationEpochByWorkspace.clear();
+}
+
+/**
  * Optional RPC dispatch callback used by workspace actions. Tests inject a
  * stub here; production code uses {@link getTransport} directly. The shape
  * mirrors the transport's `call` method so handlers can be swapped freely.
@@ -361,9 +381,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   },
 
   loadThreads: async (workspaceId) => {
+    const epochAtStart = threadListMutationEpochByWorkspace.get(workspaceId) ?? 0;
     set({ loading: true, error: null });
     try {
       const newThreads = await getTransport().listThreads(workspaceId);
+      if ((threadListMutationEpochByWorkspace.get(workspaceId) ?? 0) !== epochAtStart) {
+        set({ loading: false });
+        return;
+      }
       // Replace threads for this workspace; keep threads from other workspaces intact.
       set((state) => ({
         threads: [
@@ -372,6 +397,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         ],
         loading: false,
       }));
+
+      const epochForPrSync = epochAtStart;
 
       // Background PR sync: scanned for new PRs and refreshed stale PR states (throttled)
       const now = Date.now();
@@ -382,6 +409,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           if (results.length === 0) return;
           // Discard results if the workspace changed while the request was in flight
           if (get().activeWorkspaceId !== workspaceId) return;
+          if ((threadListMutationEpochByWorkspace.get(workspaceId) ?? 0) !== epochForPrSync) {
+            return;
+          }
           const resultMap = new Map(results.map((r) => [r.threadId, r]));
           set((state) => ({
             threads: state.threads.map((t) => {
@@ -410,6 +440,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         mode,
         branch,
       );
+      bumpThreadListMutationEpoch(activeWorkspaceId);
       set((state) => ({ threads: [thread, ...state.threads] }));
       return thread;
     } catch (e) {
@@ -443,6 +474,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       const thread = await getTransport().createAndSendMessage(
         workspaceId, content, model, permissionMode, mode, branch, existingWorktreePath, attachments, reasoningLevel, provider, interactionMode, undefined, undefined, copilotAgent, contextWindow, thinking,
       );
+      bumpThreadListMutationEpoch(workspaceId);
       set((state) => ({
         threads: [thread, ...state.threads],
         activeThreadId: thread.id,
@@ -506,6 +538,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         params.thinking,
       );
 
+      bumpThreadListMutationEpoch(workspaceId);
       set((state) => ({
         threads: [thread, ...state.threads],
         activeThreadId: thread.id,
@@ -531,7 +564,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   deleteThread: async (threadId, cleanupWorktree) => {
     set({ error: null });
     try {
+      const workspaceIdForEpoch = get().threads.find((t) => t.id === threadId)?.workspace_id;
       await getTransport().deleteThread(threadId, cleanupWorktree);
+      if (workspaceIdForEpoch) {
+        bumpThreadListMutationEpoch(workspaceIdForEpoch);
+      }
       useTerminalStore.getState().clearThread(threadId);
       useQueueStore.getState().clearQueue(threadId);
       useComposerDraftStore.getState().clearDraft(threadId);

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
       "name": "@mcode/server",
       "version": "0.0.1",
       "dependencies": {
+        "@agentclientprotocol/sdk": "^0.21.0",
         "@anthropic-ai/claude-agent-sdk": "*",
         "@github/copilot-sdk": "^0.2.2",
         "@mcode/contracts": "workspace:*",
@@ -159,6 +160,8 @@
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.21.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 


### PR DESCRIPTION
## What
Rewrite Cursor provider to use a persistent ACP subprocess (matching Claude/Codex architecture) and fix all tool call rendering in the chat UI.

## Why
Cursor was spawning a new `cursor-agent --print` subprocess per turn, causing slow first-message latency and race conditions where new threads/branches disappeared from the sidebar. ACP tool calls use fundamentally different data channels than `--print` stream-json, so tool cards (Read, Edit, Terminal, TodoWrite) were rendering empty.

## Key Changes
- **Persistent ACP subprocess**: one long-lived `cursor-agent acp` child per session with idle eviction, `session/load` fallback to `session/new` for resume failures
- **Early RPC return**: `createAndSend` returns the thread before the first turn completes so branches/new chats appear instantly in the sidebar
- **Stale loadThreads guard**: mutation epoch prevents in-flight `thread.list` responses from overwriting freshly created threads
- **Unified ACP tool mapper**: handles all three output channels:
  - `rawOutput.content` for Read (file content)
  - `content[]` with `type: "diff"` for Edit (path, oldText, newText)
  - `rawOutput.{stdout,stderr,exitCode}` for Terminal
  - `cursor/update_todos` ext method + `plan` session updates for TodoWrite
- **ACP kind/title mapping**: resolves `kind: "read"/"edit"/"command"` and title strings to Mcode tool names
- **Composer lock fix**: provider picker locks on `activeThread.provider` instead of `model` (which arrives after async send)
- **Task panel**: no longer auto-opens on TodoWrite events

Closes sidebar disappearing threads, empty tool cards, and missing task list updates for Cursor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent Cursor agent sessions with permission prompts, richer prompt/attachment handling, and normalized tool input for more reliable agent actions and todo reconciliation.
* **Bug Fixes**
  * Prevents stale thread-list results from overwriting newer local thread mutations; improved session/turn stability.
* **UI Improvements**
  * Composer provider locking tightened; renderers accept more input variants; todo writes no longer auto-open the task panel.
* **Tests**
  * Added comprehensive end-to-end and unit tests covering mapping, permissions, spawn args, guidance, todos, and tool input normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->