### PR TITLE
fix(web): restore project tree scroll when projects overflow

### DIFF
--- a/apps/web/e2e/sidebar-project-scroll.spec.ts
+++ b/apps/web/e2e/sidebar-project-scroll.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+
+/** Injects many workspaces to overflow the sidebar viewport. */
+async function injectManyWorkspaces(page: Page, count: number): Promise<void> {
+  const iso = new Date().toISOString();
+  const workspaces = Array.from({ length: count }, (_, i) => ({
+    id: `ws-scroll-${i}`,
+    name: `Project ${String(i).padStart(2, "0")}`,
+    path: `/tmp/project-${i}`,
+    is_git_repo: true,
+    sort_order: i,
+    provider_config: {},
+    pinned: false,
+    last_opened_at: null,
+    created_at: iso,
+    updated_at: iso,
+  }));
+
+  await page.evaluate(
+    ({ wsList }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({
+        workspaces: wsList,
+        activeWorkspaceId: "ws-scroll-0",
+        threads: [],
+        activeThreadId: null,
+        loading: false,
+        error: null,
+      });
+    },
+    { wsList: workspaces },
+  );
+}
+
+test.describe("Sidebar project tree scroll", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page);
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("project list scrolls when projects exceed viewport height", async ({
+    page,
+  }) => {
+    await injectManyWorkspaces(page, 20);
+
+    await expect(page.getByTestId("project-row-ws-scroll-0")).toBeVisible();
+
+    const metrics = await page.evaluate(() => {
+      const vp = document.querySelector('[data-slot="scroll-area-viewport"]');
+      if (!vp) return { scrollHeight: 0, clientHeight: 0 };
+      return {
+        scrollHeight: vp.scrollHeight,
+        clientHeight: vp.clientHeight,
+      };
+    });
+
+    // Content must overflow the viewport
+    expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight + 50);
+
+    // Viewport must be scrollable
+    const scrolled = await page.evaluate(() => {
+      const vp = document.querySelector('[data-slot="scroll-area-viewport"]');
+      if (!vp) return false;
+      vp.scrollTop = 200;
+      return vp.scrollTop > 0;
+    });
+    expect(scrolled).toBe(true);
+  });
+});

--- a/apps/web/e2e/sidebar-project-scroll.spec.ts
+++ b/apps/web/e2e/sidebar-project-scroll.spec.ts
@@ -58,9 +58,13 @@ test.describe("Sidebar project tree scroll", () => {
 
     await expect(page.getByTestId("project-row-ws-scroll-0")).toBeVisible();
 
-    const metrics = await page.evaluate(() => {
-      const vp = document.querySelector('[data-slot="scroll-area-viewport"]');
-      if (!vp) return { scrollHeight: 0, clientHeight: 0 };
+    const viewport = page
+      .getByTestId("thread-list")
+      .locator('xpath=ancestor::*[@data-slot="scroll-area-viewport"][1]');
+    await expect(viewport).toBeVisible();
+
+    const metrics = await viewport.evaluate((el) => {
+      const vp = el as HTMLElement;
       return {
         scrollHeight: vp.scrollHeight,
         clientHeight: vp.clientHeight,
@@ -71,9 +75,8 @@ test.describe("Sidebar project tree scroll", () => {
     expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight + 50);
 
     // Viewport must be scrollable
-    const scrolled = await page.evaluate(() => {
-      const vp = document.querySelector('[data-slot="scroll-area-viewport"]');
-      if (!vp) return false;
+    const scrolled = await viewport.evaluate((el) => {
+      const vp = el as HTMLElement;
       vp.scrollTop = 200;
       return vp.scrollTop > 0;
     });

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -592,7 +592,7 @@ export function ProjectTree() {
         </Tooltip>
       </div>
 
-      <ScrollArea className="flex-1" viewportRef={scrollViewportRef}>
+      <ScrollArea className="min-h-0 flex-1" viewportRef={scrollViewportRef}>
         <div className="px-1" data-testid="thread-list">
           <DndContext
             sensors={sensors}


### PR DESCRIPTION
## What
Restore scrolling in the sidebar project tree when the list of projects exceeds the viewport height.

## Why
PR #389 changed the sidebar body from `overflow-y-auto` to `overflow-hidden` to fix drag-and-drop layout issues. This left the `ScrollArea` root without `min-h-0`, so the implicit `min-height: min-content` in the flex column prevented it from being constrained to the available space, breaking scroll.

## Key Changes
- Add `min-h-0` to the `ScrollArea` className in `ProjectTree.tsx` so the scroll container shrinks within the flex layout
- Add Playwright regression test (`sidebar-project-scroll.spec.ts`) that injects 20 workspaces and verifies the viewport overflows and is scrollable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar project-tree scrolling so long project lists overflow and scroll correctly within the sidebar viewport.

* **Tests**
  * Added an end-to-end test that validates sidebar scroll behavior with many projects to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->