### PR TITLE
feat: improve stop/interrupt persistence and UX

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -108,6 +108,11 @@ export class AgentService {
   private turnSortCounters = new Map<string, number>();
   /** Threads currently running persistTurn to prevent concurrent calls. */
   private persistingThreads = new Set<string>();
+  /**
+   * Accumulates `textDelta` chunks per thread so we can persist partial assistant
+   * output when the user stops before the provider emits a final `message` event.
+   */
+  private streamingAssistantTextByThread = new Map<string, string>();
   /** Per-thread streaming parsers active while the model is generating questions in plan mode. */
   private planParsers = new Map<string, PlanQuestionParser>();
   /** Buffered plan questions awaiting broadcast until the turn closes (`ended` event).
@@ -242,6 +247,8 @@ export class AgentService {
     // answered marker in a single transaction. If the marker insert fails
     // (e.g. FK rejects an unknown messageId) the user message is rolled
     // back too, keeping marker durability == answer durability.
+    this.streamingAssistantTextByThread.delete(threadId);
+
     this.db.transaction(() => {
       this.messageRepo.create(
         threadId,
@@ -864,10 +871,13 @@ export class AgentService {
     } catch {
       // Provider may not be available
     }
+    // Persist partial assistant text before tool rows attach so `messageId` targets the assistant row.
+    this.flushInterruptedAssistantMessage(threadId);
     // Persist buffered tool calls before clearing state so the
     // client receives a turn.persisted event with the correct count.
     await this.persistTurn(threadId, true);
     this.threadRepo.updateStatus(threadId, "paused");
+    broadcast("thread.status", { threadId, status: "paused" });
     if (this.activeSessionIds.has(threadId)) {
       this.activeSessionIds.delete(threadId);
       if (this.activeSessionIds.size === 0) {
@@ -947,6 +957,8 @@ export class AgentService {
         // cannot submit answers against a still-active session, which would
         // risk overlapping sends on the same thread.
         if (event.type === AgentEventType.TextDelta) {
+          const prev = this.streamingAssistantTextByThread.get(event.threadId) ?? "";
+          this.streamingAssistantTextByThread.set(event.threadId, prev + event.delta);
           const parser = this.planParsers.get(event.threadId);
           if (parser) {
             const questions = parser.feed(event.delta);
@@ -974,6 +986,7 @@ export class AgentService {
             // through to the client. The client uses it for stable message identity
             // (branching, dedup across Electron's dual MessagePort+WebSocket channels).
             event.messageId = msg.id;
+            this.streamingAssistantTextByThread.delete(event.threadId);
           } catch (err) {
             logger.error("Failed to persist assistant message", {
               threadId: event.threadId,
@@ -1282,6 +1295,45 @@ ${userMessage}`;
         buffer[i].status = isError ? "failed" : "completed";
         break;
       }
+    }
+  }
+
+  /**
+   * Writes accumulated streaming assistant text to SQLite when a turn ends without
+   * a provider-issued `message` row (for example user stop before Claude's `result`).
+   * Broadcasts `agent.event` so clients align in-memory transcripts with the DB.
+   */
+  private flushInterruptedAssistantMessage(threadId: string): void {
+    const raw = this.streamingAssistantTextByThread.get(threadId);
+    const text = raw?.trim();
+    if (!text) {
+      this.streamingAssistantTextByThread.delete(threadId);
+      return;
+    }
+
+    const { messages } = this.messageRepo.listByThread(threadId, 1);
+    const last = messages.length > 0 ? messages[messages.length - 1] : null;
+    if (last?.role === "assistant") {
+      this.streamingAssistantTextByThread.delete(threadId);
+      return;
+    }
+
+    const nextSeq = last ? last.sequence + 1 : 1;
+    try {
+      const msg = this.messageRepo.create(threadId, "assistant", text, nextSeq);
+      this.streamingAssistantTextByThread.delete(threadId);
+      broadcast("agent.event", {
+        type: AgentEventType.Message,
+        threadId,
+        content: text,
+        tokens: null,
+        messageId: msg.id,
+      } satisfies AgentEvent);
+    } catch (err) {
+      logger.error("Failed to persist interrupted assistant message", {
+        threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/apps/web/src/__tests__/streaming.test.ts
+++ b/apps/web/src/__tests__/streaming.test.ts
@@ -173,6 +173,42 @@ describe("duplicate message prevention", () => {
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toBe("Hello world");
   });
+
+  it("session.message replaces trailing optimistic assistant when content matches server message", () => {
+    useThreadStore.setState({
+      messages: [
+        {
+          id: "client-provisional-id",
+          thread_id: "thread-1",
+          role: "assistant",
+          content: "Hello world",
+          tool_calls: null,
+          files_changed: null,
+          cost_usd: null,
+          tokens_used: null,
+          sequence: 1,
+          timestamp: new Date().toISOString(),
+          attachments: null,
+        },
+      ],
+    });
+    const { handleAgentEvent } = useThreadStore.getState();
+    handleAgentEvent("thread-1", {
+      method: "session.message",
+      params: {
+        content: "Hello world",
+        messageId: "persisted-msg-id",
+        tokens: 10,
+      },
+    });
+    vi.runAllTimers();
+
+    const messages = useThreadStore.getState().messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].id).toBe("persisted-msg-id");
+    expect(messages[0].content).toBe("Hello world");
+    expect(messages[0].tokens_used).toBe(10);
+  });
 });
 
 describe("session.textDelta", () => {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -52,6 +52,7 @@ import { QueuePopover } from "./QueuePopover";
 import { ContextTracker } from "./ContextTracker";
 import { CompactingBanner } from "./CompactingBanner";
 import { RetryBanner } from "./RetryBanner";
+import { InterruptStopBanner } from "./InterruptStopBanner";
 import { ComposerBranchBar } from "./ComposerBranchBar";
 import { ComposerReplyBar } from "./ComposerReplyBar";
 import { useReplyStore } from "@/stores/replyStore";
@@ -669,6 +670,26 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       editorRef.current.focus();
     }
   }, [pendingPrefill, clearPendingPrefill]);
+
+  const composerRecallFromStop = useThreadStore((s) => s.composerRecallFromStop);
+  const clearComposerRecallFromStop = useThreadStore((s) => s.clearComposerRecallFromStop);
+
+  useEffect(() => {
+    if (!composerRecallFromStop || composerRecallFromStop.threadId !== threadId) return;
+    const text = composerRecallFromStop.text;
+    clearComposerRecallFromStop();
+    setInput(text);
+    if (editorRef.current) {
+      editorRef.current.update(() => {
+        const root = $getRoot();
+        root.clear();
+        const para = $createParagraphNode();
+        para.append($createTextNode(text));
+        root.append(para);
+      });
+      editorRef.current.focus();
+    }
+  }, [composerRecallFromStop, threadId, clearComposerRecallFromStop]);
 
   const fileAutocomplete = useFileAutocomplete({
     workspaceId,
@@ -1561,6 +1582,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         {/* Compacting banner — shown while the SDK is summarising the context window */}
         {isCompacting && <CompactingBanner />}
         {!isCompacting && hasRetryState && threadId && <RetryBanner threadId={threadId} />}
+        {threadId && <InterruptStopBanner threadId={threadId} />}
 
         {/* Drag overlay */}
         {isDragOver && (

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -671,13 +671,15 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
   }, [pendingPrefill, clearPendingPrefill]);
 
-  const composerRecallFromStop = useThreadStore((s) => s.composerRecallFromStop);
+  const composerRecallFromStop = useThreadStore((s) =>
+    threadId ? s.composerRecallFromStopByThread[threadId] : undefined,
+  );
   const clearComposerRecallFromStop = useThreadStore((s) => s.clearComposerRecallFromStop);
 
   useEffect(() => {
-    if (!composerRecallFromStop || composerRecallFromStop.threadId !== threadId) return;
+    if (!composerRecallFromStop || !threadId) return;
     const text = composerRecallFromStop.text;
-    clearComposerRecallFromStop();
+    clearComposerRecallFromStop(threadId);
     setInput(text);
     if (editorRef.current) {
       editorRef.current.update(() => {

--- a/apps/web/src/components/chat/InterruptStopBanner.tsx
+++ b/apps/web/src/components/chat/InterruptStopBanner.tsx
@@ -1,0 +1,44 @@
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useThreadStore } from "@/stores/threadStore";
+
+/**
+ * One-shot banner after the user stops the agent mid-turn while file edits were
+ * snapshot-persisted, reminding them that workspace changes were kept on disk.
+ */
+export function InterruptStopBanner({ threadId }: { threadId: string }) {
+  const notice = useThreadStore((s) => s.interruptStopFileNotice);
+  const clear = useThreadStore((s) => s.clearInterruptStopFileNotice);
+
+  if (!notice || notice.threadId !== threadId || notice.paths.length === 0) return null;
+
+  const preview =
+    notice.paths.length <= 3
+      ? notice.paths.join(", ")
+      : `${notice.paths.slice(0, 3).join(", ")} and ${notice.paths.length - 3} more`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-2 border-t border-border/20 px-3 py-2"
+      data-testid="interrupt-stop-file-notice"
+    >
+      <span className="text-xs text-muted-foreground pt-0.5">
+        Stop: file changes from this turn are still on disk ({preview}). Use git to review or
+        undo if needed.
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 shrink-0 text-muted-foreground"
+        title="Dismiss"
+        aria-label="Dismiss"
+        onClick={() => clear()}
+      >
+        <X size={14} />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/InterruptStopBanner.tsx
+++ b/apps/web/src/components/chat/InterruptStopBanner.tsx
@@ -7,10 +7,10 @@ import { useThreadStore } from "@/stores/threadStore";
  * snapshot-persisted, reminding them that workspace changes were kept on disk.
  */
 export function InterruptStopBanner({ threadId }: { threadId: string }) {
-  const notice = useThreadStore((s) => s.interruptStopFileNotice);
+  const notice = useThreadStore((s) => s.interruptStopFileNoticeByThread[threadId]);
   const clear = useThreadStore((s) => s.clearInterruptStopFileNotice);
 
-  if (!notice || notice.threadId !== threadId || notice.paths.length === 0) return null;
+  if (!notice || notice.paths.length === 0) return null;
 
   const preview =
     notice.paths.length <= 3
@@ -35,7 +35,7 @@ export function InterruptStopBanner({ threadId }: { threadId: string }) {
         className="h-7 w-7 shrink-0 text-muted-foreground"
         title="Dismiss"
         aria-label="Dismiss"
-        onClick={() => clear()}
+        onClick={() => clear(threadId)}
       >
         <X size={14} />
       </Button>

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -116,6 +116,15 @@ interface ThreadState {
   answeredPlanMessageIdsByThread: Record<string, Set<string>>;
   /** Pending and recently-settled permission requests per thread. */
   permissionsByThread: Record<string, StoredPermission[]>;
+  /**
+   * After `agent.stop`, we wait for the next `turn.persisted` on this thread so we can
+   * show a one-shot notice if the interrupted turn touched files on disk.
+   */
+  awaitingUserStopPersistThreadId: string | null;
+  /** Dismissible notice: stop interrupted a turn that produced workspace file changes. */
+  interruptStopFileNotice: { threadId: string; paths: string[] } | null;
+  /** Pre-fill the composer with the last user prompt after the user hits Stop (consumed by Composer). */
+  composerRecallFromStop: { threadId: string; text: string } | null;
 
   /** Store tool call records in the cache. */
   cacheToolCallRecords: (key: string, records: ToolCallRecord[]) => void;
@@ -159,6 +168,10 @@ interface ThreadState {
 
   /** Handle server-side tool call persistence confirmation. */
   handleTurnPersisted: (payload: { threadId: string; messageId: string; toolCallCount: number; filesChanged: string[] }) => void;
+  /** Clear the interrupt file-notice banner (user dismissed). */
+  clearInterruptStopFileNotice: () => void;
+  /** Clears composer recall state after the Composer applies it. */
+  clearComposerRecallFromStop: () => void;
 
   // Per-thread settings
   /** Return current settings for a thread, preferring in-memory overrides over DB-persisted values. */
@@ -328,6 +341,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   planQuestionsStatusByThread: {},
   answeredPlanMessageIdsByThread: {},
   permissionsByThread: {},
+  awaitingUserStopPersistThreadId: null,
+  interruptStopFileNotice: null,
+  composerRecallFromStop: null,
 
   cacheToolCallRecords: (key, records) => {
     get().toolCallRecordCache.set(key, records);
@@ -815,12 +831,28 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
   /** Request the agent to stop on a thread. Always marks the thread as not running, even on error. */
   stopAgent: async (threadId) => {
+    set({ awaitingUserStopPersistThreadId: threadId });
     try {
       await getTransport().stopAgent(threadId);
     } catch (e) {
-      set((state) => ({ errorByThread: { ...state.errorByThread, [threadId]: String(e) } }));
+      set((state) => ({
+        errorByThread: { ...state.errorByThread, [threadId]: String(e) },
+        awaitingUserStopPersistThreadId:
+          state.awaitingUserStopPersistThreadId === threadId ? null : state.awaitingUserStopPersistThreadId,
+      }));
     }
-    // Always mark as stopped, even on error
+
+    const snap = get();
+    let lastUserText: string | null = null;
+    if (snap.currentThreadId === threadId) {
+      for (let i = snap.messages.length - 1; i >= 0; i--) {
+        if (snap.messages[i].role === "user") {
+          lastUserText = snap.messages[i].content;
+          break;
+        }
+      }
+    }
+
     set((state) => {
       const next = new Set(state.runningThreadIds);
       next.delete(threadId);
@@ -832,6 +864,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         runningThreadIds: next,
         rateLimitByThread: nextRateLimit,
         apiRetryByThread: nextApiRetry,
+        ...(lastUserText !== null && state.currentThreadId === threadId
+          ? { composerRecallFromStop: { threadId, text: lastUserText } }
+          : {}),
       };
     });
   },
@@ -1054,6 +1089,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         usageByProvider: Object.fromEntries(
           Object.entries(state.usageByProvider).filter(([k]) => !k.startsWith(`${threadId}:`)),
         ),
+        awaitingUserStopPersistThreadId:
+          state.awaitingUserStopPersistThreadId === threadId
+            ? null
+            : state.awaitingUserStopPersistThreadId,
+        interruptStopFileNotice:
+          state.interruptStopFileNotice?.threadId === threadId ? null : state.interruptStopFileNotice,
+        composerRecallFromStop:
+          state.composerRecallFromStop?.threadId === threadId ? null : state.composerRecallFromStop,
         // Clear message-keyed globals only when deleting the currently loaded thread.
         // For background threads, message-keyed maps (persistedToolCallCounts, etc.)
         // belong to the active thread's messages and must not be touched.
@@ -1137,6 +1180,21 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         usageByProvider: Object.fromEntries(
           Object.entries(state.usageByProvider).filter(([k]) => !threadIds.some((tid) => k.startsWith(`${tid}:`))),
         ),
+        awaitingUserStopPersistThreadId:
+          state.awaitingUserStopPersistThreadId != null &&
+          threadIds.includes(state.awaitingUserStopPersistThreadId)
+            ? null
+            : state.awaitingUserStopPersistThreadId,
+        interruptStopFileNotice:
+          state.interruptStopFileNotice != null &&
+          threadIds.includes(state.interruptStopFileNotice.threadId)
+            ? null
+            : state.interruptStopFileNotice,
+        composerRecallFromStop:
+          state.composerRecallFromStop != null &&
+          threadIds.includes(state.composerRecallFromStop.threadId)
+            ? null
+            : state.composerRecallFromStop,
         ...(deletingCurrentThread
           ? {
               currentThreadId: null,
@@ -1446,6 +1504,25 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           // with no ordering guarantee. Skip if already in messages to prevent
           // duplicates when both channels deliver the same message.
           if (state.messages.some((m) => m.id === message.id)) return trackTurn;
+          const last = state.messages[state.messages.length - 1];
+          if (
+            last?.role === "assistant" &&
+            last.content === content &&
+            last.id !== message.id
+          ) {
+            const replaced = state.messages.slice(0, -1).concat({
+              ...last,
+              id: message.id,
+              tokens_used: message.tokens_used,
+              timestamp: message.timestamp,
+            });
+            const { messages: capped, evicted } = capMessages(replaced);
+            return {
+              messages: capped,
+              ...(evicted && state.currentThreadId ? { hasMoreMessages: { ...state.hasMoreMessages, [state.currentThreadId]: true } } : {}),
+              ...trackTurn,
+            };
+          }
           const { messages: capped, evicted } = capMessages([...state.messages, message]);
           return {
             messages: capped,
@@ -2109,10 +2186,29 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
   },
 
+  clearInterruptStopFileNotice: () => {
+    set({ interruptStopFileNotice: null });
+  },
+
+  clearComposerRecallFromStop: () => {
+    set({ composerRecallFromStop: null });
+  },
+
   handleTurnPersisted: (payload) => {
     evictMessageCache(payload.threadId);
 
+    const awaitingId = get().awaitingUserStopPersistThreadId;
+
     set((state) => {
+      let interruptStopFileNotice = state.interruptStopFileNotice;
+      let awaitingUserStopPersistThreadId = state.awaitingUserStopPersistThreadId;
+      if (awaitingId === payload.threadId) {
+        awaitingUserStopPersistThreadId = null;
+        if (payload.filesChanged.length > 0) {
+          interruptStopFileNotice = { threadId: payload.threadId, paths: payload.filesChanged };
+        }
+      }
+
       // Clear in-memory tool calls now that the DB-backed summary takes over
       const nextToolCalls = { ...state.toolCallsByThread };
       delete nextToolCalls[payload.threadId];
@@ -2160,6 +2256,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           [localMsgId]: payload.messageId,
         },
         currentTurnMessageIdByThread: nextTurnMsgIds,
+        interruptStopFileNotice,
+        awaitingUserStopPersistThreadId,
       };
     });
 

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -831,11 +831,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
   /** Request the agent to stop on a thread. Always marks the thread as not running, even on error. */
   stopAgent: async (threadId) => {
+    let stopSucceeded = false;
     set((state) => ({
       awaitingUserStopPersistByThread: { ...state.awaitingUserStopPersistByThread, [threadId]: true },
     }));
     try {
       await getTransport().stopAgent(threadId);
+      stopSucceeded = true;
     } catch (e) {
       set((state) => {
         const nextAwaiting = { ...state.awaitingUserStopPersistByThread };
@@ -866,7 +868,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const nextApiRetry = { ...state.apiRetryByThread };
       delete nextApiRetry[threadId];
       const nextRecall =
-        lastUserText !== null && state.currentThreadId === threadId
+        stopSucceeded && lastUserText !== null && state.currentThreadId === threadId
           ? { ...state.composerRecallFromStopByThread, [threadId]: { text: lastUserText } }
           : state.composerRecallFromStopByThread;
       return {
@@ -1500,6 +1502,28 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             last.content === content &&
             last.id !== message.id
           ) {
+            const previousId = last.id;
+            const nextPersistedToolCallCounts = { ...state.persistedToolCallCounts };
+            if (previousId in nextPersistedToolCallCounts) {
+              const tc = nextPersistedToolCallCounts[previousId];
+              nextPersistedToolCallCounts[message.id] = tc;
+              delete nextPersistedToolCallCounts[previousId];
+            }
+
+            const nextPersistedFilesChanged = { ...state.persistedFilesChanged };
+            if (previousId in nextPersistedFilesChanged) {
+              const fc = nextPersistedFilesChanged[previousId];
+              nextPersistedFilesChanged[message.id] = fc;
+              delete nextPersistedFilesChanged[previousId];
+            }
+
+            const nextServerMessageIds = { ...state.serverMessageIds };
+            if (previousId in nextServerMessageIds) {
+              const sid = nextServerMessageIds[previousId];
+              nextServerMessageIds[message.id] = sid;
+              delete nextServerMessageIds[previousId];
+            }
+
             const replaced = state.messages.slice(0, -1).concat({
               ...last,
               id: message.id,
@@ -1509,7 +1533,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             const { messages: capped, evicted } = capMessages(replaced);
             return {
               messages: capped,
-              ...(evicted && state.currentThreadId ? { hasMoreMessages: { ...state.hasMoreMessages, [state.currentThreadId]: true } } : {}),
+              persistedToolCallCounts: nextPersistedToolCallCounts,
+              persistedFilesChanged: nextPersistedFilesChanged,
+              serverMessageIds: nextServerMessageIds,
+              latestTurnWithChanges:
+                state.latestTurnWithChanges === previousId ? message.id : state.latestTurnWithChanges,
+              ...(evicted && state.currentThreadId
+                ? { hasMoreMessages: { ...state.hasMoreMessages, [state.currentThreadId]: true } }
+                : {}),
               ...trackTurn,
             };
           }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -117,14 +117,14 @@ interface ThreadState {
   /** Pending and recently-settled permission requests per thread. */
   permissionsByThread: Record<string, StoredPermission[]>;
   /**
-   * After `agent.stop`, we wait for the next `turn.persisted` on this thread so we can
-   * show a one-shot notice if the interrupted turn touched files on disk.
+   * After `agent.stop`, each thread ID is marked until `turn.persisted` arrives for that
+   * thread, so we can show a one-shot file-change notice without colliding across threads.
    */
-  awaitingUserStopPersistThreadId: string | null;
-  /** Dismissible notice: stop interrupted a turn that produced workspace file changes. */
-  interruptStopFileNotice: { threadId: string; paths: string[] } | null;
-  /** Pre-fill the composer with the last user prompt after the user hits Stop (consumed by Composer). */
-  composerRecallFromStop: { threadId: string; text: string } | null;
+  awaitingUserStopPersistByThread: Record<string, true>;
+  /** Dismissible notice per thread: stop interrupted a turn that produced workspace file changes. */
+  interruptStopFileNoticeByThread: Record<string, { paths: string[] }>;
+  /** Pre-fill the composer with the last user prompt after Stop, keyed by thread (consumed by Composer). */
+  composerRecallFromStopByThread: Record<string, { text: string }>;
 
   /** Store tool call records in the cache. */
   cacheToolCallRecords: (key: string, records: ToolCallRecord[]) => void;
@@ -168,10 +168,10 @@ interface ThreadState {
 
   /** Handle server-side tool call persistence confirmation. */
   handleTurnPersisted: (payload: { threadId: string; messageId: string; toolCallCount: number; filesChanged: string[] }) => void;
-  /** Clear the interrupt file-notice banner (user dismissed). */
-  clearInterruptStopFileNotice: () => void;
-  /** Clears composer recall state after the Composer applies it. */
-  clearComposerRecallFromStop: () => void;
+  /** Clear the interrupt file-notice banner for one thread (user dismissed). */
+  clearInterruptStopFileNotice: (threadId: string) => void;
+  /** Clears composer recall state for one thread after the Composer applies it. */
+  clearComposerRecallFromStop: (threadId: string) => void;
 
   // Per-thread settings
   /** Return current settings for a thread, preferring in-memory overrides over DB-persisted values. */
@@ -341,9 +341,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   planQuestionsStatusByThread: {},
   answeredPlanMessageIdsByThread: {},
   permissionsByThread: {},
-  awaitingUserStopPersistThreadId: null,
-  interruptStopFileNotice: null,
-  composerRecallFromStop: null,
+  awaitingUserStopPersistByThread: {},
+  interruptStopFileNoticeByThread: {},
+  composerRecallFromStopByThread: {},
 
   cacheToolCallRecords: (key, records) => {
     get().toolCallRecordCache.set(key, records);
@@ -831,15 +831,20 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
   /** Request the agent to stop on a thread. Always marks the thread as not running, even on error. */
   stopAgent: async (threadId) => {
-    set({ awaitingUserStopPersistThreadId: threadId });
+    set((state) => ({
+      awaitingUserStopPersistByThread: { ...state.awaitingUserStopPersistByThread, [threadId]: true },
+    }));
     try {
       await getTransport().stopAgent(threadId);
     } catch (e) {
-      set((state) => ({
-        errorByThread: { ...state.errorByThread, [threadId]: String(e) },
-        awaitingUserStopPersistThreadId:
-          state.awaitingUserStopPersistThreadId === threadId ? null : state.awaitingUserStopPersistThreadId,
-      }));
+      set((state) => {
+        const nextAwaiting = { ...state.awaitingUserStopPersistByThread };
+        delete nextAwaiting[threadId];
+        return {
+          errorByThread: { ...state.errorByThread, [threadId]: String(e) },
+          awaitingUserStopPersistByThread: nextAwaiting,
+        };
+      });
     }
 
     const snap = get();
@@ -860,13 +865,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       delete nextRateLimit[threadId];
       const nextApiRetry = { ...state.apiRetryByThread };
       delete nextApiRetry[threadId];
+      const nextRecall =
+        lastUserText !== null && state.currentThreadId === threadId
+          ? { ...state.composerRecallFromStopByThread, [threadId]: { text: lastUserText } }
+          : state.composerRecallFromStopByThread;
       return {
         runningThreadIds: next,
         rateLimitByThread: nextRateLimit,
         apiRetryByThread: nextApiRetry,
-        ...(lastUserText !== null && state.currentThreadId === threadId
-          ? { composerRecallFromStop: { threadId, text: lastUserText } }
-          : {}),
+        composerRecallFromStopByThread: nextRecall,
       };
     });
   },
@@ -1089,14 +1096,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         usageByProvider: Object.fromEntries(
           Object.entries(state.usageByProvider).filter(([k]) => !k.startsWith(`${threadId}:`)),
         ),
-        awaitingUserStopPersistThreadId:
-          state.awaitingUserStopPersistThreadId === threadId
-            ? null
-            : state.awaitingUserStopPersistThreadId,
-        interruptStopFileNotice:
-          state.interruptStopFileNotice?.threadId === threadId ? null : state.interruptStopFileNotice,
-        composerRecallFromStop:
-          state.composerRecallFromStop?.threadId === threadId ? null : state.composerRecallFromStop,
+        awaitingUserStopPersistByThread: omitKey(state.awaitingUserStopPersistByThread, threadId),
+        interruptStopFileNoticeByThread: omitKey(state.interruptStopFileNoticeByThread, threadId),
+        composerRecallFromStopByThread: omitKey(state.composerRecallFromStopByThread, threadId),
         // Clear message-keyed globals only when deleting the currently loaded thread.
         // For background threads, message-keyed maps (persistedToolCallCounts, etc.)
         // belong to the active thread's messages and must not be touched.
@@ -1180,21 +1182,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         usageByProvider: Object.fromEntries(
           Object.entries(state.usageByProvider).filter(([k]) => !threadIds.some((tid) => k.startsWith(`${tid}:`))),
         ),
-        awaitingUserStopPersistThreadId:
-          state.awaitingUserStopPersistThreadId != null &&
-          threadIds.includes(state.awaitingUserStopPersistThreadId)
-            ? null
-            : state.awaitingUserStopPersistThreadId,
-        interruptStopFileNotice:
-          state.interruptStopFileNotice != null &&
-          threadIds.includes(state.interruptStopFileNotice.threadId)
-            ? null
-            : state.interruptStopFileNotice,
-        composerRecallFromStop:
-          state.composerRecallFromStop != null &&
-          threadIds.includes(state.composerRecallFromStop.threadId)
-            ? null
-            : state.composerRecallFromStop,
+        awaitingUserStopPersistByThread: pruneAll(state.awaitingUserStopPersistByThread),
+        interruptStopFileNoticeByThread: pruneAll(state.interruptStopFileNoticeByThread),
+        composerRecallFromStopByThread: pruneAll(state.composerRecallFromStopByThread),
         ...(deletingCurrentThread
           ? {
               currentThreadId: null,
@@ -2186,26 +2176,28 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
   },
 
-  clearInterruptStopFileNotice: () => {
-    set({ interruptStopFileNotice: null });
+  clearInterruptStopFileNotice: (threadId) => {
+    set((state) => ({
+      interruptStopFileNoticeByThread: omitKey(state.interruptStopFileNoticeByThread, threadId),
+    }));
   },
 
-  clearComposerRecallFromStop: () => {
-    set({ composerRecallFromStop: null });
+  clearComposerRecallFromStop: (threadId) => {
+    set((state) => ({
+      composerRecallFromStopByThread: omitKey(state.composerRecallFromStopByThread, threadId),
+    }));
   },
 
   handleTurnPersisted: (payload) => {
     evictMessageCache(payload.threadId);
 
-    const awaitingId = get().awaitingUserStopPersistThreadId;
-
     set((state) => {
-      let interruptStopFileNotice = state.interruptStopFileNotice;
-      let awaitingUserStopPersistThreadId = state.awaitingUserStopPersistThreadId;
-      if (awaitingId === payload.threadId) {
-        awaitingUserStopPersistThreadId = null;
+      const nextAwaiting = { ...state.awaitingUserStopPersistByThread };
+      const nextNotice = { ...state.interruptStopFileNoticeByThread };
+      if (nextAwaiting[payload.threadId]) {
+        delete nextAwaiting[payload.threadId];
         if (payload.filesChanged.length > 0) {
-          interruptStopFileNotice = { threadId: payload.threadId, paths: payload.filesChanged };
+          nextNotice[payload.threadId] = { paths: payload.filesChanged };
         }
       }
 
@@ -2256,8 +2248,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           [localMsgId]: payload.messageId,
         },
         currentTurnMessageIdByThread: nextTurnMsgIds,
-        interruptStopFileNotice,
-        awaitingUserStopPersistThreadId,
+        interruptStopFileNoticeByThread: nextNotice,
+        awaitingUserStopPersistByThread: nextAwaiting,
       };
     });
 


### PR DESCRIPTION
## What

Improve behavior when the user stops an agent mid-turn: partial assistant output and user message handling are persisted and reflected in the UI, with clearer feedback after interrupt.

## Why

Stopping mid-stream previously left confusing state: the last user prompt could be lost from the composer, partial assistant text might not persist, and users were not clearly notified when stopping with uncommitted file changes.

## Key Changes

- **Server:** Buffer streaming assistant text; on stop, flush a partial assistant message and broadcast it before persisting the turn; emit `thread.status: paused` so clients update promptly.
- **Web store:** Recall last user prompt into the composer after stop; show a dismissible notice when there are uncommitted changes; reconcile optimistic vs persisted assistant message IDs on `session.message`.
- **UI:** `Composer` applies recall from stop; `InterruptStopBanner` for the file-change notice (`data-testid="interrupt-stop-file-notice"`).
- **Tests:** Vitest covers `session.message` replacing trailing optimistic assistant when IDs differ.

## Verification

- `cd apps/server && bun run typecheck`
- `cd apps/web && bun run typecheck`
- `cd apps/web && bunx vitest run src/__tests__/streaming.test.ts` (13 passed)

**Note:** Full Playwright e2e (`cd apps/web && bun run e2e`) should be run with port 5173 free or `PLAYWRIGHT_REUSE_WEB_SERVER=1` against the matching dev server; a local run hit `port 5173 in use` when reusing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partial assistant responses interrupted by a stop are persisted and broadcast so threads can be resumed.
  * Composer restores recalled input per thread after a stop.
  * Dismissible banner shows affected file paths after a stop.

* **Bug Fixes**
  * Prevent duplicate assistant messages by reconciling optimistic and server message IDs and token counts.

* **Tests**
  * Added test covering duplicate message replacement and token update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->