### PR TITLE
fix: eliminate false thread in-progress indicators

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -954,6 +954,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                 emitResultError(anyMsg);
                 lastAssistantText = "";
                 lastStreamInputTokens = undefined;
+                awaitingResume = false;
                 break;
               }
               if (lastAssistantText) {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -794,6 +794,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
          * context fill vs. the accumulated result.usage which inflates across API calls).
          * Reset to undefined after each turnComplete. */
         let lastStreamInputTokens: number | undefined = undefined;
+        /** Set after a `result` (TurnComplete). When the SDK auto-resumes
+         *  (e.g. ScheduleWakeup/loop), the next non-system/non-result event
+         *  triggers a synthetic TurnStarted so the server and UI know a new
+         *  turn has begun without going through sendMessage(). */
+        let awaitingResume = false;
 
         /**
          * Emit an Error event with a best-effort message extracted from an SDK
@@ -855,6 +860,18 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
               type: AgentEventType.System,
               threadId,
               subtype: "sdk_session_id:" + sdkSid,
+            } satisfies AgentEvent);
+          }
+
+          // Auto-resume detection: the SDK can start a new turn without
+          // going through sendMessage() (e.g. ScheduleWakeup/loop timer).
+          // Emit a synthetic TurnStarted so AgentService re-adds to
+          // activeSessionIds and the frontend shows the running indicator.
+          if (awaitingResume && anyMsg.type !== "result" && anyMsg.type !== "system") {
+            awaitingResume = false;
+            this.emit("event", {
+              type: AgentEventType.TurnStarted,
+              threadId,
             } satisfies AgentEvent);
           }
 
@@ -1052,6 +1069,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
               lastStreamInputTokens = undefined;
 
               lastAssistantText = "";
+              awaitingResume = true;
               break;
             }
 

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -33,6 +33,7 @@ vi.mock("fs", async (importOriginal) => {
 
 const THREAD_ID = "thread-cleanup-test";
 
+/** Create a minimal Thread fixture with sensible defaults for turn cleanup tests. */
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {
     id: THREAD_ID,
@@ -291,6 +292,40 @@ describe("AgentService turn cleanup", () => {
     // Thread should be active again
     expect(service.activeThreadIds()).toContain(THREAD_ID);
     expect(memoryPressureService.markActive).toHaveBeenCalled();
+  });
+
+  it("does not re-add thread after an Error event following TurnComplete", async () => {
+    const { service, providerEmitter, memoryPressureService } = buildService();
+    service.init();
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    expect(service.activeThreadIds()).toContain(THREAD_ID);
+
+    // Turn completes, thread removed
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: THREAD_ID,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 100,
+      tokensOut: 50,
+      contextWindow: 200000,
+      totalProcessedTokens: 150,
+      providerId: "claude",
+    } satisfies AgentEvent);
+
+    expect(service.activeThreadIds()).not.toContain(THREAD_ID);
+
+    // Error event should not re-add the thread
+    memoryPressureService.markActive.mockClear();
+    providerEmitter.emit("event", {
+      type: AgentEventType.Error,
+      threadId: THREAD_ID,
+      error: "Something went wrong",
+    } satisfies AgentEvent);
+
+    expect(service.activeThreadIds()).not.toContain(THREAD_ID);
+    expect(memoryPressureService.markActive).not.toHaveBeenCalled();
   });
 
   it("removes thread from activeThreadIds on Ended event", async () => {

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -259,6 +259,40 @@ describe("AgentService turn cleanup", () => {
     expect(service.activeThreadIds()).toContain(THREAD_ID);
   });
 
+  it("re-adds thread to activeThreadIds on TurnStarted after TurnComplete (auto-resume)", async () => {
+    const { service, providerEmitter, memoryPressureService } = buildService();
+    service.init();
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    expect(service.activeThreadIds()).toContain(THREAD_ID);
+
+    // Turn completes, thread removed from active
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: THREAD_ID,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 100,
+      tokensOut: 50,
+      contextWindow: 200000,
+      totalProcessedTokens: 150,
+      providerId: "claude",
+    } satisfies AgentEvent);
+
+    expect(service.activeThreadIds()).not.toContain(THREAD_ID);
+
+    // SDK auto-resumes: TurnStarted fires from stream loop
+    memoryPressureService.markActive.mockClear();
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnStarted,
+      threadId: THREAD_ID,
+    } satisfies AgentEvent);
+
+    // Thread should be active again
+    expect(service.activeThreadIds()).toContain(THREAD_ID);
+    expect(memoryPressureService.markActive).toHaveBeenCalled();
+  });
+
   it("removes thread from activeThreadIds on Ended event", async () => {
     const { service, providerEmitter, memoryPressureService } = buildService();
     service.init();

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -1,0 +1,277 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+import { AgentEventType } from "@mcode/contracts";
+import type { AgentEvent, Thread, IProviderRegistry } from "@mcode/contracts";
+import { AgentService } from "../agent-service.js";
+import type { ThreadRepo } from "../../repositories/thread-repo.js";
+import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import type { MessageRepo } from "../../repositories/message-repo.js";
+import type { GitService } from "../git-service.js";
+import type { AttachmentService } from "../attachment-service.js";
+import type { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
+import type { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo.js";
+import type { SnapshotService } from "../snapshot-service.js";
+import type { MemoryPressureService } from "../memory-pressure-service.js";
+import type { TaskRepo } from "../../repositories/task-repo.js";
+import type { SettingsService } from "../settings-service.js";
+import type { ThreadService } from "../thread-service.js";
+import type { ProviderAvailabilityService } from "../provider-availability-service.js";
+import type { PlanQuestionAnswersRepo } from "../../repositories/plan-question-answers-repo.js";
+
+vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
+
+// Mock fs so sendMessage's cwd validation passes without a real directory
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    statSync: vi.fn(() => ({ isDirectory: () => true })),
+  };
+});
+
+const THREAD_ID = "thread-cleanup-test";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: THREAD_ID,
+    workspace_id: "ws-1",
+    title: "Test thread",
+    status: "idle",
+    mode: "direct",
+    branch: "main",
+    worktree_path: null,
+    model: "claude-sonnet-4-6",
+    provider: "claude",
+    sdk_session_id: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    copilot_agent: null,
+    last_compact_summary: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    deleted_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as Thread;
+}
+
+/**
+ * Build a minimal AgentService wired to a fake EventEmitter-based provider.
+ * The returned `providerEmitter` lets the test fire events as if the SDK
+ * produced them, exercising the handler registered in `init()`.
+ */
+function buildService(): {
+  service: AgentService;
+  providerEmitter: EventEmitter;
+  memoryPressureService: { markActive: ReturnType<typeof vi.fn>; markIdle: ReturnType<typeof vi.fn> };
+} {
+  const thread = makeThread();
+  const providerEmitter = new EventEmitter();
+
+  // sendMessage() and setSdkSessionId() are called on the resolved provider
+  (providerEmitter as any).sendMessage = vi.fn(() => Promise.resolve());
+  (providerEmitter as any).setSdkSessionId = vi.fn();
+
+  const threadRepo = {
+    findById: vi.fn(() => thread),
+    updateStatus: vi.fn(),
+    updateModel: vi.fn(),
+    updateProvider: vi.fn(),
+    updateSettings: vi.fn(),
+    create: vi.fn(),
+    softDelete: vi.fn(),
+    updateWorktreePath: vi.fn(),
+    updateContextUsage: vi.fn(),
+    updateSdkSessionId: vi.fn(),
+    updateCompactSummary: vi.fn(),
+    updateLineage: vi.fn(),
+  } as unknown as ThreadRepo;
+
+  const workspaceRepo = {
+    findById: vi.fn(() => ({ id: "ws-1", path: "/workspace" })),
+  } as unknown as WorkspaceRepo;
+
+  const messageRepo = {
+    listByThread: vi.fn(() => ({ messages: [] })),
+    create: vi.fn(() => ({ id: "msg-1", sequence: 1 })),
+    findByIdInThread: vi.fn(),
+    listByThreadUpToSequence: vi.fn(() => []),
+  } as unknown as MessageRepo;
+
+  const gitService = {
+    resolveWorkingDir: vi.fn(() => "/workspace"),
+    listWorktrees: vi.fn(() => []),
+  } as unknown as GitService;
+
+  const attachmentService = {
+    persist: vi.fn(() => Promise.resolve({ stored: [], persisted: [] })),
+  } as unknown as AttachmentService;
+
+  // The provider must be an EventEmitter so init() can subscribe via
+  // provider.on("event", ...) and tests can fire events via providerEmitter.emit()
+  const providerRegistry = {
+    resolve: vi.fn(() => providerEmitter),
+    resolveAll: vi.fn(() => [providerEmitter]),
+    shutdown: vi.fn(),
+  } as unknown as IProviderRegistry;
+
+  const threadService = {
+    create: vi.fn(),
+  } as unknown as ThreadService;
+
+  const toolCallRecordRepo = {
+    bulkCreate: vi.fn(),
+  } as unknown as ToolCallRecordRepo;
+
+  const turnSnapshotRepo = {
+    listByThread: vi.fn(() => []),
+    create: vi.fn(),
+  } as unknown as TurnSnapshotRepo;
+
+  const snapshotService = {
+    captureRef: vi.fn(() => Promise.resolve("abc123")),
+    getFilesChanged: vi.fn(() => Promise.resolve([])),
+  } as unknown as SnapshotService;
+
+  const memoryPressureService = {
+    markActive: vi.fn(),
+    markIdle: vi.fn(),
+  } as unknown as MemoryPressureService;
+
+  const taskRepo = {
+    get: vi.fn(() => []),
+    upsert: vi.fn(),
+  } as unknown as TaskRepo;
+
+  const settingsService = {
+    get: vi.fn(() => ({
+      model: { defaults: { fallbackId: undefined } },
+      agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
+      provider: { enabled: {}, cli: {} },
+    })),
+    on: vi.fn(),
+  } as unknown as SettingsService;
+
+  const availability = {
+    assertUsable: vi.fn(),
+  } as unknown as ProviderAvailabilityService;
+
+  const planQuestionAnswersRepo = {
+    markAnswered: vi.fn(),
+    isAnswered: vi.fn(() => false),
+    listAnsweredForThread: vi.fn(() => []),
+  } as unknown as PlanQuestionAnswersRepo;
+
+  const db = {
+    // better-sqlite3's transaction() returns a wrapped function; calling it executes the callback
+    transaction: vi.fn((fn: Function) => fn),
+    prepare: vi.fn(() => ({ run: vi.fn() })),
+  } as unknown as import("better-sqlite3").Database;
+
+  const service = new AgentService(
+    threadRepo,
+    workspaceRepo,
+    messageRepo,
+    gitService,
+    attachmentService,
+    providerRegistry,
+    threadService,
+    toolCallRecordRepo,
+    turnSnapshotRepo,
+    snapshotService,
+    db,
+    memoryPressureService as MemoryPressureService,
+    taskRepo,
+    settingsService,
+    availability,
+    planQuestionAnswersRepo,
+  );
+
+  return { service, providerEmitter, memoryPressureService };
+}
+
+describe("AgentService turn cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes thread from activeThreadIds on TurnComplete", async () => {
+    const { service, providerEmitter, memoryPressureService } = buildService();
+    service.init();
+
+    // sendMessage adds thread to activeSessionIds and emits TurnStarted
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    expect(service.activeThreadIds()).toContain(THREAD_ID);
+
+    // Fire TurnComplete through the provider
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: THREAD_ID,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 100,
+      tokensOut: 50,
+      contextWindow: 200000,
+      totalProcessedTokens: 150,
+      providerId: "claude",
+    } satisfies AgentEvent);
+
+    // Thread should no longer be active
+    expect(service.activeThreadIds()).not.toContain(THREAD_ID);
+    expect(memoryPressureService.markIdle).toHaveBeenCalled();
+  });
+
+  it("does NOT remove thread from activeThreadIds on TurnComplete during compaction", async () => {
+    const { service, providerEmitter } = buildService();
+    service.init();
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    expect(service.activeThreadIds()).toContain(THREAD_ID);
+
+    // Start compaction first
+    providerEmitter.emit("event", {
+      type: AgentEventType.Compacting,
+      threadId: THREAD_ID,
+      active: true,
+    } satisfies AgentEvent);
+
+    // Fire TurnComplete during compaction
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: THREAD_ID,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 100,
+      tokensOut: 50,
+      contextWindow: 200000,
+      totalProcessedTokens: 150,
+      providerId: "claude",
+    } satisfies AgentEvent);
+
+    // Thread should STILL be active (compaction guard)
+    expect(service.activeThreadIds()).toContain(THREAD_ID);
+  });
+
+  it("removes thread from activeThreadIds on Ended event", async () => {
+    const { service, providerEmitter, memoryPressureService } = buildService();
+    service.init();
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    expect(service.activeThreadIds()).toContain(THREAD_ID);
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.Ended,
+      threadId: THREAD_ID,
+    } satisfies AgentEvent);
+
+    expect(service.activeThreadIds()).not.toContain(THREAD_ID);
+    expect(memoryPressureService.markIdle).toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -193,7 +193,7 @@ function buildService(): {
     planQuestionAnswersRepo,
   );
 
-  return { service, providerEmitter, memoryPressureService };
+  return { service, providerEmitter, memoryPressureService: memoryPressureService as MemoryPressureService & { markActive: ReturnType<typeof vi.fn>; markIdle: ReturnType<typeof vi.fn> } };
 }
 
 describe("AgentService turn cleanup", () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -963,6 +963,16 @@ export class AgentService {
           this.updateBufferedToolCallOutput(event.threadId, event.toolCallId, event.output, event.isError);
         }
 
+        if (event.type === AgentEventType.TurnStarted) {
+          // Re-add to activeSessionIds for auto-resumed turns (ScheduleWakeup/loop).
+          // For sendMessage()-originated turns this is a no-op since sendMessage()
+          // already added the thread before emitting TurnStarted.
+          if (!this.activeSessionIds.has(event.threadId)) {
+            this.activeSessionIds.add(event.threadId);
+            this.memoryPressureService.markActive();
+          }
+        }
+
         if (event.type === AgentEventType.TurnComplete) {
           this.persistTurn(event.threadId).catch((err) => {
             logger.error("persistTurn failed on turnComplete", {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -987,10 +987,7 @@ export class AgentService {
           // before the compaction API call, but the session continues
           // automatically.
           if (!this.compactionInProgressByThread.has(event.threadId)) {
-            this.activeSessionIds.delete(event.threadId);
-            if (this.activeSessionIds.size === 0) {
-              this.memoryPressureService.markIdle();
-            }
+            this.trackSessionEnded(event.threadId);
           }
 
           // Persist context usage so the tracker shows immediately on thread reload.

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -971,6 +971,18 @@ export class AgentService {
             });
           });
 
+          // Clear the "running" flag so agent.listRunning no longer reports
+          // this thread and shutdown won't downgrade it to "interrupted."
+          // Skip during compaction: the SDK fires a synthetic TurnComplete
+          // before the compaction API call, but the session continues
+          // automatically.
+          if (!this.compactionInProgressByThread.has(event.threadId)) {
+            this.activeSessionIds.delete(event.threadId);
+            if (this.activeSessionIds.size === 0) {
+              this.memoryPressureService.markIdle();
+            }
+          }
+
           // Persist context usage so the tracker shows immediately on thread reload.
           // Skip during compaction: the compaction API call emits a turnComplete
           // with the pre-compaction token count. Persisting it would cause cold


### PR DESCRIPTION
## What

Fix false "in progress" orange/amber pulsing dots on sidebar threads that have no active work, and ensure auto-resumed turns (ScheduleWakeup/loop) correctly reflect running state in the UI.

## Why

Two symptoms from one root cause: `activeSessionIds` in `AgentService` tracked threads with alive SDK subprocesses, not threads with active turns. After a turn completed, the subprocess stayed alive (for fast follow-ups), but the thread lingered in `activeSessionIds`. This caused:

1. **Shutdown path:** Graceful shutdown marked idle threads as "interrupted", producing amber pulsing dots on restart.
2. **Reconnect path:** `agent.listRunning` reported idle sessions, re-populating `runningThreadIds` on WS reconnect, producing false orange dots.

A related issue: when the Claude SDK auto-resumes a session (ScheduleWakeup/loop timer), no `TurnStarted` event fired because that event only lived in `sendMessage()`. The sidebar and composer didn't reflect the running state on auto-resume.

## Key Changes

- Remove thread from `activeSessionIds` on `TurnComplete`, guarded for compaction turns where the session auto-continues
- Emit synthetic `TurnStarted` in the Claude provider stream loop when the SDK auto-resumes after a completed turn
- Handle `TurnStarted` in `AgentService.init()` to re-add the thread to `activeSessionIds` (idempotent: no-op on the `sendMessage()` path)
- Clear `awaitingResume` flag on error results to prevent spurious `TurnStarted` emission
- 4 unit tests covering TurnComplete removal, compaction guard, Ended removal, and TurnStarted re-addition

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Synthetic auto-resume signaling so the UI reflects resumed assistant turns when it continues a follow-up.

* **Bug Fixes**
  * More robust session lifecycle handling to avoid incorrect deactivation during background compaction.

* **Tests**
  * New tests covering turn cleanup and session state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->