### PR TITLE
fix: persist user-selected model for dynamic provider IDs

### DIFF
--- a/apps/server/src/__tests__/cleanup-integration.test.ts
+++ b/apps/server/src/__tests__/cleanup-integration.test.ts
@@ -18,6 +18,12 @@ import type { TerminalService } from "../services/terminal-service";
 import type { GitService } from "../services/git-service";
 import { getMcodeDir } from "@mcode/shared";
 
+// Avoid real wmic/taskkill on Windows: unbounded wall time and Vitest's default
+// 5s test timeout (integration tests must not depend on the host process tree).
+vi.mock("../services/process-kill.js", () => ({
+  killDescendantsByName: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Stub filesystem checks for synthetic test paths.
 vi.mock("fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs")>();

--- a/apps/server/src/__tests__/cleanup-integration.test.ts
+++ b/apps/server/src/__tests__/cleanup-integration.test.ts
@@ -16,6 +16,7 @@ import { ThreadService } from "../services/thread-service";
 import type { ClaudeProvider } from "../providers/claude/claude-provider";
 import type { TerminalService } from "../services/terminal-service";
 import type { GitService } from "../services/git-service";
+import { killDescendantsByName } from "../services/process-kill.js";
 import { getMcodeDir } from "@mcode/shared";
 
 // Avoid real wmic/taskkill on Windows: unbounded wall time and Vitest's default
@@ -44,6 +45,7 @@ describe("Cleanup integration", () => {
   let mockGitService: GitService;
 
   beforeEach(() => {
+    vi.mocked(killDescendantsByName).mockClear();
     db = openMemoryDatabase();
     cleanupJobRepo = new CleanupJobRepo(db);
     threadRepo = new ThreadRepo(db);
@@ -112,6 +114,8 @@ describe("Cleanup integration", () => {
 
     // Step 2: Worker processes the job
     await worker.poll();
+
+    expect(vi.mocked(killDescendantsByName)).toHaveBeenCalledWith(process.pid, "claude.exe");
 
     // Verify: subprocess signalled, terminals killed, worktree removed
     expect(mockClaudeProvider.waitForSessionExit).toHaveBeenCalledWith(

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -330,6 +330,14 @@ export class AgentService {
       ...(copilotAgent !== undefined && { copilot_agent: copilotAgent }),
     });
 
+    const persistedProvider: ProviderId =
+      provider !== undefined ? effectiveProvider : (thread.provider as ProviderId) ?? "claude";
+    broadcast("thread.modelUpdated", {
+      threadId,
+      model: resolvedModel,
+      provider: persistedProvider,
+    });
+
     const sessionName = `mcode-${threadId}`;
     // A branched child has a system handoff at seq 1 but no sdk_session_id.
     // Only treat as resume if there is actually a session to resume.

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -74,16 +74,28 @@ describe("Settings-aware defaults", () => {
     expect(getDefaultModelId()).toBe("claude-opus-4-6");
   });
 
-  it("getDefaultModelId falls back to sonnet when model ID is unknown", () => {
+  it("getDefaultModelId falls back to sonnet when model ID is unknown for a static-catalog provider", () => {
     useSettingsStore.setState({
       settings: {
         ...getDefaultSettings(),
         model: {
-          defaults: { provider: "claude", id: "nonexistent-model", reasoning: "high", fallbackId: "", contextWindow: "200k", thinking: false },
+          defaults: { provider: "codex", id: "nonexistent-model", reasoning: "high", fallbackId: "", contextWindow: "200k", thinking: false },
         },
       },
     });
     expect(getDefaultModelId()).toBe("claude-sonnet-4-6");
+  });
+
+  it("getDefaultModelId preserves Cursor settings ID when absent from the static registry", () => {
+    useSettingsStore.setState({
+      settings: {
+        ...getDefaultSettings(),
+        model: {
+          defaults: { provider: "cursor", id: "cursor-dynamic-model-xyz", reasoning: "high", fallbackId: "", contextWindow: "200k", thinking: false },
+        },
+      },
+    });
+    expect(getDefaultModelId()).toBe("cursor-dynamic-model-xyz");
   });
 
   it("getDefaultModelId returns opus-4-7 from default settings", () => {
@@ -369,7 +381,7 @@ describe("resolveThreadModelId", () => {
     expect(resolveThreadModelId(undefined, "claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
   });
 
-  it("returns default when locked model is an unknown ID", () => {
-    expect(resolveThreadModelId("some-unknown-model", "claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
+  it("passes through unknown locked model ID (dynamic listing providers)", () => {
+    expect(resolveThreadModelId("cursor-dynamic-123", "claude-sonnet-4-6")).toBe("cursor-dynamic-123");
   });
 });

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -74,7 +74,7 @@ describe("Settings-aware defaults", () => {
     expect(getDefaultModelId()).toBe("claude-opus-4-6");
   });
 
-  it("getDefaultModelId falls back to sonnet when model ID is unknown for a static-catalog provider", () => {
+  it("getDefaultModelId falls back to first catalog model when ID is unknown for a static-catalog provider", () => {
     useSettingsStore.setState({
       settings: {
         ...getDefaultSettings(),
@@ -83,7 +83,7 @@ describe("Settings-aware defaults", () => {
         },
       },
     });
-    expect(getDefaultModelId()).toBe("claude-sonnet-4-6");
+    expect(getDefaultModelId()).toBe("gpt-5.4");
   });
 
   it("getDefaultModelId preserves Cursor settings ID when absent from the static registry", () => {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -21,7 +21,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { cn } from "@/lib/utils";
 import { isWindows } from "@/lib/platform";
 import { isCursorPermissionLockedToFull } from "@/lib/cursor-permission";
-import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, findModelById, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, supportsUltrathink, supports1MContextWindow, supportsThinkingToggle, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels, providerSupportsReasoningLevels } from "@/lib/model-registry";
+import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, supportsUltrathink, supports1MContextWindow, supportsThinkingToggle, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels, providerSupportsReasoningLevels } from "@/lib/model-registry";
 import { ModelSelector } from "./ModelSelector";
 import { ModeSelector, ALL_MODE_OPTIONS } from "./ModeSelector";
 import type { ComposerMode, ModeOption } from "./ModeSelector";
@@ -487,7 +487,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     // Existing threads restore settings from the thread record in the thread-switch effect.
     if (threadId) return;
 
-    const validModelId = findModelById(settingsDefaultModelId) ? settingsDefaultModelId : "claude-sonnet-4-6";
+    const validModelId = getDefaultModelId();
     setModelId(validModelId);
     setProvider(settingsDefaultProvider ?? "claude");
     setReasoning(normalizeReasoningLevelForModel(validModelId, settingsDefaultReasoning));
@@ -804,9 +804,17 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     const hasDraft = threadId ? getDraft(threadId) != null : false;
     const isRunning = threadId ? useThreadStore.getState().runningThreadIds.has(threadId) : false;
     if (hasDraft && !isRunning) return;
-    setModelId(activeThread.model);
+    const threadModel = activeThread.model;
+    const threadProv = (activeThread.provider ?? "claude") as string;
+    if (
+      !isRunning &&
+      (modelId !== threadModel || provider !== threadProv)
+    ) {
+      return;
+    }
+    setModelId(threadModel);
     if (activeThread.provider) setProvider(activeThread.provider as string);
-  }, [activeThread?.model, activeThread?.provider, threadId, getDraft]);
+  }, [activeThread?.model, activeThread?.provider, threadId, getDraft, modelId, provider]);
 
   // Combined setter that keeps local + store in sync
   const setComposerMode = useCallback(

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -451,6 +451,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   /** Set to true by the thread-switch effect; cleared by the model-sync effect.
    *  Prevents Effect 2 from overwriting Effect 1's model choice on thread switch. */
   const threadSwitchRef = useRef(false);
+  /** Last thread row model or provider applied from the server (for multi-tab sync). */
+  const lastServerThreadModelKeyRef = useRef("");
 
   // Keep draft ref in sync so the thread-switch effect reads current values
   useEffect(() => {
@@ -799,6 +801,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     if (!activeThread?.model) return;
     if (threadSwitchRef.current) {
       threadSwitchRef.current = false;
+      lastServerThreadModelKeyRef.current = `${activeThread.model}\0${(activeThread.provider ?? "claude") as string}`;
       return;
     }
     const hasDraft = threadId ? getDraft(threadId) != null : false;
@@ -806,15 +809,21 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     if (hasDraft && !isRunning) return;
     const threadModel = activeThread.model;
     const threadProv = (activeThread.provider ?? "claude") as string;
+    const serverKey = `${threadModel}\0${threadProv}`;
+    const serverRowChanged = lastServerThreadModelKeyRef.current !== serverKey;
+    lastServerThreadModelKeyRef.current = serverKey;
     if (
       !isRunning &&
+      !serverRowChanged &&
       (modelId !== threadModel || provider !== threadProv)
     ) {
       return;
     }
     setModelId(threadModel);
     if (activeThread.provider) setProvider(activeThread.provider as string);
-  }, [activeThread?.model, activeThread?.provider, threadId, getDraft, modelId, provider]);
+    // Intentionally omit modelId/provider: this effect should run when the thread row
+    // changes, not when the user edits the picker (local drift while serverKey is stable).
+  }, [activeThread?.model, activeThread?.provider, threadId, getDraft]);
 
   // Combined setter that keeps local + store in sync
   const setComposerMode = useCallback(

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -193,21 +193,22 @@ export function findModelById(id: string): ModelDefinition | undefined {
 
 /**
  * Resolves the model ID to display when switching to a thread with no draft.
- * Returns the thread's locked model normalized to its base ID if recognized,
- * otherwise falls back to the supplied default.
+ * Normalizes dated SDK variants and known static IDs; passes through any other
+ * non-empty string so dynamic provider models stay intact.
  *
  * @param lockedModel - The thread's stored model ID (may be a dated SDK variant, null, or undefined).
- * @param defaultModelId - Fallback model ID when the locked model is absent or unrecognized.
+ * @param defaultModelId - Fallback model ID when the locked model is absent.
  */
 export function resolveThreadModelId(
   lockedModel: string | null | undefined,
   defaultModelId: string,
 ): string {
-  if (lockedModel) {
-    const def = findModelById(lockedModel);
-    if (def) return def.id;
-  }
-  return defaultModelId;
+  if (!lockedModel) return defaultModelId;
+  const def = findModelById(lockedModel);
+  if (def) return def.id;
+  // Dynamic provider models (Cursor, Copilot, future Claude SKUs) are not in
+  // the static registry but are valid persisted IDs.
+  return lockedModel;
 }
 
 /** Finds the provider that owns the given model ID, including dated SDK variants. */
@@ -224,11 +225,18 @@ export function getDefaultModel(): ModelDefinition {
 
 /**
  * Return the default model ID from user settings, falling back to
- * Claude Sonnet 4.6 when settings have not loaded yet.
+ * Claude Sonnet 4.6 when the stored value is empty or unknown for a
+ * statically catalogued provider (e.g. Codex).
  */
 export function getDefaultModelId(): string {
-  const id = useSettingsStore.getState().settings.model.defaults.id;
-  return findModelById(id) ? id : "claude-sonnet-4-6";
+  const { settings } = useSettingsStore.getState();
+  const id = settings.model.defaults.id;
+  if (!id?.trim()) return "claude-sonnet-4-6";
+  if (findModelById(id)) return id;
+  const providerId = settings.model.defaults.provider ?? "claude";
+  const catalog = MODEL_PROVIDERS.find((p) => p.id === providerId);
+  if (catalog?.supportsModelListing) return id;
+  return "claude-sonnet-4-6";
 }
 
 /**

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -224,19 +224,40 @@ export function getDefaultModel(): ModelDefinition {
 }
 
 /**
- * Return the default model ID from user settings, falling back to
- * Claude Sonnet 4.6 when the stored value is empty or unknown for a
- * statically catalogued provider (e.g. Codex).
+ * Return the default model ID from user settings. Empty or invalid values
+ * resolve to a model that belongs to the configured provider (never a Claude
+ * ID when the default provider is Codex or another catalog).
  */
 export function getDefaultModelId(): string {
   const { settings } = useSettingsStore.getState();
-  const id = settings.model.defaults.id;
-  if (!id?.trim()) return "claude-sonnet-4-6";
-  if (findModelById(id)) return id;
   const providerId = settings.model.defaults.provider ?? "claude";
   const catalog = MODEL_PROVIDERS.find((p) => p.id === providerId);
-  if (catalog?.supportsModelListing) return id;
-  return "claude-sonnet-4-6";
+  const providerStaticFallback =
+    providerId === "claude"
+      ? "claude-sonnet-4-6"
+      : (catalog?.models[0]?.id ?? "claude-sonnet-4-6");
+
+  const rawId = settings.model.defaults.id;
+  if (!rawId?.trim()) {
+    return providerId === "claude" ? "claude-sonnet-4-6" : providerStaticFallback;
+  }
+
+  const id = rawId.trim();
+
+  if (catalog?.models.some((m) => m.id === id)) {
+    return id;
+  }
+
+  const def = findModelById(id);
+  if (def?.providerId === providerId) {
+    return id;
+  }
+
+  if (catalog?.supportsModelListing) {
+    return id;
+  }
+
+  return providerStaticFallback;
 }
 
 /**

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -28,6 +28,7 @@ const _legacyEncoder = new TextEncoder();
  * - `thread.status` -- thread status changes reflected in threadStore
  * - `thread.prLinked` -- PR detected for a thread, updates pr_number/pr_status
  * - `thread.checksUpdated` -- CI check status polled for a thread's PR, updates checksById
+ * - `thread.modelUpdated` -- thread model and provider synced after a message send (multi-client)
  * - `files.changed` -- invalidates the file autocomplete cache
  * - `skills.changed` -- invalidates the skill cache; popup re-fetches on next open
  * - `turn.persisted` -- tool call persistence confirmation forwarded to threadStore
@@ -160,6 +161,23 @@ export function startPushListeners(): void {
       };
       useWorkspaceStore.setState((ws) => ({
         checksById: { ...ws.checksById, [threadId]: checks },
+      }));
+    }),
+  );
+
+  // thread.modelUpdated: thread row model/provider persisted for this send (multi-tab / client)
+  unsubs.push(
+    pushEmitter.on("thread.modelUpdated", (data) => {
+      const { threadId, model, provider } = data as {
+        threadId: string;
+        model: string;
+        provider: string;
+      };
+      if (!threadId || !model) return;
+      useWorkspaceStore.setState((ws) => ({
+        threads: ws.threads.map((t) =>
+          t.id === threadId ? { ...t, model, provider } : t,
+        ),
       }));
     }),
   );

--- a/packages/contracts/src/ws/__tests__/thread-model-updated-channel.test.ts
+++ b/packages/contracts/src/ws/__tests__/thread-model-updated-channel.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { WS_CHANNELS } from "../channels.js";
+
+/**
+ * Contract test for the `thread.modelUpdated` push channel. The web client
+ * and the server both depend on this exact payload shape.
+ */
+describe("WS_CHANNELS['thread.modelUpdated']", () => {
+  it("accepts the canonical payload", () => {
+    const result = WS_CHANNELS["thread.modelUpdated"].safeParse({
+      threadId: "thread-1",
+      model: "gpt-5.4",
+      provider: "codex",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts cursor as provider id", () => {
+    const result = WS_CHANNELS["thread.modelUpdated"].safeParse({
+      threadId: "thread-1",
+      model: "any-model",
+      provider: "cursor",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects payloads missing model", () => {
+    const result = WS_CHANNELS["thread.modelUpdated"].safeParse({
+      threadId: "thread-1",
+      provider: "claude",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -40,6 +40,12 @@ export const WS_CHANNELS = {
     threadId: z.string(),
     checks: ChecksStatusSchema(),
   }),
+  /** Emitted after the thread row's model (and active provider) are persisted for a send. */
+  "thread.modelUpdated": z.object({
+    threadId: z.string(),
+    model: z.string(),
+    provider: z.string(),
+  }),
   "files.changed": z.object({
     workspaceId: z.string(),
     threadId: z.string().optional(),


### PR DESCRIPTION
## What
Fixes model selection resetting to a static default (for example Opus on Cursor) when the chosen model ID is not in the web app static catalog, and keeps multi-client thread model state in sync after sends.

## Why
Dynamic provider models (Cursor, Copilot, future Claude SKUs) were dropped by \indModelById\ guards in \getDefaultModelId\, \esolveThreadModelId\, and Composer settings sync. Thread rows updated in SQLite on send did not notify other tabs, so stale \ctiveThread.model\ could overwrite the picker.

## Key Changes
- Pass through unknown locked model IDs in \esolveThreadModelId\; trust settings defaults when \supportsModelListing\ in \getDefaultModelId\.
- Composer: apply settings defaults via \getDefaultModelId\; avoid overwriting local model or provider when they differ from the thread row (until running or a matching push).
- Add \	hread.modelUpdated\ WebSocket push and server broadcast after persisting model or provider on send; client updates \workspaceStore.threads\.
- Contract test for the new channel; extend model-registry tests.
- test(server): mock \process-kill\ in cleanup integration tests to avoid Windows WMIC or taskkill timeouts flaking CI.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time push event for thread model/provider updates with client handling to sync threads.

* **Bug Fixes**
  * Preserve custom or unknown locked model IDs instead of forcing provider fallbacks.
  * Improve default model selection to respect provider-scoped settings and dynamic provider cases.
  * Composer now derives defaults from central model registry and avoids unnecessary overrides.

* **Tests**
  * Added schema and runtime tests for the new push event and strengthened test isolation (mocked external process calls).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->