### PR TITLE
feat(preview): Ctrl+click on links opens in browser preview

### DIFF
--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -41,7 +41,7 @@ function hasPreview(): boolean {
  * Handles a click on a previewable URL. Opens in the browser preview panel on
  * Ctrl/Cmd+click, otherwise opens externally.
  */
-function handleLinkClick(e: React.MouseEvent, url: string): void {
+function handleLinkClick(e: React.MouseEvent | React.KeyboardEvent, url: string): void {
   e.preventDefault();
 
   const isModifierClick = e.ctrlKey || e.metaKey;
@@ -218,7 +218,7 @@ function makeComponents(isStreaming: boolean, variant: "assistant" | "user") {
               tabIndex={0}
               className={`${codeClass} ${linkClass}`}
               onClick={(e) => handleLinkClick(e, text)}
-              onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e as unknown as React.MouseEvent, text); }}
+              onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e, text); }}
             >
               {children}
             </code>

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodeBlock } from "./CodeBlock";
 import { useDiffStore } from "@/stores/diffStore";
+import { isMac } from "@/lib/platform";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 /** Props for {@link MarkdownContent}. */
@@ -23,9 +24,6 @@ const plugins = [remarkGfm];
 
 /** Lazy-loaded MermaidBlock - only fetched when a mermaid fence is encountered. */
 const LazyMermaidBlock = lazy(() => import("./MermaidBlock"));
-
-/** Whether the current platform is macOS (for modifier key labels). */
-const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
 
 /**
  * Builds the static component overrides that depend on `variant`.
@@ -66,7 +64,7 @@ function makeStaticComponents(variant: "assistant" | "user") {
           target="_blank"
           rel="noopener noreferrer"
           title={
-            window.desktopBridge?.preview
+            window.desktopBridge?.preview && safeHref && (safeHref.startsWith("http:") || safeHref.startsWith("https:"))
               ? `${isMac ? "\u2318" : "Ctrl"}+click to open in preview`
               : undefined
           }
@@ -84,7 +82,11 @@ function makeStaticComponents(variant: "assistant" | "user") {
                 showRightPanel(threadId);
                 setRightPanelTab(threadId, "preview");
                 // Defer navigation so React can re-render and sync BrowserView bounds
-                setTimeout(() => window.desktopBridge!.preview!.navigate(safeHref), 0);
+                setTimeout(() => {
+                  window.desktopBridge?.preview?.navigate(safeHref).then((r) => {
+                    if (!r?.ok) window.desktopBridge?.openExternalUrl?.(safeHref);
+                  });
+                }, 0);
                 return;
               }
               // No active thread; fall through to open externally

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -24,6 +24,9 @@ const plugins = [remarkGfm];
 /** Lazy-loaded MermaidBlock - only fetched when a mermaid fence is encountered. */
 const LazyMermaidBlock = lazy(() => import("./MermaidBlock"));
 
+/** Whether the current platform is macOS (for modifier key labels). */
+const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
+
 /**
  * Builds the static component overrides that depend on `variant`.
  * Elements whose colors differ between assistant and user bubble are variant-conditional.
@@ -62,6 +65,11 @@ function makeStaticComponents(variant: "assistant" | "user") {
           className={linkClass}
           target="_blank"
           rel="noopener noreferrer"
+          title={
+            window.desktopBridge?.preview
+              ? `${isMac ? "\u2318" : "Ctrl"}+click to open in preview`
+              : undefined
+          }
           onClick={(e) => {
             if (!safeHref) return;
             e.preventDefault();

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -5,6 +5,7 @@ import { CodeBlock } from "./CodeBlock";
 import { useDiffStore } from "@/stores/diffStore";
 import { isMac } from "@/lib/platform";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 /** Props for {@link MarkdownContent}. */
 interface MarkdownContentProps {
@@ -24,6 +25,49 @@ const plugins = [remarkGfm];
 
 /** Lazy-loaded MermaidBlock - only fetched when a mermaid fence is encountered. */
 const LazyMermaidBlock = lazy(() => import("./MermaidBlock"));
+
+/** Matches a standalone HTTP(S) URL (used to detect URLs inside inline code spans). */
+const HTTP_URL_RE = /^https?:\/\/\S+$/;
+
+/** Tooltip label for the Ctrl/Cmd+click preview hint. */
+const previewHint = `${isMac ? "\u2318" : "Ctrl"}+click to open in preview`;
+
+/** Whether the desktop preview bridge is available. */
+function hasPreview(): boolean {
+  return !!window.desktopBridge?.preview;
+}
+
+/**
+ * Handles a click on a previewable URL. Opens in the browser preview panel on
+ * Ctrl/Cmd+click, otherwise opens externally.
+ */
+function handleLinkClick(e: React.MouseEvent, url: string): void {
+  e.preventDefault();
+
+  const isModifierClick = e.ctrlKey || e.metaKey;
+  if (isModifierClick && hasPreview()) {
+    const threadId = useWorkspaceStore.getState().activeThreadId;
+    if (threadId) {
+      const { showRightPanel, setRightPanelTab } = useDiffStore.getState();
+      showRightPanel(threadId);
+      setRightPanelTab(threadId, "preview");
+      // Defer navigation so React can re-render and sync BrowserView bounds
+      setTimeout(() => {
+        window.desktopBridge?.preview?.navigate(url).then((r) => {
+          if (!r?.ok) window.desktopBridge?.openExternalUrl?.(url);
+        });
+      }, 0);
+      return;
+    }
+    // No active thread; fall through to open externally
+  }
+
+  if (window.desktopBridge?.openExternalUrl) {
+    window.desktopBridge.openExternalUrl(url);
+  } else {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}
 
 /**
  * Builds the static component overrides that depend on `variant`.
@@ -57,41 +101,18 @@ function makeStaticComponents(variant: "assistant" | "user") {
       const linkClass = isUser
         ? "text-primary-foreground underline hover:opacity-80"
         : "text-primary underline hover:text-primary";
-      return (
+      const isPreviewable = safeHref && (safeHref.startsWith("http:") || safeHref.startsWith("https:"));
+      const showHint = isPreviewable && hasPreview();
+      const anchor = (
         <a
           href={safeHref}
           className={linkClass}
           target="_blank"
           rel="noopener noreferrer"
-          title={
-            window.desktopBridge?.preview && safeHref && (safeHref.startsWith("http:") || safeHref.startsWith("https:"))
-              ? `${isMac ? "\u2318" : "Ctrl"}+click to open in preview`
-              : undefined
-          }
           onClick={(e) => {
             if (!safeHref) return;
+            if (isPreviewable) return handleLinkClick(e, safeHref);
             e.preventDefault();
-
-            // Ctrl+click (Cmd+click on Mac) opens HTTP(S) links in the browser preview panel
-            const isModifierClick = e.ctrlKey || e.metaKey;
-            const isPreviewable = safeHref.startsWith("http:") || safeHref.startsWith("https:");
-            if (isModifierClick && isPreviewable && window.desktopBridge?.preview) {
-              const threadId = useWorkspaceStore.getState().activeThreadId;
-              if (threadId) {
-                const { showRightPanel, setRightPanelTab } = useDiffStore.getState();
-                showRightPanel(threadId);
-                setRightPanelTab(threadId, "preview");
-                // Defer navigation so React can re-render and sync BrowserView bounds
-                setTimeout(() => {
-                  window.desktopBridge?.preview?.navigate(safeHref).then((r) => {
-                    if (!r?.ok) window.desktopBridge?.openExternalUrl?.(safeHref);
-                  });
-                }, 0);
-                return;
-              }
-              // No active thread; fall through to open externally
-            }
-
             if (window.desktopBridge?.openExternalUrl) {
               window.desktopBridge.openExternalUrl(safeHref);
             } else {
@@ -101,6 +122,13 @@ function makeStaticComponents(variant: "assistant" | "user") {
         >
           {children}
         </a>
+      );
+      if (!showHint) return anchor;
+      return (
+        <Tooltip>
+          <TooltipTrigger render={anchor} />
+          <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+        </Tooltip>
       );
     },
     blockquote: ({ children }: { children?: React.ReactNode }) => (
@@ -174,17 +202,37 @@ function makeComponents(isStreaming: boolean, variant: "assistant" | "user") {
       const isInline = !className && !rawContent.includes("\n");
 
       if (isInline) {
-        return (
-          <code
-            className={
-              isUser
-                ? "bg-primary-foreground/15 rounded px-1.5 py-0.5 text-sm font-mono"
-                : "bg-muted rounded px-1.5 py-0.5 text-sm font-mono"
-            }
-          >
-            {children}
-          </code>
-        );
+        const codeClass = isUser
+          ? "bg-primary-foreground/15 rounded px-1.5 py-0.5 text-sm font-mono"
+          : "bg-muted rounded px-1.5 py-0.5 text-sm font-mono";
+
+        // Detect URLs inside inline code and make them clickable
+        const text = rawContent.trim();
+        if (HTTP_URL_RE.test(text)) {
+          const linkClass = isUser
+            ? "text-primary-foreground underline decoration-dotted hover:opacity-80 cursor-pointer"
+            : "text-primary underline decoration-dotted hover:text-primary cursor-pointer";
+          const codeLink = (
+            <code
+              role="link"
+              tabIndex={0}
+              className={`${codeClass} ${linkClass}`}
+              onClick={(e) => handleLinkClick(e, text)}
+              onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e as unknown as React.MouseEvent, text); }}
+            >
+              {children}
+            </code>
+          );
+          if (!hasPreview()) return codeLink;
+          return (
+            <Tooltip>
+              <TooltipTrigger render={codeLink} />
+              <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+            </Tooltip>
+          );
+        }
+
+        return <code className={codeClass}>{children}</code>;
       }
 
       const langMatch = className?.match(/language-(\S+)/);

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -66,17 +66,20 @@ function makeStaticComponents(variant: "assistant" | "user") {
             if (!safeHref) return;
             e.preventDefault();
 
-            // Ctrl+click (Cmd+click on Mac) opens in the browser preview panel
+            // Ctrl+click (Cmd+click on Mac) opens HTTP(S) links in the browser preview panel
             const isModifierClick = e.ctrlKey || e.metaKey;
-            if (isModifierClick && window.desktopBridge?.preview) {
+            const isPreviewable = safeHref.startsWith("http:") || safeHref.startsWith("https:");
+            if (isModifierClick && isPreviewable && window.desktopBridge?.preview) {
               const threadId = useWorkspaceStore.getState().activeThreadId;
               if (threadId) {
                 const { showRightPanel, setRightPanelTab } = useDiffStore.getState();
                 showRightPanel(threadId);
                 setRightPanelTab(threadId, "preview");
-                window.desktopBridge.preview.navigate(safeHref);
+                // Defer navigation so React can re-render and sync BrowserView bounds
+                setTimeout(() => window.desktopBridge!.preview!.navigate(safeHref), 0);
+                return;
               }
-              return;
+              // No active thread; fall through to open externally
             }
 
             if (window.desktopBridge?.openExternalUrl) {

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -2,6 +2,8 @@ import { memo, useMemo, lazy, Suspense } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodeBlock } from "./CodeBlock";
+import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 /** Props for {@link MarkdownContent}. */
 interface MarkdownContentProps {
@@ -63,6 +65,20 @@ function makeStaticComponents(variant: "assistant" | "user") {
           onClick={(e) => {
             if (!safeHref) return;
             e.preventDefault();
+
+            // Ctrl+click (Cmd+click on Mac) opens in the browser preview panel
+            const isModifierClick = e.ctrlKey || e.metaKey;
+            if (isModifierClick && window.desktopBridge?.preview) {
+              const threadId = useWorkspaceStore.getState().activeThreadId;
+              if (threadId) {
+                const { showRightPanel, setRightPanelTab } = useDiffStore.getState();
+                showRightPanel(threadId);
+                setRightPanelTab(threadId, "preview");
+                window.desktopBridge.preview.navigate(safeHref);
+              }
+              return;
+            }
+
             if (window.desktopBridge?.openExternalUrl) {
               window.desktopBridge.openExternalUrl(safeHref);
             } else {


### PR DESCRIPTION
## What
Ctrl+click (Cmd+click on Mac) on links in chat messages opens them in the embedded browser preview panel instead of the system browser. Also detects URLs inside inline code spans and makes them clickable.

## Why
Users browsing chat responses often want to quickly preview a link without leaving the app. This provides a native, low-friction way to open links in the built-in preview panel, with discoverability via a tooltip hint on hover.

## Key Changes
- Ctrl/Cmd+click on `<a>` links navigates the browser preview panel (auto-opens if hidden)
- Inline code spans containing HTTP(S) URLs are rendered as clickable links with the same behavior
- Shadcn Tooltip shows "Ctrl+click to open in preview" (or the Mac variant) on hover
- Falls back to external browser if preview navigation fails or no active thread
- `mailto:` links excluded from preview routing
- Uses shared `isMac` from `@/lib/platform` for platform detection
- Deferred `navigate()` via `setTimeout(0)` to avoid race condition with BrowserView bounds sync

Closes #445

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Links show tooltips with platform-specific modifier-key hints for opening an in-app side-panel preview.
  * URLs inside inline code become clickable and can open in the preview when available.
  * Modifier-clicks open preview when supported; otherwise links open externally.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/450)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->