### PR TITLE
fix(ci): pass --repo to gh upload in merge-mac-yml job

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -248,5 +248,5 @@ jobs:
           tag="${{ github.event.release.tag_name || inputs.tag }}"
           if [ -f latest-mac.yml ]; then
             echo "Uploading merged latest-mac.yml"
-            gh release upload "$tag" latest-mac.yml --clobber
+            gh release upload "$tag" latest-mac.yml --clobber --repo "${{ github.repository }}"
           fi


### PR DESCRIPTION
## What
Pass `--repo` explicitly to `gh release upload` in the `merge-mac-yml` job.

## Why
The `merge-mac-yml` job only downloads artifacts and merges YAML. It never checks out the repository, so `gh` has no `.git` directory to resolve the target repo. This caused the "Upload merged latest-mac.yml" step to fail with `fatal: not a git repository`.

## Key Changes
- Add `--repo "${{ github.repository }}"` to the `gh release upload` command in `merge-mac-yml`

Fixes the failure at https://github.com/Mzeey-Empire/mcode/actions/runs/25602495065/job/75158890868

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of the release upload process by making the repository context explicit during the release upload step.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/435)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->