### PR TITLE
fix: interrupted session sidebar label and Resume All RPC accuracy

### DIFF
--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -195,15 +195,17 @@ describe("AgentService.sendMessage — provider availability gate", () => {
 
     const svc = buildService({ assertUsable, resolveProvider });
 
-    await svc.sendMessage(
-      THREAD_ID,
-      "Hello",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "codex",
-    );
+    await expect(
+      svc.sendMessage(
+        THREAD_ID,
+        "Hello",
+        "default",
+        "claude-sonnet-4-6",
+        [],
+        undefined,
+        "codex",
+      ),
+    ).rejects.toThrow(ProviderDisabledError);
 
     // Provider must NOT be resolved — no agent session started
     expect(resolveProvider).not.toHaveBeenCalled();

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -198,7 +198,8 @@ export class AgentService {
           reason: err instanceof ProviderDisabledError ? "disabled" : "cli_missing",
           configuredPath: err instanceof ProviderCliMissingError ? err.configuredPath : undefined,
         });
-        return;
+        // RPC must reject so callers (e.g. batch resume, composer send) roll back optimistic
+        // running state instead of succeeding while nothing was persisted.
       }
       throw err;
     }

--- a/apps/web/src/__tests__/thread-status.test.ts
+++ b/apps/web/src/__tests__/thread-status.test.ts
@@ -98,8 +98,10 @@ describe("getStatusDisplay", () => {
     expect(result.shape).toBe("solid");
   });
 
-  it("interrupted status returns amber dot with pulse", () => {
+  it("interrupted status returns Interrupted label and amber dot with pulse", () => {
     const result = getStatusDisplay(makeThread({ status: "interrupted" }), false);
+    expect(result.label).toBe("Interrupted");
+    expect(result.color).toContain("amber");
     expect(result.dotClass).toContain("amber");
     expect(result.dotClass).toContain("animate-pulse");
     expect(result.shape).toBe("solid");
@@ -132,6 +134,13 @@ describe("getNotificationDot", () => {
     expect(result).not.toBeNull();
     expect(result!.dotClass).toContain("--diff-remove-strong");
     expect(result!.animate).toBe(false);
+  });
+
+  it("returns amber pulse for interrupted thread (including PR rows)", () => {
+    const result = getNotificationDot(makeThread({ status: "interrupted", pr_number: 42 }), false);
+    expect(result).not.toBeNull();
+    expect(result!.dotClass).toContain("amber");
+    expect(result!.animate).toBe(true);
   });
 
   it("returns null for idle thread", () => {

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -255,7 +255,10 @@ export function ChatView() {
       for (const threadId of threadIds) {
         try {
           const thread = currentThreads.find((t) => t.id === threadId);
-          if (!thread) continue;
+          if (!thread) {
+            failedIds.push(threadId);
+            continue;
+          }
           await sendMessage(
             threadId,
             "Continue where you left off. The server was restarted.",

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1192,7 +1192,7 @@ function VirtualizedThreadList({
                     )}
                   />
                 )}
-                {!thread.pr_number && status.label && (
+                {status.label && (
                   <span className={cn("shrink-0 font-mono text-[9.5px] uppercase tracking-[0.12em]", status.color)}>
                     {status.label}
                   </span>

--- a/apps/web/src/lib/thread-status.ts
+++ b/apps/web/src/lib/thread-status.ts
@@ -21,6 +21,8 @@ export interface NotificationDot {
 /**
  * Returns notification dot info for threads with PRs, or null if idle.
  * Used to overlay a small colored dot on the PR icon in the sidebar.
+ * Terminal states `completed`, `errored`, and `interrupted` each get a distinct dot;
+ * `interrupted` uses amber (not red) so restart cut-off reads differently from failure.
  * @param thread - The thread whose PR notification dot is being computed.
  * @param isActuallyRunning - True when the agent process is currently live.
  * @param hasPendingPermission - True when the thread has at least one unsettled permission request; renders an amber ring.
@@ -48,6 +50,8 @@ export function getNotificationDot(
       return { dotClass: "bg-[var(--diff-add-strong)]/85", animate: false, shape: "solid" };
     case "errored":
       return { dotClass: "bg-[var(--diff-remove-strong)]/90", animate: false, shape: "solid" };
+    case "interrupted":
+      return { dotClass: "bg-amber-500/85", animate: true, shape: "solid" };
     default:
       return null;
   }
@@ -103,7 +107,7 @@ export function getStatusDisplay(
       };
     case "interrupted":
       return {
-        label: "",
+        label: "Interrupted",
         color: "text-amber-500/90",
         dotClass: "bg-amber-500/85 animate-pulse",
         shape: "solid",


### PR DESCRIPTION
## What

Clarifies interrupted (post-shutdown) threads in the project tree and fixes batch resume falsely succeeding when no agent turns start.

## Why

Interrupted threads had no monospace label beside errored threads, and PR-linked interrupted rows lacked an amber agent dot so they read as idle.

Resume All awaited successful RPC responses even when the server returned early after a disabled CLI or missing provider binary; the banner cleared while threads stayed interrupted.

## Key Changes

- Sidebar: show Interrupted label consistently; amber notification dot on PR rows for interrupted status.
- Server: propagate provider availability failures as RPC errors after broadcasting providerUnavailable.
- Web: treat missing thread rows during batch resume as failures so orphaned IDs retry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->