### PR TITLE
ci: ad-hoc sign renamed macOS binary to prevent SIGKILL

### DIFF
--- a/apps/desktop/scripts/build-server-binary.mjs
+++ b/apps/desktop/scripts/build-server-binary.mjs
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, chmod, readFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, chmod, readFile, writeFile, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 
@@ -158,6 +158,21 @@ export async function buildServerBinary({
     const v8SnapDst = path.join(path.dirname(dstBinary), "v8_context_snapshot.bin");
     await copyFile(v8SnapSrc, v8SnapDst);
     console.log(`[build-server-binary] Copied v8_context_snapshot.bin to ${v8SnapDst}`);
+  }
+
+  // On macOS, the Electron binary's @rpath includes @loader_path/../Frameworks.
+  // For the original at Contents/MacOS/<name> this resolves to Contents/Frameworks.
+  // For the renamed copy at Contents/Resources/bin/mcode-server it resolves to
+  // Contents/Resources/Frameworks (doesn't exist). Create a symlink so dyld
+  // finds the Electron Framework without requiring DYLD_* env vars (which SIP
+  // strips from signed binaries).
+  if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
+    const appBundle = path.join(appOutDir, `${productFilename}.app`);
+    const frameworksLink = path.join(appBundle, "Contents", "Resources", "Frameworks");
+    if (!existsSync(frameworksLink)) {
+      await symlink("../Frameworks", frameworksLink);
+      console.log(`[build-server-binary] Created Frameworks symlink at ${frameworksLink}`);
+    }
   }
 
   // On Linux, libffmpeg.so is linked into the Electron binary. The dynamic

--- a/apps/desktop/scripts/build-server-binary.mjs
+++ b/apps/desktop/scripts/build-server-binary.mjs
@@ -1,5 +1,6 @@
 import { copyFile, mkdir, chmod, readFile, writeFile, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 
 /**
@@ -118,6 +119,13 @@ export async function buildServerBinary({
   await copyFile(srcBinary, dstBinary);
   if (electronPlatformName !== "win32") {
     await chmod(dstBinary, 0o755);
+  }
+
+  // ARM64 macOS requires all executables to be signed. The copy invalidates
+  // the original ad-hoc signature, so re-sign to prevent a kernel SIGKILL.
+  if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
+    execFileSync("codesign", ["--sign", "-", "--force", "--preserve-metadata=entitlements", dstBinary]);
+    console.log(`[build-server-binary] Ad-hoc signed ${dstBinary}`);
   }
 
   // Electron (even with ELECTRON_RUN_AS_NODE=1) resolves icudtl.dat relative


### PR DESCRIPTION
## What
Ad-hoc re-sign the renamed `mcode-server` binary on macOS after copying it from the main Electron binary.

## Why
ARM64 macOS requires all executables to be code signed. The copied binary inherits the original's signature bytes, but after relocation the signature is invalid. The kernel immediately SIGKILLs the process with no stderr output, making the failure invisible except as a silent crash in the smoke test.

## Key Changes
- **build-server-binary.mjs**: Run `codesign --sign - --force --preserve-metadata=entitlements` on the copied binary for macOS platforms

Follow-up to #400

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the macOS build process to properly sign application binaries according to platform requirements and corrected framework resource discovery paths. These improvements ensure the application builds, runs, and distributes correctly on macOS systems while maintaining security and compatibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->