### PR TITLE
ci: add Frameworks symlink for macOS renamed binary @rpath

### DIFF
--- a/apps/desktop/scripts/build-server-binary.mjs
+++ b/apps/desktop/scripts/build-server-binary.mjs
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, chmod, readFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, chmod, readFile, writeFile, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 
@@ -158,6 +158,21 @@ export async function buildServerBinary({
     const v8SnapDst = path.join(path.dirname(dstBinary), "v8_context_snapshot.bin");
     await copyFile(v8SnapSrc, v8SnapDst);
     console.log(`[build-server-binary] Copied v8_context_snapshot.bin to ${v8SnapDst}`);
+  }
+
+  // On macOS, the Electron binary's @rpath includes @loader_path/../Frameworks.
+  // For the original at Contents/MacOS/<name> this resolves to Contents/Frameworks.
+  // For the renamed copy at Contents/Resources/bin/mcode-server it resolves to
+  // Contents/Resources/Frameworks (doesn't exist). Create a symlink so dyld
+  // finds the Electron Framework without requiring DYLD_* env vars (which SIP
+  // strips from signed binaries).
+  if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
+    const appBundle = path.join(appOutDir, `${productFilename}.app`);
+    const frameworksLink = path.join(appBundle, "Contents", "Resources", "Frameworks");
+    if (!existsSync(frameworksLink)) {
+      await symlink("../Frameworks", frameworksLink);
+      console.log(`[build-server-binary] Created Frameworks symlink at ${frameworksLink}`);
+    }
   }
 
   // On Linux, libffmpeg.so is linked into the Electron binary. The dynamic


### PR DESCRIPTION
## What
Create a Frameworks symlink in the macOS app bundle so the renamed `mcode-server` binary can find `Electron Framework` via its `@rpath`.

## Why
The renamed binary at `Contents/Resources/bin/mcode-server` inherits `@loader_path/../Frameworks` in its `@rpath` from the original Electron binary. From its new location this resolves to `Contents/Resources/Frameworks/` instead of `Contents/Frameworks/`, causing a `dyld: Library not loaded` crash. A symlink at `Contents/Resources/Frameworks` -> `../Frameworks` fixes the resolution without relying on `DYLD_*` env vars (which SIP strips from signed binaries).

## Key Changes
- **build-server-binary.mjs**: Create `Contents/Resources/Frameworks` -> `../Frameworks` symlink on macOS after copying the renamed binary
- **build-server-binary.mjs**: Import `symlink` from `node:fs/promises`

Follow-up to #399

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS application build handling for framework resolution compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->