### PR TITLE
fix: make worktree creation resilient to post-checkout hook errors

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -551,7 +551,7 @@ export class AgentService {
     copilotAgent?: string,
     contextWindowMode?: ContextWindowMode,
     thinking?: boolean,
-  ): Promise<Thread> {
+  ): Promise<Thread & { warnings?: string[] }> {
     const title = truncateTitle(content);
 
     if (parentThreadId) {
@@ -636,7 +636,8 @@ export class AgentService {
     });
 
     const updated = this.threadRepo.findById(thread.id);
-    return updated ?? thread;
+    const { warnings } = thread as { warnings?: string[] };
+    return { ...(updated ?? thread), ...(warnings?.length ? { warnings } : {}) };
   }
 
   /**
@@ -665,7 +666,7 @@ export class AgentService {
     copilotAgent?: string;
     contextWindowMode?: ContextWindowMode;
     thinking?: boolean;
-  }): Promise<Thread> {
+  }): Promise<Thread & { warnings?: string[] }> {
     const {
       workspaceId, content, model, permissionMode, mode, branch,
       existingWorktreePath, attachments, reasoningLevel, provider,
@@ -850,7 +851,8 @@ export class AgentService {
       });
     });
 
-    return thread;
+    const { warnings } = thread as { warnings?: string[] };
+    return { ...thread, ...(warnings?.length ? { warnings } : {}) };
   }
 
   /** Stop the agent for a given thread, persisting any buffered tool calls first. */

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -567,6 +567,7 @@ export class AgentService {
     }
 
     let thread: Thread;
+    let threadWarnings: string[] | undefined;
     if (existingWorktreePath) {
       // Attach to existing worktree
       const workspace = this.workspaceRepo.findById(workspaceId);
@@ -598,7 +599,9 @@ export class AgentService {
         branch: canonicalBranch,
       };
     } else if (mode === "worktree") {
-      thread = await this.threadService.create(workspaceId, title, "worktree", branch);
+      const createResult = await this.threadService.create(workspaceId, title, "worktree", branch);
+      threadWarnings = createResult.warnings;
+      thread = createResult;
       this.threadRepo.updateProvider(thread.id, provider);
       thread = { ...thread, provider };
     } else {
@@ -636,8 +639,7 @@ export class AgentService {
     });
 
     const updated = this.threadRepo.findById(thread.id);
-    const { warnings } = thread as { warnings?: string[] };
-    return { ...(updated ?? thread), ...(warnings?.length ? { warnings } : {}) };
+    return { ...(updated ?? thread), ...(threadWarnings?.length ? { warnings: threadWarnings } : {}) };
   }
 
   /**
@@ -755,6 +757,7 @@ export class AgentService {
     // Create child thread with lineage
     const lineage = { parentThreadId, forkedFromMessageId: resolvedForkMessageId };
     let thread: Thread;
+    let threadWarnings: string[] | undefined;
 
     if (existingWorktreePath) {
       const workspace = this.workspaceRepo.findById(workspaceId);
@@ -769,7 +772,9 @@ export class AgentService {
       this.threadRepo.updateWorktreePath(thread.id, existingWorktreePath);
       thread = { ...thread, worktree_path: existingWorktreePath, branch: matched.branch };
     } else if (mode === "worktree") {
-      thread = await this.threadService.create(workspaceId, title, "worktree", branch);
+      const createResult = await this.threadService.create(workspaceId, title, "worktree", branch);
+      threadWarnings = createResult.warnings;
+      thread = createResult;
       // Patch lineage + provider atomically. If either fails, delete the orphan thread.
       try {
         this.threadRepo.updateLineage(thread.id, parentThreadId, resolvedForkMessageId);
@@ -851,8 +856,7 @@ export class AgentService {
       });
     });
 
-    const { warnings } = thread as { warnings?: string[] };
-    return { ...thread, ...(warnings?.length ? { warnings } : {}) };
+    return { ...thread, ...(threadWarnings?.length ? { warnings: threadWarnings } : {}) };
   }
 
   /** Stop the agent for a given thread, persisting any buffered tool calls first. */

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -207,14 +207,15 @@ export class GitService {
 
   /**
    * Create a new git worktree in the mcode data directory.
-   * Returns the worktree metadata including the filesystem path and whether this
-   * call created the branch or attached to an existing one.
+   * Returns the worktree metadata including the filesystem path, whether this
+   * call created the branch or attached to an existing one, and any non-fatal
+   * warnings (e.g. post-checkout hook failures).
    */
   createWorktree(
     repoPath: string,
     name: string,
     branchName?: string,
-  ): WorktreeInfo & { createdBranch: boolean } {
+  ): WorktreeInfo & { createdBranch: boolean; warnings: string[] } {
     validateWorktreeName(name);
 
     if (!existsSync(repoPath)) {
@@ -230,22 +231,43 @@ export class GitService {
     }
 
     const createdBranch = !branchExists(repoPath, branch);
+    const warnings: string[] = [];
 
-    if (!createdBranch) {
-      execFileSync(
-        "git",
-        ["-C", repoPath, "worktree", "add", wtPath, branch],
-        { stdio: "pipe", windowsHide: true },
-      );
-    } else {
-      execFileSync(
-        "git",
-        ["-C", repoPath, "worktree", "add", wtPath, "-b", branch],
-        { stdio: "pipe", windowsHide: true },
-      );
+    try {
+      if (!createdBranch) {
+        execFileSync(
+          "git",
+          ["-C", repoPath, "worktree", "add", wtPath, branch],
+          { stdio: "pipe", windowsHide: true },
+        );
+      } else {
+        execFileSync(
+          "git",
+          ["-C", repoPath, "worktree", "add", wtPath, "-b", branch],
+          { stdio: "pipe", windowsHide: true },
+        );
+      }
+    } catch (err) {
+      // If the worktree directory exists, git completed its work before the
+      // post-checkout hook ran. Treat the hook failure as a warning so the
+      // caller can still use the worktree rather than discarding it.
+      if (existsSync(wtPath)) {
+        const stderr =
+          err instanceof Error && "stderr" in err
+            ? String((err as { stderr: unknown }).stderr)
+            : String(err);
+        warnings.push(stderr || String(err));
+        logger.warn("Worktree created but post-checkout hook failed", {
+          wtPath,
+          branch,
+          error: stderr,
+        });
+      } else {
+        throw err;
+      }
     }
 
-    return { name, path: wtPath, branch, managed: true, createdBranch };
+    return { name, path: wtPath, branch, managed: true, createdBranch, warnings };
   }
 
   /**

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -251,7 +251,7 @@ export class GitService {
       // If the worktree directory exists, git completed its work before the
       // post-checkout hook ran. Treat the hook failure as a warning so the
       // caller can still use the worktree rather than discarding it.
-      if (existsSync(wtPath)) {
+      if (existsSync(join(wtPath, ".git"))) {
         const stderr =
           err instanceof Error && "stderr" in err
             ? String((err as { stderr: unknown }).stderr)

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -248,9 +248,9 @@ export class GitService {
         );
       }
     } catch (err) {
-      // If the worktree directory exists, git completed its work before the
-      // post-checkout hook ran. Treat the hook failure as a warning so the
-      // caller can still use the worktree rather than discarding it.
+      // If the worktree's .git file exists, git initialized the worktree
+      // successfully. The error likely comes from a post-checkout hook.
+      // Treat it as a warning so the caller can still use the worktree.
       if (existsSync(join(wtPath, ".git"))) {
         const stderr =
           err instanceof Error && "stderr" in err

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -32,7 +32,7 @@ export class ThreadService {
     title: string,
     mode: string,
     branch: string,
-  ): Promise<Thread> {
+  ): Promise<Thread & { warnings?: string[] }> {
     validateBranchName(branch);
 
     const threadMode: ThreadMode =
@@ -105,7 +105,11 @@ export class ThreadService {
           );
         }
 
-        return { ...thread, worktree_path: info.path };
+        return {
+          ...thread,
+          worktree_path: info.path,
+          warnings: info.warnings.length > 0 ? info.warnings : undefined,
+        };
       } catch (err) {
         this.threadRepo.hardDelete(thread.id);
         throw err;

--- a/apps/web/e2e/checkout-failure-ui.spec.ts
+++ b/apps/web/e2e/checkout-failure-ui.spec.ts
@@ -112,7 +112,7 @@ test.describe("Thread creation error (CollapsibleError)", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
     await page.waitForFunction(
-      () => (window as any).__mcodeHydrationComplete === true,
+      () => (window as any).__mcodeHydrationComplete === true, // eslint-disable-line @typescript-eslint/no-explicit-any
     );
   });
 
@@ -177,7 +177,7 @@ test.describe("Post-checkout warning banner (ThreadWarningBanner)", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
     await page.waitForFunction(
-      () => (window as any).__mcodeHydrationComplete === true,
+      () => (window as any).__mcodeHydrationComplete === true, // eslint-disable-line @typescript-eslint/no-explicit-any
     );
   });
 

--- a/apps/web/e2e/checkout-failure-ui.spec.ts
+++ b/apps/web/e2e/checkout-failure-ui.spec.ts
@@ -1,0 +1,269 @@
+/**
+ * E2E tests verifying that:
+ * 1. Thread creation failures render in a CollapsibleError component
+ *    (expandable details + Retry / Dismiss buttons).
+ * 2. Post-checkout warnings render in a ThreadWarningBanner component
+ *    (amber, collapsible, dismissible).
+ */
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+const WORKSPACE = {
+  id: "ws-checkout-test",
+  name: "Checkout Failure Test",
+  path: "/tmp/checkout-test",
+  provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const BASE_THREAD = {
+  workspace_id: WORKSPACE.id,
+  status: "idle" as const,
+  mode: "worktree" as const,
+  worktree_path: "/tmp/wt",
+  branch: "mcode/test-branch",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: null,
+  deleted_at: null,
+  worktree_managed: true,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const THREAD_WITH_ERROR = {
+  ...BASE_THREAD,
+  id: "thread-error-1",
+  title: "Thread with creation error",
+  clientPreparing: false,
+  clientError:
+    "fatal: post-checkout hook failed (error code 1)\nhint: The worktree was created but the hook exited with an error.\nhint: Check your .git/hooks/post-checkout script.",
+};
+
+const THREAD_WITH_WARNINGS = {
+  ...BASE_THREAD,
+  id: "thread-warning-1",
+  title: "Thread with post-checkout warnings",
+  clientWarnings: [
+    "warning: post-checkout hook exited with code 1\nfailed to install dependencies in worktree\nnpm ERR! code ERESOLVE\nnpm ERR! ERESOLVE could not resolve",
+    "warning: unable to update submodules in worktree",
+  ],
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function setupWorkspaceState(
+  page: Page,
+  opts: {
+    workspaces: (typeof WORKSPACE)[];
+    threads: (typeof BASE_THREAD)[];
+    activeWorkspaceId: string;
+    activeThreadId: string;
+  },
+): Promise<void> {
+  await page.evaluate(
+    ({ workspaces, threads, activeWorkspaceId, activeThreadId }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({
+        workspaces,
+        threads,
+        activeWorkspaceId,
+        activeThreadId,
+        loading: false,
+      });
+    },
+    opts,
+  );
+}
+
+// ── Tests: CollapsibleError ──────────────────────────────────────────────────
+
+test.describe("Thread creation error (CollapsibleError)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page);
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () => (window as any).__mcodeHydrationComplete === true,
+    );
+  });
+
+  test("shows collapsed error summary with retry and dismiss buttons", async ({
+    page,
+  }) => {
+    await setupWorkspaceState(page, {
+      workspaces: [WORKSPACE],
+      threads: [THREAD_WITH_ERROR],
+      activeWorkspaceId: WORKSPACE.id,
+      activeThreadId: THREAD_WITH_ERROR.id,
+    });
+
+    // Summary text should be visible
+    await expect(page.getByText("Failed to create thread")).toBeVisible();
+
+    // Retry and Dismiss buttons should be visible
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Dismiss" })).toBeVisible();
+
+    // Error detail should NOT be visible yet (collapsed)
+    await expect(page.locator("pre").filter({ hasText: "post-checkout" })).not.toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/screenshots/collapsible-error-collapsed.png",
+      fullPage: true,
+    });
+  });
+
+  test("expands to show error details when clicked", async ({ page }) => {
+    await setupWorkspaceState(page, {
+      workspaces: [WORKSPACE],
+      threads: [THREAD_WITH_ERROR],
+      activeWorkspaceId: WORKSPACE.id,
+      activeThreadId: THREAD_WITH_ERROR.id,
+    });
+
+    // Click the summary to expand
+    await page.getByText("Failed to create thread").click();
+
+    // Error detail should now be visible
+    const errorDetail = page.locator("pre").filter({ hasText: "post-checkout" });
+    await expect(errorDetail).toBeVisible();
+    await expect(errorDetail).toContainText("post-checkout hook failed");
+
+    await page.screenshot({
+      path: "e2e/screenshots/collapsible-error-expanded.png",
+      fullPage: true,
+    });
+  });
+});
+
+// ── Tests: ThreadWarningBanner ───────────────────────────────────────────────
+
+test.describe("Post-checkout warning banner (ThreadWarningBanner)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "thread.list": [THREAD_WITH_WARNINGS],
+      "message.list": [],
+    });
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () => (window as any).__mcodeHydrationComplete === true,
+    );
+  });
+
+  test("shows warning banner with summary and dismiss button", async ({
+    page,
+  }) => {
+    await setupWorkspaceState(page, {
+      workspaces: [WORKSPACE],
+      threads: [THREAD_WITH_WARNINGS],
+      activeWorkspaceId: WORKSPACE.id,
+      activeThreadId: THREAD_WITH_WARNINGS.id,
+    });
+
+    // Summary text should be visible
+    await expect(
+      page.getByText("Post-checkout hook encountered an error"),
+    ).toBeVisible();
+
+    // Dismiss button (X) should be visible
+    await expect(
+      page.getByRole("button", { name: "Dismiss warning" }),
+    ).toBeVisible();
+
+    // Warning details should NOT be visible yet (collapsed)
+    await expect(
+      page.locator("pre").filter({ hasText: "npm ERR" }),
+    ).not.toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/screenshots/warning-banner-collapsed.png",
+      fullPage: true,
+    });
+  });
+
+  test("expands to show warning details when clicked", async ({ page }) => {
+    await setupWorkspaceState(page, {
+      workspaces: [WORKSPACE],
+      threads: [THREAD_WITH_WARNINGS],
+      activeWorkspaceId: WORKSPACE.id,
+      activeThreadId: THREAD_WITH_WARNINGS.id,
+    });
+
+    // Click the summary to expand
+    await page.getByText("Post-checkout hook encountered an error").click();
+
+    // Warning details should now be visible
+    const warningDetail = page.locator("pre").filter({ hasText: "npm ERR" });
+    await expect(warningDetail).toBeVisible();
+
+    // Both warnings should be rendered
+    await expect(
+      page.locator("pre").filter({ hasText: "failed to install dependencies" }),
+    ).toBeVisible();
+    await expect(
+      page.locator("pre").filter({ hasText: "unable to update submodules" }),
+    ).toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/screenshots/warning-banner-expanded.png",
+      fullPage: true,
+    });
+  });
+
+  test("dismiss button removes the warning banner", async ({ page }) => {
+    await setupWorkspaceState(page, {
+      workspaces: [WORKSPACE],
+      threads: [THREAD_WITH_WARNINGS],
+      activeWorkspaceId: WORKSPACE.id,
+      activeThreadId: THREAD_WITH_WARNINGS.id,
+    });
+
+    await expect(
+      page.getByText("Post-checkout hook encountered an error"),
+    ).toBeVisible();
+
+    // Click dismiss
+    await page.getByRole("button", { name: "Dismiss warning" }).click();
+
+    // Banner should disappear
+    await expect(
+      page.getByText("Post-checkout hook encountered an error"),
+    ).not.toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/screenshots/warning-banner-dismissed.png",
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -12,11 +12,12 @@ import { PlanQuestionWizard } from "@/components/chat/PlanQuestionWizard";
 import { HeaderActions } from "./HeaderActions";
 import { CliErrorBanner, isCliError } from "./CliErrorBanner";
 import { InterruptedSessionsBanner } from "./InterruptedSessionsBanner";
+import { CollapsibleError } from "./CollapsibleError";
+import { ThreadWarningBanner } from "./ThreadWarningBanner";
 import { ThreadTitleEditor } from "./ThreadTitleEditor";
 import { SidebarRevealButton } from "@/components/sidebar/SidebarRevealButton";
 import { useUiStore } from "@/stores/uiStore";
 import { preparingStatusLabel, type WorkspaceThread } from "@/lib/workspace-thread";
-import { Button } from "@/components/ui/button";
 import { useReplyStore } from "@/stores/replyStore";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
@@ -142,17 +143,11 @@ function ThreadPreparingShell({
         </div>
 
         {thread.clientError ? (
-          <div className="mx-auto flex w-full max-w-xl flex-col items-stretch gap-3">
-            <p className="text-center text-sm text-destructive">{thread.clientError}</p>
-            <div className="flex justify-center gap-2">
-              <Button type="button" size="sm" variant="default" onClick={onRetry}>
-                Retry
-              </Button>
-              <Button type="button" size="sm" variant="outline" onClick={onDismiss}>
-                Dismiss
-              </Button>
-            </div>
-          </div>
+          <CollapsibleError
+            error={thread.clientError}
+            onRetry={onRetry}
+            onDismiss={onDismiss}
+          />
         ) : (
           <div className="text-muted-foreground flex items-center justify-center gap-2 text-sm">
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
@@ -478,6 +473,16 @@ export function ChatView() {
           />
         </div>
       )}
+
+      {/* Post-checkout warning banner — shown when worktree created but hook failed */}
+      {activeThread.clientWarnings?.length ? (
+        <div className="px-4 pt-2">
+          <ThreadWarningBanner
+            warnings={activeThread.clientWarnings}
+            onDismiss={() => useWorkspaceStore.getState().dismissWarnings(activeThread.id)}
+          />
+        </div>
+      ) : null}
 
       {/* Messages, tool calls, and streaming — all in one scrollable area.
           No `key` here: forcing remount on thread switch would destroy the

--- a/apps/web/src/components/chat/CollapsibleError.tsx
+++ b/apps/web/src/components/chat/CollapsibleError.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { AlertCircle, ChevronDown, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+interface CollapsibleErrorProps {
+  /** Raw error string from the failed RPC call. */
+  error: string;
+  onRetry: () => void;
+  onDismiss: () => void;
+}
+
+/** Thread creation error with a collapsible detail section. */
+export function CollapsibleError({ error, onRetry, onDismiss }: CollapsibleErrorProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col items-stretch gap-3">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 text-left text-sm font-medium text-destructive"
+            >
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span className="flex-1">Failed to create thread</span>
+              {open ? (
+                <ChevronDown className="h-4 w-4 shrink-0 text-destructive/60" />
+              ) : (
+                <ChevronRight className="h-4 w-4 shrink-0 text-destructive/60" />
+              )}
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <pre className="mt-3 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-destructive/20 bg-destructive/5 px-3 py-2 font-mono text-xs text-destructive/80">
+              {error}
+            </pre>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+
+      <div className="flex justify-center gap-2">
+        <Button type="button" size="sm" variant="default" onClick={onRetry}>
+          Retry
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/CollapsibleError.tsx
+++ b/apps/web/src/components/chat/CollapsibleError.tsx
@@ -21,7 +21,7 @@ export function CollapsibleError({ error, onRetry, onDismiss }: CollapsibleError
   return (
     <div className="animate-fade-up-in mx-auto flex w-full max-w-xl flex-col items-stretch gap-3">
       <Collapsible open={open} onOpenChange={setOpen}>
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 transition-colors duration-150 hover:bg-destructive/8">
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 transition-colors duration-150 hover:bg-destructive/10">
           <CollapsibleTrigger asChild>
             <button
               type="button"

--- a/apps/web/src/components/chat/CollapsibleError.tsx
+++ b/apps/web/src/components/chat/CollapsibleError.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AlertCircle, ChevronDown, ChevronRight } from "lucide-react";
+import { AlertCircle, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -19,9 +19,9 @@ export function CollapsibleError({ error, onRetry, onDismiss }: CollapsibleError
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="mx-auto flex w-full max-w-xl flex-col items-stretch gap-3">
+    <div className="animate-fade-up-in mx-auto flex w-full max-w-xl flex-col items-stretch gap-3">
       <Collapsible open={open} onOpenChange={setOpen}>
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 transition-colors duration-150 hover:bg-destructive/8">
           <CollapsibleTrigger asChild>
             <button
               type="button"
@@ -29,14 +29,13 @@ export function CollapsibleError({ error, onRetry, onDismiss }: CollapsibleError
             >
               <AlertCircle className="h-4 w-4 shrink-0" />
               <span className="flex-1">Failed to create thread</span>
-              {open ? (
-                <ChevronDown className="h-4 w-4 shrink-0 text-destructive/60" />
-              ) : (
-                <ChevronRight className="h-4 w-4 shrink-0 text-destructive/60" />
-              )}
+              <ChevronRight
+                className="h-4 w-4 shrink-0 text-destructive/60 transition-transform duration-200"
+                style={{ transform: open ? "rotate(90deg)" : "rotate(0deg)" }}
+              />
             </button>
           </CollapsibleTrigger>
-          <CollapsibleContent>
+          <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
             <pre className="mt-3 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-destructive/20 bg-destructive/5 px-3 py-2 font-mono text-xs text-destructive/80">
               {error}
             </pre>

--- a/apps/web/src/components/chat/ThreadWarningBanner.tsx
+++ b/apps/web/src/components/chat/ThreadWarningBanner.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { AlertTriangle, ChevronDown, ChevronRight, X } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+/** Non-fatal warning messages from worktree creation. */
+interface ThreadWarningBannerProps {
+  /** Non-fatal warning messages from worktree creation. */
+  warnings: string[];
+  /** Called when the user dismisses the banner via the X button. */
+  onDismiss: () => void;
+}
+
+/** Dismissible warning banner for post-checkout issues on a successfully created thread. */
+export function ThreadWarningBanner({
+  warnings,
+  onDismiss,
+}: ThreadWarningBannerProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="flex flex-1 items-center gap-2 text-left text-sm font-medium text-amber-600 dark:text-amber-400"
+              >
+                <AlertTriangle className="h-4 w-4 shrink-0" />
+                <span className="flex-1">
+                  Post-checkout hook encountered an error
+                </span>
+                {open ? (
+                  <ChevronDown className="h-4 w-4 shrink-0 opacity-60" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 shrink-0 opacity-60" />
+                )}
+              </button>
+            </CollapsibleTrigger>
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="rounded p-0.5 text-amber-600/60 transition-colors hover:text-amber-600 dark:text-amber-400/60 dark:hover:text-amber-400"
+              aria-label="Dismiss warning"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <CollapsibleContent>
+            <div className="mt-3 space-y-2">
+              {warnings.map((w, i) => (
+                <pre
+                  key={i}
+                  className="max-h-32 overflow-auto whitespace-pre-wrap break-words rounded border border-amber-500/20 bg-amber-500/5 px-3 py-2 font-mono text-xs text-amber-700 dark:text-amber-300"
+                >
+                  {w}
+                </pre>
+              ))}
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ThreadWarningBanner.tsx
+++ b/apps/web/src/components/chat/ThreadWarningBanner.tsx
@@ -22,7 +22,7 @@ export function ThreadWarningBanner({
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="animate-fade-up-in mx-auto w-full max-w-3xl px-4">
+    <div className="animate-fade-up-in mx-auto w-full max-w-3xl">
       <Collapsible open={open} onOpenChange={setOpen}>
         <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 transition-colors duration-150 hover:bg-amber-500/10">
           <div className="flex items-center gap-2">

--- a/apps/web/src/components/chat/ThreadWarningBanner.tsx
+++ b/apps/web/src/components/chat/ThreadWarningBanner.tsx
@@ -24,7 +24,7 @@ export function ThreadWarningBanner({
   return (
     <div className="animate-fade-up-in mx-auto w-full max-w-3xl px-4">
       <Collapsible open={open} onOpenChange={setOpen}>
-        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 transition-colors duration-150 hover:bg-amber-500/8">
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 transition-colors duration-150 hover:bg-amber-500/10">
           <div className="flex items-center gap-2">
             <CollapsibleTrigger asChild>
               <button

--- a/apps/web/src/components/chat/ThreadWarningBanner.tsx
+++ b/apps/web/src/components/chat/ThreadWarningBanner.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AlertTriangle, ChevronDown, ChevronRight, X } from "lucide-react";
+import { AlertTriangle, ChevronRight, X } from "lucide-react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -22,9 +22,9 @@ export function ThreadWarningBanner({
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-4">
+    <div className="animate-fade-up-in mx-auto w-full max-w-3xl px-4">
       <Collapsible open={open} onOpenChange={setOpen}>
-        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3">
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 transition-colors duration-150 hover:bg-amber-500/8">
           <div className="flex items-center gap-2">
             <CollapsibleTrigger asChild>
               <button
@@ -35,23 +35,22 @@ export function ThreadWarningBanner({
                 <span className="flex-1">
                   Post-checkout hook encountered an error
                 </span>
-                {open ? (
-                  <ChevronDown className="h-4 w-4 shrink-0 opacity-60" />
-                ) : (
-                  <ChevronRight className="h-4 w-4 shrink-0 opacity-60" />
-                )}
+                <ChevronRight
+                  className="h-4 w-4 shrink-0 opacity-60 transition-transform duration-200"
+                  style={{ transform: open ? "rotate(90deg)" : "rotate(0deg)" }}
+                />
               </button>
             </CollapsibleTrigger>
             <button
               type="button"
               onClick={onDismiss}
-              className="rounded p-0.5 text-amber-600/60 transition-colors hover:text-amber-600 dark:text-amber-400/60 dark:hover:text-amber-400"
+              className="rounded p-1 text-amber-600/60 transition-all duration-150 hover:bg-amber-500/10 hover:text-amber-600 dark:text-amber-400/60 dark:hover:bg-amber-500/10 dark:hover:text-amber-400"
               aria-label="Dismiss warning"
             >
               <X className="h-3.5 w-3.5" />
             </button>
           </div>
-          <CollapsibleContent>
+          <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
             <div className="mt-3 space-y-2">
               {warnings.map((w, i) => (
                 <pre

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -158,6 +158,23 @@
   animation: fade-up-in 150ms ease-out;
 }
 
+/* Radix Collapsible slide-open / slide-closed using the content's intrinsic
+ * height via --radix-collapsible-content-height. */
+@keyframes collapsible-down {
+  from { height: 0; opacity: 0; }
+  to   { height: var(--radix-collapsible-content-height); opacity: 1; }
+}
+@keyframes collapsible-up {
+  from { height: var(--radix-collapsible-content-height); opacity: 1; }
+  to   { height: 0; opacity: 0; }
+}
+.animate-collapsible-down {
+  animation: collapsible-down 200ms ease-out;
+}
+.animate-collapsible-up {
+  animation: collapsible-up 150ms ease-out;
+}
+
 @keyframes chip-enter {
   from { opacity: 0; transform: translateX(-4px); }
   to   { opacity: 1; transform: translateX(0); }
@@ -166,7 +183,10 @@
   animation: chip-enter 150ms ease-out;
 }
 @media (prefers-reduced-motion: reduce) {
-  .animate-chip-enter {
+  .animate-fade-up-in,
+  .animate-chip-enter,
+  .animate-collapsible-down,
+  .animate-collapsible-up {
     animation: none;
   }
 }

--- a/apps/web/src/lib/workspace-thread.ts
+++ b/apps/web/src/lib/workspace-thread.ts
@@ -9,6 +9,8 @@ export type WorkspaceThread = Thread & {
   clientPreparing?: boolean;
   /** Set when creation failed; user can retry or dismiss. */
   clientError?: string | null;
+  /** Non-fatal warnings from thread creation (e.g. worktree checkout issues). */
+  clientWarnings?: string[] | null;
   /** Message body shown in the preparing shell (mirrors cleared composer input). */
   clientQueuedMessage?: string;
   /**

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -5,7 +5,7 @@ import {
   buildPlaceholderWorkspaceThread,
   titleFromMessageContent,
 } from "@/lib/workspace-thread";
-import type { ChecksStatus } from "@mcode/contracts";
+import type { ChecksStatus, CreateAndSendResult } from "@mcode/contracts";
 import { getTransport } from "@/transport";
 import { useThreadStore } from "./threadStore";
 import { useTerminalStore } from "./terminalStore";
@@ -74,7 +74,7 @@ interface PendingThreadCreation {
 
 const pendingThreadCreationByPlaceholderId = new Map<string, PendingThreadCreation>();
 
-async function runCreateAndSend(pending: PendingThreadCreation): Promise<Thread> {
+async function runCreateAndSend(pending: PendingThreadCreation): Promise<CreateAndSendResult> {
   return getTransport().createAndSendMessage(
     pending.workspaceId,
     pending.content,
@@ -190,6 +190,8 @@ interface WorkspaceState {
   setActiveThread: (id: string | null) => void;
   setPendingNewThread: (value: boolean) => void;
   updateThreadTitle: (threadId: string, title: string) => Promise<void>;
+  /** Clear non-fatal warnings for a thread (user dismissed the warning banner). */
+  dismissWarnings: (threadId: string) => void;
 
   // Branch actions
   loadBranches: (workspaceId: string) => Promise<void>;
@@ -250,9 +252,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
   const applyOptimisticSuccess = (
     placeholderId: string,
     workspaceId: string,
-    thread: Thread,
+    result: CreateAndSendResult,
     transportWasWorktree: boolean,
   ) => {
+    const { warnings, ...thread } = result;
     if (!pendingThreadCreationByPlaceholderId.has(placeholderId)) {
       return;
     }
@@ -276,7 +279,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     set((state) => {
       const without = state.threads.filter((t) => t.id !== placeholderId);
       const deduped = without.filter((t) => t.id !== thread.id);
-      const nextThreads: WorkspaceThread[] = [thread, ...deduped];
+      const wt: WorkspaceThread = warnings?.length
+        ? { ...thread, clientWarnings: warnings }
+        : thread;
+      const nextThreads: WorkspaceThread[] = [wt, ...deduped];
       const stillOnPlaceholder = state.activeThreadId === placeholderId;
       return {
         threads: nextThreads,
@@ -692,9 +698,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     }));
 
     try {
-      const thread = await runCreateAndSend(pending);
-      applyOptimisticSuccess(placeholderId, workspaceId, thread, mode === "worktree");
-      return thread;
+      const result = await runCreateAndSend(pending);
+      applyOptimisticSuccess(placeholderId, workspaceId, result, mode === "worktree");
+      return result;
     } catch (e) {
       applyOptimisticFailure(placeholderId, e);
       throw e;
@@ -774,9 +780,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     }));
 
     try {
-      const thread = await runCreateAndSend(pending);
-      applyOptimisticSuccess(placeholderId, workspaceId, thread, transportMode === "worktree");
-      return thread;
+      const result = await runCreateAndSend(pending);
+      applyOptimisticSuccess(placeholderId, workspaceId, result, transportMode === "worktree");
+      return result;
     } catch (e) {
       applyOptimisticFailure(placeholderId, e);
       throw e;
@@ -805,9 +811,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       agentStartTimes: { ...state.agentStartTimes, [placeholderId]: Date.now() },
     }));
     try {
-      const thread = await runCreateAndSend(pending);
-      applyOptimisticSuccess(placeholderId, pending.workspaceId, thread, pending.transportMode === "worktree");
-      return thread;
+      const result = await runCreateAndSend(pending);
+      applyOptimisticSuccess(placeholderId, pending.workspaceId, result, pending.transportMode === "worktree");
+      return result;
     } catch (e) {
       applyOptimisticFailure(placeholderId, e);
       throw e;
@@ -954,6 +960,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       set({ error: String(e) });
       throw e;
     }
+  },
+
+  dismissWarnings: (threadId) => {
+    set((state) => ({
+      threads: state.threads.map((t) =>
+        t.id === threadId ? { ...t, clientWarnings: null } : t,
+      ),
+    }));
   },
 
   loadBranches: async (workspaceId) => {

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -31,6 +31,7 @@ import type {
   CopilotSubagent,
   PermissionDecision,
   PermissionRequest,
+  CreateAndSendResult,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
@@ -143,7 +144,7 @@ export interface McodeTransport {
     copilotAgent?: string,
     contextWindow?: ContextWindowMode,
     thinking?: boolean,
-  ): Promise<Thread>;
+  ): Promise<CreateAndSendResult>;
   stopAgent(threadId: string): Promise<void>;
   /** Respond to a tool permission request from the agent. */
   respondToPermission(requestId: string, decision: PermissionDecision): Promise<void>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -17,6 +17,7 @@ import type {
   ProviderModelInfo,
   CopilotSubagent,
 } from "./types";
+import type { CreateAndSendResult } from "@mcode/contracts";
 import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 import {
@@ -525,7 +526,7 @@ export function createWsTransport(
       const guardrails = state.loaded
         ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
         : {};
-      return rpc<Thread>("agent.createAndSend", {
+      return rpc<CreateAndSendResult>("agent.createAndSend", {
         workspaceId,
         content,
         model,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -150,8 +150,9 @@ export {
   CreateThreadSchema,
   SendMessageSchema,
   CreateAndSendSchema,
+  CreateAndSendResultSchema,
 } from "./ws/methods.js";
-export type { WsMethodName } from "./ws/methods.js";
+export type { WsMethodName, CreateAndSendResult } from "./ws/methods.js";
 
 export { WS_CHANNELS } from "./ws/channels.js";
 export type { WsChannelName } from "./ws/channels.js";

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -100,6 +100,16 @@ export const CreateAndSendSchema = lazySchema(() =>
   ),
 );
 
+/** Result schema for agent.createAndSend: a Thread with optional non-fatal warnings. */
+export const CreateAndSendResultSchema = lazySchema(() =>
+  ThreadSchema().extend({
+    warnings: z.array(z.string()).optional(),
+  }),
+);
+
+/** Thread with optional non-fatal warnings from worktree creation. */
+export type CreateAndSendResult = z.infer<ReturnType<typeof CreateAndSendResultSchema>>;
+
 /** All RPC method definitions keyed by method name with params and result schemas. */
 export const WS_METHODS = lazySchema(() => ({
   "workspace.list": {
@@ -297,7 +307,7 @@ export const WS_METHODS = lazySchema(() => ({
   },
   "agent.createAndSend": {
     params: CreateAndSendSchema(),
-    result: ThreadSchema(),
+    result: CreateAndSendResultSchema(),
   },
   "agent.stop": {
     params: z.object({ threadId: z.string() }),


### PR DESCRIPTION
## What
Post-checkout hook failures during `git worktree add` no longer cause the entire thread creation to fail. Errors are demoted to warnings and displayed in polished, collapsible UI components.

## Why
`git worktree add` runs post-checkout hooks after creating the worktree. If the hook exits non-zero, `execFileSync` throws, and the entire creation was treated as a failure, even though the worktree was successfully created on disk. Users lost their worktree and saw an ugly, unscrollable error dump.

## Key Changes
- **Server resilience**: `createWorktree` catches post-checkout errors, checks for `.git` file (canonical worktree marker), and demotes to a warning array instead of throwing
- **Warnings propagation**: `threadService.create` -> `agentService.createAndSend` -> `CreateAndSendResultSchema` (Zod) -> RPC -> client store (`clientWarnings` on `WorkspaceThread`)
- **CollapsibleError component**: Red-bordered card with "Failed to create thread" summary, expandable error details, Retry/Dismiss buttons
- **ThreadWarningBanner component**: Amber banner for non-fatal warnings, collapsible details, X dismiss button
- **Animations**: Collapsible slide-down/up keyframes using `--radix-collapsible-content-height`, fade-up entrance, `prefers-reduced-motion` support
- **E2E tests**: 5 Playwright tests covering collapsed/expanded/dismissed states for both components

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible error panel for thread-creation failures with Retry and Dismiss.
  * Dismissible warning banner for post-checkout/non-fatal issues; warnings surface on threads and can be cleared.
  * Worktree checkout issues may now appear as non-blocking warnings instead of hard failures; UI shows collapsible animations for these panels.

* **Tests**
  * Added end-to-end tests covering error and warning UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->