### PR TITLE
fix(web): chat scroll behaviour and thread cache sync

### DIFF
--- a/apps/web/src/__tests__/pagination.test.ts
+++ b/apps/web/src/__tests__/pagination.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { TurnSnapshot } from "@mcode/contracts";
 import { useThreadStore, TOOL_CALL_CACHE_SIZE } from "@/stores/threadStore";
+import { cacheSnapshot, clearMessageCache, getCachedSnapshot } from "@/stores/messageCache";
 import { LruCache } from "@/lib/lru-cache";
 import { mockTransport, createMockMessage } from "./mocks/transport";
 import type { Message } from "@/transport";
@@ -14,6 +16,7 @@ describe("Chat Pagination", () => {
   const threadId = "thread-1";
 
   beforeEach(() => {
+    clearMessageCache();
     useThreadStore.setState({
       messages: [],
       runningThreadIds: new Set(),
@@ -33,6 +36,9 @@ describe("Chat Pagination", () => {
       hasMoreMessages: {},
       isLoadingMore: {},
       loadEpochByThread: {},
+      persistedFilesChanged: {},
+      latestTurnWithChanges: null,
+      answeredPlanMessageIdsByThread: {},
     });
     vi.clearAllMocks();
   });
@@ -180,6 +186,58 @@ describe("Chat Pagination", () => {
     expect(state.messages).toHaveLength(1);
     expect(state.messages[0].id).toBe("m2");
     expect(state.isLoadingMore[threadId]).toBe(false);
+  });
+
+  it("loadOlderMessages writes async snapshot file lists into the message cache", async () => {
+    const mOldId = "m-old";
+    const initialMessages = [
+      createMockMessage({ id: "m3", thread_id: threadId, sequence: 51 }),
+    ];
+    useThreadStore.setState({
+      currentThreadId: threadId,
+      messages: initialMessages,
+      oldestLoadedSequence: { [threadId]: 51 },
+      hasMoreMessages: { [threadId]: true },
+      isLoadingMore: {},
+      persistedFilesChanged: { m3: ["kept.ts"] },
+      latestTurnWithChanges: "m3",
+    });
+    cacheSnapshot(threadId, {
+      messages: initialMessages,
+      oldestLoadedSequence: 51,
+      hasMoreMessages: true,
+      persistedToolCallCounts: {},
+      persistedFilesChanged: { m3: ["kept.ts"] },
+      latestTurnWithChanges: "m3",
+      answeredPlanMessageIds: [],
+    });
+
+    const olderMessages = [
+      createMockMessage({ id: mOldId, thread_id: threadId, sequence: 1 }),
+    ];
+    (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      messages: olderMessages,
+      hasMore: false,
+    });
+
+    const snap: TurnSnapshot = {
+      id: "snap-1",
+      message_id: mOldId,
+      thread_id: threadId,
+      ref_before: "a",
+      ref_after: "b",
+      files_changed: ["legacy.ts"],
+      worktree_path: null,
+      created_at: new Date().toISOString(),
+    };
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValueOnce([snap]);
+
+    await useThreadStore.getState().loadOlderMessages(threadId);
+    expect(useThreadStore.getState().persistedFilesChanged[mOldId]).toEqual(["legacy.ts"]);
+
+    const cached = getCachedSnapshot(threadId);
+    expect(cached?.persistedFilesChanged[mOldId]).toEqual(["legacy.ts"]);
+    expect(cached?.persistedFilesChanged.m3).toEqual(["kept.ts"]);
   });
 
   it("loadOlderMessages resets isLoadingMore on network error", async () => {

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -21,7 +21,7 @@ import {
 } from "./virtual-items";
 import type { ChatVirtualItem } from "./virtual-items";
 import type { ToolCall } from "@/transport/types";
-import { rememberScrollTop, recallScrollTop } from "./scrollPositionMemory";
+import { rememberScrollTop, recallScrollTop, forgetScrollTop } from "./scrollPositionMemory";
 
 const EMPTY_TOOL_CALLS: ToolCall[] = [];
 const AUTO_SCROLL_THRESHOLD = 64;
@@ -714,6 +714,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
     pendingScrollRestoreRef.current = null;
     scrollToTailIntentRef.current = false;
+    // Recall is for one-shot restore when entering a thread. The layout effect
+    // also depends on items.length (initial hydrate); without forgetting, every
+    // new message re-queues the same offset and yanks the viewport off the tail.
+    if (activeThreadId) forgetScrollTop(activeThreadId);
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     const scrolledUp = distanceFromBottom > USER_AWAY_FROM_BOTTOM_PX;
     isScrolledUpRef.current = scrolledUp;

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -204,6 +204,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const isPositionedRef = useRef(false);
   /** Blocks streaming/discrete tail snaps briefly after wheel-up while not at the tail. */
   const streamingFollowPauseUntilRef = useRef(0);
+  /**
+   * True while a smooth jump-to-bottom is in flight so scroll handlers do not
+   * treat mid-animation offsets as "reading history" and re-show the chip.
+   */
+  const scrollToTailIntentRef = useRef(false);
 
   const messages = useThreadStore((s) => s.messages);
   const loading = useThreadStore((s) => s.loading);
@@ -271,6 +276,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   /** Clears tail pin when the user scrolls content upward (wheel / trackpad). */
   const handleWheel = useCallback((e: WheelEvent<HTMLDivElement>) => {
     if (e.deltaY < 0) {
+      scrollToTailIntentRef.current = false;
       pinListTailRef.current = false;
       streamingFollowPauseUntilRef.current = Date.now() + WHEEL_UP_FOLLOW_PAUSE_MS;
     }
@@ -299,15 +305,19 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
 
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const scrolledUp = distanceFromBottom > USER_AWAY_FROM_BOTTOM_PX;
-    if (scrolledUp) pinListTailRef.current = false;
+    const awayFromTail = distanceFromBottom > USER_AWAY_FROM_BOTTOM_PX;
+    if (scrollToTailIntentRef.current && !awayFromTail) {
+      scrollToTailIntentRef.current = false;
+    }
+    const scrolledUp = awayFromTail && !scrollToTailIntentRef.current;
+    if (awayFromTail) pinListTailRef.current = false;
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
-    if (!scrolledUp) {
+    if (!awayFromTail) {
       streamingFollowPauseUntilRef.current = 0;
     }
     // Clear new-content highlight once the user reaches the bottom
-    if (!scrolledUp) setHasNewContent(false);
+    if (!awayFromTail) setHasNewContent(false);
 
     // Trigger loading older messages when near the top
     if (
@@ -541,6 +551,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     );
     if (idx !== -1) {
       pinListTailRef.current = false;
+      scrollToTailIntentRef.current = false;
       virtualizer.scrollToIndex(idx, { align: "center", behavior: "smooth" });
       setTimeout(() => {
         const element = document.querySelector(`[data-message-id="${messageId}"]`);
@@ -578,6 +589,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
         scrollTimerRef.current = null;
       }
       turnExpandRef.current.clear();
+      scrollToTailIntentRef.current = false;
       prevMessageCountRef.current = 0;
       firstMessageIdRef.current = null;
       prevScrollHeightRef.current = 0;
@@ -701,6 +713,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       el.scrollTop = target;
     }
     pendingScrollRestoreRef.current = null;
+    scrollToTailIntentRef.current = false;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     const scrolledUp = distanceFromBottom > USER_AWAY_FROM_BOTTOM_PX;
     isScrolledUpRef.current = scrolledUp;
@@ -865,6 +878,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
           onScrollToBottom={() => {
             setHasNewContent(false);
             streamingFollowPauseUntilRef.current = 0;
+            scrollToTailIntentRef.current = true;
             isScrolledUpRef.current = false;
             setShowScrollBtn(false);
             scrollToBottom(true);

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -209,6 +209,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
    * treat mid-animation offsets as "reading history" and re-show the chip.
    */
   const scrollToTailIntentRef = useRef(false);
+  /** Previous `scrollTop` from the last `onScroll` pass; detects upward interrupts during smooth tail scroll. */
+  const prevScrollTopRef = useRef(0);
 
   const messages = useThreadStore((s) => s.messages);
   const loading = useThreadStore((s) => s.loading);
@@ -288,6 +290,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     const el = containerRef.current;
     if (!el) return;
 
+    if (
+      scrollToTailIntentRef.current
+      && el.scrollTop < prevScrollTopRef.current
+    ) {
+      scrollToTailIntentRef.current = false;
+    }
+
     const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
 
     if (pinListTailRef.current) {
@@ -328,6 +337,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     ) {
       loadOlderMessages(activeThreadId);
     }
+
+    prevScrollTopRef.current = el.scrollTop;
   }, [activeThreadId, hasMore, isLoadingMore, loadOlderMessages]);
 
   const stableItems = useMemo(

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -25,6 +25,15 @@ import { rememberScrollTop, recallScrollTop } from "./scrollPositionMemory";
 
 const EMPTY_TOOL_CALLS: ToolCall[] = [];
 const AUTO_SCROLL_THRESHOLD = 64;
+/**
+ * If the viewport is farther than this from the scroll tail, the user has left
+ * "follow latest" mode: show the down control and do not auto-scroll on new content.
+ * Kept near {@link AUTO_SCROLL_THRESHOLD} so this matches virtualizer tail tracking.
+ */
+const USER_AWAY_FROM_BOTTOM_PX = AUTO_SCROLL_THRESHOLD;
+/** After the user scrolls up with the wheel, block streaming auto-scroll briefly
+ * unless they are still glued to the bottom (avoids fighting a small nudge). */
+const WHEEL_UP_FOLLOW_PAUSE_MS = 750;
 const OVERSCAN = 8;
 const DEFAULT_ITEM_HEIGHT = 80;
 const PAGINATION_THRESHOLD = 200;
@@ -193,6 +202,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const [isPositioned, setIsPositioned] = useState(false);
   /** Mirrors `isPositioned` for `handleScroll` so affordances do not run while the scroller is opacity-0. */
   const isPositionedRef = useRef(false);
+  /** Blocks streaming/discrete tail snaps briefly after wheel-up while not at the tail. */
+  const streamingFollowPauseUntilRef = useRef(0);
 
   const messages = useThreadStore((s) => s.messages);
   const loading = useThreadStore((s) => s.loading);
@@ -259,7 +270,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
   /** Clears tail pin when the user scrolls content upward (wheel / trackpad). */
   const handleWheel = useCallback((e: WheelEvent<HTMLDivElement>) => {
-    if (e.deltaY < 0) pinListTailRef.current = false;
+    if (e.deltaY < 0) {
+      pinListTailRef.current = false;
+      streamingFollowPauseUntilRef.current = Date.now() + WHEEL_UP_FOLLOW_PAUSE_MS;
+    }
   }, []);
 
   /** Track scroll-to-bottom button visibility and trigger upward pagination near the top. */
@@ -285,10 +299,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
 
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const scrolledUp = distanceFromBottom > 200;
+    const scrolledUp = distanceFromBottom > USER_AWAY_FROM_BOTTOM_PX;
     if (scrolledUp) pinListTailRef.current = false;
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
+    if (!scrolledUp) {
+      streamingFollowPauseUntilRef.current = 0;
+    }
     // Clear new-content highlight once the user reaches the bottom
     if (!scrolledUp) setHasNewContent(false);
 
@@ -685,10 +702,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
     pendingScrollRestoreRef.current = null;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const scrolledUp = distanceFromBottom > 200;
+    const scrolledUp = distanceFromBottom > USER_AWAY_FROM_BOTTOM_PX;
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
-    if (!scrolledUp) setHasNewContent(false);
+    if (!scrolledUp) {
+      streamingFollowPauseUntilRef.current = 0;
+      setHasNewContent(false);
+    }
     requestAnimationFrame(() => {
       const el2 = containerRef.current;
       if (el2 && snapToTail) {
@@ -705,9 +725,18 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (suppressPassiveAutoBottomScrollRef.current) return;
     if (isScrolledUpRef.current) {
       setHasNewContent(true);
-    } else {
-      scrollToBottom(false);
+      return;
     }
+    const el = containerRef.current;
+    const dist = el ? el.scrollHeight - el.scrollTop - el.clientHeight : 0;
+    const nearTailWhilePaused =
+      Date.now() < streamingFollowPauseUntilRef.current
+      && dist <= USER_AWAY_FROM_BOTTOM_PX;
+    if (Date.now() < streamingFollowPauseUntilRef.current && !nearTailWhilePaused) {
+      setHasNewContent(true);
+      return;
+    }
+    scrollToBottom(false);
   }, [activeThreadId, messages.length, toolCalls.length, isAgentRunning, scrollToBottom]);
 
   // Streaming deltas -> scroll if at bottom, else highlight button
@@ -716,9 +745,18 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     if (!streamingText || isInitialLoadRef.current) return;
     if (isScrolledUpRef.current) {
       setHasNewContent(true);
-    } else {
-      scrollToBottom(false);
+      return;
     }
+    const el = containerRef.current;
+    const dist = el ? el.scrollHeight - el.scrollTop - el.clientHeight : 0;
+    const nearTailWhilePaused =
+      Date.now() < streamingFollowPauseUntilRef.current
+      && dist <= USER_AWAY_FROM_BOTTOM_PX;
+    if (Date.now() < streamingFollowPauseUntilRef.current && !nearTailWhilePaused) {
+      setHasNewContent(true);
+      return;
+    }
+    scrollToBottom(false);
   }, [streamingText, activeThreadId, scrollToBottom]);
 
   // Capture text selections in message bubbles and activate reply mode for the selected text.
@@ -826,6 +864,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
           hasNewContent={hasNewContent}
           onScrollToBottom={() => {
             setHasNewContent(false);
+            streamingFollowPauseUntilRef.current = 0;
+            isScrolledUpRef.current = false;
+            setShowScrollBtn(false);
             scrollToBottom(true);
           }}
         />

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -284,5 +284,59 @@ describe("MessageList thread switch", () => {
 
     // The scroll restoration effect should have called scrollTop setter with 1500
     expect(setScrollTopValue).toBe(1500);
+    expect(recallScrollTop("thread-B")).toBeUndefined();
+  });
+
+  it("does not re-apply remembered scroll when messages append on the same thread", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    const { rerender, container } = render(<MessageList />);
+
+    rememberScrollTop("thread-B", 1500);
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement | null;
+    expect(scrollEl).not.toBeNull();
+
+    let scrollHeight = 6000;
+    Object.defineProperty(scrollEl!, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(scrollEl!, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+
+    let scrollTop = 0;
+    Object.defineProperty(scrollEl!, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v;
+      },
+    });
+
+    activeThreadIdValue = "thread-B";
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    expect(scrollTop).toBe(1500);
+    expect(recallScrollTop("thread-B")).toBeUndefined();
+
+    // Simulate user pinned at bottom, then a new message arrives.
+    scrollTop = scrollHeight - 400;
+    scrollHeight = 8000;
+
+    messagesValue = [
+      { id: "m1", sequence: 1 },
+      { id: "m2", sequence: 2 },
+    ];
+    act(() => {
+      rerender(<MessageList />);
+    });
+
+    expect(scrollTop).not.toBe(1500);
   });
 });

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -714,6 +714,19 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             }
             return { persistedFilesChanged: nextFilesChanged };
           });
+          // Keep the LRU message cache in sync: the cache was written before this
+          // async merge, so a cache-hit thread switch otherwise drops prepended
+          // turns' file lists until a full reload.
+          const cached = getCachedSnapshot(threadId);
+          if (!cached) return;
+          const mergedFiles = { ...cached.persistedFilesChanged };
+          for (const snap of relevant) {
+            mergedFiles[snap.message_id] = snap.files_changed;
+          }
+          cacheSnapshot(threadId, {
+            ...cached,
+            persistedFilesChanged: mergedFiles,
+          });
         })
         .catch(() => {});
     } catch {


### PR DESCRIPTION
## What

Improves chat list tail follow, scroll-to-bottom UX, and message cache consistency for paginated threads.

## Why

Saved scroll offsets were re-applied whenever virtual item count grew, which jerked the viewport away from the tail while the agent replied. Older turns loaded via scroll-up pagination could lose file-change metadata in the LRU cache until a full reload. Streaming and smooth scroll needed clearer tail-follow handling.

## Key Changes

- Consume scroll memory after restore so items.length updates do not keep snapping to a stale offset (orgetScrollTop after applying pendingScrollRestoreRef).
- Sync the message LRU cache when loadOlderMessages merges async listSnapshots file lists into persistedFilesChanged.
- Tail follow: align away-from-tail threshold with virtualizer tail tracking, brief wheel-up pause, intent flag during smooth scroll-to-bottom.
- Tests: pagination.test.ts cache regression, MessageList.thread-switch.test.tsx scroll memory regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll/tail-follow behavior to avoid unwanted jumps, respect a brief wheel-up pause, and preserve new-content highlighting during user and programmatic scrolls.
  * Ensure restored scroll positions are cleared after use and not reapplied incorrectly when new messages arrive.
  * Keep message cache synchronized during pagination so older messages’ file-change metadata isn’t lost on thread switches.

* **Tests**
  * Added/updated tests covering cache preservation, scroll-restoration clearing, and pagination cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->