### PR TITLE
fix(preview): preserve BrowserView on tab switch and add local file preview

### DIFF
--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -1,0 +1,533 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Electron mocks
+// ---------------------------------------------------------------------------
+
+/** Tracks all registered ipcMain.handle handlers by channel name. */
+let ipcHandlers: Record<string, (...args: unknown[]) => unknown> = {};
+
+/** Tracks all registered ipcMain.on handlers by channel name. */
+let ipcOnHandlers: Record<string, (...args: unknown[]) => unknown> = {};
+
+/** Tracks BrowserView instances created during a test. */
+let createdViews: ReturnType<typeof makeBrowserView>[] = [];
+
+function makeBrowserView() {
+  const webContents = {
+    isDestroyed: vi.fn().mockReturnValue(false),
+    getURL: vi.fn().mockReturnValue("https://example.com"),
+    getTitle: vi.fn().mockReturnValue("Example"),
+    loadURL: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn(),
+    canGoBack: vi.fn().mockReturnValue(false),
+    canGoForward: vi.fn().mockReturnValue(false),
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+    reload: vi.fn(),
+    insertCSS: vi.fn().mockResolvedValue("css-key"),
+    removeInsertedCSS: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(),
+    removeAllListeners: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+    setBackgroundThrottling: vi.fn(),
+    executeJavaScript: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn(),
+  };
+  const view = {
+    webContents,
+    setBounds: vi.fn(),
+  };
+  createdViews.push(view);
+  return view;
+}
+
+/** Auto-incrementing window ID so each test gets a fresh session in the module-level sessions Map. */
+let nextWindowId = 1;
+
+/** Minimal BrowserWindow stub. */
+function makeWindow() {
+  const id = nextWindowId++;
+  let currentView: ReturnType<typeof makeBrowserView> | null = null;
+  return {
+    id,
+    isDestroyed: vi.fn().mockReturnValue(false),
+    getBrowserView: vi.fn(() => currentView),
+    setBrowserView: vi.fn((v: ReturnType<typeof makeBrowserView>) => {
+      currentView = v;
+    }),
+    removeBrowserView: vi.fn((v: ReturnType<typeof makeBrowserView>) => {
+      if (currentView === v) currentView = null;
+    }),
+    webContents: {
+      isDestroyed: vi.fn().mockReturnValue(false),
+      send: vi.fn(),
+    },
+  };
+}
+
+vi.mock("electron", () => ({
+  BrowserView: vi.fn(function () {
+    const view = makeBrowserView();
+    return view;
+  }),
+  BrowserWindow: {
+    fromWebContents: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      ipcHandlers[channel] = handler;
+    }),
+    on: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      ipcOnHandlers[channel] = handler;
+    }),
+  },
+  session: {
+    fromPartition: vi.fn(() => ({
+      setPermissionRequestHandler: vi.fn(),
+      webRequest: {
+        onCompleted: vi.fn(),
+      },
+    })),
+  },
+  shell: {
+    openExternal: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue("/tmp"),
+  },
+}));
+
+vi.mock("@mcode/contracts", () => ({
+  clampMcodeBrowserCaptureV2: vi.fn(),
+  isBrowserCaptureSpillAppDataPath: vi.fn().mockReturnValue(false),
+  MCODE_BROWSER_CAPTURE_V2_STRING_MAX: 100_000,
+}));
+
+vi.mock("@mcode/shared", () => ({
+  getMcodeDir: vi.fn().mockReturnValue("/tmp/mcode"),
+  redactMcodeBrowserCaptureV2: vi.fn(),
+  spillWorkspaceDirSegment: vi.fn().mockReturnValue("ws"),
+}));
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readdir: vi.fn().mockResolvedValue([]),
+    stat: vi.fn().mockResolvedValue({ mtimeMs: 0 }),
+    unlink: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { BrowserWindow } from "electron";
+import { registerPreviewBrowserHandlers, disposePreviewForWindow } from "../preview-browser.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Simulate an IPC event from a window. */
+function fakeEvent(win: ReturnType<typeof makeWindow>) {
+  (BrowserWindow.fromWebContents as ReturnType<typeof vi.fn>).mockReturnValue(win);
+  return { sender: win.webContents } as unknown;
+}
+
+const VALID_BOUNDS = { x: 100, y: 100, width: 800, height: 600 };
+
+/** Show the preview for a given thread. */
+async function showPreview(
+  win: ReturnType<typeof makeWindow>,
+  opts?: { threadId?: string; url?: string },
+) {
+  const ev = fakeEvent(win);
+  await ipcHandlers["preview:sync"]!(ev, {
+    visible: true,
+    bounds: VALID_BOUNDS,
+    threadId: opts?.threadId ?? "thread-1",
+    resumeUrlHint: opts?.url ?? "https://example.com",
+    workspaceId: "ws-1",
+  });
+}
+
+/** Hide the preview: calls preview:sync with visible=false. */
+async function hidePreview(
+  win: ReturnType<typeof makeWindow>,
+  opts?: { threadId?: string },
+) {
+  const ev = fakeEvent(win);
+  await ipcHandlers["preview:sync"]!(ev, {
+    visible: false,
+    bounds: null,
+    threadId: opts?.threadId ?? "thread-1",
+    workspaceId: "ws-1",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup - registerPreviewBrowserHandlers is called once (module-level ipcMain
+// handlers can only be registered once). Each test uses a unique window ID so
+// it gets a fresh PreviewSession from the module-level sessions Map.
+// ---------------------------------------------------------------------------
+
+let handlersRegistered = false;
+
+beforeEach(() => {
+  createdViews = [];
+  if (!handlersRegistered) {
+    registerPreviewBrowserHandlers();
+    handlersRegistered = true;
+  }
+});
+
+/** Track windows created per test so we can dispose their sessions afterward. */
+let testWindows: ReturnType<typeof makeWindow>[] = [];
+
+afterEach(() => {
+  for (const win of testWindows) {
+    disposePreviewForWindow(win as never);
+  }
+  testWindows = [];
+});
+
+/** Create a window and register it for cleanup. */
+function createWindow() {
+  const win = makeWindow();
+  testWindows.push(win);
+  return win;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("preview-browser", () => {
+  describe("hidePreview (tab switch)", () => {
+    it("detaches the BrowserView from the window without destroying webContents", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      expect(win.setBrowserView).toHaveBeenCalledWith(view);
+
+      await hidePreview(win);
+
+      expect(win.removeBrowserView).toHaveBeenCalledWith(view);
+      expect(view.webContents.close).not.toHaveBeenCalled();
+    });
+
+    it("sends loading-state false when hiding", async () => {
+      const win = createWindow();
+      await showPreview(win);
+      win.webContents.send.mockClear();
+
+      await hidePreview(win);
+
+      expect(win.webContents.send).toHaveBeenCalledWith(
+        "preview:loading-state",
+        { loading: false },
+      );
+    });
+  });
+
+  describe("re-show after hide", () => {
+    it("reattaches the same BrowserView without creating a new one", async () => {
+      const win = createWindow();
+      await showPreview(win);
+      const viewCountAfterFirstShow = createdViews.length;
+
+      await hidePreview(win);
+      await showPreview(win);
+
+      expect(createdViews.length).toBe(viewCountAfterFirstShow);
+    });
+
+    it("does not reload the page when re-showing the same thread", async () => {
+      const win = createWindow();
+      await showPreview(win, { url: "https://example.com" });
+
+      const view = createdViews[0]!;
+      view.webContents.loadURL.mockClear();
+      view.webContents.getURL.mockReturnValue("https://example.com");
+
+      await hidePreview(win);
+      await showPreview(win, { url: "https://example.com" });
+
+      expect(view.webContents.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("preserves navigation history across hide/show cycle", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      view.webContents.canGoBack.mockReturnValue(true);
+      view.webContents.canGoForward.mockReturnValue(false);
+      view.webContents.getURL.mockReturnValue("https://example.com/page2");
+
+      await hidePreview(win);
+      await showPreview(win);
+
+      const ev = fakeEvent(win);
+      const state = await ipcHandlers["preview:get-navigation-state"]!(ev);
+      expect(state).toEqual({ canGoBack: true, canGoForward: false });
+    });
+  });
+
+  describe("thread switch", () => {
+    it("loads the new thread URL when switching threads", async () => {
+      const win = createWindow();
+      await showPreview(win, { threadId: "thread-1", url: "https://one.com" });
+
+      const view = createdViews[0]!;
+      view.webContents.loadURL.mockClear();
+      view.webContents.getURL.mockReturnValue("https://one.com");
+
+      await showPreview(win, { threadId: "thread-2", url: "https://two.com" });
+
+      expect(view.webContents.loadURL).toHaveBeenCalledWith("https://two.com");
+    });
+  });
+
+  describe("disposePreviewForWindow (full teardown)", () => {
+    it("destroys webContents when the window is closing", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      win.removeBrowserView.mockClear();
+
+      disposePreviewForWindow(win as never);
+      // Remove from testWindows so afterEach doesn't double-dispose.
+      testWindows = testWindows.filter((w) => w !== win);
+
+      expect(win.removeBrowserView).toHaveBeenCalled();
+      expect(view.webContents.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("navigation controls", () => {
+    it("go-back calls webContents.goBack when history exists", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      view.webContents.canGoBack.mockReturnValue(true);
+
+      const ev = fakeEvent(win);
+      const result = await ipcHandlers["preview:go-back"]!(ev);
+
+      expect(result).toBe(true);
+      expect(view.webContents.goBack).toHaveBeenCalled();
+    });
+
+    it("go-back returns false when no history", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      view.webContents.canGoBack.mockReturnValue(false);
+
+      const ev = fakeEvent(win);
+      const result = await ipcHandlers["preview:go-back"]!(ev);
+
+      expect(result).toBe(false);
+      expect(view.webContents.goBack).not.toHaveBeenCalled();
+    });
+
+    it("go-forward calls webContents.goForward when history exists", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      view.webContents.canGoForward.mockReturnValue(true);
+
+      const ev = fakeEvent(win);
+      const result = await ipcHandlers["preview:go-forward"]!(ev);
+
+      expect(result).toBe(true);
+      expect(view.webContents.goForward).toHaveBeenCalled();
+    });
+  });
+
+  describe("local file preview", () => {
+    let tempDir: string;
+
+    beforeAll(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "preview-test-"));
+      writeFileSync(join(tempDir, "index.html"), "<h1>Hello</h1>");
+      writeFileSync(join(tempDir, "doc.pdf"), "%PDF-fake");
+      mkdirSync(join(tempDir, "sub"));
+      writeFileSync(join(tempDir, "sub", "page.html"), "<p>Sub</p>");
+      writeFileSync(join(tempDir, ".env"), "SECRET=123");
+      mkdirSync(join(tempDir, "hasindex"));
+      writeFileSync(join(tempDir, "hasindex", "index.html"), "<p>Index</p>");
+    });
+
+    afterAll(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    /** Navigate via the preview:navigate handler. */
+    async function navigate(
+      win: ReturnType<typeof makeWindow>,
+      url: string,
+      workspacePath?: string | null,
+    ) {
+      const ev = fakeEvent(win);
+      return ipcHandlers["preview:navigate"]!(ev, url, workspacePath ?? null) as Promise<
+        { ok: true } | { ok: false; error: string }
+      >;
+    }
+
+    it("navigates to an absolute file path", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const filePath = join(tempDir, "index.html");
+      const result = await navigate(win, filePath);
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith(
+        pathToFileURL(filePath).href,
+      );
+    });
+
+    it("navigates to a relative file path resolved against workspace", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "sub/page.html", tempDir);
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith(
+        pathToFileURL(join(tempDir, "sub", "page.html")).href,
+      );
+    });
+
+    it("returns error for relative path without workspace", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "sub/page.html", null);
+
+      expect(result).toEqual({ ok: false, error: "no-workspace" });
+    });
+
+    it("returns file-not-found for nonexistent file", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, join(tempDir, "nope.html"));
+
+      expect(result).toEqual({ ok: false, error: "file-not-found" });
+    });
+
+    it("blocks sensitive files (.env)", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, join(tempDir, ".env"));
+
+      expect(result).toEqual({ ok: false, error: "sensitive-file" });
+    });
+
+    it("resolves directory with index.html", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, join(tempDir, "hasindex"));
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith(
+        pathToFileURL(join(tempDir, "hasindex", "index.html")).href,
+      );
+    });
+
+    it("returns is-directory for directory without index.html", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, join(tempDir, "sub"));
+
+      expect(result).toEqual({ ok: false, error: "is-directory" });
+    });
+
+    it("still navigates to http URLs normally", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "https://example.com");
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith("https://example.com");
+    });
+
+    it("still prepends https:// to bare domains", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "example.com");
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith("https://example.com");
+    });
+
+    it("navigates to file with browser-viewable extension", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "./doc.pdf", tempDir);
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith(
+        pathToFileURL(join(tempDir, "doc.pdf")).href,
+      );
+    });
+
+    it("blocks explicit file:// URL pointing to a sensitive file", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const envUrl = pathToFileURL(join(tempDir, ".env")).href;
+      const result = await navigate(win, envUrl);
+
+      expect(result).toEqual({ ok: false, error: "sensitive-file" });
+    });
+
+    it("allows explicit file:// URL pointing to a safe file", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const htmlUrl = pathToFileURL(join(tempDir, "index.html")).href;
+      const result = await navigate(win, htmlUrl);
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith(htmlUrl);
+    });
+
+    it("treats domain-like input with file extension as URL, not file path", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "example.com/page.html");
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith("https://example.com/page.html");
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -121,7 +121,6 @@ vi.mock("node:fs/promises", async () => {
     mkdir: vi.fn().mockResolvedValue(undefined),
     writeFile: vi.fn().mockResolvedValue(undefined),
     readdir: vi.fn().mockResolvedValue([]),
-    stat: vi.fn().mockResolvedValue({ mtimeMs: 0 }),
     unlink: vi.fn().mockResolvedValue(undefined),
   };
 });
@@ -539,6 +538,45 @@ describe("preview-browser", () => {
       // Should resolve through the symlink target directory's index.html.
       expect(view.webContents.loadURL).toHaveBeenCalledWith(
         pathToFileURL(join(tempDir, "hasindex", "index.html")).href,
+      );
+    });
+
+    it("blocks hosted file:// URLs with a non-local hostname", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "file://evil-host/C:/Windows/not-real.ini");
+
+      expect(result).toEqual({ ok: false, error: "sensitive-file" });
+    });
+
+    it("blocks UNC paths when entered as a Windows share path", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "\\\\fake-server\\share\\page.html");
+
+      expect(result).toEqual({ ok: false, error: "sensitive-file" });
+    });
+
+    it("resolves directory index when index.html is a symlink to a file", async () => {
+      const dirWithSymlinkIndex = join(tempDir, "symlink-index-dir");
+      mkdirSync(dirWithSymlinkIndex);
+      try {
+        symlinkSync(join(tempDir, "hasindex", "index.html"), join(dirWithSymlinkIndex, "index.html"));
+      } catch {
+        return;
+      }
+
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, dirWithSymlinkIndex);
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith(
+        pathToFileURL(join(dirWithSymlinkIndex, "index.html")).href,
       );
     });
 

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -519,6 +519,29 @@ describe("preview-browser", () => {
       expect(view.webContents.loadURL).toHaveBeenCalledWith(htmlUrl);
     });
 
+    it("follows symlink to directory and returns index.html", async () => {
+      // Create a symlink to the "hasindex" directory.
+      const linkPath = join(tempDir, "link-to-dir");
+      try {
+        symlinkSync(join(tempDir, "hasindex"), linkPath, "junction");
+      } catch {
+        // Symlink creation may require elevated privileges on Windows; skip.
+        return;
+      }
+
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, linkPath);
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      // Should resolve through the symlink target directory's index.html.
+      expect(view.webContents.loadURL).toHaveBeenCalledWith(
+        pathToFileURL(join(tempDir, "hasindex", "index.html")).href,
+      );
+    });
+
     it("treats domain-like input with file extension as URL, not file path", async () => {
       const win = createWindow();
       await showPreview(win);

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -144,8 +144,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     }): Promise<void> {
       return ipcRenderer.invoke("preview:sync", payload);
     },
-    navigate(url: string): Promise<{ ok: true } | { ok: false; error: string }> {
-      return ipcRenderer.invoke("preview:navigate", url);
+    navigate(url: string, workspacePath?: string | null): Promise<{ ok: true } | { ok: false; error: string }> {
+      return ipcRenderer.invoke("preview:navigate", url, workspacePath ?? null);
     },
     goBack(): Promise<boolean> {
       return ipcRenderer.invoke("preview:go-back");

--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -1405,15 +1405,17 @@ async function resolveLocalFileUrl(
   }
 
   try {
-    const info = await lstat(resolved);
+    let info = await lstat(resolved);
     if (info.isSymbolicLink()) {
       const real = await realpath(resolved);
       if (isSensitivePath(real)) {
         return { ok: false, error: "sensitive-file" };
       }
+      // Follow the symlink so subsequent checks use the target's type.
+      resolved = real;
+      info = await lstat(real);
     }
     if (info.isDirectory()) {
-      // Try index.html inside the directory.
       const indexPath = join(resolved, "index.html");
       try {
         const indexInfo = await lstat(indexPath);
@@ -1424,7 +1426,7 @@ async function resolveLocalFileUrl(
         return { ok: false, error: "is-directory" };
       }
     }
-    if (!info.isFile() && !info.isSymbolicLink()) {
+    if (!info.isFile()) {
       return { ok: false, error: "not-a-file" };
     }
   } catch {
@@ -1469,6 +1471,26 @@ function guestUrlNeedsHttpRestore(url: string): boolean {
   return false;
 }
 
+/**
+ * Validates a resume/hint URL before loading. HTTP(S) URLs pass through;
+ * file:// URLs are re-checked through resolveLocalFileUrl to prevent
+ * renderer-supplied hints from bypassing sensitive-path guards.
+ */
+async function validateResumeUrl(url: string | null): Promise<string | null> {
+  if (!url || !isAllowedPreviewUrl(url)) return null;
+  try {
+    const u = new URL(url);
+    if (u.protocol === "file:") {
+      const filePath = fileURLToPath(url);
+      const result = await resolveLocalFileUrl(filePath, null);
+      return result.ok ? result.url : null;
+    }
+  } catch {
+    return null;
+  }
+  return url;
+}
+
 /** Registers ipcMain handlers for `preview:*` channels (call once at startup). */
 export function registerPreviewBrowserHandlers(): void {
   const previewPartition = session.fromPartition("persist:mcode-preview");
@@ -1495,7 +1517,7 @@ export function registerPreviewBrowserHandlers(): void {
 
   ipcMain.handle(
     "preview:sync",
-    (
+    async (
       _event,
       payload: {
         visible: boolean;
@@ -1534,27 +1556,29 @@ export function registerPreviewBrowserHandlers(): void {
 
         // One BrowserView is shared across threads; without an explicit navigation on switch,
         // the previous thread's document (and resumePreviewUrl) would leak into the next thread.
+        const safeHint = await validateResumeUrl(hint);
         if (switchedThread) {
-          if (hint) {
+          if (safeHint) {
             sendPreviewLoading(win, true);
-            void wc.loadURL(hint);
-            s.resumePreviewUrl = hint;
+            void wc.loadURL(safeHint);
+            s.resumePreviewUrl = safeHint;
           } else {
             s.resumePreviewUrl = null;
             sendPreviewLoading(win, true);
             void wc.loadURL("about:blank");
           }
-        } else if (guestUrlNeedsHttpRestore(current) && hint) {
+        } else if (guestUrlNeedsHttpRestore(current) && safeHint) {
           sendPreviewLoading(win, true);
-          void wc.loadURL(hint);
-          s.resumePreviewUrl = hint;
-        } else if (
-          guestUrlNeedsHttpRestore(current) &&
-          s.resumePreviewUrl &&
-          isAllowedPreviewUrl(s.resumePreviewUrl)
-        ) {
-          sendPreviewLoading(win, true);
-          void wc.loadURL(s.resumePreviewUrl);
+          void wc.loadURL(safeHint);
+          s.resumePreviewUrl = safeHint;
+        } else if (guestUrlNeedsHttpRestore(current) && s.resumePreviewUrl) {
+          const safeResume = await validateResumeUrl(s.resumePreviewUrl);
+          if (safeResume) {
+            sendPreviewLoading(win, true);
+            void wc.loadURL(safeResume);
+          } else {
+            s.resumePreviewUrl = null;
+          }
         }
       }
       resetIdle(win, s);

--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -115,6 +115,11 @@ interface PreviewSession {
   workspaceId: string | null;
   /** Favicon URLs from the last page-favicon-updated event. */
   lastFavicons: string[];
+  /**
+   * Lets the next main-process `file:` navigation skip {@link ensureView}'s will-navigate gate,
+   * since those loads already passed {@link resolveLocalFileUrl}.
+   */
+  trustedFileNavigationBudget: number;
 }
 
 const sessions = new Map<number, PreviewSession>();
@@ -136,6 +141,7 @@ function getSession(win: BrowserWindow): PreviewSession {
       lastPreviewThreadId: null,
       workspaceId: null,
       lastFavicons: [],
+      trustedFileNavigationBudget: 0,
     };
     sessions.set(win.id, s);
   }
@@ -1014,6 +1020,7 @@ function beginOverlaySession(s: PreviewSession, webContents: BrowserView["webCon
 }
 
 function detachViewListeners(view: BrowserView): void {
+  view.webContents.removeAllListeners("will-navigate");
   view.webContents.removeAllListeners("did-navigate");
   view.webContents.removeAllListeners("did-navigate-in-page");
   view.webContents.removeAllListeners("page-title-updated");
@@ -1189,9 +1196,11 @@ function parkPreview(win: BrowserWindow, s: PreviewSession): void {
       if (!s.view.webContents.isDestroyed()) {
         void removeEpPickHighlighter(s.view.webContents);
         const parked = s.view.webContents.getURL();
-        if (isAllowedPreviewUrl(parked)) {
-          s.resumePreviewUrl = parked;
-        }
+        void validateResumeUrl(isAllowedPreviewUrl(parked) ? parked : null).then((safe) => {
+          if (!win.isDestroyed()) {
+            s.resumePreviewUrl = safe;
+          }
+        });
       }
       detachViewListeners(s.view);
       s.view.webContents.close();
@@ -1240,20 +1249,65 @@ function ensureView(win: BrowserWindow, s: PreviewSession): BrowserView {
     return { action: "deny" };
   });
 
+  view.webContents.on("will-navigate", (event, navigationUrl) => {
+    if (win.isDestroyed() || view.webContents.isDestroyed()) return;
+    let parsed: URL;
+    try {
+      parsed = new URL(navigationUrl);
+    } catch {
+      return;
+    }
+    if (parsed.protocol !== "file:") return;
+    if (s.trustedFileNavigationBudget > 0) {
+      s.trustedFileNavigationBudget--;
+      return;
+    }
+    event.preventDefault();
+    void (async () => {
+      if (win.isDestroyed() || view.webContents.isDestroyed()) return;
+      const safe = await validateResumeUrl(navigationUrl);
+      if (safe) {
+        trustMainProcessFileNavigation(s, safe);
+        sendPreviewLoading(win, true);
+        try {
+          await view.webContents.loadURL(safe);
+        } catch {
+          /* guest may be tearing down */
+        }
+      } else {
+        s.resumePreviewUrl = null;
+        sendPreviewLoading(win, true);
+        try {
+          await view.webContents.loadURL("about:blank");
+        } catch {
+          /* guest may be tearing down */
+        }
+      }
+    })();
+  });
+
   const forwardNav = () => {
     if (win.isDestroyed() || view.webContents.isDestroyed()) return;
     const url = view.webContents.getURL();
-    if (isAllowedPreviewUrl(url)) {
-      s.resumePreviewUrl = url;
-    }
-    win.webContents.send("preview:did-navigate", {
-      url,
-      title: view.webContents.getTitle(),
-      // Best-effort: lastFavicons is populated by page-favicon-updated which fires
-      // after did-navigate, so this is often null on initial load. The dedicated
-      // preview:did-update-favicon push (Step 3) is the canonical delivery path.
-      favicon: s.lastFavicons[0] ?? null,
-    });
+    void (async () => {
+      if (win.isDestroyed() || view.webContents.isDestroyed()) return;
+      const persisted = await validateResumeUrl(isAllowedPreviewUrl(url) ? url : null);
+      if (persisted) {
+        s.resumePreviewUrl = persisted;
+      } else {
+        s.resumePreviewUrl = null;
+      }
+      if (!win.isDestroyed()) {
+        win.webContents.send("preview:did-navigate", {
+          url,
+          title: view.webContents.getTitle(),
+          // Best-effort: lastFavicons is populated by page-favicon-updated which fires
+          // after did-navigate, so this is often null on initial load. The dedicated
+          // preview:did-update-favicon push (Step 3) is the canonical delivery path.
+          favicon: s.lastFavicons[0] ?? null,
+        });
+      }
+    })();
   };
 
   view.webContents.on("did-navigate", forwardNav);
@@ -1376,29 +1430,74 @@ function isSensitivePath(filePath: string): boolean {
 }
 
 /**
+ * Detects Windows UNC paths so SMB targets never reach `lstat` / `realpath`.
+ * Keeps `\\?\` and `\\.\` prefixes (local extended/device paths) allowed.
+ */
+function isUncPath(filePath: string): boolean {
+  const n = normalize(filePath);
+  if (!n.startsWith("\\\\")) return false;
+  if (n.startsWith("\\\\?\\") || n.startsWith("\\\\.\\")) return false;
+  return true;
+}
+
+/** Marks the next main-process `file:` navigation as trusted for the will-navigate gate. */
+function trustMainProcessFileNavigation(s: PreviewSession, url: string): void {
+  try {
+    if (new URL(url).protocol === "file:") {
+      s.trustedFileNavigationBudget++;
+    }
+  } catch {
+    /* malformed URLs do not consume budget */
+  }
+}
+
+/**
  * Resolve user input into a `file://` URL.
  *
- * Handles tilde expansion (`~/...`), absolute paths, and paths relative to
- * `workspacePath`. Returns `null` when the input is not a local file path
- * or the resolved file does not exist / is a directory / is sensitive.
+ * Handles tilde expansion (`~/...`), absolute paths, paths relative to
+ * `workspacePath`, and raw `file://` inputs (rejecting non-local hosts).
+ * Returns an error result when the path is not previewable, blocked, or missing.
  */
 async function resolveLocalFileUrl(
   input: string,
   workspacePath: string | null,
 ): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  const trimmed = input.trim();
+
+  if (trimmed.startsWith("\\\\")) {
+    return { ok: false, error: "sensitive-file" };
+  }
+
   let resolved: string;
 
-  if (input.startsWith("~")) {
-    resolved = resolve(homedir(), input.slice(input.startsWith("~/") || input.startsWith("~\\") ? 2 : 1));
-  } else if (isAbsolute(input)) {
-    resolved = resolve(input);
+  if (/^file:\/\//i.test(trimmed)) {
+    try {
+      const u = new URL(trimmed);
+      if (u.protocol !== "file:") {
+        return { ok: false, error: "invalid-url" };
+      }
+      const host = u.hostname.toLowerCase();
+      if (host !== "" && host !== "localhost") {
+        return { ok: false, error: "sensitive-file" };
+      }
+      resolved = normalize(fileURLToPath(trimmed));
+    } catch {
+      return { ok: false, error: "invalid-url" };
+    }
+  } else if (trimmed.startsWith("~")) {
+    resolved = resolve(homedir(), trimmed.slice(trimmed.startsWith("~/") || trimmed.startsWith("~\\") ? 2 : 1));
+    resolved = normalize(resolved);
+  } else if (isAbsolute(trimmed)) {
+    resolved = normalize(resolve(trimmed));
   } else if (workspacePath) {
-    resolved = resolve(workspacePath, input);
+    resolved = normalize(resolve(workspacePath, trimmed));
   } else {
     return { ok: false, error: "no-workspace" };
   }
 
-  resolved = normalize(resolved);
+  if (isUncPath(resolved)) {
+    return { ok: false, error: "sensitive-file" };
+  }
 
   if (isSensitivePath(resolved)) {
     return { ok: false, error: "sensitive-file" };
@@ -1418,7 +1517,7 @@ async function resolveLocalFileUrl(
     if (info.isDirectory()) {
       const indexPath = join(resolved, "index.html");
       try {
-        const indexInfo = await lstat(indexPath);
+        const indexInfo = await stat(indexPath);
         if (indexInfo.isFile()) {
           return { ok: true, url: pathToFileURL(indexPath).href };
         }
@@ -1481,6 +1580,8 @@ async function validateResumeUrl(url: string | null): Promise<string | null> {
   try {
     const u = new URL(url);
     if (u.protocol === "file:") {
+      const host = u.hostname.toLowerCase();
+      if (host !== "" && host !== "localhost") return null;
       const filePath = fileURLToPath(url);
       const result = await resolveLocalFileUrl(filePath, null);
       return result.ok ? result.url : null;
@@ -1560,6 +1661,7 @@ export function registerPreviewBrowserHandlers(): void {
         if (switchedThread) {
           if (safeHint) {
             sendPreviewLoading(win, true);
+            trustMainProcessFileNavigation(s, safeHint);
             void wc.loadURL(safeHint);
             s.resumePreviewUrl = safeHint;
           } else {
@@ -1569,12 +1671,14 @@ export function registerPreviewBrowserHandlers(): void {
           }
         } else if (guestUrlNeedsHttpRestore(current) && safeHint) {
           sendPreviewLoading(win, true);
+          trustMainProcessFileNavigation(s, safeHint);
           void wc.loadURL(safeHint);
           s.resumePreviewUrl = safeHint;
         } else if (guestUrlNeedsHttpRestore(current) && s.resumePreviewUrl) {
           const safeResume = await validateResumeUrl(s.resumePreviewUrl);
           if (safeResume) {
             sendPreviewLoading(win, true);
+            trustMainProcessFileNavigation(s, safeResume);
             void wc.loadURL(safeResume);
           } else {
             s.resumePreviewUrl = null;
@@ -1604,15 +1708,9 @@ export function registerPreviewBrowserHandlers(): void {
         // Explicit http(s) URL - use as-is.
         target = trimmed;
       } else if (/^file:\/\//i.test(trimmed)) {
-        // Explicit file URL - parse back to a path and run through security checks.
-        try {
-          const filePath = fileURLToPath(trimmed);
-          const resolved = await resolveLocalFileUrl(filePath, workspacePath?.trim() ?? null);
-          if (!resolved.ok) return resolved;
-          target = resolved.url;
-        } catch {
-          return { ok: false, error: "invalid-url" };
-        }
+        const resolved = await resolveLocalFileUrl(trimmed, workspacePath?.trim() ?? null);
+        if (!resolved.ok) return resolved;
+        target = resolved.url;
       } else if (looksLikeFilePath(trimmed)) {
         // Resolve file path (relative, absolute, or tilde-prefixed).
         const resolved = await resolveLocalFileUrl(trimmed, workspacePath?.trim() ?? null);
@@ -1638,6 +1736,7 @@ export function registerPreviewBrowserHandlers(): void {
         win.setBrowserView(view);
       }
       sendPreviewLoading(win, true);
+      trustMainProcessFileNavigation(s, target);
       void view.webContents.loadURL(target);
       s.resumePreviewUrl = target;
       resetIdle(win, s);

--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -2,9 +2,11 @@
  * Embedded preview BrowserView: navigation, bounds sync from the React shell, and idle teardown.
  */
 
-import { mkdir, writeFile, readdir, stat, unlink } from "node:fs/promises";
+import { mkdir, writeFile, readdir, stat, unlink, lstat, realpath } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import { dirname, join, normalize, resolve } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join, normalize, resolve, isAbsolute, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { BrowserView, BrowserWindow, app, ipcMain, session, shell } from "electron";
 import {
   clampMcodeBrowserCaptureV2,
@@ -15,7 +17,7 @@ import {
 } from "@mcode/contracts";
 import { getMcodeDir, redactMcodeBrowserCaptureV2, spillWorkspaceDirSegment } from "@mcode/shared";
 
-// Idle teardown removed: the React shell already parks the view on unmount/tab-switch
+// Idle teardown removed: the React shell already hides the view on unmount/tab-switch
 // via pushSync(false), so a timer-based teardown is redundant and caused the view to
 // go blank while the user was still looking at it.
 // const IDLE_MS = 120_000;
@@ -1155,22 +1157,39 @@ function clampRectInPlace(rect: Bounds, maxW: number, maxH: number): Bounds {
   return { x, y, width, height };
 }
 
-function parkPreview(win: BrowserWindow, s: PreviewSession): void {
+/**
+ * Detach the BrowserView from the window without destroying it. The web
+ * contents stay alive so navigation history, scroll position, and page
+ * state survive tab switches inside the right panel.
+ */
+function hidePreview(win: BrowserWindow, s: PreviewSession): void {
   abortOverlayCapture(s, "capture-interrupted");
   clearIdle(s);
-  if (s.view) {
-    if (!win.isDestroyed()) {
-      try {
-        win.removeBrowserView(s.view);
-      } catch {
-        // Window may already be detaching the view.
-      }
+  if (s.view && !win.isDestroyed()) {
+    try {
+      win.removeBrowserView(s.view);
+    } catch {
+      // Window may already be detaching the view.
     }
+  }
+  if (!win.isDestroyed()) {
+    sendPreviewLoading(win, false);
+  }
+}
+
+/**
+ * Fully tear down the BrowserView, destroying its web contents. Used only
+ * when the window is closing or the view must be replaced (not for
+ * routine tab switches - use {@link hidePreview} for that).
+ */
+function parkPreview(win: BrowserWindow, s: PreviewSession): void {
+  hidePreview(win, s);
+  if (s.view) {
     try {
       if (!s.view.webContents.isDestroyed()) {
         void removeEpPickHighlighter(s.view.webContents);
         const parked = s.view.webContents.getURL();
-        if (isAllowedHttpUrl(parked)) {
+        if (isAllowedPreviewUrl(parked)) {
           s.resumePreviewUrl = parked;
         }
       }
@@ -1183,9 +1202,6 @@ function parkPreview(win: BrowserWindow, s: PreviewSession): void {
     s.scrollbarCssKey = null;
     s.consoleBuffer.length = 0;
     s.failedRequestBuffer.length = 0;
-  }
-  if (!win.isDestroyed()) {
-    sendPreviewLoading(win, false);
   }
 }
 
@@ -1227,7 +1243,7 @@ function ensureView(win: BrowserWindow, s: PreviewSession): BrowserView {
   const forwardNav = () => {
     if (win.isDestroyed() || view.webContents.isDestroyed()) return;
     const url = view.webContents.getURL();
-    if (isAllowedHttpUrl(url)) {
+    if (isAllowedPreviewUrl(url)) {
       s.resumePreviewUrl = url;
     }
     win.webContents.send("preview:did-navigate", {
@@ -1258,9 +1274,7 @@ function ensureView(win: BrowserWindow, s: PreviewSession): BrowserView {
   const forwardLoadingStart = () => {
     if (win.isDestroyed() || view.webContents.isDestroyed()) return;
     s.lastFavicons = [];
-    if (!win.isDestroyed()) {
-      win.webContents.send("preview:did-update-favicon", { favicon: null });
-    }
+    win.webContents.send("preview:did-update-favicon", { favicon: null });
     sendPreviewLoading(win, true);
   };
   const forwardLoadingStop = () => {
@@ -1323,6 +1337,129 @@ function isAllowedHttpUrl(url: string): boolean {
   }
 }
 
+/** Accepts http, https, and file URLs for the preview BrowserView. */
+function isAllowedPreviewUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return u.protocol === "http:" || u.protocol === "https:" || u.protocol === "file:";
+  } catch {
+    return false;
+  }
+}
+
+/** Pre-compiled regex for browser-viewable file extensions (hoisted to avoid recompilation per navigate). */
+const BROWSER_VIEWABLE_EXT_RE = /\.(html?|pdf|svg|xml|xhtml|mhtml|txt|json|css|js|mjs|webp|png|jpe?g|gif|bmp|ico|avif)$/i;
+
+/** Basename patterns that should never be served in the preview. */
+const SENSITIVE_FILE_PATTERNS = [
+  /^\.env/i,
+  /^\.git$/i,
+  /^\.ssh$/i,
+  /^id_rsa/i,
+  /^id_ed25519/i,
+  /^\.aws$/i,
+  /^credentials/i,
+  /^\.netrc$/i,
+  /^\.npmrc$/i,
+  /^\.pypirc$/i,
+];
+
+/**
+ * Returns true when any segment of a normalized path matches a sensitive
+ * file or directory pattern (e.g. `.env`, `.git/config`, `.ssh/id_rsa`).
+ */
+function isSensitivePath(filePath: string): boolean {
+  const segments = normalize(filePath).split(sep);
+  return segments.some((seg) =>
+    SENSITIVE_FILE_PATTERNS.some((pat) => pat.test(seg)),
+  );
+}
+
+/**
+ * Resolve user input into a `file://` URL.
+ *
+ * Handles tilde expansion (`~/...`), absolute paths, and paths relative to
+ * `workspacePath`. Returns `null` when the input is not a local file path
+ * or the resolved file does not exist / is a directory / is sensitive.
+ */
+async function resolveLocalFileUrl(
+  input: string,
+  workspacePath: string | null,
+): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  let resolved: string;
+
+  if (input.startsWith("~")) {
+    resolved = resolve(homedir(), input.slice(input.startsWith("~/") || input.startsWith("~\\") ? 2 : 1));
+  } else if (isAbsolute(input)) {
+    resolved = resolve(input);
+  } else if (workspacePath) {
+    resolved = resolve(workspacePath, input);
+  } else {
+    return { ok: false, error: "no-workspace" };
+  }
+
+  resolved = normalize(resolved);
+
+  if (isSensitivePath(resolved)) {
+    return { ok: false, error: "sensitive-file" };
+  }
+
+  try {
+    const info = await lstat(resolved);
+    if (info.isSymbolicLink()) {
+      const real = await realpath(resolved);
+      if (isSensitivePath(real)) {
+        return { ok: false, error: "sensitive-file" };
+      }
+    }
+    if (info.isDirectory()) {
+      // Try index.html inside the directory.
+      const indexPath = join(resolved, "index.html");
+      try {
+        const indexInfo = await lstat(indexPath);
+        if (indexInfo.isFile()) {
+          return { ok: true, url: pathToFileURL(indexPath).href };
+        }
+      } catch {
+        return { ok: false, error: "is-directory" };
+      }
+    }
+    if (!info.isFile() && !info.isSymbolicLink()) {
+      return { ok: false, error: "not-a-file" };
+    }
+  } catch {
+    return { ok: false, error: "file-not-found" };
+  }
+
+  return { ok: true, url: pathToFileURL(resolved).href };
+}
+
+/**
+ * Heuristic: returns true when the input looks like a local file path rather
+ * than a domain name. Matches tilde prefix, drive letters (C:\), explicit
+ * slashes (./, ../, /), and common file extensions (.html, .pdf, etc.).
+ */
+function looksLikeFilePath(input: string): boolean {
+  if (input.startsWith("~")) return true;
+  if (input.startsWith("/") || input.startsWith("./") || input.startsWith("../")) return true;
+  if (input.startsWith(".\\") || input.startsWith("..\\")) return true;
+  // Windows drive letter (C:\ or C:/)
+  if (/^[A-Za-z]:[/\\]/.test(input)) return true;
+  // Reject inputs where the first segment looks like a domain (e.g.
+  // "example.com/page.html"). A domain-like segment contains a dot but no
+  // path separators before the first slash.
+  const firstSlash = input.indexOf("/");
+  const firstSegment = firstSlash >= 0 ? input.slice(0, firstSlash) : input;
+  if (firstSegment.includes(".") && !firstSegment.includes("\\")) {
+    // Could be a hostname - fall through to URL handling.
+    return false;
+  }
+  // Ends with a browser-viewable file extension and has a path separator.
+  const hasPathSep = input.includes("/") || input.includes("\\");
+  if (hasPathSep && BROWSER_VIEWABLE_EXT_RE.test(input)) return true;
+  return false;
+}
+
 /** True when the guest has no real document loaded yet (fresh view or error). */
 function guestUrlNeedsHttpRestore(url: string): boolean {
   if (url.length === 0) return true;
@@ -1376,7 +1513,7 @@ export function registerPreviewBrowserHandlers(): void {
       s.workspaceId = typeof ws === "string" && ws.trim().length > 0 ? ws.trim() : null;
       const b = payload.bounds;
       if (!payload.visible || !b || b.width < 4 || b.height < 4) {
-        parkPreview(win, s);
+        hidePreview(win, s);
         return;
       }
 
@@ -1390,7 +1527,7 @@ export function registerPreviewBrowserHandlers(): void {
       if (!wc.isDestroyed()) {
         const current = wc.getURL();
         const hintRaw = payload.resumeUrlHint?.trim() ?? "";
-        const hint = hintRaw.length > 0 && isAllowedHttpUrl(hintRaw) ? hintRaw : null;
+        const hint = hintRaw.length > 0 && isAllowedPreviewUrl(hintRaw) ? hintRaw : null;
         const tid = payload.threadId ?? null;
         const switchedThread = tid != null && tid !== s.lastPreviewThreadId;
         s.lastPreviewThreadId = tid;
@@ -1414,7 +1551,7 @@ export function registerPreviewBrowserHandlers(): void {
         } else if (
           guestUrlNeedsHttpRestore(current) &&
           s.resumePreviewUrl &&
-          isAllowedHttpUrl(s.resumePreviewUrl)
+          isAllowedPreviewUrl(s.resumePreviewUrl)
         ) {
           sendPreviewLoading(win, true);
           void wc.loadURL(s.resumePreviewUrl);
@@ -1426,18 +1563,43 @@ export function registerPreviewBrowserHandlers(): void {
 
   ipcMain.handle(
     "preview:navigate",
-    (_event, url: string): { ok: true } | { ok: false; error: string } => {
+    async (
+      _event,
+      url: string,
+      workspacePath?: string | null,
+    ): Promise<{ ok: true } | { ok: false; error: string }> => {
       const win = BrowserWindow.fromWebContents(_event.sender);
       if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
 
       const trimmed = url.trim();
       if (!trimmed) return { ok: false, error: "empty-url" };
 
-      let target = trimmed;
-      if (!/^https?:\/\//i.test(target)) {
-        target = `https://${target}`;
+      let target: string;
+
+      if (/^https?:\/\//i.test(trimmed)) {
+        // Explicit http(s) URL - use as-is.
+        target = trimmed;
+      } else if (/^file:\/\//i.test(trimmed)) {
+        // Explicit file URL - parse back to a path and run through security checks.
+        try {
+          const filePath = fileURLToPath(trimmed);
+          const resolved = await resolveLocalFileUrl(filePath, workspacePath?.trim() ?? null);
+          if (!resolved.ok) return resolved;
+          target = resolved.url;
+        } catch {
+          return { ok: false, error: "invalid-url" };
+        }
+      } else if (looksLikeFilePath(trimmed)) {
+        // Resolve file path (relative, absolute, or tilde-prefixed).
+        const resolved = await resolveLocalFileUrl(trimmed, workspacePath?.trim() ?? null);
+        if (!resolved.ok) return resolved;
+        target = resolved.url;
+      } else {
+        // Treat bare input as a URL and prepend https://.
+        target = `https://${trimmed}`;
       }
-      if (!isAllowedHttpUrl(target)) {
+
+      if (!isAllowedPreviewUrl(target)) {
         return { ok: false, error: "invalid-url" };
       }
 

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -24,6 +24,7 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import type { PendingAttachment } from "@/components/chat/AttachmentPreview";
 import { useToastStore } from "@/stores/toastStore";
 import { usePreviewReferenceQueueStore } from "@/stores/previewReferenceQueueStore";
@@ -33,9 +34,14 @@ import { MCODE_BROWSER_CONTEXT_ATTACHMENT_MIME } from "@mcode/contracts";
 
 const NAV_ERROR_LABEL: Record<string, string> = {
   "no-bounds": "Wait for the panel to finish layout, then try again.",
-  "invalid-url": "Only http and https URLs are allowed.",
-  "empty-url": "Enter a URL.",
+  "invalid-url": "Only http, https URLs and local file paths are supported.",
+  "empty-url": "Enter a URL or file path.",
   "no-window": "Preview is unavailable.",
+  "file-not-found": "File not found.",
+  "not-a-file": "Path is not a regular file.",
+  "is-directory": "Path is a directory (no index.html found).",
+  "sensitive-file": "Cannot preview sensitive files (.env, .git, keys, etc.).",
+  "no-workspace": "Open a workspace to use relative file paths.",
 };
 
 const CAPTURE_ERROR_SILENT = new Set(["cancelled", "capture-interrupted", "navigated-away"]);
@@ -113,6 +119,9 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
 
   const storedUrl = useDiffStore(
     (s) => s.previewUrlByThread[threadId] ?? "",
+  );
+  const workspacePath = useWorkspaceStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.path ?? null,
   );
 
   useEffect(() => {
@@ -258,116 +267,65 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
     await preview.openExternal();
   };
 
-  const onAddPictureReference = useCallback(async () => {
-    const preview = window.desktopBridge?.preview;
-    if (!preview?.capturePictureReference || !threadId) return;
-
-    setCaptureBusy(true);
-    try {
-      await pushSync(true);
-
-      let res: CaptureResult;
+  /** Shared capture-to-attachment pipeline: sync bounds, call IPC, build blob, enqueue. */
+  const runPictureCapture = useCallback(
+    async (
+      captureFn: () => Promise<unknown>,
+      setBusy: (v: boolean) => void,
+    ) => {
+      if (!threadId) return;
+      setBusy(true);
       try {
-        res = (await preview.capturePictureReference()) as CaptureResult;
-      } catch {
-        useToastStore.getState().show("error", "Could not capture preview", "Screenshot failed.");
-        return;
+        await pushSync(true);
+
+        let res: CaptureResult;
+        try {
+          res = (await captureFn()) as CaptureResult;
+        } catch {
+          useToastStore.getState().show("error", "Could not capture preview", "Screenshot failed.");
+          return;
+        }
+
+        showCaptureErrorIfNeeded(res);
+        if (!res.ok) return;
+
+        const copied = Uint8Array.from(res.previewBytes);
+        const blob = new Blob([copied], { type: "image/png" });
+        const previewUrl = URL.createObjectURL(blob);
+        const attachment: PendingAttachment = {
+          id: res.meta.id,
+          name: res.meta.name,
+          mimeType: res.meta.mimeType,
+          sizeBytes: res.meta.sizeBytes,
+          previewUrl,
+          filePath: res.meta.sourcePath,
+          browserCapture: res.capture,
+        };
+        usePreviewReferenceQueueStore.getState().enqueuePreviewReference(threadId, attachment);
+      } finally {
+        setBusy(false);
       }
+    },
+    [pushSync, threadId],
+  );
 
-      showCaptureErrorIfNeeded(res);
-      if (!res.ok) return;
+  const onAddPictureReference = useCallback(() => {
+    const fn = window.desktopBridge?.preview?.capturePictureReference;
+    if (!fn) return;
+    void runPictureCapture(() => fn.call(window.desktopBridge!.preview), setCaptureBusy);
+  }, [runPictureCapture]);
 
-      const copied = Uint8Array.from(res.previewBytes);
-      const blob = new Blob([copied], { type: "image/png" });
-      const previewUrl = URL.createObjectURL(blob);
-      const attachment: PendingAttachment = {
-        id: res.meta.id,
-        name: res.meta.name,
-        mimeType: res.meta.mimeType,
-        sizeBytes: res.meta.sizeBytes,
-        previewUrl,
-        filePath: res.meta.sourcePath,
-        browserCapture: res.capture,
-      };
-      usePreviewReferenceQueueStore.getState().enqueuePreviewReference(threadId, attachment);
-    } finally {
-      setCaptureBusy(false);
-    }
-  }, [pushSync, threadId]);
+  const onAddRegionPictureReference = useCallback(() => {
+    const fn = window.desktopBridge?.preview?.capturePictureReferenceRegion;
+    if (!fn) return;
+    void runPictureCapture(() => fn.call(window.desktopBridge!.preview), setRegionBusy);
+  }, [runPictureCapture]);
 
-  const onAddRegionPictureReference = useCallback(async () => {
-    const preview = window.desktopBridge?.preview;
-    if (!preview?.capturePictureReferenceRegion || !threadId) return;
-
-    setRegionBusy(true);
-    try {
-      await pushSync(true);
-
-      let res: CaptureResult;
-      try {
-        res = (await preview.capturePictureReferenceRegion()) as CaptureResult;
-      } catch {
-        useToastStore.getState().show("error", "Could not capture preview", "Screenshot failed.");
-        return;
-      }
-
-      showCaptureErrorIfNeeded(res);
-      if (!res.ok) return;
-
-      const copied = Uint8Array.from(res.previewBytes);
-      const blob = new Blob([copied], { type: "image/png" });
-      const previewUrl = URL.createObjectURL(blob);
-      const attachment: PendingAttachment = {
-        id: res.meta.id,
-        name: res.meta.name,
-        mimeType: res.meta.mimeType,
-        sizeBytes: res.meta.sizeBytes,
-        previewUrl,
-        filePath: res.meta.sourcePath,
-        browserCapture: res.capture,
-      };
-      usePreviewReferenceQueueStore.getState().enqueuePreviewReference(threadId, attachment);
-    } finally {
-      setRegionBusy(false);
-    }
-  }, [pushSync, threadId]);
-
-  const onAddElementPickPictureReference = useCallback(async () => {
-    const preview = window.desktopBridge?.preview;
-    if (!preview?.capturePictureReferenceElementPick || !threadId) return;
-
-    setElementPickBusy(true);
-    try {
-      await pushSync(true);
-
-      let res: CaptureResult;
-      try {
-        res = (await preview.capturePictureReferenceElementPick()) as CaptureResult;
-      } catch {
-        useToastStore.getState().show("error", "Could not capture preview", "Screenshot failed.");
-        return;
-      }
-
-      showCaptureErrorIfNeeded(res);
-      if (!res.ok) return;
-
-      const copied = Uint8Array.from(res.previewBytes);
-      const blob = new Blob([copied], { type: "image/png" });
-      const previewUrl = URL.createObjectURL(blob);
-      const attachment: PendingAttachment = {
-        id: res.meta.id,
-        name: res.meta.name,
-        mimeType: res.meta.mimeType,
-        sizeBytes: res.meta.sizeBytes,
-        previewUrl,
-        filePath: res.meta.sourcePath,
-        browserCapture: res.capture,
-      };
-      usePreviewReferenceQueueStore.getState().enqueuePreviewReference(threadId, attachment);
-    } finally {
-      setElementPickBusy(false);
-    }
-  }, [pushSync, threadId]);
+  const onAddElementPickPictureReference = useCallback(() => {
+    const fn = window.desktopBridge?.preview?.capturePictureReferenceElementPick;
+    if (!fn) return;
+    void runPictureCapture(() => fn.call(window.desktopBridge!.preview), setElementPickBusy);
+  }, [runPictureCapture]);
 
   const onAddPageContextOnly = useCallback(async () => {
     const preview = window.desktopBridge?.preview;
@@ -439,7 +397,8 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
           faviconUrl={faviconUrl}
           onNavigate={(target) => {
             setInputUrl(target);
-            void window.desktopBridge?.preview.navigate(target).then((r) => {
+            setNavError(null);
+            void window.desktopBridge?.preview.navigate(target, workspacePath).then((r) => {
               if (!r.ok) setNavError(formatNavError(r.error));
             });
           }}

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -37,7 +37,7 @@ export type PreviewShellBounds = {
   readonly height: number;
 };
 
-/** Result of a preview navigation attempt (http and https only). */
+/** Result of a preview navigation attempt (http, https, and local file paths). */
 export type PreviewNavigateResult =
   | { readonly ok: true }
   | { readonly ok: false; readonly error: string };
@@ -67,7 +67,7 @@ interface PreviewBridge {
     /** Active workspace id; scopes preview spill files under the Mcode app data directory. */
     workspaceId?: string | null;
   }): Promise<void>;
-  navigate(url: string): Promise<PreviewNavigateResult>;
+  navigate(url: string, workspacePath?: string | null): Promise<PreviewNavigateResult>;
   goBack(): Promise<boolean>;
   goForward(): Promise<boolean>;
   reload(): Promise<void>;


### PR DESCRIPTION
## What

Fixes two bugs in the browser preview panel and adds local file preview support.

## Why

The preview BrowserView was destroyed and recreated on every tab switch, causing the page to reload and navigation history to be lost. The forward/back arrows never worked because `webContents` history was destroyed with the view. Local file preview was requested to support viewing HTML, PDF, and other browser-viewable files without a running dev server.

## Key changes

- **Detach instead of destroy on tab switch**: split `parkPreview` into `hidePreview` (detach BrowserView, keep webContents alive) and `parkPreview` (full teardown for window close). Tab switches now call `hidePreview`, preserving navigation history, scroll position, and page state.
- **Forward/back arrows work**: navigation history survives tab switches since `webContents` is no longer destroyed.
- **Local file preview**: users can type file paths in the omnibox (absolute, relative `./`/`../`, tilde `~/`, drive letter `C:\`, or `file://` URLs). Paths resolve against the active workspace directory.
- **Security guards**: sensitive file blocklist (`.env`, `.git/`, `.ssh/`, keys), symlink target validation, sandboxed BrowserView with `contextIsolation` and no `nodeIntegration`. Explicit `file://` URLs are parsed back to path and run through the same security checks.
- **`looksLikeFilePath` heuristic**: rejects domain-like first segments (e.g. `example.com/page.html`) to avoid misclassifying URLs as file paths.
- **Directory fallback**: directory paths fall back to `index.html` inside them.
- **Performance**: extracted shared capture handler (3 near-identical callbacks collapsed), hoisted file extension regex to module level, removed redundant `isDestroyed()` check.
- **23 new tests**: 10 for hide/show lifecycle, 13 for file preview (symlinks, sensitive files, directory fallback, domain rejection, file:// URL security).

## Test plan

- [x] `bun run verify` passes (typecheck + lint + unit tests)
- [x] 85 desktop tests pass (including 23 new preview-browser tests)
- [x] Web and server typecheck clean
- [ ] Manual: open preview, navigate to a site, switch tabs, switch back - page should remain loaded
- [ ] Manual: navigate within preview, verify forward/back arrows update and work
- [ ] Manual: type `./index.html` or `~/some/file.pdf` in omnibox - file loads in preview
- [ ] Manual: type `.env` or `.git/config` - error message shown, file not loaded

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview navigation now supports local file paths (with workspace context) and explicit file:// URLs; API accepts an optional workspace path.

* **Improvements**
  * Preview can be hidden without destroying its web view, preserving page and back/forward state across tab switches.
  * Safer URL handling: allowlist, validate resume hints, symlink resolution, directory→index.html mapping, and clearer navigation error messages.
  * Centralized picture/crop capture flow.

* **Tests**
  * New comprehensive tests for navigation, state preservation, security checks, and navigation controls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/444)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->