### PR TITLE
feat: thread search, filter, and sort in sidebar

### DIFF
--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -220,8 +220,9 @@ export class ThreadRepo {
     const params: unknown[] = [];
 
     if (opts.query) {
-      conditions.push("t.title LIKE ? COLLATE NOCASE");
-      params.push(`%${opts.query}%`);
+      const escapedQuery = opts.query.replace(/[%_]/g, "\\$&");
+      conditions.push("t.title LIKE ? ESCAPE '\\' COLLATE NOCASE");
+      params.push(`%${escapedQuery}%`);
     }
 
     if (opts.filters?.status?.length) {
@@ -238,6 +239,11 @@ export class ThreadRepo {
 
     const sortField = opts.sort?.field ?? "updated_at";
     const sortDir = opts.sort?.direction ?? "desc";
+    const ALLOWED_SORT_FIELDS = new Set(["updated_at", "created_at", "title"]);
+    const ALLOWED_SORT_DIRS = new Set(["asc", "desc"]);
+    if (!ALLOWED_SORT_FIELDS.has(sortField) || !ALLOWED_SORT_DIRS.has(sortDir)) {
+      throw new Error(`Invalid sort parameters: ${sortField} ${sortDir}`);
+    }
     const orderBy = `t.${sortField} ${sortDir.toUpperCase()}`;
 
     const threadCols = THREAD_COLUMNS.split(", ").map((c) => `t.${c}`).join(", ");

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -205,6 +205,67 @@ export class ThreadRepo {
     }));
   }
 
+  /**
+   * Search non-deleted threads across all workspaces by title substring,
+   * with optional status/provider filters and sort order.
+   */
+  search(opts: {
+    query: string;
+    filters?: { status?: string[]; provider?: string[] };
+    sort?: { field: "updated_at" | "created_at" | "title"; direction: "asc" | "desc" };
+    limit?: number;
+  }): { threads: Thread[]; workspaces: { id: string; name: string; path: string }[] } {
+    const clampedLimit = Math.max(1, Math.min(200, opts.limit ?? 100));
+    const conditions: string[] = ["t.deleted_at IS NULL"];
+    const params: unknown[] = [];
+
+    if (opts.query) {
+      conditions.push("t.title LIKE ? COLLATE NOCASE");
+      params.push(`%${opts.query}%`);
+    }
+
+    if (opts.filters?.status?.length) {
+      const placeholders = opts.filters.status.map(() => "?").join(", ");
+      conditions.push(`t.status IN (${placeholders})`);
+      params.push(...opts.filters.status);
+    }
+
+    if (opts.filters?.provider?.length) {
+      const placeholders = opts.filters.provider.map(() => "?").join(", ");
+      conditions.push(`t.provider IN (${placeholders})`);
+      params.push(...opts.filters.provider);
+    }
+
+    const sortField = opts.sort?.field ?? "updated_at";
+    const sortDir = opts.sort?.direction ?? "desc";
+    const orderBy = `t.${sortField} ${sortDir.toUpperCase()}`;
+
+    const threadCols = THREAD_COLUMNS.split(", ").map((c) => `t.${c}`).join(", ");
+    const sql = `
+      SELECT ${threadCols}, w.id AS w_id, w.name AS w_name, w.path AS w_path
+      FROM threads t
+      JOIN workspaces w ON w.id = t.workspace_id
+      WHERE ${conditions.join(" AND ")}
+      ORDER BY ${orderBy}
+      LIMIT ?
+    `;
+    params.push(clampedLimit);
+
+    const rows = this.db.prepare(sql).all(...params) as Array<
+      ThreadRow & { w_id: string; w_name: string; w_path: string }
+    >;
+
+    const threads = rows.map((row) => rowToThread(row));
+    const workspaceMap = new Map<string, { id: string; name: string; path: string }>();
+    for (const row of rows) {
+      if (!workspaceMap.has(row.w_id)) {
+        workspaceMap.set(row.w_id, { id: row.w_id, name: row.w_name, path: row.w_path });
+      }
+    }
+
+    return { threads, workspaces: [...workspaceMap.values()] };
+  }
+
   /** Update a thread's lifecycle status. Returns true if a row was changed. */
   updateStatus(id: string, status: ThreadStatus): boolean {
     const now = new Date().toISOString();

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -125,6 +125,16 @@ export class ThreadService {
     return this.threadRepo.listRecent(limit);
   }
 
+  /** Search threads across all workspaces by title, status, and provider. */
+  search(opts: {
+    query: string;
+    filters?: { status?: string[]; provider?: string[] };
+    sort?: { field: "updated_at" | "created_at" | "title"; direction: "asc" | "desc" };
+    limit?: number;
+  }) {
+    return this.threadRepo.search(opts);
+  }
+
   /**
    * Soft-delete a thread and enqueue a background cleanup job when the thread
    * has a worktree path. The cleanup job handles process termination,

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -282,6 +282,13 @@ async function dispatch(
     case "thread.markViewed":
       deps.threadService.markViewed(params.threadId);
       return;
+    case "thread.search":
+      return deps.threadService.search({
+        query: params.query,
+        filters: params.filters,
+        sort: params.sort,
+        limit: params.limit,
+      });
     case "thread.syncPrs": {
       const syncWs = deps.workspaceService.findById(params.workspaceId);
       if (!syncWs?.is_git_repo) return [];

--- a/apps/web/e2e/sidebar-search.spec.ts
+++ b/apps/web/e2e/sidebar-search.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+
+test.describe("Sidebar thread search", () => {
+  test.beforeEach(async ({ page }) => {
+    const now = new Date().toISOString();
+    await mockWebSocketServer(page, {
+      "workspace.list": [
+        {
+          id: "ws-1",
+          name: "Test Workspace",
+          path: "/test/path",
+          provider_config: {},
+          is_git_repo: true,
+          pinned: false,
+          last_opened_at: Date.now() - 3600_000,
+          sort_order: 0,
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      "thread.list": [
+        {
+          id: "thread-1",
+          workspace_id: "ws-1",
+          title: "Test Thread",
+          status: "active",
+          mode: "direct",
+          worktree_path: null,
+          branch: "main",
+          worktree_managed: false,
+          issue_number: null,
+          pr_number: null,
+          pr_status: null,
+          sdk_session_id: null,
+          created_at: now,
+          updated_at: now,
+          model: "claude-3-5-sonnet",
+          provider: "claude",
+          deleted_at: null,
+          last_context_tokens: null,
+          context_window: null,
+          reasoning_level: null,
+          interaction_mode: null,
+          permission_mode: null,
+          parent_thread_id: null,
+          forked_from_message_id: null,
+          copilot_agent: null,
+          last_compact_summary: null,
+        },
+      ],
+    });
+  });
+
+  test("search input is visible and focusable", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByTestId("sidebar-search-input");
+    await expect(searchInput).toBeVisible();
+    await searchInput.focus();
+    await expect(searchInput).toBeFocused();
+  });
+
+  test("Ctrl+Shift+F focuses search input", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByTestId("sidebar-search-input");
+    await page.keyboard.press("Control+Shift+F");
+    await expect(searchInput).toBeFocused();
+  });
+
+  test("typing in search updates input value", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByTestId("sidebar-search-input");
+    await searchInput.fill("test query");
+    await expect(searchInput).toHaveValue("test query");
+  });
+
+  test("Escape clears search query", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByTestId("sidebar-search-input");
+    await searchInput.fill("some text");
+    await expect(searchInput).toHaveValue("some text");
+    await page.keyboard.press("Escape");
+    await expect(searchInput).toHaveValue("");
+  });
+
+  test("sort control is visible beside Projects", async ({ page }) => {
+    await page.goto("/");
+    const sortButton = page.getByLabel("Sort threads");
+    await expect(sortButton).toBeVisible();
+  });
+
+  test("filter icon is visible in search bar", async ({ page }) => {
+    await page.goto("/");
+    const filterButton = page.getByLabel("Filter threads");
+    await expect(filterButton).toBeVisible();
+  });
+});

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -98,6 +98,7 @@ export const mockTransport: McodeTransport = {
   createThread: vi.fn(),
   listThreads: vi.fn().mockResolvedValue([]),
   listRecentThreads: vi.fn().mockResolvedValue([]),
+  searchThreads: vi.fn().mockResolvedValue({ threads: [], workspaces: [] }),
   deleteThread: vi.fn().mockResolvedValue(true),
   listBranches: vi.fn().mockResolvedValue([]),
   getCurrentBranch: vi.fn().mockResolvedValue("main"),

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -49,6 +49,27 @@ vi.mock("@/stores/threadStore", () => ({
   ),
 }));
 
+vi.mock("@/stores/sidebarSearchStore", () => ({
+  useSidebarSearchStore: Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) =>
+      selector({
+        query: "",
+        filters: { status: [], provider: [] },
+        sortField: "updated_at",
+        sortDirection: "desc",
+        isSearching: false,
+        serverResults: [],
+        serverWorkspaces: [],
+        expandedSnapshot: null,
+        setExpandedSnapshot: vi.fn(),
+        setQuery: vi.fn(),
+        clearAll: vi.fn(),
+      })
+    ),
+    { setState: vi.fn(), getState: vi.fn() },
+  ),
+}));
+
 // The virtualizer requires a real scrollable element with measured sizes.
 // In jsdom none of that works, so we replace it with a pass-through that
 // renders every item directly.
@@ -204,8 +225,10 @@ describe("ProjectTree thread interactions", () => {
     // Navigation count stays at 1 — the second click must NOT trigger another navigate.
     expect(setActiveThread).toHaveBeenCalledTimes(1);
 
-    // Inline edit input must be visible.
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    // Inline edit input must be visible (search input is also a textbox, so check for 2).
+    const textboxes = screen.getAllByRole("textbox");
+    const renameInput = textboxes.find((el) => !el.hasAttribute("data-testid") || el.getAttribute("data-testid") !== "sidebar-search-input");
+    expect(renameInput).toBeDefined();
   });
 
   it("two clicks beyond the double-click window navigate twice (no rename)", () => {
@@ -221,8 +244,9 @@ describe("ProjectTree thread interactions", () => {
     fireEvent.click(threadButton);
 
     expect(setActiveThread).toHaveBeenCalledTimes(2);
-    // No textbox — rename should not have been triggered.
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    // No rename textbox — only the search input should be present.
+    const textboxes = screen.getAllByRole("textbox");
+    expect(textboxes.every((el) => el.getAttribute("data-testid") === "sidebar-search-input")).toBe(true);
   });
 
   it("clicking while editing does not navigate or re-enter edit", () => {
@@ -239,8 +263,10 @@ describe("ProjectTree thread interactions", () => {
     act(() => { vi.advanceTimersByTime(100); });
     fireEvent.click(threadButton);
 
-    // Confirm we're editing.
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    // Confirm we're editing (rename input + search input = 2 textboxes).
+    const textboxes = screen.getAllByRole("textbox");
+    const renameInputs = textboxes.filter((el) => el.getAttribute("data-testid") !== "sidebar-search-input");
+    expect(renameInputs).toHaveLength(1);
     expect(setActiveThread).toHaveBeenCalledTimes(1);
 
     // Click the outer row button again while editing.
@@ -248,8 +274,10 @@ describe("ProjectTree thread interactions", () => {
 
     // No additional navigation.
     expect(setActiveThread).toHaveBeenCalledTimes(1);
-    // Still one textbox (not duplicated).
-    expect(screen.getAllByRole("textbox")).toHaveLength(1);
+    // Still one rename textbox (not duplicated). Search input is separate.
+    const afterTextboxes = screen.getAllByRole("textbox");
+    const afterRenameInputs = afterTextboxes.filter((el) => el.getAttribute("data-testid") !== "sidebar-search-input");
+    expect(afterRenameInputs).toHaveLength(1);
   });
 
   it("pressing Enter on the thread row navigates immediately", () => {

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -189,15 +189,21 @@ function filterAndSortThreads(
   // Status filter
   if (filters.status.length > 0) {
     result = result.filter((t) => {
+      // "action_required" is a client-side pseudo-status
       if (filters.status.includes("action_required") && pendingPermissionThreadIds.has(t.id)) {
         return true;
       }
-      if (filters.status.includes("active") && runningThreadIds.has(t.id)) {
+      // "active" means currently running
+      if (filters.status.includes("active") && t.status === "active" && runningThreadIds.has(t.id)) {
         return true;
       }
+      // "paused" means status is active but NOT running
       if (filters.status.includes("paused") && t.status === "active" && !runningThreadIds.has(t.id)) {
         return true;
       }
+      // For DB-level statuses (completed, errored, interrupted), match directly
+      // but exclude "active" from fallthrough since it's handled above
+      if (t.status === "active") return false;
       return filters.status.includes(t.status);
     });
   }
@@ -271,6 +277,25 @@ export function ProjectTree() {
   const expandedSnapshot = useSidebarSearchStore((s) => s.expandedSnapshot);
   const isSearchActive = searchQuery.trim().length > 0 || searchFilters.status.length > 0 || searchFilters.provider.length > 0;
 
+  const availableProviders = useMemo(
+    () => [...new Set(threads.map((t) => t.provider))].sort(),
+    [threads],
+  );
+
+  const filteredThreadsByWorkspace = useMemo(() => {
+    const map = new Map<string, WorkspaceThread[]>();
+    for (const ws of workspaces) {
+      const wsThreads = threads.filter((t) => t.workspace_id === ws.id);
+      const filtered = isSearchActive
+        ? filterAndSortThreads(wsThreads, searchQuery, searchFilters, sortField, sortDirection, runningThreadIds, pendingPermissionThreadIds)
+        : sortField !== "updated_at" || sortDirection !== "desc"
+          ? filterAndSortThreads(wsThreads, "", { status: [], provider: [] }, sortField, sortDirection, runningThreadIds, pendingPermissionThreadIds)
+          : wsThreads;
+      map.set(ws.id, filtered);
+    }
+    return map;
+  }, [workspaces, threads, isSearchActive, searchQuery, searchFilters, sortField, sortDirection, runningThreadIds, pendingPermissionThreadIds]);
+
   const [expanded, setExpanded] = useState<Record<string, boolean>>(getExpandedState);
   const [threadListExpanded, setThreadListExpandedState] = useState<Record<string, boolean>>(getThreadListExpanded);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
@@ -330,31 +355,32 @@ export function ProjectTree() {
     const workspaceIdsWithMatches = new Set<string>();
 
     for (const ws of workspaces) {
-      const wsThreads = threads.filter((t) => t.workspace_id === ws.id);
-      const filtered = filterAndSortThreads(
-        wsThreads, searchQuery, searchFilters, sortField, sortDirection,
-        runningThreadIds, pendingPermissionThreadIds,
-      );
-      if (filtered.length > 0) workspaceIdsWithMatches.add(ws.id);
+      const wsThreads = filteredThreadsByWorkspace.get(ws.id) ?? [];
+      if (wsThreads.length > 0) workspaceIdsWithMatches.add(ws.id);
     }
 
     for (const t of serverResults) {
       workspaceIdsWithMatches.add(t.workspace_id);
     }
 
-    setExpanded((prev) => {
-      const next = { ...prev };
-      for (const ws of workspaces) {
-        if (workspaceIdsWithMatches.has(ws.id)) {
-          next[ws.id] = true;
-          if (!prev[ws.id]) loadThreads(ws.id);
-        } else {
-          next[ws.id] = false;
-        }
+    const next: Record<string, boolean> = {};
+    const workspacesToLoad: string[] = [];
+
+    for (const ws of workspaces) {
+      if (workspaceIdsWithMatches.has(ws.id)) {
+        next[ws.id] = true;
+        if (!expanded[ws.id]) workspacesToLoad.push(ws.id);
+      } else {
+        next[ws.id] = false;
       }
-      return next;
-    });
-  }, [isSearchActive, searchQuery, searchFilters, serverResults, workspaces, threads, sortField, sortDirection, runningThreadIds, pendingPermissionThreadIds, loadThreads]);
+    }
+
+    setExpanded(next);
+
+    for (const wsId of workspacesToLoad) {
+      loadThreads(wsId);
+    }
+  }, [isSearchActive, filteredThreadsByWorkspace, serverResults, workspaces, expanded, loadThreads]);
 
   const toggleThreadList = useCallback((wsId: string) => {
     setThreadListExpandedState((prev) => ({ ...prev, [wsId]: !prev[wsId] }));
@@ -531,7 +557,7 @@ export function ProjectTree() {
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       {/* Search bar */}
-      <ThreadSearchBar providers={[...new Set(threads.map((t) => t.provider))].sort()} />
+      <ThreadSearchBar providers={availableProviders} />
 
       <div className="flex items-center justify-between px-3 py-2 mb-0.5">
         <span className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/55">
@@ -564,19 +590,7 @@ export function ProjectTree() {
           >
             <SortableContext items={workspaceIds} strategy={verticalListSortingStrategy}>
               {workspaces.map((ws) => {
-                const wsThreads = isSearchActive
-                  ? filterAndSortThreads(
-                      threads.filter((t) => t.workspace_id === ws.id),
-                      searchQuery, searchFilters, sortField, sortDirection,
-                      runningThreadIds, pendingPermissionThreadIds,
-                    )
-                  : sortField !== "updated_at" || sortDirection !== "desc"
-                    ? filterAndSortThreads(
-                        threads.filter((t) => t.workspace_id === ws.id),
-                        "", { status: [], provider: [] }, sortField, sortDirection,
-                        runningThreadIds, pendingPermissionThreadIds,
-                      )
-                    : threads.filter((t) => t.workspace_id === ws.id);
+                const wsThreads = filteredThreadsByWorkspace.get(ws.id) ?? [];
 
                 // Hide projects with zero matches during active search
                 if (isSearchActive && wsThreads.length === 0) return null;
@@ -640,11 +654,7 @@ export function ProjectTree() {
 
           {/* No results empty state */}
           {isSearchActive && !isSearching && workspaces.every((ws) => {
-            const wsThreads = threads.filter((t) => t.workspace_id === ws.id);
-            return filterAndSortThreads(
-              wsThreads, searchQuery, searchFilters, sortField, sortDirection,
-              runningThreadIds, pendingPermissionThreadIds,
-            ).length === 0;
+            return (filteredThreadsByWorkspace.get(ws.id) ?? []).length === 0;
           }) && serverResults.length === 0 && (
             <div className="flex flex-col items-center justify-center gap-2 px-4 py-8">
               <span className="font-mono text-[28px] text-muted-foreground/15" aria-hidden>&#x2298;</span>

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -54,7 +54,6 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { ThreadSearchBar } from "./ThreadSearchBar";
-import { ThreadSortControl } from "./ThreadSortControl";
 import { useSidebarSearchStore, type ThreadSortField } from "@/stores/sidebarSearchStore";
 
 // Persist expand/collapse in localStorage
@@ -538,21 +537,18 @@ export function ProjectTree() {
         <span className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/55">
           Projects
         </span>
-        <div className="flex items-center gap-1">
-          <ThreadSortControl />
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button variant="ghost" size="icon-xs" onClick={handleOpenFolder} aria-label="Open project folder" className="text-muted-foreground/60 hover:text-foreground">
-                  <Plus size={14} />
-                </Button>
-              }
-            />
-            <TooltipContent side="right" className="text-xs">
-              Open project folder
-            </TooltipContent>
-          </Tooltip>
-        </div>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button variant="ghost" size="icon-xs" onClick={handleOpenFolder} aria-label="Open project folder" className="text-muted-foreground/60 hover:text-foreground">
+                <Plus size={14} />
+              </Button>
+            }
+          />
+          <TooltipContent side="right" className="text-xs">
+            Open project folder
+          </TooltipContent>
+        </Tooltip>
       </div>
 
       <ScrollArea className="flex-1" viewportRef={scrollViewportRef}>

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -53,6 +53,9 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { ThreadSearchBar } from "./ThreadSearchBar";
+import { ThreadSortControl } from "./ThreadSortControl";
+import { useSidebarSearchStore, type ThreadSortField } from "@/stores/sidebarSearchStore";
 
 // Persist expand/collapse in localStorage
 function getExpandedState(): Record<string, boolean> {
@@ -166,6 +169,67 @@ function buildThreadTree(threads: WorkspaceThread[]): ThreadTreeItem[] {
   return result;
 }
 
+/** Filter and sort threads based on sidebar search state. */
+function filterAndSortThreads(
+  threads: WorkspaceThread[],
+  query: string,
+  filters: { status: string[]; provider: string[] },
+  sortField: ThreadSortField,
+  sortDirection: "asc" | "desc",
+  runningThreadIds: Set<string>,
+  pendingPermissionThreadIds: Set<string>,
+): WorkspaceThread[] {
+  let result = threads;
+
+  // Text search filter
+  if (query) {
+    const q = query.toLowerCase();
+    result = result.filter((t) => t.title.toLowerCase().includes(q));
+  }
+
+  // Status filter
+  if (filters.status.length > 0) {
+    result = result.filter((t) => {
+      if (filters.status.includes("action_required") && pendingPermissionThreadIds.has(t.id)) {
+        return true;
+      }
+      if (filters.status.includes("active") && runningThreadIds.has(t.id)) {
+        return true;
+      }
+      if (filters.status.includes("paused") && t.status === "active" && !runningThreadIds.has(t.id)) {
+        return true;
+      }
+      return filters.status.includes(t.status);
+    });
+  }
+
+  // Provider filter
+  if (filters.provider.length > 0) {
+    result = result.filter((t) => filters.provider.includes(t.provider));
+  }
+
+  // Sort
+  const dir = sortDirection === "asc" ? 1 : -1;
+  result = [...result].sort((a, b) => {
+    let cmp: number;
+    switch (sortField) {
+      case "title":
+        cmp = a.title.localeCompare(b.title);
+        break;
+      case "created_at":
+        cmp = a.created_at.localeCompare(b.created_at);
+        break;
+      case "updated_at":
+      default:
+        cmp = a.updated_at.localeCompare(b.updated_at);
+        break;
+    }
+    return cmp * dir;
+  });
+
+  return result;
+}
+
 /** Sidebar tree listing workspaces and their threads with CRUD actions. */
 export function ProjectTree() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -197,6 +261,16 @@ export function ProjectTree() {
       ),
     [permissionsByThread],
   );
+
+  const searchQuery = useSidebarSearchStore((s) => s.query);
+  const searchFilters = useSidebarSearchStore((s) => s.filters);
+  const sortField = useSidebarSearchStore((s) => s.sortField);
+  const sortDirection = useSidebarSearchStore((s) => s.sortDirection);
+  const isSearching = useSidebarSearchStore((s) => s.isSearching);
+  const serverResults = useSidebarSearchStore((s) => s.serverResults);
+  const setExpandedSnapshot = useSidebarSearchStore((s) => s.setExpandedSnapshot);
+  const expandedSnapshot = useSidebarSearchStore((s) => s.expandedSnapshot);
+  const isSearchActive = searchQuery.trim().length > 0 || searchFilters.status.length > 0 || searchFilters.provider.length > 0;
 
   const [expanded, setExpanded] = useState<Record<string, boolean>>(getExpandedState);
   const [threadListExpanded, setThreadListExpandedState] = useState<Record<string, boolean>>(getThreadListExpanded);
@@ -239,6 +313,49 @@ export function ProjectTree() {
   useEffect(() => {
     setThreadListExpanded(threadListExpanded);
   }, [threadListExpanded]);
+
+  // Snapshot expanded state when search begins, restore when cleared
+  useEffect(() => {
+    if (isSearchActive && !expandedSnapshot) {
+      setExpandedSnapshot({ ...expanded });
+    }
+    if (!isSearchActive && expandedSnapshot) {
+      setExpanded(expandedSnapshot);
+      useSidebarSearchStore.setState({ expandedSnapshot: null });
+    }
+  }, [isSearchActive, expandedSnapshot, expanded, setExpandedSnapshot]);
+
+  // Auto-expand projects with matching threads during search
+  useEffect(() => {
+    if (!isSearchActive) return;
+    const workspaceIdsWithMatches = new Set<string>();
+
+    for (const ws of workspaces) {
+      const wsThreads = threads.filter((t) => t.workspace_id === ws.id);
+      const filtered = filterAndSortThreads(
+        wsThreads, searchQuery, searchFilters, sortField, sortDirection,
+        runningThreadIds, pendingPermissionThreadIds,
+      );
+      if (filtered.length > 0) workspaceIdsWithMatches.add(ws.id);
+    }
+
+    for (const t of serverResults) {
+      workspaceIdsWithMatches.add(t.workspace_id);
+    }
+
+    setExpanded((prev) => {
+      const next = { ...prev };
+      for (const ws of workspaces) {
+        if (workspaceIdsWithMatches.has(ws.id)) {
+          next[ws.id] = true;
+          if (!prev[ws.id]) loadThreads(ws.id);
+        } else {
+          next[ws.id] = false;
+        }
+      }
+      return next;
+    });
+  }, [isSearchActive, searchQuery, searchFilters, serverResults, workspaces, threads, sortField, sortDirection, runningThreadIds, pendingPermissionThreadIds, loadThreads]);
 
   const toggleThreadList = useCallback((wsId: string) => {
     setThreadListExpandedState((prev) => ({ ...prev, [wsId]: !prev[wsId] }));
@@ -414,22 +531,28 @@ export function ProjectTree() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      {/* Search bar */}
+      <ThreadSearchBar providers={[...new Set(threads.map((t) => t.provider))].sort()} />
+
       <div className="flex items-center justify-between px-3 py-2 mb-0.5">
         <span className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/55">
           Projects
         </span>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button variant="ghost" size="icon-xs" onClick={handleOpenFolder} aria-label="Open project folder" className="text-muted-foreground/60 hover:text-foreground">
-                <Plus size={14} />
-              </Button>
-            }
-          />
-          <TooltipContent side="right" className="text-xs">
-            Open project folder
-          </TooltipContent>
-        </Tooltip>
+        <div className="flex items-center gap-1">
+          <ThreadSortControl />
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button variant="ghost" size="icon-xs" onClick={handleOpenFolder} aria-label="Open project folder" className="text-muted-foreground/60 hover:text-foreground">
+                  <Plus size={14} />
+                </Button>
+              }
+            />
+            <TooltipContent side="right" className="text-xs">
+              Open project folder
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
 
       <ScrollArea className="flex-1" viewportRef={scrollViewportRef}>
@@ -453,7 +576,21 @@ export function ProjectTree() {
                   isExpanded={expanded[ws.id] ?? false}
                   isActive={activeWorkspaceId === ws.id}
                   activeThreadId={activeThreadId}
-                  threads={threads.filter((t) => t.workspace_id === ws.id)}
+                  threads={
+                    isSearchActive
+                      ? filterAndSortThreads(
+                          threads.filter((t) => t.workspace_id === ws.id),
+                          searchQuery, searchFilters, sortField, sortDirection,
+                          runningThreadIds, pendingPermissionThreadIds,
+                        )
+                      : sortField !== "updated_at" || sortDirection !== "desc"
+                        ? filterAndSortThreads(
+                            threads.filter((t) => t.workspace_id === ws.id),
+                            "", { status: [], provider: [] }, sortField, sortDirection,
+                            runningThreadIds, pendingPermissionThreadIds,
+                          )
+                        : threads.filter((t) => t.workspace_id === ws.id)
+                  }
                   runningThreadIds={runningThreadIds}
                   pendingPermissionThreadIds={pendingPermissionThreadIds}
                   isThreadListExpanded={threadListExpanded[ws.id] ?? false}
@@ -489,6 +626,32 @@ export function ProjectTree() {
               ))}
             </SortableContext>
           </DndContext>
+
+          {/* Loading more results from server */}
+          {isSearching && (
+            <div className="flex items-center gap-1.5 px-4 py-2">
+              <Loader2 size={10} className="animate-spin text-muted-foreground/30" />
+              <span className="font-mono text-[10px] text-muted-foreground/30">
+                loading more...
+              </span>
+            </div>
+          )}
+
+          {/* No results empty state */}
+          {isSearchActive && !isSearching && workspaces.every((ws) => {
+            const wsThreads = threads.filter((t) => t.workspace_id === ws.id);
+            return filterAndSortThreads(
+              wsThreads, searchQuery, searchFilters, sortField, sortDirection,
+              runningThreadIds, pendingPermissionThreadIds,
+            ).length === 0;
+          }) && serverResults.length === 0 && (
+            <div className="flex flex-col items-center justify-center gap-2 px-4 py-8">
+              <span className="font-mono text-[28px] text-muted-foreground/15" aria-hidden>&#x2298;</span>
+              <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">
+                No matching threads
+              </p>
+            </div>
+          )}
 
           {workspaces.length === 0 && (
             <div className="flex flex-col items-center justify-center gap-3 px-4 py-12">

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -567,7 +567,25 @@ export function ProjectTree() {
             onDragCancel={handleProjectDragCancel}
           >
             <SortableContext items={workspaceIds} strategy={verticalListSortingStrategy}>
-              {workspaces.map((ws) => (
+              {workspaces.map((ws) => {
+                const wsThreads = isSearchActive
+                  ? filterAndSortThreads(
+                      threads.filter((t) => t.workspace_id === ws.id),
+                      searchQuery, searchFilters, sortField, sortDirection,
+                      runningThreadIds, pendingPermissionThreadIds,
+                    )
+                  : sortField !== "updated_at" || sortDirection !== "desc"
+                    ? filterAndSortThreads(
+                        threads.filter((t) => t.workspace_id === ws.id),
+                        "", { status: [], provider: [] }, sortField, sortDirection,
+                        runningThreadIds, pendingPermissionThreadIds,
+                      )
+                    : threads.filter((t) => t.workspace_id === ws.id);
+
+                // Hide projects with zero matches during active search
+                if (isSearchActive && wsThreads.length === 0) return null;
+
+                return (
                 <SortableProjectShell
                   key={ws.id}
                   sortableId={ws.id}
@@ -576,21 +594,7 @@ export function ProjectTree() {
                   isExpanded={expanded[ws.id] ?? false}
                   isActive={activeWorkspaceId === ws.id}
                   activeThreadId={activeThreadId}
-                  threads={
-                    isSearchActive
-                      ? filterAndSortThreads(
-                          threads.filter((t) => t.workspace_id === ws.id),
-                          searchQuery, searchFilters, sortField, sortDirection,
-                          runningThreadIds, pendingPermissionThreadIds,
-                        )
-                      : sortField !== "updated_at" || sortDirection !== "desc"
-                        ? filterAndSortThreads(
-                            threads.filter((t) => t.workspace_id === ws.id),
-                            "", { status: [], provider: [] }, sortField, sortDirection,
-                            runningThreadIds, pendingPermissionThreadIds,
-                          )
-                        : threads.filter((t) => t.workspace_id === ws.id)
-                  }
+                  threads={wsThreads}
                   runningThreadIds={runningThreadIds}
                   pendingPermissionThreadIds={pendingPermissionThreadIds}
                   isThreadListExpanded={threadListExpanded[ws.id] ?? false}
@@ -623,7 +627,8 @@ export function ProjectTree() {
                     handleThreadContextMenu(e, thread, ws.path)
                   }
                 />
-              ))}
+                );
+              })}
             </SortableContext>
           </DndContext>
 

--- a/apps/web/src/components/sidebar/ThreadFilterDropdown.tsx
+++ b/apps/web/src/components/sidebar/ThreadFilterDropdown.tsx
@@ -24,6 +24,8 @@ function FilterCheckbox({
 }) {
   return (
     <button
+      role="checkbox"
+      aria-checked={checked}
       className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent/40"
       onClick={onChange}
     >

--- a/apps/web/src/components/sidebar/ThreadFilterDropdown.tsx
+++ b/apps/web/src/components/sidebar/ThreadFilterDropdown.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { useSidebarSearchStore } from "@/stores/sidebarSearchStore";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { ListFilter } from "lucide-react";
+
+const STATUS_OPTIONS = [
+  { value: "active", label: "Active" },
+  { value: "completed", label: "Completed" },
+  { value: "errored", label: "Errored" },
+  { value: "interrupted", label: "Interrupted" },
+  { value: "paused", label: "Paused" },
+  { value: "action_required", label: "Action required" },
+];
+
+/** Checkbox row inside the filter dropdown. */
+function FilterCheckbox({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: () => void;
+}) {
+  return (
+    <button
+      className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent/40"
+      onClick={onChange}
+    >
+      <span
+        className={`flex h-3 w-3 shrink-0 items-center justify-center rounded-sm border text-[8px] ${
+          checked
+            ? "border-primary/40 bg-primary/20 text-primary"
+            : "border-border"
+        }`}
+      >
+        {checked && "✓"}
+      </span>
+      {label}
+    </button>
+  );
+}
+
+/** Filter popover triggered from the search bar's filter icon. */
+export function ThreadFilterDropdown({ providers }: { providers: string[] }) {
+  const [open, setOpen] = useState(false);
+  const filters = useSidebarSearchStore((s) => s.filters);
+  const toggleFilter = useSidebarSearchStore((s) => s.toggleFilter);
+  const clearFilters = useSidebarSearchStore((s) => s.clearFilters);
+
+  const hasActiveFilters = filters.status.length > 0 || filters.provider.length > 0;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button
+            className={`absolute right-1.5 top-1/2 -translate-y-1/2 cursor-pointer rounded p-1 transition-colors ${
+              hasActiveFilters
+                ? "bg-primary/8 text-primary/60"
+                : "text-muted-foreground/20 hover:text-muted-foreground/40"
+            }`}
+            aria-label="Filter threads"
+          >
+            <ListFilter size={12} />
+          </button>
+        }
+      />
+      <PopoverContent
+        side="bottom"
+        align="end"
+        sideOffset={4}
+        className="w-44 rounded-md border border-border bg-popover p-1 shadow-lg"
+      >
+        <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/30">
+          Status
+        </div>
+        {STATUS_OPTIONS.map((opt) => (
+          <FilterCheckbox
+            key={opt.value}
+            label={opt.label}
+            checked={filters.status.includes(opt.value)}
+            onChange={() => toggleFilter("status", opt.value)}
+          />
+        ))}
+        {providers.length > 0 && (
+          <>
+            <div className="mx-1 my-1 h-px bg-border/50" />
+            <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/30">
+              Provider
+            </div>
+            {providers.map((p) => (
+              <FilterCheckbox
+                key={p}
+                label={p}
+                checked={filters.provider.includes(p)}
+                onChange={() => toggleFilter("provider", p)}
+              />
+            ))}
+          </>
+        )}
+        {hasActiveFilters && (
+          <>
+            <div className="mx-1 my-1 h-px bg-border/50" />
+            <button
+              className="w-full cursor-pointer rounded px-2 py-1.5 text-left font-mono text-[9px] text-muted-foreground/40 transition-colors hover:bg-accent/40 hover:text-muted-foreground"
+              onClick={() => {
+                clearFilters();
+                setOpen(false);
+              }}
+            >
+              Clear all
+            </button>
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/sidebar/ThreadSearchBar.tsx
+++ b/apps/web/src/components/sidebar/ThreadSearchBar.tsx
@@ -1,0 +1,118 @@
+import { useRef, useEffect } from "react";
+import { useSidebarSearchStore } from "@/stores/sidebarSearchStore";
+import { ThreadFilterDropdown } from "./ThreadFilterDropdown";
+import { Search, X, Loader2 } from "lucide-react";
+
+/** Dismissible filter chip. */
+function FilterChip({
+  label,
+  onRemove,
+}: {
+  label: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded border border-primary/15 bg-primary/8 px-1.5 py-px font-mono text-[9px] tracking-[0.04em] text-primary/60">
+      {label}
+      <button
+        className="cursor-pointer text-primary/30 transition-colors hover:text-primary/60"
+        onClick={onRemove}
+        aria-label={`Remove ${label} filter`}
+      >
+        <X size={8} />
+      </button>
+    </span>
+  );
+}
+
+/** Inset tray search input with filter icon and dismissible chip row. */
+export function ThreadSearchBar({ providers }: { providers: string[] }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const query = useSidebarSearchStore((s) => s.query);
+  const setQuery = useSidebarSearchStore((s) => s.setQuery);
+  const clearAll = useSidebarSearchStore((s) => s.clearAll);
+  const isSearching = useSidebarSearchStore((s) => s.isSearching);
+  const filters = useSidebarSearchStore((s) => s.filters);
+  const toggleFilter = useSidebarSearchStore((s) => s.toggleFilter);
+  const clearFilters = useSidebarSearchStore((s) => s.clearFilters);
+
+  const hasFilters = filters.status.length > 0 || filters.provider.length > 0;
+
+  // Ctrl+Shift+F / Cmd+Shift+F focuses the search input
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "F") {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      if (query) {
+        setQuery("");
+      } else {
+        inputRef.current?.blur();
+      }
+    }
+  };
+
+  return (
+    <div className="px-1.5 pb-0.5 pt-1.5">
+      <div className="relative">
+        <Search
+          size={12}
+          className={`pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 transition-colors ${
+            query ? "text-primary/35" : "text-muted-foreground/15"
+          }`}
+        />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search threads..."
+          className="w-full rounded-[5px] border-none bg-black/25 py-[5px] pl-7 pr-16 text-[11px] text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)] outline-none placeholder:text-muted-foreground/18 focus:shadow-[inset_0_1px_2px_rgba(0,0,0,0.4),0_0_0_1px_rgba(var(--color-primary)/0.12)]"
+          data-testid="sidebar-search-input"
+        />
+        {isSearching && (
+          <Loader2
+            size={10}
+            className="absolute right-8 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground/30"
+          />
+        )}
+        {query && !isSearching && (
+          <button
+            className="absolute right-8 top-1/2 -translate-y-1/2 cursor-pointer rounded p-0.5 text-muted-foreground/25 transition-colors hover:text-muted-foreground/50"
+            onClick={() => clearAll()}
+            aria-label="Clear search"
+          >
+            <X size={10} />
+          </button>
+        )}
+        <ThreadFilterDropdown providers={providers} />
+      </div>
+
+      {hasFilters && (
+        <div className="mt-1 flex flex-wrap items-center gap-1 px-0.5" data-testid="filter-chip-row">
+          {filters.status.map((s) => (
+            <FilterChip key={s} label={s} onRemove={() => toggleFilter("status", s)} />
+          ))}
+          {filters.provider.map((p) => (
+            <FilterChip key={p} label={p} onRemove={() => toggleFilter("provider", p)} />
+          ))}
+          <button
+            className="cursor-pointer font-mono text-[8px] tracking-[0.06em] text-muted-foreground/35 transition-colors hover:text-muted-foreground/60"
+            onClick={clearFilters}
+          >
+            clear
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar/ThreadSearchBar.tsx
+++ b/apps/web/src/components/sidebar/ThreadSearchBar.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect } from "react";
 import { useSidebarSearchStore } from "@/stores/sidebarSearchStore";
 import { ThreadFilterDropdown } from "./ThreadFilterDropdown";
+import { ThreadSortControl } from "./ThreadSortControl";
 import { Search, X, Loader2 } from "lucide-react";
 
 /** Dismissible filter chip. */
@@ -97,6 +98,19 @@ export function ThreadSearchBar({ providers }: { providers: string[] }) {
         <ThreadFilterDropdown providers={providers} />
       </div>
 
+      {/* Sort + filter controls row */}
+      <div className="mt-1 flex items-center justify-between px-0.5">
+        <ThreadSortControl />
+        {hasFilters && (
+          <button
+            className="cursor-pointer font-mono text-[8px] tracking-[0.06em] text-muted-foreground/35 transition-colors hover:text-muted-foreground/60"
+            onClick={clearFilters}
+          >
+            clear filters
+          </button>
+        )}
+      </div>
+
       {hasFilters && (
         <div className="mt-1 flex flex-wrap items-center gap-1 px-0.5" data-testid="filter-chip-row">
           {filters.status.map((s) => (
@@ -105,12 +119,6 @@ export function ThreadSearchBar({ providers }: { providers: string[] }) {
           {filters.provider.map((p) => (
             <FilterChip key={p} label={p} onRemove={() => toggleFilter("provider", p)} />
           ))}
-          <button
-            className="cursor-pointer font-mono text-[8px] tracking-[0.06em] text-muted-foreground/35 transition-colors hover:text-muted-foreground/60"
-            onClick={clearFilters}
-          >
-            clear
-          </button>
         </div>
       )}
     </div>

--- a/apps/web/src/components/sidebar/ThreadSortControl.tsx
+++ b/apps/web/src/components/sidebar/ThreadSortControl.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { useSidebarSearchStore, type ThreadSortField } from "@/stores/sidebarSearchStore";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Check } from "lucide-react";
+
+const SORT_OPTIONS: { field: ThreadSortField; label: string }[] = [
+  { field: "updated_at", label: "Recent activity" },
+  { field: "created_at", label: "Created date" },
+  { field: "title", label: "Name (A-Z)" },
+];
+
+const SORT_LABELS: Record<ThreadSortField, string> = {
+  updated_at: "recent",
+  created_at: "created",
+  title: "name",
+};
+
+/** Direction label shown at the bottom of the sort dropdown. */
+function directionLabel(field: ThreadSortField, dir: "asc" | "desc"): string {
+  if (field === "title") return dir === "asc" ? "↑ A → Z" : "↓ Z → A";
+  return dir === "desc" ? "↓ Newest first" : "↑ Oldest first";
+}
+
+/** Persistent sort label + dropdown for the sidebar PROJECTS header. */
+export function ThreadSortControl() {
+  const [open, setOpen] = useState(false);
+  const sortField = useSidebarSearchStore((s) => s.sortField);
+  const sortDirection = useSidebarSearchStore((s) => s.sortDirection);
+  const setSortField = useSidebarSearchStore((s) => s.setSortField);
+  const toggleSortDirection = useSidebarSearchStore((s) => s.toggleSortDirection);
+
+  const arrow = sortDirection === "asc" ? "↑" : "↓";
+  const isNonDefault = sortField !== "updated_at" || sortDirection !== "desc";
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button
+            className={`inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 font-mono text-[9px] tracking-[0.06em] transition-colors hover:bg-accent/40 ${
+              isNonDefault ? "text-primary/70" : "text-primary/40"
+            }`}
+            aria-label="Sort threads"
+          >
+            {SORT_LABELS[sortField]} {arrow}
+          </button>
+        }
+      />
+      <PopoverContent
+        side="bottom"
+        align="end"
+        sideOffset={4}
+        className="w-44 rounded-md border border-border bg-popover p-1 shadow-lg"
+      >
+        <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/30">
+          Sort threads by
+        </div>
+        {SORT_OPTIONS.map((opt) => (
+          <button
+            key={opt.field}
+            className={`flex w-full cursor-pointer items-center justify-between rounded px-2 py-1.5 text-[11px] transition-colors hover:bg-accent/40 ${
+              sortField === opt.field ? "text-primary" : "text-muted-foreground"
+            }`}
+            onClick={() => {
+              setSortField(opt.field);
+              setOpen(false);
+            }}
+          >
+            {opt.label}
+            {sortField === opt.field && <Check size={11} className="text-primary" />}
+          </button>
+        ))}
+        <div className="mx-1 my-1 h-px bg-border/50" />
+        <button
+          className="flex w-full cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-[10.5px] text-muted-foreground transition-colors hover:bg-accent/40"
+          onClick={toggleSortDirection}
+        >
+          {directionLabel(sortField, sortDirection)}
+          <span className="ml-auto font-mono text-[9px] text-muted-foreground/40">
+            click to flip
+          </span>
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/sidebar/__tests__/sidebar-search.test.tsx
+++ b/apps/web/src/components/sidebar/__tests__/sidebar-search.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useSidebarSearchStore } from "@/stores/sidebarSearchStore";
+
+beforeEach(() => {
+  useSidebarSearchStore.setState({
+    query: "",
+    isSearching: false,
+    serverResults: [],
+    serverWorkspaces: [],
+    sortField: "updated_at",
+    sortDirection: "desc",
+    filters: { status: [], provider: [] },
+    expandedSnapshot: null,
+  });
+  localStorage.clear();
+});
+
+describe("sidebarSearchStore", () => {
+  it("sets and clears query", () => {
+    useSidebarSearchStore.getState().setQuery("test");
+    expect(useSidebarSearchStore.getState().query).toBe("test");
+
+    useSidebarSearchStore.getState().clearAll();
+    expect(useSidebarSearchStore.getState().query).toBe("");
+  });
+
+  it("toggles filters on and off", () => {
+    const { toggleFilter } = useSidebarSearchStore.getState();
+    toggleFilter("status", "active");
+    expect(useSidebarSearchStore.getState().filters.status).toEqual(["active"]);
+
+    toggleFilter("status", "errored");
+    expect(useSidebarSearchStore.getState().filters.status).toEqual(["active", "errored"]);
+
+    toggleFilter("status", "active");
+    expect(useSidebarSearchStore.getState().filters.status).toEqual(["errored"]);
+  });
+
+  it("clears all filters", () => {
+    const { toggleFilter, clearFilters } = useSidebarSearchStore.getState();
+    toggleFilter("status", "active");
+    toggleFilter("provider", "claude");
+    clearFilters();
+    expect(useSidebarSearchStore.getState().filters).toEqual({ status: [], provider: [] });
+  });
+
+  it("persists sort preference to localStorage", () => {
+    useSidebarSearchStore.getState().setSortField("title");
+    useSidebarSearchStore.getState().setSortDirection("asc");
+
+    const stored = JSON.parse(localStorage.getItem("mcode-sidebar-search-prefs")!);
+    expect(stored.sortField).toBe("title");
+    expect(stored.sortDirection).toBe("asc");
+  });
+
+  it("toggles sort direction", () => {
+    expect(useSidebarSearchStore.getState().sortDirection).toBe("desc");
+    useSidebarSearchStore.getState().toggleSortDirection();
+    expect(useSidebarSearchStore.getState().sortDirection).toBe("asc");
+    useSidebarSearchStore.getState().toggleSortDirection();
+    expect(useSidebarSearchStore.getState().sortDirection).toBe("desc");
+  });
+
+  it("persists filters to localStorage", () => {
+    useSidebarSearchStore.getState().toggleFilter("status", "errored");
+    useSidebarSearchStore.getState().toggleFilter("provider", "claude");
+
+    const stored = JSON.parse(localStorage.getItem("mcode-sidebar-search-prefs")!);
+    expect(stored.filters.status).toEqual(["errored"]);
+    expect(stored.filters.provider).toEqual(["claude"]);
+  });
+
+  it("snapshots expanded state only once per search session", () => {
+    expect(useSidebarSearchStore.getState().expandedSnapshot).toBeNull();
+
+    useSidebarSearchStore.getState().setExpandedSnapshot({ ws1: true, ws2: false });
+    expect(useSidebarSearchStore.getState().expandedSnapshot).toEqual({ ws1: true, ws2: false });
+
+    // Second call should be ignored
+    useSidebarSearchStore.getState().setExpandedSnapshot({ ws1: false });
+    expect(useSidebarSearchStore.getState().expandedSnapshot).toEqual({ ws1: true, ws2: false });
+  });
+
+  it("clearAll resets query and snapshot", () => {
+    useSidebarSearchStore.getState().setQuery("test");
+    useSidebarSearchStore.getState().setExpandedSnapshot({ ws1: true });
+    useSidebarSearchStore.getState().clearAll();
+
+    expect(useSidebarSearchStore.getState().query).toBe("");
+    expect(useSidebarSearchStore.getState().expandedSnapshot).toBeNull();
+    expect(useSidebarSearchStore.getState().isSearching).toBe(false);
+  });
+});

--- a/apps/web/src/stores/sidebarSearchStore.ts
+++ b/apps/web/src/stores/sidebarSearchStore.ts
@@ -1,0 +1,179 @@
+import { create } from "zustand";
+import { getTransport } from "@/transport";
+import type { Thread } from "@/transport/types";
+
+/** Sort field for threads in the sidebar. */
+export type ThreadSortField = "updated_at" | "created_at" | "title";
+
+/** Sort direction. */
+export type SortDirection = "asc" | "desc";
+
+/** Active filter state. */
+export interface ThreadFilters {
+  status: string[];
+  provider: string[];
+}
+
+/** Persisted preferences restored from localStorage. */
+interface PersistedPrefs {
+  sortField: ThreadSortField;
+  sortDirection: SortDirection;
+  filters: ThreadFilters;
+}
+
+const STORAGE_KEY = "mcode-sidebar-search-prefs";
+
+function loadPrefs(): PersistedPrefs {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { sortField: "updated_at", sortDirection: "desc", filters: { status: [], provider: [] } };
+    return JSON.parse(raw);
+  } catch {
+    return { sortField: "updated_at", sortDirection: "desc", filters: { status: [], provider: [] } };
+  }
+}
+
+function savePrefs(prefs: PersistedPrefs) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+}
+
+interface SidebarSearchState {
+  /** Current search query text. */
+  query: string;
+  /** Whether a server-side search is in flight. */
+  isSearching: boolean;
+  /** Threads returned from the server search (from unloaded workspaces). */
+  serverResults: Thread[];
+  /** Workspace context for server results (id, name, path). */
+  serverWorkspaces: { id: string; name: string; path: string }[];
+  /** Active sort field. */
+  sortField: ThreadSortField;
+  /** Active sort direction. */
+  sortDirection: SortDirection;
+  /** Active filters. */
+  filters: ThreadFilters;
+  /** Snapshot of expanded state before search began (for restoring on clear). */
+  expandedSnapshot: Record<string, boolean> | null;
+
+  setQuery: (query: string) => void;
+  setSortField: (field: ThreadSortField) => void;
+  setSortDirection: (dir: SortDirection) => void;
+  toggleSortDirection: () => void;
+  toggleFilter: (category: "status" | "provider", value: string) => void;
+  clearFilters: () => void;
+  clearAll: () => void;
+  setExpandedSnapshot: (snapshot: Record<string, boolean>) => void;
+  /** Debounced server search. Call after query/filter changes. */
+  executeServerSearch: () => Promise<void>;
+}
+
+/** Sidebar search, filter, and sort state. */
+export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
+  const prefs = loadPrefs();
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    query: "",
+    isSearching: false,
+    serverResults: [],
+    serverWorkspaces: [],
+    sortField: prefs.sortField,
+    sortDirection: prefs.sortDirection,
+    filters: prefs.filters,
+    expandedSnapshot: null,
+
+    setQuery: (query) => {
+      set({ query });
+      if (debounceTimer) clearTimeout(debounceTimer);
+      if (!query.trim()) {
+        set({ serverResults: [], serverWorkspaces: [], isSearching: false });
+        return;
+      }
+      set({ isSearching: true });
+      debounceTimer = setTimeout(() => {
+        get().executeServerSearch();
+      }, 250);
+    },
+
+    setSortField: (field) => {
+      set({ sortField: field });
+      const { sortDirection, filters } = get();
+      savePrefs({ sortField: field, sortDirection, filters });
+    },
+
+    setSortDirection: (dir) => {
+      set({ sortDirection: dir });
+      const { sortField, filters } = get();
+      savePrefs({ sortField, sortDirection: dir, filters });
+    },
+
+    toggleSortDirection: () => {
+      const dir = get().sortDirection === "asc" ? "desc" : "asc";
+      get().setSortDirection(dir);
+    },
+
+    toggleFilter: (category, value) => {
+      const filters = { ...get().filters };
+      const arr = [...filters[category]];
+      const idx = arr.indexOf(value);
+      if (idx >= 0) arr.splice(idx, 1);
+      else arr.push(value);
+      filters[category] = arr;
+      set({ filters });
+      const { sortField, sortDirection } = get();
+      savePrefs({ sortField, sortDirection, filters });
+    },
+
+    clearFilters: () => {
+      const filters = { status: [], provider: [] };
+      set({ filters });
+      const { sortField, sortDirection } = get();
+      savePrefs({ sortField, sortDirection, filters });
+    },
+
+    clearAll: () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      set({
+        query: "",
+        serverResults: [],
+        serverWorkspaces: [],
+        isSearching: false,
+        expandedSnapshot: null,
+      });
+    },
+
+    setExpandedSnapshot: (snapshot) => {
+      if (!get().expandedSnapshot) {
+        set({ expandedSnapshot: snapshot });
+      }
+    },
+
+    executeServerSearch: async () => {
+      const { query, filters, sortField, sortDirection } = get();
+      if (!query.trim()) {
+        set({ isSearching: false, serverResults: [], serverWorkspaces: [] });
+        return;
+      }
+      try {
+        const result = await getTransport().searchThreads({
+          query: query.trim(),
+          filters: {
+            status: filters.status.length > 0 ? filters.status : undefined,
+            provider: filters.provider.length > 0 ? filters.provider : undefined,
+          },
+          sort: { field: sortField, direction: sortDirection },
+        });
+        // Only apply results if query hasn't changed during the request
+        if (get().query.trim() === query.trim()) {
+          set({
+            serverResults: result.threads,
+            serverWorkspaces: result.workspaces,
+            isSearching: false,
+          });
+        }
+      } catch {
+        set({ isSearching: false });
+      }
+    },
+  };
+});

--- a/apps/web/src/stores/sidebarSearchStore.ts
+++ b/apps/web/src/stores/sidebarSearchStore.ts
@@ -24,12 +24,23 @@ interface PersistedPrefs {
 const STORAGE_KEY = "mcode-sidebar-search-prefs";
 
 function loadPrefs(): PersistedPrefs {
+  const defaults: PersistedPrefs = { sortField: "updated_at", sortDirection: "desc", filters: { status: [], provider: [] } };
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return { sortField: "updated_at", sortDirection: "desc", filters: { status: [], provider: [] } };
-    return JSON.parse(raw);
+    if (!raw) return defaults;
+    const parsed = JSON.parse(raw);
+    const validFields = new Set<string>(["updated_at", "created_at", "title"]);
+    const validDirs = new Set<string>(["asc", "desc"]);
+    return {
+      sortField: validFields.has(parsed?.sortField) ? parsed.sortField : "updated_at",
+      sortDirection: validDirs.has(parsed?.sortDirection) ? parsed.sortDirection : "desc",
+      filters: {
+        status: Array.isArray(parsed?.filters?.status) ? parsed.filters.status : [],
+        provider: Array.isArray(parsed?.filters?.provider) ? parsed.filters.provider : [],
+      },
+    };
   } catch {
-    return { sortField: "updated_at", sortDirection: "desc", filters: { status: [], provider: [] } };
+    return defaults;
   }
 }
 
@@ -89,7 +100,6 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
         set({ serverResults: [], serverWorkspaces: [], isSearching: false });
         return;
       }
-      set({ isSearching: true });
       debounceTimer = setTimeout(() => {
         get().executeServerSearch();
       }, 250);
@@ -99,12 +109,20 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
       set({ sortField: field });
       const { sortDirection, filters } = get();
       savePrefs({ sortField: field, sortDirection, filters });
+      if (get().query.trim()) {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        get().executeServerSearch();
+      }
     },
 
     setSortDirection: (dir) => {
       set({ sortDirection: dir });
       const { sortField, filters } = get();
       savePrefs({ sortField, sortDirection: dir, filters });
+      if (get().query.trim()) {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        get().executeServerSearch();
+      }
     },
 
     toggleSortDirection: () => {
@@ -122,6 +140,10 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
       set({ filters });
       const { sortField, sortDirection } = get();
       savePrefs({ sortField, sortDirection, filters });
+      if (get().query.trim()) {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        get().executeServerSearch();
+      }
     },
 
     clearFilters: () => {
@@ -129,17 +151,25 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
       set({ filters });
       const { sortField, sortDirection } = get();
       savePrefs({ sortField, sortDirection, filters });
+      if (get().query.trim()) {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        get().executeServerSearch();
+      }
     },
 
     clearAll: () => {
       if (debounceTimer) clearTimeout(debounceTimer);
+      const filters = { status: [], provider: [] };
       set({
         query: "",
+        filters,
         serverResults: [],
         serverWorkspaces: [],
         isSearching: false,
         expandedSnapshot: null,
       });
+      const { sortField, sortDirection } = get();
+      savePrefs({ sortField, sortDirection, filters });
     },
 
     setExpandedSnapshot: (snapshot) => {
@@ -154,17 +184,21 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
         set({ isSearching: false, serverResults: [], serverWorkspaces: [] });
         return;
       }
+      set({ isSearching: true });
+      const requestFilters = JSON.stringify(filters);
+      // Strip pseudo-statuses that don't exist in the DB
+      const serverStatuses = filters.status.filter((s) => s !== "action_required");
       try {
         const result = await getTransport().searchThreads({
           query: query.trim(),
           filters: {
-            status: filters.status.length > 0 ? filters.status : undefined,
+            status: serverStatuses.length > 0 ? serverStatuses : undefined,
             provider: filters.provider.length > 0 ? filters.provider : undefined,
           },
           sort: { field: sortField, direction: sortDirection },
         });
-        // Only apply results if query hasn't changed during the request
-        if (get().query.trim() === query.trim()) {
+        // Only apply results if query and filters haven't changed during the request
+        if (get().query.trim() === query.trim() && JSON.stringify(get().filters) === requestFilters) {
           set({
             serverResults: result.threads,
             serverWorkspaces: result.workspaces,

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -109,6 +109,13 @@ export interface McodeTransport {
   listThreads(workspaceId: string): Promise<Thread[]>;
   /** List the most recently active threads across all workspaces, joined with workspace name + path. */
   listRecentThreads(limit?: number): Promise<RecentThread[]>;
+  /** Search threads across all workspaces by title, with optional status/provider filters. */
+  searchThreads(opts: {
+    query: string;
+    filters?: { status?: string[]; provider?: string[] };
+    sort?: { field: "updated_at" | "created_at" | "title"; direction: "asc" | "desc" };
+    limit?: number;
+  }): Promise<{ threads: Thread[]; workspaces: { id: string; name: string; path: string }[] }>;
   deleteThread(threadId: string, cleanupWorktree: boolean): Promise<boolean>;
 
   // Git branch commands

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -454,6 +454,16 @@ export function createWsTransport(
     listThreads: (workspaceId) => rpc<Thread[]>("thread.list", { workspaceId }),
     listRecentThreads: (limit) =>
       rpc<import("./types").RecentThread[]>("thread.recent", limit !== undefined ? { limit } : {}),
+    searchThreads: (opts) =>
+      rpc<{ threads: Thread[]; workspaces: { id: string; name: string; path: string }[] }>(
+        "thread.search",
+        {
+          query: opts.query,
+          filters: opts.filters,
+          sort: opts.sort,
+          limit: opts.limit,
+        },
+      ),
     deleteThread: (threadId, cleanupWorktree) =>
       rpc<boolean>("thread.delete", { threadId, cleanupWorktree }),
     updateThreadTitle: (threadId, title) =>

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -212,10 +212,10 @@ export const WS_METHODS = lazySchema(() => ({
   /** Search threads across all workspaces by title substring, with optional status/provider filters and sort order. */
   "thread.search": {
     params: z.object({
-      query: z.string(),
+      query: z.string().max(500),
       filters: z.object({
-        status: z.array(z.string()).optional(),
-        provider: z.array(z.string()).optional(),
+        status: z.array(z.string()).max(20).optional(),
+        provider: z.array(z.string()).max(20).optional(),
       }).optional(),
       sort: z.object({
         field: z.enum(["updated_at", "created_at", "title"]),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -209,6 +209,29 @@ export const WS_METHODS = lazySchema(() => ({
       prStatus: z.string().nullable(),
     })),
   },
+  /** Search threads across all workspaces by title substring, with optional status/provider filters and sort order. */
+  "thread.search": {
+    params: z.object({
+      query: z.string(),
+      filters: z.object({
+        status: z.array(z.string()).optional(),
+        provider: z.array(z.string()).optional(),
+      }).optional(),
+      sort: z.object({
+        field: z.enum(["updated_at", "created_at", "title"]),
+        direction: z.enum(["asc", "desc"]),
+      }).optional(),
+      limit: z.number().int().positive().max(200).optional(),
+    }),
+    result: z.object({
+      threads: z.array(ThreadSchema()),
+      workspaces: z.array(z.object({
+        id: z.string(),
+        name: z.string(),
+        path: z.string(),
+      })),
+    }),
+  },
   "git.listBranches": {
     params: z.object({ workspaceId: z.string() }),
     result: z.array(GitBranchSchema),


### PR DESCRIPTION
## What
Add search, filter, and sort capabilities to the sidebar thread list so developers can quickly find threads across all projects without scrolling.

## Why
As thread and workspace counts grow, the sidebar becomes hard to navigate. Users need to scroll through long lists with no way to search by title, filter by status/provider, or reorder by different criteria.

## Key Changes
- **Search**: Inset tray search input above PROJECTS heading with hybrid two-phase search (instant client-side + 250ms debounced server-side SQLite query). Cross-project results auto-expand matching workspaces
- **Sort**: Persistent mono label + dropdown (recent activity, created date, name A-Z) with direction toggle. Persists to localStorage
- **Filter**: Funnel icon in search tray opens a dropdown with status checkboxes (active, completed, errored, interrupted, paused, action required) and dynamic provider checkboxes. Active filters show as dismissible chips
- **Server**: New `thread.search` RPC method with parameterized LIKE query, status/provider IN-clause filters, and configurable sort
- **Keyboard**: Ctrl+Shift+F focuses the search input, Escape clears
- **Persistence**: Sort preference and filters persist across sessions; search query clears on restart

Closes #352

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->