### PR TITLE
fix(desktop): nightly builds auto-detect update channel

### DIFF
--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -20,9 +20,16 @@ jobs:
   prepare:
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Ensure nightly prerelease exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
           set -e
           if ! gh release view nightly --repo "${{ github.repository }}" &>/dev/null; then

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -201,6 +201,7 @@ export function checkForUpdatesNow(): Promise<UpdateStatus> {
       // without an app restart.
       const settings = loadUpdaterSettings();
       applyUpdaterChannelFromSettings(settings);
+      autoUpdater.allowPrerelease = settings.releaseLine === "nightly";
       autoUpdater.autoDownload = settings.autoDownload;
       autoUpdater.autoInstallOnAppQuit = settings.autoInstallOnQuit;
 
@@ -281,9 +282,9 @@ export function initAutoUpdater(): void {
   }
 
   autoUpdater.allowDowngrade = false;
-  autoUpdater.allowPrerelease = isNightlyBuild();
 
   const updaterSettings = loadUpdaterSettings();
+  autoUpdater.allowPrerelease = updaterSettings.releaseLine === "nightly";
   applyUpdaterChannelFromSettings(updaterSettings);
   autoUpdater.autoDownload = updaterSettings.autoDownload;
   autoUpdater.autoInstallOnAppQuit = updaterSettings.autoInstallOnQuit;

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -53,20 +53,38 @@ function applyUpdaterChannelFromSettings(settings: UpdaterSettings): void {
   autoUpdater.channel = releaseLineToUpdaterChannel(settings.releaseLine);
 }
 
+/**
+ * Returns true when the running app version contains a `-nightly.` prerelease tag
+ * (e.g. `0.11.1-nightly.20260518.3`). Used to auto-select the nightly update channel.
+ */
+function isNightlyBuild(): boolean {
+  return app.getVersion().includes("-nightly.");
+}
+
 /** Read updater settings from settings.json; falls back to safe defaults if the file is missing or invalid. */
 function loadUpdaterSettings(): UpdaterSettings {
   const defaults: UpdaterSettings = {
-    releaseLine: "stable",
+    releaseLine: isNightlyBuild() ? "nightly" : "stable",
     autoDownload: true,
     autoInstallOnQuit: true,
     checkInterval: "4hours",
   };
   try {
     const raw = readFileSync(join(getMcodeDir(), "settings.json"), "utf-8");
-    const result = SettingsSchema().safeParse(JSON.parse(raw));
+    const parsed = JSON.parse(raw);
+    const result = SettingsSchema().safeParse(parsed);
     if (result.success) {
+      // Zod applies `.default("stable")` even when the user never set a
+      // channel, so we check the raw JSON to tell "unset" from "explicit".
+      // When no explicit channel is present, nightly builds default to
+      // "nightly"; otherwise respect the user's explicit choice.
+      const explicitChannel = parsed?.updates?.channel as string | undefined;
+      const releaseLine = explicitChannel
+        ? (result.data.updates.channel as "stable" | "nightly")
+        : defaults.releaseLine;
+
       return {
-        releaseLine: result.data.updates?.channel ?? defaults.releaseLine,
+        releaseLine,
         autoDownload: result.data.updates?.autoDownload ?? defaults.autoDownload,
         autoInstallOnQuit: result.data.updates?.autoInstallOnQuit ?? defaults.autoInstallOnQuit,
         checkInterval: result.data.updates?.checkInterval ?? defaults.checkInterval,
@@ -263,6 +281,7 @@ export function initAutoUpdater(): void {
   }
 
   autoUpdater.allowDowngrade = false;
+  autoUpdater.allowPrerelease = isNightlyBuild();
 
   const updaterSettings = loadUpdaterSettings();
   applyUpdaterChannelFromSettings(updaterSettings);


### PR DESCRIPTION
## What

Nightly desktop builds now auto-detect their update channel from the version string instead of defaulting to stable.

## Why

Installed nightly builds (e.g. `0.11.1-nightly.20260518.3`) defaulted to the `stable` update channel, causing electron-updater to look for `latest.yml` on tagged releases. The nightly GitHub release only publishes `latest-nightly.yml`, so the updater reported "No published versions on GitHub".

## Key changes

- **Auto-detect nightly channel** - `isNightlyBuild()` checks if `app.getVersion()` contains `-nightly.` and defaults the update channel accordingly
- **Respect explicit user choice** - checks raw JSON (not Zod-parsed) to distinguish "user never set a channel" from an explicit selection, so switching between stable and nightly in settings works both ways
- **Enable prerelease updates** - sets `autoUpdater.allowPrerelease = true` for nightly builds so electron-updater does not skip prerelease versions
- **Use release bot for nightly release creation** - the `prepare` job now generates a GitHub App bot token (`APP_ID` + `APP_PRIVATE_KEY`) for creating the nightly prerelease, matching the `release-please.yml` pattern. Artifact uploads continue to use `GITHUB_TOKEN` (matching `build-release.yml`)

Relates to #466

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Nightly builds are now detected automatically and default to the nightly release channel so they receive prerelease updates as intended.

* **Chores**
  * Release workflow updated to use a generated app installation token for secure management of nightly prereleases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->