### PR TITLE
fix: resolve project reorder failing on duplicate sort_order

### DIFF
--- a/apps/server/src/__tests__/workspace-repo-sort-order.test.ts
+++ b/apps/server/src/__tests__/workspace-repo-sort-order.test.ts
@@ -81,4 +81,21 @@ describe("WorkspaceRepo sort_order", () => {
     const after = repo.listAll().map((w) => w.sort_order);
     expect(after).toEqual(before);
   });
+
+  it("reorderToIndex succeeds when all sort_order values are duplicates", () => {
+    // Simulate legacy databases where schema patch gave all rows sort_order=0
+    const a = repo.create("a", "/a", true);
+    const b = repo.create("b", "/b", true);
+    const c = repo.create("c", "/c", true);
+    // Force all sort_order to 0 (simulates the schema patch bug)
+    db.prepare("UPDATE workspaces SET sort_order = 0").run();
+    const before = repo.listAll().map((w) => w.name);
+    // Move last item to first position
+    const lastId = repo.listAll().at(-1)!.id;
+    repo.reorderToIndex(lastId, 0);
+    const after = repo.listAll();
+    expect(after[0]!.id).toBe(lastId);
+    // All sort_order values should now be unique and sequential
+    expect(after.map((w) => w.sort_order)).toEqual([0, 1, 2]);
+  });
 });

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -95,14 +95,14 @@ export class WorkspaceRepo {
 
   /**
    * Reorder a workspace to a zero-based index in the current sort_order ordering.
-   * Uses a two-statement range shift inside a transaction.
+   * Rebuilds sequential sort_order values to handle duplicates from legacy migrations.
    */
   reorderToIndex(id: string, newIndex: number): void {
     const rows = this.db
       .prepare(
-        "SELECT id, sort_order FROM workspaces ORDER BY sort_order ASC, id ASC",
+        "SELECT id FROM workspaces ORDER BY sort_order ASC, id ASC",
       )
-      .all() as Array<{ id: string; sort_order: number }>;
+      .all() as Array<{ id: string }>;
 
     const oldIdx = rows.findIndex((r) => r.id === id);
     if (oldIdx < 0) return;
@@ -111,27 +111,17 @@ export class WorkspaceRepo {
     const idx = Math.max(0, Math.min(newIndex, n - 1));
     if (oldIdx === idx) return;
 
-    const orders = rows.map((r) => r.sort_order);
-    const fromPos = orders[oldIdx]!;
-    const toPos = orders[idx]!;
+    const ids = rows.map((r) => r.id);
+    const [moved] = ids.splice(oldIdx, 1);
+    ids.splice(idx, 0, moved!);
 
+    const stmt = this.db.prepare(
+      "UPDATE workspaces SET sort_order = ? WHERE id = ?",
+    );
     const trx = this.db.transaction(() => {
-      if (idx < oldIdx) {
-        this.db
-          .prepare(
-            "UPDATE workspaces SET sort_order = sort_order + 1 WHERE sort_order >= ? AND sort_order < ?",
-          )
-          .run(toPos, fromPos);
-      } else {
-        this.db
-          .prepare(
-            "UPDATE workspaces SET sort_order = sort_order - 1 WHERE sort_order > ? AND sort_order <= ?",
-          )
-          .run(fromPos, toPos);
+      for (let i = 0; i < ids.length; i++) {
+        stmt.run(i, ids[i]);
       }
-      this.db
-        .prepare("UPDATE workspaces SET sort_order = ? WHERE id = ?")
-        .run(toPos, id);
     });
     trx();
   }

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -161,6 +161,42 @@ export function applySchemaPatches(db: Database.Database): void {
       }
     }
   }
+
+  // Normalize sort_order when duplicates exist (e.g. column added with DEFAULT 0).
+  // Without unique values, reorder operations silently fail.
+  if (cols.length > 0) {
+    const distinctCount = (
+      db
+        .prepare(
+          "SELECT COUNT(DISTINCT sort_order) AS cnt FROM workspaces",
+        )
+        .get() as { cnt: number }
+    ).cnt;
+    const totalCount = (
+      db.prepare("SELECT COUNT(*) AS cnt FROM workspaces").get() as {
+        cnt: number;
+      }
+    ).cnt;
+
+    if (totalCount > 1 && distinctCount < totalCount) {
+      const ids = (
+        db
+          .prepare(
+            "SELECT id FROM workspaces ORDER BY sort_order ASC, created_at ASC, id ASC",
+          )
+          .all() as Array<{ id: string }>
+      ).map((r) => r.id);
+      const stmt = db.prepare(
+        "UPDATE workspaces SET sort_order = ? WHERE id = ?",
+      );
+      const assign = db.transaction(() => {
+        for (let i = 0; i < ids.length; i++) {
+          stmt.run(i, ids[i]);
+        }
+      });
+      assign();
+    }
+  }
 }
 
 function runMigrations(db: Database.Database): void {

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -182,7 +182,7 @@ export function applySchemaPatches(db: Database.Database): void {
       const ids = (
         db
           .prepare(
-            "SELECT id FROM workspaces ORDER BY sort_order ASC, created_at ASC, id ASC",
+            "SELECT id FROM workspaces ORDER BY sort_order ASC, created_at DESC, id ASC",
           )
           .all() as Array<{ id: string }>
       ).map((r) => r.id);


### PR DESCRIPTION
## What

Project drag-and-drop reorder silently failed - projects snapped back to their original position after dropping.

## Why

The `reorderToIndex` range-shift algorithm assumed `sort_order` values were unique. When the column was added via schema patch (#404) with `DEFAULT 0`, all existing rows got `sort_order = 0`. With identical `fromPos` and `toPos`, the SQL WHERE clause became unsatisfiable (`sort_order >= 0 AND sort_order < 0`), so no rows were updated.

## Key changes

- Replaced the range-shift algorithm in `WorkspaceRepo.reorderToIndex` with sequential reassignment: reorder the ID array in-memory, then write `0, 1, 2, ...` in a transaction. Correct regardless of value distribution.
- Added startup normalization in `applySchemaPatches` to detect and fix duplicate `sort_order` values on existing databases, so reordering works immediately without requiring a first drag.
- Added regression test simulating the all-zeros scenario.

Closes #404

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace reordering to reliably handle legacy duplicate ordering and ensure consistent order after migrations.

* **Refactor**
  * Reworked reordering and migration logic to deterministically rebuild workspace order when inconsistencies are detected.

* **Tests**
  * Added test coverage for workspace reordering edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->