### PR TITLE
feat: surface hook execution events in chat UI

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1158,6 +1158,30 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                   delayMs: anyMsg.retry_delay_ms as number | undefined,
                   errorStatus: (anyMsg.error_status as number | undefined) ?? undefined,
                 } satisfies AgentEvent);
+              } else if ((anyMsg.subtype as string) === "hook_started") {
+                this.emit("event", {
+                  type: AgentEventType.HookStarted,
+                  threadId,
+                  hookName: (anyMsg.hook_name as string) || "unknown",
+                  hookType: anyMsg.tool_name ? "permission" : "stop",
+                  ...(anyMsg.tool_name ? { toolName: anyMsg.tool_name as string } : {}),
+                } satisfies AgentEvent);
+              } else if ((anyMsg.subtype as string) === "hook_progress") {
+                this.emit("event", {
+                  type: AgentEventType.HookProgress,
+                  threadId,
+                  hookName: (anyMsg.hook_name as string) || "unknown",
+                  output: (anyMsg.output as string) || "",
+                } satisfies AgentEvent);
+              } else if ((anyMsg.subtype as string) === "hook_response") {
+                this.emit("event", {
+                  type: AgentEventType.HookCompleted,
+                  threadId,
+                  hookName: (anyMsg.hook_name as string) || "unknown",
+                  exitCode: (anyMsg.exit_code as number) ?? 1,
+                  durationMs: (anyMsg.duration_ms as number) ?? 0,
+                  didBlock: (anyMsg.did_block as boolean) ?? false,
+                } satisfies AgentEvent);
               } else {
                 this.emit("event", {
                   type: AgentEventType.System,

--- a/apps/web/src/__tests__/virtual-items.test.ts
+++ b/apps/web/src/__tests__/virtual-items.test.ts
@@ -7,7 +7,7 @@ import {
   STREAMING_CARD_COLLAPSED_HEIGHT,
 } from "@/components/chat/virtual-items";
 import type { ChatVirtualItem } from "@/components/chat/virtual-items";
-import type { Message, ToolCall } from "@/transport/types";
+import type { Message, ToolCall, HookExecution } from "@/transport/types";
 
 function makeMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -233,6 +233,49 @@ describe("buildVirtualItems (combined)", () => {
     // along with the assistant message, but it's still present since stable
     // items include it. The key behavior is active-tools is present.
     expect(types).toContain("active-tools");
+  });
+});
+
+function makeHook(overrides: Partial<HookExecution> = {}): HookExecution {
+  return {
+    hookName: "pre-commit",
+    hookType: "permission",
+    status: "running",
+    outputLines: [],
+    fullOutput: [],
+    startedAt: 1000,
+    ...overrides,
+  };
+}
+
+describe("buildVolatileItems with hooks", () => {
+  it("includes hook-activity item when hooks are present", () => {
+    const hooks = [makeHook()];
+    const items = buildVolatileItems([], false, undefined, undefined, undefined, hooks);
+    expect(items.some((i) => i.type === "hook-activity")).toBe(true);
+  });
+
+  it("omits hook-activity item when hooks array is empty", () => {
+    const items = buildVolatileItems([], false, undefined, undefined, undefined, []);
+    expect(items.some((i) => i.type === "hook-activity")).toBe(false);
+  });
+
+  it("places hook-activity after permission-request items", () => {
+    const hooks = [makeHook()];
+    const permissions = [{ requestId: "p1", toolName: "Edit", settled: false }];
+    const items = buildVolatileItems([], true, 1000, undefined, permissions, hooks);
+    const types = items.map((i) => i.type);
+    const permIdx = types.indexOf("permission-request");
+    const hookIdx = types.indexOf("hook-activity");
+    expect(hookIdx).toBeGreaterThan(permIdx);
+  });
+
+  it("hook-activity item carries the hooks array", () => {
+    const hooks = [makeHook({ hookName: "lint" }), makeHook({ hookName: "test", status: "completed", exitCode: 0, durationMs: 150 })];
+    const items = buildVolatileItems([], false, undefined, undefined, undefined, hooks);
+    const hookItem = items.find((i) => i.type === "hook-activity") as Extract<(typeof items)[number], { type: "hook-activity" }>;
+    expect(hookItem.hooks).toHaveLength(2);
+    expect(hookItem.hooks[0].hookName).toBe("lint");
   });
 });
 

--- a/apps/web/src/components/chat/HookActivitySection.tsx
+++ b/apps/web/src/components/chat/HookActivitySection.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { HookExecution } from "@/transport/types";
+
+/** Maximum output lines shown before "show all" toggle. */
+const OUTPUT_LINE_CAP = 20;
+
+/** Collapsible section displaying hook execution activity for a turn. */
+export function HookActivitySection({ hooks }: { hooks: readonly HookExecution[] }) {
+  const hasError = hooks.some((h) => h.status === "completed" && (h.exitCode !== 0 || h.didBlock));
+  const hasRunning = hooks.some((h) => h.status === "running");
+  const [expanded, setExpanded] = useState(hasError || hasRunning);
+
+  // Auto-expand when an error appears
+  useEffect(() => {
+    if (hasError || hasRunning) setExpanded(true);
+  }, [hasError, hasRunning]);
+
+  return (
+    <div className="mx-3 my-1">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-1.5 py-1 group cursor-pointer"
+      >
+        <ChevronRight
+          className={cn(
+            "size-3 text-muted-foreground/50 transition-transform duration-150",
+            expanded && "rotate-90",
+          )}
+        />
+        <span className="font-mono text-[10.5px] tracking-[0.18em] uppercase text-muted-foreground/60">
+          Hooks
+        </span>
+        <span className="font-mono text-[10.5px] tabular-nums text-muted-foreground/40">
+          {hooks.length}
+        </span>
+        <StatusDot hasError={hasError} hasRunning={hasRunning} />
+      </button>
+      {expanded && (
+        <div className="ml-[18px] flex flex-col gap-0.5">
+          {hooks.map((hook, i) => (
+            <HookRow key={`${hook.hookName}-${i}`} hook={hook} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Colored dot indicating the aggregate status of all hooks in the section. */
+function StatusDot({ hasError, hasRunning }: { hasError: boolean; hasRunning: boolean }) {
+  if (hasRunning) {
+    return <span className="size-1.5 rounded-full bg-primary animate-pulse" />;
+  }
+  if (hasError) {
+    return <span className="size-1.5 rounded-full bg-diff-remove-strong" />;
+  }
+  return <span className="size-1.5 rounded-full bg-diff-add-strong" />;
+}
+
+/** Row showing a single hook execution with optional expandable output. */
+function HookRow({ hook }: { hook: HookExecution }) {
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  const hasOutput = hook.fullOutput.length > 0;
+  const displayLines = showAll ? hook.fullOutput : hook.outputLines;
+  const hasMore = hook.fullOutput.length > OUTPUT_LINE_CAP;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => hasOutput && setDetailOpen((v) => !v)}
+        className={cn(
+          "flex items-center gap-2 py-0.5 w-full text-left",
+          hasOutput && "cursor-pointer hover:bg-muted/30 rounded-sm",
+        )}
+      >
+        {hasOutput && (
+          <ChevronRight
+            className={cn(
+              "size-2.5 text-muted-foreground/40 transition-transform duration-150 shrink-0",
+              detailOpen && "rotate-90",
+            )}
+          />
+        )}
+        {!hasOutput && <span className="w-2.5 shrink-0" />}
+        <span className="font-mono text-xs text-foreground truncate">
+          {hook.hookName}
+        </span>
+        {hook.toolName && (
+          <span className="text-xs text-muted-foreground/50 truncate shrink-0">
+            triggered by {hook.toolName}
+          </span>
+        )}
+        <span className="ml-auto flex items-center gap-1.5 shrink-0">
+          {hook.status === "running" && (
+            <ElapsedTimer startedAt={hook.startedAt} />
+          )}
+          {hook.status === "completed" && hook.durationMs != null && (
+            <span className="font-mono tabular-nums text-xs text-muted-foreground">
+              {formatDuration(hook.durationMs)}
+            </span>
+          )}
+          {hook.status === "completed" && hook.exitCode != null && hook.exitCode !== 0 && (
+            <span className="font-mono text-[10px] px-1 rounded bg-diff-remove-strong/15 text-diff-remove-strong">
+              exit {hook.exitCode}
+            </span>
+          )}
+          {hook.didBlock && (
+            <span className="font-mono text-[10px] tracking-[0.12em] uppercase text-diff-remove-strong">
+              blocked
+            </span>
+          )}
+        </span>
+      </button>
+      {detailOpen && displayLines.length > 0 && (
+        <div className="ml-2.5 mt-0.5 mb-1">
+          <pre className="font-mono text-xs bg-muted/50 rounded-sm p-2 overflow-x-auto max-h-[300px] overflow-y-auto text-muted-foreground whitespace-pre-wrap break-all">
+            {displayLines.join("\n")}
+          </pre>
+          {hasMore && !showAll && (
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="text-xs text-primary hover:underline mt-0.5 cursor-pointer"
+            >
+              Show all ({hook.fullOutput.length} lines)
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Live-updating elapsed time display for a running hook. */
+function ElapsedTimer({ startedAt }: { startedAt: number }) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  const elapsed = Math.floor((Date.now() - startedAt) / 1000);
+  return (
+    <span className="font-mono tabular-nums text-xs text-muted-foreground animate-pulse">
+      {elapsed}s
+    </span>
+  );
+}
+
+/** Format a duration in milliseconds to a human-readable string. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/apps/web/src/components/chat/HookActivitySection.tsx
+++ b/apps/web/src/components/chat/HookActivitySection.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, memo } from "react";
 import { ChevronRight } from "lucide-react";
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import type { HookExecution } from "@/transport/types";
 
@@ -18,34 +19,37 @@ export function HookActivitySection({ hooks }: { hooks: readonly HookExecution[]
   }, [hasError, hasRunning]);
 
   return (
-    <div className="mx-3 my-1">
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        className="flex items-center gap-1.5 py-1 group cursor-pointer"
-      >
-        <ChevronRight
-          className={cn(
-            "size-3 text-muted-foreground/50 transition-transform duration-150",
-            expanded && "rotate-90",
-          )}
-        />
-        <span className="font-mono text-[10.5px] tracking-[0.18em] uppercase text-muted-foreground/60">
-          Hooks
-        </span>
-        <span className="font-mono text-[10.5px] tabular-nums text-muted-foreground/40">
-          {hooks.length}
-        </span>
-        <StatusDot hasError={hasError} hasRunning={hasRunning} />
-      </button>
-      {expanded && (
-        <div className="ml-[18px] flex flex-col gap-0.5">
-          {hooks.map((hook, i) => (
-            <HookRow key={`${hook.hookName}-${i}`} hook={hook} />
-          ))}
-        </div>
-      )}
-    </div>
+    <Collapsible open={expanded} onOpenChange={setExpanded} asChild>
+      <div className="mx-3 my-1">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex items-center gap-1.5 py-1 group cursor-pointer"
+          >
+            <ChevronRight
+              className={cn(
+                "size-3 text-muted-foreground/50 transition-transform duration-150",
+                expanded && "rotate-90",
+              )}
+            />
+            <span className="font-mono text-[10.5px] tracking-[0.18em] uppercase text-muted-foreground/60">
+              Hooks
+            </span>
+            <span className="font-mono text-[10.5px] tabular-nums text-muted-foreground/40">
+              {hooks.length}
+            </span>
+            <StatusDot hasError={hasError} hasRunning={hasRunning} />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="ml-[18px] flex flex-col gap-0.5">
+            {hooks.map((hook, i) => (
+              <HookRow key={`${hook.hookName}-${i}`} hook={hook} />
+            ))}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
   );
 }
 
@@ -70,70 +74,73 @@ const HookRow = memo(function HookRow({ hook }: { hook: HookExecution }) {
   const outputText = useMemo(() => displayLines.join("\n"), [displayLines]);
 
   return (
-    <div>
-      <button
-        type="button"
-        onClick={() => hasOutput && setDetailOpen((v) => !v)}
-        className={cn(
-          "flex items-center gap-2 py-0.5 w-full text-left",
-          hasOutput && "cursor-pointer hover:bg-muted/30 rounded-sm",
-        )}
-      >
-        {hasOutput && (
-          <ChevronRight
-            className={cn(
-              "size-2.5 text-muted-foreground/40 transition-transform duration-150 shrink-0",
-              detailOpen && "rotate-90",
-            )}
-          />
-        )}
-        {!hasOutput && <span className="w-2.5 shrink-0" />}
-        <span className="font-mono text-xs text-foreground truncate">
-          {hook.hookName}
-        </span>
-        {hook.toolName && (
-          <span className="text-xs text-muted-foreground/50 truncate shrink-0">
-            triggered by {hook.toolName}
+    <Collapsible open={detailOpen} onOpenChange={hasOutput ? setDetailOpen : undefined}>
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex items-center gap-2 py-0.5 w-full text-left",
+            hasOutput && "cursor-pointer hover:bg-muted/30 rounded-sm",
+          )}
+        >
+          {hasOutput && (
+            <ChevronRight
+              className={cn(
+                "size-2.5 text-muted-foreground/40 transition-transform duration-150 shrink-0",
+                detailOpen && "rotate-90",
+              )}
+            />
+          )}
+          {!hasOutput && <span className="w-2.5 shrink-0" />}
+          <span className="font-mono text-xs text-foreground truncate">
+            {hook.hookName}
           </span>
-        )}
-        <span className="ml-auto flex items-center gap-1.5 shrink-0">
-          {hook.status === "running" && (
-            <ElapsedTimer startedAt={hook.startedAt} />
-          )}
-          {hook.status === "completed" && hook.durationMs != null && (
-            <span className="font-mono tabular-nums text-xs text-muted-foreground">
-              {formatDuration(hook.durationMs)}
+          {hook.toolName && (
+            <span className="text-xs text-muted-foreground/50 truncate shrink-0">
+              triggered by {hook.toolName}
             </span>
           )}
-          {hook.status === "completed" && hook.exitCode != null && hook.exitCode !== 0 && (
-            <span className="font-mono text-[10px] px-1 rounded bg-diff-remove-strong/15 text-diff-remove-strong">
-              exit {hook.exitCode}
-            </span>
-          )}
-          {hook.didBlock && (
-            <span className="font-mono text-[10px] tracking-[0.12em] uppercase text-diff-remove-strong">
-              blocked
-            </span>
-          )}
-        </span>
-      </button>
-      {detailOpen && displayLines.length > 0 && (
-        <div className="ml-2.5 mt-0.5 mb-1">
-          <pre className="font-mono text-xs bg-muted/50 rounded-sm p-2 overflow-x-auto max-h-[300px] overflow-y-auto text-muted-foreground whitespace-pre-wrap break-all">
-            {outputText}
-          </pre>
-          {hasMore && !showAll && (
-            <button
-              type="button"
-              onClick={() => setShowAll(true)}
-              className="text-xs text-primary hover:underline mt-0.5 cursor-pointer"
-            >
-              Show all ({hook.fullOutput.length} lines)
-            </button>
-          )}
-        </div>
+          <span className="ml-auto flex items-center gap-1.5 shrink-0">
+            {hook.status === "running" && (
+              <ElapsedTimer startedAt={hook.startedAt} />
+            )}
+            {hook.status === "completed" && hook.durationMs != null && (
+              <span className="font-mono tabular-nums text-xs text-muted-foreground">
+                {formatDuration(hook.durationMs)}
+              </span>
+            )}
+            {hook.status === "completed" && hook.exitCode != null && hook.exitCode !== 0 && (
+              <span className="font-mono text-[10px] px-1 rounded bg-diff-remove-strong/15 text-diff-remove-strong">
+                exit {hook.exitCode}
+              </span>
+            )}
+            {hook.didBlock && (
+              <span className="font-mono text-[10px] tracking-[0.12em] uppercase text-diff-remove-strong">
+                blocked
+              </span>
+            )}
+          </span>
+        </button>
+      </CollapsibleTrigger>
+      {displayLines.length > 0 && (
+        <CollapsibleContent>
+          <div className="ml-2.5 mt-0.5 mb-1">
+            <pre className="font-mono text-xs bg-muted/50 rounded-sm p-2 overflow-x-auto max-h-[300px] overflow-y-auto text-muted-foreground whitespace-pre-wrap break-all">
+              {outputText}
+            </pre>
+            {hasMore && !showAll && (
+              <button
+                type="button"
+                onClick={() => setShowAll(true)}
+                className="text-xs text-primary hover:underline mt-0.5 cursor-pointer"
+              >
+                Show all ({hook.fullOutput.length} lines)
+              </button>
+            )}
+          </div>
+        </CollapsibleContent>
       )}
-    </div>
+    </Collapsible>
   );
 });
 

--- a/apps/web/src/components/chat/HookActivitySection.tsx
+++ b/apps/web/src/components/chat/HookActivitySection.tsx
@@ -12,9 +12,9 @@ export function HookActivitySection({ hooks }: { hooks: readonly HookExecution[]
   const hasRunning = hooks.some((h) => h.status === "running");
   const [expanded, setExpanded] = useState(hasError || hasRunning);
 
-  // Auto-expand when an error appears
+  // Auto-expand on error/running, auto-collapse when all hooks pass
   useEffect(() => {
-    if (hasError || hasRunning) setExpanded(true);
+    setExpanded(hasError || hasRunning);
   }, [hasError, hasRunning]);
 
   return (

--- a/apps/web/src/components/chat/HookActivitySection.tsx
+++ b/apps/web/src/components/chat/HookActivitySection.tsx
@@ -64,6 +64,51 @@ function StatusDot({ hasError, hasRunning }: { hasError: boolean; hasRunning: bo
   return <span className="size-1.5 rounded-full bg-diff-add-strong" />;
 }
 
+/** Shared row content for a single hook execution (name, trigger, status badges). */
+function HookRowContent({ hook, hasOutput, detailOpen }: { hook: HookExecution; hasOutput: boolean; detailOpen: boolean }) {
+  return (
+    <>
+      {hasOutput && (
+        <ChevronRight
+          className={cn(
+            "size-2.5 text-muted-foreground/40 transition-transform duration-150 shrink-0",
+            detailOpen && "rotate-90",
+          )}
+        />
+      )}
+      {!hasOutput && <span className="w-2.5 shrink-0" />}
+      <span className="font-mono text-xs text-foreground truncate">
+        {hook.hookName}
+      </span>
+      {hook.toolName && (
+        <span className="text-xs text-muted-foreground/50 truncate shrink-0">
+          triggered by {hook.toolName}
+        </span>
+      )}
+      <span className="ml-auto flex items-center gap-1.5 shrink-0">
+        {hook.status === "running" && (
+          <ElapsedTimer startedAt={hook.startedAt} />
+        )}
+        {hook.status === "completed" && hook.durationMs != null && (
+          <span className="font-mono tabular-nums text-xs text-muted-foreground">
+            {formatDuration(hook.durationMs)}
+          </span>
+        )}
+        {hook.status === "completed" && hook.exitCode != null && hook.exitCode !== 0 && (
+          <span className="font-mono text-[10px] px-1 rounded bg-diff-remove-strong/15 text-diff-remove-strong">
+            exit {hook.exitCode}
+          </span>
+        )}
+        {hook.didBlock && (
+          <span className="font-mono text-[10px] tracking-[0.12em] uppercase text-diff-remove-strong">
+            blocked
+          </span>
+        )}
+      </span>
+    </>
+  );
+}
+
 /** Row showing a single hook execution with optional expandable output. */
 const HookRow = memo(function HookRow({ hook }: { hook: HookExecution }) {
   const [detailOpen, setDetailOpen] = useState(false);
@@ -73,53 +118,25 @@ const HookRow = memo(function HookRow({ hook }: { hook: HookExecution }) {
   const hasMore = hook.fullOutput.length > OUTPUT_LINE_CAP;
   const outputText = useMemo(() => displayLines.join("\n"), [displayLines]);
 
+  const rowClasses = "flex items-center gap-2 py-0.5 w-full text-left";
+
+  // Hooks without output render as a static row (not focusable)
+  if (!hasOutput) {
+    return (
+      <div className={rowClasses}>
+        <HookRowContent hook={hook} hasOutput={false} detailOpen={false} />
+      </div>
+    );
+  }
+
   return (
-    <Collapsible open={detailOpen} onOpenChange={hasOutput ? setDetailOpen : undefined}>
+    <Collapsible open={detailOpen} onOpenChange={setDetailOpen}>
       <CollapsibleTrigger asChild>
         <button
           type="button"
-          className={cn(
-            "flex items-center gap-2 py-0.5 w-full text-left",
-            hasOutput && "cursor-pointer hover:bg-muted/30 rounded-sm",
-          )}
+          className={cn(rowClasses, "cursor-pointer hover:bg-muted/30 rounded-sm")}
         >
-          {hasOutput && (
-            <ChevronRight
-              className={cn(
-                "size-2.5 text-muted-foreground/40 transition-transform duration-150 shrink-0",
-                detailOpen && "rotate-90",
-              )}
-            />
-          )}
-          {!hasOutput && <span className="w-2.5 shrink-0" />}
-          <span className="font-mono text-xs text-foreground truncate">
-            {hook.hookName}
-          </span>
-          {hook.toolName && (
-            <span className="text-xs text-muted-foreground/50 truncate shrink-0">
-              triggered by {hook.toolName}
-            </span>
-          )}
-          <span className="ml-auto flex items-center gap-1.5 shrink-0">
-            {hook.status === "running" && (
-              <ElapsedTimer startedAt={hook.startedAt} />
-            )}
-            {hook.status === "completed" && hook.durationMs != null && (
-              <span className="font-mono tabular-nums text-xs text-muted-foreground">
-                {formatDuration(hook.durationMs)}
-              </span>
-            )}
-            {hook.status === "completed" && hook.exitCode != null && hook.exitCode !== 0 && (
-              <span className="font-mono text-[10px] px-1 rounded bg-diff-remove-strong/15 text-diff-remove-strong">
-                exit {hook.exitCode}
-              </span>
-            )}
-            {hook.didBlock && (
-              <span className="font-mono text-[10px] tracking-[0.12em] uppercase text-diff-remove-strong">
-                blocked
-              </span>
-            )}
-          </span>
+          <HookRowContent hook={hook} hasOutput detailOpen={detailOpen} />
         </button>
       </CollapsibleTrigger>
       {displayLines.length > 0 && (
@@ -128,13 +145,13 @@ const HookRow = memo(function HookRow({ hook }: { hook: HookExecution }) {
             <pre className="font-mono text-xs bg-muted/50 rounded-sm p-2 overflow-x-auto max-h-[300px] overflow-y-auto text-muted-foreground whitespace-pre-wrap break-all">
               {outputText}
             </pre>
-            {hasMore && !showAll && (
+            {hasMore && (
               <button
                 type="button"
-                onClick={() => setShowAll(true)}
+                onClick={() => setShowAll((v) => !v)}
                 className="text-xs text-primary hover:underline mt-0.5 cursor-pointer"
               >
-                Show all ({hook.fullOutput.length} lines)
+                {showAll ? `Show preview (${OUTPUT_LINE_CAP} lines)` : `Show all (${hook.fullOutput.length} lines)`}
               </button>
             )}
           </div>

--- a/apps/web/src/components/chat/HookActivitySection.tsx
+++ b/apps/web/src/components/chat/HookActivitySection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, memo } from "react";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { HookExecution } from "@/transport/types";
@@ -61,12 +61,13 @@ function StatusDot({ hasError, hasRunning }: { hasError: boolean; hasRunning: bo
 }
 
 /** Row showing a single hook execution with optional expandable output. */
-function HookRow({ hook }: { hook: HookExecution }) {
+const HookRow = memo(function HookRow({ hook }: { hook: HookExecution }) {
   const [detailOpen, setDetailOpen] = useState(false);
   const [showAll, setShowAll] = useState(false);
   const hasOutput = hook.fullOutput.length > 0;
   const displayLines = showAll ? hook.fullOutput : hook.outputLines;
   const hasMore = hook.fullOutput.length > OUTPUT_LINE_CAP;
+  const outputText = useMemo(() => displayLines.join("\n"), [displayLines]);
 
   return (
     <div>
@@ -119,7 +120,7 @@ function HookRow({ hook }: { hook: HookExecution }) {
       {detailOpen && displayLines.length > 0 && (
         <div className="ml-2.5 mt-0.5 mb-1">
           <pre className="font-mono text-xs bg-muted/50 rounded-sm p-2 overflow-x-auto max-h-[300px] overflow-y-auto text-muted-foreground whitespace-pre-wrap break-all">
-            {displayLines.join("\n")}
+            {outputText}
           </pre>
           {hasMore && !showAll && (
             <button
@@ -134,7 +135,7 @@ function HookRow({ hook }: { hook: HookExecution }) {
       )}
     </div>
   );
-}
+});
 
 /** Live-updating elapsed time display for a running hook. */
 function ElapsedTimer({ startedAt }: { startedAt: number }) {

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -13,6 +13,7 @@ import { StreamingCard } from "./StreamingCard";
 import { ToolCallSummary } from "./ToolCallSummary";
 import { TurnChangeSummary } from "./TurnChangeSummary";
 import { PermissionRequestCard } from "./PermissionRequestCard";
+import { HookActivitySection } from "./HookActivitySection";
 import {
   buildStableItems,
   buildVolatileItems,
@@ -107,6 +108,8 @@ const VirtualItemRenderer = memo(function VirtualItemRenderer({
           decision={item.decision}
         />
       );
+    case "hook-activity":
+      return <HookActivitySection hooks={item.hooks} />;
   }
 }, (prev, next) =>
   prev.item.key === next.item.key
@@ -250,6 +253,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const permissions = useThreadStore(
     useShallow((s) => currentThreadId ? (s.permissionsByThread[currentThreadId] ?? []) : []),
   );
+  const hooks = useThreadStore(
+    useShallow((s) => currentThreadId ? (s.hooksByThread[currentThreadId] ?? []) : []),
+  );
 
   const toolCalls = toolCallsRaw ?? EMPTY_TOOL_CALLS;
 
@@ -347,8 +353,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   );
 
   const volatileItems = useMemo(
-    () => buildVolatileItems(toolCalls, isAgentRunning, agentStartTime, streamingText, permissions),
-    [toolCalls, isAgentRunning, agentStartTime, streamingText, permissions],
+    () => buildVolatileItems(toolCalls, isAgentRunning, agentStartTime, streamingText, permissions, hooks),
+    [toolCalls, isAgentRunning, agentStartTime, streamingText, permissions, hooks],
   );
 
   const hasToolCalls = toolCalls.length > 0;

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -59,6 +59,7 @@ vi.mock("@/stores/threadStore", () => ({
       isLoadingMore: {},
       loadOlderMessages: vi.fn(),
       permissionsByThread: {},
+      hooksByThread: {},
     }),
   ),
 }));
@@ -77,6 +78,7 @@ vi.mock("../StreamingCard", () => ({ StreamingCard: () => null }));
 vi.mock("../ToolCallSummary", () => ({ ToolCallSummary: () => null }));
 vi.mock("../TurnChangeSummary", () => ({ TurnChangeSummary: () => null }));
 vi.mock("../PermissionRequestCard", () => ({ PermissionRequestCard: () => null }));
+vi.mock("../HookActivitySection", () => ({ HookActivitySection: () => null }));
 
 import { MessageList } from "../MessageList";
 import { rememberScrollTop, recallScrollTop, clearScrollMemory } from "../scrollPositionMemory";

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -1,5 +1,5 @@
 import type { PermissionDecision } from "@mcode/contracts";
-import type { Message, ToolCall } from "@/transport/types";
+import type { Message, ToolCall, HookExecution } from "@/transport/types";
 
 /** Compile-time exhaustive check; throws at runtime for unhandled discriminants. */
 function assertNever(value: never): never {
@@ -37,6 +37,11 @@ export type ChatVirtualItem =
       title?: string;
       settled: boolean;
       decision?: PermissionDecision;
+    }
+  | {
+      key: string;
+      type: "hook-activity";
+      hooks: readonly HookExecution[];
     };
 
 /**
@@ -101,6 +106,7 @@ export function buildVolatileItems(
     settled: boolean;
     decision?: PermissionDecision;
   }[],
+  hooks?: readonly HookExecution[],
 ): ChatVirtualItem[] {
   const items: ChatVirtualItem[] = [];
 
@@ -127,6 +133,11 @@ export function buildVolatileItems(
         decision: p.decision,
       });
     }
+  }
+
+  // Hook activity section — grouped below permissions, above indicator.
+  if (hooks && hooks.length > 0) {
+    items.push({ key: "hook-activity", type: "hook-activity", hooks });
   }
 
   if (isAgentRunning) {
@@ -299,6 +310,9 @@ export function estimateItemHeight(item: ChatVirtualItem): number {
     }
     case "permission-request":
       return item.settled ? 36 : 120;
+    case "hook-activity":
+      // Header (28px) + one row (28px) per hook, capped at 300px
+      return Math.min(28 + item.hooks.length * 28, 300);
     default:
       return assertNever(item);
   }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1749,23 +1749,25 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       if (!hookName || !output) return;
       set((state) => {
         const hooks = state.hooksByThread[threadId] ?? [];
-        let changed = false;
-        const updated = hooks.map((h) => {
-          if (h.hookName === hookName && h.status === "running") {
-            changed = true;
-            const nextFull = [...h.fullOutput, output];
-            return {
-              ...h,
-              fullOutput: nextFull,
-              outputLines: nextFull.length > 20 ? nextFull.slice(-20) : nextFull,
-            };
+        // Target the last running hook with this name (not all same-name runs)
+        let idx = -1;
+        for (let i = hooks.length - 1; i >= 0; i--) {
+          if (hooks[i]!.hookName === hookName && hooks[i]!.status === "running") {
+            idx = i;
+            break;
           }
-          return h;
-        });
-        if (!changed) return state;
-        return {
-          hooksByThread: { ...state.hooksByThread, [threadId]: updated },
-        };
+        }
+        if (idx < 0) return state;
+        // Split chunk into actual lines so the 20-line cap is line-based
+        const addedLines = output
+          .split(/\r?\n/)
+          .filter((line, i, arr) => !(i === arr.length - 1 && line === ""));
+        if (addedLines.length === 0) return state;
+        const next = [...hooks];
+        const target = next[idx]!;
+        const fullOutput = [...target.fullOutput, ...addedLines];
+        next[idx] = { ...target, fullOutput, outputLines: fullOutput.slice(-20) };
+        return { hooksByThread: { ...state.hooksByThread, [threadId]: next } };
       });
       return;
     }
@@ -1778,18 +1780,18 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       if (!hookName) return;
       set((state) => {
         const hooks = state.hooksByThread[threadId] ?? [];
-        let changed = false;
-        const updated = hooks.map((h) => {
-          if (h.hookName === hookName && h.status === "running") {
-            changed = true;
-            return { ...h, status: "completed" as const, exitCode, durationMs, didBlock };
+        // Target the last running hook with this name
+        let idx = -1;
+        for (let i = hooks.length - 1; i >= 0; i--) {
+          if (hooks[i]!.hookName === hookName && hooks[i]!.status === "running") {
+            idx = i;
+            break;
           }
-          return h;
-        });
-        if (!changed) return state;
-        return {
-          hooksByThread: { ...state.hooksByThread, [threadId]: updated },
-        };
+        }
+        if (idx < 0) return state;
+        const next = [...hooks];
+        next[idx] = { ...next[idx]!, status: "completed" as const, exitCode, durationMs, didBlock };
+        return { hooksByThread: { ...state.hooksByThread, [threadId]: next } };
       });
       return;
     }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1135,6 +1135,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         planQuestionsStatusByThread: omitKey(state.planQuestionsStatusByThread, threadId),
         answeredPlanMessageIdsByThread: omitKey(state.answeredPlanMessageIdsByThread, threadId),
         permissionsByThread: omitKey(state.permissionsByThread, threadId),
+        hooksByThread: omitKey(state.hooksByThread, threadId),
         usageByProvider: Object.fromEntries(
           Object.entries(state.usageByProvider).filter(([k]) => !k.startsWith(`${threadId}:`)),
         ),
@@ -1220,6 +1221,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         planQuestionsStatusByThread: pruneAll(state.planQuestionsStatusByThread),
         answeredPlanMessageIdsByThread: pruneAll(state.answeredPlanMessageIdsByThread),
         permissionsByThread: pruneAll(state.permissionsByThread),
+        hooksByThread: pruneAll(state.hooksByThread),
         usageByProvider: Object.fromEntries(
           Object.entries(state.usageByProvider).filter(([k]) => !threadIds.some((tid) => k.startsWith(`${tid}:`))),
         ),

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1765,7 +1765,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         if (addedLines.length === 0) return state;
         const next = [...hooks];
         const target = next[idx]!;
-        const fullOutput = [...target.fullOutput, ...addedLines];
+        // Cap retained output to prevent unbounded memory growth from verbose hooks
+        const raw = [...target.fullOutput, ...addedLines];
+        const fullOutput = raw.length > 500 ? raw.slice(-500) : raw;
         next[idx] = { ...target, fullOutput, outputLines: fullOutput.slice(-20) };
         return { hooksByThread: { ...state.hooksByThread, [threadId]: next } };
       });

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { Message, ToolCall, PermissionMode, InteractionMode, AttachmentMeta, ToolCallRecord } from "@/transport";
+import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, ToolCallRecord } from "@/transport";
 import type { ContextWindowMode, ReasoningLevel, PlanQuestion, PlanAnswer, ProviderUsageInfo, QuotaCategory, TurnSnapshot } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { PlanQuestionSchema, PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
@@ -115,6 +115,8 @@ interface ThreadState {
   answeredPlanMessageIdsByThread: Record<string, Set<string>>;
   /** Pending and recently-settled permission requests per thread. */
   permissionsByThread: Record<string, StoredPermission[]>;
+  /** Ephemeral hook execution state per thread. Cleared on page reload, not persisted to DB. */
+  hooksByThread: Record<string, HookExecution[]>;
   /**
    * After `agent.stop`, each thread ID is marked until `turn.persisted` arrives for that
    * thread, so we can show a one-shot file-change notice without colliding across threads.
@@ -351,6 +353,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   planQuestionsStatusByThread: {},
   answeredPlanMessageIdsByThread: {},
   permissionsByThread: {},
+  hooksByThread: {},
   awaitingUserStopPersistByThread: {},
   interruptStopFileNoticeByThread: {},
   composerRecallFromStopByThread: {},
@@ -1711,6 +1714,79 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         if (!changed) return state;
         return {
           toolCallsByThread: { ...state.toolCallsByThread, [threadId]: updated },
+        };
+      });
+      return;
+    }
+
+    if (method === "session.hookStarted") {
+      const hookName = (params.hookName as string) || "unknown";
+      const hookType = (params.hookType as "permission" | "stop") || "stop";
+      const toolName = params.toolName as string | undefined;
+      const hook: HookExecution = {
+        hookName,
+        hookType,
+        toolName,
+        status: "running",
+        outputLines: [],
+        fullOutput: [],
+        startedAt: Date.now(),
+      };
+      set((state) => ({
+        hooksByThread: {
+          ...state.hooksByThread,
+          [threadId]: [...(state.hooksByThread[threadId] ?? []), hook],
+        },
+      }));
+      return;
+    }
+
+    if (method === "session.hookProgress") {
+      const hookName = (params.hookName as string) || "";
+      const output = (params.output as string) || "";
+      if (!hookName || !output) return;
+      set((state) => {
+        const hooks = state.hooksByThread[threadId] ?? [];
+        let changed = false;
+        const updated = hooks.map((h) => {
+          if (h.hookName === hookName && h.status === "running") {
+            changed = true;
+            const nextFull = [...h.fullOutput, output];
+            return {
+              ...h,
+              fullOutput: nextFull,
+              outputLines: nextFull.length > 20 ? nextFull.slice(-20) : nextFull,
+            };
+          }
+          return h;
+        });
+        if (!changed) return state;
+        return {
+          hooksByThread: { ...state.hooksByThread, [threadId]: updated },
+        };
+      });
+      return;
+    }
+
+    if (method === "session.hookCompleted") {
+      const hookName = (params.hookName as string) || "";
+      const exitCode = (params.exitCode as number) ?? 1;
+      const durationMs = (params.durationMs as number) ?? 0;
+      const didBlock = (params.didBlock as boolean) ?? false;
+      if (!hookName) return;
+      set((state) => {
+        const hooks = state.hooksByThread[threadId] ?? [];
+        let changed = false;
+        const updated = hooks.map((h) => {
+          if (h.hookName === hookName && h.status === "running") {
+            changed = true;
+            return { ...h, status: "completed" as const, exitCode, durationMs, didBlock };
+          }
+          return h;
+        });
+        if (!changed) return state;
+        return {
+          hooksByThread: { ...state.hooksByThread, [threadId]: updated },
         };
       });
       return;

--- a/apps/web/src/transport/index.ts
+++ b/apps/web/src/transport/index.ts
@@ -8,7 +8,7 @@ import { useProviderModelsStore } from "@/stores/providerModelsStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 
 /** Re-exported transport and domain types for use across the web app. */
-export type { McodeTransport, Workspace, Thread, Message, ToolCall, GitBranch, WorktreeInfo, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, SkillInfo, PrInfo, PrDetail, ToolCallRecord, Settings, PartialSettings, PlanAnswer } from "./types";
+export type { McodeTransport, Workspace, Thread, Message, ToolCall, HookExecution, GitBranch, WorktreeInfo, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, SkillInfo, PrInfo, PrDetail, ToolCallRecord, Settings, PartialSettings, PlanAnswer } from "./types";
 export { PERMISSION_MODES, INTERACTION_MODES } from "./types";
 export { pushEmitter } from "./ws-transport";
 

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -77,6 +77,23 @@ export interface ToolCall {
   elapsedSeconds?: number;
 }
 
+/** Ephemeral hook execution state tracked during a session. Not persisted to DB. */
+export interface HookExecution {
+  hookName: string;
+  hookType: "permission" | "stop";
+  toolName?: string;
+  status: "running" | "completed";
+  /** Last 20 lines of hook output, shown by default in the UI. */
+  outputLines: string[];
+  /** Full hook output buffer, available via "show all" toggle. */
+  fullOutput: string[];
+  exitCode?: number;
+  durationMs?: number;
+  didBlock?: boolean;
+  /** Timestamp when the hook started, used to derive an elapsed timer. */
+  startedAt: number;
+}
+
 /** Transport interface consumed by the web app to communicate with the backend. */
 export interface McodeTransport {
   // Workspace commands

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -30,6 +30,9 @@ export const AgentEventType = {
   ProviderUnavailable: "providerUnavailable",
   RateLimited: "rateLimited",
   ApiRetry: "apiRetry",
+  HookStarted: "hookStarted",
+  HookProgress: "hookProgress",
+  HookCompleted: "hookCompleted",
 } as const;
 
 /** Union of all valid `AgentEvent` type discriminants. */
@@ -210,6 +213,37 @@ export const AgentEventSchema = lazySchema(() =>
       delayMs: z.number().optional(),
       /** HTTP status code that triggered the retry, if available. Omitted for connection errors. */
       errorStatus: z.number().optional(),
+    }),
+    z.object({
+      /** Emitted when a hook begins executing (permission or stop hook). */
+      type: z.literal(AgentEventType.HookStarted),
+      threadId: z.string(),
+      /** Name of the hook as configured in settings. */
+      hookName: z.string(),
+      /** Whether this is a permission hook (fires before a tool) or a stop hook (fires after the turn). */
+      hookType: z.enum(["permission", "stop"]),
+      /** Tool that triggered a permission hook. Absent for stop hooks. */
+      toolName: z.string().optional(),
+    }),
+    z.object({
+      /** Incremental stdout output from a running hook. */
+      type: z.literal(AgentEventType.HookProgress),
+      threadId: z.string(),
+      hookName: z.string(),
+      /** One or more lines of stdout output from the hook process. */
+      output: z.string(),
+    }),
+    z.object({
+      /** Emitted when a hook finishes executing. */
+      type: z.literal(AgentEventType.HookCompleted),
+      threadId: z.string(),
+      hookName: z.string(),
+      /** Process exit code. 0 = success. */
+      exitCode: z.number(),
+      /** Wall-clock execution time in milliseconds. */
+      durationMs: z.number(),
+      /** Whether the hook blocked the tool call or agent turn from proceeding. */
+      didBlock: z.boolean(),
     }),
   ]),
 );


### PR DESCRIPTION
## What
Surface Claude Code hook lifecycle events (hook_started, hook_progress, hook_response) so users can see what hooks are running, why the agent paused, and whether a hook failed or blocked.

## Why
Hooks can take seconds to run (linting, formatting, test runners, custom scripts). Without visibility, users don't know why the agent paused after a turn, hook errors are invisible, and there's no timing information to identify slow hooks.

## Key Changes
- **Contracts:** Add `hookStarted`, `hookProgress`, `hookCompleted` event types to `AgentEventSchema` discriminated union
- **Server:** Map SDK `system` subtypes (`hook_started`, `hook_progress`, `hook_response`) to new agent events in the Claude provider
- **Store:** Add ephemeral `hooksByThread` state with three event handlers (started, progress, completed). Output capped at last 20 lines with "show all" toggle
- **UI:** New `HookActivitySection` component renders a collapsible "HOOKS" section below tool calls. Auto-expands on error/block, auto-collapses when all hooks pass. Status dots follow the app's design system (primary/pulsing for running, sage for pass, clay for error)
- **Virtual items:** New `hook-activity` item type plumbed through `buildVolatileItems` and `VirtualItemRenderer`

Hooks are ephemeral (Zustand only, not persisted to DB). When a hook blocks, the SDK already injects feedback into the conversation as a system message, so blocking outcomes are naturally persisted.

Closes #153

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time hook execution tracking in chat: a collapsible "Hooks" activity section with per-hook rows, live elapsed time, formatted durations, exit-code and "blocked" indicators, streamed output with a "Show all" toggle, and placement after permission requests.
  * Per-thread ephemeral hook state and a new HookExecution type to keep UI synchronized with hook lifecycle events; runtime events for hook start/progress/completion added to the agent event contract.

* **Tests**
  * Added tests covering hook-driven virtual items and related behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/447)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->