### PR TITLE
fix: improve search box visibility and fix filter render loop

### DIFF
--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -302,6 +302,9 @@ export function ProjectTree() {
   }, [workspaces, threads, isSearchActive, searchQuery, searchFilters, sortField, sortDirection, runningThreadIds, pendingPermissionThreadIds]);
 
   const [expanded, setExpanded] = useState<Record<string, boolean>>(getExpandedState);
+  /** Ref mirror of `expanded` so effects can read current state without re-triggering. */
+  const expandedRef = useRef(expanded);
+  expandedRef.current = expanded;
   const [threadListExpanded, setThreadListExpandedState] = useState<Record<string, boolean>>(getThreadListExpanded);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [inlineEdit, setInlineEdit] = useState<InlineEditState | null>(null);
@@ -346,13 +349,14 @@ export function ProjectTree() {
   // Snapshot expanded state when search begins, restore when cleared
   useEffect(() => {
     if (isSearchActive && !expandedSnapshot) {
-      setExpandedSnapshot({ ...expanded });
+      setExpandedSnapshot({ ...expandedRef.current });
     }
     if (!isSearchActive && expandedSnapshot) {
       setExpanded(expandedSnapshot);
       useSidebarSearchStore.setState({ expandedSnapshot: null });
     }
-  }, [isSearchActive, expandedSnapshot, expanded, setExpandedSnapshot]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- expandedRef avoids infinite loop
+  }, [isSearchActive, expandedSnapshot, setExpandedSnapshot]);
 
   // Auto-expand projects with matching threads during search
   useEffect(() => {
@@ -368,24 +372,32 @@ export function ProjectTree() {
       workspaceIdsWithMatches.add(t.workspace_id);
     }
 
+    const prev = expandedRef.current;
     const next: Record<string, boolean> = {};
     const workspacesToLoad: string[] = [];
 
     for (const ws of workspaces) {
       if (workspaceIdsWithMatches.has(ws.id)) {
         next[ws.id] = true;
-        if (!expanded[ws.id]) workspacesToLoad.push(ws.id);
+        if (!prev[ws.id]) workspacesToLoad.push(ws.id);
       } else {
         next[ws.id] = false;
       }
     }
 
-    setExpanded(next);
+    // Only update state if expanded values actually changed (prevents infinite loop)
+    const changed = workspaces.some(
+      (ws) => (prev[ws.id] ?? false) !== (next[ws.id] ?? false),
+    );
+    if (changed) {
+      setExpanded(next);
+    }
 
     for (const wsId of workspacesToLoad) {
       loadThreads(wsId);
     }
-  }, [isSearchActive, filteredThreadsByWorkspace, serverResults, workspaces, expanded, loadThreads]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- expandedRef avoids infinite loop
+  }, [isSearchActive, filteredThreadsByWorkspace, serverResults, workspaces, loadThreads]);
 
   const toggleThreadList = useCallback((wsId: string) => {
     setThreadListExpandedState((prev) => ({ ...prev, [wsId]: !prev[wsId] }));

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -355,7 +355,6 @@ export function ProjectTree() {
       setExpanded(expandedSnapshot);
       useSidebarSearchStore.setState({ expandedSnapshot: null });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- expandedRef avoids infinite loop
   }, [isSearchActive, expandedSnapshot, setExpandedSnapshot]);
 
   // Auto-expand projects with matching threads during search
@@ -396,7 +395,6 @@ export function ProjectTree() {
     for (const wsId of workspacesToLoad) {
       loadThreads(wsId);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- expandedRef avoids infinite loop
   }, [isSearchActive, filteredThreadsByWorkspace, serverResults, workspaces, loadThreads]);
 
   const toggleThreadList = useCallback((wsId: string) => {

--- a/apps/web/src/components/sidebar/ThreadFilterDropdown.tsx
+++ b/apps/web/src/components/sidebar/ThreadFilterDropdown.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useSidebarSearchStore } from "@/stores/sidebarSearchStore";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
-import { ListFilter } from "lucide-react";
+import { Check, ListFilter } from "lucide-react";
 
 const STATUS_OPTIONS = [
   { value: "active", label: "Active" },
@@ -26,7 +26,7 @@ function FilterCheckbox({
     <button
       role="checkbox"
       aria-checked={checked}
-      className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent/40"
+      className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent/40 focus-visible:ring-1 focus-visible:ring-primary/40"
       onClick={onChange}
     >
       <span
@@ -36,7 +36,7 @@ function FilterCheckbox({
             : "border-border"
         }`}
       >
-        {checked && "✓"}
+        {checked && <Check size={8} strokeWidth={3} />}
       </span>
       {label}
     </button>
@@ -57,10 +57,10 @@ export function ThreadFilterDropdown({ providers }: { providers: string[] }) {
       <PopoverTrigger
         render={
           <button
-            className={`absolute right-1.5 top-1/2 -translate-y-1/2 cursor-pointer rounded p-1 transition-colors ${
+            className={`absolute right-1.5 top-1/2 -translate-y-1/2 cursor-pointer rounded p-1 transition-colors focus-visible:ring-1 focus-visible:ring-primary/40 ${
               hasActiveFilters
                 ? "bg-primary/8 text-primary/60"
-                : "text-muted-foreground/20 hover:text-muted-foreground/40"
+                : "text-muted-foreground/40 hover:text-muted-foreground/55"
             }`}
             aria-label="Filter threads"
           >
@@ -74,7 +74,7 @@ export function ThreadFilterDropdown({ providers }: { providers: string[] }) {
         sideOffset={4}
         className="w-44 rounded-md border border-border bg-popover p-1 shadow-lg"
       >
-        <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/30">
+        <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/50">
           Status
         </div>
         {STATUS_OPTIONS.map((opt) => (
@@ -88,7 +88,7 @@ export function ThreadFilterDropdown({ providers }: { providers: string[] }) {
         {providers.length > 0 && (
           <>
             <div className="mx-1 my-1 h-px bg-border/50" />
-            <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/30">
+            <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/50">
               Provider
             </div>
             {providers.map((p) => (
@@ -105,7 +105,7 @@ export function ThreadFilterDropdown({ providers }: { providers: string[] }) {
           <>
             <div className="mx-1 my-1 h-px bg-border/50" />
             <button
-              className="w-full cursor-pointer rounded px-2 py-1.5 text-left font-mono text-[9px] text-muted-foreground/40 transition-colors hover:bg-accent/40 hover:text-muted-foreground"
+              className="w-full cursor-pointer rounded px-2 py-1.5 text-left font-mono text-[9px] text-muted-foreground/40 transition-colors hover:bg-accent/40 hover:text-muted-foreground focus-visible:ring-1 focus-visible:ring-primary/40"
               onClick={() => {
                 clearFilters();
                 setOpen(false);

--- a/apps/web/src/components/sidebar/ThreadSearchBar.tsx
+++ b/apps/web/src/components/sidebar/ThreadSearchBar.tsx
@@ -78,7 +78,7 @@ export function ThreadSearchBar({ providers }: { providers: string[] }) {
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Search threads..."
-          className="w-full rounded-[5px] border border-sidebar-border/40 bg-white/[0.06] py-[5px] pl-7 pr-16 text-[11px] text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.2)] outline-none transition-[box-shadow,border-color] duration-150 ease-out placeholder:text-muted-foreground/40 focus:border-primary/30 focus:shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),0_0_0_1px_rgba(var(--color-primary)/0.35)]"
+          className="w-full rounded-[5px] border border-sidebar-border/40 bg-white/[0.06] py-[5px] pl-7 pr-16 text-[11px] text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.2)] outline-none transition-[box-shadow,border-color] duration-150 ease-out placeholder:text-muted-foreground/40 focus-visible:border-primary/30 focus-visible:shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)] focus-visible:ring-1 focus-visible:ring-primary/35"
           data-testid="sidebar-search-input"
         />
         {isSearching && (
@@ -100,7 +100,7 @@ export function ThreadSearchBar({ providers }: { providers: string[] }) {
       </div>
 
       {searchError && (
-        <div className="mt-1 px-0.5 text-[9px] text-destructive/60">
+        <div role="status" aria-live="polite" className="mt-1 px-0.5 text-[9px] text-destructive/60">
           Search unavailable
         </div>
       )}

--- a/apps/web/src/components/sidebar/ThreadSearchBar.tsx
+++ b/apps/web/src/components/sidebar/ThreadSearchBar.tsx
@@ -13,10 +13,10 @@ function FilterChip({
   onRemove: () => void;
 }) {
   return (
-    <span className="inline-flex items-center gap-1 rounded border border-primary/15 bg-primary/8 px-1.5 py-px font-mono text-[9px] tracking-[0.04em] text-primary/60">
+    <span className="animate-chip-enter inline-flex items-center gap-1 rounded border border-primary/25 bg-primary/8 px-1.5 py-px font-mono text-[9px] tracking-[0.04em] text-primary/60">
       {label}
       <button
-        className="cursor-pointer text-primary/30 transition-colors hover:text-primary/60"
+        className="cursor-pointer p-1 -m-0.5 text-primary/40 transition-colors hover:text-primary/60 focus-visible:ring-1 focus-visible:ring-primary/40"
         onClick={onRemove}
         aria-label={`Remove ${label} filter`}
       >
@@ -31,8 +31,9 @@ export function ThreadSearchBar({ providers }: { providers: string[] }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const query = useSidebarSearchStore((s) => s.query);
   const setQuery = useSidebarSearchStore((s) => s.setQuery);
-  const clearAll = useSidebarSearchStore((s) => s.clearAll);
+  const clearQuery = useSidebarSearchStore((s) => s.clearQuery);
   const isSearching = useSidebarSearchStore((s) => s.isSearching);
+  const searchError = useSidebarSearchStore((s) => s.searchError);
   const filters = useSidebarSearchStore((s) => s.filters);
   const toggleFilter = useSidebarSearchStore((s) => s.toggleFilter);
   const clearFilters = useSidebarSearchStore((s) => s.clearFilters);
@@ -67,7 +68,7 @@ export function ThreadSearchBar({ providers }: { providers: string[] }) {
         <Search
           size={12}
           className={`pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 transition-colors ${
-            query ? "text-primary/35" : "text-muted-foreground/15"
+            query ? "text-primary/50" : "text-muted-foreground/35"
           }`}
         />
         <input
@@ -77,19 +78,19 @@ export function ThreadSearchBar({ providers }: { providers: string[] }) {
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Search threads..."
-          className="w-full rounded-[5px] border-none bg-black/25 py-[5px] pl-7 pr-16 text-[11px] text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)] outline-none placeholder:text-muted-foreground/18 focus:shadow-[inset_0_1px_2px_rgba(0,0,0,0.4),0_0_0_1px_rgba(var(--color-primary)/0.12)]"
+          className="w-full rounded-[5px] border border-sidebar-border/40 bg-white/[0.06] py-[5px] pl-7 pr-16 text-[11px] text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.2)] outline-none transition-[box-shadow,border-color] duration-150 ease-out placeholder:text-muted-foreground/40 focus:border-primary/30 focus:shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),0_0_0_1px_rgba(var(--color-primary)/0.35)]"
           data-testid="sidebar-search-input"
         />
         {isSearching && (
           <Loader2
             size={10}
-            className="absolute right-8 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground/30"
+            className="absolute right-8 top-1/2 -translate-y-1/2 animate-spin text-muted-foreground/45 motion-reduce:animate-none"
           />
         )}
         {query && !isSearching && (
           <button
-            className="absolute right-8 top-1/2 -translate-y-1/2 cursor-pointer rounded p-0.5 text-muted-foreground/25 transition-colors hover:text-muted-foreground/50"
-            onClick={() => clearAll()}
+            className="absolute right-8 top-1/2 -translate-y-1/2 cursor-pointer rounded p-0.5 text-muted-foreground/40 transition-colors hover:text-muted-foreground/60 focus-visible:ring-1 focus-visible:ring-primary/40"
+            onClick={clearQuery}
             aria-label="Clear search"
           >
             <X size={10} />
@@ -98,12 +99,18 @@ export function ThreadSearchBar({ providers }: { providers: string[] }) {
         <ThreadFilterDropdown providers={providers} />
       </div>
 
+      {searchError && (
+        <div className="mt-1 px-0.5 text-[9px] text-destructive/60">
+          Search unavailable
+        </div>
+      )}
+
       {/* Sort + filter controls row */}
       <div className="mt-1 flex items-center justify-between px-0.5">
         <ThreadSortControl />
         {hasFilters && (
           <button
-            className="cursor-pointer font-mono text-[8px] tracking-[0.06em] text-muted-foreground/35 transition-colors hover:text-muted-foreground/60"
+            className="cursor-pointer font-mono text-[9px] tracking-[0.06em] text-muted-foreground/45 transition-colors hover:text-muted-foreground/60 focus-visible:ring-1 focus-visible:ring-primary/40"
             onClick={clearFilters}
           >
             clear filters

--- a/apps/web/src/components/sidebar/ThreadSortControl.tsx
+++ b/apps/web/src/components/sidebar/ThreadSortControl.tsx
@@ -37,8 +37,8 @@ export function ThreadSortControl() {
       <PopoverTrigger
         render={
           <button
-            className={`inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 font-mono text-[9px] tracking-[0.06em] transition-colors hover:bg-accent/40 ${
-              isNonDefault ? "text-primary/70" : "text-primary/40"
+            className={`inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 font-mono text-[9px] tracking-[0.06em] transition-colors hover:bg-accent/40 focus-visible:ring-1 focus-visible:ring-primary/40 ${
+              isNonDefault ? "text-primary/70" : "text-primary/55"
             }`}
             aria-label="Sort threads"
           >
@@ -52,13 +52,13 @@ export function ThreadSortControl() {
         sideOffset={4}
         className="w-44 rounded-md border border-border bg-popover p-1 shadow-lg"
       >
-        <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/30">
+        <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/50">
           Sort threads by
         </div>
         {SORT_OPTIONS.map((opt) => (
           <button
             key={opt.field}
-            className={`flex w-full cursor-pointer items-center justify-between rounded px-2 py-1.5 text-[11px] transition-colors hover:bg-accent/40 ${
+            className={`flex w-full cursor-pointer items-center justify-between rounded px-2 py-1.5 text-[11px] transition-colors hover:bg-accent/40 focus-visible:ring-1 focus-visible:ring-primary/40 ${
               sortField === opt.field ? "text-primary" : "text-muted-foreground"
             }`}
             onClick={() => {
@@ -72,7 +72,7 @@ export function ThreadSortControl() {
         ))}
         <div className="mx-1 my-1 h-px bg-border/50" />
         <button
-          className="flex w-full cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-[10.5px] text-muted-foreground transition-colors hover:bg-accent/40"
+          className="flex w-full cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-[10.5px] text-muted-foreground transition-colors hover:bg-accent/40 focus-visible:ring-1 focus-visible:ring-primary/40"
           onClick={toggleSortDirection}
         >
           {directionLabel(sortField, sortDirection)}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -158,6 +158,19 @@
   animation: fade-up-in 150ms ease-out;
 }
 
+@keyframes chip-enter {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.animate-chip-enter {
+  animation: chip-enter 150ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-chip-enter {
+    animation: none;
+  }
+}
+
 /* Indeterminate progress sweep used on running-CI chrome (PrSplitButton).
  * Belt-and-braces reduced-motion handling: callers gate .animate-ci-slide with
  * motion-reduce:hidden, and this rule also neutralises the animation in case

--- a/apps/web/src/stores/sidebarSearchStore.ts
+++ b/apps/web/src/stores/sidebarSearchStore.ts
@@ -170,7 +170,6 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
         serverWorkspaces: [],
         isSearching: false,
         searchError: false,
-        expandedSnapshot: null,
       });
     },
 

--- a/apps/web/src/stores/sidebarSearchStore.ts
+++ b/apps/web/src/stores/sidebarSearchStore.ts
@@ -65,6 +65,8 @@ interface SidebarSearchState {
   filters: ThreadFilters;
   /** Snapshot of expanded state before search began (for restoring on clear). */
   expandedSnapshot: Record<string, boolean> | null;
+  /** Whether the last server search failed. */
+  searchError: boolean;
 
   setQuery: (query: string) => void;
   setSortField: (field: ThreadSortField) => void;
@@ -72,6 +74,8 @@ interface SidebarSearchState {
   toggleSortDirection: () => void;
   toggleFilter: (category: "status" | "provider", value: string) => void;
   clearFilters: () => void;
+  /** Clear only the search query, preserving active filters. */
+  clearQuery: () => void;
   clearAll: () => void;
   setExpandedSnapshot: (snapshot: Record<string, boolean>) => void;
   /** Debounced server search. Call after query/filter changes. */
@@ -92,9 +96,10 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
     sortDirection: prefs.sortDirection,
     filters: prefs.filters,
     expandedSnapshot: null,
+    searchError: false,
 
     setQuery: (query) => {
-      set({ query });
+      set({ query, searchError: false });
       if (debounceTimer) clearTimeout(debounceTimer);
       if (!query.trim()) {
         set({ serverResults: [], serverWorkspaces: [], isSearching: false });
@@ -157,6 +162,18 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
       }
     },
 
+    clearQuery: () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      set({
+        query: "",
+        serverResults: [],
+        serverWorkspaces: [],
+        isSearching: false,
+        searchError: false,
+        expandedSnapshot: null,
+      });
+    },
+
     clearAll: () => {
       if (debounceTimer) clearTimeout(debounceTimer);
       const filters = { status: [], provider: [] };
@@ -166,6 +183,7 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
         serverResults: [],
         serverWorkspaces: [],
         isSearching: false,
+        searchError: false,
         expandedSnapshot: null,
       });
       const { sortField, sortDirection } = get();
@@ -203,10 +221,11 @@ export const useSidebarSearchStore = create<SidebarSearchState>((set, get) => {
             serverResults: result.threads,
             serverWorkspaces: result.workspaces,
             isSearching: false,
+            searchError: false,
           });
         }
       } catch {
-        set({ isSearching: false });
+        set({ isSearching: false, searchError: true });
       }
     },
   };


### PR DESCRIPTION
## What

Raise the sidebar search bar from near-invisible (12-20% opacity) to confidently visible contrast levels, and fix a latent infinite render loop that crashed the app when filters were activated.

## Why

The search bar, filter icon, sort control, and focus ring all used sub-WCAG contrast ratios (1.2:1 - 2.0:1) against the dark sidebar. Users could not locate the search box without prior knowledge it existed. The filter UI was so invisible that a latent infinite render loop in ProjectTree's auto-expand effects went unnoticed - activating a filter crashed the page to black.

## Key changes

**Visibility (5 files, +63 -24):**
- Input surface: `bg-black/25 border-none` → `bg-white/[0.06] border border-sidebar-border/40`
- Placeholder: `muted-foreground/18` → `/40`; search icon: `/15` → `/35`
- Filter icon: `/20` → `/40`; sort control: `/40` → `/55`
- Focus ring: 12% shadow → `border-primary/30` + 35% ring with `transition-shadow`
- `focus-visible:ring` on all interactive buttons
- `motion-reduce:animate-none` on Loader2 spinner
- FilterChip X hit target padded from 8px to 24px
- Split `clearAll` into `clearQuery` (X clears text only, preserves filters)
- Add `searchError` state for silent failure feedback
- Normalize checkbox `✓` to Lucide `<Check>` icon
- Add `chip-enter` animation with reduced-motion guard

**Render loop fix (1 file, +17 -5):**
- Two `useEffect`s listed `expanded` as a dependency while calling `setExpanded()` inside the body - new object reference on every call meant React never bailed out → infinite loop → crash (no ErrorBoundary)
- Add `expandedRef` to read current state without dependency
- Add shallow-equality guard before `setExpanded` in auto-expand effect

## Test plan

- [ ] Open sidebar - search box is visibly distinct from background
- [ ] Tab through search bar, filter icon, sort control - focus rings visible
- [ ] Type a query - icon tints amber, placeholder disappears, X button visible
- [ ] Click X - clears text but preserves active filters
- [ ] Click filter icon → select "Errored" - page does NOT go black, threads filter correctly
- [ ] Refresh with a filter persisted in localStorage - page loads normally
- [ ] Verify `prefers-reduced-motion` disables spinner and chip animations
- [ ] Open filter/sort dropdowns - section labels ("STATUS", "PROVIDER") are legible

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit "clear query" action and surfaced search error state with a "Search unavailable" message.

* **Improvements**
  * Refreshed search bar, chips, and filter visuals (animated chips, icon updates, stronger focus rings).
  * Improved filter dropdown hierarchy and provider section styling.
  * Better keyboard accessibility and consistent focus styling across sidebar controls.
  * Smarter auto-expand behavior in the project tree to avoid redundant updates and reliably load threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->