### PR TITLE
fix(web): hide model reasoning effort for Cursor and Copilot

### DIFF
--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -14,6 +14,7 @@ import {
   normalizeReasoningLevelForModel,
   getCodexReasoningLevels,
   pickProviderModelsForSettings,
+  providerSupportsReasoningLevels,
   type ModelDefinition,
 } from "@/lib/model-registry";
 import { SettingRow } from "../SettingRow";
@@ -95,8 +96,9 @@ function buildProviderOption(
 }
 
 /**
- * Model settings section: provider, default model, fallback model, reasoning effort,
- * utility model provider/model, diff summary toggle, and CLI paths.
+ * Model settings section: provider, default model, fallback model, reasoning effort
+ * (only when the provider exposes an effort tier), utility model provider/model,
+ * diff summary toggle, and CLI paths.
  *
  * Default and fallback pickers merge live `listProviderModels` results with static
  * catalog fallbacks (needed for Cursor, Copilot, and Claude API discovery). Stale
@@ -447,7 +449,8 @@ export function ModelSection() {
         </div>
       </SettingRow>
 
-      {(provider !== "claude" || supportsEffortParameter(modelId)) && (
+      {providerSupportsReasoningLevels(provider) &&
+        (provider !== "claude" || supportsEffortParameter(modelId)) && (
         <SettingRow
           label="Reasoning effort"
           configKey="model.defaults.reasoning"

--- a/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
@@ -153,6 +153,18 @@ describe("ModelSection reasoning options", () => {
     expect(screen.queryByText("Reasoning effort")).not.toBeInTheDocument();
   });
 
+  it("Reasoning Effort row is hidden for Cursor (no backend effort parameter)", () => {
+    renderWithModel("cursor", "composer-fast");
+
+    expect(screen.queryByText("Reasoning effort")).not.toBeInTheDocument();
+  });
+
+  it("Reasoning Effort row is hidden for Copilot (no backend effort parameter)", () => {
+    renderWithModel("copilot", "gpt-5");
+
+    expect(screen.queryByText("Reasoning effort")).not.toBeInTheDocument();
+  });
+
   it("Reasoning Effort row is visible for Claude Opus 4.7", () => {
     renderWithModel("claude", "claude-opus-4-7");
 


### PR DESCRIPTION
## What

The MODEL settings section no longer shows the **Reasoning effort** control when the default provider is Cursor or Copilot.

## Why

Those providers are listed as backends that do not accept a per-call reasoning effort parameter (see `providerSupportsReasoningLevels` in `model-registry`). The composer already hides the reasoning pill for them, but settings still rendered a Claude-style segmented control, which was misleading.

## Key Changes

- Gate the Reasoning effort row on `providerSupportsReasoningLevels(provider)` in `ModelSection.tsx`.
- Add unit tests asserting the row stays hidden for Cursor and Copilot defaults.

## Config Changes

None

## Related issues/PRs

N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reasoning effort setting now appears only when both the chosen provider and model support it, preventing the option from showing for incompatible providers.

* **Tests**
  * Added tests to ensure the reasoning effort row is hidden for providers/models that do not support reasoning levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/457)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->