### PR TITLE
feat(web): right panel default width, min width, and resize grip

### DIFF
--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   useDiffStore,
-  RIGHT_PANEL_DEFAULTS,
-  PANEL_DEFAULT_WIDTH,
   PANEL_MIN_WIDTH,
+  getDefaultPanelWidthPx,
+  createDefaultRightPanelState,
 } from "../stores/diffStore";
 
 describe("diffStore", () => {
@@ -27,7 +27,7 @@ describe("diffStore", () => {
   describe("getRightPanel", () => {
     it("should return defaults for unknown thread", () => {
       const { getRightPanel } = useDiffStore.getState();
-      expect(getRightPanel("unknown")).toEqual(RIGHT_PANEL_DEFAULTS);
+      expect(getRightPanel("unknown")).toEqual(createDefaultRightPanelState());
     });
 
     it("should return stored state for known thread", () => {
@@ -79,7 +79,7 @@ describe("diffStore", () => {
       const { setRightPanelWidth, getRightPanel } = useDiffStore.getState();
       setRightPanelWidth("thread-1", 500);
       expect(getRightPanel("thread-1").width).toBe(500);
-      expect(getRightPanel("thread-2").width).toBe(PANEL_DEFAULT_WIDTH);
+      expect(getRightPanel("thread-2").width).toBe(getDefaultPanelWidthPx());
     });
 
     it("should clamp width to PANEL_MIN_WIDTH", () => {
@@ -140,7 +140,7 @@ describe("diffStore", () => {
       const state = useDiffStore.getState();
       expect(state.previewUrlByThread["thread-1"]).toBeUndefined();
       expect(state.rightPanelByThread["thread-1"]).toBeUndefined();
-      expect(getRightPanel("thread-1")).toEqual(RIGHT_PANEL_DEFAULTS);
+      expect(getRightPanel("thread-1")).toEqual(createDefaultRightPanelState());
       expect(state.snapshotsByThread["thread-1"]).toBeUndefined();
       expect(state.snapshotsLoadingByThread["thread-1"]).toBeUndefined();
       expect(state.commitsByThread["thread-1"]).toBeUndefined();

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -1,10 +1,16 @@
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ListChecks, Diff, Globe, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTaskStore } from "@/stores/taskStore";
-import { useDiffStore, PANEL_MIN_WIDTH, PANEL_DEFAULT_WIDTH, PANEL_WIDE_WIDTH, RIGHT_PANEL_DEFAULTS } from "@/stores/diffStore";
+import {
+  useDiffStore,
+  PANEL_MIN_WIDTH,
+  PANEL_WIDE_WIDTH,
+  createDefaultRightPanelState,
+  getDefaultPanelWidthPx,
+} from "@/stores/diffStore";
 import { TaskPanel } from "@/components/tasks/TaskPanel";
 import { TaskPanelHeader } from "@/components/tasks/TaskPanelHeader";
 import { DiffPanel } from "@/components/diff";
@@ -16,23 +22,6 @@ import { cn } from "@/lib/utils";
 export function RightPanel() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
-
-  // Per-thread panel state
-  const panelState = useDiffStore((s) =>
-    activeThreadId
-      ? (s.rightPanelByThread[activeThreadId] ?? RIGHT_PANEL_DEFAULTS)
-      : RIGHT_PANEL_DEFAULTS,
-  );
-  const { visible: panelVisible, width: panelWidth, activeTab } = panelState;
-
-  // Zustand action refs are stable (same identity for the store's lifetime),
-  // so destructuring from getState() at render time is safe and avoids
-  // adding actions to useCallback/useEffect dependency arrays.
-  const { setRightPanelWidth, setRightPanelTab, hideRightPanel } = useDiffStore.getState();
-
-  const tasks = useTaskStore(
-    (s) => (activeThreadId ? s.tasksByThread[activeThreadId] : undefined),
-  );
 
   // Render the panel as a modal overlay anchored to the right edge with a
   // backdrop covering the chat whenever side-by-side layout would leave the
@@ -64,6 +53,25 @@ export function RightPanel() {
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
   }, []);
+
+  const storedPanel = useDiffStore((s) =>
+    activeThreadId ? s.rightPanelByThread[activeThreadId] : undefined,
+  );
+  /** Avoid a Zustand selector that allocates a fresh default object every evaluation. */
+  const panelState = useMemo(
+    () => storedPanel ?? createDefaultRightPanelState(),
+    [storedPanel, viewportWidth],
+  );
+  const { visible: panelVisible, width: panelWidth, activeTab } = panelState;
+
+  // Zustand action refs are stable (same identity for the store's lifetime),
+  // so destructuring from getState() at render time is safe and avoids
+  // adding actions to useCallback/useEffect dependency arrays.
+  const { setRightPanelWidth, setRightPanelTab, hideRightPanel } = useDiffStore.getState();
+
+  const tasks = useTaskStore(
+    (s) => (activeThreadId ? s.tasksByThread[activeThreadId] : undefined),
+  );
 
   // Thresholds tuned for a readable chat column next to an expanded sidebar.
   const CHAT_COMFORT_MIN = 520;
@@ -200,8 +208,8 @@ export function RightPanel() {
         tabIndex={isOverlay ? -1 : undefined}
         style={
           isOverlay
-            // Drop minWidth entirely on overlay: on sub-300px viewports the
-            // 90vw cap would still be exceeded by a 300px minimum.
+            // Drop minWidth entirely on overlay: on narrow viewports the
+            // 90vw cap would still exceed a large pixel minimum.
             ? { width: overlayWidth }
             : { width: panelWidth, minWidth: PANEL_MIN_WIDTH, maxWidth: `calc(100vw - ${PANEL_MIN_WIDTH}px)` }
         }
@@ -219,27 +227,35 @@ export function RightPanel() {
         role="separator"
         aria-orientation="vertical"
         tabIndex={0}
-        className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10
-                   hover:bg-primary/25 active:bg-primary/40 focus-visible:bg-primary/25 transition-colors duration-150"
+        className="absolute left-0 top-0 bottom-0 z-10 flex w-3 cursor-col-resize justify-center bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         onMouseDown={onDragStart}
         onDoubleClick={() => {
           const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
-          const target = panelWidth >= PANEL_WIDE_WIDTH
-            ? PANEL_DEFAULT_WIDTH
-            : Math.min(PANEL_WIDE_WIDTH, viewportCap);
+          const narrow = getDefaultPanelWidthPx();
+          const target =
+            panelWidth >= PANEL_WIDE_WIDTH
+              ? narrow
+              : Math.min(PANEL_WIDE_WIDTH, viewportCap);
           setRightPanelWidth(activeThreadId!, Math.max(PANEL_MIN_WIDTH, target));
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
-            const target = panelWidth >= PANEL_WIDE_WIDTH
-              ? PANEL_DEFAULT_WIDTH
-              : Math.min(PANEL_WIDE_WIDTH, viewportCap);
+            const narrow = getDefaultPanelWidthPx();
+            const target =
+              panelWidth >= PANEL_WIDE_WIDTH
+                ? narrow
+                : Math.min(PANEL_WIDE_WIDTH, viewportCap);
             setRightPanelWidth(activeThreadId!, Math.max(PANEL_MIN_WIDTH, target));
           }
         }}
-      />
+      >
+        <span
+          className="pointer-events-none h-full w-px shrink-0 rounded-none bg-border/45"
+          aria-hidden
+        />
+      </div>
 
       {/* Tab header */}
       <div className="flex-none border-b border-border/40">

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -13,14 +13,26 @@ export type DiffViewMode = "by-turn" | "all" | "commits" | "summary";
 export type DiffRenderMode = "unified" | "side-by-side";
 
 /** Minimum right panel width in pixels. */
-export const PANEL_MIN_WIDTH = 300;
-/** Default right panel width in pixels. */
+export const PANEL_MIN_WIDTH = 384;
+/**
+ * Fallback width when the viewport is unavailable (tests, SSR). Live UI uses half the
+ * viewport via {@link getDefaultPanelWidthPx}.
+ */
 export const PANEL_DEFAULT_WIDTH = 380;
 /** Wide snap target for the right panel (double-click drag handle). */
 export const PANEL_WIDE_WIDTH = 680;
 
 function clampWidth(w: number): number {
   return Math.max(PANEL_MIN_WIDTH, w);
+}
+
+/**
+ * Returns the default panel width for the current window (50% of the viewport, clamped
+ * to {@link PANEL_MIN_WIDTH}). Used when a thread has no stored width yet.
+ */
+export function getDefaultPanelWidthPx(): number {
+  if (typeof globalThis.window === "undefined") return clampWidth(PANEL_DEFAULT_WIDTH);
+  return clampWidth(Math.round(globalThis.window.innerWidth * 0.5));
 }
 
 /** Currently selected file for diff viewing. */
@@ -40,7 +52,21 @@ export type RightPanelState = {
   readonly activeTab: RightPanelTab;
 };
 
-/** Default state for threads with no panel record. Panels start closed. */
+/**
+ * Baseline right-panel state for a thread that has no persisted row (50% viewport width).
+ */
+export function createDefaultRightPanelState(): RightPanelState {
+  return {
+    visible: false,
+    width: getDefaultPanelWidthPx(),
+    activeTab: "tasks",
+  };
+}
+
+/**
+ * Static defaults for threads with no panel store row; live width uses
+ * {@link getDefaultPanelWidthPx} through {@link createDefaultRightPanelState}.
+ */
 export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
   visible: false,
   width: PANEL_DEFAULT_WIDTH,
@@ -128,11 +154,11 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   summaryLoading: false,
 
   getRightPanel: (threadId) =>
-    get().rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS,
+    get().rightPanelByThread[threadId] ?? createDefaultRightPanelState(),
 
   toggleRightPanel: (threadId) =>
     set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
       return {
         rightPanelByThread: {
           ...state.rightPanelByThread,
@@ -143,7 +169,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
 
   showRightPanel: (threadId) =>
     set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
       return {
         rightPanelByThread: {
           ...state.rightPanelByThread,
@@ -154,7 +180,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
 
   hideRightPanel: (threadId) =>
     set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
       return {
         rightPanelByThread: {
           ...state.rightPanelByThread,
@@ -165,7 +191,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
 
   setRightPanelWidth: (threadId, width) =>
     set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
       return {
         rightPanelByThread: {
           ...state.rightPanelByThread,
@@ -176,7 +202,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
 
   setRightPanelTab: (threadId, tab) =>
     set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? RIGHT_PANEL_DEFAULTS;
+      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
       return {
         rightPanelByThread: {
           ...state.rightPanelByThread,


### PR DESCRIPTION
## What

Updates the thread right panel so its default size and minimum width match the intended layout, and tones down the left-edge resize control styling.

## Why

Half of the viewport is a better default than a fixed pixel width when opening the panel. A 384px minimum keeps the panel usable. The previous drag strip used strong primary hover states and a thick hit target that read as noisy.

## Key changes

- Default width for a thread with no stored width: 50% of the viewport (clamped to the minimum).
- Minimum panel width raised to 384px.
- Double-click and keyboard snap narrow target uses the same half-viewport default as first open.
- Resize grip: 1px neutral line, no primary hover fill, wider invisible hit area; keyboard focus keeps a visible ring.
- `RightPanel` subscribes only to stored state and merges defaults with `useMemo` so Zustand does not get a new default object every selector run.
- `diffStore` tests updated for dynamic defaults.

## Configuration changes

None.

## Related issues/PRs

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Right panel width now responsive: calculated as 50% of viewport with a 384px minimum.
  * Improved drag-handle snap behavior (double-click and keyboard) and widened the draggable area for more reliable interaction.
  * More robust panel state initialization and fallback handling across threads.

* **Tests**
  * Updated tests to assert against dynamically computed default panel state and width.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/458)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->