### PR TITLE
feat(server): label child processes in Windows Task Manager

### DIFF
--- a/apps/server/src/__tests__/claude-provider-complete.test.ts
+++ b/apps/server/src/__tests__/claude-provider-complete.test.ts
@@ -94,13 +94,14 @@ vi.mock("@mcode/shared", () => ({
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { stubEnvService } from "./stub-env-service.js";
+import { stubJobObject } from "./stub-job-object.js";
 
 describe("ClaudeProvider.complete()", () => {
   let provider: ClaudeProvider;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    provider = new ClaudeProvider(stubEnvService());
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject());
   });
 
   it("resolves with the result text (does not deadlock)", async () => {

--- a/apps/server/src/__tests__/claude-provider-eviction.test.ts
+++ b/apps/server/src/__tests__/claude-provider-eviction.test.ts
@@ -13,6 +13,7 @@ vi.mock("@mcode/shared", async (importOriginal) => {
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { stubEnvService } from "./stub-env-service.js";
+import { stubJobObject } from "./stub-job-object.js";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";
 
 /** Mock SDK that yields a tool_use then pauses indefinitely (simulating a long-running tool). */
@@ -57,7 +58,7 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    provider = new ClaudeProvider(stubEnvService());
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject());
   });
 
   afterEach(() => {

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -77,6 +77,7 @@ vi.mock("@mcode/shared", async (importOriginal) => {
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { stubEnvService } from "./stub-env-service.js";
+import { stubJobObject } from "./stub-job-object.js";
 
 describe("ClaudeProvider permission mode changes", () => {
   let provider: ClaudeProvider;
@@ -85,7 +86,7 @@ describe("ClaudeProvider permission mode changes", () => {
     vi.clearAllMocks();
     sdkCalls.length = 0;
     mockQuery.mockImplementation(makeFakeSdkQuery(sdkCalls));
-    provider = new ClaudeProvider(stubEnvService());
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject());
   });
 
   it("reuses the session when permissionMode is unchanged", async () => {

--- a/apps/server/src/__tests__/claude-provider-queue.test.ts
+++ b/apps/server/src/__tests__/claude-provider-queue.test.ts
@@ -54,6 +54,7 @@ vi.mock("@mcode/shared", async (importOriginal) => {
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { stubEnvService } from "./stub-env-service.js";
+import { stubJobObject } from "./stub-job-object.js";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";
 
 describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
@@ -83,7 +84,7 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
       });
     });
 
-    provider = new ClaudeProvider(stubEnvService());
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject());
     const events: Array<{ type: string; error?: string }> = [];
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
@@ -142,7 +143,7 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
       });
     });
 
-    provider = new ClaudeProvider(stubEnvService());
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject());
     const events: Array<{ type: string; error?: string }> = [];
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 

--- a/apps/server/src/__tests__/claude-provider-result-error.test.ts
+++ b/apps/server/src/__tests__/claude-provider-result-error.test.ts
@@ -14,6 +14,7 @@ vi.mock("@mcode/shared", async (importOriginal) => {
 
 import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { stubEnvService } from "./stub-env-service.js";
+import { stubJobObject } from "./stub-job-object.js";
 import { queryMethodStubs } from "./helpers/mock-sdk-query";
 import { AgentEventType } from "@mcode/contracts";
 
@@ -47,7 +48,7 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
   let provider: ClaudeProvider;
   beforeEach(() => {
     vi.clearAllMocks();
-    provider = new ClaudeProvider(stubEnvService());
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject());
   });
 
   afterEach(() => {

--- a/apps/server/src/__tests__/resume-listener-cleanup.test.ts
+++ b/apps/server/src/__tests__/resume-listener-cleanup.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { EventEmitter } from "events";
 import { ClaudeProvider } from "../providers/claude/claude-provider.js";
 import { stubEnvService } from "./stub-env-service.js";
+import { stubJobObject } from "./stub-job-object.js";
 
 /**
  * Tests that verify resume listener cleanup in ClaudeProvider.
@@ -16,7 +17,7 @@ describe("ClaudeProvider resume listener cleanup", () => {
   let provider: ClaudeProvider;
 
   beforeEach(() => {
-    provider = new ClaudeProvider(stubEnvService());
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject());
   });
 
   /**

--- a/apps/server/src/__tests__/stub-job-object.ts
+++ b/apps/server/src/__tests__/stub-job-object.ts
@@ -1,0 +1,14 @@
+import type { JobObject } from "../services/job-object.js";
+
+/**
+ * Minimal `JobObject` for unit tests that construct providers without the DI container.
+ * All methods are no-ops; `isWindowsJob` is false so platform-gated code paths are skipped.
+ */
+export function stubJobObject(): JobObject {
+  return {
+    isWindowsJob: false,
+    assign: () => {},
+    setDescription: () => {},
+    close: () => {},
+  } as JobObject;
+}

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -32,6 +32,8 @@ import { AnthropicOAuthUsageSource } from "./usage/oauth-usage-source.js";
 import { AnthropicHeaderUsageSource } from "./usage/header-usage-source.js";
 import { CompositeUsageSource } from "./usage/composite-usage-source.js";
 import { EnvService } from "../../services/env-service.js";
+import { JobObject } from "../../services/job-object.js";
+import { listDirectChildren } from "../../services/process-kill.js";
 
 /** Shallow snapshot of `process.env` for temporary Claude SDK subprocess alignment. */
 function snapshotProcessEnv(): Record<string, string | undefined> {
@@ -237,7 +239,10 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     new AnthropicHeaderUsageSource(),
   ]);
 
-  constructor(@inject(EnvService) private readonly envService: EnvService) {
+  constructor(
+    @inject(EnvService) private readonly envService: EnvService,
+    @inject("JobObject") private readonly jobObject: JobObject,
+  ) {
     super();
   }
 
@@ -695,7 +700,21 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       cwd: resolvedCwd,
     });
 
+    let beforePids: Set<number> | undefined;
+    if (this.jobObject.isWindowsJob) {
+      try {
+        const children = await listDirectChildren(process.pid);
+        beforePids = new Set(children.map((c) => c.pid));
+      } catch {
+        // Best-effort
+      }
+    }
+
     const q = this.withSdkSpawnEnv(() => sdkQuery({ prompt: queue.iterable, options }));
+
+    if (beforePids) {
+      void this.labelSdkSubprocess(beforePids);
+    }
 
     const entry: SessionEntry = {
       query: q,
@@ -748,12 +767,26 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         const freshQueue = createPromptQueue();
         const freshOptions = { ...baseOptions, sessionId: uuid };
 
+        let freshBeforePids: Set<number> | undefined;
+        if (this.jobObject.isWindowsJob) {
+          try {
+            const children = await listDirectChildren(process.pid);
+            freshBeforePids = new Set(children.map((c) => c.pid));
+          } catch {
+            // Best-effort
+          }
+        }
+
         const freshQ = this.withSdkSpawnEnv(() =>
           sdkQuery({
             prompt: freshQueue.iterable,
             options: freshOptions,
           }),
         );
+
+        if (freshBeforePids) {
+          void this.labelSdkSubprocess(freshBeforePids);
+        }
         const freshEntry: SessionEntry = {
           query: freshQ,
           pushMessage: freshQueue.push,
@@ -1329,6 +1362,28 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         }
       }
     })();
+  }
+
+  /**
+   * Discover and label new child PIDs spawned by sdkQuery().
+   * Compares direct children of the server process before and after the spawn.
+   * Best-effort: races with other concurrent spawns are tolerated because
+   * labelling a wrong process is harmless (the description is overwritten
+   * on the next setDescription call for that PID).
+   */
+  private async labelSdkSubprocess(beforePids: Set<number>): Promise<void> {
+    if (!this.jobObject.isWindowsJob) return;
+    try {
+      const after = await listDirectChildren(process.pid);
+      for (const child of after) {
+        if (!beforePids.has(child.pid)) {
+          this.jobObject.assign(child.pid);
+          this.jobObject.setDescription(child.pid, "Mcode Agent: Claude");
+        }
+      }
+    } catch {
+      // Best-effort: process enumeration can fail transiently
+    }
   }
 
   /** Build a multimodal SDKUserMessage from text and attachments. */

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -292,6 +292,7 @@ export class CodexAppServer extends EventEmitter {
     // Must happen after spawn succeeds but before any async handshake steps.
     if (this.options.jobObject && child.pid) {
       this.options.jobObject.assign(child.pid);
+      this.options.jobObject.setDescription(child.pid, "Mcode Agent: Codex");
     }
 
     this.child = child;

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -28,6 +28,7 @@ import {
 import { SettingsService } from "../../services/settings-service.js";
 import { SkillService } from "../../services/skill-service.js";
 import { EnvService } from "../../services/env-service.js";
+import { JobObject } from "../../services/job-object.js";
 import {
   AgentEventType,
   CURSOR_STATIC_MODEL_FALLBACK,
@@ -112,6 +113,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     @inject(SettingsService) private readonly settingsService: SettingsService,
     @inject(SkillService) private readonly skillService: SkillService,
     @inject(EnvService) private readonly envService: EnvService,
+    @inject("JobObject") private readonly jobObject: JobObject,
   ) {
     super();
   }
@@ -312,6 +314,11 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
 
     if (!child.stdin || !child.stdout) {
       throw new Error("Failed to spawn cursor-agent: stdio pipes unavailable");
+    }
+
+    if (child.pid) {
+      this.jobObject.assign(child.pid);
+      this.jobObject.setDescription(child.pid, "Mcode Agent: Cursor");
     }
 
     const out = Writable.toWeb(child.stdin) as WritableStream<Uint8Array>;

--- a/apps/server/src/services/job-object.test.ts
+++ b/apps/server/src/services/job-object.test.ts
@@ -53,4 +53,24 @@ describe.runIf(process.platform === "win32")("JobObject (Windows)", () => {
     expect(() => job.assign(999_999_999)).not.toThrow();
     job.close();
   });
+
+  it("setDescription does not throw on a live process", async () => {
+    const job = new JobObject();
+    const child = spawn("ping", ["-n", "10", "127.0.0.1"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    try {
+      expect(() => job.setDescription(child.pid!, "Mcode Test Process")).not.toThrow();
+    } finally {
+      child.kill();
+      job.close();
+    }
+  });
+
+  it("setDescription is a no-op for dead PIDs", () => {
+    const job = new JobObject();
+    expect(() => job.setDescription(999_999_999, "Ghost")).not.toThrow();
+    job.close();
+  });
 });

--- a/apps/server/src/services/job-object.ts
+++ b/apps/server/src/services/job-object.ts
@@ -17,6 +17,8 @@ const _require = createRequire(import.meta.url);
 
 const PROCESS_SET_QUOTA = 0x0100;
 const PROCESS_TERMINATE = 0x0001;
+// SetProcessDescription requires only limited-information access, not full terminate rights.
+const PROCESS_SET_LIMITED_INFORMATION = 0x2000;
 const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
 const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
 // JOBOBJECT_EXTENDED_LIMIT_INFORMATION sizes:
@@ -29,6 +31,8 @@ interface WindowsState {
   CloseHandle: (h: unknown) => number;
   AssignProcessToJobObject: (job: unknown, proc: unknown) => number;
   OpenProcess: (access: number, inherit: number, pid: number) => unknown;
+  // Null when unavailable (not exported on all Windows SKUs/builds).
+  SetProcessDescription: ((proc: unknown, desc: string) => number) | null;
 }
 
 /**
@@ -65,6 +69,12 @@ export class JobObject {
     this.closeWindows();
   }
 
+  /** Set a human-readable description on a process (visible in Task Manager). No-op on non-Windows. */
+  setDescription(pid: number, description: string): void {
+    if (!this.initialized) return;
+    this.setDescriptionWindows(pid, description);
+  }
+
   private initWindows(): void {
     try {
       // Dynamic require so non-Windows builds never load the native binary.
@@ -98,7 +108,17 @@ export class JobObject {
         throw new Error("SetInformationJobObject failed");
       }
 
-      this.windowsState = { jobHandle, CloseHandle, AssignProcessToJobObject, OpenProcess };
+      // Load SetProcessDescription separately: not exported on all Windows SKUs/builds,
+      // so a failure here must not prevent the job object from initializing.
+      // Returns HRESULT (0=S_OK, negative=failure), unlike the BOOL-returning functions above.
+      let SetProcessDescription: WindowsState["SetProcessDescription"] = null;
+      try {
+        SetProcessDescription = kernel32.func("int32 __stdcall SetProcessDescription(void*, str16)");
+      } catch {
+        // Degrade gracefully; setDescription() will be a no-op on this machine.
+      }
+
+      this.windowsState = { jobHandle, CloseHandle, AssignProcessToJobObject, OpenProcess, SetProcessDescription };
       this.initialized = true;
       logger.info("JobObject initialized");
     } catch (err) {
@@ -123,6 +143,33 @@ export class JobObject {
       }
     } catch (err) {
       logger.debug("JobObject: assign threw", {
+        pid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      if (procHandle) {
+        try { s.CloseHandle(procHandle); } catch { /* ignore */ }
+      }
+    }
+  }
+
+  private setDescriptionWindows(pid: number, description: string): void {
+    const s = this.windowsState!;
+    if (!s.SetProcessDescription) return;
+    let procHandle: unknown = null;
+    try {
+      procHandle = s.OpenProcess(PROCESS_SET_LIMITED_INFORMATION, 0, pid);
+      if (!procHandle) return;
+      const hr = s.SetProcessDescription(procHandle, description);
+      // HRESULT: 0 (S_OK) = success, negative = failure
+      if (hr < 0) {
+        logger.debug("JobObject: SetProcessDescription failed", {
+          pid,
+          hr: `0x${(hr >>> 0).toString(16)}`,
+        });
+      }
+    } catch (err) {
+      logger.debug("JobObject: setDescription threw", {
         pid,
         error: err instanceof Error ? err.message : String(err),
       });

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -177,6 +177,8 @@ export class TerminalService {
     // so explicit assignment is needed — inheritance alone is not sufficient.
     // Best-effort: no-op on non-Windows or if JobObject failed to init.
     this.jobObject.assign(pty.pid);
+    const shellBasename = shell.split(/[\\/]/).pop() ?? shell;
+    this.jobObject.setDescription(pty.pid, `Mcode Terminal: ${shellBasename}`);
 
     const dataDisposable = pty.onData((data: string) => {
       // Re-encode to bytes so multi-byte sequences that straddle a node-pty


### PR DESCRIPTION
## What
Add human-readable descriptions to child processes spawned by the mCode server so they appear with meaningful names in Windows Task Manager instead of generic "node javascript runtime". Also fixes a bug where Cursor provider subprocesses were never assigned to the Job Object.

## Why
When multiple AI agent sessions run concurrently, users see a sea of identical "node.exe" entries in Task Manager with no way to tell them apart. This makes debugging, monitoring resource usage, and manual process management unnecessarily difficult.

## Key Changes
- Add `SetProcessDescription` Win32 API binding (via koffi FFI) to `JobObject` with graceful degradation when the API is unavailable
- Label terminal PTY processes as "Mcode Terminal: powershell" (or whichever shell)
- Label Codex agent subprocesses as "Mcode Agent: Codex"
- Label Cursor agent subprocesses as "Mcode Agent: Cursor" and fix missing Job Object assignment (subprocesses previously survived server crashes)
- Discover and label Claude SDK subprocesses as "Mcode Agent: Claude" via PID diff (SDK doesn't expose subprocess PID)

### Technical notes
- `SetProcessDescription` returns HRESULT (not BOOL like other kernel32 bindings), handled with `hr < 0` check
- Uses `PROCESS_SET_LIMITED_INFORMATION` (0x2000) access right, separate from the existing `PROCESS_SET_QUOTA | PROCESS_TERMINATE`
- `SetProcessDescription` binding is nullable in `WindowsState` because it's not exported on all Windows builds; gracefully degrades to no-op
- Claude PID discovery uses `listDirectChildren(process.pid)` diff before/after `sdkQuery()`, fire-and-forget
- `complete()` in ClaudeProvider intentionally excluded (ephemeral, sub-second lifetime)
- Windows-only; all methods are no-ops on macOS/Linux

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Windows: subprocesses for AI agents and background servers are now assigned human-readable process descriptions (e.g., agent and terminal labels) and tracked more reliably for better visibility and management.
* **Tests**
  * Added Windows-focused tests and a test helper to validate process-description behavior and ensure robustness across live and terminated subprocesses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->