### PR TITLE
perf: optimisations scan (server, web, desktop)

### DIFF
--- a/apps/server/src/__tests__/message-repo.test.ts
+++ b/apps/server/src/__tests__/message-repo.test.ts
@@ -28,6 +28,7 @@ function createTestDb(): Database.Database {
       arguments TEXT,
       result TEXT
     );
+    CREATE INDEX idx_tool_call_records_message ON tool_call_records(message_id);
   `);
   return db;
 }
@@ -39,6 +40,44 @@ describe("MessageRepo", () => {
   beforeEach(() => {
     db = createTestDb();
     repo = new MessageRepo(db);
+  });
+
+  describe("listByThread", () => {
+    it("returns tool_call_count per message via indexed lookup", () => {
+      const m1 = repo.create("thread-1", "user", "a", 1);
+      const m2 = repo.create("thread-1", "assistant", "b", 2);
+      db.prepare(
+        "INSERT INTO tool_call_records (id, message_id, name) VALUES (?, ?, ?)",
+      ).run("tc1", m2.id, "Bash");
+      db.prepare(
+        "INSERT INTO tool_call_records (id, message_id, name) VALUES (?, ?, ?)",
+      ).run("tc2", m2.id, "Read");
+
+      const { messages } = repo.listByThread("thread-1", 10);
+      expect(messages).toHaveLength(2);
+      expect(messages[0].tool_call_count).toBeUndefined();
+      expect(messages[1].tool_call_count).toBe(2);
+    });
+
+    it("EXPLAIN avoids full-table scan on tool_call_records", () => {
+      repo.create("thread-1", "user", "x", 1);
+      const stmt = db.prepare(
+        `EXPLAIN QUERY PLAN 
+SELECT id, thread_id, role, content, tool_calls, files_changed, cost_usd, tokens_used, timestamp, sequence, attachments, reply_to_message_id, quoted_text,
+(SELECT COUNT(*) FROM tool_call_records WHERE message_id = m.id) AS tool_call_count
+FROM (
+  SELECT m.id, m.thread_id, m.role, m.content, m.tool_calls, m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence, m.attachments, m.reply_to_message_id, m.quoted_text
+  FROM messages m
+  WHERE m.thread_id = ?
+  ORDER BY m.sequence DESC
+  LIMIT ?
+) m
+ORDER BY m.sequence ASC`,
+      );
+      const plan = stmt.all("thread-1", 11) as Array<{ detail?: string }>;
+      const text = plan.map((r) => r.detail ?? "").join("\n").toUpperCase();
+      expect(text).not.toContain("SCAN TOOL_CALL_RECORDS");
+    });
   });
 
   describe("listByThreadUpToSequence", () => {

--- a/apps/server/src/repositories/message-repo.ts
+++ b/apps/server/src/repositories/message-repo.ts
@@ -72,6 +72,13 @@ const MESSAGE_COLUMNS =
 const MESSAGE_COLUMNS_PREFIXED =
   "m.id, m.thread_id, m.role, m.content, m.tool_calls, m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence, m.attachments, m.reply_to_message_id, m.quoted_text";
 
+/**
+ * Per-row tool call counts via index on `message_id`.
+ * Avoids a full-table `GROUP BY` over `tool_call_records` for each list query.
+ */
+const TOOL_CALL_COUNT_SQL =
+  "(SELECT COUNT(*) FROM tool_call_records WHERE message_id = m.id) AS tool_call_count";
+
 /** Repository for message creation and retrieval against SQLite. */
 @injectable()
 export class MessageRepo {
@@ -146,7 +153,7 @@ export class MessageRepo {
 
     let rows = this.db
       .prepare(
-        `SELECT ${MESSAGE_COLUMNS}, tc_count.cnt as tool_call_count
+        `SELECT ${MESSAGE_COLUMNS}, ${TOOL_CALL_COUNT_SQL}
 FROM (
   SELECT ${MESSAGE_COLUMNS_PREFIXED}
   FROM messages m
@@ -154,11 +161,6 @@ FROM (
   ORDER BY m.sequence DESC
   LIMIT ?
 ) m
-LEFT JOIN (
-  SELECT message_id, COUNT(*) as cnt
-  FROM tool_call_records
-  GROUP BY message_id
-) tc_count ON tc_count.message_id = m.id
 ORDER BY m.sequence ASC`,
       )
       .all(...queryParams) as MessageRow[];
@@ -175,6 +177,9 @@ ORDER BY m.sequence ASC`,
    * Return ALL messages for a thread with sequence <= maxSequence,
    * in ascending sequence order. No row limit — used for fork resolution
    * where the full history up to the fork point is needed.
+   *
+   * Callers must enforce an upper bound on `maxSequence` or total rows
+   * (see `AgentService` fork guard) so pathological threads cannot OOM the server.
    */
   listByThreadUpToSequence(
     threadId: string,
@@ -182,13 +187,8 @@ ORDER BY m.sequence ASC`,
   ): Message[] {
     const rows = this.db
       .prepare(
-        `SELECT ${MESSAGE_COLUMNS_PREFIXED}, tc_count.cnt as tool_call_count
+        `SELECT ${MESSAGE_COLUMNS_PREFIXED}, ${TOOL_CALL_COUNT_SQL}
 FROM messages m
-LEFT JOIN (
-  SELECT message_id, COUNT(*) as cnt
-  FROM tool_call_records
-  GROUP BY message_id
-) tc_count ON tc_count.message_id = m.id
 WHERE m.thread_id = ? AND m.sequence <= ?
 ORDER BY m.sequence ASC`,
       )

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -742,6 +742,14 @@ export class AgentService {
       throw new Error(`Fork message not found in parent thread: ${resolvedForkMessageId}`);
     }
 
+    /** Guards fork handoff against loading unbounded history into memory. */
+    const FORK_HISTORY_MAX_SEQUENCE = 10_000;
+    if (forkMessage.sequence > FORK_HISTORY_MAX_SEQUENCE) {
+      throw new Error(
+        `Fork point is too far back in this thread (sequence ${forkMessage.sequence}; max ${FORK_HISTORY_MAX_SEQUENCE}). Choose a more recent message to branch from.`,
+      );
+    }
+
     // Load all messages up to and including the fork point — no row cap.
     const forkedMessages = this.messageRepo.listByThreadUpToSequence(
       parentThreadId,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -746,7 +746,7 @@ export class AgentService {
     const FORK_HISTORY_MAX_SEQUENCE = 10_000;
     if (forkMessage.sequence > FORK_HISTORY_MAX_SEQUENCE) {
       throw new Error(
-        `Fork point is too far back in this thread (sequence ${forkMessage.sequence}; max ${FORK_HISTORY_MAX_SEQUENCE}). Choose a more recent message to branch from.`,
+        `Fork point includes too much prior history (sequence ${forkMessage.sequence}; max ${FORK_HISTORY_MAX_SEQUENCE}). Choose an earlier message (lower sequence) to branch from.`,
       );
     }
 

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -4,7 +4,10 @@
     "noEmit": false,
     "outDir": "dist-tsc",
     "declaration": false,
-    "declarationMap": false
+    "declarationMap": false,
+    // dist-tsc is only an esbuild input. Per-file .source maps race `tsc --watch` on Windows
+    // (esbuild can read an empty .map mid-write) and break the desktop dev bundle.
+    "sourceMap": false
   },
   "exclude": ["node_modules", "dist", "dist-tsc", "src/__tests__"]
 }

--- a/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
+++ b/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
@@ -47,9 +47,16 @@ describe("Agent event thread isolation", () => {
     });
     useToastStore.setState({ toasts: [] });
     vi.clearAllMocks();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback): number => {
+      queueMicrotask(() => {
+        cb(0);
+      });
+      return 1;
+    });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -195,7 +202,7 @@ describe("Agent event thread isolation", () => {
   // ── Streaming isolation ──────────────────────────────────────────────
 
   describe("streaming text isolation", () => {
-    it("textDelta for background thread does not appear in active thread's streaming", () => {
+    it("textDelta for background thread does not appear in active thread's streaming", async () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
       handleAgentEvent(THREAD_B, {
@@ -203,6 +210,9 @@ describe("Agent event thread isolation", () => {
         delta: "background text",
       });
 
+      for (let i = 0; i < 8; i++) {
+        await Promise.resolve();
+      }
       const state = useThreadStore.getState();
       expect(state.streamingByThread[THREAD_A]).toBeUndefined();
       expect(state.streamingByThread[THREAD_B]).toBe("background text");

--- a/apps/web/src/__tests__/streaming.test.ts
+++ b/apps/web/src/__tests__/streaming.test.ts
@@ -211,8 +211,22 @@ describe("duplicate message prevention", () => {
 });
 
 describe("session.textDelta", () => {
+  /** Drain microtasks for mocked requestAnimationFrame (matches store assign-then-callback ordering). */
+  async function flushRafChain(): Promise<void> {
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+  }
+
   beforeEach(() => {
-    vi.useFakeTimers();
+    // Thread store coalesces deltas on rAF; fake timers don't run those frames,
+    // and a stuck frame leaves pending state that leaks across examples.
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback): number => {
+      queueMicrotask(() => {
+        cb(0);
+      });
+      return 1;
+    });
     useWorkspaceStore.setState({ threads: [createMockThread({ id: "thread-1" })] });
     useThreadStore.setState({
       messages: [],
@@ -226,23 +240,27 @@ describe("session.textDelta", () => {
     });
   });
 
-  afterEach(() => { vi.useRealTimers(); });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-  it("appends delta to streamingByThread", () => {
+  it("appends delta to streamingByThread", async () => {
     const { handleAgentEvent } = useThreadStore.getState();
     handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: "Hello" } });
     handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: " world" } });
 
+    await flushRafChain();
     expect(useThreadStore.getState().streamingByThread["thread-1"]).toBe("Hello world");
   });
 
-  it("stores full text in streamingByThread and truncated preview in streamingPreviewByThread", () => {
+  it("stores full text in streamingByThread and truncated preview in streamingPreviewByThread", async () => {
     const longText = "x".repeat(250);
     useThreadStore.setState({ streamingByThread: { "thread-1": longText } });
     const { handleAgentEvent } = useThreadStore.getState();
 
     handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: "end" } });
 
+    await flushRafChain();
     const state = useThreadStore.getState();
     // Full buffer is preserved
     expect(state.streamingByThread["thread-1"]).toBe(longText + "end");
@@ -253,7 +271,7 @@ describe("session.textDelta", () => {
     expect(preview.endsWith("end")).toBe(true);
   });
 
-  it("marks prior tool calls complete on first textDelta", () => {
+  it("marks prior tool calls complete on first textDelta", async () => {
     useThreadStore.setState({
       toolCallsByThread: {
         "thread-1": [
@@ -264,14 +282,16 @@ describe("session.textDelta", () => {
     const { handleAgentEvent } = useThreadStore.getState();
     handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: "Hi" } });
 
+    await flushRafChain();
     const calls = useThreadStore.getState().toolCallsByThread["thread-1"];
     expect(calls[0].isComplete).toBe(true);
   });
 
-  it("does not affect other threads", () => {
+  it("does not affect other threads", async () => {
     const { handleAgentEvent } = useThreadStore.getState();
     handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: "ping" } });
 
+    await flushRafChain();
     expect(useThreadStore.getState().streamingByThread["thread-2"]).toBeUndefined();
   });
 });

--- a/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
+++ b/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useThreadStore } from "@/stores/threadStore";
+
+describe("threadStore textDelta batching", () => {
+  beforeEach(() => {
+    useThreadStore.setState({
+      streamingByThread: {},
+      streamingPreviewByThread: {},
+      toolCallsByThread: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("schedules one rAF for many deltas and applies combined text when the frame runs", () => {
+    const queue: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      queue.push(cb);
+      return queue.length;
+    });
+
+    const tid = "thread-coalesce";
+    for (let i = 0; i < 8; i++) {
+      useThreadStore.getState().handleAgentEvent(tid, {
+        method: "session.textDelta",
+        params: { delta: String(i) },
+      });
+    }
+
+    expect(queue).toHaveLength(1);
+    expect(useThreadStore.getState().streamingByThread[tid]).toBeUndefined();
+
+    queue[0]!(0);
+
+    expect(useThreadStore.getState().streamingByThread[tid]).toBe("01234567");
+  });
+
+  it("flushes pending deltas before session.turnComplete reads streaming", () => {
+    const queue: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      queue.push(cb);
+      return queue.length;
+    });
+
+    const tid = "thread-flush";
+    useThreadStore.getState().handleAgentEvent(tid, {
+      method: "session.textDelta",
+      params: { delta: "hello " },
+    });
+    expect(queue).toHaveLength(1);
+
+    useThreadStore.getState().handleAgentEvent(tid, {
+      method: "session.turnComplete",
+      params: { costUsd: null, tokensIn: 0, tokensOut: 0 },
+    });
+
+    expect(useThreadStore.getState().streamingByThread[tid]).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,14 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, lazy, Suspense } from "react";
 import { Sidebar } from "@/components/sidebar/Sidebar";
 import { ChatView } from "@/components/chat/ChatView";
-import { SettingsView } from "@/components/settings/SettingsView";
 import { ConnectionBanner } from "@/components/ConnectionBanner";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { useUpdateStore } from "@/stores/updateStore";
 import type { UpdateStatus } from "@/transport/desktop-bridge";
-import { TerminalPanel } from "@/components/terminal";
-import { RightPanel } from "@/components/panels/RightPanel";
-import { CommandPalette } from "@/components/palette/CommandPalette";
 import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
 import { ProjectSelectorLanding } from "@/components/projects/ProjectSelectorLanding";
 import { SidebarRevealButton } from "@/components/sidebar/SidebarRevealButton";
@@ -28,6 +24,26 @@ import { useIdleReclamation } from "@/hooks/useIdleReclamation";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ToastContainer } from "@/components/Toast";
 import type { SettingsSection } from "@/components/settings/settings-nav";
+
+const LazySettingsView = lazy(async () => {
+  const m = await import("@/components/settings/SettingsView");
+  return { default: m.SettingsView };
+});
+
+const LazyTerminalPanel = lazy(async () => {
+  const m = await import("@/components/terminal");
+  return { default: m.TerminalPanel };
+});
+
+const LazyRightPanel = lazy(async () => {
+  const m = await import("@/components/panels/RightPanel");
+  return { default: m.RightPanel };
+});
+
+const LazyCommandPalette = lazy(async () => {
+  const m = await import("@/components/palette/CommandPalette");
+  return { default: m.CommandPalette };
+});
 
 /**
  * Tracks threads for which a PTY creation RPC is already in flight.
@@ -366,7 +382,9 @@ export function App() {
             <div className="flex flex-1 gap-1.5 overflow-hidden">
               <main className="flex-1 overflow-hidden rounded-lg bg-background shadow-sm">
                 {settingsOpen ? (
-                  <SettingsView section={settingsSection} />
+                  <Suspense fallback={null}>
+                    <LazySettingsView section={settingsSection} />
+                  </Suspense>
                 ) : showLanding ? (
                   <div className="flex h-full flex-col">
                     {/* When the sidebar is collapsed, show the reveal button so the
@@ -382,13 +400,23 @@ export function App() {
                   <ChatView />
                 )}
               </main>
-              {!settingsOpen && !showLanding && <RightPanel />}
+              {!settingsOpen && !showLanding && (
+                <Suspense fallback={null}>
+                  <LazyRightPanel />
+                </Suspense>
+              )}
             </div>
-            {!settingsOpen && !showLanding && <TerminalPanel />}
+            {!settingsOpen && !showLanding && (
+              <Suspense fallback={null}>
+                <LazyTerminalPanel />
+              </Suspense>
+            )}
           </div>
         </div>
       </div>
-      <CommandPalette />
+      <Suspense fallback={null}>
+        <LazyCommandPalette />
+      </Suspense>
       <ShortcutHelpDialog />
       <ToastContainer />
     </TooltipProvider>

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -177,7 +177,7 @@ export function ChatView() {
   const loadMessages = useThreadStore((s) => s.loadMessages);
   const clearMessages = useThreadStore((s) => s.clearMessages);
   const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
-  const messages = useThreadStore((s) => s.messages);
+  const messageCount = useThreadStore((s) => s.messages.length);
   const setPendingPrefill = useComposerDraftStore((s) => s.setPendingPrefill);
 
   const isAgentRunning = activeThreadId ? runningThreadIds.has(activeThreadId) : false;
@@ -415,7 +415,7 @@ export function ChatView() {
     );
   }
 
-  const hasMessages = messages.length > 0;
+  const hasMessages = messageCount > 0;
   const showEmptyState = !hasMessages && !isAgentRunning;
 
   return (

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1496,6 +1496,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     setPrDismissed(false);
     const currentAttachments = collectAndClearAttachments();
     if (threadId) clearDraftFromStore(threadId);
+    // Hide the reply bar with the composer reset; sendMessage still receives reply IDs from this render.
+    if (threadId) clearReply(threadId);
 
     if (isNewThread && workspaceId) {
       await useWorkspaceStore
@@ -1566,7 +1568,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         replyContext?.messageId,
         replyContext?.quotedText,
       );
-      if (threadId) clearReply(threadId);
     }
 
     // Auto-save last-used mode and access as defaults (model defaults are managed in Settings)
@@ -2110,6 +2111,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                     next.replyToMessageId,
                     next.quotedText,
                   );
+                  clearReply(threadId);
                 } catch {
                   void releaseBrowserCaptureSpills(next.browserCaptureSpillPaths ?? []);
                 }

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -2111,7 +2111,13 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                     next.replyToMessageId,
                     next.quotedText,
                   );
-                  clearReply(threadId);
+                  const activeReply = useReplyStore.getState().getReply(threadId);
+                  if (
+                    next.replyToMessageId &&
+                    activeReply?.messageId === next.replyToMessageId
+                  ) {
+                    clearReply(threadId);
+                  }
                 } catch {
                   void releaseBrowserCaptureSpills(next.browserCaptureSpillPaths ?? []);
                 }

--- a/apps/web/src/components/chat/CreatePrDialog.tsx
+++ b/apps/web/src/components/chat/CreatePrDialog.tsx
@@ -125,7 +125,9 @@ export function CreatePrDialog({
   workspaceId,
   branch,
 }: CreatePrDialogProps) {
-  const { branches, branchesLoading, loadBranches } = useWorkspaceStore();
+  const branches = useWorkspaceStore((s) => s.branches);
+  const branchesLoading = useWorkspaceStore((s) => s.branchesLoading);
+  const loadBranches = useWorkspaceStore((s) => s.loadBranches);
 
   const [state, setState] = useState<DialogState>("ready");
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/src/components/palette/views/BrowseView.tsx
+++ b/apps/web/src/components/palette/views/BrowseView.tsx
@@ -36,7 +36,8 @@ export function BrowseView() {
   const setQuery = useCommandPaletteStore((s) => s.setQuery);
   const setPendingConfirm = useCommandPaletteStore((s) => s.setPendingConfirm);
   const close = useCommandPaletteStore((s) => s.close);
-  const { createWorkspace, setActiveWorkspace } = useWorkspaceStore();
+  const createWorkspace = useWorkspaceStore((s) => s.createWorkspace);
+  const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
 
   const mode = getPaletteMode(query);
   const isDrivesMode = mode === "drives";

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -318,8 +318,41 @@ export function extractPendingPlanQuestions(
 }
 
 export const useThreadStore = create<ThreadState>((set, get) => {
+  let textDeltaFlushRaf: number | null = null;
+  const pendingTextDeltaByThread = new Map<string, string>();
+
+  /** Applies coalesced `session.textDelta` strings batched on `requestAnimationFrame`. */
+  const flushPendingTextDeltas = () => {
+    if (pendingTextDeltaByThread.size === 0) return;
+    const batch = new Map(pendingTextDeltaByThread);
+    pendingTextDeltaByThread.clear();
+    set((state) => {
+      const nextStreaming = { ...state.streamingByThread };
+      const nextPreview = { ...state.streamingPreviewByThread };
+      for (const [tid, acc] of batch) {
+        if (!acc) continue;
+        const cur = nextStreaming[tid] ?? "";
+        const combined = cur + acc;
+        nextStreaming[tid] = combined;
+        nextPreview[tid] = combined.length > 200 ? combined.slice(-200) : combined;
+      }
+      return {
+        streamingByThread: nextStreaming,
+        streamingPreviewByThread: nextPreview,
+      };
+    });
+  };
+
+  const scheduleTextDeltaFlush = () => {
+    if (textDeltaFlushRaf != null) return;
+    textDeltaFlushRaf = requestAnimationFrame(() => {
+      textDeltaFlushRaf = null;
+      flushPendingTextDeltas();
+    });
+  };
+
   return {
-  messages: [],
+    messages: [],
   runningThreadIds: new Set<string>(),
   loading: false,
   errorByThread: {},
@@ -376,6 +409,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * real-time state intact to avoid disrupting live tool call rendering.
    */
   loadMessages: async (threadId) => {
+    flushPendingTextDeltas();
     // Cache-hit fast path. Restores message-loading state synchronously,
     // skipping the getMessages RPC and avoiding the blank-flash transition.
     const cached = getCachedSnapshot(threadId);
@@ -959,6 +993,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * Does NOT reset runningThreadIds since agents may still be executing.
    */
   clearMessages: () => {
+    flushPendingTextDeltas();
     const current = get().currentThreadId;
     if (current) evictMessageCache(current);
 
@@ -1397,6 +1432,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     const method = (event.method as string) || "";
     const params = (event.params as Record<string, unknown>) || event;
 
+    if (method !== "session.textDelta") {
+      flushPendingTextDeltas();
+    }
+
     // Only evict the message cache on structural changes that add or modify
     // persisted messages. Streaming deltas (textDelta, toolProgress) are
     // ephemeral and don't change what loadMessages would return from the DB.
@@ -1679,17 +1718,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (method === "session.textDelta") {
       const delta = (params.delta as string) || "";
       if (!delta) return;
-      // Text deltas signal Claude is responding — mark prior tool calls complete.
-      markPriorToolCallsComplete();
-      set((state) => {
-        const current = state.streamingByThread[threadId] ?? "";
-        const combined = current + delta;
-        const preview = combined.length > 200 ? combined.slice(-200) : combined;
-        return {
-          streamingByThread: { ...state.streamingByThread, [threadId]: combined },
-          streamingPreviewByThread: { ...state.streamingPreviewByThread, [threadId]: preview },
-        };
-      });
+      const hadPending = pendingTextDeltaByThread.has(threadId);
+      pendingTextDeltaByThread.set(
+        threadId,
+        (pendingTextDeltaByThread.get(threadId) ?? "") + delta,
+      );
+      if (!hadPending) {
+        markPriorToolCallsComplete();
+      }
+      scheduleTextDeltaFlush();
       return;
     }
 
@@ -2232,6 +2269,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   },
 
   handleTurnPersisted: (payload) => {
+    flushPendingTextDeltas();
     evictMessageCache(payload.threadId);
 
     set((state) => {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -317,12 +317,17 @@ export function extractPendingPlanQuestions(
   }
 }
 
+/** Zustand store for thread-scoped messages, streaming session state, and agent event handling. */
 export const useThreadStore = create<ThreadState>((set, get) => {
   let textDeltaFlushRaf: number | null = null;
   const pendingTextDeltaByThread = new Map<string, string>();
 
   /** Applies coalesced `session.textDelta` strings batched on `requestAnimationFrame`. */
   const flushPendingTextDeltas = () => {
+    if (textDeltaFlushRaf != null) {
+      cancelAnimationFrame(textDeltaFlushRaf);
+      textDeltaFlushRaf = null;
+    }
     if (pendingTextDeltaByThread.size === 0) return;
     const batch = new Map(pendingTextDeltaByThread);
     pendingTextDeltaByThread.clear();


### PR DESCRIPTION
## What

Performance and reliability improvements across server, web, and desktop, plus a composer fix so the reply bar clears when a message is sent.

## Why

Reduce load and churn on hot paths (SQL, streaming UI updates, initial bundle), stop incomplete `dist-tsc` source maps from breaking desktop dev esbuild on Windows, and keep reply UI consistent with an empty composer after send.

## Key Changes

- **Server:** Correlated subquery for per-message tool call counts in `message-repo`; fork guard when listing messages by sequence.
- **Web:** Coalesce `session.textDelta` in `threadStore` via `requestAnimationFrame`; flush before non-delta events and key loads; narrower store selectors in a few views; lazy-load heavy App panels with `React.lazy` and `Suspense`.
- **Desktop:** Turn off TypeScript `sourceMap` for `dist-tsc` only (esbuild still emits maps for the final bundle) to avoid watch races on Windows.
- **Web (UX):** Clear `replyStore` with the composer reset on send (including branch path) and after a successful queued-message dequeue.

## Verification

- `cd apps/web && bunx tsc --noEmit` (pass)
- `cd apps/web && bun run e2e` was not completed here (port 5173 already in use on runner). Run locally after freeing the port or with your usual Playwright setup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Major UI panes now load on demand for faster startup.

* **Bug Fixes**
  * Prevent branching from very old fork points (sequence >10,000).
  * Composer clears reply state correctly after non-agent sends.
  * Chat uses a lightweight message-count check.

* **Performance**
  * Thread listing computes per-message tool-call counts and now uses indexed access for faster queries.

* **Improvements**
  * Streaming text deltas are coalesced per thread and flushed on RAF to avoid frequent updates.

* **Tests**
  * Added/updated suites verifying streaming batching, RAF behavior, and DB query plans.

* **Chores**
  * Build config updated to disable per-file source maps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/437)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->