### PR TITLE
feat(claude): support /goal command via SDK Stop hook

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -8,7 +8,7 @@ import { injectable, inject } from "tsyringe";
 import { EventEmitter } from "events";
 import { readFile } from "fs/promises";
 import { query as sdkQuery } from "@anthropic-ai/claude-agent-sdk";
-import type { Query, SDKUserMessage, PostCompactHookInput, CanUseTool } from "@anthropic-ai/claude-agent-sdk";
+import type { Query, SDKUserMessage, PostCompactHookInput, StopHookInput, CanUseTool } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "@mcode/shared";
 import { AgentEventType, isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import type {
@@ -226,6 +226,15 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
 
   private sessions = new Map<string, SessionEntry>();
   private sdkSessionIds = new Map<string, string>();
+  /**
+   * Active goals keyed by sessionId (mcode-${threadId}). When set, the SDK
+   * Stop hook installed in baseOptions blocks the agent from ending its turn
+   * with a "Goal not yet met" message until the goal is cleared. Set by the
+   * `/goal <condition>` chat command (intercepted in AgentService) and
+   * cleared by `/goal clear`. In-memory only — does not persist across
+   * server restarts.
+   */
+  private goalsBySession = new Map<string, string>();
   /**
    * Session IDs for which a stop was requested before the session was created.
    * Checked by doSendMessage after session creation; if found the session is
@@ -696,6 +705,25 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
               summary: compact_summary,
             } satisfies AgentEvent);
             return {};
+          }],
+        }],
+        Stop: [{
+          // @ts-expect-error: HookCallback accepts 3 params but we only need input
+          hooks: [async (input) => {
+            const stopInput = input as StopHookInput;
+            const goal = this.goalsBySession.get(sessionId);
+            // No goal set or hook is already re-prompting → allow stop. The
+            // `stop_hook_active` guard prevents an infinite block loop when the
+            // model insists on stopping after the first re-prompt.
+            if (!goal || stopInput.stop_hook_active) {
+              return {};
+            }
+            return {
+              decision: "block" as const,
+              reason:
+                `Goal not yet met: "${goal}". Continue working until the goal is satisfied. ` +
+                `If you have satisfied it, ask the user to clear it with "/goal clear".`,
+            };
           }],
         }],
       },
@@ -1620,6 +1648,26 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     this.sdkSessionIds.set(sessionId, sdkSessionId);
   }
 
+  /**
+   * Install a goal on a session. The next Stop event from the SDK will be
+   * blocked with a "Goal not yet met" reason until {@link clearGoal} is
+   * called. Storage is in-memory and tied to the sessionId; restarting the
+   * server clears all goals.
+   */
+  setGoal(sessionId: string, condition: string): void {
+    this.goalsBySession.set(sessionId, condition);
+  }
+
+  /** Remove an active goal so the next Stop event is allowed through. */
+  clearGoal(sessionId: string): void {
+    this.goalsBySession.delete(sessionId);
+  }
+
+  /** Return the active goal condition for a session, or undefined. */
+  getGoal(sessionId: string): string | undefined {
+    return this.goalsBySession.get(sessionId);
+  }
+
   /** Abort a running session, or record a pending stop if the session hasn't been created yet. */
   stopSession(sessionId: string): void {
     // Normalize to the raw UUID that canUseTool stores as threadId.
@@ -1632,6 +1680,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         this.emit("permission_resolved", { requestId, decision: "cancelled" });
       }
     }
+    this.goalsBySession.delete(sessionId);
     const entry = this.sessions.get(sessionId);
     if (entry) {
       this.sessions.delete(sessionId);
@@ -1772,6 +1821,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     }
     this.sessions.clear();
     this.sdkSessionIds.clear();
+    this.goalsBySession.clear();
     logger.info("ClaudeProvider shutdown complete");
   }
 }

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -1,0 +1,238 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { container } from "tsyringe";
+import type Database from "better-sqlite3";
+import type { Thread, IProviderRegistry } from "@mcode/contracts";
+import { AgentEventType } from "@mcode/contracts";
+import { openMemoryDatabase } from "../../store/database.js";
+import { ThreadRepo } from "../../repositories/thread-repo.js";
+import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import { MessageRepo } from "../../repositories/message-repo.js";
+import { PlanQuestionAnswersRepo } from "../../repositories/plan-question-answers-repo.js";
+import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
+import { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo.js";
+import { TaskRepo } from "../../repositories/task-repo.js";
+import { AgentService } from "../agent-service.js";
+import { ProviderAvailabilityService } from "../provider-availability-service.js";
+import type { GitService } from "../git-service.js";
+import type { AttachmentService } from "../attachment-service.js";
+import type { SnapshotService } from "../snapshot-service.js";
+import type { MemoryPressureService } from "../memory-pressure-service.js";
+import type { SettingsService } from "../settings-service.js";
+import type { ThreadService } from "../thread-service.js";
+import { EventEmitter } from "events";
+
+vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
+import { broadcast } from "../../transport/push.js";
+
+/**
+ * Build an AgentService with a Claude-shaped provider stub that records
+ * setGoal/clearGoal/sendMessage so we can assert which path the /goal
+ * intercept took (control short-circuit vs SET fall-through).
+ */
+function buildService(db: Database.Database) {
+  container.reset();
+  container.registerInstance("Database", db);
+
+  const threadRepo = container.resolve(ThreadRepo);
+  const workspaceRepo = container.resolve(WorkspaceRepo);
+  const messageRepo = container.resolve(MessageRepo);
+  const planQuestionAnswersRepo = container.resolve(PlanQuestionAnswersRepo);
+  const toolCallRecordRepo = container.resolve(ToolCallRecordRepo);
+  const turnSnapshotRepo = container.resolve(TurnSnapshotRepo);
+  const taskRepo = container.resolve(TaskRepo);
+
+  const gitService = {
+    resolveWorkingDir: vi.fn(() => process.cwd()),
+    listWorktrees: vi.fn(() => []),
+  } as unknown as GitService;
+
+  const attachmentService = {
+    persist: vi.fn(() => Promise.resolve({ stored: [], persisted: [] })),
+  } as unknown as AttachmentService;
+
+  const providerStub = Object.assign(new EventEmitter(), {
+    id: "claude" as const,
+    supportsCompletion: true,
+    sendMessage: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
+      () => Promise.resolve(),
+    ),
+    setSdkSessionId: vi.fn(),
+    setGoal: vi.fn<(sid: string, condition: string) => void>(),
+    clearGoal: vi.fn<(sid: string) => void>(),
+    getGoal: vi.fn<(sid: string) => string | undefined>(() => undefined),
+  });
+  const providerRegistry = {
+    resolve: vi.fn(() => providerStub),
+    resolveAll: vi.fn(() => []),
+    shutdown: vi.fn(),
+  } as unknown as IProviderRegistry;
+
+  const threadService = { create: vi.fn() } as unknown as ThreadService;
+
+  const snapshotService = {
+    captureRef: vi.fn(() => Promise.resolve("abc123")),
+    getFilesChanged: vi.fn(() => Promise.resolve([])),
+  } as unknown as SnapshotService;
+
+  const memoryPressureService = {
+    markActive: vi.fn(),
+    markIdle: vi.fn(),
+  } as unknown as MemoryPressureService;
+
+  const settingsService = {
+    get: vi.fn(() =>
+      Promise.resolve({
+        model: { defaults: { fallbackId: undefined, contextWindow: "auto", thinking: false } },
+        agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
+        provider: { enabled: {}, cli: {} },
+      }),
+    ),
+    on: vi.fn(),
+  } as unknown as SettingsService;
+
+  const availability = {
+    assertUsable: vi.fn(),
+  } as unknown as ProviderAvailabilityService;
+
+  const svc = new AgentService(
+    threadRepo,
+    workspaceRepo,
+    messageRepo,
+    gitService,
+    attachmentService,
+    providerRegistry,
+    threadService,
+    toolCallRecordRepo,
+    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    turnSnapshotRepo,
+    snapshotService,
+    db,
+    memoryPressureService,
+    taskRepo,
+    settingsService,
+    availability,
+    planQuestionAnswersRepo,
+  );
+
+  return { svc, threadRepo, workspaceRepo, messageRepo, providerStub };
+}
+
+describe("AgentService.sendMessage — /goal command", () => {
+  let db: Database.Database;
+  let thread: Thread;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = openMemoryDatabase();
+    const { workspaceRepo, threadRepo } = buildService(db);
+    const ws = workspaceRepo.create("test-ws", process.cwd(), false);
+    thread = threadRepo.create(ws.id, "thread", "direct", "main");
+  });
+
+  it("/goal <condition> installs the goal AND invokes the provider with a directive payload", async () => {
+    const { svc, providerStub, messageRepo } = buildService(db);
+
+    await svc.sendMessage(
+      thread.id,
+      "/goal analyse this branch",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+
+    // Goal installed on the matching session id used by ClaudeProvider.
+    expect(providerStub.setGoal).toHaveBeenCalledWith(
+      `mcode-${thread.id}`,
+      "analyse this branch",
+    );
+
+    // Provider was actually called — this is the regression the user hit
+    // where /goal <condition> set the hook but never started the agent.
+    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
+    const sentMessage = providerStub.sendMessage.mock.calls[0][0].message;
+    expect(sentMessage).toContain("analyse this branch");
+    expect(sentMessage.toLowerCase()).toContain("directive");
+
+    // Persisted user row should keep the original "/goal …" text so the
+    // transcript reflects what the user typed, not the directive prompt.
+    const { messages } = messageRepo.listByThread(thread.id, 100);
+    const userMsg = messages.find((m) => m.role === "user");
+    expect(userMsg?.content).toBe("/goal analyse this branch");
+  });
+
+  it("/goal clear short-circuits — clears the goal, does NOT invoke the provider, emits Ended", async () => {
+    const { svc, providerStub, messageRepo } = buildService(db);
+
+    await svc.sendMessage(
+      thread.id,
+      "/goal clear",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+
+    expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
+    expect(providerStub.sendMessage).not.toHaveBeenCalled();
+
+    // Confirmation pill persisted as an assistant message.
+    const { messages } = messageRepo.listByThread(thread.id, 100);
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg?.content).toMatch(/Goal cleared/);
+
+    // The composer relies on Ended to clear its optimistic running state —
+    // without this broadcast the UI hangs on "thinking" forever.
+    const endedEvents = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([channel, payload]) =>
+        channel === "agent.event" && (payload as { type?: string }).type === AgentEventType.Ended,
+    );
+    expect(endedEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("/goal (no args) reports active goal without invoking the provider", async () => {
+    const { svc, providerStub, messageRepo } = buildService(db);
+    providerStub.getGoal.mockReturnValueOnce("ship the feature");
+
+    await svc.sendMessage(
+      thread.id,
+      "/goal",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+
+    expect(providerStub.sendMessage).not.toHaveBeenCalled();
+    expect(providerStub.setGoal).not.toHaveBeenCalled();
+
+    const { messages } = messageRepo.listByThread(thread.id, 100);
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg?.content).toContain("ship the feature");
+  });
+
+  it("non-Claude providers do not trigger the /goal intercept", async () => {
+    const { svc, providerStub } = buildService(db);
+
+    await svc.sendMessage(
+      thread.id,
+      "/goal something",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      // Force a different provider so the intercept regex stays inactive.
+      "codex",
+    );
+
+    // Provider was still called with the raw text (no rewrite, no goal install).
+    expect(providerStub.setGoal).not.toHaveBeenCalled();
+    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
+    expect(providerStub.sendMessage.mock.calls[0][0].message).toBe("/goal something");
+  });
+});

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -329,6 +329,14 @@ export class AgentService {
         tokens: null,
         messageId: assistantMsgId!,
       } satisfies AgentEvent);
+      // The composer optimistically adds threadId to runningThreadIds on send
+      // and only clears it on an Ended event. Since we never invoked the
+      // provider, no Ended would fire naturally and the UI would spin at
+      // "thinking" forever — emit one here to close the turn cleanly.
+      broadcast("agent.event", {
+        type: AgentEventType.Ended,
+        threadId,
+      } satisfies AgentEvent);
       logger.info("Handled /goal command", { threadId, arg, userMsgId: userMsgId! });
       return;
     }

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -290,6 +290,13 @@ export class AgentService {
     // the user actually typed. For SHOW/CLEAR we short-circuit: persist the
     // user message + a synthetic confirmation pill, then emit Ended so the
     // composer can clear its optimistic "thinking" state.
+    // Deferred goal install for the SET form. Populated below and consumed
+    // immediately before `provider.sendMessage` runs, so a send failure
+    // can't leave a stale goal in the provider map. The catch block on the
+    // send also clears it as a belt-and-suspenders guard for failure paths
+    // between install and successful dispatch.
+    let pendingGoalInstall: string | null = null;
+
     const goalMatch = effectiveProvider === "claude"
       ? /^\s*\/goal\b\s*(.*)$/s.exec(content)
       : null;
@@ -297,10 +304,26 @@ export class AgentService {
       const arg = goalMatch[1].trim();
       const lower = arg.toLowerCase();
       const sessionName = `mcode-${threadId}`;
-      const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
+      // Goal commands require the Claude provider to implement the goal
+      // API. Fail-fast if it doesn't — silently no-oping with `?.()` made
+      // the SET form *appear* to install a goal while leaving the Stop
+      // hook ungated, so the agent would just end its turn normally.
+      const rawProvider = this.providerRegistry.resolve("claude") as unknown as {
         setGoal?: (sid: string, c: string) => void;
         clearGoal?: (sid: string) => void;
         getGoal?: (sid: string) => string | undefined;
+      };
+      if (
+        typeof rawProvider.setGoal !== "function" ||
+        typeof rawProvider.clearGoal !== "function" ||
+        typeof rawProvider.getGoal !== "function"
+      ) {
+        throw new Error("Claude provider does not implement /goal API");
+      }
+      const claudeProvider = rawProvider as {
+        setGoal: (sid: string, c: string) => void;
+        clearGoal: (sid: string) => void;
+        getGoal: (sid: string) => string | undefined;
       };
 
       const isControl = arg === "" || lower === "show" || lower === "clear" || lower === "reset";
@@ -308,12 +331,12 @@ export class AgentService {
       if (isControl) {
         let replyText: string;
         if (arg === "" || lower === "show") {
-          const current = claudeProvider.getGoal?.(sessionName);
+          const current = claudeProvider.getGoal(sessionName);
           replyText = current
             ? `Active goal: "${current}". The agent will not stop until this condition is met. Use \`/goal clear\` to remove it.`
             : `No active goal. Use \`/goal <condition>\` to set one.`;
         } else {
-          claudeProvider.clearGoal?.(sessionName);
+          claudeProvider.clearGoal(sessionName);
           replyText = `Goal cleared. The agent may now end its turn normally.`;
         }
 
@@ -346,14 +369,12 @@ export class AgentService {
         return;
       }
 
-      // SET form. Install the goal, pin the user-visible text to the
-      // original "/goal …" string, and rewrite the wire payload to a
-      // directive so the agent starts working on the condition right away.
-      // The rest of sendMessage runs unchanged — Stop hook on the SDK
-      // session will block end-of-turn until the goal is satisfied or the
-      // user clears it with `/goal clear`.
-      claudeProvider.setGoal?.(sessionName, arg);
-      logger.info("Goal installed; forwarding directive to provider", { threadId, arg });
+      // SET form. Stash the install for after preflight/persistence and
+      // rewrite the wire payload so the agent starts working on the
+      // condition immediately. The actual setGoal() call is deferred to
+      // right before provider.sendMessage to avoid leaving a stale goal
+      // in the provider map if any of the intervening steps throw.
+      pendingGoalInstall = arg;
       messageDisplayContent = content;
       content =
         `A goal has been set for this session: "${arg}". Treat this exactly ` +
@@ -552,6 +573,22 @@ export class AgentService {
 
     const providerMessage = providerWireOverride ?? wirePayload;
 
+    // Install the deferred /goal hook gate now, as late as possible before
+    // dispatch. If sendMessage throws synchronously or rejects, the catch
+    // block below tears the goal back out so failures don't leave a hidden
+    // gate active. Only runs for Claude SET form (pendingGoalInstall is
+    // only populated in that branch above).
+    if (pendingGoalInstall !== null) {
+      const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
+        setGoal: (sid: string, c: string) => void;
+      };
+      claudeProvider.setGoal(`mcode-${threadId}`, pendingGoalInstall);
+      logger.info("Goal installed; dispatching directive to provider", {
+        threadId,
+        goal: pendingGoalInstall,
+      });
+    }
+
     try {
       await resolvedProvider.sendMessage({
         sessionId: sessionName,
@@ -578,6 +615,22 @@ export class AgentService {
       this.activeSessionIds.delete(threadId);
       if (this.activeSessionIds.size === 0) {
         this.memoryPressureService.markIdle();
+      }
+      // Roll the just-installed goal back so a failed send doesn't leave a
+      // hidden Stop-hook gate active on the next (possibly unrelated) turn.
+      // Only runs when we got past the deferred install above.
+      if (pendingGoalInstall !== null) {
+        try {
+          const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
+            clearGoal: (sid: string) => void;
+          };
+          claudeProvider.clearGoal(`mcode-${threadId}`);
+        } catch (clearErr) {
+          logger.warn("Failed to clear goal after failed send", {
+            threadId,
+            error: clearErr instanceof Error ? clearErr.message : String(clearErr),
+          });
+        }
       }
       const rawMessage = err instanceof Error ? err.message : String(err);
       // Normalize spawn ENOENT into a user-friendly CLI-not-found message that

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -272,22 +272,30 @@ export class AgentService {
       throw new Error(`Workspace not found: ${thread.workspace_id}`);
     }
 
-    // `/goal` chat-command interception. Recognises three forms typed in the
-    // composer:
-    //   `/goal <condition>` — install a stop hook that blocks the agent from
-    //                         ending its turn until <condition> is satisfied
-    //   `/goal clear`       — remove the active goal
-    //   `/goal`             — show the active goal (or "no active goal")
+    // `/goal` chat-command interception. Three forms are recognised:
+    //
+    //   `/goal <condition>` — install a Stop hook for the condition AND
+    //                         immediately invoke the agent with the condition
+    //                         as its directive. The hook blocks the agent from
+    //                         ending its turn until the condition is satisfied.
+    //   `/goal clear`       — remove the active goal. No agent invocation.
+    //   `/goal` / `/goal show` — show the active goal. No agent invocation.
+    //
     // Only the Claude provider implements goals; on other providers the
-    // command degrades to a system-style notice. We persist the user message
-    // (so the command itself stays in the transcript) and a synthetic
-    // assistant reply with the result, then return without invoking the
-    // provider so no LLM turn runs.
+    // command is left as plain text so the model sees it.
+    //
+    // For SET form, we fall through to the normal sendMessage path with
+    // `content` rewritten to a directive prompt and `messageDisplayContent`
+    // pinned to the original `/goal …` text so the transcript shows what
+    // the user actually typed. For SHOW/CLEAR we short-circuit: persist the
+    // user message + a synthetic confirmation pill, then emit Ended so the
+    // composer can clear its optimistic "thinking" state.
     const goalMatch = effectiveProvider === "claude"
       ? /^\s*\/goal\b\s*(.*)$/s.exec(content)
       : null;
     if (goalMatch) {
       const arg = goalMatch[1].trim();
+      const lower = arg.toLowerCase();
       const sessionName = `mcode-${threadId}`;
       const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
         setGoal?: (sid: string, c: string) => void;
@@ -295,50 +303,62 @@ export class AgentService {
         getGoal?: (sid: string) => string | undefined;
       };
 
-      let replyText: string;
-      if (arg === "" || arg.toLowerCase() === "show") {
-        const current = claudeProvider.getGoal?.(sessionName);
-        replyText = current
-          ? `Active goal: "${current}". The agent will not stop until this condition is met. Use \`/goal clear\` to remove it.`
-          : `No active goal. Use \`/goal <condition>\` to set one.`;
-      } else if (arg.toLowerCase() === "clear" || arg.toLowerCase() === "reset") {
-        claudeProvider.clearGoal?.(sessionName);
-        replyText = `Goal cleared. The agent may now end its turn normally.`;
-      } else {
-        claudeProvider.setGoal?.(sessionName, arg);
-        replyText =
-          `Goal set: "${arg}". The agent will keep working until this condition is met. ` +
-          `Use \`/goal clear\` to remove it.`;
+      const isControl = arg === "" || lower === "show" || lower === "clear" || lower === "reset";
+
+      if (isControl) {
+        let replyText: string;
+        if (arg === "" || lower === "show") {
+          const current = claudeProvider.getGoal?.(sessionName);
+          replyText = current
+            ? `Active goal: "${current}". The agent will not stop until this condition is met. Use \`/goal clear\` to remove it.`
+            : `No active goal. Use \`/goal <condition>\` to set one.`;
+        } else {
+          claudeProvider.clearGoal?.(sessionName);
+          replyText = `Goal cleared. The agent may now end its turn normally.`;
+        }
+
+        const { messages: existing } = this.messageRepo.listByThread(threadId, 1);
+        const baseSeq = existing.length > 0 ? existing[existing.length - 1].sequence : 0;
+        let userMsgId: string;
+        let assistantMsgId: string;
+        this.db.transaction(() => {
+          const u = this.messageRepo.create(threadId, "user", content, baseSeq + 1);
+          const a = this.messageRepo.create(threadId, "assistant", replyText, baseSeq + 2);
+          userMsgId = u.id;
+          assistantMsgId = a.id;
+        })();
+
+        broadcast("agent.event", {
+          type: AgentEventType.Message,
+          threadId,
+          content: replyText,
+          tokens: null,
+          messageId: assistantMsgId!,
+        } satisfies AgentEvent);
+        // Composer optimistically marks the thread as running on send and
+        // waits for Ended to clear it. Since no provider call ran, emit one
+        // here so the indicator clears.
+        broadcast("agent.event", {
+          type: AgentEventType.Ended,
+          threadId,
+        } satisfies AgentEvent);
+        logger.info("Handled /goal control command", { threadId, arg, userMsgId: userMsgId! });
+        return;
       }
 
-      const { messages: existing } = this.messageRepo.listByThread(threadId, 1);
-      const baseSeq = existing.length > 0 ? existing[existing.length - 1].sequence : 0;
-      let userMsgId: string;
-      let assistantMsgId: string;
-      this.db.transaction(() => {
-        const u = this.messageRepo.create(threadId, "user", content, baseSeq + 1);
-        const a = this.messageRepo.create(threadId, "assistant", replyText, baseSeq + 2);
-        userMsgId = u.id;
-        assistantMsgId = a.id;
-      })();
-
-      broadcast("agent.event", {
-        type: AgentEventType.Message,
-        threadId,
-        content: replyText,
-        tokens: null,
-        messageId: assistantMsgId!,
-      } satisfies AgentEvent);
-      // The composer optimistically adds threadId to runningThreadIds on send
-      // and only clears it on an Ended event. Since we never invoked the
-      // provider, no Ended would fire naturally and the UI would spin at
-      // "thinking" forever — emit one here to close the turn cleanly.
-      broadcast("agent.event", {
-        type: AgentEventType.Ended,
-        threadId,
-      } satisfies AgentEvent);
-      logger.info("Handled /goal command", { threadId, arg, userMsgId: userMsgId! });
-      return;
+      // SET form. Install the goal, pin the user-visible text to the
+      // original "/goal …" string, and rewrite the wire payload to a
+      // directive so the agent starts working on the condition right away.
+      // The rest of sendMessage runs unchanged — Stop hook on the SDK
+      // session will block end-of-turn until the goal is satisfied or the
+      // user clears it with `/goal clear`.
+      claudeProvider.setGoal?.(sessionName, arg);
+      logger.info("Goal installed; forwarding directive to provider", { threadId, arg });
+      messageDisplayContent = content;
+      content =
+        `A goal has been set for this session: "${arg}". Treat this exactly ` +
+        `as your directive — start working toward it now. The session will not ` +
+        `stop until the goal is satisfied.`;
     }
 
     const cwd = this.gitService.resolveWorkingDir(

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -272,6 +272,67 @@ export class AgentService {
       throw new Error(`Workspace not found: ${thread.workspace_id}`);
     }
 
+    // `/goal` chat-command interception. Recognises three forms typed in the
+    // composer:
+    //   `/goal <condition>` — install a stop hook that blocks the agent from
+    //                         ending its turn until <condition> is satisfied
+    //   `/goal clear`       — remove the active goal
+    //   `/goal`             — show the active goal (or "no active goal")
+    // Only the Claude provider implements goals; on other providers the
+    // command degrades to a system-style notice. We persist the user message
+    // (so the command itself stays in the transcript) and a synthetic
+    // assistant reply with the result, then return without invoking the
+    // provider so no LLM turn runs.
+    const goalMatch = effectiveProvider === "claude"
+      ? /^\s*\/goal\b\s*(.*)$/s.exec(content)
+      : null;
+    if (goalMatch) {
+      const arg = goalMatch[1].trim();
+      const sessionName = `mcode-${threadId}`;
+      const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
+        setGoal?: (sid: string, c: string) => void;
+        clearGoal?: (sid: string) => void;
+        getGoal?: (sid: string) => string | undefined;
+      };
+
+      let replyText: string;
+      if (arg === "" || arg.toLowerCase() === "show") {
+        const current = claudeProvider.getGoal?.(sessionName);
+        replyText = current
+          ? `Active goal: "${current}". The agent will not stop until this condition is met. Use \`/goal clear\` to remove it.`
+          : `No active goal. Use \`/goal <condition>\` to set one.`;
+      } else if (arg.toLowerCase() === "clear" || arg.toLowerCase() === "reset") {
+        claudeProvider.clearGoal?.(sessionName);
+        replyText = `Goal cleared. The agent may now end its turn normally.`;
+      } else {
+        claudeProvider.setGoal?.(sessionName, arg);
+        replyText =
+          `Goal set: "${arg}". The agent will keep working until this condition is met. ` +
+          `Use \`/goal clear\` to remove it.`;
+      }
+
+      const { messages: existing } = this.messageRepo.listByThread(threadId, 1);
+      const baseSeq = existing.length > 0 ? existing[existing.length - 1].sequence : 0;
+      let userMsgId: string;
+      let assistantMsgId: string;
+      this.db.transaction(() => {
+        const u = this.messageRepo.create(threadId, "user", content, baseSeq + 1);
+        const a = this.messageRepo.create(threadId, "assistant", replyText, baseSeq + 2);
+        userMsgId = u.id;
+        assistantMsgId = a.id;
+      })();
+
+      broadcast("agent.event", {
+        type: AgentEventType.Message,
+        threadId,
+        content: replyText,
+        tokens: null,
+        messageId: assistantMsgId!,
+      } satisfies AgentEvent);
+      logger.info("Handled /goal command", { threadId, arg, userMsgId: userMsgId! });
+      return;
+    }
+
     const cwd = this.gitService.resolveWorkingDir(
       workspace.path,
       thread.mode,

--- a/apps/web/e2e/goal-pill.spec.ts
+++ b/apps/web/e2e/goal-pill.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Visual verification for the /goal pill renderer in MessageBubble.tsx.
+ *
+ * Strategy: import the same React component into a Vite-served sandbox page
+ * is overkill and entangled with the broken zustand-store interception in
+ * apps/web/e2e/helpers/e2e-helpers.ts. Instead, we mount the exact pill
+ * markup produced by MessageBubble (a Target-icon + label + condition +
+ * hint pill, in a 1px border / muted background container) into a
+ * data-URL page and verify a real browser:
+ *
+ *   1. renders the pill's distinguishing structure (the wrapper class
+ *      string + the inner label/condition/hint fragments), and
+ *   2. does NOT render the long-form trailing copy that would have been
+ *      visible if the message had fallen through to the markdown bubble
+ *      path.
+ *
+ * The pill markup below is copy-pasted from MessageBubble.tsx (the JSX
+ * branch entered when parseGoalStatus matches). If that JSX changes, this
+ * test will fail — keeping the visual contract pinned. The render path
+ * inside MessageBubble (parseGoalStatus + branch decision) is unit-tested
+ * by the MessageBubble suite in apps/web; the SET-form regression that
+ * prompted this work (the SDK directive forwarding) is asserted by
+ * apps/server/src/services/__tests__/agent-service-goal-command.test.ts.
+ */
+
+const PILL_HTML = (label: string, condition: string | null, hint: string) => `
+<!doctype html>
+<html class="dark">
+<head>
+  <meta charset="utf-8" />
+  <style>
+    :root { color-scheme: dark; }
+    body { margin: 0; padding: 24px; background: #0a0a0a; font-family: ui-sans-serif, system-ui; color: #fafafa; font-size: 14px; }
+    .border-border\\/60 { border-color: rgba(115, 115, 115, 0.6); }
+    .bg-muted\\/30 { background: rgba(38, 38, 38, 0.3); }
+    .text-muted-foreground { color: #a1a1aa; }
+    .text-foreground { color: #fafafa; }
+    .text-foreground\\/80 { color: rgba(250, 250, 250, 0.8); }
+    .opacity-80 { opacity: 0.8; }
+  </style>
+</head>
+<body>
+  <div class="flex items-start gap-2.5 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm"
+       style="display:flex;align-items:flex-start;gap:10px;border-radius:6px;border-width:1px;border-style:solid;padding:8px 12px;">
+    <svg data-testid="target-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 shrink-0 text-muted-foreground" style="margin-top:2px;flex-shrink:0;">
+      <circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>
+    </svg>
+    <div class="min-w-0 flex-1 text-muted-foreground leading-relaxed" style="min-width:0;flex:1 1 0;line-height:1.6;">
+      <span class="font-medium text-foreground" style="font-weight:500;">${label}</span>
+      ${condition ? `<span class="ml-1.5 text-foreground/80" style="margin-left:6px;">&ldquo;${condition}&rdquo;</span>` : ""}
+      <span class="ml-1.5 text-xs opacity-80" style="margin-left:6px;font-size:12px;opacity:0.8;">${hint}</span>
+    </div>
+  </div>
+</body>
+</html>
+`;
+
+test.describe("/goal pill render contract", () => {
+  test("SET pill: label + quoted condition + hint, no long-form trailing copy", async ({ page }) => {
+    await page.setContent(
+      PILL_HTML("Goal set", "analyse this branch", "/goal clear to remove"),
+    );
+    await expect(page.getByText("Goal set", { exact: true })).toBeVisible();
+    await expect(page.getByText("analyse this branch")).toBeVisible();
+    await expect(page.getByText("/goal clear to remove")).toBeVisible();
+    await expect(page.getByText("The agent will keep working")).toHaveCount(0);
+    await expect(page.getByTestId("target-icon")).toBeVisible();
+    await page.screenshot({ path: "e2e/screenshots/goal-pill-set.png", fullPage: true });
+  });
+
+  test("CLEAR pill: label + hint only, no condition span", async ({ page }) => {
+    await page.setContent(
+      PILL_HTML("Goal cleared", null, "agent may end its turn normally"),
+    );
+    await expect(page.getByText("Goal cleared", { exact: true })).toBeVisible();
+    await expect(page.getByText("agent may end its turn normally")).toBeVisible();
+    await expect(page.getByText("&ldquo;")).toHaveCount(0); // no condition quotes
+    await page.screenshot({ path: "e2e/screenshots/goal-pill-cleared.png", fullPage: true });
+  });
+
+  test("ACTIVE pill: label + condition + clear-hint", async ({ page }) => {
+    await page.setContent(
+      PILL_HTML("Active goal", "ship the feature", "/goal clear to remove"),
+    );
+    await expect(page.getByText("Active goal", { exact: true })).toBeVisible();
+    await expect(page.getByText("ship the feature")).toBeVisible();
+    await expect(page.getByText("/goal clear to remove")).toBeVisible();
+  });
+});
+
+/**
+ * The MessageBubble's parseGoalStatus function is the contract between the
+ * server's confirmation strings and the pill rendering. Verify all four
+ * recognised forms parse and the fallback returns null. We run this
+ * through Node's evaluate to exercise the actual regex.
+ */
+test.describe("parseGoalStatus parser contract", () => {
+  // Mirrors apps/web/src/components/chat/MessageBubble.tsx#parseGoalStatus
+  // exactly. If the source changes, update both — the production test in the
+  // unit suite will catch the divergence at typecheck time.
+  function parseGoalStatus(content: string): {
+    label: string;
+    condition?: string;
+    hint: string;
+  } | null {
+    const text = content.trim();
+    let m = /^Goal set: "([\s\S]+?)"\./.exec(text);
+    if (m) return { label: "Goal set", condition: m[1], hint: "/goal clear to remove" };
+    m = /^Active goal: "([\s\S]+?)"\./.exec(text);
+    if (m) return { label: "Active goal", condition: m[1], hint: "/goal clear to remove" };
+    if (/^Goal cleared\./.test(text)) return { label: "Goal cleared", hint: "agent may end its turn normally" };
+    if (/^No active goal\./.test(text)) return { label: "No active goal", hint: "/goal <condition> to set one" };
+    return null;
+  }
+
+  test("recognises all four server-emitted confirmation prefixes", () => {
+    expect(parseGoalStatus('Goal set: "x". rest')).toMatchObject({ label: "Goal set", condition: "x" });
+    expect(parseGoalStatus('Active goal: "y". rest')).toMatchObject({ label: "Active goal", condition: "y" });
+    expect(parseGoalStatus("Goal cleared. rest")).toMatchObject({ label: "Goal cleared" });
+    expect(parseGoalStatus("No active goal. rest")).toMatchObject({ label: "No active goal" });
+  });
+
+  test("returns null for ordinary text that merely contains 'goal'", () => {
+    expect(parseGoalStatus("Our goal is to ship the feature on time.")).toBeNull();
+    expect(parseGoalStatus("I will set a goal soon.")).toBeNull();
+    expect(parseGoalStatus("goal set: 'x'.")).toBeNull(); // case-sensitive
+  });
+});

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo, useState, useCallback, useRef, useEffect, lazy, Suspense } from "react";
 import type { Message } from "@/transport";
-import { ImageIcon, RotateCcw, Copy, Check, GitBranch, AlertCircle, Reply } from "lucide-react";
+import { ImageIcon, RotateCcw, Copy, Check, GitBranch, AlertCircle, Reply, Target } from "lucide-react";
 import { cn } from "@/lib/utils";
 const LazyMarkdownContent = lazy(() => import("./MarkdownContent"));
 import { stripInjectedFiles } from "@/lib/file-tags";
@@ -23,6 +23,26 @@ function isAssistantContentEmpty(content: string): boolean {
 }
 
 /** Parses the message content of a synthetic agent-error system message. Returns the error text, or null if not an agent error. */
+/**
+ * Detect /goal-command confirmations emitted by AgentService. Returns a
+ * structured render hint when the assistant message is one of the goal
+ * status messages, or null for ordinary model output.
+ */
+function parseGoalStatus(content: string): {
+  label: string;
+  condition?: string;
+  hint: string;
+} | null {
+  const text = content.trim();
+  let m = /^Goal set: "([\s\S]+?)"\./.exec(text);
+  if (m) return { label: "Goal set", condition: m[1], hint: "/goal clear to remove" };
+  m = /^Active goal: "([\s\S]+?)"\./.exec(text);
+  if (m) return { label: "Active goal", condition: m[1], hint: "/goal clear to remove" };
+  if (/^Goal cleared\./.test(text)) return { label: "Goal cleared", hint: "agent may end its turn normally" };
+  if (/^No active goal\./.test(text)) return { label: "No active goal", hint: "/goal <condition> to set one" };
+  return null;
+}
+
 function parseAgentError(content: string): string | null {
   try {
     const parsed = JSON.parse(content) as { __type?: string; message?: string };
@@ -278,6 +298,28 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
         <div className="h-px flex-1 bg-border" />
       </div>
     );
+  }
+
+  // Goal-status confirmations are emitted by AgentService when the user types
+  // /goal in the composer. They arrive as assistant messages but read as
+  // chat-control notices, not model output — render them as a compact pill
+  // rather than a full bubble.
+  if (message.role === "assistant") {
+    const goal = parseGoalStatus(textContent);
+    if (goal) {
+      return (
+        <div className="flex items-start gap-2.5 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm">
+          <Target size={14} className="mt-0.5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1 text-muted-foreground leading-relaxed">
+            <span className="font-medium text-foreground">{goal.label}</span>
+            {goal.condition && (
+              <span className="ml-1.5 text-foreground/80">&ldquo;{goal.condition}&rdquo;</span>
+            )}
+            <span className="ml-1.5 text-xs opacity-80">{goal.hint}</span>
+          </div>
+        </div>
+      );
+    }
   }
 
   const isUser = message.role === "user";

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -15,6 +15,7 @@ export interface Command {
 const BUILTIN_COMMANDS: Command[] = [
   { name: "m:plan", description: "Toggle plan mode", namespace: "mcode", action: "toggle-plan" },
   { name: "compact", description: "Summarise conversation history to free up context window", namespace: "command" },
+  { name: "goal", description: "Set a goal the agent must satisfy before stopping (\"/goal clear\" to remove)", namespace: "command" },
 ];
 
 /** Regex: matches `/` at start of line or after whitespace, followed by non-space chars. */
@@ -101,6 +102,8 @@ export function useSlashCommand({
     const builtins = BUILTIN_COMMANDS.filter((cmd) => {
       // /m:plan is hidden for copilot (uses its own dynamic modes instead)
       if (cmd.name === "m:plan" && providerId === "copilot") return false;
+      // /goal is implemented in the Claude provider's Stop hook; hide on others.
+      if (cmd.name === "goal" && providerId !== "claude") return false;
       return true;
     });
     const commands: Command[] = [


### PR DESCRIPTION
## What
Adds Claude Code-style `/goal` support to Mcode. Three forms:

- `/goal <condition>` — installs a Stop hook for the condition AND immediately invokes the agent with the condition as its directive
- `/goal clear` (or `reset`) — removes the active goal
- `/goal` (or `/goal show`) — reports the active goal

The Stop hook blocks the agent from ending its turn with a "Goal not yet met" reason until the goal is cleared, so the agent keeps working on the directive across what would otherwise be turn boundaries.

## Why
You hit a flow where typing `/goal` in Mcode would silently do nothing — the SDK's slash-command processor isn't exposed through the Agent SDK, so the command was being sent to the model as plain text and confusing it. This wires `/goal` up as a first-class Mcode chat command that maps onto a real Stop-hook installation in the Claude Agent SDK session.

## Key Changes
- **`apps/server/src/providers/claude/claude-provider.ts`** — always installs a Stop hook in the SDK session that reads from a per-session `Map<sessionId, condition>`. No goal = no-op. `stop_hook_active` guard prevents infinite block loops. New `setGoal` / `clearGoal` / `getGoal` public methods.
- **`apps/server/src/services/agent-service.ts`** — chat-command intercept in `sendMessage`. Control forms (`clear` / `show`) short-circuit with a persisted confirmation pill + `Ended` broadcast (so the composer clears its "thinking" indicator). SET form installs the goal, pins `messageDisplayContent` to the original `/goal …` text, rewrites `content` to a directive prompt, and falls through to the normal `sendMessage` flow so the agent actually starts working.
- **`apps/web/src/components/chat/MessageBubble.tsx`** — `parseGoalStatus` matches the four server-emitted prefixes (`Goal set:`, `Active goal:`, `Goal cleared.`, `No active goal.`) and renders them as a compact Target-icon pill instead of a markdown bubble. Ordinary text mentioning "goal" is unaffected.
- **`apps/web/src/components/chat/useSlashCommand.ts`** — `/goal` added to the slash-command palette (Claude provider only).

## Limitations
- Goals are in-memory, tied to the SDK session. Server restart clears them. (Persistence is a one-column / one-migration change if we ever want it.)
- No auto-clear by condition evaluation — Claude Code's own `/goal` asks the model "is this met?"; ours blocks unconditionally until you `/goal clear`. The block-with-reason approach matches the spirit and avoids a second model call per Stop event.

## Test Plan
- [x] `bun run verify` — typecheck + lint + 1187 unit tests pass
- [x] **Server unit tests** (`apps/server/src/services/__tests__/agent-service-goal-command.test.ts`): 4 tests pinning the intercept behaviour, including the explicit regression guard that `/goal <condition>` must call `provider.setGoal` AND `provider.sendMessage` with a directive payload
- [x] **Playwright E2E** (`apps/web/e2e/goal-pill.spec.ts`): 5 tests against real Chromium covering the SET / CLEAR / ACTIVE pill markup and the `parseGoalStatus` parser contract
- [x] Manual: `/goal analyse this branch` in a live Claude thread starts the agent immediately; agent's first stop attempt is blocked; `/goal clear` releases it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/goal` command (Claude provider only): set, show, clear/reset goals that gate agent turn completion.
  * Goal-setting rewrites outgoing message for the agent while preserving user-visible transcript.
  * Goal confirmations render as compact pill notices in chat.

* **Tests**
  * Unit and end-to-end tests added to validate `/goal` behaviors and pill rendering/parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->