### PR TITLE
ci: fix release build failures on all platforms

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install Python setuptools (node-gyp on Python 3.12+ needs it)
         shell: bash
-        run: pip install setuptools 2>/dev/null || pip install --break-system-packages setuptools 2>/dev/null || true
+        run: python3 -m pip install setuptools --break-system-packages 2>/dev/null || python3 -m pip install setuptools 2>/dev/null || pip install setuptools 2>/dev/null || true
 
       - name: Package with electron-builder
         run: node apps/desktop/scripts/ci-package.mjs ${{ matrix.build-args }}

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -26,7 +26,44 @@ export default async function afterPack(context) {
   );
 
   // -------------------------------------------------------------------------
-  // Step 1: V8 snapshot copy + fuse flip (skip if snapshot not generated)
+  // Step 1: Produce renamed server binary BEFORE the fuse flip. The server
+  // binary runs with ELECTRON_RUN_AS_NODE=1 and must NOT have the browser
+  // V8 snapshot fuse enabled, otherwise it crashes trying to load a snapshot
+  // file that isn't alongside it.
+  // -------------------------------------------------------------------------
+
+  const productFilename =
+    context.packager.appInfo.productFilename ??
+    context.packager.appInfo.productName;
+  // Windows VERSIONINFO requires a numeric dotted quad (x.x.x.x). package.json
+  // versions can include semver prerelease/build suffixes (e.g. "1.2.3-beta.1"),
+  // so extract numeric segments only and pad to four.
+  const rawVersion = context.packager.appInfo.version;
+  const numericSegments = (rawVersion.match(/\d+/g) ?? []).slice(0, 4);
+  const appVersion = [
+    ...numericSegments,
+    ...Array(Math.max(0, 4 - numericSegments.length)).fill("0"),
+  ].join(".");
+  const companyName = context.packager.appInfo.companyName ?? "Mcode";
+
+  // The renamed copy at Contents/Resources/bin/mcode-server is co-signed by
+  // electron-builder via the `mac.binaries` entry in package.json, so it
+  // passes notarytool when notarization is enabled.
+  await buildServerBinary({
+    appOutDir: context.appOutDir,
+    electronPlatformName,
+    productFilename,
+    executableName: context.packager.executableName,
+    appVersion,
+    companyName,
+  });
+
+  console.log("[after-pack] Built renamed server binary");
+
+  // -------------------------------------------------------------------------
+  // Step 2: V8 snapshot copy + fuse flip (skip if snapshot not generated).
+  // This runs AFTER the server binary copy so only the main Electron binary
+  // (used for the GUI) gets the fuse — not the ELECTRON_RUN_AS_NODE copy.
   // -------------------------------------------------------------------------
 
   if (!existsSync(snapshotFile)) {
@@ -72,36 +109,4 @@ export default async function afterPack(context) {
 
     console.log("[after-pack] V8 snapshot fuse enabled");
   }
-
-  // -------------------------------------------------------------------------
-  // Step 2: Produce renamed server binary (runs after fuse flip so the copy
-  // inherits the already-flipped state byte-for-byte).
-  // -------------------------------------------------------------------------
-
-  const productFilename =
-    context.packager.appInfo.productFilename ??
-    context.packager.appInfo.productName;
-  // Windows VERSIONINFO requires a numeric dotted quad (x.x.x.x). package.json
-  // versions can include semver prerelease/build suffixes (e.g. "1.2.3-beta.1"),
-  // so extract numeric segments only and pad to four.
-  const rawVersion = context.packager.appInfo.version;
-  const numericSegments = (rawVersion.match(/\d+/g) ?? []).slice(0, 4);
-  const appVersion = [
-    ...numericSegments,
-    ...Array(Math.max(0, 4 - numericSegments.length)).fill("0"),
-  ].join(".");
-  const companyName = context.packager.appInfo.companyName ?? "Mcode";
-
-  // The renamed copy at Contents/Resources/bin/mcode-server is co-signed by
-  // electron-builder via the `mac.binaries` entry in package.json, so it
-  // passes notarytool when notarization is enabled.
-  await buildServerBinary({
-    appOutDir: context.appOutDir,
-    electronPlatformName,
-    productFilename,
-    appVersion,
-    companyName,
-  });
-
-  console.log("[after-pack] Built renamed server binary");
 }

--- a/apps/desktop/scripts/build-server-binary.mjs
+++ b/apps/desktop/scripts/build-server-binary.mjs
@@ -10,9 +10,10 @@ import path from "node:path";
  * @param {string} args.appOutDir - electron-builder afterPack appOutDir.
  * @param {"win32"|"darwin"|"linux"|"mas"|string} args.electronPlatformName
  * @param {string} args.productFilename - filename (no extension) of the main app binary.
+ * @param {string} [args.executableName] - Linux executable name (defaults to productFilename).
  * @returns {{ srcBinary: string, dstBinary: string }}
  */
-export function resolveBinaryPaths({ appOutDir, electronPlatformName, productFilename }) {
+export function resolveBinaryPaths({ appOutDir, electronPlatformName, productFilename, executableName }) {
   if (!productFilename || typeof productFilename !== "string") {
     throw new Error(
       `resolveBinaryPaths: productFilename is required (got ${productFilename === undefined ? "undefined" : JSON.stringify(productFilename)})`,
@@ -31,9 +32,10 @@ export function resolveBinaryPaths({ appOutDir, electronPlatformName, productFil
       dstBinary: path.join(appBundle, "Contents", "Resources", "bin", "mcode-server"),
     };
   }
-  // linux and any other Unix
+  // linux and any other Unix — electron-builder names the binary after
+  // executableName (package.json "name"), not productName.
   return {
-    srcBinary: path.join(appOutDir, productFilename),
+    srcBinary: path.join(appOutDir, executableName || productFilename),
     dstBinary: path.join(appOutDir, "resources", "bin", "mcode-server"),
   };
 }
@@ -94,6 +96,7 @@ export async function stampWindowsVersionInfo(exePath, info) {
  * @param {string} args.appOutDir
  * @param {"win32"|"darwin"|"linux"|"mas"|string} args.electronPlatformName
  * @param {string} args.productFilename
+ * @param {string} [args.executableName] - Linux executable name (defaults to productFilename).
  * @param {string} [args.appVersion] - dotted quad like "1.2.3.0"; required on win32
  * @param {string} [args.companyName] - default "Mcode"
  */
@@ -101,6 +104,7 @@ export async function buildServerBinary({
   appOutDir,
   electronPlatformName,
   productFilename,
+  executableName,
   appVersion,
   companyName = "Mcode",
 }) {
@@ -108,6 +112,7 @@ export async function buildServerBinary({
     appOutDir,
     electronPlatformName,
     productFilename,
+    executableName,
   });
   await mkdir(path.dirname(dstBinary), { recursive: true });
   await copyFile(srcBinary, dstBinary);


### PR DESCRIPTION
## What
Fix three independent failures that caused all four v0.8.0 release builds to fail.

## Why
The first build attempt after PR #397 revealed issues that only surface during full electron-builder packaging (not caught by CI lint/typecheck/bundle tests).

## Key Changes
- **macOS distutils** (`build-release.yml`): Use `python3 -m pip` with `--break-system-packages` as primary install path for setuptools, since Blacksmith macOS runners have Python 3.12+ where `distutils` was removed
- **Linux binary name** (`build-server-binary.mjs`): Add `executableName` parameter; on Linux, electron-builder names the binary after `executableName` (`mcode-desktop`), not `productName` (`Mcode`)
- **V8 snapshot fuse** (`after-pack.mjs`): Move `buildServerBinary` before the fuse flip so the `ELECTRON_RUN_AS_NODE` copy doesn't inherit the browser V8 snapshot fuse (which causes a fatal crash when no snapshot file exists alongside it)

Related to #397

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build workflow with improved Python setuptools installation using multi-command fallback chain for better resilience
  * Optimized desktop application build sequence for improved reliability and consistency in binary packaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->