### PR TITLE
ci: use main Electron binary for macOS smoke test

### DIFF
--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -72,9 +72,12 @@ function findUnpackedServer() {
   ];
 
   for (const c of candidates) {
-    // The renamed binary mirrors production; fall back to the main binary.
-    // Track the original Electron dir so we can set library search paths.
-    const useRenamed = existsSync(c.renamedBinary);
+    // On macOS, the renamed binary triggers SIGTRAP due to library validation
+    // when not co-signed by electron-builder (CI runs with signing disabled).
+    // In production, mac.binaries handles co-signing. For the smoke test, use
+    // the main Electron binary on macOS to validate the server bundle.
+    const isMac = c.server.includes(".app/Contents/");
+    const useRenamed = !isMac && existsSync(c.renamedBinary);
     const runtime = useRenamed ? c.renamedBinary : c.electron;
     if (existsSync(c.server) && existsSync(runtime)) {
       const electronBinding = resolve(c.sqlite, "better_sqlite3.electron.node");


### PR DESCRIPTION
## What
Use the main Electron binary instead of the renamed mcode-server for smoke testing on macOS.

## Why
The renamed binary triggers SIGTRAP on macOS ARM64 due to library validation failure. Without full code signing (CI uses `CSC_IDENTITY_AUTO_DISCOVERY=false`), the ad-hoc signed copy can't load the Electron Framework signed by a different identity. In production, electron-builder's `mac.binaries` handles co-signing. The smoke test's purpose is validating the server.cjs bundle and native modules, not the binary rename, so using the main binary is sufficient.

## Key Changes
- **smoke-test.mjs**: Skip renamed binary preference on macOS (detect via `.app/Contents/` in path); fall back to main Electron binary

Follow-up to #402

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed platform-specific binary selection on macOS to ensure proper application startup behavior, while maintaining existing settings on Windows and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->