### PR TITLE
feat: workspace HTML preview links in markdown

### DIFF
--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -439,6 +439,33 @@ describe("preview-browser", () => {
       expect(result).toEqual({ ok: false, error: "no-workspace" });
     });
 
+    it("returns invalid-url for mcode-workspace path with encoded absolute root", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "mcode-workspace:///%2Ftmp%2Foutside.html", tempDir);
+
+      expect(result).toEqual({ ok: false, error: "invalid-url" });
+    });
+
+    it("returns invalid-url for mcode-workspace path with encoded parent segments", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "mcode-workspace:///%2e%2e%2Fescape.html", tempDir);
+
+      expect(result).toEqual({ ok: false, error: "invalid-url" });
+    });
+
+    it("returns invalid-url for malformed percent escapes in mcode-workspace path", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "mcode-workspace:///bad%ZZ/x.html", tempDir);
+
+      expect(result).toEqual({ ok: false, error: "invalid-url" });
+    });
+
     it("returns error for relative path without workspace", async () => {
       const win = createWindow();
       await showPreview(win);

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -102,11 +102,15 @@ vi.mock("electron", () => ({
   },
 }));
 
-vi.mock("@mcode/contracts", () => ({
-  clampMcodeBrowserCaptureV2: vi.fn(),
-  isBrowserCaptureSpillAppDataPath: vi.fn().mockReturnValue(false),
-  MCODE_BROWSER_CAPTURE_V2_STRING_MAX: 100_000,
-}));
+vi.mock("@mcode/contracts", async () => {
+  const actual = await vi.importActual<typeof import("@mcode/contracts")>("@mcode/contracts");
+  return {
+    ...actual,
+    clampMcodeBrowserCaptureV2: vi.fn(),
+    isBrowserCaptureSpillAppDataPath: vi.fn().mockReturnValue(false),
+    MCODE_BROWSER_CAPTURE_V2_STRING_MAX: 100_000,
+  };
+});
 
 vi.mock("@mcode/shared", () => ({
   getMcodeDir: vi.fn().mockReturnValue("/tmp/mcode"),
@@ -411,6 +415,28 @@ describe("preview-browser", () => {
       expect(view.webContents.loadURL).toHaveBeenCalledWith(
         pathToFileURL(join(tempDir, "sub", "page.html")).href,
       );
+    });
+
+    it("navigates mcode-workspace URLs resolved against workspace", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "mcode-workspace:///sub/page.html", tempDir);
+
+      expect(result).toEqual({ ok: true });
+      const view = createdViews[0]!;
+      expect(view.webContents.loadURL).toHaveBeenCalledWith(
+        pathToFileURL(join(tempDir, "sub", "page.html")).href,
+      );
+    });
+
+    it("returns no-workspace for mcode-workspace URL without workspace path", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const result = await navigate(win, "mcode-workspace:///sub/page.html", null);
+
+      expect(result).toEqual({ ok: false, error: "no-workspace" });
     });
 
     it("returns error for relative path without workspace", async () => {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -24,7 +24,7 @@ import { isAbsolute, join } from "path";
 import { randomUUID } from "crypto";
 import { Readable } from "stream";
 import { getLogPath, getMcodeDir, getRecentLogs } from "@mcode/shared";
-import { getExtension as bundledGetExtension } from "@mcode/contracts";
+import { getExtension as bundledGetExtension, isMcodeWorkspacePreviewUrl } from "@mcode/contracts";
 
 /** Use snapshot-provided module when available (V8 snapshot skips re-init). */
 const getExtension = globalThis.__v8Snapshot?.contracts?.getExtension ?? bundledGetExtension;
@@ -41,6 +41,7 @@ import {
 } from "./auto-updater.js";
 import { setupSpellcheck } from "./spellcheck.js";
 import { registerPreviewBrowserHandlers, disposePreviewForWindow } from "./preview/index.js";
+import { resolveMcodeWorkspacePreviewUrl } from "./preview/preview-local-file.js";
 
 // Isolate dev's Electron userData (cache, cookies, localStorage, IndexedDB)
 // from the installed prod build. Without this, both share %APPDATA%/Mcode/
@@ -377,10 +378,27 @@ function registerIpcHandlers(): void {
     return shell.openPath(dirPath);
   });
 
-  // Open external URL (https, http, mailto)
-  ipcMain.handle("open-external-url", (_event, url: string) => {
-    openIfAllowed(url);
-  });
+  // Open external URL (https, http, mailto), or workspace-relative preview targets in the default browser.
+  ipcMain.handle(
+    "open-external-url",
+    async (_event, url: string, workspacePath?: string | null) => {
+      const trimmed = typeof url === "string" ? url.trim() : "";
+      if (!trimmed) return;
+      if (isMcodeWorkspacePreviewUrl(trimmed)) {
+        const ws =
+          typeof workspacePath === "string" && workspacePath.trim().length > 0
+            ? workspacePath.trim()
+            : null;
+        const resolved = await resolveMcodeWorkspacePreviewUrl(trimmed, ws);
+        if (!resolved.ok) return;
+        void shell.openExternal(resolved.url).catch((err: unknown) => {
+          console.error(`[open-external-url] Failed to open file URL: ${resolved.url}`, err);
+        });
+        return;
+      }
+      openIfAllowed(trimmed);
+    },
+  );
 
   // Read clipboard image and save to temp JPEG
   ipcMain.handle("read-clipboard-image", async () => {

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -23,9 +23,9 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   openInExplorer: (path: string): Promise<void> =>
     ipcRenderer.invoke("open-in-explorer", path),
 
-  /** Open a URL in the default browser (https, http, mailto). */
-  openExternalUrl: (url: string): Promise<void> =>
-    ipcRenderer.invoke("open-external-url", url),
+  /** Open a URL in the default browser (https, http, mailto, or resolved mcode-workspace file targets). */
+  openExternalUrl: (url: string, workspacePath?: string | null): Promise<void> =>
+    ipcRenderer.invoke("open-external-url", url, workspacePath ?? null),
 
   /** Detect which supported editors are installed. */
   detectEditors: (): Promise<string[]> => ipcRenderer.invoke("detect-editors"),

--- a/apps/desktop/src/main/preview/preview-local-file.ts
+++ b/apps/desktop/src/main/preview/preview-local-file.ts
@@ -8,6 +8,8 @@ import { homedir } from "node:os";
 import { isAbsolute, join, normalize, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { isMcodeWorkspacePreviewUrl } from "@mcode/contracts";
+
 import { type PreviewSession, isAllowedPreviewUrl } from "./preview-session.js";
 
 /** Pre-compiled regex for browser-viewable file extensions (hoisted to avoid recompilation per navigate). */
@@ -59,6 +61,33 @@ export function trustMainProcessFileNavigation(s: PreviewSession, url: string): 
   } catch {
     /* malformed URLs do not consume budget */
   }
+}
+
+/**
+ * Resolves an `mcode-workspace:` navigation string to a local `file:` URL using
+ * the active workspace root (same rules as relative paths in {@link resolveLocalFileUrl}).
+ */
+export async function resolveMcodeWorkspacePreviewUrl(
+  input: string,
+  workspacePath: string | null,
+): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  const trimmed = input.trim();
+  if (!isMcodeWorkspacePreviewUrl(trimmed)) {
+    return { ok: false, error: "invalid-url" };
+  }
+  let pathname: string;
+  try {
+    pathname = new URL(trimmed).pathname;
+  } catch {
+    return { ok: false, error: "invalid-url" };
+  }
+  const raw = pathname.replace(/^\/+/, "");
+  if (!raw) return { ok: false, error: "empty-url" };
+  const rel = raw
+    .split("/")
+    .map((seg) => decodeURIComponent(seg))
+    .join("/");
+  return resolveLocalFileUrl(rel, workspacePath);
 }
 
 /**

--- a/apps/desktop/src/main/preview/preview-local-file.ts
+++ b/apps/desktop/src/main/preview/preview-local-file.ts
@@ -83,10 +83,35 @@ export async function resolveMcodeWorkspacePreviewUrl(
   }
   const raw = pathname.replace(/^\/+/, "");
   if (!raw) return { ok: false, error: "empty-url" };
-  const rel = raw
-    .split("/")
-    .map((seg) => decodeURIComponent(seg))
-    .join("/");
+  const decodedSegments: string[] = [];
+  for (const urlSeg of raw.split("/")) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(urlSeg);
+    } catch {
+      return { ok: false, error: "invalid-url" };
+    }
+    if (decoded.includes("\0")) {
+      return { ok: false, error: "invalid-url" };
+    }
+    for (const piece of decoded.split(/[/\\]/)) {
+      if (piece === "..") {
+        return { ok: false, error: "invalid-url" };
+      }
+    }
+    decodedSegments.push(decoded.replace(/\\/g, "/"));
+  }
+  const rel = decodedSegments.join("/");
+  const normalizedRel = normalize(rel);
+  if (
+    isAbsolute(normalizedRel) ||
+    normalizedRel === ".." ||
+    normalizedRel.startsWith(`..${sep}`) ||
+    normalizedRel.startsWith("../") ||
+    normalizedRel.startsWith("..\\")
+  ) {
+    return { ok: false, error: "invalid-url" };
+  }
   return resolveLocalFileUrl(rel, workspacePath);
 }
 

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -17,10 +17,12 @@ import { hidePreview, ensureView } from "./preview-lifecycle.js";
 import { type Bounds } from "./preview-session.js";
 import {
   resolveLocalFileUrl,
+  resolveMcodeWorkspacePreviewUrl,
   looksLikeFilePath,
   validateResumeUrl,
   trustMainProcessFileNavigation,
 } from "./preview-local-file.js";
+import { isMcodeWorkspacePreviewUrl } from "@mcode/contracts";
 
 /**
  * Registers all navigation-related IPC handlers:
@@ -121,7 +123,14 @@ export function registerNavigationHandlers(): void {
 
       let target: string;
 
-      if (/^https?:\/\//i.test(trimmed)) {
+      if (isMcodeWorkspacePreviewUrl(trimmed)) {
+        const resolved = await resolveMcodeWorkspacePreviewUrl(
+          trimmed,
+          workspacePath?.trim() ?? null,
+        );
+        if (!resolved.ok) return resolved;
+        target = resolved.url;
+      } else if (/^https?:\/\//i.test(trimmed)) {
         target = trimmed;
       } else if (/^file:\/\//i.test(trimmed)) {
         const resolved = await resolveLocalFileUrl(trimmed, workspacePath?.trim() ?? null);

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -188,6 +188,56 @@ describe("MarkdownContent workspace preview navigation", () => {
       );
     });
   });
+
+  it("falls back to openExternalUrl when preview.navigate is missing after ctrl+click", async () => {
+    const mockOpenExternal = vi.fn();
+    const ws = createMockWorkspace({ id: "ws-fallback", path: "/tmp/ws-fallback" });
+    useWorkspaceStore.setState({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      activeThreadId: "thread-fallback",
+    });
+    window.desktopBridge = {
+      openExternalUrl: mockOpenExternal,
+      preview: {},
+    } as unknown as typeof window.desktopBridge;
+
+    const { container } = render(<MarkdownContent content="[doc](mcode-workspace:///page.html)" />);
+    const link = container.querySelector("a");
+    expect(link).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(link!, { ctrlKey: true });
+    });
+    await waitFor(() => {
+      expect(mockOpenExternal).toHaveBeenCalledWith("mcode-workspace:///page.html", "/tmp/ws-fallback");
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("falls back to openExternalUrl when preview.navigate rejects", async () => {
+    const mockOpenExternal = vi.fn();
+    const nav = vi.fn().mockRejectedValue(new Error("nav failed"));
+    const ws = createMockWorkspace({ id: "ws-rej", path: "/tmp/ws-rej" });
+    useWorkspaceStore.setState({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      activeThreadId: "thread-rej",
+    });
+    window.desktopBridge = {
+      openExternalUrl: mockOpenExternal,
+      preview: { navigate: nav },
+    } as unknown as typeof window.desktopBridge;
+
+    const { container } = render(<MarkdownContent content="[doc](https://example.com/x)" />);
+    const link = container.querySelector("a");
+    expect(link).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(link!, { ctrlKey: true });
+    });
+    await waitFor(() => {
+      expect(mockOpenExternal).toHaveBeenCalledWith("https://example.com/x");
+    });
+  });
 });
 
 describe("MarkdownContent variant styling", () => {

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { MarkdownContent } from "../components/chat/MarkdownContent";
 import { CodeBlock } from "../components/chat/CodeBlock";
+import { useWorkspaceStore } from "../stores/workspaceStore";
+import { createMockWorkspace } from "./mocks/transport";
 
 // Mock CodeBlock to avoid shiki/worker dependencies
 vi.mock("../components/chat/MermaidBlock", () => ({
@@ -83,6 +85,108 @@ describe("MarkdownContent link handling", () => {
     render(<MarkdownContent content="[link](https://example.com)" />);
     fireEvent.click(screen.getByText("link"));
     expect(mockOpen).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
+  });
+});
+
+describe("MarkdownContent workspace preview navigation", () => {
+  let mockNavigate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockNavigate = vi.fn().mockResolvedValue({ ok: true });
+    const ws = createMockWorkspace({ id: "ws-prev", path: "/tmp/ws-preview-test" });
+    useWorkspaceStore.setState({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      activeThreadId: "thread-prev",
+    });
+    window.desktopBridge = {
+      openExternalUrl: vi.fn(),
+      preview: { navigate: mockNavigate },
+    } as unknown as typeof window.desktopBridge;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
+    useWorkspaceStore.setState({
+      workspaces: [],
+      activeWorkspaceId: null,
+      activeThreadId: null,
+    });
+  });
+
+  it("passes workspace path when opening mcode-workspace link with ctrl+click", async () => {
+    const { container } = render(<MarkdownContent content="[doc](mcode-workspace:///sub/page.html)" />);
+    const link = container.querySelector("a");
+    expect(link).toBeTruthy();
+    expect(link).toHaveAttribute("href", "mcode-workspace:///sub/page.html");
+    await act(async () => {
+      fireEvent.click(link!, { ctrlKey: true });
+    });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        "mcode-workspace:///sub/page.html",
+        "/tmp/ws-preview-test",
+      );
+    });
+  });
+
+  it("rewrites relative html link to mcode-workspace for navigation", async () => {
+    const { container } = render(<MarkdownContent content="[doc](./sub/page.html)" />);
+    const link = container.querySelector("a");
+    expect(link).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(link!, { ctrlKey: true });
+    });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        "mcode-workspace:///sub/page.html",
+        "/tmp/ws-preview-test",
+      );
+    });
+  });
+
+  it("opens mcode-workspace in the default browser on plain click", async () => {
+    const mockOpenExternal = vi.fn();
+    const ws = createMockWorkspace({ id: "ws-plain", path: "/proj/plain" });
+    useWorkspaceStore.setState({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      activeThreadId: "thread-plain",
+    });
+    window.desktopBridge = {
+      openExternalUrl: mockOpenExternal,
+      preview: { navigate: vi.fn() },
+    } as unknown as typeof window.desktopBridge;
+
+    const { container } = render(<MarkdownContent content="[doc](mcode-workspace:///page.html)" />);
+    const link = container.querySelector("a");
+    expect(link).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(link!);
+    });
+    expect(mockOpenExternal).toHaveBeenCalledWith("mcode-workspace:///page.html", "/proj/plain");
+
+    useWorkspaceStore.setState({
+      workspaces: [],
+      activeWorkspaceId: null,
+      activeThreadId: null,
+    });
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
+  });
+
+  it("treats inline workspace html path like a previewable shortcut", async () => {
+    const { container } = render(<MarkdownContent content="Open `report.html` now" />);
+    const el = container.querySelector('[role="link"]');
+    expect(el).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(el!, { ctrlKey: true });
+    });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        "mcode-workspace:///report.html",
+        "/tmp/ws-preview-test",
+      );
+    });
   });
 });
 

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -75,15 +75,25 @@ function handleLinkClick(e: React.MouseEvent | React.KeyboardEvent, url: string)
       setRightPanelTab(threadId, "preview");
       // Defer navigation so React can re-render and sync BrowserView bounds
       setTimeout(() => {
-        window.desktopBridge?.preview?.navigate(url, workspacePath).then((r) => {
-          if (!r?.ok) {
-            if (isMcodeWorkspacePreviewUrl(url)) {
-              void window.desktopBridge?.openExternalUrl?.(url, workspacePath ?? undefined);
-            } else {
-              window.desktopBridge?.openExternalUrl?.(url);
-            }
+        const fallback = (): void => {
+          if (isMcodeWorkspacePreviewUrl(url)) {
+            void window.desktopBridge?.openExternalUrl?.(url, workspacePath ?? undefined);
+          } else {
+            window.desktopBridge?.openExternalUrl?.(url);
           }
-        });
+        };
+        const navigatePromise = window.desktopBridge?.preview?.navigate?.(url, workspacePath);
+        if (!navigatePromise) {
+          fallback();
+          return;
+        }
+        void navigatePromise
+          .then((r) => {
+            if (!r?.ok) fallback();
+          })
+          .catch(() => {
+            fallback();
+          });
       }, 0);
       return;
     }

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -1,11 +1,22 @@
 import { memo, useMemo, lazy, Suspense } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import {
+  isMcodeWorkspacePreviewUrl,
+  mcodeWorkspacePreviewHref,
+  looksLikeWorkspaceRelativeFileRef,
+} from "@mcode/contracts";
 import { CodeBlock } from "./CodeBlock";
 import { useDiffStore } from "@/stores/diffStore";
 import { isMac } from "@/lib/platform";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+
+/** Pass through workspace preview URLs; otherwise use react-markdown's default sanitizer. */
+function markdownUrlTransform(value: string): string {
+  const trimmed = value.trim();
+  if (isMcodeWorkspacePreviewUrl(trimmed)) return trimmed;
+  return defaultUrlTransform(value);
+}
 
 /** Props for {@link MarkdownContent}. */
 interface MarkdownContentProps {
@@ -38,12 +49,23 @@ function hasPreview(): boolean {
 }
 
 /**
- * Handles a click on a previewable URL. Opens in the browser preview panel on
- * Ctrl/Cmd+click, otherwise opens externally.
+ * Looks up the on-disk path for the active workspace so the desktop preview
+ * can resolve relative files and `mcode-workspace:` URLs.
+ */
+function getWorkspacePathForPreview(): string | null {
+  const { activeWorkspaceId, workspaces } = useWorkspaceStore.getState();
+  if (!activeWorkspaceId) return null;
+  return workspaces.find((w) => w.id === activeWorkspaceId)?.path ?? null;
+}
+
+/**
+ * Handles a click on a previewable URL. Ctrl/Cmd+click opens in the embedded
+ * preview when available; a normal click opens in the system default browser.
  */
 function handleLinkClick(e: React.MouseEvent | React.KeyboardEvent, url: string): void {
   e.preventDefault();
 
+  const workspacePath = getWorkspacePathForPreview();
   const isModifierClick = e.ctrlKey || e.metaKey;
   if (isModifierClick && hasPreview()) {
     const threadId = useWorkspaceStore.getState().activeThreadId;
@@ -53,27 +75,36 @@ function handleLinkClick(e: React.MouseEvent | React.KeyboardEvent, url: string)
       setRightPanelTab(threadId, "preview");
       // Defer navigation so React can re-render and sync BrowserView bounds
       setTimeout(() => {
-        window.desktopBridge?.preview?.navigate(url).then((r) => {
-          if (!r?.ok) window.desktopBridge?.openExternalUrl?.(url);
+        window.desktopBridge?.preview?.navigate(url, workspacePath).then((r) => {
+          if (!r?.ok) {
+            if (isMcodeWorkspacePreviewUrl(url)) {
+              void window.desktopBridge?.openExternalUrl?.(url, workspacePath ?? undefined);
+            } else {
+              window.desktopBridge?.openExternalUrl?.(url);
+            }
+          }
         });
       }, 0);
       return;
     }
-    // No active thread; fall through to open externally
   }
 
   if (window.desktopBridge?.openExternalUrl) {
-    window.desktopBridge.openExternalUrl(url);
-  } else {
+    if (isMcodeWorkspacePreviewUrl(url)) {
+      void window.desktopBridge.openExternalUrl(url, workspacePath ?? null);
+    } else {
+      void window.desktopBridge.openExternalUrl(url);
+    }
+  } else if (!isMcodeWorkspacePreviewUrl(url)) {
     window.open(url, "_blank", "noopener,noreferrer");
   }
 }
 
 /**
- * Builds the static component overrides that depend on `variant`.
+ * Builds the static component overrides that depend on `variant` and workspace context.
  * Elements whose colors differ between assistant and user bubble are variant-conditional.
  */
-function makeStaticComponents(variant: "assistant" | "user") {
+function makeStaticComponents(variant: "assistant" | "user", workspacePath: string | null) {
   const isUser = variant === "user";
 
   return {
@@ -89,23 +120,33 @@ function makeStaticComponents(variant: "assistant" | "user") {
     a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
       let safeHref: string | undefined;
       if (href) {
-        try {
+        const raw = href.trim();
+        if (isMcodeWorkspacePreviewUrl(raw)) {
+          safeHref = raw;
+        } else if (workspacePath && looksLikeWorkspaceRelativeFileRef(raw)) {
+          safeHref = mcodeWorkspacePreviewHref(raw);
+        } else try {
           const { protocol } = new URL(href);
           if (protocol === "https:" || protocol === "http:" || protocol === "mailto:") {
             safeHref = href;
           }
         } catch {
-          // Invalid URL - safeHref stays undefined
+          /* invalid URL */
         }
       }
       const linkClass = isUser
         ? "text-primary-foreground underline hover:opacity-80"
         : "text-primary underline hover:text-primary";
-      const isPreviewable = safeHref && (safeHref.startsWith("http:") || safeHref.startsWith("https:"));
+      const isPreviewable =
+        !!safeHref &&
+        (safeHref.startsWith("http:") ||
+          safeHref.startsWith("https:") ||
+          isMcodeWorkspacePreviewUrl(safeHref));
       const showHint = isPreviewable && hasPreview();
-      const anchor = (
+      return (
         <a
           href={safeHref}
+          title={showHint ? previewHint : undefined}
           className={linkClass}
           target="_blank"
           rel="noopener noreferrer"
@@ -114,7 +155,7 @@ function makeStaticComponents(variant: "assistant" | "user") {
             if (isPreviewable) return handleLinkClick(e, safeHref);
             e.preventDefault();
             if (window.desktopBridge?.openExternalUrl) {
-              window.desktopBridge.openExternalUrl(safeHref);
+              void window.desktopBridge.openExternalUrl(safeHref);
             } else {
               window.open(safeHref, "_blank", "noopener,noreferrer");
             }
@@ -122,13 +163,6 @@ function makeStaticComponents(variant: "assistant" | "user") {
         >
           {children}
         </a>
-      );
-      if (!showHint) return anchor;
-      return (
-        <Tooltip>
-          <TooltipTrigger render={anchor} />
-          <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
-        </Tooltip>
       );
     },
     blockquote: ({ children }: { children?: React.ReactNode }) => (
@@ -185,13 +219,17 @@ function makeStaticComponents(variant: "assistant" | "user") {
 }
 
 /**
- * Builds the `code` override that depends on `isStreaming` and `variant`.
+ * Builds the `code` override that depends on `isStreaming`, `variant`, and workspace path.
  * Only recreated when those props change; static overrides are reused.
  */
-function makeComponents(isStreaming: boolean, variant: "assistant" | "user") {
+function makeComponents(
+  isStreaming: boolean,
+  variant: "assistant" | "user",
+  workspacePath: string | null,
+) {
   const isUser = variant === "user";
   return {
-    ...makeStaticComponents(variant),
+    ...makeStaticComponents(variant, workspacePath),
     code: ({ children, className }: { children?: React.ReactNode; className?: string }) => {
       // Detect inline vs block code. In react-markdown's HAST, fenced code
       // blocks are wrapped in a <pre> parent (even without a language tag).
@@ -212,10 +250,11 @@ function makeComponents(isStreaming: boolean, variant: "assistant" | "user") {
           const linkClass = isUser
             ? "text-primary-foreground underline decoration-dotted hover:opacity-80 cursor-pointer"
             : "text-primary underline decoration-dotted hover:text-primary cursor-pointer";
-          const codeLink = (
+          return (
             <code
               role="link"
               tabIndex={0}
+              title={hasPreview() ? previewHint : undefined}
               className={`${codeClass} ${linkClass}`}
               onClick={(e) => handleLinkClick(e, text)}
               onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e, text); }}
@@ -223,12 +262,24 @@ function makeComponents(isStreaming: boolean, variant: "assistant" | "user") {
               {children}
             </code>
           );
-          if (!hasPreview()) return codeLink;
+        }
+
+        if (workspacePath && looksLikeWorkspaceRelativeFileRef(text)) {
+          const previewUrl = mcodeWorkspacePreviewHref(text);
+          const linkClass = isUser
+            ? "text-primary-foreground underline decoration-dotted hover:opacity-80 cursor-pointer"
+            : "text-primary underline decoration-dotted hover:text-primary cursor-pointer";
           return (
-            <Tooltip>
-              <TooltipTrigger render={codeLink} />
-              <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
-            </Tooltip>
+            <code
+              role="link"
+              tabIndex={0}
+              title={hasPreview() ? previewHint : undefined}
+              className={`${codeClass} ${linkClass}`}
+              onClick={(e) => handleLinkClick(e, previewUrl)}
+              onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e, previewUrl); }}
+            >
+              {children}
+            </code>
           );
         }
 
@@ -272,10 +323,19 @@ export const MarkdownContent = memo(function MarkdownContent({
   isStreaming = false,
   variant = "assistant",
 }: MarkdownContentProps) {
-  const components = useMemo(() => makeComponents(isStreaming, variant), [isStreaming, variant]);
+  const workspacePath = useWorkspaceStore((s) => {
+    const id = s.activeWorkspaceId;
+    if (!id) return null;
+    return s.workspaces.find((w) => w.id === id)?.path ?? null;
+  });
+
+  const components = useMemo(
+    () => makeComponents(isStreaming, variant, workspacePath),
+    [isStreaming, variant, workspacePath],
+  );
 
   return (
-    <ReactMarkdown remarkPlugins={plugins} components={components}>
+    <ReactMarkdown remarkPlugins={plugins} components={components} urlTransform={markdownUrlTransform}>
       {content}
     </ReactMarkdown>
   );

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -149,7 +149,7 @@ interface DesktopBridge {
   /** Open the OS file explorer at the given directory. */
   openInExplorer(dirPath: string): Promise<void>;
   /** Open a URL in the default browser. */
-  openExternalUrl(url: string): Promise<void>;
+  openExternalUrl(url: string, workspacePath?: string | null): Promise<void>;
   /** Return a list of detected editor names on the system. */
   detectEditors(): Promise<string[]>;
   /** Read an image from the system clipboard. Returns metadata or null. */

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -31,6 +31,14 @@ export type { AttachmentMeta, StoredAttachment } from "./models/attachment.js";
 export { WorkspaceSchema, WorkspaceEnrichmentSchema } from "./models/workspace.js";
 export type { Workspace, WorkspaceEnrichment } from "./models/workspace.js";
 
+export {
+  MCODE_WORKSPACE_PREVIEW_PROTOCOL,
+  isMcodeWorkspacePreviewUrl,
+  mcodeWorkspacePreviewHref,
+  markdownWorkspaceRefToPreviewPath,
+  looksLikeWorkspaceRelativeFileRef,
+} from "./models/workspace-preview-uri.js";
+
 export { ThreadSchema, RecentThreadSchema } from "./models/thread.js";
 export type { Thread, RecentThread } from "./models/thread.js";
 

--- a/packages/contracts/src/models/__tests__/workspace-preview-uri.test.ts
+++ b/packages/contracts/src/models/__tests__/workspace-preview-uri.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import {
+  isMcodeWorkspacePreviewUrl,
+  mcodeWorkspacePreviewHref,
+  markdownWorkspaceRefToPreviewPath,
+  looksLikeWorkspaceRelativeFileRef,
+} from "../workspace-preview-uri.js";
+
+describe("workspace preview URI helpers", () => {
+  it("detects mcode-workspace URLs case-insensitively on prefix", () => {
+    expect(isMcodeWorkspacePreviewUrl("mcode-workspace:///a.html")).toBe(true);
+    expect(isMcodeWorkspacePreviewUrl("  MCODE-WORKSPACE:///x  ")).toBe(true);
+    expect(isMcodeWorkspacePreviewUrl("https://x")).toBe(false);
+  });
+
+  it("builds mcode-workspace hrefs with encoded path segments", () => {
+    expect(mcodeWorkspacePreviewHref("sub/page.html")).toBe(
+      "mcode-workspace:///sub/page.html",
+    );
+    expect(mcodeWorkspacePreviewHref("./sub/a b.html")).toBe(
+      "mcode-workspace:///sub/a%20b.html",
+    );
+  });
+
+  it("markdownWorkspaceRefToPreviewPath strips absolute markers and drive paths", () => {
+    expect(markdownWorkspaceRefToPreviewPath("/docs/x.html")).toBe("docs/x.html");
+    expect(markdownWorkspaceRefToPreviewPath("C:/x.html")).toBe("");
+    expect(markdownWorkspaceRefToPreviewPath("~/x.html")).toBe("");
+  });
+
+  it("looksLikeWorkspaceRelativeFileRef accepts common agent emittable shapes", () => {
+    expect(looksLikeWorkspaceRelativeFileRef("report.html")).toBe(true);
+    expect(looksLikeWorkspaceRelativeFileRef("src/index.html")).toBe(true);
+    expect(looksLikeWorkspaceRelativeFileRef("./preview.svg")).toBe(true);
+    expect(looksLikeWorkspaceRelativeFileRef("example.com")).toBe(false);
+    expect(looksLikeWorkspaceRelativeFileRef("https://a/b.html")).toBe(false);
+  });
+});

--- a/packages/contracts/src/models/__tests__/workspace-preview-uri.test.ts
+++ b/packages/contracts/src/models/__tests__/workspace-preview-uri.test.ts
@@ -35,4 +35,8 @@ describe("workspace preview URI helpers", () => {
     expect(looksLikeWorkspaceRelativeFileRef("example.com")).toBe(false);
     expect(looksLikeWorkspaceRelativeFileRef("https://a/b.html")).toBe(false);
   });
+
+  it("looksLikeWorkspaceRelativeFileRef rejects domain-like hosts with a path", () => {
+    expect(looksLikeWorkspaceRelativeFileRef("example.com/page.html")).toBe(false);
+  });
 });

--- a/packages/contracts/src/models/workspace-preview-uri.ts
+++ b/packages/contracts/src/models/workspace-preview-uri.ts
@@ -45,8 +45,10 @@ export function looksLikeWorkspaceRelativeFileRef(text: string): boolean {
   if (!WORKSPACE_MARKDOWN_PREVIEW_EXT_RE.test(t)) return false;
   if (t.startsWith("/")) return true;
   if (t.startsWith("./") || t.startsWith("../")) return true;
-  if (t.includes("/") || t.includes("\\")) return true;
   const firstSeg = t.split(/[/\\]/)[0] ?? "";
+  const looksDomainLike = /^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$/.test(firstSeg);
+  if ((t.includes("/") || t.includes("\\")) && looksDomainLike) return false;
+  if (t.includes("/") || t.includes("\\")) return true;
   if (!firstSeg.includes(".")) return false;
   return WORKSPACE_MARKDOWN_PREVIEW_EXT_RE.test(firstSeg);
 }

--- a/packages/contracts/src/models/workspace-preview-uri.ts
+++ b/packages/contracts/src/models/workspace-preview-uri.ts
@@ -1,0 +1,52 @@
+/**
+ * Virtual URL scheme for workspace-relative preview targets. Electron resolves these
+ * with the active workspace root before loading `file:` URLs in the embedded BrowserView.
+ */
+export const MCODE_WORKSPACE_PREVIEW_PROTOCOL = "mcode-workspace:";
+
+/** File extensions surfaced as Markdown preview shortcuts (links and inline code). */
+const WORKSPACE_MARKDOWN_PREVIEW_EXT_RE = /\.(html?|svg)$/i;
+
+/**
+ * Returns true when `url` uses the mcode-workspace preview scheme.
+ */
+export function isMcodeWorkspacePreviewUrl(url: string): boolean {
+  return url.trim().toLowerCase().startsWith(MCODE_WORKSPACE_PREVIEW_PROTOCOL);
+}
+
+/**
+ * Builds an `mcode-workspace:` URL for a path relative to the workspace root. Slashes may be `/` or `\\`.
+ */
+export function mcodeWorkspacePreviewHref(relativePosixPath: string): string {
+  const rel = markdownWorkspaceRefToPreviewPath(relativePosixPath);
+  if (!rel) return `${MCODE_WORKSPACE_PREVIEW_PROTOCOL}///`;
+  const segments = rel.split("/").map((seg) => encodeURIComponent(seg));
+  return `${MCODE_WORKSPACE_PREVIEW_PROTOCOL}///${segments.join("/")}`;
+}
+
+/**
+ * Strips leading `./`, `../` segments are kept; removes leading slashes so resolution stays workspace-relative.
+ */
+export function markdownWorkspaceRefToPreviewPath(href: string): string {
+  let h = href.trim().replace(/\\/g, "/");
+  if (/^[A-Za-z]:\//.test(h) || h.startsWith("~")) return "";
+  while (h.startsWith("/")) h = h.slice(1);
+  if (h.startsWith("./")) h = h.slice(2);
+  return h;
+}
+
+/**
+ * True when `text` looks like a workspace-relative previewable path in Markdown (inline code or link `href`).
+ */
+export function looksLikeWorkspaceRelativeFileRef(text: string): boolean {
+  const t = text.trim();
+  if (!t || t.includes("://")) return false;
+  if (/^[A-Za-z]:[/\\]/.test(t) || t.startsWith("~")) return false;
+  if (!WORKSPACE_MARKDOWN_PREVIEW_EXT_RE.test(t)) return false;
+  if (t.startsWith("/")) return true;
+  if (t.startsWith("./") || t.startsWith("../")) return true;
+  if (t.includes("/") || t.includes("\\")) return true;
+  const firstSeg = t.split(/[/\\]/)[0] ?? "";
+  if (!firstSeg.includes(".")) return false;
+  return WORKSPACE_MARKDOWN_PREVIEW_EXT_RE.test(firstSeg);
+}


### PR DESCRIPTION
## What

This change introduces virtual `mcode-workspace:` URLs in chat markdown. Workspace-relative HTML and SVG references can open in the embedded preview when the user uses a modifier click, and in the system default browser on a plain click.

## Why

Agents often point at local HTML output. Users should preview those files inside Mcode without leaking absolute paths into rendered markdown, and still be able to open the same file externally when they want the full browser chrome.

## Key Changes

- **Contracts:** shared helpers to build, detect, and normalize `mcode-workspace` preview URLs and workspace-relative file refs.
- **Desktop:** resolve `mcode-workspace` for embedded preview navigation and for `shell.openExternal`, using the thread workspace root supplied over IPC.
- **Web:** custom markdown URL transform allowlists the virtual protocol (react-markdown was stripping it), wires Ctrl/Cmd+click to `preview.navigate`, and plain click to `openExternalUrl` with workspace context.
- **Tests:** `workspace-preview-uri`, `MarkdownContent`, and `preview-browser` unit specs cover the new behavior.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace preview support with a new workspace-relative preview URL scheme and desktop preview handling.
  * Markdown link handling now recognizes workspace-relative references, offering richer preview/navigation and correct external-open behavior.

* **Bug Fixes**
  * Improved validation and rejection of malformed or unsafe workspace-preview links to prevent incorrect navigation.

* **Tests**
  * Added unit and integration tests covering workspace-preview URL handling and Markdown preview/navigation behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->