### PR TITLE
feat(preview): responsive viewport emulation

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -40,7 +40,7 @@ import {
   setBeforeInstallHook,
 } from "./auto-updater.js";
 import { setupSpellcheck } from "./spellcheck.js";
-import { registerPreviewBrowserHandlers, disposePreviewForWindow } from "./preview-browser.js";
+import { registerPreviewBrowserHandlers, disposePreviewForWindow, parkPreviewForWindow } from "./preview-browser.js";
 
 // Isolate dev's Electron userData (cache, cookies, localStorage, IndexedDB)
 // from the installed prod build. Without this, both share %APPDATA%/Mcode/
@@ -279,6 +279,13 @@ function createWindow(): void {
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     openIfAllowed(url);
     return { action: "deny" };
+  });
+
+  // Park the preview BrowserView when the shell renderer refreshes (F5 / Ctrl+R)
+  // so the native overlay does not linger on top of the fresh page.
+  mainWindow.webContents.on("did-start-navigation", (_event, _url, isInPlace, isMainFrame) => {
+    if (!isMainFrame || isInPlace) return;
+    parkPreviewForWindow(mainWindow!);
   });
 
   // Prevent the main window from navigating away from the app.

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -141,6 +141,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       threadId?: string | null;
       resumeUrlHint?: string | null;
       workspaceId?: string | null;
+      deviceEmulation?: unknown;
     }): Promise<void> {
       return ipcRenderer.invoke("preview:sync", payload);
     },
@@ -161,6 +162,9 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     },
     getNavigationState(): Promise<{ canGoBack: boolean; canGoForward: boolean }> {
       return ipcRenderer.invoke("preview:get-navigation-state");
+    },
+    focusGuest(): Promise<void> {
+      return ipcRenderer.invoke("preview:focus-guest");
     },
     /** Capture the visible preview viewport as a PNG for attaching to the composer. */
     capturePictureReference(): Promise<unknown> {

--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -951,6 +951,7 @@ async function buildBrowserCapturePayload(
     captureKind?: "viewport" | "region" | "element";
     selectorHint?: string | null;
     htmlExcerpt?: string | null;
+    emulation?: McodeBrowserCaptureEmulation;
   },
 ): Promise<McodeBrowserCaptureV2> {
   const ctx = await captureGuestPageContextForCapture(webContents);
@@ -967,6 +968,9 @@ async function buildBrowserCapturePayload(
   };
   if (extras?.captureKind !== undefined) {
     out.captureKind = extras.captureKind;
+  }
+  if (extras?.emulation) {
+    out.emulation = { ...extras.emulation };
   }
   if (extras?.htmlExcerpt != null && extras.htmlExcerpt.length > 0) {
     const scrubbed = scrubHtmlExcerptForOutbound(extras.htmlExcerpt);
@@ -1954,6 +1958,7 @@ export function registerPreviewBrowserHandlers(): void {
         s.workspaceId,
         {
           captureKind: "viewport",
+          emulation: s.captureEmulationSnapshot ?? undefined,
         },
       );
       resetIdle(win, s);
@@ -1985,7 +1990,7 @@ export function registerPreviewBrowserHandlers(): void {
         s.consoleBuffer,
         snapshotFailedRequestsForCapture(s),
         s.workspaceId,
-        { captureKind: "viewport" },
+        { captureKind: "viewport", emulation: s.captureEmulationSnapshot ?? undefined },
       );
       resetIdle(win, s);
       return { ok: true, capture };
@@ -2061,6 +2066,7 @@ export function registerPreviewBrowserHandlers(): void {
         s.workspaceId,
         {
           captureKind: "region",
+          emulation: s.captureEmulationSnapshot ?? undefined,
         },
       );
 
@@ -2212,6 +2218,7 @@ export function registerPreviewBrowserHandlers(): void {
             captureKind: "element",
             selectorHint: hit.selectorHint,
             htmlExcerpt: hit.htmlExcerpt,
+            emulation: s.captureEmulationSnapshot ?? undefined,
           },
         );
 

--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -1652,11 +1652,15 @@ function layoutPreviewGuest(s: PreviewSession): void {
   const resolved = resolvePreviewDeviceEmulation(s.deviceEmulationConfig);
 
   if (!resolved) {
-    // Desktop mode: fill the panel, disable any prior emulation
+    // Desktop mode: fill the panel, disable any prior emulation.
+    // Only call disableDeviceEmulation when emulation was previously active;
+    // calling it on a fresh BrowserView that never had emulation enabled
+    // crashes the Chromium compositor on Windows.
+    const hadEmulation = s.captureEmulationSnapshot !== null;
     s.view.setBounds(sh);
     s.lastBounds = { ...sh };
     s.captureEmulationSnapshot = null;
-    if (s.defaultGuestUserAgent) {
+    if (hadEmulation && s.defaultGuestUserAgent) {
       try {
         wc.disableDeviceEmulation();
         wc.setUserAgent(s.defaultGuestUserAgent);

--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -12,12 +12,20 @@ import {
   clampMcodeBrowserCaptureV2,
   isBrowserCaptureSpillAppDataPath,
   MCODE_BROWSER_CAPTURE_V2_STRING_MAX,
+  PreviewDeviceEmulationConfigSchema,
   type AttachmentMeta,
   type McodeBrowserCaptureEmulation,
   type McodeBrowserCaptureV2,
   type PreviewDeviceEmulationConfig,
 } from "@mcode/contracts";
 import { getMcodeDir, redactMcodeBrowserCaptureV2, spillWorkspaceDirSegment } from "@mcode/shared";
+import {
+  applyPreviewDeviceEmulation,
+  buildCaptureEmulationSnapshot,
+  buildPreviewMobileUserAgent,
+  layoutGuestBoundsForEmulation,
+  resolvePreviewDeviceEmulation,
+} from "./preview-device-emulation.js";
 
 // Idle teardown removed: the React shell already hides the view on unmount/tab-switch
 // via pushSync(false), so a timer-based teardown is redundant and caused the view to
@@ -1350,6 +1358,10 @@ function ensureView(win: BrowserWindow, s: PreviewSession): BrowserView {
   });
   view.webContents.on("did-finish-load", () => {
     void injectPreviewScrollbarStyles(s);
+    // Re-apply deferred emulation after the guest loads a real document
+    if (s.deviceEmulationConfig.kind !== "off" && !s.captureEmulationSnapshot) {
+      layoutPreviewGuest(s);
+    }
   });
 
   const forwardLoadingStart = () => {
@@ -1625,6 +1637,61 @@ async function validateResumeUrl(url: string | null): Promise<string | null> {
   return url;
 }
 
+/**
+ * Centers the guest BrowserView inside the shell surface and applies device emulation when enabled.
+ */
+function layoutPreviewGuest(s: PreviewSession): void {
+  if (!s.view || s.view.webContents.isDestroyed() || !s.shellBounds) return;
+  const sh = s.shellBounds;
+  const wc = s.view.webContents;
+
+  const resolved = resolvePreviewDeviceEmulation(s.deviceEmulationConfig);
+
+  if (!resolved) {
+    // Desktop mode: fill the panel, disable any prior emulation
+    s.view.setBounds(sh);
+    s.lastBounds = { ...sh };
+    s.captureEmulationSnapshot = null;
+    if (s.defaultGuestUserAgent) {
+      try {
+        wc.disableDeviceEmulation();
+        wc.setUserAgent(s.defaultGuestUserAgent);
+      } catch { /* view tearing down */ }
+    }
+    return;
+  }
+
+  try {
+    const { guest, scaleToFit } = layoutGuestBoundsForEmulation(sh, resolved.cssWidth, resolved.cssHeight);
+    const safeScale = Number.isFinite(scaleToFit) && scaleToFit > 0 ? Math.min(scaleToFit, 1) : 1;
+    s.view.setBounds(guest);
+    s.lastBounds = { ...guest };
+
+    const chromeV = process.versions.chrome ?? "120.0.0.0";
+    const mobileUa = buildPreviewMobileUserAgent(chromeV);
+    applyPreviewDeviceEmulation(wc, {
+      active: true,
+      cssViewport: { width: resolved.cssWidth, height: resolved.cssHeight },
+      deviceScaleFactor: resolved.deviceScaleFactor,
+      scaleToFit: safeScale,
+      mobileUserAgent: mobileUa,
+      defaultUserAgent: s.defaultGuestUserAgent,
+    });
+
+    s.captureEmulationSnapshot = buildCaptureEmulationSnapshot(
+      s.deviceEmulationConfig,
+      resolved,
+      safeScale,
+      mobileUa,
+    );
+  } catch (err) {
+    console.warn("[preview-browser] device emulation failed; falling back to desktop layout:", err);
+    s.view.setBounds(sh);
+    s.lastBounds = { ...sh };
+    s.captureEmulationSnapshot = null;
+  }
+}
+
 /** Registers ipcMain handlers for `preview:*` channels (call once at startup). */
 export function registerPreviewBrowserHandlers(): void {
   const previewPartition = session.fromPartition("persist:mcode-preview");
@@ -1659,6 +1726,7 @@ export function registerPreviewBrowserHandlers(): void {
         threadId?: string | null;
         resumeUrlHint?: string | null;
         workspaceId?: string | null;
+        deviceEmulation?: unknown;
       },
     ) => {
       const win = BrowserWindow.fromWebContents(_event.sender);
@@ -1667,15 +1735,18 @@ export function registerPreviewBrowserHandlers(): void {
       const s = getSession(win);
       const ws = payload.workspaceId;
       s.workspaceId = typeof ws === "string" && ws.trim().length > 0 ? ws.trim() : null;
+      const rawEmu = payload.deviceEmulation ?? { kind: "off" };
+      const emParsed = PreviewDeviceEmulationConfigSchema().safeParse(rawEmu);
+      s.deviceEmulationConfig = emParsed.success ? emParsed.data : { kind: "off" };
       const b = payload.bounds;
       if (!payload.visible || !b || b.width < 4 || b.height < 4) {
         hidePreview(win, s);
         return;
       }
 
-      s.lastBounds = { x: b.x, y: b.y, width: b.width, height: b.height };
+      s.shellBounds = { x: b.x, y: b.y, width: b.width, height: b.height };
       const view = ensureView(win, s);
-      view.setBounds(s.lastBounds);
+      layoutPreviewGuest(s);
       if (win.getBrowserView() !== view) {
         win.setBrowserView(view);
       }

--- a/apps/desktop/src/main/preview-browser.ts
+++ b/apps/desktop/src/main/preview-browser.ts
@@ -13,7 +13,9 @@ import {
   isBrowserCaptureSpillAppDataPath,
   MCODE_BROWSER_CAPTURE_V2_STRING_MAX,
   type AttachmentMeta,
+  type McodeBrowserCaptureEmulation,
   type McodeBrowserCaptureV2,
+  type PreviewDeviceEmulationConfig,
 } from "@mcode/contracts";
 import { getMcodeDir, redactMcodeBrowserCaptureV2, spillWorkspaceDirSegment } from "@mcode/shared";
 
@@ -120,6 +122,14 @@ interface PreviewSession {
    * since those loads already passed {@link resolveLocalFileUrl}.
    */
   trustedFileNavigationBudget: number;
+  /** Per-thread device emulation config from the renderer (synced on each preview:sync). */
+  deviceEmulationConfig: PreviewDeviceEmulationConfig;
+  /** Full shell surface rect for emulation layout (the panel bounds before centering). */
+  shellBounds: Bounds | null;
+  /** Default Chromium user agent captured when the view was created (restored when emulation turns off). */
+  defaultGuestUserAgent: string;
+  /** Structured emulation metadata included on v2 captures (null when emulation is off). */
+  captureEmulationSnapshot: McodeBrowserCaptureEmulation | null;
 }
 
 const sessions = new Map<number, PreviewSession>();
@@ -142,6 +152,10 @@ function getSession(win: BrowserWindow): PreviewSession {
       workspaceId: null,
       lastFavicons: [],
       trustedFileNavigationBudget: 0,
+      deviceEmulationConfig: { kind: "off" },
+      shellBounds: null,
+      defaultGuestUserAgent: "",
+      captureEmulationSnapshot: null,
     };
     sessions.set(win.id, s);
   }
@@ -1211,11 +1225,24 @@ function parkPreview(win: BrowserWindow, s: PreviewSession): void {
     s.scrollbarCssKey = null;
     s.consoleBuffer.length = 0;
     s.failedRequestBuffer.length = 0;
+    s.captureEmulationSnapshot = null;
   }
 }
 
 /**
- * Removes the preview BrowserView and timers when a window is closing.
+ * Tears down the preview BrowserView without deleting the session.
+ * Called when the shell renderer refreshes so the native overlay does not
+ * linger on top of the fresh page; the next `preview:sync` from the
+ * re-mounted React tree will recreate the view.
+ */
+export function parkPreviewForWindow(win: BrowserWindow): void {
+  const s = sessions.get(win.id);
+  if (!s) return;
+  parkPreview(win, s);
+}
+
+/**
+ * Removes the preview BrowserView and session when a window is closing.
  */
 export function disposePreviewForWindow(win: BrowserWindow): void {
   const s = sessions.get(win.id);
@@ -1338,11 +1365,17 @@ function ensureView(win: BrowserWindow, s: PreviewSession): BrowserView {
   view.webContents.on("did-start-loading", forwardLoadingStart);
   view.webContents.on("did-stop-loading", forwardLoadingStop);
 
-  view.webContents.on("console-message", (_event, level, message) => {
-    pushPreviewConsoleLine(s, level, message);
+  view.webContents.on("console-message", (event) => {
+    const lvl = typeof event.level === "number" ? event.level : 0;
+    pushPreviewConsoleLine(s, lvl, event.message);
   });
 
   s.view = view;
+  try {
+    s.defaultGuestUserAgent = view.webContents.getUserAgent();
+  } catch {
+    s.defaultGuestUserAgent = "";
+  }
   return view;
 }
 
@@ -1749,9 +1782,9 @@ export function registerPreviewBrowserHandlers(): void {
     if (!win || win.isDestroyed()) return false;
     const s = getSession(win);
     if (!s.view || s.view.webContents.isDestroyed()) return false;
-    if (s.view.webContents.canGoBack()) {
+    if (s.view.webContents.navigationHistory.canGoBack()) {
       sendPreviewLoading(win, true);
-      s.view.webContents.goBack();
+      s.view.webContents.navigationHistory.goBack();
       resetIdle(win, s);
       return true;
     }
@@ -1763,9 +1796,9 @@ export function registerPreviewBrowserHandlers(): void {
     if (!win || win.isDestroyed()) return false;
     const s = getSession(win);
     if (!s.view || s.view.webContents.isDestroyed()) return false;
-    if (s.view.webContents.canGoForward()) {
+    if (s.view.webContents.navigationHistory.canGoForward()) {
       sendPreviewLoading(win, true);
-      s.view.webContents.goForward();
+      s.view.webContents.navigationHistory.goForward();
       resetIdle(win, s);
       return true;
     }
@@ -1801,8 +1834,8 @@ export function registerPreviewBrowserHandlers(): void {
       return { canGoBack: false, canGoForward: false };
     }
     return {
-      canGoBack: s.view.webContents.canGoBack(),
-      canGoForward: s.view.webContents.canGoForward(),
+      canGoBack: s.view.webContents.navigationHistory.canGoBack(),
+      canGoForward: s.view.webContents.navigationHistory.canGoForward(),
     };
   });
 

--- a/apps/desktop/src/main/preview-device-emulation.ts
+++ b/apps/desktop/src/main/preview-device-emulation.ts
@@ -1,0 +1,145 @@
+import type { WebContents } from "electron";
+import {
+  findBrowserPreviewDevicePreset,
+  type McodeBrowserCaptureEmulation,
+  type PreviewDeviceEmulationConfig,
+} from "@mcode/contracts";
+
+export type Bounds = { x: number; y: number; width: number; height: number };
+
+export type ResolvedPreviewEmulation = {
+  readonly cssWidth: number;
+  readonly cssHeight: number;
+  readonly deviceScaleFactor: number;
+  readonly label: string;
+};
+
+/**
+ * Resolved emulation metrics and Chrome version token for a mobile-style user-agent string.
+ */
+export function buildPreviewMobileUserAgent(chromeVersion: string): string {
+  const cv = chromeVersion.trim() || "0.0.0.0";
+  return `Mozilla/5.0 (Linux; Android 13; Mobile) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${cv} Mobile Safari/537.36 McodePreview/1.0`;
+}
+
+/**
+ * Maps a per-thread emulation config to CSS viewport size, DPR, and a short label.
+ */
+export function resolvePreviewDeviceEmulation(
+  cfg: PreviewDeviceEmulationConfig,
+): ResolvedPreviewEmulation | null {
+  if (cfg.kind === "off") return null;
+  if (cfg.kind === "custom") {
+    const dpr = cfg.deviceScaleFactor ?? 2;
+    return {
+      cssWidth: cfg.width,
+      cssHeight: cfg.height,
+      deviceScaleFactor: dpr,
+      label: `${cfg.width}×${cfg.height}`,
+    };
+  }
+  const preset = findBrowserPreviewDevicePreset(cfg.presetId);
+  if (!preset) return null;
+  const baseW: number = preset.width;
+  const baseH: number = preset.height;
+  const cssWidth = cfg.orientation === "landscape" ? baseH : baseW;
+  const cssHeight = cfg.orientation === "landscape" ? baseW : baseH;
+  const orient = cfg.orientation === "landscape" ? "landscape" : "portrait";
+  return {
+    cssWidth,
+    cssHeight,
+    deviceScaleFactor: preset.deviceScaleFactor,
+    label: orient === "portrait" ? preset.label : `${preset.label} · landscape`,
+  };
+}
+
+/**
+ * Places a centered guest rectangle inside the shell surface and returns the uniform fit scale (max 1).
+ */
+export function layoutGuestBoundsForEmulation(
+  shell: Bounds,
+  cssWidth: number,
+  cssHeight: number,
+): { guest: Bounds; scaleToFit: number } {
+  const sw = Math.max(4, Math.floor(shell.width));
+  const sh = Math.max(4, Math.floor(shell.height));
+  const scaleToFit = Math.min(sw / cssWidth, sh / cssHeight, 1);
+  const gw = Math.max(4, Math.floor(cssWidth * scaleToFit));
+  const gh = Math.max(4, Math.floor(cssHeight * scaleToFit));
+  const x = shell.x + Math.floor((shell.width - gw) / 2);
+  const y = shell.y + Math.floor((shell.height - gh) / 2);
+  return {
+    guest: { x, y, width: gw, height: gh },
+    scaleToFit,
+  };
+}
+
+/**
+ * Applies or clears Chromium device emulation and guest user-agent for the preview surface.
+ */
+export function applyPreviewDeviceEmulation(
+  wc: WebContents,
+  opts: {
+    active: boolean;
+    cssViewport: { width: number; height: number };
+    deviceScaleFactor: number;
+    scaleToFit: number;
+    mobileUserAgent: string;
+    defaultUserAgent: string;
+  },
+): void {
+  if (wc.isDestroyed()) return;
+  if (!opts.active) {
+    wc.disableDeviceEmulation();
+    wc.setUserAgent(opts.defaultUserAgent);
+    return;
+  }
+  // Guard: calling enableDeviceEmulation on a BrowserView that hasn't loaded
+  // any content (empty URL or about:blank) can crash the Chromium compositor
+  // on Windows. Defer emulation until the guest has a real document.
+  const guestUrl = wc.getURL();
+  if (!guestUrl || guestUrl === "about:blank" || guestUrl.startsWith("about:")) {
+    return;
+  }
+  wc.setUserAgent(opts.mobileUserAgent);
+  const w = opts.cssViewport.width;
+  const h = opts.cssViewport.height;
+  wc.enableDeviceEmulation({
+    screenPosition: "mobile",
+    screenSize: { width: w, height: h },
+    viewPosition: { x: 0, y: 0 },
+    viewSize: { width: w, height: h },
+    deviceScaleFactor: opts.deviceScaleFactor,
+    scale: opts.scaleToFit,
+  });
+}
+
+/**
+ * Builds the structured emulation block attached to browser capture v2 payloads.
+ */
+export function buildCaptureEmulationSnapshot(
+  cfg: PreviewDeviceEmulationConfig,
+  resolved: ResolvedPreviewEmulation,
+  scaleToFit: number,
+  mobileUserAgent: string,
+): McodeBrowserCaptureEmulation {
+  const base = {
+    label: resolved.label,
+    cssViewport: { width: resolved.cssWidth, height: resolved.cssHeight },
+    deviceScaleFactor: resolved.deviceScaleFactor,
+    scaleToFit,
+    userAgent: mobileUserAgent.length > 512 ? mobileUserAgent.slice(0, 512) : mobileUserAgent,
+  };
+  if (cfg.kind === "preset") {
+    return {
+      mode: "preset",
+      ...base,
+      presetId: cfg.presetId,
+      orientation: cfg.orientation,
+    };
+  }
+  return {
+    mode: "custom",
+    ...base,
+  };
+}

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -8,7 +8,6 @@ import {
   ArrowLeft,
   ArrowRight,
   Check,
-  ChevronsUpDown,
   Crosshair,
   Crop,
   ExternalLink,
@@ -523,20 +522,24 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
                 <Popover open={devicePickerOpen} onOpenChange={setDevicePickerOpen}>
                   <PopoverTrigger
                     render={
-                      <Button type="button" variant="outline" size="sm"
-                        className={cn(
-                          "h-7 max-w-[13rem] justify-between gap-1 px-2 font-mono text-xs",
-                          deviceEmu.kind !== "off" && "border-primary/50 text-primary glow-primary",
-                        )}
-                        aria-label="Preview device frame"
-                      >
-                        <MonitorSmartphone className="size-3 shrink-0" aria-hidden />
-                        <span className="truncate">{previewDeviceDisplayLabel(deviceEmu)}</span>
-                        <ChevronsUpDown className="size-3 shrink-0 opacity-50" aria-hidden />
-                      </Button>
+                      deviceEmu.kind === "off" ? (
+                        <Button type="button" variant="ghost" size="icon-xs" className="shrink-0"
+                          aria-label="Device emulation"
+                        >
+                          <MonitorSmartphone size={14} aria-hidden />
+                        </Button>
+                      ) : (
+                        <Button type="button" variant="ghost" size="sm"
+                          className="h-7 gap-1 px-1.5 font-mono text-xs text-primary"
+                          aria-label="Preview device frame"
+                        >
+                          <MonitorSmartphone className="size-3.5 shrink-0" aria-hidden />
+                          <span className="truncate">{previewDeviceDisplayLabel(deviceEmu)}</span>
+                        </Button>
+                      )
                     }
                   />
-                  <PopoverContent side="bottom" sideOffset={6} className="w-[15rem] p-0 font-mono text-xs">
+                  <PopoverContent side="bottom" sideOffset={6} className="w-[17rem] p-0 font-mono text-xs">
                     <Command>
                       <CommandInput placeholder="Search devices..." className="h-8 text-xs" />
                       <CommandList>

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -7,6 +7,8 @@ import {
 import {
   ArrowLeft,
   ArrowRight,
+  Check,
+  ChevronsUpDown,
   Crosshair,
   Crop,
   ExternalLink,
@@ -14,7 +16,12 @@ import {
   Globe,
   ImagePlus,
   Loader2,
+  MonitorSmartphone,
+  Pencil,
+  Repeat2,
   RotateCw,
+  Settings2,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -23,14 +30,44 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandEmpty,
+} from "@/components/ui/command";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import type { PendingAttachment } from "@/components/chat/AttachmentPreview";
 import { useToastStore } from "@/stores/toastStore";
 import { usePreviewReferenceQueueStore } from "@/stores/previewReferenceQueueStore";
 import type { McodeBrowserCapture } from "@mcode/contracts";
+import {
+  BROWSER_PREVIEW_DEVICE_PRESETS,
+  findBrowserPreviewDevicePreset,
+  MCODE_BROWSER_CONTEXT_ATTACHMENT_MIME,
+  PREVIEW_DEVICE_EMULATION_OFF,
+  type PreviewDeviceEmulationConfig,
+} from "@mcode/contracts";
 import { SmartOmnibox } from "./SmartOmnibox";
-import { MCODE_BROWSER_CONTEXT_ATTACHMENT_MIME } from "@mcode/contracts";
+
+/**
+ * Returns a short human-readable label for the current device emulation config.
+ * Used in the picker trigger button to show what's currently selected.
+ */
+function previewDeviceDisplayLabel(cfg: PreviewDeviceEmulationConfig): string {
+  if (cfg.kind === "off") return "Desktop";
+  if (cfg.kind === "custom") return `${cfg.width}×${cfg.height}`;
+  const p = findBrowserPreviewDevicePreset(cfg.presetId);
+  if (!p) return cfg.presetId;
+  const w = cfg.orientation === "landscape" ? p.height : p.width;
+  const h = cfg.orientation === "landscape" ? p.width : p.height;
+  return `${p.label} ${w}×${h}`;
+}
 
 const NAV_ERROR_LABEL: Record<string, string> = {
   "no-bounds": "Wait for the panel to finish layout, then try again.",
@@ -120,6 +157,15 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
   const storedUrl = useDiffStore(
     (s) => s.previewUrlByThread[threadId] ?? "",
   );
+  const deviceEmu = useDiffStore(
+    (s) => s.previewDeviceEmulationByThread[threadId] ?? PREVIEW_DEVICE_EMULATION_OFF,
+  );
+  const setDeviceEmu = useDiffStore((s) => s.setPreviewDeviceEmulationForThread);
+  const [devicePickerOpen, setDevicePickerOpen] = useState(false);
+  const [customEditing, setCustomEditing] = useState(false);
+  const [customW, setCustomW] = useState("390");
+  const [customH, setCustomH] = useState("844");
+  const customWRef = useRef<HTMLInputElement>(null);
   const workspacePath = useWorkspaceStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.path ?? null,
   );
@@ -152,6 +198,7 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
           threadId,
           resumeUrlHint: hint,
           workspaceId: workspaceId ?? null,
+          deviceEmulation: deviceEmu,
         });
         return;
       }
@@ -167,9 +214,10 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
         threadId,
         resumeUrlHint: hint,
         workspaceId: workspaceId ?? null,
+        deviceEmulation: deviceEmu,
       });
     },
-    [threadId, storedUrl, workspaceId],
+    [threadId, storedUrl, workspaceId, deviceEmu],
   );
 
   useEffect(() => {
@@ -406,6 +454,182 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
 
         {/* Toolbar: nav | capture | external */}
         <div className="flex min-w-0 items-center">
+          {/* Device emulation group */}
+          <div className="flex items-center gap-0.5">
+            {customEditing ? (
+              <div className="flex h-7 items-center gap-1 rounded-md border border-primary/50 bg-background px-1.5 font-mono text-xs text-primary animate-fade-up-in">
+                <MonitorSmartphone className="size-3 shrink-0" aria-hidden />
+                <input
+                  ref={customWRef}
+                  type="text"
+                  inputMode="numeric"
+                  className="h-5 w-12 rounded border-none bg-muted px-1 text-center text-xs outline-none focus:ring-1 focus:ring-primary/50"
+                  value={customW}
+                  onChange={(e) => setCustomW(e.target.value.replace(/\D/g, ""))}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const w = Number.parseInt(customW, 10);
+                      const h = Number.parseInt(customH, 10);
+                      if (w >= 100 && h >= 100) {
+                        setDeviceEmu(threadId, { kind: "custom", width: Math.min(w, 8192), height: Math.min(h, 8192), deviceScaleFactor: 2 });
+                        setCustomEditing(false);
+                      }
+                    }
+                    if (e.key === "Escape") setCustomEditing(false);
+                  }}
+                  aria-label="Viewport width"
+                />
+                <span className="text-muted-foreground">×</span>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  className="h-5 w-12 rounded border-none bg-muted px-1 text-center text-xs outline-none focus:ring-1 focus:ring-primary/50"
+                  value={customH}
+                  onChange={(e) => setCustomH(e.target.value.replace(/\D/g, ""))}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const w = Number.parseInt(customW, 10);
+                      const h = Number.parseInt(customH, 10);
+                      if (w >= 100 && h >= 100) {
+                        setDeviceEmu(threadId, { kind: "custom", width: Math.min(w, 8192), height: Math.min(h, 8192), deviceScaleFactor: 2 });
+                        setCustomEditing(false);
+                      }
+                    }
+                    if (e.key === "Escape") setCustomEditing(false);
+                  }}
+                  aria-label="Viewport height"
+                />
+                <Button type="button" variant="ghost" size="icon-xs" className="shrink-0 text-primary"
+                  onClick={() => {
+                    const w = Number.parseInt(customW, 10);
+                    const h = Number.parseInt(customH, 10);
+                    if (w >= 100 && h >= 100) {
+                      setDeviceEmu(threadId, { kind: "custom", width: Math.min(w, 8192), height: Math.min(h, 8192), deviceScaleFactor: 2 });
+                      setCustomEditing(false);
+                    }
+                  }}
+                  aria-label="Apply custom dimensions"
+                >
+                  <Check size={14} aria-hidden />
+                </Button>
+                <Button type="button" variant="ghost" size="icon-xs" className="shrink-0 text-muted-foreground"
+                  onClick={() => setCustomEditing(false)} aria-label="Cancel"
+                >
+                  <X size={14} aria-hidden />
+                </Button>
+              </div>
+            ) : (
+              <>
+                <Popover open={devicePickerOpen} onOpenChange={setDevicePickerOpen}>
+                  <PopoverTrigger
+                    render={
+                      <Button type="button" variant="outline" size="sm"
+                        className={cn(
+                          "h-7 max-w-[13rem] justify-between gap-1 px-2 font-mono text-xs",
+                          deviceEmu.kind !== "off" && "border-primary/50 text-primary glow-primary",
+                        )}
+                        aria-label="Preview device frame"
+                      >
+                        <MonitorSmartphone className="size-3 shrink-0" aria-hidden />
+                        <span className="truncate">{previewDeviceDisplayLabel(deviceEmu)}</span>
+                        <ChevronsUpDown className="size-3 shrink-0 opacity-50" aria-hidden />
+                      </Button>
+                    }
+                  />
+                  <PopoverContent side="bottom" sideOffset={6} className="w-[15rem] p-0 font-mono text-xs">
+                    <Command>
+                      <CommandInput placeholder="Search devices..." className="h-8 text-xs" />
+                      <CommandList>
+                        <CommandEmpty>No device found.</CommandEmpty>
+                        <CommandGroup>
+                          <CommandItem onSelect={() => {
+                            setDeviceEmu(threadId, { kind: "off" });
+                            setDevicePickerOpen(false);
+                          }}>
+                            <Check className={cn("size-3", deviceEmu.kind === "off" ? "opacity-100" : "opacity-0")} />
+                            Desktop
+                          </CommandItem>
+                          {BROWSER_PREVIEW_DEVICE_PRESETS.map((p) => {
+                            const active = deviceEmu.kind === "preset" && deviceEmu.presetId === p.id;
+                            return (
+                              <CommandItem key={p.id} onSelect={() => {
+                                const orientation = deviceEmu.kind === "preset" && deviceEmu.presetId === p.id
+                                  ? deviceEmu.orientation : "portrait";
+                                setDeviceEmu(threadId, { kind: "preset", presetId: p.id, orientation });
+                                setDevicePickerOpen(false);
+                              }}>
+                                <Check className={cn("size-3", active ? "opacity-100" : "opacity-0")} />
+                                <span className="flex-1 truncate">{p.label}</span>
+                                <span className="text-muted-foreground">{p.width}×{p.height}</span>
+                              </CommandItem>
+                            );
+                          })}
+                        </CommandGroup>
+                        <CommandSeparator />
+                        <CommandGroup>
+                          <CommandItem onSelect={() => {
+                            setDevicePickerOpen(false);
+                            if (deviceEmu.kind === "custom") {
+                              setCustomW(String(deviceEmu.width));
+                              setCustomH(String(deviceEmu.height));
+                            } else {
+                              setCustomW("390");
+                              setCustomH("844");
+                            }
+                            setCustomEditing(true);
+                            requestAnimationFrame(() => customWRef.current?.select());
+                          }}>
+                            <Settings2 className="size-3" />
+                            Custom...
+                          </CommandItem>
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+                {deviceEmu.kind === "preset" && (
+                  <Tooltip>
+                    <TooltipTrigger render={
+                      <Button type="button" variant="ghost" size="icon-xs" className="shrink-0 text-primary"
+                        onClick={() => {
+                          setDeviceEmu(threadId, {
+                            kind: "preset", presetId: deviceEmu.presetId,
+                            orientation: deviceEmu.orientation === "portrait" ? "landscape" : "portrait",
+                          });
+                        }}
+                        aria-label="Rotate device frame"
+                      >
+                        <Repeat2 size={14} aria-hidden />
+                      </Button>
+                    } />
+                    <TooltipContent side="bottom" sideOffset={6} className="text-xs">Toggle portrait / landscape</TooltipContent>
+                  </Tooltip>
+                )}
+                {deviceEmu.kind === "custom" && (
+                  <Tooltip>
+                    <TooltipTrigger render={
+                      <Button type="button" variant="ghost" size="icon-xs" className="shrink-0 text-primary"
+                        onClick={() => {
+                          setCustomW(String(deviceEmu.width));
+                          setCustomH(String(deviceEmu.height));
+                          setCustomEditing(true);
+                          requestAnimationFrame(() => customWRef.current?.select());
+                        }}
+                        aria-label="Edit custom dimensions"
+                      >
+                        <Pencil size={14} aria-hidden />
+                      </Button>
+                    } />
+                    <TooltipContent side="bottom" sideOffset={6} className="text-xs">Edit dimensions</TooltipContent>
+                  </Tooltip>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Separator: device | nav */}
+          <div className="mx-1 h-4 w-px bg-border/40" aria-hidden />
+
           {/* Navigation group */}
           <div className="flex items-center gap-0.5">
             <Tooltip>
@@ -573,7 +797,10 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
       {/* BrowserView placeholder / empty state */}
       <div
         ref={surfaceRef}
-        className="relative mx-2 mb-2 mt-1 min-h-[min(40vh,20rem)] min-w-0 flex-1 rounded-md border border-dashed border-border/50 bg-muted/10"
+        className={cn(
+          "relative mx-2 mb-2 mt-1 min-h-[min(40vh,20rem)] min-w-0 flex-1 rounded-md border border-dashed border-border/50 bg-muted/10",
+          deviceEmu.kind !== "off" && "bg-muted",
+        )}
         aria-hidden
       >
         {/* Loading: thin indeterminate progress bar at top of content area */}

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -304,7 +304,11 @@ export function RightPanel() {
         )}
         {activeTab === "changes" && <DiffPanel />}
         {activeTab === "preview" && (
-          <PreviewPanel threadId={activeThreadId} workspaceId={activeWorkspaceId} />
+          <PreviewPanel
+            threadId={activeThreadId}
+            workspaceId={activeWorkspaceId}
+            isPreviewActive={activeTab === "preview"}
+          />
         )}
       </div>
       </div>

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -220,7 +220,7 @@ export function RightPanel() {
         aria-orientation="vertical"
         tabIndex={0}
         className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10
-                   hover:bg-primary/25 active:bg-primary/40 focus-visible:bg-primary/25 transition-colors duration-150"
+                   hover:bg-border/60 active:bg-primary/40 focus-visible:bg-border/60 transition-colors duration-150"
         onMouseDown={onDragStart}
         onDoubleClick={() => {
           const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
@@ -307,7 +307,6 @@ export function RightPanel() {
           <PreviewPanel
             threadId={activeThreadId}
             workspaceId={activeWorkspaceId}
-            isPreviewActive={activeTab === "preview"}
           />
         )}
       </div>

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { TurnSnapshot, GitCommit } from "@mcode/contracts";
+import type { TurnSnapshot, GitCommit, PreviewDeviceEmulationConfig } from "@mcode/contracts";
 
 export type { GitCommit };
 
@@ -51,6 +51,8 @@ export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
 interface DiffState {
   /** Last preview URL typed or loaded per thread (in-memory only). */
   readonly previewUrlByThread: Record<string, string>;
+  /** Per-thread embedded preview device emulation (synced to the desktop main process). */
+  readonly previewDeviceEmulationByThread: Record<string, PreviewDeviceEmulationConfig>;
   /** Per-thread right panel state keyed by thread ID. */
   readonly rightPanelByThread: Record<string, RightPanelState>;
   /** View mode within the Changes tab. */
@@ -107,12 +109,15 @@ interface DiffState {
   setSummaryLoading: (loading: boolean) => void;
   /** Persist the omnibox URL for a thread's embedded preview. */
   setPreviewUrlForThread: (threadId: string, url: string) => void;
+  /** Set device viewport emulation for a thread's preview (desktop applies on next sync). */
+  setPreviewDeviceEmulationForThread: (threadId: string, cfg: PreviewDeviceEmulationConfig) => void;
   clearThread: (threadId: string) => void;
 }
 
 /** Zustand store for diff panel and right panel tab state. */
 export const useDiffStore = create<DiffState>((set, get) => ({
   previewUrlByThread: {},
+  previewDeviceEmulationByThread: {},
   rightPanelByThread: {},
   viewMode: "by-turn",
   renderMode: "unified",
@@ -205,6 +210,10 @@ export const useDiffStore = create<DiffState>((set, get) => ({
     set((s) => ({
       previewUrlByThread: { ...s.previewUrlByThread, [threadId]: url },
     })),
+  setPreviewDeviceEmulationForThread: (threadId, cfg) =>
+    set((s) => ({
+      previewDeviceEmulationByThread: { ...s.previewDeviceEmulationByThread, [threadId]: cfg },
+    })),
   clearThread: (threadId) =>
     set((state) => {
       const snapshots = { ...state.snapshotsByThread };
@@ -219,6 +228,8 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       delete rightPanels[threadId];
       const previewUrls = { ...state.previewUrlByThread };
       delete previewUrls[threadId];
+      const previewEmu = { ...state.previewDeviceEmulationByThread };
+      delete previewEmu[threadId];
 
       // Only clear the global selection when it belongs to the deleted thread.
       const selectionBelongsToThread = state.selectedFile?.threadId === threadId;
@@ -231,6 +242,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         commitsLoadingByThread: commitsLoading,
         rightPanelByThread: rightPanels,
         previewUrlByThread: previewUrls,
+        previewDeviceEmulationByThread: previewEmu,
         ...(selectionBelongsToThread
           ? { selectedFile: null, diffContent: null, diffLoading: false }
           : {}),

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -1,5 +1,5 @@
 import type { AttachmentMeta } from "./types";
-import type { McodeBrowserCapture } from "@mcode/contracts";
+import type { McodeBrowserCapture, PreviewDeviceEmulationConfig } from "@mcode/contracts";
 
 /** Discriminated union describing the auto-updater lifecycle state. */
 export type UpdateStatus =
@@ -66,6 +66,8 @@ interface PreviewBridge {
     resumeUrlHint?: string | null;
     /** Active workspace id; scopes preview spill files under the Mcode app data directory. */
     workspaceId?: string | null;
+    /** Mobile or custom viewport emulation for this thread's guest surface. */
+    deviceEmulation?: PreviewDeviceEmulationConfig;
   }): Promise<void>;
   navigate(url: string, workspacePath?: string | null): Promise<PreviewNavigateResult>;
   goBack(): Promise<boolean>;
@@ -73,6 +75,8 @@ interface PreviewBridge {
   reload(): Promise<void>;
   openExternal(): Promise<void>;
   getNavigationState(): Promise<{ canGoBack: boolean; canGoForward: boolean }>;
+  /** Moves keyboard focus into the guest page (desktop only). */
+  focusGuest(): Promise<void>;
   /** Captures the visible preview as PNG; desktop only. */
   capturePictureReference(): Promise<PreviewPictureReferenceResult>;
   /** Drag a rectangle on the preview, then capture that region as PNG; desktop only. */

--- a/apps/web/src/transport/index.ts
+++ b/apps/web/src/transport/index.ts
@@ -24,15 +24,23 @@ let transport: (McodeTransport & { close(): void; waitForConnection(timeoutMs: n
  * Resolve the WebSocket server URL and IPC path.
  *
  * In Electron, `window.desktopBridge.getServerUrl()` returns the URL and IPC
- * path of the server spawned by the main process. In standalone / dev mode we
- * fall back to an environment variable or the default localhost URL.
+ * path of the server spawned by the main process. Retries the IPC call to
+ * avoid falling back to the standalone port when the production app is also
+ * running. In standalone / dev mode we fall back to an environment variable
+ * or the default localhost URL.
  */
 async function resolveServerUrl(): Promise<{ url: string; ipcPath: string }> {
   if (window.desktopBridge?.getServerUrl) {
-    try {
-      return await window.desktopBridge.getServerUrl();
-    } catch {
-      // fall through
+    // Retry the IPC call a few times; during shell refresh the handler may
+    // not be ready on the first attempt. Without retries the renderer falls
+    // through to DEFAULT_SERVER_URL (port 19400) and connects to the
+    // production server instead of the dev server.
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        return await window.desktopBridge.getServerUrl();
+      } catch {
+        await new Promise((r) => setTimeout(r, 200));
+      }
     }
   }
 
@@ -74,13 +82,23 @@ export async function initTransport(): Promise<McodeTransport> {
         }
       },
       discoverServerUrl: async () => {
-        // In Electron, ask the desktop bridge for the current server URL
+        // In Electron, retry the desktop bridge IPC to get the server URL
+        // from the main process. Avoid falling through to the port scan
+        // which can find a production server running on a different port.
         if (window.desktopBridge?.getServerUrl) {
-          const info = await window.desktopBridge.getServerUrl();
-          return info.url;
+          for (let attempt = 0; attempt < 5; attempt++) {
+            try {
+              const info = await window.desktopBridge.getServerUrl();
+              return info.url;
+            } catch {
+              await new Promise((r) => setTimeout(r, 300));
+            }
+          }
+          throw new Error("Desktop bridge IPC failed after retries");
         }
-        // In browser, scan the port range. Use the last-known token from
-        // localStorage so the reconnect URL includes valid auth.
+        // In browser (no Electron shell), scan the port range. Use the
+        // last-known token from localStorage so the reconnect URL includes
+        // valid auth.
         const savedToken = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ?? "";
         const found = await scanPortRange(19400, 19800, savedToken);
         if (found) return found;

--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -21,6 +21,8 @@ Per-setting reference for Mcode's `settings.json`. For schema conventions and st
 | `model.defaults.contextWindow` | integer | - | > 0, ≤ 2,000,000 | - | Override the context window (tokens) for the default model. When set, takes priority over API-fetched and SDK-reported values. Useful when the SDK reports stale data (e.g. 200K instead of 1M). Omit to use the automatically detected value. Claude only. |
 | `terminal.scrollback` | integer | `250` | >= 0 | - | Number of scrollback lines to retain |
 | `notifications.enabled` | boolean | `true` | - | - | Whether desktop notifications are enabled |
+| `browserPreview.allowSitePermissions` | boolean | `false` | - | - | When true, grant site permission prompts in the embedded preview (camera, mic, notifications, etc.). When false, all are denied. |
+| `browserPreview.isolateStorageByWorkspace` | boolean | `false` | - | - | When true, use a separate Chromium storage partition per workspace for the preview. When false, all workspaces share one preview partition. |
 | `worktree.naming.mode` | enum | `"auto"` | `"auto"` \| `"custom"` \| `"ai"` | - | Naming strategy for new worktree branches |
 | `worktree.naming.aiConfirmation` | boolean | `true` | - | - | Prompt before using AI-generated branch names |
 | `performance.threadCacheSize` | integer | `10` | 1-25 | - | Number of threads to keep in memory for instant switching. Lower values reduce memory use; values ≤ 3 mean most thread switches reload from the server. Takes effect immediately. |

--- a/docs/specs/2026-05-10-responsive-viewport-emulation-design.md
+++ b/docs/specs/2026-05-10-responsive-viewport-emulation-design.md
@@ -1,0 +1,439 @@
+# Responsive Viewport Emulation for Browser Preview
+
+## Summary
+
+Add device viewport emulation to the browser preview panel, allowing users to preview web apps at phone, tablet, and desktop sizes with correct DPR, user agent, touch emulation, and CSS media feature overrides. State is scoped per thread. The UI layers a visual device bar (primary) over a keyboard-driven command palette (power-user shortcut).
+
+## User Personas
+
+### 1. Frontend Web Developer
+
+**Profile:** Builds responsive web apps with React, Vue, or similar frameworks. Tests across breakpoints daily.
+
+**Context:** Working in Mcode on a feature branch, iterating on a component. Needs to verify that a layout works at mobile widths without leaving the editor to open Chrome DevTools or a separate browser.
+
+**Key needs:**
+- Quick switching between common phone/tablet sizes
+- CSS media queries (`max-width`, `min-width`) must fire correctly at emulated dimensions
+- See the actual viewport dimensions at a glance
+- Custom dimension input for testing exact breakpoints (e.g., 412px for a specific snap point)
+
+**Success criteria:** "I can check my responsive layout in the preview panel and trust that it matches what a real phone browser would render."
+
+### 2. Mobile / Hybrid App Developer
+
+**Profile:** Works with React Native, Capacitor, or Ionic. Builds apps that run in webviews on physical devices. Frequently tests how web content renders inside a mobile viewport.
+
+**Key needs:**
+- Accurate mobile user agent (some APIs and CSS feature detections depend on it)
+- Touch emulation (`ontouchstart`, `navigator.maxTouchPoints`) for testing touch-specific code paths
+- Correct `hover: none` / `pointer: coarse` media features for hiding hover-only UI
+- Orientation toggle to test portrait and landscape layouts
+
+**Success criteria:** "The preview behaves like a mobile webview, not a desktop browser at a small size."
+
+### 3. Full-Stack Developer
+
+**Profile:** Primarily writes backend code but occasionally touches frontend templates, responsive emails, or admin dashboards. Not a daily responsive testing user.
+
+**Context:** Needs to verify a UI change looks reasonable on mobile before pushing. Does not need pixel-perfect fidelity.
+
+**Key needs:**
+- Discoverability: obvious how to switch to a phone view without reading docs
+- One-click presets: pick "iPhone" from a list, done
+- Easy reset: get back to normal desktop view quickly
+
+**Success criteria:** "I found the mobile preview button, checked the page, and went back to desktop in under 10 seconds."
+
+### 4. Designer-Developer
+
+**Profile:** Works on pixel-perfect responsive implementations. Cares about device-specific rendering details like DPR, safe areas, and accurate viewport dimensions.
+
+**Key needs:**
+- Correct `devicePixelRatio` (2x, 3x) for testing retina rendering
+- Precise viewport dimensions matching real device CSS viewports
+- v2 interest: device chrome (notch, dynamic island) for design presentations
+
+**Success criteria:** "The emulated viewport matches the real device closely enough to catch layout bugs before deploying to a physical device."
+
+---
+
+## Goals
+
+1. Emulate phone, tablet, and desktop viewports with correct dimensions, DPR, user agent, touch, and CSS media features.
+2. Provide a discoverable UI-first device picker with a power-user keyboard shortcut.
+3. Scope device state per thread so switching threads restores the correct viewport.
+4. Integrate cleanly with existing preview features (capture, page context, navigation, idle parking).
+
+## Non-Goals
+
+- Device chrome / bezels / notch rendering (deferred to v2)
+- Network throttling (3G, offline simulation)
+- Persisting device state to disk across app restarts
+- Multi-viewport side-by-side comparison
+- WebRTC or geolocation emulation
+
+---
+
+## Shared Types
+
+All types live in `packages/contracts/src/models/browser-preview.ts` as Zod schemas using the existing `lazySchema` pattern.
+
+```typescript
+/** Device form factor category. */
+type DeviceCategory = "phone" | "tablet" | "desktop";
+
+/** Screen orientation. */
+type DeviceOrientation = "portrait" | "landscape";
+
+/** A device preset definition. */
+interface DevicePreset {
+  id: string;                    // e.g. "iphone-14-pro"
+  name: string;                  // e.g. "iPhone 14 Pro"
+  category: DeviceCategory;
+  viewport: { width: number; height: number };
+  deviceScaleFactor: number;     // e.g. 2, 3
+  mobile: boolean;               // maps to screenPosition: "mobile" | "desktop"
+  hasTouch: boolean;             // triggers CDP touch emulation
+  userAgent: string;             // full UA string
+}
+
+/** Payload sent from renderer to main for setDeviceEmulation. */
+interface DeviceEmulationPayload {
+  preset: DevicePreset | null;   // null = reset to desktop
+  orientation: DeviceOrientation;
+  customViewport?: { width: number; height: number; dpr: number };
+}
+
+/** Emulation state pushed from main to renderer after apply/reset. */
+interface DeviceEmulationState {
+  presetId: string | null;       // null = desktop (no emulation)
+  orientation: DeviceOrientation;
+  effectiveViewport: { width: number; height: number };
+}
+```
+
+---
+
+## Device Presets
+
+Curated, not exhaustive. Sourced from Playwright's canonical device descriptors.
+
+### Phones
+
+| ID | Name | Viewport | DPR | UA Base |
+|----|------|----------|-----|---------|
+| `iphone-se` | iPhone SE | 375x667 | 2 | Safari/Mobile |
+| `iphone-14-pro` | iPhone 14 Pro | 393x852 | 3 | Safari/Mobile |
+| `galaxy-s24` | Galaxy S24 | 360x780 | 3 | Chrome/Mobile |
+| `pixel-7` | Pixel 7 | 412x915 | 2.625 | Chrome/Mobile |
+
+### Tablets
+
+| ID | Name | Viewport | DPR | UA Base |
+|----|------|----------|-----|---------|
+| `ipad-air` | iPad Air | 820x1180 | 2 | Safari/Mobile |
+| `ipad-pro-11` | iPad Pro 11" | 834x1194 | 2 | Safari/Mobile |
+| `galaxy-tab-s9` | Galaxy Tab S9 | 640x1024 | 2.5 | Chrome |
+
+### Desktop
+
+| ID | Name | Viewport | DPR | UA Base |
+|----|------|----------|-----|---------|
+| `desktop-hd` | HD | 1280x720 | 1 | Default Chromium |
+| `desktop-fhd` | Full HD | 1920x1080 | 1 | Default Chromium |
+
+User agent strings template the Chrome version from Electron's bundled Chromium to stay consistent with the shell.
+
+### Custom
+
+When preset ID is `"custom"`, the user provides width, height, and DPR manually. Defaults: `mobile = false`, `hasTouch = false`, `userAgent = default Chromium`.
+
+**Validation constraints:**
+- Width: 120 - 3840 (integer)
+- Height: 120 - 3840 (integer)
+- DPR: 1 - 5 (one decimal allowed, e.g. 2.5)
+
+---
+
+## Architecture
+
+### Technical Approach
+
+**Electron-native `enableDeviceEmulation` + CDP for gaps.**
+
+| Capability | API |
+|------------|-----|
+| Viewport, DPR, screen type | `webContents.enableDeviceEmulation(params)` |
+| User agent | `webContents.setUserAgent(ua)` |
+| Touch emulation | CDP `Emulation.setTouchEmulationEnabled` via `webContents.debugger` |
+| CSS media features (`hover`, `pointer`) | CDP `Emulation.setEmulatedMedia` via `webContents.debugger` |
+| Reset | `webContents.disableDeviceEmulation()` + UA revert + CDP disable + debugger detach |
+
+CDP debugger is attached only when a mobile/tablet device with `hasTouch: true` or `mobile: true` is selected. Desktop mode has zero CDP overhead.
+
+### Emulation State (Main Process)
+
+Tracked per `PreviewSession`:
+
+```typescript
+interface EmulationState {
+  preset: DevicePreset | null;       // null = desktop
+  orientation: DeviceOrientation;
+  debuggerAttached: boolean;
+}
+```
+
+### Apply Sequence
+
+When a device is selected:
+
+1. **Reset** current emulation (full reset sequence below)
+2. Call `webContents.enableDeviceEmulation()` with viewport, DPR, `screenPosition`
+3. Call `webContents.setUserAgent()` with preset UA
+4. If `preset.hasTouch` or `preset.mobile`: attach `webContents.debugger` (if not already)
+5. If `preset.hasTouch`: send CDP `Emulation.setTouchEmulationEnabled({ enabled: true, maxTouchPoints: 5 })`
+6. If `preset.mobile`: send CDP `Emulation.setEmulatedMedia({ features: [{ name: 'hover', value: 'none' }, { name: 'pointer', value: 'coarse' }] })`
+7. Update `session.emulationState`
+8. Fire `onDeviceEmulationChanged` push event to renderer
+
+### Reset Sequence
+
+Always runs before applying a new device, and when returning to desktop:
+
+1. `webContents.disableDeviceEmulation()`
+2. `webContents.setUserAgent('')` (revert to Chromium default)
+3. If debugger attached:
+   a. Send CDP `Emulation.setTouchEmulationEnabled({ enabled: false })`
+   b. Send CDP `Emulation.setEmulatedMedia({ features: [] })`
+   c. `webContents.debugger.detach()`
+4. Set `session.emulationState = { preset: null, orientation: 'portrait', debuggerAttached: false }`
+
+**Key rule:** Device-to-device switch always runs reset-then-apply. No partial updates.
+
+### Orientation Toggle
+
+Swaps width and height in the emulation params and re-runs the apply sequence from step 2 (skip reset since `enableDeviceEmulation` overwrites previous params).
+
+### Graceful Degradation
+
+If CDP debugger fails to attach (e.g., another debugger is connected), apply viewport and UA only. Surface a toast: "Touch emulation unavailable." The viewport and media query behavior still works correctly.
+
+---
+
+## IPC Contract
+
+### Renderer to Main
+
+```typescript
+/** Apply a device preset, or null to reset to desktop. */
+preview.setDeviceEmulation(payload: DeviceEmulationPayload):
+  Promise<{ ok: true } | { ok: false; error: string }>
+
+/** Query current emulation state (for restoring after thread switch). */
+preview.getDeviceEmulation():
+  Promise<DeviceEmulationState | null>
+```
+
+### Main to Renderer (Push Event)
+
+```typescript
+/** Fired after emulation applies or resets. Keeps UI in sync. */
+preview.onDeviceEmulationChanged(
+  callback: (state: DeviceEmulationState) => void
+): () => void  // returns unsubscribe
+```
+
+### Integration with Existing IPC
+
+The `preview:sync` payload is unchanged. When device emulation is active, the main process uses emulated dimensions for bounds calculation instead of filling the full panel rect. The `resumeUrlHint` and `threadId` fields continue to work as before.
+
+---
+
+## Per-Thread State
+
+### Renderer (Zustand)
+
+```typescript
+interface ThreadDeviceState {
+  presetId: string | null;
+  orientation: DeviceOrientation;
+  customViewport?: { width: number; height: number; dpr: number };
+}
+
+// In the preview store, keyed by threadId
+deviceStateByThread: Record<string, ThreadDeviceState>
+```
+
+### Thread Switch Flow
+
+1. User switches from Thread A to Thread B
+2. Existing `pushSync` fires with new `threadId`
+3. Main process runs full reset (clears Thread A's emulation)
+4. Renderer reads `deviceStateByThread[threadB.id]`
+5. If Thread B has a stored device: renderer calls `preview.setDeviceEmulation()` with that state
+6. If Thread B has no stored device: stays in desktop mode (reset already happened)
+
+### No Disk Persistence
+
+Thread device state lives in memory only. Closing the app resets all threads to desktop. This avoids stale device configs and keeps the feature lightweight.
+
+---
+
+## Bounds Calculation and Scaling
+
+When device emulation is active, the BrowserView is positioned within the panel rather than filling it.
+
+### Logic (Main Process)
+
+```
+panelBounds   = bounds from ResizeObserver (renderer sends via preview:sync)
+emulatedSize  = effective viewport from active preset
+
+IF no emulation active:
+    view.setBounds(panelBounds)                      // current behavior
+
+IF emulatedSize fits inside panelBounds:
+    // Center at native CSS pixel size
+    offsetX = floor((panelBounds.width - emulatedSize.width) / 2)
+    offsetY = floor((panelBounds.height - emulatedSize.height) / 2)
+    view.setBounds({
+      x: panelBounds.x + offsetX,
+      y: panelBounds.y + offsetY,
+      width: emulatedSize.width,
+      height: emulatedSize.height
+    })
+    enableDeviceEmulation({ ..., scale: 1 })
+
+IF emulatedSize exceeds panelBounds:
+    // Scale down to fit, maintain aspect ratio
+    scaleFactor = min(
+      panelBounds.width  / emulatedSize.width,
+      panelBounds.height / emulatedSize.height
+    )
+    scaledW = floor(emulatedSize.width  * scaleFactor)
+    scaledH = floor(emulatedSize.height * scaleFactor)
+    offsetX = floor((panelBounds.width  - scaledW) / 2)
+    offsetY = floor((panelBounds.height - scaledH) / 2)
+    view.setBounds({
+      x: panelBounds.x + offsetX,
+      y: panelBounds.y + offsetY,
+      width: scaledW,
+      height: scaledH
+    })
+    enableDeviceEmulation({ ..., scale: scaleFactor })
+```
+
+The `scale` parameter in `enableDeviceEmulation` handles visual scaling. The emulated viewport stays at full CSS pixel resolution (e.g., 1920x1080), but Chromium renders it scaled down. Media queries fire at the emulated size, not the physical size.
+
+### Background Fill
+
+The renderer draws a `bg-muted` fill behind the surface div. The gap between the centered BrowserView and panel edges shows this background, giving a clear visual boundary around the emulated device.
+
+---
+
+## UI Design
+
+### Layer 1: Device Icon (Toolbar)
+
+A device icon button added to the preview toolbar between the capture group and the external link button.
+
+- **No emulation:** Icon is in default/inactive style
+- **Emulation active:** Icon shows a small accent dot badge
+
+Clicking the icon opens the device dropdown.
+
+### Layer 2: Device Dropdown
+
+A `DropdownMenu` (shadcn) anchored to the device icon:
+
+```
+PHONES
+  iPhone SE                375x667
+  iPhone 14 Pro            393x852
+  Galaxy S24               360x780
+  Pixel 7                  412x915
+
+TABLETS
+  iPad Air                 820x1180
+  iPad Pro 11"             834x1194
+  Galaxy Tab S9            640x1024
+
+DESKTOP
+  HD                       1280x720
+  Full HD                  1920x1080
+
+Custom...
+```
+
+- Category headers as non-interactive labels
+- Each item shows name and dimensions
+- Active device shows a checkmark
+- "Custom..." opens an inline form with width, height, and DPR fields
+- Selecting a preset immediately applies emulation and closes the menu
+
+### Layer 3: Device Bar (Below Toolbar)
+
+Appears only when emulation is active. Single compact row:
+
+```
+[icon] iPhone 14 Pro   393x852   [orientation toggle]   [reset x]
+```
+
+- Device icon + name + dimensions: clickable area that re-opens the dropdown
+- Orientation toggle: rotates between portrait/landscape (hidden for desktop presets)
+- Reset button: clears emulation, hides the bar, returns to fill-panel behavior
+- Subtle `bg-muted` background to visually separate from the toolbar
+
+### Layer 4: Keyboard Shortcut (Power User)
+
+`Ctrl+Shift+D` (`Cmd+Shift+D` on Mac) opens a cmdk `Command` palette scoped to device selection. Type-to-filter across all presets. Same data source as the dropdown.
+
+### UI States
+
+| State | Toolbar Icon | Device Bar | Panel Background |
+|-------|-------------|------------|------------------|
+| Desktop (no emulation) | Default | Hidden | Not visible (view fills panel) |
+| Device active | Accent dot | Visible with device info | `bg-muted` fill around centered view |
+| Custom active | Accent dot | Shows "Custom" + dimensions | `bg-muted` fill around centered view |
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `enableDeviceEmulation` throws | Toast: "Device emulation failed", revert to desktop, log error |
+| CDP debugger fails to attach | Apply viewport + UA only (graceful degradation), toast: "Touch emulation unavailable" |
+| Invalid custom dimensions | Inline validation, apply button disabled until valid |
+| BrowserView destroyed during apply | No-op; next `pushSync` recreates view and re-applies thread state |
+| Orientation toggle on desktop preset | Toggle is hidden; no-op if reached programmatically |
+
+## Integration with Existing Features
+
+| Feature | Behavior |
+|---------|----------|
+| Thread switch | Reset current emulation, apply new thread's stored state |
+| Idle parking (`parkPreview`) | Emulation state preserved in `session.emulationState`; re-applied after `ensureView` on wake |
+| Panel resize | Recalculate centering/scaling; no emulation reset needed |
+| Panel hide (`pushSync(false)`) | View parked as before; emulation state preserved in memory |
+| Panel show (`pushSync(true)`) | View recreated; emulation re-applied from thread state |
+| Screenshot capture | Captures emulated viewport; metadata includes device name and dimensions |
+| Page context extraction | `layoutWidth`/`layoutHeight` reflect emulated viewport (correct behavior) |
+| Navigation / reload | Emulation persists across navigations; no re-apply needed |
+
+---
+
+## v2: Device Chrome (Deferred)
+
+Future work to render visual device frames (bezels, notch, dynamic island, punch-hole cutout) around the emulated viewport. This benefits mobile developers and designer-developers who want presentation-quality previews.
+
+Planned approach: CSS pseudo-elements or overlay SVGs rendered by the shell around the BrowserView bounds. The emulated viewport shrinks by the frame insets. Device chrome data (inset dimensions, notch type) added to `DevicePreset`.
+
+---
+
+## Open Questions
+
+1. **User agent Chrome version:** Should the UA string dynamically template the Chrome version from `process.versions.chrome` (Electron's bundled Chromium), or use static strings? Dynamic keeps UAs truthful as Electron upgrades; static is simpler.
+2. **Preset extensibility:** Should users be able to add custom named presets via settings in a future iteration, or is "Custom dimensions" sufficient?
+3. **Capture metadata format:** How should device info appear in capture fences sent to the agent? e.g., `[device: iPhone 14 Pro, 393x852, 3x]` prepended to the fence?

--- a/docs/specs/2026-05-10-responsive-viewport-emulation-plan.md
+++ b/docs/specs/2026-05-10-responsive-viewport-emulation-plan.md
@@ -1,0 +1,724 @@
+# Responsive Viewport Emulation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add device viewport emulation to the browser preview panel so users can test responsive layouts at phone, tablet, and desktop sizes with correct DPR, user agent, and viewport dimensions.
+
+**Architecture:** The renderer sends a `PreviewDeviceEmulationConfig` (off/preset/custom) on every `preview:sync` call. The main process resolves it to CSS dimensions, centers/scales the BrowserView inside the panel, and calls `webContents.enableDeviceEmulation()`. Helper functions in `preview-device-emulation.ts` already exist for resolution, layout, and application. The UI uses a searchable Popover+Command picker inline in the toolbar with an inline custom dimension editor (no dialog).
+
+**Tech Stack:** Electron BrowserView, `webContents.enableDeviceEmulation()`, React, Zustand, cmdk (Command), base-ui (Popover), Tailwind CSS, lucide-react icons.
+
+**Design spec:** `docs/specs/2026-05-10-responsive-viewport-emulation-design.md`
+
+**Existing code to build on:**
+- Contract types: `packages/contracts/src/models/preview-device-emulation.ts` (presets, schemas, types)
+- Desktop helpers: `apps/desktop/src/main/preview-device-emulation.ts` (resolve, layout, apply, snapshot)
+- Store state: `apps/web/src/stores/diffStore.ts` has `previewDeviceEmulationByThread` and `setPreviewDeviceEmulationForThread`
+- Bridge types: `apps/web/src/transport/desktop-bridge.d.ts` already accepts `deviceEmulation` in `preview:sync` payload
+- Preload: `apps/desktop/src/main/preload.ts` already passes `deviceEmulation` in sync payload (line 144)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `apps/desktop/src/main/preview-browser.ts` | Modify | Add emulation state to PreviewSession, integrate layout+emulation in sync handler, add emulation fields to capture payloads |
+| `apps/desktop/src/main/preview-device-emulation.ts` | Exists | Already has `resolvePreviewDeviceEmulation`, `layoutGuestBoundsForEmulation`, `applyPreviewDeviceEmulation`, `buildCaptureEmulationSnapshot` |
+| `apps/web/src/components/panels/PreviewPanel.tsx` | Modify | Add device picker UI, inline custom editor, pass deviceEmulation in pushSync, show bg-muted when emulated |
+| `packages/contracts/src/models/preview-device-emulation.ts` | Exists | Presets, schemas, types |
+| `apps/web/src/stores/diffStore.ts` | Exists | Already has per-thread emulation state |
+| `apps/desktop/src/main/preload.ts` | Exists | Already passes deviceEmulation in sync |
+| `apps/web/src/transport/desktop-bridge.d.ts` | Exists | Already typed |
+
+---
+
+### Task 1: Main Process - Add Emulation State to PreviewSession
+
+**Files:**
+- Modify: `apps/desktop/src/main/preview-browser.ts` (lines 1-20 imports, lines 89-146 PreviewSession + getSession)
+
+- [ ] **Step 1: Add imports from preview-device-emulation**
+
+At the top of `preview-browser.ts`, add the import after the existing `@mcode/shared` import (around line 19):
+
+```typescript
+import {
+  applyPreviewDeviceEmulation,
+  buildCaptureEmulationSnapshot,
+  buildPreviewMobileUserAgent,
+  layoutGuestBoundsForEmulation,
+  resolvePreviewDeviceEmulation,
+} from "./preview-device-emulation.js";
+```
+
+Also add contract imports. Find the existing `from "@mcode/contracts"` import block and add:
+
+```typescript
+import {
+  // ... existing imports ...
+  PreviewDeviceEmulationConfigSchema,
+  type McodeBrowserCaptureEmulation,
+  type PreviewDeviceEmulationConfig,
+} from "@mcode/contracts";
+```
+
+- [ ] **Step 2: Extend PreviewSession interface**
+
+Find the `PreviewSession` interface (line 89). Add these fields before the closing brace:
+
+```typescript
+  /** Per-thread device emulation config from the renderer (synced on each preview:sync). */
+  deviceEmulationConfig: PreviewDeviceEmulationConfig;
+  /** Full shell surface rect for emulation layout (the panel bounds before centering). */
+  shellBounds: Bounds | null;
+  /** Default Chromium user agent captured when the view was created (restored when emulation turns off). */
+  defaultGuestUserAgent: string;
+  /** Structured emulation metadata included on v2 captures (null when emulation is off). */
+  captureEmulationSnapshot: McodeBrowserCaptureEmulation | null;
+```
+
+- [ ] **Step 3: Initialize new fields in getSession**
+
+Find `getSession()` (line 127). Add the new field initializers alongside existing ones:
+
+```typescript
+      deviceEmulationConfig: { kind: "off" },
+      shellBounds: null,
+      defaultGuestUserAgent: "",
+      captureEmulationSnapshot: null,
+```
+
+- [ ] **Step 4: Capture default UA in ensureView**
+
+Find `ensureView()` (line 1239). After `s.view = view;` (around line 1358), add:
+
+```typescript
+    try {
+      s.defaultGuestUserAgent = view.webContents.getUserAgent();
+    } catch {
+      s.defaultGuestUserAgent = "";
+    }
+```
+
+- [ ] **Step 5: Clear emulation state in parkPreview**
+
+Find `parkPreview()` (line 1192). After `s.view = null;` (around line 1207), add:
+
+```typescript
+    s.captureEmulationSnapshot = null;
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cd apps/desktop && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/main/preview-browser.ts
+git commit -m "feat(preview): add emulation state fields to PreviewSession"
+```
+
+---
+
+### Task 2: Main Process - Layout and Emulation in Sync Handler
+
+**Files:**
+- Modify: `apps/desktop/src/main/preview-browser.ts` (preview:sync handler around line 1632, and a new `layoutPreviewGuest` function)
+
+- [ ] **Step 1: Add layoutPreviewGuest function**
+
+Add this function after `getSession()` (around line 147), before any IPC handler registration:
+
+```typescript
+/**
+ * Centers the guest BrowserView inside the shell surface and applies device emulation when enabled.
+ */
+function layoutPreviewGuest(s: PreviewSession): void {
+  if (!s.view || s.view.webContents.isDestroyed() || !s.shellBounds) return;
+  const sh = s.shellBounds;
+  const wc = s.view.webContents;
+
+  const resolved = resolvePreviewDeviceEmulation(s.deviceEmulationConfig);
+
+  if (!resolved) {
+    // Desktop mode: fill the panel, disable any prior emulation
+    s.view.setBounds(sh);
+    s.lastBounds = { ...sh };
+    s.captureEmulationSnapshot = null;
+    if (s.defaultGuestUserAgent) {
+      try {
+        wc.disableDeviceEmulation();
+        wc.setUserAgent(s.defaultGuestUserAgent);
+      } catch { /* view tearing down */ }
+    }
+    return;
+  }
+
+  try {
+    const { guest, scaleToFit } = layoutGuestBoundsForEmulation(sh, resolved.cssWidth, resolved.cssHeight);
+    const safeScale = Number.isFinite(scaleToFit) && scaleToFit > 0 ? Math.min(scaleToFit, 1) : 1;
+    s.view.setBounds(guest);
+    s.lastBounds = { ...guest };
+
+    const chromeV = process.versions.chrome ?? "120.0.0.0";
+    const mobileUa = buildPreviewMobileUserAgent(chromeV);
+    applyPreviewDeviceEmulation(wc, {
+      active: true,
+      cssViewport: { width: resolved.cssWidth, height: resolved.cssHeight },
+      deviceScaleFactor: resolved.deviceScaleFactor,
+      scaleToFit: safeScale,
+      mobileUserAgent: mobileUa,
+      defaultUserAgent: s.defaultGuestUserAgent,
+    });
+
+    s.captureEmulationSnapshot = buildCaptureEmulationSnapshot(
+      s.deviceEmulationConfig,
+      resolved,
+      safeScale,
+      mobileUa,
+    );
+  } catch (err) {
+    console.warn("[preview-browser] device emulation failed; falling back to desktop layout:", err);
+    s.view.setBounds(sh);
+    s.lastBounds = { ...sh };
+    s.captureEmulationSnapshot = null;
+  }
+}
+```
+
+- [ ] **Step 2: Modify preview:sync handler to parse emulation config**
+
+Find the `preview:sync` handler (line 1632). The payload type already includes `deviceEmulation?: unknown` from the preload changes.
+
+After the line that sets `s.workspaceId` (around line 1649), add emulation config parsing:
+
+```typescript
+      const rawEmu = payload.deviceEmulation ?? { kind: "off" };
+      const emParsed = PreviewDeviceEmulationConfigSchema().safeParse(rawEmu);
+      s.deviceEmulationConfig = emParsed.success ? emParsed.data : { kind: "off" };
+```
+
+- [ ] **Step 3: Replace setBounds with layoutPreviewGuest in sync handler**
+
+Find the line `s.lastBounds = { ... }` followed by `view.setBounds(s.lastBounds)` in the sync handler (around lines 1656-1658). Replace with:
+
+```typescript
+      s.shellBounds = { x: b.x, y: b.y, width: b.width, height: b.height };
+      const view = ensureView(win, s);
+      layoutPreviewGuest(s);
+```
+
+Remove the old `s.lastBounds = ...` and `view.setBounds(s.lastBounds)` lines that were there.
+
+- [ ] **Step 4: Re-apply emulation after page loads**
+
+Find the `did-finish-load` listener in `ensureView()` (around line 1336). Add emulation re-apply after the scrollbar injection:
+
+```typescript
+  view.webContents.on("did-finish-load", () => {
+    void injectPreviewScrollbarStyles(s);
+    // Re-apply deferred emulation after the guest loads a real document
+    if (s.deviceEmulationConfig.kind !== "off" && !s.captureEmulationSnapshot) {
+      layoutPreviewGuest(s);
+    }
+  });
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `cd apps/desktop && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/main/preview-browser.ts
+git commit -m "feat(preview): integrate device emulation layout in sync handler"
+```
+
+---
+
+### Task 3: Main Process - Emulation Metadata in Captures
+
+**Files:**
+- Modify: `apps/desktop/src/main/preview-browser.ts` (capture handlers and `buildBrowserCapturePayload`)
+
+- [ ] **Step 1: Add emulation field to buildBrowserCapturePayload extras**
+
+Find `buildBrowserCapturePayload()` (search for `async function buildBrowserCapturePayload`). In the `extras` parameter type, add:
+
+```typescript
+    emulation?: McodeBrowserCaptureEmulation;
+```
+
+Inside the function body, after the `captureKind` assignment, add:
+
+```typescript
+  if (extras?.emulation) {
+    out.emulation = { ...extras.emulation };
+  }
+```
+
+- [ ] **Step 2: Pass emulation snapshot in capture calls**
+
+Find each capture handler (`preview:capture-picture-reference`, `preview:capture-picture-reference-region`, `preview:capture-picture-reference-element-pick`, `preview:capture-page-context`). In the `buildBrowserCapturePayload` call's extras object, add:
+
+```typescript
+          emulation: s.captureEmulationSnapshot ?? undefined,
+```
+
+There are 4 capture handlers to update. Search for `captureKind:` to find them all.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cd apps/desktop && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop/src/main/preview-browser.ts
+git commit -m "feat(preview): include emulation metadata in capture payloads"
+```
+
+---
+
+### Task 4: Renderer - Pass Emulation Config in pushSync
+
+**Files:**
+- Modify: `apps/web/src/components/panels/PreviewPanel.tsx` (pushSync callback, around line 142)
+
+- [ ] **Step 1: Import emulation types and store selector**
+
+Add to the existing `@mcode/contracts` import block:
+
+```typescript
+import {
+  MCODE_BROWSER_CONTEXT_ATTACHMENT_MIME,
+  PREVIEW_DEVICE_EMULATION_OFF,
+  type PreviewDeviceEmulationConfig,
+} from "@mcode/contracts";
+```
+
+- [ ] **Step 2: Add emulation store selector**
+
+After the existing `storedUrl` selector (around line 120), add:
+
+```typescript
+  const deviceEmu = useDiffStore(
+    (s) => s.previewDeviceEmulationByThread[threadId] ?? PREVIEW_DEVICE_EMULATION_OFF,
+  );
+  const setDeviceEmu = useDiffStore((s) => s.setPreviewDeviceEmulationForThread);
+```
+
+- [ ] **Step 3: Pass deviceEmulation in pushSync**
+
+Find `pushSync` (around line 142). In both the `visible: false` and `visible: true` calls to `preview.sync()`, add `deviceEmulation`:
+
+```typescript
+        await preview.sync({
+          visible: false,
+          bounds: null,
+          threadId,
+          resumeUrlHint: hint,
+          workspaceId: workspaceId ?? null,
+          deviceEmulation: deviceEmu,
+        });
+```
+
+And for the visible path:
+
+```typescript
+        await preview.sync({
+          visible: true,
+          bounds: { ... },
+          threadId,
+          resumeUrlHint: hint,
+          workspaceId: workspaceId ?? null,
+          deviceEmulation: deviceEmu,
+        });
+```
+
+- [ ] **Step 4: Add deviceEmu to pushSync dependency array**
+
+The `pushSync` useCallback currently depends on `[threadId, storedUrl, workspaceId]`. Add `deviceEmu`:
+
+```typescript
+    [threadId, storedUrl, workspaceId, deviceEmu],
+```
+
+- [ ] **Step 5: Add bg-muted to surface div when emulation is active**
+
+Find the BrowserView surface div (search for `data-testid="preview-surface"` or the surface `<div>` with `ref={surfaceRef}`). Add conditional background:
+
+```typescript
+        className={cn(
+          "... existing classes ...",
+          deviceEmu.kind !== "off" && "bg-muted",
+        )}
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/panels/PreviewPanel.tsx
+git commit -m "feat(preview): pass device emulation config through pushSync"
+```
+
+---
+
+### Task 5: Renderer - Device Picker UI
+
+**Files:**
+- Modify: `apps/web/src/components/panels/PreviewPanel.tsx` (toolbar section, around line 390)
+
+- [ ] **Step 1: Add UI component imports**
+
+Add these imports at the top of PreviewPanel.tsx:
+
+```typescript
+import {
+  Check,
+  ChevronsUpDown,
+  MonitorSmartphone,
+  Pencil,
+  Repeat2,
+  Settings2,
+  X,
+} from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandEmpty,
+} from "@/components/ui/command";
+import {
+  BROWSER_PREVIEW_DEVICE_PRESETS,
+  findBrowserPreviewDevicePreset,
+} from "@mcode/contracts";
+```
+
+- [ ] **Step 2: Add display label helper**
+
+Before the component function, add:
+
+```typescript
+function previewDeviceDisplayLabel(cfg: PreviewDeviceEmulationConfig): string {
+  if (cfg.kind === "off") return "Desktop";
+  if (cfg.kind === "custom") return `${cfg.width}x${cfg.height}`;
+  const p = findBrowserPreviewDevicePreset(cfg.presetId);
+  if (!p) return cfg.presetId;
+  const w = cfg.orientation === "landscape" ? p.height : p.width;
+  const h = cfg.orientation === "landscape" ? p.width : p.height;
+  return `${p.label} ${w}x${h}`;
+}
+```
+
+- [ ] **Step 3: Add picker state**
+
+Inside the component, after the `setDeviceEmu` line, add:
+
+```typescript
+  const [devicePickerOpen, setDevicePickerOpen] = useState(false);
+  const [customEditing, setCustomEditing] = useState(false);
+  const [customW, setCustomW] = useState("390");
+  const [customH, setCustomH] = useState("844");
+  const customWRef = useRef<HTMLInputElement>(null);
+```
+
+- [ ] **Step 4: Add device picker group to the toolbar**
+
+Find the toolbar `<div>` (search for `{/* Navigation group */}`). Before the navigation group, add the device emulation group with a separator after it:
+
+```tsx
+          {/* Device emulation group */}
+          <div className="flex items-center gap-0.5">
+            {customEditing ? (
+              <div className="flex h-7 items-center gap-1 rounded-md border border-primary/50 bg-background px-1.5 font-mono text-xs text-primary animate-fade-up-in">
+                <MonitorSmartphone className="size-3 shrink-0" aria-hidden />
+                <input
+                  ref={customWRef}
+                  type="text"
+                  inputMode="numeric"
+                  className="h-5 w-12 rounded border-none bg-muted px-1 text-center text-xs outline-none focus:ring-1 focus:ring-primary/50"
+                  value={customW}
+                  onChange={(e) => setCustomW(e.target.value.replace(/\D/g, ""))}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const w = Number.parseInt(customW, 10);
+                      const h = Number.parseInt(customH, 10);
+                      if (w >= 100 && h >= 100) {
+                        setDeviceEmu(threadId, { kind: "custom", width: Math.min(w, 8192), height: Math.min(h, 8192), deviceScaleFactor: 2 });
+                        setCustomEditing(false);
+                      }
+                    }
+                    if (e.key === "Escape") setCustomEditing(false);
+                  }}
+                  aria-label="Viewport width"
+                />
+                <span className="text-muted-foreground">x</span>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  className="h-5 w-12 rounded border-none bg-muted px-1 text-center text-xs outline-none focus:ring-1 focus:ring-primary/50"
+                  value={customH}
+                  onChange={(e) => setCustomH(e.target.value.replace(/\D/g, ""))}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const w = Number.parseInt(customW, 10);
+                      const h = Number.parseInt(customH, 10);
+                      if (w >= 100 && h >= 100) {
+                        setDeviceEmu(threadId, { kind: "custom", width: Math.min(w, 8192), height: Math.min(h, 8192), deviceScaleFactor: 2 });
+                        setCustomEditing(false);
+                      }
+                    }
+                    if (e.key === "Escape") setCustomEditing(false);
+                  }}
+                  aria-label="Viewport height"
+                />
+                <Button type="button" variant="ghost" size="icon-xs" className="shrink-0 text-primary"
+                  onClick={() => {
+                    const w = Number.parseInt(customW, 10);
+                    const h = Number.parseInt(customH, 10);
+                    if (w >= 100 && h >= 100) {
+                      setDeviceEmu(threadId, { kind: "custom", width: Math.min(w, 8192), height: Math.min(h, 8192), deviceScaleFactor: 2 });
+                      setCustomEditing(false);
+                    }
+                  }}
+                  aria-label="Apply custom dimensions"
+                >
+                  <Check size={14} aria-hidden />
+                </Button>
+                <Button type="button" variant="ghost" size="icon-xs" className="shrink-0 text-muted-foreground"
+                  onClick={() => setCustomEditing(false)} aria-label="Cancel"
+                >
+                  <X size={14} aria-hidden />
+                </Button>
+              </div>
+            ) : (
+              <>
+                <Popover open={devicePickerOpen} onOpenChange={setDevicePickerOpen}>
+                  <PopoverTrigger
+                    render={
+                      <Button type="button" variant="outline" size="sm"
+                        className={cn(
+                          "h-7 max-w-[13rem] justify-between gap-1 px-2 font-mono text-xs",
+                          deviceEmu.kind !== "off" && "border-primary/50 text-primary glow-primary",
+                        )}
+                        aria-label="Preview device frame"
+                      >
+                        <MonitorSmartphone className="size-3 shrink-0" aria-hidden />
+                        <span className="truncate">{previewDeviceDisplayLabel(deviceEmu)}</span>
+                        <ChevronsUpDown className="size-3 shrink-0 opacity-50" aria-hidden />
+                      </Button>
+                    }
+                  />
+                  <PopoverContent side="bottom" sideOffset={6} className="w-[15rem] p-0 font-mono text-xs">
+                    <Command>
+                      <CommandInput placeholder="Search devices..." className="h-8 text-xs" />
+                      <CommandList>
+                        <CommandEmpty>No device found.</CommandEmpty>
+                        <CommandGroup>
+                          <CommandItem onSelect={() => {
+                            setDeviceEmu(threadId, { kind: "off" });
+                            setDevicePickerOpen(false);
+                          }}>
+                            <Check className={cn("size-3", deviceEmu.kind === "off" ? "opacity-100" : "opacity-0")} />
+                            Desktop
+                          </CommandItem>
+                          {BROWSER_PREVIEW_DEVICE_PRESETS.map((p) => {
+                            const active = deviceEmu.kind === "preset" && deviceEmu.presetId === p.id;
+                            return (
+                              <CommandItem key={p.id} onSelect={() => {
+                                const orientation = deviceEmu.kind === "preset" && deviceEmu.presetId === p.id
+                                  ? deviceEmu.orientation : "portrait";
+                                setDeviceEmu(threadId, { kind: "preset", presetId: p.id, orientation });
+                                setDevicePickerOpen(false);
+                              }}>
+                                <Check className={cn("size-3", active ? "opacity-100" : "opacity-0")} />
+                                <span className="flex-1 truncate">{p.label}</span>
+                                <span className="text-muted-foreground">{p.width}x{p.height}</span>
+                              </CommandItem>
+                            );
+                          })}
+                        </CommandGroup>
+                        <CommandSeparator />
+                        <CommandGroup>
+                          <CommandItem onSelect={() => {
+                            setDevicePickerOpen(false);
+                            if (deviceEmu.kind === "custom") {
+                              setCustomW(String(deviceEmu.width));
+                              setCustomH(String(deviceEmu.height));
+                            } else {
+                              setCustomW("390");
+                              setCustomH("844");
+                            }
+                            setCustomEditing(true);
+                            requestAnimationFrame(() => customWRef.current?.select());
+                          }}>
+                            <Settings2 className="size-3" />
+                            Custom...
+                          </CommandItem>
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+                {deviceEmu.kind === "preset" && (
+                  <Tooltip>
+                    <TooltipTrigger render={
+                      <Button type="button" variant="ghost" size="icon-xs" className="shrink-0 text-primary"
+                        onClick={() => {
+                          setDeviceEmu(threadId, {
+                            kind: "preset", presetId: deviceEmu.presetId,
+                            orientation: deviceEmu.orientation === "portrait" ? "landscape" : "portrait",
+                          });
+                        }}
+                        aria-label="Rotate device frame"
+                      >
+                        <Repeat2 size={14} aria-hidden />
+                      </Button>
+                    } />
+                    <TooltipContent side="bottom" sideOffset={6} className="text-xs">Toggle portrait / landscape</TooltipContent>
+                  </Tooltip>
+                )}
+                {deviceEmu.kind === "custom" && (
+                  <Tooltip>
+                    <TooltipTrigger render={
+                      <Button type="button" variant="ghost" size="icon-xs" className="shrink-0 text-primary"
+                        onClick={() => {
+                          setCustomW(String(deviceEmu.width));
+                          setCustomH(String(deviceEmu.height));
+                          setCustomEditing(true);
+                          requestAnimationFrame(() => customWRef.current?.select());
+                        }}
+                        aria-label="Edit custom dimensions"
+                      >
+                        <Pencil size={14} aria-hidden />
+                      </Button>
+                    } />
+                    <TooltipContent side="bottom" sideOffset={6} className="text-xs">Edit dimensions</TooltipContent>
+                  </Tooltip>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Separator: device | nav */}
+          <div className="mx-1 h-4 w-px bg-border/40" aria-hidden />
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 6: Manually test in the app**
+
+Start the dev server (`bun run dev` from project root). Open the preview panel, click the device picker, select a preset, toggle orientation, try custom dimensions, switch threads and verify state is preserved.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/panels/PreviewPanel.tsx
+git commit -m "feat(preview): add searchable device picker and inline custom editor"
+```
+
+---
+
+### Task 6: Integration Testing and Edge Cases
+
+**Files:**
+- Test: Manual testing across the full feature surface
+
+- [ ] **Step 1: Test preset selection with loaded page**
+
+1. Navigate to `https://example.com` in the preview
+2. Select "iPhone SE" from the device picker
+3. Verify: BrowserView centers in the panel with bg-muted background visible around it
+4. Verify: Page renders at 375px width (responsive layout should change)
+5. Verify: Trigger button shows "iPhone SE 375x667" with primary accent styling
+
+- [ ] **Step 2: Test orientation toggle**
+
+1. With "iPhone SE" selected, click the rotate button
+2. Verify: Viewport swaps to 667x375
+3. Verify: Display label updates
+4. Click rotate again, verify it returns to portrait
+
+- [ ] **Step 3: Test custom dimensions**
+
+1. Click the device picker, select "Custom..."
+2. Verify: Inline editor appears with two input fields
+3. Type 412 x 900, press Enter
+4. Verify: Emulation applies at those dimensions
+5. Click the pencil icon to re-edit
+6. Press Escape to cancel without changes
+
+- [ ] **Step 4: Test reset to desktop**
+
+1. With a device active, open the picker and select "Desktop"
+2. Verify: BrowserView fills the panel again, bg-muted background disappears
+3. Verify: Trigger returns to default styling (no primary accent)
+
+- [ ] **Step 5: Test thread switching**
+
+1. Select a device preset in Thread A
+2. Switch to Thread B (should be desktop by default)
+3. Switch back to Thread A (should restore the device preset)
+
+- [ ] **Step 6: Test emulation on empty BrowserView**
+
+1. Open a fresh preview with no URL loaded
+2. Select a device preset
+3. Verify: No crash (emulation deferred until page loads)
+4. Navigate to a URL
+5. Verify: Emulation applies after the page loads
+
+- [ ] **Step 7: Test capture with emulation active**
+
+1. With a device preset active and a page loaded
+2. Capture a viewport screenshot
+3. Verify: Capture succeeds and includes emulation metadata
+
+- [ ] **Step 8: Verify no console errors**
+
+Check the terminal running the dev server for any Electron deprecation warnings or errors during all tests above.
+
+- [ ] **Step 9: Full type-check**
+
+```bash
+cd apps/desktop && npx tsc --noEmit
+cd apps/web && npx tsc --noEmit
+```
+Expected: No errors in either package
+
+- [ ] **Step 10: Commit any fixes**
+
+If any issues were found and fixed during testing:
+
+```bash
+git add -A
+git commit -m "fix(preview): address edge cases in device emulation"
+```
+
+---
+
+## Execution Notes
+
+- **Task ordering matters:** Tasks 1-3 are main process (desktop). Task 4-5 are renderer (web). Task 6 is integration testing. Tasks 1-3 can be done in sequence; tasks 4-5 depend on task 1-3 being done for the emulation to actually work end-to-end.
+- **The helper functions already exist:** `preview-device-emulation.ts` has all the math and Electron API calls. The tasks wire them into the existing sync flow and add UI.
+- **No new IPC channels needed for v1:** The `deviceEmulation` field is already in the `preview:sync` payload. The main process reads it on every sync and applies/resets accordingly. Separate `setDeviceEmulation` / `getDeviceEmulation` IPC methods from the spec are deferred; the sync-based approach is simpler and sufficient.
+- **The spec mentions CDP touch emulation and media features.** These are intentionally omitted from this plan for v1 simplicity. The `applyPreviewDeviceEmulation()` function in `preview-device-emulation.ts` currently uses only `enableDeviceEmulation()` and `setUserAgent()`. CDP integration can be added in a follow-up without changing the architecture.

--- a/packages/contracts/src/__tests__/settings.test.ts
+++ b/packages/contracts/src/__tests__/settings.test.ts
@@ -169,4 +169,23 @@ describe("SettingsSchema", () => {
       ).toThrow();
     });
   });
+
+  describe("browserPreview", () => {
+    it("defaults allowSitePermissions and isolateStorageByWorkspace to false", () => {
+      const result = SettingsSchema().parse({});
+      expect(result.browserPreview.allowSitePermissions).toBe(false);
+      expect(result.browserPreview.isolateStorageByWorkspace).toBe(false);
+    });
+
+    it("accepts true for both flags", () => {
+      const result = SettingsSchema().parse({
+        browserPreview: {
+          allowSitePermissions: true,
+          isolateStorageByWorkspace: true,
+        },
+      });
+      expect(result.browserPreview.allowSitePermissions).toBe(true);
+      expect(result.browserPreview.isolateStorageByWorkspace).toBe(true);
+    });
+  });
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -115,6 +115,21 @@ export type {
   BrowserCaptureSpillFile,
 } from "./models/browser-preview.js";
 
+export {
+  BROWSER_PREVIEW_DEVICE_PRESETS,
+  PREVIEW_DEVICE_EMULATION_OFF,
+  PreviewDeviceOrientationSchema,
+  PreviewDeviceEmulationConfigSchema,
+  McodeBrowserCaptureEmulationSchema,
+  findBrowserPreviewDevicePreset,
+} from "./models/preview-device-emulation.js";
+export type {
+  BrowserPreviewDevicePresetId,
+  PreviewDeviceOrientation,
+  PreviewDeviceEmulationConfig,
+  McodeBrowserCaptureEmulation,
+} from "./models/preview-device-emulation.js";
+
 // Events
 export { AgentEventSchema, AgentEventType } from "./events/agent-event.js";
 export type { AgentEvent } from "./events/agent-event.js";

--- a/packages/contracts/src/models/__tests__/browser-preview-clamp.test.ts
+++ b/packages/contracts/src/models/__tests__/browser-preview-clamp.test.ts
@@ -26,6 +26,29 @@ describe("browser capture clamp", () => {
     expect(() => McodeBrowserCaptureV2Schema().parse(clamped)).not.toThrow();
   });
 
+  it("truncates emulation label and userAgent on clamp", () => {
+    const lbl = MCODE_BROWSER_CAPTURE_V2_STRING_MAX.emulationLabel;
+    const ua = MCODE_BROWSER_CAPTURE_V2_STRING_MAX.emulationUserAgent;
+    const row: McodeBrowserCaptureV2 = {
+      schemaVersion: 2,
+      pageUrl: "https://example.com/",
+      pageTitle: "Example",
+      capturedAt: "2026-05-08T12:00:00.000Z",
+      bounds: { x: 0, y: 0, width: 1, height: 1 },
+      emulation: {
+        mode: "custom",
+        label: "x".repeat(lbl + 10),
+        cssViewport: { width: 390, height: 844 },
+        deviceScaleFactor: 2,
+        userAgent: "z".repeat(ua + 10),
+      },
+    };
+    const clamped = clampMcodeBrowserCaptureV2(row);
+    expect(clamped.emulation?.label).toHaveLength(lbl);
+    expect(clamped.emulation?.userAgent).toHaveLength(ua);
+    expect(() => McodeBrowserCaptureV2Schema().parse(clamped)).not.toThrow();
+  });
+
   it("clampAttachedBrowserCaptureForOutbound makes oversized outbound rows parseable", () => {
     const cap = MCODE_BROWSER_CAPTURE_V2_STRING_MAX.consoleTail;
     const row: AttachedBrowserCaptureV2 = {

--- a/packages/contracts/src/models/__tests__/preview-device-emulation.test.ts
+++ b/packages/contracts/src/models/__tests__/preview-device-emulation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { PreviewDeviceEmulationConfigSchema } from "../preview-device-emulation.js";
+
+describe("PreviewDeviceEmulationConfigSchema", () => {
+  it("accepts off, preset, and custom shapes", () => {
+    const schema = PreviewDeviceEmulationConfigSchema();
+    expect(schema.parse({ kind: "off" })).toEqual({ kind: "off" });
+    expect(
+      schema.parse({
+        kind: "preset",
+        presetId: "iphone-14-pro",
+        orientation: "landscape",
+      }),
+    ).toEqual({
+      kind: "preset",
+      presetId: "iphone-14-pro",
+      orientation: "landscape",
+    });
+    expect(
+      schema.parse({
+        kind: "custom",
+        width: 390,
+        height: 844,
+        deviceScaleFactor: 2,
+      }),
+    ).toEqual({
+      kind: "custom",
+      width: 390,
+      height: 844,
+      deviceScaleFactor: 2,
+    });
+  });
+
+  it("rejects custom dimensions below the minimum", () => {
+    const schema = PreviewDeviceEmulationConfigSchema();
+    const r = schema.safeParse({ kind: "custom", width: 50, height: 844 });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/models/browser-preview.ts
+++ b/packages/contracts/src/models/browser-preview.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { lazySchema } from "../utils/lazySchema.js";
+import { McodeBrowserCaptureEmulationSchema } from "./preview-device-emulation.js";
 
 /** Max lengths for {@link McodeBrowserCaptureV1} excerpt fields (matches Zod). */
 export const MCODE_BROWSER_CAPTURE_V1_STRING_MAX = {
@@ -18,6 +19,8 @@ export const MCODE_BROWSER_CAPTURE_V2_STRING_MAX = {
   consoleTail: 4000,
   failedRequestUrl: 2048,
   failedRequestResourceType: 32,
+  emulationLabel: 80,
+  emulationUserAgent: 512,
 } as const;
 
 /** Max length for spillAppDataPath (POSIX path segments under the Mcode app data directory). */
@@ -175,6 +178,8 @@ export const McodeBrowserCaptureV2Schema = lazySchema(() =>
       .optional(),
     /** Native absolute path to the same spill file (convenience for read_file style tools). */
     spillAbsolutePath: z.string().max(MCODE_BROWSER_CAPTURE_SPILL_ABSOLUTE_PATH_MAX).optional(),
+    /** Device emulation snapshot when the capture used a mobile or custom viewport frame. */
+    emulation: McodeBrowserCaptureEmulationSchema().optional(),
   }),
 );
 
@@ -237,6 +242,15 @@ export function clampMcodeBrowserCaptureV2<T extends McodeBrowserCaptureV2>(capt
       url: clampStrLen(e.url, m.failedRequestUrl),
       resourceType: clampOptStr(e.resourceType, m.failedRequestResourceType),
     }));
+  }
+  if (next.emulation !== undefined) {
+    const e = next.emulation;
+    next.emulation = {
+      ...e,
+      label: clampStrLen(e.label, m.emulationLabel),
+      presetId: clampOptStr(e.presetId, 64),
+      userAgent: clampOptStr(e.userAgent, m.emulationUserAgent),
+    };
   }
   if (next.spillAbsolutePath !== undefined) {
     next.spillAbsolutePath = clampStrLen(next.spillAbsolutePath, MCODE_BROWSER_CAPTURE_SPILL_ABSOLUTE_PATH_MAX);

--- a/packages/contracts/src/models/preview-device-emulation.ts
+++ b/packages/contracts/src/models/preview-device-emulation.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+
+/**
+ * Curated device frames for responsive preview emulation (CSS viewport sizes in portrait).
+ * Desktop maps orientation by swapping width and height when needed.
+ */
+export const BROWSER_PREVIEW_DEVICE_PRESETS = [
+  {
+    id: "iphone-se",
+    label: "iPhone SE",
+    width: 375,
+    height: 667,
+    deviceScaleFactor: 2,
+  },
+  {
+    id: "iphone-14-pro",
+    label: "iPhone 14 Pro",
+    width: 393,
+    height: 852,
+    deviceScaleFactor: 3,
+  },
+  {
+    id: "pixel-7",
+    label: "Pixel 7",
+    width: 412,
+    height: 915,
+    deviceScaleFactor: 2.625,
+  },
+  {
+    id: "galaxy-s21",
+    label: "Galaxy S21",
+    width: 360,
+    height: 800,
+    deviceScaleFactor: 3,
+  },
+  {
+    id: "ipad-mini",
+    label: "iPad Mini",
+    width: 768,
+    height: 1024,
+    deviceScaleFactor: 2,
+  },
+] as const;
+
+/** Union of built-in preset ids. */
+export type BrowserPreviewDevicePresetId = (typeof BROWSER_PREVIEW_DEVICE_PRESETS)[number]["id"];
+
+/**
+ * Looks up a device preset by id for emulation layout and capture labels.
+ */
+export function findBrowserPreviewDevicePreset(
+  id: string,
+): (typeof BROWSER_PREVIEW_DEVICE_PRESETS)[number] | undefined {
+  return BROWSER_PREVIEW_DEVICE_PRESETS.find((p) => p.id === id);
+}
+
+/** Default emulation state when no mobile frame is active. */
+export const PREVIEW_DEVICE_EMULATION_OFF = { kind: "off" } as const;
+
+/** Screen rotation for preset emulation. */
+export const PreviewDeviceOrientationSchema = lazySchema(() => z.enum(["portrait", "landscape"]));
+
+export type PreviewDeviceOrientation = z.infer<ReturnType<typeof PreviewDeviceOrientationSchema>>;
+
+/**
+ * Per-thread preview device emulation choice synced from the renderer and applied in the main process.
+ */
+export const PreviewDeviceEmulationConfigSchema = lazySchema(() =>
+  z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("off") }),
+    z.object({
+      kind: z.literal("preset"),
+      presetId: z.string().min(1).max(64),
+      orientation: PreviewDeviceOrientationSchema(),
+    }),
+    z.object({
+      kind: z.literal("custom"),
+      width: z.number().int().min(100).max(8192),
+      height: z.number().int().min(100).max(8192),
+      deviceScaleFactor: z.number().min(0.75).max(4).optional(),
+    }),
+  ]),
+);
+
+export type PreviewDeviceEmulationConfig = z.infer<ReturnType<typeof PreviewDeviceEmulationConfigSchema>>;
+
+/**
+ * Structured emulation metadata embedded in {@link McodeBrowserCaptureV2} for agent context.
+ */
+export const McodeBrowserCaptureEmulationSchema = lazySchema(() =>
+  z.object({
+    mode: z.enum(["preset", "custom"]),
+    label: z.string().max(80),
+    presetId: z.string().max(64).optional(),
+    orientation: PreviewDeviceOrientationSchema().optional(),
+    cssViewport: z.object({
+      width: z.number().int().min(1).max(8192),
+      height: z.number().int().min(1).max(8192),
+    }),
+    deviceScaleFactor: z.number().min(0.25).max(4),
+    /** Scale applied so the emulated viewport fits the preview panel (0–1). */
+    scaleToFit: z.number().min(0.05).max(1).optional(),
+    /** User-Agent string applied to the guest for this session (truncated in fences if needed). */
+    userAgent: z.string().max(512).optional(),
+  }),
+);
+
+export type McodeBrowserCaptureEmulation = z.infer<ReturnType<typeof McodeBrowserCaptureEmulationSchema>>;

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -338,6 +338,22 @@ export const SettingsSchema = lazySchema(() =>
       })
       .default({}),
 
+    /** Embedded site preview (Electron BrowserView) in the desktop shell. */
+    browserPreview: z
+      .object({
+        /**
+         * When true, allow sites in the embedded preview to receive standard permission
+         * grants (camera, microphone, notifications, etc.). When false, all requests are denied.
+         */
+        allowSitePermissions: z.boolean().default(false),
+        /**
+         * When true, use a separate Chromium storage partition per workspace. When false,
+         * every workspace shares one global preview session (cookies and storage leak across workspaces).
+         */
+        isolateStorageByWorkspace: z.boolean().default(false),
+      })
+      .default({}),
+
     /** Runtime performance and resource-usage settings. */
     performance: z
       .object({
@@ -514,6 +530,12 @@ export const PartialSettingsSchema = lazySchema(() =>
     diffSummary: z
       .object({
         enabled: z.boolean().optional(),
+      })
+      .optional(),
+    browserPreview: z
+      .object({
+        allowSitePermissions: z.boolean().optional(),
+        isolateStorageByWorkspace: z.boolean().optional(),
       })
       .optional(),
     performance: z

--- a/packages/shared/src/browser-preview/__tests__/redact.test.ts
+++ b/packages/shared/src/browser-preview/__tests__/redact.test.ts
@@ -19,4 +19,22 @@ describe("redactMcodeBrowserCaptureV2", () => {
     expect(capture.headingOutline).toContain("[redacted-email]");
     expect(capture.pageUrl).toBe("https://example.com");
   });
+
+  it("redacts emails inside emulation userAgent snippets", () => {
+    const capture = redactMcodeBrowserCaptureV2({
+      schemaVersion: 2,
+      pageUrl: "https://example.com",
+      pageTitle: "t",
+      capturedAt: "2026-01-01T00:00:00.000Z",
+      bounds: { x: 0, y: 0, width: 100, height: 100 },
+      emulation: {
+        mode: "preset",
+        label: "Phone",
+        cssViewport: { width: 360, height: 800 },
+        deviceScaleFactor: 2,
+        userAgent: "Mozilla/5.0 Mobile dev@example.com",
+      },
+    });
+    expect(capture.emulation?.userAgent).toContain("[redacted-email]");
+  });
 });

--- a/packages/shared/src/browser-preview/redact.ts
+++ b/packages/shared/src/browser-preview/redact.ts
@@ -32,5 +32,8 @@ export function redactMcodeBrowserCaptureV2<T extends McodeBrowserCaptureV2>(cap
   if (next.htmlExcerpt) {
     next.htmlExcerpt = redactSegment(next.htmlExcerpt);
   }
+  if (next.emulation?.userAgent) {
+    next.emulation = { ...next.emulation, userAgent: redactSegment(next.emulation.userAgent) };
+  }
   return next;
 }


### PR DESCRIPTION
## What

Add responsive viewport emulation to the browser preview panel. Users can test web apps at phone, tablet, and desktop sizes with correct DPR, user agent, and CSS viewport dimensions, directly from the preview panel.

## Why

Frontend and mobile developers need to verify responsive layouts without leaving Mcode to open Chrome DevTools or a separate browser. This feature brings device emulation into the preview panel with a searchable device picker, inline custom dimensions, and per-thread state.

## Key Changes

### Main process (`preview-browser.ts`)
- `PreviewSession` extended with `deviceEmulationConfig`, `shellBounds`, `defaultGuestUserAgent`, `captureEmulationSnapshot`
- `layoutPreviewGuest()` centers/scales the BrowserView for emulated viewports using `enableDeviceEmulation()`
- `preview:sync` handler parses `deviceEmulation` from the renderer and applies layout
- Emulation re-applied on `did-finish-load` (deferred until page loads)
- `disableDeviceEmulation()` guarded against fresh BrowserView crash on Windows
- Emulation metadata included in all 4 capture payloads
- `parkPreviewForWindow()` export for shell-refresh cleanup
- Deprecated Electron 35 APIs migrated (`navigationHistory`, `console-message` event)

### Renderer (`PreviewPanel.tsx`)
- Searchable device picker (Popover + Command/cmdk) with 5 device presets
- Inline custom dimension editor (no dialog)
- Orientation toggle for preset devices
- Per-thread device state via Zustand (`previewDeviceEmulationByThread`)
- `bg-muted` background fill when viewport is emulated
- Device picker trigger matches toolbar icon pattern (ghost icon when off, expanded label when active)

### Contracts & shared
- `PreviewDeviceEmulationConfig` discriminated union (off / preset / custom)
- `BROWSER_PREVIEW_DEVICE_PRESETS` with iPhone SE, iPhone 14 Pro, Pixel 7, Galaxy S21, iPad Mini
- `McodeBrowserCaptureEmulation` schema for capture metadata
- `browserPreview` settings section (allowSitePermissions, isolateStorageByWorkspace)
- Desktop emulation helpers: resolve, layout, apply, capture snapshot

### Bug fixes
- Shell refresh no longer leaves BrowserView stuck on screen
- Drag handle amber glow toned down to neutral border color
- Transport retry logic prevents dev connecting to production backend

### Docs
- `docs/specs/2026-05-10-responsive-viewport-emulation-design.md` - Full design spec with user personas
- `docs/specs/2026-05-10-responsive-viewport-emulation-plan.md` - Implementation plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device/responsive viewport emulation to the preview panel with preset devices (mobile, tablet, desktop), custom dimension support, and portrait/landscape orientation toggles.
  * Added ability to focus the embedded preview for keyboard interaction.
  * Extended browser preview settings: `allowSitePermissions` and `isolateStorageByWorkspace` options.

* **Bug Fixes**
  * Fixed native overlay persisting after preview refresh and navigation.
  * Improved desktop bridge connection reliability with automatic retry logic.

* **Documentation**
  * Added responsive viewport emulation design and implementation specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/456)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->