### PR TITLE
fix(cursor): suppress thinking data leak in ACP responses

### DIFF
--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
@@ -39,7 +39,7 @@ describe("mapCursorAcpSessionNotification", () => {
     expect(state.accumulator.assistantText).toBe("Hi there");
   });
 
-  it("maps agent_thought_chunk to TextDelta like message chunks", () => {
+  it("suppresses agent_thought_chunk so thinking data never leaks to the UI", () => {
     const state = createCursorAcpTurnState();
     const ev = mapCursorAcpSessionNotification(
       {
@@ -52,9 +52,8 @@ describe("mapCursorAcpSessionNotification", () => {
       threadId,
       state,
     );
-    expect(ev).toEqual([
-      { type: AgentEventType.TextDelta, threadId, delta: "Thinking out loud..." },
-    ]);
+    expect(ev).toEqual([]);
+    expect(state.accumulator.assistantText).toBe("");
   });
 
   it("maps tool_call_update to ToolResult", () => {

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -98,10 +98,10 @@ export function mapCursorAcpSessionNotification(
 
   switch (update.sessionUpdate) {
     case "agent_message_chunk":
-    case "agent_thought_chunk":
       return mapAgentLanguageChunk(threadId, acc, update);
     case "plan":
       return mapAcpPlanUpdate(update, threadId, todoSnapshot);
+    case "agent_thought_chunk":
     case "user_message_chunk":
     case "available_commands_update":
     case "current_mode_update":
@@ -125,13 +125,9 @@ export function mapCursorAcpSessionNotification(
 function mapAgentLanguageChunk(
   threadId: string,
   acc: CursorStreamAccumulator,
-  update:
-    | (import("@agentclientprotocol/sdk").ContentChunk & {
-        sessionUpdate: "agent_message_chunk";
-      })
-    | (import("@agentclientprotocol/sdk").ContentChunk & {
-        sessionUpdate: "agent_thought_chunk";
-      }),
+  update: import("@agentclientprotocol/sdk").ContentChunk & {
+    sessionUpdate: "agent_message_chunk";
+  },
 ): AgentEvent[] {
   if (update.content.type !== "text" || !update.content.text) return [];
   const text = update.content.text;


### PR DESCRIPTION
## What
Suppress `agent_thought_chunk` ACP session updates so Cursor's internal reasoning/thinking data is never streamed to the UI.

## Why
The ACP event mapper treated `agent_thought_chunk` identically to `agent_message_chunk`, routing both through `mapAgentLanguageChunk()`. This emitted thinking content as `TextDelta` events and accumulated it into `assistantText`, causing internal reasoning data to appear in the chat response and persist in the `Message` event at turn completion.

## Key Changes
- Move `agent_thought_chunk` from the `mapAgentLanguageChunk` case into the silent-drop `return []` group in `cursor-acp-event-mapper.ts`
- Narrow the `mapAgentLanguageChunk` type signature to only accept `agent_message_chunk`
- Update the test to assert `agent_thought_chunk` returns `[]` and leaves `assistantText` empty

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent thought chunk updates are now suppressed and no longer accumulated into assistant text responses.

* **Tests**
  * Updated test verification for suppressed thought chunk event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->