### PR TITLE
feat(desktop): stable and nightly desktop updates

### DIFF
--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -1,0 +1,276 @@
+# Packs the desktop app from the default branch and uploads to the rolling
+# prerelease tagged `nightly`, using electron-builder publish channel `nightly`
+# so clients with `updates.channel` = `nightly` resolve `latest-nightly.yml` (etc.).
+
+name: Nightly Desktop
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-desktop
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Ensure nightly prerelease exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          if ! gh release view nightly --repo "${{ github.repository }}" &>/dev/null; then
+            gh release create nightly --prerelease --title "Mcode nightly" \
+              --notes "Automated desktop builds from the default branch. Assets are replaced on each successful run." \
+              --repo "${{ github.repository }}"
+          fi
+
+  build:
+    needs: [prepare]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: blacksmith-4vcpu-windows-2025
+            build-args: ""
+            target-arch: ""
+          - os: ubuntu-22.04
+            build-args: ""
+            target-arch: ""
+          - os: blacksmith-12vcpu-macos-26
+            build-args: "--mac --arm64"
+            target-arch: "arm64"
+          - os: blacksmith-12vcpu-macos-26
+            build-args: "--mac --x64"
+            target-arch: "x64"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Set nightly package version
+        shell: bash
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const manifest = JSON.parse(fs.readFileSync(".release-please-manifest.json", "utf8"));
+          const base = manifest["."];
+          const day = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+          const run = process.env.GITHUB_RUN_NUMBER || "0";
+          const version = `${base}-nightly.${day}.${run}`;
+          const pkgPath = "apps/desktop/package.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.version = version;
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+          console.log("Nightly desktop version:", version);
+          NODE
+
+      - name: Build main & renderer
+        run: bun run --cwd apps/desktop build
+
+      - name: Generate V8 snapshot
+        run: bun apps/desktop/scripts/generate-snapshot.mjs
+        env:
+          MCODE_TARGET_ARCH: ${{ matrix.target-arch }}
+
+      - name: Install Python setuptools (node-gyp on Python 3.12+ needs it)
+        shell: bash
+        run: python3 -m pip install setuptools --break-system-packages 2>/dev/null || python3 -m pip install setuptools 2>/dev/null || pip install setuptools 2>/dev/null || true
+
+      - name: Package with electron-builder (nightly channel)
+        run: node apps/desktop/scripts/ci-package.mjs --config.publish.channel=nightly ${{ matrix.build-args }}
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && 'false' || '' }}
+
+      - name: Smoke test packaged server
+        if: matrix.target-arch == '' || matrix.target-arch == 'arm64'
+        run: node apps/desktop/scripts/smoke-test.mjs
+
+      - name: Upload macOS update metadata (nightly channel)
+        if: matrix.target-arch == 'arm64' || matrix.target-arch == 'x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: latest-mac-yml-${{ matrix.target-arch }}-nightly
+          path: apps/desktop/release/latest-mac-nightly.yml
+          retention-days: 1
+
+      - name: Collect nightly release artifacts
+        id: artifacts
+        shell: bash
+        run: |
+          echo "tag=nightly" >> "$GITHUB_OUTPUT"
+          shopt -s nullglob
+          files=()
+          for f in \
+            apps/desktop/release/*.exe \
+            apps/desktop/release/*.exe.blockmap \
+            apps/desktop/release/*.dmg \
+            apps/desktop/release/*.dmg.blockmap \
+            apps/desktop/release/*.zip \
+            apps/desktop/release/*.zip.blockmap \
+            apps/desktop/release/*.AppImage \
+            apps/desktop/release/*.deb \
+            apps/desktop/release/latest-nightly.yml \
+            apps/desktop/release/latest-linux-nightly.yml; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f")
+            [[ "$base" == "elevate.exe" ]] && continue
+            files+=("$f")
+          done
+
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No artifacts found to upload"
+            exit 0
+          fi
+
+          printf '%s\n' "${files[@]}"
+          printf '%s\n' "${files[@]}" > artifact-list.txt
+          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload nightly release artifacts
+        if: steps.artifacts.outputs.count > 0
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          while IFS= read -r f; do
+            echo "Uploading: $f"
+            gh release upload nightly "$f" --clobber --repo "${{ github.repository }}"
+          done < artifact-list.txt
+
+  merge-mac-yml-nightly:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download arm64 yml
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: latest-mac-yml-arm64-nightly
+          path: yml-arm64
+
+      - name: Download x64 yml
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: latest-mac-yml-x64-nightly
+          path: yml-x64
+
+      - name: Merge latest-mac-nightly.yml
+        shell: bash
+        run: |
+          ARM64_YML="yml-arm64/latest-mac-nightly.yml"
+          X64_YML="yml-x64/latest-mac-nightly.yml"
+
+          if [ ! -f "$ARM64_YML" ] || [ ! -f "$X64_YML" ]; then
+            echo "One or both nightly mac yml files missing, skipping merge"
+            if [ -f "$ARM64_YML" ]; then cp "$ARM64_YML" latest-mac-nightly.yml; fi
+            if [ -f "$X64_YML" ]; then cp "$X64_YML" latest-mac-nightly.yml; fi
+            if [ ! -f latest-mac-nightly.yml ]; then exit 0; fi
+          else
+            node -e "
+              const fs = require('fs');
+              const arm64 = fs.readFileSync('$ARM64_YML', 'utf8');
+              const x64 = fs.readFileSync('$X64_YML', 'utf8');
+
+              function parseFiles(yml) {
+                const lines = yml.split('\n');
+                const files = [];
+                let inFiles = false;
+                let current = null;
+                for (const line of lines) {
+                  if (line.startsWith('files:')) { inFiles = true; continue; }
+                  if (inFiles) {
+                    if (line.match(/^  - url:/)) {
+                      if (current) files.push(current);
+                      current = line + '\n';
+                    } else if (line.match(/^    \w/) && current) {
+                      current += line + '\n';
+                    } else if (line.match(/^\w/) && line.trim()) {
+                      if (current) files.push(current);
+                      current = null;
+                      inFiles = false;
+                    } else if (current) {
+                      current += line + '\n';
+                    }
+                  }
+                }
+                if (current) files.push(current);
+                return files;
+              }
+
+              const arm64Files = parseFiles(arm64);
+              const x64Files = parseFiles(x64);
+
+              const arm64Urls = new Set(arm64Files.map(f => {
+                const m = f.match(/url:\s*(.+)/);
+                return m ? m[1].trim() : '';
+              }));
+
+              const newEntries = x64Files.filter(f => {
+                const m = f.match(/url:\s*(.+)/);
+                return m && !arm64Urls.has(m[1].trim());
+              });
+
+              if (newEntries.length === 0) {
+                fs.writeFileSync('latest-mac-nightly.yml', arm64);
+              } else {
+                const lines = arm64.split('\n');
+                const out = [];
+                let insertedExtra = false;
+                let inFilesBlock = false;
+
+                for (let i = 0; i < lines.length; i++) {
+                  out.push(lines[i]);
+                  if (lines[i].startsWith('files:')) {
+                    inFilesBlock = true;
+                  }
+                  if (inFilesBlock && i > 0 && lines[i].match(/^\w/) && lines[i].trim() && !lines[i].startsWith('files:')) {
+                    if (!insertedExtra) {
+                      const lastLine = out.pop();
+                      for (const entry of newEntries) {
+                        out.push(entry.trimEnd());
+                      }
+                      out.push(lastLine);
+                      insertedExtra = true;
+                    }
+                    inFilesBlock = false;
+                  }
+                }
+                if (inFilesBlock && !insertedExtra) {
+                  for (const entry of newEntries) {
+                    out.push(entry.trimEnd());
+                  }
+                }
+                fs.writeFileSync('latest-mac-nightly.yml', out.join('\n'));
+              }
+              console.log('Merged latest-mac-nightly.yml:');
+              console.log(fs.readFileSync('latest-mac-nightly.yml', 'utf8'));
+            "
+          fi
+
+      - name: Upload merged latest-mac-nightly.yml
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f latest-mac-nightly.yml ]; then
+            echo "Uploading merged latest-mac-nightly.yml"
+            gh release upload nightly latest-mac-nightly.yml --clobber --repo "${{ github.repository }}"
+          fi

--- a/apps/desktop/dev-app-update.yml
+++ b/apps/desktop/dev-app-update.yml
@@ -1,3 +1,4 @@
 provider: github
 owner: mzeey-empire
 repo: mcode
+# Optional third line for local nightly feed tests: channel: nightly

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -6,8 +6,9 @@
  * render an in-app banner and an "About" panel showing current state.
  * Also fires a native OS Notification when an update finishes downloading.
  *
- * Update behavior (auto-download, auto-install, check interval) is controlled
- * via user settings read from settings.json. Changes take effect on next app launch.
+ * Update behavior (release line, auto-download, auto-install, check interval)
+ * is read from settings.json. Release line changes apply on the next check;
+ * check interval still applies after restart (timer started at launch).
  */
 
 import { autoUpdater } from "electron-updater";
@@ -31,14 +32,31 @@ const INTERVAL_MS_MAP: Record<string, number> = {
 };
 
 interface UpdaterSettings {
+  /** Stable follows tagged releases; nightly follows the CI prerelease channel. */
+  releaseLine: "stable" | "nightly";
   autoDownload: boolean;
   autoInstallOnQuit: boolean;
   checkInterval: string;
 }
 
+/**
+ * Maps persisted `updates.channel` to the electron-updater publish channel name.
+ */
+function releaseLineToUpdaterChannel(releaseLine: "stable" | "nightly"): string {
+  return releaseLine === "nightly" ? "nightly" : "latest";
+}
+
+/**
+ * Applies `autoUpdater.channel` from user settings so checks target stable or nightly feeds.
+ */
+function applyUpdaterChannelFromSettings(settings: UpdaterSettings): void {
+  autoUpdater.channel = releaseLineToUpdaterChannel(settings.releaseLine);
+}
+
 /** Read updater settings from settings.json; falls back to safe defaults if the file is missing or invalid. */
 function loadUpdaterSettings(): UpdaterSettings {
   const defaults: UpdaterSettings = {
+    releaseLine: "stable",
     autoDownload: true,
     autoInstallOnQuit: true,
     checkInterval: "4hours",
@@ -48,6 +66,7 @@ function loadUpdaterSettings(): UpdaterSettings {
     const result = SettingsSchema().safeParse(JSON.parse(raw));
     if (result.success) {
       return {
+        releaseLine: result.data.updates?.channel ?? defaults.releaseLine,
         autoDownload: result.data.updates?.autoDownload ?? defaults.autoDownload,
         autoInstallOnQuit: result.data.updates?.autoInstallOnQuit ?? defaults.autoInstallOnQuit,
         checkInterval: result.data.updates?.checkInterval ?? defaults.checkInterval,
@@ -160,11 +179,12 @@ export function checkForUpdatesNow(): Promise<UpdateStatus> {
   }
   inFlightCheck = (async () => {
     try {
-      // Re-read settings so toggling "auto-download" in the UI takes
-      // effect without an app restart.
-      const { autoDownload, autoInstallOnQuit } = loadUpdaterSettings();
-      autoUpdater.autoDownload = autoDownload;
-      autoUpdater.autoInstallOnAppQuit = autoInstallOnQuit;
+      // Re-read settings so toggles and release line in the UI take effect
+      // without an app restart.
+      const settings = loadUpdaterSettings();
+      applyUpdaterChannelFromSettings(settings);
+      autoUpdater.autoDownload = settings.autoDownload;
+      autoUpdater.autoInstallOnAppQuit = settings.autoInstallOnQuit;
 
       broadcastStatus({ state: "checking" });
       await autoUpdater.checkForUpdates();
@@ -244,9 +264,11 @@ export function initAutoUpdater(): void {
 
   autoUpdater.allowDowngrade = false;
 
-  const { autoDownload, autoInstallOnQuit, checkInterval } = loadUpdaterSettings();
-  autoUpdater.autoDownload = autoDownload;
-  autoUpdater.autoInstallOnAppQuit = autoInstallOnQuit;
+  const updaterSettings = loadUpdaterSettings();
+  applyUpdaterChannelFromSettings(updaterSettings);
+  autoUpdater.autoDownload = updaterSettings.autoDownload;
+  autoUpdater.autoInstallOnAppQuit = updaterSettings.autoInstallOnQuit;
+  const { checkInterval } = updaterSettings;
 
   autoUpdater.on("checking-for-update", () => {
     broadcastStatus({ state: "checking" });

--- a/apps/web/e2e/about-visual.spec.ts
+++ b/apps/web/e2e/about-visual.spec.ts
@@ -15,7 +15,7 @@ const MOCK_SETTINGS = {
   notifications: { enabled: false },
   worktree: { naming: { mode: "auto", aiConfirmation: true } },
   server: { memory: { heapMb: 96 } },
-  updates: { autoDownload: true, autoInstallOnQuit: true, checkInterval: "4hours" },
+  updates: { channel: "stable", autoDownload: true, autoInstallOnQuit: true, checkInterval: "4hours" },
 };
 
 test.describe("About section visual", () => {

--- a/apps/web/e2e/settings-visual.spec.ts
+++ b/apps/web/e2e/settings-visual.spec.ts
@@ -23,7 +23,7 @@ const DEFAULT_SETTINGS = {
   notifications: { enabled: false },
   worktree: { naming: { mode: "auto", aiConfirmation: true } },
   server: { memory: { heapMb: 96 } },
-  updates: { autoDownload: true, autoInstallOnQuit: true, checkInterval: "4hours" },
+  updates: { channel: "stable", autoDownload: true, autoInstallOnQuit: true, checkInterval: "4hours" },
 };
 
 const SECTIONS = ["Model", "Agent", "Worktrees", "Appearance", "Notifications", "Terminal", "Performance", "About"];

--- a/apps/web/src/components/settings/sections/AboutSection.tsx
+++ b/apps/web/src/components/settings/sections/AboutSection.tsx
@@ -7,7 +7,13 @@ import { SectionHeading } from "../SectionHeading";
 import { Switch } from "@/components/ui/switch";
 import { SegControl } from "../SegControl";
 import type { UpdateStatus } from "@/transport/desktop-bridge";
-import type { UpdateCheckInterval } from "@mcode/contracts";
+import type { UpdateCheckInterval, UpdateReleaseLine } from "@mcode/contracts";
+
+/** Segmented control options for update release line (electron-updater publish channel). */
+const RELEASE_LINE_OPTIONS: { value: UpdateReleaseLine; label: string }[] = [
+  { value: "stable", label: "Stable" },
+  { value: "nightly", label: "Nightly" },
+];
 
 /** Segmented control options for update check frequency. */
 const INTERVAL_OPTIONS = [
@@ -97,8 +103,17 @@ export function AboutSection() {
   const autoDownload = settings.updates?.autoDownload ?? true;
   const autoInstallOnQuit = settings.updates?.autoInstallOnQuit ?? true;
   const checkInterval = settings.updates?.checkInterval ?? "4hours";
+  const releaseLine = settings.updates?.channel ?? "stable";
 
   const isBusy = checking || status.state === "checking" || status.state === "downloading";
+
+  let updatesHint = "Checks for new releases on the configured interval.";
+  if (checkInterval === "never") {
+    updatesHint = "Automatic checks disabled.";
+  } else if (releaseLine === "nightly") {
+    updatesHint =
+      "Nightly uses prerelease builds. They may be unstable. Switching back to Stable with a newer nightly installed can require a reinstall from the website if no stable update appears.";
+  }
 
   // Derive the inline status label shown beside the button.
   const statusLabel = upToDateLabel ? "Up to date" : describeStatus(status);
@@ -113,14 +128,7 @@ export function AboutSection() {
           </span>
         </SettingRow>
 
-        <SettingRow
-          label="Updates"
-          hint={
-            checkInterval === "never"
-              ? "Automatic checks disabled."
-              : "Checks for new releases on the configured interval."
-          }
-        >
+        <SettingRow label="Updates" hint={updatesHint}>
           <div className="flex items-center gap-3">
             {statusLabel && (
               <span
@@ -156,6 +164,21 @@ export function AboutSection() {
               </button>
             )}
           </div>
+        </SettingRow>
+
+        <SettingRow
+          label="Release line"
+          hint="Stable follows tagged releases. Nightly follows automated prerelease builds when the project publishes them."
+        >
+          <SegControl
+            options={RELEASE_LINE_OPTIONS}
+            value={releaseLine}
+            onChange={(v) =>
+              void updateSettings({
+                updates: { channel: v as UpdateReleaseLine },
+              })
+            }
+          />
         </SettingRow>
 
         <SettingRow

--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -21,6 +21,10 @@ Per-setting reference for Mcode's `settings.json`. For schema conventions and st
 | `model.defaults.contextWindow` | integer | - | > 0, ≤ 2,000,000 | - | Override the context window (tokens) for the default model. When set, takes priority over API-fetched and SDK-reported values. Useful when the SDK reports stale data (e.g. 200K instead of 1M). Omit to use the automatically detected value. Claude only. |
 | `terminal.scrollback` | integer | `250` | >= 0 | - | Number of scrollback lines to retain |
 | `notifications.enabled` | boolean | `true` | - | - | Whether desktop notifications are enabled |
+| `updates.channel` | enum | `"stable"` | `"stable"` \| `"nightly"` | - | Desktop auto-update release line. Stable uses normal GitHub releases; nightly uses the maintainers' prerelease channel when CI publishes it. |
+| `updates.autoDownload` | boolean | `true` | - | - | Download updates automatically when available |
+| `updates.autoInstallOnQuit` | boolean | `true` | - | - | Install downloaded updates when the app quits |
+| `updates.checkInterval` | enum | `"4hours"` | `"15min"` \| `"1hour"` \| `"4hours"` \| `"1day"` \| `"never"` | - | How often the desktop app checks for updates. Check interval is applied at launch; other update options re-read from disk on each check. |
 | `worktree.naming.mode` | enum | `"auto"` | `"auto"` \| `"custom"` \| `"ai"` | - | Naming strategy for new worktree branches |
 | `worktree.naming.aiConfirmation` | boolean | `true` | - | - | Prompt before using AI-generated branch names |
 | `performance.threadCacheSize` | integer | `10` | 1-25 | - | Number of threads to keep in memory for instant switching. Lower values reduce memory use; values ≤ 3 mean most thread switches reload from the server. Takes effect immediately. |

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -75,6 +75,7 @@ export {
   ProviderIdSchema,
   NamingModeSchema,
   UpdateCheckIntervalSchema,
+  UpdateReleaseLineSchema,
   GRACE_PERIOD_DEFAULT_SECONDS,
 } from "./models/settings.js";
 export type {
@@ -87,6 +88,7 @@ export type {
   SettingsProviderId,
   NamingMode,
   UpdateCheckInterval,
+  UpdateReleaseLine,
 } from "./models/settings.js";
 
 export {

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -69,6 +69,15 @@ export const UpdateCheckIntervalSchema = z.enum(["15min", "1hour", "4hours", "1d
 /** Auto-update check interval value. */
 export type UpdateCheckInterval = z.infer<typeof UpdateCheckIntervalSchema>;
 
+/**
+ * Desktop auto-update release line. Maps to electron-updater publish channel:
+ * `stable` uses the default `latest` feed; `nightly` uses the `nightly` channel
+ * (prerelease artifacts from CI).
+ */
+export const UpdateReleaseLineSchema = z.enum(["stable", "nightly"]);
+/** Desktop auto-update release line value. */
+export type UpdateReleaseLine = z.infer<typeof UpdateReleaseLineSchema>;
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -353,6 +362,11 @@ export const SettingsSchema = lazySchema(() =>
     /** App auto-update settings. */
     updates: z
       .object({
+        /**
+         * Release line to follow. Stable uses tagged releases; nightly uses automated
+         * prerelease builds from the default branch (when published by maintainers).
+         */
+        channel: UpdateReleaseLineSchema.default("stable"),
         /** Whether to automatically download available updates. */
         autoDownload: z.boolean().default(true),
         /** Whether to automatically install updates when the app quits. */
@@ -523,6 +537,7 @@ export const PartialSettingsSchema = lazySchema(() =>
       .optional(),
     updates: z
       .object({
+        channel: UpdateReleaseLineSchema.optional(),
         autoDownload: z.boolean().optional(),
         autoInstallOnQuit: z.boolean().optional(),
         checkInterval: UpdateCheckIntervalSchema.optional(),


### PR DESCRIPTION
## What
Users can choose Stable or Nightly for desktop auto-updates. Nightly follows a rolling GitHub prerelease fed by a new scheduled CI workflow.

## Why
Ship prerelease builds for early testing without changing the stable release pipeline.

## Key Changes
- Add `updates.channel` (`stable` | `nightly`) to contracts, settings reference, and About UI; map to `electron-updater` publish channel (`latest` vs `nightly`).
- Add `nightly-desktop.yml`: daily cron plus `workflow_dispatch`, merge from `main`, version `* -nightly.{date}.{run}`, upload to prerelease tag `nightly` with `--clobber`.
- Merged current `origin/main` into this branch so the PR is up to date.

## Test plan
- [ ] Confirm Settings About: Release line toggles persist.
- [ ] After merge, run Nightly Desktop workflow manually once; confirm `nightly` release assets and YAML names match electron-builder output.
- [ ] Smoke: packaged app on Stable still resolves normal `latest` feeds (unchanged `build-release.yml`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release line selection in update settings, allowing users to choose between stable and nightly channels to opt into early builds

* **Documentation**
  * Updated settings reference to document all auto-update configuration options including the new release line setting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->