### PR TITLE
feat(server): refresh child env from shell or registry on demand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,10 @@ Syntax highlighting runs in `apps/web/src/workers/shiki.worker.ts` via `@shikijs
 
 See **[docs/guides/provider-architecture.md](docs/guides/provider-architecture.md)**.
 
+## Child process environment (server)
+
+Integrated terminals and provider subprocesses use **`EnvService`** plus **`ProtectedEnvStore`** and **`ShellEnvResolver`** under `apps/server/src/services/`. Keys prefixed with `MCODE_`, `ELECTRON_`, or `BETTER_SQLITE3_` are snapshotted at server boot and always win over shell or registry resolution. For one-off internal variables without those prefixes, call `ProtectedEnvStore.protect("NAME")` during server startup before spawning children.
+
 ## Key Documentation
 
 - **Architecture:** [ARCHITECTURE.md](ARCHITECTURE.md)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -520,6 +520,8 @@ Lifecycle per session:
 
 On Windows, `shell: true` on spawn resolves `.cmd` shims. Process tree kill uses `taskkill /T /F /PID` because Node's `child.kill()` does not kill grandchildren.
 
+Child processes inherit an explicit `env` object from **`EnvService`**, which layers a short-TTL refresh of the user's shell or Windows registry configuration over the server's `process.env`, then applies **`ProtectedEnvStore`** so `MCODE_*`, `ELECTRON_*`, and `BETTER_SQLITE3_*` values from server startup are not overridden (see `docs/agents/runtime.md`).
+
 ## 9. Desktop Shell
 
 ### 9.1 ServerManager

--- a/apps/server/src/__tests__/claude-provider-complete.test.ts
+++ b/apps/server/src/__tests__/claude-provider-complete.test.ts
@@ -93,13 +93,14 @@ vi.mock("@mcode/shared", () => ({
 }));
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
+import { stubEnvService } from "./stub-env-service.js";
 
 describe("ClaudeProvider.complete()", () => {
   let provider: ClaudeProvider;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    provider = new ClaudeProvider();
+    provider = new ClaudeProvider(stubEnvService());
   });
 
   it("resolves with the result text (does not deadlock)", async () => {

--- a/apps/server/src/__tests__/claude-provider-eviction.test.ts
+++ b/apps/server/src/__tests__/claude-provider-eviction.test.ts
@@ -12,6 +12,7 @@ vi.mock("@mcode/shared", async (importOriginal) => {
 });
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
+import { stubEnvService } from "./stub-env-service.js";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";
 
 /** Mock SDK that yields a tool_use then pauses indefinitely (simulating a long-running tool). */
@@ -56,7 +57,7 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    provider = new ClaudeProvider();
+    provider = new ClaudeProvider(stubEnvService());
   });
 
   afterEach(() => {

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -76,6 +76,7 @@ vi.mock("@mcode/shared", async (importOriginal) => {
 });
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
+import { stubEnvService } from "./stub-env-service.js";
 
 describe("ClaudeProvider permission mode changes", () => {
   let provider: ClaudeProvider;
@@ -84,7 +85,7 @@ describe("ClaudeProvider permission mode changes", () => {
     vi.clearAllMocks();
     sdkCalls.length = 0;
     mockQuery.mockImplementation(makeFakeSdkQuery(sdkCalls));
-    provider = new ClaudeProvider();
+    provider = new ClaudeProvider(stubEnvService());
   });
 
   it("reuses the session when permissionMode is unchanged", async () => {

--- a/apps/server/src/__tests__/claude-provider-queue.test.ts
+++ b/apps/server/src/__tests__/claude-provider-queue.test.ts
@@ -53,6 +53,7 @@ vi.mock("@mcode/shared", async (importOriginal) => {
 });
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
+import { stubEnvService } from "./stub-env-service.js";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";
 
 describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
@@ -82,7 +83,7 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
       });
     });
 
-    provider = new ClaudeProvider();
+    provider = new ClaudeProvider(stubEnvService());
     const events: Array<{ type: string; error?: string }> = [];
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
@@ -141,7 +142,7 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
       });
     });
 
-    provider = new ClaudeProvider();
+    provider = new ClaudeProvider(stubEnvService());
     const events: Array<{ type: string; error?: string }> = [];
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 

--- a/apps/server/src/__tests__/claude-provider-result-error.test.ts
+++ b/apps/server/src/__tests__/claude-provider-result-error.test.ts
@@ -13,6 +13,7 @@ vi.mock("@mcode/shared", async (importOriginal) => {
 });
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
+import { stubEnvService } from "./stub-env-service.js";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";
 import { AgentEventType } from "@mcode/contracts";
 
@@ -46,7 +47,7 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
   let provider: ClaudeProvider;
   beforeEach(() => {
     vi.clearAllMocks();
-    provider = new ClaudeProvider();
+    provider = new ClaudeProvider(stubEnvService());
   });
 
   afterEach(() => {

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -65,6 +65,7 @@ vi.mock("@github/copilot-sdk", () => ({
 
 import which from "which";
 import { CopilotProvider } from "../providers/copilot/copilot-provider.js";
+import { stubEnvService } from "./stub-env-service.js";
 
 /** Minimal SettingsService stub. */
 function makeSettingsService(cliPath = "") {
@@ -110,7 +111,7 @@ describe("CopilotProvider bootstrap", () => {
       });
       (which as unknown as Mock).mockResolvedValue("/usr/bin/node");
 
-      const provider = new CopilotProvider(makeSettingsService() as any);
+      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
       await provider.listModels();
 
       // which was called to find the real node binary
@@ -127,7 +128,7 @@ describe("CopilotProvider bootstrap", () => {
         configurable: true,
       });
 
-      const provider = new CopilotProvider(makeSettingsService() as any);
+      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
       await provider.listModels();
 
       // which should not be called when not in Electron
@@ -145,7 +146,7 @@ describe("CopilotProvider bootstrap", () => {
         },
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any);
+      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
       await provider.listModels();
 
       const opts = MockCopilotClient.mock.calls[0]?.[0];
@@ -159,7 +160,7 @@ describe("CopilotProvider bootstrap", () => {
         },
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any);
+      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
       await provider.listModels();
 
       const opts = MockCopilotClient.mock.calls[0]?.[0] ?? {};
@@ -169,7 +170,7 @@ describe("CopilotProvider bootstrap", () => {
 
   describe("client reuse", () => {
     it("reuses healthy connected client", async () => {
-      const provider = new CopilotProvider(makeSettingsService() as any);
+      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
 
       await provider.listModels();
       mockClient.getState.mockReturnValue("connected");
@@ -188,7 +189,7 @@ describe("CopilotProvider bootstrap", () => {
         new Error("CLI server exited with code 1"),
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any);
+      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
 
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
@@ -214,7 +215,7 @@ describe("CopilotProvider bootstrap", () => {
         new Error("Could not find @github/copilot"),
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any);
+      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
 
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
@@ -266,7 +267,7 @@ async function runWithMockSession(
     mockSession.fire("session.idle");
   });
 
-  const provider = new CopilotProvider(makeSettingsService() as any);
+  const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
   const events: AgentEvent[] = [];
   provider.on("event", (e: AgentEvent) => events.push(e));
 
@@ -408,7 +409,7 @@ describe("CopilotProvider.complete()", () => {
       mockSession.fire("session.idle");
     });
 
-    const provider = new CopilotProvider(makeSettingsService() as any);
+    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
     const result = await provider.complete("Generate PR draft", "gpt-4.1", "/tmp");
 
     expect(result).toBe(jsonResponse);
@@ -426,7 +427,7 @@ describe("CopilotProvider.complete()", () => {
       mockSession.fire("session.idle");
     });
 
-    const provider = new CopilotProvider(makeSettingsService() as any);
+    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
     const result = await provider.complete("Generate PR draft", "gpt-4.1", "/tmp");
 
     expect(result).toBe('{"title":"feat: x","body":"b"}');
@@ -441,7 +442,7 @@ describe("CopilotProvider.complete()", () => {
       mockSession.fire("session.error", { message: "Model not available" });
     });
 
-    const provider = new CopilotProvider(makeSettingsService() as any);
+    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
 
     await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
       "Model not available",
@@ -457,7 +458,7 @@ describe("CopilotProvider.complete()", () => {
       mockSession.fire("session.idle");
     });
 
-    const provider = new CopilotProvider(makeSettingsService() as any);
+    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
 
     await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
       "no text content",
@@ -470,7 +471,7 @@ describe("CopilotProvider.complete()", () => {
     mockClient.createSession.mockResolvedValue(mockSession);
     mockSession.send.mockRejectedValue(new Error("network error"));
 
-    const provider = new CopilotProvider(makeSettingsService() as any);
+    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
 
     await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
       "network error",
@@ -573,7 +574,7 @@ describe("CopilotProvider.listModels() cache", () => {
       { id: "gpt-4.1", name: "GPT-4.1", capabilities: {}, billing: {} },
     ]);
 
-    const provider = new CopilotProvider(makeSettingsService() as any);
+    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
 
     const first = await provider.listModels();
     const second = await provider.listModels();
@@ -589,7 +590,7 @@ describe("CopilotProvider.listModels() cache", () => {
       { id: "gpt-4.1", name: "GPT-4.1", capabilities: {}, billing: {} },
     ]);
 
-    const provider = new CopilotProvider(makeSettingsService() as any);
+    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
 
     await provider.listModels();
     // Advance past the 10-minute TTL

--- a/apps/server/src/__tests__/resume-listener-cleanup.test.ts
+++ b/apps/server/src/__tests__/resume-listener-cleanup.test.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { describe, it, expect, beforeEach } from "vitest";
 import { EventEmitter } from "events";
 import { ClaudeProvider } from "../providers/claude/claude-provider.js";
+import { stubEnvService } from "./stub-env-service.js";
 
 /**
  * Tests that verify resume listener cleanup in ClaudeProvider.
@@ -15,7 +16,7 @@ describe("ClaudeProvider resume listener cleanup", () => {
   let provider: ClaudeProvider;
 
   beforeEach(() => {
-    provider = new ClaudeProvider();
+    provider = new ClaudeProvider(stubEnvService());
   });
 
   /**

--- a/apps/server/src/__tests__/stub-env-service.ts
+++ b/apps/server/src/__tests__/stub-env-service.ts
@@ -1,0 +1,11 @@
+import type { EnvService } from "../services/env-service.js";
+import { flattenProcessEnv } from "../services/shell-env-utils.js";
+
+/**
+ * Minimal `EnvService` for unit tests that construct providers without the DI container.
+ */
+export function stubEnvService(): EnvService {
+  return {
+    getEnv: () => ({ ...flattenProcessEnv(process.env) }),
+  } as EnvService;
+}

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -53,6 +53,9 @@ import { JobObject } from "./services/job-object.js";
 import { WorkspaceEnricher } from "./services/workspace-enricher";
 import { FilesystemBrowser } from "./services/filesystem-browser";
 import { ModelCacheService } from "./services/model-cache-service";
+import { ProtectedEnvStore } from "./services/protected-env-store";
+import { ShellEnvResolver } from "./services/shell-env-resolver";
+import { EnvService } from "./services/env-service";
 
 /** Initialize the DI container with all server dependencies. */
 export function setupContainer(mcodeDir: string): typeof container {
@@ -64,6 +67,22 @@ export function setupContainer(mcodeDir: string): typeof container {
   // JobObject — constructed once so all child processes share the same kernel job
   const jobObject = new JobObject();
   container.registerInstance("JobObject", jobObject);
+
+  container.register(
+    ProtectedEnvStore,
+    { useClass: ProtectedEnvStore },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    ShellEnvResolver,
+    { useClass: ShellEnvResolver },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    EnvService,
+    { useClass: EnvService },
+    { lifecycle: Lifecycle.Singleton },
+  );
 
   // Database
   const db = openDatabase();

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -33,6 +33,27 @@ import { AnthropicHeaderUsageSource } from "./usage/header-usage-source.js";
 import { CompositeUsageSource } from "./usage/composite-usage-source.js";
 import { EnvService } from "../../services/env-service.js";
 
+/** Shallow snapshot of `process.env` for temporary Claude SDK subprocess alignment. */
+function snapshotProcessEnv(): Record<string, string | undefined> {
+  return { ...process.env };
+}
+
+/** Restores `process.env` after {@link snapshotProcessEnv}. */
+function restoreProcessEnv(backup: Record<string, string | undefined>): void {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in backup)) {
+      delete process.env[k];
+    }
+  }
+  for (const [k, v] of Object.entries(backup)) {
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+}
+
 /** Idle TTL before a session is evicted (10 minutes). */
 const IDLE_TTL_MS = 10 * 60 * 1000;
 /** How often to check for idle sessions (1 minute). */
@@ -220,6 +241,23 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     super();
   }
 
+  /**
+   * Merges {@link EnvService.getEnv} into `process.env` for the Claude SDK spawn window
+   * only, then restores the previous environment.
+   */
+  private withSdkSpawnEnv<T>(fn: () => T): T {
+    const backup = snapshotProcessEnv();
+    try {
+      const merged = this.envService.getEnv();
+      for (const [k, v] of Object.entries(merged)) {
+        process.env[k] = v;
+      }
+      return fn();
+    } finally {
+      restoreProcessEnv(backup);
+    }
+  }
+
   /** Start or continue a session by sending a message via the SDK. */
   async sendMessage(params: {
     sessionId: string;
@@ -253,82 +291,89 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
    * disabled and maxTurns: 1, collects the response text, then tears down.
    */
   async complete(prompt: string, model: string, cwd: string): Promise<string> {
-    const queue = createPromptQueue();
-    const ephemeralId = `complete-${crypto.randomUUID()}`;
-
-    // Note: the Claude Agent SDK spawns a 'claude' CLI subprocess internally.
-    // That subprocess PID is not exposed by the SDK, so it cannot be added to
-    // the server's Job Object. On server crash, this subprocess may briefly
-    // outlive the server until the OS job-object kill propagates via inheritance.
-    // Track: expose subprocess PID from claude-agent-sdk for explicit assignment.
-    // The SDK spawns `claude` internally without accepting a custom env; align
-    // `process.env` once per subprocess start so PATH and user tools stay current.
-    Object.assign(process.env, this.envService.getEnv());
-    const q = sdkQuery({
-      prompt: queue.iterable,
-      options: {
-        cwd,
-        model,
-        maxTurns: 1,
-        tools: [],
-        systemPrompt: "Respond with exactly what is requested. No questions, no commentary.",
-        settingSources: [],
-        permissionMode: "default" as const,
-        persistSession: false,
-        includePartialMessages: true,
-      },
-    });
-
-    queue.push(toUserMessage(prompt, ephemeralId));
-    // Close immediately: the message is already queued. This signals end-of-input
-    // so the SDK subprocess exits after processing instead of blocking on the
-    // next read from the queue (which would deadlock the for-await loop below).
-    queue.close();
-
-    let resultText = "";
-    let assistantText = "";
-    let deltaText = "";
-
-    for await (const msg of q) {
-      const anyMsg = msg as Record<string, unknown>;
-
-      if (anyMsg.type === "result") {
-        if (anyMsg.is_error) {
-          const errors = (anyMsg.errors as string[]) ?? [];
-          throw new Error(`Claude SDK error: ${errors.join(", ") || "unknown error"}`);
-        }
-        const res = anyMsg.result;
-        if (typeof res === "string" && res) resultText = res;
+    const backup = snapshotProcessEnv();
+    try {
+      const merged = this.envService.getEnv();
+      for (const [k, v] of Object.entries(merged)) {
+        process.env[k] = v;
       }
 
-      if (anyMsg.type === "assistant") {
-        const content =
-          (anyMsg.message as { content?: Array<{ type: string; text?: string }> })
-            ?.content ?? [];
-        for (const block of content) {
-          if (block.type === "text" && block.text) assistantText += block.text;
+      const queue = createPromptQueue();
+      const ephemeralId = `complete-${crypto.randomUUID()}`;
+
+      // Note: the Claude Agent SDK spawns a 'claude' CLI subprocess internally.
+      // That subprocess PID is not exposed by the SDK, so it cannot be added to
+      // the server's Job Object. On server crash, this subprocess may briefly
+      // outlive the server until the OS job-object kill propagates via inheritance.
+      // Track: expose subprocess PID from claude-agent-sdk for explicit assignment.
+      const q = sdkQuery({
+        prompt: queue.iterable,
+        options: {
+          cwd,
+          model,
+          maxTurns: 1,
+          tools: [],
+          systemPrompt: "Respond with exactly what is requested. No questions, no commentary.",
+          settingSources: [],
+          permissionMode: "default" as const,
+          persistSession: false,
+          includePartialMessages: true,
+        },
+      });
+
+      queue.push(toUserMessage(prompt, ephemeralId));
+      // Close immediately: the message is already queued. This signals end-of-input
+      // so the SDK subprocess exits after processing instead of blocking on the
+      // next read from the queue (which would deadlock the for-await loop below).
+      queue.close();
+
+      let resultText = "";
+      let assistantText = "";
+      let deltaText = "";
+
+      for await (const msg of q) {
+        const anyMsg = msg as Record<string, unknown>;
+
+        if (anyMsg.type === "result") {
+          if (anyMsg.is_error) {
+            const errors = (anyMsg.errors as string[]) ?? [];
+            throw new Error(`Claude SDK error: ${errors.join(", ") || "unknown error"}`);
+          }
+          const res = anyMsg.result;
+          if (typeof res === "string" && res) resultText = res;
+        }
+
+        if (anyMsg.type === "assistant") {
+          const content =
+            (anyMsg.message as { content?: Array<{ type: string; text?: string }> })
+              ?.content ?? [];
+          for (const block of content) {
+            if (block.type === "text" && block.text) assistantText += block.text;
+          }
+        }
+
+        // Collect incremental text deltas as a third fallback source
+        if (anyMsg.type === "stream_event") {
+          const streamEvent = anyMsg.event as {
+            type?: string;
+            delta?: { type?: string; text?: string };
+          };
+          if (
+            streamEvent?.type === "content_block_delta" &&
+            streamEvent.delta?.type === "text_delta" &&
+            streamEvent.delta.text
+          ) {
+            deltaText += streamEvent.delta.text;
+          }
         }
       }
 
-      // Collect incremental text deltas as a third fallback source
-      if (anyMsg.type === "stream_event") {
-        const streamEvent = anyMsg.event as {
-          type?: string;
-          delta?: { type?: string; text?: string };
-        };
-        if (
-          streamEvent?.type === "content_block_delta" &&
-          streamEvent.delta?.type === "text_delta" &&
-          streamEvent.delta.text
-        ) {
-          deltaText += streamEvent.delta.text;
-        }
-      }
+      const text = resultText || assistantText || deltaText;
+      if (!text) throw new Error("Claude SDK returned no text content");
+      return text.trim();
+    } finally {
+      restoreProcessEnv(backup);
     }
-
-    const text = resultText || assistantText || deltaText;
-    if (!text) throw new Error("Claude SDK returned no text content");
-    return text.trim();
   }
 
   private async doSendMessage(params: {
@@ -650,8 +695,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       cwd: resolvedCwd,
     });
 
-    Object.assign(process.env, this.envService.getEnv());
-    const q = sdkQuery({ prompt: queue.iterable, options });
+    const q = this.withSdkSpawnEnv(() => sdkQuery({ prompt: queue.iterable, options }));
 
     const entry: SessionEntry = {
       query: q,
@@ -704,11 +748,12 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         const freshQueue = createPromptQueue();
         const freshOptions = { ...baseOptions, sessionId: uuid };
 
-        Object.assign(process.env, this.envService.getEnv());
-        const freshQ = sdkQuery({
-          prompt: freshQueue.iterable,
-          options: freshOptions,
-        });
+        const freshQ = this.withSdkSpawnEnv(() =>
+          sdkQuery({
+            prompt: freshQueue.iterable,
+            options: freshOptions,
+          }),
+        );
         const freshEntry: SessionEntry = {
           query: freshQ,
           pushMessage: freshQueue.push,

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -4,7 +4,7 @@
  * Migrated from apps/desktop/src/main/sidecar/client.ts.
  */
 
-import { injectable } from "tsyringe";
+import { injectable, inject } from "tsyringe";
 import { EventEmitter } from "events";
 import { readFile } from "fs/promises";
 import { query as sdkQuery } from "@anthropic-ai/claude-agent-sdk";
@@ -31,6 +31,7 @@ import { readAnthropicOauthToken } from "@mcode/shared/usage";
 import { AnthropicOAuthUsageSource } from "./usage/oauth-usage-source.js";
 import { AnthropicHeaderUsageSource } from "./usage/header-usage-source.js";
 import { CompositeUsageSource } from "./usage/composite-usage-source.js";
+import { EnvService } from "../../services/env-service.js";
 
 /** Idle TTL before a session is evicted (10 minutes). */
 const IDLE_TTL_MS = 10 * 60 * 1000;
@@ -215,7 +216,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     new AnthropicHeaderUsageSource(),
   ]);
 
-  constructor() {
+  constructor(@inject(EnvService) private readonly envService: EnvService) {
     super();
   }
 
@@ -260,6 +261,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     // the server's Job Object. On server crash, this subprocess may briefly
     // outlive the server until the OS job-object kill propagates via inheritance.
     // Track: expose subprocess PID from claude-agent-sdk for explicit assignment.
+    // The SDK spawns `claude` internally without accepting a custom env; align
+    // `process.env` once per subprocess start so PATH and user tools stay current.
+    Object.assign(process.env, this.envService.getEnv());
     const q = sdkQuery({
       prompt: queue.iterable,
       options: {
@@ -646,6 +650,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       cwd: resolvedCwd,
     });
 
+    Object.assign(process.env, this.envService.getEnv());
     const q = sdkQuery({ prompt: queue.iterable, options });
 
     const entry: SessionEntry = {
@@ -699,6 +704,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         const freshQueue = createPromptQueue();
         const freshOptions = { ...baseOptions, sessionId: uuid };
 
+        Object.assign(process.env, this.envService.getEnv());
         const freshQ = sdkQuery({
           prompt: freshQueue.iterable,
           options: freshOptions,

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -7,6 +7,7 @@ vi.mock("@mcode/shared", () => ({
 
 import { CodexProvider } from "../codex-provider.js";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
+import { stubEnvService } from "../../../__tests__/stub-env-service.js";
 
 /**
  * These tests exercise the provider-level permission plumbing in isolation:
@@ -26,6 +27,7 @@ describe("CodexProvider permission flow", () => {
     provider = new CodexProvider(
       { get: async () => ({ provider: { cli: { codex: "codex" } } }) } as never,
       { assign: vi.fn() } as never,
+      stubEnvService() as never,
     );
     // Pre-register a session entry so drain logic has something to iterate.
     (provider as unknown as { sessions: Map<string, unknown> }).sessions.set(sessionId, {

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -13,6 +13,7 @@ import { EventEmitter } from "events";
 import { isAbsolute } from "path";
 import which from "which";
 import { logger } from "@mcode/shared";
+import { flattenProcessEnv } from "../../services/shell-env-utils.js";
 import { CodexRpcClient } from "./codex-rpc-client.js";
 import { mapDecisionToCodexResponse } from "./codex-permission-mapper.js";
 import type {
@@ -70,6 +71,10 @@ export interface CodexAppServerOptions {
    * When set, the codex process dies with the server on crash.
    */
   jobObject?: import("../../services/job-object.js").JobObject;
+  /**
+   * Supplies env for the child `codex` process. When unset, `process.env` is copied.
+   */
+  getSpawnEnv?: () => Record<string, string>;
 }
 
 /**
@@ -264,7 +269,7 @@ export class CodexAppServer extends EventEmitter {
       stdio: ["pipe", "pipe", "pipe"],
       shell: needsShell,
       cwd: workingDirectory,
-      env: { ...process.env },
+      env: this.options.getSpawnEnv ? this.options.getSpawnEnv() : flattenProcessEnv(process.env),
       windowsHide: true,
     });
 

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -15,6 +15,7 @@ import { randomUUID } from "crypto";
 import { logger } from "@mcode/shared";
 import { SettingsService } from "../../services/settings-service.js";
 import { JobObject } from "../../services/job-object.js";
+import { EnvService } from "../../services/env-service.js";
 import type {
   IAgentProvider,
   ProviderId,
@@ -114,6 +115,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
     @inject("JobObject") private readonly jobObject: JobObject,
+    @inject(EnvService) private readonly envService: EnvService,
   ) {
     super();
   }
@@ -224,6 +226,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
         ? (req) => this.handleApprovalRequest(sessionId, threadId, req)
         : undefined,
       jobObject: this.jobObject,
+      getSpawnEnv: () => this.envService.getEnv(),
     });
 
     const mapper = new CodexEventMapper(threadId);

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -22,6 +22,7 @@ import type { CopilotSession, ModelInfo } from "@github/copilot-sdk";
 import { discoverCopilotAgents, COPILOT_DEFAULT_AGENTS } from "./copilot-agent-discovery.js";
 import { logger } from "@mcode/shared";
 import { SettingsService } from "../../services/settings-service.js";
+import { EnvService } from "../../services/env-service.js";
 import type {
   IAgentProvider,
   ProviderId,
@@ -157,6 +158,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
+    @inject(EnvService) private readonly envService: EnvService,
   ) {
     super();
   }
@@ -360,6 +362,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       env?: Record<string, string | undefined>;
     } = {};
 
+    opts.env = { ...this.envService.getEnv() };
+
     // User-configured CLI path takes priority over all other resolution.
     if (configuredCliPath) {
       opts.cliPath = configuredCliPath;
@@ -382,8 +386,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       if (this.cachedNodePath) {
         const nodeDir = dirname(this.cachedNodePath);
         opts.env = {
-          ...process.env,
-          PATH: `${nodeDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+          ...opts.env,
+          PATH: `${nodeDir}${process.platform === "win32" ? ";" : ":"}${opts.env?.PATH ?? ""}`,
         };
       }
     }

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -385,9 +385,14 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       }
       if (this.cachedNodePath) {
         const nodeDir = dirname(this.cachedNodePath);
+        const sep = process.platform === "win32" ? ";" : ":";
+        const existingPath =
+          opts.env?.PATH ?? opts.env?.Path ?? "";
+        const pathValue = existingPath ? `${nodeDir}${sep}${existingPath}` : nodeDir;
         opts.env = {
           ...opts.env,
-          PATH: `${nodeDir}${process.platform === "win32" ? ";" : ":"}${opts.env?.PATH ?? ""}`,
+          PATH: pathValue,
+          ...(process.platform === "win32" ? { Path: pathValue } : {}),
         };
       }
     }

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -27,6 +27,7 @@ import {
 
 import { SettingsService } from "../../services/settings-service.js";
 import { SkillService } from "../../services/skill-service.js";
+import { EnvService } from "../../services/env-service.js";
 import {
   AgentEventType,
   CURSOR_STATIC_MODEL_FALLBACK,
@@ -110,6 +111,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
     @inject(SkillService) private readonly skillService: SkillService,
+    @inject(EnvService) private readonly envService: EnvService,
   ) {
     super();
   }
@@ -305,7 +307,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       stdio: ["pipe", "pipe", "pipe"],
       cwd,
       shell: process.platform === "win32",
-      env: { ...process.env },
+      env: this.envService.getEnv(),
     });
 
     if (!child.stdin || !child.stdout) {

--- a/apps/server/src/providers/cursor/cursor-turn-runner.ts
+++ b/apps/server/src/providers/cursor/cursor-turn-runner.ts
@@ -20,6 +20,7 @@ import { spawn as nodeSpawn } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { logger } from "@mcode/shared";
 import type { AgentEvent } from "@mcode/contracts";
+import { flattenProcessEnv } from "../../services/shell-env-utils.js";
 import { CursorStreamJsonParser } from "./cursor-stream-json-parser.js";
 import {
   createCursorStreamAccumulator,
@@ -64,6 +65,8 @@ export interface CursorTurnRunnerOptions {
   permissionMode: "default" | "full";
   /** Persistent chat id to resume; pass null on the first turn of a thread. */
   chatId: string | null;
+  /** When set, passed to `spawn` as `env` (defaults to a string snapshot of `process.env`). */
+  env?: Record<string, string>;
 }
 
 /** Successful turn outcome. The caller persists `chatId` for the next turn. */
@@ -164,7 +167,7 @@ export async function runCursorTurn(
     stdio: ["pipe", "pipe", "pipe"],
     shell: process.platform === "win32",
     cwd: options.cwd,
-    env: { ...process.env },
+    env: options.env ?? flattenProcessEnv(process.env),
   });
 
   return new Promise<CursorTurnResult>((resolve, reject) => {

--- a/apps/server/src/services/__tests__/env-service.test.ts
+++ b/apps/server/src/services/__tests__/env-service.test.ts
@@ -1,0 +1,99 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EnvService } from "../env-service.js";
+import type { ProtectedEnvStore } from "../protected-env-store.js";
+import type { ShellEnvResolver } from "../shell-env-resolver.js";
+
+function makeResolver(
+  envMap: Record<string, string> = { PATH: "/usr/bin", HOME: "/home/user" },
+): ShellEnvResolver {
+  return { resolveFresh: vi.fn(() => ({ ...envMap })) } as unknown as ShellEnvResolver;
+}
+
+function makeStore(
+  snapshot: Record<string, string> = { MCODE_PORT: "19400" },
+): ProtectedEnvStore {
+  return {
+    applyTo: vi.fn((resolved: Record<string, string>) => ({
+      ...resolved,
+      ...snapshot,
+    })),
+  } as unknown as ProtectedEnvStore;
+}
+
+describe("EnvService", () => {
+  let resolver: ShellEnvResolver;
+  let store: ProtectedEnvStore;
+  let service: EnvService;
+
+  beforeEach(() => {
+    resolver = makeResolver();
+    store = makeStore();
+    service = new EnvService(resolver, store);
+  });
+
+  it("returns merged env with protected keys winning", () => {
+    const env = service.getEnv();
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/user");
+    expect(env.MCODE_PORT).toBe("19400");
+  });
+
+  it("calls resolveFresh on first access", () => {
+    service.getEnv();
+    expect(resolver.resolveFresh).toHaveBeenCalledOnce();
+  });
+
+  it("returns cached result within TTL window", () => {
+    service.getEnv();
+    service.getEnv();
+    service.getEnv();
+    // Only one resolution despite three calls.
+    expect(resolver.resolveFresh).toHaveBeenCalledOnce();
+  });
+
+  it("re-resolves after TTL expires", () => {
+    vi.useFakeTimers();
+    try {
+      service.getEnv();
+      expect(resolver.resolveFresh).toHaveBeenCalledOnce();
+
+      // Advance past the 60s TTL.
+      vi.advanceTimersByTime(61_000);
+      service.getEnv();
+      expect(resolver.resolveFresh).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns a defensive copy (mutations do not leak back)", () => {
+    const first = service.getEnv();
+    first.PATH = "/hacked";
+    const second = service.getEnv();
+    expect(second.PATH).toBe("/usr/bin");
+  });
+
+  it("includes current process.env as base layer", () => {
+    const prev = process.env.SOME_RANDOM_VAR;
+    process.env.SOME_RANDOM_VAR = "from-process";
+    try {
+      const env = service.getEnv();
+      // process.env values appear in the base, but shell resolution values
+      // override them when both define the same key.
+      expect(env.SOME_RANDOM_VAR).toBe("from-process");
+    } finally {
+      if (prev === undefined) delete process.env.SOME_RANDOM_VAR;
+      else process.env.SOME_RANDOM_VAR = prev;
+    }
+  });
+
+  it("protected keys override shell-resolved values", () => {
+    const resolverWithConflict = makeResolver({ MCODE_PORT: "from-shell" });
+    const storeWithMcode = makeStore({ MCODE_PORT: "19400" });
+    const svc = new EnvService(resolverWithConflict, storeWithMcode);
+
+    const env = svc.getEnv();
+    expect(env.MCODE_PORT).toBe("19400");
+  });
+});

--- a/apps/server/src/services/__tests__/env-service.test.ts
+++ b/apps/server/src/services/__tests__/env-service.test.ts
@@ -7,18 +7,36 @@ import type { ShellEnvResolver } from "../shell-env-resolver.js";
 function makeResolver(
   envMap: Record<string, string> = { PATH: "/usr/bin", HOME: "/home/user" },
 ): ShellEnvResolver {
-  return { resolveFresh: vi.fn(() => ({ ...envMap })) } as unknown as ShellEnvResolver;
+  return {
+    peekResolvedOverlay: vi.fn(() => ({ ...envMap })),
+    resolveFreshAsync: vi.fn(async () => ({ ...envMap })),
+  } as unknown as ShellEnvResolver;
 }
 
 function makeStore(
   snapshot: Record<string, string> = { MCODE_PORT: "19400" },
 ): ProtectedEnvStore {
   return {
-    applyTo: vi.fn((resolved: Record<string, string>) => ({
-      ...resolved,
-      ...snapshot,
-    })),
+    applyTo: vi.fn((resolved: Record<string, string>) => {
+      const out: Record<string, string> = { ...resolved };
+      for (const k of Object.keys(resolved)) {
+        if (
+          k.startsWith("MCODE_") ||
+          k.startsWith("ELECTRON_") ||
+          k.startsWith("BETTER_SQLITE3_")
+        ) {
+          delete out[k];
+        }
+      }
+      return { ...out, ...snapshot };
+    }),
   } as unknown as ProtectedEnvStore;
+}
+
+async function flushRefresh(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("EnvService", () => {
@@ -39,37 +57,43 @@ describe("EnvService", () => {
     expect(env.MCODE_PORT).toBe("19400");
   });
 
-  it("calls resolveFresh on first access", () => {
+  it("schedules resolveFreshAsync on first access", async () => {
     service.getEnv();
-    expect(resolver.resolveFresh).toHaveBeenCalledOnce();
+    expect(resolver.resolveFreshAsync).toHaveBeenCalledOnce();
+    await flushRefresh();
   });
 
-  it("returns cached result within TTL window", () => {
+  it("does not call resolveFreshAsync again until TTL expires after refresh", async () => {
+    service.getEnv();
+    await flushRefresh();
+    vi.mocked(resolver.resolveFreshAsync).mockClear();
+
     service.getEnv();
     service.getEnv();
-    service.getEnv();
-    // Only one resolution despite three calls.
-    expect(resolver.resolveFresh).toHaveBeenCalledOnce();
+    expect(resolver.resolveFreshAsync).not.toHaveBeenCalled();
   });
 
-  it("re-resolves after TTL expires", () => {
+  it("re-resolves after TTL expires", async () => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
     try {
       service.getEnv();
-      expect(resolver.resolveFresh).toHaveBeenCalledOnce();
+      await flushRefresh();
+      expect(resolver.resolveFreshAsync).toHaveBeenCalledTimes(1);
 
-      // Advance past the 60s TTL.
-      vi.advanceTimersByTime(61_000);
+      vi.setSystemTime(new Date(61_000));
       service.getEnv();
-      expect(resolver.resolveFresh).toHaveBeenCalledTimes(2);
+      await flushRefresh();
+      expect(resolver.resolveFreshAsync).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("returns a defensive copy (mutations do not leak back)", () => {
+  it("returns a defensive copy (mutations do not leak back)", async () => {
     const first = service.getEnv();
     first.PATH = "/hacked";
+    await flushRefresh();
     const second = service.getEnv();
     expect(second.PATH).toBe("/usr/bin");
   });
@@ -79,8 +103,6 @@ describe("EnvService", () => {
     process.env.SOME_RANDOM_VAR = "from-process";
     try {
       const env = service.getEnv();
-      // process.env values appear in the base, but shell resolution values
-      // override them when both define the same key.
       expect(env.SOME_RANDOM_VAR).toBe("from-process");
     } finally {
       if (prev === undefined) delete process.env.SOME_RANDOM_VAR;

--- a/apps/server/src/services/__tests__/protected-env-store.test.ts
+++ b/apps/server/src/services/__tests__/protected-env-store.test.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata";
+import { describe, it, expect } from "vitest";
+import { ProtectedEnvStore } from "../protected-env-store.js";
+
+describe("ProtectedEnvStore", () => {
+  it("overlays startup MCODE_ values onto a resolved map", () => {
+    const prev = process.env.MCODE_PORT;
+    process.env.MCODE_PORT = "19400";
+    try {
+      const store = new ProtectedEnvStore();
+      const merged = store.applyTo({ MCODE_PORT: "1", USER: "shell" });
+      expect(merged.MCODE_PORT).toBe("19400");
+      expect(merged.USER).toBe("shell");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.MCODE_PORT;
+      } else {
+        process.env.MCODE_PORT = prev;
+      }
+    }
+  });
+
+  it("honours protect() for non-prefixed keys", () => {
+    const prev = process.env.CUSTOM_SERVER_FLAG;
+    process.env.CUSTOM_SERVER_FLAG = "keep-me";
+    try {
+      const store = new ProtectedEnvStore();
+      store.protect("CUSTOM_SERVER_FLAG");
+      const merged = store.applyTo({ CUSTOM_SERVER_FLAG: "from-shell" });
+      expect(merged.CUSTOM_SERVER_FLAG).toBe("keep-me");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.CUSTOM_SERVER_FLAG;
+      } else {
+        process.env.CUSTOM_SERVER_FLAG = prev;
+      }
+    }
+  });
+});

--- a/apps/server/src/services/__tests__/protected-env-store.test.ts
+++ b/apps/server/src/services/__tests__/protected-env-store.test.ts
@@ -73,6 +73,19 @@ describe("ProtectedEnvStore", () => {
     }
   });
 
+  it("drops explicit protected keys from resolved when no snapshot value exists", () => {
+    delete process.env.ORPHAN_PROTECTED_KEY;
+    const store = new ProtectedEnvStore();
+    store.protect("ORPHAN_PROTECTED_KEY");
+
+    const merged = store.applyTo({
+      ORPHAN_PROTECTED_KEY: "from-shell",
+      PATH: "/bin",
+    });
+    expect(merged.ORPHAN_PROTECTED_KEY).toBeUndefined();
+    expect(merged.PATH).toBe("/bin");
+  });
+
   it("passes through non-protected keys unchanged", () => {
     const store = new ProtectedEnvStore();
     const merged = store.applyTo({ PATH: "/usr/bin", HOME: "/home/dev" });

--- a/apps/server/src/services/__tests__/protected-env-store.test.ts
+++ b/apps/server/src/services/__tests__/protected-env-store.test.ts
@@ -20,12 +20,48 @@ describe("ProtectedEnvStore", () => {
     }
   });
 
+  it("auto-protects ELECTRON_ prefixed keys", () => {
+    const prev = process.env.ELECTRON_RUN_AS_NODE;
+    process.env.ELECTRON_RUN_AS_NODE = "1";
+    try {
+      const store = new ProtectedEnvStore();
+      expect(store.isProtected("ELECTRON_RUN_AS_NODE")).toBe(true);
+      const merged = store.applyTo({ ELECTRON_RUN_AS_NODE: "from-shell" });
+      expect(merged.ELECTRON_RUN_AS_NODE).toBe("1");
+    } finally {
+      if (prev === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+      else process.env.ELECTRON_RUN_AS_NODE = prev;
+    }
+  });
+
+  it("auto-protects BETTER_SQLITE3_ prefixed keys", () => {
+    const prev = process.env.BETTER_SQLITE3_BINDING;
+    process.env.BETTER_SQLITE3_BINDING = "/native/path";
+    try {
+      const store = new ProtectedEnvStore();
+      expect(store.isProtected("BETTER_SQLITE3_BINDING")).toBe(true);
+      const merged = store.applyTo({ BETTER_SQLITE3_BINDING: "from-shell" });
+      expect(merged.BETTER_SQLITE3_BINDING).toBe("/native/path");
+    } finally {
+      if (prev === undefined) delete process.env.BETTER_SQLITE3_BINDING;
+      else process.env.BETTER_SQLITE3_BINDING = prev;
+    }
+  });
+
+  it("isProtected returns false for non-protected keys", () => {
+    const store = new ProtectedEnvStore();
+    expect(store.isProtected("PATH")).toBe(false);
+    expect(store.isProtected("HOME")).toBe(false);
+    expect(store.isProtected("USER")).toBe(false);
+  });
+
   it("honours protect() for non-prefixed keys", () => {
     const prev = process.env.CUSTOM_SERVER_FLAG;
     process.env.CUSTOM_SERVER_FLAG = "keep-me";
     try {
       const store = new ProtectedEnvStore();
       store.protect("CUSTOM_SERVER_FLAG");
+      expect(store.isProtected("CUSTOM_SERVER_FLAG")).toBe(true);
       const merged = store.applyTo({ CUSTOM_SERVER_FLAG: "from-shell" });
       expect(merged.CUSTOM_SERVER_FLAG).toBe("keep-me");
     } finally {
@@ -35,5 +71,12 @@ describe("ProtectedEnvStore", () => {
         process.env.CUSTOM_SERVER_FLAG = prev;
       }
     }
+  });
+
+  it("passes through non-protected keys unchanged", () => {
+    const store = new ProtectedEnvStore();
+    const merged = store.applyTo({ PATH: "/usr/bin", HOME: "/home/dev" });
+    expect(merged.PATH).toBe("/usr/bin");
+    expect(merged.HOME).toBe("/home/dev");
   });
 });

--- a/apps/server/src/services/__tests__/shell-env-resolver.test.ts
+++ b/apps/server/src/services/__tests__/shell-env-resolver.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { flattenProcessEnv, parseNullDelimitedEnv } from "../shell-env-utils.js";
+
+describe("shell-env-resolver helpers", () => {
+  it("parseNullDelimitedEnv splits on NUL and supports = in values", () => {
+    const buf = Buffer.from("A=1\0B=x=y\0", "utf8");
+    expect(parseNullDelimitedEnv(buf)).toEqual({ A: "1", B: "x=y" });
+  });
+
+  it("flattenProcessEnv drops undefined entries", () => {
+    const env = { X: "a", Y: undefined } as NodeJS.ProcessEnv;
+    expect(flattenProcessEnv(env)).toEqual({ X: "a" });
+  });
+});

--- a/apps/server/src/services/__tests__/shell-env-resolver.test.ts
+++ b/apps/server/src/services/__tests__/shell-env-resolver.test.ts
@@ -1,14 +1,62 @@
 import { describe, it, expect } from "vitest";
-import { flattenProcessEnv, parseNullDelimitedEnv } from "../shell-env-utils.js";
+import {
+  flattenProcessEnv,
+  parseNewlineDelimitedEnv,
+  parseNullDelimitedEnv,
+} from "../shell-env-utils.js";
 
-describe("shell-env-resolver helpers", () => {
-  it("parseNullDelimitedEnv splits on NUL and supports = in values", () => {
-    const buf = Buffer.from("A=1\0B=x=y\0", "utf8");
-    expect(parseNullDelimitedEnv(buf)).toEqual({ A: "1", B: "x=y" });
+describe("shell-env-utils", () => {
+  describe("parseNullDelimitedEnv", () => {
+    it("splits on NUL and supports = in values", () => {
+      const buf = Buffer.from("A=1\0B=x=y\0", "utf8");
+      expect(parseNullDelimitedEnv(buf)).toEqual({ A: "1", B: "x=y" });
+    });
+
+    it("returns empty object for empty buffer", () => {
+      expect(parseNullDelimitedEnv(Buffer.alloc(0))).toEqual({});
+    });
+
+    it("skips entries without = separator", () => {
+      const buf = Buffer.from("A=1\0NOEQ\0B=2\0", "utf8");
+      expect(parseNullDelimitedEnv(buf)).toEqual({ A: "1", B: "2" });
+    });
   });
 
-  it("flattenProcessEnv drops undefined entries", () => {
-    const env = { X: "a", Y: undefined } as NodeJS.ProcessEnv;
-    expect(flattenProcessEnv(env)).toEqual({ X: "a" });
+  describe("parseNewlineDelimitedEnv", () => {
+    it("splits on newlines and supports = in values", () => {
+      expect(parseNewlineDelimitedEnv("A=1\nB=x=y\n")).toEqual({
+        A: "1",
+        B: "x=y",
+      });
+    });
+
+    it("returns empty object for empty string", () => {
+      expect(parseNewlineDelimitedEnv("")).toEqual({});
+    });
+
+    it("skips lines without = separator", () => {
+      expect(parseNewlineDelimitedEnv("A=1\nNOEQ\nB=2\n")).toEqual({
+        A: "1",
+        B: "2",
+      });
+    });
+
+    it("handles values containing = characters", () => {
+      expect(parseNewlineDelimitedEnv("FORMULA=a=b=c\n")).toEqual({
+        FORMULA: "a=b=c",
+      });
+    });
+  });
+
+  describe("flattenProcessEnv", () => {
+    it("drops undefined entries", () => {
+      const env = { X: "a", Y: undefined } as NodeJS.ProcessEnv;
+      expect(flattenProcessEnv(env)).toEqual({ X: "a" });
+    });
+
+    it("preserves empty string values", () => {
+      const env = { EMPTY: "" } as NodeJS.ProcessEnv;
+      expect(flattenProcessEnv(env)).toEqual({ EMPTY: "" });
+    });
   });
 });

--- a/apps/server/src/services/env-service.ts
+++ b/apps/server/src/services/env-service.ts
@@ -10,6 +10,8 @@ import { flattenProcessEnv } from "./shell-env-utils.js";
 import { ShellEnvResolver } from "./shell-env-resolver.js";
 
 const DEFAULT_TTL_MS = 60_000;
+/** Coalesces overlapping `getEnv` calls while an async shell/registry refresh is in flight. */
+const UNTIL_ASYNC_MS = 2_000;
 
 /**
  * Public facade used by terminals and providers when spawning subprocesses.
@@ -18,6 +20,7 @@ const DEFAULT_TTL_MS = 60_000;
 export class EnvService {
   private cached: Record<string, string> | null = null;
   private cacheExpiresAt = 0;
+  private refreshInFlight = false;
 
   constructor(
     @inject(ShellEnvResolver) private readonly shellEnvResolver: ShellEnvResolver,
@@ -25,21 +28,43 @@ export class EnvService {
   ) {}
 
   /**
-   * Returns env for `spawn` / PTY: live `process.env`, overlaid with cached
-   * shell/registry resolution (refreshed at most every {@link DEFAULT_TTL_MS}),
-   * then server-protected keys from startup.
+   * Returns env for `spawn` / PTY: live `process.env`, overlaid with the last
+   * async shell/registry resolution (TTL {@link DEFAULT_TTL_MS}), then
+   * server-protected keys. Never blocks the event loop on a shell spawn; a
+   * background refresh runs when the cache expires.
    */
   getEnv(): Record<string, string> {
     const now = Date.now();
-    if (this.cached && now < this.cacheExpiresAt) {
+    if (this.cached !== null && now < this.cacheExpiresAt) {
       return { ...this.cached };
     }
 
-    const resolved = this.shellEnvResolver.resolveFresh();
     const base = flattenProcessEnv(process.env);
-    const merged = this.protectedEnvStore.applyTo({ ...base, ...resolved });
+    const overlay = this.shellEnvResolver.peekResolvedOverlay();
+    const merged = this.protectedEnvStore.applyTo({ ...base, ...overlay });
     this.cached = merged;
-    this.cacheExpiresAt = now + DEFAULT_TTL_MS;
+    this.cacheExpiresAt = now + UNTIL_ASYNC_MS;
+    this.scheduleRefresh();
     return { ...merged };
+  }
+
+  private scheduleRefresh(): void {
+    if (this.refreshInFlight) {
+      return;
+    }
+    this.refreshInFlight = true;
+    void this.shellEnvResolver
+      .resolveFreshAsync()
+      .then((resolved) => {
+        const base = flattenProcessEnv(process.env);
+        this.cached = this.protectedEnvStore.applyTo({ ...base, ...resolved });
+        this.cacheExpiresAt = Date.now() + DEFAULT_TTL_MS;
+      })
+      .catch(() => {
+        /* resolveFreshAsync already logged and returned fallback */
+      })
+      .finally(() => {
+        this.refreshInFlight = false;
+      });
   }
 }

--- a/apps/server/src/services/env-service.ts
+++ b/apps/server/src/services/env-service.ts
@@ -1,0 +1,45 @@
+/**
+ * Builds complete environment objects for child spawns: current process env,
+ * merged with a periodic fresh resolution from the user's shell or OS config,
+ * with server-owned keys forced to the values captured at startup.
+ */
+
+import { injectable, inject } from "tsyringe";
+import { ProtectedEnvStore } from "./protected-env-store.js";
+import { flattenProcessEnv } from "./shell-env-utils.js";
+import { ShellEnvResolver } from "./shell-env-resolver.js";
+
+const DEFAULT_TTL_MS = 60_000;
+
+/**
+ * Public facade used by terminals and providers when spawning subprocesses.
+ */
+@injectable()
+export class EnvService {
+  private cached: Record<string, string> | null = null;
+  private cacheExpiresAt = 0;
+
+  constructor(
+    @inject(ShellEnvResolver) private readonly shellEnvResolver: ShellEnvResolver,
+    @inject(ProtectedEnvStore) private readonly protectedEnvStore: ProtectedEnvStore,
+  ) {}
+
+  /**
+   * Returns env for `spawn` / PTY: live `process.env`, overlaid with cached
+   * shell/registry resolution (refreshed at most every {@link DEFAULT_TTL_MS}),
+   * then server-protected keys from startup.
+   */
+  getEnv(): Record<string, string> {
+    const now = Date.now();
+    if (this.cached && now < this.cacheExpiresAt) {
+      return { ...this.cached };
+    }
+
+    const resolved = this.shellEnvResolver.resolveFresh();
+    const base = flattenProcessEnv(process.env);
+    const merged = this.protectedEnvStore.applyTo({ ...base, ...resolved });
+    this.cached = merged;
+    this.cacheExpiresAt = now + DEFAULT_TTL_MS;
+    return { ...merged };
+  }
+}

--- a/apps/server/src/services/protected-env-store.ts
+++ b/apps/server/src/services/protected-env-store.ts
@@ -46,10 +46,17 @@ export class ProtectedEnvStore {
   }
 
   /**
-   * Overlays captured server values onto a resolved env so protected keys always win.
+   * Drops protected names from the resolved map, then overlays the snapshotted
+   * server values so shell or registry cannot set server-owned keys.
    */
   applyTo(resolved: Record<string, string>): Record<string, string> {
-    return { ...resolved, ...this.snapshot };
+    const out: Record<string, string> = { ...resolved };
+    for (const key of Object.keys(out)) {
+      if (this.isProtected(key)) {
+        delete out[key];
+      }
+    }
+    return { ...out, ...this.snapshot };
   }
 
   private captureFromProcessEnv(): void {

--- a/apps/server/src/services/protected-env-store.ts
+++ b/apps/server/src/services/protected-env-store.ts
@@ -1,0 +1,62 @@
+/**
+ * Tracks environment variable keys owned by the Mcode server process so they
+ * are never replaced by values from the user's shell or Windows registry.
+ */
+
+import { injectable } from "tsyringe";
+
+const AUTO_PROTECT_PREFIXES = ["MCODE_", "ELECTRON_", "BETTER_SQLITE3_"] as const;
+
+/**
+ * Holds a snapshot of server-owned env values and merges them over resolved
+ * child-process environments so spawns keep a stable runtime contract.
+ */
+@injectable()
+export class ProtectedEnvStore {
+  private readonly explicitKeys = new Set<string>();
+  private readonly snapshot: Record<string, string>;
+
+  constructor() {
+    this.snapshot = {};
+    this.captureFromProcessEnv();
+  }
+
+  /**
+   * Declares a key as server-owned when it does not match an auto-protected prefix
+   * (e.g. a future internal variable with no prefix).
+   */
+  protect(key: string): void {
+    this.explicitKeys.add(key);
+    const v = process.env[key];
+    if (v !== undefined) {
+      this.snapshot[key] = v;
+    }
+  }
+
+  /**
+   * Returns whether a key is treated as owned by the server (prefix or explicit).
+   */
+  isProtected(key: string): boolean {
+    for (const prefix of AUTO_PROTECT_PREFIXES) {
+      if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return this.explicitKeys.has(key);
+  }
+
+  /**
+   * Overlays captured server values onto a resolved env so protected keys always win.
+   */
+  applyTo(resolved: Record<string, string>): Record<string, string> {
+    return { ...resolved, ...this.snapshot };
+  }
+
+  private captureFromProcessEnv(): void {
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined && this.isProtected(key)) {
+        this.snapshot[key] = value;
+      }
+    }
+  }
+}

--- a/apps/server/src/services/shell-env-resolver.ts
+++ b/apps/server/src/services/shell-env-resolver.ts
@@ -6,13 +6,13 @@
 import { execFileSync } from "node:child_process";
 import { injectable } from "tsyringe";
 import { logger } from "@mcode/shared";
-import { flattenProcessEnv, parseNullDelimitedEnv } from "./shell-env-utils.js";
+import { flattenProcessEnv, parseNewlineDelimitedEnv, parseNullDelimitedEnv } from "./shell-env-utils.js";
 
 const RESOLVE_TIMEOUT_MS = 5000;
 const MAX_ENV_BUFFER_BYTES = 32 * 1024 * 1024;
 
 // Re-export for call sites that only need helpers without pulling tsyringe metadata.
-export { flattenProcessEnv, parseNullDelimitedEnv } from "./shell-env-utils.js";
+export { flattenProcessEnv, parseNewlineDelimitedEnv, parseNullDelimitedEnv } from "./shell-env-utils.js";
 
 /**
  * Platform-specific env resolution with a retained last-good fallback.
@@ -49,13 +49,31 @@ export class ShellEnvResolver {
 
   private resolveUnix(): Record<string, string> {
     const shell = process.env.SHELL ?? "/bin/bash";
-    const buf = execFileSync(shell, ["-ilc", "env -0"], {
-      encoding: "buffer",
+    // `env -0` is a GNU extension unavailable on macOS/BSD. Try it first,
+    // and fall back to newline-delimited `env` when it fails.
+    try {
+      const buf = execFileSync(shell, ["-ilc", "env -0"], {
+        encoding: "buffer",
+        timeout: RESOLVE_TIMEOUT_MS,
+        maxBuffer: MAX_ENV_BUFFER_BYTES,
+        windowsHide: true,
+      }) as Buffer;
+      // Sanity: NUL-delimited output must contain at least one NUL byte.
+      if (buf.includes(0)) {
+        return parseNullDelimitedEnv(buf);
+      }
+    } catch {
+      // Expected on macOS/BSD where env(1) lacks -0. Fall through.
+    }
+    // Newline-delimited fallback. Values containing literal newlines will
+    // be split incorrectly, but that is rare and matches VS Code's behavior.
+    const text = execFileSync(shell, ["-ilc", "env"], {
+      encoding: "utf8",
       timeout: RESOLVE_TIMEOUT_MS,
       maxBuffer: MAX_ENV_BUFFER_BYTES,
       windowsHide: true,
-    }) as Buffer;
-    return parseNullDelimitedEnv(buf);
+    });
+    return parseNewlineDelimitedEnv(text);
   }
 
   private resolveWindows(): Record<string, string> {

--- a/apps/server/src/services/shell-env-resolver.ts
+++ b/apps/server/src/services/shell-env-resolver.ts
@@ -3,10 +3,14 @@
  * Windows registry machine + user hives, for passing to child processes.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { userInfo } from "node:os";
+import { promisify } from "node:util";
 import { injectable } from "tsyringe";
 import { logger } from "@mcode/shared";
 import { flattenProcessEnv, parseNewlineDelimitedEnv, parseNullDelimitedEnv } from "./shell-env-utils.js";
+
+const execFileAsync = promisify(execFile);
 
 const RESOLVE_TIMEOUT_MS = 5000;
 const MAX_ENV_BUFFER_BYTES = 32 * 1024 * 1024;
@@ -27,13 +31,39 @@ export class ShellEnvResolver {
   }
 
   /**
-   * Attempts a fresh resolution; on failure logs and returns the last successful
-   * map, or the boot-time process env if none.
+   * Best-known resolved overlay (fresh shell/registry or boot snapshot).
+   * Safe to merge synchronously without blocking on a shell spawn.
    */
-  resolveFresh(): Record<string, string> {
+  peekResolvedOverlay(): Record<string, string> {
+    return this.lastSuccess ?? { ...this.bootEnv };
+  }
+
+  private unixLoginShell(): string {
+    const fromEnv = process.env.SHELL?.trim();
+    if (fromEnv) {
+      return fromEnv;
+    }
+    try {
+      const fromOs = userInfo().shell?.trim();
+      if (fromOs) {
+        return fromOs;
+      }
+    } catch {
+      /* ignored: unmapped uid on some systems */
+    }
+    return "/bin/sh";
+  }
+
+  /**
+   * Refreshes overlay asynchronously (no `execFileSync`) and updates
+   * {@link peekResolvedOverlay} on success.
+   */
+  async resolveFreshAsync(): Promise<Record<string, string>> {
     try {
       const resolved =
-        process.platform === "win32" ? this.resolveWindows() : this.resolveUnix();
+        process.platform === "win32"
+          ? await this.resolveWindowsAsync()
+          : await this.resolveUnixAsync();
       if (Object.keys(resolved).length === 0) {
         throw new Error("resolved env empty");
       }
@@ -47,38 +77,32 @@ export class ShellEnvResolver {
     }
   }
 
-  private resolveUnix(): Record<string, string> {
-    const shell = process.env.SHELL ?? "/bin/bash";
-    // `env -0` is a GNU extension unavailable on macOS/BSD. Try it first,
-    // and fall back to newline-delimited `env` when it fails.
+  private async resolveUnixAsync(): Promise<Record<string, string>> {
+    const shell = this.unixLoginShell();
     try {
-      const buf = execFileSync(shell, ["-ilc", "env -0"], {
+      const { stdout: buf } = await execFileAsync(shell, ["-ilc", "env -0"], {
         encoding: "buffer",
         timeout: RESOLVE_TIMEOUT_MS,
         maxBuffer: MAX_ENV_BUFFER_BYTES,
         windowsHide: true,
-      }) as Buffer;
-      // Sanity: NUL-delimited output must contain at least one NUL byte.
-      if (buf.includes(0)) {
-        return parseNullDelimitedEnv(buf);
+      });
+      const buffer = Buffer.isBuffer(buf) ? buf : Buffer.from(buf as string, "utf8");
+      if (buffer.includes(0)) {
+        return parseNullDelimitedEnv(buffer);
       }
     } catch {
-      // Expected on macOS/BSD where env(1) lacks -0. Fall through.
+      /* macOS/BSD often lack env -0 */
     }
-    // Newline-delimited fallback. Values containing literal newlines will
-    // be split incorrectly, but that is rare and matches VS Code's behavior.
-    const text = execFileSync(shell, ["-ilc", "env"], {
+    const { stdout: text } = await execFileAsync(shell, ["-ilc", "env"], {
       encoding: "utf8",
       timeout: RESOLVE_TIMEOUT_MS,
       maxBuffer: MAX_ENV_BUFFER_BYTES,
       windowsHide: true,
     });
-    return parseNewlineDelimitedEnv(text);
+    return parseNewlineDelimitedEnv(text as string);
   }
 
-  private resolveWindows(): Record<string, string> {
-    // Base64 wraps UTF-8 NUL-delimited pairs so we do not depend on the console
-    // code page (raw Write would often emit UTF-16 on Windows).
+  private async resolveWindowsAsync(): Promise<Record<string, string>> {
     const script = [
       "$m = [Environment]::GetEnvironmentVariables('Machine')",
       "$u = [Environment]::GetEnvironmentVariables('User')",
@@ -96,7 +120,7 @@ export class ShellEnvResolver {
       "[Console]::Out.Write([Convert]::ToBase64String($bytes))",
     ].join("; ");
 
-    const out = execFileSync(
+    const { stdout: out } = await execFileAsync(
       "powershell.exe",
       ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
       {
@@ -105,8 +129,8 @@ export class ShellEnvResolver {
         maxBuffer: MAX_ENV_BUFFER_BYTES,
         windowsHide: true,
       },
-    ).trim();
-    const buf = Buffer.from(out, "base64");
+    );
+    const buf = Buffer.from((out as string).trim(), "base64");
     return parseNullDelimitedEnv(buf);
   }
 }

--- a/apps/server/src/services/shell-env-resolver.ts
+++ b/apps/server/src/services/shell-env-resolver.ts
@@ -1,0 +1,94 @@
+/**
+ * Resolves the user's current environment from a login shell (Unix) or the
+ * Windows registry machine + user hives, for passing to child processes.
+ */
+
+import { execFileSync } from "node:child_process";
+import { injectable } from "tsyringe";
+import { logger } from "@mcode/shared";
+import { flattenProcessEnv, parseNullDelimitedEnv } from "./shell-env-utils.js";
+
+const RESOLVE_TIMEOUT_MS = 5000;
+const MAX_ENV_BUFFER_BYTES = 32 * 1024 * 1024;
+
+// Re-export for call sites that only need helpers without pulling tsyringe metadata.
+export { flattenProcessEnv, parseNullDelimitedEnv } from "./shell-env-utils.js";
+
+/**
+ * Platform-specific env resolution with a retained last-good fallback.
+ */
+@injectable()
+export class ShellEnvResolver {
+  private lastSuccess: Record<string, string> | null = null;
+  private readonly bootEnv: Record<string, string>;
+
+  constructor() {
+    this.bootEnv = flattenProcessEnv(process.env);
+  }
+
+  /**
+   * Attempts a fresh resolution; on failure logs and returns the last successful
+   * map, or the boot-time process env if none.
+   */
+  resolveFresh(): Record<string, string> {
+    try {
+      const resolved =
+        process.platform === "win32" ? this.resolveWindows() : this.resolveUnix();
+      if (Object.keys(resolved).length === 0) {
+        throw new Error("resolved env empty");
+      }
+      this.lastSuccess = resolved;
+      return resolved;
+    } catch (err) {
+      logger.warn("ShellEnvResolver: fresh resolution failed; using fallback env", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return this.lastSuccess ?? { ...this.bootEnv };
+    }
+  }
+
+  private resolveUnix(): Record<string, string> {
+    const shell = process.env.SHELL ?? "/bin/bash";
+    const buf = execFileSync(shell, ["-ilc", "env -0"], {
+      encoding: "buffer",
+      timeout: RESOLVE_TIMEOUT_MS,
+      maxBuffer: MAX_ENV_BUFFER_BYTES,
+      windowsHide: true,
+    }) as Buffer;
+    return parseNullDelimitedEnv(buf);
+  }
+
+  private resolveWindows(): Record<string, string> {
+    // Base64 wraps UTF-8 NUL-delimited pairs so we do not depend on the console
+    // code page (raw Write would often emit UTF-16 on Windows).
+    const script = [
+      "$m = [Environment]::GetEnvironmentVariables('Machine')",
+      "$u = [Environment]::GetEnvironmentVariables('User')",
+      "$r = @{}",
+      "foreach ($k in $m.Keys) { $r[$k] = $m[$k] }",
+      "foreach ($k in $u.Keys) {",
+      "  if ($k -eq 'Path') { $r[$k] = $m[$k] + ';' + $u[$k] }",
+      "  else { $r[$k] = $u[$k] }",
+      "}",
+      "$sb = New-Object System.Text.StringBuilder",
+      "foreach ($k in $r.Keys) {",
+      "  [void]$sb.Append($k).Append('=').Append($r[$k]).Append([char]0)",
+      "}",
+      "$bytes = [System.Text.Encoding]::UTF8.GetBytes($sb.ToString())",
+      "[Console]::Out.Write([Convert]::ToBase64String($bytes))",
+    ].join("; ");
+
+    const out = execFileSync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
+      {
+        encoding: "utf8",
+        timeout: RESOLVE_TIMEOUT_MS,
+        maxBuffer: MAX_ENV_BUFFER_BYTES,
+        windowsHide: true,
+      },
+    ).trim();
+    const buf = Buffer.from(out, "base64");
+    return parseNullDelimitedEnv(buf);
+  }
+}

--- a/apps/server/src/services/shell-env-utils.ts
+++ b/apps/server/src/services/shell-env-utils.ts
@@ -17,6 +17,22 @@ export function flattenProcessEnv(env: NodeJS.ProcessEnv): Record<string, string
 }
 
 /**
+ * Parses newline-delimited `env` output (KEY=value per line).
+ * Values containing literal newlines will be split incorrectly;
+ * prefer {@link parseNullDelimitedEnv} when `env -0` is available.
+ */
+export function parseNewlineDelimitedEnv(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    if (!line) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    out[line.slice(0, eq)] = line.slice(eq + 1);
+  }
+  return out;
+}
+
+/**
  * Parses `env -0` style NUL-delimited KEY=value chunks.
  */
 export function parseNullDelimitedEnv(buf: Buffer): Record<string, string> {

--- a/apps/server/src/services/shell-env-utils.ts
+++ b/apps/server/src/services/shell-env-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure helpers for serializing and parsing environment maps used by
+ * {@link ShellEnvResolver} and child-process spawns (no DI).
+ */
+
+/**
+ * Flattens `process.env` to a string-only record (drops undefined entries).
+ */
+export function flattenProcessEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Parses `env -0` style NUL-delimited KEY=value chunks.
+ */
+export function parseNullDelimitedEnv(buf: Buffer): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (buf.length === 0) {
+    return out;
+  }
+  const raw = buf.toString("utf8");
+  const parts = raw.split("\0");
+  for (const part of parts) {
+    if (!part) {
+      continue;
+    }
+    const eq = part.indexOf("=");
+    if (eq <= 0) {
+      continue;
+    }
+    const key = part.slice(0, eq);
+    const value = part.slice(eq + 1);
+    out[key] = value;
+  }
+  return out;
+}

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -19,6 +19,7 @@ import type { ThreadRepo } from "../repositories/thread-repo";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { GitService } from "./git-service";
 import type { SettingsService } from "./settings-service";
+import { EnvService } from "./env-service.js";
 
 // createRequire lets us load native CJS modules (node-pty) from both ESM
 // (Bun running `src/index.ts`) and the CJS production / dev bundle.
@@ -92,6 +93,7 @@ export class TerminalService {
     @inject("WorkspaceRepo") private readonly workspaceRepo: WorkspaceRepo,
     @inject("GitService") private readonly gitService: GitService,
     @inject("SettingsService") private readonly settingsService: SettingsService,
+    @inject(EnvService) private readonly envService: EnvService,
     @inject("PtyPidRegistry") private readonly pidRegistry: PtyPidRegistry,
     @inject("JobObject") private readonly jobObject: import("./job-object.js").JobObject,
   ) {}
@@ -148,6 +150,7 @@ export class TerminalService {
       cols: DEFAULT_COLS,
       rows: DEFAULT_ROWS,
       cwd,
+      env: this.envService.getEnv(),
     });
 
     let seq = 0;

--- a/docs/agents/runtime.md
+++ b/docs/agents/runtime.md
@@ -81,6 +81,16 @@ All variables are optional — defaults work for local development.
 
 Copy `.env.example` to `.env` and uncomment to override any variable.
 
+### Child process environment
+
+PTY sessions, provider CLI subprocesses, and other server-spawned children receive environment built by **`EnvService`** (`apps/server/src/services/env-service.ts`). It merges, in order:
+
+1. The current server `process.env` (keeps volatile vars such as `TEMP` on Windows)
+2. A refresh from the user's login shell (`env -0` on Unix) or from the Windows user and machine registry (cached about 60 seconds)
+3. **`ProtectedEnvStore`**, which forces keys captured at server startup whose names start with `MCODE_`, `ELECTRON_`, or `BETTER_SQLITE3_`, plus any key registered via `protect()`
+
+The server does not periodically mutate its own `process.env`. The Claude Agent SDK subprocess reads `process.env` at session start only; the provider updates `process.env` once immediately before each `sdkQuery()` call so that path stays aligned.
+
 ---
 
 ## Runtime Artifact Locations


### PR DESCRIPTION
## What

Resolve fresh environment variables from the user's login shell (Unix) or Windows registry on demand, cache them with a 60-second TTL, and pass them explicitly to every child process spawn. Server-owned variables are protected from being overwritten by shell values.

## Why

Electron captures `process.env` at launch time. The server inherits that snapshot, and every child process (terminals, agent providers) inherits the stale copy. If a user installs a new CLI tool, updates their PATH, or modifies their shell profile after launching Mcode, new terminals and agent sessions don't see the changes. The user must restart the entire app.

## Key Changes

- **Three new services** under `apps/server/src/services/`:
  - `ProtectedEnvStore`: tracks server-owned env keys by prefix (`MCODE_*`, `ELECTRON_*`, `BETTER_SQLITE3_*`) and explicit registration. Snapshots values at boot so they always win during merge.
  - `ShellEnvResolver`: platform-specific fresh env resolution. Unix: login shell spawn (`$SHELL -ilc`) with `env -0` (GNU) / `env` (macOS/BSD) fallback. Windows: registry read via PowerShell with base64-encoded output.
  - `EnvService`: public facade combining resolver + protected store. Exposes `getEnv()` returning fresh shell env merged with protected server keys.

- **All spawn sites updated** to use `envService.getEnv()`:
  - `terminal-service.ts`: `env` option added to `node-pty.spawn()`
  - `codex-app-server.ts`: `getSpawnEnv` callback added to options
  - `cursor-provider.ts`: `env` passed to `spawnOneCli()`
  - `cursor-turn-runner.ts`: optional `env` added to options
  - `copilot-provider.ts`: base env set from `envService.getEnv()`, node PATH prepend preserved on top
  - `claude-provider.ts`: selective `Object.assign` to `process.env` before SDK calls (SDK manages its own subprocess)

- **DI registration** in `container.ts` before all consumers
- **Documentation** updated in AGENTS.md, ARCHITECTURE.md, and docs/agents/runtime.md
- **Tests**: EnvService, ProtectedEnvStore, ShellEnvResolver, and parser utils fully covered (22 new tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child processes and integrated terminals now inherit a consolidated, refreshable environment that preserves server-startup-protected variables and refreshes short-lived overlays.

* **Documentation**
  * Added guidance describing child-process environment construction, precedence of protected variables, and when environment snapshots are applied.

* **Tests**
  * Expanded test coverage for environment parsing, protection rules, caching/refresh behavior, and provider/terminal integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->