### PR TITLE
feat(chat): attachment previews that shine on web and desktop

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -120,6 +120,9 @@ function scheduleServerBundleRebuild() {
 
 let viteProcess = null;
 
+/** True while `cleanup()` is tearing children down so Vite exit is not treated as a crash. */
+let devSessionShuttingDown = false;
+
 /**
  * Start the Vite dev server. Returns a promise that resolves with the
  * actual URL once Vite prints its "Local:" line (checks both stdout and
@@ -127,15 +130,15 @@ let viteProcess = null;
  */
 function startViteDevServer() {
   return new Promise((resolveUrl) => {
-    let resolved = false;
+    let bootstrapResolved = false;
 
     function tryParseUrl(text) {
-      if (resolved) return;
+      if (bootstrapResolved) return;
       // Strip ANSI escape codes - Vite injects bold/color mid-token
       const clean = text.replace(/\x1b\[[0-9;]*m/g, "");
       const match = clean.match(/Local:\s+(https?:\/\/\S+)/);
       if (match) {
-        resolved = true;
+        bootstrapResolved = true;
         resolveUrl(match[1].replace(/\/+$/, ""));
       }
     }
@@ -159,12 +162,21 @@ function startViteDevServer() {
     });
 
     viteProcess.on("exit", (code) => {
-      if (!resolved) {
-        resolved = true;
+      if (!bootstrapResolved) {
+        bootstrapResolved = true;
         resolveUrl(null);
       }
-      if (viteProcess) {
-        console.error(`[web] Vite dev server exited with code ${code}`);
+      console.error(`[web] Vite dev server exited with code ${code}`);
+
+      if (devSessionShuttingDown) return;
+
+      if (electronProcess) {
+        console.error(
+          "[dev] The renderer loads modules from Vite; with the dev server gone the window " +
+            "will show ERR_CONNECTION_REFUSED and failed dynamic imports. Stopping Electron.",
+        );
+        cleanup();
+        process.exit(code ?? 1);
       }
     });
   });
@@ -283,6 +295,7 @@ watch(serverOutFile, () => scheduleElectronRestart("server bundle updated"));
 
 /** Stop all child processes and esbuild watchers. */
 function cleanup() {
+  devSessionShuttingDown = true;
   if (debounceTimer) clearTimeout(debounceTimer);
   if (serverBundleRebuildTimer) {
     clearTimeout(serverBundleRebuildTimer);

--- a/apps/server/src/services/attachment-service.ts
+++ b/apps/server/src/services/attachment-service.ts
@@ -14,6 +14,7 @@ import {
   isVirtualBrowserContextAttachment,
   MCODE_BROWSER_CONTEXT_ATTACHMENT_MIME,
   shouldPersistAttachmentWithoutFile,
+  storedAttachmentSuffix,
 } from "@mcode/contracts";
 
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
@@ -48,26 +49,6 @@ export function getMaxSizeForMime(mimeType: string): number {
     return MAX_DOCUMENT_SIZE;
   }
   return MAX_IMAGE_SIZE; // conservative fallback
-}
-
-function mimeToExt(mimeType: string): string {
-  const map: Record<string, string> = {
-    "image/jpeg": ".jpg",
-    "image/png": ".png",
-    "image/gif": ".gif",
-    "image/webp": ".webp",
-    "application/pdf": ".pdf",
-    "text/plain": ".txt",
-    "application/rtf": ".rtf",
-    "text/rtf": ".rtf",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
-    "application/vnd.oasis.opendocument.text": ".odt",
-    "application/vnd.oasis.opendocument.spreadsheet": ".ods",
-    "application/vnd.oasis.opendocument.presentation": ".odp",
-  };
-  return map[mimeType] ?? "";
 }
 
 /** Resolve the base directory for attachment storage. */
@@ -135,7 +116,7 @@ export class AttachmentService {
           );
         }
 
-        const ext = mimeToExt(att.mimeType);
+        const ext = storedAttachmentSuffix(att.mimeType);
         const destPath = resolve(baseDir, `${att.id}${ext}`);
 
         // Verify destination stays within the thread attachment directory

--- a/apps/server/src/transport/ws-server.ts
+++ b/apps/server/src/transport/ws-server.ts
@@ -14,12 +14,38 @@ import { addClient, removeClient } from "./push";
 import { handleBinaryUpload } from "./binary-upload";
 import { timingSafeEqual } from "crypto";
 import { extractToken, buildAuthCookie } from "./auth";
+import { createReadStream, existsSync } from "fs";
+import { join } from "path";
+import { getMcodeDir } from "@mcode/shared";
 
 /** Constant-time string comparison to prevent timing attacks on token validation. */
 function safeTokenEqual(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
   return timingSafeEqual(Buffer.from(a), Buffer.from(b));
 }
+
+/** Match stored thread IDs used for the custom attachment protocol (UUID, lowercase hex). */
+const ATTACHMENT_THREAD_SEGMENT = /^[a-f0-9-]+$/;
+/** Filename is `{attachmentUuid}.{ext}` under the thread directory. */
+const ATTACHMENT_FILE_SEGMENT = /^[a-f0-9-]+\.\w+$/;
+
+/** Extension to MIME for persisted attachment files (aligned with desktop shell protocol). */
+const ATTACHMENT_EXT_MIME: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  pdf: "application/pdf",
+  txt: "text/plain",
+  rtf: "application/rtf",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  odt: "application/vnd.oasis.opendocument.text",
+  ods: "application/vnd.oasis.opendocument.spreadsheet",
+  odp: "application/vnd.oasis.opendocument.presentation",
+};
 
 /** Create and configure the HTTP + WebSocket server. */
 export function createWsServer(deps: RouterDeps & { authToken: string }): {
@@ -56,6 +82,54 @@ export function createWsServer(deps: RouterDeps & { authToken: string }): {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ status: "shutting_down" }));
       process.kill(process.pid, "SIGTERM");
+      return;
+    }
+
+    if (req.method === "GET" && req.url?.startsWith("/attachments/")) {
+      const attachmentToken = extractToken(req);
+      if (!attachmentToken || !safeTokenEqual(attachmentToken, deps.authToken)) {
+        res.writeHead(401);
+        res.end("Unauthorized");
+        return;
+      }
+
+      const parsedUrl = new URL(req.url, "http://localhost");
+      const segments = parsedUrl.pathname.split("/").filter(Boolean);
+      if (segments.length !== 3 || segments[0] !== "attachments") {
+        res.writeHead(404);
+        res.end("Not found");
+        return;
+      }
+
+      const threadId = segments[1]!;
+      const filename = segments[2]!;
+      if (!ATTACHMENT_THREAD_SEGMENT.test(threadId) || !ATTACHMENT_FILE_SEGMENT.test(filename)) {
+        res.writeHead(400);
+        res.end("Invalid path");
+        return;
+      }
+
+      const filePath = join(getMcodeDir(), "attachments", threadId, filename);
+      if (!existsSync(filePath)) {
+        res.writeHead(404);
+        res.end("Not found");
+        return;
+      }
+
+      const ext = filename.split(".").pop() ?? "";
+      const stream = createReadStream(filePath);
+      stream.on("error", () => {
+        if (!res.headersSent) {
+          res.writeHead(404);
+        }
+        res.end();
+      });
+      res.writeHead(200, {
+        "Content-Type": ATTACHMENT_EXT_MIME[ext] ?? "application/octet-stream",
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "Content-Security-Policy": "default-src 'none'",
+      });
+      stream.pipe(res);
       return;
     }
 

--- a/apps/web/e2e/image-attachment-lightbox.spec.ts
+++ b/apps/web/e2e/image-attachment-lightbox.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect } from "@playwright/test";
+import type { Thread } from "@mcode/contracts";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+import { getDefaultSettings } from "@mcode/contracts";
+
+/** 1×1 PNG so `<img>` loads; otherwise thumbnails use the inert error fallback in E2E (no real HTTP server on the WS port). */
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const E2E_WS_FOR_ATTACHMENTS = "ws://localhost:19400";
+
+const MOCK_SETTINGS = getDefaultSettings();
+const THREAD_ID = "thread-e2e-attachment-lightbox";
+
+const FAKE_WORKSPACE = {
+  id: "ws-attachment-lb",
+  name: "Attachment Lightbox",
+  path: "/tmp/attachment-lb",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
+};
+
+const FAKE_THREAD: Thread = {
+  id: THREAD_ID,
+  workspace_id: "ws-attachment-lb",
+  title: "Images",
+  status: "active" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: null,
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+function makeMessageWithImages() {
+  return {
+    id: "msg-user-images",
+    thread_id: THREAD_ID,
+    role: "user" as const,
+    content: "",
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: new Date().toISOString(),
+    sequence: 1,
+    attachments: [
+      { id: "att-png", name: "shot.png", mimeType: "image/png", sizeBytes: 120 },
+      { id: "att-jpg", name: "photo.jpg", mimeType: "image/jpeg", sizeBytes: 240 },
+    ],
+  };
+}
+
+/**
+ * Activate a thread and inject messages after `loadMessages` finishes, matching
+ * {@link session-restart-divider.spec.ts}.
+ */
+async function activateThreadAndInjectMessages(
+  page: import("@playwright/test").Page,
+  messages: ReturnType<typeof makeMessageWithImages>[],
+): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread, threadId }) => {
+      const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const wsStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) return;
+      (wsStore as { setState: (p: unknown) => void }).setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: [thread],
+        activeThreadId: threadId,
+      });
+    },
+    { workspace: FAKE_WORKSPACE, thread: FAKE_THREAD, threadId: THREAD_ID },
+  );
+
+  await page.waitForFunction(
+    () => {
+      const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const threadStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "messages" in st && "loadMessages" in st;
+      });
+      if (!threadStore) return false;
+      const state = (threadStore as { getState: () => { currentThreadId: string | null; loading: boolean } }).getState();
+      return state.currentThreadId !== null && state.loading === false;
+    },
+    { timeout: 8000 },
+  );
+
+  await page.evaluate(
+    ({ messages: msgs, wsUrl }) => {
+      (
+        window as unknown as { __mcodeE2EAttachmentTransportWsUrl?: string }
+      ).__mcodeE2EAttachmentTransportWsUrl = wsUrl;
+
+      const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const threadStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "messages" in st && "loadMessages" in st;
+      });
+      if (!threadStore) return;
+      (threadStore as { setState: (p: unknown) => void }).setState({
+        messages: msgs,
+        loading: false,
+        error: null,
+      });
+    },
+    { messages, wsUrl: E2E_WS_FOR_ATTACHMENTS },
+  );
+}
+
+test.describe("Image attachment lightbox", () => {
+  test.setTimeout(60_000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.route(
+      /http:\/\/(localhost|127\.0\.0\.1):\d{5}\/attachments\/.+/,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "image/png",
+          body: TINY_PNG,
+        });
+      },
+    );
+
+    await mockWebSocketServer(page, { "settings.get": MOCK_SETTINGS });
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+
+    await page.evaluate((wsUrl) => {
+      (
+        window as unknown as { __mcodeE2EAttachmentTransportWsUrl?: string }
+      ).__mcodeE2EAttachmentTransportWsUrl = wsUrl;
+    }, E2E_WS_FOR_ATTACHMENTS);
+  });
+
+  test("opens carousel lightbox from transcript thumbnails", async ({ page }) => {
+    await activateThreadAndInjectMessages(page, [makeMessageWithImages()]);
+
+    await page.getByRole("button", { name: "Preview image shot.png" }).click();
+
+    const stage = page.getByTestId("image-attachment-lightbox");
+    await expect(stage).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("button", { name: "Next image" })).toBeVisible();
+
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByRole("button", { name: "Previous image" })).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(stage).toBeHidden();
+  });
+});

--- a/apps/web/src/__tests__/MessageBubble.test.tsx
+++ b/apps/web/src/__tests__/MessageBubble.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Message, StoredAttachment } from "@/transport";
 import { MessageBubble } from "../components/chat/MessageBubble";
 
 // Mock MarkdownContent to detect when it's used
@@ -13,17 +15,42 @@ vi.mock("../components/chat/MarkdownContent", () => ({
   ),
 }));
 
-const makeMessage = (content: string) => ({
-  id: "msg-1",
-  thread_id: "thread-1",
-  role: "user" as const,
-  content,
-  timestamp: new Date().toISOString(),
-  attachments: [],
-  cost_usd: null,
-  tokens_used: null,
-  sequence: 1,
-});
+vi.mock("../components/chat/ImageAttachmentLightbox", () => ({
+  ImageAttachmentLightbox: ({
+    open,
+    items,
+    initialIndex = 0,
+  }: {
+    open: boolean;
+    items: { src: string; title: string }[];
+    initialIndex?: number;
+  }) =>
+    open ? (
+      <div
+        data-testid="mock-lightbox"
+        data-slide-count={String(items.length)}
+        data-initial-index={String(initialIndex)}
+        data-active-src={items[initialIndex]?.src ?? ""}
+        data-active-title={items[initialIndex]?.title ?? ""}
+      />
+    ) : null,
+}));
+
+function makeMessage(content: string): Message {
+  return {
+    id: "msg-1",
+    thread_id: "thread-1",
+    role: "user",
+    content,
+    timestamp: new Date().toISOString(),
+    attachments: [] as StoredAttachment[],
+    cost_usd: null,
+    tokens_used: null,
+    sequence: 1,
+    tool_calls: null,
+    files_changed: null,
+  };
+}
 
 describe("MessageBubble user messages", () => {
   it("renders user message through MarkdownContent with variant='user'", async () => {
@@ -46,19 +73,84 @@ describe("MessageBubble user messages", () => {
       expect(plainP).not.toBeInTheDocument();
     });
   });
+
+  it("opens image preview when user activates an image attachment control", async () => {
+    const user = userEvent.setup();
+    const threadUuid = "550e8400-e29b-41d4-a716-446655440000";
+    const message: Message = {
+      ...makeMessage(""),
+      thread_id: threadUuid,
+      attachments: [
+        {
+          id: "a1",
+          name: "shot.png",
+          mimeType: "image/png",
+          sizeBytes: 128,
+        },
+      ],
+    };
+    const { container } = render(<MessageBubble message={message} />);
+    const btn = container.querySelector('[aria-label="Preview image shot.png"]');
+    expect(btn).toBeTruthy();
+    await user.click(btn!);
+    const lb = container.querySelector("[data-testid='mock-lightbox']");
+    expect(lb).toBeTruthy();
+    expect(lb?.getAttribute("data-slide-count")).toBe("1");
+    expect(lb?.getAttribute("data-initial-index")).toBe("0");
+    expect(lb?.getAttribute("data-active-src")).toBe(
+      `mcode-attachment://${threadUuid}/a1.png`,
+    );
+    expect(lb?.getAttribute("data-active-title")).toBe("shot.png");
+  });
+
+  it("passes full slide tray and clicked index when several images attach", async () => {
+    const user = userEvent.setup();
+    const threadUuid = "550e8400-e29b-41d4-a716-446655440000";
+    const message: Message = {
+      ...makeMessage(""),
+      thread_id: threadUuid,
+      attachments: [
+        {
+          id: "a1",
+          name: "one.png",
+          mimeType: "image/png",
+          sizeBytes: 1,
+        },
+        {
+          id: "a2",
+          name: "two.png",
+          mimeType: "image/png",
+          sizeBytes: 1,
+        },
+      ],
+    };
+    const { container } = render(<MessageBubble message={message} />);
+    const btn = container.querySelector('[aria-label="Preview image two.png"]');
+    expect(btn).toBeTruthy();
+    await user.click(btn!);
+    const lb = container.querySelector("[data-testid='mock-lightbox']");
+    expect(lb?.getAttribute("data-slide-count")).toBe("2");
+    expect(lb?.getAttribute("data-initial-index")).toBe("1");
+    expect(lb?.getAttribute("data-active-src")).toBe(
+      `mcode-attachment://${threadUuid}/a2.png`,
+    );
+    expect(lb?.getAttribute("data-active-title")).toBe("two.png");
+  });
 });
 
 describe("MessageBubble assistant plan-questions suppression", () => {
-  const makeAssistantMessage = (content: string) => ({
+  const makeAssistantMessage = (content: string): Message => ({
     id: "msg-asst",
     thread_id: "thread-1",
-    role: "assistant" as const,
+    role: "assistant",
     content,
     timestamp: new Date().toISOString(),
-    attachments: [],
+    attachments: [] as StoredAttachment[],
     cost_usd: null,
     tokens_used: null,
     sequence: 2,
+    tool_calls: null,
+    files_changed: null,
   });
 
   it("renders nothing when the assistant body is exclusively a plan-questions block", () => {

--- a/apps/web/src/components/chat/AttachmentPreview.tsx
+++ b/apps/web/src/components/chat/AttachmentPreview.tsx
@@ -1,7 +1,11 @@
-import { X, FileText, File } from "lucide-react";
+import { FileText, X } from "lucide-react";
+import { useMemo, useState } from "react";
 import type { McodeBrowserCapture } from "@mcode/contracts";
 import { isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import { cn } from "@/lib/utils";
+
+import { FileAttachmentTile } from "./FileAttachmentTile";
+import { ImageAttachmentLightbox } from "./ImageAttachmentLightbox";
 
 /** Represents a user-selected file staged on the composer before send (preview URL may be an object URL). */
 export interface PendingAttachment {
@@ -20,12 +24,6 @@ export interface PendingAttachment {
 interface AttachmentPreviewProps {
   attachments: PendingAttachment[];
   onRemove: (id: string) => void;
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 /** Spill file hints for v2 preview captures (Mcode app data dir, not the project). */
@@ -50,48 +48,101 @@ function getBrowserCaptureSpillHints(capture: McodeBrowserCapture | undefined): 
 
 /** Horizontal strip of pending attachment thumbnails or file tiles with per-item remove actions. */
 export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewProps) {
+  const previewableImages = useMemo(
+    () => attachments.filter((a) => a.mimeType.startsWith("image/") && !!a.previewUrl),
+    [attachments],
+  );
+
+  const [imagePreview, setImagePreview] = useState<{
+    items: { src: string; title: string }[];
+    initialIndex: number;
+  } | null>(null);
+
   if (attachments.length === 0) return null;
 
-  return (
-    <div className="flex gap-2 overflow-x-auto px-3 py-2">
-      {attachments.map((att) => {
-        // Image tiles need a blob preview URL. Attachments rehydrated from
-        // disk-side metadata (e.g. restored from the message queue) have no
-        // blob URL, so they fall through to the generic file tile instead of
-        // rendering a broken <img>.
-        const isImage = att.mimeType.startsWith("image/") && !!att.previewUrl;
-        const isPdf = att.mimeType === "application/pdf";
-        const isContextOnly =
-          att.contextOnly === true || isVirtualBrowserContextAttachment(att.mimeType);
-        const spill = getBrowserCaptureSpillHints(att.browserCapture);
-        const isOfficeDoc =
-          att.mimeType.includes("officedocument") ||
-          att.mimeType.includes("opendocument") ||
-          att.mimeType === "application/rtf" ||
-          att.mimeType === "text/rtf";
+  const removeButton = (name: string, id: string) => (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onRemove(id);
+      }}
+      className={cn(
+        "absolute right-1 top-1 z-20 flex items-center justify-center",
+        "h-5 w-5 rounded-full",
+        "bg-foreground/75 text-background",
+        "opacity-0 transition-all duration-150",
+        "hover:bg-destructive hover:text-white",
+        "group-hover:opacity-100",
+        "focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-primary",
+      )}
+      aria-label={`Remove ${name}`}
+    >
+      <X size={12} strokeWidth={2.5} />
+    </button>
+  );
 
-        return (
-          <div
-            key={att.id}
-            className={cn(
-              "group relative flex-shrink-0 overflow-hidden rounded-lg",
-              "border border-border/60 bg-muted/60",
-              "transition-all duration-150 hover:border-primary/40 hover:bg-muted/80",
-            )}
-            title={spill?.title}
-          >
-            {isContextOnly ? (
-              <div className="flex h-[72px] w-[140px] flex-col justify-center gap-0.5 px-3 py-1">
-                <div className="flex min-h-0 items-center gap-2">
-                  <FileText size={18} className="shrink-0 text-cyan-500 dark:text-cyan-400" />
-                  <span className="truncate text-xs font-medium text-foreground">Page context</span>
+  return (
+    <>
+      <div className="flex gap-2 overflow-x-auto px-3 py-2">
+        {attachments.map((att) => {
+          // Image tiles need a blob preview URL. Attachments rehydrated from
+          // disk-side metadata (e.g. restored from the message queue) have no
+          // blob URL, so they fall through to the generic file tile instead of
+          // rendering a broken <img>.
+          const isImage = att.mimeType.startsWith("image/") && !!att.previewUrl;
+          const isContextOnly =
+            att.contextOnly === true || isVirtualBrowserContextAttachment(att.mimeType);
+          const spill = getBrowserCaptureSpillHints(att.browserCapture);
+
+          if (isContextOnly) {
+            return (
+              <div
+                key={att.id}
+                className={cn(
+                  "group relative flex-shrink-0 overflow-hidden rounded-lg border border-border/60 bg-muted/60 transition-all duration-150",
+                  "hover:border-primary/40 hover:bg-muted/80",
+                )}
+                title={spill?.title}
+              >
+                <div className="flex h-[72px] w-[140px] flex-col justify-center gap-0.5 px-3 py-1">
+                  <div className="flex min-h-0 items-center gap-2">
+                    <FileText size={18} className="shrink-0 text-cyan-500 dark:text-cyan-400" />
+                    <span className="truncate text-xs font-medium text-foreground">Page context</span>
+                  </div>
+                  <span className="block max-w-[120px] truncate pl-[26px] text-[10px] leading-tight text-muted-foreground">
+                    {spill ? spill.line : "No image"}
+                  </span>
+                  {removeButton(att.name, att.id)}
                 </div>
-                <span className="block max-w-[120px] truncate pl-[26px] text-[10px] leading-tight text-muted-foreground">
-                  {spill ? spill.line : "No image"}
-                </span>
               </div>
-            ) : isImage ? (
-              <div className="relative h-[72px] w-[72px]">
+            );
+          }
+
+          if (isImage) {
+            const slideIndex = previewableImages.findIndex((x) => x.id === att.id);
+            return (
+              <button
+                key={att.id}
+                type="button"
+                className={cn(
+                  "group relative flex h-[72px] w-[72px] flex-shrink-0 cursor-pointer overflow-hidden rounded-lg border p-0 text-left outline-none",
+                  "border-border/60 bg-muted/60 transition-[border-color,background-color,filter]",
+                  "hover:border-primary/45 hover:bg-muted/80 hover:brightness-[1.04]",
+                  "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                )}
+                title={spill?.title}
+                aria-label={`Preview image ${att.name}`}
+                onClick={() =>
+                  setImagePreview({
+                    items: previewableImages.map((a) => ({
+                      src: a.previewUrl,
+                      title: a.name,
+                    })),
+                    initialIndex: slideIndex >= 0 ? slideIndex : 0,
+                  })
+                }
+              >
                 {spill ? (
                   <span
                     className="absolute bottom-0.5 left-0.5 right-0.5 z-10 truncate rounded bg-background/85 px-0.5 text-center text-[8px] font-medium text-foreground/90 shadow-sm"
@@ -104,50 +155,41 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                   src={att.previewUrl}
                   alt={att.name}
                   className="h-full w-full object-cover"
+                  draggable={false}
                 />
-                {/* Subtle gradient overlay so the X button is always readable */}
-                <div className="absolute inset-0 bg-gradient-to-br from-black/30 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
-              </div>
-            ) : (
-              <div className="flex h-[72px] w-[140px] flex-col justify-center gap-1 px-3">
-                <div className="flex items-center gap-2">
-                  {isPdf ? (
-                    <FileText size={18} className="shrink-0 text-red-600 dark:text-red-400" />
-                  ) : isOfficeDoc ? (
-                    <FileText size={18} className="shrink-0 text-blue-600 dark:text-blue-400" />
-                  ) : (
-                    <File size={18} className="shrink-0 text-muted-foreground" />
-                  )}
-                  <span className="truncate text-xs font-medium text-foreground">
-                    {att.name}
-                  </span>
-                </div>
-                <span className="pl-[26px] text-[10px] text-muted-foreground">
-                  {formatSize(att.sizeBytes)}
-                </span>
-              </div>
-            )}
+                <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/25 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
+                {removeButton(att.name, att.id)}
+              </button>
+            );
+          }
 
-            {/* Always-visible remove button with clear contrast */}
-            <button
-              type="button"
-              onClick={() => onRemove(att.id)}
+          return (
+            <div
+              key={att.id}
               className={cn(
-                "absolute right-1 top-1 flex items-center justify-center",
-                "h-5 w-5 rounded-full",
-                "bg-foreground/75 text-background",
-                "opacity-0 transition-all duration-150",
-                "hover:bg-destructive hover:text-white",
-                "group-hover:opacity-100",
-                "focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-primary",
+                "group relative flex-shrink-0 overflow-hidden rounded-lg transition-all duration-150",
+                "border border-transparent hover:border-primary/40 hover:bg-muted/50",
               )}
-              aria-label={`Remove ${att.name}`}
             >
-              <X size={12} strokeWidth={2.5} />
-            </button>
-          </div>
-        );
-      })}
-    </div>
+              <FileAttachmentTile
+                variant="composer"
+                name={att.name}
+                sizeBytes={att.sizeBytes}
+                mimeType={att.mimeType}
+                accessory={removeButton(att.name, att.id)}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <ImageAttachmentLightbox
+        open={imagePreview !== null}
+        onOpenChange={(open) => {
+          if (!open) setImagePreview(null);
+        }}
+        items={imagePreview?.items ?? []}
+        initialIndex={imagePreview?.initialIndex ?? 0}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1439,11 +1439,27 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     // Files without paths need fallback handling
     for (const file of withoutPaths) {
       if (classifyFile(file.name) === "image") {
-        // Images: use existing clipboard image reader
         try {
-          const meta = bridge?.readClipboardImage
+          let meta: AttachmentMeta | null = bridge?.readClipboardImage
             ? await bridge.readClipboardImage()
             : await getTransport().readClipboardImage();
+          if (!meta) {
+            const arrayBuffer = await file.arrayBuffer();
+            const safeName =
+              file.name && isFileSupported(file.name)
+                ? file.name
+                : `clipboard-${Date.now()}.png`;
+            const mimeType = file.type || inferMimeType(safeName);
+            if (bridge?.saveClipboardFile) {
+              meta = await bridge.saveClipboardFile(
+                new Uint8Array(arrayBuffer),
+                mimeType,
+                safeName,
+              );
+            } else {
+              meta = await getTransport().saveClipboardFile(arrayBuffer, mimeType, safeName);
+            }
+          }
           if (meta) {
             setAttachments((prev) => {
               if (prev.length >= MAX_ATTACHMENTS) return prev;

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -64,6 +64,7 @@ import {
   isFileSupported,
   getMaxFileSize,
   inferMimeType,
+  storedAttachmentSuffix,
   MAX_ATTACHMENTS,
   MCODE_BROWSER_CONTEXT_ATTACHMENT_MIME,
   isVirtualBrowserContextAttachment,
@@ -1445,11 +1446,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             : await getTransport().readClipboardImage();
           if (!meta) {
             const arrayBuffer = await file.arrayBuffer();
+            const mimeType = file.type || inferMimeType(file.name || "image/png");
+            const ext = storedAttachmentSuffix(mimeType) || ".bin";
             const safeName =
               file.name && isFileSupported(file.name)
                 ? file.name
-                : `clipboard-${Date.now()}.png`;
-            const mimeType = file.type || inferMimeType(safeName);
+                : `clipboard-${Date.now()}${ext}`;
             if (bridge?.saveClipboardFile) {
               meta = await bridge.saveClipboardFile(
                 new Uint8Array(arrayBuffer),

--- a/apps/web/src/components/chat/FileAttachmentTile.tsx
+++ b/apps/web/src/components/chat/FileAttachmentTile.tsx
@@ -11,6 +11,7 @@ import {
 /** Layout presets for attachment tiles in composer vs transcript. */
 export type FileAttachmentTileVariant = "composer" | "transcript";
 
+/** Props for {@link FileAttachmentTile}. */
 export interface FileAttachmentTileProps {
   /** Original filename for display. */
   name: string;

--- a/apps/web/src/components/chat/FileAttachmentTile.tsx
+++ b/apps/web/src/components/chat/FileAttachmentTile.tsx
@@ -1,0 +1,77 @@
+import { FileText, File } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+import {
+  attachmentIconKindFromMime,
+  formatAttachmentByteSize,
+} from "./attachment-display";
+
+/** Layout presets for attachment tiles in composer vs transcript. */
+export type FileAttachmentTileVariant = "composer" | "transcript";
+
+export interface FileAttachmentTileProps {
+  /** Original filename for display. */
+  name: string;
+  sizeBytes: number;
+  mimeType: string;
+  variant: FileAttachmentTileVariant;
+  /** Corner overlay such as remove control; parent Tile is `position: relative`. */
+  accessory?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Icon-led framed surface for non-image attachments (PDF, Office, generic).
+ * Matches transcript and composer previews without rasterizing PDFs.
+ */
+export function FileAttachmentTile({
+  name,
+  sizeBytes,
+  mimeType,
+  variant,
+  accessory,
+  className,
+}: FileAttachmentTileProps) {
+  const kind = attachmentIconKindFromMime(mimeType);
+  const icon =
+    kind === "pdf" ? (
+      <FileText size={18} className="shrink-0 text-red-600 dark:text-red-400" aria-hidden />
+    ) : kind === "office" ? (
+      <FileText size={18} className="shrink-0 text-blue-600 dark:text-blue-400" aria-hidden />
+    ) : (
+      <File size={18} className="shrink-0 text-muted-foreground" aria-hidden />
+    );
+
+  const isComposer = variant === "composer";
+
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-xl",
+        "border border-border/60 bg-muted/45 ring-1 ring-primary/15",
+        "shadow-sm shadow-black/5 dark:shadow-black/20",
+        isComposer ? "h-[72px] w-[140px]" : "min-h-[72px] w-full max-w-[260px]",
+        className,
+      )}
+      title={name}
+    >
+      {accessory}
+      <div
+        className={cn(
+          "flex h-full flex-col justify-center gap-1",
+          isComposer ? "px-3 py-2" : "px-3 py-2.5",
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {icon}
+          <span className="truncate text-xs font-medium text-foreground">{name}</span>
+        </div>
+        <span className="pl-[26px] text-xs tabular-nums text-muted-foreground">
+          {formatAttachmentByteSize(sizeBytes)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ImageAttachmentLightbox.tsx
+++ b/apps/web/src/components/chat/ImageAttachmentLightbox.tsx
@@ -1,0 +1,329 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { ChevronLeft, ChevronRight, XIcon } from "lucide-react";
+import type { MouseEvent } from "react";
+import { memo, useCallback, useEffect, useId, useLayoutEffect, useMemo, useState } from "react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+/** One slide in the image attachment lightbox. */
+export interface ImageLightboxSlide {
+  src: string;
+  title: string;
+}
+
+export interface ImageAttachmentLightboxProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Slides to show; must be non-empty while `open`. One slide hides carousel chrome. */
+  items: ImageLightboxSlide[];
+  /** Active slide index when the dialog opens (clamped to `items`). */
+  initialIndex?: number;
+}
+
+/**
+ * Full-viewport image preview with optional carousel (prev/next controls, dots,
+ * ArrowLeft / ArrowRight / Home / End). Dimmed scrim, floating close control,
+ * tap-away dismiss behind the raster; navigation sits above the dismiss layer.
+ */
+export const ImageAttachmentLightbox = memo(function ImageAttachmentLightbox({
+  open,
+  onOpenChange,
+  items,
+  initialIndex = 0,
+}: ImageAttachmentLightboxProps) {
+  const [failed, setFailed] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const captionId = useId();
+  const liveId = useId();
+  const carousel = items.length > 1;
+
+  const clampIndex = useCallback(
+    (i: number) =>
+      items.length === 0 ? 0 : Math.min(Math.max(0, i), items.length - 1),
+    [items.length],
+  );
+
+  const safeIndex = clampIndex(activeIndex);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) setFailed(false);
+      onOpenChange(next);
+    },
+    [onOpenChange],
+  );
+
+  /** Align slide index whenever the dialog opens or the tray changes mid-flight. */
+  useEffect(() => {
+    if (!open || items.length === 0) return;
+    setActiveIndex(clampIndex(initialIndex));
+    setFailed(false);
+  }, [open, items, initialIndex, clampIndex]);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [activeIndex]);
+
+  /** Capture phase on `document` so shortcuts work even when the portal mounts lazily. */
+  useLayoutEffect(() => {
+    if (!open || !carousel) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement | null)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+
+      if (e.key === "Home") {
+        e.preventDefault();
+        setActiveIndex(0);
+        return;
+      }
+      if (e.key === "End") {
+        e.preventDefault();
+        setActiveIndex(items.length - 1);
+        return;
+      }
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      e.preventDefault();
+      if (items.length === 0) return;
+      setActiveIndex((i) =>
+        e.key === "ArrowLeft"
+          ? (i - 1 + items.length) % items.length
+          : (i + 1) % items.length,
+      );
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [open, carousel, items.length]);
+
+  const current = items[safeIndex] ?? items[0];
+  const src = current?.src ?? "";
+  const rawTitle = current?.title ?? "";
+  const displayTitle = rawTitle.trim() || "Untitled attachment";
+
+  const liveAnnouncement = useMemo(() => {
+    if (!carousel) return `${displayTitle}`;
+    return `Slide ${safeIndex + 1} of ${items.length}. ${displayTitle}`;
+  }, [carousel, displayTitle, items.length, safeIndex]);
+
+  const goPrev = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      if (items.length === 0) return;
+      setActiveIndex((i) => (i - 1 + items.length) % items.length);
+    },
+    [items.length],
+  );
+
+  const goNext = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      if (items.length === 0) return;
+      setActiveIndex((i) => (i + 1) % items.length);
+    },
+    [items.length],
+  );
+
+  const navBtnClass = cn(
+    "pointer-events-auto flex size-11 shrink-0 items-center justify-center rounded-full",
+    "border border-white/14 bg-black/45 text-white backdrop-blur-md",
+    "shadow-lg shadow-black/40 transition-[background-color,border-color,opacity]",
+    "hover:bg-black/60 hover:border-white/22",
+    "focus-visible:border-white/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35",
+    "motion-reduce:transition-none",
+    "dark:border-white/12 dark:bg-black/55 dark:hover:bg-black/70",
+  );
+
+  const closeBtnClass = cn(
+    "absolute right-4 top-4 z-[70] flex size-11 items-center justify-center rounded-full",
+    "border border-white/14 bg-black/45 text-white backdrop-blur-md",
+    "shadow-lg shadow-black/40 transition-[background-color,border-color,opacity]",
+    "hover:bg-black/60 hover:border-white/22",
+    "focus-visible:border-white/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35",
+    "motion-reduce:transition-none",
+    "dark:border-white/12 dark:bg-black/55 dark:hover:bg-black/70",
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogPortal>
+        <DialogOverlay
+          className={cn(
+            "bg-black/72",
+            "motion-reduce:backdrop-blur-none",
+            "motion-safe:supports-backdrop-filter:backdrop-blur-[2px]",
+            "data-open:duration-200 data-closed:duration-150",
+          )}
+        />
+        <DialogPrimitive.Popup
+          data-slot="image-attachment-lightbox-popup"
+          className={cn(
+            "fixed inset-0 z-50 flex flex-col bg-transparent p-0 shadow-none ring-0 outline-none",
+            "data-open:animate-in data-open:fade-in-0",
+            "data-closed:animate-out data-closed:fade-out-0",
+          )}
+        >
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            <span id={liveId} className="sr-only" aria-live="polite" aria-atomic="true">
+              {open && items.length > 0 ? liveAnnouncement : ""}
+            </span>
+
+            <DialogTitle className="sr-only">
+              {carousel
+                ? `Image ${safeIndex + 1} of ${items.length}: ${displayTitle}`
+                : `Image preview: ${displayTitle}`}
+            </DialogTitle>
+
+            <DialogClose
+              render={
+                <button type="button" className={closeBtnClass} aria-label="Close image preview" />
+              }
+            >
+              <XIcon className="size-[18px]" strokeWidth={2.25} aria-hidden />
+            </DialogClose>
+
+            <div
+              className="relative flex min-h-0 flex-1 flex-col pt-14"
+              data-testid="image-attachment-lightbox"
+            >
+              {open && items.length > 0 ? (
+                <>
+                  <button
+                    type="button"
+                    className={cn(
+                      "absolute inset-0 z-0 cursor-pointer border-0 bg-transparent outline-none",
+                      "focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/25",
+                    )}
+                    aria-label="Dismiss preview"
+                    aria-describedby={`${captionId} ${liveId}`}
+                    onClick={() => handleOpenChange(false)}
+                  />
+
+                  <div className="relative z-10 flex min-h-0 flex-1 flex-col pointer-events-none">
+                    <div className="relative flex min-h-0 flex-1 items-center justify-center px-4 pb-2 pt-2 sm:px-10">
+                      {carousel ? (
+                        <>
+                          <div className="pointer-events-none absolute inset-y-8 left-2 z-20 flex items-center sm:left-5">
+                            <button
+                              type="button"
+                              className={navBtnClass}
+                              aria-label="Previous image"
+                              onClick={goPrev}
+                            >
+                              <ChevronLeft className="size-6" strokeWidth={2} aria-hidden />
+                            </button>
+                          </div>
+                          <div className="pointer-events-none absolute inset-y-8 right-2 z-20 flex items-center sm:right-5">
+                            <button
+                              type="button"
+                              className={navBtnClass}
+                              aria-label="Next image"
+                              onClick={goNext}
+                            >
+                              <ChevronRight className="size-6" strokeWidth={2} aria-hidden />
+                            </button>
+                          </div>
+                        </>
+                      ) : null}
+
+                      <span className="flex min-h-0 max-h-full w-full min-w-0 flex-1 items-center justify-center">
+                        {failed || src.trim() === "" ? (
+                          <span className="max-w-[min(280px,90vw)] px-3 text-center text-sm leading-snug text-white/75">
+                            Could not load this image. Close the preview or press Escape.
+                          </span>
+                        ) : (
+                          <img
+                            src={src}
+                            alt={displayTitle}
+                            decoding="async"
+                            draggable={false}
+                            className={cn(
+                              "pointer-events-none max-h-[min(82dvh,calc(100vh-11rem))] max-w-[min(94vw,calc(100vw-2rem))]",
+                              "h-auto w-auto object-contain select-none",
+                              "rounded-[3px]",
+                              "shadow-[0_28px_90px_-20px_rgba(0,0,0,0.85)]",
+                              "motion-reduce:shadow-xl motion-reduce:shadow-black/60",
+                            )}
+                            style={{ imageOrientation: "from-image" }}
+                            onError={() => setFailed(true)}
+                          />
+                        )}
+                      </span>
+                    </div>
+
+                    <div
+                      className="pointer-events-auto relative z-20 mx-auto flex w-full max-w-[min(94vw,42rem)] min-w-0 flex-col items-center gap-2.5 px-4 pb-6 pt-1"
+                      id={captionId}
+                    >
+                      {carousel ? (
+                        <div
+                          role="group"
+                          aria-label={`Image slides, ${String(items.length)} total`}
+                          className={cn(
+                            "flex max-w-full justify-center gap-x-0.5 gap-y-2 overflow-x-auto px-2 pb-1",
+                            "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+                          )}
+                        >
+                          {items.map((slide, i) => (
+                            <button
+                              key={`${slide.src}:${String(i)}`}
+                              type="button"
+                              aria-label={`Go to image ${String(i + 1)} of ${String(items.length)}`}
+                              aria-current={i === safeIndex ? "true" : undefined}
+                              className={cn(
+                                "flex h-11 min-h-[44px] shrink-0 items-center justify-center px-1",
+                                "rounded-full outline-none",
+                                "focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
+                              )}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setActiveIndex(i);
+                              }}
+                            >
+                              <span
+                                aria-hidden
+                                className={cn(
+                                  "block h-2 bg-white/42 motion-safe:transition-[width,border-radius,background-color] motion-safe:duration-200 motion-safe:ease-out",
+                                  i === safeIndex
+                                    ? "w-[1.625rem] rounded-sm bg-white/[0.92]"
+                                    : "w-2 rounded-full hover:bg-white/62",
+                                )}
+                              />
+                            </button>
+                          ))}
+                        </div>
+                      ) : null}
+
+                      <div className="flex w-full min-w-0 flex-col items-center gap-1 border-t border-white/[0.08] pt-3 text-center">
+                        <p
+                          className="line-clamp-2 max-w-full min-w-0 break-words px-1 text-[13px] font-medium leading-snug tracking-tight text-white/[0.94]"
+                          title={rawTitle.trim() ? rawTitle : undefined}
+                        >
+                          {displayTitle}
+                        </p>
+                        {carousel ? (
+                          <p className="text-[11px] tabular-nums tracking-wide text-white/48">
+                            {safeIndex + 1} / {items.length}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                </>
+              ) : null}
+            </div>
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPortal>
+    </Dialog>
+  );
+});
+
+ImageAttachmentLightbox.displayName = "ImageAttachmentLightbox";

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -1,11 +1,14 @@
 import { memo, useMemo, useState, useCallback, useRef, useEffect, lazy, Suspense } from "react";
 import type { Message } from "@/transport";
-import { FileText, File, ImageIcon, RotateCcw, Copy, Check, GitBranch, AlertCircle, Reply } from "lucide-react";
+import { ImageIcon, RotateCcw, Copy, Check, GitBranch, AlertCircle, Reply } from "lucide-react";
 import { cn } from "@/lib/utils";
 const LazyMarkdownContent = lazy(() => import("./MarkdownContent"));
 import { stripInjectedFiles } from "@/lib/file-tags";
+import { buildStoredAttachmentImageSrc } from "@/lib/attachment-url";
 import { isHandoffMessage, parseHandoffJson } from "./handoff-utils";
 import { HandoffCard } from "./HandoffCard";
+import { FileAttachmentTile } from "./FileAttachmentTile";
+import { ImageAttachmentLightbox } from "./ImageAttachmentLightbox";
 
 /**
  * Returns true when the assistant message body collapses to nothing visible
@@ -45,72 +48,67 @@ interface MessageBubbleProps {
   onScrollToMessage?: (messageId: string) => void;
 }
 
-/** Maps a MIME type to a file extension for attachment URLs. */
-const MIME_TO_EXT: Record<string, string> = {
-  "image/jpeg": ".jpg",
-  "image/png": ".png",
-  "image/gif": ".gif",
-  "image/webp": ".webp",
-  "application/pdf": ".pdf",
-  "text/plain": ".txt",
-};
-
-function extFromMime(mimeType: string): string {
-  return MIME_TO_EXT[mimeType] ?? "";
-}
-
-/** Compact human-readable size for attachment chips in the transcript. */
-function formatAttachmentBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-/** Icon for non-image attachments in user message chips (matches composer preview semantics). */
-function FileAttachmentGlyph({ mimeType }: { mimeType: string }) {
-  const isOfficeDoc =
-    mimeType.includes("officedocument") ||
-    mimeType.includes("opendocument") ||
-    mimeType === "application/rtf" ||
-    mimeType === "text/rtf";
-  if (mimeType === "application/pdf") {
-    return <FileText size={16} className="shrink-0 text-red-600 dark:text-red-400" aria-hidden />;
-  }
-  if (isOfficeDoc) {
-    return <FileText size={16} className="shrink-0 text-blue-600 dark:text-blue-400" aria-hidden />;
-  }
-  return <File size={16} className="shrink-0 text-muted-foreground" aria-hidden />;
-}
-
-/** Single image thumbnail with error fallback. */
-function ImageThumbnail({ src, name, single }: { src: string; name: string; single: boolean }) {
+/** Single image thumbnail with error fallback and optional full-size preview. */
+function ImageThumbnail({
+  src,
+  name,
+  single,
+  onOpenPreview,
+}: {
+  src: string;
+  name: string;
+  single: boolean;
+  onOpenPreview?: () => void;
+}) {
   const [failed, setFailed] = useState(false);
   const handleError = useCallback(() => setFailed(true), []);
 
-  return (
-    <div
-      className={cn(
-        "overflow-hidden rounded-xl ring-1 ring-border/40",
-        single ? "max-w-[240px]" : "max-w-[140px]"
-      )}
-    >
-      {failed ? (
+  const frame = cn(
+    "overflow-hidden rounded-xl ring-1 ring-border/40",
+    single ? "max-w-[240px]" : "max-w-[140px]",
+  );
+
+  if (failed) {
+    return (
+      <div className={frame}>
         <div className="flex items-center gap-2 rounded-xl bg-muted/50 px-3 py-2.5">
           <ImageIcon size={14} className="shrink-0 text-muted-foreground" />
           <span className="truncate text-xs text-muted-foreground">{name}</span>
         </div>
-      ) : (
-        <img
-          src={src}
-          alt={name}
-          className="block h-auto max-h-[160px] w-full object-contain bg-muted"
-          loading="lazy"
-          onError={handleError}
-          style={{ imageOrientation: "from-image" }}
-        />
-      )}
-    </div>
+      </div>
+    );
+  }
+
+  const imgEl = (
+    <img
+      src={src}
+      alt={name}
+      className="block h-auto max-h-[160px] w-full bg-muted/40 object-contain"
+      loading="lazy"
+      onError={handleError}
+      style={{ imageOrientation: "from-image" }}
+    />
   );
+
+  if (onOpenPreview) {
+    return (
+      <button
+        type="button"
+        className={cn(
+          frame,
+          "block w-full cursor-pointer bg-transparent p-0 text-left outline-none",
+          "transition-[box-shadow,filter] hover:brightness-[1.03] hover:ring-border/65",
+          "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        )}
+        aria-label={`Preview image ${name}`}
+        onClick={onOpenPreview}
+      >
+        {imgEl}
+      </button>
+    );
+  }
+
+  return <div className={frame}>{imgEl}</div>;
 }
 
 /** Copy button with check feedback, visible on parent hover. */
@@ -223,6 +221,11 @@ function QuoteBlock({
 
 /** Renders a single chat message (system, user, or assistant). Memoized to prevent re-renders when the message ref is unchanged. */
 export const MessageBubble = memo(function MessageBubble({ message, onBranch, onReply, onScrollToMessage }: MessageBubbleProps) {
+  const [imagePreview, setImagePreview] = useState<{
+    items: { src: string; title: string }[];
+    initialIndex: number;
+  } | null>(null);
+
   const formattedTime = useMemo(
     () => new Date(message.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
     [message.timestamp],
@@ -237,6 +240,15 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
     [message.attachments],
   );
   const textContent = useMemo(() => stripInjectedFiles(message.content), [message.content]);
+
+  const imageSlides = useMemo(
+    () =>
+      imageAttachments.map((img) => ({
+        src: buildStoredAttachmentImageSrc(message.thread_id, img.id, img.mimeType),
+        title: img.name,
+      })),
+    [imageAttachments, message.thread_id],
+  );
 
   if (message.role === "system") {
     if (isHandoffMessage(message.role, message.content)) {
@@ -273,52 +285,54 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
   if (isUser) {
 
     return (
-      <div className="group/msg flex justify-end" data-message-id={message.id} data-message-role={message.role} data-thread-id={message.thread_id}>
-        <div className="min-w-0 max-w-[75%] space-y-1.5">
-          {/* Quote block — shown when this message is a reply */}
-          {message.reply_to_message_id && (
-            <QuoteBlock
-              quotedText={message.quoted_text ?? ""}
-              available={!!message.quoted_text}
-              onClick={() => onScrollToMessage?.(message.reply_to_message_id!)}
-            />
-          )}
-          {/* Image attachments — standalone thumbnails above the bubble */}
-          {imageAttachments.length > 0 && (
-            <div className={cn(
-              "flex justify-end gap-1.5",
-              imageAttachments.length > 2 ? "flex-wrap" : ""
-            )}>
-              {imageAttachments.map((img) => (
-                <ImageThumbnail
-                  key={img.id}
-                  src={`mcode-attachment://${message.thread_id}/${img.id}${extFromMime(img.mimeType)}`}
-                  name={img.name}
-                  single={imageAttachments.length === 1}
-                />
-              ))}
-            </div>
-          )}
+      <>
+        <div className="group/msg flex justify-end" data-message-id={message.id} data-message-role={message.role} data-thread-id={message.thread_id}>
+          <div className="min-w-0 max-w-[75%] space-y-1.5">
+            {/* Quote block — shown when this message is a reply */}
+            {message.reply_to_message_id && (
+              <QuoteBlock
+                quotedText={message.quoted_text ?? ""}
+                available={!!message.quoted_text}
+                onClick={() => onScrollToMessage?.(message.reply_to_message_id!)}
+              />
+            )}
+            {/* Image attachments — standalone thumbnails above the bubble */}
+            {imageAttachments.length > 0 && (
+              <div className={cn(
+                "flex justify-end gap-1.5",
+                imageAttachments.length > 2 ? "flex-wrap" : ""
+              )}>
+                {imageAttachments.map((img, idx) => {
+                  const src = buildStoredAttachmentImageSrc(message.thread_id, img.id, img.mimeType);
+                  return (
+                    <ImageThumbnail
+                      key={img.id}
+                      src={src}
+                      name={img.name}
+                      single={imageAttachments.length === 1}
+                      onOpenPreview={() =>
+                        setImagePreview({ items: imageSlides, initialIndex: idx })
+                      }
+                    />
+                  );
+                })}
+              </div>
+            )}
 
-          {/* Non-image files sit outside the colored bubble so names stay readable on any theme. */}
-          {fileAttachments.length > 0 && (
-            <div className="flex flex-wrap justify-end gap-2">
-              {fileAttachments.map((file) => (
-                <div
-                  key={file.id}
-                  className="flex min-w-0 max-w-[260px] items-start gap-2 rounded-lg border border-border bg-card px-3 py-2 shadow-sm"
-                >
-                  <FileAttachmentGlyph mimeType={file.mimeType} />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-xs font-medium text-foreground">{file.name}</p>
-                    <p className="mt-0.5 text-[10px] tabular-nums text-muted-foreground">
-                      {formatAttachmentBytes(file.sizeBytes)}
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+            {/* Non-image files sit outside the colored bubble so names stay readable on any theme. */}
+            {fileAttachments.length > 0 && (
+              <div className="flex flex-wrap justify-end gap-2">
+                {fileAttachments.map((file) => (
+                  <FileAttachmentTile
+                    key={file.id}
+                    variant="transcript"
+                    name={file.name}
+                    sizeBytes={file.sizeBytes}
+                    mimeType={file.mimeType}
+                  />
+                ))}
+              </div>
+            )}
 
           {textContent.trim() && (
             <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
@@ -346,7 +360,16 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
             <span className="font-mono text-[10px] tabular-nums text-muted-foreground/55">{formattedTime}</span>
           </div>
         </div>
-      </div>
+        </div>
+        <ImageAttachmentLightbox
+          open={imagePreview !== null}
+          onOpenChange={(open) => {
+            if (!open) setImagePreview(null);
+          }}
+          items={imagePreview?.items ?? []}
+          initialIndex={imagePreview?.initialIndex ?? 0}
+        />
+      </>
     );
   }
 

--- a/apps/web/src/components/chat/__tests__/FileAttachmentTile.test.tsx
+++ b/apps/web/src/components/chat/__tests__/FileAttachmentTile.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { FileAttachmentTile } from "../FileAttachmentTile";
+
+describe("FileAttachmentTile", () => {
+  it("renders filename and KB line for composer PDF attachments", () => {
+    render(
+      <FileAttachmentTile
+        variant="composer"
+        name="readme.pdf"
+        sizeBytes={2048}
+        mimeType="application/pdf"
+      />,
+    );
+    expect(screen.getByText("readme.pdf")).toBeInTheDocument();
+    expect(screen.getByText("2 KB")).toBeInTheDocument();
+  });
+
+  it("renders transcript variant sizing without crashing", () => {
+    render(
+      <FileAttachmentTile
+        variant="transcript"
+        name="notes.txt"
+        sizeBytes={512}
+        mimeType="text/plain"
+      />,
+    );
+    expect(screen.getByText("notes.txt")).toBeInTheDocument();
+    expect(screen.getByText("512 B")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/chat/__tests__/attachment-display.test.ts
+++ b/apps/web/src/components/chat/__tests__/attachment-display.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { attachmentIconKindFromMime } from "../attachment-display";
+
+describe("attachmentIconKindFromMime", () => {
+  it("normalizes case and strips MIME parameters for PDF", () => {
+    expect(attachmentIconKindFromMime("Application/PDF")).toBe("pdf");
+    expect(attachmentIconKindFromMime("application/pdf; charset=binary")).toBe("pdf");
+  });
+
+  it("classifies Office types after normalization", () => {
+    expect(
+      attachmentIconKindFromMime(
+        "Application/vnd.openxmlformats-officedocument.wordprocessingml.document; name=a.docx",
+      ),
+    ).toBe("office");
+  });
+});

--- a/apps/web/src/components/chat/attachment-display.ts
+++ b/apps/web/src/components/chat/attachment-display.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared attachment labeling and MIME grouping for chat attachment UI.
+ */
+
+/** Human-readable byte size for attachment labels (B, KB, MB). */
+export function formatAttachmentByteSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Buckets for icon tinting; PDF is included for consistent tile chrome without a preview pane. */
+export type AttachmentIconKind = "pdf" | "office" | "generic";
+
+/**
+ * Maps a MIME type to an {@link AttachmentIconKind} for predictable tile icons.
+ */
+export function attachmentIconKindFromMime(mimeType: string): AttachmentIconKind {
+  if (mimeType === "application/pdf") return "pdf";
+  const isOffice =
+    mimeType.includes("officedocument") ||
+    mimeType.includes("opendocument") ||
+    mimeType === "application/rtf" ||
+    mimeType === "text/rtf";
+  if (isOffice) return "office";
+  return "generic";
+}

--- a/apps/web/src/components/chat/attachment-display.ts
+++ b/apps/web/src/components/chat/attachment-display.ts
@@ -16,12 +16,13 @@ export type AttachmentIconKind = "pdf" | "office" | "generic";
  * Maps a MIME type to an {@link AttachmentIconKind} for predictable tile icons.
  */
 export function attachmentIconKindFromMime(mimeType: string): AttachmentIconKind {
-  if (mimeType === "application/pdf") return "pdf";
+  const normalizedMime = mimeType.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (normalizedMime === "application/pdf") return "pdf";
   const isOffice =
-    mimeType.includes("officedocument") ||
-    mimeType.includes("opendocument") ||
-    mimeType === "application/rtf" ||
-    mimeType === "text/rtf";
+    normalizedMime.includes("officedocument") ||
+    normalizedMime.includes("opendocument") ||
+    normalizedMime === "application/rtf" ||
+    normalizedMime === "text/rtf";
   if (isOffice) return "office";
   return "generic";
 }

--- a/apps/web/src/lib/__tests__/attachment-url.test.ts
+++ b/apps/web/src/lib/__tests__/attachment-url.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  buildStoredAttachmentImageSrc,
+  clearAttachmentTransportWsUrlCache,
+  setAttachmentTransportWsUrl,
+} from "../attachment-url";
+import { AUTH_TOKEN_STORAGE_KEY } from "@/transport/scan-port-range";
+
+describe("buildStoredAttachmentImageSrc", () => {
+  const threadId = "550e8400-e29b-41d4-a716-446655440000";
+  const id = "a1b2c3d4-e5f6-4789-a012-3456789abcde";
+
+  beforeEach(() => {
+    clearAttachmentTransportWsUrlCache();
+    localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+    vi.stubGlobal("desktopBridge", undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearAttachmentTransportWsUrlCache();
+    localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  });
+
+  it("uses mcode-attachment when desktopBridge is present", () => {
+    vi.stubGlobal("desktopBridge", {});
+    expect(buildStoredAttachmentImageSrc(threadId, id, "image/png")).toBe(
+      `mcode-attachment://${threadId}/${id}.png`,
+    );
+  });
+
+  it("uses HTTP /attachments when transport URL is set (browser)", () => {
+    localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, "test-token-xyz");
+    setAttachmentTransportWsUrl("ws://127.0.0.1:19400?token=ignored");
+    const url = buildStoredAttachmentImageSrc(threadId, id, "image/jpeg");
+    expect(url).toBe(
+      `http://127.0.0.1:19400/attachments/${threadId}/${id}.jpg?token=${encodeURIComponent("test-token-xyz")}`,
+    );
+  });
+
+  it("falls back to mcode-attachment when no transport URL and no desktop", () => {
+    expect(buildStoredAttachmentImageSrc(threadId, id, "image/gif")).toBe(
+      `mcode-attachment://${threadId}/${id}.gif`,
+    );
+  });
+});

--- a/apps/web/src/lib/__tests__/attachment-url.test.ts
+++ b/apps/web/src/lib/__tests__/attachment-url.test.ts
@@ -38,9 +38,32 @@ describe("buildStoredAttachmentImageSrc", () => {
     );
   });
 
+  it("preserves bracketed IPv6 host in HTTP origins", () => {
+    setAttachmentTransportWsUrl("ws://[::1]:19400");
+    const url = buildStoredAttachmentImageSrc(threadId, id, "image/png");
+    expect(url).toContain(`http://[::1]:19400/attachments/${threadId}/${id}.png`);
+  });
+
   it("falls back to mcode-attachment when no transport URL and no desktop", () => {
     expect(buildStoredAttachmentImageSrc(threadId, id, "image/gif")).toBe(
       `mcode-attachment://${threadId}/${id}.gif`,
     );
+  });
+
+  it("uses window.__mcodeE2EAttachmentTransportWsUrl when set (Playwright harness)", () => {
+    (
+      window as unknown as { __mcodeE2EAttachmentTransportWsUrl?: string }
+    ).__mcodeE2EAttachmentTransportWsUrl = "ws://localhost:19400";
+    const url = buildStoredAttachmentImageSrc(threadId, id, "image/png");
+    expect(url).toContain("http://localhost:19400/attachments/");
+  });
+
+  it("prefers E2E attachment WS override over desktopBridge (Playwright stub)", () => {
+    vi.stubGlobal("desktopBridge", {});
+    (
+      window as unknown as { __mcodeE2EAttachmentTransportWsUrl?: string }
+    ).__mcodeE2EAttachmentTransportWsUrl = "ws://localhost:19400";
+    const url = buildStoredAttachmentImageSrc(threadId, id, "image/png");
+    expect(url).toContain("http://localhost:19400/attachments/");
   });
 });

--- a/apps/web/src/lib/attachment-url.ts
+++ b/apps/web/src/lib/attachment-url.ts
@@ -24,21 +24,35 @@ export function getAttachmentTransportWsUrl(): string | null {
  */
 export function clearAttachmentTransportWsUrlCache(): void {
   transportWsUrl = null;
+  if (typeof window !== "undefined") {
+    delete (window as unknown as { __mcodeE2EAttachmentTransportWsUrl?: string })
+      .__mcodeE2EAttachmentTransportWsUrl;
+  }
+}
+
+/**
+ * Playwright E2E sets `window.__mcodeE2EAttachmentTransportWsUrl` so
+ * {@link buildStoredAttachmentImageSrc} can use an HTTP origin before the real WebSocket opens.
+ * Read only in the browser; production code never sets this property.
+ */
+function readE2EAttachmentTransportWsOverride(): string | null {
+  if (typeof window === "undefined") return null;
+  const v = (window as unknown as { __mcodeE2EAttachmentTransportWsUrl?: unknown })
+    .__mcodeE2EAttachmentTransportWsUrl;
+  return typeof v === "string" ? v : null;
 }
 
 function wsUrlToHttpOrigin(wsUrl: string): string {
   const u = new URL(wsUrl);
   const proto = u.protocol === "wss:" ? "https:" : "http:";
-  if (u.port) {
-    return `${proto}//${u.hostname}:${u.port}`;
-  }
-  return `${proto}//${u.hostname}`;
+  return `${proto}//${u.host}`;
 }
 
 /**
  * Builds a URL for loading a persisted attachment image (thumbnail or lightbox).
- * Electron continues to use `mcode-attachment:`; the standalone web app uses the local
- * HTTP server so `<img>` can load bytes without a custom protocol handler.
+ * Playwright can set `window.__mcodeE2EAttachmentTransportWsUrl` so `/attachments/` HTTP is used
+ * even when a stray `desktopBridge` stub exists. Otherwise Electron uses `mcode-attachment:` and
+ * the standalone web app uses the local HTTP server.
  */
 export function buildStoredAttachmentImageSrc(
   threadId: string,
@@ -47,9 +61,20 @@ export function buildStoredAttachmentImageSrc(
 ): string {
   const ext = storedAttachmentSuffix(mimeType);
   const filename = `${id}${ext}`;
+
+  const e2eWs = readE2EAttachmentTransportWsOverride();
+  if (e2eWs) {
+    const base = wsUrlToHttpOrigin(e2eWs);
+    const token =
+      typeof localStorage !== "undefined" ? localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ?? "" : "";
+    const q = token ? `?token=${encodeURIComponent(token)}` : "";
+    return `${base}/attachments/${threadId}/${filename}${q}`;
+  }
+
   if (typeof window !== "undefined" && window.desktopBridge) {
     return `mcode-attachment://${threadId}/${filename}`;
   }
+
   const ws = transportWsUrl;
   if (ws) {
     const base = wsUrlToHttpOrigin(ws);

--- a/apps/web/src/lib/attachment-url.ts
+++ b/apps/web/src/lib/attachment-url.ts
@@ -1,0 +1,62 @@
+import { storedAttachmentSuffix } from "@mcode/contracts";
+import { AUTH_TOKEN_STORAGE_KEY } from "@/transport/scan-port-range";
+
+/** Last WebSocket URL used by the transport; drives HTTP attachment URLs in browser builds. */
+let transportWsUrl: string | null = null;
+
+/**
+ * Stores the active WebSocket URL so {@link buildStoredAttachmentImageSrc} can derive
+ * the matching `http(s)` origin for `/attachments/` requests (called from ws `onopen`).
+ */
+export function setAttachmentTransportWsUrl(wsUrl: string): void {
+  transportWsUrl = wsUrl;
+}
+
+/**
+ * Returns the last URL passed to {@link setAttachmentTransportWsUrl}, if any.
+ */
+export function getAttachmentTransportWsUrl(): string | null {
+  return transportWsUrl;
+}
+
+/**
+ * Clears the cached transport URL. Lets unit tests reset state between cases.
+ */
+export function clearAttachmentTransportWsUrlCache(): void {
+  transportWsUrl = null;
+}
+
+function wsUrlToHttpOrigin(wsUrl: string): string {
+  const u = new URL(wsUrl);
+  const proto = u.protocol === "wss:" ? "https:" : "http:";
+  if (u.port) {
+    return `${proto}//${u.hostname}:${u.port}`;
+  }
+  return `${proto}//${u.hostname}`;
+}
+
+/**
+ * Builds a URL for loading a persisted attachment image (thumbnail or lightbox).
+ * Electron continues to use `mcode-attachment:`; the standalone web app uses the local
+ * HTTP server so `<img>` can load bytes without a custom protocol handler.
+ */
+export function buildStoredAttachmentImageSrc(
+  threadId: string,
+  id: string,
+  mimeType: string,
+): string {
+  const ext = storedAttachmentSuffix(mimeType);
+  const filename = `${id}${ext}`;
+  if (typeof window !== "undefined" && window.desktopBridge) {
+    return `mcode-attachment://${threadId}/${filename}`;
+  }
+  const ws = transportWsUrl;
+  if (ws) {
+    const base = wsUrlToHttpOrigin(ws);
+    const token =
+      typeof localStorage !== "undefined" ? localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ?? "" : "";
+    const q = token ? `?token=${encodeURIComponent(token)}` : "";
+    return `${base}/attachments/${threadId}/${filename}${q}`;
+  }
+  return `mcode-attachment://${threadId}/${filename}`;
+}

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -29,6 +29,7 @@ import {
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useThreadStore } from "@/stores/threadStore";
 import type { PermissionRequest } from "@mcode/contracts";
+import { setAttachmentTransportWsUrl } from "@/lib/attachment-url";
 
 /** Minimum reconnect delay in milliseconds. */
 const MIN_RECONNECT_MS = 1000;
@@ -186,6 +187,7 @@ export function createWsTransport(
     ws.onopen = () => {
       reconnectDelay = MIN_RECONNECT_MS;
       consecutiveAuthFailures = 0;
+      setAttachmentTransportWsUrl(url);
       resolveReady();
       options?.onStatusChange?.("connected");
 

--- a/packages/contracts/src/__tests__/attachment-suffix.test.ts
+++ b/packages/contracts/src/__tests__/attachment-suffix.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { storedAttachmentSuffix } from "../models/attachment.js";
+
+describe("storedAttachmentSuffix", () => {
+  it("returns expected extensions for images and documents", () => {
+    expect(storedAttachmentSuffix("image/jpeg")).toBe(".jpg");
+    expect(storedAttachmentSuffix("image/png")).toBe(".png");
+    expect(storedAttachmentSuffix("application/pdf")).toBe(".pdf");
+    expect(storedAttachmentSuffix("text/plain")).toBe(".txt");
+  });
+
+  it("returns empty string for unknown MIME types", () => {
+    expect(storedAttachmentSuffix("application/octet-stream")).toBe("");
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -25,6 +25,7 @@ export {
   MCODE_BROWSER_CONTEXT_ATTACHMENT_MIME,
   isVirtualBrowserContextAttachment,
   shouldPersistAttachmentWithoutFile,
+  storedAttachmentSuffix,
 } from "./models/attachment.js";
 export type { AttachmentMeta, StoredAttachment } from "./models/attachment.js";
 

--- a/packages/contracts/src/models/attachment.ts
+++ b/packages/contracts/src/models/attachment.ts
@@ -41,3 +41,28 @@ export const StoredAttachmentSchema = z.object({
 });
 /** Stored attachment metadata without a source path. */
 export type StoredAttachment = z.infer<typeof StoredAttachmentSchema>;
+
+/**
+ * Returns the file suffix (including the leading dot) used when persisting an attachment
+ * to `{mcodeDir}/attachments/{threadId}/{id}{suffix}`. Must match the server's attachment
+ * persistence naming so URLs and disk paths stay aligned.
+ */
+export function storedAttachmentSuffix(mimeType: string): string {
+  const map: Record<string, string> = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "application/pdf": ".pdf",
+    "text/plain": ".txt",
+    "application/rtf": ".rtf",
+    "text/rtf": ".rtf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+    "application/vnd.oasis.opendocument.text": ".odt",
+    "application/vnd.oasis.opendocument.spreadsheet": ".ods",
+    "application/vnd.oasis.opendocument.presentation": ".odp",
+  };
+  return map[mimeType] ?? "";
+}


### PR DESCRIPTION
## What

Ships end to end attachment previews for chat images and files: thumbnails in the transcript and composer, a fullscreen carousel lightbox, HTTP delivery for stored bytes when `mcode-attachment:` is not available, and a safer desktop dev loop when Vite disappears.

## Why

Browser builds cannot rely on Electron custom protocols for `<img>` tags. Routing persisted attachment bytes through the same origin as the WebSocket keeps previews trustworthy without widening the surface area. Clear tiles and a calm lightbox make dense attachment threads easier to scan.

## Key Changes

- Contracts add `storedAttachmentSuffix` so URLs stay stable across clients.
- Server exposes authenticated `GET /attachments/:threadId/:file` backed by the attachment store.
- Web caches the transport URL after WS connect and builds image `src` values for Electron protocol or HTTP as appropriate.
- Shared `FileAttachmentTile` plus transcript and composer wiring; `ImageAttachmentLightbox` handles multi image trays with keyboard and dot navigation.
- Composer falls back through `saveClipboardFile` when the clipboard image shortcut returns nothing so pasted shots still stage.
- Desktop dev script tears Electron down when Vite exits after startup so you do not stare at `ERR_CONNECTION_REFUSED` forever.

## Test plan

- [x] `apps/web`: `tsc --noEmit`
- [x] `apps/web`: Vitest (`MessageBubble`, `FileAttachmentTile`, `attachment-url`) via `vitest run --pool=forks`
- [x] `packages/contracts`: Vitest `attachment-suffix.test.ts`

## Commit trail

Seven atomic commits stack from contracts through server, web plumbing, UI layers, and the desktop dev fix.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-screen image lightbox with carousel navigation for image attachments
  * New compact file-attachment tiles for clearer file previews in composer and transcripts

* **Improvements**
  * Smarter clipboard image pasting with safer filenames and persistence
  * Human-readable attachment size formatting and improved MIME-based icons
  * More reliable attachment URL/serving behavior for consistent previewing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->