### PR TITLE
chore(agent): cross-harness agent setup parity (Claude / Cursor / Codex / OpenCode)

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -1,0 +1,54 @@
+---
+name: backend-engineer
+description: Backend engineer for apps/server (tsyringe DI, Drizzle, WebSocket RPC, AI provider adapters). Use for service, repository, transport, or provider work.
+model: sonnet
+---
+
+You are a backend engineer for Mcode, working in `apps/server/` (standalone Node.js HTTP + WebSocket server, SQLite via Drizzle, tsyringe DI, AI provider adapters).
+
+## Must-read before making changes
+
+- `ARCHITECTURE.md` — system architecture, data model, IPC flow
+- `docs/agents/runtime.md` — startup commands, env vars, runtime artifacts, write boundaries
+- `docs/guides/provider-architecture.md` — IAgentProvider contract and registry pattern
+- `docs/guides/settings-schema.md` — settings JSON conventions
+- `apps/server/src/store/schema.ts` — Drizzle schema (single source of truth)
+
+## Write boundaries
+
+- Primary: `apps/server/**`, `packages/contracts/**`, `packages/shared/**`
+- Allowed: `apps/server/drizzle/**` (generated migrations) via `bun run db:generate`
+- Forbidden without explicit user approval: `apps/web/**`, `apps/desktop/**` (changes there belong to the frontend agent)
+
+## Conventions
+
+- Zod schemas in `packages/contracts` must be wrapped with `lazySchema(() => …)`
+- JSDoc on every exported function, class, type, and interface (AI reviews depend on these)
+- Comments explain **why**, not **what**
+- Child processes that need protected env vars use `ProtectedEnvStore.protect("NAME")` at boot, or rely on the `MCODE_`/`ELECTRON_`/`BETTER_SQLITE3_` prefix snapshot
+- Never bake a qualifier into a settings key — nest it (max depth 3)
+
+## Database changes
+
+1. Edit `apps/server/src/store/schema.ts`
+2. `cd apps/server && bun run db:generate` — review the emitted SQL before commit
+3. App startup runs `migrate()` automatically; do not write manual SQL unless splitting a non-transactional step (FK rebuilds — see `AGENTS.md` known limitation)
+
+## Verification (mandatory before declaring done)
+
+1. `bun run verify` — typecheck, lint, unit tests
+2. If you changed a shared type or function signature, typecheck every consumer:
+   ```sh
+   (cd apps/server && bun x tsc --noEmit)
+   (cd apps/web && bun x tsc --noEmit)
+   (cd apps/desktop && bun x tsc --noEmit)
+   ```
+3. Smoke the running server: `bun run dev:web` and exercise the changed RPC/push paths via the UI or a direct WebSocket client. Never claim success without fresh passing output.
+
+## Performance budgets (from `AGENTS.md`)
+
+| Metric | Target |
+|--------|--------|
+| Idle memory | < 150MB |
+| First 100 messages load | < 50ms |
+| App startup to usable | < 2s |

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -1,0 +1,49 @@
+---
+name: frontend-engineer
+description: React + Tailwind + shadcn engineer for apps/web. Use for any UI component, route, store, or web-side logic change.
+model: sonnet
+---
+
+You are a frontend engineer for Mcode, working in `apps/web/` (React SPA, Vite, Tailwind 4, shadcn/ui, Zustand stores, WebSocket transport).
+
+## Must-read before making changes
+
+- `AGENTS.md` — repo conventions, performance targets, commit style
+- `docs/guides/ui-components.md` — component registry; **always use existing shadcn primitives** from `apps/web/src/components/ui/` before creating custom elements
+- `docs/guides/agent-workflow.md` — the verify → visual-verify → e2e workflow
+- `apps/web/src/transport/` — WebSocket RPC client + push event channels (this is how you talk to the server)
+
+## Write boundaries
+
+- Primary: `apps/web/**`
+- Allowed: `packages/contracts/**`, `packages/shared/**` when changing shared types
+- Forbidden without explicit user approval: `apps/server/**`, `apps/desktop/**`, migrations, package scripts
+
+## Conventions
+
+- JSDoc on every exported component, hook, type, and store
+- Comments explain **why**, not **what**
+- Nested settings JSON per `docs/guides/settings-schema.md` (max depth 3, no qualifier-prefixed keys)
+- Shiki language imports require parallel entry in `apps/web/vite.config.ts` `optimizeDeps`
+
+## Verification (mandatory before declaring done)
+
+1. `bun run verify` — typecheck, lint, unit tests
+2. Visual verify with Playwright MCP if Playwright MCP is connected and the change touches UI:
+   - `browser_navigate` to the affected page
+   - `browser_snapshot` to read the a11y tree
+   - `browser_take_screenshot` to capture state
+   - `browser_console_messages` to check for errors
+3. `bun run verify:e2e` if the change touches: interactive components, keyboard nav, focus trap, responsive layout, a11y semantics, floating overlays, or persisted first-paint state
+
+Never claim success without fresh passing output.
+
+## Cross-package changes
+
+If you change a shared type or function signature, typecheck every consumer:
+
+```sh
+(cd apps/server && bun x tsc --noEmit)
+(cd apps/web && bun x tsc --noEmit)
+(cd apps/desktop && bun x tsc --noEmit)
+```

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -1,0 +1,48 @@
+---
+name: qa-engineer
+description: QA engineer for Playwright E2E, visual verification, and console-error checks. Use after a feature lands to write/extend specs and validate the running app.
+model: sonnet
+---
+
+You are a QA engineer for Mcode. Your job is to verify that features work in the running app, not just that the code compiles.
+
+## Must-read before testing
+
+- `docs/guides/agent-workflow.md` — verify → visual → e2e pipeline
+- `apps/web/e2e/` — existing Playwright specs; follow the conventions there
+- `docs/guides/ui-components.md` — the **Testing UI Changes** section lists the triggers that mandate an E2E spec
+
+## E2E trigger list (when a spec is required, not optional)
+
+Write or extend a Playwright spec when the change touches any of:
+
+- Interactive components (menus, dialogs, popovers, comboboxes)
+- Keyboard navigation or focus trapping
+- Responsive layout breakpoints
+- Accessibility semantics (roles, aria-*, labels)
+- Floating overlays
+- `data-testid` changes
+- Theme tokens
+- Persisted first-paint state
+
+"If applicable" is not a loophole. When in doubt, write the spec.
+
+## Write boundaries
+
+- Primary: `apps/web/e2e/**`, `apps/web/playwright.config.*`, test fixtures
+- Allowed: small `data-testid` additions to `apps/web/src/**` to make a component testable (flag these to the user)
+- Forbidden without explicit user approval: production logic in `apps/web/src/**`, anything in `apps/server/**` or `apps/desktop/**`
+
+## Verification workflow
+
+1. `cd apps/web && bun run e2e` (or `bun run verify:e2e` from root) — full Playwright run
+2. For interactive debugging: `bun run e2e:headed`
+3. Screenshots land in `apps/web/e2e/screenshots/` — reference them in your report
+
+If Playwright MCP is connected, also drive a manual smoke pass:
+- `browser_navigate` → affected page
+- `browser_snapshot` → a11y tree
+- `browser_console_messages` → must be error-free
+- `browser_take_screenshot` → capture final state
+
+Report: pass count, failure count, screenshot paths, any console errors. Never claim a UI feature works without fresh evidence.

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -29,9 +29,13 @@ Write or extend a Playwright spec when the change touches any of:
 
 ## Write boundaries
 
-- Primary: `apps/web/e2e/**`, `apps/web/playwright.config.*`, test fixtures
+- Primary: `apps/web/e2e/**`, `apps/web/playwright.config.*`, `apps/desktop/e2e/**`, `apps/desktop/playwright.config.*`, test fixtures
 - Allowed: small `data-testid` additions to `apps/web/src/**` to make a component testable (flag these to the user)
-- Forbidden without explicit user approval: production logic in `apps/web/src/**`, anything in `apps/server/**` or `apps/desktop/**`
+- Forbidden without explicit user approval: production logic in `apps/web/src/**`, anything in `apps/server/**` or `apps/desktop/src/**`
+
+## Web vs Electron specs
+
+Default to web E2E (`apps/web/e2e/`, runs under Vite) — it covers the same React tree an order of magnitude faster than Electron. Use Electron E2E (`apps/desktop/e2e/`, drives the real Electron process via `_electron.launch()`) **only** for surfaces that don't exist in the browser: native menus, tray, BrowserView, contextBridge IPC, window chrome, deep links, auto-updater.
 
 ## Verification workflow
 

--- a/.claude/commands/demo-desktop.md
+++ b/.claude/commands/demo-desktop.md
@@ -1,0 +1,18 @@
+---
+description: Launch the Electron desktop app under Playwright, screenshot the first window, and report renderer errors
+argument-hint: [feature-name]
+---
+
+Goal: demo the Electron-specific feature `$ARGUMENTS` in the running desktop app.
+
+Use this **only** for features that need the actual Electron runtime — native menus, tray, BrowserView, contextBridge IPC, deep links, window chrome. For anything that renders identically in the browser, prefer `/demo` (Vite) — it is faster and the Playwright MCP can drive it interactively.
+
+1. Ensure the Electron bundles are built:
+   ```sh
+   cd apps/desktop && bun run build
+   ```
+2. Run `node scripts/agent/demo-desktop.mjs`. It launches Electron via Playwright's `_electron.launch()`, waits for the first window, screenshots it to `apps/web/e2e/screenshots/demo-desktop/`, and prints renderer errors.
+3. To drive interactively, pass `--keep-open` and then attach via the `apps/desktop/e2e/electron-smoke.spec.ts` pattern (Playwright library, not the MCP — the MCP does not support Electron).
+4. Promote any regression-risk flow you discovered into `apps/desktop/e2e/` and run `/verify-e2e-desktop`.
+
+See `docs/agents/demo.md` § Demoing the Desktop App for the full runbook.

--- a/.claude/commands/demo.md
+++ b/.claude/commands/demo.md
@@ -1,0 +1,17 @@
+---
+description: Boot the dev web app and prepare a Playwright MCP session for demoing a feature
+argument-hint: [feature-name]
+---
+
+Goal: demo the feature `$ARGUMENTS` end-to-end in the running app.
+
+1. Run `node scripts/agent/demo.mjs`. It boots `bun run dev:web` (if not already running), polls the dev URL until ready, and prints the URL + a Playwright MCP entry point.
+2. Use the Playwright MCP tools to drive the feature:
+   - `mcp__playwright__browser_navigate` to the printed URL
+   - `mcp__playwright__browser_snapshot` to read the accessibility tree
+   - `mcp__playwright__browser_take_screenshot` to capture state to `apps/web/e2e/screenshots/demo/`
+   - `mcp__playwright__browser_console_messages` to surface any errors
+3. Walk the golden path for `$ARGUMENTS`, then 1–2 edge cases.
+4. Report screenshot paths so the user can review without re-running the app.
+
+See `docs/agents/demo.md` for the full runbook.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,15 @@
+---
+description: Run a 4-parallel-subagent code review (security, performance, quality, correctness)
+argument-hint: [pr-number-or-branch]
+---
+
+Review the changes in `$ARGUMENTS` (PR number, branch name, or HEAD if empty).
+
+Dispatch four subagents in parallel in a single message — do NOT run them sequentially:
+
+1. **Security** — use the `security-reviewer` subagent. Focus: Electron contextBridge surface, child-process spawning, SQLite parameterization, XSS, secrets.
+2. **Performance** — general-purpose subagent. Focus: bundle size, render hot paths, DB query patterns, memory targets in `AGENTS.md`.
+3. **Quality** — general-purpose subagent. Focus: code style per `AGENTS.md`, JSDoc on exports, no needless abstractions, naming.
+4. **Correctness** — general-purpose subagent. Focus: does the diff do what the PR/commit description claims, edge cases, error handling at boundaries.
+
+After all four return, cross-reference findings, eliminate false positives, and present a single consolidated report grouped by severity (blocker / major / minor / nit).

--- a/.claude/commands/verify-e2e-desktop.md
+++ b/.claude/commands/verify-e2e-desktop.md
@@ -1,0 +1,9 @@
+---
+description: Run Electron-only Playwright E2E specs (apps/desktop/e2e/)
+---
+
+Run `cd apps/desktop && bun run e2e` and show the output.
+
+This drives the actual Electron app via Playwright's `_electron.launch()` and is heavier than the web `/verify-e2e`. Use it when you change anything in `apps/desktop/src/main/` (native IPC, window/tray/menu, BrowserView, deep links) or anything that crosses the contextBridge.
+
+For pure-renderer changes, `/verify-e2e` is the right tool — it covers the same React tree via Vite and is much faster.

--- a/.claude/commands/verify-e2e.md
+++ b/.claude/commands/verify-e2e.md
@@ -1,0 +1,9 @@
+---
+description: Run Playwright E2E tests and report results
+---
+
+Run `bun run verify:e2e` and show the output.
+
+Requires the dev server (`bun run dev:web`) to be running, or the script will auto-start it.
+
+Use after UI changes that touch: interactive components, keyboard navigation, focus trapping, responsive layout, accessibility semantics, floating overlays, or persisted state. See `docs/guides/agent-workflow.md` for the full trigger list.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,9 @@
+---
+description: Run typecheck, lint, and unit tests across all packages and report results
+---
+
+Run `bun run verify` and show the output.
+
+If it fails, fix the errors and re-run until it passes. Do not claim completion without fresh passing output.
+
+This is the same command the Stop hook enforces, so running it proactively saves a turn.

--- a/.codex/prompts/demo-desktop.md
+++ b/.codex/prompts/demo-desktop.md
@@ -1,0 +1,14 @@
+---
+description: Launch the Electron desktop app under Playwright and screenshot the first window
+---
+
+Goal: demo an Electron-specific feature in the running desktop app.
+
+Use this **only** for features that need the actual Electron runtime — native menus, tray, BrowserView, contextBridge IPC, deep links, window chrome. For anything that renders identically in the browser, prefer `/demo` (faster, Playwright MCP can drive it interactively).
+
+1. Build the Electron bundles: `cd apps/desktop && bun run build`.
+2. Run `node scripts/agent/demo-desktop.mjs`. It launches Electron via Playwright's `_electron.launch()`, waits for the first window, screenshots to `apps/web/e2e/screenshots/demo-desktop/`, and prints renderer errors.
+3. Pass `--keep-open` to leave Electron running. Drive it programmatically using the `apps/desktop/e2e/electron-smoke.spec.ts` pattern (Playwright library, not the MCP — the MCP does not support Electron).
+4. Promote regression-risk flows into `apps/desktop/e2e/` and run `/verify-e2e-desktop`.
+
+See `docs/agents/demo.md` § Demoing the Desktop App for the full runbook.

--- a/.codex/prompts/demo.md
+++ b/.codex/prompts/demo.md
@@ -1,0 +1,12 @@
+---
+description: Boot the dev web app and drive it via Playwright MCP for a feature demo
+---
+
+Goal: demo a feature end-to-end in the running web app.
+
+1. Run `node scripts/agent/demo.mjs`. It boots `bun run dev:web` (if not already running), polls the dev URL until ready, and prints a Playwright MCP entry point.
+2. Use the Playwright MCP tools (registered in `.mcp.json`) to drive the feature: navigate, snapshot, screenshot to `apps/web/e2e/screenshots/demo/`, check console messages.
+3. Walk the golden path, then 1–2 edge cases.
+4. Report screenshot paths.
+
+See `docs/agents/demo.md` for the full runbook.

--- a/.codex/prompts/review-pr.md
+++ b/.codex/prompts/review-pr.md
@@ -1,0 +1,12 @@
+---
+description: Review changes across four dimensions — security, performance, quality, correctness
+---
+
+Review the changes in the current branch / PR / argument-supplied ref across four dimensions. In Cursor, run them as four sequential focused passes (or parallel chats if you have multiple agents):
+
+1. **Security** — Electron contextBridge surface, child-process spawning, SQLite parameterization, XSS, secrets, log content. Reference `.claude/agents/security-reviewer.md` for the full checklist.
+2. **Performance** — bundle size, render hot paths, DB query patterns, the memory/startup targets in `AGENTS.md`.
+3. **Quality** — code style per `AGENTS.md`, JSDoc on exports, no needless abstractions, naming.
+4. **Correctness** — does the diff do what the PR description claims, edge cases, error handling at boundaries.
+
+Then cross-reference findings, eliminate false positives, and present a single consolidated report grouped by severity (blocker / major / minor / nit).

--- a/.codex/prompts/review-pr.md
+++ b/.codex/prompts/review-pr.md
@@ -2,7 +2,7 @@
 description: Review changes across four dimensions — security, performance, quality, correctness
 ---
 
-Review the changes in the current branch / PR / argument-supplied ref across four dimensions. In Cursor, run them as four sequential focused passes (or parallel chats if you have multiple agents):
+Review the changes in the current branch / PR / argument-supplied ref across four dimensions. In Codex, run them as four sequential focused passes (or parallel chats if you have multiple agents):
 
 1. **Security** — Electron contextBridge surface, child-process spawning, SQLite parameterization, XSS, secrets, log content. Reference `.claude/agents/security-reviewer.md` for the full checklist.
 2. **Performance** — bundle size, render hot paths, DB query patterns, the memory/startup targets in `AGENTS.md`.

--- a/.codex/prompts/verify-e2e-desktop.md
+++ b/.codex/prompts/verify-e2e-desktop.md
@@ -1,0 +1,9 @@
+---
+description: Run Electron-only Playwright E2E specs (apps/desktop/e2e/)
+---
+
+Run `cd apps/desktop && bun run e2e` and show the output.
+
+This drives the actual Electron app via Playwright's `_electron.launch()` and is heavier than the web `/verify-e2e`. Use it only when you change anything in `apps/desktop/src/main/` (native IPC, window/tray/menu, BrowserView, deep links) or anything that crosses the contextBridge.
+
+For pure-renderer changes, `/verify-e2e` is the right tool — it covers the same React tree via Vite and is much faster.

--- a/.codex/prompts/verify-e2e.md
+++ b/.codex/prompts/verify-e2e.md
@@ -1,0 +1,9 @@
+---
+description: Run Playwright E2E tests for the web app
+---
+
+Run `bun run verify:e2e` and show the output.
+
+Requires `bun run dev:web` to be running, or the script will auto-start it.
+
+Use after UI changes that touch interactive components, keyboard navigation, focus trapping, responsive layout, accessibility semantics, floating overlays, or persisted state. See `docs/guides/agent-workflow.md` for the full trigger list.

--- a/.codex/prompts/verify.md
+++ b/.codex/prompts/verify.md
@@ -1,0 +1,7 @@
+---
+description: Run typecheck, lint, and unit tests across all packages
+---
+
+Run `bun run verify` and show the output.
+
+If it fails, fix the errors and re-run until it passes. The Stop hook runs the same command before letting you finish a turn, so running it proactively saves a turn.

--- a/.cursor/commands/demo-desktop.md
+++ b/.cursor/commands/demo-desktop.md
@@ -1,0 +1,14 @@
+---
+description: Launch the Electron desktop app under Playwright and screenshot the first window
+---
+
+Goal: demo an Electron-specific feature in the running desktop app.
+
+Use this **only** for features that need the actual Electron runtime — native menus, tray, BrowserView, contextBridge IPC, deep links, window chrome. For anything that renders identically in the browser, prefer `/demo` (faster, Playwright MCP can drive it interactively).
+
+1. Build the Electron bundles: `cd apps/desktop && bun run build`.
+2. Run `node scripts/agent/demo-desktop.mjs`. It launches Electron via Playwright's `_electron.launch()`, waits for the first window, screenshots to `apps/web/e2e/screenshots/demo-desktop/`, and prints renderer errors.
+3. Pass `--keep-open` to leave Electron running. Drive it programmatically using the `apps/desktop/e2e/electron-smoke.spec.ts` pattern (Playwright library, not the MCP — the MCP does not support Electron).
+4. Promote regression-risk flows into `apps/desktop/e2e/` and run `/verify-e2e-desktop`.
+
+See `docs/agents/demo.md` § Demoing the Desktop App for the full runbook.

--- a/.cursor/commands/demo.md
+++ b/.cursor/commands/demo.md
@@ -1,0 +1,12 @@
+---
+description: Boot the dev web app and drive it via Playwright MCP for a feature demo
+---
+
+Goal: demo a feature end-to-end in the running web app.
+
+1. Run `node scripts/agent/demo.mjs`. It boots `bun run dev:web` (if not already running), polls the dev URL until ready, and prints a Playwright MCP entry point.
+2. Use the Playwright MCP tools (registered in `.cursor/mcp.json`) to drive the feature: navigate, snapshot, screenshot to `apps/web/e2e/screenshots/demo/`, check console messages.
+3. Walk the golden path, then 1–2 edge cases.
+4. Report screenshot paths.
+
+See `docs/agents/demo.md` for the full runbook.

--- a/.cursor/commands/review-pr.md
+++ b/.cursor/commands/review-pr.md
@@ -1,0 +1,12 @@
+---
+description: Review changes across four dimensions — security, performance, quality, correctness
+---
+
+Review the changes in the current branch / PR / argument-supplied ref across four dimensions. In Cursor, run them as four sequential focused passes (or parallel chats if you have multiple agents):
+
+1. **Security** — Electron contextBridge surface, child-process spawning, SQLite parameterization, XSS, secrets, log content. Reference `.claude/agents/security-reviewer.md` for the full checklist.
+2. **Performance** — bundle size, render hot paths, DB query patterns, the memory/startup targets in `AGENTS.md`.
+3. **Quality** — code style per `AGENTS.md`, JSDoc on exports, no needless abstractions, naming.
+4. **Correctness** — does the diff do what the PR description claims, edge cases, error handling at boundaries.
+
+Then cross-reference findings, eliminate false positives, and present a single consolidated report grouped by severity (blocker / major / minor / nit).

--- a/.cursor/commands/verify-e2e-desktop.md
+++ b/.cursor/commands/verify-e2e-desktop.md
@@ -1,0 +1,9 @@
+---
+description: Run Electron-only Playwright E2E specs (apps/desktop/e2e/)
+---
+
+Run `cd apps/desktop && bun run e2e` and show the output.
+
+This drives the actual Electron app via Playwright's `_electron.launch()` and is heavier than the web `/verify-e2e`. Use it only when you change anything in `apps/desktop/src/main/` (native IPC, window/tray/menu, BrowserView, deep links) or anything that crosses the contextBridge.
+
+For pure-renderer changes, `/verify-e2e` is the right tool — it covers the same React tree via Vite and is much faster.

--- a/.cursor/commands/verify-e2e.md
+++ b/.cursor/commands/verify-e2e.md
@@ -1,0 +1,9 @@
+---
+description: Run Playwright E2E tests for the web app
+---
+
+Run `bun run verify:e2e` and show the output.
+
+Requires `bun run dev:web` to be running, or the script will auto-start it.
+
+Use after UI changes that touch interactive components, keyboard navigation, focus trapping, responsive layout, accessibility semantics, floating overlays, or persisted state. See `docs/guides/agent-workflow.md` for the full trigger list.

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -1,0 +1,7 @@
+---
+description: Run typecheck, lint, and unit tests across all packages
+---
+
+Run `bun run verify` and show the output.
+
+If it fails, fix the errors and re-run until it passes. The Stop hook runs the same command before letting you finish a turn, so running it proactively saves a turn.

--- a/.opencode/command/demo-desktop.md
+++ b/.opencode/command/demo-desktop.md
@@ -1,0 +1,14 @@
+---
+description: Launch the Electron desktop app under Playwright and screenshot the first window
+---
+
+Goal: demo an Electron-specific feature in the running desktop app.
+
+Use this **only** for features that need the actual Electron runtime — native menus, tray, BrowserView, contextBridge IPC, deep links, window chrome. For anything that renders identically in the browser, prefer `/demo` (faster, Playwright MCP can drive it interactively).
+
+1. Build the Electron bundles: `cd apps/desktop && bun run build`.
+2. Run `node scripts/agent/demo-desktop.mjs`. It launches Electron via Playwright's `_electron.launch()`, waits for the first window, screenshots to `apps/web/e2e/screenshots/demo-desktop/`, and prints renderer errors.
+3. Pass `--keep-open` to leave Electron running. Drive it programmatically using the `apps/desktop/e2e/electron-smoke.spec.ts` pattern (Playwright library, not the MCP — the MCP does not support Electron).
+4. Promote regression-risk flows into `apps/desktop/e2e/` and run `/verify-e2e-desktop`.
+
+See `docs/agents/demo.md` § Demoing the Desktop App for the full runbook.

--- a/.opencode/command/demo.md
+++ b/.opencode/command/demo.md
@@ -1,0 +1,12 @@
+---
+description: Boot the dev web app and drive it via Playwright MCP for a feature demo
+---
+
+Goal: demo a feature end-to-end in the running web app.
+
+1. Run `node scripts/agent/demo.mjs`. It boots `bun run dev:web` (if not already running), polls the dev URL until ready, and prints a Playwright MCP entry point.
+2. Use the Playwright MCP tools (registered in `.opencode/opencode.json`) to drive the feature: navigate, snapshot, screenshot to `apps/web/e2e/screenshots/demo/`, check console messages.
+3. Walk the golden path, then 1–2 edge cases.
+4. Report screenshot paths.
+
+See `docs/agents/demo.md` for the full runbook.

--- a/.opencode/command/review-pr.md
+++ b/.opencode/command/review-pr.md
@@ -2,7 +2,7 @@
 description: Review changes across four dimensions — security, performance, quality, correctness
 ---
 
-Review the changes in the current branch / PR / argument-supplied ref across four dimensions. In Cursor, run them as four sequential focused passes (or parallel chats if you have multiple agents):
+Review the changes in the current branch / PR / argument-supplied ref across four dimensions. In OpenCode, run them as four sequential focused passes (or parallel chats if you have multiple agents):
 
 1. **Security** — Electron contextBridge surface, child-process spawning, SQLite parameterization, XSS, secrets, log content. Reference `.claude/agents/security-reviewer.md` for the full checklist.
 2. **Performance** — bundle size, render hot paths, DB query patterns, the memory/startup targets in `AGENTS.md`.

--- a/.opencode/command/review-pr.md
+++ b/.opencode/command/review-pr.md
@@ -1,0 +1,12 @@
+---
+description: Review changes across four dimensions — security, performance, quality, correctness
+---
+
+Review the changes in the current branch / PR / argument-supplied ref across four dimensions. In Cursor, run them as four sequential focused passes (or parallel chats if you have multiple agents):
+
+1. **Security** — Electron contextBridge surface, child-process spawning, SQLite parameterization, XSS, secrets, log content. Reference `.claude/agents/security-reviewer.md` for the full checklist.
+2. **Performance** — bundle size, render hot paths, DB query patterns, the memory/startup targets in `AGENTS.md`.
+3. **Quality** — code style per `AGENTS.md`, JSDoc on exports, no needless abstractions, naming.
+4. **Correctness** — does the diff do what the PR description claims, edge cases, error handling at boundaries.
+
+Then cross-reference findings, eliminate false positives, and present a single consolidated report grouped by severity (blocker / major / minor / nit).

--- a/.opencode/command/verify-e2e-desktop.md
+++ b/.opencode/command/verify-e2e-desktop.md
@@ -1,0 +1,9 @@
+---
+description: Run Electron-only Playwright E2E specs (apps/desktop/e2e/)
+---
+
+Run `cd apps/desktop && bun run e2e` and show the output.
+
+This drives the actual Electron app via Playwright's `_electron.launch()` and is heavier than the web `/verify-e2e`. Use it only when you change anything in `apps/desktop/src/main/` (native IPC, window/tray/menu, BrowserView, deep links) or anything that crosses the contextBridge.
+
+For pure-renderer changes, `/verify-e2e` is the right tool — it covers the same React tree via Vite and is much faster.

--- a/.opencode/command/verify-e2e.md
+++ b/.opencode/command/verify-e2e.md
@@ -1,0 +1,9 @@
+---
+description: Run Playwright E2E tests for the web app
+---
+
+Run `bun run verify:e2e` and show the output.
+
+Requires `bun run dev:web` to be running, or the script will auto-start it.
+
+Use after UI changes that touch interactive components, keyboard navigation, focus trapping, responsive layout, accessibility semantics, floating overlays, or persisted state. See `docs/guides/agent-workflow.md` for the full trigger list.

--- a/.opencode/command/verify.md
+++ b/.opencode/command/verify.md
@@ -1,0 +1,7 @@
+---
+description: Run typecheck, lint, and unit tests across all packages
+---
+
+Run `bun run verify` and show the output.
+
+If it fails, fix the errors and re-run until it passes. The Stop hook runs the same command before letting you finish a turn, so running it proactively saves a turn.

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "playwright": {
+      "type": "local",
+      "command": ["npx", "@playwright/mcp@0.0.75"]
+    }
+  },
+  "hooks": {
+    "preToolUse": [
+      {
+        "matcher": "edit|write",
+        "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -qE \"\\.env(\\.|$)\" && ! echo \"$TOOL_INPUT\" | grep -qE \"\\.env\\.example(\\.|$)\"; then echo \"{\\\"decision\\\":\\\"block\\\",\\\"reason\\\":\\\"Do not edit .env files directly. Update .env.example instead.\\\"}\"; fi'"
+      }
+    ],
+    "stop": [
+      {
+        "command": "node scripts/agent/hooks/codex-stop.mjs",
+        "timeout": 120
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,19 @@ and agent write boundaries.
 Run `bun run setup` to bootstrap from a fresh clone.
 Run `bun run doctor` to verify all prerequisites are installed.
 
+## Supported Agent Harnesses
+
+This repo is configured for four agent harnesses. All four read `AGENTS.md` (Claude Code via `CLAUDE.md` which re-exports it), share the same `.env`-edit block and Stop-hook verify, and load the Playwright MCP for visual verification.
+
+| Harness | Config | Stop hook | MCP |
+|---------|--------|-----------|-----|
+| Claude Code | `.claude/settings.json`, `.claude/agents/`, `.claude/commands/`, `CLAUDE.md` | `scripts/agent/verify-tests.mjs` | `.mcp.json` |
+| Cursor | `.cursor/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/cursor-stop.mjs` | `.cursor/mcp.json` |
+| Codex | `.codex/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` | `.mcp.json` |
+| OpenCode | `.opencode/opencode.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` (shared; Codex-compatible JSON contract) | `.opencode/opencode.json` |
+
+Claude Code additionally exposes slash commands under `.claude/commands/` (`/verify`, `/verify-e2e`, `/demo`, `/review-pr`) and specialized subagents under `.claude/agents/` (`frontend-engineer`, `backend-engineer`, `qa-engineer`, `security-reviewer`). Other harnesses run the underlying `bun run …` commands directly — see `docs/agents/runtime.md` § Common Workflows.
+
 ## Directory Structure
 
 ```text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,14 +17,14 @@ Run `bun run doctor` to verify all prerequisites are installed.
 
 This repo is configured for four agent harnesses. All four read `AGENTS.md` (Claude Code via `CLAUDE.md` which re-exports it), share the same `.env`-edit block and Stop-hook verify, and load the Playwright MCP for visual verification.
 
-| Harness | Config | Stop hook | MCP |
-|---------|--------|-----------|-----|
-| Claude Code | `.claude/settings.json`, `.claude/agents/`, `.claude/commands/`, `CLAUDE.md` | `scripts/agent/verify-tests.mjs` | `.mcp.json` |
-| Cursor | `.cursor/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/cursor-stop.mjs` | `.cursor/mcp.json` |
-| Codex | `.codex/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` | `.mcp.json` |
-| OpenCode | `.opencode/opencode.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` (shared; Codex-compatible JSON contract) | `.opencode/opencode.json` |
+| Harness | Config | Stop hook | MCP | Slash commands |
+|---------|--------|-----------|-----|----------------|
+| Claude Code | `.claude/settings.json`, `.claude/agents/`, `.claude/commands/`, `CLAUDE.md` | `scripts/agent/verify-tests.mjs` | `.mcp.json` | `.claude/commands/` (auto) |
+| Cursor | `.cursor/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/cursor-stop.mjs` | `.cursor/mcp.json` | `.cursor/commands/` (auto) |
+| Codex | `.codex/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` | `.mcp.json` | `.codex/prompts/` → install once with `node scripts/agent/install-codex-prompts.mjs` (copies to `~/.codex/prompts/`) |
+| OpenCode | `.opencode/opencode.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` (shared; Codex-compatible JSON contract) | `.opencode/opencode.json` | `.opencode/command/` (auto) |
 
-Claude Code additionally exposes slash commands under `.claude/commands/` (`/verify`, `/verify-e2e`, `/verify-e2e-desktop`, `/demo`, `/demo-desktop`, `/review-pr`) and specialized subagents under `.claude/agents/` (`frontend-engineer`, `backend-engineer`, `qa-engineer`, `security-reviewer`). Other harnesses run the underlying `bun run …` commands directly — see `docs/agents/runtime.md` § Common Workflows.
+All four harnesses expose the same six commands: `/verify`, `/verify-e2e`, `/verify-e2e-desktop`, `/demo`, `/demo-desktop`, `/review-pr`. Claude Code additionally has specialized subagents under `.claude/agents/` (`frontend-engineer`, `backend-engineer`, `qa-engineer`, `security-reviewer`). The shell equivalents are documented in `docs/agents/runtime.md` § Common Workflows.
 
 ## Directory Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ This repo is configured for four agent harnesses. All four read `AGENTS.md` (Cla
 | Codex | `.codex/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` | `.mcp.json` |
 | OpenCode | `.opencode/opencode.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` (shared; Codex-compatible JSON contract) | `.opencode/opencode.json` |
 
-Claude Code additionally exposes slash commands under `.claude/commands/` (`/verify`, `/verify-e2e`, `/demo`, `/review-pr`) and specialized subagents under `.claude/agents/` (`frontend-engineer`, `backend-engineer`, `qa-engineer`, `security-reviewer`). Other harnesses run the underlying `bun run …` commands directly — see `docs/agents/runtime.md` § Common Workflows.
+Claude Code additionally exposes slash commands under `.claude/commands/` (`/verify`, `/verify-e2e`, `/verify-e2e-desktop`, `/demo`, `/demo-desktop`, `/review-pr`) and specialized subagents under `.claude/agents/` (`frontend-engineer`, `backend-engineer`, `qa-engineer`, `security-reviewer`). Other harnesses run the underlying `bun run …` commands directly — see `docs/agents/runtime.md` § Common Workflows.
 
 ## Directory Structure
 

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Electron smoke spec. Launches the packaged main process via Playwright's
+ * `_electron.launch()`, asserts a first window appears, captures a screenshot,
+ * and fails on renderer-side console errors.
+ *
+ * Future Electron-only features (native menus, tray, BrowserView, deep links)
+ * should be appended to this suite as additional specs in this directory.
+ *
+ * Requires `apps/desktop/dist/main/main.cjs` to exist — the Playwright config
+ * runs `bun run build` first via the `webServer`/`globalSetup` hook, but you
+ * can also build manually with `cd apps/desktop && bun run build`.
+ */
+import { test, expect, _electron as electron } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const DESKTOP_DIR = resolve(__dirname, "..");
+const MAIN_BUNDLE = join(DESKTOP_DIR, "dist", "main", "main.cjs");
+
+test.describe("Electron smoke", () => {
+  test.beforeAll(() => {
+    if (!existsSync(MAIN_BUNDLE)) {
+      throw new Error(
+        `Missing ${MAIN_BUNDLE}. Run \`cd apps/desktop && bun run build\` first.`,
+      );
+    }
+  });
+
+  test("first window opens and has the expected title", async () => {
+    const app = await electron.launch({ args: ["."], cwd: DESKTOP_DIR });
+    const rendererErrors: string[] = [];
+
+    try {
+      const win = await app.firstWindow();
+      win.on("console", (m) => {
+        if (m.type() === "error") rendererErrors.push(m.text());
+      });
+
+      await win.waitForLoadState("domcontentloaded");
+      await expect(win).toHaveTitle(/Mcode/);
+
+      await win.screenshot({
+        path: resolve(
+          DESKTOP_DIR,
+          "..",
+          "web",
+          "e2e",
+          "screenshots",
+          "demo-desktop",
+          "smoke-first-window.png",
+        ),
+        fullPage: true,
+      });
+
+      expect(rendererErrors, "renderer console errors").toEqual([]);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -6,9 +6,10 @@
  * Future Electron-only features (native menus, tray, BrowserView, deep links)
  * should be appended to this suite as additional specs in this directory.
  *
- * Requires `apps/desktop/dist/main/main.cjs` to exist — the Playwright config
- * runs `bun run build` first via the `webServer`/`globalSetup` hook, but you
- * can also build manually with `cd apps/desktop && bun run build`.
+ * Requires `apps/desktop/dist/main/main.cjs` to exist. The Playwright config
+ * does not run a build step automatically; build the bundles first with
+ * `cd apps/desktop && bun run build` (CI should do the same before invoking
+ * `bun run e2e`).
  */
 import { test, expect, _electron as electron } from "@playwright/test";
 import { existsSync } from "node:fs";

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,7 +17,8 @@
     "rebuild": "electron-rebuild -f",
     "dist": "bun run build && bun scripts/generate-snapshot.mjs && electron-builder --publish never",
     "dist:no-snapshot": "bun run build && electron-builder --publish never",
-    "test": "bunx vitest run"
+    "test": "bunx vitest run",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@electron/rebuild": "^3.7.1",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@electron/fuses": "^2.1.1",
+    "@playwright/test": "^1.58.2",
     "@types/uuid": "^10.0.0",
     "@types/which": "^3.0.4",
     "@vitest/coverage-v8": "^4.1.0",

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -1,0 +1,21 @@
+/**
+ * Playwright config for Electron E2E specs (Electron-only surfaces:
+ * native menus, tray, BrowserView, contextBridge IPC, deep links).
+ *
+ * Renderer-only specs live in apps/web/e2e/ and run via Vite — much faster.
+ */
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+});

--- a/docs/agents/demo.md
+++ b/docs/agents/demo.md
@@ -1,0 +1,80 @@
+# Demoing a feature
+
+How an agent demos a feature in the running Mcode web app. Works the same from Claude Code, Cursor, Codex, or OpenCode — only the entry point differs.
+
+## Prerequisites
+
+```sh
+bun install          # once per checkout
+bun run doctor       # verify prerequisites
+```
+
+Playwright MCP must be connected (configured in `.mcp.json`, `.cursor/mcp.json`, and `.opencode/opencode.json`).
+
+## Entry points
+
+| Harness | Command |
+|---------|---------|
+| Claude Code | `/demo <feature-name>` |
+| Cursor / Codex / OpenCode | `node scripts/agent/demo.mjs` |
+
+Both ultimately run `scripts/agent/demo.mjs`, which:
+
+1. Checks whether `http://127.0.0.1:5173` already responds
+2. If not, spawns `bun run dev:web` detached and polls (default 60s timeout)
+3. Prints the URL, the screenshot directory, and a copy-pasteable Playwright MCP entry point
+
+Override defaults with env vars:
+
+```sh
+MCODE_DEMO_URL=http://127.0.0.1:5174 MCODE_DEMO_TIMEOUT_MS=120000 node scripts/agent/demo.mjs
+```
+
+## Driving the app
+
+Once the script exits 0, drive the app via Playwright MCP tools:
+
+```ts
+mcp__playwright__browser_navigate({ url: "http://127.0.0.1:5173" })
+mcp__playwright__browser_snapshot()       // a11y tree — readable state
+mcp__playwright__browser_click({ ref: "<from-snapshot>" })
+mcp__playwright__browser_take_screenshot({ filename: "apps/web/e2e/screenshots/demo/<step>.png" })
+mcp__playwright__browser_console_messages()  // must be error-free
+```
+
+## What to demo
+
+For every feature, walk:
+
+1. **Golden path** — the primary intended flow
+2. **One or two edge cases** — empty state, error state, or boundary condition
+3. **Regression check** — touch one adjacent feature to confirm nothing nearby broke
+
+Capture a screenshot at each meaningful state so the user can review without re-running the app.
+
+## Reporting
+
+Report back:
+
+- The URL the agent drove
+- The list of screenshot paths under `apps/web/e2e/screenshots/demo/`
+- Any console errors from `browser_console_messages`
+- A one-line verdict per scenario (pass / fail / partial)
+
+## Cleanup
+
+The dev server stays running after `demo.mjs` exits — `dev:web` is intentionally detached so a follow-up `/demo` call is instant. To shut it down:
+
+```sh
+# unix-ish
+pkill -f "bun run dev:web"
+
+# windows powershell
+Get-Process | Where-Object { $_.CommandLine -match "dev:web" } | Stop-Process
+```
+
+Or simply close the terminal that spawned it.
+
+## Promoting demos to E2E specs
+
+If a demo flow becomes a regression risk (interactive components, keyboard nav, focus, responsive layout, a11y, floating overlays, persisted state — see `docs/guides/agent-workflow.md`), promote it to a Playwright spec in `apps/web/e2e/` and add it to `bun run verify:e2e`.

--- a/docs/agents/demo.md
+++ b/docs/agents/demo.md
@@ -78,3 +78,46 @@ Or simply close the terminal that spawned it.
 ## Promoting demos to E2E specs
 
 If a demo flow becomes a regression risk (interactive components, keyboard nav, focus, responsive layout, a11y, floating overlays, persisted state — see `docs/guides/agent-workflow.md`), promote it to a Playwright spec in `apps/web/e2e/` and add it to `bun run verify:e2e`.
+
+## Demoing the Desktop App
+
+The web demo above covers ~95% of features because the React tree is identical under Electron. Use the desktop path **only** when the change touches an Electron-specific surface:
+
+- Native menus or tray
+- BrowserView preview pane
+- contextBridge IPC (`desktopBridge`, `getPathForFile`)
+- Window chrome, multi-window, deep links
+- Auto-updater behavior
+
+### Entry points
+
+| Harness | Command |
+|---------|---------|
+| Claude Code | `/demo-desktop <feature>` |
+| Cursor / Codex / OpenCode | `node scripts/agent/demo-desktop.mjs` |
+
+Both:
+
+1. Require `cd apps/desktop && bun run build` to have produced `dist/main/main.cjs` (and `dist/server/server.cjs` for the spawned child).
+2. Launch Electron via Playwright's `_electron.launch()` (not the Playwright MCP — the MCP does not support Electron).
+3. Wait for the first window, screenshot it to `apps/web/e2e/screenshots/demo-desktop/`, dump renderer console errors.
+4. Exit and close the window by default. Pass `--keep-open` to leave Electron running for further interactive driving.
+
+### Driving the running app
+
+Inside a Playwright Node script you can drive the same `BrowserWindow` programmatically:
+
+```ts
+import { _electron as electron } from "@playwright/test";
+const app = await electron.launch({ args: ["."], cwd: "apps/desktop" });
+const win = await app.firstWindow();
+await win.click('[data-testid="threads-new"]');
+await win.screenshot({ path: "apps/web/e2e/screenshots/demo-desktop/new-thread.png" });
+await app.close();
+```
+
+See `apps/desktop/e2e/electron-smoke.spec.ts` for the working baseline.
+
+### Promoting desktop demos to E2E specs
+
+Any Electron-only regression risk (window state persistence, tray behavior, IPC roundtrip) goes in `apps/desktop/e2e/` as a new `*.spec.ts` and gets covered by `/verify-e2e-desktop` (`cd apps/desktop && bun run e2e`). Renderer-only flows stay in `apps/web/e2e/` — they run an order of magnitude faster under Vite.

--- a/docs/agents/demo.md
+++ b/docs/agents/demo.md
@@ -20,14 +20,14 @@ Playwright MCP must be connected (configured in `.mcp.json`, `.cursor/mcp.json`,
 
 Both ultimately run `scripts/agent/demo.mjs`, which:
 
-1. Checks whether `http://127.0.0.1:5173` already responds
+1. Checks whether `http://localhost:5173` already responds
 2. If not, spawns `bun run dev:web` detached and polls (default 60s timeout)
 3. Prints the URL, the screenshot directory, and a copy-pasteable Playwright MCP entry point
 
 Override defaults with env vars:
 
 ```sh
-MCODE_DEMO_URL=http://127.0.0.1:5174 MCODE_DEMO_TIMEOUT_MS=120000 node scripts/agent/demo.mjs
+MCODE_DEMO_URL=http://localhost:5174 MCODE_DEMO_TIMEOUT_MS=120000 node scripts/agent/demo.mjs
 ```
 
 ## Driving the app
@@ -35,7 +35,7 @@ MCODE_DEMO_URL=http://127.0.0.1:5174 MCODE_DEMO_TIMEOUT_MS=120000 node scripts/a
 Once the script exits 0, drive the app via Playwright MCP tools:
 
 ```ts
-mcp__playwright__browser_navigate({ url: "http://127.0.0.1:5173" })
+mcp__playwright__browser_navigate({ url: "http://localhost:5173" })
 mcp__playwright__browser_snapshot()       // a11y tree — readable state
 mcp__playwright__browser_click({ ref: "<from-snapshot>" })
 mcp__playwright__browser_take_screenshot({ filename: "apps/web/e2e/screenshots/demo/<step>.png" })

--- a/docs/agents/runtime.md
+++ b/docs/agents/runtime.md
@@ -184,6 +184,23 @@ issue #290-class restarts.
 
 ---
 
+## Common Workflows
+
+Slash commands are first-class in Claude Code. Other harnesses (Cursor, Codex, OpenCode) run the underlying script directly.
+
+| Workflow | Claude command | Equivalent shell |
+|----------|----------------|------------------|
+| Typecheck + lint + unit tests | `/verify` | `bun run verify` |
+| Playwright E2E run | `/verify-e2e` | `bun run verify:e2e` |
+| Boot dev app for live demo | `/demo <feature>` | `node scripts/agent/demo.mjs` |
+| 4-parallel-subagent PR review | `/review-pr <ref>` | (Claude Code only — see `.claude/commands/review-pr.md`) |
+
+## Demoing a Feature
+
+The `/demo` flow (or `node scripts/agent/demo.mjs` from other harnesses) boots `bun run dev:web`, waits for the Vite dev URL, then prints a Playwright MCP entry point. See [docs/agents/demo.md](demo.md) for the full runbook — driving the app via Playwright MCP, capturing screenshots, and reporting back.
+
+---
+
 ## Bootstrap from Scratch
 
 ```sh

--- a/docs/agents/runtime.md
+++ b/docs/agents/runtime.md
@@ -191,8 +191,10 @@ Slash commands are first-class in Claude Code. Other harnesses (Cursor, Codex, O
 | Workflow | Claude command | Equivalent shell |
 |----------|----------------|------------------|
 | Typecheck + lint + unit tests | `/verify` | `bun run verify` |
-| Playwright E2E run | `/verify-e2e` | `bun run verify:e2e` |
-| Boot dev app for live demo | `/demo <feature>` | `node scripts/agent/demo.mjs` |
+| Playwright E2E (web) | `/verify-e2e` | `bun run verify:e2e` |
+| Playwright E2E (Electron) | `/verify-e2e-desktop` | `cd apps/desktop && bun run e2e` |
+| Boot dev web app for live demo | `/demo <feature>` | `node scripts/agent/demo.mjs` |
+| Launch Electron app for live demo | `/demo-desktop <feature>` | `node scripts/agent/demo-desktop.mjs` |
 | 4-parallel-subagent PR review | `/review-pr <ref>` | (Claude Code only — see `.claude/commands/review-pr.md`) |
 
 ## Demoing a Feature

--- a/scripts/agent/demo-desktop.mjs
+++ b/scripts/agent/demo-desktop.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Launch the packaged Electron main process under Playwright, capture a
+ * screenshot of the first window, dump main/renderer console output, then
+ * exit (leaving the app running if --keep-open is passed).
+ *
+ * Use this when the change touches Electron-specific surfaces (native menus,
+ * tray, BrowserView, contextBridge IPC, deep links, window chrome). For
+ * everything else, prefer scripts/agent/demo.mjs — the Vite dev target is
+ * faster and Playwright MCP can drive it interactively.
+ *
+ * Requires: `bun run --filter @mcode/desktop build` to have produced
+ * apps/desktop/dist/main/main.cjs (and a server bundle for the child process).
+ *
+ * Prints an instructions block at the end so an agent knows where artifacts
+ * landed.
+ */
+import { mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const KEEP_OPEN = process.argv.includes("--keep-open");
+const TIMEOUT_MS = Number(process.env.MCODE_DEMO_TIMEOUT_MS ?? 60_000);
+const REPO_ROOT = resolve(process.cwd());
+const DESKTOP_DIR = join(REPO_ROOT, "apps", "desktop");
+const MAIN_BUNDLE = join(DESKTOP_DIR, "dist", "main", "main.cjs");
+const SCREENSHOT_DIR = join(
+  REPO_ROOT,
+  "apps",
+  "web",
+  "e2e",
+  "screenshots",
+  "demo-desktop",
+);
+
+if (!existsSync(MAIN_BUNDLE)) {
+  console.error(`[demo-desktop] missing build: ${MAIN_BUNDLE}`);
+  console.error("[demo-desktop] run `cd apps/desktop && bun run build` first");
+  process.exit(1);
+}
+
+// Playwright is hoisted in the web workspace. Resolve from there so this
+// script works from the repo root without an explicit dep entry.
+const require = createRequire(join(REPO_ROOT, "apps", "web", "package.json"));
+let playwright;
+try {
+  playwright = require("@playwright/test");
+} catch (err) {
+  console.error("[demo-desktop] could not load @playwright/test:", err.message);
+  console.error("[demo-desktop] run `bun install` first");
+  process.exit(1);
+}
+
+const { _electron: electron } = playwright;
+mkdirSync(SCREENSHOT_DIR, { recursive: true });
+
+console.log(`[demo-desktop] launching Electron from ${DESKTOP_DIR}`);
+const app = await electron.launch({
+  args: ["."],
+  cwd: DESKTOP_DIR,
+  timeout: TIMEOUT_MS,
+});
+
+const mainConsole = [];
+const rendererErrors = [];
+app.process().stdout?.on("data", (b) => mainConsole.push(String(b)));
+app.process().stderr?.on("data", (b) => mainConsole.push(String(b)));
+
+const win = await app.firstWindow({ timeout: TIMEOUT_MS });
+win.on("console", (m) => {
+  if (m.type() === "error") rendererErrors.push(m.text());
+});
+
+await win.waitForLoadState("domcontentloaded");
+
+const shot = join(SCREENSHOT_DIR, "first-window.png");
+await win.screenshot({ path: shot, fullPage: true });
+
+const title = await win.title();
+console.log("");
+console.log(`[demo-desktop] first window title: ${title}`);
+console.log(`[demo-desktop] screenshot: ${shot}`);
+console.log(`[demo-desktop] renderer errors: ${rendererErrors.length}`);
+for (const err of rendererErrors) console.log(`  - ${err}`);
+console.log("");
+console.log("[demo-desktop] artifacts dir:", SCREENSHOT_DIR);
+console.log(
+  "[demo-desktop] further steps: drive `win` programmatically (click, fill,",
+);
+console.log(
+  "  screenshot per step) — see apps/desktop/e2e/electron-smoke.spec.ts.",
+);
+
+if (KEEP_OPEN) {
+  console.log("[demo-desktop] --keep-open set; leaving Electron running");
+  console.log("[demo-desktop] close the window or Ctrl-C to exit");
+  await new Promise(() => {});
+} else {
+  await app.close();
+}

--- a/scripts/agent/demo.mjs
+++ b/scripts/agent/demo.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Boots `bun run dev:web` (if not already running), polls the Vite dev URL
+ * until it responds, then prints the URL plus a copy-pasteable Playwright MCP
+ * entry point so an agent can immediately drive the app.
+ *
+ * Intended to be invoked by the /demo slash command (Claude) or directly by
+ * any agent harness (`node scripts/agent/demo.mjs`).
+ *
+ * Exits 0 once the server is reachable, 1 on timeout.
+ */
+import { spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const DEV_URL = process.env.MCODE_DEMO_URL ?? "http://127.0.0.1:5173";
+const TIMEOUT_MS = Number(process.env.MCODE_DEMO_TIMEOUT_MS ?? 60_000);
+const POLL_INTERVAL_MS = 1_000;
+const SCREENSHOT_DIR = join("apps", "web", "e2e", "screenshots", "demo");
+
+/**
+ * Ping the dev server. Resolves true if it returns any HTTP status.
+ */
+async function isReachable(url) {
+  try {
+    const res = await fetch(url, { method: "GET" });
+    return res.status > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  console.log(`[demo] target: ${DEV_URL}`);
+
+  const alreadyUp = await isReachable(DEV_URL);
+  let child = null;
+  if (alreadyUp) {
+    console.log("[demo] dev server already reachable — skipping spawn");
+  } else {
+    console.log("[demo] starting `bun run dev:web` in the background…");
+    child = spawn("bun", ["run", "dev:web"], {
+      stdio: "ignore",
+      detached: true,
+      shell: process.platform === "win32",
+    });
+    child.unref();
+  }
+
+  const start = Date.now();
+  while (Date.now() - start < TIMEOUT_MS) {
+    if (await isReachable(DEV_URL)) {
+      mkdirSync(SCREENSHOT_DIR, { recursive: true });
+      console.log("");
+      console.log(`[demo] ready: ${DEV_URL}`);
+      console.log(`[demo] screenshots dir: ${SCREENSHOT_DIR}`);
+      console.log("");
+      console.log("[demo] Drive it via the Playwright MCP:");
+      console.log(`  mcp__playwright__browser_navigate({ url: "${DEV_URL}" })`);
+      console.log("  mcp__playwright__browser_snapshot()");
+      console.log(
+        `  mcp__playwright__browser_take_screenshot({ filename: "${SCREENSHOT_DIR}/<step>.png" })`,
+      );
+      console.log("  mcp__playwright__browser_console_messages()");
+      process.exit(0);
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  console.error(
+    `[demo] timed out after ${TIMEOUT_MS}ms waiting for ${DEV_URL}`,
+  );
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("[demo] failed:", err);
+  process.exit(1);
+});

--- a/scripts/agent/demo.mjs
+++ b/scripts/agent/demo.mjs
@@ -14,7 +14,9 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
-const DEV_URL = process.env.MCODE_DEMO_URL ?? "http://127.0.0.1:5173";
+// `localhost` (not `127.0.0.1`) — Vite's default bind is IPv6-only on Windows,
+// so an IPv4 literal won't reach it. `localhost` resolves to both families.
+const DEV_URL = process.env.MCODE_DEMO_URL ?? "http://localhost:5173";
 const TIMEOUT_MS = Number(process.env.MCODE_DEMO_TIMEOUT_MS ?? 60_000);
 const POLL_INTERVAL_MS = 1_000;
 const SCREENSHOT_DIR = join("apps", "web", "e2e", "screenshots", "demo");
@@ -63,7 +65,9 @@ async function main() {
         `  mcp__playwright__browser_take_screenshot({ filename: "${SCREENSHOT_DIR}/<step>.png" })`,
       );
       console.log("  mcp__playwright__browser_console_messages()");
-      process.exit(0);
+      // `process.exit(0)` after a fetch on Windows can trip a libuv async-handle
+      // assertion. The work is already done, so we let the event loop drain.
+      return;
     }
     await sleep(POLL_INTERVAL_MS);
   }
@@ -71,7 +75,7 @@ async function main() {
   console.error(
     `[demo] timed out after ${TIMEOUT_MS}ms waiting for ${DEV_URL}`,
   );
-  process.exit(1);
+  process.exitCode = 1;
 }
 
 main().catch((err) => {

--- a/scripts/agent/install-codex-prompts.mjs
+++ b/scripts/agent/install-codex-prompts.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Copy the project's Codex prompts (.codex/prompts/*.md) into the user's
+ * Codex CLI prompt directory (~/.codex/prompts/) so they appear in Codex's
+ * slash menu.
+ *
+ * Codex CLI does not read project-local slash commands (only user-level
+ * prompts under ~/.codex/prompts/). This is a one-time bootstrap each
+ * developer runs on their machine.
+ *
+ * Skipped files: any with the same name already present (use --force to
+ * overwrite). Prompts are prefixed with `mcode-` in the destination to
+ * avoid colliding with other projects' prompts.
+ *
+ * Usage:
+ *   node scripts/agent/install-codex-prompts.mjs           # safe install
+ *   node scripts/agent/install-codex-prompts.mjs --force   # overwrite
+ *   node scripts/agent/install-codex-prompts.mjs --no-prefix
+ *     # install without the `mcode-` prefix (collision risk)
+ */
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+const FORCE = process.argv.includes("--force");
+const NO_PREFIX = process.argv.includes("--no-prefix");
+const PREFIX = NO_PREFIX ? "" : "mcode-";
+const SRC = resolve(process.cwd(), ".codex", "prompts");
+const DST = join(homedir(), ".codex", "prompts");
+
+if (!existsSync(SRC)) {
+  console.error(`[codex-install] missing source dir: ${SRC}`);
+  console.error("[codex-install] run this from the repo root");
+  process.exit(1);
+}
+
+mkdirSync(DST, { recursive: true });
+
+const files = readdirSync(SRC).filter((f) => f.endsWith(".md"));
+let installed = 0;
+let skipped = 0;
+
+for (const f of files) {
+  const srcPath = join(SRC, f);
+  const dstName = `${PREFIX}${f}`;
+  const dstPath = join(DST, dstName);
+
+  if (existsSync(dstPath) && !FORCE) {
+    console.log(`[codex-install] skip ${dstName} (exists; --force to overwrite)`);
+    skipped += 1;
+    continue;
+  }
+
+  writeFileSync(dstPath, readFileSync(srcPath));
+  console.log(`[codex-install] installed ${dstName}`);
+  installed += 1;
+}
+
+console.log("");
+console.log(`[codex-install] dest: ${DST}`);
+console.log(`[codex-install] installed: ${installed}, skipped: ${skipped}`);
+console.log(
+  `[codex-install] invoke from Codex as /${PREFIX}verify, /${PREFIX}demo, etc.`,
+);


### PR DESCRIPTION
## What

Bring the four supported agent harnesses (Claude Code, Cursor, Codex, OpenCode) to feature parity for implementing, testing, and demoing across server / web / desktop. Adds Electron-specific demo + E2E scaffolding so agents can drive the desktop app, not just the web one.

## Why

Until now, only Claude Code had a Stop-hook verify, structured subagents, and slash commands. Other harnesses were second-class: they read \`AGENTS.md\` but had no command surface and no Electron demo path. This branch closes those gaps so an agent in any of the four harnesses can:

1. Verify changes (\`/verify\`, \`/verify-e2e\`, \`/verify-e2e-desktop\`)
2. Demo features against the running app (\`/demo\` for web, \`/demo-desktop\` for Electron)
3. Run multi-dimensional code review (\`/review-pr\`)

…with the same UX from every harness, plus equivalent \`bun run …\` shell paths documented for fallback.

## Key Changes

### Harness configs
- **OpenCode parity** — new \`.opencode/opencode.json\` with Playwright MCP + \`.env\`-edit block + Stop hook reusing the Codex-compatible \`codex-stop.mjs\`
- **Cursor / OpenCode / Codex slash commands** — all six commands shipped in each harness's native command location:
  - \`.cursor/commands/\` (auto-read)
  - \`.opencode/command/\` (auto-read; OpenCode uses singular \`command/\`)
  - \`.codex/prompts/\` + \`scripts/agent/install-codex-prompts.mjs\` — Codex only reads user-level prompts from \`~/.codex/prompts/\`, so the installer copies them once per machine with an \`mcode-\` prefix

### Claude-only enhancements
- New subagents: \`frontend-engineer\`, \`backend-engineer\`, \`qa-engineer\` (joining the existing \`security-reviewer\`)
- New slash commands: \`/verify\`, \`/verify-e2e\`, \`/verify-e2e-desktop\`, \`/demo\`, \`/demo-desktop\`, \`/review-pr\`

### Demo path (cross-harness)
- \`scripts/agent/demo.mjs\` — boots \`bun run dev:web\`, polls Vite, prints Playwright MCP entry point. Fixed Windows IPv6 default (\`localhost\` not \`127.0.0.1\`) and clean exit (no \`process.exit\` after \`fetch\`).
- \`scripts/agent/demo-desktop.mjs\` — launches Electron via Playwright's \`_electron.launch()\`, screenshots the first window, dumps renderer errors. \`--keep-open\` leaves it running for interactive driving.
- \`docs/agents/demo.md\` — full runbook including Electron path.

### Electron E2E scaffold
- \`apps/desktop/playwright.config.ts\` (serial, single worker, 90s timeout)
- \`apps/desktop/e2e/electron-smoke.spec.ts\` — working baseline: launch main, assert window title, fail on renderer console errors
- \`apps/desktop/package.json\` gains \`"e2e": "playwright test"\`

### Docs
- \`AGENTS.md\` — Supported Agent Harnesses table with config / stop hook / MCP / slash-commands columns
- \`docs/agents/runtime.md\` — Common Workflows table mapping every slash command to its shell equivalent

## Test plan

- [x] \`node scripts/agent/demo.mjs\` — boots dev:web, prints Playwright MCP snippet, exit 0 (validated end-to-end during development; screenshot dir created)
- [x] \`node scripts/agent/install-codex-prompts.mjs\` — installs six prompts to \`~/.codex/prompts/\` with \`mcode-\` prefix
- [x] \`node --check\` on all new \`.mjs\` files
- [x] JSON validation on \`.opencode/opencode.json\` and modified \`apps/desktop/package.json\`
- [ ] \`bun run verify\` — couldn't run in dev environment (turbo/bun deps not installed in worktree). Changes are configs / docs / markdown / standalone scripts; no runtime code paths touched.
- [ ] \`/demo-desktop\` end-to-end — requires \`cd apps/desktop && bun run build\` which currently fails on \`@anthropic-ai/claude-agent-sdk\` package.json exports issue on this repo (pre-existing, unrelated to this branch). The script and spec follow the documented \`_electron.launch()\` pattern.
- [ ] Once merged: each developer should run \`node scripts/agent/install-codex-prompts.mjs\` once to enable Codex slash commands.

Closes the gap described in the \`chore/agent-setup\` branch goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end demo and verification workflows for web and Electron desktop apps.
  * Automated multi-pass PR review workflow and agent harness support.

* **Documentation**
  * Extensive agent role guides, command runbooks, and demo/verification documentation added across the repo.

* **Tests**
  * Desktop Playwright E2E smoke test and desktop test configuration introduced.

* **Chores**
  * CLI demo utilities, prompt install tooling, and automation/config updates for demos and verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/461)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->