### PR TITLE
feat: surface rate limit and API retry events to users

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1089,6 +1089,16 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                     trigger: metadata.trigger,
                   });
                 }
+              } else if ((anyMsg.subtype as string) === "api_retry") {
+                this.emit("event", {
+                  type: AgentEventType.ApiRetry,
+                  threadId,
+                  reason: (anyMsg.error as string) || "unknown",
+                  attempt: anyMsg.attempt as number | undefined,
+                  maxRetries: anyMsg.max_retries as number | undefined,
+                  delayMs: anyMsg.retry_delay_ms as number | undefined,
+                  errorStatus: (anyMsg.error_status as number | null) ?? undefined,
+                } satisfies AgentEvent);
               } else {
                 this.emit("event", {
                   type: AgentEventType.System,
@@ -1217,6 +1227,39 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                   toolCallId: toolUseId,
                   toolName,
                   elapsedSeconds,
+                } satisfies AgentEvent);
+              }
+              break;
+            }
+
+            case "rate_limit_event": {
+              const info = anyMsg.rate_limit_info as {
+                status?: string;
+                resetsAt?: number;
+                rateLimitType?: string;
+                utilization?: number;
+              } | undefined;
+              const status = info?.status;
+
+              // Only surface warnings and rejections; 'allowed' is noise
+              if (status === "allowed_warning" || status === "rejected") {
+                const retryAfterMs = info?.resetsAt
+                  ? Math.max(0, info.resetsAt * 1000 - Date.now())
+                  : undefined;
+                this.emit("event", {
+                  type: AgentEventType.RateLimited,
+                  threadId,
+                  active: true,
+                  retryAfterMs,
+                  limitType: info?.rateLimitType,
+                  utilization: info?.utilization,
+                } satisfies AgentEvent);
+              } else if (status === "allowed") {
+                // Clear any previously active rate limit indicator
+                this.emit("event", {
+                  type: AgentEventType.RateLimited,
+                  threadId,
+                  active: false,
                 } satisfies AgentEvent);
               }
               break;

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1097,7 +1097,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                   attempt: anyMsg.attempt as number | undefined,
                   maxRetries: anyMsg.max_retries as number | undefined,
                   delayMs: anyMsg.retry_delay_ms as number | undefined,
-                  errorStatus: (anyMsg.error_status as number | null) ?? undefined,
+                  errorStatus: (anyMsg.error_status as number | undefined) ?? undefined,
                 } satisfies AgentEvent);
               } else {
                 this.emit("event", {

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -121,11 +121,10 @@ export class CodexEventMapper {
       const errorMsg = notification.params.error?.message ?? "Unknown error from codex app-server";
       const willRetry = notification.params.willRetry ?? false;
       logger.debug("Codex error notification", { error: errorMsg, willRetry });
-      // Only surface non-retried errors; retried ones are transient and will resolve
-      if (!willRetry) {
-        return [{ type: AgentEventType.Error, threadId: this.threadId, error: errorMsg }];
+      if (willRetry) {
+        return [{ type: AgentEventType.ApiRetry, threadId: this.threadId, reason: errorMsg }];
       }
-      return [];
+      return [{ type: AgentEventType.Error, threadId: this.threadId, error: errorMsg }];
     }
 
     if (SILENCED_METHODS.has(method)) {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -51,6 +51,7 @@ import type { PrDetail } from "@/transport/types";
 import { QueuePopover } from "./QueuePopover";
 import { ContextTracker } from "./ContextTracker";
 import { CompactingBanner } from "./CompactingBanner";
+import { RetryBanner } from "./RetryBanner";
 import { ComposerBranchBar } from "./ComposerBranchBar";
 import { useQueueStore } from "@/stores/queueStore";
 import {
@@ -708,6 +709,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   }, [permissionLocked, access, threadId, setThreadSettings]);
   const contextEntry = useThreadStore((s) => threadId ? s.contextByThread[threadId] : undefined);
   const isCompacting = useThreadStore((s) => !!(threadId && s.isCompactingByThread[threadId]));
+  const hasRetryState = useThreadStore(
+    (s) => !!(threadId && (s.rateLimitByThread[threadId] || s.apiRetryByThread[threadId])),
+  );
   const planPending = useThreadStore(
     (s) => !!threadId && (s.planQuestionsStatusByThread[threadId] ?? "idle") === "pending",
   );
@@ -1520,6 +1524,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
         {/* Compacting banner — shown while the SDK is summarising the context window */}
         {isCompacting && <CompactingBanner />}
+        {!isCompacting && hasRetryState && <RetryBanner />}
 
         {/* Drag overlay */}
         {isDragOver && (

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1524,7 +1524,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
         {/* Compacting banner — shown while the SDK is summarising the context window */}
         {isCompacting && <CompactingBanner />}
-        {!isCompacting && hasRetryState && <RetryBanner />}
+        {!isCompacting && hasRetryState && threadId && <RetryBanner threadId={threadId} />}
 
         {/* Drag overlay */}
         {isDragOver && (

--- a/apps/web/src/components/chat/RetryBanner.tsx
+++ b/apps/web/src/components/chat/RetryBanner.tsx
@@ -18,9 +18,9 @@ export function RetryBanner() {
   if (rateLimit) {
     if (rateLimit.retryAfterMs && rateLimit.retryAfterMs > 0) {
       const seconds = Math.ceil(rateLimit.retryAfterMs / 1000);
-      label = `Rate limited \u2014 retrying in ${formatDuration(seconds)}`;
+      label = `Rate limited - retrying in ${formatDuration(seconds)}`;
     } else {
-      label = "Rate limited \u2014 waiting for capacity\u2026";
+      label = "Rate limited - waiting for capacity...";
     }
   } else if (apiRetry) {
     const parts: string[] = ["Retrying"];
@@ -33,7 +33,7 @@ export function RetryBanner() {
       const seconds = Math.ceil(apiRetry.delayMs / 1000);
       parts.push(`in ${formatDuration(seconds)}`);
     }
-    label = parts.join(" ") + "\u2026";
+    label = parts.join(" ") + "...";
   } else {
     return null;
   }

--- a/apps/web/src/components/chat/RetryBanner.tsx
+++ b/apps/web/src/components/chat/RetryBanner.tsx
@@ -1,0 +1,58 @@
+import { useThreadStore } from "@/stores/threadStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+/**
+ * Inline banner shown when the provider is rate-limited or retrying an API request.
+ *
+ * Renders in the same Composer slot as CompactingBanner. Shows a pulsing indicator
+ * with a human-readable description of why the agent is paused.
+ */
+export function RetryBanner() {
+  const threadId = useWorkspaceStore((s) => s.activeThreadId);
+  const rateLimit = useThreadStore((s) => threadId ? s.rateLimitByThread[threadId] : undefined);
+  const apiRetry = useThreadStore((s) => threadId ? s.apiRetryByThread[threadId] : undefined);
+
+  if (!rateLimit && !apiRetry) return null;
+
+  let label: string;
+  if (rateLimit) {
+    if (rateLimit.retryAfterMs && rateLimit.retryAfterMs > 0) {
+      const seconds = Math.ceil(rateLimit.retryAfterMs / 1000);
+      label = `Rate limited \u2014 retrying in ${formatDuration(seconds)}`;
+    } else {
+      label = "Rate limited \u2014 waiting for capacity\u2026";
+    }
+  } else if (apiRetry) {
+    const parts: string[] = ["Retrying"];
+    if (apiRetry.attempt != null && apiRetry.maxRetries != null) {
+      parts.push(`(${apiRetry.attempt}/${apiRetry.maxRetries})`);
+    } else if (apiRetry.attempt != null) {
+      parts.push(`(attempt ${apiRetry.attempt})`);
+    }
+    if (apiRetry.delayMs != null && apiRetry.delayMs > 0) {
+      const seconds = Math.ceil(apiRetry.delayMs / 1000);
+      parts.push(`in ${formatDuration(seconds)}`);
+    }
+    label = parts.join(" ") + "\u2026";
+  } else {
+    return null;
+  }
+
+  return (
+    <div role="status" aria-live="polite" className="flex items-center gap-2 px-3 py-2 border-t border-border/20">
+      <span className="relative flex h-3 w-3 shrink-0">
+        <span className="motion-safe:animate-ping motion-reduce:hidden absolute inline-flex h-full w-full rounded-full bg-amber-500/60" />
+        <span className="relative inline-flex h-3 w-3 rounded-full bg-amber-500" />
+      </span>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+/** Format seconds into a compact human-readable duration (e.g. "12s", "2m 30s"). */
+function formatDuration(totalSeconds: number): string {
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}

--- a/apps/web/src/components/chat/RetryBanner.tsx
+++ b/apps/web/src/components/chat/RetryBanner.tsx
@@ -1,5 +1,4 @@
 import { useThreadStore } from "@/stores/threadStore";
-import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 /**
  * Inline banner shown when the provider is rate-limited or retrying an API request.
@@ -7,10 +6,9 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
  * Renders in the same Composer slot as CompactingBanner. Shows a pulsing indicator
  * with a human-readable description of why the agent is paused.
  */
-export function RetryBanner() {
-  const threadId = useWorkspaceStore((s) => s.activeThreadId);
-  const rateLimit = useThreadStore((s) => threadId ? s.rateLimitByThread[threadId] : undefined);
-  const apiRetry = useThreadStore((s) => threadId ? s.apiRetryByThread[threadId] : undefined);
+export function RetryBanner({ threadId }: { threadId: string }) {
+  const rateLimit = useThreadStore((s) => s.rateLimitByThread[threadId]);
+  const apiRetry = useThreadStore((s) => s.apiRetryByThread[threadId]);
 
   if (!rateLimit && !apiRetry) return null;
 

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -96,6 +96,10 @@ interface ThreadState {
   isCompactingByThread: Record<string, boolean>;
   /** Transient fallback state per thread. Cleared when the user sends the next message. */
   lastFallbackByThread: Record<string, { requestedModel: string; actualModel: string }>;
+  /** Transient rate-limit indicator per thread. Cleared when the provider reports the limit has lifted. */
+  rateLimitByThread: Record<string, { retryAfterMs?: number; limitType?: string; utilization?: number }>;
+  /** Transient API retry indicator per thread. Cleared when a non-retry event arrives. */
+  apiRetryByThread: Record<string, { reason: string; attempt?: number; maxRetries?: number; delayMs?: number }>;
   /** Questions proposed by the model in plan mode, keyed by thread ID. Null when not pending. */
   planQuestionsByThread: Record<string, PlanQuestion[] | null>;
   /** User's answers to plan questions, keyed by thread ID then question ID. */
@@ -316,6 +320,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   usageByProvider: {},
   isCompactingByThread: {},
   lastFallbackByThread: {},
+  rateLimitByThread: {},
+  apiRetryByThread: {},
   planQuestionsByThread: {},
   planAnswersByThread: {},
   activeQuestionIndexByThread: {},
@@ -751,6 +757,16 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         delete next[threadId];
         return next;
       })(),
+      rateLimitByThread: (() => {
+        const next = { ...state.rateLimitByThread };
+        delete next[threadId];
+        return next;
+      })(),
+      apiRetryByThread: (() => {
+        const next = { ...state.apiRetryByThread };
+        delete next[threadId];
+        return next;
+      })(),
       errorByThread: (() => {
         const next = { ...state.errorByThread };
         delete next[threadId];
@@ -996,6 +1012,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         contextByThread: omitKey(state.contextByThread, threadId),
         isCompactingByThread: omitKey(state.isCompactingByThread, threadId),
         lastFallbackByThread: omitKey(state.lastFallbackByThread, threadId),
+        rateLimitByThread: omitKey(state.rateLimitByThread, threadId),
+        apiRetryByThread: omitKey(state.apiRetryByThread, threadId),
         planQuestionsByThread: omitKey(state.planQuestionsByThread, threadId),
         planAnswersByThread: omitKey(state.planAnswersByThread, threadId),
         activeQuestionIndexByThread: omitKey(state.activeQuestionIndexByThread, threadId),
@@ -1076,6 +1094,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         contextByThread: pruneAll(state.contextByThread),
         isCompactingByThread: pruneAll(state.isCompactingByThread),
         lastFallbackByThread: pruneAll(state.lastFallbackByThread),
+        rateLimitByThread: pruneAll(state.rateLimitByThread),
+        apiRetryByThread: pruneAll(state.apiRetryByThread),
         planQuestionsByThread: pruneAll(state.planQuestionsByThread),
         planAnswersByThread: pruneAll(state.planAnswersByThread),
         activeQuestionIndexByThread: pruneAll(state.activeQuestionIndexByThread),
@@ -1325,6 +1345,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         next.add(threadId);
         return { runningThreadIds: next, agentStartTimes: { ...state.agentStartTimes, [threadId]: Date.now() } };
       });
+      // A new turn means any pending retry is resolved — clear it regardless of
+      // whether this thread was already in runningThreadIds.
+      set((state) => ({
+        apiRetryByThread: (() => {
+          const next = { ...state.apiRetryByThread };
+          delete next[threadId];
+          return next;
+        })(),
+      }));
       // Clear interrupted status so the resume banner no longer lists this
       // thread while the agent processes the continuation message.
       useWorkspaceStore.setState((ws) => {
@@ -1822,6 +1851,39 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           };
         });
       }
+      return;
+    }
+
+    if (method === "session.rateLimited") {
+      const active = params.active as boolean;
+      set((state) => {
+        const next = { ...state.rateLimitByThread };
+        if (active) {
+          next[threadId] = {
+            retryAfterMs: params.retryAfterMs as number | undefined,
+            limitType: params.limitType as string | undefined,
+            utilization: params.utilization as number | undefined,
+          };
+        } else {
+          delete next[threadId];
+        }
+        return { rateLimitByThread: next };
+      });
+      return;
+    }
+
+    if (method === "session.apiRetry") {
+      set((state) => ({
+        apiRetryByThread: {
+          ...state.apiRetryByThread,
+          [threadId]: {
+            reason: params.reason as string,
+            attempt: params.attempt as number | undefined,
+            maxRetries: params.maxRetries as number | undefined,
+            delayMs: params.delayMs as number | undefined,
+          },
+        },
+      }));
       return;
     }
 

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -799,8 +799,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     set((state) => {
       const next = new Set(state.runningThreadIds);
       next.delete(threadId);
+      const nextRateLimit = { ...state.rateLimitByThread };
+      delete nextRateLimit[threadId];
+      const nextApiRetry = { ...state.apiRetryByThread };
+      delete nextApiRetry[threadId];
       return {
         runningThreadIds: next,
+        rateLimitByThread: nextRateLimit,
+        apiRetryByThread: nextApiRetry,
       };
     });
   },
@@ -1354,15 +1360,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         next.add(threadId);
         return { runningThreadIds: next, agentStartTimes: { ...state.agentStartTimes, [threadId]: Date.now() } };
       });
-      // A new turn means any pending retry is resolved — clear it regardless of
-      // whether this thread was already in runningThreadIds.
-      set((state) => ({
-        apiRetryByThread: (() => {
-          const next = { ...state.apiRetryByThread };
-          delete next[threadId];
-          return next;
-        })(),
-      }));
       // Clear interrupted status so the resume banner no longer lists this
       // thread while the agent processes the continuation message.
       useWorkspaceStore.setState((ws) => {
@@ -2016,6 +2013,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         delete nextCompacting[threadId];
         const nextRateLimit = { ...state.rateLimitByThread };
         delete nextRateLimit[threadId];
+        const nextApiRetry = { ...state.apiRetryByThread };
+        delete nextApiRetry[threadId];
         const base = {
           errorByThread: { ...state.errorByThread, [threadId]: errorMsg },
           runningThreadIds: nextRunning,
@@ -2026,6 +2025,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           activeSubagentsByThread: nextSubagents,
           isCompactingByThread: nextCompacting,
           rateLimitByThread: nextRateLimit,
+          apiRetryByThread: nextApiRetry,
         };
         if (state.currentThreadId !== threadId) return base;
         const { messages: capped, evicted } = capMessages([...state.messages, errorMessage]);

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1307,6 +1307,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
     // -- Sidecar events (new format) --
 
+    // Any non-retry event on this thread means a pending API retry resolved
+    if (method !== "session.apiRetry" && get().apiRetryByThread[threadId]) {
+      set((state) => {
+        const next = { ...state.apiRetryByThread };
+        delete next[threadId];
+        return { apiRetryByThread: next };
+      });
+    }
+
     if (method === "session.system") {
       const subtype = params.subtype as string;
       if (subtype === "session_restarted") {
@@ -1644,6 +1653,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               delete next[threadId];
               return next;
             })(),
+            rateLimitByThread: (() => {
+              const next = { ...state.rateLimitByThread };
+              delete next[threadId];
+              return next;
+            })(),
           };
         });
       } else {
@@ -1683,6 +1697,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             // Clear permission cards now that the agent has responded.
             permissionsByThread: (() => {
               const next = { ...state.permissionsByThread };
+              delete next[threadId];
+              return next;
+            })(),
+            rateLimitByThread: (() => {
+              const next = { ...state.rateLimitByThread };
               delete next[threadId];
               return next;
             })(),
@@ -1995,6 +2014,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         delete nextSubagents[threadId];
         const nextCompacting = { ...state.isCompactingByThread };
         delete nextCompacting[threadId];
+        const nextRateLimit = { ...state.rateLimitByThread };
+        delete nextRateLimit[threadId];
         const base = {
           errorByThread: { ...state.errorByThread, [threadId]: errorMsg },
           runningThreadIds: nextRunning,
@@ -2004,6 +2025,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           toolCallsByThread: nextToolCalls,
           activeSubagentsByThread: nextSubagents,
           isCompactingByThread: nextCompacting,
+          rateLimitByThread: nextRateLimit,
         };
         if (state.currentThreadId !== threadId) return base;
         const { messages: capped, evicted } = capMessages([...state.messages, errorMessage]);

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -194,7 +194,7 @@ export const AgentEventSchema = lazySchema(() =>
       /** Provider-specific rate limit category (e.g. 'five_hour', 'seven_day'). */
       limitType: z.string().optional(),
       /** Utilization fraction (0-1) of the current rate limit window, if available. */
-      utilization: z.number().optional(),
+      utilization: z.number().min(0).max(1).optional(),
     }),
     z.object({
       /** Emitted when an API request fails with a retryable error and the provider will retry. */

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -28,6 +28,8 @@ export const AgentEventType = {
   ContextEstimate: "contextEstimate",
   QuotaUpdate: "quotaUpdate",
   ProviderUnavailable: "providerUnavailable",
+  RateLimited: "rateLimited",
+  ApiRetry: "apiRetry",
 } as const;
 
 /** Union of all valid `AgentEvent` type discriminants. */
@@ -180,6 +182,34 @@ export const AgentEventSchema = lazySchema(() =>
        * enforces this at emission, and consumers can rely on the invariant.
        */
       configuredPath: z.string().optional(),
+    }),
+    z.object({
+      /** Emitted when the provider is rate-limited or approaching its rate limit. */
+      type: z.literal(AgentEventType.RateLimited),
+      threadId: z.string(),
+      /** Whether the rate limit is currently active (warning or rejected). False clears the indicator. */
+      active: z.boolean(),
+      /** Milliseconds until the rate limit resets. Computed from the SDK's absolute timestamp at emission time. */
+      retryAfterMs: z.number().optional(),
+      /** Provider-specific rate limit category (e.g. 'five_hour', 'seven_day'). */
+      limitType: z.string().optional(),
+      /** Utilization fraction (0-1) of the current rate limit window, if available. */
+      utilization: z.number().optional(),
+    }),
+    z.object({
+      /** Emitted when an API request fails with a retryable error and the provider will retry. */
+      type: z.literal(AgentEventType.ApiRetry),
+      threadId: z.string(),
+      /** Human-readable reason for the retry (e.g. 'rate_limit', 'server_error'). */
+      reason: z.string(),
+      /** Current retry attempt number (1-based). */
+      attempt: z.number().optional(),
+      /** Maximum number of retries the provider will attempt. */
+      maxRetries: z.number().optional(),
+      /** Milliseconds until the next retry attempt. */
+      delayMs: z.number().optional(),
+      /** HTTP status code that triggered the retry, if available. Null for connection errors. */
+      errorStatus: z.number().nullable().optional(),
     }),
   ]),
 );

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -208,8 +208,8 @@ export const AgentEventSchema = lazySchema(() =>
       maxRetries: z.number().optional(),
       /** Milliseconds until the next retry attempt. */
       delayMs: z.number().optional(),
-      /** HTTP status code that triggered the retry, if available. Null for connection errors. */
-      errorStatus: z.number().nullable().optional(),
+      /** HTTP status code that triggered the retry, if available. Omitted for connection errors. */
+      errorStatus: z.number().optional(),
     }),
   ]),
 );


### PR DESCRIPTION
## What
Surface SDK rate-limit pauses and API retry backoffs to users via a transient banner in the Composer, so they understand why an agent has gone quiet instead of assuming it crashed.

## Why
When an agent goes quiet for 10-30s, users have no idea why. It could be a slow tool call, a rate limit pause, or an API retry after a 529. Without feedback, users assume something is broken. A simple status indicator eliminates this confusion entirely.

## Key Changes
- **Contracts**: Add `RateLimited` and `ApiRetry` event types to the `AgentEvent` discriminated union with provider-agnostic fields (generous `optional` to accommodate varying provider data richness)
- **Claude provider**: Handle `rate_limit_event` (top-level SDK type) and `system/api_retry` (system subtype), filtering noise (`status: "allowed"`) and converting `resetsAt` epoch to relative milliseconds
- **Codex provider**: Emit `ApiRetry` for `willRetry: true` errors instead of silently dropping them
- **Frontend store**: `rateLimitByThread` and `apiRetryByThread` transient state maps with cleanup in all exit paths (error, ended, turnComplete, sendMessage, stopAgent, thread removal, prune) plus a catch-all that clears `apiRetry` state when any non-retry event arrives
- **RetryBanner component**: Pulsing amber dot banner (same visual pattern as `CompactingBanner`) with contextual labels: "Rate limited - retrying in 12s", "Retrying (2/5) in 3s...", or minimal "Retrying..." for Codex

Copilot and Cursor providers are out of scope (neither SDK exposes rate-limit or retry data).

Closes #152

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now shows per-thread retry and rate-limit status banners with live updates and visual indicator.
  * Banners display human-readable countdowns and optional retry-attempt info when requests are delayed or retried.
  * Statuses clear automatically when a message is sent or the thread advances.
  * Accessible announcements (role=status, aria-live) ensure screen readers receive live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->