### PR TITLE
ci: macOS ARM64 smoke test diagnostics and codesign fix

### DIFF
--- a/apps/desktop/scripts/build-server-binary.mjs
+++ b/apps/desktop/scripts/build-server-binary.mjs
@@ -124,7 +124,7 @@ export async function buildServerBinary({
   // ARM64 macOS requires all executables to be signed. The copy invalidates
   // the original ad-hoc signature, so re-sign to prevent a kernel SIGKILL.
   if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
-    execFileSync("codesign", ["--sign", "-", "--force", "--preserve-metadata=entitlements", dstBinary]);
+    execFileSync("codesign", ["--sign", "-", "--force", dstBinary]);
     console.log(`[build-server-binary] Ad-hoc signed ${dstBinary}`);
   }
 

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -17,7 +17,7 @@
  *   node apps/desktop/scripts/smoke-test.mjs --bundle    # test pre-packaging bundle (requires native deps on PATH)
  */
 
-import { spawn } from "child_process";
+import { spawn, execFileSync } from "child_process";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -153,6 +153,23 @@ if (found.electronDir) {
   }
 }
 
+// On macOS, verify the binary's code signature before attempting to run.
+// A bad signature causes a silent SIGKILL from the kernel.
+if (process.platform === "darwin") {
+  try {
+    const sigInfo = execFileSync("codesign", ["-dvv", found.electron], { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+    console.log(`[smoke-test] codesign info:\n${sigInfo}`);
+  } catch (e) {
+    console.log(`[smoke-test] codesign -dvv output: ${e.stderr || e.stdout || e.message}`);
+  }
+  try {
+    execFileSync("codesign", ["--verify", "--strict", found.electron], { encoding: "utf-8" });
+    console.log("[smoke-test] codesign --verify: OK");
+  } catch (e) {
+    console.error(`[smoke-test] codesign --verify FAILED: ${e.stderr || e.message}`);
+  }
+}
+
 console.log(`[smoke-test] Starting server on port ${SMOKE_PORT}...`);
 
 const child = spawn(found.electron, [
@@ -175,10 +192,15 @@ child.stdout.on("data", (chunk) => { process.stdout.write(chunk); });
 let exited = false;
 /** Resolves when the child process exits. */
 const exitPromise = new Promise((resolve) => {
-  child.on("exit", (code) => {
+  child.on("exit", (code, signal) => {
     exited = true;
+    if (signal) {
+      console.error(`[smoke-test] Server killed by signal ${signal}`);
+    }
     if (code !== null && code !== 0) {
       console.error(`[smoke-test] Server exited with code ${code}`);
+    }
+    if ((code !== null && code !== 0) || signal) {
       if (serverStderr) {
         console.error("[smoke-test] stderr:\n" + serverStderr.slice(-2000));
       }


### PR DESCRIPTION
## What
Add diagnostic output and simplify codesign for the renamed macOS binary.

## Why
macOS ARM64 smoke test crashes silently (no stderr, no exit code). Need codesign verification output and exit signal logging to diagnose whether this is a code signing issue or something else.

## Key Changes
- **smoke-test.mjs**: Run `codesign -dvv` and `codesign --verify` before spawning on macOS; log exit signal in addition to exit code
- **build-server-binary.mjs**: Drop `--preserve-metadata=entitlements` from codesign (may fail on binaries without embedded entitlements)

Follow-up to #401

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified macOS binary code signing configuration
  * Added code signing verification checks to macOS quality assurance testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->