### PR TITLE
ci: fix renamed server binary deps and macOS fuse path

### DIFF
--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -79,10 +79,13 @@ export default async function afterPack(context) {
         "Contents/Frameworks/Electron Framework.framework/Resources",
       );
       snapshotDest = join(frameworkDir, "browser_v8_context_snapshot.bin");
+      // @electron/fuses expects the main executable, not the framework binary.
+      // It resolves to the framework internally; passing the framework path
+      // causes double Frameworks/ resolution (ENOENT).
       electronBinary = join(
         appOutDir,
         `${context.packager.appInfo.productFilename}.app`,
-        "Contents/Frameworks/Electron Framework.framework/Electron Framework",
+        "Contents", "MacOS", context.packager.appInfo.productFilename,
       );
     } else if (electronPlatformName === "win32") {
       snapshotDest = join(appOutDir, "browser_v8_context_snapshot.bin");

--- a/apps/desktop/scripts/build-server-binary.mjs
+++ b/apps/desktop/scripts/build-server-binary.mjs
@@ -141,6 +141,37 @@ export async function buildServerBinary({
     console.warn(`[build-server-binary] icudtl.dat not found at ${icuSrc}, server may fail to start`);
   }
 
+  // Electron's built-in v8_context_snapshot.bin is required by V8 at startup
+  // (separate from the custom browser snapshot used by the GUI fuse). Without
+  // it next to the binary, ELECTRON_RUN_AS_NODE crashes on snapshot load.
+  let v8SnapSrc;
+  if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
+    const appBundle = path.join(appOutDir, `${productFilename}.app`);
+    v8SnapSrc = path.join(
+      appBundle, "Contents", "Frameworks",
+      "Electron Framework.framework", "Resources", "v8_context_snapshot.bin",
+    );
+  } else {
+    v8SnapSrc = path.join(path.dirname(srcBinary), "v8_context_snapshot.bin");
+  }
+  if (existsSync(v8SnapSrc)) {
+    const v8SnapDst = path.join(path.dirname(dstBinary), "v8_context_snapshot.bin");
+    await copyFile(v8SnapSrc, v8SnapDst);
+    console.log(`[build-server-binary] Copied v8_context_snapshot.bin to ${v8SnapDst}`);
+  }
+
+  // On Linux, libffmpeg.so is linked into the Electron binary. The dynamic
+  // linker uses RPATH ($ORIGIN) to find it, so a copy in a different directory
+  // needs the library alongside it or LD_LIBRARY_PATH set at runtime.
+  if (electronPlatformName === "linux") {
+    const ffmpegSrc = path.join(path.dirname(srcBinary), "libffmpeg.so");
+    if (existsSync(ffmpegSrc)) {
+      const ffmpegDst = path.join(path.dirname(dstBinary), "libffmpeg.so");
+      await copyFile(ffmpegSrc, ffmpegDst);
+      console.log(`[build-server-binary] Copied libffmpeg.so to ${ffmpegDst}`);
+    }
+  }
+
   if (electronPlatformName === "win32") {
     if (!appVersion) {
       throw new Error(

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -72,13 +72,16 @@ function findUnpackedServer() {
   ];
 
   for (const c of candidates) {
-    // The renamed binary mirrors production; fall back to the main binary
-    const runtime = existsSync(c.renamedBinary) ? c.renamedBinary : c.electron;
+    // The renamed binary mirrors production; fall back to the main binary.
+    // Track the original Electron dir so we can set library search paths.
+    const useRenamed = existsSync(c.renamedBinary);
+    const runtime = useRenamed ? c.renamedBinary : c.electron;
     if (existsSync(c.server) && existsSync(runtime)) {
       const electronBinding = resolve(c.sqlite, "better_sqlite3.electron.node");
       const nodeBinding = resolve(c.sqlite, "better_sqlite3.node");
       const binding = existsSync(electronBinding) ? electronBinding : existsSync(nodeBinding) ? nodeBinding : undefined;
-      return { server: c.server, electron: runtime, binding };
+      const electronDir = useRenamed ? dirname(c.electron) : undefined;
+      return { server: c.server, electron: runtime, binding, electronDir };
     }
   }
   return null;
@@ -137,6 +140,17 @@ const env = {
 
 if (found.binding) {
   env.BETTER_SQLITE3_BINDING = found.binding;
+}
+
+// When using the renamed binary in a different directory, the dynamic linker
+// can't find Electron's shared libraries (libffmpeg.so on Linux). Point
+// LD_LIBRARY_PATH at the original Electron binary directory as a fallback.
+if (found.electronDir) {
+  if (process.platform === "linux") {
+    env.LD_LIBRARY_PATH = [found.electronDir, process.env.LD_LIBRARY_PATH].filter(Boolean).join(":");
+  } else if (process.platform === "darwin") {
+    env.DYLD_LIBRARY_PATH = [found.electronDir, process.env.DYLD_LIBRARY_PATH].filter(Boolean).join(":");
+  }
 }
 
 console.log(`[smoke-test] Starting server on port ${SMOKE_PORT}...`);

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -368,6 +368,14 @@ export class ServerManager {
         env.BETTER_SQLITE3_BINDING = nativeBindingPath;
       }
 
+      // The renamed server binary lives in resources/bin/ which lacks Electron's
+      // shared libraries (libffmpeg.so). Point LD_LIBRARY_PATH at the original
+      // Electron binary directory so the dynamic linker finds them.
+      if (process.platform === "linux" && app.isPackaged) {
+        const electronDir = dirname(process.execPath);
+        env.LD_LIBRARY_PATH = [electronDir, process.env.LD_LIBRARY_PATH].filter(Boolean).join(":");
+      }
+
       // V8 flags go in the args array for child_process.spawn.
       const v8Flags = [`--max-old-space-size=${heapMb}`, "--max-semi-space-size=2", "--expose-gc"];
       const args = [...v8Flags, entry];


### PR DESCRIPTION
## What
Fix the three remaining release build failures (macOS ARM64, Windows, Linux) caused by the renamed `mcode-server` binary missing Electron support files and an incorrect fuse flip path on macOS.

## Why
After PRs #397 and #398 fixed the initial CI migration issues, three platforms still fail: macOS ARM64 hits an ENOENT from `@electron/fuses` double-resolving the Frameworks path, Windows crashes loading the V8 startup snapshot, and Linux can't find `libffmpeg.so`. All stem from the renamed binary living in `resources/bin/` without the support files Electron expects alongside its binary.

## Key Changes
- **after-pack.mjs**: Pass the main executable path (`Contents/MacOS/<name>`) to `flipFuses` instead of the framework binary path. `@electron/fuses` resolves to the framework internally; passing the framework path caused double `Frameworks/` resolution.
- **build-server-binary.mjs**: Copy `v8_context_snapshot.bin` alongside the renamed binary (same pattern as the existing ICU copy). Also copy `libffmpeg.so` on Linux so the dynamic linker finds it via `$ORIGIN` RPATH.
- **smoke-test.mjs**: Track the original Electron binary directory and set `LD_LIBRARY_PATH` (Linux) / `DYLD_LIBRARY_PATH` (macOS) when spawning the renamed binary.
- **server-manager.ts**: Set `LD_LIBRARY_PATH` to include the Electron binary directory in production Linux builds, ensuring `libffmpeg.so` is found at runtime.

Related to #391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->