### PR TITLE
fix(server): self-heal migrations on databases from older builds

### DIFF
--- a/apps/server/src/__tests__/bootstrap-drizzle.test.ts
+++ b/apps/server/src/__tests__/bootstrap-drizzle.test.ts
@@ -97,4 +97,75 @@ describe("bootstrapDrizzle", () => {
     bootstrapDrizzle(db, DRIZZLE_DIR);
     expect(tableExists(db, "__drizzle_migrations")).toBe(false);
   });
+
+  it("recovers when __drizzle_migrations exists but is empty (interrupted bootstrap)", () => {
+    seedLegacyMigrations(db);
+    db.exec("CREATE TABLE workspaces (id TEXT PRIMARY KEY)");
+    db.exec(`
+      CREATE TABLE __drizzle_migrations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        hash text NOT NULL,
+        created_at numeric
+      )
+    `);
+
+    bootstrapDrizzle(db, DRIZZLE_DIR);
+
+    const rows = db.prepare("SELECT * FROM __drizzle_migrations").all() as Array<{
+      hash: string;
+      created_at: number;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].hash).toBe(baselineSqlHash());
+    expect(rows[0].created_at).toBe(journal.entries[0].when);
+  });
+
+  it("does nothing when __drizzle_migrations is empty and no legacy tracker exists", () => {
+    db.exec(`
+      CREATE TABLE __drizzle_migrations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        hash text NOT NULL,
+        created_at numeric
+      )
+    `);
+
+    bootstrapDrizzle(db, DRIZZLE_DIR);
+
+    const rows = db.prepare("SELECT * FROM __drizzle_migrations").all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("seeds when sentinel app table exists but no migration tracking (db:push DB)", () => {
+    // No _migrations, no __drizzle_migrations: schema came from db:push or
+    // a pre-legacy build. Sentinel `workspaces` proves the baseline ran.
+    db.exec("CREATE TABLE workspaces (id TEXT PRIMARY KEY)");
+
+    bootstrapDrizzle(db, DRIZZLE_DIR);
+
+    const rows = db.prepare("SELECT * FROM __drizzle_migrations").all() as Array<{
+      hash: string;
+      created_at: number;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].hash).toBe(baselineSqlHash());
+  });
+
+  it("seeds when sentinel app table exists and __drizzle_migrations is empty", () => {
+    db.exec("CREATE TABLE workspaces (id TEXT PRIMARY KEY)");
+    db.exec(`
+      CREATE TABLE __drizzle_migrations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        hash text NOT NULL,
+        created_at numeric
+      )
+    `);
+
+    bootstrapDrizzle(db, DRIZZLE_DIR);
+
+    const rows = db.prepare("SELECT * FROM __drizzle_migrations").all() as Array<{
+      hash: string;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].hash).toBe(baselineSqlHash());
+  });
 });

--- a/apps/server/src/__tests__/migration-backup.test.ts
+++ b/apps/server/src/__tests__/migration-backup.test.ts
@@ -1,0 +1,122 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createMigrationBackup,
+  pruneMigrationBackups,
+  restoreMigrationBackup,
+} from "../store/migration-backup.js";
+
+describe("migration-backup", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcode-backup-test-"));
+    dbPath = join(dir, "mcode.db");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null for an in-memory DB and creates no files", () => {
+    const result = createMigrationBackup(":memory:");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the DB file does not exist (first-run install)", () => {
+    const result = createMigrationBackup(dbPath);
+    expect(result).toBeNull();
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  it("copies the DB file and a present WAL sidecar", () => {
+    writeFileSync(dbPath, "DBCONTENT");
+    writeFileSync(`${dbPath}-wal`, "WALCONTENT");
+
+    const backupPath = createMigrationBackup(dbPath);
+    expect(backupPath).not.toBeNull();
+    expect(readFileSync(backupPath!, "utf-8")).toBe("DBCONTENT");
+    expect(readFileSync(`${backupPath}-wal`, "utf-8")).toBe("WALCONTENT");
+  });
+
+  it("restores DB content and WAL while clearing stale sidecars", () => {
+    writeFileSync(dbPath, "ORIGINAL");
+    writeFileSync(`${dbPath}-wal`, "ORIG_WAL");
+    const backupPath = createMigrationBackup(dbPath)!;
+
+    // Simulate a failed migration: main file mutated, sidecars dirty.
+    writeFileSync(dbPath, "PARTIALLY_MUTATED");
+    writeFileSync(`${dbPath}-wal`, "STALE_WAL");
+    writeFileSync(`${dbPath}-shm`, "STALE_SHM");
+
+    restoreMigrationBackup(backupPath, dbPath);
+
+    expect(readFileSync(dbPath, "utf-8")).toBe("ORIGINAL");
+    expect(readFileSync(`${dbPath}-wal`, "utf-8")).toBe("ORIG_WAL");
+    // SHM is regenerable; restore must not leave a stale one in place.
+    expect(readdirSync(dir).filter((f) => f.endsWith("-shm"))).toEqual([]);
+  });
+
+  it("prunes old backups but keeps the N most recent (with their WALs)", () => {
+    writeFileSync(dbPath, "DB");
+
+    // Author 5 backup pairs with explicit filenames AND explicit, ordered
+    // mtimes so the test is robust to filesystem timestamp resolution and
+    // does not rely on millisecond-uniqueness inside `createMigrationBackup`.
+    const baseTime = Math.floor(Date.now() / 1000);
+    const backupNames = [
+      "mcode.db.bak-1",
+      "mcode.db.bak-2",
+      "mcode.db.bak-3",
+      "mcode.db.bak-4",
+      "mcode.db.bak-5",
+    ];
+    backupNames.forEach((name, i) => {
+      const path = join(dir, name);
+      writeFileSync(path, `db-${i}`);
+      writeFileSync(`${path}-wal`, `wal-${i}`);
+      const t = baseTime + i;
+      utimesSync(path, t, t);
+      utimesSync(`${path}-wal`, t, t);
+    });
+
+    pruneMigrationBackups(dbPath, 3);
+
+    const remaining = readdirSync(dir)
+      .filter((f) => f.startsWith("mcode.db.bak-") && !f.endsWith("-wal"))
+      .sort();
+    expect(remaining).toEqual(["mcode.db.bak-3", "mcode.db.bak-4", "mcode.db.bak-5"]);
+
+    const dirContents = readdirSync(dir);
+    expect(dirContents).not.toContain("mcode.db.bak-1");
+    expect(dirContents).not.toContain("mcode.db.bak-1-wal");
+    expect(dirContents).not.toContain("mcode.db.bak-2");
+    expect(dirContents).not.toContain("mcode.db.bak-2-wal");
+    expect(dirContents).toContain("mcode.db.bak-5-wal");
+  });
+
+  it("does nothing when keep is larger than the number of backups", () => {
+    writeFileSync(dbPath, "DB");
+    createMigrationBackup(dbPath);
+
+    pruneMigrationBackups(dbPath, 10);
+
+    const remaining = readdirSync(dir).filter((f) => f.startsWith("mcode.db.bak-"));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("rejects negative keep values", () => {
+    expect(() => pruneMigrationBackups(dbPath, -1)).toThrow();
+  });
+});

--- a/apps/server/src/store/bootstrap-drizzle.ts
+++ b/apps/server/src/store/bootstrap-drizzle.ts
@@ -17,22 +17,58 @@ function tableExists(db: Database.Database, name: string): boolean {
 }
 
 /**
- * When `_migrations` has rows but Drizzle tracking is absent, inserts the
- * baseline migration row using the same hash algorithm as Drizzle Kit.
- * Packaged production builds hit this path once per legacy database so
- * `migrate()` never replays destructive baseline SQL on existing installs.
+ * Sentinel application table. Its presence on a DB without any migration
+ * tracking means the schema was set up out-of-band (e.g. `drizzle-kit push`
+ * during dev) or by a build older than the legacy `_migrations` runner. In
+ * both cases the baseline DDL has effectively been applied and must be
+ * marked as such so `migrate()` does not try to replay it.
+ */
+const SCHEMA_SENTINEL_TABLE = "workspaces";
+
+/**
+ * Returns `true` when the DB should be treated as having the Drizzle baseline
+ * already applied. Three independent signals satisfy this:
+ *   1. Legacy `_migrations` has at least one row (snapshot from the old runner).
+ *   2. The sentinel application table exists (DB created via `db:push` or by
+ *      a pre-legacy build).
+ *   3. Both — handled by either branch above.
+ */
+function baselineAlreadyApplied(db: Database.Database): boolean {
+  if (tableExists(db, "_migrations")) {
+    const legacyCount = (
+      db.prepare("SELECT count(*) AS c FROM _migrations").get() as { c: number }
+    ).c;
+    if (legacyCount > 0) return true;
+  }
+  return tableExists(db, SCHEMA_SENTINEL_TABLE);
+}
+
+/**
+ * Seeds Drizzle's tracking table so `migrate()` skips the baseline SQL on
+ * databases that were already set up by an older path. Covers four cases:
+ *
+ *   - Legacy `_migrations` populated, no Drizzle tracker → seed baseline.
+ *   - `__drizzle_migrations` exists but empty (interrupted bootstrap, or
+ *     Drizzle's own migrator created the table before failing) → seed.
+ *   - Sentinel app table exists with no tracking at all (`db:push` or
+ *     pre-legacy DB) → seed.
+ *   - Truly fresh DB → no-op; `migrate()` applies everything from scratch.
+ *
+ * The CREATE + INSERT runs in a single transaction so an interrupted
+ * bootstrap can never leave the tracking table in a half-initialised state.
  *
  * @param db Open SQLite database (foreign keys enabled by caller).
  * @param drizzleDir Absolute or cwd-relative path to `apps/server/drizzle`.
  */
 export function bootstrapDrizzle(db: Database.Database, drizzleDir: string): void {
-  if (tableExists(db, "__drizzle_migrations")) return;
+  if (tableExists(db, "__drizzle_migrations")) {
+    const drizzleCount = (
+      db.prepare("SELECT count(*) AS c FROM __drizzle_migrations").get() as { c: number }
+    ).c;
+    if (drizzleCount > 0) return;
+  }
 
-  if (!tableExists(db, "_migrations")) return;
-  const legacyCount = (
-    db.prepare("SELECT count(*) AS c FROM _migrations").get() as { c: number }
-  ).c;
-  if (legacyCount === 0) return;
+  if (!baselineAlreadyApplied(db)) return;
 
   const journalPath = join(drizzleDir, "meta", "_journal.json");
   const journal = JSON.parse(readFileSync(journalPath, "utf-8")) as {
@@ -47,14 +83,18 @@ export function bootstrapDrizzle(db: Database.Database, drizzleDir: string): voi
   const sqlContent = readFileSync(sqlPath, "utf-8");
   const hash = createHash("sha256").update(sqlContent).digest("hex");
 
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS __drizzle_migrations (
-      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-      hash text NOT NULL,
-      created_at numeric
-    )
-  `);
-  db.prepare(
-    `INSERT INTO __drizzle_migrations ("hash", "created_at") VALUES (?, ?)`,
-  ).run(hash, baseline.when);
+  // Atomic CREATE + INSERT so an interrupted bootstrap can never leave the
+  // tracking table in a "exists but empty" state that fools the early-return.
+  db.transaction(() => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        hash text NOT NULL,
+        created_at numeric
+      )
+    `);
+    db.prepare(
+      `INSERT INTO __drizzle_migrations ("hash", "created_at") VALUES (?, ?)`,
+    ).run(hash, baseline.when);
+  })();
 }

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -11,6 +11,14 @@ import { getMcodeDir, resolveDbPath } from "@mcode/shared";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { bootstrapDrizzle } from "./bootstrap-drizzle.js";
+import {
+  createMigrationBackup,
+  pruneMigrationBackups,
+  restoreMigrationBackup,
+} from "./migration-backup.js";
+
+/** How many pre-migration backups to retain per DB file. */
+const MIGRATION_BACKUP_RETENTION = 3;
 
 /**
  * Drizzle's migrator joins paths with `/` inside readMigrationFiles; normalize so
@@ -129,6 +137,40 @@ function runMigrations(db: Database.Database): void {
 }
 
 /**
+ * Run migrations with a pre-flight backup and auto-restore on failure.
+ *
+ * The backup is created from the on-disk file before opening the connection,
+ * so a partially-applied migration that throws cannot leave the user without
+ * a clean recovery point. On success, old backups are pruned to a small ring
+ * so disk usage stays bounded across many app starts.
+ *
+ * `:memory:` databases skip the backup path entirely (nothing to restore).
+ */
+function runMigrationsWithBackup(db: Database.Database, dbPath: string): void {
+  const backupPath = createMigrationBackup(dbPath);
+  try {
+    runMigrations(db);
+  } catch (err) {
+    if (backupPath) {
+      try {
+        db.close();
+      } catch {
+        // ignore: connection may already be invalid after a failed migration
+      }
+      restoreMigrationBackup(backupPath, dbPath);
+    }
+    throw err;
+  }
+  if (backupPath) {
+    try {
+      pruneMigrationBackups(dbPath, MIGRATION_BACKUP_RETENTION);
+    } catch {
+      // ignore: pruning is best-effort and should never block startup
+    }
+  }
+}
+
+/**
  * Open (or create) a SQLite database with WAL mode and foreign keys enabled,
  * then run any pending Drizzle migrations.
  *
@@ -157,9 +199,13 @@ export function openDatabase(opts?: {
   const db = new Database(resolvedPath, { nativeBinding });
   applyPragmas(db, true);
   try {
-    runMigrations(db);
+    runMigrationsWithBackup(db, resolvedPath);
   } catch (err) {
-    db.close();
+    try {
+      db.close();
+    } catch {
+      // ignore: connection may already be invalid
+    }
     throw err;
   }
   return db;

--- a/apps/server/src/store/migration-backup.ts
+++ b/apps/server/src/store/migration-backup.ts
@@ -1,0 +1,100 @@
+/**
+ * Pre-migration safety net: copies the SQLite file (and its WAL sidecar) to a
+ * timestamped backup before `migrate()` runs, so a botched migration can be
+ * fully restored even if the schema mutation itself committed partial damage
+ * before throwing. Old backups are pruned to a small ring so disk pressure
+ * stays bounded over many app starts.
+ */
+
+import { copyFileSync, existsSync, readdirSync, statSync, unlinkSync } from "fs";
+import { basename, dirname, join } from "path";
+
+/** Sidecar files SQLite may write next to the main DB in WAL mode. */
+const WAL_SUFFIX = "-wal";
+const SHM_SUFFIX = "-shm";
+
+/** Suffix used to identify migration backups belonging to a given DB file. */
+function backupPrefix(dbPath: string): string {
+  return `${basename(dbPath)}.bak-`;
+}
+
+/**
+ * Copy `dbPath` (and its WAL sidecar, if present) to a timestamped backup.
+ *
+ * Returns the backup path on success or `null` when there is nothing to back
+ * up (in-memory database, or the file does not exist yet because this is a
+ * first-run install). The DB does not need to be closed; SQLite's WAL design
+ * keeps the main file consistent with respect to its own checkpointed pages.
+ */
+export function createMigrationBackup(dbPath: string): string | null {
+  if (dbPath === ":memory:" || !existsSync(dbPath)) return null;
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = `${dbPath}.bak-${stamp}`;
+  copyFileSync(dbPath, backupPath);
+
+  const walSrc = `${dbPath}${WAL_SUFFIX}`;
+  if (existsSync(walSrc)) {
+    copyFileSync(walSrc, `${backupPath}${WAL_SUFFIX}`);
+  }
+  return backupPath;
+}
+
+/**
+ * Restore a backup created by `createMigrationBackup` over the live DB path.
+ *
+ * Removes any current `-wal` / `-shm` sidecars first so SQLite cannot replay
+ * a journal from the failed migration over the restored file. The shared
+ * memory file is regenerated automatically on next open.
+ */
+export function restoreMigrationBackup(backupPath: string, dbPath: string): void {
+  for (const suffix of [WAL_SUFFIX, SHM_SUFFIX]) {
+    const sidecar = `${dbPath}${suffix}`;
+    if (existsSync(sidecar)) unlinkSync(sidecar);
+  }
+
+  copyFileSync(backupPath, dbPath);
+
+  const walBackup = `${backupPath}${WAL_SUFFIX}`;
+  if (existsSync(walBackup)) {
+    copyFileSync(walBackup, `${dbPath}${WAL_SUFFIX}`);
+  }
+}
+
+/**
+ * Delete all but the most recent `keep` migration backups for `dbPath`.
+ * Backup pairs (`.bak-*` and matching `-wal`) are removed together so the
+ * directory does not accumulate orphan WAL copies.
+ */
+export function pruneMigrationBackups(dbPath: string, keep: number): void {
+  if (keep < 0) throw new Error("keep must be >= 0");
+  if (dbPath === ":memory:") return;
+
+  const dir = dirname(dbPath);
+  if (!existsSync(dir)) return;
+
+  const prefix = backupPrefix(dbPath);
+  const entries = readdirSync(dir)
+    .filter((f) => f.startsWith(prefix) && !f.endsWith(WAL_SUFFIX))
+    .map((f) => {
+      const full = join(dir, f);
+      return { full, mtime: statSync(full).mtimeMs };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+
+  for (const { full } of entries.slice(keep)) {
+    try {
+      unlinkSync(full);
+    } catch {
+      // ignore: another process may have cleaned it up first
+    }
+    const wal = `${full}${WAL_SUFFIX}`;
+    if (existsSync(wal)) {
+      try {
+        unlinkSync(wal);
+      } catch {
+        // ignore: best-effort sidecar cleanup
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Make migration startup resilient to legacy databases. Two failure modes are addressed together because they share the same root cause — assumptions about `__drizzle_migrations` being either absent or fully populated:

1. Existing installs hit `DrizzleError: table workspaces already exists` if `__drizzle_migrations` existed but was empty, or if the schema was set up out-of-band (e.g. `drizzle-kit push` during dev) with no tracking at all.
2. A botched migration could mutate the DB before throwing, leaving users without a clean recovery point.

## Why

After #393 introduced Drizzle, real users on previously-working installs could not start the app. Drizzle's `migrate()` creates `__drizzle_migrations` as its first step; if anything failed afterwards, `bootstrapDrizzle` early-returned forever on the empty table and `migrate()` retried the baseline against a populated schema on every restart. Manual DB surgery was the only fix.

Beyond that specific case, anyone whose DB was created via `db:push` (a documented dev shortcut in `AGENTS.md`) had no migration tracking at all and would fail the same way on first migrate. We need the bootstrap to work for any DB whose schema effectively matches the baseline, regardless of how it got there.

## Key Changes

- **`bootstrap-drizzle.ts`** — Treat the baseline as already-applied when either (a) legacy `_migrations` has rows or (b) the sentinel app table (`workspaces`) exists. Wrap CREATE + INSERT in a single transaction so an interrupted bootstrap cannot leave the tracker in a half-initialised state. Recover from "exists but empty `__drizzle_migrations`" by re-checking row count instead of mere existence.
- **`migration-backup.ts`** (new) — Pre-flight backup utility: copies the DB and its WAL sidecar to `<db>.bak-<timestamp>` before `migrate()` runs, restores on failure, and prunes to the last 3 backups so disk pressure stays bounded.
- **`database.ts`** — `runMigrationsWithBackup` wraps the existing `runMigrations` so any thrown error rolls the file back to the pre-migration state.
- **Tests** — 14 tests across `bootstrap-drizzle.test.ts` and the new `migration-backup.test.ts` covering: empty-tracker recovery, sentinel-only DBs, `db:push`-style DBs, prune retention, WAL/SHM sidecar handling, and restore semantics. All 839 server tests pass.

## Verification

Reproduced the original failure on a real broken DB (`__drizzle_migrations` empty, `_migrations` with 25 rows). After this change, the bundled server self-heals on first start: baseline gets seeded, `0001_outgoing_paibok` applies cleanly, all 25 legacy rows preserved, no data loss.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database migrations now include automatic backup and recovery capabilities to protect against migration failures.
  * Enhanced database initialization to handle incomplete setup states gracefully.

* **Chores**
  * Expanded test coverage for database bootstrap and migration backup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->