### PR TITLE
fix(: new thread from command palette clears active thread

### DIFF
--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -712,11 +712,17 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           root.append($createParagraphNode());
         });
       }
+      if (isNewThread) {
+        // Focus after the palette closes and Lexical has applied the empty root.
+        queueMicrotask(() => {
+          editorRef.current?.focus();
+        });
+      }
     }
 
     threadSwitchRef.current = true;
     prevThreadIdRef.current = threadId;
-  }, [threadId, saveDraft, getDraft]);
+  }, [threadId, isNewThread, saveDraft, getDraft]);
 
   // Selectors needed by the branch-mode effect below — must be declared before the effect
   // to avoid temporal dead zone errors in the dependency array.

--- a/apps/web/src/components/palette/views/ProjectsView.tsx
+++ b/apps/web/src/components/palette/views/ProjectsView.tsx
@@ -22,6 +22,7 @@ export function ProjectsView() {
   const nextAction = currentView?.kind === "projects" ? currentView.nextAction : undefined;
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
+  const setActiveThread = useWorkspaceStore((s) => s.setActiveThread);
   const setPendingNewThread = useWorkspaceStore((s) => s.setPendingNewThread);
   const pinWorkspace = useWorkspaceStore((s) => s.pinWorkspace);
 
@@ -55,7 +56,11 @@ export function ProjectsView() {
     setActiveWorkspace(id);
     // setActiveWorkspace clears `pendingNewThread`, so re-set it AFTER activation
     // when the caller asked us to chain into the new-thread state.
+    // Clear the active thread even when staying on the same workspace; otherwise
+    // `ChatView` stays on the old thread (same-workspace early-return + keep thread
+    // when thread belongs to selected workspace).
     if (nextAction === "newThread") {
+      setActiveThread(null);
       setPendingNewThread(true);
     }
     close();

--- a/apps/web/src/components/palette/views/__tests__/ProjectsView.test.tsx
+++ b/apps/web/src/components/palette/views/__tests__/ProjectsView.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi, beforeAll } from "vitest";
+import type { Workspace } from "@/transport/types";
+import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
+import { Command } from "@/components/ui/command";
+
+const hoisted = vi.hoisted(() => {
+  const pinnedWorkspace: Workspace = {
+    id: "ws-1",
+    name: "Alpha",
+    path: "/alpha",
+    provider_config: {},
+    is_git_repo: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    pinned: true,
+    last_opened_at: Date.now(),
+    sort_order: 0,
+    deleted_at: null,
+  };
+  return {
+    pinnedWorkspace,
+    setActiveWorkspace: vi.fn(),
+    setActiveThread: vi.fn(),
+    setPendingNewThread: vi.fn(),
+    enrich: vi.fn(),
+  };
+});
+
+beforeAll(() => {
+  if (typeof window.ResizeObserver === "undefined") {
+    window.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  Element.prototype.scrollIntoView = () => {};
+});
+
+vi.mock("@/stores/workspaceStore", () => ({
+  useWorkspaceStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      workspaces: [hoisted.pinnedWorkspace],
+      setActiveWorkspace: hoisted.setActiveWorkspace,
+      setActiveThread: hoisted.setActiveThread,
+      setPendingNewThread: hoisted.setPendingNewThread,
+      pinWorkspace: vi.fn(),
+    }),
+}));
+
+vi.mock("@/stores/projectSelectorStore", () => ({
+  useProjectSelectorStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      enrich: hoisted.enrich,
+      enrichmentCache: new Map(),
+    }),
+}));
+
+import { ProjectsView } from "../ProjectsView";
+
+/** cmdk list primitives require a parent {@link Command} for context. */
+function renderWithCommandPaletteShell(ui: ReactElement) {
+  return render(
+    <Command shouldFilter={false} loop>
+      {ui}
+    </Command>,
+  );
+}
+
+describe("ProjectsView", () => {
+  beforeEach(() => {
+    hoisted.setActiveWorkspace.mockClear();
+    hoisted.setActiveThread.mockClear();
+    hoisted.setPendingNewThread.mockClear();
+    hoisted.enrich.mockClear();
+    act(() => {
+      useCommandPaletteStore.getState().close();
+    });
+  });
+
+  it("clears the active thread and sets pending new thread when choosing a project after New Thread", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      useCommandPaletteStore.getState().open({
+        intent: "projects",
+        nextAction: "newThread",
+      });
+    });
+
+    renderWithCommandPaletteShell(<ProjectsView />);
+
+    await user.click(screen.getByTestId("project-row"));
+
+    expect(hoisted.setActiveWorkspace).toHaveBeenCalledWith("ws-1");
+    // cmdk's CommandItem and ProjectRow's onClick both call handleSelect on mouse pick.
+    expect(hoisted.setActiveThread).toHaveBeenCalledWith(null);
+    expect(hoisted.setPendingNewThread).toHaveBeenCalledWith(true);
+
+    expect(hoisted.setActiveWorkspace.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.setActiveThread.mock.invocationCallOrder[0]!,
+    );
+    expect(hoisted.setActiveThread.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.setPendingNewThread.mock.invocationCallOrder[0]!,
+    );
+
+    expect(useCommandPaletteStore.getState().isOpen).toBe(false);
+  });
+
+  it("only switches workspace when the projects view has no newThread follow-up", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      useCommandPaletteStore.getState().open({ intent: "projects" });
+    });
+
+    renderWithCommandPaletteShell(<ProjectsView />);
+
+    await user.click(screen.getByTestId("project-row"));
+
+    expect(hoisted.setActiveWorkspace).toHaveBeenCalledWith("ws-1");
+    expect(hoisted.setActiveThread).not.toHaveBeenCalled();
+    expect(hoisted.setPendingNewThread).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Fixes the command palette flow (**New Thread** then pick a project) when a thread is already open. The app now leaves that thread and shows the new-thread composer with the input focused.

## Why

ChatView only renders the new-thread UI when \pendingNewThread && !activeThreadId\. Choosing the same workspace as the current thread left \ctiveThreadId\ set (\setActiveWorkspace\ no-ops and keeps the thread for that workspace), so the old chat stayed visible.

## Key changes

- \ProjectsView\: when following \
extAction: newThread\, call \setActiveThread(null)\ after activating the workspace, then \setPendingNewThread(true)\ (same idea as the sidebar **New thread** control).
- \Composer\: after resetting the editor for new-thread mode, defer focus to the Lexical surface so the caret lands in the composer once the palette closes.
- \ProjectsView.test.tsx\: unit tests for the new-thread vs plain project selection paths (cmdk \Command\ shell and jsdom polyfills).

## Configuration changes

None.

## Related issues/PRs

None.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editor now reliably focuses when starting a new thread so the message input is immediately ready.
  * Selecting a project to create a new thread clears any prior thread state to avoid carrying context across workspaces.

* **Tests**
  * Added tests verifying project selection behavior, thread-clearing, pending-new-thread handling, and palette close behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/438)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->