### PR TITLE
fix(composer): slash command autocomplete when trigger is mid-text

### DIFF
--- a/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
+++ b/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
@@ -74,8 +74,8 @@ export function SlashCommandPlugin({
           return;
         }
 
-        // Pass full text content to the existing hook's input handler
-        onTriggerRef.current(textContent);
+        // Pass only text before the cursor so the regex $ anchor matches
+        onTriggerRef.current(textBeforeCursor);
       });
     });
   }, [editor]);


### PR DESCRIPTION
## What

Slash command autocomplete now opens when the `/trigger` is surrounded by text (e.g., `some text /commit more text`), not only when it's at the end of the input.

## Why

`SlashCommandPlugin` passed the full text node content to `onInputChange`, but `useSlashCommand` treats `value.length` as the cursor position. The regex `/(^|\s)(\/\S*)$/` requires the trigger at the end of the string, so autocomplete never opened when any text followed the `/command`.

## Key changes

- `SlashCommandPlugin.tsx:78`: pass `textBeforeCursor` instead of `textContent` to `onTrigger`, so the regex `$` anchor matches at the actual cursor position
- No change to `insertSlashCommandNode` - it already reads cursor offset directly from the Lexical editor state

## Test plan

- [ ] Type `/commit` at the start of the input - autocomplete opens
- [ ] Type `some text /commit` at the end - autocomplete opens
- [ ] Type `some text /commit more text` with cursor after `/commit` - autocomplete opens
- [ ] Select a command from the popup mid-text - chip inserted correctly
- [ ] Existing slash-command unit tests pass (21/21)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed slash command triggering to correctly align with cursor position, improving command detection accuracy when the cursor is positioned within the text.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/443)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->