### PR TITLE
fix(preview): add cancel button to capture overlays

### DIFF
--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -1017,6 +1017,26 @@ function detachViewListeners(view: BrowserView): void {
   view.webContents.removeAllListeners("console-message");
 }
 
+/** Height in px of the cancel-pill bar above the overlay's interactive area. */
+const OVERLAY_PILL_HEIGHT = 28;
+
+/** Shared CSS + HTML for the cancel-pill bar used by both region and element-pick overlays. */
+const OVERLAY_PILL_STYLES = `
+#pill-bar{position:fixed;top:0;left:0;right:0;height:${OVERLAY_PILL_HEIGHT}px;display:flex;align-items:center;justify-content:center;background:rgb(15,23,42);}
+@media(prefers-color-scheme:light){#pill-bar{background:rgb(238,236,232);}}
+#esc-pill{display:flex;align-items:center;gap:4px;min-height:28px;padding:8px 10px 8px 8px;border:1px solid rgba(255,255,255,.18);border-radius:6px;background:rgba(15,23,42,.72);backdrop-filter:blur(8px);color:rgba(255,255,255,.85);font:500 11px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;letter-spacing:.04em;cursor:pointer;user-select:none;transition:background .12s,border-color .12s;}
+#esc-pill:hover{background:rgba(15,23,42,.88);border-color:rgba(255,255,255,.32);}
+#esc-pill:focus-visible{outline:2px solid rgba(255,255,255,.6);outline-offset:2px;}
+#esc-pill kbd{display:inline-block;padding:1px 5px;border:1px solid rgba(255,255,255,.22);border-radius:3px;background:rgba(255,255,255,.08);font:inherit;font-size:10px;line-height:14px;}
+@media(prefers-color-scheme:light){
+#esc-pill{border-color:rgba(0,0,0,.12);background:rgba(255,255,255,.82);color:rgba(15,23,42,.85);}
+#esc-pill:hover{background:rgba(255,255,255,.95);border-color:rgba(0,0,0,.2);}
+#esc-pill:focus-visible{outline-color:rgba(15,23,42,.5);}
+#esc-pill kbd{border-color:rgba(0,0,0,.15);background:rgba(0,0,0,.06);}
+}`.trim();
+
+const OVERLAY_PILL_HTML = `<div id="pill-bar"><div id="esc-pill" role="button" tabindex="0" aria-label="Cancel capture"><kbd aria-hidden="true">Esc</kbd> Cancel</div></div>`;
+
 /**
  * Drag-marquee overlay: nodeIntegration is limited to this inline page string so OS-level
  * pointer events sit above the preview BrowserView while the user draws a crop rectangle.
@@ -1025,13 +1045,15 @@ const REGION_OVERLAY_DATA_URL =
   "data:text/html;charset=utf-8," +
   encodeURIComponent(`<!DOCTYPE html><html><head><meta charset="utf-8"/><style>
 html,body{margin:0;width:100%;height:100%;overflow:hidden;background:transparent;}
-#layer{position:fixed;inset:0;background:rgba(15,23,42,.35);cursor:crosshair;touch-action:none;}
+${OVERLAY_PILL_STYLES}
+#layer{position:fixed;top:${OVERLAY_PILL_HEIGHT}px;left:0;right:0;bottom:0;background:rgba(15,23,42,.35);cursor:crosshair;touch-action:none;}
 #box{position:fixed;border:2px dashed #fff;box-sizing:border-box;pointer-events:none;display:none;box-shadow:0 0 0 1px rgba(0,0,0,.4) inset;}
-</style></head><body><div id="layer"></div><div id="box"></div>
+</style></head><body>${OVERLAY_PILL_HTML}<div id="layer"></div><div id="box"></div>
 <script>
 const { ipcRenderer } = require("electron");
 const layer = document.getElementById("layer");
 const box = document.getElementById("box");
+const PILL_H = ${OVERLAY_PILL_HEIGHT};
 let start = null, drag = false, cx = 0, cy = 0;
 function lay() {
   if (!start) { box.style.display = "none"; return; }
@@ -1049,7 +1071,8 @@ function endDrag() {
   const x = Math.min(start.x, cx), y = Math.min(start.y, cy), w = Math.abs(cx - start.x), h = Math.abs(cy - start.y);
   start = null;
   box.style.display = "none";
-  if (w >= 4 && h >= 4) void ipcRenderer.invoke("preview:region-overlay-submit", { x, y, width: w, height: h });
+  /* y offset compensates for pill-bar height above the BrowserView */
+  if (w >= 4 && h >= 4) void ipcRenderer.invoke("preview:region-overlay-submit", { x, y: y - PILL_H, width: w, height: h });
   else void ipcRenderer.invoke("preview:region-overlay-cancel");
 }
 layer.addEventListener("mousedown", (ev) => { drag = true; start = pt(ev); cx = start.x; cy = start.y; lay(); });
@@ -1059,6 +1082,9 @@ layer.addEventListener("touchstart", (ev) => { ev.preventDefault(); drag = true;
 layer.addEventListener("touchmove", (ev) => { ev.preventDefault(); if (!drag) return; const p = pt(ev); cx = p.x; cy = p.y; lay(); }, { passive: false });
 layer.addEventListener("touchend", (ev) => { ev.preventDefault(); endDrag(); }, { passive: false });
 window.addEventListener("keydown", (ev) => { if (ev.key === "Escape") void ipcRenderer.invoke("preview:region-overlay-cancel"); });
+const pill = document.getElementById("esc-pill");
+pill.addEventListener("click", (ev) => { ev.stopPropagation(); void ipcRenderer.invoke("preview:region-overlay-cancel"); });
+pill.addEventListener("keydown", (ev) => { if (ev.key === "Enter" || ev.key === " ") { ev.preventDefault(); void ipcRenderer.invoke("preview:region-overlay-cancel"); } });
 </script></body></html>`);
 
 /**
@@ -1069,11 +1095,13 @@ const ELEMENT_OVERLAY_DATA_URL =
   "data:text/html;charset=utf-8," +
   encodeURIComponent(`<!DOCTYPE html><html><head><meta charset="utf-8"/><style>
 html,body{margin:0;width:100%;height:100%;overflow:hidden;background:transparent;}
-#layer{position:fixed;inset:0;background:rgba(15,23,42,.18);cursor:crosshair;touch-action:none;}
-</style></head><body><div id="layer"></div>
+${OVERLAY_PILL_STYLES}
+#layer{position:fixed;top:${OVERLAY_PILL_HEIGHT}px;left:0;right:0;bottom:0;background:rgba(15,23,42,.18);cursor:crosshair;touch-action:none;}
+</style></head><body>${OVERLAY_PILL_HTML}<div id="layer"></div>
 <script>
 const { ipcRenderer } = require("electron");
 const layer = document.getElementById("layer");
+const PILL_H = ${OVERLAY_PILL_HEIGHT};
 let rafHover = 0;
 let hx = 0, hy = 0;
 function scheduleHover() {
@@ -1081,17 +1109,17 @@ function scheduleHover() {
   rafHover = requestAnimationFrame(async () => {
     rafHover = 0;
     try {
-      await ipcRenderer.invoke("preview:element-pick-hover", { x: hx, y: hy });
+      await ipcRenderer.invoke("preview:element-pick-hover", { x: hx, y: hy - PILL_H });
     } catch (_e) {}
   });
 }
 function pt(ev) {
-  if (ev.touches && ev.touches[0]) return { x: ev.touches[0].clientX, y: ev.touches[0].clientY };
-  return { x: ev.clientX, y: ev.clientY };
+  if (ev.touches && ev.touches[0]) return { x: ev.touches[0].clientX, y: ev.touches[0].clientY - PILL_H };
+  return { x: ev.clientX, y: ev.clientY - PILL_H };
 }
 function ptEnd(ev) {
   if (ev.changedTouches && ev.changedTouches[0]) {
-    return { x: ev.changedTouches[0].clientX, y: ev.changedTouches[0].clientY };
+    return { x: ev.changedTouches[0].clientX, y: ev.changedTouches[0].clientY - PILL_H };
   }
   return pt(ev);
 }
@@ -1109,13 +1137,13 @@ layer.addEventListener("click", async (ev) => {
 });
 layer.addEventListener("touchstart", (ev) => {
   ev.preventDefault();
-  const p = pt(ev);
+  const p = { x: ev.touches[0].clientX, y: ev.touches[0].clientY };
   hx = p.x; hy = p.y;
   scheduleHover();
 }, { passive: false });
 layer.addEventListener("touchmove", (ev) => {
   ev.preventDefault();
-  const p = pt(ev);
+  const p = { x: ev.touches[0].clientX, y: ev.touches[0].clientY };
   hx = p.x; hy = p.y;
   scheduleHover();
 }, { passive: false });
@@ -1124,6 +1152,9 @@ layer.addEventListener("touchend", async (ev) => {
   try { await ipcRenderer.invoke("preview:element-pick-commit", ptEnd(ev)); } catch (_e) {}
 }, { passive: false });
 window.addEventListener("keydown", (ev) => { if (ev.key === "Escape") void ipcRenderer.invoke("preview:element-pick-cancel"); });
+const pill = document.getElementById("esc-pill");
+pill.addEventListener("click", (ev) => { ev.stopPropagation(); void ipcRenderer.invoke("preview:element-pick-cancel"); });
+pill.addEventListener("keydown", (ev) => { if (ev.key === "Enter" || ev.key === " ") { ev.preventDefault(); void ipcRenderer.invoke("preview:element-pick-cancel"); } });
 </script></body></html>`);
 
 function destroySelectionOverlayOnly(s: PreviewSession): void {
@@ -1842,14 +1873,14 @@ export function registerPreviewBrowserHandlers(): void {
         };
 
         const b = s.lastBounds!;
-
+        const cb = win.getContentBounds();
         const ov = new BrowserWindow({
           parent: win,
           modal: false,
-          x: Math.round(b.x),
-          y: Math.round(b.y),
+          x: Math.round(cb.x + b.x),
+          y: Math.round(cb.y + b.y - OVERLAY_PILL_HEIGHT),
           width: Math.max(1, Math.round(b.width)),
-          height: Math.max(1, Math.round(b.height)),
+          height: Math.max(1, Math.round(b.height + OVERLAY_PILL_HEIGHT)),
           frame: false,
           transparent: true,
           hasShadow: false,
@@ -1919,14 +1950,14 @@ export function registerPreviewBrowserHandlers(): void {
         };
 
         const b = s.lastBounds!;
-
+        const cb = win.getContentBounds();
         const ov = new BrowserWindow({
           parent: win,
           modal: false,
-          x: Math.round(b.x),
-          y: Math.round(b.y),
+          x: Math.round(cb.x + b.x),
+          y: Math.round(cb.y + b.y - OVERLAY_PILL_HEIGHT),
           width: Math.max(1, Math.round(b.width)),
-          height: Math.max(1, Math.round(b.height)),
+          height: Math.max(1, Math.round(b.height + OVERLAY_PILL_HEIGHT)),
           frame: false,
           transparent: true,
           hasShadow: false,


### PR DESCRIPTION
## What

Add a visible cancel affordance to the browser preview's region-drag and element-pick capture overlays. Fix overlay positioning bug when running multiple Mcode instances.

## Why

Users had no visible way to exit capture mode once started - the only mechanism was pressing Escape with no UI hint. Additionally, overlay windows were positioned using viewport-relative coordinates as screen coordinates, causing them to appear on the wrong window in multi-instance setups.

## Key changes

- **Cancel pill bar**: `[Esc] Cancel` button rendered in a 28px strip above the BrowserView overlay area, so it never blocks page content the user wants to select
- **Overlay positioning fix**: Convert viewport-relative `lastBounds` to screen coordinates via `win.getContentBounds()` before creating the overlay `BrowserWindow`
- **Theme-aware**: `prefers-color-scheme` media queries for light/dark pill-bar and button styles
- **Accessible**: `role="button"`, `aria-label`, `tabindex="0"`, `focus-visible` outline, Enter/Space keyboard activation
- **DRY**: Shared `OVERLAY_PILL_STYLES`, `OVERLAY_PILL_HTML`, and `OVERLAY_PILL_HEIGHT` constants used by both overlay templates
- **Coordinate math**: All IPC handlers subtract `OVERLAY_PILL_HEIGHT` from y-coordinates so hit-testing stays aligned with the BrowserView

## Test plan

- [ ] Open browser preview, load a page, click element-pick (crosshair) - cancel pill visible above the page, click or press Esc to cancel
- [ ] Same for region-drag (crop) - pill visible, cancel works
- [ ] Run two Mcode instances side by side, trigger capture in one - overlay appears on the correct window
- [ ] Tab to the cancel pill - focus ring visible, Enter/Space dismisses
- [ ] Element pick hit-testing still highlights correct elements after coordinate changes
- [ ] Region drag coordinates produce correct crop after y-offset adjustment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->