### PR TITLE
feat(server): two-phase workspace hard-delete with async cleanup

### DIFF
--- a/apps/server/drizzle/0002_calm_ghost_rider.sql
+++ b/apps/server/drizzle/0002_calm_ghost_rider.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `workspaces` ADD `deleted_at` text;

--- a/apps/server/drizzle/meta/0002_snapshot.json
+++ b/apps/server/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1002 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2313b05c-dbaf-4eea-82c3-038bab856770",
+  "prevId": "8b1a8b2a-7f70-4d56-a43d-c6ea2eedf540",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777901649311,
       "tag": "0001_outgoing_paibok",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1778008737310,
+      "tag": "0002_calm_ghost_rider",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/__tests__/cleanup-integration.test.ts
+++ b/apps/server/src/__tests__/cleanup-integration.test.ts
@@ -17,6 +17,8 @@ import type { ClaudeProvider } from "../providers/claude/claude-provider";
 import type { TerminalService } from "../services/terminal-service";
 import type { GitService } from "../services/git-service";
 import { AttachmentService } from "../services/attachment-service";
+import { WorkspaceService } from "../services/workspace-service";
+import type { AgentService } from "../services/agent-service";
 import { killDescendantsByName } from "../services/process-kill.js";
 import { getMcodeDir } from "@mcode/shared";
 
@@ -44,6 +46,9 @@ describe("Cleanup integration", () => {
   let mockClaudeProvider: ClaudeProvider;
   let mockTerminalService: TerminalService;
   let mockGitService: GitService;
+  let mockAttachmentService: AttachmentService;
+  let mockAgentService: AgentService;
+  let workspaceService: WorkspaceService;
 
   beforeEach(() => {
     vi.mocked(killDescendantsByName).mockClear();
@@ -63,6 +68,7 @@ describe("Cleanup integration", () => {
     mockGitService = {
       createWorktree: vi.fn().mockReturnValue({ path: join(WT_BASE, "test-wt") }),
       removeWorktree: vi.fn().mockResolvedValue(true),
+      isRegisteredWorktreePath: vi.fn().mockReturnValue(true),
     } as unknown as GitService;
 
     threadService = new ThreadService(threadRepo, workspaceRepo, mockGitService, cleanupJobRepo);
@@ -76,6 +82,16 @@ describe("Cleanup integration", () => {
       mockGitService,
       workspaceRepo,
       { removeForThread: vi.fn() } as unknown as AttachmentService,
+    );
+
+    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+    mockAgentService = { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService;
+    workspaceService = new WorkspaceService(
+      workspaceRepo,
+      threadRepo,
+      cleanupJobRepo,
+      mockAttachmentService,
+      mockAgentService,
     );
   });
 
@@ -245,5 +261,42 @@ describe("Cleanup integration", () => {
     const after = cleanupJobRepo.findById(job.id)!;
     expect(after.attempts).toBe(0);
     expect(after.next_retry_at).toBe(0);
+  });
+
+  describe("Workspace deletion - full lifecycle", () => {
+    it("completes two-phase delete: soft-delete → worker drains → hard-delete", async () => {
+      const ws = workspaceRepo.create("Full Test", "/tmp/full");
+      const direct = threadRepo.create(ws.id, "Direct", "direct", "main");
+      const wt1 = threadRepo.create(ws.id, "WT1", "worktree", "feat/a");
+      const wt2 = threadRepo.create(ws.id, "WT2", "worktree", "feat/b");
+      db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+        .run("/tmp/full/.worktrees/a", wt1.id);
+      db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+        .run("/tmp/full/.worktrees/b", wt2.id);
+
+      // Phase 1: workspace service delete
+      workspaceService.delete(ws.id);
+
+      // Direct thread is hard-deleted immediately
+      expect(threadRepo.findById(direct.id)).toBeNull();
+      // Worktree threads are soft-deleted with pending jobs
+      expect(cleanupJobRepo.countByWorkspacePath("/tmp/full")).toBe(2);
+      // Workspace is soft-deleted (not visible in listAll)
+      expect(workspaceRepo.listAll().find((w) => w.id === ws.id)).toBeUndefined();
+
+      // Phase 2: worker processes first job
+      await worker.processOneJob();
+
+      // One job remaining, workspace still in DB
+      expect(cleanupJobRepo.countByWorkspacePath("/tmp/full")).toBe(1);
+      expect(db.prepare("SELECT id FROM workspaces WHERE id = ?").get(ws.id)).toBeDefined();
+
+      // Phase 2 continued: worker processes second job
+      await worker.processOneJob();
+
+      // Zero jobs remaining, workspace hard-deleted
+      expect(cleanupJobRepo.countByWorkspacePath("/tmp/full")).toBe(0);
+      expect(db.prepare("SELECT id FROM workspaces WHERE id = ?").get(ws.id)).toBeUndefined();
+    });
   });
 });

--- a/apps/server/src/__tests__/cleanup-integration.test.ts
+++ b/apps/server/src/__tests__/cleanup-integration.test.ts
@@ -16,6 +16,7 @@ import { ThreadService } from "../services/thread-service";
 import type { ClaudeProvider } from "../providers/claude/claude-provider";
 import type { TerminalService } from "../services/terminal-service";
 import type { GitService } from "../services/git-service";
+import { AttachmentService } from "../services/attachment-service";
 import { killDescendantsByName } from "../services/process-kill.js";
 import { getMcodeDir } from "@mcode/shared";
 
@@ -73,6 +74,8 @@ describe("Cleanup integration", () => {
       mockClaudeProvider,
       mockTerminalService,
       mockGitService,
+      workspaceRepo,
+      { removeForThread: vi.fn() } as unknown as AttachmentService,
     );
   });
 

--- a/apps/server/src/__tests__/cleanup-worker.test.ts
+++ b/apps/server/src/__tests__/cleanup-worker.test.ts
@@ -10,6 +10,7 @@ import { CleanupWorker } from "../services/cleanup-worker";
 import type { ClaudeProvider } from "../providers/claude/claude-provider";
 import type { TerminalService } from "../services/terminal-service";
 import type { GitService } from "../services/git-service";
+import { AttachmentService } from "../services/attachment-service";
 import { killDescendantsByName } from "../services/process-kill";
 import { getMcodeDir } from "@mcode/shared";
 
@@ -67,6 +68,8 @@ describe("CleanupWorker", () => {
       mockClaudeProvider,
       mockTerminalService,
       mockGitService,
+      workspaceRepo,
+      { removeForThread: vi.fn() } as unknown as AttachmentService,
     );
   });
 

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -530,3 +530,80 @@ describe("CleanupWorker - startup reconciliation", () => {
     expect(workspaceRepo.findById(ws.id)).not.toBeNull();
   });
 });
+
+describe("CleanupWorker - shared branch protection", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let mockClaudeProvider: ClaudeProvider;
+  let mockTerminalService: TerminalService;
+  let mockGitService: GitService;
+  let mockAttachmentService: AttachmentService;
+  let worker: CleanupWorker;
+
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(killDescendantsByName).mockClear();
+
+    db = openMemoryDatabase();
+    cleanupJobRepo = new CleanupJobRepo(db);
+    threadRepo = new ThreadRepo(db);
+    workspaceRepo = new WorkspaceRepo(db);
+
+    mockClaudeProvider = { waitForSessionExit: vi.fn().mockResolvedValue(undefined) } as unknown as ClaudeProvider;
+    mockTerminalService = { killByThread: vi.fn() } as unknown as TerminalService;
+    mockGitService = { removeWorktree: vi.fn().mockResolvedValue(true), isRegisteredWorktreePath: vi.fn().mockReturnValue(true) } as unknown as GitService;
+    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+
+    worker = new CleanupWorker(db, cleanupJobRepo, threadRepo, mockClaudeProvider, mockTerminalService, mockGitService, workspaceRepo, mockAttachmentService);
+  });
+
+  afterEach(() => { worker.dispose(); });
+
+  it("skips branch deletion if another active thread uses the same branch", async () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "T1", "worktree", "feat/shared");
+    const t2 = threadRepo.create(ws.id, "T2", "worktree", "feat/shared");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?").run("/tmp/ws/.worktrees/t1", t1.id);
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?").run("/tmp/ws/.worktrees/t2", t2.id);
+    threadRepo.softDelete(t1.id);
+
+    cleanupJobRepo.insert({
+      thread_id: t1.id,
+      workspace_path: "/tmp/ws",
+      worktree_path: "/tmp/ws/.worktrees/t1",
+      branch: "feat/shared",
+    });
+
+    await worker.processOneJob();
+
+    expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ deleteBranch: false }),
+    );
+  });
+
+  it("deletes the branch when no other active thread uses it", async () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "T1", "worktree", "feat/solo");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?").run("/tmp/ws/.worktrees/t1", t1.id);
+    threadRepo.softDelete(t1.id);
+
+    cleanupJobRepo.insert({
+      thread_id: t1.id,
+      workspace_path: "/tmp/ws",
+      worktree_path: "/tmp/ws/.worktrees/t1",
+      branch: "feat/solo",
+    });
+
+    await worker.processOneJob();
+
+    expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ branchName: "feat/solo" }),
+    );
+  });
+});

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -4,6 +4,7 @@ import type Database from "better-sqlite3";
 import { openMemoryDatabase } from "../store/database";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { ThreadRepo } from "../repositories/thread-repo";
+import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 
 describe("WorkspaceRepo - soft/hard delete", () => {
   let db: Database.Database;
@@ -130,5 +131,56 @@ describe("ThreadRepo - workspace deletion helpers", () => {
 
     const all = threadRepo.listAllByWorkspace(ws.id);
     expect(all).toHaveLength(2);
+  });
+});
+
+describe("CleanupJobRepo - workspace helpers", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    workspaceRepo = new WorkspaceRepo(db);
+    threadRepo = new ThreadRepo(db);
+    cleanupJobRepo = new CleanupJobRepo(db);
+  });
+
+  it("insertBatch creates multiple cleanup jobs in one transaction", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "T1", "worktree", "feat/a");
+    const t2 = threadRepo.create(ws.id, "T2", "worktree", "feat/b");
+
+    cleanupJobRepo.insertBatch([
+      { thread_id: t1.id, workspace_path: "/tmp/ws", worktree_path: "/tmp/ws/.worktrees/a", branch: "feat/a" },
+      { thread_id: t2.id, workspace_path: "/tmp/ws", worktree_path: "/tmp/ws/.worktrees/b", branch: "feat/b" },
+    ]);
+
+    const count = cleanupJobRepo.countByWorkspacePath("/tmp/ws");
+    expect(count).toBe(2);
+  });
+
+  it("insertBatch skips threads that already have a cleanup job", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "T1", "worktree", "feat/a");
+
+    // Insert one job directly
+    cleanupJobRepo.insert({
+      thread_id: t1.id, workspace_path: "/tmp/ws", worktree_path: "/tmp/ws/.worktrees/a", branch: "feat/a",
+    });
+
+    // Batch should not fail on duplicate thread_id
+    cleanupJobRepo.insertBatch([
+      { thread_id: t1.id, workspace_path: "/tmp/ws", worktree_path: "/tmp/ws/.worktrees/a", branch: "feat/a" },
+    ]);
+
+    const count = cleanupJobRepo.countByWorkspacePath("/tmp/ws");
+    expect(count).toBe(1);
+  });
+
+  it("countByWorkspacePath returns 0 when no jobs exist for the path", () => {
+    const count = cleanupJobRepo.countByWorkspacePath("/tmp/nonexistent");
+    expect(count).toBe(0);
   });
 });

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -1,12 +1,26 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type Database from "better-sqlite3";
+import { existsSync } from "fs";
 import { openMemoryDatabase } from "../store/database";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { WorkspaceService } from "../services/workspace-service";
 import { AttachmentService } from "../services/attachment-service";
+import { CleanupWorker } from "../services/cleanup-worker";
+import type { ClaudeProvider } from "../providers/claude/claude-provider";
+import type { TerminalService } from "../services/terminal-service";
+import type { GitService } from "../services/git-service";
+import { killDescendantsByName } from "../services/process-kill";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return { ...actual, existsSync: vi.fn().mockReturnValue(true) };
+});
+vi.mock("../services/process-kill.js", () => ({
+  killDescendantsByName: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe("WorkspaceRepo - soft/hard delete", () => {
   let db: Database.Database;
@@ -305,5 +319,125 @@ describe("WorkspaceService.delete - two-phase orchestration", () => {
   it("returns false for non-existent workspace", () => {
     const result = workspaceService.delete("fake-id");
     expect(result).toBe(false);
+  });
+});
+
+describe("CleanupWorker - attachment cleanup and workspace finalization", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let mockClaudeProvider: ClaudeProvider;
+  let mockTerminalService: TerminalService;
+  let mockGitService: GitService;
+  let mockAttachmentService: AttachmentService;
+  let worker: CleanupWorker;
+
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(killDescendantsByName).mockClear();
+
+    db = openMemoryDatabase();
+    cleanupJobRepo = new CleanupJobRepo(db);
+    threadRepo = new ThreadRepo(db);
+    workspaceRepo = new WorkspaceRepo(db);
+
+    mockClaudeProvider = {
+      waitForSessionExit: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ClaudeProvider;
+
+    mockTerminalService = {
+      killByThread: vi.fn(),
+    } as unknown as TerminalService;
+
+    mockGitService = {
+      removeWorktree: vi.fn().mockResolvedValue(true),
+      isRegisteredWorktreePath: vi.fn().mockReturnValue(true),
+    } as unknown as GitService;
+
+    mockAttachmentService = {
+      removeForThread: vi.fn(),
+    } as unknown as AttachmentService;
+
+    worker = new CleanupWorker(
+      db,
+      cleanupJobRepo,
+      threadRepo,
+      mockClaudeProvider,
+      mockTerminalService,
+      mockGitService,
+      workspaceRepo,
+      mockAttachmentService,
+    );
+  });
+
+  afterEach(() => {
+    worker.dispose();
+  });
+
+  it("calls removeForThread during job execution", async () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/feat-x", t1.id);
+    threadRepo.softDelete(t1.id);
+
+    cleanupJobRepo.insert({
+      thread_id: t1.id,
+      workspace_path: "/tmp/ws",
+      worktree_path: "/tmp/ws/.worktrees/feat-x",
+      branch: "feat/x",
+    });
+
+    await worker.processOneJob();
+
+    expect(mockAttachmentService.removeForThread).toHaveBeenCalledWith(t1.id);
+  });
+
+  it("hard-deletes workspace after last cleanup job completes", async () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    workspaceRepo.softDelete(ws.id);
+
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/feat-x", t1.id);
+    threadRepo.softDelete(t1.id);
+
+    cleanupJobRepo.insert({
+      thread_id: t1.id,
+      workspace_path: "/tmp/ws",
+      worktree_path: "/tmp/ws/.worktrees/feat-x",
+      branch: "feat/x",
+    });
+
+    await worker.processOneJob();
+
+    // Workspace should now be fully gone
+    const row = db.prepare("SELECT id FROM workspaces WHERE id = ?").get(ws.id);
+    expect(row).toBeUndefined();
+  });
+
+  it("does NOT hard-delete workspace if other cleanup jobs remain", async () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    workspaceRepo.softDelete(ws.id);
+
+    const t1 = threadRepo.create(ws.id, "T1", "worktree", "feat/a");
+    const t2 = threadRepo.create(ws.id, "T2", "worktree", "feat/b");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/a", t1.id);
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/b", t2.id);
+    threadRepo.softDelete(t1.id);
+    threadRepo.softDelete(t2.id);
+
+    cleanupJobRepo.insert({ thread_id: t1.id, workspace_path: "/tmp/ws", worktree_path: "/tmp/ws/.worktrees/a", branch: "feat/a" });
+    cleanupJobRepo.insert({ thread_id: t2.id, workspace_path: "/tmp/ws", worktree_path: "/tmp/ws/.worktrees/b", branch: "feat/b" });
+
+    // Process only one job
+    await worker.processOneJob();
+
+    // Workspace should still exist (one job remaining)
+    const row = db.prepare("SELECT id FROM workspaces WHERE id = ?").get(ws.id);
+    expect(row).toBeDefined();
   });
 });

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -1,10 +1,12 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type Database from "better-sqlite3";
 import { openMemoryDatabase } from "../store/database";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
+import { WorkspaceService } from "../services/workspace-service";
+import { AttachmentService } from "../services/attachment-service";
 
 describe("WorkspaceRepo - soft/hard delete", () => {
   let db: Database.Database;
@@ -182,5 +184,126 @@ describe("CleanupJobRepo - workspace helpers", () => {
   it("countByWorkspacePath returns 0 when no jobs exist for the path", () => {
     const count = cleanupJobRepo.countByWorkspacePath("/tmp/nonexistent");
     expect(count).toBe(0);
+  });
+});
+
+describe("WorkspaceService.delete - two-phase orchestration", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let workspaceService: WorkspaceService;
+  let mockAttachmentService: AttachmentService;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    workspaceRepo = new WorkspaceRepo(db);
+    threadRepo = new ThreadRepo(db);
+    cleanupJobRepo = new CleanupJobRepo(db);
+
+    mockAttachmentService = {
+      removeForThread: vi.fn(),
+    } as unknown as AttachmentService;
+
+    workspaceService = new WorkspaceService(
+      workspaceRepo,
+      threadRepo,
+      cleanupJobRepo,
+      mockAttachmentService,
+    );
+  });
+
+  it("immediately hides workspace from listing", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    workspaceService.delete(ws.id);
+    expect(workspaceRepo.listAll()).toHaveLength(0);
+  });
+
+  it("soft-deletes all active threads", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "T1", "direct", "main");
+    const t2 = threadRepo.create(ws.id, "T2", "direct", "main");
+
+    workspaceService.delete(ws.id);
+
+    const threads = threadRepo.listAllByWorkspace(ws.id);
+    expect(threads.every((t) => t.deleted_at !== null)).toBe(true);
+  });
+
+  it("enqueues cleanup jobs for threads with worktrees", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/feat-x", t1.id);
+
+    workspaceService.delete(ws.id);
+
+    expect(cleanupJobRepo.countByWorkspacePath("/tmp/ws")).toBe(1);
+  });
+
+  it("hard-deletes workspace immediately when no worktree threads exist", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    threadRepo.create(ws.id, "Direct", "direct", "main");
+
+    workspaceService.delete(ws.id);
+
+    // Workspace should be fully gone
+    const row = db.prepare("SELECT id FROM workspaces WHERE id = ?").get(ws.id);
+    expect(row).toBeUndefined();
+  });
+
+  it("keeps workspace in soft-deleted state when worktree cleanup is pending", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/feat-x", t1.id);
+
+    workspaceService.delete(ws.id);
+
+    // Workspace row still exists (soft-deleted, waiting for cleanup)
+    const row = db.prepare("SELECT deleted_at FROM workspaces WHERE id = ?").get(ws.id) as any;
+    expect(row).toBeDefined();
+    expect(row.deleted_at).not.toBeNull();
+  });
+
+  it("removes attachments for non-worktree threads before hard-deleting them", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "Direct", "direct", "main");
+
+    workspaceService.delete(ws.id);
+
+    expect(mockAttachmentService.removeForThread).toHaveBeenCalledWith(t1.id);
+  });
+
+  it("handles workspace with no threads (immediate hard-delete)", () => {
+    const ws = workspaceRepo.create("Empty", "/tmp/empty");
+    workspaceService.delete(ws.id);
+
+    const row = db.prepare("SELECT id FROM workspaces WHERE id = ?").get(ws.id);
+    expect(row).toBeUndefined();
+  });
+
+  it("does not enqueue duplicate cleanup jobs for already-soft-deleted threads with pending jobs", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/feat-x", t1.id);
+
+    // Pre-existing cleanup job (thread was individually deleted before workspace delete)
+    threadRepo.softDelete(t1.id);
+    cleanupJobRepo.insert({
+      thread_id: t1.id, workspace_path: "/tmp/ws",
+      worktree_path: "/tmp/ws/.worktrees/feat-x", branch: "feat/x",
+    });
+
+    workspaceService.delete(ws.id);
+
+    // Should still be 1 job, not 2
+    expect(cleanupJobRepo.countByWorkspacePath("/tmp/ws")).toBe(1);
+  });
+
+  it("returns false for non-existent workspace", () => {
+    const result = workspaceService.delete("fake-id");
+    expect(result).toBe(false);
   });
 });

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -85,3 +85,50 @@ describe("WorkspaceRepo - soft/hard delete", () => {
     expect(threads).toHaveLength(0);
   });
 });
+
+describe("ThreadRepo - workspace deletion helpers", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    workspaceRepo = new WorkspaceRepo(db);
+    threadRepo = new ThreadRepo(db);
+  });
+
+  it("findWorktreeThreadsByWorkspace returns threads with worktree_path set", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/test-ws");
+    const t1 = threadRepo.create(ws.id, "Direct", "direct", "main");
+    const t2 = threadRepo.create(ws.id, "Worktree", "worktree", "feat/x");
+    // Simulate worktree path being set after creation
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/test-ws/.worktrees/feat-x", t2.id);
+
+    const results = threadRepo.findWorktreeThreadsByWorkspace(ws.id);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(t2.id);
+    expect(results[0].worktree_path).toBe("/tmp/test-ws/.worktrees/feat-x");
+  });
+
+  it("findWorktreeThreadsByWorkspace includes soft-deleted threads", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/test-ws");
+    const t1 = threadRepo.create(ws.id, "WT Thread", "worktree", "feat/y");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/wt", t1.id);
+    threadRepo.softDelete(t1.id);
+
+    const results = threadRepo.findWorktreeThreadsByWorkspace(ws.id);
+    expect(results).toHaveLength(1);
+  });
+
+  it("listAllByWorkspace returns both active and soft-deleted threads", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/test-ws");
+    threadRepo.create(ws.id, "Active", "direct", "main");
+    const t2 = threadRepo.create(ws.id, "Deleted", "direct", "main");
+    threadRepo.softDelete(t2.id);
+
+    const all = threadRepo.listAllByWorkspace(ws.id);
+    expect(all).toHaveLength(2);
+  });
+});

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -665,6 +665,62 @@ describe("WorkspaceService.delete - active session handling", () => {
   });
 });
 
+describe("Workspace delete - cross-workspace fork lineage", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let workspaceService: WorkspaceService;
+  let mockAttachmentService: AttachmentService;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    workspaceRepo = new WorkspaceRepo(db);
+    threadRepo = new ThreadRepo(db);
+    cleanupJobRepo = new CleanupJobRepo(db);
+    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+    workspaceService = new WorkspaceService(
+      workspaceRepo,
+      threadRepo,
+      cleanupJobRepo,
+      mockAttachmentService,
+      { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService,
+    );
+  });
+
+  it("nullifies forked_from_message_id on threads in other workspaces", () => {
+    const wsX = workspaceRepo.create("Source", "/tmp/source");
+    const wsY = workspaceRepo.create("Target", "/tmp/target");
+
+    const tA = threadRepo.create(wsX.id, "Parent", "direct", "main");
+    const tB = threadRepo.create(wsY.id, "Fork", "direct", "main", true, "claude", {
+      parentThreadId: tA.id,
+      forkedFromMessageId: "msg-123",
+    });
+
+    workspaceService.delete(wsX.id);
+
+    const updatedTB = threadRepo.findById(tB.id);
+    expect(updatedTB!.parent_thread_id).toBeNull();
+    expect(updatedTB!.forked_from_message_id).toBeNull();
+  });
+
+  it("does not nullify lineage within the same workspace (handled by cascade)", () => {
+    const ws = workspaceRepo.create("Same", "/tmp/same");
+    const t1 = threadRepo.create(ws.id, "Parent", "direct", "main");
+    const t2 = threadRepo.create(ws.id, "Fork", "direct", "main", true, "claude", {
+      parentThreadId: t1.id,
+      forkedFromMessageId: "msg-456",
+    });
+
+    workspaceService.delete(ws.id);
+
+    // Both threads should be gone (cascade from workspace hardDelete)
+    const row = db.prepare("SELECT id FROM threads WHERE id = ?").get(t2.id);
+    expect(row).toBeUndefined();
+  });
+});
+
 describe("CleanupWorker - exhausted retries", () => {
   let db: Database.Database;
   let workspaceRepo: WorkspaceRepo;

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -9,6 +9,7 @@ import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { WorkspaceService } from "../services/workspace-service";
 import { AttachmentService } from "../services/attachment-service";
 import { CleanupWorker } from "../services/cleanup-worker";
+import type { AgentService } from "../services/agent-service";
 import type { ClaudeProvider } from "../providers/claude/claude-provider";
 import type { TerminalService } from "../services/terminal-service";
 import type { GitService } from "../services/git-service";
@@ -224,6 +225,7 @@ describe("WorkspaceService.delete - two-phase orchestration", () => {
       threadRepo,
       cleanupJobRepo,
       mockAttachmentService,
+      { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService,
     );
   });
 
@@ -605,6 +607,61 @@ describe("CleanupWorker - shared branch protection", () => {
       expect.any(String),
       expect.objectContaining({ branchName: "feat/solo" }),
     );
+  });
+});
+
+describe("WorkspaceService.delete - active session handling", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let workspaceService: WorkspaceService;
+  let mockAttachmentService: AttachmentService;
+  let mockAgentService: { stopSession: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    workspaceRepo = new WorkspaceRepo(db);
+    threadRepo = new ThreadRepo(db);
+    cleanupJobRepo = new CleanupJobRepo(db);
+
+    mockAttachmentService = {
+      removeForThread: vi.fn(),
+    } as unknown as AttachmentService;
+
+    mockAgentService = {
+      stopSession: vi.fn().mockResolvedValue(undefined),
+    };
+
+    workspaceService = new WorkspaceService(
+      workspaceRepo,
+      threadRepo,
+      cleanupJobRepo,
+      mockAttachmentService,
+      mockAgentService as unknown as AgentService,
+    );
+  });
+
+  it("signals all active agent sessions in the workspace to stop", () => {
+    const ws = workspaceRepo.create("Active", "/tmp/active");
+    const t1 = threadRepo.create(ws.id, "Running", "direct", "main");
+    db.prepare("UPDATE threads SET sdk_session_id = ? WHERE id = ?")
+      .run("session-123", t1.id);
+
+    workspaceService.delete(ws.id);
+
+    expect(mockAgentService.stopSession).toHaveBeenCalledWith(t1.id);
+  });
+
+  it("proceeds with deletion even if stop fails", () => {
+    const ws = workspaceRepo.create("Active", "/tmp/active");
+    const t1 = threadRepo.create(ws.id, "Running", "direct", "main");
+    db.prepare("UPDATE threads SET sdk_session_id = ? WHERE id = ?")
+      .run("session-123", t1.id);
+
+    mockAgentService.stopSession.mockRejectedValue(new Error("process gone"));
+
+    expect(() => workspaceService.delete(ws.id)).not.toThrow();
   });
 });
 

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -608,6 +608,57 @@ describe("CleanupWorker - shared branch protection", () => {
   });
 });
 
+describe("CleanupWorker - exhausted retries", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let worker: CleanupWorker;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    workspaceRepo = new WorkspaceRepo(db);
+    threadRepo = new ThreadRepo(db);
+    cleanupJobRepo = new CleanupJobRepo(db);
+
+    worker = new CleanupWorker(
+      db,
+      cleanupJobRepo,
+      threadRepo,
+      { waitForSessionExit: vi.fn().mockResolvedValue(undefined) } as any,
+      { killByThread: vi.fn() } as any,
+      { removeWorktree: vi.fn().mockResolvedValue(true), isRegisteredWorktreePath: vi.fn().mockReturnValue(true) } as any,
+      workspaceRepo,
+      { removeForThread: vi.fn() } as any,
+    );
+  });
+
+  afterEach(() => { worker.dispose(); });
+
+  it("finds stuck workspaces when all jobs exhausted retries", () => {
+    const ws = workspaceRepo.create("Stuck", "/tmp/stuck");
+    workspaceRepo.softDelete(ws.id);
+
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/stuck/.worktrees/x", t1.id);
+    threadRepo.softDelete(t1.id);
+
+    cleanupJobRepo.insert({
+      thread_id: t1.id,
+      workspace_path: "/tmp/stuck",
+      worktree_path: "/tmp/stuck/.worktrees/x",
+      branch: "feat/x",
+    });
+    // Set attempts to 5 (max)
+    db.prepare("UPDATE cleanup_jobs SET attempts = 5 WHERE thread_id = ?").run(t1.id);
+
+    const stuckWorkspaces = worker.findStuckWorkspaces();
+    expect(stuckWorkspaces).toHaveLength(1);
+    expect(stuckWorkspaces[0].workspaceId).toBe(ws.id);
+  });
+});
+
 describe("CleanupWorker - missing directory handling", () => {
   let db: Database.Database;
   let workspaceRepo: WorkspaceRepo;

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -441,3 +441,92 @@ describe("CleanupWorker - attachment cleanup and workspace finalization", () => 
     expect(row).toBeDefined();
   });
 });
+
+describe("CleanupWorker - startup reconciliation", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let mockClaudeProvider: ClaudeProvider;
+  let mockTerminalService: TerminalService;
+  let mockGitService: GitService;
+  let mockAttachmentService: AttachmentService;
+  let worker: CleanupWorker;
+
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    db = openMemoryDatabase();
+    cleanupJobRepo = new CleanupJobRepo(db);
+    threadRepo = new ThreadRepo(db);
+    workspaceRepo = new WorkspaceRepo(db);
+
+    mockClaudeProvider = {
+      waitForSessionExit: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ClaudeProvider;
+
+    mockTerminalService = {
+      killByThread: vi.fn(),
+    } as unknown as TerminalService;
+
+    mockGitService = {
+      removeWorktree: vi.fn().mockResolvedValue(true),
+      isRegisteredWorktreePath: vi.fn().mockReturnValue(true),
+    } as unknown as GitService;
+
+    mockAttachmentService = {
+      removeForThread: vi.fn(),
+    } as unknown as AttachmentService;
+
+    worker = new CleanupWorker(
+      db,
+      cleanupJobRepo,
+      threadRepo,
+      mockClaudeProvider,
+      mockTerminalService,
+      mockGitService,
+      workspaceRepo,
+      mockAttachmentService,
+    );
+  });
+
+  afterEach(() => {
+    worker.dispose();
+  });
+
+  it("enqueues missing cleanup jobs for soft-deleted workspaces on startup", () => {
+    const ws = workspaceRepo.create("Orphan", "/tmp/orphan");
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/orphan/.worktrees/x", t1.id);
+    threadRepo.softDelete(t1.id);
+    workspaceRepo.softDelete(ws.id);
+
+    // No cleanup job exists (simulating crash after soft-delete)
+    expect(cleanupJobRepo.countByWorkspacePath("/tmp/orphan")).toBe(0);
+
+    worker.reconcileOnStartup();
+
+    expect(cleanupJobRepo.countByWorkspacePath("/tmp/orphan")).toBe(1);
+  });
+
+  it("hard-deletes soft-deleted workspace with no remaining threads or jobs", () => {
+    const ws = workspaceRepo.create("Empty Deleted", "/tmp/empty-del");
+    workspaceRepo.softDelete(ws.id);
+    // No threads at all
+
+    worker.reconcileOnStartup();
+
+    const row = db.prepare("SELECT id FROM workspaces WHERE id = ?").get(ws.id);
+    expect(row).toBeUndefined();
+  });
+
+  it("does not touch active workspaces during reconciliation", () => {
+    const ws = workspaceRepo.create("Active", "/tmp/active");
+    threadRepo.create(ws.id, "Thread", "direct", "main");
+
+    worker.reconcileOnStartup();
+
+    expect(workspaceRepo.findById(ws.id)).not.toBeNull();
+  });
+});

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -607,3 +607,85 @@ describe("CleanupWorker - shared branch protection", () => {
     );
   });
 });
+
+describe("CleanupWorker - missing directory handling", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let mockClaudeProvider: ClaudeProvider;
+  let mockTerminalService: TerminalService;
+  let mockGitService: GitService;
+  let mockAttachmentService: AttachmentService;
+  let worker: CleanupWorker;
+
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(killDescendantsByName).mockClear();
+
+    db = openMemoryDatabase();
+    cleanupJobRepo = new CleanupJobRepo(db);
+    threadRepo = new ThreadRepo(db);
+    workspaceRepo = new WorkspaceRepo(db);
+
+    mockClaudeProvider = { waitForSessionExit: vi.fn().mockResolvedValue(undefined) } as unknown as ClaudeProvider;
+    mockTerminalService = { killByThread: vi.fn() } as unknown as TerminalService;
+    mockGitService = { removeWorktree: vi.fn().mockResolvedValue(true), isRegisteredWorktreePath: vi.fn().mockReturnValue(true) } as unknown as GitService;
+    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+
+    worker = new CleanupWorker(db, cleanupJobRepo, threadRepo, mockClaudeProvider, mockTerminalService, mockGitService, workspaceRepo, mockAttachmentService);
+  });
+
+  afterEach(() => { worker.dispose(); });
+
+  it("treats non-existent worktree directory as successful cleanup", async () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/gone", t1.id);
+    threadRepo.softDelete(t1.id);
+
+    cleanupJobRepo.insert({
+      thread_id: t1.id,
+      workspace_path: "/tmp/ws",
+      worktree_path: "/tmp/ws/.worktrees/gone",
+      branch: "feat/x",
+    });
+
+    // Both workspace and worktree paths missing
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await worker.processOneJob();
+
+    // Thread should still be hard-deleted (cleanup succeeded)
+    const thread = db.prepare("SELECT id FROM threads WHERE id = ?").get(t1.id);
+    expect(thread).toBeUndefined();
+    // Cleanup job should be removed
+    expect(cleanupJobRepo.countByWorkspacePath("/tmp/ws")).toBe(0);
+  });
+
+  it("treats non-existent workspace path gracefully (skip git commands)", async () => {
+    const ws = workspaceRepo.create("Test", "/tmp/gone-ws");
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/gone-ws/.worktrees/x", t1.id);
+    threadRepo.softDelete(t1.id);
+
+    cleanupJobRepo.insert({
+      thread_id: t1.id,
+      workspace_path: "/tmp/gone-ws",
+      worktree_path: "/tmp/gone-ws/.worktrees/x",
+      branch: "feat/x",
+    });
+
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await worker.processOneJob();
+
+    // Should complete without error, thread hard-deleted
+    const thread = db.prepare("SELECT id FROM threads WHERE id = ?").get(t1.id);
+    expect(thread).toBeUndefined();
+    // removeWorktree should NOT have been called (no filesystem to clean)
+    expect(mockGitService.removeWorktree).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -1,0 +1,87 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../store/database";
+import { WorkspaceRepo } from "../repositories/workspace-repo";
+import { ThreadRepo } from "../repositories/thread-repo";
+
+describe("WorkspaceRepo - soft/hard delete", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    workspaceRepo = new WorkspaceRepo(db);
+    threadRepo = new ThreadRepo(db);
+  });
+
+  it("softDelete sets deleted_at and returns true", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/test-ws");
+    const result = workspaceRepo.softDelete(ws.id);
+    expect(result).toBe(true);
+
+    // Direct DB check - row still exists but has deleted_at set
+    const row = db.prepare("SELECT deleted_at FROM workspaces WHERE id = ?").get(ws.id) as any;
+    expect(row.deleted_at).not.toBeNull();
+  });
+
+  it("softDelete returns false for non-existent workspace", () => {
+    const result = workspaceRepo.softDelete("non-existent-id");
+    expect(result).toBe(false);
+  });
+
+  it("listAll excludes soft-deleted workspaces", () => {
+    const ws1 = workspaceRepo.create("Active", "/tmp/active");
+    const ws2 = workspaceRepo.create("Deleted", "/tmp/deleted");
+    workspaceRepo.softDelete(ws2.id);
+
+    const list = workspaceRepo.listAll();
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(ws1.id);
+  });
+
+  it("findById returns null for soft-deleted workspace", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/test-ws");
+    workspaceRepo.softDelete(ws.id);
+    expect(workspaceRepo.findById(ws.id)).toBeNull();
+  });
+
+  it("findByPath returns null for soft-deleted workspace", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/test-ws");
+    workspaceRepo.softDelete(ws.id);
+    expect(workspaceRepo.findByPath("/tmp/test-ws")).toBeNull();
+  });
+
+  it("findDeletingWorkspaces returns only soft-deleted workspaces", () => {
+    const ws1 = workspaceRepo.create("Active", "/tmp/active");
+    const ws2 = workspaceRepo.create("Deleting", "/tmp/deleting");
+    workspaceRepo.softDelete(ws2.id);
+
+    const deleting = workspaceRepo.findDeleting();
+    expect(deleting).toHaveLength(1);
+    expect(deleting[0].id).toBe(ws2.id);
+  });
+
+  it("hardDelete permanently removes the workspace row", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/test-ws");
+    workspaceRepo.softDelete(ws.id);
+    const result = workspaceRepo.hardDelete(ws.id);
+    expect(result).toBe(true);
+
+    const row = db.prepare("SELECT id FROM workspaces WHERE id = ?").get(ws.id);
+    expect(row).toBeUndefined();
+  });
+
+  it("hardDelete cascades to all threads (active and soft-deleted)", () => {
+    const ws = workspaceRepo.create("Test", "/tmp/test-ws");
+    threadRepo.create(ws.id, "Thread 1", "direct", "main");
+    const t2 = threadRepo.create(ws.id, "Thread 2", "worktree", "feat/x");
+    threadRepo.softDelete(t2.id);
+
+    workspaceRepo.hardDelete(ws.id);
+
+    const threads = db.prepare("SELECT id FROM threads WHERE workspace_id = ?").all(ws.id);
+    expect(threads).toHaveLength(0);
+  });
+});

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -853,3 +853,120 @@ describe("CleanupWorker - missing directory handling", () => {
     expect(mockGitService.removeWorktree).not.toHaveBeenCalled();
   });
 });
+
+describe("CleanupWorker - idempotent retry", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let mockClaudeProvider: ClaudeProvider;
+  let mockTerminalService: TerminalService;
+  let mockGitService: GitService;
+  let mockAttachmentService: AttachmentService;
+  let worker: CleanupWorker;
+
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(killDescendantsByName).mockClear();
+
+    db = openMemoryDatabase();
+    cleanupJobRepo = new CleanupJobRepo(db);
+    threadRepo = new ThreadRepo(db);
+    workspaceRepo = new WorkspaceRepo(db);
+
+    mockClaudeProvider = { waitForSessionExit: vi.fn().mockResolvedValue(undefined) } as unknown as ClaudeProvider;
+    mockTerminalService = { killByThread: vi.fn() } as unknown as TerminalService;
+    mockGitService = { removeWorktree: vi.fn().mockResolvedValue(true), isRegisteredWorktreePath: vi.fn().mockReturnValue(true) } as unknown as GitService;
+    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+
+    worker = new CleanupWorker(db, cleanupJobRepo, threadRepo, mockClaudeProvider, mockTerminalService, mockGitService, workspaceRepo, mockAttachmentService);
+  });
+
+  afterEach(() => { worker.dispose(); });
+
+  it("does not fail when retrying after attachment dir was already removed", async () => {
+    const ws = workspaceRepo.create("Test", "/tmp/ws");
+    const t1 = threadRepo.create(ws.id, "WT", "worktree", "feat/x");
+    db.prepare("UPDATE threads SET worktree_path = ? WHERE id = ?")
+      .run("/tmp/ws/.worktrees/x", t1.id);
+    threadRepo.softDelete(t1.id);
+
+    cleanupJobRepo.insert({
+      thread_id: t1.id,
+      workspace_path: "/tmp/ws",
+      worktree_path: "/tmp/ws/.worktrees/x",
+      branch: "feat/x",
+    });
+
+    // First call: attachment removal succeeds, but removeWorktree returns false
+    (mockGitService.removeWorktree as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+
+    await worker.processOneJob();
+    // Job should still exist (recorded failure - worktree still exists)
+    expect(cleanupJobRepo.countByWorkspacePath("/tmp/ws")).toBe(1);
+
+    // Reset retry backoff so the job is eligible immediately on the next poll
+    db.prepare("UPDATE cleanup_jobs SET next_retry_at = 0").run();
+
+    // Second call: removeWorktree succeeds this time
+    (mockGitService.removeWorktree as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+
+    await worker.processOneJob();
+    // Should succeed this time
+    expect(cleanupJobRepo.countByWorkspacePath("/tmp/ws")).toBe(0);
+  });
+});
+
+describe("Workspace delete - zero-worktree fast path", () => {
+  let db: Database.Database;
+  let workspaceRepo: WorkspaceRepo;
+  let threadRepo: ThreadRepo;
+  let cleanupJobRepo: CleanupJobRepo;
+  let workspaceService: WorkspaceService;
+  let mockAttachmentService: AttachmentService;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    workspaceRepo = new WorkspaceRepo(db);
+    threadRepo = new ThreadRepo(db);
+    cleanupJobRepo = new CleanupJobRepo(db);
+    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+    workspaceService = new WorkspaceService(
+      workspaceRepo,
+      threadRepo,
+      cleanupJobRepo,
+      mockAttachmentService,
+      { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService,
+    );
+  });
+
+  it("synchronously hard-deletes workspace with only direct-mode threads", () => {
+    const ws = workspaceRepo.create("Direct Only", "/tmp/direct");
+    const t1 = threadRepo.create(ws.id, "T1", "direct", "main");
+    const t2 = threadRepo.create(ws.id, "T2", "direct", "develop");
+    const t3 = threadRepo.create(ws.id, "T3", "direct", "main");
+    threadRepo.softDelete(t3.id);
+
+    workspaceService.delete(ws.id);
+
+    // Everything should be gone from DB
+    expect(db.prepare("SELECT COUNT(*) AS c FROM workspaces WHERE id = ?").get(ws.id)).toEqual({ c: 0 });
+    expect(db.prepare("SELECT COUNT(*) AS c FROM threads WHERE workspace_id = ?").get(ws.id)).toEqual({ c: 0 });
+    expect(db.prepare("SELECT COUNT(*) AS c FROM cleanup_jobs WHERE workspace_path = ?").get("/tmp/direct")).toEqual({ c: 0 });
+
+    // Attachments removed for each thread
+    expect(mockAttachmentService.removeForThread).toHaveBeenCalledTimes(3);
+  });
+
+  it("completes in a single synchronous call (no worker needed)", () => {
+    const ws = workspaceRepo.create("Fast", "/tmp/fast");
+    threadRepo.create(ws.id, "T", "direct", "main");
+
+    const before = Date.now();
+    workspaceService.delete(ws.id);
+    const elapsed = Date.now() - before;
+
+    expect(elapsed).toBeLessThan(100);
+    expect(cleanupJobRepo.countByWorkspacePath("/tmp/fast")).toBe(0);
+  });
+});

--- a/apps/server/src/__tests__/workspace-repo.test.ts
+++ b/apps/server/src/__tests__/workspace-repo.test.ts
@@ -18,17 +18,17 @@ describe("WorkspaceRepo", () => {
     repo = new WorkspaceRepo(db);
   });
 
-  it("remove() deletes the workspace row", () => {
+  it("hardDelete() deletes the workspace row", () => {
     const ws = repo.create("test", "/tmp/test");
     expect(repo.findById(ws.id)).not.toBeNull();
 
-    const deleted = repo.remove(ws.id);
+    const deleted = repo.hardDelete(ws.id);
 
     expect(deleted).toBe(true);
     expect(repo.findById(ws.id)).toBeNull();
   });
 
-  it("remove() cascade-deletes associated threads", () => {
+  it("hardDelete() cascade-deletes associated threads", () => {
     const ws = repo.create("test", "/tmp/test");
     const now = new Date().toISOString();
     db.prepare(
@@ -38,7 +38,7 @@ describe("WorkspaceRepo", () => {
       "INSERT INTO threads (id, workspace_id, title, branch, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
     ).run("t-2", ws.id, "Thread 2", "main", now, now);
 
-    repo.remove(ws.id);
+    repo.hardDelete(ws.id);
 
     const threads = db
       .prepare("SELECT id FROM threads WHERE workspace_id = ?")
@@ -46,7 +46,7 @@ describe("WorkspaceRepo", () => {
     expect(threads).toHaveLength(0);
   });
 
-  it("remove() cascade-deletes messages through threads", () => {
+  it("hardDelete() cascade-deletes messages through threads", () => {
     const ws = repo.create("test", "/tmp/test");
     const now = new Date().toISOString();
     db.prepare(
@@ -56,7 +56,7 @@ describe("WorkspaceRepo", () => {
       "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence) VALUES (?, ?, ?, ?, ?, ?)",
     ).run("m-1", "t-1", "user", "hello", now, 1);
 
-    repo.remove(ws.id);
+    repo.hardDelete(ws.id);
 
     const messages = db
       .prepare("SELECT id FROM messages WHERE thread_id = ?")
@@ -64,13 +64,13 @@ describe("WorkspaceRepo", () => {
     expect(messages).toHaveLength(0);
   });
 
-  it("remove() returns false for non-existent ID", () => {
-    expect(repo.remove("non-existent")).toBe(false);
+  it("hardDelete() returns false for non-existent ID", () => {
+    expect(repo.hardDelete("non-existent")).toBe(false);
   });
 
   it("create() allows re-using a path after the previous workspace was deleted", () => {
     const ws1 = repo.create("test", "/tmp/reuse");
-    repo.remove(ws1.id);
+    repo.hardDelete(ws1.id);
 
     const ws2 = repo.create("test-2", "/tmp/reuse");
 

--- a/apps/server/src/__tests__/workspace-repo.test.ts
+++ b/apps/server/src/__tests__/workspace-repo.test.ts
@@ -7,6 +7,7 @@ import { ThreadRepo } from "../repositories/thread-repo";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { WorkspaceService } from "../services/workspace-service";
 import { AttachmentService } from "../services/attachment-service";
+import type { AgentService } from "../services/agent-service";
 
 describe("WorkspaceRepo", () => {
   let db: Database.Database;
@@ -89,7 +90,7 @@ describe("WorkspaceService", () => {
     const threadRepo = new ThreadRepo(db);
     const cleanupJobRepo = new CleanupJobRepo(db);
     const mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
-    service = new WorkspaceService(repo, threadRepo, cleanupJobRepo, mockAttachmentService);
+    service = new WorkspaceService(repo, threadRepo, cleanupJobRepo, mockAttachmentService, { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService);
   });
 
   it("create() returns existing workspace when path already exists", () => {

--- a/apps/server/src/__tests__/workspace-repo.test.ts
+++ b/apps/server/src/__tests__/workspace-repo.test.ts
@@ -1,9 +1,12 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type Database from "better-sqlite3";
 import { openMemoryDatabase } from "../store/database";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
+import { ThreadRepo } from "../repositories/thread-repo";
+import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { WorkspaceService } from "../services/workspace-service";
+import { AttachmentService } from "../services/attachment-service";
 
 describe("WorkspaceRepo", () => {
   let db: Database.Database;
@@ -83,7 +86,10 @@ describe("WorkspaceService", () => {
   beforeEach(() => {
     db = openMemoryDatabase();
     repo = new WorkspaceRepo(db);
-    service = new WorkspaceService(repo);
+    const threadRepo = new ThreadRepo(db);
+    const cleanupJobRepo = new CleanupJobRepo(db);
+    const mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+    service = new WorkspaceService(repo, threadRepo, cleanupJobRepo, mockAttachmentService);
   });
 
   it("create() returns existing workspace when path already exists", () => {

--- a/apps/server/src/repositories/cleanup-job-repo.ts
+++ b/apps/server/src/repositories/cleanup-job-repo.ts
@@ -219,7 +219,12 @@ export class CleanupJobRepo {
   /** Get the most recent error message from cleanup jobs for a workspace path. */
   getLastErrorByWorkspacePath(workspacePath: string): string | null {
     const row = this.db
-      .prepare("SELECT last_error FROM cleanup_jobs WHERE workspace_path = ? ORDER BY created_at DESC LIMIT 1")
+      .prepare(
+        `SELECT last_error FROM cleanup_jobs
+          WHERE workspace_path = ? AND last_error IS NOT NULL
+          ORDER BY next_retry_at DESC, created_at DESC
+          LIMIT 1`,
+      )
       .get(workspacePath) as { last_error: string | null } | undefined;
     return row?.last_error ?? null;
   }

--- a/apps/server/src/repositories/cleanup-job-repo.ts
+++ b/apps/server/src/repositories/cleanup-job-repo.ts
@@ -44,7 +44,7 @@ export class CleanupJobRepo {
   private readonly stmtFindByThreadId: Statement;
   private readonly stmtCount: Statement;
 
-  constructor(@inject("Database") db: Database.Database) {
+  constructor(@inject("Database") private readonly db: Database.Database) {
     this.stmtInsert = db.prepare(
       `INSERT OR IGNORE INTO cleanup_jobs
         (id, thread_id, workspace_path, worktree_path, branch, attempts, next_retry_at, created_at)
@@ -159,5 +159,68 @@ export class CleanupJobRepo {
   count(): number {
     const row = this.stmtCount.get() as { n: number };
     return row.n;
+  }
+
+  /**
+   * Insert multiple cleanup jobs in a single transaction.
+   * Skips any thread_id that already has a pending job (ON CONFLICT IGNORE).
+   */
+  insertBatch(jobs: Array<{ thread_id: string; workspace_path: string; worktree_path: string; branch: string | null }>): number {
+    if (jobs.length === 0) return 0;
+
+    const insert = this.db.prepare(
+      `INSERT OR IGNORE INTO cleanup_jobs (id, thread_id, workspace_path, worktree_path, branch, attempts, next_retry_at, created_at)
+       VALUES (?, ?, ?, ?, ?, 0, 0, ?)`,
+    );
+
+    let inserted = 0;
+    const now = Date.now();
+
+    const tx = this.db.transaction(() => {
+      for (const job of jobs) {
+        const result = insert.run(randomUUID(), job.thread_id, job.workspace_path, job.worktree_path, job.branch, now);
+        if (result.changes > 0) inserted++;
+      }
+    });
+    tx();
+
+    return inserted;
+  }
+
+  /** Count pending cleanup jobs for a given workspace path. */
+  countByWorkspacePath(workspacePath: string): number {
+    const row = this.db
+      .prepare("SELECT COUNT(*) AS count FROM cleanup_jobs WHERE workspace_path = ?")
+      .get(workspacePath) as { count: number };
+    return row.count;
+  }
+
+  /** Find a cleanup job by thread ID. Returns null if no job exists. */
+  findByThreadId(threadId: string): CleanupJob | null {
+    const row = this.stmtFindByThreadId.get(threadId) as CleanupJob | undefined;
+    return row ?? null;
+  }
+
+  /** Delete a cleanup job by its associated thread ID. Returns true if a row was removed. */
+  deleteByThreadId(threadId: string): boolean {
+    const job = this.findByThreadId(threadId);
+    if (!job) return false;
+    return this.delete(job.id);
+  }
+
+  /** Count jobs that still have retries remaining for a workspace path. */
+  countRetriableByWorkspacePath(workspacePath: string): number {
+    const row = this.db
+      .prepare("SELECT COUNT(*) AS count FROM cleanup_jobs WHERE workspace_path = ? AND attempts < 5")
+      .get(workspacePath) as { count: number };
+    return row.count;
+  }
+
+  /** Get the most recent error message from cleanup jobs for a workspace path. */
+  getLastErrorByWorkspacePath(workspacePath: string): string | null {
+    const row = this.db
+      .prepare("SELECT last_error FROM cleanup_jobs WHERE workspace_path = ? ORDER BY created_at DESC LIMIT 1")
+      .get(workspacePath) as { last_error: string | null } | undefined;
+    return row?.last_error ?? null;
   }
 }

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -418,4 +418,47 @@ export class ThreadRepo {
       .run(parentThreadId, forkedFromMessageId, now, id);
     return result.changes > 0;
   }
+
+  /**
+   * Find all threads in a workspace that have a worktree_path set (both active and deleted).
+   * Used during workspace deletion to know which threads need filesystem cleanup.
+   */
+  findWorktreeThreadsByWorkspace(workspaceId: string): Thread[] {
+    const rows = this.db
+      .prepare(
+        `SELECT ${THREAD_COLUMNS} FROM threads WHERE workspace_id = ? AND worktree_path IS NOT NULL`,
+      )
+      .all(workspaceId) as ThreadRow[];
+    return rows.map(rowToThread);
+  }
+
+  /**
+   * List ALL threads for a workspace regardless of deletion status.
+   * Used during workspace hard-delete reconciliation.
+   */
+  listAllByWorkspace(workspaceId: string): Thread[] {
+    const rows = this.db
+      .prepare(
+        `SELECT ${THREAD_COLUMNS} FROM threads WHERE workspace_id = ?`,
+      )
+      .all(workspaceId) as ThreadRow[];
+    return rows.map(rowToThread);
+  }
+
+  /**
+   * Count active (non-deleted) threads on a given branch in the same workspace,
+   * excluding a specific thread. Used to decide whether a branch is safe to delete.
+   */
+  countActiveByBranch(threadId: string, branch: string): number {
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM threads
+         WHERE workspace_id = (SELECT workspace_id FROM threads WHERE id = ?)
+         AND branch = ?
+         AND id != ?
+         AND deleted_at IS NULL`,
+      )
+      .get(threadId, branch, threadId) as { count: number };
+    return row.count;
+  }
 }

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -446,6 +446,22 @@ export class ThreadRepo {
   }
 
   /**
+   * Nullify parent_thread_id and forked_from_message_id on threads in OTHER workspaces
+   * that reference threads in the given workspace. Prevents dangling references
+   * when a workspace is deleted.
+   */
+  nullifyExternalLineage(workspaceId: string): number {
+    const result = this.db
+      .prepare(
+        `UPDATE threads SET parent_thread_id = NULL, forked_from_message_id = NULL, updated_at = ?
+         WHERE parent_thread_id IN (SELECT id FROM threads WHERE workspace_id = ?)
+         AND workspace_id != ?`,
+      )
+      .run(new Date().toISOString(), workspaceId, workspaceId);
+    return result.changes;
+  }
+
+  /**
    * Count active (non-deleted) threads on a given branch in the same workspace,
    * excluding a specific thread. Used to decide whether a branch is safe to delete.
    */

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -52,6 +52,10 @@ export class WorkspaceRepo {
     const now = new Date().toISOString();
 
     const trx = this.db.transaction(() => {
+      // Evict any soft-deleted row occupying this path so the UNIQUE constraint won't block re-creation.
+      this.db
+        .prepare("DELETE FROM workspaces WHERE path = ? AND deleted_at IS NOT NULL")
+        .run(path);
       this.db
         .prepare("UPDATE workspaces SET sort_order = sort_order + 1")
         .run();
@@ -209,6 +213,14 @@ export class WorkspaceRepo {
     return this.db
       .prepare("SELECT id, path, deleted_at AS deletedAt FROM workspaces WHERE deleted_at IS NOT NULL")
       .all() as Array<{ id: string; path: string; deletedAt: string }>;
+  }
+
+  /** Find a single soft-deleted workspace by path. O(1) lookup for finalization. */
+  findDeletingByPath(path: string): { id: string; path: string; deletedAt: string } | null {
+    const row = this.db
+      .prepare("SELECT id, path, deleted_at AS deletedAt FROM workspaces WHERE path = ? AND deleted_at IS NOT NULL")
+      .get(path) as { id: string; path: string; deletedAt: string } | undefined;
+    return row ?? null;
   }
 
   /** Find a workspace by ID regardless of deletion status. Used during cleanup. */

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -52,10 +52,20 @@ export class WorkspaceRepo {
     const now = new Date().toISOString();
 
     const trx = this.db.transaction(() => {
-      // Evict any soft-deleted row occupying this path so the UNIQUE constraint won't block re-creation.
-      this.db
-        .prepare("DELETE FROM workspaces WHERE path = ? AND deleted_at IS NOT NULL")
-        .run(path);
+      // Evict a soft-deleted row occupying this path only if it has no remaining
+      // child threads (i.e. async cleanup already finished). If threads still
+      // exist the CleanupWorker will hard-delete the workspace once done.
+      const stale = this.db
+        .prepare("SELECT id FROM workspaces WHERE path = ? AND deleted_at IS NOT NULL")
+        .get(path) as { id: string } | undefined;
+      if (stale) {
+        const threadCount = this.db
+          .prepare("SELECT COUNT(*) AS n FROM threads WHERE workspace_id = ?")
+          .get(stale.id) as { n: number };
+        if (threadCount.n === 0) {
+          this.db.prepare("DELETE FROM workspaces WHERE id = ?").run(stale.id);
+        }
+      }
       this.db
         .prepare("UPDATE workspaces SET sort_order = sort_order + 1")
         .run();

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -19,6 +19,7 @@ interface WorkspaceRow {
   pinned: number;
   last_opened_at: number | null;
   sort_order: number;
+  deleted_at: string | null;
 }
 
 function rowToWorkspace(row: WorkspaceRow): Workspace {
@@ -36,6 +37,7 @@ function rowToWorkspace(row: WorkspaceRow): Workspace {
     pinned: row.pinned === 1,
     last_opened_at: row.last_opened_at ?? null,
     sort_order: row.sort_order,
+    deleted_at: row.deleted_at ?? null,
   };
 }
 
@@ -72,6 +74,7 @@ export class WorkspaceRepo {
       pinned: false,
       last_opened_at: null,
       sort_order: 0,
+      deleted_at: null,
     };
   }
 
@@ -136,33 +139,33 @@ export class WorkspaceRepo {
     trx();
   }
 
-  /** Find a workspace by its primary key. Returns null if not found. */
+  /** Find a workspace by its primary key. Returns null if not found or soft-deleted. */
   findById(id: string): Workspace | null {
     const row = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order FROM workspaces WHERE id = ?",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order, deleted_at FROM workspaces WHERE id = ? AND deleted_at IS NULL",
       )
       .get(id) as WorkspaceRow | undefined;
 
     return row ? rowToWorkspace(row) : null;
   }
 
-  /** Find a workspace by its filesystem path. Returns null if not found. */
+  /** Find a workspace by its filesystem path. Returns null if not found or soft-deleted. */
   findByPath(path: string): Workspace | null {
     const row = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order FROM workspaces WHERE path = ?",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order, deleted_at FROM workspaces WHERE path = ? AND deleted_at IS NULL",
       )
       .get(path) as WorkspaceRow | undefined;
 
     return row ? rowToWorkspace(row) : null;
   }
 
-  /** List all workspaces ordered by ascending sidebar sort_order. */
+  /** List all non-deleted workspaces ordered by ascending sidebar sort_order. */
   listAll(): Workspace[] {
     const rows = this.db
       .prepare(
-        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order FROM workspaces ORDER BY sort_order ASC, id ASC",
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order, deleted_at FROM workspaces WHERE deleted_at IS NULL ORDER BY sort_order ASC, id ASC",
       )
       .all() as WorkspaceRow[];
 
@@ -191,6 +194,40 @@ export class WorkspaceRepo {
       .run(id);
 
     return result.changes > 0;
+  }
+
+  /** Soft-delete a workspace by setting deleted_at. Returns true if a row was changed. */
+  softDelete(id: string): boolean {
+    const now = new Date().toISOString();
+    const result = this.db
+      .prepare("UPDATE workspaces SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL")
+      .run(now, now, id);
+    return result.changes > 0;
+  }
+
+  /** Permanently remove a workspace and all its children (via FK cascade). */
+  hardDelete(id: string): boolean {
+    const result = this.db
+      .prepare("DELETE FROM workspaces WHERE id = ?")
+      .run(id);
+    return result.changes > 0;
+  }
+
+  /** Find all workspaces currently in the soft-deleted (deleting) state. */
+  findDeleting(): Array<{ id: string; path: string; deletedAt: string }> {
+    return this.db
+      .prepare("SELECT id, path, deleted_at AS deletedAt FROM workspaces WHERE deleted_at IS NOT NULL")
+      .all() as Array<{ id: string; path: string; deletedAt: string }>;
+  }
+
+  /** Find a workspace by ID regardless of deletion status. Used during cleanup. */
+  findByIdIncludeDeleted(id: string): Workspace | null {
+    const row = this.db
+      .prepare(
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order, deleted_at FROM workspaces WHERE id = ?",
+      )
+      .get(id) as WorkspaceRow | undefined;
+    return row ? rowToWorkspace(row) : null;
   }
 
   /** Bump updated_at to the current time so the workspace sorts to the top of the recent list. */

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -187,15 +187,6 @@ export class WorkspaceRepo {
     this.db.prepare("UPDATE workspaces SET last_opened_at = NULL, pinned = 0 WHERE id = ?").run(id);
   }
 
-  /** Delete a workspace by ID. Returns true if a row was removed. */
-  remove(id: string): boolean {
-    const result = this.db
-      .prepare("DELETE FROM workspaces WHERE id = ?")
-      .run(id);
-
-    return result.changes > 0;
-  }
-
   /** Soft-delete a workspace by setting deleted_at. Returns true if a row was changed. */
   softDelete(id: string): boolean {
     const now = new Date().toISOString();

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -252,6 +252,10 @@ export class CleanupWorker {
   /** Check whether the branch is safe to delete (no other active thread references it). */
   private shouldDeleteBranch(job: CleanupJob): boolean {
     if (!job.branch) return false;
+    // If the source thread has already been hard-deleted, we can't resolve its
+    // workspace to check for siblings. Conservatively keep the branch.
+    const thread = this.threadRepo.findById(job.thread_id);
+    if (!thread) return false;
     return this.threadRepo.countActiveByBranch(job.thread_id, job.branch) === 0;
   }
 

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -313,9 +313,7 @@ export class CleanupWorker {
     const remaining = this.cleanupJobRepo.countByWorkspacePath(workspacePath);
     if (remaining > 0) return;
 
-    // Find the soft-deleted workspace for this path and hard-delete it
-    const deleting = this.workspaceRepo.findDeleting();
-    const workspace = deleting.find((w) => w.path === workspacePath);
+    const workspace = this.workspaceRepo.findDeletingByPath(workspacePath);
     if (workspace) {
       this.workspaceRepo.hardDelete(workspace.id);
       broadcast("workspace.deleted", { workspaceId: workspace.id });

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -16,7 +16,9 @@ import { ThreadRepo } from "../repositories/thread-repo.js";
 import { ClaudeProvider } from "../providers/claude/claude-provider.js";
 import { TerminalService } from "./terminal-service.js";
 import { GitService } from "./git-service.js";
+import { AttachmentService } from "./attachment-service.js";
 import { killDescendantsByName } from "./process-kill.js";
+import { WorkspaceRepo } from "../repositories/workspace-repo.js";
 
 /** How often to check for due cleanup jobs (ms). */
 const POLL_INTERVAL_MS = 5_000;
@@ -53,6 +55,8 @@ export class CleanupWorker {
     @inject(ClaudeProvider) private readonly claudeProvider: ClaudeProvider,
     @inject(TerminalService) private readonly terminalService: TerminalService,
     @inject(GitService) private readonly gitService: GitService,
+    @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
+    @inject(AttachmentService) private readonly attachmentService: AttachmentService,
   ) {}
 
   /**
@@ -184,6 +188,9 @@ export class CleanupWorker {
         throw new Error(`Worktree directory still exists after removal: ${resolvedWt}`);
       }
 
+      // 5b. Clean up attachment files for this thread (idempotent - ignores missing dirs)
+      this.attachmentService.removeForThread(job.thread_id);
+
       // 6. Hard-delete thread row and cleanup job atomically.
       //    Wrapping in a transaction ensures no orphaned job if either statement fails.
       this.db.transaction(() => {
@@ -195,6 +202,9 @@ export class CleanupWorker {
         jobId: job.id,
         threadId: job.thread_id,
       });
+
+      // 7. If this was the last cleanup job for a soft-deleted workspace, hard-delete it.
+      this.finalizeWorkspaceIfDone(job.workspace_path);
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       logger.warn("CleanupWorker job failed, scheduled for retry", {
@@ -205,5 +215,30 @@ export class CleanupWorker {
       });
       this.cleanupJobRepo.recordFailure(job.id, error);
     }
+  }
+
+  /** Check if workspace cleanup is complete and hard-delete if so. */
+  private finalizeWorkspaceIfDone(workspacePath: string): void {
+    const remaining = this.cleanupJobRepo.countByWorkspacePath(workspacePath);
+    if (remaining > 0) return;
+
+    // Find the soft-deleted workspace for this path and hard-delete it
+    const deleting = this.workspaceRepo.findDeleting();
+    const workspace = deleting.find((w) => w.path === workspacePath);
+    if (workspace) {
+      this.workspaceRepo.hardDelete(workspace.id);
+      logger.info("Workspace hard-deleted after final cleanup job", {
+        workspaceId: workspace.id,
+        workspacePath,
+      });
+    }
+  }
+
+  /** Process a single due cleanup job. Returns true if a job was processed. Exported for testing. */
+  async processOneJob(): Promise<boolean> {
+    const jobs = this.cleanupJobRepo.findDue(Date.now());
+    if (jobs.length === 0) return false;
+    await this.executeJob(jobs[0]);
+    return true;
   }
 }

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -174,8 +174,10 @@ export class CleanupWorker {
       // 5. Remove the worktree directory and delete the exact thread branch when
       //    the thread record has one. The delete-thread dialog is the user intent
       //    boundary; rollback paths are handled separately in ThreadService.
+      //    Skip branch deletion when another active thread references the same branch.
       const wtName = resolvedWt.replace(/\\/g, "/").split("/").pop() ?? resolvedWt;
-      const removeOptions = job.branch
+      const shouldDelete = job.branch ? this.shouldDeleteBranch(job) : false;
+      const removeOptions = (job.branch && shouldDelete)
         ? { branchName: job.branch, worktreePath: resolvedWt }
         : { deleteBranch: false, worktreePath: resolvedWt };
 
@@ -216,6 +218,12 @@ export class CleanupWorker {
       });
       this.cleanupJobRepo.recordFailure(job.id, error);
     }
+  }
+
+  /** Check whether the branch is safe to delete (no other active thread references it). */
+  private shouldDeleteBranch(job: CleanupJob): boolean {
+    if (!job.branch) return false;
+    return this.threadRepo.countActiveByBranch(job.thread_id, job.branch) === 0;
   }
 
   /**

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -66,6 +66,7 @@ export class CleanupWorker {
   start(): void {
     if (this.pollTimer !== null) return;
     this.cleanupJobRepo.resetAttempts();
+    this.reconcileOnStartup();
     this.stopped = false;
     this.pollTimer = setInterval(() => {
       this.poll().catch((err) => {
@@ -214,6 +215,59 @@ export class CleanupWorker {
         error,
       });
       this.cleanupJobRepo.recordFailure(job.id, error);
+    }
+  }
+
+  /**
+   * Reconcile incomplete workspace deletions after app restart.
+   * Finds soft-deleted workspaces and ensures all their worktree threads
+   * have cleanup jobs enqueued. If a workspace has no remaining threads or jobs,
+   * hard-deletes it immediately.
+   */
+  reconcileOnStartup(): void {
+    const deletingWorkspaces = this.workspaceRepo.findDeleting();
+
+    for (const ws of deletingWorkspaces) {
+      const threads = this.threadRepo.listAllByWorkspace(ws.id);
+
+      if (threads.length === 0) {
+        // No threads remain - just hard-delete the workspace
+        this.workspaceRepo.hardDelete(ws.id);
+        logger.info("Reconciled orphaned workspace (no threads)", { workspaceId: ws.id });
+        continue;
+      }
+
+      // Find worktree threads missing cleanup jobs
+      const worktreeThreads = threads.filter((t) => t.worktree_path);
+      const missingJobs = worktreeThreads.filter(
+        (t) => !this.cleanupJobRepo.findByThreadId(t.id),
+      );
+
+      if (missingJobs.length > 0) {
+        this.cleanupJobRepo.insertBatch(
+          missingJobs.map((t) => ({
+            thread_id: t.id,
+            workspace_path: ws.path,
+            worktree_path: t.worktree_path!,
+            branch: t.branch,
+          })),
+        );
+        logger.info("Reconciled missing cleanup jobs for workspace", {
+          workspaceId: ws.id,
+          jobsEnqueued: missingJobs.length,
+        });
+      }
+
+      // If the only remaining threads are non-worktree (already soft-deleted),
+      // hard-delete them and the workspace now
+      const pendingJobs = this.cleanupJobRepo.countByWorkspacePath(ws.path);
+      if (pendingJobs === 0) {
+        for (const t of threads) {
+          this.threadRepo.hardDelete(t.id);
+        }
+        this.workspaceRepo.hardDelete(ws.id);
+        logger.info("Reconciled workspace with no pending cleanup", { workspaceId: ws.id });
+      }
     }
   }
 

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -315,6 +315,13 @@ export class CleanupWorker {
 
     const workspace = this.workspaceRepo.findDeletingByPath(workspacePath);
     if (workspace) {
+      // Clean up any remaining threads (e.g. crash-orphaned soft-deleted direct threads)
+      // before FK cascade removes them without attachment file cleanup.
+      const remainingThreads = this.threadRepo.listAllByWorkspace(workspace.id);
+      for (const thread of remainingThreads) {
+        this.attachmentService.removeForThread(thread.id);
+      }
+
       this.workspaceRepo.hardDelete(workspace.id);
       broadcast("workspace.deleted", { workspaceId: workspace.id });
       logger.info("Workspace hard-deleted after final cleanup job", {

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -127,7 +127,19 @@ export class CleanupWorker {
       const resolvedWs = resolve(job.workspace_path.replace(/\\/g, "/"));
 
       if (!existsSync(resolvedWs)) {
-        throw new Error(`workspace_path does not exist: ${resolvedWs}`);
+        // The workspace directory is already gone (e.g. external deletion, re-installation).
+        // Treat this as a successful cleanup: there's nothing on disk to remove.
+        logger.info("Workspace directory gone, skipping filesystem cleanup", {
+          threadId: job.thread_id,
+          workspacePath: resolvedWs,
+        });
+        this.attachmentService.removeForThread(job.thread_id);
+        this.db.transaction(() => {
+          this.threadRepo.hardDelete(job.thread_id);
+          this.cleanupJobRepo.delete(job.id);
+        })();
+        this.finalizeWorkspaceIfDone(job.workspace_path);
+        return;
       }
       if (resolvedWt === resolvedWs) {
         throw new Error(`worktree_path must not equal workspace_path: ${resolvedWt}`);
@@ -169,6 +181,22 @@ export class CleanupWorker {
       // 4. Brief delay on Windows so the OS releases directory handles.
       if (process.platform === "win32") {
         await new Promise<void>((resolve) => setTimeout(resolve, HANDLE_RELEASE_DELAY_MS));
+      }
+
+      if (!existsSync(resolvedWt)) {
+        // The worktree directory is already gone but the workspace root exists.
+        // Treat this as a successful cleanup: no git operation needed.
+        logger.info("Worktree directory already removed, skipping filesystem cleanup", {
+          threadId: job.thread_id,
+          worktreePath: resolvedWt,
+        });
+        this.attachmentService.removeForThread(job.thread_id);
+        this.db.transaction(() => {
+          this.threadRepo.hardDelete(job.thread_id);
+          this.cleanupJobRepo.delete(job.id);
+        })();
+        this.finalizeWorkspaceIfDone(job.workspace_path);
+        return;
       }
 
       // 5. Remove the worktree directory and delete the exact thread branch when

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -19,6 +19,7 @@ import { GitService } from "./git-service.js";
 import { AttachmentService } from "./attachment-service.js";
 import { killDescendantsByName } from "./process-kill.js";
 import { WorkspaceRepo } from "../repositories/workspace-repo.js";
+import { broadcast } from "../transport/push.js";
 
 /** How often to check for due cleanup jobs (ms). */
 const POLL_INTERVAL_MS = 5_000;
@@ -317,6 +318,7 @@ export class CleanupWorker {
     const workspace = deleting.find((w) => w.path === workspacePath);
     if (workspace) {
       this.workspaceRepo.hardDelete(workspace.id);
+      broadcast("workspace.deleted", { workspaceId: workspace.id });
       logger.info("Workspace hard-deleted after final cleanup job", {
         workspaceId: workspace.id,
         workspacePath,

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -300,10 +300,11 @@ export class CleanupWorker {
       }
 
       // If the only remaining threads are non-worktree (already soft-deleted),
-      // hard-delete them and the workspace now
+      // clean up attachments, hard-delete them, and hard-delete the workspace now
       const pendingJobs = this.cleanupJobRepo.countByWorkspacePath(ws.path);
       if (pendingJobs === 0) {
         for (const t of threads) {
+          this.attachmentService.removeForThread(t.id);
           this.threadRepo.hardDelete(t.id);
         }
         this.workspaceRepo.hardDelete(ws.id);

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -324,6 +324,32 @@ export class CleanupWorker {
     }
   }
 
+  /**
+   * Find soft-deleted workspaces where ALL remaining cleanup jobs have exhausted retries.
+   * These workspaces are permanently stuck and need user intervention (force-delete).
+   */
+  findStuckWorkspaces(): Array<{ workspaceId: string; workspacePath: string; reason: string }> {
+    const deleting = this.workspaceRepo.findDeleting();
+    const stuck: Array<{ workspaceId: string; workspacePath: string; reason: string }> = [];
+
+    for (const ws of deleting) {
+      const totalJobs = this.cleanupJobRepo.countByWorkspacePath(ws.path);
+      if (totalJobs === 0) continue;
+
+      const retriable = this.cleanupJobRepo.countRetriableByWorkspacePath(ws.path);
+      if (retriable === 0) {
+        const lastError = this.cleanupJobRepo.getLastErrorByWorkspacePath(ws.path);
+        stuck.push({
+          workspaceId: ws.id,
+          workspacePath: ws.path,
+          reason: lastError ?? "Unknown error after 5 attempts",
+        });
+      }
+    }
+
+    return stuck;
+  }
+
   /** Process a single due cleanup job. Returns true if a job was processed. Exported for testing. */
   async processOneJob(): Promise<boolean> {
     const jobs = this.cleanupJobRepo.findDue(Date.now());

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -29,8 +29,9 @@ export class WorkspaceService {
   /**
    * Create a new workspace, or return the existing one if the path is already registered.
    * Detects whether the path is a git repository and stores the result.
-   * Handles the case where the workspace still exists in the DB (e.g., after a failed
-   * delete or stale client state) to prevent UNIQUE constraint errors on re-add.
+   * If a soft-deleted workspace occupies the path and cleanup has finished (no threads
+   * remain), it is evicted automatically. If cleanup is still in progress, force-deletes
+   * the stale workspace so the user can re-add immediately.
    */
   create(name: string, path: string): Workspace {
     const existing = this.workspaceRepo.findByPath(path);
@@ -39,6 +40,15 @@ export class WorkspaceService {
       this.workspaceRepo.prependToSortOrder(existing.id);
       return this.workspaceRepo.findById(existing.id)!;
     }
+
+    // A soft-deleted workspace may still occupy this path. findByPath filters those
+    // out, but the UNIQUE constraint will block the insert. The repo-level create
+    // evicts only if no threads remain; if it can't, force-delete here.
+    const stale = this.workspaceRepo.findDeletingByPath(path);
+    if (stale) {
+      this.forceDelete(stale.id);
+    }
+
     const isGitRepo = this.detectGitRepo(path);
     return this.workspaceRepo.create(name, path, isGitRepo);
   }

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -1,6 +1,6 @@
 /**
  * Workspace CRUD service.
- * Thin orchestration layer over WorkspaceRepo with git detection.
+ * Orchestrates two-phase workspace deletion: soft-delete + async cleanup.
  */
 
 import { execFileSync } from "child_process";
@@ -9,13 +9,19 @@ import { join } from "path";
 import { injectable, inject } from "tsyringe";
 import type { Workspace } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
+import { ThreadRepo } from "../repositories/thread-repo";
+import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
+import { AttachmentService } from "./attachment-service";
 import { logger } from "@mcode/shared";
 
-/** Handles workspace creation, listing, and deletion. */
+/** Handles workspace creation, listing, and two-phase deletion. */
 @injectable()
 export class WorkspaceService {
   constructor(
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
+    @inject(ThreadRepo) private readonly threadRepo: ThreadRepo,
+    @inject(CleanupJobRepo) private readonly cleanupJobRepo: CleanupJobRepo,
+    @inject(AttachmentService) private readonly attachmentService: AttachmentService,
   ) {}
 
   /**
@@ -48,9 +54,66 @@ export class WorkspaceService {
     return this.workspaceRepo.listAll();
   }
 
-  /** Delete a workspace by ID. Returns true if the workspace was removed. */
+  /**
+   * Two-phase workspace deletion.
+   * Phase 1 (synchronous): soft-delete workspace + threads, enqueue cleanup jobs.
+   * Phase 2 (async via CleanupWorker): drain jobs, then hard-delete workspace.
+   *
+   * Returns false if the workspace does not exist.
+   */
   delete(id: string): boolean {
-    return this.workspaceRepo.remove(id);
+    // Attempt soft-delete. If workspace doesn't exist or is already deleted, bail.
+    if (!this.workspaceRepo.softDelete(id)) {
+      return false;
+    }
+
+    const workspacePath = this.getWorkspacePathForCleanup(id);
+
+    // Gather all threads (active + already-soft-deleted) that have a worktree
+    const worktreeThreads = this.threadRepo.findWorktreeThreadsByWorkspace(id);
+
+    // Get all threads regardless of status
+    const allThreads = this.threadRepo.listAllByWorkspace(id);
+
+    // Separate threads by whether they need async worktree cleanup
+    const worktreeThreadIds = new Set(worktreeThreads.map((t) => t.id));
+    const directThreads = allThreads.filter((t) => !worktreeThreadIds.has(t.id));
+
+    // Soft-delete all threads that aren't already deleted
+    for (const thread of allThreads) {
+      if (!thread.deleted_at) {
+        this.threadRepo.softDelete(thread.id);
+      }
+    }
+
+    // Enqueue cleanup jobs for worktree threads (batch, skips duplicates)
+    if (worktreeThreads.length > 0 && workspacePath) {
+      this.cleanupJobRepo.insertBatch(
+        worktreeThreads.map((t) => ({
+          thread_id: t.id,
+          workspace_path: workspacePath,
+          worktree_path: t.worktree_path!,
+          branch: t.branch,
+        })),
+      );
+    }
+
+    // For direct threads (no worktree), clean up attachments and hard-delete now
+    for (const thread of directThreads) {
+      this.attachmentService.removeForThread(thread.id);
+      this.threadRepo.hardDelete(thread.id);
+    }
+
+    // If no worktree cleanup is pending, hard-delete the workspace immediately
+    const pendingJobs = workspacePath
+      ? this.cleanupJobRepo.countByWorkspacePath(workspacePath)
+      : 0;
+
+    if (pendingJobs === 0) {
+      this.workspaceRepo.hardDelete(id);
+    }
+
+    return true;
   }
 
   /** Find a workspace by its primary key. Returns null if not found. */
@@ -66,6 +129,12 @@ export class WorkspaceService {
   /** Update the is_git_repo flag on a workspace record. */
   setIsGitRepo(id: string, isGitRepo: boolean): void {
     this.workspaceRepo.setIsGitRepo(id, isGitRepo);
+  }
+
+  /** Retrieve workspace path even if soft-deleted (uses unfiltered repo lookup). */
+  private getWorkspacePathForCleanup(id: string): string | null {
+    const ws = this.workspaceRepo.findByIdIncludeDeleted(id);
+    return ws?.path ?? null;
   }
 
   /** Check whether a filesystem path is inside a git repository. */

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -141,11 +141,20 @@ export class WorkspaceService {
 
   /**
    * Force-delete a workspace, abandoning any pending filesystem cleanup.
-   * Removes all DB records immediately. Orphaned worktree directories may remain on disk.
+   * Signals active sessions to stop (best-effort), then removes all DB records
+   * immediately. Orphaned worktree directories may remain on disk.
    */
   forceDelete(id: string): boolean {
     this.threadRepo.nullifyExternalLineage(id);
     const threads = this.threadRepo.listAllByWorkspace(id);
+
+    // Best-effort signal to active sessions before removing their backing rows
+    for (const t of threads) {
+      if (t.sdk_session_id) {
+        this.agentService.stopSession(t.id).catch(() => {});
+      }
+    }
+
     for (const t of threads) {
       this.cleanupJobRepo.deleteByThreadId(t.id);
       this.attachmentService.removeForThread(t.id);

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -12,6 +12,7 @@ import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { AttachmentService } from "./attachment-service";
+import { AgentService } from "./agent-service.js";
 import { logger } from "@mcode/shared";
 
 /** Handles workspace creation, listing, and two-phase deletion. */
@@ -22,6 +23,7 @@ export class WorkspaceService {
     @inject(ThreadRepo) private readonly threadRepo: ThreadRepo,
     @inject(CleanupJobRepo) private readonly cleanupJobRepo: CleanupJobRepo,
     @inject(AttachmentService) private readonly attachmentService: AttachmentService,
+    @inject(AgentService) private readonly agentService: AgentService,
   ) {}
 
   /**
@@ -74,6 +76,14 @@ export class WorkspaceService {
 
     // Get all threads regardless of status
     const allThreads = this.threadRepo.listAllByWorkspace(id);
+
+    // Signal all active agent sessions to stop (fire-and-forget)
+    const activeThreads = allThreads.filter((t) => t.sdk_session_id);
+    for (const thread of activeThreads) {
+      this.agentService.stopSession(thread.id).catch(() => {
+        logger.debug("Failed to stop session during workspace delete", { threadId: thread.id });
+      });
+    }
 
     // Separate threads by whether they need async worktree cleanup
     const worktreeThreadIds = new Set(worktreeThreads.map((t) => t.id));

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -71,6 +71,9 @@ export class WorkspaceService {
 
     const workspacePath = this.getWorkspacePathForCleanup(id);
 
+    // Nullify cross-workspace fork lineage before threads are deleted
+    this.threadRepo.nullifyExternalLineage(id);
+
     // Gather all threads (active + already-soft-deleted) that have a worktree
     const worktreeThreads = this.threadRepo.findWorktreeThreadsByWorkspace(id);
 

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -116,6 +116,19 @@ export class WorkspaceService {
     return true;
   }
 
+  /**
+   * Force-delete a workspace, abandoning any pending filesystem cleanup.
+   * Removes all DB records immediately. Orphaned worktree directories may remain on disk.
+   */
+  forceDelete(id: string): boolean {
+    const threads = this.threadRepo.listAllByWorkspace(id);
+    for (const t of threads) {
+      this.cleanupJobRepo.deleteByThreadId(t.id);
+      this.attachmentService.removeForThread(t.id);
+    }
+    return this.workspaceRepo.hardDelete(id);
+  }
+
   /** Find a workspace by its primary key. Returns null if not found. */
   findById(id: string): Workspace | null {
     return this.workspaceRepo.findById(id);

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -134,6 +134,7 @@ export class WorkspaceService {
    * Removes all DB records immediately. Orphaned worktree directories may remain on disk.
    */
   forceDelete(id: string): boolean {
+    this.threadRepo.nullifyExternalLineage(id);
     const threads = this.threadRepo.listAllByWorkspace(id);
     for (const t of threads) {
       this.cleanupJobRepo.deleteByThreadId(t.id);

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -22,6 +22,7 @@ export const workspaces = sqliteTable(
     lastOpenedAt: integer("last_opened_at"),
     sortOrder: integer("sort_order").notNull().default(0),
     isGitRepo: integer("is_git_repo").notNull().default(1),
+    deletedAt: text("deleted_at"),
   },
   (table) => [
     index("idx_workspaces_sort_order").on(asc(table.sortOrder)),

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -212,7 +212,19 @@ async function dispatch(
     }
     case "workspace.delete": {
       const result = deps.workspaceService.delete(params.id);
-      deps.gitWatcherService.unwatchWorkspace(params.id);
+      if (result) {
+        deps.gitWatcherService.unwatchWorkspace(params.id);
+        broadcast("workspace.orderChanged", {});
+      }
+      return result;
+    }
+    case "workspace.forceDelete": {
+      const result = deps.workspaceService.forceDelete(params.id);
+      if (result) {
+        deps.gitWatcherService.unwatchWorkspace(params.id);
+        broadcast("workspace.deleted", { workspaceId: params.id });
+        broadcast("workspace.orderChanged", {});
+      }
       return result;
     }
     case "workspace.pin":

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -27,6 +27,7 @@ export function createMockWorkspace(
     pinned: false,
     last_opened_at: null,
     sort_order: 0,
+    deleted_at: null,
     ...overrides,
   };
 }

--- a/apps/web/src/stores/__tests__/workspaceStore.actions.test.ts
+++ b/apps/web/src/stores/__tests__/workspaceStore.actions.test.ts
@@ -14,6 +14,7 @@ function makeWs(overrides?: Partial<Workspace>): Workspace {
     pinned: false,
     last_opened_at: null,
     sort_order: 0,
+    deleted_at: null,
     ...overrides,
   };
 }

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -136,6 +136,8 @@ interface WorkspaceState {
   loadWorkspaces: () => Promise<void>;
   createWorkspace: (name: string, path: string) => Promise<Workspace>;
   deleteWorkspace: (id: string) => Promise<void>;
+  /** Remove a workspace from local state immediately (used by push channel handlers). */
+  removeWorkspaceFromState: (id: string) => void;
   /**
    * Set the active workspace by ID. Clears the active thread if it belongs to a
    * different workspace, and bumps the workspace's last_opened_at locally so
@@ -403,6 +405,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       set({ error: String(e) });
       throw e;
     }
+  },
+
+  removeWorkspaceFromState: (id) => {
+    set((state) => ({
+      workspaces: state.workspaces.filter((w) => w.id !== id),
+      activeWorkspaceId: state.activeWorkspaceId === id ? null : state.activeWorkspaceId,
+    }));
   },
 
   setActiveWorkspace: (id, call) => {

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -41,6 +41,8 @@ const _legacyEncoder = new TextEncoder();
  * - `providers.availability` -- server-pushed provider availability snapshot forwarded to providerAvailabilityStore
  * - `workspace.gitStatusChanged` -- workspace git status changed (e.g. non-git folder became a repo), updates is_git_repo flag
  * - `workspace.orderChanged` -- sidebar project order changed on the server; refreshes workspace list
+ * - `workspace.deleted` -- workspace hard-delete complete; removes it from local state
+ * - `workspace.deleteFailed` -- workspace deletion permanently stuck; reloads workspace list
  */
 export function startPushListeners(): void {
   // Guard against double-init
@@ -292,6 +294,27 @@ export function startPushListeners(): void {
   unsubs.push(
     pushEmitter.on("workspace.orderChanged", () => {
       void useWorkspaceStore.getState().loadWorkspaces();
+    }),
+  );
+
+  // workspace.deleted: remove the workspace from local state when hard-delete completes
+  unsubs.push(
+    pushEmitter.on("workspace.deleted", (data) => {
+      const { workspaceId } = data as { workspaceId: string };
+      const store = useWorkspaceStore.getState();
+      if (store.activeWorkspaceId === workspaceId) {
+        store.setActiveWorkspace(null);
+      }
+      store.removeWorkspaceFromState(workspaceId);
+    }),
+  );
+
+  // workspace.deleteFailed: reload workspaces so stuck state is reflected
+  unsubs.push(
+    pushEmitter.on("workspace.deleteFailed", (data) => {
+      const { workspaceId, reason } = data as { workspaceId: string; reason: string };
+      void useWorkspaceStore.getState().loadWorkspaces();
+      console.error(`Workspace ${workspaceId} deletion failed: ${reason}`);
     }),
   );
 

--- a/packages/contracts/src/models/workspace.ts
+++ b/packages/contracts/src/models/workspace.ts
@@ -17,6 +17,8 @@ export const WorkspaceSchema = lazySchema(() =>
     last_opened_at: z.number().nullable(),
     /** Ascending sidebar order; lower values appear higher in the project list. */
     sort_order: z.number().int(),
+    /** ISO timestamp when the workspace was soft-deleted. Null if active. */
+    deleted_at: z.string().nullable(),
   }),
 );
 /** Workspace record from the database. */

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -89,6 +89,8 @@ export const WS_CHANNELS = {
     requestId: z.string(),
     decision: PermissionDecisionSchema,
   }),
+  /** Emitted when a workspace is fully hard-deleted (all cleanup complete). */
+  "workspace.deleted": z.object({ workspaceId: z.string() }),
   /** Emitted when a workspace deletion is permanently stuck after max retries. */
   "workspace.deleteFailed": z.object({
     workspaceId: z.string(),

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -89,6 +89,12 @@ export const WS_CHANNELS = {
     requestId: z.string(),
     decision: PermissionDecisionSchema,
   }),
+  /** Emitted when a workspace deletion is permanently stuck after max retries. */
+  "workspace.deleteFailed": z.object({
+    workspaceId: z.string(),
+    workspacePath: z.string(),
+    reason: z.string(),
+  }),
 } as const;
 
 /** Union of all push channel names. */

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -110,6 +110,11 @@ export const WS_METHODS = lazySchema(() => ({
     params: z.object({ id: z.string() }),
     result: z.boolean(),
   },
+  /** Hard-delete a workspace and all its data immediately, bypassing the cleanup queue. */
+  "workspace.forceDelete": {
+    params: z.object({ id: z.string() }),
+    result: z.boolean(),
+  },
   /** Pin or unpin a workspace in the project selector. */
   "workspace.pin": {
     params: z.object({ id: z.string(), pinned: z.boolean() }),


### PR DESCRIPTION
## What

Implements two-phase workspace deletion: immediate soft-delete hides the workspace from the UI, then CleanupWorker asynchronously drains per-thread worktree cleanup jobs before hard-deleting the workspace row via FK cascade.

## Why

Previously, workspace deletion was synchronous and could fail partway through (leaving orphaned worktrees, dangling threads, or half-deleted state). The new approach is crash-safe, resumable, and non-blocking: the UI responds instantly while heavy filesystem work happens in the background with exponential-backoff retries.

## Key Changes

- **Schema migration**: adds `deleted_at` column to workspaces table
- **WorkspaceRepo**: new `softDelete()`, `hardDelete()`, `findDeleting()` methods; all queries filter out soft-deleted rows
- **ThreadRepo**: workspace-level helpers (`findWorktreeThreadsByWorkspace`, `listAllByWorkspace`, `nullifyExternalLineage`)
- **CleanupJobRepo**: `insertBatch()`, `countByWorkspacePath()`, workspace-scoped queries
- **WorkspaceService.delete()**: orchestrates soft-delete, session signaling, lineage nullification, job enqueue, and conditional hard-delete
- **CleanupWorker**: attachment cleanup before hard-delete, `finalizeWorkspaceIfDone()` for workspace hard-delete after last job, `reconcileOnStartup()` for crash recovery
- **Safety**: shared branch protection, missing-directory-is-success, idempotent retry, stuck workspace detection with `forceDelete` escape hatch
- **Push channels**: `workspace.deleted` and `workspace.deleteFailed` for frontend reactivity
- **Frontend**: Zustand store subscribes to push events and removes workspace from state
- **Tests**: 60+ unit/integration tests covering all deletion scenarios

Closes #93

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two‑phase workspace deletion (soft-delete + background cleanup) and a force‑delete RPC.
  * Workspace objects include deleted_at; clients handle delete events and can remove workspaces locally.

* **Real-time**
  * New push events: workspace.deleted and workspace.deleteFailed for reactive client updates.

* **Tests**
  * Extensive integration and unit tests covering deletion lifecycles, worker reconciliation, attachments, and edge cases.

* **Chores**
  * Startup reconciliation and attachment cleanup added to background worker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->