### PR TITLE
feat: project actions with keybindings and worktree hooks

### DIFF
--- a/apps/server/drizzle/0005_wakeful_pixie.sql
+++ b/apps/server/drizzle/0005_wakeful_pixie.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `workspaces` ADD `last_action_id` text;

--- a/apps/server/drizzle/meta/0005_snapshot.json
+++ b/apps/server/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1118 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "aee73df7-397e-4e76-95cb-42104bb873fb",
+  "prevId": "a533fa21-f276-4f46-b989-6322caa59bd0",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diff_summaries": {
+      "name": "diff_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_turn_id": {
+          "name": "last_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_diff_summaries_thread": {
+          "name": "idx_diff_summaries_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "diff_summaries_thread_id_threads_id_fk": {
+          "name": "diff_summaries_thread_id_threads_id_fk",
+          "tableFrom": "diff_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_action_id": {
+          "name": "last_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778050324939,
       "tag": "0004_funny_layla_miller",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1778620774532,
+      "tag": "0005_wakeful_pixie",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/__tests__/cleanup-integration.test.ts
+++ b/apps/server/src/__tests__/cleanup-integration.test.ts
@@ -19,6 +19,7 @@ import type { GitService } from "../services/git-service";
 import { AttachmentService } from "../services/attachment-service";
 import { WorkspaceService } from "../services/workspace-service";
 import type { AgentService } from "../services/agent-service";
+import type { ActionService } from "../services/action-service";
 import { killDescendantsByName } from "../services/process-kill.js";
 import { getMcodeDir } from "@mcode/shared";
 
@@ -71,7 +72,7 @@ describe("Cleanup integration", () => {
       isRegisteredWorktreePath: vi.fn().mockReturnValue(true),
     } as unknown as GitService;
 
-    threadService = new ThreadService(threadRepo, workspaceRepo, mockGitService, cleanupJobRepo);
+    threadService = new ThreadService(threadRepo, workspaceRepo, mockGitService, cleanupJobRepo, { runSetupAction: vi.fn().mockResolvedValue(undefined) } as unknown as ActionService);
 
     worker = new CleanupWorker(
       db,
@@ -92,6 +93,7 @@ describe("Cleanup integration", () => {
       cleanupJobRepo,
       mockAttachmentService,
       mockAgentService,
+      { removeDataDir: vi.fn().mockResolvedValue(undefined) } as unknown as ActionService,
     );
   });
 

--- a/apps/server/src/__tests__/thread-service.test.ts
+++ b/apps/server/src/__tests__/thread-service.test.ts
@@ -7,6 +7,7 @@ import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { ThreadService } from "../services/thread-service";
 import type { GitService } from "../services/git-service";
+import type { ActionService } from "../services/action-service";
 
 describe("ThreadService.delete", () => {
   let db: Database.Database;
@@ -36,6 +37,7 @@ describe("ThreadService.delete", () => {
       workspaceRepo,
       mockGitService,
       cleanupJobRepo,
+      { runSetupAction: vi.fn().mockResolvedValue(undefined) } as unknown as ActionService,
     );
   });
 

--- a/apps/server/src/__tests__/workspace-hard-delete.test.ts
+++ b/apps/server/src/__tests__/workspace-hard-delete.test.ts
@@ -10,6 +10,7 @@ import { WorkspaceService } from "../services/workspace-service";
 import { AttachmentService } from "../services/attachment-service";
 import { CleanupWorker } from "../services/cleanup-worker";
 import type { AgentService } from "../services/agent-service";
+import type { ActionService } from "../services/action-service";
 import type { ClaudeProvider } from "../providers/claude/claude-provider";
 import type { TerminalService } from "../services/terminal-service";
 import type { GitService } from "../services/git-service";
@@ -226,6 +227,7 @@ describe("WorkspaceService.delete - two-phase orchestration", () => {
       cleanupJobRepo,
       mockAttachmentService,
       { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService,
+      { removeDataDir: vi.fn().mockResolvedValue(undefined) } as unknown as ActionService,
     );
   });
 
@@ -639,6 +641,7 @@ describe("WorkspaceService.delete - active session handling", () => {
       cleanupJobRepo,
       mockAttachmentService,
       mockAgentService as unknown as AgentService,
+      { removeDataDir: vi.fn().mockResolvedValue(undefined) } as unknown as ActionService,
     );
   });
 
@@ -685,6 +688,7 @@ describe("Workspace delete - cross-workspace fork lineage", () => {
       cleanupJobRepo,
       mockAttachmentService,
       { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService,
+      { removeDataDir: vi.fn().mockResolvedValue(undefined) } as unknown as ActionService,
     );
   });
 
@@ -937,6 +941,7 @@ describe("Workspace delete - zero-worktree fast path", () => {
       cleanupJobRepo,
       mockAttachmentService,
       { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService,
+      { removeDataDir: vi.fn().mockResolvedValue(undefined) } as unknown as ActionService,
     );
   });
 

--- a/apps/server/src/__tests__/workspace-repo.test.ts
+++ b/apps/server/src/__tests__/workspace-repo.test.ts
@@ -8,6 +8,7 @@ import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { WorkspaceService } from "../services/workspace-service";
 import { AttachmentService } from "../services/attachment-service";
 import type { AgentService } from "../services/agent-service";
+import type { ActionService } from "../services/action-service";
 
 describe("WorkspaceRepo", () => {
   let db: Database.Database;
@@ -90,7 +91,7 @@ describe("WorkspaceService", () => {
     const threadRepo = new ThreadRepo(db);
     const cleanupJobRepo = new CleanupJobRepo(db);
     const mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
-    service = new WorkspaceService(repo, threadRepo, cleanupJobRepo, mockAttachmentService, { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService);
+    service = new WorkspaceService(repo, threadRepo, cleanupJobRepo, mockAttachmentService, { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService, { removeDataDir: vi.fn().mockResolvedValue(undefined) } as unknown as ActionService);
   });
 
   it("create() returns existing workspace when path already exists", () => {

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -58,6 +58,7 @@ import { ShellEnvResolver } from "./services/shell-env-resolver";
 import { EnvService } from "./services/env-service";
 import { UtilityCompletionService } from "./services/utility-completion-service";
 import { DiffSummaryService } from "./services/diff-summary-service";
+import { ActionService } from "./services/action-service";
 
 /** Initialize the DI container with all server dependencies. */
 export function setupContainer(mcodeDir: string): typeof container {
@@ -333,6 +334,11 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(
     DiffSummaryService,
     { useClass: DiffSummaryService },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    ActionService,
+    { useClass: ActionService },
     { lifecycle: Lifecycle.Singleton },
   );
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -48,6 +48,7 @@ import { WorkspaceEnricher } from "./services/workspace-enricher";
 import { FilesystemBrowser } from "./services/filesystem-browser";
 import { ModelCacheService } from "./services/model-cache-service";
 import { DiffSummaryService } from "./services/diff-summary-service";
+import { ActionService } from "./services/action-service";
 import { WebSocket } from "ws";
 import { resolveGracePeriodMs } from "./grace-period-ms";
 import { AgentEventType } from "@mcode/contracts";
@@ -203,6 +204,7 @@ settingsService.on("change", (next) => {
 const cleanupWorker = container.resolve(CleanupWorker);
 const prDraftService = container.resolve(PrDraftService);
 const diffSummaryService = container.resolve(DiffSummaryService);
+const actionService = container.resolve(ActionService);
 const db = container.resolve<Database.Database>("Database");
 const jobObject = container.resolve<JobObject>("JobObject");
 
@@ -447,6 +449,7 @@ const { httpServer, wss } = createWsServer({
   enricher,
   filesystemBrowser,
   diffSummaryService,
+  actionService,
   authToken: AUTH_TOKEN,
 });
 

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -246,4 +246,19 @@ export class WorkspaceRepo {
       .prepare("UPDATE workspaces SET is_git_repo = ? WHERE id = ?")
       .run(isGitRepo ? 1 : 0, id);
   }
+
+  /** Update the last-used action ID for a workspace. */
+  updateLastActionId(workspaceId: string, actionId: string): void {
+    this.db
+      .prepare("UPDATE workspaces SET last_action_id = ? WHERE id = ?")
+      .run(actionId, workspaceId);
+  }
+
+  /** Get the last-used action ID for a workspace. Returns null if not set. */
+  getLastActionId(workspaceId: string): string | null {
+    const row = this.db
+      .prepare("SELECT last_action_id FROM workspaces WHERE id = ?")
+      .get(workspaceId) as { last_action_id: string | null } | undefined;
+    return row?.last_action_id ?? null;
+  }
 }

--- a/apps/server/src/services/action-service.ts
+++ b/apps/server/src/services/action-service.ts
@@ -1,12 +1,12 @@
 /**
  * Project action management service.
- * Reads, writes, watches, and runs workspace actions stored as JSON on disk.
+ * Reads, writes, and runs workspace actions stored as JSON on disk.
  * Follows the SettingsService pattern: file-based storage with in-memory cache,
- * atomic writes (temp + rename), debounced file watcher, and push broadcasts on change.
+ * atomic writes (temp + rename), and push broadcasts on change.
  */
 
 import { join } from "path";
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, watch } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { rm } from "fs/promises";
 import { injectable, inject } from "tsyringe";
 import { type Action, type ActionsFile, ActionsFileSchema } from "@mcode/contracts";
@@ -28,15 +28,10 @@ function workspaceDataDir(workspaceId: string): string {
 /**
  * Manages project actions for workspaces.
  * Actions are stored in per-workspace JSON files and cached in memory.
- * External file edits are detected via fs.watch and broadcast to clients.
  */
 @injectable()
 export class ActionService {
   private cache = new Map<string, Action[]>();
-  private watchers = new Map<string, ReturnType<typeof watch>>();
-  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  /** Workspace IDs whose next watch event should be ignored (self-write). */
-  private selfWriteFlags = new Set<string>();
 
   constructor(
     @inject("WorkspaceRepo") private readonly workspaceRepo: WorkspaceRepo,
@@ -171,63 +166,8 @@ export class ActionService {
     }
   }
 
-  /**
-   * Start watching the actions file for external changes.
-   * Lazy: only activates for workspaces that have been accessed.
-   * Debounces watch events at 100ms to tolerate editor write+rename patterns.
-   */
-  startWatching(workspaceId: string): void {
-    if (this.watchers.has(workspaceId)) return;
-
-    const filePath = actionsFilePath(workspaceId);
-    const dir = workspaceDataDir(workspaceId);
-
-    // Watch the file if it exists, otherwise watch the directory so we can
-    // detect when the file is first created.
-    const target = existsSync(filePath) ? filePath : dir;
-    if (!existsSync(target)) return;
-
-    try {
-      const watcher = watch(target, () => {
-        if (this.selfWriteFlags.has(workspaceId)) {
-          this.selfWriteFlags.delete(workspaceId);
-          return;
-        }
-
-        const existing = this.debounceTimers.get(workspaceId);
-        if (existing) clearTimeout(existing);
-        this.debounceTimers.set(
-          workspaceId,
-          setTimeout(() => {
-            this.cache.delete(workspaceId);
-            this.list(workspaceId);
-            broadcast("action.changed", { workspaceId });
-          }, 100),
-        );
-      });
-      this.watchers.set(workspaceId, watcher);
-    } catch {
-      // Directory may not yet exist; caller can retry after creation.
-    }
-  }
-
-  /** Stop watching the actions file for a workspace. */
-  stopWatching(workspaceId: string): void {
-    const watcher = this.watchers.get(workspaceId);
-    if (watcher) {
-      watcher.close();
-      this.watchers.delete(workspaceId);
-    }
-    const timer = this.debounceTimers.get(workspaceId);
-    if (timer) {
-      clearTimeout(timer);
-      this.debounceTimers.delete(workspaceId);
-    }
-  }
-
   /** Remove the workspace data directory. Called during workspace deletion. */
   async removeDataDir(workspaceId: string): Promise<void> {
-    this.stopWatching(workspaceId);
     this.cache.delete(workspaceId);
     const dir = workspaceDataDir(workspaceId);
     if (existsSync(dir)) {
@@ -235,11 +175,8 @@ export class ActionService {
     }
   }
 
-  /** Stop all watchers and clear caches on server shutdown. */
+  /** Clear caches on server shutdown. */
   dispose(): void {
-    for (const [id] of this.watchers) {
-      this.stopWatching(id);
-    }
     this.cache.clear();
   }
 
@@ -252,13 +189,8 @@ export class ActionService {
     const json = JSON.stringify(data, null, 2);
     const tmpPath = filePath + ".tmp";
 
-    // Flag the next watch event as self-triggered to avoid re-reading our own write.
-    this.selfWriteFlags.add(workspaceId);
     writeFileSync(tmpPath, json, "utf-8");
     renameSync(tmpPath, filePath);
-
-    // Safety net: clear the flag after a window in case fs.watch never fires.
-    setTimeout(() => this.selfWriteFlags.delete(workspaceId), 500);
 
     this.cache.set(workspaceId, actions);
     broadcast("action.changed", { workspaceId });

--- a/apps/server/src/services/action-service.ts
+++ b/apps/server/src/services/action-service.ts
@@ -1,0 +1,266 @@
+/**
+ * Project action management service.
+ * Reads, writes, watches, and runs workspace actions stored as JSON on disk.
+ * Follows the SettingsService pattern: file-based storage with in-memory cache,
+ * atomic writes (temp + rename), debounced file watcher, and push broadcasts on change.
+ */
+
+import { join } from "path";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, watch } from "fs";
+import { rm } from "fs/promises";
+import { injectable, inject } from "tsyringe";
+import { type Action, type ActionsFile, ActionsFileSchema } from "@mcode/contracts";
+import { getMcodeDir, logger } from "@mcode/shared";
+import { broadcast } from "../transport/push";
+import type { WorkspaceRepo } from "../repositories/workspace-repo.js";
+import { TerminalService } from "./terminal-service.js";
+
+/** Resolves the actions JSON file path for a workspace. */
+function actionsFilePath(workspaceId: string): string {
+  return join(getMcodeDir(), "workspaces", workspaceId, "actions.json");
+}
+
+/** Resolves the workspace-scoped data directory. */
+function workspaceDataDir(workspaceId: string): string {
+  return join(getMcodeDir(), "workspaces", workspaceId);
+}
+
+/**
+ * Manages project actions for workspaces.
+ * Actions are stored in per-workspace JSON files and cached in memory.
+ * External file edits are detected via fs.watch and broadcast to clients.
+ */
+@injectable()
+export class ActionService {
+  private cache = new Map<string, Action[]>();
+  private watchers = new Map<string, ReturnType<typeof watch>>();
+  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Workspace IDs whose next watch event should be ignored (self-write). */
+  private selfWriteFlags = new Set<string>();
+
+  constructor(
+    @inject("WorkspaceRepo") private readonly workspaceRepo: WorkspaceRepo,
+    @inject(TerminalService) private readonly terminalService: TerminalService,
+  ) {}
+
+  /** Read actions for a workspace. Returns [] if file missing or invalid. */
+  list(workspaceId: string): Action[] {
+    const cached = this.cache.get(workspaceId);
+    if (cached) return cached;
+
+    const filePath = actionsFilePath(workspaceId);
+    if (!existsSync(filePath)) {
+      this.cache.set(workspaceId, []);
+      return [];
+    }
+
+    try {
+      const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+      const parsed = ActionsFileSchema().safeParse(raw);
+      if (!parsed.success) {
+        logger.warn("Invalid actions file, returning empty", {
+          workspaceId,
+          error: parsed.error.message,
+        });
+        this.cache.set(workspaceId, []);
+        return [];
+      }
+      this.cache.set(workspaceId, parsed.data.actions);
+      return parsed.data.actions;
+    } catch (err) {
+      logger.warn("Failed to read actions file", { workspaceId, err });
+      this.cache.set(workspaceId, []);
+      return [];
+    }
+  }
+
+  /**
+   * Upsert an action. Enforces that at most one action has setup=true.
+   * Returns the saved action.
+   */
+  save(workspaceId: string, action: Action): Action {
+    const actions = [...this.list(workspaceId)];
+    const idx = actions.findIndex((a) => a.id === action.id);
+
+    // Clear setup flag on all other actions when setting a new setup action.
+    if (action.setup) {
+      for (const a of actions) {
+        if (a.id !== action.id) a.setup = false;
+      }
+    }
+
+    if (idx >= 0) {
+      actions[idx] = action;
+    } else {
+      actions.push(action);
+    }
+
+    this.writeFile(workspaceId, actions);
+    return action;
+  }
+
+  /** Delete an action by ID. Returns true if found and removed. */
+  delete(workspaceId: string, actionId: string): boolean {
+    const actions = this.list(workspaceId);
+    const filtered = actions.filter((a) => a.id !== actionId);
+    if (filtered.length === actions.length) return false;
+    this.writeFile(workspaceId, filtered);
+    return true;
+  }
+
+  /**
+   * Reorder actions by ID list.
+   * Any actions not in orderedIds are appended after the reordered set.
+   */
+  reorder(workspaceId: string, orderedIds: string[]): boolean {
+    const actions = this.list(workspaceId);
+    const map = new Map(actions.map((a) => [a.id, a]));
+    const reordered: Action[] = [];
+    for (const id of orderedIds) {
+      const action = map.get(id);
+      if (action) reordered.push(action);
+    }
+    // Append any actions not in the ordered list so nothing is lost.
+    for (const action of actions) {
+      if (!orderedIds.includes(action.id)) reordered.push(action);
+    }
+    this.writeFile(workspaceId, reordered);
+    return true;
+  }
+
+  /**
+   * Run an action by writing its command to the thread's terminal.
+   * Reuses the first existing terminal for the thread, or creates a new one.
+   */
+  async run(workspaceId: string, actionId: string, threadId: string): Promise<void> {
+    const actions = this.list(workspaceId);
+    const action = actions.find((a) => a.id === actionId);
+    if (!action) throw new Error(`Action '${actionId}' not found`);
+
+    // Find or create terminal for the thread.
+    const sessions = this.terminalService.listByThread(threadId);
+    let ptyId: string;
+    if (sessions.length > 0) {
+      ptyId = sessions[0]!.ptyId;
+    } else {
+      ptyId = this.terminalService.create(threadId);
+    }
+
+    // Write command with trailing newline to execute immediately.
+    this.terminalService.write(ptyId, action.command + "\n");
+
+    // Track the last-used action so the UI can highlight it.
+    this.workspaceRepo.updateLastActionId(workspaceId, actionId);
+
+    broadcast("action.ran", { workspaceId, actionId });
+  }
+
+  /**
+   * Run the setup action for a workspace (if one is defined).
+   * Called automatically after worktree creation. Fire-and-forget.
+   */
+  async runSetupAction(workspaceId: string, threadId: string): Promise<void> {
+    const actions = this.list(workspaceId);
+    const setup = actions.find((a) => a.setup);
+    if (!setup) return;
+
+    try {
+      await this.run(workspaceId, setup.id, threadId);
+    } catch (err) {
+      logger.warn("Setup action failed", { workspaceId, actionId: setup.id, err });
+    }
+  }
+
+  /**
+   * Start watching the actions file for external changes.
+   * Lazy: only activates for workspaces that have been accessed.
+   * Debounces watch events at 100ms to tolerate editor write+rename patterns.
+   */
+  startWatching(workspaceId: string): void {
+    if (this.watchers.has(workspaceId)) return;
+
+    const filePath = actionsFilePath(workspaceId);
+    const dir = workspaceDataDir(workspaceId);
+
+    // Watch the file if it exists, otherwise watch the directory so we can
+    // detect when the file is first created.
+    const target = existsSync(filePath) ? filePath : dir;
+    if (!existsSync(target)) return;
+
+    try {
+      const watcher = watch(target, () => {
+        if (this.selfWriteFlags.has(workspaceId)) {
+          this.selfWriteFlags.delete(workspaceId);
+          return;
+        }
+
+        const existing = this.debounceTimers.get(workspaceId);
+        if (existing) clearTimeout(existing);
+        this.debounceTimers.set(
+          workspaceId,
+          setTimeout(() => {
+            this.cache.delete(workspaceId);
+            this.list(workspaceId);
+            broadcast("action.changed", { workspaceId });
+          }, 100),
+        );
+      });
+      this.watchers.set(workspaceId, watcher);
+    } catch {
+      // Directory may not yet exist; caller can retry after creation.
+    }
+  }
+
+  /** Stop watching the actions file for a workspace. */
+  stopWatching(workspaceId: string): void {
+    const watcher = this.watchers.get(workspaceId);
+    if (watcher) {
+      watcher.close();
+      this.watchers.delete(workspaceId);
+    }
+    const timer = this.debounceTimers.get(workspaceId);
+    if (timer) {
+      clearTimeout(timer);
+      this.debounceTimers.delete(workspaceId);
+    }
+  }
+
+  /** Remove the workspace data directory. Called during workspace deletion. */
+  async removeDataDir(workspaceId: string): Promise<void> {
+    this.stopWatching(workspaceId);
+    this.cache.delete(workspaceId);
+    const dir = workspaceDataDir(workspaceId);
+    if (existsSync(dir)) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  /** Stop all watchers and clear caches on server shutdown. */
+  dispose(): void {
+    for (const [id] of this.watchers) {
+      this.stopWatching(id);
+    }
+    this.cache.clear();
+  }
+
+  private writeFile(workspaceId: string, actions: Action[]): void {
+    const filePath = actionsFilePath(workspaceId);
+    const dir = workspaceDataDir(workspaceId);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+    const data: ActionsFile = { actions };
+    const json = JSON.stringify(data, null, 2);
+    const tmpPath = filePath + ".tmp";
+
+    // Flag the next watch event as self-triggered to avoid re-reading our own write.
+    this.selfWriteFlags.add(workspaceId);
+    writeFileSync(tmpPath, json, "utf-8");
+    renameSync(tmpPath, filePath);
+
+    // Safety net: clear the flag after a window in case fs.watch never fires.
+    setTimeout(() => this.selfWriteFlags.delete(workspaceId), 500);
+
+    this.cache.set(workspaceId, actions);
+    broadcast("action.changed", { workspaceId });
+  }
+}

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -331,6 +331,15 @@ export class TerminalService {
     }));
   }
 
+  /** List active PTY session IDs for a thread. Used by ActionService to find an existing terminal. */
+  listByThread(threadId: string): Array<{ ptyId: string }> {
+    const ptyIds = this.threadIndex.get(threadId);
+    if (!ptyIds) return [];
+    return [...ptyIds]
+      .filter((id) => this.sessions.has(id))
+      .map((ptyId) => ({ ptyId }));
+  }
+
   /**
    * Returns whether a PTY has non-shell child processes running.
    * Used by the optional kill confirmation feature (#315).

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -11,6 +11,7 @@ import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { GitService } from "./git-service";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
+import { ActionService } from "./action-service.js";
 
 /** Handles thread creation, deletion, worktree provisioning, and lifecycle. */
 @injectable()
@@ -20,6 +21,7 @@ export class ThreadService {
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
     @inject(GitService) private readonly gitService: GitService,
     @inject(CleanupJobRepo) private readonly cleanupJobRepo: CleanupJobRepo,
+    @inject(ActionService) private readonly actionService: ActionService,
   ) {}
 
   /**
@@ -103,6 +105,18 @@ export class ThreadService {
           throw new Error(
             `Failed to persist worktree path for thread ${thread.id}`,
           );
+        }
+
+        // Fire setup action if defined (non-blocking)
+        if (thread.mode === "worktree" && info.path) {
+          this.actionService
+            .runSetupAction(workspaceId, thread.id)
+            .catch((err) =>
+              logger.warn("Setup action failed after worktree creation", {
+                threadId: thread.id,
+                err,
+              }),
+            );
         }
 
         return {

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -166,6 +166,12 @@ export class WorkspaceService {
       this.cleanupJobRepo.deleteByThreadId(t.id);
       this.attachmentService.removeForThread(t.id);
     }
+
+    // Clean up actions directory (best-effort; must not block force-delete)
+    this.actionService.removeDataDir(id).catch((err) =>
+      logger.warn("Failed to remove actions directory during force-delete", { workspaceId: id, err }),
+    );
+
     return this.workspaceRepo.hardDelete(id);
   }
 

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -13,6 +13,7 @@ import { ThreadRepo } from "../repositories/thread-repo";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { AttachmentService } from "./attachment-service";
 import { AgentService } from "./agent-service.js";
+import { ActionService } from "./action-service.js";
 import { logger } from "@mcode/shared";
 
 /** Handles workspace creation, listing, and two-phase deletion. */
@@ -24,6 +25,7 @@ export class WorkspaceService {
     @inject(CleanupJobRepo) private readonly cleanupJobRepo: CleanupJobRepo,
     @inject(AttachmentService) private readonly attachmentService: AttachmentService,
     @inject(AgentService) private readonly agentService: AgentService,
+    @inject(ActionService) private readonly actionService: ActionService,
   ) {}
 
   /**
@@ -135,6 +137,11 @@ export class WorkspaceService {
     if (pendingJobs === 0) {
       this.workspaceRepo.hardDelete(id);
     }
+
+    // Clean up actions data directory
+    this.actionService.removeDataDir(id).catch((err) =>
+      logger.warn("Failed to remove actions directory", { workspaceId: id, err }),
+    );
 
     return true;
   }

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -23,6 +23,7 @@ export const workspaces = sqliteTable(
     sortOrder: integer("sort_order").notNull().default(0),
     isGitRepo: integer("is_git_repo").notNull().default(1),
     deletedAt: text("deleted_at"),
+    lastActionId: text("last_action_id"),
   },
   (table) => [
     index("idx_workspaces_sort_order").on(asc(table.sortOrder)),

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -844,7 +844,10 @@ async function dispatch(
 
     // Actions
     case "action.list":
-      return deps.actionService.list(params.workspaceId);
+      return {
+        actions: deps.actionService.list(params.workspaceId),
+        lastActionId: deps.workspaceRepo.getLastActionId(params.workspaceId),
+      };
     case "action.save":
       return deps.actionService.save(params.workspaceId, params.action);
     case "action.delete":

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -53,6 +53,7 @@ import {
 import type { ProviderAvailabilityService } from "../services/provider-availability-service.js";
 import type { ModelCacheService } from "../services/model-cache-service.js";
 import type { DiffSummaryService } from "../services/diff-summary-service.js";
+import type { ActionService } from "../services/action-service";
 
 /** Service dependencies for the router. */
 export interface RouterDeps {
@@ -97,6 +98,8 @@ export interface RouterDeps {
   filesystemBrowser: FilesystemBrowser;
   /** Generates and persists AI-powered diff summaries for threads. */
   diffSummaryService: DiffSummaryService;
+  /** Manages project actions (list, save, delete, run, reorder) per workspace. */
+  actionService: ActionService;
 }
 
 /**
@@ -838,6 +841,22 @@ async function dispatch(
     }
     case "permission.listPending":
       return deps.agentService.listPendingPermissions(params.threadId);
+
+    // Actions
+    case "action.list":
+      return deps.actionService.list(params.workspaceId);
+    case "action.save":
+      return deps.actionService.save(params.workspaceId, params.action);
+    case "action.delete":
+      return deps.actionService.delete(params.workspaceId, params.actionId);
+    case "action.run":
+      return deps.actionService.run(
+        params.workspaceId,
+        params.actionId,
+        params.threadId,
+      );
+    case "action.reorder":
+      return deps.actionService.reorder(params.workspaceId, params.orderedIds);
 
     default:
       throw new Error(`Unhandled method: ${method}`);

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -180,4 +180,9 @@ export const mockTransport: McodeTransport = {
     model: "mock-model",
     createdAt: new Date().toISOString(),
   }),
+  actionList: vi.fn().mockResolvedValue([]),
+  actionSave: vi.fn().mockResolvedValue(undefined),
+  actionDelete: vi.fn().mockResolvedValue(true),
+  actionRun: vi.fn().mockResolvedValue(undefined),
+  actionReorder: vi.fn().mockResolvedValue(true),
 };

--- a/apps/web/src/components/chat/ActionDropdown.tsx
+++ b/apps/web/src/components/chat/ActionDropdown.tsx
@@ -1,4 +1,141 @@
-/** Placeholder for action dropdown content. Replaced by Task 12. */
-export function ActionDropdown({ onClose: _onClose }: { onClose: () => void }) {
-  return null;
+import { useState } from "react";
+import { Settings } from "lucide-react";
+import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { useActionStore } from "@/stores/actionStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { getLucideIcon } from "@/lib/action-icons";
+import { getKeybindingForCommand, formatKeybinding } from "@/lib/keybinding-manager";
+import { isMac } from "@/lib/platform";
+import { ActionEditorDialog } from "./ActionEditorDialog";
+
+/** Props for the ActionDropdown component. */
+interface ActionDropdownProps {
+  /** Called after an action is run or the editor dialog is opened to close the dropdown. */
+  onClose: () => void;
+}
+
+/**
+ * Dropdown content listing all project actions for the active workspace.
+ *
+ * Renders action rows with icons, names, optional setup labels, and shortcut hints.
+ * The last-used action row receives a subtle highlight. A footer "Manage Actions..."
+ * item opens the action editor dialog. When no actions exist, an empty state with an
+ * "Add Action..." link is shown instead.
+ */
+export function ActionDropdown({ onClose }: ActionDropdownProps) {
+  const [editorOpen, setEditorOpen] = useState(false);
+
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+
+  const actions = useActionStore(
+    (s) => s.actionsByWorkspace[activeWorkspaceId ?? ""] ?? [],
+  );
+  const lastUsedId = useActionStore(
+    (s) => s.lastUsedByWorkspace[activeWorkspaceId ?? ""],
+  );
+  const runAction = useActionStore((s) => s.runAction);
+
+  function handleRunAction(actionId: string) {
+    if (!activeWorkspaceId || !activeThreadId) return;
+    void runAction(activeWorkspaceId, actionId, activeThreadId);
+    onClose();
+  }
+
+  function handleOpenEditor() {
+    onClose();
+    setEditorOpen(true);
+  }
+
+  if (actions.length === 0) {
+    return (
+      <>
+        <div className="flex flex-col items-center gap-1.5 px-3 py-4">
+          <span
+            className="font-mono text-muted-foreground/15"
+            style={{ fontSize: 28 }}
+            aria-hidden
+          >
+            ◌
+          </span>
+          <span
+            className="font-mono tracking-[0.18em] text-muted-foreground/40 uppercase"
+            style={{ fontSize: 10.5, fontVariant: "small-caps" }}
+          >
+            No Actions
+          </span>
+          <button
+            type="button"
+            className="text-xs text-muted-foreground/60 hover:text-foreground underline-offset-2 hover:underline transition-colors mt-0.5"
+            onClick={handleOpenEditor}
+          >
+            Add Action...
+          </button>
+        </div>
+
+        {editorOpen && (
+          <ActionEditorDialog open={editorOpen} onOpenChange={setEditorOpen} />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {actions.map((action) => {
+        const Icon = getLucideIcon(action.icon);
+        const binding = getKeybindingForCommand(`action.run.${action.id}`);
+        const shortcutLabel = binding ? formatKeybinding(binding.key, isMac) : null;
+        const isLastUsed = action.id === lastUsedId;
+
+        return (
+          <DropdownMenuItem
+            key={action.id}
+            className={cn(
+              "flex items-center justify-between gap-3 min-w-[180px]",
+              isLastUsed && "bg-accent/5",
+            )}
+            onClick={() => handleRunAction(action.id)}
+          >
+            <span className="flex items-center gap-2 min-w-0">
+              <Icon size={13} className="shrink-0 text-muted-foreground" />
+              <span className="truncate">{action.name}</span>
+              {action.setup && (
+                <span
+                  className="font-mono text-muted-foreground/30 uppercase shrink-0"
+                  style={{ fontSize: 9, fontVariant: "small-caps" }}
+                >
+                  setup
+                </span>
+              )}
+            </span>
+
+            {shortcutLabel && (
+              <span
+                className="font-mono text-muted-foreground/50 uppercase shrink-0 ml-auto"
+                style={{ fontSize: 10, fontVariant: "small-caps" }}
+              >
+                {shortcutLabel}
+              </span>
+            )}
+          </DropdownMenuItem>
+        );
+      })}
+
+      <DropdownMenuSeparator />
+
+      <DropdownMenuItem
+        className="flex items-center gap-2 text-muted-foreground"
+        onClick={handleOpenEditor}
+      >
+        <Settings size={13} className="shrink-0" />
+        <span>Manage Actions...</span>
+      </DropdownMenuItem>
+
+      {editorOpen && (
+        <ActionEditorDialog open={editorOpen} onOpenChange={setEditorOpen} />
+      )}
+    </>
+  );
 }

--- a/apps/web/src/components/chat/ActionDropdown.tsx
+++ b/apps/web/src/components/chat/ActionDropdown.tsx
@@ -99,7 +99,7 @@ export function ActionDropdown({ onClose }: ActionDropdownProps) {
             onClick={() => handleRunAction(action.id)}
           >
             <span className="flex items-center gap-2 min-w-0">
-              <Icon size={13} className="shrink-0 text-muted-foreground" />
+              <Icon size={14} className="shrink-0 text-muted-foreground" />
               <span className="truncate">{action.name}</span>
               {action.setup && (
                 <span

--- a/apps/web/src/components/chat/ActionDropdown.tsx
+++ b/apps/web/src/components/chat/ActionDropdown.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for action dropdown content. Replaced by Task 12. */
+export function ActionDropdown({ onClose: _onClose }: { onClose: () => void }) {
+  return null;
+}

--- a/apps/web/src/components/chat/ActionDropdown.tsx
+++ b/apps/web/src/components/chat/ActionDropdown.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Settings } from "lucide-react";
 import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -7,12 +6,13 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { getLucideIcon } from "@/lib/action-icons";
 import { getKeybindingForCommand, formatKeybinding } from "@/lib/keybinding-manager";
 import { isMac } from "@/lib/platform";
-import { ActionEditorDialog } from "./ActionEditorDialog";
 
 /** Props for the ActionDropdown component. */
 interface ActionDropdownProps {
   /** Called after an action is run or the editor dialog is opened to close the dropdown. */
   onClose: () => void;
+  /** Called when the user requests to open the action editor dialog. */
+  onOpenEditor: () => void;
 }
 
 /**
@@ -23,9 +23,7 @@ interface ActionDropdownProps {
  * item opens the action editor dialog. When no actions exist, an empty state with an
  * "Add Action..." link is shown instead.
  */
-export function ActionDropdown({ onClose }: ActionDropdownProps) {
-  const [editorOpen, setEditorOpen] = useState(false);
-
+export function ActionDropdown({ onClose, onOpenEditor }: ActionDropdownProps) {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
 
@@ -45,7 +43,7 @@ export function ActionDropdown({ onClose }: ActionDropdownProps) {
 
   function handleOpenEditor() {
     onClose();
-    setEditorOpen(true);
+    onOpenEditor();
   }
 
   if (actions.length === 0) {
@@ -73,10 +71,6 @@ export function ActionDropdown({ onClose }: ActionDropdownProps) {
             Add Action...
           </button>
         </div>
-
-        {editorOpen && (
-          <ActionEditorDialog open={editorOpen} onOpenChange={setEditorOpen} />
-        )}
       </>
     );
   }
@@ -132,10 +126,6 @@ export function ActionDropdown({ onClose }: ActionDropdownProps) {
         <Settings size={13} className="shrink-0" />
         <span>Manage Actions...</span>
       </DropdownMenuItem>
-
-      {editorOpen && (
-        <ActionEditorDialog open={editorOpen} onOpenChange={setEditorOpen} />
-      )}
     </>
   );
 }

--- a/apps/web/src/components/chat/ActionEditorDialog.tsx
+++ b/apps/web/src/components/chat/ActionEditorDialog.tsx
@@ -1,12 +1,551 @@
-/**
- * Placeholder for action editor dialog. Replaced by Task 13.
- */
-export function ActionEditorDialog({
-  open: _open,
-  onOpenChange: _onOpenChange,
-}: {
+import { useState, useEffect, useCallback } from "react";
+import { Pencil, Trash2, ChevronLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { ShortcutRecorder } from "./ShortcutRecorder";
+import { useActionStore } from "@/stores/actionStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { getLucideIcon } from "@/lib/action-icons";
+import { ACTION_ICONS } from "@mcode/contracts";
+import { formatKeybinding } from "@/lib/keybinding-manager";
+import { isMac } from "@/lib/platform";
+import type { Action, ActionIcon } from "@mcode/contracts";
+
+/** Props for the ActionEditorDialog component. */
+interface ActionEditorDialogProps {
+  /** Whether the dialog is open. */
   open: boolean;
+  /** Callback to toggle the dialog open state. */
   onOpenChange: (open: boolean) => void;
-}) {
-  return null;
+}
+
+/** Draft state for the edit/add sub-view form fields. */
+interface ActionDraft {
+  name: string;
+  command: string;
+  icon: ActionIcon;
+  shortcut: string | undefined;
+  setup: boolean;
+}
+
+/** Default draft values for a new action. */
+const DEFAULT_DRAFT: ActionDraft = {
+  name: "",
+  command: "",
+  icon: "play",
+  shortcut: undefined,
+  setup: false,
+};
+
+/**
+ * Generates a URL-safe slug from a human-readable action name.
+ * Used as the action ID for newly created actions.
+ */
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Dialog for managing project actions.
+ *
+ * Contains two views within a single dialog:
+ * - List view: shows all actions with edit/delete controls and an "Add action" button.
+ * - Edit/Add view: form for creating or editing a single action.
+ *
+ * No nested modals. Delete confirmation is inline within the list row.
+ */
+export function ActionEditorDialog({ open, onOpenChange }: ActionEditorDialogProps) {
+  const [view, setView] = useState<"list" | "edit">("list");
+  const [editingAction, setEditingAction] = useState<Action | null>(null);
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<ActionDraft>(DEFAULT_DRAFT);
+  const [saving, setSaving] = useState(false);
+
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+
+  const actions = useActionStore(
+    (s) => s.actionsByWorkspace[activeWorkspaceId ?? ""] ?? [],
+  );
+  const saveAction = useActionStore((s) => s.saveAction);
+  const deleteAction = useActionStore((s) => s.deleteAction);
+
+  // Reset to list view whenever dialog reopens.
+  useEffect(() => {
+    if (open) {
+      setView("list");
+      setEditingAction(null);
+      setConfirmingDeleteId(null);
+      setDraft(DEFAULT_DRAFT);
+    }
+  }, [open]);
+
+  const handleEditAction = useCallback((action: Action) => {
+    setEditingAction(action);
+    setDraft({
+      name: action.name,
+      command: action.command,
+      icon: action.icon,
+      shortcut: action.shortcut,
+      setup: action.setup,
+    });
+    setView("edit");
+  }, []);
+
+  const handleAddAction = useCallback(() => {
+    setEditingAction(null);
+    setDraft(DEFAULT_DRAFT);
+    setView("edit");
+  }, []);
+
+  const handleBack = useCallback(() => {
+    setView("list");
+    setEditingAction(null);
+    setDraft(DEFAULT_DRAFT);
+  }, []);
+
+  const handleDeleteConfirm = useCallback(
+    async (actionId: string) => {
+      if (!activeWorkspaceId) return;
+      await deleteAction(activeWorkspaceId, actionId);
+      setConfirmingDeleteId(null);
+    },
+    [activeWorkspaceId, deleteAction],
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!activeWorkspaceId || !draft.name.trim() || !draft.command.trim()) return;
+
+    setSaving(true);
+    try {
+      const id = editingAction?.id ?? slugify(draft.name.trim());
+      const action: Action = {
+        id,
+        name: draft.name.trim(),
+        command: draft.command.trim(),
+        icon: draft.icon,
+        shortcut: draft.shortcut,
+        setup: draft.setup,
+      };
+      await saveAction(activeWorkspaceId, action);
+      setView("list");
+      setEditingAction(null);
+      setDraft(DEFAULT_DRAFT);
+    } finally {
+      setSaving(false);
+    }
+  }, [activeWorkspaceId, draft, editingAction, saveAction]);
+
+  // The action that will be displaced if setup is toggled on.
+  const displacedSetupAction =
+    draft.setup
+      ? actions.find((a) => a.setup && a.id !== editingAction?.id) ?? null
+      : null;
+
+  const canSave = draft.name.trim().length > 0 && draft.command.trim().length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {view === "list" ? (
+          <ListView
+            actions={actions}
+            confirmingDeleteId={confirmingDeleteId}
+            onEdit={handleEditAction}
+            onDeleteRequest={(id) => setConfirmingDeleteId(id)}
+            onDeleteConfirm={handleDeleteConfirm}
+            onDeleteCancel={() => setConfirmingDeleteId(null)}
+            onAdd={handleAddAction}
+          />
+        ) : (
+          <EditView
+            editingAction={editingAction}
+            draft={draft}
+            actions={actions}
+            displacedSetupAction={displacedSetupAction}
+            saving={saving}
+            canSave={canSave}
+            onDraftChange={setDraft}
+            onBack={handleBack}
+            onCancel={handleBack}
+            onSave={handleSave}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ListViewProps + ListRow
+// ---------------------------------------------------------------------------
+
+/** Props for the ListView sub-component. */
+interface ListViewProps {
+  actions: Action[];
+  confirmingDeleteId: string | null;
+  onEdit: (action: Action) => void;
+  onDeleteRequest: (id: string) => void;
+  onDeleteConfirm: (id: string) => Promise<void>;
+  onDeleteCancel: () => void;
+  onAdd: () => void;
+}
+
+/**
+ * List view rendered inside the action editor dialog.
+ * Shows all project actions with inline edit/delete controls.
+ */
+function ListView({
+  actions,
+  confirmingDeleteId,
+  onEdit,
+  onDeleteRequest,
+  onDeleteConfirm,
+  onDeleteCancel,
+  onAdd,
+}: ListViewProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <DialogTitle
+        className={cn(
+          "font-mono uppercase tracking-[0.18em] text-muted-foreground/40",
+          "text-[10.5px]",
+        )}
+      >
+        Project Actions
+      </DialogTitle>
+
+      <div className="flex flex-col">
+        {actions.length === 0 ? (
+          <div className="flex flex-col items-center gap-1.5 py-6">
+            <span
+              className="font-mono text-muted-foreground/15"
+              style={{ fontSize: 28 }}
+              aria-hidden
+            >
+              ◌
+            </span>
+            <span
+              className="font-mono tracking-[0.18em] text-muted-foreground/40 uppercase"
+              style={{ fontSize: 10.5 }}
+            >
+              No Actions
+            </span>
+          </div>
+        ) : (
+          actions.map((action) => (
+            <ActionRow
+              key={action.id}
+              action={action}
+              isConfirmingDelete={confirmingDeleteId === action.id}
+              onEdit={() => onEdit(action)}
+              onDeleteRequest={() => onDeleteRequest(action.id)}
+              onDeleteConfirm={() => onDeleteConfirm(action.id)}
+              onDeleteCancel={onDeleteCancel}
+            />
+          ))
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={onAdd}
+        className="flex items-center gap-1.5 self-start text-xs text-muted-foreground/60 hover:text-foreground transition-colors"
+      >
+        <span className="text-base leading-none">+</span>
+        <span>Add action</span>
+      </button>
+
+      {/* Footer separator and open file link */}
+      <div className="border-t pt-2 -mx-4 px-4">
+        <button
+          type="button"
+          className="flex items-center gap-1 text-[10.5px] font-mono text-muted-foreground/40 hover:text-muted-foreground/70 transition-colors uppercase tracking-[0.12em]"
+          onClick={() => {
+            // The file path is server-side only; gracefully skip if unavailable.
+            // Future: add a transport method to return the path.
+          }}
+          disabled
+          title="actions.json location is resolved server-side"
+        >
+          Open actions.json ↗
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ActionRow
+// ---------------------------------------------------------------------------
+
+/** Props for a single row in the action list. */
+interface ActionRowProps {
+  action: Action;
+  isConfirmingDelete: boolean;
+  onEdit: () => void;
+  onDeleteRequest: () => void;
+  onDeleteConfirm: () => Promise<void>;
+  onDeleteCancel: () => void;
+}
+
+/**
+ * Single row in the action list showing icon, name, shortcut badge, setup label,
+ * and edit/delete icon buttons. Delete shows an inline confirm prompt.
+ */
+function ActionRow({
+  action,
+  isConfirmingDelete,
+  onEdit,
+  onDeleteRequest,
+  onDeleteConfirm,
+  onDeleteCancel,
+}: ActionRowProps) {
+  const Icon = getLucideIcon(action.icon);
+  const shortcutLabel = action.shortcut ? formatKeybinding(action.shortcut, isMac) : null;
+
+  return (
+    <div className="group flex items-center gap-2 rounded-md px-1 py-1.5 hover:bg-muted/50 transition-colors">
+      <Icon size={14} className="shrink-0 text-muted-foreground/60" aria-hidden />
+
+      <span className="flex-1 truncate text-sm">{action.name}</span>
+
+      {shortcutLabel && (
+        <span
+          className="font-mono text-muted-foreground/40 uppercase shrink-0"
+          style={{ fontSize: 10, fontVariant: "small-caps" }}
+        >
+          {shortcutLabel}
+        </span>
+      )}
+
+      {action.setup && (
+        <span
+          className="font-mono text-muted-foreground/30 uppercase shrink-0"
+          style={{ fontSize: 9, fontVariant: "small-caps" }}
+        >
+          setup
+        </span>
+      )}
+
+      {isConfirmingDelete ? (
+        <span className="flex items-center gap-1.5 text-xs shrink-0">
+          <span className="text-destructive font-medium">Delete?</span>
+          <button
+            type="button"
+            onClick={onDeleteConfirm}
+            className="text-destructive hover:text-destructive/80 transition-colors"
+          >
+            Confirm
+          </button>
+          <button
+            type="button"
+            onClick={onDeleteCancel}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Cancel
+          </button>
+        </span>
+      ) : (
+        <span className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={onEdit}
+            aria-label={`Edit ${action.name}`}
+          >
+            <Pencil size={14} className="text-muted-foreground/50" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={onDeleteRequest}
+            aria-label={`Delete ${action.name}`}
+          >
+            <Trash2 size={14} className="text-muted-foreground/50" />
+          </Button>
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// EditView
+// ---------------------------------------------------------------------------
+
+/** Props for the EditView sub-component. */
+interface EditViewProps {
+  editingAction: Action | null;
+  draft: ActionDraft;
+  actions: Action[];
+  displacedSetupAction: Action | null;
+  saving: boolean;
+  canSave: boolean;
+  onDraftChange: (draft: ActionDraft) => void;
+  onBack: () => void;
+  onCancel: () => void;
+  onSave: () => Promise<void>;
+}
+
+/**
+ * Edit/Add sub-view rendered inside the action editor dialog.
+ * Replaces the list content without opening a nested modal.
+ */
+function EditView({
+  editingAction,
+  draft,
+  actions,
+  displacedSetupAction,
+  saving,
+  canSave,
+  onDraftChange,
+  onBack,
+  onCancel,
+  onSave,
+}: EditViewProps) {
+  const isNew = editingAction === null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex items-center gap-1 text-xs text-muted-foreground/60 hover:text-foreground transition-colors"
+          aria-label="Back to action list"
+        >
+          <ChevronLeft size={14} />
+          <span>Back</span>
+        </button>
+        <DialogTitle
+          className={cn(
+            "font-mono uppercase tracking-[0.18em] text-muted-foreground/40",
+            "text-[10.5px]",
+          )}
+        >
+          {isNew ? "New Action" : "Edit Action"}
+        </DialogTitle>
+      </div>
+
+      {/* Name field */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="action-name" className="text-xs">
+          Name
+        </Label>
+        <Input
+          id="action-name"
+          size="sm"
+          placeholder="e.g. Run Tests"
+          value={draft.name}
+          onChange={(e) => onDraftChange({ ...draft, name: e.target.value })}
+          autoFocus
+        />
+      </div>
+
+      {/* Command field */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="action-command" className="text-xs">
+          Command
+        </Label>
+        <Input
+          id="action-command"
+          size="sm"
+          placeholder="e.g. bun run test"
+          value={draft.command}
+          onChange={(e) => onDraftChange({ ...draft, command: e.target.value })}
+          className="font-mono"
+        />
+      </div>
+
+      {/* Icon picker */}
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-xs">Icon</Label>
+        <div className="grid grid-cols-8 gap-1">
+          {ACTION_ICONS.map((iconName) => {
+            const IconComponent = getLucideIcon(iconName);
+            const isSelected = draft.icon === iconName;
+            return (
+              <button
+                key={iconName}
+                type="button"
+                onClick={() => onDraftChange({ ...draft, icon: iconName })}
+                aria-label={iconName}
+                aria-pressed={isSelected}
+                className={cn(
+                  "flex items-center justify-center rounded-md p-1.5 transition-colors",
+                  isSelected
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground/60 hover:bg-muted hover:text-foreground",
+                )}
+              >
+                <IconComponent size={14} />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Shortcut recorder */}
+      <div className="flex flex-col gap-1.5">
+        <Label className="text-xs">Shortcut</Label>
+        <ShortcutRecorder
+          value={draft.shortcut}
+          onChange={(shortcut) => onDraftChange({ ...draft, shortcut })}
+          siblingShortcuts={actions.map((a) => ({
+            id: a.id,
+            name: a.name,
+            shortcut: a.shortcut,
+          }))}
+          currentActionId={editingAction?.id}
+        />
+      </div>
+
+      {/* Setup switch */}
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="action-setup" className="text-xs cursor-pointer">
+            Setup action
+          </Label>
+          <Switch
+            id="action-setup"
+            checked={draft.setup}
+            onCheckedChange={(checked) =>
+              onDraftChange({ ...draft, setup: checked })
+            }
+          />
+        </div>
+        {displacedSetupAction && (
+          <p className="text-[10.5px] text-muted-foreground/60">
+            Replaced &apos;{displacedSetupAction.name}&apos; as setup action
+          </p>
+        )}
+      </div>
+
+      {/* Footer buttons */}
+      <div className="flex items-center justify-end gap-2 border-t pt-3 -mx-4 px-4 -mb-4 pb-4 bg-muted/50 rounded-b-xl">
+        <Button variant="outline" size="sm" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          onClick={onSave}
+          disabled={!canSave || saving}
+        >
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/components/chat/ActionEditorDialog.tsx
+++ b/apps/web/src/components/chat/ActionEditorDialog.tsx
@@ -1,4 +1,6 @@
-/** Placeholder for action editor dialog. Replaced by Task 13. */
+/**
+ * Placeholder for action editor dialog. Replaced by Task 13.
+ */
 export function ActionEditorDialog({
   open: _open,
   onOpenChange: _onOpenChange,

--- a/apps/web/src/components/chat/ActionEditorDialog.tsx
+++ b/apps/web/src/components/chat/ActionEditorDialog.tsx
@@ -450,6 +450,7 @@ function EditView({
           placeholder="e.g. Run Tests"
           value={draft.name}
           onChange={(e) => onDraftChange({ ...draft, name: e.target.value })}
+          required
           autoFocus
         />
       </div>
@@ -465,6 +466,7 @@ function EditView({
           placeholder="e.g. bun run test"
           value={draft.command}
           onChange={(e) => onDraftChange({ ...draft, command: e.target.value })}
+          required
           className="font-mono"
         />
       </div>

--- a/apps/web/src/components/chat/ActionEditorDialog.tsx
+++ b/apps/web/src/components/chat/ActionEditorDialog.tsx
@@ -1,0 +1,10 @@
+/** Placeholder for action editor dialog. Replaced by Task 13. */
+export function ActionEditorDialog({
+  open: _open,
+  onOpenChange: _onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return null;
+}

--- a/apps/web/src/components/chat/ActionTrigger.tsx
+++ b/apps/web/src/components/chat/ActionTrigger.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 import { useActionStore } from "@/stores/actionStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { ActionDropdown } from "./ActionDropdown";
@@ -26,9 +27,13 @@ export function ActionTrigger() {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
 
+  const actions = useActionStore(
+    (s) => s.actionsByWorkspace[activeWorkspaceId ?? ""] ?? [],
+  );
+  const lastUsedId = useActionStore(
+    (s) => s.lastUsedByWorkspace[activeWorkspaceId ?? ""],
+  );
   const loadActions = useActionStore((s) => s.loadActions);
-  const getActions = useActionStore((s) => s.getActions);
-  const getLastUsed = useActionStore((s) => s.getLastUsed);
   const runAction = useActionStore((s) => s.runAction);
 
   const [running, setRunning] = useState(false);
@@ -48,13 +53,11 @@ export function ActionTrigger() {
     };
   }, []);
 
-  if (!activeWorkspaceId) return null;
+  if (!activeWorkspaceId || actions.length === 0) return null;
 
-  const actions = getActions(activeWorkspaceId);
-  if (actions.length === 0) return null;
-
-  const lastUsed = getLastUsed(activeWorkspaceId);
-  // getLastUsed falls back to actions[0], which is always defined here since length > 0.
+  const lastUsed = lastUsedId
+    ? actions.find((a) => a.id === lastUsedId)
+    : undefined;
   const action = lastUsed ?? actions[0]!;
 
   const hasThread = activeThreadId != null;
@@ -74,8 +77,11 @@ export function ActionTrigger() {
       variant="ghost"
       size="xs"
       onClick={handleRun}
-      disabled={!hasThread}
-      className="gap-1 text-xs h-6 rounded-r-none text-foreground/70 hover:text-foreground hover:bg-muted/40"
+      aria-disabled={!hasThread}
+      className={cn(
+        "gap-1 text-xs h-6 rounded-r-none text-foreground/70 hover:text-foreground hover:bg-muted/40",
+        !hasThread && "opacity-50 pointer-events-auto cursor-not-allowed",
+      )}
       aria-label={`Run ${action.name}`}
     >
       {running ? (
@@ -91,16 +97,12 @@ export function ActionTrigger() {
   return (
     <div className="flex items-center gap-0.5 bg-muted/20 rounded-md px-1 py-0.5">
       <div className="inline-flex">
-        {disabledReason ? (
-          <Tooltip>
-            <TooltipTrigger render={bodyButton} />
-            <TooltipContent side="bottom" className="text-xs">
-              {disabledReason}
-            </TooltipContent>
-          </Tooltip>
-        ) : (
-          bodyButton
-        )}
+        <Tooltip>
+          <TooltipTrigger render={bodyButton} />
+          <TooltipContent side="bottom" className="text-xs">
+            {disabledReason ?? `Run ${action.name}`}
+          </TooltipContent>
+        </Tooltip>
 
         <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
           <DropdownMenuTrigger
@@ -109,7 +111,7 @@ export function ActionTrigger() {
           >
             <ChevronDown
               size={10}
-              className={`transition-transform duration-150 ${dropdownOpen ? "rotate-180" : ""}`}
+              className={cn("transition-transform duration-150", dropdownOpen && "rotate-180")}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" sideOffset={4}>

--- a/apps/web/src/components/chat/ActionTrigger.tsx
+++ b/apps/web/src/components/chat/ActionTrigger.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+} from "@/components/ui/dropdown-menu";
+import { useActionStore } from "@/stores/actionStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { ActionDropdown } from "./ActionDropdown";
+import { getLucideIcon } from "@/lib/action-icons";
+
+/** Duration in ms that the spinner replaces the action icon after a run is triggered. */
+const RUN_SPINNER_MS = 600;
+
+/**
+ * Split-click header button for running project actions.
+ *
+ * Left-clicking the body runs the last-used action (or the first defined action when no
+ * history exists). Clicking the chevron opens a dropdown listing all actions.
+ * Hidden entirely when the workspace has no actions configured.
+ */
+export function ActionTrigger() {
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+
+  const loadActions = useActionStore((s) => s.loadActions);
+  const getActions = useActionStore((s) => s.getActions);
+  const getLastUsed = useActionStore((s) => s.getLastUsed);
+  const runAction = useActionStore((s) => s.runAction);
+
+  const [running, setRunning] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Load actions whenever the active workspace changes.
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    loadActions(activeWorkspaceId);
+  }, [activeWorkspaceId, loadActions]);
+
+  // Clear the spinner timer on unmount to avoid state updates on an unmounted component.
+  useEffect(() => {
+    return () => {
+      clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  if (!activeWorkspaceId) return null;
+
+  const actions = getActions(activeWorkspaceId);
+  if (actions.length === 0) return null;
+
+  const lastUsed = getLastUsed(activeWorkspaceId);
+  // getLastUsed falls back to actions[0], which is always defined here since length > 0.
+  const action = lastUsed ?? actions[0]!;
+
+  const hasThread = activeThreadId != null;
+  const disabledReason = hasThread ? undefined : "Open a thread to run actions";
+
+  const ActionIcon = getLucideIcon(action.icon);
+
+  function handleRun() {
+    if (!hasThread || !activeWorkspaceId || running) return;
+    setRunning(true);
+    void runAction(activeWorkspaceId, action.id, activeThreadId!);
+    timerRef.current = setTimeout(() => setRunning(false), RUN_SPINNER_MS);
+  }
+
+  const bodyButton = (
+    <Button
+      variant="ghost"
+      size="xs"
+      onClick={handleRun}
+      disabled={!hasThread}
+      className="gap-1 text-xs h-6 rounded-r-none text-foreground/70 hover:text-foreground hover:bg-muted/40"
+      aria-label={`Run ${action.name}`}
+    >
+      {running ? (
+        <Loader2 size={12} className="animate-spin" />
+      ) : (
+        <ActionIcon size={12} />
+      )}
+      {/* Hide label at narrow widths; icon + chevron alone is sufficient at xs. */}
+      <span className="hidden sm:inline">{action.name}</span>
+    </Button>
+  );
+
+  return (
+    <div className="flex items-center gap-0.5 bg-muted/20 rounded-md px-1 py-0.5">
+      <div className="inline-flex">
+        {disabledReason ? (
+          <Tooltip>
+            <TooltipTrigger render={bodyButton} />
+            <TooltipContent side="bottom" className="text-xs">
+              {disabledReason}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          bodyButton
+        )}
+
+        <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
+          <DropdownMenuTrigger
+            aria-label="Open actions menu"
+            className="inline-flex items-center px-1.5 h-6 text-xs border-l border-border/20 rounded-r transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring text-foreground/70 hover:text-foreground hover:bg-muted/40"
+          >
+            <ChevronDown
+              size={10}
+              className={`transition-transform duration-150 ${dropdownOpen ? "rotate-180" : ""}`}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" sideOffset={4}>
+            <ActionDropdown onClose={() => setDropdownOpen(false)} />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ActionTrigger.tsx
+++ b/apps/web/src/components/chat/ActionTrigger.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 import { useActionStore } from "@/stores/actionStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { ActionDropdown } from "./ActionDropdown";
+import { ActionEditorDialog } from "./ActionEditorDialog";
 import { getLucideIcon } from "@/lib/action-icons";
 
 /** Duration in ms that the spinner replaces the action icon after a run is triggered. */
@@ -38,6 +39,7 @@ export function ActionTrigger() {
 
   const [running, setRunning] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Load actions whenever the active workspace changes.
@@ -115,10 +117,17 @@ export function ActionTrigger() {
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" sideOffset={4}>
-            <ActionDropdown onClose={() => setDropdownOpen(false)} />
+            <ActionDropdown
+              onClose={() => setDropdownOpen(false)}
+              onOpenEditor={() => setEditorOpen(true)}
+            />
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      {editorOpen && (
+        <ActionEditorDialog open={editorOpen} onOpenChange={setEditorOpen} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -52,6 +52,10 @@ vi.mock("./CreatePrDialog", () => ({
   CreatePrDialog: () => <div data-testid="create-pr-dialog" />,
 }));
 
+vi.mock("./ActionTrigger", () => ({
+  ActionTrigger: () => <div data-testid="action-trigger" />,
+}));
+
 vi.mock("@/hooks/useBranchPr", () => ({
   useBranchPr: (...args: unknown[]) => mockUseBranchPr(...args),
 }));

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -147,7 +147,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
   }, []);
 
   return (
-    <div className="flex items-center justify-between gap-0.5">
+    <div className="flex items-center justify-between gap-2">
       {dirPath && (
         <div className="flex items-center gap-0.5 bg-muted/20 rounded-md px-1 py-0.5">
           {shouldPollPr && (
@@ -166,80 +166,84 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
         </div>
       )}
 
-      {/* Terminal toggle */}
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={toggleTerminal}
-              className={`gap-1 text-xs h-6 ${
-                terminalVisible
-                  ? "text-foreground bg-muted/40"
-                  : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
-              }`}
-              aria-label="Toggle terminal"
-              aria-pressed={terminalVisible}
-            >
-              <Terminal size={12} />
-            </Button>
-          }
-        />
-        <TooltipContent side="bottom" className="text-xs">
-          Toggle terminal (Ctrl+J)
-        </TooltipContent>
-      </Tooltip>
+      {/* Action trigger will be inserted here by Task 11 */}
 
-      {/* Preview panel toggle */}
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={togglePreview}
-              className={`gap-1 text-xs h-6 ${
-                previewActive
-                  ? "text-foreground bg-muted/40"
-                  : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
-              }`}
-              aria-label="Toggle preview panel"
-              aria-pressed={previewActive}
-            >
-              <Globe size={12} />
-            </Button>
-          }
-        />
-        <TooltipContent side="bottom" className="text-xs">
-          Toggle preview (Ctrl+Shift+B)
-        </TooltipContent>
-      </Tooltip>
+      <div className="flex items-center gap-0.5 rounded-md bg-muted/10 px-1 py-0.5">
+        {/* Terminal toggle */}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={toggleTerminal}
+                className={`gap-1 text-xs h-6 ${
+                  terminalVisible
+                    ? "text-foreground bg-muted/40"
+                    : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
+                }`}
+                aria-label="Toggle terminal"
+                aria-pressed={terminalVisible}
+              >
+                <Terminal size={12} />
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom" className="text-xs">
+            Toggle terminal (Ctrl+J)
+          </TooltipContent>
+        </Tooltip>
 
-      {/* Diff panel toggle */}
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={toggleDiff}
-              className={`gap-1 text-xs h-6 ${
-                diffActive
-                  ? "text-foreground bg-muted/40"
-                  : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
-              }`}
-              aria-label="Toggle changes panel"
-              aria-pressed={diffActive}
-            >
-              <Diff size={12} />
-            </Button>
-          }
-        />
-        <TooltipContent side="bottom" className="text-xs">
-          Toggle changes (Ctrl+D)
-        </TooltipContent>
-      </Tooltip>
+        {/* Preview panel toggle */}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={togglePreview}
+                className={`gap-1 text-xs h-6 ${
+                  previewActive
+                    ? "text-foreground bg-muted/40"
+                    : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
+                }`}
+                aria-label="Toggle preview panel"
+                aria-pressed={previewActive}
+              >
+                <Globe size={12} />
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom" className="text-xs">
+            Toggle preview (Ctrl+Shift+B)
+          </TooltipContent>
+        </Tooltip>
+
+        {/* Diff panel toggle */}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={toggleDiff}
+                className={`gap-1 text-xs h-6 ${
+                  diffActive
+                    ? "text-foreground bg-muted/40"
+                    : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
+                }`}
+                aria-label="Toggle changes panel"
+                aria-pressed={diffActive}
+              >
+                <Diff size={12} />
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom" className="text-xs">
+            Toggle changes (Ctrl+D)
+          </TooltipContent>
+        </Tooltip>
+      </div>
 
       {shouldPollPr && (
         <CreatePrDialog

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -3,6 +3,7 @@ import { Terminal, Diff, Globe } from "lucide-react";
 import { OpenInEditorMenu } from "./OpenInEditorMenu";
 import { CreatePrDialog } from "./CreatePrDialog";
 import { PrSplitButton } from "./PrSplitButton";
+import { ActionTrigger } from "./ActionTrigger";
 import { useBranchPr } from "@/hooks/useBranchPr";
 import { useHasCommitsAhead } from "@/hooks/useHasCommitsAhead";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -166,7 +167,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
         </div>
       )}
 
-      {/* Action trigger will be inserted here by Task 11 */}
+      <ActionTrigger />
 
       <div className="flex items-center gap-0.5 rounded-md bg-muted/10 px-1 py-0.5">
         {/* Terminal toggle */}

--- a/apps/web/src/components/chat/ShortcutRecorder.tsx
+++ b/apps/web/src/components/chat/ShortcutRecorder.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+import { getKeybindings, formatKeybinding } from "@/lib/keybinding-manager";
+
+/** Props for the ShortcutRecorder component. */
+interface ShortcutRecorderProps {
+  /** Current shortcut value (e.g., "mod+shift+k"). */
+  value: string | undefined;
+  /** Called when the user records or clears a shortcut. */
+  onChange: (shortcut: string | undefined) => void;
+  /** Sibling actions for conflict checking. */
+  siblingShortcuts: Array<{ id: string; name: string; shortcut?: string }>;
+  /** Current action ID (excluded from sibling conflict check). */
+  currentActionId?: string;
+}
+
+/**
+ * Press-to-record keyboard shortcut input.
+ * Validates against system keybindings and sibling action shortcuts.
+ */
+export function ShortcutRecorder({
+  value,
+  onChange,
+  siblingShortcuts,
+  currentActionId,
+}: ShortcutRecorderProps) {
+  const [recording, setRecording] = useState(false);
+  const [conflict, setConflict] = useState<string | null>(null);
+  const inputRef = useRef<HTMLDivElement>(null);
+  const isMac = navigator.platform.toLowerCase().includes("mac");
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!recording) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Ignore bare modifier keys — wait for an actual key press
+      if (["Control", "Shift", "Alt", "Meta"].includes(e.key)) return;
+
+      const parts: string[] = [];
+      if (e.metaKey || e.ctrlKey) parts.push("mod");
+      if (e.shiftKey) parts.push("shift");
+      if (e.altKey) parts.push("alt");
+      parts.push(e.key.toLowerCase());
+      const shortcut = parts.join("+");
+
+      // Check system keybinding conflicts
+      const systemBindings = getKeybindings();
+      const systemConflict = systemBindings.find(
+        (b) => b.key.toLowerCase() === shortcut.toLowerCase(),
+      );
+      if (systemConflict) {
+        setConflict(`Used by ${systemConflict.command}`);
+        return;
+      }
+
+      // Check sibling action conflicts
+      const siblingConflict = siblingShortcuts.find(
+        (s) =>
+          s.id !== currentActionId &&
+          s.shortcut?.toLowerCase() === shortcut.toLowerCase(),
+      );
+      if (siblingConflict) {
+        setConflict(`Used by ${siblingConflict.name}`);
+        return;
+      }
+
+      setConflict(null);
+      setRecording(false);
+      onChange(shortcut);
+    },
+    [recording, siblingShortcuts, currentActionId, onChange],
+  );
+
+  const handleFocus = useCallback(() => setRecording(true), []);
+  const handleBlur = useCallback(() => {
+    setRecording(false);
+    setConflict(null);
+  }, []);
+
+  const handleClear = useCallback(() => {
+    onChange(undefined);
+    setConflict(null);
+  }, [onChange]);
+
+  return (
+    <div className="space-y-1">
+      <div
+        ref={inputRef}
+        tabIndex={0}
+        role="textbox"
+        aria-label="Press keys to record shortcut"
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        className={`flex h-8 items-center justify-between rounded-md border px-3 text-xs font-mono cursor-pointer
+          ${recording ? "border-primary ring-1 ring-primary/30" : "border-border"}
+          ${conflict ? "border-destructive" : ""}`}
+      >
+        {recording ? (
+          <span className="text-muted-foreground">Press keys to record...</span>
+        ) : value ? (
+          <span>{formatKeybinding(value, isMac)}</span>
+        ) : (
+          <span className="text-muted-foreground/50">No shortcut</span>
+        )}
+        {value && !recording && (
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleClear();
+            }}
+            className="h-4 w-4 p-0"
+          >
+            <X size={10} />
+          </Button>
+        )}
+      </div>
+      {conflict && (
+        <p className="text-[10px] text-destructive">{conflict}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/action-icons.ts
+++ b/apps/web/src/lib/action-icons.ts
@@ -1,0 +1,48 @@
+import {
+  Play,
+  Square,
+  FlaskConical,
+  Download,
+  Hammer,
+  Zap,
+  Terminal,
+  Bug,
+  Package,
+  Rocket,
+  RefreshCw,
+  Check,
+  Code,
+  Database,
+  Globe,
+  Shield,
+  type LucideIcon,
+} from "lucide-react";
+import type { ActionIcon } from "@mcode/contracts";
+
+/** Maps the 16 curated ActionIcon names to their Lucide components. */
+const ICON_MAP: Record<ActionIcon, LucideIcon> = {
+  play: Play,
+  square: Square,
+  "flask-conical": FlaskConical,
+  download: Download,
+  hammer: Hammer,
+  zap: Zap,
+  terminal: Terminal,
+  bug: Bug,
+  package: Package,
+  rocket: Rocket,
+  "refresh-cw": RefreshCw,
+  check: Check,
+  code: Code,
+  database: Database,
+  globe: Globe,
+  shield: Shield,
+};
+
+/**
+ * Returns the Lucide icon component for a given ActionIcon name.
+ * Falls back to the Play icon when the name is not in the curated set.
+ */
+export function getLucideIcon(icon: ActionIcon): LucideIcon {
+  return ICON_MAP[icon] ?? Play;
+}

--- a/apps/web/src/lib/keybinding-manager.ts
+++ b/apps/web/src/lib/keybinding-manager.ts
@@ -171,3 +171,32 @@ export function clearKeybindings(): void {
   keybindings = [];
   parsedCache = [];
 }
+
+/**
+ * Add a dynamic keybinding at runtime (e.g., for project action shortcuts).
+ * Returns a dispose function that removes the binding.
+ */
+export function addDynamicKeybinding(binding: Keybinding): () => void {
+  keybindings.push(binding);
+  parsedCache.push(parseKeybinding(binding.key));
+  return () => {
+    const idx = keybindings.indexOf(binding);
+    if (idx >= 0) {
+      keybindings.splice(idx, 1);
+      parsedCache.splice(idx, 1);
+    }
+  };
+}
+
+/**
+ * Remove all dynamic keybindings whose command ID starts with the given prefix.
+ * Used to clear project action keybindings when the workspace changes.
+ */
+export function removeDynamicKeybindings(prefix: string): void {
+  for (let i = keybindings.length - 1; i >= 0; i--) {
+    if (keybindings[i].command.startsWith(prefix)) {
+      keybindings.splice(i, 1);
+      parsedCache.splice(i, 1);
+    }
+  }
+}

--- a/apps/web/src/lib/shortcuts.ts
+++ b/apps/web/src/lib/shortcuts.ts
@@ -8,11 +8,15 @@ import {
   getKeybindings,
   getParsedKeybinding,
   loadKeybindings,
+  addDynamicKeybinding,
+  removeDynamicKeybindings,
   type Keybinding,
 } from "./keybinding-manager";
 import { evaluateWhen, setContext } from "./context-tracker";
-import { executeCommand } from "./command-registry";
+import { executeCommand, registerCommand } from "./command-registry";
 import defaultKeybindings from "@/config/default-keybindings.json";
+import { useActionStore } from "@/stores/actionStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 /** Detect whether an element is an input that should set the inputFocused context. */
 function isInputElement(el: Element | null): boolean {
@@ -57,10 +61,65 @@ function handleKeyDown(e: KeyboardEvent): void {
   }
 }
 
+/** Disposers for currently registered action commands and their keybindings. */
+let actionCommandDisposers: (() => void)[] = [];
+
+/**
+ * Register keybindings for the active workspace's actions.
+ *
+ * Clears any previously registered action bindings first, then registers
+ * a command and keybinding for each action that has a shortcut defined.
+ */
+export function registerActionKeybindings(): void {
+  unregisterActionKeybindings();
+
+  const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
+  if (!workspaceId) return;
+
+  const actions = useActionStore.getState().getActions(workspaceId);
+  for (const action of actions) {
+    if (!action.shortcut) continue;
+
+    const commandId = `action.run.${action.id}`;
+    const commandDispose = registerCommand({
+      id: commandId,
+      title: `Run: ${action.name}`,
+      category: "Project Actions",
+      handler: () => {
+        const threadId = useWorkspaceStore.getState().activeThreadId;
+        if (!threadId || !workspaceId) return;
+        useActionStore.getState().runAction(workspaceId, action.id, threadId);
+      },
+    });
+
+    const bindingDispose = addDynamicKeybinding({
+      command: commandId,
+      key: action.shortcut,
+      when: "!inputFocused && !terminalFocused",
+    });
+
+    actionCommandDisposers.push(commandDispose, bindingDispose);
+  }
+}
+
+/**
+ * Remove all action keybindings and unregister their commands.
+ *
+ * Also calls removeDynamicKeybindings as a safety net to clean up
+ * any bindings not tracked via the disposers array.
+ */
+export function unregisterActionKeybindings(): void {
+  for (const dispose of actionCommandDisposers) dispose();
+  actionCommandDisposers = [];
+  removeDynamicKeybindings("action.run.");
+}
+
 /**
  * Initialize the keybinding system.
  * Loads default keybindings (merged with optional user overrides),
  * attaches the global keydown listener, and sets up focus tracking.
+ * Also subscribes to workspace and action store changes to keep action
+ * keybindings in sync with the active workspace.
  */
 export function initShortcuts(overrides?: Keybinding[]): () => void {
   loadKeybindings(defaultKeybindings as Keybinding[], overrides);
@@ -68,10 +127,28 @@ export function initShortcuts(overrides?: Keybinding[]): () => void {
   document.addEventListener("focusin", updateFocusContext);
   document.addEventListener("focusout", updateFocusContext);
 
+  // Re-register action keybindings when active workspace changes.
+  // Both stores use plain `create` without subscribeWithSelector, so we
+  // compare the relevant slice manually to avoid spurious re-registrations.
+  const unsubWorkspace = useWorkspaceStore.subscribe((state, prevState) => {
+    if (state.activeWorkspaceId !== prevState.activeWorkspaceId) {
+      registerActionKeybindings();
+    }
+  });
+
+  const unsubActions = useActionStore.subscribe((state, prevState) => {
+    if (state.actionsByWorkspace !== prevState.actionsByWorkspace) {
+      registerActionKeybindings();
+    }
+  });
+
   return () => {
     document.removeEventListener("keydown", handleKeyDown);
     document.removeEventListener("focusin", updateFocusContext);
     document.removeEventListener("focusout", updateFocusContext);
+    unsubWorkspace();
+    unsubActions();
+    unregisterActionKeybindings();
   };
 }
 

--- a/apps/web/src/stores/actionStore.ts
+++ b/apps/web/src/stores/actionStore.ts
@@ -1,0 +1,141 @@
+/**
+ * Zustand store for managing project actions per workspace.
+ *
+ * Handles loading, saving, deleting, reordering, and tracking last-used
+ * actions. Calls transport methods added alongside this store
+ * (actionList, actionSave, actionDelete, actionRun, actionReorder).
+ */
+
+import { create } from "zustand";
+import type { Action } from "@mcode/contracts";
+import { getTransport } from "@/transport";
+
+/** State and actions for the action Zustand store. */
+interface ActionState {
+  /** Per-workspace action lists, keyed by workspaceId. */
+  actionsByWorkspace: Record<string, Action[]>;
+  /** Last-used action ID per workspace, keyed by workspaceId. */
+  lastUsedByWorkspace: Record<string, string | null>;
+  /** In-flight loading flag per workspace, keyed by workspaceId. */
+  loading: Record<string, boolean>;
+
+  /** Fetch the action list for a workspace from the server. */
+  loadActions: (workspaceId: string) => Promise<void>;
+  /** Trigger a run of a specific action within a thread. */
+  runAction: (workspaceId: string, actionId: string, threadId: string) => Promise<void>;
+  /** Persist an action (create or update). Updates local state optimistically. */
+  saveAction: (workspaceId: string, action: Action) => Promise<void>;
+  /** Delete an action and remove it from local state. */
+  deleteAction: (workspaceId: string, actionId: string) => Promise<void>;
+  /** Persist the display order for workspace actions. */
+  reorderActions: (workspaceId: string, orderedIds: string[]) => Promise<void>;
+  /** Push handler: re-fetches actions when the server signals a change. */
+  handleActionsChanged: (workspaceId: string) => void;
+  /** Push handler: records the last-run action for a workspace. */
+  handleActionRan: (workspaceId: string, actionId: string) => void;
+  /** Return the cached action list for a workspace (never undefined). */
+  getActions: (workspaceId: string) => Action[];
+  /**
+   * Return the last-used action for a workspace.
+   * Falls back to the first action if no last-used ID is recorded.
+   */
+  getLastUsed: (workspaceId: string) => Action | undefined;
+}
+
+/** Per-workspace Zustand store for project actions. */
+export const useActionStore = create<ActionState>((set, get) => ({
+  actionsByWorkspace: {},
+  lastUsedByWorkspace: {},
+  loading: {},
+
+  loadActions: async (workspaceId) => {
+    set((s) => ({ loading: { ...s.loading, [workspaceId]: true } }));
+    try {
+      const { actions, lastActionId } = await getTransport().actionList(workspaceId);
+      set((s) => ({
+        actionsByWorkspace: { ...s.actionsByWorkspace, [workspaceId]: actions },
+        lastUsedByWorkspace: { ...s.lastUsedByWorkspace, [workspaceId]: lastActionId },
+        loading: { ...s.loading, [workspaceId]: false },
+      }));
+    } catch {
+      set((s) => ({ loading: { ...s.loading, [workspaceId]: false } }));
+    }
+  },
+
+  runAction: async (workspaceId, actionId, threadId) => {
+    await getTransport().actionRun(workspaceId, actionId, threadId);
+    set((s) => ({
+      lastUsedByWorkspace: { ...s.lastUsedByWorkspace, [workspaceId]: actionId },
+    }));
+  },
+
+  saveAction: async (workspaceId, action) => {
+    const saved = await getTransport().actionSave(workspaceId, action);
+    set((s) => {
+      const existing = s.actionsByWorkspace[workspaceId] ?? [];
+      const idx = existing.findIndex((a) => a.id === saved.id);
+      const updated = [...existing];
+      if (idx >= 0) {
+        updated[idx] = saved;
+      } else {
+        updated.push(saved);
+      }
+      // Enforce single-setup invariant: only one action may be flagged as setup.
+      if (saved.setup) {
+        for (const a of updated) {
+          if (a.id !== saved.id) a.setup = false;
+        }
+      }
+      return { actionsByWorkspace: { ...s.actionsByWorkspace, [workspaceId]: updated } };
+    });
+  },
+
+  deleteAction: async (workspaceId, actionId) => {
+    await getTransport().actionDelete(workspaceId, actionId);
+    set((s) => {
+      const existing = s.actionsByWorkspace[workspaceId] ?? [];
+      return {
+        actionsByWorkspace: {
+          ...s.actionsByWorkspace,
+          [workspaceId]: existing.filter((a) => a.id !== actionId),
+        },
+      };
+    });
+  },
+
+  reorderActions: async (workspaceId, orderedIds) => {
+    await getTransport().actionReorder(workspaceId, orderedIds);
+    set((s) => {
+      const existing = s.actionsByWorkspace[workspaceId] ?? [];
+      const map = new Map(existing.map((a) => [a.id, a]));
+      const reordered: Action[] = [];
+      for (const id of orderedIds) {
+        const a = map.get(id);
+        if (a) reordered.push(a);
+      }
+      return { actionsByWorkspace: { ...s.actionsByWorkspace, [workspaceId]: reordered } };
+    });
+  },
+
+  handleActionsChanged: (workspaceId) => {
+    get().loadActions(workspaceId);
+  },
+
+  handleActionRan: (workspaceId, actionId) => {
+    set((s) => ({
+      lastUsedByWorkspace: { ...s.lastUsedByWorkspace, [workspaceId]: actionId },
+    }));
+  },
+
+  getActions: (workspaceId) => get().actionsByWorkspace[workspaceId] ?? [],
+
+  getLastUsed: (workspaceId) => {
+    const actions = get().actionsByWorkspace[workspaceId] ?? [];
+    const lastId = get().lastUsedByWorkspace[workspaceId];
+    if (lastId) {
+      const found = actions.find((a) => a.id === lastId);
+      if (found) return found;
+    }
+    return actions[0];
+  },
+}));

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -367,8 +367,8 @@ export interface McodeTransport {
   setBackground(background: boolean): Promise<void>;
 
   // Project actions
-  /** List all actions for a workspace. */
-  actionList(workspaceId: string): Promise<Action[]>;
+  /** List all actions for a workspace, including the last-used action ID. */
+  actionList(workspaceId: string): Promise<{ actions: Action[]; lastActionId: string | null }>;
   /** Create or update an action for a workspace. */
   actionSave(workspaceId: string, action: Action): Promise<Action>;
   /** Delete an action from a workspace. */

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -32,6 +32,7 @@ import type {
   PermissionDecision,
   PermissionRequest,
   CreateAndSendResult,
+  Action,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
@@ -59,7 +60,7 @@ export type {
   ProviderModelInfo,
 } from "@mcode/contracts";
 
-export type { PaginatedMessages, ToolCallRecord, TurnSnapshot, CopilotSubagent } from "@mcode/contracts";
+export type { PaginatedMessages, ToolCallRecord, TurnSnapshot, CopilotSubagent, Action } from "@mcode/contracts";
 
 export { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
 
@@ -364,4 +365,16 @@ export interface McodeTransport {
   // Memory pressure
   /** Notify server of window background/foreground state for memory management. */
   setBackground(background: boolean): Promise<void>;
+
+  // Project actions
+  /** List all actions for a workspace. */
+  actionList(workspaceId: string): Promise<Action[]>;
+  /** Create or update an action for a workspace. */
+  actionSave(workspaceId: string, action: Action): Promise<Action>;
+  /** Delete an action from a workspace. */
+  actionDelete(workspaceId: string, actionId: string): Promise<boolean>;
+  /** Run an action in a thread's terminal. */
+  actionRun(workspaceId: string, actionId: string, threadId: string): Promise<void>;
+  /** Persist a new display order for all actions in a workspace. */
+  actionReorder(workspaceId: string, orderedIds: string[]): Promise<boolean>;
 }

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -10,6 +10,7 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { useSkillsStore } from "@/stores/skillsStore";
 import { clearFileListCache } from "@/components/chat/useFileAutocomplete";
+import { useActionStore } from "@/stores/actionStore";
 
 /** Unsubscribe handles for all push listeners. */
 let unsubs: (() => void)[] = [];
@@ -43,6 +44,8 @@ const _legacyEncoder = new TextEncoder();
  * - `workspace.orderChanged` -- sidebar project order changed on the server; refreshes workspace list
  * - `workspace.deleted` -- workspace hard-delete complete; removes it from local state
  * - `workspace.deleteFailed` -- workspace deletion permanently stuck; reloads workspace list
+ * - `action.changed` -- actions file was modified (external edit or server save); re-fetches for the workspace
+ * - `action.ran` -- an action was executed; updates last-used metadata in actionStore
  */
 export function startPushListeners(): void {
   // Guard against double-init
@@ -369,6 +372,29 @@ export function startPushListeners(): void {
       // Reject malformed payloads rather than overwriting the store with garbage.
       if (!Array.isArray(data)) return;
       useProviderAvailabilityStore.getState().replace(data as ProviderAvailability[]);
+    }),
+  );
+
+  // action.changed: actions file was modified (external edit or server save)
+  unsubs.push(
+    pushEmitter.on("action.changed", (data) => {
+      const { workspaceId } = data as { workspaceId: string };
+      if (workspaceId) {
+        useActionStore.getState().handleActionsChanged(workspaceId);
+      }
+    }),
+  );
+
+  // action.ran: an action was executed, update last-used
+  unsubs.push(
+    pushEmitter.on("action.ran", (data) => {
+      const { workspaceId, actionId } = data as {
+        workspaceId: string;
+        actionId: string;
+      };
+      if (workspaceId && actionId) {
+        useActionStore.getState().handleActionRan(workspaceId, actionId);
+      }
     }),
   );
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -17,7 +17,7 @@ import type {
   ProviderModelInfo,
   CopilotSubagent,
 } from "./types";
-import type { CreateAndSendResult } from "@mcode/contracts";
+import type { CreateAndSendResult, Action } from "@mcode/contracts";
 import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 import {
@@ -735,6 +735,18 @@ export function createWsTransport(
 
     // Memory pressure
     setBackground: (background) => rpc<void>("memory.setBackground", { background }),
+
+    // Project actions
+    /** List actions for a workspace. */
+    actionList: (workspaceId) => rpc<Action[]>("action.list", { workspaceId }),
+    /** Save (create/update) an action. */
+    actionSave: (workspaceId, action) => rpc<Action>("action.save", { workspaceId, action }),
+    /** Delete an action. */
+    actionDelete: (workspaceId, actionId) => rpc<boolean>("action.delete", { workspaceId, actionId }),
+    /** Run an action in a thread's terminal. */
+    actionRun: (workspaceId, actionId, threadId) => rpc<void>("action.run", { workspaceId, actionId, threadId }),
+    /** Reorder actions. */
+    actionReorder: (workspaceId, orderedIds) => rpc<boolean>("action.reorder", { workspaceId, orderedIds }),
 
     // Lifecycle
     close: () => {

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -738,7 +738,7 @@ export function createWsTransport(
 
     // Project actions
     /** List actions for a workspace. */
-    actionList: (workspaceId) => rpc<Action[]>("action.list", { workspaceId }),
+    actionList: (workspaceId) => rpc<{ actions: Action[]; lastActionId: string | null }>("action.list", { workspaceId }),
     /** Save (create/update) an action. */
     actionSave: (workspaceId, action) => rpc<Action>("action.save", { workspaceId, action }),
     /** Delete an action. */

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -50,6 +50,14 @@ export { TurnSnapshotSchema } from "./models/turn-snapshot.js";
 export type { TurnSnapshot } from "./models/turn-snapshot.js";
 
 export {
+  ActionSchema,
+  ActionsFileSchema,
+  ActionIconSchema,
+  ACTION_ICONS,
+} from "./models/action.js";
+export type { Action, ActionsFile, ActionIcon } from "./models/action.js";
+
+export {
   SettingsSchema,
   PartialSettingsSchema,
   getDefaultSettings,

--- a/packages/contracts/src/models/action.ts
+++ b/packages/contracts/src/models/action.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+
+/** Lucide icon names available for project actions. */
+export const ACTION_ICONS = [
+  "play",
+  "square",
+  "flask-conical",
+  "download",
+  "hammer",
+  "zap",
+  "terminal",
+  "bug",
+  "package",
+  "rocket",
+  "refresh-cw",
+  "check",
+  "code",
+  "database",
+  "globe",
+  "shield",
+] as const;
+
+export const ActionIconSchema = z.enum(ACTION_ICONS);
+
+/** Schema for a single project action. */
+export const ActionSchema = lazySchema(() =>
+  z.object({
+    id: z.string().min(1).regex(/^[a-z0-9-]+$/, "Must be a URL-safe slug"),
+    name: z.string().min(1).max(50),
+    command: z.string().min(1),
+    icon: ActionIconSchema,
+    shortcut: z.string().optional(),
+    setup: z.boolean().default(false),
+  }),
+);
+
+export type Action = z.infer<ReturnType<typeof ActionSchema>>;
+export type ActionIcon = z.infer<typeof ActionIconSchema>;
+
+/** Schema for the actions JSON file. */
+export const ActionsFileSchema = lazySchema(() =>
+  z.object({
+    actions: z.array(ActionSchema()),
+  }),
+);
+
+export type ActionsFile = z.infer<ReturnType<typeof ActionsFileSchema>>;

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -97,6 +97,13 @@ export const WS_CHANNELS = {
     workspacePath: z.string(),
     reason: z.string(),
   }),
+  /** Emitted when the actions file changes (external edit, save, delete, reorder). */
+  "action.changed": z.object({ workspaceId: z.string() }),
+  /** Emitted after an action is executed, so UI can update last-used indicator. */
+  "action.ran": z.object({
+    workspaceId: z.string(),
+    actionId: z.string(),
+  }),
 } as const;
 
 /** Union of all push channel names. */

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -639,7 +639,10 @@ export const WS_METHODS = lazySchema(() => ({
   },
   "action.list": {
     params: z.object({ workspaceId: z.string() }),
-    result: z.array(ActionSchema()),
+    result: z.object({
+      actions: z.array(ActionSchema()),
+      lastActionId: z.string().nullable(),
+    }),
   },
   "action.save": {
     params: z.object({

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -26,6 +26,7 @@ import { ProviderUsageInfoSchema } from "../providers/usage.js";
 import { ProviderAvailabilitySchema } from "../providers/availability.js";
 import { CopilotSubagentSchema, CopilotAgentNameSchema } from "../providers/copilot-agent.js";
 import { PermissionDecisionSchema, PermissionRequestSchema } from "../models/permission.js";
+import { ActionSchema } from "../models/action.js";
 
 /** Schema for creating a new thread. */
 export const CreateThreadSchema = lazySchema(() =>
@@ -635,6 +636,39 @@ export const WS_METHODS = lazySchema(() => ({
       model: z.string(),
       createdAt: z.string(),
     }),
+  },
+  "action.list": {
+    params: z.object({ workspaceId: z.string() }),
+    result: z.array(ActionSchema()),
+  },
+  "action.save": {
+    params: z.object({
+      workspaceId: z.string(),
+      action: ActionSchema(),
+    }),
+    result: ActionSchema(),
+  },
+  "action.delete": {
+    params: z.object({
+      workspaceId: z.string(),
+      actionId: z.string(),
+    }),
+    result: z.boolean(),
+  },
+  "action.run": {
+    params: z.object({
+      workspaceId: z.string(),
+      actionId: z.string(),
+      threadId: z.string(),
+    }),
+    result: z.void(),
+  },
+  "action.reorder": {
+    params: z.object({
+      workspaceId: z.string(),
+      orderedIds: z.array(z.string()),
+    }),
+    result: z.boolean(),
   },
 } as const));
 


### PR DESCRIPTION
## What

Per-project shell commands (actions) that can be run from the header, assigned keyboard shortcuts, and auto-executed on worktree creation.

## Why

Developers repeatedly run the same project-specific commands (install deps, run dev server, build, lint). This feature lets them define those commands once per project and trigger them instantly from the UI or via keybindings.

Closes #448

## Key Changes

**Contracts**
- `Action` Zod schema with `lazySchema` pattern
- 5 RPC methods (`action.list`, `action.save`, `action.delete`, `action.run`, `action.reorder`)
- 2 push channels (`action.changed`, `action.ran`)

**Server**
- `ActionService` with file-based storage, atomic writes (tmp + rename), in-memory cache
- Database migration adding `last_action_id` to workspaces table
- Setup action hook: auto-runs designated action after worktree creation
- Workspace cleanup: removes action data directory on workspace delete (both normal and force-delete)

**Frontend**
- `actionStore` (Zustand) with workspace-scoped actions, last-used tracking persisted via server
- `ActionTrigger` split-click header button (run last-used / open dropdown)
- `ActionDropdown` with action list, shortcut hints, last-used highlight, empty state
- `ActionEditorDialog` with list view + edit view, icon grid (16 Lucide icons), setup switch
- `ShortcutRecorder` press-to-record input with conflict detection
- Dynamic keybinding registration/unregistration when workspace or actions change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom action management for workspaces with an editor UI to create, edit, and delete actions.
  * Actions support keyboard shortcuts, custom icons, and can be marked as setup actions.
  * New action dropdown in the header provides quick access to run workspace actions.
  * Last-used action tracking for faster access to frequently used actions.
  * Automatic cleanup of workspace actions on workspace deletion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->