### PR TITLE
perf(install): drop better-sqlite3 from trustedDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "mcode-desktop",
-      "version": "0.7.0",
+      "version": "0.10.1",
       "dependencies": {
         "@electron/rebuild": "^3.7.1",
         "@mcode/contracts": "workspace:*",
@@ -39,7 +39,7 @@
     },
     "apps/server": {
       "name": "@mcode/server",
-      "version": "0.0.1",
+      "version": "0.10.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.21.0",
         "@anthropic-ai/claude-agent-sdk": "*",
@@ -71,7 +71,7 @@
     },
     "apps/web": {
       "name": "mcode-frontend",
-      "version": "0.0.1",
+      "version": "0.10.1",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@dnd-kit/core": "^6.3.1",
@@ -157,9 +157,8 @@
   },
   "trustedDependencies": [
     "electron",
-    "better-sqlite3",
-    "node-pty",
     "@electron/rebuild",
+    "node-pty",
     "electron-mksnapshot",
   ],
   "packages": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "trustedDependencies": [
     "electron",
     "electron-mksnapshot",
-    "better-sqlite3",
     "node-pty",
     "@electron/rebuild"
   ],


### PR DESCRIPTION
## What
Removes `better-sqlite3` from root `trustedDependencies` so `bun install` no longer runs its lifecycle scripts. The existing `scripts/postinstall.mjs` already downloads the correct Node-ABI and Electron-ABI prebuilds, so the package ends up in the same state without bun's broken rebuild path.

## Why
On Windows, bun invokes better-sqlite3's `install` script under cmd.exe. Its `prebuild-install` bin stub fails with `Permission denied`, the `||` fallback drops into `node-gyp rebuild`, and on machines without a Visual Studio C++ toolchain the install hangs for **~5m22s** before erroring out — every single `bun install`. The whole monorepo install is unusable on a clean Windows dev box without MSVC.

Removing the package from `trustedDependencies` skips that path entirely. The pre-existing postinstall's "missing or wrong ABI" branch picks up the slack via `curl` + `tar`, which works identically on win/mac/linux.

`node-pty` stays trusted: it ships prebuilds for win/mac inside the package but has no Linux prebuild, so its install script must run on Linux to fall back to node-gyp.

## Key Changes
- `package.json`: remove `better-sqlite3` from `trustedDependencies`
- `bun.lock`: refreshed

## Verification

| OS | Install | Typecheck | Build |
|---|---|---|---|
| Windows 11 (native) | cold 9m45s / warm 1m32s (was: fails after 5m22s) | 5/5 packages | 2/2 packages |
| Linux (Docker `oven/bun:1.2.14`) | exit 0, better-sqlite3 prebuild verified for ABI 127 | contracts, shared, server, frontend all exit 0 | n/a |
| macOS | covered by `build-release.yml` matrix on this PR | | |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->