### PR TITLE
fix(browser-preview): remove idle timer that blanked the view

### DIFF
--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -15,7 +15,10 @@ import {
 } from "@mcode/contracts";
 import { getMcodeDir, redactMcodeBrowserCaptureV2, spillWorkspaceDirSegment } from "@mcode/shared";
 
-const IDLE_MS = 120_000;
+// Idle teardown removed: the React shell already parks the view on unmount/tab-switch
+// via pushSync(false), so a timer-based teardown is redundant and caused the view to
+// go blank while the user was still looking at it.
+// const IDLE_MS = 120_000;
 
 /** Hard cap per guest-derived string before redaction so hostile pages cannot exhaust memory. */
 const GUEST_TEXT_SAFETY_MAX = 500_000;
@@ -141,11 +144,9 @@ function clearIdle(s: PreviewSession): void {
   }
 }
 
-function resetIdle(win: BrowserWindow, s: PreviewSession): void {
+/** No-op: idle teardown removed (the React shell parks the view on unmount). */
+function resetIdle(_win: BrowserWindow, s: PreviewSession): void {
   clearIdle(s);
-  s.idleTimer = setTimeout(() => {
-    parkPreview(win, s);
-  }, IDLE_MS);
 }
 
 /** Full viewport bounds in BrowserView-relative CSS pixels. */


### PR DESCRIPTION
## What

Browser preview went blank after ~2 minutes of passive viewing.

## Why

The 120-second idle timer (`IDLE_MS`) in `preview-browser.ts` called `parkPreview()`, which destroyed the `BrowserView` and its `webContents`. The timer only reset on resize events from the React shell - not on user viewing. The React shell already parks the view explicitly on unmount, tab switch, and window close via `pushSync(false)`, making the timer redundant.

## Key changes

- Disabled the `IDLE_MS` constant (no longer used)
- `resetIdle()` now only clears any existing timer without scheduling a new one
- All 30+ call sites left intact (no-op) to avoid unnecessary churn

## Configuration changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the embedded preview experience by removing the automatic timeout behavior that was closing the preview view during periods of inactivity. The preview window now remains available throughout your session, allowing for uninterrupted development and testing workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/439)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->