### PR TITLE
feat(web): optimistic thread scaffold during create and branch

### DIFF
--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -496,5 +496,28 @@ describe("Workspace Behavior", () => {
       resolveRpc(createMockThread({ id: "real-new", workspace_id: ws.id, title: "New" }));
       await sendOp;
     });
+
+    it("loadThreads retains errored client placeholders for retry UI", async () => {
+      const ws = createMockWorkspace({ id: "ws-err-ph" });
+      const errRow = {
+        ...createMockThread({
+          id: "ph-err",
+          workspace_id: ws.id,
+          title: "Failed",
+        }),
+        clientPreparing: false,
+        clientError: "rpc failed",
+        clientQueuedMessage: "hello",
+      };
+      useWorkspaceStore.setState({
+        workspaces: [ws],
+        activeWorkspaceId: ws.id,
+        threads: [errRow],
+      });
+      (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      await useWorkspaceStore.getState().loadThreads(ws.id);
+      expect(useWorkspaceStore.getState().threads.some((t) => t.id === "ph-err")).toBe(true);
+    });
   });
 });
+

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useWorkspaceStore, __resetThreadListMutationEpochForTests } from "@/stores/workspaceStore";
+import { useWorkspaceStore, __resetThreadListMutationEpochForTests, __clearPendingThreadCreationsForTests } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import {
   mockTransport,
@@ -15,6 +15,7 @@ vi.mock("@/transport", async () => ({
 describe("Workspace Behavior", () => {
   beforeEach(() => {
     __resetThreadListMutationEpochForTests();
+    __clearPendingThreadCreationsForTests();
     useWorkspaceStore.setState({
       workspaces: [],
       activeWorkspaceId: null,
@@ -390,6 +391,110 @@ describe("Workspace Behavior", () => {
       expect(ts.errorByThread["t-2"]).toBeUndefined();
       expect(ts.streamingByThread["t-1"]).toBeUndefined();
       expect(ts.streamingByThread["t-2"]).toBeUndefined();
+    });
+  });
+
+  describe("optimistic thread scaffolding", () => {
+    it("createAndSendMessage shows a preparing placeholder before the RPC resolves", async () => {
+      const ws = createMockWorkspace({ id: "ws-opt" });
+      let resolveRpc!: (value: ReturnType<typeof createMockThread>) => void;
+      const rpcPromise = new Promise<ReturnType<typeof createMockThread>>((resolve) => {
+        resolveRpc = resolve;
+      });
+
+      useWorkspaceStore.setState({
+        workspaces: [ws],
+        activeWorkspaceId: ws.id,
+      });
+      (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mockReturnValue(rpcPromise);
+
+      const done = useWorkspaceStore.getState().createAndSendMessage("Hello world", "composer-2-fast");
+      await Promise.resolve();
+
+      const mid = useWorkspaceStore.getState();
+      expect(mid.activeThreadId).not.toBeNull();
+      expect(mid.threads[0]?.clientPreparing).toBe(true);
+      expect(mid.threads[0]?.clientQueuedMessage).toBe("Hello world");
+
+      const created = createMockThread({
+        id: "server-thread-1",
+        workspace_id: ws.id,
+        title: "Hello world",
+      });
+      resolveRpc(created);
+      await done;
+
+      const fin = useWorkspaceStore.getState();
+      expect(fin.threads.some((t) => t.id === "server-thread-1")).toBe(true);
+      expect(fin.activeThreadId).toBe("server-thread-1");
+    });
+
+    it("when createAndSendMessage succeeds after the user navigates away, activeThreadId is not forced to the new thread", async () => {
+      const ws = createMockWorkspace({ id: "ws-nav" });
+      let resolveRpc!: (value: ReturnType<typeof createMockThread>) => void;
+      const rpcPromise = new Promise<ReturnType<typeof createMockThread>>((resolve) => {
+        resolveRpc = resolve;
+      });
+
+      useWorkspaceStore.setState({
+        workspaces: [ws],
+        activeWorkspaceId: ws.id,
+      });
+      (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mockReturnValue(rpcPromise);
+
+      const done = useWorkspaceStore.getState().createAndSendMessage("Hi", "composer-2-fast");
+      await Promise.resolve();
+      useWorkspaceStore.getState().setActiveThread(null);
+
+      resolveRpc(
+        createMockThread({ id: "server-thread-2", workspace_id: ws.id, title: "Hi" }),
+      );
+      await done;
+
+      const fin = useWorkspaceStore.getState();
+      expect(fin.activeThreadId).toBeNull();
+      expect(fin.threads.some((t) => t.id === "server-thread-2")).toBe(true);
+    });
+
+    it("stale loadThreads does not drop a preparing placeholder mid-RPC", async () => {
+      const ws = createMockWorkspace({ id: "ws-ph" });
+      const existing = createMockThread({ id: "old-1", workspace_id: ws.id, title: "Old" });
+      let listResolve!: (value: typeof existing[]) => void;
+      const listPromise = new Promise<typeof existing[]>((resolve) => {
+        listResolve = resolve;
+      });
+
+      useWorkspaceStore.setState({
+        workspaces: [ws],
+        activeWorkspaceId: ws.id,
+        threads: [existing],
+      });
+      (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockImplementation(() => listPromise);
+
+      void useWorkspaceStore.getState().loadThreads(ws.id);
+
+      let resolveRpc!: (value: ReturnType<typeof createMockThread>) => void;
+      const rpcPromise = new Promise<ReturnType<typeof createMockThread>>((resolve) => {
+        resolveRpc = resolve;
+      });
+      (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mockReturnValue(rpcPromise);
+
+      const sendOp = useWorkspaceStore.getState().createAndSendMessage("New", "composer-2-fast");
+      await Promise.resolve();
+
+      const mid = useWorkspaceStore.getState();
+      const placeholderId = mid.activeThreadId;
+      expect(placeholderId).not.toBeNull();
+      expect(mid.threads.some((t) => t.clientPreparing)).toBe(true);
+
+      listResolve([existing]);
+      await listPromise;
+      await Promise.resolve();
+
+      expect(useWorkspaceStore.getState().threads.some((t) => t.id === placeholderId)).toBe(true);
+
+      resolveRpc(createMockThread({ id: "real-new", workspace_id: ws.id, title: "New" }));
+      await sendOp;
     });
   });
 });

--- a/apps/web/src/__tests__/workspace-thread.test.ts
+++ b/apps/web/src/__tests__/workspace-thread.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { titleFromMessageContent, preparingStatusLabel } from "@/lib/workspace-thread";
+
+describe("workspace-thread helpers", () => {
+  it("titleFromMessageContent uses the first non-empty line and trims", () => {
+    expect(titleFromMessageContent("\n\nHello\nrest")).toBe("Hello");
+  });
+
+  it("preparingStatusLabel covers new-direct", () => {
+    expect(preparingStatusLabel("new-direct")).toContain("Starting");
+  });
+});

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -5,9 +5,29 @@ import type { Thread } from "@/transport/types";
 
 // Store mocks must be declared before importing the component under test.
 
+/** Holds the store snapshot backing both the hook selector and `getState()` (real Zustand API). */
+const { chatViewWorkspaceMockRef } = vi.hoisted(() => ({
+  chatViewWorkspaceMockRef: { current: null as Record<string, unknown> | null },
+}));
+
 vi.mock("@/stores/workspaceStore", () => ({
-  useWorkspaceStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector(defaultWorkspaceState())
+  useWorkspaceStore: Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => {
+      const snap = chatViewWorkspaceMockRef.current;
+      if (!snap) {
+        throw new Error("ChatView tests: set chatViewWorkspaceMockRef via setupWorkspaceMock before render");
+      }
+      return selector(snap);
+    }),
+    {
+      getState: () => {
+        const snap = chatViewWorkspaceMockRef.current;
+        if (!snap) {
+          throw new Error("ChatView tests: set chatViewWorkspaceMockRef via setupWorkspaceMock before render");
+        }
+        return snap;
+      },
+    },
   ),
 }));
 
@@ -120,12 +140,20 @@ function defaultWorkspaceState(overrides: Partial<{
     deleteThread: vi.fn(),
     setPendingNewThread: vi.fn(),
     updateThreadTitle: overrides.updateThreadTitle ?? vi.fn().mockResolvedValue(undefined),
+    failPreparingThreadOnConnectionLost: vi.fn(),
+    retryPreparingThread: vi.fn(),
+    dismissPreparingThread: vi.fn(),
+    loadWorktrees: vi.fn(),
+    worktrees: [],
+    worktreesLoadedForWorkspace: null,
+    checksById: {},
     error: null,
   };
 }
 
 /** Re-configure the workspace store mock with the given state. */
 function setupWorkspaceMock(state: ReturnType<typeof defaultWorkspaceState>) {
+  chatViewWorkspaceMockRef.current = state;
   // Cast via unknown to avoid requiring every field of WorkspaceState in the fixture.
   (useWorkspaceStore as unknown as { mockImplementation: (fn: (selector: (s: unknown) => unknown) => unknown) => void }).mockImplementation(
     (selector) => selector(state)

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -317,7 +317,7 @@ export function ChatView() {
       clearMessages();
     } else {
       const row = useWorkspaceStore.getState().threads.find((t) => t.id === activeThreadId);
-      if (row?.clientPreparing) {
+      if (row?.clientPreparing || row?.clientError) {
         clearMessages();
       } else {
         loadMessages(activeThreadId);

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
-import { GitBranch } from "lucide-react";
+import { GitBranch, Loader2 } from "lucide-react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useConnectionStore } from "@/stores/connectionStore";
@@ -15,6 +15,8 @@ import { InterruptedSessionsBanner } from "./InterruptedSessionsBanner";
 import { ThreadTitleEditor } from "./ThreadTitleEditor";
 import { SidebarRevealButton } from "@/components/sidebar/SidebarRevealButton";
 import { useUiStore } from "@/stores/uiStore";
+import { preparingStatusLabel, type WorkspaceThread } from "@/lib/workspace-thread";
+import { Button } from "@/components/ui/button";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -71,7 +73,97 @@ function EmptyState({ onPromptSelect }: EmptyStateProps) {
   );
 }
 
-/** Blink cache threshold (bytes) above which we evict on thread switch. */
+/** Props for {@link ThreadPreparingShell}. */
+interface ThreadPreparingShellProps {
+  /** Placeholder or errored row until the server thread exists. */
+  thread: WorkspaceThread;
+  workspaceName: string;
+  sidebarCollapsed: boolean;
+  onRetry: () => void;
+  onDismiss: () => void;
+  activeWorkspaceId: string | null;
+}
+
+/** Full-height chat layout while a thread row is still being created on the server. */
+function ThreadPreparingShell({
+  thread,
+  workspaceName,
+  sidebarCollapsed,
+  onRetry,
+  onDismiss,
+  activeWorkspaceId,
+}: ThreadPreparingShellProps) {
+  const statusLabel = thread.clientPreparingContext
+    ? preparingStatusLabel(thread.clientPreparingContext)
+    : "Preparing…";
+  const threads = useWorkspaceStore((s) => s.threads);
+
+  return (
+    <div className="flex h-full flex-col bg-background" data-testid="thread-preparing-shell">
+      <div className="flex h-11 items-center justify-between border-b border-border pr-4 pl-2">
+        <div className="flex min-w-0 items-center gap-2">
+          {sidebarCollapsed && <SidebarRevealButton />}
+          <span
+            data-testid="chat-header-title"
+            className="truncate text-sm font-medium"
+          >
+            {thread.title}
+            {thread.clientPreparing && (
+              <span className="ml-2 inline-block h-2 w-2 shrink-0 animate-pulse rounded-full bg-primary/60 align-middle" aria-hidden />
+            )}
+          </span>
+          {activeWorkspaceId && (
+            <Badge variant="secondary">{workspaceName}</Badge>
+          )}
+          {thread.parent_thread_id && threads.some((t) => t.id === thread.parent_thread_id) && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    onClick={() => useWorkspaceStore.getState().setActiveThread(thread.parent_thread_id!)}
+                    className="flex shrink-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-[11px] font-medium text-primary/80 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
+                  >
+                    <GitBranch size={10} />
+                    <span>Branched</span>
+                  </button>
+                }
+              />
+              <TooltipContent side="bottom" className="text-xs">Go to parent thread</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col items-stretch justify-center gap-6 px-6 py-8">
+        <div className="mx-auto w-full max-w-xl rounded-xl border border-border/50 bg-muted/15 px-4 py-3 text-sm text-foreground/90 shadow-sm">
+          <p className="whitespace-pre-wrap break-words">{thread.clientQueuedMessage ?? ""}</p>
+        </div>
+
+        {thread.clientError ? (
+          <div className="mx-auto flex w-full max-w-xl flex-col items-stretch gap-3">
+            <p className="text-center text-sm text-destructive">{thread.clientError}</p>
+            <div className="flex justify-center gap-2">
+              <Button type="button" size="sm" variant="default" onClick={onRetry}>
+                Retry
+              </Button>
+              <Button type="button" size="sm" variant="outline" onClick={onDismiss}>
+                Dismiss
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="text-muted-foreground flex items-center justify-center gap-2 text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            <span>{statusLabel}</span>
+          </div>
+        )}
+      </div>
+
+      <Composer threadId={thread.id} workspaceId={activeWorkspaceId ?? undefined} />
+    </div>
+  );
+}
 const CACHE_PRESSURE_BYTES = 20 * 1024 * 1024; // 20 MB
 
 /** Renders the main chat UI for sending and receiving messages within a thread. */
@@ -203,13 +295,33 @@ export function ChatView() {
     [workspaces, activeThread?.workspace_id, activeWorkspaceId],
   );
 
+  const prevConnectionStatusRef = useRef(connectionStatus);
+
+  useEffect(() => {
+    const prev = prevConnectionStatusRef.current;
+    prevConnectionStatusRef.current = connectionStatus;
+    if (prev !== "connected") return;
+    if (connectionStatus !== "reconnecting" && connectionStatus !== "authFailed") return;
+    const id = useWorkspaceStore.getState().activeThreadId;
+    if (!id) return;
+    const row = useWorkspaceStore.getState().threads.find((t) => t.id === id);
+    if (row?.clientPreparing) {
+      useWorkspaceStore.getState().failPreparingThreadOnConnectionLost(id);
+    }
+  }, [connectionStatus]);
+
   const prevThreadIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (activeThreadId) {
-      loadMessages(activeThreadId);
-    } else {
+    if (!activeThreadId) {
       clearMessages();
+    } else {
+      const row = useWorkspaceStore.getState().threads.find((t) => t.id === activeThreadId);
+      if (row?.clientPreparing) {
+        clearMessages();
+      } else {
+        loadMessages(activeThreadId);
+      }
     }
     // Only evict Blink's resource cache when it exceeds the pressure threshold.
     // Avoids unnecessary re-fetches on routine thread switches.
@@ -248,6 +360,26 @@ export function ChatView() {
         {/* Composer for new thread */}
         <Composer isNewThread workspaceId={activeWorkspaceId ?? undefined} />
       </div>
+    );
+  }
+
+  if (
+    activeThread &&
+    (activeThread.clientPreparing || activeThread.clientError)
+  ) {
+    return (
+      <ThreadPreparingShell
+        thread={activeThread}
+        workspaceName={activeWorkspaceName}
+        sidebarCollapsed={sidebarCollapsed}
+        activeWorkspaceId={activeWorkspaceId}
+        onRetry={() => {
+          void useWorkspaceStore.getState().retryPreparingThread(activeThread.id);
+        }}
+        onDismiss={() => {
+          useWorkspaceStore.getState().dismissPreparingThread(activeThread.id);
+        }}
+      />
     );
   }
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1845,18 +1845,22 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                       : "bg-muted text-muted-foreground opacity-40"
             )}
             title={
-              isAgentRunning && hasContent
-                ? "Queue message"
-                : isAgentRunning
-                  ? "Stop agent"
-                  : "Send message"
+              isThreadScaffold
+                ? "Starting thread"
+                : isAgentRunning && hasContent
+                  ? "Queue message"
+                  : isAgentRunning
+                    ? "Stop agent"
+                    : "Send message"
             }
             aria-label={
-              isAgentRunning && hasContent
-                ? "Queue message"
-                : isAgentRunning
-                  ? "Stop agent"
-                  : "Send message"
+              isThreadScaffold
+                ? "Starting thread"
+                : isAgentRunning && hasContent
+                  ? "Queue message"
+                  : isAgentRunning
+                    ? "Stop agent"
+                    : "Send message"
             }
           >
             {isThreadScaffold ? (

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -425,7 +425,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const [access, setAccess] = useState<AccessMode>(PERMISSION_MODES.FULL);
   const [showReasoningPicker, setShowReasoningPicker] = useState(false);
   const [composerMode, setComposerModeLocal] = useState<ComposerMode>("direct");
-  const [preparingWorktree, setPreparingWorktree] = useState(false);
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
   const dragDepthRef = useRef(0);
@@ -717,6 +716,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
   const threads = useWorkspaceStore((s) => s.threads);
   const activeThread = threadId ? threads.find((t) => t.id === threadId) : undefined;
+  const isThreadScaffold = !!(
+    activeThread?.clientPreparing || activeThread?.clientError
+  );
 
   const activeProviderId = activeThread?.provider ?? "claude";
   const usageInfo = useThreadStore((s) => s.usageByProvider[activeProviderId]);
@@ -1185,11 +1187,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
   const handleSend = useCallback(async () => {
     if (!hasContent) return;
-    // Prevent double-submission via keyboard while a worktree is being created.
-    // The button is already disabled via `preparingWorktree`, but the keyboard
-    // Enter handler bypasses that. Without this guard, a second Enter press can
-    // trigger a duplicate createAndSendMessage call before the first RPC returns.
-    if (preparingWorktree) return;
+    // Avoid duplicate submissions while a placeholder thread is still materializing.
+    if (isThreadScaffold) return;
     const trimmed = input.trim();
 
     // ---- Queue path: agent is running on this thread ----
@@ -1261,14 +1260,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     if (threadId) clearDraftFromStore(threadId);
 
     if (isNewThread && workspaceId) {
-      if (newThreadMode === "worktree" || newThreadMode === "existing-worktree") {
-        setPreparingWorktree(true);
-      }
-      try {
-        await useWorkspaceStore.getState().createAndSendMessage(messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, reasoning, provider, mode, provider === "copilot" ? (copilotAgent ?? undefined) : undefined, contextWindow ?? undefined, thinking ?? undefined);
-      } finally {
-        setPreparingWorktree(false);
-      }
+      await useWorkspaceStore.getState().createAndSendMessage(messageContent, modelId, access, currentAttachments.length > 0 ? currentAttachments : undefined, reasoning, provider, mode, provider === "copilot" ? (copilotAgent ?? undefined) : undefined, contextWindow ?? undefined, thinking ?? undefined);
     } else if (branchFromMessageId && threadId) {
       // Branch mode: create a child thread from the quoted message instead of sending.
       let branchMode: "direct" | "worktree" | "existing-worktree" = "direct";
@@ -1323,7 +1315,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
 
     editorRef.current?.focus();
-  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, contextWindow, thinking, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, preparingWorktree, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, branchAutoPreview, onBranchModeExit]);
+  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, contextWindow, thinking, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, isThreadScaffold, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, branchAutoPreview, onBranchModeExit]);
 
   const handleEditorChange = useCallback((text: string) => {
     setInput(text);
@@ -1767,9 +1759,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           <div className="flex-1" />
 
           {/* Preparing worktree indicator */}
-          {preparingWorktree && (
+          {isThreadScaffold && (
             <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              Preparing worktree...
+              Preparing thread…
             </span>
           )}
 
@@ -1825,7 +1817,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           {/* Send / Queue / Stop button */}
           <button
             onClick={
-              preparingWorktree
+              isThreadScaffold
                 ? undefined
                 : isAgentRunning && hasContent
                   ? handleSend
@@ -1837,12 +1829,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
               !!providerReason ||
               isStaleWorktree ||
               planPending ||
-              preparingWorktree ||
+              isThreadScaffold ||
               (!isAgentRunning && !hasContent)
             }
             className={cn(
               "rounded-full p-1.5 transition-colors",
-              preparingWorktree
+              isThreadScaffold
                 ? "bg-primary text-primary-foreground animate-spin"
                 : isAgentRunning && hasContent
                   ? "bg-primary/60 text-primary-foreground hover:bg-primary/75"
@@ -1867,7 +1859,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                   : "Send message"
             }
           >
-            {preparingWorktree ? (
+            {isThreadScaffold ? (
               <Loader2 size={14} />
             ) : isAgentRunning && hasContent ? (
               <ArrowUp size={14} />

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -429,4 +429,40 @@ describe("ProjectTree action-required indicator", () => {
     // CI "failing" would normally paint bg-red-500; the ring must suppress it.
     expect(indicator.className).not.toContain("bg-red-500");
   });
+
+  it("does not dim the CI chip when the thread row is a client scaffold", () => {
+    currentThread = {
+      ...makeThread({
+        id: "thread-pending",
+        pr_number: 42,
+        pr_status: "open",
+      }),
+      clientPreparing: true,
+    } as Thread;
+    currentChecks = {
+      "thread-pending": {
+        aggregate: "pending",
+        runs: [
+          {
+            name: "build",
+            status: "in_progress",
+            conclusion: null,
+            durationMs: null,
+            startedAt: null,
+          },
+        ],
+      },
+    };
+    installWorkspaceMock();
+    render(<ProjectTree />);
+
+    const row = screen.getByRole("button", { name: /My Thread/i });
+    expect(row.className).not.toContain("opacity-[0.72]");
+
+    const titleCluster = screen.getByTestId("thread-title").parentElement;
+    expect(titleCluster?.className).toContain("opacity-[0.72]");
+
+    const chip = screen.getByLabelText("0 of 1 checks done");
+    expect(chip.className).not.toContain("opacity-[0.72]");
+  });
 });

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -25,6 +25,7 @@ import { getStatusDisplay, getNotificationDot } from "@/lib/thread-status";
 import { getBreakdown, getCiVisual, CI_ICON_STROKE } from "@/lib/ci-status";
 import type { ChecksStatus } from "@mcode/contracts";
 import type { Workspace, Thread } from "@/transport/types";
+import type { WorkspaceThread } from "@/lib/workspace-thread";
 
 // Persist expand/collapse in localStorage
 function getExpandedState(): Record<string, boolean> {
@@ -99,14 +100,14 @@ interface InlineEditState {
 
 /** A thread with its nesting depth in the sidebar tree. */
 interface ThreadTreeItem {
-  thread: Thread;
+  thread: WorkspaceThread;
   depth: number;
 }
 
 /** Builds a depth-first flattened tree from a flat list of threads, ordered by parent-child relationships. */
-function buildThreadTree(threads: Thread[]): ThreadTreeItem[] {
-  const childrenByParent = new Map<string, Thread[]>();
-  const roots: Thread[] = [];
+function buildThreadTree(threads: WorkspaceThread[]): ThreadTreeItem[] {
+  const childrenByParent = new Map<string, WorkspaceThread[]>();
+  const roots: WorkspaceThread[] = [];
   const threadIds = new Set(threads.map((t) => t.id));
 
   for (const thread of threads) {
@@ -121,7 +122,7 @@ function buildThreadTree(threads: Thread[]): ThreadTreeItem[] {
   }
 
   const result: ThreadTreeItem[] = [];
-  function walk(thread: Thread, depth: number) {
+  function walk(thread: WorkspaceThread, depth: number) {
     result.push({ thread, depth });
     const children = childrenByParent.get(thread.id);
     if (children) {
@@ -577,7 +578,7 @@ export function ProjectTree() {
 
 /** Props for the virtualized thread list rendered inside an expanded workspace. */
 interface VirtualizedThreadListProps {
-  threads: Thread[];
+  threads: WorkspaceThread[];
   /** Maximum number of tree rows to render. Used by the parent to enforce the THREAD_LIST_CAP. */
   maxVisible: number;
   activeThreadId: string | null;
@@ -663,7 +664,7 @@ function WorkspaceCiRollupChip({
   threads,
   checksById,
 }: {
-  threads: Thread[];
+  threads: WorkspaceThread[];
   checksById: Record<string, ChecksStatus>;
 }) {
   // Count threads by their CI aggregate — one per thread, regardless of how many
@@ -849,6 +850,7 @@ function VirtualizedThreadList({
                 onContextMenu={(e) => onThreadContextMenu(e, thread)}
                 className={cn(
                   "group/row flex items-center gap-2 rounded-md pr-2 py-1 text-[13px] cursor-pointer transition-colors",
+                  (thread.clientPreparing || thread.clientError) && "opacity-[0.72]",
                   activeThreadId === thread.id
                     ? "bg-accent text-foreground"
                     : "text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground"
@@ -969,7 +971,7 @@ interface ProjectNodeProps {
   isExpanded: boolean;
   isActive: boolean;
   activeThreadId: string | null;
-  threads: Thread[];
+  threads: WorkspaceThread[];
   runningThreadIds: Set<string>;
   /** Thread IDs with at least one unsettled permission request. */
   pendingPermissionThreadIds: Set<string>;

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -820,6 +820,9 @@ function VirtualizedThreadList({
           : !providerRow.enabled
             ? "Provider disabled"
             : "CLI not found";
+        // Opacity on the row would compound onto CiChip; dim only the title cluster and timestamp.
+        const scaffoldDim =
+          (thread.clientPreparing || thread.clientError) && "opacity-[0.72]";
         return (
           <div
             key={thread.id}
@@ -850,13 +853,18 @@ function VirtualizedThreadList({
                 onContextMenu={(e) => onThreadContextMenu(e, thread)}
                 className={cn(
                   "group/row flex items-center gap-2 rounded-md pr-2 py-1 text-[13px] cursor-pointer transition-colors",
-                  (thread.clientPreparing || thread.clientError) && "opacity-[0.72]",
                   activeThreadId === thread.id
                     ? "bg-accent text-foreground"
                     : "text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground"
                 )}
                 style={{ paddingLeft: `${10 + depth * 14}px` }}
               >
+                <div
+                  className={cn(
+                    "flex min-w-0 flex-1 items-center gap-2",
+                    scaffoldDim,
+                  )}
+                >
                 {thread.pr_number != null ? (() => {
                   const { Icon: PrIcon, color: prColor } = getPrVisual(thread.pr_status);
                   const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
@@ -944,11 +952,17 @@ function VirtualizedThreadList({
                     <TooltipContent side="right" className="text-xs">{unusableReason}</TooltipContent>
                   </Tooltip>
                 )}
+                </div>
                 {!isEditing && thread.pr_number != null && checksById[thread.id] && (
                   <CiChip checks={checksById[thread.id]} />
                 )}
                 {!isEditing && (
-                  <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/45">
+                  <span
+                    className={cn(
+                      "shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/45",
+                      scaffoldDim,
+                    )}
+                  >
                     {thread.pr_number != null && (
                       <span className="mr-1 opacity-80">#{thread.pr_number}</span>
                     )}

--- a/apps/web/src/lib/workspace-thread.ts
+++ b/apps/web/src/lib/workspace-thread.ts
@@ -1,0 +1,112 @@
+import type { Thread } from "@/transport";
+
+/**
+ * Thread row in the workspace store may include client-only fields while the
+ * server-backed record is still being created.
+ */
+export type WorkspaceThread = Thread & {
+  /** True while createAndSend / branch RPC is in flight. */
+  clientPreparing?: boolean;
+  /** Set when creation failed; user can retry or dismiss. */
+  clientError?: string | null;
+  /** Message body shown in the preparing shell (mirrors cleared composer input). */
+  clientQueuedMessage?: string;
+  /**
+   * Drives status copy in the preparing shell (new vs branch, direct vs worktree).
+   */
+  clientPreparingContext?:
+    | "new-direct"
+    | "new-worktree"
+    | "new-existing-worktree"
+    | "branch-direct"
+    | "branch-worktree"
+    | "branch-existing-worktree";
+};
+
+const TITLE_MAX = 72;
+
+/**
+ * Derives a thread title from the first line or first chars of the user's message.
+ */
+export function titleFromMessageContent(content: string): string {
+  const firstLine = content.split(/\r?\n/).find((l) => l.trim().length > 0) ?? content;
+  const trimmed = firstLine.trim();
+  if (trimmed.length <= TITLE_MAX) return trimmed || "New thread";
+  return `${trimmed.slice(0, TITLE_MAX - 1)}…`;
+}
+
+/** Union of all preparing-context values for exhaustive switch checks. */
+export type ClientPreparingContext = NonNullable<WorkspaceThread["clientPreparingContext"]>;
+
+/**
+ * User-visible status line for the preparing shell.
+ */
+export function preparingStatusLabel(ctx: ClientPreparingContext): string {
+  switch (ctx) {
+    case "new-direct":
+    case "branch-direct":
+      return "Starting thread…";
+    case "new-worktree":
+    case "branch-worktree":
+      return "Creating worktree…";
+    case "new-existing-worktree":
+    case "branch-existing-worktree":
+      return "Attaching worktree…";
+    default: {
+      const _exhaustive: never = ctx;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Builds a minimal {@link Thread} shape for an optimistic sidebar row and chat shell.
+ */
+export function buildPlaceholderWorkspaceThread(params: {
+  id: string;
+  workspaceId: string;
+  title: string;
+  queuedMessage: string;
+  transportMode: "direct" | "worktree";
+  branch: string;
+  clientPreparingContext: ClientPreparingContext;
+  parentThreadId?: string | null;
+  forkedFromMessageId?: string | null;
+}): WorkspaceThread {
+  const now = new Date().toISOString();
+  return {
+    id: params.id,
+    workspace_id: params.workspaceId,
+    title: params.title,
+    status: "active",
+    mode: params.transportMode,
+    worktree_path: null,
+    branch: params.branch,
+    worktree_managed: params.transportMode === "worktree",
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    has_file_changes: false,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: null,
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
+    copilot_agent: null,
+    parent_thread_id: params.parentThreadId ?? null,
+    forked_from_message_id: params.forkedFromMessageId ?? null,
+    last_compact_summary: null,
+    clientPreparing: true,
+    clientError: null,
+    clientQueuedMessage: params.queuedMessage,
+    clientPreparingContext: params.clientPreparingContext,
+  };
+}

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
 import type { Workspace, Thread, GitBranch, PermissionMode, WorktreeInfo, AttachmentMeta, PrDetail } from "@/transport";
+import {
+  type WorkspaceThread,
+  buildPlaceholderWorkspaceThread,
+  titleFromMessageContent,
+} from "@/lib/workspace-thread";
 import type { ChecksStatus } from "@mcode/contracts";
 import { getTransport } from "@/transport";
 import { useThreadStore } from "./threadStore";
@@ -42,6 +47,53 @@ export function __resetThreadListMutationEpochForTests(): void {
   threadListMutationEpochByWorkspace.clear();
 }
 
+/** RPC payload remembered so a failed placeholder can retry. Used by Vitest only. */
+export function __clearPendingThreadCreationsForTests(): void {
+  pendingThreadCreationByPlaceholderId.clear();
+}
+
+/** Parameters to replay {@link McodeTransport.createAndSendMessage} after an optimistic insert. */
+interface PendingThreadCreation {
+  workspaceId: string;
+  content: string;
+  model: string;
+  permissionMode?: PermissionMode;
+  transportMode: "direct" | "worktree";
+  branch: string;
+  existingWorktreePath?: string;
+  attachments?: AttachmentMeta[];
+  reasoningLevel?: ReasoningLevel;
+  provider?: string;
+  interactionMode?: InteractionMode;
+  sourceThreadId?: string;
+  forkedFromMessageId?: string;
+  copilotAgent?: string;
+  contextWindow?: ContextWindowMode;
+  thinking?: boolean;
+}
+
+const pendingThreadCreationByPlaceholderId = new Map<string, PendingThreadCreation>();
+
+async function runCreateAndSend(pending: PendingThreadCreation): Promise<Thread> {
+  return getTransport().createAndSendMessage(
+    pending.workspaceId,
+    pending.content,
+    pending.model,
+    pending.permissionMode,
+    pending.transportMode,
+    pending.branch,
+    pending.existingWorktreePath,
+    pending.attachments,
+    pending.reasoningLevel,
+    pending.provider,
+    pending.interactionMode,
+    pending.sourceThreadId,
+    pending.forkedFromMessageId,
+    pending.copilotAgent,
+    pending.contextWindow,
+    pending.thinking,
+  );
+}
 /**
  * Optional RPC dispatch callback used by workspace actions. Tests inject a
  * stub here; production code uses {@link getTransport} directly. The shape
@@ -53,7 +105,7 @@ export type WorkspaceRpcCall = (method: string, params: unknown) => Promise<unkn
 interface WorkspaceState {
   workspaces: Workspace[];
   activeWorkspaceId: string | null;
-  threads: Thread[];
+  threads: WorkspaceThread[];
   activeThreadId: string | null;
   pendingNewThread: boolean;
   loading: boolean;
@@ -122,6 +174,14 @@ interface WorkspaceState {
     contextWindow?: ContextWindowMode;
     thinking?: boolean;
   }) => Promise<Thread>;
+  /**
+   * Re-run server creation for a placeholder thread after {@link WorkspaceThread.clientError}.
+   */
+  retryPreparingThread: (placeholderId: string) => Promise<Thread>;
+  /** Remove a failed or abandoned placeholder row and drop selection when it was active. */
+  dismissPreparingThread: (placeholderId: string) => void;
+  /** Surface connection loss while {@link WorkspaceThread.clientPreparing} is true. */
+  failPreparingThreadOnConnectionLost: (placeholderId: string) => void;
   deleteThread: (threadId: string, cleanupWorktree: boolean) => Promise<void>;
   setActiveThread: (id: string | null) => void;
   setPendingNewThread: (value: boolean) => void;
@@ -182,7 +242,63 @@ interface WorkspaceState {
 }
 
 /** Zustand store for workspace, thread, branch, and PR state management. */
-export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
+  const applyOptimisticSuccess = (
+    placeholderId: string,
+    workspaceId: string,
+    thread: Thread,
+    transportWasWorktree: boolean,
+  ) => {
+    bumpThreadListMutationEpoch(workspaceId);
+    pendingThreadCreationByPlaceholderId.delete(placeholderId);
+    const startTime =
+      useThreadStore.getState().agentStartTimes[placeholderId] ?? Date.now();
+    useThreadStore.setState((state) => {
+      const nextRunning = new Set(state.runningThreadIds);
+      nextRunning.delete(placeholderId);
+      nextRunning.add(thread.id);
+      const nextTimes = { ...state.agentStartTimes };
+      delete nextTimes[placeholderId];
+      nextTimes[thread.id] = startTime;
+      return { runningThreadIds: nextRunning, agentStartTimes: nextTimes };
+    });
+    set((state) => {
+      const without = state.threads.filter((t) => t.id !== placeholderId);
+      const deduped = without.filter((t) => t.id !== thread.id);
+      const nextThreads: WorkspaceThread[] = [thread, ...deduped];
+      const stillOnPlaceholder = state.activeThreadId === placeholderId;
+      return {
+        threads: nextThreads,
+        activeThreadId: stillOnPlaceholder ? thread.id : state.activeThreadId,
+        error: null,
+        ...(transportWasWorktree ? { worktreesLoadedForWorkspace: null } : {}),
+      };
+    });
+    if (get().activeThreadId === thread.id) {
+      void useThreadStore.getState().loadMessages(thread.id);
+    }
+  };
+
+  const applyOptimisticFailure = (placeholderId: string, err: unknown) => {
+    const msg = String(err);
+    useThreadStore.setState((state) => {
+      const nextRunning = new Set(state.runningThreadIds);
+      nextRunning.delete(placeholderId);
+      const nextTimes = { ...state.agentStartTimes };
+      delete nextTimes[placeholderId];
+      return { runningThreadIds: nextRunning, agentStartTimes: nextTimes };
+    });
+    set((state) => ({
+      threads: state.threads.map((t) =>
+        t.id === placeholderId
+          ? { ...t, clientPreparing: false, clientError: msg }
+          : t,
+      ),
+      error: msg,
+    }));
+  };
+
+  return {
   workspaces: [],
   activeWorkspaceId: null,
   threads: [],
@@ -391,13 +507,24 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         return;
       }
       // Replace threads for this workspace; keep threads from other workspaces intact.
-      set((state) => ({
-        threads: [
-          ...state.threads.filter((t) => t.workspace_id !== workspaceId),
-          ...newThreads,
-        ],
-        loading: false,
-      }));
+      // Retain optimistic placeholder rows until the server confirms the real thread.
+      set((state) => {
+        const placeholders = state.threads.filter(
+          (t) =>
+            t.workspace_id === workspaceId &&
+            t.clientPreparing === true,
+        );
+        const incomingIds = new Set(newThreads.map((t) => t.id));
+        const extraPlaceholders = placeholders.filter((p) => !incomingIds.has(p.id));
+        const mergedForWorkspace = [...extraPlaceholders, ...newThreads];
+        return {
+          threads: [
+            ...state.threads.filter((t) => t.workspace_id !== workspaceId),
+            ...mergedForWorkspace,
+          ],
+          loading: false,
+        };
+      });
 
       const epochForPrSync = epochAtStart;
 
@@ -470,32 +597,62 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       existingWorktreePath = selectedWorktree.path;
     }
 
-    set({ error: null });
+    const clientPreparingContext =
+      newThreadMode === "worktree"
+        ? "new-worktree"
+        : newThreadMode === "existing-worktree"
+          ? "new-existing-worktree"
+          : "new-direct";
+
+    const placeholderId = crypto.randomUUID();
+    const pending: PendingThreadCreation = {
+      workspaceId,
+      content,
+      model,
+      permissionMode,
+      transportMode: mode,
+      branch,
+      existingWorktreePath,
+      attachments,
+      reasoningLevel,
+      provider,
+      interactionMode,
+      copilotAgent,
+      contextWindow,
+      thinking,
+    };
+
+    const placeholder = buildPlaceholderWorkspaceThread({
+      id: placeholderId,
+      workspaceId,
+      title: titleFromMessageContent(content),
+      queuedMessage: content,
+      transportMode: mode,
+      branch,
+      clientPreparingContext,
+    });
+
+    bumpThreadListMutationEpoch(workspaceId);
+    pendingThreadCreationByPlaceholderId.set(placeholderId, pending);
+    set((state) => ({
+      threads: [placeholder, ...state.threads],
+      activeThreadId: placeholderId,
+      pendingNewThread: false,
+      branchManuallySelected: false,
+      error: null,
+    }));
+
+    useThreadStore.setState((state) => ({
+      runningThreadIds: new Set([...state.runningThreadIds, placeholderId]),
+      agentStartTimes: { ...state.agentStartTimes, [placeholderId]: Date.now() },
+    }));
+
     try {
-      const thread = await getTransport().createAndSendMessage(
-        workspaceId, content, model, permissionMode, mode, branch, existingWorktreePath, attachments, reasoningLevel, provider, interactionMode, undefined, undefined, copilotAgent, contextWindow, thinking,
-      );
-      bumpThreadListMutationEpoch(workspaceId);
-      set((state) => ({
-        threads: [thread, ...state.threads],
-        activeThreadId: thread.id,
-        pendingNewThread: false,
-        branchManuallySelected: false,
-        // Invalidate worktree cache so the new worktree is included in the
-        // stale-worktree check. ProjectTree's effect will reload the list.
-        ...(mode === "worktree" ? { worktreesLoadedForWorkspace: null } : {}),
-      }));
-
-      // Mark the new thread as running in the threadStore so the
-      // "Working for Xs" timer appears for the first message too.
-      useThreadStore.setState((state) => ({
-        runningThreadIds: new Set([...state.runningThreadIds, thread.id]),
-        agentStartTimes: { ...state.agentStartTimes, [thread.id]: Date.now() },
-      }));
-
+      const thread = await runCreateAndSend(pending);
+      applyOptimisticSuccess(placeholderId, workspaceId, thread, mode === "worktree");
       return thread;
     } catch (e) {
-      set({ error: String(e) });
+      applyOptimisticFailure(placeholderId, e);
       throw e;
     }
   },
@@ -518,54 +675,151 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       existingWorktreePath = params.existingWorktreePath;
     }
 
-    set({ error: null });
+    const clientPreparingContext =
+      params.mode === "worktree"
+        ? "branch-worktree"
+        : params.mode === "existing-worktree"
+          ? "branch-existing-worktree"
+          : "branch-direct";
+
+    const placeholderId = crypto.randomUUID();
+    const pending: PendingThreadCreation = {
+      workspaceId,
+      content: params.content,
+      model: params.model,
+      permissionMode: params.permissionMode,
+      transportMode,
+      branch,
+      existingWorktreePath,
+      attachments: params.attachments,
+      reasoningLevel: params.reasoningLevel,
+      provider: params.provider,
+      interactionMode: params.interactionMode,
+      sourceThreadId: params.sourceThreadId,
+      forkedFromMessageId: params.forkedFromMessageId,
+      copilotAgent: params.copilotAgent,
+      contextWindow: params.contextWindow,
+      thinking: params.thinking,
+    };
+
+    const placeholder = buildPlaceholderWorkspaceThread({
+      id: placeholderId,
+      workspaceId,
+      title: titleFromMessageContent(params.content),
+      queuedMessage: params.content,
+      transportMode,
+      branch,
+      clientPreparingContext,
+      parentThreadId: params.sourceThreadId,
+      forkedFromMessageId: params.forkedFromMessageId,
+    });
+
+    bumpThreadListMutationEpoch(workspaceId);
+    pendingThreadCreationByPlaceholderId.set(placeholderId, pending);
+    set((state) => ({
+      threads: [placeholder, ...state.threads],
+      activeThreadId: placeholderId,
+      pendingNewThread: false,
+      branchManuallySelected: false,
+      error: null,
+    }));
+
+    useThreadStore.setState((state) => ({
+      runningThreadIds: new Set([...state.runningThreadIds, placeholderId]),
+      agentStartTimes: { ...state.agentStartTimes, [placeholderId]: Date.now() },
+    }));
+
     try {
-      const thread = await getTransport().createAndSendMessage(
-        workspaceId,
-        params.content,
-        params.model,
-        params.permissionMode,
-        transportMode,
-        branch,
-        existingWorktreePath,
-        params.attachments,
-        params.reasoningLevel,
-        params.provider,
-        params.interactionMode,
-        params.sourceThreadId,
-        params.forkedFromMessageId,
-        params.copilotAgent,
-        params.contextWindow,
-        params.thinking,
-      );
-
-      bumpThreadListMutationEpoch(workspaceId);
-      set((state) => ({
-        threads: [thread, ...state.threads],
-        activeThreadId: thread.id,
-        pendingNewThread: false,
-        branchManuallySelected: false,
-        // Invalidate worktree cache so the branched worktree is included in
-        // the stale-worktree check. ProjectTree's effect will reload the list.
-        ...(transportMode === "worktree" ? { worktreesLoadedForWorkspace: null } : {}),
-      }));
-
-      useThreadStore.setState((state) => ({
-        runningThreadIds: new Set([...state.runningThreadIds, thread.id]),
-        agentStartTimes: { ...state.agentStartTimes, [thread.id]: Date.now() },
-      }));
-
+      const thread = await runCreateAndSend(pending);
+      applyOptimisticSuccess(placeholderId, workspaceId, thread, transportMode === "worktree");
       return thread;
     } catch (e) {
-      set({ error: String(e) });
+      applyOptimisticFailure(placeholderId, e);
       throw e;
     }
+  },
+
+  retryPreparingThread: async (placeholderId) => {
+    const pending = pendingThreadCreationByPlaceholderId.get(placeholderId);
+    if (!pending) {
+      throw new Error("No pending creation for this thread");
+    }
+    const row = get().threads.find((t) => t.id === placeholderId);
+    if (!row?.clientError) {
+      throw new Error("Thread is not in a retryable state");
+    }
+    set((state) => ({
+      error: null,
+      threads: state.threads.map((t) =>
+        t.id === placeholderId
+          ? { ...t, clientPreparing: true, clientError: null }
+          : t,
+      ),
+    }));
+    useThreadStore.setState((state) => ({
+      runningThreadIds: new Set([...state.runningThreadIds, placeholderId]),
+      agentStartTimes: { ...state.agentStartTimes, [placeholderId]: Date.now() },
+    }));
+    try {
+      const thread = await runCreateAndSend(pending);
+      applyOptimisticSuccess(placeholderId, pending.workspaceId, thread, pending.transportMode === "worktree");
+      return thread;
+    } catch (e) {
+      applyOptimisticFailure(placeholderId, e);
+      throw e;
+    }
+  },
+
+  dismissPreparingThread: (placeholderId) => {
+    pendingThreadCreationByPlaceholderId.delete(placeholderId);
+    useThreadStore.getState().clearThreadState(placeholderId);
+    set((state) => ({
+      threads: state.threads.filter((t) => t.id !== placeholderId),
+      activeThreadId: state.activeThreadId === placeholderId ? null : state.activeThreadId,
+    }));
+  },
+
+  failPreparingThreadOnConnectionLost: (placeholderId) => {
+    const row = get().threads.find((t) => t.id === placeholderId);
+    if (!row?.clientPreparing) return;
+    applyOptimisticFailure(placeholderId, new Error("Connection lost while creating this thread. Try again."));
   },
 
   deleteThread: async (threadId, cleanupWorktree) => {
     set({ error: null });
     try {
-      const workspaceIdForEpoch = get().threads.find((t) => t.id === threadId)?.workspace_id;
+      pendingThreadCreationByPlaceholderId.delete(threadId);
+      const row = get().threads.find((t) => t.id === threadId);
+      const workspaceIdForEpoch = row?.workspace_id;
+      const isClientOnly = !!(row?.clientPreparing || row?.clientError);
+
+      if (isClientOnly) {
+        if (workspaceIdForEpoch) {
+          bumpThreadListMutationEpoch(workspaceIdForEpoch);
+        }
+        useTerminalStore.getState().clearThread(threadId);
+        useQueueStore.getState().clearQueue(threadId);
+        useComposerDraftStore.getState().clearDraft(threadId);
+        useTaskStore.getState().clearTasks(threadId);
+        useDiffStore.getState().clearThread(threadId);
+        set((state) => {
+          const remainingUrls = Object.fromEntries(
+            Object.entries(state.prUrlsByThreadId).filter(([k]) => k !== threadId),
+          ) as Record<string, string>;
+          const remainingChecks = Object.fromEntries(
+            Object.entries(state.checksById).filter(([k]) => k !== threadId),
+          ) as typeof state.checksById;
+          return {
+            threads: state.threads.filter((t) => t.id !== threadId),
+            activeThreadId: state.activeThreadId === threadId ? null : state.activeThreadId,
+            prUrlsByThreadId: remainingUrls,
+            checksById: remainingChecks,
+          };
+        });
+        useThreadStore.getState().clearThreadState(threadId);
+        return;
+      }
+
       await getTransport().deleteThread(threadId, cleanupWorktree);
       if (workspaceIdForEpoch) {
         bumpThreadListMutationEpoch(workspaceIdForEpoch);
@@ -762,4 +1016,5 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       };
     });
   },
-}));
+};
+});

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -249,6 +249,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     thread: Thread,
     transportWasWorktree: boolean,
   ) => {
+    if (!pendingThreadCreationByPlaceholderId.has(placeholderId)) {
+      return;
+    }
+    if (!get().workspaces.some((w) => w.id === workspaceId)) {
+      pendingThreadCreationByPlaceholderId.delete(placeholderId);
+      return;
+    }
     bumpThreadListMutationEpoch(workspaceId);
     pendingThreadCreationByPlaceholderId.delete(placeholderId);
     const startTime =
@@ -512,7 +519,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         const placeholders = state.threads.filter(
           (t) =>
             t.workspace_id === workspaceId &&
-            t.clientPreparing === true,
+            (t.clientPreparing === true || t.clientError != null),
         );
         const incomingIds = new Set(newThreads.map((t) => t.id));
         const extraPlaceholders = placeholders.filter((p) => !incomingIds.has(p.id));


### PR DESCRIPTION
## What

Adds client-side optimistic thread scaffolding so the first message on a new thread or a branch-from-message navigates immediately into a preparing shell instead of leaving the UI idle until the server returns.

## Why

Long-running \createAndSend\ (worktrees, branching) made the chat feel frozen: input cleared with no feedback, and navigation could snap the user into a thread later even after they moved elsewhere.

## Key Changes

- \WorkspaceThread\ client fields, placeholder builder, and pending-RPC map in \workspaceStore\
- Preparing shell in \ChatView\ with status, retry, dismiss, and reconnect handling
- \loadThreads\ merges in-flight placeholders; client-only rows skip server \deleteThread\
- Composer uses scaffold state from the store (replacing local \preparingWorktree\)
- Vitest coverage for optimistic insert, navigation preservation, and stale list races


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now short-circuits to a full-height “Preparing thread…” shell showing the queued message, spinner/status label, generated title, and Retry/Dismiss controls; send button and accessibility labels reflect the scaffold state. Sidebar rows visually dim for preparing/errored threads while CI chip remains undimmed.

* **Bug Fixes**
  * Optimistic placeholders are preserved across thread loads/updates; connection loss converts in-progress placeholders to failed state without forcing navigation; local placeholder deletions handled client-side; prevents duplicate sends during scaffold state.

* **Tests**
  * Added tests for optimistic scaffolding behavior, title extraction, preparing labels, and sidebar dimming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->