### PR TITLE
fix(ci): nightly version exceeds Windows VERSIONINFO 16-bit limit

### DIFF
--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -1,0 +1,276 @@
+# Packs the desktop app from the default branch and uploads to the rolling
+# prerelease tagged `nightly`, using electron-builder publish channel `nightly`
+# so clients with `updates.channel` = `nightly` resolve `latest-nightly.yml` (etc.).
+
+name: Nightly Desktop
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-desktop
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Ensure nightly prerelease exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          if ! gh release view nightly --repo "${{ github.repository }}" &>/dev/null; then
+            gh release create nightly --prerelease --title "Mcode nightly" \
+              --notes "Automated desktop builds from the default branch. Assets are replaced on each successful run." \
+              --repo "${{ github.repository }}"
+          fi
+
+  build:
+    needs: [prepare]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: blacksmith-4vcpu-windows-2025
+            build-args: ""
+            target-arch: ""
+          - os: ubuntu-22.04
+            build-args: ""
+            target-arch: ""
+          - os: blacksmith-12vcpu-macos-26
+            build-args: "--mac --arm64"
+            target-arch: "arm64"
+          - os: blacksmith-12vcpu-macos-26
+            build-args: "--mac --x64"
+            target-arch: "x64"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Set nightly package version
+        shell: bash
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+          const manifest = JSON.parse(fs.readFileSync(".release-please-manifest.json", "utf8"));
+          const base = manifest["."];
+          const day = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+          const run = process.env.GITHUB_RUN_NUMBER || "0";
+          const version = `${base}-nightly.${day}.${run}`;
+          const pkgPath = "apps/desktop/package.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.version = version;
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+          console.log("Nightly desktop version:", version);
+          NODE
+
+      - name: Build main & renderer
+        run: bun run --cwd apps/desktop build
+
+      - name: Generate V8 snapshot
+        run: bun apps/desktop/scripts/generate-snapshot.mjs
+        env:
+          MCODE_TARGET_ARCH: ${{ matrix.target-arch }}
+
+      - name: Install Python setuptools (node-gyp on Python 3.12+ needs it)
+        shell: bash
+        run: python3 -m pip install setuptools --break-system-packages 2>/dev/null || python3 -m pip install setuptools 2>/dev/null || pip install setuptools 2>/dev/null || true
+
+      - name: Package with electron-builder (nightly channel)
+        run: node apps/desktop/scripts/ci-package.mjs --config.publish.channel=nightly ${{ matrix.build-args }}
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && 'false' || '' }}
+
+      - name: Smoke test packaged server
+        if: matrix.target-arch == '' || matrix.target-arch == 'arm64'
+        run: node apps/desktop/scripts/smoke-test.mjs
+
+      - name: Upload macOS update metadata (nightly channel)
+        if: matrix.target-arch == 'arm64' || matrix.target-arch == 'x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: latest-mac-yml-${{ matrix.target-arch }}-nightly
+          path: apps/desktop/release/latest-mac-nightly.yml
+          retention-days: 1
+
+      - name: Collect nightly release artifacts
+        id: artifacts
+        shell: bash
+        run: |
+          echo "tag=nightly" >> "$GITHUB_OUTPUT"
+          shopt -s nullglob
+          files=()
+          for f in \
+            apps/desktop/release/*.exe \
+            apps/desktop/release/*.exe.blockmap \
+            apps/desktop/release/*.dmg \
+            apps/desktop/release/*.dmg.blockmap \
+            apps/desktop/release/*.zip \
+            apps/desktop/release/*.zip.blockmap \
+            apps/desktop/release/*.AppImage \
+            apps/desktop/release/*.deb \
+            apps/desktop/release/latest-nightly.yml \
+            apps/desktop/release/latest-linux-nightly.yml; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f")
+            [[ "$base" == "elevate.exe" ]] && continue
+            files+=("$f")
+          done
+
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No artifacts found to upload"
+            exit 0
+          fi
+
+          printf '%s\n' "${files[@]}"
+          printf '%s\n' "${files[@]}" > artifact-list.txt
+          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload nightly release artifacts
+        if: steps.artifacts.outputs.count > 0
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          while IFS= read -r f; do
+            echo "Uploading: $f"
+            gh release upload nightly "$f" --clobber --repo "${{ github.repository }}"
+          done < artifact-list.txt
+
+  merge-mac-yml-nightly:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download arm64 yml
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: latest-mac-yml-arm64-nightly
+          path: yml-arm64
+
+      - name: Download x64 yml
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: latest-mac-yml-x64-nightly
+          path: yml-x64
+
+      - name: Merge latest-mac-nightly.yml
+        shell: bash
+        run: |
+          ARM64_YML="yml-arm64/latest-mac-nightly.yml"
+          X64_YML="yml-x64/latest-mac-nightly.yml"
+
+          if [ ! -f "$ARM64_YML" ] || [ ! -f "$X64_YML" ]; then
+            echo "One or both nightly mac yml files missing, skipping merge"
+            if [ -f "$ARM64_YML" ]; then cp "$ARM64_YML" latest-mac-nightly.yml; fi
+            if [ -f "$X64_YML" ]; then cp "$X64_YML" latest-mac-nightly.yml; fi
+            if [ ! -f latest-mac-nightly.yml ]; then exit 0; fi
+          else
+            node -e "
+              const fs = require('fs');
+              const arm64 = fs.readFileSync('$ARM64_YML', 'utf8');
+              const x64 = fs.readFileSync('$X64_YML', 'utf8');
+
+              function parseFiles(yml) {
+                const lines = yml.split('\n');
+                const files = [];
+                let inFiles = false;
+                let current = null;
+                for (const line of lines) {
+                  if (line.startsWith('files:')) { inFiles = true; continue; }
+                  if (inFiles) {
+                    if (line.match(/^  - url:/)) {
+                      if (current) files.push(current);
+                      current = line + '\n';
+                    } else if (line.match(/^    \w/) && current) {
+                      current += line + '\n';
+                    } else if (line.match(/^\w/) && line.trim()) {
+                      if (current) files.push(current);
+                      current = null;
+                      inFiles = false;
+                    } else if (current) {
+                      current += line + '\n';
+                    }
+                  }
+                }
+                if (current) files.push(current);
+                return files;
+              }
+
+              const arm64Files = parseFiles(arm64);
+              const x64Files = parseFiles(x64);
+
+              const arm64Urls = new Set(arm64Files.map(f => {
+                const m = f.match(/url:\s*(.+)/);
+                return m ? m[1].trim() : '';
+              }));
+
+              const newEntries = x64Files.filter(f => {
+                const m = f.match(/url:\s*(.+)/);
+                return m && !arm64Urls.has(m[1].trim());
+              });
+
+              if (newEntries.length === 0) {
+                fs.writeFileSync('latest-mac-nightly.yml', arm64);
+              } else {
+                const lines = arm64.split('\n');
+                const out = [];
+                let insertedExtra = false;
+                let inFilesBlock = false;
+
+                for (let i = 0; i < lines.length; i++) {
+                  out.push(lines[i]);
+                  if (lines[i].startsWith('files:')) {
+                    inFilesBlock = true;
+                  }
+                  if (inFilesBlock && i > 0 && lines[i].match(/^\w/) && lines[i].trim() && !lines[i].startsWith('files:')) {
+                    if (!insertedExtra) {
+                      const lastLine = out.pop();
+                      for (const entry of newEntries) {
+                        out.push(entry.trimEnd());
+                      }
+                      out.push(lastLine);
+                      insertedExtra = true;
+                    }
+                    inFilesBlock = false;
+                  }
+                }
+                if (inFilesBlock && !insertedExtra) {
+                  for (const entry of newEntries) {
+                    out.push(entry.trimEnd());
+                  }
+                }
+                fs.writeFileSync('latest-mac-nightly.yml', out.join('\n'));
+              }
+              console.log('Merged latest-mac-nightly.yml:');
+              console.log(fs.readFileSync('latest-mac-nightly.yml', 'utf8'));
+            "
+          fi
+
+      - name: Upload merged latest-mac-nightly.yml
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f latest-mac-nightly.yml ]; then
+            echo "Uploading merged latest-mac-nightly.yml"
+            gh release upload nightly latest-mac-nightly.yml --clobber --repo "${{ github.repository }}"
+          fi

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -35,15 +35,24 @@ export default async function afterPack(context) {
   const productFilename =
     context.packager.appInfo.productFilename ??
     context.packager.appInfo.productName;
-  // Windows VERSIONINFO requires a numeric dotted quad (x.x.x.x). package.json
-  // versions can include semver prerelease/build suffixes (e.g. "1.2.3-beta.1"),
-  // so extract numeric segments only and pad to four.
+  // Windows VERSIONINFO requires a numeric dotted quad (x.x.x.x) where each
+  // segment fits in [0, 65535]. Parse only the semver core (major.minor.patch)
+  // and derive a bounded fourth segment from the prerelease metadata. Nightly
+  // versions like "0.11.1-nightly.20260518.42" contain a date segment that
+  // exceeds 65535, so we use the run number (last prerelease segment) instead.
   const rawVersion = context.packager.appInfo.version;
-  const numericSegments = (rawVersion.match(/\d+/g) ?? []).slice(0, 4);
-  const appVersion = [
-    ...numericSegments,
-    ...Array(Math.max(0, 4 - numericSegments.length)).fill("0"),
-  ].join(".");
+  const semverCore = rawVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
+  const [major, minor, patch] = semverCore
+    ? [semverCore[1], semverCore[2], semverCore[3]]
+    : ["0", "0", "0"];
+  // Extract the last numeric segment from the prerelease suffix (typically the
+  // CI run number), clamped to 65535 so it always fits VERSIONINFO.
+  const prerelease = rawVersion.replace(/^\d+\.\d+\.\d+[-.]?/, "");
+  const preNums = prerelease.match(/\d+/g);
+  const fourth = preNums
+    ? String(Math.min(Number(preNums[preNums.length - 1]), 65535))
+    : "0";
+  const appVersion = `${major}.${minor}.${patch}.${fourth}`;
   const companyName = context.packager.appInfo.companyName ?? "Mcode";
 
   // The renamed copy at Contents/Resources/bin/mcode-server is co-signed by


### PR DESCRIPTION
## What

Fix the Windows nightly build failure caused by the version string `0.11.1.20260518` containing a segment that exceeds the VERSIONINFO 16-bit maximum (65535).

## Why

The `after-pack.mjs` script extracted all numeric segments from the version string using `/\d+/g`. For nightly versions like `0.11.1-nightly.20260518.42`, this produced the dotted quad `0.11.1.20260518` where the date segment (20260518) breaks the Windows VERSIONINFO constraint of `[0, 65535]` per segment.

## Key changes

- Parse only the semver core (`major.minor.patch`) instead of greedily extracting all numeric runs
- Use the CI run number (last prerelease segment) as the fourth VERSIONINFO segment, clamped to 65535
- Add `nightly-desktop.yml` workflow to version control (previously only existed on GitHub, not in the repo)

## Configuration changes

None.

## Related issues/PRs

Fixes failing run: https://github.com/Mzeey-Empire/mcode/actions/runs/26019364128

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated daily nightly releases of the desktop application now available across Windows, Linux, and macOS for ARM and x64 architectures, providing early access to upcoming features.

* **Chores**
  * Improved desktop app versioning scheme for Windows releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->