### PR TITLE
fix(web): MessageList scroll behavior on thread open and switch

### DIFF
--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -299,6 +299,27 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     [virtualizer],
   );
 
+  /**
+   * Positions the list at the bottom synchronously and reveals the container.
+   * Used for initial layout and cache-hit thread switches so discrete scroll
+   * effects never show a smooth scroll from the wrong offset.
+   */
+  const positionAtBottom = useCallback(() => {
+    isInitialLoadRef.current = false;
+    const count = itemsLengthRef.current;
+    if (count > 0) {
+      virtualizer.scrollToIndex(count - 1, {
+        align: "end",
+        behavior: "auto",
+      });
+    }
+    requestAnimationFrame(() => {
+      const el = containerRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+      setIsPositioned(true);
+    });
+  }, [virtualizer]);
+
   // Clean up pending scroll timer on unmount
   useEffect(() => {
     return () => {
@@ -367,18 +388,23 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
     // Cache hit: keep the virtualizer's measurement cache (those rows have the
     // same item keys and dimensions — re-estimating would defeat the optimization).
-    // Skip the opacity flash; mark initial-load done so the bottom-scroll effect
-    // does not retrigger. Only enter this branch when there's a remembered
-    // scroll position; otherwise this also fires when `loading` flips
-    // true→false after a fresh fetch and would prematurely clear
-    // `isInitialLoadRef`, blocking the bottom-positioning effect.
+    // With a remembered offset, restore it in a later effect. On thread switch
+    // with no memory, jump to the bottom synchronously so the discrete-messages
+    // effect does not run a visible smooth scroll from a stale offset. This block
+    // still runs when `loading` flips true→false on the same thread; the
+    // `isThreadSwitch` guard on the bottom branch avoids clobbering initial load.
     const rememberedScrollTop = recallScrollTop(activeThreadId);
     if (rememberedScrollTop != null) {
       isInitialLoadRef.current = false;
       setIsPositioned(true);
       pendingScrollRestoreRef.current = rememberedScrollTop;
+    } else if (isThreadSwitch) {
+      // Cache hit on switch with no saved offset: avoid leaving stale scroll and
+      // throttled smooth scroll from the discrete-messages effect.
+      pendingScrollRestoreRef.current = null;
+      positionAtBottom();
     }
-  }, [activeThreadId, loading, virtualizer]);
+  }, [activeThreadId, loading, virtualizer, positionAtBottom]);
 
   // Stabilize scroll position when older messages are prepended.
   // Detects real prepends by comparing the first message ID before and after
@@ -427,21 +453,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (items.length === 0) return;
     if (loading) return; // don't position until persisted messages are loaded
 
-    isInitialLoadRef.current = false;
-
-    virtualizer.scrollToIndex(items.length - 1, {
-      align: "end",
-      behavior: "auto",
-    });
-
-    // Fallback nudge + reveal: the virtualizer may not have measured all items
-    // yet, so force scrollTop to the absolute bottom and then show the container.
-    requestAnimationFrame(() => {
-      const el = containerRef.current;
-      if (el) el.scrollTop = el.scrollHeight;
-      setIsPositioned(true);
-    });
-  }, [items.length, loading, virtualizer]);
+    positionAtBottom();
+  }, [items.length, loading, virtualizer, positionAtBottom]);
 
   // Apply the remembered scrollTop after the virtualizer has rendered the
   // restored items. useLayoutEffect runs before paint, so the user never sees

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -305,26 +305,26 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
   /**
    * Positions the list at the bottom synchronously and reveals the container.
-   * Used for initial layout and cache-hit thread switches. Skips the next
-   * passive auto-scroll effects so they do not schedule a throttled smooth scroll.
+   * Sets the scroll element's `scrollTop` directly instead of calling the
+   * virtualizer's `scrollToIndex`, avoiding TanStack Virtual's multi-frame
+   * scroll reconciliation (that loop retriggers as row heights settle and looks
+   * like motion). Skips the next passive auto-scroll effects so they do not
+   * schedule a throttled smooth scroll.
    */
   const positionAtBottom = useCallback(() => {
     skipDiscreteAutoBottomScrollRef.current = true;
     skipStreamingAutoBottomScrollRef.current = true;
     isInitialLoadRef.current = false;
-    const count = itemsLengthRef.current;
-    if (count > 0) {
-      virtualizer.scrollToIndex(count - 1, {
-        align: "end",
-        behavior: "auto",
-      });
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
     }
     requestAnimationFrame(() => {
-      const el = containerRef.current;
-      if (el) el.scrollTop = el.scrollHeight;
+      const el2 = containerRef.current;
+      if (el2) el2.scrollTop = el2.scrollHeight;
       setIsPositioned(true);
     });
-  }, [virtualizer]);
+  }, []);
 
   // Clean up pending scroll timer on unmount
   useEffect(() => {
@@ -466,7 +466,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (loading) return; // don't position until persisted messages are loaded
 
     positionAtBottom();
-  }, [items.length, loading, virtualizer, positionAtBottom]);
+  }, [items.length, loading, positionAtBottom]);
 
   // Apply the remembered scrollTop after the virtualizer has rendered the
   // restored items. useLayoutEffect runs before paint, so the user never sees

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -153,6 +153,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const suppressPassiveAutoBottomScrollRef = useRef(false);
   /** Cancels stale double-rAF clears when another navigation starts. */
   const suppressPassiveAutoBottomGenRef = useRef(0);
+  /**
+   * While true, list height growth snaps the viewport to the tail so virtual rows
+   * and async layout cannot leave the thread short of the bottom after open.
+   */
+  const pinListTailRef = useRef(false);
   /** Tracks the previous activeThreadId so we can save its scrollTop before switching. */
   const prevActiveThreadIdRef = useRef<string | null>(null);
   /** Holds the scrollTop value to restore on the next layout effect. */
@@ -215,9 +220,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     const gen = ++suppressPassiveAutoBottomGenRef.current;
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        if (suppressPassiveAutoBottomGenRef.current === gen) {
-          suppressPassiveAutoBottomScrollRef.current = false;
-        }
+        requestAnimationFrame(() => {
+          if (suppressPassiveAutoBottomGenRef.current === gen) {
+            suppressPassiveAutoBottomScrollRef.current = false;
+          }
+        });
       });
     });
   }, []);
@@ -228,6 +235,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (!el) return;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     const scrolledUp = distanceFromBottom > 200;
+    if (scrolledUp) pinListTailRef.current = false;
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
     // Clear new-content highlight once the user reaches the bottom
@@ -299,30 +307,36 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     return item.start < scrollOffset;
   };
 
-  // Throttled scroll-to-bottom using virtualizer.
-  // Uses refs to avoid stale closures: itemsLengthRef always has the
-  // current count when the timer fires, even if messages arrived after
-  // the timer was scheduled.
+  /**
+   * Programmatic scroll to the list tail. Auto-follow uses the scroll element
+   * directly (no virtualizer reconcile, no CSS smooth). The floating button
+   * passes smooth=true for intentional animation.
+   */
   const scrollToBottom = useCallback(
     (smooth: boolean) => {
       if (scrollTimerRef.current) return;
+      const delay = smooth ? 200 : 0;
       scrollTimerRef.current = setTimeout(() => {
         scrollTimerRef.current = null;
         const count = itemsLengthRef.current;
         if (count === 0) return;
-        virtualizer.scrollToIndex(count - 1, {
-          align: "end",
-          behavior: smooth ? "smooth" : "auto",
-        });
-        // Fallback nudge for items whose size is not yet measured.
-        // Only for instant scroll to avoid cancelling smooth animations.
-        if (!smooth) {
+        const el = containerRef.current;
+        if (smooth) {
+          virtualizer.scrollToIndex(count - 1, {
+            align: "end",
+            behavior: "smooth",
+          });
+          return;
+        }
+        if (el) {
+          pinListTailRef.current = true;
+          el.scrollTop = el.scrollHeight;
           requestAnimationFrame(() => {
-            const el = containerRef.current;
-            if (el) el.scrollTop = el.scrollHeight;
+            const el2 = containerRef.current;
+            if (el2) el2.scrollTop = el2.scrollHeight;
           });
         }
-      }, 200);
+      }, delay);
     },
     [virtualizer],
   );
@@ -337,6 +351,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
    */
   const positionAtBottom = useCallback(() => {
     beginSuppressPassiveAutoBottomScroll();
+    pinListTailRef.current = true;
     isInitialLoadRef.current = false;
     const el = containerRef.current;
     if (el) {
@@ -401,6 +416,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       // Reset thread-scoped refs and affordance state so the prepend-detection
       // effect, scroll-affordance UI, and turn-expand map don't carry stale
       // measurements from the previous thread into the new one.
+      pinListTailRef.current = false;
       if (scrollTimerRef.current) {
         clearTimeout(scrollTimerRef.current);
         scrollTimerRef.current = null;
@@ -511,11 +527,12 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
     const withinTail =
       target <= maxScroll && maxScroll - target <= AUTO_SCROLL_THRESHOLD;
-    if (withinTail) {
+    const snapToTail = withinTail || target > maxScroll;
+    if (snapToTail) {
+      pinListTailRef.current = true;
       el.scrollTop = el.scrollHeight;
-    } else if (target > maxScroll) {
-      el.scrollTop = maxScroll;
     } else {
+      pinListTailRef.current = false;
       el.scrollTop = target;
     }
     pendingScrollRestoreRef.current = null;
@@ -526,7 +543,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (!scrolledUp) setHasNewContent(false);
     requestAnimationFrame(() => {
       const el2 = containerRef.current;
-      if (el2 && withinTail) el2.scrollTop = el2.scrollHeight;
+      if (el2 && snapToTail) el2.scrollTop = el2.scrollHeight;
       scheduleEndSuppressPassiveAutoBottomScroll();
     });
   }, [activeThreadId, items.length, loading, beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
@@ -538,7 +555,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (isScrolledUpRef.current) {
       setHasNewContent(true);
     } else {
-      scrollToBottom(true);
+      scrollToBottom(false);
     }
   }, [activeThreadId, messages.length, toolCalls.length, isAgentRunning, scrollToBottom]);
 
@@ -589,6 +606,20 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     document.addEventListener("mouseup", handleMouseUp);
     return () => document.removeEventListener("mouseup", handleMouseUp);
   }, []);
+
+  /** While {@link pinListTailRef} is set (open or tail restore), keep the viewport on the tail as row heights stabilize. */
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+    const outer = containerRef.current;
+    const inner = outer?.firstElementChild as HTMLElement | undefined;
+    if (!outer || !inner) return;
+    const ro = new ResizeObserver(() => {
+      if (!pinListTailRef.current) return;
+      outer.scrollTop = outer.scrollHeight;
+    });
+    ro.observe(inner);
+    return () => ro.disconnect();
+  }, [activeThreadId]);
 
   return (
     <div className="relative h-full" data-testid="message-list">

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -184,6 +184,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const isScrolledUpRef = useRef(false);
   /** Controls container visibility: hidden while positioning to prevent top-to-bottom flash. */
   const [isPositioned, setIsPositioned] = useState(false);
+  /** Mirrors `isPositioned` for `handleScroll` so affordances do not run while the scroller is opacity-0. */
+  const isPositionedRef = useRef(false);
 
   const messages = useThreadStore((s) => s.messages);
   const loading = useThreadStore((s) => s.loading);
@@ -226,6 +228,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
   const toolCalls = toolCallsRaw ?? EMPTY_TOOL_CALLS;
 
+  useLayoutEffect(() => {
+    isPositionedRef.current = isPositioned;
+  }, [isPositioned]);
+
   const beginSuppressPassiveAutoBottomScroll = useCallback(() => {
     suppressPassiveAutoBottomScrollRef.current = true;
   }, []);
@@ -251,6 +257,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
   /** Track scroll-to-bottom button visibility and trigger upward pagination near the top. */
   const handleScroll = useCallback(() => {
+    if (!isPositionedRef.current) return;
     const el = containerRef.current;
     if (!el) return;
 
@@ -400,6 +407,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     isInitialLoadRef.current = false;
 
     let lastScrollHeight = -1;
+    let lastTotalSize = -1;
     let stableHeightFrames = 0;
     let frame = 0;
 
@@ -422,13 +430,15 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
 
       const h = el.scrollHeight;
+      const total = virtualizer.getTotalSize();
       frame++;
-      if (frame > TAIL_SETTLE_MIN_FRAMES && h === lastScrollHeight) {
+      if (frame > TAIL_SETTLE_MIN_FRAMES && h === lastScrollHeight && total === lastTotalSize) {
         stableHeightFrames++;
-      } else if (h !== lastScrollHeight) {
+      } else if (h !== lastScrollHeight || total !== lastTotalSize) {
         stableHeightFrames = 0;
       }
       lastScrollHeight = h;
+      lastTotalSize = total;
 
       const settled =
         stableHeightFrames >= TAIL_SETTLE_STABLE_FRAMES
@@ -517,6 +527,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       // and clear stale measurements so previous-thread heights don't bleed in.
       isInitialLoadRef.current = true;
       setIsPositioned(false);
+      setShowScrollBtn(false);
+      setHasNewContent(false);
       pendingScrollRestoreRef.current = null;
       virtualizer.measure();
       return;
@@ -759,7 +771,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       )}
 
       {/* Scroll-to-bottom floating button — pulses when new content arrives */}
-      {showScrollBtn && (
+      {showScrollBtn && isPositioned && (
         <ScrollToBottomButton
           hasNewContent={hasNewContent}
           onScrollToBottom={() => {

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -279,11 +279,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     overscan: OVERSCAN,
   });
 
-  // Don't adjust scroll when near bottom -- prevents jitter during streaming.
+  // Near the tail: allow TanStack scroll compensation when row heights update
+  // so opening or revisiting lands on the true bottom as items measure.
+  // Farther up: keep default above-viewport anchoring so history reading stays stable.
   // Assigned on the stable virtualizer instance (TanStack Virtual v3 API);
   // not available as a useVirtualizer option in the current type definitions.
   virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (
-    _item,
+    item,
     _delta,
     instance,
   ) => {
@@ -291,7 +293,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     const scrollOffset = instance.scrollOffset ?? 0;
     const remaining =
       instance.getTotalSize() - (scrollOffset + viewportHeight);
-    return remaining > AUTO_SCROLL_THRESHOLD;
+    if (remaining <= AUTO_SCROLL_THRESHOLD) {
+      return true;
+    }
+    return item.start < scrollOffset;
   };
 
   // Throttled scroll-to-bottom using virtualizer.
@@ -340,8 +345,12 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     requestAnimationFrame(() => {
       const el2 = containerRef.current;
       if (el2) el2.scrollTop = el2.scrollHeight;
-      setIsPositioned(true);
-      scheduleEndSuppressPassiveAutoBottomScroll();
+      requestAnimationFrame(() => {
+        const el3 = containerRef.current;
+        if (el3) el3.scrollTop = el3.scrollHeight;
+        setIsPositioned(true);
+        scheduleEndSuppressPassiveAutoBottomScroll();
+      });
     });
   }, [beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
 
@@ -427,14 +436,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       isInitialLoadRef.current = false;
       setIsPositioned(true);
       pendingScrollRestoreRef.current = rememberedScrollTop;
-      beginSuppressPassiveAutoBottomScroll();
     } else if (isThreadSwitch) {
       // Cache hit on switch with no saved offset: avoid leaving stale scroll and
       // throttled smooth scroll from the discrete-messages effect.
       pendingScrollRestoreRef.current = null;
       positionAtBottom();
     }
-  }, [activeThreadId, loading, virtualizer, positionAtBottom, beginSuppressPassiveAutoBottomScroll]);
+  }, [activeThreadId, loading, virtualizer, positionAtBottom]);
 
   // Stabilize scroll position when older messages are prepended.
   // Detects real prepends by comparing the first message ID before and after
@@ -499,20 +507,29 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // to be briefly visible. When items load, items.length will change and trigger
     // another effect pass where loading is false.
     if (loading) return;
+    beginSuppressPassiveAutoBottomScroll();
     const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
-    // Revisit: scrollHeight can grow after the last visit. A stored "at bottom"
-    // offset would sit high above the new tail and read as drift, and passive
-    // scroll effects may animate to the true bottom.
-    const nearBottom = target >= maxScroll - AUTO_SCROLL_THRESHOLD;
-    el.scrollTop = nearBottom ? el.scrollHeight : target;
+    const withinTail =
+      target <= maxScroll && maxScroll - target <= AUTO_SCROLL_THRESHOLD;
+    if (withinTail) {
+      el.scrollTop = el.scrollHeight;
+    } else if (target > maxScroll) {
+      el.scrollTop = maxScroll;
+    } else {
+      el.scrollTop = target;
+    }
     pendingScrollRestoreRef.current = null;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     const scrolledUp = distanceFromBottom > 200;
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
     if (!scrolledUp) setHasNewContent(false);
-    scheduleEndSuppressPassiveAutoBottomScroll();
-  }, [activeThreadId, items.length, loading, scheduleEndSuppressPassiveAutoBottomScroll]);
+    requestAnimationFrame(() => {
+      const el2 = containerRef.current;
+      if (el2 && withinTail) el2.scrollTop = el2.scrollHeight;
+      scheduleEndSuppressPassiveAutoBottomScroll();
+    });
+  }, [activeThreadId, items.length, loading, beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
 
   // Discrete events (new message, tool call) -> scroll if at bottom, else highlight button
   useEffect(() => {

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -457,8 +457,15 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       // throttled smooth scroll from the discrete-messages effect.
       pendingScrollRestoreRef.current = null;
       positionAtBottom();
+    } else if (isInitialLoadRef.current && items.length > 0) {
+      // Cache miss (or same-thread load): when `loading` becomes false, `prevId`
+      // already matches `activeThreadId`, so `isThreadSwitch` is false. First open
+      // also hits this branch. Pin the tail here so it tracks the same path as a
+      // cache-hit switch (lazy markdown and measured row heights included).
+      pendingScrollRestoreRef.current = null;
+      positionAtBottom();
     }
-  }, [activeThreadId, loading, virtualizer, positionAtBottom]);
+  }, [activeThreadId, loading, virtualizer, positionAtBottom, items.length]);
 
   // Stabilize scroll position when older messages are prepended.
   // Detects real prepends by comparing the first message ID before and after
@@ -492,8 +499,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
   }, [messages]);
 
-  // Initial load: position at the bottom before paint to avoid top-to-bottom flash.
-  // useLayoutEffect fires after DOM mutations but before the browser paints.
+  // Empty thread: reveal without a tail jump. Non-empty initial tail positioning
+  // runs in the active-thread useLayoutEffect so cache-miss completion (same
+  // `activeThreadId` as `prevId`) is not skipped when `isThreadSwitch` is false.
   useLayoutEffect(() => {
     if (!isInitialLoadRef.current) return;
 
@@ -505,10 +513,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
 
     if (items.length === 0) return;
-    if (loading) return; // don't position until persisted messages are loaded
-
-    positionAtBottom();
-  }, [items.length, loading, positionAtBottom]);
+    if (loading) return;
+  }, [items.length, loading]);
 
   // Apply the remembered scrollTop after the virtualizer has rendered the
   // restored items. useLayoutEffect runs before paint, so the user never sees
@@ -607,7 +613,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     return () => document.removeEventListener("mouseup", handleMouseUp);
   }, []);
 
-  /** While {@link pinListTailRef} is set (open or tail restore), keep the viewport on the tail as row heights stabilize. */
+  /**
+   * While {@link pinListTailRef} is set (open or tail restore), keep the viewport on the tail as row heights stabilize.
+   * Re-run when `loading` clears so the observer attaches after the list inner exists and has non-zero size.
+   */
   useEffect(() => {
     if (typeof ResizeObserver === "undefined") return;
     const outer = containerRef.current;
@@ -619,7 +628,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     });
     ro.observe(inner);
     return () => ro.disconnect();
-  }, [activeThreadId]);
+  }, [activeThreadId, loading]);
 
   return (
     <div className="relative h-full" data-testid="message-list">

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -28,6 +28,13 @@ const AUTO_SCROLL_THRESHOLD = 64;
 const OVERSCAN = 8;
 const DEFAULT_ITEM_HEIGHT = 80;
 const PAGINATION_THRESHOLD = 200;
+/**
+ * Keep the list hidden until the scroll container's height stops changing for a few
+ * frames so long threads do not reveal while the virtual spacer is still mostly estimates.
+ */
+const TAIL_SETTLE_MIN_FRAMES = 20;
+const TAIL_SETTLE_STABLE_FRAMES = 3;
+const TAIL_SETTLE_MAX_FRAMES = 180;
 
 /** Renders a single virtual item based on its type discriminant. */
 const VirtualItemRenderer = memo(function VirtualItemRenderer({
@@ -151,8 +158,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
    * One-shot skip flags miss follow-up effect runs when stores settle after revisit.
    */
   const suppressPassiveAutoBottomScrollRef = useRef(false);
-  /** Cancels stale double-rAF clears when another navigation starts. */
+  /** Cancels stale triple-rAF clears when another navigation starts. */
   const suppressPassiveAutoBottomGenRef = useRef(0);
+  /** Cancels in-flight tail-settle rAF loops when a new navigation calls `positionAtBottom`. */
+  const tailSettleGenRef = useRef(0);
   /**
    * While true, list height growth snaps the viewport to the tail so virtual rows
    * and async layout cannot leave the thread short of the bottom after open.
@@ -374,43 +383,76 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   );
 
   /**
-   * Positions the list at the bottom synchronously and reveals the container.
-   * Sets the scroll element's `scrollTop` directly instead of calling the
-   * virtualizer's `scrollToIndex`, avoiding TanStack Virtual's multi-frame
-   * scroll reconciliation (that loop retriggers as row heights settle and looks
-   * like motion). Arms passive auto-scroll suppression until
-   * `scheduleEndSuppressPassiveAutoBottomScroll` runs after layout settles.
+   * Positions the list at the bottom and reveals only after {@link scrollHeight}
+   * has been stable across frames (long threads: virtual row measurement and lazy
+   * content). Avoids revealing at the bottom of an underestimated spacer.
+   *
+   * @param options.measureFirst - When true, runs `virtualizer.measure()` first (cache miss
+   *   and first open). Omit on cache-hit switches so the measurement cache stays warm.
    */
-  const positionAtBottom = useCallback(() => {
+  const positionAtBottom = useCallback((options?: { measureFirst?: boolean }) => {
     beginSuppressPassiveAutoBottomScroll();
+    if (options?.measureFirst) {
+      virtualizer.measure();
+    }
+    const settleGen = ++tailSettleGenRef.current;
     pinListTailRef.current = true;
     isInitialLoadRef.current = false;
-    const el = containerRef.current;
-    if (el) {
-      el.scrollTop = el.scrollHeight;
-      pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
-    }
-    requestAnimationFrame(() => {
-      const el2 = containerRef.current;
-      if (el2) {
-        el2.scrollTop = el2.scrollHeight;
-        pinTailBaselineMaxScrollRef.current = Math.max(0, el2.scrollHeight - el2.clientHeight);
-      }
-      requestAnimationFrame(() => {
-        const el3 = containerRef.current;
-        if (el3) {
-          el3.scrollTop = el3.scrollHeight;
-          pinTailBaselineMaxScrollRef.current = Math.max(0, el3.scrollHeight - el3.clientHeight);
-        }
+
+    let lastScrollHeight = -1;
+    let stableHeightFrames = 0;
+    let frame = 0;
+
+    const snapAndStep = () => {
+      if (tailSettleGenRef.current !== settleGen) return;
+      if (!pinListTailRef.current) {
         setIsPositioned(true);
         scheduleEndSuppressPassiveAutoBottomScroll();
-      });
-    });
-  }, [beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
+        return;
+      }
+
+      const el = containerRef.current;
+      if (!el) {
+        setIsPositioned(true);
+        scheduleEndSuppressPassiveAutoBottomScroll();
+        return;
+      }
+
+      el.scrollTop = el.scrollHeight;
+      pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
+
+      const h = el.scrollHeight;
+      frame++;
+      if (frame > TAIL_SETTLE_MIN_FRAMES && h === lastScrollHeight) {
+        stableHeightFrames++;
+      } else if (h !== lastScrollHeight) {
+        stableHeightFrames = 0;
+      }
+      lastScrollHeight = h;
+
+      const settled =
+        stableHeightFrames >= TAIL_SETTLE_STABLE_FRAMES
+        || frame >= TAIL_SETTLE_MAX_FRAMES;
+      if (settled) {
+        setIsPositioned(true);
+        scheduleEndSuppressPassiveAutoBottomScroll();
+        return;
+      }
+      requestAnimationFrame(snapAndStep);
+    };
+
+    const el0 = containerRef.current;
+    if (el0) {
+      el0.scrollTop = el0.scrollHeight;
+      pinTailBaselineMaxScrollRef.current = Math.max(0, el0.scrollHeight - el0.clientHeight);
+    }
+    requestAnimationFrame(snapAndStep);
+  }, [beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll, virtualizer]);
 
   // Clean up pending scroll timer on unmount
   useEffect(() => {
     return () => {
+      tailSettleGenRef.current++;
       if (scrollTimerRef.current) {
         clearTimeout(scrollTimerRef.current);
         scrollTimerRef.current = null;
@@ -503,7 +545,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       // also hits this branch. Pin the tail here so it tracks the same path as a
       // cache-hit switch (lazy markdown and measured row heights included).
       pendingScrollRestoreRef.current = null;
-      positionAtBottom();
+      positionAtBottom({ measureFirst: true });
     }
   }, [activeThreadId, loading, virtualizer, positionAtBottom, items.length]);
 

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useLayoutEffect, useMemo, useCallback, memo, useState } from "react";
+import { useRef, useEffect, useLayoutEffect, useMemo, useCallback, memo, useState, type WheelEvent } from "react";
 import { useReplyStore } from "@/stores/replyStore";
 import { ArrowDown, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -158,6 +158,12 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
    * and async layout cannot leave the thread short of the bottom after open.
    */
   const pinListTailRef = useRef(false);
+  /**
+   * Last `scrollHeight - clientHeight` when we believed the viewport sat on the pinned
+   * tail. Used to tell virtualizer measurement growth (`scrollTop` stale vs old max)
+   * from the user leaving the tail (`scrollTop` below this baseline).
+   */
+  const pinTailBaselineMaxScrollRef = useRef(0);
   /** Tracks the previous activeThreadId so we can save its scrollTop before switching. */
   const prevActiveThreadIdRef = useRef<string | null>(null);
   /** Holds the scrollTop value to restore on the next layout effect. */
@@ -229,10 +235,32 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     });
   }, []);
 
+  /** Clears tail pin when the user scrolls content upward (wheel / trackpad). */
+  const handleWheel = useCallback((e: WheelEvent<HTMLDivElement>) => {
+    if (e.deltaY < 0) pinListTailRef.current = false;
+  }, []);
+
   /** Track scroll-to-bottom button visibility and trigger upward pagination near the top. */
   const handleScroll = useCallback(() => {
     const el = containerRef.current;
     if (!el) return;
+
+    const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
+
+    if (pinListTailRef.current) {
+      const gap = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (gap > AUTO_SCROLL_THRESHOLD) {
+        if (el.scrollTop < pinTailBaselineMaxScrollRef.current - 1) {
+          pinListTailRef.current = false;
+        } else {
+          el.scrollTop = el.scrollHeight;
+          pinTailBaselineMaxScrollRef.current = maxScroll;
+        }
+      } else {
+        pinTailBaselineMaxScrollRef.current = maxScroll;
+      }
+    }
+
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     const scrolledUp = distanceFromBottom > 200;
     if (scrolledUp) pinListTailRef.current = false;
@@ -331,9 +359,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
         if (el) {
           pinListTailRef.current = true;
           el.scrollTop = el.scrollHeight;
+          pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
           requestAnimationFrame(() => {
             const el2 = containerRef.current;
-            if (el2) el2.scrollTop = el2.scrollHeight;
+            if (el2) {
+              el2.scrollTop = el2.scrollHeight;
+              pinTailBaselineMaxScrollRef.current = Math.max(0, el2.scrollHeight - el2.clientHeight);
+            }
           });
         }
       }, delay);
@@ -356,13 +388,20 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     const el = containerRef.current;
     if (el) {
       el.scrollTop = el.scrollHeight;
+      pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
     }
     requestAnimationFrame(() => {
       const el2 = containerRef.current;
-      if (el2) el2.scrollTop = el2.scrollHeight;
+      if (el2) {
+        el2.scrollTop = el2.scrollHeight;
+        pinTailBaselineMaxScrollRef.current = Math.max(0, el2.scrollHeight - el2.clientHeight);
+      }
       requestAnimationFrame(() => {
         const el3 = containerRef.current;
-        if (el3) el3.scrollTop = el3.scrollHeight;
+        if (el3) {
+          el3.scrollTop = el3.scrollHeight;
+          pinTailBaselineMaxScrollRef.current = Math.max(0, el3.scrollHeight - el3.clientHeight);
+        }
         setIsPositioned(true);
         scheduleEndSuppressPassiveAutoBottomScroll();
       });
@@ -385,6 +424,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       (item) => item.type === "message" && item.message.id === messageId,
     );
     if (idx !== -1) {
+      pinListTailRef.current = false;
       virtualizer.scrollToIndex(idx, { align: "center", behavior: "smooth" });
       setTimeout(() => {
         const element = document.querySelector(`[data-message-id="${messageId}"]`);
@@ -537,6 +577,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (snapToTail) {
       pinListTailRef.current = true;
       el.scrollTop = el.scrollHeight;
+      pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
     } else {
       pinListTailRef.current = false;
       el.scrollTop = target;
@@ -549,7 +590,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (!scrolledUp) setHasNewContent(false);
     requestAnimationFrame(() => {
       const el2 = containerRef.current;
-      if (el2 && snapToTail) el2.scrollTop = el2.scrollHeight;
+      if (el2 && snapToTail) {
+        el2.scrollTop = el2.scrollHeight;
+        pinTailBaselineMaxScrollRef.current = Math.max(0, el2.scrollHeight - el2.clientHeight);
+      }
       scheduleEndSuppressPassiveAutoBottomScroll();
     });
   }, [activeThreadId, items.length, loading, beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
@@ -625,6 +669,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     const ro = new ResizeObserver(() => {
       if (!pinListTailRef.current) return;
       outer.scrollTop = outer.scrollHeight;
+      pinTailBaselineMaxScrollRef.current = Math.max(0, outer.scrollHeight - outer.clientHeight);
     });
     ro.observe(inner);
     return () => ro.disconnect();
@@ -635,6 +680,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       <div
         ref={containerRef}
         onScroll={handleScroll}
+        onWheel={handleWheel}
         className="h-full overflow-y-auto pt-4 transition-opacity duration-75"
         style={{ opacity: isPositioned ? 1 : 0 }}
       >

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -28,13 +28,6 @@ const AUTO_SCROLL_THRESHOLD = 64;
 const OVERSCAN = 8;
 const DEFAULT_ITEM_HEIGHT = 80;
 const PAGINATION_THRESHOLD = 200;
-/**
- * Keep the list hidden until the scroll container's height stops changing for a few
- * frames so long threads do not reveal while the virtual spacer is still mostly estimates.
- */
-const TAIL_SETTLE_MIN_FRAMES = 20;
-const TAIL_SETTLE_STABLE_FRAMES = 3;
-const TAIL_SETTLE_MAX_FRAMES = 180;
 
 /** Renders a single virtual item based on its type discriminant. */
 const VirtualItemRenderer = memo(function VirtualItemRenderer({
@@ -390,73 +383,47 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   );
 
   /**
-   * Positions the list at the bottom and reveals only after {@link scrollHeight}
-   * has been stable across frames (long threads: virtual row measurement and lazy
-   * content). Avoids revealing at the bottom of an underestimated spacer.
+   * Pins the scroll element to the list tail, then reveals after layout frames.
+   * Initial hydrate also calls `scrollToIndex` with `behavior: 'auto'` so the virtualizer
+   * anchors the viewport before row heights finish measuring (stable `scrollHeight` alone
+   * can sit on estimates for long threads).
    *
    * @param options.measureFirst - When true, runs `virtualizer.measure()` first (cache miss
    *   and first open). Omit on cache-hit switches so the measurement cache stays warm.
    */
   const positionAtBottom = useCallback((options?: { measureFirst?: boolean }) => {
     beginSuppressPassiveAutoBottomScroll();
-    if (options?.measureFirst) {
-      virtualizer.measure();
-    }
     const settleGen = ++tailSettleGenRef.current;
     pinListTailRef.current = true;
     isInitialLoadRef.current = false;
 
-    let lastScrollHeight = -1;
-    let lastTotalSize = -1;
-    let stableHeightFrames = 0;
-    let frame = 0;
-
-    const snapAndStep = () => {
-      if (tailSettleGenRef.current !== settleGen) return;
-      if (!pinListTailRef.current) {
-        setIsPositioned(true);
-        scheduleEndSuppressPassiveAutoBottomScroll();
-        return;
+    if (options?.measureFirst) {
+      virtualizer.measure();
+      const n = itemsLengthRef.current;
+      if (n > 0) {
+        virtualizer.scrollToIndex(n - 1, { align: "end", behavior: "auto" });
       }
+    }
 
+    const snap = () => {
       const el = containerRef.current;
-      if (!el) {
-        setIsPositioned(true);
-        scheduleEndSuppressPassiveAutoBottomScroll();
-        return;
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+        pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
       }
-
-      el.scrollTop = el.scrollHeight;
-      pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
-
-      const h = el.scrollHeight;
-      const total = virtualizer.getTotalSize();
-      frame++;
-      if (frame > TAIL_SETTLE_MIN_FRAMES && h === lastScrollHeight && total === lastTotalSize) {
-        stableHeightFrames++;
-      } else if (h !== lastScrollHeight || total !== lastTotalSize) {
-        stableHeightFrames = 0;
-      }
-      lastScrollHeight = h;
-      lastTotalSize = total;
-
-      const settled =
-        stableHeightFrames >= TAIL_SETTLE_STABLE_FRAMES
-        || frame >= TAIL_SETTLE_MAX_FRAMES;
-      if (settled) {
-        setIsPositioned(true);
-        scheduleEndSuppressPassiveAutoBottomScroll();
-        return;
-      }
-      requestAnimationFrame(snapAndStep);
     };
 
-    const el0 = containerRef.current;
-    if (el0) {
-      el0.scrollTop = el0.scrollHeight;
-      pinTailBaselineMaxScrollRef.current = Math.max(0, el0.scrollHeight - el0.clientHeight);
-    }
-    requestAnimationFrame(snapAndStep);
+    snap();
+    requestAnimationFrame(() => {
+      if (tailSettleGenRef.current !== settleGen) return;
+      snap();
+      requestAnimationFrame(() => {
+        if (tailSettleGenRef.current !== settleGen) return;
+        snap();
+        setIsPositioned(true);
+        scheduleEndSuppressPassiveAutoBottomScroll();
+      });
+    });
   }, [beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll, virtualizer]);
 
   // Clean up pending scroll timer on unmount

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -28,6 +28,20 @@ const AUTO_SCROLL_THRESHOLD = 64;
 const OVERSCAN = 8;
 const DEFAULT_ITEM_HEIGHT = 80;
 const PAGINATION_THRESHOLD = 200;
+/**
+ * Initial-load reveal is gated on the inner list height stabilizing across frames.
+ * TanStack Virtual measures rows asynchronously after mount, so `scrollHeight`
+ * grows for several frames after we first snap to it. Revealing during that
+ * growth lands on a stale tail (the bug: long threads sit short of the bottom).
+ *
+ * STABLE: number of consecutive identical frames required before revealing.
+ *   4 frames ≈ 67ms — imperceptible on the happy path (short threads).
+ * MAX:    hard cap so a perpetually-growing list (e.g. lazy markdown that
+ *   never settles within a second) cannot leave the user staring at a blank pane.
+ *   60 frames ≈ 1s.
+ */
+const TAIL_SETTLE_STABLE_FRAMES = 4;
+const TAIL_SETTLE_MAX_FRAMES = 60;
 
 /** Renders a single virtual item based on its type discriminant. */
 const VirtualItemRenderer = memo(function VirtualItemRenderer({
@@ -324,8 +338,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     overscan: OVERSCAN,
   });
 
-  // Near the tail: allow TanStack scroll compensation when row heights update
-  // so opening or revisiting lands on the true bottom as items measure.
+  // Pinned to tail: always compensate for size changes so the viewport tracks
+  // the bottom as rows measure. Adjusting by +delta when at scrollOffset = oldMaxScroll
+  // gives newScrollOffset = oldMaxScroll + delta = newMaxScroll, exactly the new tail.
+  // Near the tail (not pinned): adjust within AUTO_SCROLL_THRESHOLD so a small
+  // user-induced scroll-up can still settle on the true bottom as items measure.
   // Farther up: keep default above-viewport anchoring so history reading stays stable.
   // Assigned on the stable virtualizer instance (TanStack Virtual v3 API);
   // not available as a useVirtualizer option in the current type definitions.
@@ -334,6 +351,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     _delta,
     instance,
   ) => {
+    if (pinListTailRef.current) return true;
     const viewportHeight = instance.scrollRect?.height ?? 0;
     const scrollOffset = instance.scrollOffset ?? 0;
     const remaining =
@@ -383,13 +401,24 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   );
 
   /**
-   * Pins the scroll element to the list tail, then reveals after layout frames.
-   * Initial hydrate also calls `scrollToIndex` with `behavior: 'auto'` so the virtualizer
-   * anchors the viewport before row heights finish measuring (stable `scrollHeight` alone
-   * can sit on estimates for long threads).
+   * Pins the scroll element to the list tail and reveals only after the inner
+   * list height has been stable for {@link TAIL_SETTLE_STABLE_FRAMES} consecutive
+   * frames (or {@link TAIL_SETTLE_MAX_FRAMES} hard cap, whichever comes first).
    *
-   * @param options.measureFirst - When true, runs `virtualizer.measure()` first (cache miss
-   *   and first open). Omit on cache-hit switches so the measurement cache stays warm.
+   * Why a settle loop: TanStack Virtual measures rows after mount via its
+   * internal ResizeObserver. On long threads the estimated total size can be
+   * significantly less than the measured total. A single (or few) `scrollTop =
+   * scrollHeight` snap revealed before measurements complete leaves the user
+   * sitting *above* the real tail. ResizeObserver-based pinning fires too late
+   * to fix the perceived first paint. Hiding the list (opacity: 0) until both
+   * `scrollHeight` and `virtualizer.getTotalSize()` stop changing means the
+   * very first thing the user sees is already at the true bottom.
+   *
+   * @param options.measureFirst - When true, runs `virtualizer.measure()` and
+   *   `scrollToIndex(n-1, end, auto)` to anchor the virtualizer to the tail
+   *   before rows finish measuring. Used on cache-miss completion and first
+   *   open. Cache-hit switches omit this so the cached measurement state stays
+   *   warm and we land exactly where the cache says the tail is.
    */
   const positionAtBottom = useCallback((options?: { measureFirst?: boolean }) => {
     beginSuppressPassiveAutoBottomScroll();
@@ -407,23 +436,65 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
     const snap = () => {
       const el = containerRef.current;
-      if (el) {
-        el.scrollTop = el.scrollHeight;
-        pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
-      }
+      if (!el) return;
+      el.scrollTop = el.scrollHeight;
+      pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
     };
 
+    // Synchronous first snap so non-rAF environments (jsdom in unit tests)
+    // still see scrollTop applied before the rAF-based settle loop runs.
     snap();
-    requestAnimationFrame(() => {
-      if (tailSettleGenRef.current !== settleGen) return;
+
+    let lastScrollHeight = -1;
+    let lastTotalSize = -1;
+    let stableFrames = 0;
+    let frame = 0;
+
+    const reveal = () => {
       snap();
-      requestAnimationFrame(() => {
-        if (tailSettleGenRef.current !== settleGen) return;
-        snap();
+      setIsPositioned(true);
+      scheduleEndSuppressPassiveAutoBottomScroll();
+    };
+
+    const tick = () => {
+      if (tailSettleGenRef.current !== settleGen) return;
+      // If the user cleared the pin (wheel up, scrollbar drag) during settle,
+      // reveal immediately so they can interact with whatever they've scrolled to.
+      if (!pinListTailRef.current) {
         setIsPositioned(true);
         scheduleEndSuppressPassiveAutoBottomScroll();
-      });
-    });
+        return;
+      }
+      frame++;
+      snap();
+      const el = containerRef.current;
+      if (!el) {
+        setIsPositioned(true);
+        scheduleEndSuppressPassiveAutoBottomScroll();
+        return;
+      }
+      const h = el.scrollHeight;
+      const total = virtualizer.getTotalSize();
+      // Both scrollHeight (DOM) and getTotalSize (virtualizer state) must be
+      // unchanged. They can drift by one frame: the virtualizer updates its
+      // internal total first, then React re-renders the inner div with the new
+      // height. Requiring both to match for STABLE_FRAMES proves no measurement
+      // is in flight.
+      if (h === lastScrollHeight && total === lastTotalSize) {
+        stableFrames++;
+      } else {
+        stableFrames = 0;
+      }
+      lastScrollHeight = h;
+      lastTotalSize = total;
+      if (stableFrames >= TAIL_SETTLE_STABLE_FRAMES || frame >= TAIL_SETTLE_MAX_FRAMES) {
+        reveal();
+        return;
+      }
+      requestAnimationFrame(tick);
+    };
+
+    requestAnimationFrame(tick);
   }, [beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll, virtualizer]);
 
   // Clean up pending scroll timer on unmount

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -497,10 +497,19 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     requestAnimationFrame(tick);
   }, [beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll, virtualizer]);
 
-  // Clean up pending scroll timer on unmount
+  // Clean up pending scroll timer on unmount.
+  //
+  // Do NOT bump `tailSettleGenRef` here. In React StrictMode dev the unmount
+  // cleanup fires between mount-1 and mount-2 of the initial mount; if we
+  // bumped the gen we would invalidate the in-flight settle rAF scheduled by
+  // mount-1, and mount-2 would not re-call `positionAtBottom` (because
+  // `isInitialLoadRef.current` was already flipped to false). The list would
+  // then sit at opacity:0 forever. A real unmount makes `containerRef.current`
+  // null, which the settle tick already handles by revealing and bailing.
+  // The gen is still bumped by each new `positionAtBottom` call, which is what
+  // we actually need to cancel a stale tick when the user navigates.
   useEffect(() => {
     return () => {
-      tailSettleGenRef.current++;
       if (scrollTimerRef.current) {
         clearTimeout(scrollTimerRef.current);
         scrollTimerRef.current = null;

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -146,10 +146,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const firstMessageIdRef = useRef<string | null>(null);
   /** True until initial messages are positioned at the bottom after a thread switch. */
   const isInitialLoadRef = useRef(true);
-  /** Drops the next discrete auto bottom-scroll (layout already positioned the list). */
-  const skipDiscreteAutoBottomScrollRef = useRef(false);
-  /** Drops the next streaming auto bottom-scroll (same as discrete, separate effect). */
-  const skipStreamingAutoBottomScrollRef = useRef(false);
+  /**
+   * Blocks discrete/streaming auto bottom-scroll while a navigation applies scroll.
+   * One-shot skip flags miss follow-up effect runs when stores settle after revisit.
+   */
+  const suppressPassiveAutoBottomScrollRef = useRef(false);
+  /** Cancels stale double-rAF clears when another navigation starts. */
+  const suppressPassiveAutoBottomGenRef = useRef(0);
   /** Tracks the previous activeThreadId so we can save its scrollTop before switching. */
   const prevActiveThreadIdRef = useRef<string | null>(null);
   /** Holds the scrollTop value to restore on the next layout effect. */
@@ -202,6 +205,22 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   );
 
   const toolCalls = toolCallsRaw ?? EMPTY_TOOL_CALLS;
+
+  const beginSuppressPassiveAutoBottomScroll = useCallback(() => {
+    suppressPassiveAutoBottomScrollRef.current = true;
+  }, []);
+
+  /** Ends passive auto bottom-scroll suppression after layout settles across frames. */
+  const scheduleEndSuppressPassiveAutoBottomScroll = useCallback(() => {
+    const gen = ++suppressPassiveAutoBottomGenRef.current;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (suppressPassiveAutoBottomGenRef.current === gen) {
+          suppressPassiveAutoBottomScrollRef.current = false;
+        }
+      });
+    });
+  }, []);
 
   /** Track scroll-to-bottom button visibility and trigger upward pagination near the top. */
   const handleScroll = useCallback(() => {
@@ -308,12 +327,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
    * Sets the scroll element's `scrollTop` directly instead of calling the
    * virtualizer's `scrollToIndex`, avoiding TanStack Virtual's multi-frame
    * scroll reconciliation (that loop retriggers as row heights settle and looks
-   * like motion). Skips the next passive auto-scroll effects so they do not
-   * schedule a throttled smooth scroll.
+   * like motion). Arms passive auto-scroll suppression until
+   * `scheduleEndSuppressPassiveAutoBottomScroll` runs after layout settles.
    */
   const positionAtBottom = useCallback(() => {
-    skipDiscreteAutoBottomScrollRef.current = true;
-    skipStreamingAutoBottomScrollRef.current = true;
+    beginSuppressPassiveAutoBottomScroll();
     isInitialLoadRef.current = false;
     const el = containerRef.current;
     if (el) {
@@ -323,8 +341,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       const el2 = containerRef.current;
       if (el2) el2.scrollTop = el2.scrollHeight;
       setIsPositioned(true);
+      scheduleEndSuppressPassiveAutoBottomScroll();
     });
-  }, []);
+  }, [beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
 
   // Clean up pending scroll timer on unmount
   useEffect(() => {
@@ -408,15 +427,14 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       isInitialLoadRef.current = false;
       setIsPositioned(true);
       pendingScrollRestoreRef.current = rememberedScrollTop;
-      skipDiscreteAutoBottomScrollRef.current = true;
-      skipStreamingAutoBottomScrollRef.current = true;
+      beginSuppressPassiveAutoBottomScroll();
     } else if (isThreadSwitch) {
       // Cache hit on switch with no saved offset: avoid leaving stale scroll and
       // throttled smooth scroll from the discrete-messages effect.
       pendingScrollRestoreRef.current = null;
       positionAtBottom();
     }
-  }, [activeThreadId, loading, virtualizer, positionAtBottom]);
+  }, [activeThreadId, loading, virtualizer, positionAtBottom, beginSuppressPassiveAutoBottomScroll]);
 
   // Stabilize scroll position when older messages are prepended.
   // Detects real prepends by comparing the first message ID before and after
@@ -481,17 +499,25 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // to be briefly visible. When items load, items.length will change and trigger
     // another effect pass where loading is false.
     if (loading) return;
-    el.scrollTop = target;
+    const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
+    // Revisit: scrollHeight can grow after the last visit. A stored "at bottom"
+    // offset would sit high above the new tail and read as drift, and passive
+    // scroll effects may animate to the true bottom.
+    const nearBottom = target >= maxScroll - AUTO_SCROLL_THRESHOLD;
+    el.scrollTop = nearBottom ? el.scrollHeight : target;
     pendingScrollRestoreRef.current = null;
-  }, [activeThreadId, items.length, loading]);
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const scrolledUp = distanceFromBottom > 200;
+    isScrolledUpRef.current = scrolledUp;
+    setShowScrollBtn(scrolledUp);
+    if (!scrolledUp) setHasNewContent(false);
+    scheduleEndSuppressPassiveAutoBottomScroll();
+  }, [activeThreadId, items.length, loading, scheduleEndSuppressPassiveAutoBottomScroll]);
 
   // Discrete events (new message, tool call) -> scroll if at bottom, else highlight button
   useEffect(() => {
     if (isInitialLoadRef.current) return;
-    if (skipDiscreteAutoBottomScrollRef.current) {
-      skipDiscreteAutoBottomScrollRef.current = false;
-      return;
-    }
+    if (suppressPassiveAutoBottomScrollRef.current) return;
     if (isScrolledUpRef.current) {
       setHasNewContent(true);
     } else {
@@ -501,10 +527,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
   // Streaming deltas -> scroll if at bottom, else highlight button
   useEffect(() => {
-    if (skipStreamingAutoBottomScrollRef.current) {
-      skipStreamingAutoBottomScrollRef.current = false;
-      return;
-    }
+    if (suppressPassiveAutoBottomScrollRef.current) return;
     if (!streamingText || isInitialLoadRef.current) return;
     if (isScrolledUpRef.current) {
       setHasNewContent(true);

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -146,6 +146,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const firstMessageIdRef = useRef<string | null>(null);
   /** True until initial messages are positioned at the bottom after a thread switch. */
   const isInitialLoadRef = useRef(true);
+  /** Drops the next discrete auto bottom-scroll (layout already positioned the list). */
+  const skipDiscreteAutoBottomScrollRef = useRef(false);
+  /** Drops the next streaming auto bottom-scroll (same as discrete, separate effect). */
+  const skipStreamingAutoBottomScrollRef = useRef(false);
   /** Tracks the previous activeThreadId so we can save its scrollTop before switching. */
   const prevActiveThreadIdRef = useRef<string | null>(null);
   /** Holds the scrollTop value to restore on the next layout effect. */
@@ -301,10 +305,12 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
   /**
    * Positions the list at the bottom synchronously and reveals the container.
-   * Used for initial layout and cache-hit thread switches so discrete scroll
-   * effects never show a smooth scroll from the wrong offset.
+   * Used for initial layout and cache-hit thread switches. Skips the next
+   * passive auto-scroll effects so they do not schedule a throttled smooth scroll.
    */
   const positionAtBottom = useCallback(() => {
+    skipDiscreteAutoBottomScrollRef.current = true;
+    skipStreamingAutoBottomScrollRef.current = true;
     isInitialLoadRef.current = false;
     const count = itemsLengthRef.current;
     if (count > 0) {
@@ -367,6 +373,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       // Reset thread-scoped refs and affordance state so the prepend-detection
       // effect, scroll-affordance UI, and turn-expand map don't carry stale
       // measurements from the previous thread into the new one.
+      if (scrollTimerRef.current) {
+        clearTimeout(scrollTimerRef.current);
+        scrollTimerRef.current = null;
+      }
       turnExpandRef.current.clear();
       prevMessageCountRef.current = 0;
       firstMessageIdRef.current = null;
@@ -398,6 +408,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       isInitialLoadRef.current = false;
       setIsPositioned(true);
       pendingScrollRestoreRef.current = rememberedScrollTop;
+      skipDiscreteAutoBottomScrollRef.current = true;
+      skipStreamingAutoBottomScrollRef.current = true;
     } else if (isThreadSwitch) {
       // Cache hit on switch with no saved offset: avoid leaving stale scroll and
       // throttled smooth scroll from the discrete-messages effect.
@@ -476,22 +488,30 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   // Discrete events (new message, tool call) -> scroll if at bottom, else highlight button
   useEffect(() => {
     if (isInitialLoadRef.current) return;
+    if (skipDiscreteAutoBottomScrollRef.current) {
+      skipDiscreteAutoBottomScrollRef.current = false;
+      return;
+    }
     if (isScrolledUpRef.current) {
       setHasNewContent(true);
     } else {
       scrollToBottom(true);
     }
-  }, [messages.length, toolCalls.length, isAgentRunning, scrollToBottom]);
+  }, [activeThreadId, messages.length, toolCalls.length, isAgentRunning, scrollToBottom]);
 
   // Streaming deltas -> scroll if at bottom, else highlight button
   useEffect(() => {
+    if (skipStreamingAutoBottomScrollRef.current) {
+      skipStreamingAutoBottomScrollRef.current = false;
+      return;
+    }
     if (!streamingText || isInitialLoadRef.current) return;
     if (isScrolledUpRef.current) {
       setHasNewContent(true);
     } else {
       scrollToBottom(false);
     }
-  }, [streamingText, scrollToBottom]);
+  }, [streamingText, activeThreadId, scrollToBottom]);
 
   // Capture text selections in message bubbles and activate reply mode for the selected text.
   // Fires on mouseup so the selection is already finalised when we read it.

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -3,9 +3,10 @@
  * virtualizer measurement optimization, scroll position restoration, and
  * synchronous bottom positioning when a prefetched thread has no saved offset.
  *
- * Opening the bottom uses direct `scrollTop` assignment so TanStack Virtual's
- * `scrollToIndex` reconcile loop does not run (that loop causes visible motion
- * while row heights settle).
+ * Revisits use double-requestAnimationFrame suppression so passive effects
+ * that fire again after the store settles do not call smooth scrollToBottom.
+ * Near-bottom remembered offsets clamp to the current max scroll when content
+ * grew so a stale pixel does not sit above the tail.
  *
  * A cache hit occurs when threadStore has messages already loaded (loading: false
  * synchronously after activeThreadId changes). On cache hit, we skip virtualizer.measure()
@@ -186,6 +187,15 @@ describe("MessageList thread switch", () => {
 
     const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement | null;
     expect(scrollEl).not.toBeNull();
+
+    Object.defineProperty(scrollEl!, "scrollHeight", {
+      configurable: true,
+      value: 5000,
+    });
+    Object.defineProperty(scrollEl!, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
 
     // Mock scrollTop setter to track if it's called with the right value
     let setScrollTopValue: number | null = null;

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -212,6 +212,39 @@ describe("MessageList thread switch", () => {
     expect(smoothCalls.length).toBe(0);
   });
 
+  it("keeps scroll container hidden until layout has had a chance to settle on cache-miss hydrate", () => {
+    // Long-thread regression: TanStack Virtual measures rows after mount and
+    // `scrollHeight` keeps growing for several frames. Revealing immediately
+    // (before settle) leaves the user above the true tail. Verify that on a
+    // cache-miss hydrate completion the container is still opacity:0
+    // synchronously after the rerender — settle happens in rAF.
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m-a", sequence: 1 }];
+    const { rerender, container } = render(<MessageList />);
+
+    // Cache miss begins
+    loadingValue = true;
+    activeThreadIdValue = "thread-B";
+    messagesValue = [];
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    // Cache miss completes with messages
+    loadingValue = false;
+    messagesValue = [{ id: "m-b", sequence: 1 }];
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    // Scroll container is the .overflow-y-auto div; settle holds opacity at 0
+    // until the rAF chain stabilizes scrollHeight + getTotalSize.
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement | null;
+    expect(scrollEl).not.toBeNull();
+    expect(scrollEl!.style.opacity).toBe("0");
+  });
+
   it("restores remembered scrollTop on a cache-hit switch", () => {
     loadingValue = false;
     activeThreadIdValue = "thread-A";

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -13,6 +13,10 @@
  * to preserve cached row heights. Without a remembered scroll offset, we pin
  * `scrollTop` on switch instead of calling `scrollToIndex`, so no smooth or
  * reconcile-driven motion runs on open.
+ *
+ * When a cache miss finishes (`loading` true to false) on the same thread,
+ * `positionAtBottom({ measureFirst: true })` calls `scrollToIndex` with
+ * `behavior: "auto"` so the list anchors to the tail before rows finish measuring.
  */
 import { render, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -112,6 +116,39 @@ describe("MessageList thread switch", () => {
     rerender(<MessageList />);
 
     expect(measureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls scrollToIndex with auto when cache-miss hydrate completes", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m-a", sequence: 1 }];
+    const { rerender } = render(<MessageList />);
+
+    measureSpy.mockClear();
+    scrollToIndexSpy.mockClear();
+
+    loadingValue = true;
+    activeThreadIdValue = "thread-B";
+    messagesValue = [];
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    expect(scrollToIndexSpy).not.toHaveBeenCalled();
+
+    loadingValue = false;
+    messagesValue = [{ id: "m-b", sequence: 1 }];
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    const autoTailCalls = scrollToIndexSpy.mock.calls.filter(
+      (call) =>
+        (call[1] as { behavior?: string; align?: string } | undefined)?.behavior === "auto" &&
+        (call[1] as { align?: string } | undefined)?.align === "end",
+    );
+    expect(autoTailCalls.length).toBe(1);
+    expect(autoTailCalls[0]?.[0]).toBeGreaterThanOrEqual(0);
   });
 
   it("pins scrollTop without virtualizer scrollToIndex on cache-hit switch without remembered scroll", () => {

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -1,10 +1,12 @@
 /**
  * Tests for MessageList thread-switch behavior: cache-hit detection,
- * virtualizer measurement optimization, and scroll position restoration.
+ * virtualizer measurement optimization, scroll position restoration, and
+ * synchronous bottom positioning when a prefetched thread has no saved offset.
  *
  * A cache hit occurs when threadStore has messages already loaded (loading: false
  * synchronously after activeThreadId changes). On cache hit, we skip virtualizer.measure()
- * to preserve cached row heights and avoid opacity flash by keeping isPositioned=true.
+ * to preserve cached row heights. Without a remembered scroll offset, we still call
+ * scrollToIndex (instant) on switch so the list does not animate from a stale position.
  */
 import { render, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -100,6 +102,30 @@ describe("MessageList thread switch", () => {
     rerender(<MessageList />);
 
     expect(measureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("scrolls to bottom with instant behavior on cache-hit switch without remembered scroll", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m-a", sequence: 1 }];
+    const { rerender } = render(<MessageList />);
+
+    scrollToIndexSpy.mockClear();
+    activeThreadIdValue = "thread-B";
+    messagesValue = [{ id: "m-b", sequence: 1 }];
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    expect(scrollToIndexSpy).toHaveBeenCalled();
+    const matchingCalls = scrollToIndexSpy.mock.calls.filter(
+      (call) =>
+        call[1] != null
+        && typeof call[1] === "object"
+        && (call[1] as { align?: string; behavior?: string }).align === "end"
+        && (call[1] as { align?: string; behavior?: string }).behavior === "auto",
+    );
+    expect(matchingCalls.length).toBeGreaterThanOrEqual(1);
   });
 
   it("restores remembered scrollTop on a cache-hit switch", () => {

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -3,10 +3,15 @@
  * virtualizer measurement optimization, scroll position restoration, and
  * synchronous bottom positioning when a prefetched thread has no saved offset.
  *
+ * Opening the bottom uses direct `scrollTop` assignment so TanStack Virtual's
+ * `scrollToIndex` reconcile loop does not run (that loop causes visible motion
+ * while row heights settle).
+ *
  * A cache hit occurs when threadStore has messages already loaded (loading: false
  * synchronously after activeThreadId changes). On cache hit, we skip virtualizer.measure()
- * to preserve cached row heights. Without a remembered scroll offset, we still call
- * scrollToIndex (instant) on switch so the list does not animate from a stale position.
+ * to preserve cached row heights. Without a remembered scroll offset, we pin
+ * `scrollTop` on switch instead of calling `scrollToIndex`, so no smooth or
+ * reconcile-driven motion runs on open.
  */
 import { render, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -108,11 +113,31 @@ describe("MessageList thread switch", () => {
     expect(measureSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("scrolls to bottom with instant behavior on cache-hit switch without remembered scroll", () => {
+  it("pins scrollTop without virtualizer scrollToIndex on cache-hit switch without remembered scroll", () => {
     loadingValue = false;
     activeThreadIdValue = "thread-A";
     messagesValue = [{ id: "m-a", sequence: 1 }];
-    const { rerender } = render(<MessageList />);
+    const { rerender, container } = render(<MessageList />);
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement | null;
+    expect(scrollEl).not.toBeNull();
+
+    let scrollTop = 0;
+    Object.defineProperty(scrollEl!, "scrollHeight", {
+      configurable: true,
+      value: 10_000,
+    });
+    Object.defineProperty(scrollEl!, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(scrollEl!, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v;
+      },
+    });
 
     scrollToIndexSpy.mockClear();
     activeThreadIdValue = "thread-B";
@@ -121,15 +146,8 @@ describe("MessageList thread switch", () => {
       rerender(<MessageList />);
     });
 
-    expect(scrollToIndexSpy).toHaveBeenCalled();
-    const matchingCalls = scrollToIndexSpy.mock.calls.filter(
-      (call) =>
-        call[1] != null
-        && typeof call[1] === "object"
-        && (call[1] as { align?: string; behavior?: string }).align === "end"
-        && (call[1] as { align?: string; behavior?: string }).behavior === "auto",
-    );
-    expect(matchingCalls.length).toBeGreaterThanOrEqual(1);
+    expect(scrollToIndexSpy).not.toHaveBeenCalled();
+    expect(scrollTop).toBe(10_000);
   });
 
   it("does not schedule throttled smooth scroll after cache-hit switch without remembered scroll", () => {

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -9,7 +9,7 @@
  * scrollToIndex (instant) on switch so the list does not animate from a stale position.
  */
 import { render, act } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const measureSpy = vi.fn();
 const scrollToIndexSpy = vi.fn();
@@ -77,6 +77,10 @@ beforeEach(() => {
   clearScrollMemory();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("MessageList thread switch", () => {
   it("does not call virtualizer.measure() on a cache-hit switch", () => {
     loadingValue = false;            // cache hit ⇒ loading is false synchronously
@@ -126,6 +130,30 @@ describe("MessageList thread switch", () => {
         && (call[1] as { align?: string; behavior?: string }).behavior === "auto",
     );
     expect(matchingCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not schedule throttled smooth scroll after cache-hit switch without remembered scroll", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m-a", sequence: 1 }];
+    const { rerender } = render(<MessageList />);
+
+    scrollToIndexSpy.mockClear();
+    activeThreadIdValue = "thread-B";
+    messagesValue = [{ id: "m-b", sequence: 1 }];
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const smoothCalls = scrollToIndexSpy.mock.calls.filter(
+      (call) => (call[1] as { behavior?: string } | undefined)?.behavior === "smooth",
+    );
+    expect(smoothCalls.length).toBe(0);
   });
 
   it("restores remembered scrollTop on a cache-hit switch", () => {


### PR DESCRIPTION
## What

Stabilises the MessageList virtualizer scroll behaviour on initial app load, cache-miss hydrate, cache-hit thread switch, and revisits with a remembered offset.

## Why

The virtualised chat list mixes async per-row measurement (TanStack Virtual) with several scroll mechanisms (programmatic snap, scroll memory, smooth auto-follow, ResizeObserver pin). Multiple bugs accumulated:

- Smooth scroll flash on cache-hit thread switch.
- Throttled smooth scroll firing again after layout positioning.
- Post-open drift on long threads as rows measured.
- Scroll-down arrow appearing over an empty pane during settle.
- And finally, list never revealing on initial mount under React StrictMode dev because the unmount cleanup was invalidating the in-flight settle rAF.

## Key changes

- **Settle-loop reveal** (`positionAtBottom`): hold opacity: 0 until both ``scrollHeight`` and ``virtualizer.getTotalSize()`` are unchanged for 4 frames, capped at 60 frames (~1s). Long threads land at the true tail; short threads reveal within ~67ms.
- **Pin-aware ``shouldAdjustScrollPositionOnItemSizeChange``**: returns true whenever ``pinListTailRef.current`` is set, so post-reveal row growth keeps the viewport on the bottom (defense-in-depth alongside the existing ResizeObserver pin).
- **StrictMode dev fix**: dropped the ``tailSettleGenRef.current++`` from the unmount cleanup. The cleanup ran between mount-1 and mount-2 of the initial mount and killed the in-flight settle tick, leaving the list at opacity: 0. The gen is still bumped by each new ``positionAtBottom`` call, which is the only place cancellation is actually needed.
- **Cache-miss hydrate**: when ``loading`` flips true → false on the same thread, calls ``positionAtBottom({ measureFirst: true })`` so first open and cache-miss completion follow the same tail-anchor path as cache-hit switches.
- **Suppression window** for passive auto-bottom-scroll across triple-rAF so discrete-event and streaming effects cannot fire smooth scrolls during a navigation.
- **Tail pin + ResizeObserver** keep the viewport on the tail as virtual rows measure; baseline tracking distinguishes virtualizer growth from intentional scroll-up.
- **Near-bottom restore clamp** snaps to the true max scroll when the remembered offset is within the tail band.
- **Affordance gating**: ``handleScroll`` is no-op while ``isPositioned`` is false; ``ScrollToBottomButton`` only renders when both ``showScrollBtn`` and ``isPositioned`` are true.

## Configuration changes

None.

## Test plan

- [x] ``bun run --filter=mcode-frontend typecheck`` passes
- [x] ``bun run --filter=mcode-frontend test`` — 1009 / 1009 pass (includes 7 ``MessageList.thread-switch`` tests covering cache-hit / cache-miss / remembered-scroll / settle paths)
- [x] Manual verification by author: long and short threads open at the bottom on first load, on cache-miss completion, on cache-hit switch, and on revisit with a remembered offset
- [ ] Reviewer: open a long thread on a fresh app start and confirm it lands at the tail without visible scroll motion
- [ ] Reviewer: switch back and forth between threads and confirm remembered offsets restore without a smooth-scroll flash

## Related

Closes the regression introduced over the recent ``fix/thread-scroll`` iteration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved scroll behavior when navigating between conversation threads
  * Enhanced scroll-to-bottom button visibility and responsiveness
  * Refined viewport positioning during thread loading and cache restoration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->