### PR TITLE
fix: collapse all projects during drag to prevent render distortion

### DIFF
--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1511,7 +1511,7 @@ function SortableProjectShell(
   props: ProjectNodeProps & { sortableId: string; activeDragId: string | null },
 ) {
   const { sortableId, activeDragId, ...nodeProps } = props;
-  const collapseForDrag = activeDragId === sortableId;
+  const collapseForDrag = activeDragId !== null;
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: sortableId,
   });


### PR DESCRIPTION
## What

Fixed a visual bug where dragging a project in the sidebar caused sibling projects to expand and squash, overlapping their thread rows.

## Why

Only the dragged project collapsed its thread list during drag. Sibling projects stayed expanded while dnd-kit applied CSS `transform: translateY(...)` to displace them. Since CSS transforms don't affect DOM layout flow, `VirtualizedThreadList` computed `scrollMargin` from stale `offsetTop` values, placing absolute-positioned thread rows at wrong coordinates.

## Key changes

- Changed `collapseForDrag` in `SortableProjectShell` from `activeDragId === sortableId` to `activeDragId !== null`, collapsing all projects during any active drag operation

## Test plan

- [ ] Drag a project in the sidebar with multiple expanded projects - verify no visual overlap or squashing
- [ ] Drop the project - verify all previously expanded projects restore their thread lists
- [ ] Verify thread selection and navigation still work after drag-and-drop

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Emipre/codesmith/mcode/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop collapse behavior in the project sidebar to properly collapse thread children when any project is being dragged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->