### PR TITLE
fix(web): keep modals above embedded preview and soften dialog backdrop

### DIFF
--- a/apps/web/src/components/palette/CommandPalette.tsx
+++ b/apps/web/src/components/palette/CommandPalette.tsx
@@ -5,6 +5,7 @@ import { SearchIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Command } from "@/components/ui/command";
 import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
+import { syncElectronBlockingOverlayOpen } from "@/stores/electronBlockingOverlayStore";
 import { setContext } from "@/lib/context-tracker";
 import { isMac } from "@/lib/platform";
 import { RootView } from "./views/RootView";
@@ -44,6 +45,13 @@ export function CommandPalette() {
     setContext("commandPaletteOpen", isOpen);
   }, [isOpen]);
 
+  /** Hide Electron BrowserView during palette focus (same native stacking constraint as Dialog). */
+  useEffect(() => {
+    if (!isOpen) return
+    syncElectronBlockingOverlayOpen(true)
+    return () => syncElectronBlockingOverlayOpen(false)
+  }, [isOpen])
+
   // The placeholder hints at what the input does in the current view/mode.
   const placeholder = browseMode
     ? "Type a path or filter…"
@@ -54,13 +62,19 @@ export function CommandPalette() {
         : "Search commands, type ~/ to browse, > for actions only…";
 
   return (
-    <DialogPrimitive.Root open={isOpen} onOpenChange={(o) => !o && close()} modal="trap-focus">
+    <DialogPrimitive.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+      modal="trap-focus"
+    >
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-foreground/40 backdrop-blur-sm" />
+        <DialogPrimitive.Backdrop className="fixed inset-0 z-[100] bg-white/[0.04] supports-backdrop-filter:backdrop-blur-[1px] dark:bg-white/[0.05]" />
         <DialogPrimitive.Popup
           data-testid="command-palette"
           className={cn(
-            "fixed left-1/2 top-[clamp(4rem,15vh,9rem)] z-50 w-full -translate-x-1/2 outline-none",
+            "fixed left-1/2 top-[clamp(4rem,15vh,9rem)] z-[100] w-full -translate-x-1/2 outline-none",
             top?.kind === "projects" ? "max-w-2xl" : "max-w-xl",
           )}
         >

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -6,6 +6,7 @@ import {
   type RefObject,
 } from "react";
 import { useDiffStore } from "@/stores/diffStore";
+import { useElectronBlockingOverlayStore } from "@/stores/electronBlockingOverlayStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 const NAV_ERROR_LABEL: Record<string, string> = {
@@ -86,6 +87,9 @@ export function usePreviewBridge({
   const storedUrl = useDiffStore(
     (s) => s.previewUrlByThread[threadId] ?? "",
   );
+
+  /** Non-zero while a fullscreen modal hides the Electron preview (BrowserView composites above renderer HTML). */
+  const electronBlockingOverlayDepth = useElectronBlockingOverlayStore((s) => s.depth);
 
   /** Stable ref to the current storedUrl, read inside pushSync to avoid
    *  adding storedUrl to pushSync's dependency array. */
@@ -213,6 +217,16 @@ export function usePreviewBridge({
       void pushSyncRef.current(false);
     };
   }, []);
+
+  /** Detach BrowserView while blocking modals are open so confirmation dialogs remain visible above the preview. */
+  useEffect(() => {
+    if (!window.desktopBridge?.preview) return;
+    if (electronBlockingOverlayDepth > 0) {
+      void pushSyncRef.current(false);
+      return;
+    }
+    void pushSyncRef.current(true);
+  }, [electronBlockingOverlayDepth]);
 
   const onGoBack = useCallback(async () => {
     const preview = window.desktopBridge?.preview;

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -3,10 +3,30 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { syncElectronBlockingOverlayOpen } from "@/stores/electronBlockingOverlayStore"
 import { XIcon } from "lucide-react"
 
-function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+function Dialog(props: DialogPrimitive.Root.Props) {
+  const { onOpenChange, open, ...rest } = props
+  const controlled = typeof open === "boolean"
+
+  React.useEffect(() => {
+    if (!controlled || !open) return
+    syncElectronBlockingOverlayOpen(true)
+    return () => syncElectronBlockingOverlayOpen(false)
+  }, [controlled, open])
+
+  return (
+    <DialogPrimitive.Root
+      data-slot="dialog"
+      {...rest}
+      open={open}
+      onOpenChange={(nextOpen, details) => {
+        if (!controlled) syncElectronBlockingOverlayOpen(nextOpen)
+        onOpenChange?.(nextOpen, details)
+      }}
+    />
+  )
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
@@ -29,7 +49,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-foreground/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-[100] bg-white/[0.04] duration-100 supports-backdrop-filter:backdrop-blur-[1px] data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 dark:bg-white/[0.05]",
         className
       )}
       {...props}
@@ -51,7 +71,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-[100] grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/apps/web/src/stores/electronBlockingOverlayStore.ts
+++ b/apps/web/src/stores/electronBlockingOverlayStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+/**
+ * Counts fullscreen modal dialogs that must sit visually above Electron's embedded
+ * preview BrowserView. The native view always composites above renderer HTML,
+ * so the preview is temporarily hidden whenever this depth is greater than zero.
+ */
+interface ElectronBlockingOverlayState {
+  readonly depth: number;
+  increment: () => void;
+  decrement: () => void;
+}
+
+export const useElectronBlockingOverlayStore = create<ElectronBlockingOverlayState>((set) => ({
+  depth: 0,
+  increment: () => set((s) => ({ depth: s.depth + 1 })),
+  decrement: () => set((s) => ({ depth: Math.max(0, s.depth - 1) })),
+}));
+
+/**
+ * Keeps preview BrowserView suppressed while at least one blocking modal reports open.
+ * Call from modal root `onOpenChange` alongside any existing handler (Command Palette,
+ * shadcn `Dialog`, or raw Base UI dialogs).
+ *
+ * @param open When `true`, a blocking overlay gained focus; when `false`, it closed.
+ */
+export function syncElectronBlockingOverlayOpen(open: boolean): void {
+  const { increment, decrement } = useElectronBlockingOverlayStore.getState();
+  if (open) increment();
+  else decrement();
+}


### PR DESCRIPTION
## What

Ensures modal dialogs and the command palette stay visually correct on desktop when the embedded BrowserView preview is visible. Electron composites BrowserView above rendered HTML, so CSS z-index alone cannot stack dialogs above the preview. This branch hides the preview while blocking overlays are open and restores it afterward. Dialog backdrops use a subtler veil.

## Why

Users saw the preview paint over destructive-action modals (for example delete thread), which hid critical UI and looked broken. The previous light overlay also felt heavy on light theme.

## Key Changes

- Add `electronBlockingOverlayStore` depth counter and `syncElectronBlockingOverlayOpen` for paired register/unregister (Strict Mode safe).
- Wrap shared `Dialog` so controlled dialogs sync overlay depth on mount/unmount and uncontrolled dialogs sync via `onOpenChange`.
- `usePreviewBridge`: when blocking depth > 0, call `preview:visible` false; when depth returns to 0, restore bounds with `preview:visible` true.
- Command palette: same blocking lifecycle while open; palette layers use higher z-index and lighter backdrop styling.

## Test plan

- [ ] Manual desktop: open preview, open Delete thread (or another modal); confirm modal is fully readable and preview does not occlude it.
- [ ] Manual desktop: close modal; confirm preview returns with correct bounds.
- [ ] Manual: command palette over preview; preview hides while open.
- [ ] `cd apps/web && bun run e2e` (recommended for overlay changes per AGENTS.md).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed modal dialogs and command palette display to properly appear above preview elements without being obscured.
  
* **Improvements**
  * Enhanced overlay z-index and backdrop styling for improved visibility of modal dialogs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->