### PR TITLE
feat(web): infer syntax language from path-like code fences

### DIFF
--- a/apps/web/src/__tests__/CodeBlock.test.tsx
+++ b/apps/web/src/__tests__/CodeBlock.test.tsx
@@ -29,6 +29,14 @@ describe("CodeBlock", () => {
     expect(screen.getByText("python")).toBeInTheDocument();
   });
 
+  it("shows languageLabel in the header when provided", () => {
+    mockUseHighlighter.mockReturnValue({ html: null });
+    render(
+      <CodeBlock code="const x = 1;" language="typescript" languageLabel="foo.ts" isStreaming={false} />,
+    );
+    expect(screen.getByText("foo.ts")).toBeInTheDocument();
+  });
+
   it("renders highlighted html when available", () => {
     mockUseHighlighter.mockReturnValue({
       html: '<pre class="shiki github-dark"><code><span>const x = 1;</span></code></pre>',

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -11,13 +11,20 @@ vi.mock("../components/chat/MermaidBlock", () => ({
 }));
 
 vi.mock("../components/chat/CodeBlock", () => ({
-  CodeBlock: vi.fn(({ code, language, disableHighlighting, isStreaming }: {
+  CodeBlock: vi.fn(({ code, language, languageLabel, disableHighlighting, isStreaming }: {
     code: string;
     language: string;
+    languageLabel?: string;
     disableHighlighting?: boolean;
     isStreaming?: boolean;
   }) => (
-    <pre data-testid="code-block" data-language={language} data-disable-highlighting={String(disableHighlighting)} data-streaming={String(isStreaming)}>
+    <pre
+      data-testid="code-block"
+      data-language={language}
+      data-language-label={languageLabel ?? ""}
+      data-disable-highlighting={String(disableHighlighting)}
+      data-streaming={String(isStreaming)}
+    >
       {code}
     </pre>
   )),
@@ -149,6 +156,17 @@ describe("MarkdownContent variant styling", () => {
         undefined,
       );
     });
+  });
+});
+
+describe("MarkdownContent path-based fence language", () => {
+  it("resolves GitHub-style start:end:path fences to Shiki language and basename label", () => {
+    render(
+      <MarkdownContent content={'```1:20:apps/web/foo.ts\nconst a = 1;\n```'} />,
+    );
+    const block = screen.getByTestId("code-block");
+    expect(block).toHaveAttribute("data-language", "typescript");
+    expect(block).toHaveAttribute("data-language-label", "foo.ts");
   });
 });
 

--- a/apps/web/src/components/chat/CodeBlock.tsx
+++ b/apps/web/src/components/chat/CodeBlock.tsx
@@ -9,6 +9,10 @@ interface CodeBlockProps {
   code: string;
   /** Language identifier from the code fence (e.g. "typescript", "python"). */
   language: string;
+  /**
+   * Optional header text; when set (e.g. basename inferred from a path), shown instead of {@link language}.
+   */
+  languageLabel?: string;
   /** When true, shows raw code inline and hides the copy button. */
   isStreaming: boolean;
   /** When true, skips Shiki highlighting but keeps the copy button and language label. */
@@ -19,7 +23,13 @@ interface CodeBlockProps {
  * Renders a syntax-highlighted code block with a language header and copy button.
  * Uses a CSS grid stack to crossfade from plain to highlighted code with zero layout shift.
  */
-export const CodeBlock = memo(function CodeBlock({ code, language, isStreaming, disableHighlighting = false }: CodeBlockProps) {
+export const CodeBlock = memo(function CodeBlock({
+  code,
+  language,
+  languageLabel,
+  isStreaming,
+  disableHighlighting = false,
+}: CodeBlockProps) {
   const theme = useShikiTheme();
   // The hook is always called unconditionally (rules of hooks), but `enabled`
   // suppresses the Worker postMessage during streaming so no requests are wasted.
@@ -51,7 +61,7 @@ export const CodeBlock = memo(function CodeBlock({ code, language, isStreaming, 
   return (
     <div className="my-2 rounded-lg overflow-hidden border border-border">
       <div className="flex items-center justify-between bg-background px-3 py-1 border-b border-border">
-        <span className="text-xs text-muted-foreground">{language || "text"}</span>
+        <span className="text-xs text-muted-foreground">{languageLabel || language || "text"}</span>
         {!isStreaming && (
           <button
             type="button"

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo, lazy, Suspense } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodeBlock } from "./CodeBlock";
+import { resolveCodeBlockLanguage } from "@/lib/resolve-code-block-language";
 import { useDiffStore } from "@/stores/diffStore";
 import { isMac } from "@/lib/platform";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -236,15 +237,15 @@ function makeComponents(isStreaming: boolean, variant: "assistant" | "user") {
       }
 
       const langMatch = className?.match(/language-(\S+)/);
-      const language = langMatch ? langMatch[1] : "";
+      const rawFence = langMatch ? langMatch[1] : "";
 
       // Suppress the fenced block the model emits to signal plan questions —
       // the wizard renders from the parsed payload, not from raw markdown.
-      if (language === "plan-questions") return null;
+      if (rawFence === "plan-questions") return null;
 
       const code = String(children).replace(/\n$/, "");
 
-      if (language === "mermaid") {
+      if (rawFence === "mermaid") {
         return (
           <Suspense fallback={
             <pre className="bg-muted/30 rounded-lg p-4 overflow-x-auto"><code>{code}</code></pre>
@@ -254,10 +255,13 @@ function makeComponents(isStreaming: boolean, variant: "assistant" | "user") {
         );
       }
 
+      const { language, label } = resolveCodeBlockLanguage(rawFence, code);
+
       return (
         <CodeBlock
           code={code}
           language={language}
+          languageLabel={label}
           isStreaming={isStreaming}
           disableHighlighting={isUser}
         />

--- a/apps/web/src/lib/__tests__/resolve-code-block-language.test.ts
+++ b/apps/web/src/lib/__tests__/resolve-code-block-language.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { resolveCodeBlockLanguage } from "@/lib/resolve-code-block-language";
+
+describe("resolveCodeBlockLanguage", () => {
+  it("passes normal fence tags through to the worker unchanged", () => {
+    expect(resolveCodeBlockLanguage("ts")).toEqual({ language: "ts", label: "ts" });
+    expect(resolveCodeBlockLanguage("typescript")).toEqual({ language: "typescript", label: "typescript" });
+    expect(resolveCodeBlockLanguage("python")).toEqual({ language: "python", label: "python" });
+  });
+
+  it("maps GitHub start:end:path fences using the file path extension", () => {
+    expect(resolveCodeBlockLanguage("12:34:preview-browser.ts")).toEqual({
+      language: "typescript",
+      label: "preview-browser.ts",
+    });
+    expect(resolveCodeBlockLanguage("1:10:apps/web/src/foo.tsx")).toEqual({
+      language: "typescript",
+      label: "foo.tsx",
+    });
+  });
+
+  it("maps bare path fences with a known extension", () => {
+    expect(resolveCodeBlockLanguage("src/lib/bar.rs")).toEqual({
+      language: "rust",
+      label: "bar.rs",
+    });
+    expect(resolveCodeBlockLanguage("hello.py")).toEqual({
+      language: "python",
+      label: "hello.py",
+    });
+  });
+
+  it("infers from the first line when the fence info is empty", () => {
+    expect(
+      resolveCodeBlockLanguage(
+        "",
+        "88:99:components/CodeBlock.tsx\nexport const x = 1;\n",
+      ),
+    ).toEqual({
+      language: "typescript",
+      label: "CodeBlock.tsx",
+    });
+  });
+
+  it("maps line:path fences (single line ref)", () => {
+    expect(resolveCodeBlockLanguage("42:preview-browser.ts")).toEqual({
+      language: "typescript",
+      label: "preview-browser.ts",
+    });
+  });
+
+  it("prefers start:end:path over line:path when both patterns could apply", () => {
+    expect(resolveCodeBlockLanguage("12:34:deep/file.ts")).toEqual({
+      language: "typescript",
+      label: "file.ts",
+    });
+  });
+
+  it("returns text when nothing matches", () => {
+    expect(resolveCodeBlockLanguage("")).toEqual({ language: "text", label: "text" });
+    expect(resolveCodeBlockLanguage("", "const n = 1;\n")).toEqual({ language: "text", label: "text" });
+    expect(resolveCodeBlockLanguage("plain-words")).toEqual({ language: "plain-words", label: "plain-words" });
+  });
+});

--- a/apps/web/src/lib/resolve-code-block-language.ts
+++ b/apps/web/src/lib/resolve-code-block-language.ts
@@ -1,0 +1,93 @@
+import { langFromPath } from "@/lib/lang-from-path";
+
+/** GitHub-style code reference fence: startLine:endLine:path (path may be relative or absolute). */
+const LINE_RANGE_FENCE = /^\d+:\d+:(.+)$/;
+
+/** Alternate tool output: lineNumber:path (one line ref before the path). */
+const LINE_START_FENCE = /^\d+:(.+)$/;
+
+/**
+ * Returns true when `s` is plausibly a file path worth mapping (has a separator
+ * or a basename.extension shape). Keeps hot paths cheap by avoiding regex when
+ * there is no dot.
+ */
+function looksLikeFilePath(s: string): boolean {
+  if (!s.includes(".") && !s.includes("/") && !s.includes("\\")) return false;
+  if (s.includes("/") || s.includes("\\")) return true;
+  // Basename.extension (e.g. preview-browser.ts). Requires a final segment after the last dot.
+  return /^[\w.-]+\.[\w]+$/u.test(s);
+}
+
+function firstLine(s: string): string {
+  const i = s.indexOf("\n");
+  return i === -1 ? s : s.slice(0, i);
+}
+
+/**
+ * Returns the path segment embedded in tool-style fence metadata, or a bare path-looking string.
+ * Tries `line:line:path` before `line:path` so values like `12:34:file.ts` are not parsed as `34:file.ts`.
+ */
+function pathSegmentFromFenceInfo(fenceInfo: string): string | null {
+  const rangeMatch = LINE_RANGE_FENCE.exec(fenceInfo);
+  if (rangeMatch?.[1]) return rangeMatch[1].trim();
+
+  const startMatch = LINE_START_FENCE.exec(fenceInfo);
+  if (startMatch?.[1]) return startMatch[1].trim();
+
+  if (looksLikeFilePath(fenceInfo)) return fenceInfo.trim();
+  return null;
+}
+
+/**
+ * If the fence info string embeds a path with an extension, returns the inferred
+ * Shiki language and a short display label. Otherwise returns null so callers can
+ * pass the raw fence language to the worker (aliases like `ts` stay unchanged).
+ */
+function tryLangFromEmbeddedPath(fenceInfo: string): { language: string; label: string } | null {
+  const pathPart = pathSegmentFromFenceInfo(fenceInfo);
+  if (!pathPart) return null;
+
+  const lang = langFromPath(pathPart);
+  if (lang === "text") return null;
+
+  const slash = Math.max(pathPart.lastIndexOf("/"), pathPart.lastIndexOf("\\"));
+  const label = slash >= 0 ? pathPart.slice(slash + 1) : pathPart;
+  return { language: lang, label };
+}
+
+export interface ResolvedCodeBlockLanguage {
+  /** Shiki / worker language id (e.g. `typescript`). */
+  language: string;
+  /** Human-readable header for {@link CodeBlock} (filename or original fence tag). */
+  label: string;
+}
+
+/**
+ * Derives the syntax highlighting language from a markdown fence info string,
+ * including GitHub `line:line:path` references and bare paths ending in a known extension.
+ * Falls back to the trimmed fence string for the worker (which applies its own aliases).
+ *
+ * @param fenceInfo - The info string after the opening fence (e.g. `ts`, `12:34:src/a.ts`).
+ * @param code - When `fenceInfo` is empty, only the first line is scanned for a line:line:path prefix
+ *   so the common hot path (non-empty fences) never walks past the opening line.
+ */
+export function resolveCodeBlockLanguage(fenceInfo: string, code = ""): ResolvedCodeBlockLanguage {
+  const trimmed = fenceInfo.trim();
+  if (!trimmed) {
+    const head = firstLine(code).trim();
+    if (head) {
+      const fromHead = tryLangFromEmbeddedPath(head);
+      if (fromHead) {
+        return { language: fromHead.language, label: fromHead.label };
+      }
+    }
+    return { language: "text", label: "text" };
+  }
+
+  const fromPath = tryLangFromEmbeddedPath(trimmed);
+  if (fromPath) {
+    return { language: fromPath.language, label: fromPath.label };
+  }
+
+  return { language: trimmed, label: trimmed };
+}


### PR DESCRIPTION
## What
Chat markdown code fences that embed file paths (for example GitHub-style `startLine:endLine:path` or `line:path`) now map the path extension to the correct Shiki language instead of falling back to plain text.

## Why
Agent and console output often use fence metadata that names a file with an extension. Previously that string was passed straight to the highlighter, so highlighting did not match the real source language.

## Key Changes
- Add `resolveCodeBlockLanguage` to derive Shiki language and a short header label from fence info (reuses `langFromPath`).
- Wire it into `MarkdownContent` fenced blocks; `CodeBlock` supports an optional `languageLabel` for the header.
- Add unit tests for the resolver and shallow tests for `MarkdownContent` / `CodeBlock`.

## Test plan
- [ ] `cd apps/web && bun run test` for affected specs
- [ ] `cd apps/web && bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code blocks now display file labels (e.g., "foo.ts") in their headers when available, providing better context.
  * Enhanced markdown code fence handling with improved automatic language detection and syntax highlighting from file path information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->