### PR TITLE
feat(sidebar): persist project sort order and drag reorder

### DIFF
--- a/apps/server/src/__tests__/workspace-repo-pinning.test.ts
+++ b/apps/server/src/__tests__/workspace-repo-pinning.test.ts
@@ -44,29 +44,25 @@ describe("WorkspaceRepo pinning + recency", () => {
     expect(after.pinned).toBe(false);
   });
 
-  it("listAll orders pinned first, then last_opened_at DESC, excludes workspaces never opened", () => {
+  it("listAll includes never-opened workspaces and follows sort_order only", () => {
     const a = repo.create("a", "/a", true);
     const b = repo.create("b", "/b", true);
     const c = repo.create("c", "/c", true);
     const d = repo.create("d", "/d", true); // never opened
 
-    // Stub Date.now so each touchLastOpened gets a strictly-increasing timestamp.
-    // Without this, three rapid Date.now() calls inside the same ms tick can
-    // produce equal values and the "DESC by last_opened_at" ordering becomes
-    // ambiguous, making this test flaky on fast hardware.
     let tick = 1_700_000_000_000;
     const spy = vi.spyOn(Date, "now").mockImplementation(() => ++tick);
 
     try {
-      // Open in order: b, then c, then a (so a is most recent)
       repo.touchLastOpened(b.id);
       repo.touchLastOpened(c.id);
       repo.touchLastOpened(a.id);
-      repo.setPinned(b.id, true); // b is pinned
+      repo.setPinned(b.id, true);
 
       const list = repo.listAll();
-      expect(list.map((w) => w.name)).toEqual(["b", "a", "c"]);
-      expect(list.find((w) => w.id === d.id)).toBeUndefined();
+      // Created newest-first sort_order (d,c,b,a) by create(); pin/recency does not reorder the sidebar.
+      expect(list.map((w) => w.name)).toEqual(["d", "c", "b", "a"]);
+      expect(list.find((w) => w.id === d.id)).toBeDefined();
     } finally {
       spy.mockRestore();
     }

--- a/apps/server/src/__tests__/workspace-repo-sort-order.test.ts
+++ b/apps/server/src/__tests__/workspace-repo-sort-order.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for workspaces.sort_order: listing, creation prepend, and reorder transactions.
+ */
+
+import "reflect-metadata";
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../store/database.js";
+import { WorkspaceRepo } from "../repositories/workspace-repo.js";
+
+describe("WorkspaceRepo sort_order", () => {
+  let db: Database.Database;
+  let repo: WorkspaceRepo;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    repo = new WorkspaceRepo(db);
+  });
+
+  it("listAll returns every workspace ordered by sort_order ascending", () => {
+    const a = repo.create("a", "/a", true);
+    const b = repo.create("b", "/b", true);
+    repo.touchLastOpened(a.id);
+    // never opened b still appears
+    const list = repo.listAll();
+    expect(list).toHaveLength(2);
+    expect(list[0]!.sort_order).toBe(0);
+    expect(list[1]!.sort_order).toBe(1);
+    expect(list.map((w) => w.name)).toEqual(["b", "a"]);
+  });
+
+  it("create shifts existing rows down and places the new workspace at sort_order 0", () => {
+    repo.create("first", "/1", true);
+    repo.create("second", "/2", true);
+    const list = repo.listAll();
+    expect(list.map((w) => w.name)).toEqual(["second", "first"]);
+    expect(list.map((w) => w.sort_order)).toEqual([0, 1]);
+  });
+
+  it("reorderToIndex moves an item up with a range increment", () => {
+    const a = repo.create("a", "/a", true);
+    const b = repo.create("b", "/b", true);
+    const c = repo.create("c", "/c", true);
+    expect(repo.listAll().map((w) => w.name)).toEqual(["c", "b", "a"]);
+    repo.reorderToIndex(a.id, 0);
+    expect(repo.listAll().map((w) => w.name)).toEqual(["a", "c", "b"]);
+  });
+
+  it("reorderToIndex moves an item down with a range decrement", () => {
+    const a = repo.create("a", "/a", true);
+    const b = repo.create("b", "/b", true);
+    const c = repo.create("c", "/c", true);
+    repo.reorderToIndex(c.id, 2);
+    expect(repo.listAll().map((w) => w.name)).toEqual(["b", "a", "c"]);
+  });
+
+  it("prependToSortOrder moves a workspace to the top without duplicates", () => {
+    const a = repo.create("a", "/a", true);
+    const b = repo.create("b", "/b", true);
+    repo.prependToSortOrder(a.id);
+    const list = repo.listAll();
+    expect(list.map((w) => w.name)).toEqual(["a", "b"]);
+    const orders = list.map((w) => w.sort_order);
+    expect(new Set(orders).size).toBe(orders.length);
+  });
+});

--- a/apps/server/src/__tests__/workspace-repo-sort-order.test.ts
+++ b/apps/server/src/__tests__/workspace-repo-sort-order.test.ts
@@ -63,4 +63,22 @@ describe("WorkspaceRepo sort_order", () => {
     const orders = list.map((w) => w.sort_order);
     expect(new Set(orders).size).toBe(orders.length);
   });
+
+  it("prependToSortOrder is a no-op when the workspace is already first", () => {
+    const a = repo.create("a", "/a", true);
+    const b = repo.create("b", "/b", true);
+    repo.prependToSortOrder(b.id);
+    const before = repo.listAll().map((w) => ({ id: w.id, sort_order: w.sort_order }));
+    repo.prependToSortOrder(b.id);
+    const after = repo.listAll().map((w) => ({ id: w.id, sort_order: w.sort_order }));
+    expect(after).toEqual(before);
+  });
+
+  it("prependToSortOrder ignores unknown ids without shifting other rows", () => {
+    repo.create("a", "/a", true);
+    const before = repo.listAll().map((w) => w.sort_order);
+    repo.prependToSortOrder("nonexistent-id");
+    const after = repo.listAll().map((w) => w.sort_order);
+    expect(after).toEqual(before);
+  });
 });

--- a/apps/server/src/__tests__/workspace-repo.test.ts
+++ b/apps/server/src/__tests__/workspace-repo.test.ts
@@ -88,11 +88,13 @@ describe("WorkspaceService", () => {
 
   it("create() returns existing workspace when path already exists", () => {
     const ws1 = service.create("project-a", "/tmp/existing");
+    service.create("other", "/tmp/other");
 
     const ws2 = service.create("project-a-renamed", "/tmp/existing");
 
     expect(ws2.id).toBe(ws1.id);
     expect(ws2.name).toBe("project-a");
+    expect(repo.listAll()[0]!.id).toBe(ws1.id);
   });
 
   it("create() creates a new workspace when path does not exist", () => {

--- a/apps/server/src/__tests__/workspace-sort-order-migration.test.ts
+++ b/apps/server/src/__tests__/workspace-sort-order-migration.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression: legacy sibling DBs may already have workspaces.sort_order while
+ * this timestamp migration is still pending. up() must not ALTER ADD the column twice.
+ */
+
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { up } from "../store/migrations/20260501120000_workspace_sort_order.js";
+
+describe("migration 20260501120000: workspace_sort_order", () => {
+  it("up() does not fail when sort_order already exists", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE workspaces (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        path TEXT NOT NULL UNIQUE,
+        provider_config TEXT NOT NULL DEFAULT '{}',
+        is_git_repo INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        last_opened_at INTEGER,
+        sort_order INTEGER NOT NULL DEFAULT 0
+      );
+      INSERT INTO workspaces (id, name, path, created_at, updated_at, pinned, last_opened_at, sort_order)
+      VALUES
+        ('id-a', 'a', '/a', '2020-01-01', '2020-01-01', 0, NULL, 0),
+        ('id-b', 'b', '/b', '2020-01-01', '2020-01-01', 0, 1000, 0);
+    `);
+
+    expect(() => up(db)).not.toThrow();
+
+    const orders = db
+      .prepare("SELECT sort_order FROM workspaces ORDER BY id")
+      .all() as Array<{ sort_order: number }>;
+    expect(orders).toHaveLength(2);
+    expect(new Set(orders.map((r) => r.sort_order)).size).toBe(2);
+  });
+});

--- a/apps/server/src/__tests__/workspace-sort-order-migration.test.ts
+++ b/apps/server/src/__tests__/workspace-sort-order-migration.test.ts
@@ -37,4 +37,36 @@ describe("migration 20260501120000: workspace_sort_order", () => {
     expect(orders).toHaveLength(2);
     expect(new Set(orders.map((r) => r.sort_order)).size).toBe(2);
   });
+
+  it("up() does not overwrite existing distinct sort_order values", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE workspaces (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        path TEXT NOT NULL UNIQUE,
+        provider_config TEXT NOT NULL DEFAULT '{}',
+        is_git_repo INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        last_opened_at INTEGER,
+        sort_order INTEGER NOT NULL DEFAULT 0
+      );
+      INSERT INTO workspaces (id, name, path, created_at, updated_at, pinned, last_opened_at, sort_order)
+      VALUES
+        ('id-a', 'a', '/a', '2020-01-01', '2020-01-01', 0, NULL, 3),
+        ('id-b', 'b', '/b', '2020-01-01', '2020-01-01', 0, 1000, 7);
+    `);
+
+    expect(() => up(db)).not.toThrow();
+
+    const orders = db
+      .prepare("SELECT id, sort_order FROM workspaces ORDER BY id")
+      .all() as Array<{ id: string; sort_order: number }>;
+    expect(orders).toEqual([
+      { id: "id-a", sort_order: 3 },
+      { id: "id-b", sort_order: 7 },
+    ]);
+  });
 });

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -18,6 +18,7 @@ interface WorkspaceRow {
   updated_at: string;
   pinned: number;
   last_opened_at: number | null;
+  sort_order: number;
 }
 
 function rowToWorkspace(row: WorkspaceRow): Workspace {
@@ -34,6 +35,7 @@ function rowToWorkspace(row: WorkspaceRow): Workspace {
     updated_at: row.updated_at,
     pinned: row.pinned === 1,
     last_opened_at: row.last_opened_at ?? null,
+    sort_order: row.sort_order,
   };
 }
 
@@ -47,11 +49,17 @@ export class WorkspaceRepo {
     const id = randomUUID();
     const now = new Date().toISOString();
 
-    this.db
-      .prepare(
-        "INSERT INTO workspaces (id, name, path, is_git_repo, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-      )
-      .run(id, name, path, isGitRepo ? 1 : 0, now, now);
+    const trx = this.db.transaction(() => {
+      this.db
+        .prepare("UPDATE workspaces SET sort_order = sort_order + 1")
+        .run();
+      this.db
+        .prepare(
+          "INSERT INTO workspaces (id, name, path, is_git_repo, created_at, updated_at, sort_order) VALUES (?, ?, ?, ?, ?, ?, 0)",
+        )
+        .run(id, name, path, isGitRepo ? 1 : 0, now, now);
+    });
+    trx();
 
     return {
       id,
@@ -63,14 +71,69 @@ export class WorkspaceRepo {
       updated_at: now,
       pinned: false,
       last_opened_at: null,
+      sort_order: 0,
     };
+  }
+
+  /** Move an existing workspace to the top of the sidebar (sort_order 0). */
+  prependToSortOrder(id: string): void {
+    const trx = this.db.transaction(() => {
+      this.db
+        .prepare("UPDATE workspaces SET sort_order = sort_order + 1 WHERE id != ?")
+        .run(id);
+      this.db.prepare("UPDATE workspaces SET sort_order = 0 WHERE id = ?").run(id);
+    });
+    trx();
+  }
+
+  /**
+   * Reorder a workspace to a zero-based index in the current sort_order ordering.
+   * Uses a two-statement range shift inside a transaction.
+   */
+  reorderToIndex(id: string, newIndex: number): void {
+    const rows = this.db
+      .prepare(
+        "SELECT id, sort_order FROM workspaces ORDER BY sort_order ASC, id ASC",
+      )
+      .all() as Array<{ id: string; sort_order: number }>;
+
+    const oldIdx = rows.findIndex((r) => r.id === id);
+    if (oldIdx < 0) return;
+
+    const n = rows.length;
+    const idx = Math.max(0, Math.min(newIndex, n - 1));
+    if (oldIdx === idx) return;
+
+    const orders = rows.map((r) => r.sort_order);
+    const fromPos = orders[oldIdx]!;
+    const toPos = orders[idx]!;
+
+    const trx = this.db.transaction(() => {
+      if (idx < oldIdx) {
+        this.db
+          .prepare(
+            "UPDATE workspaces SET sort_order = sort_order + 1 WHERE sort_order >= ? AND sort_order < ?",
+          )
+          .run(toPos, fromPos);
+      } else {
+        this.db
+          .prepare(
+            "UPDATE workspaces SET sort_order = sort_order - 1 WHERE sort_order > ? AND sort_order <= ?",
+          )
+          .run(fromPos, toPos);
+      }
+      this.db
+        .prepare("UPDATE workspaces SET sort_order = ? WHERE id = ?")
+        .run(toPos, id);
+    });
+    trx();
   }
 
   /** Find a workspace by its primary key. Returns null if not found. */
   findById(id: string): Workspace | null {
     const row = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at FROM workspaces WHERE id = ?",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order FROM workspaces WHERE id = ?",
       )
       .get(id) as WorkspaceRow | undefined;
 
@@ -81,21 +144,18 @@ export class WorkspaceRepo {
   findByPath(path: string): Workspace | null {
     const row = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at FROM workspaces WHERE path = ?",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order FROM workspaces WHERE path = ?",
       )
       .get(path) as WorkspaceRow | undefined;
 
     return row ? rowToWorkspace(row) : null;
   }
 
-  /**
-   * List workspaces that have been opened or pinned, ordered by pinned first then
-   * most recently opened. Workspaces that were never opened and are not pinned are excluded.
-   */
+  /** List all workspaces ordered by ascending sidebar sort_order. */
   listAll(): Workspace[] {
     const rows = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at FROM workspaces WHERE last_opened_at IS NOT NULL OR pinned = 1 ORDER BY pinned DESC, last_opened_at DESC",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order FROM workspaces ORDER BY sort_order ASC, id ASC",
       )
       .all() as WorkspaceRow[];
 

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -77,10 +77,17 @@ export class WorkspaceRepo {
 
   /** Move an existing workspace to the top of the sidebar (sort_order 0). */
   prependToSortOrder(id: string): void {
+    const row = this.db
+      .prepare("SELECT sort_order FROM workspaces WHERE id = ?")
+      .get(id) as { sort_order: number } | undefined;
+    if (!row || row.sort_order === 0) return;
+
     const trx = this.db.transaction(() => {
       this.db
-        .prepare("UPDATE workspaces SET sort_order = sort_order + 1 WHERE id != ?")
-        .run(id);
+        .prepare(
+          "UPDATE workspaces SET sort_order = sort_order + 1 WHERE sort_order < ?",
+        )
+        .run(row.sort_order);
       this.db.prepare("UPDATE workspaces SET sort_order = 0 WHERE id = ?").run(id);
     });
     trx();

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -28,13 +28,22 @@ export class WorkspaceService {
     const existing = this.workspaceRepo.findByPath(path);
     if (existing) {
       this.workspaceRepo.touch(existing.id);
-      return existing;
+      this.workspaceRepo.prependToSortOrder(existing.id);
+      return this.workspaceRepo.findById(existing.id)!;
     }
     const isGitRepo = this.detectGitRepo(path);
     return this.workspaceRepo.create(name, path, isGitRepo);
   }
 
-  /** List all workspaces ordered by most recently updated. */
+  /**
+   * Persist a new sidebar index for a workspace (zero-based). Other connected
+   * clients receive `workspace.orderChanged` and should refresh the list.
+   */
+  reorder(id: string, newIndex: number): void {
+    this.workspaceRepo.reorderToIndex(id, newIndex);
+  }
+
+  /** List all workspaces ordered by ascending sidebar `sort_order`. */
   list(): Workspace[] {
     return this.workspaceRepo.listAll();
   }

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -32,6 +32,7 @@ import * as m020 from "./migrations/00000000000020_thread_has_file_changes.js";
 import * as mPinned from "./migrations/20260429000000_workspace_pinned_and_last_opened.js";
 import * as mModelCache from "./migrations/20260429100000_provider_model_cache.js";
 import * as mPlanQuestionAnswers from "./migrations/20260430142010_plan_question_answers.js";
+import * as mWorkspaceSortOrder from "./migrations/20260501120000_workspace_sort_order.js";
 
 /**
  * Resolve the correct native binding for better-sqlite3 based on runtime.
@@ -102,6 +103,7 @@ export function loadMigrations(): Map<string, MigrationModule> {
   migrations.set("20260429000000", mPinned);
   migrations.set("20260429100000", mModelCache);
   migrations.set("20260430142010", mPlanQuestionAnswers);
+  migrations.set("20260501120000", mWorkspaceSortOrder);
   return migrations;
 }
 

--- a/apps/server/src/store/migrations/20260501120000_workspace_sort_order.ts
+++ b/apps/server/src/store/migrations/20260501120000_workspace_sort_order.ts
@@ -1,17 +1,30 @@
 /**
  * Add sort_order for persistent sidebar project ordering.
  * Backfills from legacy pinned + last_opened_at visual order (with id tiebreaker).
+ *
+ * Idempotent: some databases already have `workspaces.sort_order` from a sibling
+ * legacy migration (`00000000000019`) while `_migrations` has no row for this
+ * timestamp. Re-adding the column would raise SQLITE_ERROR duplicate column.
  */
 
 import type Database from "better-sqlite3";
 
 export const description = "Add workspaces.sort_order and backfill from legacy order";
 
-/** Apply migration: add sort_order, rank rows, index for list queries. */
-export function up(db: Database.Database): void {
-  db.exec(`
-    ALTER TABLE workspaces ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+function workspacesHasSortOrder(db: Database.Database): boolean {
+  const cols = db.pragma("table_info(workspaces)") as Array<{ name: string }>;
+  return cols.some((c) => c.name === "sort_order");
+}
 
+/** Apply migration: add sort_order if missing, rank rows, index for list queries. */
+export function up(db: Database.Database): void {
+  if (!workspacesHasSortOrder(db)) {
+    db.exec(
+      "ALTER TABLE workspaces ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;",
+    );
+  }
+
+  db.exec(`
     UPDATE workspaces SET sort_order = (
       SELECT COUNT(*) FROM workspaces w2
       WHERE (w2.pinned > workspaces.pinned)
@@ -33,8 +46,9 @@ export function up(db: Database.Database): void {
 
 /** Revert migration: drop sort_order. Requires SQLite 3.35+. */
 export function down(db: Database.Database): void {
-  db.exec(`
-    DROP INDEX IF EXISTS idx_workspaces_sort_order;
-    ALTER TABLE workspaces DROP COLUMN sort_order;
-  `);
+  db.exec("DROP INDEX IF EXISTS idx_workspaces_sort_order;");
+  if (!workspacesHasSortOrder(db)) {
+    return;
+  }
+  db.exec("ALTER TABLE workspaces DROP COLUMN sort_order;");
 }

--- a/apps/server/src/store/migrations/20260501120000_workspace_sort_order.ts
+++ b/apps/server/src/store/migrations/20260501120000_workspace_sort_order.ts
@@ -5,6 +5,8 @@
  * Idempotent: some databases already have `workspaces.sort_order` from a sibling
  * legacy migration (`00000000000019`) while `_migrations` has no row for this
  * timestamp. Re-adding the column would raise SQLITE_ERROR duplicate column.
+ * When the column already exists with non-default ranks, the UPDATE backfill is
+ * skipped so a persisted order is not reset.
  */
 
 import type Database from "better-sqlite3";
@@ -16,32 +18,52 @@ function workspacesHasSortOrder(db: Database.Database): boolean {
   return cols.some((c) => c.name === "sort_order");
 }
 
+/**
+ * True when every row still has the default rank (0). Used so a re-run of this
+ * migration does not overwrite a persisted custom order after the column already
+ * existed (for example only `_migrations` was missing).
+ */
+function sortOrdersLookUninitialized(db: Database.Database): boolean {
+  const row = db
+    .prepare(
+      "SELECT COUNT(*) AS n, MIN(sort_order) AS lo, MAX(sort_order) AS hi FROM workspaces",
+    )
+    .get() as { n: number; lo: number | null; hi: number | null };
+  if (row.n === 0) return false;
+  return row.lo === 0 && row.hi === 0;
+}
+
 /** Apply migration: add sort_order if missing, rank rows, index for list queries. */
 export function up(db: Database.Database): void {
-  if (!workspacesHasSortOrder(db)) {
+  const hadSortOrder = workspacesHasSortOrder(db);
+  if (!hadSortOrder) {
     db.exec(
       "ALTER TABLE workspaces ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;",
     );
   }
 
-  db.exec(`
-    UPDATE workspaces SET sort_order = (
-      SELECT COUNT(*) FROM workspaces w2
-      WHERE (w2.pinned > workspaces.pinned)
-         OR (w2.pinned = workspaces.pinned AND w2.last_opened_at IS NOT NULL
-             AND workspaces.last_opened_at IS NOT NULL
-             AND w2.last_opened_at > workspaces.last_opened_at)
-         OR (w2.pinned = workspaces.pinned AND w2.last_opened_at IS NOT NULL
-             AND workspaces.last_opened_at IS NULL)
-         OR (w2.pinned = workspaces.pinned
-             AND ((w2.last_opened_at IS NULL AND workspaces.last_opened_at IS NULL)
-                  OR (w2.last_opened_at IS NOT NULL AND workspaces.last_opened_at IS NOT NULL
-                      AND w2.last_opened_at = workspaces.last_opened_at))
-             AND w2.id < workspaces.id)
-    );
+  if (!hadSortOrder || sortOrdersLookUninitialized(db)) {
+    db.exec(`
+      UPDATE workspaces SET sort_order = (
+        SELECT COUNT(*) FROM workspaces w2
+        WHERE (w2.pinned > workspaces.pinned)
+           OR (w2.pinned = workspaces.pinned AND w2.last_opened_at IS NOT NULL
+               AND workspaces.last_opened_at IS NOT NULL
+               AND w2.last_opened_at > workspaces.last_opened_at)
+           OR (w2.pinned = workspaces.pinned AND w2.last_opened_at IS NOT NULL
+               AND workspaces.last_opened_at IS NULL)
+           OR (w2.pinned = workspaces.pinned
+               AND ((w2.last_opened_at IS NULL AND workspaces.last_opened_at IS NULL)
+                    OR (w2.last_opened_at IS NOT NULL AND workspaces.last_opened_at IS NOT NULL
+                        AND w2.last_opened_at = workspaces.last_opened_at))
+               AND w2.id < workspaces.id)
+      );
+    `);
+  }
 
-    CREATE INDEX IF NOT EXISTS idx_workspaces_sort_order ON workspaces (sort_order ASC);
-  `);
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_workspaces_sort_order ON workspaces (sort_order ASC);",
+  );
 }
 
 /** Revert migration: drop sort_order. Requires SQLite 3.35+. */

--- a/apps/server/src/store/migrations/20260501120000_workspace_sort_order.ts
+++ b/apps/server/src/store/migrations/20260501120000_workspace_sort_order.ts
@@ -1,0 +1,40 @@
+/**
+ * Add sort_order for persistent sidebar project ordering.
+ * Backfills from legacy pinned + last_opened_at visual order (with id tiebreaker).
+ */
+
+import type Database from "better-sqlite3";
+
+export const description = "Add workspaces.sort_order and backfill from legacy order";
+
+/** Apply migration: add sort_order, rank rows, index for list queries. */
+export function up(db: Database.Database): void {
+  db.exec(`
+    ALTER TABLE workspaces ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+
+    UPDATE workspaces SET sort_order = (
+      SELECT COUNT(*) FROM workspaces w2
+      WHERE (w2.pinned > workspaces.pinned)
+         OR (w2.pinned = workspaces.pinned AND w2.last_opened_at IS NOT NULL
+             AND workspaces.last_opened_at IS NOT NULL
+             AND w2.last_opened_at > workspaces.last_opened_at)
+         OR (w2.pinned = workspaces.pinned AND w2.last_opened_at IS NOT NULL
+             AND workspaces.last_opened_at IS NULL)
+         OR (w2.pinned = workspaces.pinned
+             AND ((w2.last_opened_at IS NULL AND workspaces.last_opened_at IS NULL)
+                  OR (w2.last_opened_at IS NOT NULL AND workspaces.last_opened_at IS NOT NULL
+                      AND w2.last_opened_at = workspaces.last_opened_at))
+             AND w2.id < workspaces.id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspaces_sort_order ON workspaces (sort_order ASC);
+  `);
+}
+
+/** Revert migration: drop sort_order. Requires SQLite 3.35+. */
+export function down(db: Database.Database): void {
+  db.exec(`
+    DROP INDEX IF EXISTS idx_workspaces_sort_order;
+    ALTER TABLE workspaces DROP COLUMN sort_order;
+  `);
+}

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -224,6 +224,11 @@ async function dispatch(
     case "workspace.touchLastOpened":
       deps.workspaceRepo.touchLastOpened(params.id);
       return { ok: true as const };
+    case "workspace.reorder": {
+      deps.workspaceService.reorder(params.id, params.newIndex);
+      broadcast("workspace.orderChanged", {});
+      return { ok: true as const };
+    }
     case "workspace.enrich": {
       const wsItems = (params.ids as string[])
         .map((id: string) => deps.workspaceRepo.findById(id))

--- a/apps/web/e2e/architecture.spec.ts
+++ b/apps/web/e2e/architecture.spec.ts
@@ -47,6 +47,10 @@ const WORKSPACE_A = {
   name: "Architecture Test",
   path: "/tmp/arch-test",
   provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
 };
@@ -56,6 +60,10 @@ const WORKSPACE_B = {
   name: "Second Project",
   path: "/tmp/second-project",
   provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 1,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
 };

--- a/apps/web/e2e/chat-header-rename.spec.ts
+++ b/apps/web/e2e/chat-header-rename.spec.ts
@@ -16,6 +16,7 @@ const workspace = {
   updated_at: now,
   pinned: false,
   last_opened_at: Date.now() - 3600_000,
+  sort_order: 0,
 };
 
 const thread1 = {

--- a/apps/web/e2e/ci-reconnect-no-fanout.spec.ts
+++ b/apps/web/e2e/ci-reconnect-no-fanout.spec.ts
@@ -17,6 +17,10 @@ async function mockCiServer(page: Page): Promise<CiMockController> {
     name: "Test Workspace",
     path: "/test/path",
     provider_config: {},
+    is_git_repo: true,
+    pinned: false,
+    last_opened_at: null,
+    sort_order: 0,
     created_at: now,
     updated_at: now,
   };

--- a/apps/web/e2e/command-palette.spec.ts
+++ b/apps/web/e2e/command-palette.spec.ts
@@ -13,6 +13,7 @@ const MOCK_WORKSPACES = [
     updated_at: new Date().toISOString(),
     pinned: true,
     last_opened_at: Date.now() - 3600_000,
+    sort_order: 0,
   },
   {
     id: "ws-2",
@@ -24,6 +25,7 @@ const MOCK_WORKSPACES = [
     updated_at: new Date().toISOString(),
     pinned: false,
     last_opened_at: Date.now() - 86400_000,
+    sort_order: 1,
   },
 ];
 
@@ -55,6 +57,7 @@ async function setupPage(page: import("@playwright/test").Page) {
       updated_at: new Date().toISOString(),
       pinned: false,
       last_opened_at: null,
+      sort_order: 0,
     },
     "settings.get": MOCK_SETTINGS,
   });

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -102,6 +102,7 @@ export async function mockWebSocketServer(
       // Return canonical settings defaults so App can bootstrap correctly.
       // Using getDefaultSettings() ensures this stays in sync with schema changes.
       else if (method === "settings.get") result = getDefaultSettings();
+      else if (method === "workspace.reorder") result = { ok: true };
       else {
         ws.send(
           JSON.stringify({

--- a/apps/web/e2e/project-selector.spec.ts
+++ b/apps/web/e2e/project-selector.spec.ts
@@ -15,6 +15,7 @@ const MOCK_WORKSPACES = [
     updated_at: new Date().toISOString(),
     pinned: true,
     last_opened_at: NOW - 3600_000,
+    sort_order: 0,
   },
   {
     id: "ws-recent",
@@ -26,6 +27,7 @@ const MOCK_WORKSPACES = [
     updated_at: new Date().toISOString(),
     pinned: false,
     last_opened_at: NOW - 7200_000,
+    sort_order: 1,
   },
   {
     id: "ws-older",
@@ -37,6 +39,7 @@ const MOCK_WORKSPACES = [
     updated_at: new Date().toISOString(),
     pinned: false,
     last_opened_at: NOW - 86400_000,
+    sort_order: 2,
   },
 ];
 

--- a/apps/web/e2e/sidebar-action-required.spec.ts
+++ b/apps/web/e2e/sidebar-action-required.spec.ts
@@ -22,6 +22,7 @@ async function mockWebSocketServer(
     is_git_repo: true,
     pinned: false,
     last_opened_at: Date.now() - 3600_000,
+    sort_order: 0,
     created_at: now,
     updated_at: now,
   };

--- a/apps/web/e2e/sidebar-interrupted-state.spec.ts
+++ b/apps/web/e2e/sidebar-interrupted-state.spec.ts
@@ -20,6 +20,9 @@ const WORKSPACE = {
   path: "/tmp/interrupted-test",
   provider_config: {},
   is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
 };

--- a/apps/web/e2e/sidebar-project-drag-scroll.spec.ts
+++ b/apps/web/e2e/sidebar-project-drag-scroll.spec.ts
@@ -60,7 +60,7 @@ test.describe("Sidebar project drag — scroll and layout", () => {
 
   test("dragging short project list does not grow sidebar-body scrollbox", async ({
     page,
-  }) => {
+  }, testInfo) => {
     await injectWorkspaceList(
       page,
       [
@@ -142,7 +142,7 @@ test.describe("Sidebar project drag — scroll and layout", () => {
     );
 
     await page.screenshot({
-      path: "e2e/screenshots/sidebar-project-drag-mid.png",
+      path: testInfo.outputPath("sidebar-project-drag-mid.png"),
     });
 
     await page.mouse.up();

--- a/apps/web/e2e/sidebar-project-drag-scroll.spec.ts
+++ b/apps/web/e2e/sidebar-project-drag-scroll.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+
+/** Injects workspace store state for sidebar project list tests. */
+async function injectWorkspaceList(
+  page: Page,
+  workspaces: Array<{
+    id: string;
+    name: string;
+    path: string;
+    is_git_repo: boolean;
+    sort_order: number;
+  }>,
+  activeWorkspaceId: string,
+): Promise<void> {
+  const iso = new Date().toISOString();
+  const full = workspaces.map((w) => ({
+    ...w,
+    provider_config: {},
+    pinned: false,
+    last_opened_at: null,
+    created_at: iso,
+    updated_at: iso,
+  }));
+  await page.evaluate(
+    ({ full: wsList, activeId }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({
+        workspaces: wsList,
+        activeWorkspaceId: activeId,
+        threads: [],
+        activeThreadId: null,
+        loading: false,
+        error: null,
+      });
+    },
+    { full, activeId: activeWorkspaceId },
+  );
+}
+
+test.describe("Sidebar project drag — scroll and layout", () => {
+  test.setTimeout(45000);
+
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page);
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("dragging short project list does not grow sidebar-body scrollbox", async ({
+    page,
+  }) => {
+    await injectWorkspaceList(
+      page,
+      [
+        {
+          id: "ws-drag-a",
+          name: "AlphaProject",
+          path: "/tmp/alpha",
+          is_git_repo: true,
+          sort_order: 0,
+        },
+        {
+          id: "ws-drag-b",
+          name: "BetaProject",
+          path: "/tmp/beta",
+          is_git_repo: true,
+          sort_order: 1,
+        },
+      ],
+      "ws-drag-a",
+    );
+
+    await expect(page.getByTestId("project-row-ws-drag-a")).toBeVisible();
+
+    const projectScrollViewport = page.locator(
+      '[data-slot="scroll-area-viewport"]',
+    );
+
+    const scrollMetricsBefore = await page.evaluate(() => {
+      const body = document.querySelector('[data-testid="sidebar-body"]');
+      const vp = document.querySelector('[data-slot="scroll-area-viewport"]');
+      return {
+        bodyOverflowY: body ? getComputedStyle(body).overflowY : "",
+        bodyScrollH: body?.scrollHeight ?? 0,
+        bodyClientH: body?.clientHeight ?? 0,
+        vpScrollH: vp?.scrollHeight ?? 0,
+        vpClientH: vp?.clientHeight ?? 0,
+      };
+    });
+
+    expect(scrollMetricsBefore.bodyOverflowY).toBe("hidden");
+    expect(scrollMetricsBefore.bodyScrollH).toBeLessThanOrEqual(
+      scrollMetricsBefore.bodyClientH + 2,
+    );
+    expect(scrollMetricsBefore.vpScrollH).toBeLessThanOrEqual(
+      scrollMetricsBefore.vpClientH + 2,
+    );
+
+    const row = page.getByTestId("project-row-ws-drag-a");
+    const box = await row.boundingBox();
+    expect(box, "project row box").not.toBeNull();
+
+    const sidebarBox = await page.getByTestId("sidebar-body").boundingBox();
+    expect(sidebarBox, "sidebar body box").not.toBeNull();
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(
+      sidebarBox!.x + sidebarBox!.width / 2,
+      sidebarBox!.y + sidebarBox!.height - 8,
+      { steps: 14 },
+    );
+
+    const scrollMetricsDuring = await page.evaluate(() => {
+      const body = document.querySelector('[data-testid="sidebar-body"]');
+      const vp = document.querySelector('[data-slot="scroll-area-viewport"]');
+      return {
+        bodyScrollH: body?.scrollHeight ?? 0,
+        bodyClientH: body?.clientHeight ?? 0,
+        vpScrollH: vp?.scrollHeight ?? 0,
+        vpClientH: vp?.clientHeight ?? 0,
+      };
+    });
+
+    expect(scrollMetricsDuring.bodyScrollH).toBeLessThanOrEqual(
+      scrollMetricsDuring.bodyClientH + 2,
+    );
+    expect(scrollMetricsDuring.vpScrollH).toBeLessThanOrEqual(
+      scrollMetricsDuring.vpClientH + 2,
+    );
+
+    await page.screenshot({
+      path: "e2e/screenshots/sidebar-project-drag-mid.png",
+    });
+
+    await page.mouse.up();
+
+    await expect(projectScrollViewport).toBeVisible();
+  });
+});

--- a/apps/web/e2e/sidebar-rename.spec.ts
+++ b/apps/web/e2e/sidebar-rename.spec.ts
@@ -16,6 +16,7 @@ const workspace = {
   updated_at: now,
   pinned: false,
   last_opened_at: Date.now() - 3600_000,
+  sort_order: 0,
 };
 
 const thread = {

--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -21,6 +21,10 @@ const WORKSPACE = {
   name: "Test Workspace",
   path: "/test/path",
   provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
   created_at: NOW,
   updated_at: NOW,
 };

--- a/apps/web/e2e/spellcheck-context-menu.spec.ts
+++ b/apps/web/e2e/spellcheck-context-menu.spec.ts
@@ -12,6 +12,10 @@ const WORKSPACE = {
   name: "Test Workspace",
   path: "/test/path",
   provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
   created_at: now,
   updated_at: now,
 };

--- a/apps/web/e2e/thread-switch-no-remount.spec.ts
+++ b/apps/web/e2e/thread-switch-no-remount.spec.ts
@@ -20,8 +20,12 @@ async function mockWebSocketServer(page: Page): Promise<void> {
     name: "Test Workspace",
     path: "/test/path",
     provider_config: {},
+    is_git_repo: true,
     created_at: now,
     updated_at: now,
+    pinned: false,
+    last_opened_at: Date.now(),
+    sort_order: 0,
   };
   const threadA = {
     id: "thread-a",

--- a/apps/web/e2e/ui-improvements-floating.spec.ts
+++ b/apps/web/e2e/ui-improvements-floating.spec.ts
@@ -19,6 +19,7 @@ const WORKSPACE_FIXTURE = {
   is_git_repo: true,
   pinned: false,
   last_opened_at: null,
+  sort_order: 0,
   created_at: now,
   updated_at: now,
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,10 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@lexical/react": "^0.42.0",
     "@mcode/contracts": "workspace:*",

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -26,6 +26,7 @@ export function createMockWorkspace(
     updated_at: new Date().toISOString(),
     pinned: false,
     last_opened_at: null,
+    sort_order: 0,
     ...overrides,
   };
 }
@@ -89,6 +90,7 @@ export const mockTransport: McodeTransport = {
   listWorkspaces: vi.fn().mockResolvedValue([]),
   deleteWorkspace: vi.fn().mockResolvedValue(true),
   touchLastOpened: vi.fn().mockResolvedValue(undefined),
+  reorderWorkspace: vi.fn().mockResolvedValue(undefined),
   pinWorkspace: vi.fn().mockResolvedValue(undefined),
   removeRecent: vi.fn().mockResolvedValue(undefined),
   enrichWorkspaces: vi.fn().mockResolvedValue({ items: [] }),

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/stores/workspaceStore", () => ({
       worktreesLoadedForWorkspace: null,
       checksById: {},
       error: null,
+      reorderWorkspace: vi.fn(),
     })
   ),
 }));

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1138,8 +1138,7 @@ function ProjectNode({
         aria-expanded={isExpanded}
         data-testid={`project-row-${workspace.id}`}
         className={cn(
-          "group/ws relative flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12.5px] transition-colors touch-none",
-          sortableListeners ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
+          "group/ws relative flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12.5px] cursor-pointer transition-colors touch-none",
           isProjectDragging && "cursor-grabbing",
           isActive
             ? "text-foreground"

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1327,7 +1327,10 @@ function SortableProjectShell(
       ? { opacity: 0.92, zIndex: 2, boxShadow: "0 2px 10px rgba(0,0,0,0.08)" }
       : {}),
   };
-  const { role: _sortableOuterRole, tabIndex: _outerTab, ...sortableA11y } = attributes;
+  // useSortable sets role/tabIndex on the activator; this outer div uses explicit group semantics.
+  const { role, tabIndex, ...sortableA11y } = attributes;
+  void role;
+  void tabIndex;
   return (
     <div
       ref={setNodeRef}

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useCallback, useState, useRef, useMemo } from "react";
+import { useEffect, useLayoutEffect, useCallback, useState, useRef, useMemo, type CSSProperties } from "react";
 import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useShallow } from "zustand/shallow";
@@ -25,6 +25,25 @@ import { getStatusDisplay, getNotificationDot } from "@/lib/thread-status";
 import { getBreakdown, getCiVisual, CI_ICON_STROKE } from "@/lib/ci-status";
 import type { ChecksStatus } from "@mcode/contracts";
 import type { Workspace, Thread } from "@/transport/types";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+  type DraggableSyntheticListeners,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 
 // Persist expand/collapse in localStorage
 function getExpandedState(): Record<string, boolean> {
@@ -154,6 +173,7 @@ export function ProjectTree() {
   const deleteThread = useWorkspaceStore((s) => s.deleteThread);
   const setPendingNewThread = useWorkspaceStore((s) => s.setPendingNewThread);
   const updateThreadTitle = useWorkspaceStore((s) => s.updateThreadTitle);
+  const reorderWorkspace = useWorkspaceStore((s) => s.reorderWorkspace);
   const error = useWorkspaceStore((s) => s.error);
   const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
   const permissionsByThread = useThreadStore((s) => s.permissionsByThread);
@@ -177,6 +197,13 @@ export function ProjectTree() {
   const [deleteWorktree, setDeleteWorktree] = useState(false);
   const [wsDeleteDialog, setWsDeleteDialog] = useState<WorkspaceDeleteDialogState | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+
+  const workspaceIds = useMemo(() => workspaces.map((w) => w.id), [workspaces]);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   useEffect(() => {
     loadWorkspaces();
@@ -330,6 +357,27 @@ export function ProjectTree() {
     setInlineEdit({ threadId, title, originalTitle: title });
   }, []);
 
+  const handleProjectDragStart = useCallback((event: DragStartEvent) => {
+    setActiveDragId(String(event.active.id));
+  }, []);
+
+  const handleProjectDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveDragId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldIndex = workspaceIds.indexOf(active.id as string);
+      const newIndex = workspaceIds.indexOf(over.id as string);
+      if (oldIndex < 0 || newIndex < 0) return;
+      void reorderWorkspace(active.id as string, newIndex);
+    },
+    [workspaceIds, reorderWorkspace],
+  );
+
+  const handleProjectDragCancel = useCallback(() => {
+    setActiveDragId(null);
+  }, []);
+
   const scrollViewportRef = useRef<HTMLDivElement>(null);
 
   return (
@@ -354,47 +402,60 @@ export function ProjectTree() {
 
       <ScrollArea className="flex-1" viewportRef={scrollViewportRef}>
         <div className="px-1" data-testid="thread-list">
-          {workspaces.map((ws) => (
-            <ProjectNode
-              key={ws.id}
-              workspace={ws}
-              isExpanded={expanded[ws.id] ?? false}
-              isActive={activeWorkspaceId === ws.id}
-              activeThreadId={activeThreadId}
-              threads={threads.filter((t) => t.workspace_id === ws.id)}
-              runningThreadIds={runningThreadIds}
-              pendingPermissionThreadIds={pendingPermissionThreadIds}
-              isThreadListExpanded={threadListExpanded[ws.id] ?? false}
-              onToggleThreadList={() => toggleThreadList(ws.id)}
-              scrollElementRef={scrollViewportRef}
-              inlineEdit={inlineEdit}
-              onInlineEditChange={(title) =>
-                setInlineEdit((prev) => prev ? { ...prev, title } : null)
-              }
-              onInlineEditCommit={handleInlineEditCommit}
-              onInlineEditCancel={() => setInlineEdit(null)}
-              onStartInlineEdit={handleStartInlineEdit}
-              onToggle={() => toggleExpand(ws.id)}
-              onSelectThread={(id) => {
-                setActiveWorkspace(ws.id);
-                setActiveThread(id);
-              }}
-              onCreateThread={() => {
-                setActiveWorkspace(ws.id);
-                setPendingNewThread(true);
-                setActiveThread(null);
-              }}
-              onDelete={() => {
-                setWsDeleteDialog({
-                  workspaceId: ws.id,
-                  workspaceName: ws.name,
-                });
-              }}
-              onThreadContextMenu={(e, thread) =>
-                handleThreadContextMenu(e, thread, ws.path)
-              }
-            />
-          ))}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            modifiers={[restrictToVerticalAxis]}
+            onDragStart={handleProjectDragStart}
+            onDragEnd={handleProjectDragEnd}
+            onDragCancel={handleProjectDragCancel}
+          >
+            <SortableContext items={workspaceIds} strategy={verticalListSortingStrategy}>
+              {workspaces.map((ws) => (
+                <SortableProjectShell
+                  key={ws.id}
+                  sortableId={ws.id}
+                  activeDragId={activeDragId}
+                  workspace={ws}
+                  isExpanded={expanded[ws.id] ?? false}
+                  isActive={activeWorkspaceId === ws.id}
+                  activeThreadId={activeThreadId}
+                  threads={threads.filter((t) => t.workspace_id === ws.id)}
+                  runningThreadIds={runningThreadIds}
+                  pendingPermissionThreadIds={pendingPermissionThreadIds}
+                  isThreadListExpanded={threadListExpanded[ws.id] ?? false}
+                  onToggleThreadList={() => toggleThreadList(ws.id)}
+                  scrollElementRef={scrollViewportRef}
+                  inlineEdit={inlineEdit}
+                  onInlineEditChange={(title) =>
+                    setInlineEdit((prev) => prev ? { ...prev, title } : null)
+                  }
+                  onInlineEditCommit={handleInlineEditCommit}
+                  onInlineEditCancel={() => setInlineEdit(null)}
+                  onStartInlineEdit={handleStartInlineEdit}
+                  onToggle={() => toggleExpand(ws.id)}
+                  onSelectThread={(id) => {
+                    setActiveWorkspace(ws.id);
+                    setActiveThread(id);
+                  }}
+                  onCreateThread={() => {
+                    setActiveWorkspace(ws.id);
+                    setPendingNewThread(true);
+                    setActiveThread(null);
+                  }}
+                  onDelete={() => {
+                    setWsDeleteDialog({
+                      workspaceId: ws.id,
+                      workspaceName: ws.name,
+                    });
+                  }}
+                  onThreadContextMenu={(e, thread) =>
+                    handleThreadContextMenu(e, thread, ws.path)
+                  }
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
 
           {workspaces.length === 0 && (
             <div className="flex flex-col items-center justify-center gap-3 px-4 py-12">
@@ -989,6 +1050,8 @@ interface ProjectNodeProps {
   onCreateThread: () => void;
   onDelete: () => void;
   onThreadContextMenu: (e: React.MouseEvent, thread: Thread) => void;
+  /** When set, forwards drag-handle listeners from `@dnd-kit/sortable` onto the project row. */
+  sortableListeners?: DraggableSyntheticListeners;
 }
 
 /** Renders a collapsible workspace row with its virtualized thread list. */
@@ -1013,6 +1076,7 @@ function ProjectNode({
   onCreateThread,
   onDelete,
   onThreadContextMenu,
+  sortableListeners,
 }: ProjectNodeProps) {
   const checksById = useWorkspaceStore(useShallow((s) => s.checksById));
   const parentDir = useMemo(() => parentDirName(workspace.path), [workspace.path]);
@@ -1031,25 +1095,30 @@ function ProjectNode({
   const maxVisible = !needsCap || isThreadListExpanded || forceExpand ? Infinity : THREAD_LIST_CAP;
 
   return (
-    <div className="mb-1">
+    <div>
       {/* Workspace row — typographic anchor. No folder icon; a quiet caret + name + parent caption. */}
       <div
         role="button"
         tabIndex={0}
         aria-expanded={isExpanded}
+        data-testid={`project-row-${workspace.id}`}
+        className={cn(
+          "group/ws relative flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12.5px] cursor-pointer transition-colors touch-none",
+          isActive
+            ? "text-foreground"
+            : "text-muted-foreground/85 hover:text-foreground"
+        )}
+        {...sortableListeners}
         onKeyDown={(e) => {
+          sortableListeners?.onKeyDown?.(e);
           if ((e.key === "Enter" || e.key === " ") && e.target === e.currentTarget) {
             e.preventDefault();
             onToggle();
           }
         }}
-        onClick={onToggle}
-        className={cn(
-          "group/ws relative flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12.5px] cursor-pointer transition-colors",
-          isActive
-            ? "text-foreground"
-            : "text-muted-foreground/85 hover:text-foreground"
-        )}
+        onClick={() => {
+          onToggle();
+        }}
       >
         {isExpanded ? (
           <ChevronDown size={12} className="shrink-0 text-muted-foreground/55 transition-transform" />
@@ -1182,6 +1251,44 @@ function ProjectNode({
           </Button>
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Wraps {@link ProjectNode} with `@dnd-kit/sortable` transforms and collapses
+ * thread children while the user is dragging this project.
+ */
+function SortableProjectShell(
+  props: ProjectNodeProps & { sortableId: string; activeDragId: string | null },
+) {
+  const { sortableId, activeDragId, ...nodeProps } = props;
+  const collapseForDrag = activeDragId === sortableId;
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: sortableId,
+  });
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    ...(isDragging
+      ? { opacity: 0.92, zIndex: 2, boxShadow: "0 2px 10px rgba(0,0,0,0.08)" }
+      : {}),
+  };
+  const { role: _sortableOuterRole, tabIndex: _outerTab, ...sortableA11y } = attributes;
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="mb-1"
+      {...sortableA11y}
+      role="group"
+      tabIndex={-1}
+    >
+      <ProjectNode
+        {...nodeProps}
+        isExpanded={nodeProps.isExpanded && !collapseForDrag}
+        sortableListeners={listeners}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useLayoutEffect, useCallback, useState, useRef, useMemo, type CSSProperties } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useState,
+  useRef,
+  useMemo,
+  type CSSProperties,
+} from "react";
 import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useShallow } from "zustand/shallow";
@@ -380,6 +388,29 @@ export function ProjectTree() {
 
   const scrollViewportRef = useRef<HTMLDivElement>(null);
 
+  /**
+   * Only the project list viewport may autoscroll during drag so outer sidebar
+   * regions (or the document) are not pulled by `@dnd-kit` when reordering.
+   */
+  const projectTreeAutoScroll = useMemo(
+    () => ({
+      canScroll(element: Element) {
+        const vp = scrollViewportRef.current;
+        return vp != null && element === vp;
+      },
+    }),
+    [],
+  );
+
+  useLayoutEffect(() => {
+    if (!activeDragId) return;
+    const prev = document.body.style.cursor;
+    document.body.style.cursor = "grabbing";
+    return () => {
+      document.body.style.cursor = prev;
+    };
+  }, [activeDragId]);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="flex items-center justify-between px-3 py-2 mb-0.5">
@@ -406,6 +437,7 @@ export function ProjectTree() {
             sensors={sensors}
             collisionDetection={closestCenter}
             modifiers={[restrictToVerticalAxis]}
+            autoScroll={projectTreeAutoScroll}
             onDragStart={handleProjectDragStart}
             onDragEnd={handleProjectDragEnd}
             onDragCancel={handleProjectDragCancel}
@@ -1052,6 +1084,8 @@ interface ProjectNodeProps {
   onThreadContextMenu: (e: React.MouseEvent, thread: Thread) => void;
   /** When set, forwards drag-handle listeners from `@dnd-kit/sortable` onto the project row. */
   sortableListeners?: DraggableSyntheticListeners;
+  /** True while this project row is the item being dragged. */
+  isProjectDragging?: boolean;
 }
 
 /** Renders a collapsible workspace row with its virtualized thread list. */
@@ -1077,6 +1111,7 @@ function ProjectNode({
   onDelete,
   onThreadContextMenu,
   sortableListeners,
+  isProjectDragging = false,
 }: ProjectNodeProps) {
   const checksById = useWorkspaceStore(useShallow((s) => s.checksById));
   const parentDir = useMemo(() => parentDirName(workspace.path), [workspace.path]);
@@ -1103,10 +1138,12 @@ function ProjectNode({
         aria-expanded={isExpanded}
         data-testid={`project-row-${workspace.id}`}
         className={cn(
-          "group/ws relative flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12.5px] cursor-pointer transition-colors touch-none",
+          "group/ws relative flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12.5px] transition-colors touch-none",
+          sortableListeners ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
+          isProjectDragging && "cursor-grabbing",
           isActive
             ? "text-foreground"
-            : "text-muted-foreground/85 hover:text-foreground"
+            : "text-muted-foreground/85 hover:text-foreground",
         )}
         {...sortableListeners}
         onKeyDown={(e) => {
@@ -1287,6 +1324,7 @@ function SortableProjectShell(
       <ProjectNode
         {...nodeProps}
         isExpanded={nodeProps.isExpanded && !collapseForDrag}
+        isProjectDragging={isDragging}
         sortableListeners={listeners}
       />
     </div>

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1147,6 +1147,7 @@ function ProjectNode({
         {...sortableListeners}
         onKeyDown={(e) => {
           sortableListeners?.onKeyDown?.(e);
+          if (e.defaultPrevented) return;
           if ((e.key === "Enter" || e.key === " ") && e.target === e.currentTarget) {
             e.preventDefault();
             onToggle();

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -72,10 +72,17 @@ export function Sidebar({
         )}
       </div>
 
-      {/* Body */}
-      <div className="flex-1 overflow-y-auto">
+      {/* Body: projects use an inner ScrollArea only; avoid stacking overflow-y-auto
+          here or drag transforms and autoscroll can expand this region and show a
+          scrollbar when the list is short. Settings stays scrollable. */}
+      <div
+        data-testid="sidebar-body"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
         {settingsOpen && settingsSection && onSettingsSection ? (
-          <SettingsNav section={settingsSection} onSection={onSettingsSection} />
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+            <SettingsNav section={settingsSection} onSection={onSettingsSection} />
+          </div>
         ) : (
           <ProjectTree />
         )}

--- a/apps/web/src/stores/__tests__/workspaceStore.actions.test.ts
+++ b/apps/web/src/stores/__tests__/workspaceStore.actions.test.ts
@@ -13,6 +13,7 @@ function makeWs(overrides?: Partial<Workspace>): Workspace {
     updated_at: new Date().toISOString(),
     pinned: false,
     last_opened_at: null,
+    sort_order: 0,
     ...overrides,
   };
 }
@@ -53,5 +54,36 @@ describe("workspaceStore pin/remove/touch", () => {
     expect(ws.last_opened_at).toBeNull();
     expect(ws.pinned).toBe(false);
     expect(call).toHaveBeenCalledWith("workspace.removeRecent", { id: "ws-1" });
+  });
+});
+
+describe("workspaceStore reorderWorkspace", () => {
+  it("splices order locally and calls workspace.reorder with the bounded index", async () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        makeWs({ id: "a", name: "a", sort_order: 0 }),
+        makeWs({ id: "b", name: "b", sort_order: 1 }),
+        makeWs({ id: "c", name: "c", sort_order: 2 }),
+      ],
+    });
+    const call = vi.fn().mockResolvedValue({ ok: true });
+    await useWorkspaceStore.getState().reorderWorkspace("c", 0, call as unknown as WorkspaceRpcCall);
+    expect(useWorkspaceStore.getState().workspaces.map((w) => w.id)).toEqual(["c", "a", "b"]);
+    expect(call).toHaveBeenCalledWith("workspace.reorder", { id: "c", newIndex: 0 });
+  });
+
+  it("reverts workspaces order when RPC fails", async () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        makeWs({ id: "a", name: "a", sort_order: 0 }),
+        makeWs({ id: "b", name: "b", sort_order: 1 }),
+      ],
+    });
+    const call = vi.fn().mockRejectedValue(new Error("offline"));
+    try {
+      await useWorkspaceStore.getState().reorderWorkspace("b", 0, call as unknown as WorkspaceRpcCall);
+    } catch { /* expected */ }
+    expect(useWorkspaceStore.getState().workspaces.map((w) => w.id)).toEqual(["a", "b"]);
+    expect(useWorkspaceStore.getState().error).toMatch(/offline/);
   });
 });

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -95,6 +95,8 @@ interface WorkspaceState {
   pinWorkspace: (id: string, pinned: boolean, call?: WorkspaceRpcCall) => Promise<void>;
   /** Remove a workspace from the recents list. Clears last_opened_at and pinned locally; reverts on RPC failure. */
   removeRecent: (id: string, call?: WorkspaceRpcCall) => Promise<void>;
+  /** Reorder a workspace in the sidebar (zero-based index). Optimistic update with RPC persistence. */
+  reorderWorkspace: (id: string, newIndex: number, call?: WorkspaceRpcCall) => Promise<void>;
 
   // Thread actions
   loadThreads: (workspaceId: string) => Promise<void>;
@@ -377,6 +379,28 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
           ),
         }));
       }
+      throw err;
+    }
+  },
+
+  reorderWorkspace: async (id, newIndex, call) => {
+    const prev = get().workspaces.slice();
+    const oldIndex = prev.findIndex((w) => w.id === id);
+    if (oldIndex < 0) return;
+    const bounded = Math.max(0, Math.min(newIndex, prev.length - 1));
+    if (oldIndex === bounded) return;
+    const next = [...prev];
+    const [removed] = next.splice(oldIndex, 1);
+    next.splice(bounded, 0, removed!);
+    set({ workspaces: next, error: null });
+    try {
+      if (call) {
+        await call("workspace.reorder", { id, newIndex: bounded });
+      } else {
+        await getTransport().reorderWorkspace(id, bounded);
+      }
+    } catch (err) {
+      set({ workspaces: prev, error: String(err) });
       throw err;
     }
   },

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -88,6 +88,8 @@ export interface McodeTransport {
   pinWorkspace(id: string, pinned: boolean): Promise<void>;
   /** Remove a workspace from the recents list and unpin it. */
   removeRecent(id: string): Promise<void>;
+  /** Persist sidebar index for a workspace after drag-and-drop (zero-based). */
+  reorderWorkspace(id: string, newIndex: number): Promise<void>;
   /** Batch-fetch git branch, cleanliness, and thread count for the given workspace ids. */
   enrichWorkspaces(ids: string[]): Promise<{ items: WorkspaceEnrichment[] }>;
   /** Browse the host filesystem at the given path. Returns entries and parent path. */

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -39,6 +39,7 @@ const _legacyEncoder = new TextEncoder();
  * - `permission.resolved` -- a permission was settled (by user or session stop)
  * - `providers.availability` -- server-pushed provider availability snapshot forwarded to providerAvailabilityStore
  * - `workspace.gitStatusChanged` -- workspace git status changed (e.g. non-git folder became a repo), updates is_git_repo flag
+ * - `workspace.orderChanged` -- sidebar project order changed on the server; refreshes workspace list
  */
 export function startPushListeners(): void {
   // Guard against double-init
@@ -267,6 +268,12 @@ export function startPushListeners(): void {
           w.id === workspaceId ? { ...w, is_git_repo: isGitRepo } : w,
         ),
       }));
+    }),
+  );
+
+  unsubs.push(
+    pushEmitter.on("workspace.orderChanged", () => {
+      void useWorkspaceStore.getState().loadWorkspaces();
     }),
   );
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -436,6 +436,8 @@ export function createWsTransport(
     createWorkspace: (name, path) => rpc<Workspace>("workspace.create", { name, path }),
     deleteWorkspace: (id) => rpc<boolean>("workspace.delete", { id }),
     touchLastOpened: (id) => rpc<void>("workspace.touchLastOpened", { id }),
+    reorderWorkspace: (id, newIndex) =>
+      rpc<void>("workspace.reorder", { id, newIndex }),
     pinWorkspace: (id, pinned) => rpc<void>("workspace.pin", { id, pinned }),
     removeRecent: (id) => rpc<void>("workspace.removeRecent", { id }),
     enrichWorkspaces: (ids) =>

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,10 @@
       "version": "0.0.1",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/geist": "^5.2.8",
         "@lexical/react": "^0.42.0",
         "@mcode/contracts": "workspace:*",
@@ -272,6 +276,16 @@
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
     "@develar/schema-utils": ["@develar/schema-utils@2.6.5", "", { "dependencies": { "ajv": "^6.12.0", "ajv-keywords": "^3.4.1" } }, "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/modifiers": ["@dnd-kit/modifiers@9.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.61.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-utL3cpZoFzflyqUkjYbxYujI6STBTmO5LFn4bbin/NZnRWN6wQ7eErhr3/Vpa5h/jicPFC6kTa42r940mQftJQ=="],
 
@@ -2580,6 +2594,16 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@dnd-kit/accessibility/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@dnd-kit/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@dnd-kit/modifiers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@dnd-kit/sortable/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@dnd-kit/utilities/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 

--- a/docs/specs/2026-05-01-project-sort-order-design.md
+++ b/docs/specs/2026-05-01-project-sort-order-design.md
@@ -1,0 +1,182 @@
+# Project Sort Order and Draggable Sidebar
+
+## Summary
+
+Add persistent, user-controlled ordering to the sidebar project list and make projects drag-and-drop reorderable using `@dnd-kit`. The sidebar stops deriving order from `pinned`/`last_opened_at` and instead uses an explicit `sort_order` column that the user controls by dragging.
+
+## Goals
+
+1. **Stable order**: Opening a project no longer shifts its sidebar position.
+2. **Manual reordering**: Users can drag projects up and down to arrange the sidebar.
+3. **Seamless upgrade**: Existing users see the same order they had before the migration.
+4. **Reusable pattern**: The infrastructure (column, transaction, store logic) is generic enough to extend to thread reordering later.
+
+## Non-Goals
+
+- Thread reordering (future follow-up)
+- Changes to the Project Selector Landing page (pinned/recent cards remain timestamp-driven)
+- Multi-select drag
+
+---
+
+## Data Model
+
+### New Column
+
+Add `sort_order INTEGER NOT NULL DEFAULT 0` to the `workspaces` table.
+
+- Lower values appear higher in the sidebar (ascending sort).
+- New workspaces get `sort_order = 0`; all existing workspaces increment by 1 (new project appears at the top).
+- Sequential integers, increments of 1. No sparse gaps or fractional values.
+
+### Migration
+
+A new migration assigns initial `sort_order` values preserving the current visual order (`pinned DESC, last_opened_at DESC`, with `id` as tiebreaker):
+
+```sql
+UPDATE workspaces SET sort_order = (
+  SELECT COUNT(*) FROM workspaces w2
+  WHERE (w2.pinned > workspaces.pinned)
+     OR (w2.pinned = workspaces.pinned AND w2.last_opened_at > workspaces.last_opened_at)
+     OR (w2.pinned = workspaces.pinned AND w2.last_opened_at = workspaces.last_opened_at AND w2.id < workspaces.id)
+);
+```
+
+### Query Change
+
+`workspace-repo.listAll()` changes from:
+
+```sql
+SELECT ... FROM workspaces
+WHERE last_opened_at IS NOT NULL OR pinned = 1
+ORDER BY pinned DESC, last_opened_at DESC
+```
+
+to:
+
+```sql
+SELECT ... FROM workspaces
+ORDER BY sort_order ASC
+```
+
+The `WHERE` filter is removed. Every workspace now has an explicit position in the sidebar. The migration assigns positions to all workspaces (including those that were previously hidden because they had never been opened). Users see their full project list, ordered as they arrange it.
+
+---
+
+## RPC / Server Layer
+
+### New Method: `workspace.reorder`
+
+```typescript
+// Request
+{ id: string; newIndex: number }
+
+// Response
+{ ok: true }
+```
+
+Server logic:
+1. Look up the workspace's current `sort_order`.
+2. Determine direction (moving up or down).
+3. Execute a 2-statement transaction:
+
+**Moving up** (e.g., position 30 to position 5):
+
+```sql
+BEGIN TRANSACTION;
+UPDATE workspaces SET sort_order = sort_order + 1
+  WHERE sort_order >= 5 AND sort_order < 30;
+UPDATE workspaces SET sort_order = 5 WHERE id = ?;
+COMMIT;
+```
+
+**Moving down** (e.g., position 5 to position 30):
+
+```sql
+BEGIN TRANSACTION;
+UPDATE workspaces SET sort_order = sort_order - 1
+  WHERE sort_order > 5 AND sort_order <= 30;
+UPDATE workspaces SET sort_order = 30 WHERE id = ?;
+COMMIT;
+```
+
+4. Broadcast a push event so other connected clients stay in sync.
+
+### Modified Methods
+
+- `workspace.list`: Returns workspaces ordered by `sort_order ASC`.
+- `workspace.create`: Assigns `sort_order = 0` and increments all existing values by 1.
+
+### Unchanged
+
+`pinned` and `last_opened_at` remain in the schema. They continue to drive the Project Selector Landing page. The sidebar and landing page use independent ordering strategies.
+
+---
+
+## Frontend Store
+
+### Workspace Store Changes
+
+New action: `reorderWorkspace(id: string, newIndex: number)`
+
+1. Optimistically splice the array (remove from old index, insert at new index).
+2. Fire `workspace.reorder` RPC in the background.
+3. On failure: roll back to the previous array order and surface an error toast.
+
+### Behavioral Changes
+
+- `createWorkspace()` prepends the new workspace to the array (index 0).
+- `setActiveWorkspace()` no longer reorders the sidebar. It still updates `last_opened_at` for the landing page, but the sidebar array position is unchanged.
+
+---
+
+## Drag-and-Drop UI
+
+### Library
+
+`@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` (~12KB gzipped total).
+
+### Integration with `ProjectTree`
+
+- Wrap the project list in `<DndContext>` and `<SortableContext>` with a vertical sorting strategy.
+- Each `ProjectNode` becomes a sortable item via the `useSortable()` hook.
+- Drag handle: the entire project row.
+
+### Visual Feedback
+
+- Dragged item: subtle elevation/opacity change.
+- Drop position: indicator line between items.
+- Transitions: CSS `transform` (GPU-accelerated, no layout thrashing).
+
+### Constraints and Sensors
+
+| Config | Value |
+|--------|-------|
+| Axis lock | `restrictToVerticalAxis` |
+| Container lock | `restrictToParentElement` |
+| Collision detection | `closestCenter` |
+| Pointer activation | 5px distance threshold |
+| Keyboard | `sortableKeyboardCoordinates` (arrow keys + Enter) |
+
+### Interaction Rules
+
+- Only top-level project nodes are draggable (not threads).
+- If a project is expanded during drag, it collapses for the duration of the drag to keep the overlay compact.
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Deleted workspace | Gap in `sort_order` values is harmless; no renumbering needed |
+| Multiple windows | Push event syncs all clients; last write wins |
+| Empty list | No drag targets; existing empty-state UI unchanged |
+| Single workspace | `DndContext` is inert with one item |
+| New workspace added | Appears at top (index 0); others shift down |
+
+---
+
+## Future: Thread Reordering
+
+The same pattern applies: add `sort_order` to the `threads` table, implement `thread.reorder` RPC, and extend the virtualized thread list with `@dnd-kit/sortable`. The infrastructure built here (range-shift transactions, optimistic splice, push sync) is directly reusable.

--- a/packages/contracts/src/models/workspace.ts
+++ b/packages/contracts/src/models/workspace.ts
@@ -15,6 +15,8 @@ export const WorkspaceSchema = lazySchema(() =>
     pinned: z.boolean(),
     /** Unix timestamp (ms) of when this workspace was last opened. Null if never explicitly opened. */
     last_opened_at: z.number().nullable(),
+    /** Ascending sidebar order; lower values appear higher in the project list. */
+    sort_order: z.number().int(),
   }),
 );
 /** Workspace record from the database. */

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -54,6 +54,8 @@ export const WS_CHANNELS = {
   "workspace.gitStatusChanged": lazySchema(() =>
     z.object({ workspaceId: z.string(), isGitRepo: z.boolean() }),
   )(),
+  /** Sidebar project order changed on the server; clients should refresh `workspace.list`. */
+  "workspace.orderChanged": z.object({}),
   "turn.persisted": z.object({
     threadId: z.string(),
     messageId: z.string(),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -125,6 +125,11 @@ export const WS_METHODS = lazySchema(() => ({
     params: z.object({ id: z.string() }),
     result: z.object({ ok: z.literal(true) }),
   },
+  /** Move a workspace to a new zero-based index in the sidebar order. */
+  "workspace.reorder": {
+    params: z.object({ id: z.string(), newIndex: z.number().int().nonnegative() }),
+    result: z.object({ ok: z.literal(true) }),
+  },
   /** Batch-fetch git + thread enrichment for up to 200 workspace ids. */
   "workspace.enrich": {
     params: z.object({ ids: z.array(z.string()).max(200) }),


### PR DESCRIPTION
## What
Adds persisted sort_order for workspaces, server RPC to reorder, and sidebar drag-to-reorder with scroll and cursor behavior that fits clickable project rows.

## Why
Users need a stable custom order for projects in the sidebar. Drag reorder must not introduce spurious scrollbars or misleading grab cursors on idle rows.

## Key Changes
- Persist workspaces.sort_order, migration (idempotent when column already exists), workspace.reorder RPC, store + push handling
- Sidebar ProjectTree uses @dnd-kit for vertical reorder; collapse threads on the active drag for clarity
- Sidebar layout: single scroll surface for the project list, DndContext autoscroll limited to the list viewport
- Cursors: pointer when idle, grabbing only during an active drag (row + body)
- E2E: sidebar-project-drag-scroll.spec.ts for scroll metrics while dragging



Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop to reorder projects in the sidebar with persistent, server-backed ordering, a reorder RPC, and a push event to sync clients; optimistic frontend reorder with rollback on failure.
  * Sidebar ordering now follows an explicit numeric sort_order; creating/adding projects places them at the top.

* **Tests**
  * Added and updated unit & E2E tests and fixtures for ordering, reordering, migration, and drag interactions.

* **Documentation**
  * Added design spec for persistent sidebar ordering.

* **Chores**
  * Database migration to introduce and backfill sort_order; frontend DnD dependencies added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->