### PR TITLE
feat(web): settings pickers, attachments cap, and composer model UX

### DIFF
--- a/apps/server/src/__tests__/model-cache-service.test.ts
+++ b/apps/server/src/__tests__/model-cache-service.test.ts
@@ -154,6 +154,40 @@ describe("ModelCacheService", () => {
     expect(provider.listModels).toHaveBeenCalledTimes(1);
   });
 
+  it("invalidate during in-flight refresh does not repopulate cache", async () => {
+    let resolveList!: (value: ProviderModelInfo[]) => void;
+    const listPromise = new Promise<ProviderModelInfo[]>((resolve) => {
+      resolveList = resolve;
+    });
+    const stale: ProviderModelInfo[] = [{ id: "stale", name: "Stale" }];
+    const provider = {
+      id: "cursor",
+      listModels: vi.fn().mockReturnValue(listPromise),
+      sendMessage: vi.fn(),
+      cancelSession: vi.fn(),
+      shutdown: vi.fn(),
+    };
+    repo.upsert("cursor", [{ id: "seed", name: "Seed" }]);
+    const registry = makeRegistry(new Map([["cursor", provider]]));
+    const service = new ModelCacheService(repo, registry);
+
+    expect(service.getCached("cursor")).toEqual([{ id: "seed", name: "Seed" }]);
+
+    const refreshDone = service.refreshProvider("cursor");
+
+    service.invalidate("cursor");
+
+    expect(service.getCached("cursor")).toBeUndefined();
+    expect(repo.get("cursor")).toBeNull();
+
+    resolveList(stale);
+    await refreshDone;
+
+    expect(service.getCached("cursor")).toBeUndefined();
+    expect(repo.get("cursor")).toBeNull();
+    expect(provider.listModels).toHaveBeenCalledTimes(1);
+  });
+
   it("throws when fetching from a provider that does not implement listModels", async () => {
     const provider = {
       id: "no-list",

--- a/apps/server/src/__tests__/model-cache-service.test.ts
+++ b/apps/server/src/__tests__/model-cache-service.test.ts
@@ -135,6 +135,25 @@ describe("ModelCacheService", () => {
     expect(cached!.models).toEqual(newModels);
   });
 
+  it("invalidate clears memory and SQLite so the next read refetches", async () => {
+    repo.upsert("cursor", [{ id: "c1", name: "Cached" }]);
+    const fresh: ProviderModelInfo[] = [{ id: "c2", name: "Fresh" }];
+    const provider = makeProvider(fresh);
+    const registry = makeRegistry(new Map([["cursor", provider]]));
+    const service = new ModelCacheService(repo, registry);
+
+    expect(service.getCached("cursor")).toEqual([{ id: "c1", name: "Cached" }]);
+
+    service.invalidate("cursor");
+
+    expect(service.getCached("cursor")).toBeUndefined();
+    expect(repo.get("cursor")).toBeNull();
+
+    const result = await service.listModels("cursor");
+    expect(result).toEqual(fresh);
+    expect(provider.listModels).toHaveBeenCalledTimes(1);
+  });
+
   it("throws when fetching from a provider that does not implement listModels", async () => {
     const provider = {
       id: "no-list",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -184,6 +184,19 @@ const workspaceRepo = container.resolve(WorkspaceRepo); // Used only for startup
 const enricher = container.resolve(WorkspaceEnricher);
 const filesystemBrowser = container.resolve(FilesystemBrowser);
 const modelCacheService = container.resolve(ModelCacheService);
+
+/** Tracks CLI path edits so model catalog caches refresh when a different binary is targeted. */
+let lastCliPathsForModelCache = settingsService.get().provider.cli;
+settingsService.on("change", (next) => {
+  if (next.provider.cli.cursor !== lastCliPathsForModelCache.cursor) {
+    modelCacheService.invalidate("cursor");
+  }
+  if (next.provider.cli.copilot !== lastCliPathsForModelCache.copilot) {
+    modelCacheService.invalidate("copilot");
+  }
+  lastCliPathsForModelCache = next.provider.cli;
+});
+
 const cleanupWorker = container.resolve(CleanupWorker);
 const prDraftService = container.resolve(PrDraftService);
 const diffSummaryService = container.resolve(DiffSummaryService);

--- a/apps/server/src/services/attachment-service.ts
+++ b/apps/server/src/services/attachment-service.ts
@@ -22,7 +22,14 @@ const MAX_DOCUMENT_SIZE = 16 * 1024 * 1024;
  */
 const SAFE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
-/** Size limits per MIME category. Shared with binary upload handler. */
+/**
+ * Returns the maximum allowed size in bytes for a MIME type used by attachments.
+ *
+ * Shared with binary upload validation. Unknown categories fall back to the image cap for safety.
+ *
+ * @param mimeType - MIME type string for the upload (for example `image/png` or `application/pdf`).
+ * @returns Maximum permitted bytes for that category.
+ */
 export function getMaxSizeForMime(mimeType: string): number {
   if (mimeType.startsWith("image/")) return MAX_IMAGE_SIZE;
   if (mimeType === "application/pdf") return MAX_PDF_SIZE;

--- a/apps/server/src/services/attachment-service.ts
+++ b/apps/server/src/services/attachment-service.ts
@@ -36,6 +36,7 @@ export function getMaxSizeForMime(mimeType: string): number {
   if (mimeType === "text/plain") return MAX_TEXT_SIZE;
   if (
     mimeType === "application/rtf" ||
+    mimeType === "text/rtf" ||
     mimeType.startsWith("application/vnd.openxmlformats-officedocument.") ||
     mimeType.startsWith("application/vnd.oasis.opendocument.")
   ) {
@@ -53,6 +54,7 @@ function mimeToExt(mimeType: string): string {
     "application/pdf": ".pdf",
     "text/plain": ".txt",
     "application/rtf": ".rtf",
+    "text/rtf": ".rtf",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
     "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",

--- a/apps/server/src/services/attachment-service.ts
+++ b/apps/server/src/services/attachment-service.ts
@@ -14,6 +14,7 @@ import type { AttachmentMeta, StoredAttachment } from "@mcode/contracts";
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 const MAX_PDF_SIZE = 32 * 1024 * 1024;
 const MAX_TEXT_SIZE = 1 * 1024 * 1024;
+const MAX_DOCUMENT_SIZE = 16 * 1024 * 1024;
 
 /**
  * Pattern matching safe attachment IDs: alphanumerics, hyphens, and underscores only.
@@ -26,6 +27,13 @@ export function getMaxSizeForMime(mimeType: string): number {
   if (mimeType.startsWith("image/")) return MAX_IMAGE_SIZE;
   if (mimeType === "application/pdf") return MAX_PDF_SIZE;
   if (mimeType === "text/plain") return MAX_TEXT_SIZE;
+  if (
+    mimeType === "application/rtf" ||
+    mimeType.startsWith("application/vnd.openxmlformats-officedocument.") ||
+    mimeType.startsWith("application/vnd.oasis.opendocument.")
+  ) {
+    return MAX_DOCUMENT_SIZE;
+  }
   return MAX_IMAGE_SIZE; // conservative fallback
 }
 
@@ -37,6 +45,13 @@ function mimeToExt(mimeType: string): string {
     "image/webp": ".webp",
     "application/pdf": ".pdf",
     "text/plain": ".txt",
+    "application/rtf": ".rtf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+    "application/vnd.oasis.opendocument.text": ".odt",
+    "application/vnd.oasis.opendocument.spreadsheet": ".ods",
+    "application/vnd.oasis.opendocument.presentation": ".odp",
   };
   return map[mimeType] ?? "";
 }

--- a/apps/server/src/services/model-cache-service.ts
+++ b/apps/server/src/services/model-cache-service.ts
@@ -110,6 +110,16 @@ export class ModelCacheService {
   }
 
   /**
+   * Drops persisted and in-memory entries for a provider so the next model list
+   * fetch runs against the live CLI or SDK again.
+   */
+  invalidate(providerId: string): void {
+    this.memoryCache.delete(providerId);
+    this.fetchedAt.delete(providerId);
+    this.repo.delete(providerId);
+  }
+
+  /**
    * Fetches models from the provider, updates both in-memory and SQLite caches.
    * Coalesces concurrent calls for the same provider so we never issue
    * duplicate requests in flight.

--- a/apps/server/src/services/model-cache-service.ts
+++ b/apps/server/src/services/model-cache-service.ts
@@ -45,6 +45,12 @@ export class ModelCacheService {
   /** In-flight refresh promises to coalesce concurrent fetches. */
   private inflight = new Map<string, Promise<ProviderModelInfo[]>>();
 
+  /**
+   * Increments when `invalidate` runs so a refresh that started earlier cannot
+   * repopulate SQLite or memory after the cache was cleared.
+   */
+  private generation = new Map<string, number>();
+
   constructor(
     @inject(ModelCacheRepo) private repo: ModelCacheRepo,
     @inject("IProviderRegistry") private registry: IProviderRegistry,
@@ -114,6 +120,8 @@ export class ModelCacheService {
    * fetch runs against the live CLI or SDK again.
    */
   invalidate(providerId: string): void {
+    this.generation.set(providerId, (this.generation.get(providerId) ?? 0) + 1);
+    this.inflight.delete(providerId);
     this.memoryCache.delete(providerId);
     this.fetchedAt.delete(providerId);
     this.repo.delete(providerId);
@@ -153,8 +161,14 @@ export class ModelCacheService {
   }
 
   private async doRefresh(providerId: string): Promise<ProviderModelInfo[]> {
+    const genAtStart = this.generation.get(providerId) ?? 0;
     const provider = this.registry.resolve(providerId as never);
     const models = await provider.listModels();
+
+    if ((this.generation.get(providerId) ?? 0) !== genAtStart) {
+      return models;
+    }
+
     const now = Date.now();
 
     // Compare ID sets: the model array is rewritten by providers (ordering and

--- a/apps/web/e2e/composer-toolbar.spec.ts
+++ b/apps/web/e2e/composer-toolbar.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+import { getDefaultSettings } from "@mcode/contracts";
+
+const MOCK_SETTINGS = getDefaultSettings();
+
+const WORKSPACE = {
+  id: "ws-composer-toolbar",
+  name: "Composer Toolbar Test",
+  path: "/tmp/composer-toolbar",
+  provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const THREAD = {
+  id: "thread-composer-toolbar",
+  workspace_id: WORKSPACE.id,
+  title: "Active Thread",
+  status: "active" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: "claude-sonnet-4-6",
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+async function setupChat(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ ws, th }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({
+        workspaces: [ws],
+        threads: [th],
+        activeWorkspaceId: ws.id,
+        activeThreadId: th.id,
+        loading: false,
+        error: null,
+      });
+    },
+    { ws: WORKSPACE, th: THREAD },
+  );
+}
+
+test.describe("Composer toolbar", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.enrich": { items: [] },
+      "settings.get": MOCK_SETTINGS,
+      "provider.listModels": () => [
+        { id: "alpha-model", name: "Alpha Model", group: "Test" },
+        { id: "beta-model", name: "Beta Model", group: "Test" },
+      ],
+    });
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(() => (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete === true);
+    await setupChat(page);
+
+    await page.waitForSelector('[contenteditable="true"]', { timeout: 30_000 });
+  });
+
+  test("shows attach control and hidden file input", async ({ page }) => {
+    await expect(page.getByTestId("composer-attach")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("composer-attachment-input")).toBeAttached();
+    await page.screenshot({
+      path: "e2e/screenshots/composer-toolbar-attach.png",
+      fullPage: true,
+    });
+  });
+
+  test("locked-provider model search filters RPC-backed models", async ({ page }) => {
+    await page.getByTestId("model-selector-trigger").click();
+    // Persisted threads lock the provider; models are listed with the locked-panel search,
+    // not the hover submenu used when picking a provider from the full list.
+    const search = page.getByTestId("model-selector-locked-search");
+    await expect(search).toBeVisible({ timeout: 10_000 });
+    await search.fill("Beta");
+
+    await expect(page.getByRole("button", { name: "Beta Model" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Alpha Model" })).toHaveCount(0);
+
+    await page.screenshot({
+      path: "e2e/screenshots/model-selector-search-filter.png",
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/e2e/composer-toolbar.spec.ts
+++ b/apps/web/e2e/composer-toolbar.spec.ts
@@ -105,8 +105,8 @@ test.describe("Composer toolbar", () => {
     const search = page.getByTestId("model-selector-locked-search");
     await search.fill("Beta");
 
-    await expect(page.getByRole("button", { name: "Beta Model" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Alpha Model" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Select Beta Model", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Select Alpha Model", exact: true })).toHaveCount(0);
 
     await page.screenshot({
       path: "e2e/screenshots/model-selector-search-filter.png",

--- a/apps/web/e2e/composer-toolbar.spec.ts
+++ b/apps/web/e2e/composer-toolbar.spec.ts
@@ -101,10 +101,8 @@ test.describe("Composer toolbar", () => {
 
   test("locked-provider model search filters RPC-backed models", async ({ page }) => {
     await page.getByTestId("model-selector-trigger").click();
-    // Persisted threads lock the provider; models are listed with the locked-panel search,
-    // not the hover submenu used when picking a provider from the full list.
+    await expect(page.getByTestId("model-selector-locked-search")).toBeVisible({ timeout: 10_000 });
     const search = page.getByTestId("model-selector-locked-search");
-    await expect(search).toBeVisible({ timeout: 10_000 });
     await search.fill("Beta");
 
     await expect(page.getByRole("button", { name: "Beta Model" })).toBeVisible();
@@ -114,5 +112,21 @@ test.describe("Composer toolbar", () => {
       path: "e2e/screenshots/model-selector-search-filter.png",
       fullPage: true,
     });
+  });
+
+  test("model selector left rail switches search context", async ({ page }) => {
+    await page.getByTestId("model-selector-trigger").click();
+    await expect(page.getByTestId("model-selector-rail-favorites")).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId("model-selector-rail-favorites").click();
+    await expect(page.getByTestId("model-selector-locked-search")).toHaveAttribute(
+      "placeholder",
+      "Search favorites…",
+    );
+
+    await page.getByTestId("model-group-claude").click();
+    await expect(page.getByTestId("model-selector-locked-search")).toHaveAttribute(
+      "placeholder",
+      "Search models…",
+    );
   });
 });

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -93,7 +93,19 @@ export async function mockWebSocketServer(
       }
       // Default responses
       let result: unknown;
-      if (method?.endsWith(".list") || method === "provider.listModels") result = [];
+      // `message.list` matches the generic *.list branch below but must return a
+      // paginated shape; returning [] leaves loadMessages in an error state.
+      if (method === "message.list") {
+        result = { messages: [], hasMore: false, answeredPlanMessageIds: [] };
+      } else if (method === "permission.listPending") {
+        result = [];
+      } else if (method === "thread.getTasks") {
+        result = [];
+      } else if (method === "snapshot.listByThread") {
+        result = [];
+      } else if (method === "providers.listAvailability") {
+        result = [];
+      } else if (method?.endsWith(".list") || method === "provider.listModels") result = [];
       else if (method === "git.currentBranch") result = "main";
       else if (method === "agent.activeCount") result = 0;
       else if (method === "agent.listRunning") result = [];

--- a/apps/web/e2e/qa-codex-reasoning.spec.ts
+++ b/apps/web/e2e/qa-codex-reasoning.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { mockWebSocketServer } from "./helpers/e2e-helpers";
 import { fileURLToPath } from "url";
 import path from "path";
@@ -25,6 +25,15 @@ function makeDefaultSettings(provider: string, modelId: string, reasoning: strin
 }
 
 test.describe("Codex reasoning selector QA", () => {
+  /** SegControl for reasoning lives inside the "Reasoning effort" settings row. */
+  function reasoningEffortRadiogroup(page: Page) {
+    return page
+      .locator('[class*="flex-wrap"][class*="justify-between"]')
+      .filter({ has: page.getByText("Reasoning effort", { exact: true }) })
+      .first()
+      .getByRole("radiogroup");
+  }
+
   test.beforeEach(async ({ page }) => {
     currentSettings = makeDefaultSettings("claude", "claude-sonnet-4-6", "high");
 
@@ -90,27 +99,30 @@ test.describe("Codex reasoning selector QA", () => {
     await page.waitForTimeout(500);
 
     // Verify Claude default: reasoning shows Low, Medium, High, Max
-    const reasoningGroup = () => page.locator('[role="radiogroup"]').nth(3);
-    const claudeOptions = await reasoningGroup().locator('[role="radio"]').allInnerTexts();
+    const claudeOptions = await reasoningEffortRadiogroup(page).locator('[role="radio"]').allInnerTexts();
     console.log(`Claude reasoning: ${claudeOptions.join(", ")}`);
     expect(claudeOptions).toContain("Max");
     expect(claudeOptions).not.toContain("X-High");
     await page.screenshot({ path: path.join(SCREENSHOT_DIR, "qa-01-claude-reasoning.png") });
 
-    // Switch to Codex provider
-    const codexRadio = page.getByRole("radio", { name: "Codex" });
-    await codexRadio.click();
+    // Switch to Codex provider (searchable provider picker)
+    await page.getByTestId("settings-default-provider-trigger").click();
+    await page.waitForTimeout(200);
+    await page.getByTestId("settings-provider-rail-codex").click();
     await page.waitForTimeout(1000);
     await page.screenshot({ path: path.join(SCREENSHOT_DIR, "qa-02-codex-selected.png") });
 
-    // Verify model list changed to Codex models
-    const modelGroup = page.locator('[role="radiogroup"]').nth(1);
-    const modelTexts = await modelGroup.locator('[role="radio"]').allInnerTexts();
-    console.log(`Codex models: ${modelTexts.join(", ")}`);
-    expect(modelTexts.some((t: string) => t.includes("GPT"))).toBeTruthy();
+    // Verify model picker lists Codex-style models
+    await page.getByTestId("settings-default-model-trigger").click();
+    await page.waitForTimeout(300);
+    const modelItems = await page.locator('[data-slot="command-item"]').allInnerTexts();
+    console.log(`Codex models: ${modelItems.join(", ")}`);
+    expect(modelItems.some((t: string) => t.includes("GPT"))).toBeTruthy();
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(200);
 
     // Verify reasoning options now show X-High instead of Max
-    const codexOptions = await reasoningGroup().locator('[role="radio"]').allInnerTexts();
+    const codexOptions = await reasoningEffortRadiogroup(page).locator('[role="radio"]').allInnerTexts();
     console.log(`Codex reasoning: ${codexOptions.join(", ")}`);
     expect(codexOptions).toContain("X-High");
     expect(codexOptions).not.toContain("Max");
@@ -123,20 +135,20 @@ test.describe("Codex reasoning selector QA", () => {
     await expect(codexHint).toBeVisible();
 
     // Click X-High and verify it's checked
-    const xhighRadio = page.getByRole("radio", { name: "X-High" });
+    const xhighRadio = reasoningEffortRadiogroup(page).getByRole("radio", { name: "X-High" });
     await xhighRadio.click();
     await page.waitForTimeout(300);
     await expect(xhighRadio).toHaveAttribute("aria-checked", "true");
     await page.screenshot({ path: path.join(SCREENSHOT_DIR, "qa-03-xhigh-selected.png") });
 
-    // Switch back to Claude (scoped to the first Provider radiogroup to avoid
-    // ambiguity with the PR Draft provider row which also contains "Claude")
-    const claudeRadio = page.locator('[role="radiogroup"]').first().getByRole("radio", { name: "Claude" });
-    await claudeRadio.click();
+    // Switch back to Claude via provider picker
+    await page.getByTestId("settings-default-provider-trigger").click();
+    await page.waitForTimeout(200);
+    await page.getByTestId("settings-provider-rail-claude").click();
     await page.waitForTimeout(1000);
 
     // Verify Max is back and X-High is gone
-    const restoredOptions = await reasoningGroup().locator('[role="radio"]').allInnerTexts();
+    const restoredOptions = await reasoningEffortRadiogroup(page).locator('[role="radio"]').allInnerTexts();
     console.log(`Claude restored: ${restoredOptions.join(", ")}`);
     expect(restoredOptions).toContain("Max");
     expect(restoredOptions).not.toContain("X-High");

--- a/apps/web/e2e/qa-codex-reasoning.spec.ts
+++ b/apps/web/e2e/qa-codex-reasoning.spec.ts
@@ -108,7 +108,7 @@ test.describe("Codex reasoning selector QA", () => {
     // Switch to Codex provider (searchable provider picker)
     await page.getByTestId("settings-default-provider-trigger").click();
     await page.waitForTimeout(200);
-    await page.getByTestId("settings-provider-rail-codex").click();
+    await page.getByTestId("settings-provider-option-codex").click();
     await page.waitForTimeout(1000);
     await page.screenshot({ path: path.join(SCREENSHOT_DIR, "qa-02-codex-selected.png") });
 
@@ -144,7 +144,7 @@ test.describe("Codex reasoning selector QA", () => {
     // Switch back to Claude via provider picker
     await page.getByTestId("settings-default-provider-trigger").click();
     await page.waitForTimeout(200);
-    await page.getByTestId("settings-provider-rail-claude").click();
+    await page.getByTestId("settings-provider-option-claude").click();
     await page.waitForTimeout(1000);
 
     // Verify Max is back and X-High is gone

--- a/apps/web/e2e/settings-visual.spec.ts
+++ b/apps/web/e2e/settings-visual.spec.ts
@@ -72,8 +72,10 @@ test.describe("Settings visual review", () => {
     const modelNav = page.getByRole("button", { name: "Model", exact: true });
     await modelNav.click();
     await page.waitForTimeout(300);
-    const codexBtn = page.getByRole("radio", { name: /Codex/ });
-    await codexBtn.hover();
+    await page.getByTestId("settings-default-provider-trigger").click();
+    await page.waitForTimeout(200);
+    const codexRail = page.getByTestId("settings-provider-rail-codex");
+    await codexRail.hover();
     await page.waitForTimeout(500);
     await page.screenshot({
       path: path.join(SCREENSHOT_DIR, "settings-provider-tooltip.png"),

--- a/apps/web/e2e/settings-visual.spec.ts
+++ b/apps/web/e2e/settings-visual.spec.ts
@@ -74,8 +74,8 @@ test.describe("Settings visual review", () => {
     await page.waitForTimeout(300);
     await page.getByTestId("settings-default-provider-trigger").click();
     await page.waitForTimeout(200);
-    const codexRail = page.getByTestId("settings-provider-rail-codex");
-    await codexRail.hover();
+    const codexOption = page.getByTestId("settings-provider-option-codex");
+    await codexOption.hover();
     await page.waitForTimeout(500);
     await page.screenshot({
       path: path.join(SCREENSHOT_DIR, "settings-provider-tooltip.png"),

--- a/apps/web/src/__tests__/Composer.paste.test.ts
+++ b/apps/web/src/__tests__/Composer.paste.test.ts
@@ -25,6 +25,10 @@ describe("Extension-based file filtering (integration)", () => {
     expect(isFileSupported(name)).toBe(expected);
   });
 
+  it("accepts common Office documents", () => {
+    expect(isFileSupported("report.docx")).toBe(true);
+  });
+
   it("handles browser File objects with empty MIME types", () => {
     const file = createMockFile("app.ts", "", 1024);
     expect(isFileSupported(file.name)).toBe(true);

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -13,7 +13,25 @@ import {
   normalizeReasoningLevelForModel,
   resolveThreadModelId,
   supportsEffortParameter,
+  pickProviderModelsForSettings,
 } from "@/lib/model-registry";
+
+describe("pickProviderModelsForSettings", () => {
+  const staticModels = [{ id: "a", label: "A", providerId: "cursor" }];
+
+  it("prefers a non-empty dynamic list", () => {
+    const dynamic = [{ id: "b", label: "B", providerId: "cursor" }];
+    expect(pickProviderModelsForSettings(staticModels, dynamic)).toEqual(dynamic);
+  });
+
+  it("falls back to static models when dynamic is undefined", () => {
+    expect(pickProviderModelsForSettings(staticModels, undefined)).toEqual(staticModels);
+  });
+
+  it("falls back to static models when dynamic is empty", () => {
+    expect(pickProviderModelsForSettings(staticModels, [])).toEqual(staticModels);
+  });
+});
 
 describe("ModelRegistry", () => {
   it("MODEL_PROVIDERS contains Claude with 4 models", () => {

--- a/apps/web/src/components/chat/AttachmentPreview.tsx
+++ b/apps/web/src/components/chat/AttachmentPreview.tsx
@@ -34,7 +34,8 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
         const isOfficeDoc =
           att.mimeType.includes("officedocument") ||
           att.mimeType.includes("opendocument") ||
-          att.mimeType === "application/rtf";
+          att.mimeType === "application/rtf" ||
+          att.mimeType === "text/rtf";
 
         return (
           <div

--- a/apps/web/src/components/chat/AttachmentPreview.tsx
+++ b/apps/web/src/components/chat/AttachmentPreview.tsx
@@ -29,6 +29,10 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
       {attachments.map((att) => {
         const isImage = att.mimeType.startsWith("image/");
         const isPdf = att.mimeType === "application/pdf";
+        const isOfficeDoc =
+          att.mimeType.includes("officedocument") ||
+          att.mimeType.includes("opendocument") ||
+          att.mimeType === "application/rtf";
 
         return (
           <div
@@ -54,6 +58,8 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                 <div className="flex items-center gap-2">
                   {isPdf ? (
                     <FileText size={18} className="shrink-0 text-red-600 dark:text-red-400" />
+                  ) : isOfficeDoc ? (
+                    <FileText size={18} className="shrink-0 text-blue-600 dark:text-blue-400" />
                   ) : (
                     <File size={18} className="shrink-0 text-muted-foreground" />
                   )}

--- a/apps/web/src/components/chat/AttachmentPreview.tsx
+++ b/apps/web/src/components/chat/AttachmentPreview.tsx
@@ -1,6 +1,7 @@
 import { X, FileText, File } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+/** Represents a user-selected file staged on the composer before send (preview URL may be an object URL). */
 export interface PendingAttachment {
   id: string;
   name: string;
@@ -21,6 +22,7 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+/** Horizontal strip of pending attachment thumbnails or file tiles with per-item remove actions. */
 export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewProps) {
   if (attachments.length === 0) return null;
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -14,6 +14,7 @@ import {
   Check,
   ListTodo,
   MoreHorizontal,
+  Paperclip,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -62,6 +63,7 @@ import {
   getMaxFileSize,
   inferMimeType,
   MAX_ATTACHMENTS,
+  attachmentAcceptAttribute,
 } from "@mcode/contracts";
 import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
 import { getModelContextWindow } from "@mcode/shared/model-context";
@@ -71,6 +73,9 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { useElementWidth } from "@/hooks/useElementWidth";
 import { ProviderUnavailableBanner } from "./ProviderUnavailableBanner";
+
+/** `accept` list for the composer's hidden file input (mirrors {@link isFileSupported}). */
+const ATTACHMENT_INPUT_ACCEPT = attachmentAcceptAttribute();
 
 /** ReasoningLevel values as a Set for O(1) membership checks in the Codex level filter. */
 const VALID_REASONING_LEVELS_SET = new Set<string>(["low", "medium", "high", "xhigh", "max", "ultrathink"]);
@@ -440,6 +445,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
   const editorRef = useRef<LexicalEditor | null>(null);
   const editorContainerRef = useRef<HTMLDivElement>(null);
+  const attachmentInputRef = useRef<HTMLInputElement>(null);
 
   const prevThreadIdRef = useRef<string | undefined>(threadId);
   const draftRef = useRef<{
@@ -1045,6 +1051,29 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     });
   }, []);
 
+  const handleAttachmentInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const list = e.target.files;
+      if (!list?.length) return;
+      const files = Array.from(list);
+      const bridge = window.desktopBridge;
+      const paths = files.map((f) => {
+        try {
+          return bridge?.getPathForFile?.(f) ?? null;
+        } catch {
+          return null;
+        }
+      });
+      addFiles(files, paths);
+      e.target.value = "";
+    },
+    [addFiles],
+  );
+
+  const handleAttachPick = useCallback(() => {
+    attachmentInputRef.current?.click();
+  }, []);
+
   const removeAttachment = useCallback((id: string) => {
     setAttachments((prev) => {
       const removed = prev.find((a) => a.id === id);
@@ -1054,8 +1083,18 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   }, []);
 
   const handlePaste = useCallback(async (e: React.ClipboardEvent) => {
-    const files = Array.from(e.clipboardData.files);
-    const supported = files.filter((f) => isFileSupported(f.name));
+    const fromFiles = Array.from(e.clipboardData.files);
+    const fromItems: File[] = [];
+    for (const item of Array.from(e.clipboardData.items)) {
+      if (item.kind !== "file") continue;
+      const f = item.getAsFile();
+      if (!f) continue;
+      if (!fromFiles.some((x) => x.name === f.name && x.size === f.size)) {
+        fromItems.push(f);
+      }
+    }
+    const merged = [...fromFiles, ...fromItems];
+    const supported = merged.filter((f) => isFileSupported(f.name));
     if (supported.length === 0) return;
 
     e.preventDefault();
@@ -1573,6 +1612,34 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             collapses Mode/Permissions/Tasks into a popover before this row would
             need to wrap, so the send button stays anchored on the right. */}
         <div className="flex items-center gap-x-1.5 sm:gap-x-2.5 border-t border-border/20 px-3 py-1.5">
+          <input
+            ref={attachmentInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            accept={ATTACHMENT_INPUT_ACCEPT}
+            data-testid="composer-attachment-input"
+            onChange={handleAttachmentInputChange}
+          />
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="Attach files"
+                  data-testid="composer-attach"
+                  onClick={handleAttachPick}
+                  className="text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+                  disabled={planPending || isStaleWorktree || !!providerReason}
+                >
+                  <Paperclip size={14} />
+                </Button>
+              }
+            />
+            <TooltipContent>Attach files</TooltipContent>
+          </Tooltip>
           {/* Model picker */}
           <ModelSelector
             selectedModelId={modelId}

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -71,7 +71,8 @@ function FileAttachmentGlyph({ mimeType }: { mimeType: string }) {
   const isOfficeDoc =
     mimeType.includes("officedocument") ||
     mimeType.includes("opendocument") ||
-    mimeType === "application/rtf";
+    mimeType === "application/rtf" ||
+    mimeType === "text/rtf";
   if (mimeType === "application/pdf") {
     return <FileText size={16} className="shrink-0 text-red-600 dark:text-red-400" aria-hidden />;
   }

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -59,6 +59,28 @@ function extFromMime(mimeType: string): string {
   return MIME_TO_EXT[mimeType] ?? "";
 }
 
+/** Compact human-readable size for attachment chips in the transcript. */
+function formatAttachmentBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Icon for non-image attachments in user message chips (matches composer preview semantics). */
+function FileAttachmentGlyph({ mimeType }: { mimeType: string }) {
+  const isOfficeDoc =
+    mimeType.includes("officedocument") ||
+    mimeType.includes("opendocument") ||
+    mimeType === "application/rtf";
+  if (mimeType === "application/pdf") {
+    return <FileText size={16} className="shrink-0 text-red-600 dark:text-red-400" aria-hidden />;
+  }
+  if (isOfficeDoc) {
+    return <FileText size={16} className="shrink-0 text-blue-600 dark:text-blue-400" aria-hidden />;
+  }
+  return <File size={16} className="shrink-0 text-muted-foreground" aria-hidden />;
+}
+
 /** Single image thumbnail with error fallback. */
 function ImageThumbnail({ src, name, single }: { src: string; name: string; single: boolean }) {
   const [failed, setFailed] = useState(false);
@@ -277,28 +299,31 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
             </div>
           )}
 
-          {/* Text bubble — only if there's text or file attachments */}
-          {(textContent.trim() || fileAttachments.length > 0) && (
-            <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
-              {fileAttachments.length > 0 && (
-                <div className="mb-2 space-y-1">
-                  {fileAttachments.map((file) => (
-                    <div key={file.id} className="flex items-center gap-1.5 rounded-md bg-primary-foreground/10 px-2 py-1">
-                      {file.mimeType === "application/pdf" ? (
-                        <FileText size={14} className="text-primary-foreground/80" />
-                      ) : (
-                        <File size={14} className="text-primary-foreground/80" />
-                      )}
-                      <span className="truncate text-xs text-primary-foreground/90">{file.name}</span>
-                    </div>
-                  ))}
+          {/* Non-image files sit outside the colored bubble so names stay readable on any theme. */}
+          {fileAttachments.length > 0 && (
+            <div className="flex flex-wrap justify-end gap-2">
+              {fileAttachments.map((file) => (
+                <div
+                  key={file.id}
+                  className="flex min-w-0 max-w-[260px] items-start gap-2 rounded-lg border border-border bg-card px-3 py-2 shadow-sm"
+                >
+                  <FileAttachmentGlyph mimeType={file.mimeType} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-xs font-medium text-foreground">{file.name}</p>
+                    <p className="mt-0.5 text-[10px] tabular-nums text-muted-foreground">
+                      {formatAttachmentBytes(file.sizeBytes)}
+                    </p>
+                  </div>
                 </div>
-              )}
-              {textContent.trim() && (
-                <Suspense fallback={null}>
-                  <LazyMarkdownContent content={textContent} isStreaming={false} variant="user" />
-                </Suspense>
-              )}
+              ))}
+            </div>
+          )}
+
+          {textContent.trim() && (
+            <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
+              <Suspense fallback={null}>
+                <LazyMarkdownContent content={textContent} isStreaming={false} variant="user" />
+              </Suspense>
             </div>
           )}
 

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -1,10 +1,14 @@
-import { useState, useEffect, useRef, useCallback, useMemo, type ComponentType } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, useId, type ComponentType } from "react";
 import { ChevronDown, Lock, Check, Loader2, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatContextWindow } from "./format-context-window";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   MODEL_PROVIDERS,
   findModelById,
@@ -36,6 +40,41 @@ const PROVIDER_META: Record<string, { icon: IconComponent; color: string }> = {
   gemini: { icon: GeminiIcon, color: "text-sky-400" },
 };
 
+/** Matches Tailwind `w-[52px]` for header alignment and icon-first rail. */
+const LEFT_RAIL_WIDTH_CLASS = "w-[52px]";
+
+/** Splits a query into lowercase tokens (whitespace). Empty input yields no tokens. */
+function tokenizeSearch(raw: string): string[] {
+  return raw.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/** Requires every token to appear as a substring (AND semantics across fields). */
+function matchesAllTokens(parts: string[], tokens: string[]): boolean {
+  if (tokens.length === 0) return true;
+  const haystack = parts.join(" ").toLowerCase();
+  return tokens.every((t) => haystack.includes(t));
+}
+
+/** True when the catalog uses subgroup rows so a provider title above would repeat RPC group labels. */
+function catalogUsesModelGroups(models: ModelProvider["models"]): boolean {
+  return models.some((m) => Boolean(m.group?.trim()));
+}
+
+/** Tooltip copy for the left rail when a row cannot open a catalog. */
+function providerRailUnavailableReason(
+  p: ModelProvider,
+  providerDisabled: boolean,
+): string {
+  if (p.comingSoon && providerDisabled) {
+    return `${p.name} is coming soon and disabled in settings.`;
+  }
+  if (p.comingSoon) return `${p.name} is coming soon.`;
+  if (providerDisabled) {
+    return `${p.name} is disabled. Enable it in Settings under Providers.`;
+  }
+  return `${p.name}`;
+}
+
 /** Left rail segment: browse starred models or a single provider's catalog. */
 type LeftRailSelection = "favorites" | string;
 
@@ -63,6 +102,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   const [rightPanelSearch, setRightPanelSearch] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
   const prevOpenRef = useRef(false);
+  const panelId = useId();
 
   const favorites = useModelFavoritesStore((s) => s.entries);
   const toggleFavorite = useModelFavoritesStore((s) => s.toggleFavorite);
@@ -128,13 +168,11 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     [availabilityList],
   );
 
-  const filterModelsBySearch = useCallback((models: ModelProvider["models"], q: string) => {
-    const n = q.trim().toLowerCase();
-    if (!n) return models;
-    return models.filter(
-      (m) =>
-        m.label.toLowerCase().includes(n) ||
-        m.id.toLowerCase().includes(n),
+  const filterModelsBySearchQuery = useCallback((models: ModelProvider["models"], q: string) => {
+    const tokens = tokenizeSearch(q);
+    if (tokens.length === 0) return models;
+    return models.filter((m) =>
+      matchesAllTokens([m.label, m.id, m.group ?? ""], tokens),
     );
   }, []);
 
@@ -174,12 +212,10 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   }, [favorites, isProviderUsable, providerLocked, displayProvider]);
 
   const favoritesFiltered = useMemo(() => {
-    const n = rightPanelSearch.trim().toLowerCase();
-    if (!n) return favoritesVisible;
-    return favoritesVisible.filter(
-      (f) =>
-        f.label.toLowerCase().includes(n) ||
-        f.modelId.toLowerCase().includes(n),
+    const tokens = tokenizeSearch(rightPanelSearch);
+    if (tokens.length === 0) return favoritesVisible;
+    return favoritesVisible.filter((f) =>
+      matchesAllTokens([f.label, f.modelId], tokens),
     );
   }, [favoritesVisible, rightPanelSearch]);
 
@@ -222,9 +258,9 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   if (locked) {
     return (
       <span className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground">
-        <Icon size={12} className={iconClass} />
-        {shortLabel}
-        <Lock size={10} className="ml-0.5 opacity-75" />
+        <Icon size={12} className={iconClass} aria-hidden />
+        <span>{shortLabel}</span>
+        <Lock size={10} className="ml-0.5 opacity-75" aria-hidden />
       </span>
     );
   }
@@ -239,11 +275,19 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     setRightPanelSearch("");
   };
 
+  const searchAriaLabel =
+    leftRailSelection === "favorites"
+      ? "Filter favorites by name. Use multiple words to narrow results."
+      : "Filter models by name or id. Use multiple words to narrow results.";
+
   const renderFavoriteRow = (entry: ModelFavoriteEntry) => {
     const pm = PROVIDER_META[entry.providerId];
     const ProvIcon = pm?.icon ?? ClaudeIcon;
     const provIconClass = pm?.color ?? "";
     const starred = isFavorite(entry.providerId, entry.modelId);
+    const selected =
+      entry.modelId === normalizedSelectedId &&
+      entry.providerId === (selectedProviderId ?? displayProvider?.id);
     return (
       <div
         key={`${entry.providerId}:${entry.modelId}`}
@@ -254,7 +298,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
           variant="ghost"
           size="icon-xs"
           className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-          aria-label={starred ? "Remove from favorites" : "Add to favorites"}
+          aria-label={starred ? `Remove ${entry.label} from favorites` : `Add ${entry.label} to favorites`}
           onClick={(e) => {
             e.stopPropagation();
             toggleFavorite({
@@ -267,19 +311,24 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
           <Star
             size={12}
             className={cn(starred && "fill-amber-400 text-amber-400")}
+            aria-hidden
           />
         </Button>
         <button
           type="button"
+          aria-current={selected ? "true" : undefined}
+          aria-label={
+            selected ? `${entry.label}, selected` : `Select ${entry.label}`
+          }
           onClick={() => handleSelectModel(entry.modelId, entry.providerId)}
           className={cn(
             "flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-xs",
-            entry.modelId === normalizedSelectedId && entry.providerId === (selectedProviderId ?? displayProvider?.id)
+            selected
               ? "bg-accent text-foreground"
               : "text-popover-foreground hover:bg-accent/50 hover:text-foreground",
           )}
         >
-          <ProvIcon size={12} className={provIconClass} />
+          <ProvIcon size={12} className={provIconClass} aria-hidden />
           <span className="truncate text-left">{entry.label}</span>
         </button>
       </div>
@@ -288,11 +337,11 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
 
   /** Groups a provider's models by their `group` field. Returns ungrouped if none use it. */
   const groupModels = (models: ModelProvider["models"]) => {
-    const hasGroups = models.some((m) => m.group);
+    const hasGroups = models.some((m) => m.group?.trim());
     if (!hasGroups) return null;
     const seen = new Map<string, typeof models>();
     for (const m of models) {
-      const g = m.group ?? "";
+      const g = m.group?.trim() ?? "";
       if (!seen.has(g)) seen.set(g, []);
       seen.get(g)!.push(m);
     }
@@ -308,6 +357,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   ) => {
     const ctxLabel = formatContextWindow(m.contextWindow);
     const starred = isFavorite(providerId, m.id);
+    const selected = isSelected(m.id);
     return (
       <div key={m.id} className="flex w-full items-center gap-0.5 rounded px-1">
         <Button
@@ -315,7 +365,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
           variant="ghost"
           size="icon-xs"
           className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-          aria-label={starred ? "Remove from favorites" : "Add to favorites"}
+          aria-label={starred ? `Remove ${m.label} from favorites` : `Add ${m.label} to favorites`}
           onClick={(e) => {
             e.stopPropagation();
             toggleFavorite({ providerId, modelId: m.id, label: m.label });
@@ -324,14 +374,17 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
           <Star
             size={12}
             className={cn(starred && "fill-amber-400 text-amber-400")}
+            aria-hidden
           />
         </Button>
         <button
           type="button"
+          aria-current={selected ? "true" : undefined}
+          aria-label={selected ? `${m.label}, selected` : `Select ${m.label}`}
           onClick={() => handleSelectModel(m.id, providerId)}
           className={cn(
             "flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-xs",
-            isSelected(m.id)
+            selected
               ? "bg-accent text-foreground"
               : "text-popover-foreground hover:bg-accent/50 hover:text-foreground",
           )}
@@ -347,8 +400,8 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
               {m.multiplier}x
             </span>
           )}
-          {isSelected(m.id) && (
-            <Check size={10} className="shrink-0 text-foreground" />
+          {selected && (
+            <Check size={10} className="shrink-0 text-foreground" aria-hidden />
           )}
         </button>
       </div>
@@ -361,19 +414,28 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     isSelected: (id: string) => boolean,
     searchQuery: string,
   ) => {
-    const filtered = filterModelsBySearch(models, searchQuery);
+    const filtered = filterModelsBySearchQuery(models, searchQuery);
     const groups = groupModels(filtered);
     if (!groups) {
       return filtered.map((m) => renderModelRow(m, providerId, isSelected));
     }
-    return groups.map(({ label, models: gModels }) => (
+    return groups.map(({ label, models: gModels }) => {
+      const groupSlug = label.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9_-]/g, "");
+      const headingId = `${panelId}-g-${providerId}-${groupSlug}`;
+      return (
       <div key={label}>
-        <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
+        <div
+          className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none"
+          id={headingId}
+        >
           {label}
         </div>
-        {gModels.map((m) => renderModelRow(m, providerId, isSelected))}
+        <div aria-labelledby={headingId}>
+          {gModels.map((m) => renderModelRow(m, providerId, isSelected))}
+        </div>
       </div>
-    ));
+    );
+    });
   };
 
   const panelSearchTestId =
@@ -407,17 +469,25 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     const isSelected = (modelId: string) =>
       modelId === normalizedSelectedId && p.id === (selectedProviderId ?? displayProvider?.id);
 
+    const loadedModels = getModels(p);
+    const showProviderTitle = !catalogUsesModelGroups(loadedModels);
+
     return (
       <div className="space-y-0.5">
-        <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
-          {p.name}
-        </div>
         {loadingProviders.has(p.id) ? (
           <div className="flex items-center justify-center py-8">
-            <Loader2 size={14} className="animate-spin text-muted-foreground" />
+            <Loader2 size={14} className="animate-spin text-muted-foreground" aria-hidden />
+            <span className="sr-only">Loading models</span>
           </div>
         ) : (
-          renderGroupedModels(getModels(p), p.id, isSelected, rightPanelSearch)
+          <>
+            {showProviderTitle && (
+              <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
+                {p.name}
+              </div>
+            )}
+            {renderGroupedModels(loadedModels, p.id, isSelected, rightPanelSearch)}
+          </>
         )}
       </div>
     );
@@ -425,24 +495,35 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
 
   return (
     <div ref={containerRef} className="relative">
-      <Button variant="ghost" size="xs" data-testid="model-selector-trigger" onClick={() => setOpen(!open)} className="text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors">
-        <Icon size={14} className={iconClass} />
+      <Button
+        variant="ghost"
+        size="xs"
+        data-testid="model-selector-trigger"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setOpen(!open)}
+        className="text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors"
+      >
+        <Icon size={14} className={iconClass} aria-hidden />
         <span className="text-sm">{shortLabel}</span>
-        <ChevronDown size={11} />
+        <ChevronDown size={11} aria-hidden />
       </Button>
 
       {open && (
         <div
+          id={panelId}
+          role="dialog"
+          aria-label="Choose model and provider"
           className={cn(
             "absolute bottom-full left-0 z-20 mb-1 flex max-h-[min(480px,calc(100vh-8rem))] w-[min(92vw,520px)] flex-col overflow-hidden rounded-lg border border-border bg-popover shadow-lg",
           )}
         >
           <div className="flex shrink-0 border-b border-border/40">
-            <div className="flex w-[148px] shrink-0 items-center border-r border-border/40 px-2 py-2">
-              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 select-none">
-                {providerLocked ? "Scope" : "Browse"}
-              </span>
-            </div>
+            <div
+              className={cn(LEFT_RAIL_WIDTH_CLASS, "shrink-0 border-r border-border/40")}
+              aria-hidden="true"
+            />
             <div className="min-w-0 flex-1 p-1.5">
               <Input
                 size="xs"
@@ -451,34 +532,47 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
                 onChange={(e) => setRightPanelSearch(e.target.value)}
                 data-testid={panelSearchTestId}
                 className="h-7"
+                aria-label={searchAriaLabel}
               />
             </div>
           </div>
 
           <div className="flex min-h-0 flex-1 divide-x divide-border/40">
-            <div className="flex w-[148px] shrink-0 flex-col gap-0.5 overflow-y-auto bg-muted/15 p-1">
-              <button
-                type="button"
-                data-testid="model-selector-rail-favorites"
-                onClick={() => selectLeftRail("favorites")}
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs transition-colors",
-                  leftRailSelection === "favorites"
-                    ? "bg-accent text-foreground shadow-sm"
-                    : "text-popover-foreground hover:bg-accent/40 hover:text-foreground",
-                )}
-              >
-                <Star
-                  size={14}
-                  className={cn(
-                    "shrink-0 text-muted-foreground",
-                    leftRailSelection === "favorites" && "fill-amber-400 text-amber-400",
-                  )}
+            <nav
+              className={cn(
+                LEFT_RAIL_WIDTH_CLASS,
+                "flex shrink-0 flex-col items-center gap-1 overflow-y-auto bg-muted/15 py-1",
+              )}
+              aria-label={providerLocked ? "Scope and favorites" : "Favorites and providers"}
+            >
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      type="button"
+                      data-testid="model-selector-rail-favorites"
+                      onClick={() => selectLeftRail("favorites")}
+                      aria-current={leftRailSelection === "favorites" ? "true" : undefined}
+                      aria-label="Favorites"
+                      className={cn(
+                        "flex h-10 w-10 items-center justify-center rounded-md transition-colors",
+                        leftRailSelection === "favorites"
+                          ? "bg-accent text-foreground shadow-sm"
+                          : "text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+                      )}
+                    >
+                      <Star
+                        size={18}
+                        className={cn(leftRailSelection === "favorites" && "fill-amber-400 text-amber-400")}
+                        aria-hidden
+                      />
+                    </button>
+                  }
                 />
-                <span className="truncate font-medium">Favorites</span>
-              </button>
+                <TooltipContent side="right">Saved models</TooltipContent>
+              </Tooltip>
 
-              <div className="my-0.5 border-t border-border/40" />
+              <div className="my-0.5 h-px w-8 shrink-0 bg-border/50" aria-hidden />
 
               {providersForLeftRail.map((p) => {
                 const pm = PROVIDER_META[p.id];
@@ -487,46 +581,60 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
                 const providerRecord = availabilityList.find((x) => x.id === p.id);
                 const providerDisabled = providerRecord ? !providerRecord.enabled : false;
                 const singleStaticModel = p.models.length === 1;
+                const unavailable = p.comingSoon || providerDisabled;
+                const tip = unavailable
+                  ? providerRailUnavailableReason(p, providerDisabled)
+                  : singleStaticModel
+                    ? `Select ${p.models[0].label}`
+                    : `Browse ${p.name} models`;
 
                 return (
-                  <button
-                    key={p.id}
-                    type="button"
-                    data-testid={`model-group-${p.id}`}
-                    data-disabled={providerDisabled ? "true" : "false"}
-                    disabled={p.comingSoon || providerDisabled}
-                    onClick={() => {
-                      if (providerDisabled) return;
-                      if (singleStaticModel) {
-                        handleSelectModel(p.models[0].id, p.id);
-                        return;
+                  <Tooltip key={p.id}>
+                    <TooltipTrigger
+                      render={
+                        <button
+                          type="button"
+                          data-testid={`model-group-${p.id}`}
+                          data-disabled={providerDisabled ? "true" : "false"}
+                          disabled={unavailable}
+                          aria-current={leftRailSelection === p.id && !singleStaticModel ? "true" : undefined}
+                          aria-label={unavailable ? tip : p.name}
+                          onClick={() => {
+                            if (unavailable) return;
+                            if (singleStaticModel) {
+                              handleSelectModel(p.models[0].id, p.id);
+                              return;
+                            }
+                            selectLeftRail(p.id);
+                          }}
+                          className={cn(
+                            "relative flex h-10 w-10 shrink-0 items-center justify-center rounded-md transition-colors",
+                            unavailable && "cursor-not-allowed opacity-45",
+                            !unavailable && "text-popover-foreground hover:bg-accent/40 hover:text-foreground",
+                            leftRailSelection === p.id && !singleStaticModel && !unavailable && "bg-accent text-foreground shadow-sm",
+                          )}
+                        >
+                          <ProvIcon size={18} className={p.comingSoon ? "opacity-50" : provIconClass} aria-hidden />
+                          {unavailable && (
+                            <span
+                              className="absolute bottom-1 right-1 h-1.5 w-1.5 rounded-full bg-muted-foreground/80"
+                              aria-hidden
+                            />
+                          )}
+                        </button>
                       }
-                      selectLeftRail(p.id);
-                    }}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs transition-colors",
-                      p.comingSoon || providerDisabled
-                        ? "cursor-not-allowed opacity-50"
-                        : "text-popover-foreground hover:bg-accent/40 hover:text-foreground",
-                      leftRailSelection === p.id && !singleStaticModel && "bg-accent text-foreground shadow-sm",
-                    )}
-                  >
-                    <ProvIcon size={14} className={p.comingSoon ? "opacity-40" : provIconClass} />
-                    <span className="min-w-0 flex-1 truncate font-medium">{p.name}</span>
-                    <span className="flex shrink-0 flex-col items-end gap-0.5">
-                      {p.comingSoon && (
-                        <Badge variant="secondary" size="sm">SOON</Badge>
-                      )}
-                      {providerDisabled && (
-                        <Badge variant="outline" size="sm">Disabled</Badge>
-                      )}
-                    </span>
-                  </button>
+                    />
+                    <TooltipContent side="right">{tip}</TooltipContent>
+                  </Tooltip>
                 );
               })}
-            </div>
+            </nav>
 
-            <div className="min-h-[220px] min-w-0 flex-1 overflow-y-auto bg-popover p-1">
+            <div
+              className="min-h-[220px] min-w-0 flex-1 overflow-y-auto bg-popover p-1"
+              role="region"
+              aria-label="Model list"
+            >
               {renderRightPanel()}
             </div>
           </div>

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ComponentType } from "react";
-import { ChevronDown, ChevronRight, Lock, Check, Loader2, Star } from "lucide-react";
+import { ChevronDown, Lock, Check, Loader2, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatContextWindow } from "./format-context-window";
 import { Button } from "@/components/ui/button";
@@ -36,6 +36,9 @@ const PROVIDER_META: Record<string, { icon: IconComponent; color: string }> = {
   gemini: { icon: GeminiIcon, color: "text-sky-400" },
 };
 
+/** Left rail segment: browse starred models or a single provider's catalog. */
+type LeftRailSelection = "favorites" | string;
+
 interface ModelSelectorProps {
   selectedModelId: string;
   /**
@@ -56,21 +59,17 @@ interface ModelSelectorProps {
 /** Renders a model selection dropdown and controls selection state. */
 export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, locked, providerLocked }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
-  const [hoveredProvider, setHoveredProvider] = useState<string | null>(null);
-  const [favoriteSearch, setFavoriteSearch] = useState("");
-  const [submenuSearch, setSubmenuSearch] = useState("");
-  const [lockedPanelSearch, setLockedPanelSearch] = useState("");
+  const [leftRailSelection, setLeftRailSelection] = useState<LeftRailSelection>("favorites");
+  const [rightPanelSearch, setRightPanelSearch] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
-  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevOpenRef = useRef(false);
 
   const favorites = useModelFavoritesStore((s) => s.entries);
   const toggleFavorite = useModelFavoritesStore((s) => s.toggleFavorite);
   const isFavorite = useModelFavoritesStore((s) => s.isFavorite);
 
-  // Read the full list once at the top level -- hooks cannot be called inside .map().
   const availabilityList = useProviderAvailabilityStore((s) => s.providers);
 
-  // Dynamically fetched model lists, keyed by provider ID.
   const [dynamicModels, setDynamicModels] = useState<Map<string, ModelProvider["models"]>>(new Map());
   const dynamicModelsRef = useRef<Map<string, ModelProvider["models"]>>(new Map());
   const [loadingProviders, setLoadingProviders] = useState<Set<string>>(new Set());
@@ -104,8 +103,6 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
       dynamicModelsRef.current = updated;
       setDynamicModels(updated);
     } catch {
-      // Record failure time so retries are throttled — leave the cache unpopulated
-      // so a subsequent hover after the cooldown triggers a fresh attempt.
       fetchFailedAtRef.current.set(providerId, Date.now());
     } finally {
       fetchingRef.current.delete(providerId);
@@ -117,12 +114,6 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     }
   }, []);
 
-  /**
-   * Returns live models for a provider, falling back to the static registry.
-   * Empty dynamic lists fall through to the static registry — `listClaudeModels`
-   * returns `[]` when ANTHROPIC_API_KEY is unset, and `??` does not fall
-   * through on a truthy empty array, which would hide all Claude models.
-   */
   const getModels = (p: ModelProvider): ModelProvider["models"] => {
     const dynamic = dynamicModels.get(p.id);
     return dynamic && dynamic.length > 0 ? dynamic : p.models;
@@ -147,47 +138,9 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     );
   }, []);
 
-  useEffect(() => {
-    if (!open) {
-      setFavoriteSearch("");
-      setSubmenuSearch("");
-      setLockedPanelSearch("");
-    }
-  }, [open]);
-
-  useEffect(() => {
-    setSubmenuSearch("");
-  }, [hoveredProvider]);
-
-  useEffect(() => {
-    if (!open || locked) return;
-    const ids = new Set<string>();
-    for (const f of favorites) {
-      if (isProviderUsable(f.providerId)) ids.add(f.providerId);
-    }
-    for (const id of ids) void fetchProviderModels(id);
-  }, [open, locked, favorites, fetchProviderModels, isProviderUsable]);
-
-  // Delayed hover close so user has time to move to submenu
-  const setHoveredWithDelay = (providerId: string | null) => {
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
-      hoverTimeoutRef.current = null;
-    }
-    if (providerId) {
-      setHoveredProvider(providerId);
-    } else {
-      hoverTimeoutRef.current = setTimeout(() => {
-        setHoveredProvider(null);
-      }, 300);
-    }
-  };
-
   const model = findModelById(selectedModelId);
   const normalizedSelectedId = model?.id ?? selectedModelId;
 
-  // Resolve display provider: prefer the explicit selectedProviderId so that
-  // providers sharing the same model ID (e.g. Codex vs Copilot) show correctly.
   const displayProvider = selectedProviderId
     ? MODEL_PROVIDERS.find((p) => p.id === selectedProviderId)
     : MODEL_PROVIDERS.find((p) => p.models.some((m) => m.id === normalizedSelectedId));
@@ -199,39 +152,71 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     ? model.label.replace(`${displayProvider.name} `, "")
     : (model?.label ?? selectedModelId);
 
-  const favoriteSearchNorm = favoriteSearch.trim().toLowerCase();
+  const defaultProviderId = useMemo(() => {
+    const preferred = selectedProviderId ?? displayProvider?.id;
+    if (preferred && MODEL_PROVIDERS.some((p) => p.id === preferred)) return preferred;
+    return MODEL_PROVIDERS.find((p) => !p.comingSoon)?.id ?? "favorites";
+  }, [selectedProviderId, displayProvider?.id]);
 
-  const filteredFavorites = useMemo(() => {
+  const providersForLeftRail = useMemo(() => {
+    if (providerLocked && displayProvider) {
+      return MODEL_PROVIDERS.filter((p) => p.id === displayProvider.id);
+    }
+    return MODEL_PROVIDERS;
+  }, [providerLocked, displayProvider]);
+
+  const favoritesVisible = useMemo(() => {
     return favorites.filter((f) => {
       if (!isProviderUsable(f.providerId)) return false;
       if (providerLocked && displayProvider && f.providerId !== displayProvider.id) return false;
-      if (!favoriteSearchNorm) return true;
-      return (
-        f.label.toLowerCase().includes(favoriteSearchNorm) ||
-        f.modelId.toLowerCase().includes(favoriteSearchNorm)
-      );
+      return true;
     });
-  }, [favorites, favoriteSearchNorm, isProviderUsable, providerLocked, displayProvider]);
+  }, [favorites, isProviderUsable, providerLocked, displayProvider]);
 
-  // For a provider-locked thread, fetch immediately so the list is current.
+  const favoritesFiltered = useMemo(() => {
+    const n = rightPanelSearch.trim().toLowerCase();
+    if (!n) return favoritesVisible;
+    return favoritesVisible.filter(
+      (f) =>
+        f.label.toLowerCase().includes(n) ||
+        f.modelId.toLowerCase().includes(n),
+    );
+  }, [favoritesVisible, rightPanelSearch]);
+
+  /** When the menu opens, reset rail + search so the right pane matches the current thread provider. */
   useEffect(() => {
-    if (providerLocked && displayProvider) {
-      fetchProviderModels(displayProvider.id);
+    if (open && !prevOpenRef.current) {
+      if (providerLocked && displayProvider) {
+        setLeftRailSelection(displayProvider.id);
+      } else {
+        setLeftRailSelection(defaultProviderId);
+      }
+      setRightPanelSearch("");
     }
-  }, [providerLocked, displayProvider?.id, fetchProviderModels]);
+    prevOpenRef.current = open;
+  }, [open, providerLocked, displayProvider?.id, defaultProviderId]);
+
+  useEffect(() => {
+    if (!open || locked) return;
+    if (leftRailSelection !== "favorites") {
+      void fetchProviderModels(leftRailSelection);
+      return;
+    }
+    const ids = new Set<string>();
+    for (const f of favoritesVisible) {
+      ids.add(f.providerId);
+    }
+    for (const id of ids) void fetchProviderModels(id);
+  }, [open, locked, leftRailSelection, favoritesVisible, fetchProviderModels]);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setOpen(false);
-        setHoveredProvider(null);
       }
     };
     document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
-    };
+    return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
   if (locked) {
@@ -247,7 +232,11 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   const handleSelectModel = (modelId: string, providerId: string) => {
     onSelect(modelId, providerId);
     setOpen(false);
-    setHoveredProvider(null);
+  };
+
+  const selectLeftRail = (key: LeftRailSelection) => {
+    setLeftRailSelection(key);
+    setRightPanelSearch("");
   };
 
   const renderFavoriteRow = (entry: ModelFavoriteEntry) => {
@@ -315,7 +304,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   const renderModelRow = (
     m: ModelProvider["models"][0],
     providerId: string,
-    isSelected: (id: string) => boolean
+    isSelected: (id: string) => boolean,
   ) => {
     const ctxLabel = formatContextWindow(m.contextWindow);
     const starred = isFavorite(providerId, m.id);
@@ -344,7 +333,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
             "flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-xs",
             isSelected(m.id)
               ? "bg-accent text-foreground"
-              : "text-popover-foreground hover:bg-accent/50 hover:text-foreground"
+              : "text-popover-foreground hover:bg-accent/50 hover:text-foreground",
           )}
         >
           <span className="flex-1 truncate text-left">{m.label}</span>
@@ -387,40 +376,49 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     ));
   };
 
-  const renderSubmenu = (p: ModelProvider) => {
-    // A model row is "selected" only when both ID and provider match.
+  const panelSearchTestId =
+    providerLocked && displayProvider ? "model-selector-locked-search" : "model-selector-panel-search";
+
+  const renderRightPanel = () => {
+    if (leftRailSelection === "favorites") {
+      if (favoritesFiltered.length === 0) {
+        const emptyList = favoritesVisible.length === 0;
+        return (
+          <p className="px-3 py-8 text-center text-xs text-muted-foreground leading-relaxed">
+            {emptyList
+              ? "No favorites yet. Open a provider on the left, then star models you use often."
+              : "No favorites match your search."}
+          </p>
+        );
+      }
+      return (
+        <div className="space-y-0.5">
+          <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
+            Favorites
+          </div>
+          {favoritesFiltered.map((entry) => renderFavoriteRow(entry))}
+        </div>
+      );
+    }
+
+    const p = MODEL_PROVIDERS.find((x) => x.id === leftRailSelection);
+    if (!p) return null;
+
     const isSelected = (modelId: string) =>
       modelId === normalizedSelectedId && p.id === (selectedProviderId ?? displayProvider?.id);
 
     return (
-      <div
-        className="absolute left-full bottom-0 z-30 -ml-1 min-w-[220px] pl-2"
-        onMouseEnter={() => setHoveredWithDelay(p.id)}
-        onMouseLeave={() => setHoveredWithDelay(null)}
-      >
-        <div className="flex max-h-[min(480px,calc(100vh-8rem))] flex-col overflow-hidden rounded-md border border-border bg-popover shadow-lg">
-          <div className="border-b border-border/40 p-1.5">
-            <Input
-              size="xs"
-              placeholder="Search models..."
-              value={submenuSearch}
-              onChange={(e) => setSubmenuSearch(e.target.value)}
-              data-testid="model-selector-submenu-search"
-              className="h-7"
-              onMouseDown={(e) => e.stopPropagation()}
-              onClick={(e) => e.stopPropagation()}
-            />
-          </div>
-          <div className="overflow-y-auto p-1">
-            {loadingProviders.has(p.id) ? (
-              <div className="flex items-center justify-center py-6">
-                <Loader2 size={14} className="animate-spin text-muted-foreground" />
-              </div>
-            ) : (
-              renderGroupedModels(getModels(p), p.id, isSelected, submenuSearch)
-            )}
-          </div>
+      <div className="space-y-0.5">
+        <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
+          {p.name}
         </div>
+        {loadingProviders.has(p.id) ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 size={14} className="animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          renderGroupedModels(getModels(p), p.id, isSelected, rightPanelSearch)
+        )}
       </div>
     );
   };
@@ -434,134 +432,104 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
       </Button>
 
       {open && (
-        <div className="absolute bottom-full left-0 z-20 mb-1 min-w-[240px] rounded-md border border-border bg-popover p-1 shadow-lg">
-          {/* When provider is locked, show only that provider's models directly */}
-          {providerLocked && displayProvider ? (
-            <div className="flex max-h-[min(480px,calc(100vh-8rem))] flex-col overflow-hidden">
-              <div className="border-b border-border/40 p-1.5">
-                <Input
-                  size="xs"
-                  placeholder="Search favorites..."
-                  value={favoriteSearch}
-                  onChange={(e) => setFavoriteSearch(e.target.value)}
-                  data-testid="model-selector-favorite-search"
-                  className="h-7"
-                />
-              </div>
-              {filteredFavorites.length > 0 && (
-                <div className="border-b border-border/40 py-1">
-                  <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
-                    Favorites
-                  </div>
-                  {filteredFavorites.map((entry) => renderFavoriteRow(entry))}
-                </div>
-              )}
-              <div className="border-b border-border/40 p-1.5">
-                <Input
-                  size="xs"
-                  placeholder="Search models..."
-                  value={lockedPanelSearch}
-                  onChange={(e) => setLockedPanelSearch(e.target.value)}
-                  data-testid="model-selector-locked-search"
-                  className="h-7"
-                />
-              </div>
-              <div className="overflow-y-auto p-1">
-                {loadingProviders.has(displayProvider.id) ? (
-                  <div className="flex items-center justify-center py-6">
-                    <Loader2 size={14} className="animate-spin text-muted-foreground" />
-                  </div>
-                ) : (
-                  renderGroupedModels(
-                    getModels(displayProvider),
-                    displayProvider.id,
-                    (id) => id === normalizedSelectedId,
-                    lockedPanelSearch,
-                  )
-                )}
-              </div>
-            </div>
-          ) : (
-            <>
-              <div className="border-b border-border/40 p-1.5">
-                <Input
-                  size="xs"
-                  placeholder="Search favorites..."
-                  value={favoriteSearch}
-                  onChange={(e) => setFavoriteSearch(e.target.value)}
-                  data-testid="model-selector-favorite-search"
-                  className="h-7"
-                />
-              </div>
-              {filteredFavorites.length > 0 && (
-                <div className="border-b border-border/40 py-1">
-                  <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
-                    Favorites
-                  </div>
-                  {filteredFavorites.map((entry) => renderFavoriteRow(entry))}
-                </div>
-              )}
-              {MODEL_PROVIDERS.map((p) => {
-            const pm = PROVIDER_META[p.id];
-            const ProvIcon = pm?.icon ?? ClaudeIcon;
-            const provIconClass = pm?.color ?? "";
-            const hasModels = p.models.length > 0;
-
-            // Derive disabled state from the availability store. An absent record is treated
-            // as enabled so newly-registered providers don't appear broken before the server
-            // has had a chance to push their availability.
-            const providerRecord = availabilityList.find((x) => x.id === p.id);
-            const providerDisabled = providerRecord ? !providerRecord.enabled : false;
-
-            return (
-              <div
-                key={p.id}
-                data-testid={`model-group-${p.id}`}
-                data-disabled={providerDisabled ? "true" : "false"}
-                className={cn("relative", providerDisabled && "opacity-50 pointer-events-none")}
-                onMouseEnter={() => {
-                    if (!p.comingSoon && !providerDisabled && hasModels) {
-                      setHoveredWithDelay(p.id);
-                      fetchProviderModels(p.id);
-                    }
-                  }}
-                onMouseLeave={() => setHoveredWithDelay(null)}
-              >
-                <button
-                  disabled={p.comingSoon || providerDisabled}
-                  onClick={() => {
-                    // Guard against disabled providers in case pointer-events-none is overridden
-                    // by a theme or browser extension.
-                    if (providerDisabled) return;
-                    if (hasModels && p.models.length === 1) {
-                      handleSelectModel(p.models[0].id, p.id);
-                    }
-                  }}
-                  className={cn(
-                    "flex w-full items-center gap-2 rounded px-3 py-1.5 text-xs",
-                    p.comingSoon
-                      ? "cursor-default text-muted-foreground/70"
-                      : "text-popover-foreground hover:bg-accent/50 hover:text-foreground"
-                  )}
-                >
-                  <ProvIcon size={12} className={p.comingSoon ? "opacity-40" : provIconClass} />
-                  <span className="flex-1 text-left">{p.name}</span>
-                  {p.comingSoon && (
-                    <Badge variant="secondary" size="sm">SOON</Badge>
-                  )}
-                  {providerDisabled && (
-                    <Badge variant="outline" size="sm">Disabled</Badge>
-                  )}
-                  {!p.comingSoon && !providerDisabled && hasModels && p.models.length > 1 && (
-                    <ChevronRight size={10} className="text-muted-foreground" />
-                  )}
-                </button>
-                {hoveredProvider === p.id && hasModels && p.models.length > 1 && renderSubmenu(p)}
-              </div>
-            );
-          })}
-            </>
+        <div
+          className={cn(
+            "absolute bottom-full left-0 z-20 mb-1 flex max-h-[min(480px,calc(100vh-8rem))] w-[min(92vw,520px)] flex-col overflow-hidden rounded-lg border border-border bg-popover shadow-lg",
           )}
+        >
+          <div className="flex shrink-0 border-b border-border/40">
+            <div className="flex w-[148px] shrink-0 items-center border-r border-border/40 px-2 py-2">
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 select-none">
+                {providerLocked ? "Scope" : "Browse"}
+              </span>
+            </div>
+            <div className="min-w-0 flex-1 p-1.5">
+              <Input
+                size="xs"
+                placeholder={leftRailSelection === "favorites" ? "Search favorites…" : "Search models…"}
+                value={rightPanelSearch}
+                onChange={(e) => setRightPanelSearch(e.target.value)}
+                data-testid={panelSearchTestId}
+                className="h-7"
+              />
+            </div>
+          </div>
+
+          <div className="flex min-h-0 flex-1 divide-x divide-border/40">
+            <div className="flex w-[148px] shrink-0 flex-col gap-0.5 overflow-y-auto bg-muted/15 p-1">
+              <button
+                type="button"
+                data-testid="model-selector-rail-favorites"
+                onClick={() => selectLeftRail("favorites")}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs transition-colors",
+                  leftRailSelection === "favorites"
+                    ? "bg-accent text-foreground shadow-sm"
+                    : "text-popover-foreground hover:bg-accent/40 hover:text-foreground",
+                )}
+              >
+                <Star
+                  size={14}
+                  className={cn(
+                    "shrink-0 text-muted-foreground",
+                    leftRailSelection === "favorites" && "fill-amber-400 text-amber-400",
+                  )}
+                />
+                <span className="truncate font-medium">Favorites</span>
+              </button>
+
+              <div className="my-0.5 border-t border-border/40" />
+
+              {providersForLeftRail.map((p) => {
+                const pm = PROVIDER_META[p.id];
+                const ProvIcon = pm?.icon ?? ClaudeIcon;
+                const provIconClass = pm?.color ?? "";
+                const providerRecord = availabilityList.find((x) => x.id === p.id);
+                const providerDisabled = providerRecord ? !providerRecord.enabled : false;
+                const singleStaticModel = p.models.length === 1;
+
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    data-testid={`model-group-${p.id}`}
+                    data-disabled={providerDisabled ? "true" : "false"}
+                    disabled={p.comingSoon || providerDisabled}
+                    onClick={() => {
+                      if (providerDisabled) return;
+                      if (singleStaticModel) {
+                        handleSelectModel(p.models[0].id, p.id);
+                        return;
+                      }
+                      selectLeftRail(p.id);
+                    }}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs transition-colors",
+                      p.comingSoon || providerDisabled
+                        ? "cursor-not-allowed opacity-50"
+                        : "text-popover-foreground hover:bg-accent/40 hover:text-foreground",
+                      leftRailSelection === p.id && !singleStaticModel && "bg-accent text-foreground shadow-sm",
+                    )}
+                  >
+                    <ProvIcon size={14} className={p.comingSoon ? "opacity-40" : provIconClass} />
+                    <span className="min-w-0 flex-1 truncate font-medium">{p.name}</span>
+                    <span className="flex shrink-0 flex-col items-end gap-0.5">
+                      {p.comingSoon && (
+                        <Badge variant="secondary" size="sm">SOON</Badge>
+                      )}
+                      {providerDisabled && (
+                        <Badge variant="outline" size="sm">Disabled</Badge>
+                      )}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="min-h-[220px] min-w-0 flex-1 overflow-y-auto bg-popover p-1">
+              {renderRightPanel()}
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -499,13 +499,14 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
         <ChevronDown size={11} aria-hidden />
       </Button>
 
+      {/* Fixed shell height keeps layout stable when switching providers; lists scroll inside. */}
       {open && (
         <div
           id={panelId}
           role="dialog"
           aria-label="Choose model and provider"
           className={cn(
-            "absolute bottom-full left-0 z-20 mb-1 flex max-h-[min(480px,calc(100vh-8rem))] w-[min(92vw,520px)] flex-col overflow-hidden rounded-lg border border-border bg-popover shadow-lg",
+            "absolute bottom-full left-0 z-20 mb-1 flex h-[min(440px,calc(100vh-8rem))] w-[min(92vw,520px)] flex-col overflow-hidden rounded-lg border border-border bg-popover shadow-lg",
           )}
         >
           <div className="flex shrink-0 border-b border-border/40">
@@ -620,7 +621,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
             </nav>
 
             <div
-              className="min-h-[220px] min-w-0 flex-1 overflow-y-auto bg-popover p-1"
+              className="min-h-0 min-w-0 flex-1 overflow-y-auto bg-popover p-1"
               role="region"
               aria-label="Model list"
             >

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -20,6 +20,7 @@ import {
   useModelFavoritesStore,
   type ModelFavoriteEntry,
 } from "@/stores/modelFavoritesStore";
+import { tokenizeSearch, matchesAllTokens } from "@/lib/searchTokens";
 import {
   ClaudeIcon,
   CodexIcon,
@@ -42,18 +43,6 @@ const PROVIDER_META: Record<string, { icon: IconComponent; color: string }> = {
 
 /** Matches Tailwind `w-[52px]` for header alignment and icon-first rail. */
 const LEFT_RAIL_WIDTH_CLASS = "w-[52px]";
-
-/** Splits a query into lowercase tokens (whitespace). Empty input yields no tokens. */
-function tokenizeSearch(raw: string): string[] {
-  return raw.trim().toLowerCase().split(/\s+/).filter(Boolean);
-}
-
-/** Requires every token to appear as a substring (AND semantics across fields). */
-function matchesAllTokens(parts: string[], tokens: string[]): boolean {
-  if (tokens.length === 0) return true;
-  const haystack = parts.join(" ").toLowerCase();
-  return tokens.every((t) => haystack.includes(t));
-}
 
 /** True when the catalog uses subgroup rows so a provider title above would repeat RPC group labels. */
 function catalogUsesModelGroups(models: ModelProvider["models"]): boolean {

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useRef, useCallback, type ComponentType } from "react";
-import { ChevronDown, ChevronRight, Lock, Check, Loader2 } from "lucide-react";
+import { useState, useEffect, useRef, useCallback, useMemo, type ComponentType } from "react";
+import { ChevronDown, ChevronRight, Lock, Check, Loader2, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatContextWindow } from "./format-context-window";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import {
   MODEL_PROVIDERS,
@@ -11,6 +12,10 @@ import {
 } from "@/lib/model-registry";
 import { getTransport } from "@/transport";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
+import {
+  useModelFavoritesStore,
+  type ModelFavoriteEntry,
+} from "@/stores/modelFavoritesStore";
 import {
   ClaudeIcon,
   CodexIcon,
@@ -52,8 +57,15 @@ interface ModelSelectorProps {
 export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, locked, providerLocked }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
   const [hoveredProvider, setHoveredProvider] = useState<string | null>(null);
+  const [favoriteSearch, setFavoriteSearch] = useState("");
+  const [submenuSearch, setSubmenuSearch] = useState("");
+  const [lockedPanelSearch, setLockedPanelSearch] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const favorites = useModelFavoritesStore((s) => s.entries);
+  const toggleFavorite = useModelFavoritesStore((s) => s.toggleFavorite);
+  const isFavorite = useModelFavoritesStore((s) => s.isFavorite);
 
   // Read the full list once at the top level -- hooks cannot be called inside .map().
   const availabilityList = useProviderAvailabilityStore((s) => s.providers);
@@ -116,6 +128,46 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     return dynamic && dynamic.length > 0 ? dynamic : p.models;
   };
 
+  const isProviderUsable = useCallback(
+    (id: string) => {
+      const r = availabilityList.find((x) => x.id === id);
+      if (!r) return true;
+      return r.enabled && r.hasAdapter && r.cli.status !== "not_found";
+    },
+    [availabilityList],
+  );
+
+  const filterModelsBySearch = useCallback((models: ModelProvider["models"], q: string) => {
+    const n = q.trim().toLowerCase();
+    if (!n) return models;
+    return models.filter(
+      (m) =>
+        m.label.toLowerCase().includes(n) ||
+        m.id.toLowerCase().includes(n),
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setFavoriteSearch("");
+      setSubmenuSearch("");
+      setLockedPanelSearch("");
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setSubmenuSearch("");
+  }, [hoveredProvider]);
+
+  useEffect(() => {
+    if (!open || locked) return;
+    const ids = new Set<string>();
+    for (const f of favorites) {
+      if (isProviderUsable(f.providerId)) ids.add(f.providerId);
+    }
+    for (const id of ids) void fetchProviderModels(id);
+  }, [open, locked, favorites, fetchProviderModels, isProviderUsable]);
+
   // Delayed hover close so user has time to move to submenu
   const setHoveredWithDelay = (providerId: string | null) => {
     if (hoverTimeoutRef.current) {
@@ -146,6 +198,20 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
   const shortLabel = model && displayProvider
     ? model.label.replace(`${displayProvider.name} `, "")
     : (model?.label ?? selectedModelId);
+
+  const favoriteSearchNorm = favoriteSearch.trim().toLowerCase();
+
+  const filteredFavorites = useMemo(() => {
+    return favorites.filter((f) => {
+      if (!isProviderUsable(f.providerId)) return false;
+      if (providerLocked && displayProvider && f.providerId !== displayProvider.id) return false;
+      if (!favoriteSearchNorm) return true;
+      return (
+        f.label.toLowerCase().includes(favoriteSearchNorm) ||
+        f.modelId.toLowerCase().includes(favoriteSearchNorm)
+      );
+    });
+  }, [favorites, favoriteSearchNorm, isProviderUsable, providerLocked, displayProvider]);
 
   // For a provider-locked thread, fetch immediately so the list is current.
   useEffect(() => {
@@ -184,6 +250,53 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     setHoveredProvider(null);
   };
 
+  const renderFavoriteRow = (entry: ModelFavoriteEntry) => {
+    const pm = PROVIDER_META[entry.providerId];
+    const ProvIcon = pm?.icon ?? ClaudeIcon;
+    const provIconClass = pm?.color ?? "";
+    const starred = isFavorite(entry.providerId, entry.modelId);
+    return (
+      <div
+        key={`${entry.providerId}:${entry.modelId}`}
+        className="flex w-full items-center gap-0.5 rounded px-1"
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+          aria-label={starred ? "Remove from favorites" : "Add to favorites"}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleFavorite({
+              providerId: entry.providerId,
+              modelId: entry.modelId,
+              label: entry.label,
+            });
+          }}
+        >
+          <Star
+            size={12}
+            className={cn(starred && "fill-amber-400 text-amber-400")}
+          />
+        </Button>
+        <button
+          type="button"
+          onClick={() => handleSelectModel(entry.modelId, entry.providerId)}
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-xs",
+            entry.modelId === normalizedSelectedId && entry.providerId === (selectedProviderId ?? displayProvider?.id)
+              ? "bg-accent text-foreground"
+              : "text-popover-foreground hover:bg-accent/50 hover:text-foreground",
+          )}
+        >
+          <ProvIcon size={12} className={provIconClass} />
+          <span className="truncate text-left">{entry.label}</span>
+        </button>
+      </div>
+    );
+  };
+
   /** Groups a provider's models by their `group` field. Returns ungrouped if none use it. */
   const groupModels = (models: ModelProvider["models"]) => {
     const hasGroups = models.some((m) => m.group);
@@ -205,43 +318,64 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     isSelected: (id: string) => boolean
   ) => {
     const ctxLabel = formatContextWindow(m.contextWindow);
+    const starred = isFavorite(providerId, m.id);
     return (
-      <button
-        key={m.id}
-        onClick={() => handleSelectModel(m.id, providerId)}
-        className={cn(
-          "flex w-full items-center gap-2 rounded px-3 py-1.5 text-xs",
-          isSelected(m.id)
-            ? "bg-accent text-foreground"
-            : "text-popover-foreground hover:bg-accent/50 hover:text-foreground"
-        )}
-      >
-        <span className="flex-1 text-left">{m.label}</span>
-        {ctxLabel && (
-          <span className="text-[10px] text-muted-foreground/60 tabular-nums">
-            {ctxLabel}
-          </span>
-        )}
-        {m.multiplier != null && (
-          <span className="text-[10px] text-muted-foreground/60 tabular-nums">
-            {m.multiplier}x
-          </span>
-        )}
-        {isSelected(m.id) && (
-          <Check size={10} className="shrink-0 text-foreground" />
-        )}
-      </button>
+      <div key={m.id} className="flex w-full items-center gap-0.5 rounded px-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+          aria-label={starred ? "Remove from favorites" : "Add to favorites"}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleFavorite({ providerId, modelId: m.id, label: m.label });
+          }}
+        >
+          <Star
+            size={12}
+            className={cn(starred && "fill-amber-400 text-amber-400")}
+          />
+        </Button>
+        <button
+          type="button"
+          onClick={() => handleSelectModel(m.id, providerId)}
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-xs",
+            isSelected(m.id)
+              ? "bg-accent text-foreground"
+              : "text-popover-foreground hover:bg-accent/50 hover:text-foreground"
+          )}
+        >
+          <span className="flex-1 truncate text-left">{m.label}</span>
+          {ctxLabel && (
+            <span className="text-[10px] text-muted-foreground/60 tabular-nums shrink-0">
+              {ctxLabel}
+            </span>
+          )}
+          {m.multiplier != null && (
+            <span className="text-[10px] text-muted-foreground/60 tabular-nums shrink-0">
+              {m.multiplier}x
+            </span>
+          )}
+          {isSelected(m.id) && (
+            <Check size={10} className="shrink-0 text-foreground" />
+          )}
+        </button>
+      </div>
     );
   };
 
   const renderGroupedModels = (
     models: ModelProvider["models"],
     providerId: string,
-    isSelected: (id: string) => boolean
+    isSelected: (id: string) => boolean,
+    searchQuery: string,
   ) => {
-    const groups = groupModels(models);
+    const filtered = filterModelsBySearch(models, searchQuery);
+    const groups = groupModels(filtered);
     if (!groups) {
-      return models.map((m) => renderModelRow(m, providerId, isSelected));
+      return filtered.map((m) => renderModelRow(m, providerId, isSelected));
     }
     return groups.map(({ label, models: gModels }) => (
       <div key={label}>
@@ -260,18 +394,32 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
 
     return (
       <div
-        className="absolute left-full bottom-0 -ml-1 pl-2 min-w-[180px]"
+        className="absolute left-full bottom-0 z-30 -ml-1 min-w-[220px] pl-2"
         onMouseEnter={() => setHoveredWithDelay(p.id)}
         onMouseLeave={() => setHoveredWithDelay(null)}
       >
-        <div className="max-h-[min(480px,calc(100vh-8rem))] overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-lg">
-          {loadingProviders.has(p.id) ? (
-            <div className="flex items-center justify-center py-6">
-              <Loader2 size={14} className="animate-spin text-muted-foreground" />
-            </div>
-          ) : (
-            renderGroupedModels(getModels(p), p.id, isSelected)
-          )}
+        <div className="flex max-h-[min(480px,calc(100vh-8rem))] flex-col overflow-hidden rounded-md border border-border bg-popover shadow-lg">
+          <div className="border-b border-border/40 p-1.5">
+            <Input
+              size="xs"
+              placeholder="Search models..."
+              value={submenuSearch}
+              onChange={(e) => setSubmenuSearch(e.target.value)}
+              data-testid="model-selector-submenu-search"
+              className="h-7"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>
+          <div className="overflow-y-auto p-1">
+            {loadingProviders.has(p.id) ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 size={14} className="animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              renderGroupedModels(getModels(p), p.id, isSelected, submenuSearch)
+            )}
+          </div>
         </div>
       </div>
     );
@@ -279,30 +427,81 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
 
   return (
     <div ref={containerRef} className="relative">
-      <Button variant="ghost" size="xs" onClick={() => setOpen(!open)} className="text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors">
+      <Button variant="ghost" size="xs" data-testid="model-selector-trigger" onClick={() => setOpen(!open)} className="text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors">
         <Icon size={14} className={iconClass} />
         <span className="text-sm">{shortLabel}</span>
         <ChevronDown size={11} />
       </Button>
 
       {open && (
-        <div className="absolute bottom-full left-0 z-20 mb-1 min-w-[180px] rounded-md border border-border bg-popover p-1 shadow-lg">
+        <div className="absolute bottom-full left-0 z-20 mb-1 min-w-[240px] rounded-md border border-border bg-popover p-1 shadow-lg">
           {/* When provider is locked, show only that provider's models directly */}
           {providerLocked && displayProvider ? (
-            <div className="max-h-[min(480px,calc(100vh-8rem))] overflow-y-auto">
-              {loadingProviders.has(displayProvider.id) ? (
-                <div className="flex items-center justify-center py-6">
-                  <Loader2 size={14} className="animate-spin text-muted-foreground" />
+            <div className="flex max-h-[min(480px,calc(100vh-8rem))] flex-col overflow-hidden">
+              <div className="border-b border-border/40 p-1.5">
+                <Input
+                  size="xs"
+                  placeholder="Search favorites..."
+                  value={favoriteSearch}
+                  onChange={(e) => setFavoriteSearch(e.target.value)}
+                  data-testid="model-selector-favorite-search"
+                  className="h-7"
+                />
+              </div>
+              {filteredFavorites.length > 0 && (
+                <div className="border-b border-border/40 py-1">
+                  <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
+                    Favorites
+                  </div>
+                  {filteredFavorites.map((entry) => renderFavoriteRow(entry))}
                 </div>
-              ) : (
-                renderGroupedModels(
-                  getModels(displayProvider),
-                  displayProvider.id,
-                  (id) => id === normalizedSelectedId
-                )
               )}
+              <div className="border-b border-border/40 p-1.5">
+                <Input
+                  size="xs"
+                  placeholder="Search models..."
+                  value={lockedPanelSearch}
+                  onChange={(e) => setLockedPanelSearch(e.target.value)}
+                  data-testid="model-selector-locked-search"
+                  className="h-7"
+                />
+              </div>
+              <div className="overflow-y-auto p-1">
+                {loadingProviders.has(displayProvider.id) ? (
+                  <div className="flex items-center justify-center py-6">
+                    <Loader2 size={14} className="animate-spin text-muted-foreground" />
+                  </div>
+                ) : (
+                  renderGroupedModels(
+                    getModels(displayProvider),
+                    displayProvider.id,
+                    (id) => id === normalizedSelectedId,
+                    lockedPanelSearch,
+                  )
+                )}
+              </div>
             </div>
-          ) : MODEL_PROVIDERS.map((p) => {
+          ) : (
+            <>
+              <div className="border-b border-border/40 p-1.5">
+                <Input
+                  size="xs"
+                  placeholder="Search favorites..."
+                  value={favoriteSearch}
+                  onChange={(e) => setFavoriteSearch(e.target.value)}
+                  data-testid="model-selector-favorite-search"
+                  className="h-7"
+                />
+              </div>
+              {filteredFavorites.length > 0 && (
+                <div className="border-b border-border/40 py-1">
+                  <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
+                    Favorites
+                  </div>
+                  {filteredFavorites.map((entry) => renderFavoriteRow(entry))}
+                </div>
+              )}
+              {MODEL_PROVIDERS.map((p) => {
             const pm = PROVIDER_META[p.id];
             const ProvIcon = pm?.icon ?? ClaudeIcon;
             const provIconClass = pm?.color ?? "";
@@ -361,6 +560,8 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
               </div>
             );
           })}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/chat/__tests__/ModelSelector.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ModelSelector.test.tsx
@@ -23,25 +23,15 @@ vi.mock("@/components/ui/button", () => ({
   ),
 }));
 
-// @base-ui/react (used by Badge) does not work in jsdom; stub as a plain span.
-vi.mock("@/components/ui/badge", () => ({
-  Badge: ({
-    children,
-    "data-testid": testId,
-    ...rest
-  }: {
-    children?: React.ReactNode;
-    "data-testid"?: string;
-    [key: string]: unknown;
-  }) => (
-    <span data-testid={testId} {...rest}>
-      {children}
-    </span>
-  ),
-}));
-
 vi.mock("@/components/ui/input", () => ({
   Input: ({ ...props }: React.ComponentProps<"input">) => <input {...props} />,
+}));
+
+/** Tooltip relies on Base UI and App-level TooltipProvider; unwrap triggers for jsdom. */
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render }: { render?: React.ReactElement }) => <>{render}</>,
+  TooltipContent: () => null,
 }));
 
 // Prevent real RPC calls triggered when a provider rail tab loads models.
@@ -77,7 +67,7 @@ beforeEach(() => {
 });
 
 describe("ModelSelector", () => {
-  it("marks disabled providers with data-disabled='true' on their group container", async () => {
+  it("marks disabled providers with data-disabled='true' on their rail button", async () => {
     render(
       <ModelSelector
         selectedModelId="claude-sonnet-4-6"
@@ -87,16 +77,15 @@ describe("ModelSelector", () => {
       />,
     );
 
-    // Open the dropdown by clicking the trigger button.
     const trigger = screen.getAllByRole("button")[0];
     await userEvent.click(trigger);
 
-    const codexGroup = document.querySelector("[data-testid='model-group-codex']");
-    expect(codexGroup).not.toBeNull();
-    expect(codexGroup).toHaveAttribute("data-disabled", "true");
+    const codexBtn = document.querySelector("[data-testid='model-group-codex']");
+    expect(codexBtn).not.toBeNull();
+    expect(codexBtn).toHaveAttribute("data-disabled", "true");
   });
 
-  it("shows a 'Disabled' badge for the disabled provider", async () => {
+  it("disables the rail button when the provider is disabled in settings", async () => {
     render(
       <ModelSelector
         selectedModelId="claude-sonnet-4-6"
@@ -109,7 +98,9 @@ describe("ModelSelector", () => {
     const trigger = screen.getAllByRole("button")[0];
     await userEvent.click(trigger);
 
-    expect(screen.getByText("Disabled")).toBeInTheDocument();
+    const codexBtn = document.querySelector("[data-testid='model-group-codex']") as HTMLButtonElement | null;
+    expect(codexBtn).not.toBeNull();
+    expect(codexBtn?.disabled).toBe(true);
   });
 
   it("does not mark enabled providers as disabled", async () => {
@@ -125,7 +116,7 @@ describe("ModelSelector", () => {
     const trigger = screen.getAllByRole("button")[0];
     await userEvent.click(trigger);
 
-    const claudeGroup = document.querySelector("[data-testid='model-group-claude']");
-    expect(claudeGroup).toHaveAttribute("data-disabled", "false");
+    const claudeBtn = document.querySelector("[data-testid='model-group-claude']");
+    expect(claudeBtn).toHaveAttribute("data-disabled", "false");
   });
 });

--- a/apps/web/src/components/chat/__tests__/ModelSelector.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ModelSelector.test.tsx
@@ -40,6 +40,10 @@ vi.mock("@/components/ui/badge", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/input", () => ({
+  Input: ({ ...props }: React.ComponentProps<"input">) => <input {...props} />,
+}));
+
 // Prevent real RPC calls triggered by fetchProviderModels on hover.
 vi.mock("@/transport", () => ({
   getTransport: () => ({

--- a/apps/web/src/components/chat/__tests__/ModelSelector.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ModelSelector.test.tsx
@@ -44,7 +44,7 @@ vi.mock("@/components/ui/input", () => ({
   Input: ({ ...props }: React.ComponentProps<"input">) => <input {...props} />,
 }));
 
-// Prevent real RPC calls triggered by fetchProviderModels on hover.
+// Prevent real RPC calls triggered when a provider rail tab loads models.
 vi.mock("@/transport", () => ({
   getTransport: () => ({
     listProviderModels: vi.fn().mockResolvedValue([]),

--- a/apps/web/src/components/settings/SearchableGroupedPicker.tsx
+++ b/apps/web/src/components/settings/SearchableGroupedPicker.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { tokenizeSearch, matchesAllTokens } from "@/lib/searchTokens";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+
+/** cmdk Item `value` must be non-empty; map "" to this sentinel internally. */
+const EMPTY_OPTION_CMDK = "__mcode_empty_option__";
+
+/** One selectable row for {@link SearchableGroupedPicker}. */
+export interface GroupedPickOption {
+  value: string;
+  label: string;
+  group?: string;
+  disabled?: boolean;
+}
+
+interface SearchableGroupedPickerProps {
+  /** Current selection id (empty string allowed). */
+  value: string;
+  /** Called when the user picks an option. */
+  onChange: (next: string) => void;
+  /** Full option list (typically catalog plus stale saved rows). */
+  options: GroupedPickOption[];
+  /** Text on the closed trigger when there is no matching label. */
+  emptyTriggerLabel?: string;
+  /** Placeholder for the search field inside the popover. */
+  searchPlaceholder?: string;
+  /** Disables opening the picker. */
+  disabled?: boolean;
+  /** Shows a spinner-style hint on the trigger while models load. */
+  loading?: boolean;
+  /** Optional anchor alignment for the popover. */
+  align?: "start" | "center" | "end";
+  /** Optional test id on the trigger button. */
+  "data-testid"?: string;
+}
+
+/**
+ * Settings-friendly combobox: popover with multi-token search and optional group headings.
+ * Matches composer model search semantics via {@link tokenizeSearch}.
+ */
+export function SearchableGroupedPicker({
+  value,
+  onChange,
+  options,
+  emptyTriggerLabel = "Choose…",
+  searchPlaceholder = "Search…",
+  disabled,
+  loading,
+  align = "end",
+  "data-testid": testId,
+}: SearchableGroupedPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
+
+  const selectedLabel = useMemo(() => {
+    const row = options.find((o) => o.value === value && !o.disabled);
+    return row?.label ?? (value ? value : emptyTriggerLabel);
+  }, [options, value, emptyTriggerLabel]);
+
+  const filtered = useMemo(() => {
+    const tokens = tokenizeSearch(query);
+    return options.filter((o) => matchesAllTokens([o.label, o.value, o.group ?? ""], tokens));
+  }, [options, query]);
+
+  const groupedSections = useMemo(() => {
+    const hasHeading = filtered.some((o) => Boolean(o.group?.trim()));
+    if (!hasHeading) {
+      return [{ heading: undefined as string | undefined, items: filtered }];
+    }
+    const map = new Map<string, GroupedPickOption[]>();
+    for (const o of filtered) {
+      const g = o.group?.trim() ?? "";
+      if (!map.has(g)) map.set(g, []);
+      map.get(g)!.push(o);
+    }
+    return Array.from(map.entries()).map(([heading, items]) => ({
+      heading: heading || undefined,
+      items,
+    }));
+  }, [filtered]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled || loading}
+            data-testid={testId}
+            aria-expanded={open}
+            aria-haspopup="dialog"
+            className={cn(
+              "h-8 min-w-[220px] max-w-[280px] justify-between gap-2 px-2.5 text-xs font-normal",
+              (disabled || loading) && "opacity-60",
+            )}
+          >
+            <span className="min-w-0 flex-1 truncate text-left">{loading ? "Loading…" : selectedLabel}</span>
+            <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+          </Button>
+        }
+      />
+      <PopoverContent
+        align={align}
+        side="bottom"
+        sideOffset={4}
+        className="w-[min(92vw,320px)] p-0 shadow-lg"
+      >
+        <Command shouldFilter={false} className="rounded-lg border-0">
+          <CommandInput
+            placeholder={searchPlaceholder}
+            value={query}
+            onValueChange={setQuery}
+            aria-label={searchPlaceholder}
+          />
+          <CommandList>
+            <CommandEmpty>No matches.</CommandEmpty>
+            {groupedSections.map((section) => (
+              <CommandGroup
+                key={section.heading ?? "__flat"}
+                {...(section.heading ? { heading: section.heading } : {})}
+              >
+                {section.items.map((o) => (
+                  <CommandItem
+                    key={`${section.heading ?? ""}:${o.label}:${o.value || EMPTY_OPTION_CMDK}`}
+                    value={o.value === "" ? EMPTY_OPTION_CMDK : o.value}
+                    disabled={o.disabled}
+                    keywords={[o.label, o.value, o.group ?? ""].filter(Boolean)}
+                    onSelect={() => {
+                      if (o.disabled) return;
+                      onChange(o.value);
+                      setOpen(false);
+                    }}
+                    className="text-xs"
+                  >
+                    <span className="flex-1 truncate">{o.label}</span>
+                    {value === o.value && <Check className="size-3.5 shrink-0" aria-hidden />}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/settings/SearchableGroupedPicker.tsx
+++ b/apps/web/src/components/settings/SearchableGroupedPicker.tsx
@@ -120,16 +120,16 @@ export function SearchableGroupedPicker({
         align={align}
         side="bottom"
         sideOffset={4}
-        className="w-[min(92vw,320px)] p-0 shadow-lg"
+        className="flex h-[min(320px,calc(100vh-10rem))] w-[min(92vw,320px)] flex-col overflow-hidden p-0 shadow-lg"
       >
-        <Command shouldFilter={false} className="rounded-lg border-0">
+        <Command shouldFilter={false} className="min-h-0 flex-1 rounded-lg border-0">
           <CommandInput
             placeholder={searchPlaceholder}
             value={query}
             onValueChange={setQuery}
             aria-label={searchPlaceholder}
           />
-          <CommandList>
+          <CommandList className="max-h-none min-h-0 flex-1 overflow-y-auto">
             <CommandEmpty>No matches.</CommandEmpty>
             {groupedSections.map((section) => (
               <CommandGroup

--- a/apps/web/src/components/settings/SettingsProviderPicker.tsx
+++ b/apps/web/src/components/settings/SettingsProviderPicker.tsx
@@ -22,7 +22,7 @@ import {
 /** Matches Tailwind `w-[52px]` for alignment with the composer model picker rail. */
 const LEFT_RAIL_WIDTH_CLASS = "w-[52px]";
 
-/** cmdk rejects empty `value`; utility “Auto” uses an empty provider id. */
+/** cmdk rejects empty `value`; utility "Auto" uses an empty provider id. */
 const EMPTY_PROVIDER_CMDK = "__mcode_provider_auto__";
 
 /** One selectable provider row for {@link SettingsProviderPicker}. */
@@ -112,7 +112,7 @@ export function SettingsProviderPicker({
           <div
             role="dialog"
             aria-label="Choose provider"
-            className="flex h-[min(340px,42vh)] overflow-hidden rounded-lg border border-border bg-popover"
+            className="flex h-[min(340px,calc(100vh-10rem))] overflow-hidden rounded-lg border border-border bg-popover"
           >
             <nav
               className={cn(
@@ -165,14 +165,14 @@ export function SettingsProviderPicker({
               })}
             </nav>
 
-            <Command shouldFilter={false} className="min-w-0 flex-1 rounded-none border-0">
+            <Command shouldFilter={false} className="min-h-0 min-w-0 flex-1 rounded-none border-0">
               <CommandInput
                 placeholder="Search providers…"
                 value={query}
                 onValueChange={setQuery}
                 aria-label="Search providers"
               />
-              <CommandList>
+              <CommandList className="max-h-none min-h-0 flex-1 overflow-y-auto">
                 <CommandEmpty>No matches.</CommandEmpty>
                 <CommandGroup>
                   {filtered.map((opt) => (

--- a/apps/web/src/components/settings/SettingsProviderPicker.tsx
+++ b/apps/web/src/components/settings/SettingsProviderPicker.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { ChevronDown, Check } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { tokenizeSearch, matchesAllTokens } from "@/lib/searchTokens";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -12,17 +11,8 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
-/** Matches Tailwind `w-[52px]` for alignment with the composer model picker rail. */
-const LEFT_RAIL_WIDTH_CLASS = "w-[52px]";
-
-/** cmdk rejects empty `value`; utility "Auto" uses an empty provider id. */
+/** cmdk Item `value` must be non-empty; utility "Auto" uses an empty provider id. */
 const EMPTY_PROVIDER_CMDK = "__mcode_provider_auto__";
 
 /** One selectable provider row for {@link SettingsProviderPicker}. */
@@ -47,9 +37,21 @@ interface SettingsProviderPickerProps {
   "data-testid"?: string;
 }
 
+/** Wraps SVG provider marks so rows stay monochrome in settings (no brand tint). */
+function NeutralProviderGlyph({ children }: { children: ReactNode }) {
+  return (
+    <span
+      className="flex size-4 shrink-0 items-center justify-center text-muted-foreground [&_svg]:size-3.5"
+      aria-hidden
+    >
+      {children}
+    </span>
+  );
+}
+
 /**
- * Settings provider selector with an icon-first rail and searchable list,
- * consistent with the composer {@link ModelSelector} layout.
+ * Settings provider combobox: searchable list only (no composer-style rail).
+ * Icons use muted foreground so the panel stays visually quiet next to model pickers.
  */
 export function SettingsProviderPicker({
   value,
@@ -91,11 +93,7 @@ export function SettingsProviderPicker({
             className="h-8 min-w-[200px] max-w-[260px] justify-between gap-2 px-2.5 text-xs font-normal"
           >
             <span className="flex min-w-0 flex-1 items-center gap-2">
-              {selected?.icon != null && (
-                <span className="flex shrink-0 items-center justify-center" aria-hidden>
-                  {selected.icon}
-                </span>
-              )}
+              {selected?.icon != null && <NeutralProviderGlyph>{selected.icon}</NeutralProviderGlyph>}
               <span className="truncate text-left">{selected?.label ?? value}</span>
             </span>
             <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden />
@@ -106,104 +104,43 @@ export function SettingsProviderPicker({
         align={align}
         side="bottom"
         sideOffset={4}
-        className="w-[min(92vw,380px)] p-0 shadow-lg"
+        className="flex h-[min(340px,calc(100vh-10rem))] w-[min(92vw,320px)] flex-col overflow-hidden p-0 shadow-lg"
       >
-        <TooltipProvider delay={200}>
-          <div
-            role="dialog"
-            aria-label="Choose provider"
-            className="flex h-[min(340px,calc(100vh-10rem))] overflow-hidden rounded-lg border border-border bg-popover"
-          >
-            <nav
-              className={cn(
-                LEFT_RAIL_WIDTH_CLASS,
-                "flex shrink-0 flex-col items-center gap-1 overflow-y-auto border-r border-border bg-muted/15 py-1",
-              )}
-              aria-label="Providers"
-            >
-              {options.map((opt) => {
-                const active = opt.value === value;
-                const tip =
-                  opt.title ??
-                  (opt.disabled ? `${opt.label} is unavailable.` : opt.label);
-                const railBtn = (
-                  <button
-                    type="button"
-                    disabled={opt.disabled}
-                    data-disabled={opt.disabled ? "" : undefined}
-                    data-testid={`settings-provider-rail-${opt.value || "auto"}`}
-                    aria-current={active ? "true" : undefined}
-                    aria-label={
-                      opt.disabled && opt.title ? `${opt.label}: ${opt.title}` : opt.label
-                    }
-                    onClick={() => {
-                      if (opt.disabled) return;
-                      onChange(opt.value);
-                      setOpen(false);
-                    }}
-                    className={cn(
-                      "relative flex h-10 w-10 shrink-0 items-center justify-center rounded-md transition-colors",
-                      active && !opt.disabled && "bg-accent text-foreground shadow-sm",
-                      !active && !opt.disabled && "text-muted-foreground hover:bg-accent/40 hover:text-foreground",
-                      opt.disabled && "cursor-not-allowed opacity-45",
-                    )}
-                  >
-                    {opt.icon ?? (
-                      <span className="text-[10px] font-semibold uppercase text-muted-foreground">
-                        {opt.label.slice(0, 2)}
-                      </span>
-                    )}
-                  </button>
-                );
-
-                return (
-                  <Tooltip key={opt.value || "__auto"}>
-                    <TooltipTrigger render={railBtn} />
-                    <TooltipContent side="right">{tip}</TooltipContent>
-                  </Tooltip>
-                );
-              })}
-            </nav>
-
-            <Command shouldFilter={false} className="min-h-0 min-w-0 flex-1 rounded-none border-0">
-              <CommandInput
-                placeholder="Search providers…"
-                value={query}
-                onValueChange={setQuery}
-                aria-label="Search providers"
-              />
-              <CommandList className="max-h-none min-h-0 flex-1 overflow-y-auto">
-                <CommandEmpty>No matches.</CommandEmpty>
-                <CommandGroup>
-                  {filtered.map((opt) => (
-                    <CommandItem
-                      key={opt.value || "__auto"}
-                      value={opt.value === "" ? EMPTY_PROVIDER_CMDK : opt.value}
-                      disabled={opt.disabled}
-                      keywords={[opt.label, opt.value].filter(Boolean)}
-                      onSelect={() => {
-                        if (opt.disabled) return;
-                        onChange(opt.value);
-                        setOpen(false);
-                      }}
-                      className="text-xs"
-                    >
-                      <span className="flex min-w-0 flex-1 items-center gap-2">
-                        {opt.icon != null && (
-                          <span className="flex shrink-0" aria-hidden>
-                            {opt.icon}
-                          </span>
-                        )}
-                        <span className="truncate">{opt.label}</span>
-                      </span>
-                      {value === opt.value && <Check className="size-3.5 shrink-0" aria-hidden />}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </div>
-        </TooltipProvider>
+        <Command shouldFilter={false} className="min-h-0 flex-1 rounded-lg border-0">
+          <CommandInput
+            placeholder="Search providers…"
+            value={query}
+            onValueChange={setQuery}
+            aria-label="Search providers"
+          />
+          <CommandList className="max-h-none min-h-0 flex-1 overflow-y-auto">
+            <CommandEmpty>No matches.</CommandEmpty>
+            <CommandGroup>
+              {filtered.map((opt) => (
+                <CommandItem
+                  key={opt.value || "__auto"}
+                  value={opt.value === "" ? EMPTY_PROVIDER_CMDK : opt.value}
+                  disabled={opt.disabled}
+                  data-testid={`settings-provider-option-${opt.value || "auto"}`}
+                  title={opt.title}
+                  keywords={[opt.label, opt.value].filter(Boolean)}
+                  onSelect={() => {
+                    if (opt.disabled) return;
+                    onChange(opt.value);
+                    setOpen(false);
+                  }}
+                  className="text-xs"
+                >
+                  <span className="flex min-w-0 flex-1 items-center gap-2">
+                    {opt.icon != null && <NeutralProviderGlyph>{opt.icon}</NeutralProviderGlyph>}
+                    <span className="truncate">{opt.label}</span>
+                  </span>
+                  {value === opt.value && <Check className="size-3.5 shrink-0" aria-hidden />}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/src/components/settings/SettingsProviderPicker.tsx
+++ b/apps/web/src/components/settings/SettingsProviderPicker.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { ChevronDown, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { tokenizeSearch, matchesAllTokens } from "@/lib/searchTokens";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/** Matches Tailwind `w-[52px]` for alignment with the composer model picker rail. */
+const LEFT_RAIL_WIDTH_CLASS = "w-[52px]";
+
+/** cmdk rejects empty `value`; utility “Auto” uses an empty provider id. */
+const EMPTY_PROVIDER_CMDK = "__mcode_provider_auto__";
+
+/** One selectable provider row for {@link SettingsProviderPicker}. */
+export interface SettingsProviderPickOption {
+  value: string;
+  label: string;
+  disabled: boolean;
+  icon?: ReactNode;
+  title?: string;
+}
+
+interface SettingsProviderPickerProps {
+  /** Current provider id (empty string allowed for utility "Auto" mode). */
+  value: string;
+  /** Called when the user commits a provider selection. */
+  onChange: (providerId: string) => void;
+  /** Ordered options (typically aligned with {@link MODEL_PROVIDERS}). */
+  options: SettingsProviderPickOption[];
+  /** Popover alignment relative to the trigger. */
+  align?: "start" | "center" | "end";
+  /** Optional test id on the trigger button. */
+  "data-testid"?: string;
+}
+
+/**
+ * Settings provider selector with an icon-first rail and searchable list,
+ * consistent with the composer {@link ModelSelector} layout.
+ */
+export function SettingsProviderPicker({
+  value,
+  onChange,
+  options,
+  align = "end",
+  "data-testid": testId,
+}: SettingsProviderPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
+
+  const selected = useMemo(
+    () =>
+      options.find((o) => o.value === value && !o.disabled) ??
+      options.find((o) => o.value === value),
+    [options, value],
+  );
+
+  const filtered = useMemo(() => {
+    const tokens = tokenizeSearch(query);
+    return options.filter((o) => matchesAllTokens([o.label, o.value], tokens));
+  }, [options, query]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid={testId}
+            aria-expanded={open}
+            aria-haspopup="dialog"
+            className="h-8 min-w-[200px] max-w-[260px] justify-between gap-2 px-2.5 text-xs font-normal"
+          >
+            <span className="flex min-w-0 flex-1 items-center gap-2">
+              {selected?.icon != null && (
+                <span className="flex shrink-0 items-center justify-center" aria-hidden>
+                  {selected.icon}
+                </span>
+              )}
+              <span className="truncate text-left">{selected?.label ?? value}</span>
+            </span>
+            <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+          </Button>
+        }
+      />
+      <PopoverContent
+        align={align}
+        side="bottom"
+        sideOffset={4}
+        className="w-[min(92vw,380px)] p-0 shadow-lg"
+      >
+        <TooltipProvider delay={200}>
+          <div
+            role="dialog"
+            aria-label="Choose provider"
+            className="flex h-[min(340px,42vh)] overflow-hidden rounded-lg border border-border bg-popover"
+          >
+            <nav
+              className={cn(
+                LEFT_RAIL_WIDTH_CLASS,
+                "flex shrink-0 flex-col items-center gap-1 overflow-y-auto border-r border-border bg-muted/15 py-1",
+              )}
+              aria-label="Providers"
+            >
+              {options.map((opt) => {
+                const active = opt.value === value;
+                const tip =
+                  opt.title ??
+                  (opt.disabled ? `${opt.label} is unavailable.` : opt.label);
+                const railBtn = (
+                  <button
+                    type="button"
+                    disabled={opt.disabled}
+                    data-disabled={opt.disabled ? "" : undefined}
+                    data-testid={`settings-provider-rail-${opt.value || "auto"}`}
+                    aria-current={active ? "true" : undefined}
+                    aria-label={
+                      opt.disabled && opt.title ? `${opt.label}: ${opt.title}` : opt.label
+                    }
+                    onClick={() => {
+                      if (opt.disabled) return;
+                      onChange(opt.value);
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      "relative flex h-10 w-10 shrink-0 items-center justify-center rounded-md transition-colors",
+                      active && !opt.disabled && "bg-accent text-foreground shadow-sm",
+                      !active && !opt.disabled && "text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+                      opt.disabled && "cursor-not-allowed opacity-45",
+                    )}
+                  >
+                    {opt.icon ?? (
+                      <span className="text-[10px] font-semibold uppercase text-muted-foreground">
+                        {opt.label.slice(0, 2)}
+                      </span>
+                    )}
+                  </button>
+                );
+
+                return (
+                  <Tooltip key={opt.value || "__auto"}>
+                    <TooltipTrigger render={railBtn} />
+                    <TooltipContent side="right">{tip}</TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </nav>
+
+            <Command shouldFilter={false} className="min-w-0 flex-1 rounded-none border-0">
+              <CommandInput
+                placeholder="Search providers…"
+                value={query}
+                onValueChange={setQuery}
+                aria-label="Search providers"
+              />
+              <CommandList>
+                <CommandEmpty>No matches.</CommandEmpty>
+                <CommandGroup>
+                  {filtered.map((opt) => (
+                    <CommandItem
+                      key={opt.value || "__auto"}
+                      value={opt.value === "" ? EMPTY_PROVIDER_CMDK : opt.value}
+                      disabled={opt.disabled}
+                      keywords={[opt.label, opt.value].filter(Boolean)}
+                      onSelect={() => {
+                        if (opt.disabled) return;
+                        onChange(opt.value);
+                        setOpen(false);
+                      }}
+                      className="text-xs"
+                    >
+                      <span className="flex min-w-0 flex-1 items-center gap-2">
+                        {opt.icon != null && (
+                          <span className="flex shrink-0" aria-hidden>
+                            {opt.icon}
+                          </span>
+                        )}
+                        <span className="truncate">{opt.label}</span>
+                      </span>
+                      {value === opt.value && <Check className="size-3.5 shrink-0" aria-hidden />}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </div>
+        </TooltipProvider>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -19,9 +19,11 @@ import {
 import { SettingRow } from "../SettingRow";
 import { SegControl } from "../SegControl";
 import { SectionHeading } from "../SectionHeading";
+import { SearchableGroupedPicker } from "../SearchableGroupedPicker";
+import { SettingsProviderPicker } from "../SettingsProviderPicker";
 import { Switch } from "@/components/ui/switch";
 import type { ContextWindowMode, ProviderAvailability, SettingsProviderId, ReasoningLevel } from "@mcode/contracts";
-import { ChevronDown } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import {
   ClaudeIcon,
   CodexIcon,
@@ -30,19 +32,7 @@ import {
   GeminiIcon,
   CopilotIcon,
 } from "@/components/chat/ProviderIcons";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useToastStore } from "@/stores/toastStore";
-
-/** Providers with more models than this threshold use a Select dropdown instead of SegControl. */
-const SEG_CONTROL_MAX_MODELS = 6;
 
 /** Maps provider id to its brand icon component. */
 const PROVIDER_ICONS: Record<string, ReactNode> = {
@@ -142,7 +132,13 @@ export function ModelSection() {
 
   const utilityProviderOptions = useMemo(
     () => [
-      { value: "", label: "Auto" },
+      {
+        value: "",
+        label: "Auto",
+        disabled: false,
+        icon: <Sparkles size={12} className="text-muted-foreground" aria-hidden />,
+        title: "Use the default provider above",
+      },
       ...MODEL_PROVIDERS.filter((p) => p.supportsCompletion).map((p) =>
         buildProviderOption(p, availabilityById.get(p.id)),
       ),
@@ -159,6 +155,7 @@ export function ModelSection() {
 
   const utilityEffectiveId = utilityProvider || provider;
   const dynamicUtilityModels = useProviderModelsStore((s) => s.models[utilityEffectiveId]);
+  const utilityModelsLoading = useProviderModelsStore((s) => s.loading[utilityEffectiveId] ?? false);
 
   const fetchModels = useProviderModelsStore((s) => s.fetchModels);
   const dynamicModels = useProviderModelsStore((s) => s.models[provider]);
@@ -167,10 +164,21 @@ export function ModelSection() {
   const cliPaths = useSettingsStore((s) => s.settings.provider.cli);
   const dynamicCliPath =
     provider === "cursor" ? cliPaths.cursor : provider === "copilot" ? cliPaths.copilot : "";
+  const utilityDynamicCliPath =
+    utilityEffectiveId === "cursor"
+      ? cliPaths.cursor
+      : utilityEffectiveId === "copilot"
+        ? cliPaths.copilot
+        : "";
 
   useEffect(() => {
     void fetchModels(provider, { force: true });
   }, [provider, dynamicCliPath, fetchModels]);
+
+  useEffect(() => {
+    if (!utilityProvider) return;
+    void fetchModels(utilityEffectiveId, { force: true });
+  }, [utilityProvider, utilityEffectiveId, utilityDynamicCliPath, fetchModels]);
 
   const mergedCatalogModels = useMemo(
     () => pickProviderModelsForSettings(activeProvider?.models ?? [], dynamicModels),
@@ -368,7 +376,12 @@ export function ModelSection() {
         configKey="model.defaults.provider"
         hint="AI provider for new threads."
       >
-        <SegControl options={providerOptions} value={provider} onChange={handleProviderChange} />
+        <SettingsProviderPicker
+          value={provider}
+          onChange={handleProviderChange}
+          options={providerOptions}
+          data-testid="settings-default-provider-trigger"
+        />
       </SettingRow>
 
       <SettingRow
@@ -377,41 +390,14 @@ export function ModelSection() {
         hint="New threads start with this model."
       >
         <div className="flex flex-col items-end gap-2">
-          {modelOptions.length > SEG_CONTROL_MAX_MODELS ? (
-            <Select value={modelId} onValueChange={(v) => v != null && handleModelChange(v)}>
-              <SelectTrigger size="sm" className="w-56 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {modelOptions.some((m) => m.group)
-                  ? (() => {
-                      const groups = new Map<string, typeof modelOptions>();
-                      for (const m of modelOptions) {
-                        const g = m.group ?? "";
-                        if (!groups.has(g)) groups.set(g, []);
-                        groups.get(g)!.push(m);
-                      }
-                      return Array.from(groups.entries()).map(([g, items]) => (
-                        <SelectGroup key={g}>
-                          {g && <SelectLabel>{g}</SelectLabel>}
-                          {items.map((m) => (
-                            <SelectItem key={m.value} value={m.value}>
-                              {m.label}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      ));
-                    })()
-                  : modelOptions.map((m) => (
-                      <SelectItem key={m.value} value={m.value}>
-                        {m.label}
-                      </SelectItem>
-                    ))}
-              </SelectContent>
-            </Select>
-          ) : (
-            <SegControl options={modelOptions} value={modelId} onChange={handleModelChange} />
-          )}
+          <SearchableGroupedPicker
+            value={modelId}
+            onChange={handleModelChange}
+            options={modelOptions}
+            searchPlaceholder="Search models…"
+            loading={modelsLoading}
+            data-testid="settings-default-model-trigger"
+          />
           {defaultModelStale && (
             <p className="max-w-xs text-right text-xs text-amber-600 dark:text-amber-500">
               This model is not in the current catalog. Sending messages may fail until you choose a
@@ -427,48 +413,15 @@ export function ModelSection() {
         hint="Used when the primary model is unavailable. Off disables fallback."
       >
         <div className="flex flex-col items-end gap-2">
-          {fallbackOptions.length > SEG_CONTROL_MAX_MODELS ? (
-            <Select
-              value={fallbackId}
-              onValueChange={(v) => v != null && update({ model: { defaults: { fallbackId: v } } })}
-            >
-              <SelectTrigger size="sm" className="w-56 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {fallbackOptions.some((m) => m.group)
-                  ? (() => {
-                      const groups = new Map<string, typeof fallbackOptions>();
-                      for (const m of fallbackOptions) {
-                        const g = m.group ?? "";
-                        if (!groups.has(g)) groups.set(g, []);
-                        groups.get(g)!.push(m);
-                      }
-                      return Array.from(groups.entries()).map(([g, items]) => (
-                        <SelectGroup key={g}>
-                          {g && <SelectLabel>{g}</SelectLabel>}
-                          {items.map((m) => (
-                            <SelectItem key={m.value} value={m.value}>
-                              {m.label}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      ));
-                    })()
-                  : fallbackOptions.map((m) => (
-                      <SelectItem key={m.value} value={m.value}>
-                        {m.label}
-                      </SelectItem>
-                    ))}
-              </SelectContent>
-            </Select>
-          ) : (
-            <SegControl
-              options={fallbackOptions}
-              value={fallbackId}
-              onChange={(v) => update({ model: { defaults: { fallbackId: v } } })}
-            />
-          )}
+          <SearchableGroupedPicker
+            value={fallbackId}
+            onChange={(v) => void update({ model: { defaults: { fallbackId: v } } })}
+            options={fallbackOptions}
+            emptyTriggerLabel="Off"
+            searchPlaceholder="Search models…"
+            loading={modelsLoading}
+            data-testid="settings-fallback-model-trigger"
+          />
           {fallbackModelStale && (
             <p className="max-w-xs text-right text-xs text-amber-600 dark:text-amber-500">
               This fallback model is not in the current catalog. Consider turning fallback off or
@@ -542,10 +495,15 @@ export function ModelSection() {
             configKey="model.utility.provider"
             hint="AI provider for lightweight tasks (PR drafts, diff summaries). Auto inherits from the default provider above."
           >
-            <SegControl
-              options={utilityProviderOptions}
+            <SettingsProviderPicker
               value={utilityProvider}
-              onChange={(v) => void update({ model: { utility: { provider: v as SettingsProviderId | "", id: "" } } })}
+              onChange={(v) =>
+                void update({
+                  model: { utility: { provider: v as SettingsProviderId | "", id: "" } },
+                })
+              }
+              options={utilityProviderOptions}
+              data-testid="settings-utility-provider-trigger"
             />
           </SettingRow>
           <SettingRow
@@ -554,25 +512,20 @@ export function ModelSection() {
             hint="Model for utility tasks. Auto selects a provider-appropriate cheap default."
           >
             {utilityProvider ? (
-              <div className="relative inline-flex w-56">
-                <select
-                  value={utilityModelId}
-                  onChange={(e) => void update({ model: { utility: { id: e.target.value } } })}
-                  className="h-7 w-full appearance-none cursor-pointer rounded-[min(var(--radius-md),12px)] border border-input bg-background pl-2 pr-7 py-0.5 text-xs text-foreground focus-visible:border-ring focus-visible:outline-none"
-                >
-                  {utilityModelOptions.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-                <ChevronDown
-                  size={12}
-                  className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
-                />
-              </div>
+              <SearchableGroupedPicker
+                value={utilityModelId}
+                onChange={(v) => void update({ model: { utility: { id: v } } })}
+                options={utilityModelOptions.map((o) => ({
+                  value: o.value,
+                  label: o.label,
+                }))}
+                emptyTriggerLabel="Auto"
+                searchPlaceholder="Search utility models…"
+                loading={utilityModelsLoading}
+                data-testid="settings-utility-model-trigger"
+              />
             ) : (
-              <div className="h-7 w-56 rounded-[min(var(--radius-md),12px)] border border-input bg-background px-2 py-0.5 text-xs text-muted-foreground flex items-center select-none">
+              <div className="flex h-8 min-w-[220px] max-w-[280px] items-center rounded-[min(var(--radius-md),12px)] border border-input bg-background px-2.5 text-xs text-muted-foreground select-none">
                 Auto
               </div>
             )}

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useMemo, useEffect, useRef, type ReactNode } from "react";
 import { ProviderSection } from "./ProviderSection";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
@@ -13,6 +13,8 @@ import {
   supportsThinkingToggle,
   normalizeReasoningLevelForModel,
   getCodexReasoningLevels,
+  pickProviderModelsForSettings,
+  type ModelDefinition,
 } from "@/lib/model-registry";
 import { SettingRow } from "../SettingRow";
 import { SegControl } from "../SegControl";
@@ -37,6 +39,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useToastStore } from "@/stores/toastStore";
 
 /** Providers with more models than this threshold use a Select dropdown instead of SegControl. */
 const SEG_CONTROL_MAX_MODELS = 6;
@@ -105,6 +108,10 @@ function buildProviderOption(
  * Model settings section: provider, default model, fallback model, reasoning effort,
  * utility model provider/model, diff summary toggle, and CLI paths.
  *
+ * Default and fallback pickers merge live `listProviderModels` results with static
+ * catalog fallbacks (needed for Cursor, Copilot, and Claude API discovery). Stale
+ * saved IDs that disappear from the catalog stay selectable with a warning until the user changes them.
+ *
  * Model options update when the provider changes. Switching provider resets the default
  * model to the new provider's first model and clears the fallback. The reasoning level
  * is normalized down when the new model does not support the current tier.
@@ -153,18 +160,99 @@ export function ModelSection() {
   const utilityEffectiveId = utilityProvider || provider;
   const dynamicUtilityModels = useProviderModelsStore((s) => s.models[utilityEffectiveId]);
 
+  const fetchModels = useProviderModelsStore((s) => s.fetchModels);
+  const dynamicModels = useProviderModelsStore((s) => s.models[provider]);
+  const modelsLoading = useProviderModelsStore((s) => s.loading[provider] ?? false);
+
+  const cliPaths = useSettingsStore((s) => s.settings.provider.cli);
+  const dynamicCliPath =
+    provider === "cursor" ? cliPaths.cursor : provider === "copilot" ? cliPaths.copilot : "";
+
+  useEffect(() => {
+    void fetchModels(provider, { force: true });
+  }, [provider, dynamicCliPath, fetchModels]);
+
+  const mergedCatalogModels = useMemo(
+    () => pickProviderModelsForSettings(activeProvider?.models ?? [], dynamicModels),
+    [activeProvider, dynamicModels],
+  );
+
+  const modelsForDefaultPicker = useMemo(() => {
+    const ids = new Set(mergedCatalogModels.map((m) => m.id));
+    if (modelId.trim() && !ids.has(modelId)) {
+      const orphan: ModelDefinition = {
+        id: modelId,
+        label: `${modelId} (unlisted)`,
+        providerId: provider,
+        group: "Saved selection",
+      };
+      return [orphan, ...mergedCatalogModels];
+    }
+    return mergedCatalogModels;
+  }, [mergedCatalogModels, modelId, provider]);
+
+  const modelsForFallbackPicker = useMemo(() => {
+    const ids = new Set(mergedCatalogModels.map((m) => m.id));
+    if (fallbackId.trim() && !ids.has(fallbackId)) {
+      const orphan: ModelDefinition = {
+        id: fallbackId,
+        label: `${fallbackId} (unlisted)`,
+        providerId: provider,
+        group: "Saved selection",
+      };
+      return [orphan, ...mergedCatalogModels];
+    }
+    return mergedCatalogModels;
+  }, [mergedCatalogModels, fallbackId, provider]);
+
+  const staleDefaultToastSigRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (modelsLoading || mergedCatalogModels.length === 0) return;
+    if (!modelId.trim()) return;
+    if (mergedCatalogModels.some((m) => m.id === modelId)) return;
+    const sig = `${provider}:${modelId}`;
+    if (staleDefaultToastSigRef.current === sig) return;
+    staleDefaultToastSigRef.current = sig;
+    useToastStore.getState().show(
+      "info",
+      "Saved model not in catalog",
+      `'${modelId}' is missing from the latest ${provider} model list. Pick another model in Settings.`,
+      8000,
+    );
+  }, [modelsLoading, mergedCatalogModels, modelId, provider]);
+
+  const defaultModelStale =
+    !modelsLoading &&
+    Boolean(modelId.trim()) &&
+    mergedCatalogModels.length > 0 &&
+    !mergedCatalogModels.some((m) => m.id === modelId);
+
+  const fallbackModelStale =
+    !modelsLoading &&
+    Boolean(fallbackId.trim()) &&
+    mergedCatalogModels.length > 0 &&
+    !mergedCatalogModels.some((m) => m.id === fallbackId);
+
   const modelOptions = useMemo(
-    () => (activeProvider?.models ?? []).map((m) => ({
-      value: m.id,
-      label: m.multiplier != null && m.multiplier !== 1 ? `${m.label} (${m.multiplier}x)` : m.label,
-      group: m.group,
-    })),
-    [activeProvider],
+    () =>
+      modelsForDefaultPicker.map((m) => ({
+        value: m.id,
+        label: m.multiplier != null && m.multiplier !== 1 ? `${m.label} (${m.multiplier}x)` : m.label,
+        group: m.group,
+      })),
+    [modelsForDefaultPicker],
   );
 
   const fallbackOptions = useMemo(
-    () => [{ value: "", label: "Off", group: undefined }, ...modelOptions],
-    [modelOptions],
+    () => [
+      { value: "", label: "Off", group: undefined },
+      ...modelsForFallbackPicker.map((m) => ({
+        value: m.id,
+        label: m.multiplier != null && m.multiplier !== 1 ? `${m.label} (${m.multiplier}x)` : m.label,
+        group: m.group,
+      })),
+    ],
+    [modelsForFallbackPicker],
   );
 
   // Utility model options: "Auto" (provider default) + all models for the effective provider.
@@ -221,27 +309,30 @@ export function ModelSection() {
   }, [codexLevels, provider]);
 
   const handleProviderChange = (v: string) => {
-    const newProvider = MODEL_PROVIDERS.find((p) => p.id === v);
-    const firstModel = newProvider?.models[0];
-    let newReasoning: string = reasoning;
-    if (firstModel) {
-      const codexLevels = getCodexReasoningLevels(firstModel.id);
-      if (codexLevels) {
-        // Switching to Codex: reset to model default if current level isn't valid
-        newReasoning = codexLevels.includes(reasoning as never) ? reasoning : "medium";
-      } else {
-        newReasoning = normalizeReasoningLevelForModel(firstModel.id, reasoning);
+    void (async () => {
+      await useProviderModelsStore.getState().fetchModels(v, { force: true });
+      const newProvider = MODEL_PROVIDERS.find((p) => p.id === v);
+      const dynamicFirst = useProviderModelsStore.getState().models[v]?.[0];
+      const firstModel = dynamicFirst ?? newProvider?.models[0];
+      let newReasoning: string = reasoning;
+      if (firstModel) {
+        const codexLevels = getCodexReasoningLevels(firstModel.id);
+        if (codexLevels) {
+          newReasoning = codexLevels.includes(reasoning as never) ? reasoning : "medium";
+        } else {
+          newReasoning = normalizeReasoningLevelForModel(firstModel.id, reasoning);
+        }
       }
-    }
-    void update({
-      model: {
-        defaults: {
-          provider: v as SettingsProviderId,
-          ...(firstModel && { id: firstModel.id, fallbackId: "" }),
-          reasoning: newReasoning as ReasoningLevel,
+      void update({
+        model: {
+          defaults: {
+            provider: v as SettingsProviderId,
+            ...(firstModel && { id: firstModel.id, fallbackId: "" }),
+            reasoning: newReasoning as ReasoningLevel,
+          },
         },
-      },
-    });
+      });
+    })();
   };
 
   const handleModelChange = (v: string) => {
@@ -285,41 +376,49 @@ export function ModelSection() {
         configKey="model.defaults.id"
         hint="New threads start with this model."
       >
-        {modelOptions.length > SEG_CONTROL_MAX_MODELS ? (
-          <Select value={modelId} onValueChange={(v) => v != null && handleModelChange(v)}>
-            <SelectTrigger size="sm" className="w-56 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {modelOptions.some((m) => m.group)
-                ? (() => {
-                    const groups = new Map<string, typeof modelOptions>();
-                    for (const m of modelOptions) {
-                      const g = m.group ?? "";
-                      if (!groups.has(g)) groups.set(g, []);
-                      groups.get(g)!.push(m);
-                    }
-                    return Array.from(groups.entries()).map(([g, items]) => (
-                      <SelectGroup key={g}>
-                        {g && <SelectLabel>{g}</SelectLabel>}
-                        {items.map((m) => (
-                          <SelectItem key={m.value} value={m.value}>
-                            {m.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    ));
-                  })()
-                : modelOptions.map((m) => (
-                    <SelectItem key={m.value} value={m.value}>
-                      {m.label}
-                    </SelectItem>
-                  ))}
-            </SelectContent>
-          </Select>
-        ) : (
-          <SegControl options={modelOptions} value={modelId} onChange={handleModelChange} />
-        )}
+        <div className="flex flex-col items-end gap-2">
+          {modelOptions.length > SEG_CONTROL_MAX_MODELS ? (
+            <Select value={modelId} onValueChange={(v) => v != null && handleModelChange(v)}>
+              <SelectTrigger size="sm" className="w-56 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {modelOptions.some((m) => m.group)
+                  ? (() => {
+                      const groups = new Map<string, typeof modelOptions>();
+                      for (const m of modelOptions) {
+                        const g = m.group ?? "";
+                        if (!groups.has(g)) groups.set(g, []);
+                        groups.get(g)!.push(m);
+                      }
+                      return Array.from(groups.entries()).map(([g, items]) => (
+                        <SelectGroup key={g}>
+                          {g && <SelectLabel>{g}</SelectLabel>}
+                          {items.map((m) => (
+                            <SelectItem key={m.value} value={m.value}>
+                              {m.label}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      ));
+                    })()
+                  : modelOptions.map((m) => (
+                      <SelectItem key={m.value} value={m.value}>
+                        {m.label}
+                      </SelectItem>
+                    ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <SegControl options={modelOptions} value={modelId} onChange={handleModelChange} />
+          )}
+          {defaultModelStale && (
+            <p className="max-w-xs text-right text-xs text-amber-600 dark:text-amber-500">
+              This model is not in the current catalog. Sending messages may fail until you choose a
+              listed model.
+            </p>
+          )}
+        </div>
       </SettingRow>
 
       <SettingRow
@@ -327,48 +426,56 @@ export function ModelSection() {
         configKey="model.defaults.fallbackId"
         hint="Used when the primary model is unavailable. Off disables fallback."
       >
-        {fallbackOptions.length > SEG_CONTROL_MAX_MODELS ? (
-          <Select
-            value={fallbackId}
-            onValueChange={(v) => v != null && update({ model: { defaults: { fallbackId: v } } })}
-          >
-            <SelectTrigger size="sm" className="w-56 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {fallbackOptions.some((m) => m.group)
-                ? (() => {
-                    const groups = new Map<string, typeof fallbackOptions>();
-                    for (const m of fallbackOptions) {
-                      const g = m.group ?? "";
-                      if (!groups.has(g)) groups.set(g, []);
-                      groups.get(g)!.push(m);
-                    }
-                    return Array.from(groups.entries()).map(([g, items]) => (
-                      <SelectGroup key={g}>
-                        {g && <SelectLabel>{g}</SelectLabel>}
-                        {items.map((m) => (
-                          <SelectItem key={m.value} value={m.value}>
-                            {m.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    ));
-                  })()
-                : fallbackOptions.map((m) => (
-                    <SelectItem key={m.value} value={m.value}>
-                      {m.label}
-                    </SelectItem>
-                  ))}
-            </SelectContent>
-          </Select>
-        ) : (
-          <SegControl
-            options={fallbackOptions}
-            value={fallbackId}
-            onChange={(v) => update({ model: { defaults: { fallbackId: v } } })}
-          />
-        )}
+        <div className="flex flex-col items-end gap-2">
+          {fallbackOptions.length > SEG_CONTROL_MAX_MODELS ? (
+            <Select
+              value={fallbackId}
+              onValueChange={(v) => v != null && update({ model: { defaults: { fallbackId: v } } })}
+            >
+              <SelectTrigger size="sm" className="w-56 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {fallbackOptions.some((m) => m.group)
+                  ? (() => {
+                      const groups = new Map<string, typeof fallbackOptions>();
+                      for (const m of fallbackOptions) {
+                        const g = m.group ?? "";
+                        if (!groups.has(g)) groups.set(g, []);
+                        groups.get(g)!.push(m);
+                      }
+                      return Array.from(groups.entries()).map(([g, items]) => (
+                        <SelectGroup key={g}>
+                          {g && <SelectLabel>{g}</SelectLabel>}
+                          {items.map((m) => (
+                            <SelectItem key={m.value} value={m.value}>
+                              {m.label}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      ));
+                    })()
+                  : fallbackOptions.map((m) => (
+                      <SelectItem key={m.value} value={m.value}>
+                        {m.label}
+                      </SelectItem>
+                    ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <SegControl
+              options={fallbackOptions}
+              value={fallbackId}
+              onChange={(v) => update({ model: { defaults: { fallbackId: v } } })}
+            />
+          )}
+          {fallbackModelStale && (
+            <p className="max-w-xs text-right text-xs text-amber-600 dark:text-amber-500">
+              This fallback model is not in the current catalog. Consider turning fallback off or
+              picking a listed model.
+            </p>
+          )}
+        </div>
       </SettingRow>
 
       {(provider !== "claude" || supportsEffortParameter(modelId)) && (

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -139,9 +139,7 @@ export function ModelSection() {
         icon: <Sparkles size={12} className="text-muted-foreground" aria-hidden />,
         title: "Use the default provider above",
       },
-      ...MODEL_PROVIDERS.filter((p) => p.supportsCompletion).map((p) =>
-        buildProviderOption(p, availabilityById.get(p.id)),
-      ),
+      ...MODEL_PROVIDERS.map((p) => buildProviderOption(p, availabilityById.get(p.id))),
     ],
     [availabilityById],
   );
@@ -263,18 +261,36 @@ export function ModelSection() {
     [modelsForFallbackPicker],
   );
 
-  // Utility model options: "Auto" (provider default) + all models for the effective provider.
-  // Dynamic models from the store take priority; static registry is the fallback when the
-  // store hasn't fetched yet (e.g. Copilot not connected).
+  const mergedUtilityCatalogModels = useMemo(
+    () =>
+      pickProviderModelsForSettings(utilityEffectiveProvider?.models ?? [], dynamicUtilityModels),
+    [utilityEffectiveProvider, dynamicUtilityModels],
+  );
+
+  const modelsForUtilityPicker = useMemo(() => {
+    const ids = new Set(mergedUtilityCatalogModels.map((m) => m.id));
+    if (utilityModelId.trim() && !ids.has(utilityModelId)) {
+      const orphan: ModelDefinition = {
+        id: utilityModelId,
+        label: `${utilityModelId} (unlisted)`,
+        providerId: utilityEffectiveId,
+        group: "Saved selection",
+      };
+      return [orphan, ...mergedUtilityCatalogModels];
+    }
+    return mergedUtilityCatalogModels;
+  }, [mergedUtilityCatalogModels, utilityModelId, utilityEffectiveId]);
+
   const utilityModelOptions = useMemo(
     () => [
-      { value: "", label: "Auto" },
-      ...(dynamicUtilityModels ?? utilityEffectiveProvider?.models ?? []).map((m) => ({
+      { value: "", label: "Auto", group: undefined },
+      ...modelsForUtilityPicker.map((m) => ({
         value: m.id,
-        label: m.label,
+        label: m.multiplier != null && m.multiplier !== 1 ? `${m.label} (${m.multiplier}x)` : m.label,
+        group: m.group,
       })),
     ],
-    [dynamicUtilityModels, utilityEffectiveProvider],
+    [modelsForUtilityPicker],
   );
 
   // Gate on provider so Copilot models that share IDs with Codex models
@@ -518,6 +534,7 @@ export function ModelSection() {
                 options={utilityModelOptions.map((o) => ({
                   value: o.value,
                   label: o.label,
+                  group: o.group,
                 }))}
                 emptyTriggerLabel="Auto"
                 searchPlaceholder="Search utility models…"

--- a/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
@@ -55,20 +55,6 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-// Select primitives from Radix can be tricky in jsdom; stub them since the
-// reasoning row always uses SegControl (not Select) in the tested scenarios.
-vi.mock("@/components/ui/select", () => ({
-  Select: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectValue: () => <span />,
-  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
-    <div data-value={value}>{children}</div>
-  ),
-}));
-
 import { ModelSection } from "../ModelSection";
 
 /** Builds the full settings state shape required by ModelSection. */

--- a/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
@@ -2,8 +2,14 @@ import { render, screen, within } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // vi.hoisted ensures these refs are available inside the vi.mock factory below.
-const { mockSettingsSelector } = vi.hoisted(() => ({
+const { mockSettingsSelector, mockPmState } = vi.hoisted(() => ({
   mockSettingsSelector: vi.fn(),
+  mockPmState: {
+    models: {} as Record<string, import("@/lib/model-registry").ModelDefinition[]>,
+    loading: {} as Record<string, boolean>,
+    fetchModels: vi.fn(),
+    initialize: vi.fn(),
+  },
 }));
 
 vi.mock("@/stores/settingsStore", () => {
@@ -16,7 +22,7 @@ vi.mock("@/stores/settingsStore", () => {
             defaults: { provider: "claude", id: "claude-opus-4-7", reasoning: "high", fallbackId: "" },
             utility: { provider: "", id: "" },
           },
-          provider: { cli: { codex: "", claude: "", copilot: "" } },
+          provider: { cli: { codex: "", claude: "", copilot: "", cursor: "" } },
           diffSummary: { enabled: false },
         },
       }),
@@ -25,6 +31,21 @@ vi.mock("@/stores/settingsStore", () => {
   );
   return { useSettingsStore: store };
 });
+
+vi.mock("@/stores/providerModelsStore", () => ({
+  useProviderModelsStore: (fn: (s: typeof mockPmState) => unknown) => fn(mockPmState),
+}));
+
+vi.mock("@/stores/providerAvailabilityStore", () => ({
+  useProviderAvailabilityStore: (fn: (s: { providers: unknown[] }) => unknown) =>
+    fn({ providers: [] }),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: Object.assign(vi.fn(), {
+    getState: () => ({ show: vi.fn(), dismiss: vi.fn(), toasts: [] }),
+  }),
+}));
 
 // @base-ui/react (used by Tooltip) does not work in jsdom; stub it out.
 vi.mock("@/components/ui/tooltip", () => ({
@@ -58,7 +79,7 @@ function makeState(provider: string, modelId: string, reasoning = "high") {
         defaults: { provider, id: modelId, reasoning, fallbackId: "" },
         utility: { provider: "", id: "" },
       },
-      provider: { cli: { codex: "", claude: "", copilot: "" } },
+      provider: { cli: { codex: "", claude: "", copilot: "", cursor: "" } },
       diffSummary: { enabled: false },
     },
     update: vi.fn(),

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -158,6 +158,20 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
 ];
 
 /**
+ * Chooses model definitions for Settings pickers: prefers a non-empty live list
+ * from the server; otherwise keeps static catalog entries when discovery fails or returns nothing.
+ */
+export function pickProviderModelsForSettings(
+  staticModels: readonly ModelDefinition[],
+  dynamicModels: readonly ModelDefinition[] | undefined,
+): ModelDefinition[] {
+  if (dynamicModels != null && dynamicModels.length > 0) {
+    return [...dynamicModels];
+  }
+  return [...staticModels];
+}
+
+/**
  * Flat model list sorted longest-ID-first, precomputed once at module load.
  * Used by `matchDatedVariant` to avoid reallocating and sorting on every call.
  */

--- a/apps/web/src/lib/searchTokens.ts
+++ b/apps/web/src/lib/searchTokens.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared multi-token search helpers for composer and settings pickers.
+ * Queries split on whitespace; every token must match as a substring somewhere
+ * in the joined candidate fields (AND semantics).
+ */
+
+/** Splits a query into lowercase tokens (whitespace). Empty input yields no tokens. */
+export function tokenizeSearch(raw: string): string[] {
+  return raw.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/** Requires every token to appear as a substring in the joined parts string. */
+export function matchesAllTokens(parts: string[], tokens: string[]): boolean {
+  if (tokens.length === 0) return true;
+  const haystack = parts.join(" ").toLowerCase();
+  return tokens.every((t) => haystack.includes(t));
+}

--- a/apps/web/src/stores/modelFavoritesStore.ts
+++ b/apps/web/src/stores/modelFavoritesStore.ts
@@ -1,0 +1,55 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+/** Maximum starred models kept locally so composer menus stay fast to render. */
+const MAX_FAVORITES = 40;
+
+/** One starred model row persisted for quick selection in the composer. */
+export interface ModelFavoriteEntry {
+  providerId: string;
+  modelId: string;
+  label: string;
+}
+
+/** Persisted favorite models for {@link ModelSelector}. */
+interface ModelFavoritesState {
+  entries: ModelFavoriteEntry[];
+  /** Adds or removes a favorite keyed by provider and model id. */
+  toggleFavorite: (entry: ModelFavoriteEntry) => void;
+  isFavorite: (providerId: string, modelId: string) => boolean;
+}
+
+/** Zustand store persisted to localStorage for starred composer models. */
+export const useModelFavoritesStore = create<ModelFavoritesState>()(
+  persist(
+    (set, get) => ({
+      entries: [],
+      toggleFavorite: (entry) => {
+        const label = entry.label.trim() || entry.modelId;
+        set((s) => {
+          const idx = s.entries.findIndex(
+            (e) => e.providerId === entry.providerId && e.modelId === entry.modelId,
+          );
+          if (idx >= 0) {
+            const next = [...s.entries];
+            next.splice(idx, 1);
+            return { entries: next };
+          }
+          const row: ModelFavoriteEntry = {
+            providerId: entry.providerId,
+            modelId: entry.modelId,
+            label,
+          };
+          return { entries: [row, ...s.entries].slice(0, MAX_FAVORITES) };
+        });
+      },
+      isFavorite: (providerId, modelId) =>
+        get().entries.some((e) => e.providerId === providerId && e.modelId === modelId),
+    }),
+    {
+      name: "mcode-model-favorites",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ entries: s.entries }),
+    },
+  ),
+);

--- a/apps/web/src/stores/providerModelsStore.ts
+++ b/apps/web/src/stores/providerModelsStore.ts
@@ -2,8 +2,11 @@ import { create } from "zustand";
 import { MODEL_PROVIDERS, type ModelDefinition } from "@/lib/model-registry";
 import { getTransport } from "@/transport";
 
-/** How long cached models remain valid before a background refresh. */
-const MODEL_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+/**
+ * Client-side TTL aligned with `ModelCacheService` on the server (~1h fresh window).
+ * Repeated `listProviderModels` calls stay cheap while entries remain warm there.
+ */
+const MODEL_CACHE_TTL_MS = 60 * 60 * 1000;
 
 /** State and actions for the provider models Zustand store. */
 interface ProviderModelsState {
@@ -15,9 +18,9 @@ interface ProviderModelsState {
   loading: Record<string, boolean>;
   /**
    * Fetch models for a single provider.
-   * No-ops if a fetch is in-flight or the cache is still fresh.
+   * No-ops if a fetch is in-flight or the cache is still fresh unless `force` is set.
    */
-  fetchModels: (providerId: string) => Promise<void>;
+  fetchModels: (providerId: string, opts?: { force?: boolean }) => Promise<void>;
   /**
    * Eagerly fetch models for all providers that support dynamic listing.
    * Called on WS connection and reconnection.
@@ -31,14 +34,14 @@ export const useProviderModelsStore = create<ProviderModelsState>((set, get) => 
   lastFetched: {},
   loading: {},
 
-  fetchModels: async (providerId: string) => {
+  fetchModels: async (providerId: string, opts?: { force?: boolean }) => {
     // Atomic check-and-set: read loading + TTL inside the updater to avoid a
     // TOCTOU race where two concurrent callers both pass the guard.
     let shouldFetch = false;
     set((s) => {
       if (s.loading[providerId]) return s;
       const lastFetch = s.lastFetched[providerId] ?? 0;
-      if (Date.now() - lastFetch < MODEL_CACHE_TTL_MS) return s;
+      if (!opts?.force && Date.now() - lastFetch < MODEL_CACHE_TTL_MS) return s;
       shouldFetch = true;
       return { loading: { ...s.loading, [providerId]: true } };
     });

--- a/packages/contracts/src/__tests__/file-types.test.ts
+++ b/packages/contracts/src/__tests__/file-types.test.ts
@@ -5,6 +5,7 @@ import {
   isFileSupported,
   getExtension,
   inferMimeType,
+  attachmentAcceptAttribute,
 } from "../models/file-types.js";
 
 describe("getExtension", () => {
@@ -90,6 +91,14 @@ describe("classifyFile", () => {
     expect(classifyFile("update.patch")).toBe("text");
   });
 
+  it("classifies Office-style documents", () => {
+    expect(classifyFile("spec.docx")).toBe("document");
+    expect(classifyFile("sheet.xlsx")).toBe("document");
+    expect(classifyFile("deck.pptx")).toBe("document");
+    expect(classifyFile("notes.odt")).toBe("document");
+    expect(classifyFile("memo.rtf")).toBe("document");
+  });
+
   it("returns null for unsupported extensions", () => {
     expect(classifyFile("archive.zip")).toBeNull();
     expect(classifyFile("video.mp4")).toBeNull();
@@ -121,6 +130,7 @@ describe("isFileSupported", () => {
     expect(isFileSupported("app.tsx")).toBe(true);
     expect(isFileSupported("photo.png")).toBe(true);
     expect(isFileSupported("doc.pdf")).toBe(true);
+    expect(isFileSupported("notes.docx")).toBe(true);
   });
 
   it("returns false for unsupported extensions", () => {
@@ -140,6 +150,10 @@ describe("getMaxFileSize", () => {
 
   it("returns 10MB for text/code files", () => {
     expect(getMaxFileSize("app.ts")).toBe(10 * 1024 * 1024);
+  });
+
+  it("returns 16MB for document attachments", () => {
+    expect(getMaxFileSize("sheet.xlsx")).toBe(16 * 1024 * 1024);
   });
 
   it("returns 0 for unsupported files", () => {
@@ -166,7 +180,26 @@ describe("inferMimeType", () => {
     expect(inferMimeType("README.md")).toBe("text/plain");
   });
 
+  it("infers Office Open XML MIME types", () => {
+    expect(inferMimeType("file.docx")).toBe(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+    expect(inferMimeType("grid.xlsx")).toBe(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    );
+  });
+
   it("returns empty string for unsupported", () => {
     expect(inferMimeType("archive.zip")).toBe("");
+  });
+});
+
+describe("attachmentAcceptAttribute", () => {
+  it("lists dotted extensions for file inputs", () => {
+    const attr = attachmentAcceptAttribute();
+    expect(attr).toContain(".png");
+    expect(attr).toContain(".pdf");
+    expect(attr).toContain(".docx");
+    expect(attr.startsWith(".")).toBe(true);
   });
 });

--- a/packages/contracts/src/__tests__/send-message-attachments.test.ts
+++ b/packages/contracts/src/__tests__/send-message-attachments.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { SendMessageSchema } from "../ws/methods.js";
+import { MAX_ATTACHMENTS } from "../models/file-types.js";
+
+const sampleAttachment = {
+  id: "att-x",
+  name: "note.txt",
+  mimeType: "text/plain",
+  sizeBytes: 4,
+  sourcePath: "/tmp/note.txt",
+};
+
+describe("SendMessageSchema attachments", () => {
+  it(`allows up to ${MAX_ATTACHMENTS} attachments`, () => {
+    const attachments = Array.from({ length: MAX_ATTACHMENTS }, (_, i) => ({
+      ...sampleAttachment,
+      id: `att-${i}`,
+    }));
+    const result = SendMessageSchema().safeParse({
+      threadId: "550e8400-e29b-41d4-a716-446655440000",
+      content: "hi",
+      attachments,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects more than MAX_ATTACHMENTS", () => {
+    const attachments = Array.from({ length: MAX_ATTACHMENTS + 1 }, (_, i) => ({
+      ...sampleAttachment,
+      id: `att-${i}`,
+    }));
+    const result = SendMessageSchema().safeParse({
+      threadId: "550e8400-e29b-41d4-a716-446655440000",
+      content: "hi",
+      attachments,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -79,6 +79,7 @@ export {
   inferMimeType,
   MAX_ATTACHMENTS,
   SUPPORTED_EXTENSIONS,
+  attachmentAcceptAttribute,
 } from "./models/file-types.js";
 export type { FileCategory } from "./models/file-types.js";
 

--- a/packages/contracts/src/models/file-types.ts
+++ b/packages/contracts/src/models/file-types.ts
@@ -15,7 +15,7 @@ const MAX_TEXT_SIZE = 10 * 1024 * 1024;
 const MAX_DOCUMENT_SIZE = 16 * 1024 * 1024;
 
 /** Maximum number of attachments per message. */
-export const MAX_ATTACHMENTS = 5;
+export const MAX_ATTACHMENTS = 10;
 
 /** Image extensions mapped to MIME types. */
 const IMAGE_EXTENSIONS: Record<string, string> = {

--- a/packages/contracts/src/models/file-types.ts
+++ b/packages/contracts/src/models/file-types.ts
@@ -6,12 +6,13 @@
  */
 
 /** File categories recognized by the attachment system. */
-export type FileCategory = "image" | "pdf" | "text";
+export type FileCategory = "image" | "pdf" | "text" | "document";
 
 /** Size limits per category. */
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024;
 const MAX_PDF_SIZE = 32 * 1024 * 1024;
 const MAX_TEXT_SIZE = 10 * 1024 * 1024;
+const MAX_DOCUMENT_SIZE = 16 * 1024 * 1024;
 
 /** Maximum number of attachments per message. */
 export const MAX_ATTACHMENTS = 5;
@@ -51,8 +52,19 @@ const TEXT_EXTENSIONS = new Set([
   "lock",
   // Dotfiles (after stripping leading dot)
   "gitignore", "gitattributes", "editorconfig",
-  "eslintrc", "prettierrc", "dockerignore",
+  "eslintrc", "prettierrc",   "dockerignore",
 ]);
+
+/** Office-style attachments (allowed as blobs; providers may still decline exotic formats). */
+const DOCUMENT_EXTENSIONS: Record<string, string> = {
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  rtf: "application/rtf",
+  odt: "application/vnd.oasis.opendocument.text",
+  ods: "application/vnd.oasis.opendocument.spreadsheet",
+  odp: "application/vnd.oasis.opendocument.presentation",
+};
 
 /** Well-known filenames without extensions that are text files (lowercase). */
 const KNOWN_TEXT_FILENAMES = new Set([
@@ -83,6 +95,7 @@ export function classifyFile(fileName: string): FileCategory | null {
 
   if (ext && ext in IMAGE_EXTENSIONS) return "image";
   if (ext === "pdf") return "pdf";
+  if (ext && ext in DOCUMENT_EXTENSIONS) return "document";
   if (ext && TEXT_EXTENSIONS.has(ext)) return "text";
 
   // Check well-known extensionless filenames (case-insensitive)
@@ -108,6 +121,7 @@ export function getMaxFileSize(fileName: string): number {
     case "image": return MAX_IMAGE_SIZE;
     case "pdf": return MAX_PDF_SIZE;
     case "text": return MAX_TEXT_SIZE;
+    case "document": return MAX_DOCUMENT_SIZE;
     default: return 0;
   }
 }
@@ -122,6 +136,7 @@ export function inferMimeType(fileName: string): string {
 
   if (ext && ext in IMAGE_EXTENSIONS) return IMAGE_EXTENSIONS[ext];
   if (ext === "pdf") return "application/pdf";
+  if (ext && ext in DOCUMENT_EXTENSIONS) return DOCUMENT_EXTENSIONS[ext];
 
   // All recognized text-based extensions
   if ((ext && TEXT_EXTENSIONS.has(ext)) || KNOWN_TEXT_FILENAMES.has(fileName.toLowerCase())) {
@@ -135,5 +150,13 @@ export function inferMimeType(fileName: string): string {
 export const SUPPORTED_EXTENSIONS = new Set([
   ...Object.keys(IMAGE_EXTENSIONS),
   "pdf",
+  ...Object.keys(DOCUMENT_EXTENSIONS),
   ...TEXT_EXTENSIONS,
 ]);
+
+/**
+ * Builds the `accept` attribute for a hidden `<input type="file">` in the composer.
+ */
+export function attachmentAcceptAttribute(): string {
+  return [...SUPPORTED_EXTENSIONS].map((ext) => `.${ext}`).join(",");
+}

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -4,6 +4,7 @@ import { ThreadSchema, RecentThreadSchema } from "../models/thread.js";
 import { ThreadModeSchema, PermissionModeSchema, InteractionModeSchema } from "../models/enums.js";
 import { PaginatedMessagesSchema } from "../models/message.js";
 import { AttachmentMetaSchema } from "../models/attachment.js";
+import { MAX_ATTACHMENTS } from "../models/file-types.js";
 import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { GitBranchSchema, WorktreeSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
@@ -43,7 +44,7 @@ export const SendMessageSchema = lazySchema(() =>
     content: z.string(),
     model: z.string().optional(),
     permissionMode: PermissionModeSchema.optional(),
-    attachments: z.array(AttachmentMetaSchema).optional(),
+    attachments: z.array(AttachmentMetaSchema).max(MAX_ATTACHMENTS).optional(),
     reasoningLevel: ReasoningLevelSchema.optional(),
     provider: ProviderIdSchema.optional(),
     /** When "plan", the server wraps the message with the plan-mode question prompt. */
@@ -75,7 +76,7 @@ export const CreateAndSendSchema = lazySchema(() =>
     mode: ThreadModeSchema.optional(),
     branch: z.string().optional(),
     existingWorktreePath: z.string().optional(),
-    attachments: z.array(AttachmentMetaSchema).optional(),
+    attachments: z.array(AttachmentMetaSchema).max(MAX_ATTACHMENTS).optional(),
     reasoningLevel: ReasoningLevelSchema.optional(),
     provider: ProviderIdSchema.optional(),
     /** When "plan", the server wraps the message with the plan-mode question prompt. */


### PR DESCRIPTION
## What

This branch improves settings model and provider selection (search, fixed-height scroll regions, simplified provider list), raises the chat attachment limit to 10 with validation in contracts, adjusts user message layout so non-image file chips sit outside the orange bubble, and carries related composer model selector and attachment work from the same effort.

## Why

Make models and providers easier to find without layout jumps from growing popovers, expose the full utility provider catalog in settings, support heavier attachment use in chat, and keep file chips readable outside the user bubble styling.

## Key Changes

- Searchable settings model and provider pickers with fixed-height shells and internal scrolling
- Settings provider picker simplified to a search-only list with monochrome provider glyphs and stable option test ids
- Utility settings pickers list all registered providers and use grouped searchable pickers where applicable
- MAX_ATTACHMENTS raised to 10 in contracts with Zod limits on send payloads and tests; MessageBubble renders detached file chips above the bubble
- Composer work includes model favorites rail, tokenized search shared helpers, document MIME acceptance on server/contracts, and E2E updates for settings and composer toolbar



Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialog-style model selector with left-rail, model favorites, and searchable grouped/provider pickers; live model pickers in settings.

* **Improvements**
  * Office (docx/xlsx/pptx/odt/rtf) attachments supported with correct icons/extensions and 16MB per-document limit; max attachments increased to 10.
  * Composer: improved attach button, paste handling, and non-image attachment chip layout.
  * Client/server model caching: invalidation and longer client TTL with optional force refresh.

* **Tests**
  * New and updated unit and E2E tests covering composer, model selector, settings, attachments, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->