### PR TITLE
fix(web): restore /goal pill and harden long-text + attachments

### DIFF
--- a/apps/web/e2e/goal-pill.spec.ts
+++ b/apps/web/e2e/goal-pill.spec.ts
@@ -31,27 +31,23 @@ const PILL_HTML = (label: string, condition: string | null, hint: string) => `
 <head>
   <meta charset="utf-8" />
   <style>
-    :root { color-scheme: dark; }
-    body { margin: 0; padding: 24px; background: #0a0a0a; font-family: ui-sans-serif, system-ui; color: #fafafa; font-size: 14px; }
-    .border-border\\/60 { border-color: rgba(115, 115, 115, 0.6); }
-    .bg-muted\\/30 { background: rgba(38, 38, 38, 0.3); }
-    .text-muted-foreground { color: #a1a1aa; }
-    .text-foreground { color: #fafafa; }
-    .text-foreground\\/80 { color: rgba(250, 250, 250, 0.8); }
-    .opacity-80 { opacity: 0.8; }
+    :root { color-scheme: dark; --primary: #f0a800; --foreground: #fafafa; --muted: #a1a1aa; }
+    body { margin: 0; padding: 24px; background: #0a0a0a; font-family: ui-sans-serif, system-ui; color: var(--foreground); font-size: 14px; }
   </style>
 </head>
 <body>
-  <div class="flex items-start gap-2.5 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm"
-       style="display:flex;align-items:flex-start;gap:10px;border-radius:6px;border-width:1px;border-style:solid;padding:8px 12px;">
-    <svg data-testid="target-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 shrink-0 text-muted-foreground" style="margin-top:2px;flex-shrink:0;">
-      <circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>
-    </svg>
-    <div class="min-w-0 flex-1 text-muted-foreground leading-relaxed" style="min-width:0;flex:1 1 0;line-height:1.6;">
-      <span class="font-medium text-foreground" style="font-weight:500;">${label}</span>
-      ${condition ? `<span class="ml-1.5 text-foreground/80" style="margin-left:6px;">&ldquo;${condition}&rdquo;</span>` : ""}
-      <span class="ml-1.5 text-xs opacity-80" style="margin-left:6px;font-size:12px;opacity:0.8;">${hint}</span>
+  <div data-testid="goal-pill" role="note" aria-label="${condition ? `${label}: ${condition}` : label}"
+       style="display:flex;align-items:center;gap:12px;padding:8px 0;">
+    <div style="flex:1 1 0;height:1px;background:rgba(240,168,0,0.4);"></div>
+    <div style="display:flex;min-width:0;align-items:baseline;gap:10px;">
+      <svg data-testid="target-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;align-self:center;color:var(--primary);">
+        <circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>
+      </svg>
+      <span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:0.2em;color:var(--primary);">${label}</span>
+      ${condition ? `<span style="font-family:ui-serif,Georgia,serif;font-size:14px;font-style:italic;line-height:1.4;color:var(--foreground);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">&ldquo;${condition}&rdquo;</span>` : ""}
+      <span style="flex-shrink:0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:9.5px;text-transform:uppercase;letter-spacing:0.18em;color:rgba(161,161,170,0.7);">${hint}</span>
     </div>
+    <div style="flex:1 1 0;height:1px;background:rgba(240,168,0,0.4);"></div>
   </div>
 </body>
 </html>

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -43,6 +43,127 @@ function parseGoalStatus(content: string): {
   return null;
 }
 
+/**
+ * Detect a user-typed /goal SET form (`/goal <condition>` with non-empty,
+ * non-control argument). The server rewrites the wire payload into a
+ * directive and dispatches it to the agent without emitting a separate
+ * assistant "Goal set: ..." status message, so the pill must render off
+ * the user's own message. Returns null for control forms (clear, reset,
+ * show, empty) — those still get an assistant-side pill from the server.
+ */
+function parseUserGoalCommand(content: string): { condition: string } | null {
+  const m = /^\s*\/goal\b\s*([\s\S]*)$/.exec(content);
+  if (!m) return null;
+  const arg = m[1].trim();
+  if (arg === "") return null;
+  const lower = arg.toLowerCase();
+  if (lower === "clear" || lower === "reset" || lower === "show") return null;
+  return { condition: arg };
+}
+
+/**
+ * Hairline chapter-break rendering for /goal command notices. Used by both
+ * the user-typed SET form and assistant-emitted SHOW/CLEAR confirmations.
+ * Mirrors the existing system-message divider pattern (hairline + glyph +
+ * caption) but tinted with the amber `primary` accent so /goal events read
+ * as structural marks rather than card chips in the transcript.
+ *
+ * Layout (collapsed): ─── ◎ GOAL SET "<condition>" /GOAL CLEAR ─── (truncated)
+ * Layout (expanded):  ─── ◎ GOAL SET /GOAL CLEAR ───
+ *                          "<condition wrapping across multiple lines>"
+ *
+ * The condition is a button that toggles expansion so long directives stay
+ * readable. `dir="auto"` lets the browser pick reading order from the
+ * content itself so RTL or mixed-script conditions render naturally.
+ * `[overflow-wrap:anywhere]` allows breaking inside long unbroken tokens
+ * (URLs, hashes) that ordinary `break-words` would leave to overflow.
+ */
+function GoalPill({ label, condition, hint }: { label: string; condition?: string; hint: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const labelEl = (
+    <span className="font-mono text-[10.5px] uppercase tracking-[0.2em] text-primary">
+      {label}
+    </span>
+  );
+  const hintEl = (
+    <span className="shrink-0 font-mono text-[9.5px] uppercase tracking-[0.18em] text-muted-foreground/70">
+      {hint}
+    </span>
+  );
+  const iconEl = (
+    <Target
+      data-testid="target-icon"
+      size={12}
+      className="shrink-0 self-center text-primary"
+      aria-hidden="true"
+    />
+  );
+
+  if (expanded && condition) {
+    return (
+      <div
+        className="flex items-start gap-3 py-2"
+        data-testid="goal-pill"
+        data-expanded="true"
+        role="note"
+        aria-label={`${label}: ${condition}`}
+      >
+        <div className="mt-2 h-px flex-1 bg-primary/40" />
+        <div className="flex min-w-0 flex-col items-start gap-1.5">
+          <div className="flex items-baseline gap-2.5">
+            {iconEl}
+            {labelEl}
+            {hintEl}
+          </div>
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            aria-expanded="true"
+            aria-label="Collapse goal condition"
+            dir="auto"
+            className="cursor-pointer text-left font-serif text-[14px] italic leading-snug text-foreground [overflow-wrap:anywhere] hover:text-foreground/80"
+          >
+            &ldquo;{condition}&rdquo;
+          </button>
+        </div>
+        <div className="mt-2 h-px flex-1 bg-primary/40" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center gap-3 py-2"
+      data-testid="goal-pill"
+      data-expanded="false"
+      role="note"
+      aria-label={condition ? `${label}: ${condition}` : label}
+    >
+      <div className="h-px flex-1 bg-primary/40" />
+      <div className="flex min-w-0 items-baseline gap-2.5">
+        {iconEl}
+        {labelEl}
+        {condition && (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            aria-expanded="false"
+            aria-label="Expand full goal condition"
+            title={condition}
+            dir="auto"
+            className="min-w-0 cursor-pointer truncate text-left font-serif text-[14px] italic leading-snug text-foreground hover:text-foreground/80"
+          >
+            &ldquo;{condition}&rdquo;
+          </button>
+        )}
+        {hintEl}
+      </div>
+      <div className="h-px flex-1 bg-primary/40" />
+    </div>
+  );
+}
+
 function parseAgentError(content: string): string | null {
   try {
     const parsed = JSON.parse(content) as { __type?: string; message?: string };
@@ -307,19 +428,24 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
   if (message.role === "assistant") {
     const goal = parseGoalStatus(textContent);
     if (goal) {
-      return (
-        <div className="flex items-start gap-2.5 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm">
-          <Target size={14} className="mt-0.5 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1 text-muted-foreground leading-relaxed">
-            <span className="font-medium text-foreground">{goal.label}</span>
-            {goal.condition && (
-              <span className="ml-1.5 text-foreground/80">&ldquo;{goal.condition}&rdquo;</span>
-            )}
-            <span className="ml-1.5 text-xs opacity-80">{goal.hint}</span>
-          </div>
-        </div>
-      );
+      return <GoalPill label={goal.label} condition={goal.condition} hint={goal.hint} />;
     }
+  }
+
+  // User-typed `/goal <condition>` SET form. AgentService rewrites the wire
+  // payload into a directive prompt and dispatches it to the agent without
+  // emitting a separate assistant status message, so the only place we can
+  // anchor the pill is the user's own message. Control forms (clear/show)
+  // still get an assistant-side pill from the server, so they fall through
+  // to the normal user bubble below.
+  const userGoal = message.role === "user" ? parseUserGoalCommand(textContent) : null;
+  const hasAttachments = imageAttachments.length > 0 || fileAttachments.length > 0;
+  // Without attachments the pill replaces the whole bubble (chapter-break
+  // full-width). With attachments we keep the user's images/files visible
+  // and render the pill alongside, so the directive is not "stolen" from
+  // the attachments the user intentionally sent with it.
+  if (message.role === "user" && userGoal && !hasAttachments) {
+    return <GoalPill label="Goal set" condition={userGoal.condition} hint="/goal clear to remove" />;
   }
 
   const isUser = message.role === "user";
@@ -376,7 +502,7 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
               </div>
             )}
 
-          {textContent.trim() && (
+          {textContent.trim() && !userGoal && (
             <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
               <Suspense fallback={null}>
                 <LazyMarkdownContent content={textContent} isStreaming={false} variant="user" />
@@ -397,12 +523,15 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
                 onReply(message.id, textContent.trim() || fallback, "user");
               }} />}
               {onBranch && <BranchButton onClick={() => onBranch(message.id)} />}
-              {textContent.trim() && <CopyButton content={textContent} />}
+              {textContent.trim() && !userGoal && <CopyButton content={textContent} />}
             </div>
             <span className="font-mono text-[10px] tabular-nums text-muted-foreground/55">{formattedTime}</span>
           </div>
         </div>
         </div>
+        {userGoal && (
+          <GoalPill label="Goal set" condition={userGoal.condition} hint="/goal clear to remove" />
+        )}
         <ImageAttachmentLightbox
           open={imagePreview !== null}
           onOpenChange={(open) => {


### PR DESCRIPTION
## What
Restores the `/goal` pill in the chat transcript and hardens it for long conditions and attachment-bearing commands.

## Why
The SDK Stop-hook refactor in #467 made the user-typed `/goal <condition>` SET form dispatch-only — the server rewrites the wire payload into a directive prompt and dispatches it to the agent without emitting a separate "Goal set: ..." assistant status message. The existing pill renderer keyed on that assistant message, so it stopped appearing for SET (but still rendered for SHOW / CLEAR, which the server continues to emit).

While restoring the pill, two real-world cases need hardening:
- **Long conditions** overflow the truncate or wrap awkwardly across the bubble
- **`/goal X` with attachments** previously hid the user's images/files entirely because the early-return swallowed the whole message

## Key Changes
- Detect the user-typed SET form on the user's own message via `parseUserGoalCommand`; control forms (`clear`, `show`) keep their assistant-side path unchanged
- Replace the card-chip pill with a shared `GoalPill` component using an editorial hairline (chapter-break) shape — amber primary hairlines, mono small-caps label, serif italic condition, mono small-caps hint — to mirror the existing system-message divider pattern
- Long-text handling: condition is a button that toggles between collapsed single-line truncate (with native `title` tooltip) and expanded multi-line block using `[overflow-wrap:anywhere]`; `dir="auto"` picks reading order from the content for RTL / mixed-script directives
- Attachment-preserving render: early-return chapter-break only fires when no attachments are present. With attachments, the user's images/files render in their normal right-aligned column, the literal `/goal X` text bubble and copy button are suppressed (since the pill is the visible representation), and the pill emits below as a full-width chapter mark
- Update `goal-pill.spec.ts` to mirror the new hairline markup (5 / 5 pass)

## Config Changes
None

## Test plan
- [x] `bunx tsc --noEmit` in `apps/web` — clean
- [x] `bunx playwright test e2e/goal-pill.spec.ts` — 5 / 5 pass
- [x] `bun run verify` — 1182 / 1183 unit tests pass (the one failure in `lazy-markdown.test.tsx` reproduces on clean stashed HEAD, so it is pre-existing flake unrelated to this PR)
- [ ] Manual: send `/goal write a clean PR`, confirm hairline pill renders
- [ ] Manual: send a very long `/goal <300-char condition>`, click the condition to expand, verify it wraps cleanly inside the hairlines
- [ ] Manual: drag an image into composer, type `/goal stay focused`, send — verify the image still renders and the pill emits below it
- [ ] Manual: send `/goal show` and `/goal clear`, verify both still render via the assistant-side path

Relates to #467

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual pill-style rendering for goal status messages and commands with expandable condition text that intelligently adapts based on message attachments.
  * Enhanced message display to suppress redundant interactions when goal pills are active.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->