### PR TITLE
fix(web): Ctrl+Enter for new project on landing and in browse palette

### DIFF
--- a/apps/web/src/__tests__/context-tracker-lib.test.ts
+++ b/apps/web/src/__tests__/context-tracker-lib.test.ts
@@ -17,6 +17,7 @@ describe("ContextTracker", () => {
     expect(ctx.terminalFocused).toBe(false);
     expect(ctx.commandPaletteOpen).toBe(false);
     expect(ctx.settingsOpen).toBe(false);
+    expect(ctx.showLanding).toBe(false);
   });
 
   it("updates a context value", () => {
@@ -43,5 +44,18 @@ describe("ContextTracker", () => {
 
   it("evaluateWhen returns false for unknown context keys", () => {
     expect(evaluateWhen("unknownKey")).toBe(false);
+  });
+
+  it("evaluateWhen supports && conjunction", () => {
+    setContext("showLanding", true);
+    setContext("commandPaletteOpen", false);
+    setContext("inputFocused", false);
+    expect(
+      evaluateWhen("showLanding && !commandPaletteOpen && !inputFocused"),
+    ).toBe(true);
+    setContext("commandPaletteOpen", true);
+    expect(
+      evaluateWhen("showLanding && !commandPaletteOpen && !inputFocused"),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -97,6 +97,12 @@ export function App() {
     setContext("settingsOpen", settingsOpen);
   }, [settingsOpen]);
 
+  // Landing-only shortcuts (e.g. mod+Enter for new project) should not fire
+  // when settings covers the main pane or chat is visible.
+  useEffect(() => {
+    setContext("showLanding", showLanding && !settingsOpen);
+  }, [showLanding, settingsOpen]);
+
   // Register all commands and initialize shortcuts
   useEffect(() => {
     const cleanup = initShortcuts();

--- a/apps/web/src/components/palette/CommandPalette.tsx
+++ b/apps/web/src/components/palette/CommandPalette.tsx
@@ -82,10 +82,14 @@ export function CommandPalette() {
               modeLabel={browseMode ? "browse" : top?.kind === "projects" ? "projects" : getPaletteMode(query)}
               onKeyDown={(e) => {
                 // Ctrl/Cmd+Enter triggers the active view's confirm action.
-                if (e.key === "Enter" && (e.ctrlKey || e.metaKey) && pendingConfirm) {
-                  e.preventDefault();
-                  pendingConfirm();
-                  return;
+                if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                  const confirm = useCommandPaletteStore.getState().pendingConfirm;
+                  if (confirm) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    confirm();
+                    return;
+                  }
                 }
                 // Backspace on empty input pops the view stack.
                 if (e.key === "Backspace" && query === "" && viewStack.length > 1) {

--- a/apps/web/src/components/projects/ProjectSelectorLanding.tsx
+++ b/apps/web/src/components/projects/ProjectSelectorLanding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
 import { useProjectSelectorStore } from "@/stores/projectSelectorStore";
@@ -14,8 +14,7 @@ import type { RecentThread } from "@/transport/types";
  * Renders the app wordmark, then pinned and recent projects.
  * Opening a project calls setActiveWorkspace (same as the palette flow).
  * The "+ Add project" button opens the palette in browse mode (input seeded to `~/`).
- * While this screen is mounted, Ctrl/Cmd+Enter runs the same action (mirrors browse
- * mode's confirm shortcut) and is suppressed when an input or contenteditable is focused.
+ * Mod+Enter runs the same action via default keybindings when the landing context is active.
  */
 export function ProjectSelectorLanding() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -88,27 +87,6 @@ export function ProjectSelectorLanding() {
   const handleAdd = () =>
     useCommandPaletteStore.getState().open({ intent: "addProject" });
 
-  useEffect(() => {
-    function isInputFocused(): boolean {
-      const el = document.activeElement;
-      if (!el) return false;
-      const tag = el.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA") return true;
-      if (el instanceof HTMLElement && el.isContentEditable) return true;
-      return false;
-    }
-    function onKeyDown(e: KeyboardEvent) {
-      const isEnter =
-        e.key === "Enter" || e.code === "Enter" || e.code === "NumpadEnter";
-      if (!(e.ctrlKey || e.metaKey) || !isEnter) return;
-      if (e.shiftKey || e.altKey) return;
-      if (isInputFocused()) return;
-      e.preventDefault();
-      useCommandPaletteStore.getState().open({ intent: "addProject" });
-    }
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => document.removeEventListener("keydown", onKeyDown, true);
-  }, []);
   /**
    * Open a thread from the recent-threads list. Activate the parent workspace
    * first so downstream selectors (sidebar highlight, breadcrumb, settings) see

--- a/apps/web/src/config/default-keybindings.json
+++ b/apps/web/src/config/default-keybindings.json
@@ -4,6 +4,11 @@
   { "key": "mod+o", "command": "explorer.open", "when": "!inputFocused" },
   { "key": "mod+n", "command": "thread.new", "when": "!inputFocused" },
   { "key": "mod+shift+n", "command": "workspace.new", "when": "!inputFocused" },
+  {
+    "key": "mod+enter",
+    "command": "workspace.new",
+    "when": "showLanding && !commandPaletteOpen && !inputFocused"
+  },
   { "key": "mod+\\", "command": "sidebar.toggle", "when": "!inputFocused" },
   { "key": "mod+j", "command": "terminal.toggle" },
   { "key": "mod+,", "command": "settings.open", "when": "!inputFocused" },

--- a/apps/web/src/lib/context-tracker.ts
+++ b/apps/web/src/lib/context-tracker.ts
@@ -8,6 +8,11 @@ export interface ContextState {
   commandPaletteOpen: boolean;
   /** The settings view is visible. */
   settingsOpen: boolean;
+  /**
+   * The project landing is visible (no active thread, not obscured by settings).
+   * Used so landing-only shortcuts do not fire in chat or fullscreen settings.
+   */
+  showLanding: boolean;
 }
 
 /** Valid context key names. */
@@ -20,6 +25,7 @@ function getDefaultContext(): ContextState {
     terminalFocused: false,
     commandPaletteOpen: false,
     settingsOpen: false,
+    showLanding: false,
   };
 }
 
@@ -36,20 +42,33 @@ export function setContext<K extends ContextKey>(key: K, value: ContextState[K])
 }
 
 /**
- * Evaluate a "when" clause against the current context.
- * Supports simple keys ("inputFocused") and negation ("!inputFocused").
- * Returns true if the clause is undefined (unconditional).
+ * Evaluates one context atom: `key` or `!key` for a known `ContextKey`.
  */
-export function evaluateWhen(when: string | undefined): boolean {
-  if (when === undefined) return true;
-
-  const negated = when.startsWith("!");
-  const key = (negated ? when.slice(1) : when) as ContextKey;
+function evaluateWhenAtom(atom: string): boolean {
+  const trimmed = atom.trim();
+  const negated = trimmed.startsWith("!");
+  const key = (negated ? trimmed.slice(1) : trimmed) as ContextKey;
 
   if (!Object.prototype.hasOwnProperty.call(state, key)) return false;
 
   const value = state[key];
-  return negated ? !value : value;
+  return negated ? !value : !!value;
+}
+
+/**
+ * Evaluate a "when" clause against the current context.
+ * Supports simple keys (`inputFocused`), negation (`!inputFocused`), and
+ * conjunction with ` && ` (all subclauses must pass). Returns true if the
+ * clause is undefined (unconditional).
+ */
+export function evaluateWhen(when: string | undefined): boolean {
+  if (when === undefined) return true;
+
+  const parts = when.split(/\s+&&\s+/);
+  for (let i = 0; i < parts.length; i++) {
+    if (!evaluateWhenAtom(parts[i]!)) return false;
+  }
+  return true;
 }
 
 /** Reset all context to defaults (for testing). */


### PR DESCRIPTION
## What

Restores Mod+Enter for **New project** on the cold-start landing and for **Add** when browsing folders in the command palette.

## Why

The palette used a stale \pendingConfirm\ closure and cmdk could still handle Enter after confirm. Landing relied on a document listener tied to a conditionally mounted component.

## Key changes

- Command palette: read \pendingConfirm\ from the store on keydown and call \stopPropagation()\ when confirming with Mod+Enter.
- Landing: bind \mod+enter\ to \workspace.new\ in default keybindings with \showLanding && !commandPaletteOpen && !inputFocused\.
- Sync \showLanding\ context from App (false when settings covers the pane).
- Context \valuateWhen\ supports \ && \-joined clauses.
- Removed the landing capture-phase keydown workaround.

## Configuration changes

None (no new env vars or secrets).

## Verification

- \un run test\ (turbo): all packages passed (e.g. web 984 tests, server 845 tests).

## Related issues/PRs

(none linked)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->