### PR TITLE
fix(web): New Thread palette flow, picker layout, stable E2E

### DIFF
--- a/apps/web/e2e/ui-improvements-floating.spec.ts
+++ b/apps/web/e2e/ui-improvements-floating.spec.ts
@@ -10,7 +10,7 @@ import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpe
  */
 
 const now = new Date().toISOString();
-/** Minimal workspace fixture used to suppress the cold-start landing page. */
+/** Minimal workspace so the palette projects list has at least one row to select. */
 const WORKSPACE_FIXTURE = {
   id: "ws-float-1",
   name: "Test Workspace",
@@ -24,9 +24,8 @@ const WORKSPACE_FIXTURE = {
 };
 
 /**
- * Activate a minimal workspace in the Zustand store so the landing page gives
- * way to ChatView. Requires interceptZustandStores() to have been called in the
- * enclosing test's beforeEach (before page.goto).
+ * Activate a minimal workspace in the Zustand store. Requires interceptZustandStores()
+ * before page.goto in the enclosing test so the patched store receives injected state.
  */
 async function activateWorkspace(page: Page): Promise<void> {
   await page.evaluate((workspace) => {
@@ -49,16 +48,14 @@ async function activateWorkspace(page: Page): Promise<void> {
 }
 
 async function openComposerInNewThread(page: Page): Promise<void> {
-  // Activate a workspace so ChatView mounts (landing page would block it otherwise).
   await activateWorkspace(page);
-  // App.tsx registers a "thread.new" command via the command registry; the
-  // shortcut layer wires Cmd/Ctrl+N to thread.new which sets pendingNewThread
-  // and renders the composer.
   const isMac = process.platform === "darwin";
   await page.keyboard.press(isMac ? "Meta+n" : "Control+n");
-  // Wait for the composer's send button to mount instead of sleeping a fixed
-  // interval. Send is the stable terminal control on the composer; if it's in
-  // the DOM the surrounding mode/permissions controls have rendered too.
+  await expect(page.getByPlaceholder("Search projects…")).toBeVisible();
+  // Palette content portals after the landing; prefer the last row when both surfaces list projects.
+  const projectRow = page.getByTestId("project-row").last();
+  await expect(projectRow).toBeVisible();
+  await projectRow.click();
   await expect(page.getByRole("button", { name: /^(Send message|Queue message|Stop agent)$/ })).toBeVisible();
 }
 
@@ -223,7 +220,6 @@ test.describe("Visual regression — floating layout", () => {
   test.beforeEach(async ({ page }) => {
     await mockWebSocketServer(page);
     // Must be called before page.goto so zustand.js is intercepted on load.
-    // Needed by the composer popover test which injects a workspace to bypass landing.
     await interceptZustandStores(page);
   });
 
@@ -253,11 +249,7 @@ test.describe("Visual regression — floating layout", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    // Activate a workspace so the landing page gives way to ChatView before Ctrl+N.
-    await activateWorkspace(page);
-    const isMac = process.platform === "darwin";
-    await page.keyboard.press(isMac ? "Meta+n" : "Control+n");
-    // Wait for the composer's overflow trigger to mount.
+    await openComposerInNewThread(page);
     const trigger = page.getByRole("button", { name: "Composer options" });
     await expect(trigger).toBeVisible();
     await trigger.click();

--- a/apps/web/e2e/ui-improvements-floating.spec.ts
+++ b/apps/web/e2e/ui-improvements-floating.spec.ts
@@ -52,8 +52,11 @@ async function openComposerInNewThread(page: Page): Promise<void> {
   const isMac = process.platform === "darwin";
   await page.keyboard.press(isMac ? "Meta+n" : "Control+n");
   await expect(page.getByPlaceholder("Search projects…")).toBeVisible();
-  // Palette content portals after the landing; prefer the last row when both surfaces list projects.
-  const projectRow = page.getByTestId("project-row").last();
+  // Palette content portals after the landing; scope rows to the palette shell so we do not
+  // collide with landing page project lists that reuse the same data-testid.
+  const palette = page.getByTestId("command-palette");
+  await expect(palette).toBeVisible();
+  const projectRow = palette.getByTestId("project-row").last();
   await expect(projectRow).toBeVisible();
   await projectRow.click();
   await expect(page.getByRole("button", { name: /^(Send message|Queue message|Stop agent)$/ })).toBeVisible();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "NODE_ENV=development vite",
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -10,10 +10,13 @@ const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
 const reuseExistingServer =
   !process.env.CI && process.env.PLAYWRIGHT_REUSE_WEB_SERVER === "1";
 
+const isCI = Boolean(process.env.CI);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  retries: 0,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
   workers: 1,
   reporter: [["html", { outputFolder: "playwright-report" }]],
   use: {
@@ -30,6 +33,12 @@ export default defineConfig({
     command: "bun run dev",
     url: BASE_URL,
     reuseExistingServer,
-    timeout: 30000,
+    timeout: 120_000,
+    // Spawning inherits the parent process env. React Fast Refresh in Vite
+    // assumes development; a production NODE_ENV causes `$RefreshReg$` runtime errors.
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+    },
   },
 });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -142,19 +142,10 @@ export function App() {
         title: "New Thread",
         category: "Thread",
         handler: () => {
-          const ws = useWorkspaceStore.getState();
-          // When invoked from the cold-start landing there's no active project
-          // to attach the thread to, so the composer would render with a null
-          // workspaceId and quietly fail to send. Route through the project
-          // picker first and chain into the new-thread state on selection.
-          if (ws.activeWorkspaceId) {
-            ws.setPendingNewThread(true);
-          } else {
-            useCommandPaletteStore.getState().open({
-              intent: "projects",
-              nextAction: "newThread",
-            });
-          }
+          useCommandPaletteStore.getState().open({
+            intent: "projects",
+            nextAction: "newThread",
+          });
         },
       }),
       registerCommand({

--- a/apps/web/src/components/palette/CommandPalette.tsx
+++ b/apps/web/src/components/palette/CommandPalette.tsx
@@ -13,6 +13,7 @@ import { BrowseView } from "./views/BrowseView";
 import { SelectionListView } from "./views/SelectionListView";
 import { Kbd } from "./Kbd";
 import { isBrowseQuery, getPaletteMode } from "./CommandPalette.logic";
+import { cn } from "@/lib/utils";
 
 /**
  * Top-center floating command palette overlay — the single shell that handles
@@ -56,7 +57,12 @@ export function CommandPalette() {
     <DialogPrimitive.Root open={isOpen} onOpenChange={(o) => !o && close()} modal="trap-focus">
       <DialogPrimitive.Portal>
         <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-foreground/40 backdrop-blur-sm" />
-        <DialogPrimitive.Popup className="fixed left-1/2 top-[clamp(4rem,15vh,9rem)] z-50 w-full max-w-xl -translate-x-1/2 outline-none">
+        <DialogPrimitive.Popup
+          className={cn(
+            "fixed left-1/2 top-[clamp(4rem,15vh,9rem)] z-50 w-full -translate-x-1/2 outline-none",
+            top?.kind === "projects" ? "max-w-2xl" : "max-w-xl",
+          )}
+        >
           <Command
             className="rounded-lg border border-border bg-popover shadow-2xl"
             // We do all filtering/ranking ourselves (filterCommandPaletteGroups,

--- a/apps/web/src/components/palette/CommandPalette.tsx
+++ b/apps/web/src/components/palette/CommandPalette.tsx
@@ -58,6 +58,7 @@ export function CommandPalette() {
       <DialogPrimitive.Portal>
         <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-foreground/40 backdrop-blur-sm" />
         <DialogPrimitive.Popup
+          data-testid="command-palette"
           className={cn(
             "fixed left-1/2 top-[clamp(4rem,15vh,9rem)] z-50 w-full -translate-x-1/2 outline-none",
             top?.kind === "projects" ? "max-w-2xl" : "max-w-xl",

--- a/apps/web/src/components/palette/views/ProjectsView.tsx
+++ b/apps/web/src/components/palette/views/ProjectsView.tsx
@@ -81,12 +81,13 @@ export function ProjectsView() {
             {pinned.map((w) => (
               // CommandItem makes the row visible to cmdk's keyboard navigator.
               // p-0 removes CommandItem's own padding since ProjectRow has its own layout.
+              // w-full/min-w-0: cmdk items shrink-wrap otherwise; fills list width for hit area + selection.
               // group/cmd propagates aria-selected into ProjectRow via group-aria-selected/cmd
               <CommandItem
                 key={w.id}
                 value={`${w.name} ${w.path}`}
                 onSelect={() => handleSelect(w.id)}
-                className="p-0 rounded-sm aria-selected:bg-transparent group/cmd"
+                className="w-full min-w-0 p-0 rounded-sm aria-selected:bg-transparent group/cmd"
               >
                 <ProjectRow
                   workspace={w}
@@ -105,7 +106,7 @@ export function ProjectsView() {
                 key={w.id}
                 value={`${w.name} ${w.path}`}
                 onSelect={() => handleSelect(w.id)}
-                className="p-0 rounded-sm aria-selected:bg-transparent group/cmd"
+                className="w-full min-w-0 p-0 rounded-sm aria-selected:bg-transparent group/cmd"
               >
                 <ProjectRow
                   workspace={w}
@@ -124,7 +125,7 @@ export function ProjectsView() {
                 key={w.id}
                 value={`${w.name} ${w.path}`}
                 onSelect={() => handleSelect(w.id)}
-                className="p-0 rounded-sm aria-selected:bg-transparent group/cmd"
+                className="w-full min-w-0 p-0 rounded-sm aria-selected:bg-transparent group/cmd"
               >
                 <ProjectRow
                   workspace={w}

--- a/apps/web/src/components/projects/ProjectRow.tsx
+++ b/apps/web/src/components/projects/ProjectRow.tsx
@@ -110,14 +110,13 @@ export function ProjectRow({ workspace, isActive, onSelect, onPin, onRemove, hom
       </div>
 
       {/* Right: meta strip — branch, status dot, thread count, relative timestamp.
-          The column caps at ~45% of the row so a long branch name can never
-          push the project name + path to a thin truncated stub on the left.
-          `min-w-0` lets the inner flex row shrink when the branch overflows;
-          the branch span itself has its own `max-w` + `truncate` ceiling. */}
-      <div className="flex shrink-0 min-w-0 max-w-[45%] flex-col items-end gap-0.5 font-mono text-[11px] text-muted-foreground/60">
+          Cap the column fraction so the project title + path keep priority; inner
+          layout uses a grid so the branch absorbs remaining width inside that cap
+          instead of an arbitrary 10rem clip (impeccable: information-dense, mono meta). */}
+      <div className="flex shrink-0 min-w-0 max-w-[52%] flex-col items-end gap-0.5 font-mono text-[11px] text-muted-foreground/60">
         {enrichment ? (
           <>
-            <div className="flex min-w-0 items-center gap-1.5">
+            <div className="grid w-full min-w-0 grid-cols-[auto_auto_minmax(0,1fr)_auto] items-center gap-1.5">
               {enrichment.isGit ? (
                 <>
                   <span
@@ -130,23 +129,24 @@ export function ProjectRow({ workspace, isActive, onSelect, onPin, onRemove, hom
                   />
                   <GitBranch size={10} strokeWidth={2} className="shrink-0 opacity-70" aria-hidden />
                   <span
-                    className="block max-w-[10rem] truncate"
+                    className="min-w-0 truncate text-right"
                     title={enrichment.branch ?? "detached"}
                   >
                     {enrichment.branch ?? "detached"}
                   </span>
-                  {enrichment.threadCount > 0 && (
+                  {enrichment.threadCount > 0 ? (
                     <span
                       className="shrink-0 tabular-nums"
                       title={`${enrichment.threadCount} thread${enrichment.threadCount === 1 ? "" : "s"}`}
                     >
                       · {enrichment.threadCount}
                     </span>
-                  )}
+                  ) : null}
                 </>
               ) : (
-                // Non-git workspace indicator — quiet, all-lowercase reads less alarming than "no git"
-                <span className="truncate text-muted-foreground/40">not a git repo</span>
+                <span className="col-span-4 truncate justify-self-end text-muted-foreground/40">
+                  not a git repo
+                </span>
               )}
             </div>
             {lastOpenedLabel && (

--- a/apps/web/src/components/projects/ProjectRow.tsx
+++ b/apps/web/src/components/projects/ProjectRow.tsx
@@ -75,7 +75,7 @@ export function ProjectRow({ workspace, isActive, onSelect, onPin, onRemove, hom
         }
       }}
       className={cn(
-        "group flex cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-[13px] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "group flex w-full min-w-0 cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-[13px] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring",
         // group-aria-selected/cmd responds to parent CommandItem keyboard focus in the palette.
         // has no effect in landing page context (no parent with group/cmd).
         "hover:bg-accent/60 data-[active=true]:bg-accent group-aria-selected/cmd:bg-accent",


### PR DESCRIPTION
## What

Opens the in-palette project picker when starting a new thread instead of full-screen landing. Improves project row layout in the palette (wider branch meta, full-width rows), and stabilizes Playwright against Vite React refresh and port conflicts.

## Why

New Thread should stay in context with the command palette. Project rows were visually narrow and cmdk items shrink-wrapped, leaving empty space beside selection. E2E needed a reliable dev server env and updated selectors for the palette flow.

## Key Changes

- Route `thread.new` to `open({ intent: "projects", nextAction: "newThread" })` in `App.tsx`.
- `ProjectsView`: `w-full min-w-0` on `CommandItem`; `ProjectRow`: full width and branch column layout tweaks.
- `CommandPalette`: wider max width in projects mode.
- Playwright: `NODE_ENV=development` for webServer, Vite `dev` script, timeouts and retries; E2E waits for palette and targets `project-row`.
- Full-width project list rows so hover and selection backgrounds fill the list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Command palette max width adapts when browsing projects for improved visibility and layout.
  * Project rows and list items resized for better spacing, hit areas, and reliable selection; Git branch text now truncates more gracefully.
  * Creating a new thread consistently opens the projects command palette for a smoother workflow.

* **Tests**
  * End-to-end tests and helpers updated to follow the new command-palette project-selection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->