### PR TITLE
ci: fix release builds across all platforms

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,12 +22,16 @@ jobs:
         include:
           - os: blacksmith-4vcpu-windows-2025
             build-args: ""
+            target-arch: ""
           - os: ubuntu-22.04
             build-args: ""
+            target-arch: ""
           - os: blacksmith-12vcpu-macos-26
             build-args: "--mac --arm64"
+            target-arch: "arm64"
           - os: blacksmith-12vcpu-macos-26
             build-args: "--mac --x64"
+            target-arch: "x64"
 
     runs-on: ${{ matrix.os }}
 
@@ -46,10 +50,12 @@ jobs:
 
       - name: Generate V8 snapshot
         run: bun apps/desktop/scripts/generate-snapshot.mjs
+        env:
+          MCODE_TARGET_ARCH: ${{ matrix.target-arch }}
 
       - name: Install Python setuptools (node-gyp on Python 3.12+ needs it)
-        if: runner.os == 'Windows'
-        run: pip install setuptools
+        shell: bash
+        run: pip install setuptools 2>/dev/null || pip install --break-system-packages setuptools 2>/dev/null || true
 
       - name: Package with electron-builder
         run: node apps/desktop/scripts/ci-package.mjs ${{ matrix.build-args }}
@@ -57,6 +63,7 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && 'false' || '' }}
 
       - name: Smoke test packaged server
+        if: matrix.target-arch == '' || matrix.target-arch == 'arm64'
         run: node apps/desktop/scripts/smoke-test.mjs
 
       - name: Collect release artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,6 @@ jobs:
 
       - name: Generate V8 snapshot
         run: bun apps/desktop/scripts/generate-snapshot.mjs
+
+      - name: Smoke test server bundle
+        run: node apps/desktop/scripts/smoke-test.mjs --bundle

--- a/apps/desktop/scripts/build-server-binary.mjs
+++ b/apps/desktop/scripts/build-server-binary.mjs
@@ -1,4 +1,5 @@
 import { copyFile, mkdir, chmod, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 /**
@@ -113,6 +114,28 @@ export async function buildServerBinary({
   if (electronPlatformName !== "win32") {
     await chmod(dstBinary, 0o755);
   }
+
+  // Electron (even with ELECTRON_RUN_AS_NODE=1) resolves icudtl.dat relative
+  // to its own binary location. The renamed copy lives in a different directory
+  // than the original, so we must place a copy of icudtl.dat alongside it.
+  let icuSrc;
+  if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
+    const appBundle = path.join(appOutDir, `${productFilename}.app`);
+    icuSrc = path.join(
+      appBundle, "Contents", "Frameworks",
+      "Electron Framework.framework", "Resources", "icudtl.dat",
+    );
+  } else {
+    icuSrc = path.join(path.dirname(srcBinary), "icudtl.dat");
+  }
+  if (existsSync(icuSrc)) {
+    const icuDst = path.join(path.dirname(dstBinary), "icudtl.dat");
+    await copyFile(icuSrc, icuDst);
+    console.log(`[build-server-binary] Copied icudtl.dat to ${icuDst}`);
+  } else {
+    console.warn(`[build-server-binary] icudtl.dat not found at ${icuSrc}, server may fail to start`);
+  }
+
   if (electronPlatformName === "win32") {
     if (!appVersion) {
       throw new Error(

--- a/apps/desktop/scripts/generate-snapshot.mjs
+++ b/apps/desktop/scripts/generate-snapshot.mjs
@@ -19,6 +19,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
 const snapshotDir = resolve(desktopRoot, "dist/snapshot");
 
+// ---------------------------------------------------------------------------
+// Cross-arch guard: electron-mksnapshot can only produce snapshots for the
+// host architecture. When CI cross-compiles (e.g. arm64 host → x64 target),
+// skip snapshot generation entirely. The after-pack hook handles the missing
+// snapshot gracefully by skipping the fuse flip.
+// ---------------------------------------------------------------------------
+
+const targetArch = process.env.MCODE_TARGET_ARCH || process.arch;
+if (targetArch !== process.arch) {
+  console.log(
+    `Skipping V8 snapshot: target arch "${targetArch}" !== host arch "${process.arch}". ` +
+    `The app will start without a custom snapshot.`,
+  );
+  process.exit(0);
+}
+
 // Clean stale artifacts from previous builds to prevent after-pack from
 // copying an outdated snapshot if this script fails mid-way.
 if (existsSync(snapshotDir)) {

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -36,42 +36,49 @@ const POLL_INTERVAL_MS = 300;
 // Locate the unpacked server bundle and Electron binary
 // ---------------------------------------------------------------------------
 
-/** Find the server.cjs and runtime binary from the unpacked directory. */
+/** Find the server.cjs and runtime binary from the unpacked directory.
+ *  Prefers the renamed `mcode-server` binary (production code path) and
+ *  falls back to the main Electron binary when the renamed copy is absent. */
 function findUnpackedServer() {
   const candidates = [
     // Windows
     {
       server: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/dist/server/server.cjs"),
+      renamedBinary: resolve(releaseDir, "win-unpacked/resources/bin/mcode-server.exe"),
       electron: resolve(releaseDir, "win-unpacked/Mcode.exe"),
       sqlite: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
     },
     // Linux (electron-builder uses package name as binary name)
     {
       server: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/dist/server/server.cjs"),
+      renamedBinary: resolve(releaseDir, "linux-unpacked/resources/bin/mcode-server"),
       electron: resolve(releaseDir, "linux-unpacked/mcode-desktop"),
       sqlite: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
     },
     // macOS Intel
     {
       server: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/dist/server/server.cjs"),
+      renamedBinary: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/bin/mcode-server"),
       electron: resolve(releaseDir, "mac/Mcode.app/Contents/MacOS/Mcode"),
       sqlite: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
     },
     // macOS ARM
     {
       server: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/dist/server/server.cjs"),
+      renamedBinary: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/bin/mcode-server"),
       electron: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/MacOS/Mcode"),
       sqlite: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
     },
   ];
 
   for (const c of candidates) {
-    if (existsSync(c.server) && existsSync(c.electron)) {
-      // Find the actual .node binding
+    // The renamed binary mirrors production; fall back to the main binary
+    const runtime = existsSync(c.renamedBinary) ? c.renamedBinary : c.electron;
+    if (existsSync(c.server) && existsSync(runtime)) {
       const electronBinding = resolve(c.sqlite, "better_sqlite3.electron.node");
       const nodeBinding = resolve(c.sqlite, "better_sqlite3.node");
       const binding = existsSync(electronBinding) ? electronBinding : existsSync(nodeBinding) ? nodeBinding : undefined;
-      return { server: c.server, electron: c.electron, binding };
+      return { server: c.server, electron: runtime, binding };
     }
   }
   return null;


### PR DESCRIPTION
## What
Fix broken release builds on Windows, macOS, and Ubuntu after the Blacksmith runner migration.

## Why
PR #391 added macOS builds via Blacksmith ARM64 runners, but introduced three independent failures:
1. The renamed `mcode-server` binary couldn't find `icudtl.dat` (ICU error at runtime on all platforms)
2. V8 snapshot generation produced wrong-arch snapshots when cross-compiling macOS x64 on ARM64 runners
3. The smoke test used the main Electron binary instead of the renamed `mcode-server`, missing runtime failures

## Key Changes
- **ICU data copy** (`build-server-binary.mjs`): Copy `icudtl.dat` alongside the renamed `mcode-server` binary so Electron can resolve ICU data at runtime
- **Cross-arch snapshot guard** (`generate-snapshot.mjs`): Skip `electron-mksnapshot` when target arch differs from host arch; `after-pack.mjs` already handles absent snapshots gracefully
- **Smoke test binary preference** (`smoke-test.mjs`): Prefer `mcode-server` over the main Electron binary to mirror the production spawn path
- **Workflow fixes** (`build-release.yml`): Pass `MCODE_TARGET_ARCH` to snapshot step, skip smoke test for cross-arch x64 builds, make setuptools install defensive across all platforms (PEP 668 fallback)
- **CI bundle smoke test** (`ci.yml`): Run `smoke-test.mjs --bundle` in the build-check job to catch server startup failures on every PR

Related to #391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened build and release processes with enhanced cross-architecture support and comprehensive validation testing to ensure reliable binary packaging across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->