### PR TITLE
fix: require Ctrl+highlight to activate reply mode

### DIFF
--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -960,16 +960,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     return () => document.removeEventListener("click", handleClickOutside);
   }, []);
 
-  // Clear reply context when the user copies text — disambiguates "copy to reply"
-  // from "copy for clipboard" so the reply bar doesn't linger unexpectedly.
-  useEffect(() => {
-    const handleCopy = () => {
-      if (threadId) clearReply(threadId);
-    };
-    document.addEventListener("copy", handleCopy);
-    return () => document.removeEventListener("copy", handleCopy);
-  }, [threadId, clearReply]);
-
   // Dismiss reply when the user clicks outside both the composer and any message bubble.
   // Portaled overlays (popovers, dropdowns) render outside the composer DOM tree,
   // so we also check for popover-content markers to avoid false dismissals.

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -481,9 +481,12 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   }, [streamingText, scrollToBottom]);
 
   // Capture text selections in message bubbles and activate reply mode for the selected text.
-  // Fires on mouseup so the selection is already finalised when we read it.
+  // Only triggers when Ctrl (or Cmd on Mac) is held during mouseup so casual
+  // highlights don't accidentally activate the reply bar.
   useEffect(() => {
-    const handleMouseUp = () => {
+    const handleMouseUp = (e: MouseEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+
       const selection = window.getSelection();
       if (!selection || selection.isCollapsed || !selection.toString().trim()) return;
 


### PR DESCRIPTION
## What

Reply-on-highlight now requires the user to hold Ctrl (Cmd on Mac) while selecting text. Casual highlights no longer activate the reply bar.

## Why

The previous implementation triggered reply mode on every text selection, including accidental highlights. This made casual copying or reading disruptive because the reply bar appeared unexpectedly.

## Key changes

- **`MessageList.tsx`** - Added `ctrlKey`/`metaKey` guard to the `handleMouseUp` handler so only deliberate Ctrl+highlight activates reply mode
- **`Composer.tsx`** - Removed the copy-event handler that cleared reply on Ctrl+C, since the modifier key now gates activation rather than needing post-hoc disambiguation

## Test plan

- [ ] Highlight text in a message without holding Ctrl - reply bar should **not** appear
- [ ] Hold Ctrl (or Cmd on Mac) and highlight text - reply bar **should** appear with the selected text
- [ ] Click outside the composer/messages - reply bar dismisses
- [ ] Use the explicit Reply button on a message - still works as before
- [ ] Submit a reply with quoted text - quoted text is included in the sent message

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reply activation behavior to require Ctrl (or Cmd on macOS) + mouse release when selecting text, improving context handling and reply interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->