### PR TITLE
ci: add macOS builds via Blacksmith runners

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,9 +21,13 @@ jobs:
       matrix:
         include:
           - os: blacksmith-4vcpu-windows-2025
+            build-args: ""
           - os: ubuntu-22.04
-          # Uncomment when ready to spend macOS CI minutes:
-          # - os: macos-latest
+            build-args: ""
+          - os: blacksmith-12vcpu-macos-26
+            build-args: "--mac --arm64"
+          - os: blacksmith-12vcpu-macos-26
+            build-args: "--mac --x64"
 
     runs-on: ${{ matrix.os }}
 
@@ -48,7 +52,9 @@ jobs:
         run: pip install setuptools
 
       - name: Package with electron-builder
-        run: node apps/desktop/scripts/ci-package.mjs
+        run: node apps/desktop/scripts/ci-package.mjs ${{ matrix.build-args }}
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && 'false' || '' }}
 
       - name: Smoke test packaged server
         run: node apps/desktop/scripts/smoke-test.mjs

--- a/apps/desktop/scripts/ci-package.mjs
+++ b/apps/desktop/scripts/ci-package.mjs
@@ -125,11 +125,12 @@ const ebCli = findEbCli();
 console.log(`[ci-package] Resolved electron-builder CLI: ${ebCli}`);
 
 // ---------------------------------------------------------------------------
-// 7. Run electron-builder
+// 7. Run electron-builder (extra CLI args forwarded for platform/arch control)
 // ---------------------------------------------------------------------------
 
+const extraArgs = process.argv.slice(2);
 console.log("[ci-package] Running electron-builder (npm fallback)...");
-execFileSync(process.execPath, [ebCli, "--publish", "never"], {
+execFileSync(process.execPath, [ebCli, "--publish", "never", ...extraArgs], {
   cwd: desktopRoot,
   stdio: "inherit",
   env: { ...process.env, PATH: filteredPath },


### PR DESCRIPTION
## What
Add macOS arm64 and x64 builds to the release workflow using Blacksmith Mac runners.

## Why
With Blacksmith providing 3,000 macOS CI minutes, we can now produce Mac installers (DMG + ZIP) for both Apple Silicon and Intel Macs as part of every release.

## Key Changes
- Add two `blacksmith-12vcpu-macos-26` matrix entries (arm64 native + x64 cross-compiled)
- Forward CLI args from workflow to electron-builder via `ci-package.mjs`
- Disable code signing auto-discovery (`CSC_IDENTITY_AUTO_DISCOVERY=false`) until Apple Developer credentials are set up
- Artifacts (DMG, ZIP, blockmap, updater manifest) upload to GitHub Releases alongside existing Windows/Linux builds

Signing and distribution via Homebrew/Scoop will follow in a later PR once branding is finalized.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to support multiple macOS architectures
  * Enhanced packaging process with flexible build argument handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->