### PR TITLE
fix(web): restore /goal pill, harden long-text/attachments, and fix queue deadlock

### DIFF
--- a/apps/web/e2e/goal-clear-bypass-queue.spec.ts
+++ b/apps/web/e2e/goal-clear-bypass-queue.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+import { getDefaultSettings } from "@mcode/contracts";
+
+/**
+ * Regression spec for the `/goal clear` queue-deadlock fix.
+ *
+ * Background: when a goal is active, the Claude provider's Stop hook keeps
+ * the agent's turn open until the goal is met. The composer was enqueueing
+ * every message while `isAgentRunning` was true, so `/goal clear` sat in
+ * the queue forever because `session.turnComplete` (which drains the queue)
+ * could never fire while the goal was blocking the turn. The fix routes
+ * `/goal` control forms directly to `sendMessage` even mid-turn so the
+ * server intercept can clear the goal synchronously.
+ *
+ * This spec asserts both halves of the new routing rule:
+ *   1. `/goal clear` typed while the agent is running dispatches via
+ *      `agent.send` (bypass) and does NOT appear in the queue.
+ *   2. A non-control message typed under the same conditions still
+ *      enqueues (so we don't regress the original queue behavior).
+ */
+
+const MOCK_SETTINGS = getDefaultSettings();
+
+const WORKSPACE = {
+  id: "ws-goal-clear-bypass",
+  name: "Goal Clear Bypass",
+  path: "/tmp/goal-clear-bypass",
+  provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const THREAD = {
+  id: "thread-goal-clear-bypass",
+  workspace_id: WORKSPACE.id,
+  title: "Goal-blocked thread",
+  status: "active" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: "claude-sonnet-4-6",
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+async function setupChat(page: Page, running: boolean): Promise<void> {
+  await page.evaluate(
+    ({ ws, th, run }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({
+        workspaces: [ws],
+        threads: [th],
+        activeWorkspaceId: ws.id,
+        activeThreadId: th.id,
+        loading: false,
+        error: null,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const threadStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "runningThreadIds" in st && "contextByThread" in st;
+      });
+      if (threadStore && run) {
+        threadStore.setState({
+          runningThreadIds: new Set([th.id]),
+        });
+      }
+    },
+    { ws: WORKSPACE, th: THREAD, run: running },
+  );
+}
+
+async function readQueueLength(page: Page, threadId: string): Promise<number> {
+  return page.evaluate((tid) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stores: any[] = (window as any).__mcodeStores ?? [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const queueStore = stores.find((s: any) => {
+      const st = s.getState();
+      return "queues" in st && "enqueue" in st;
+    });
+    if (!queueStore) return -1;
+    const queues = queueStore.getState().queues as Record<string, unknown[]>;
+    return (queues[tid] ?? []).length;
+  }, threadId);
+}
+
+test.describe("/goal control commands bypass the composer queue", () => {
+  test("`/goal clear` mid-turn dispatches via agent.send and never enters the queue", async ({
+    page,
+  }) => {
+    const sentMessages: string[] = [];
+    await mockWebSocketServer(page, {
+      "workspace.enrich": { items: [] },
+      "settings.get": MOCK_SETTINGS,
+      "provider.listModels": () => [
+        { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", group: "Claude" },
+      ],
+      "agent.send": (params?: unknown) => {
+        const p = params as { content?: string } | undefined;
+        if (typeof p?.content === "string") sentMessages.push(p.content);
+        return { ok: true };
+      },
+    });
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean })
+          .__mcodeHydrationComplete === true,
+    );
+    await setupChat(page, true);
+    await page.waitForSelector('[contenteditable="true"]', { timeout: 30_000 });
+
+    const editor = page.locator('[contenteditable="true"]').first();
+    await editor.click();
+    // Typing the bare `/` would open the slash-command popup and route the
+    // subsequent Enter to its key handler (selecting an item, not submitting).
+    // Type the full string in one go via fill() so the popup never opens with
+    // a partial trigger - by the time the editor sees the value, the text
+    // does not match the trailing-`/\S*` regex anymore (it ends in `clear`).
+    await editor.fill("/goal clear");
+    await page.keyboard.press("Enter");
+
+    await expect.poll(() => sentMessages, { timeout: 5_000 }).toContain(
+      "/goal clear",
+    );
+    expect(await readQueueLength(page, THREAD.id)).toBe(0);
+  });
+
+  test("non-control messages still enqueue while the agent is running", async ({
+    page,
+  }) => {
+    const sentMessages: string[] = [];
+    await mockWebSocketServer(page, {
+      "workspace.enrich": { items: [] },
+      "settings.get": MOCK_SETTINGS,
+      "provider.listModels": () => [
+        { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", group: "Claude" },
+      ],
+      "agent.send": (params?: unknown) => {
+        const p = params as { content?: string } | undefined;
+        if (typeof p?.content === "string") sentMessages.push(p.content);
+        return { ok: true };
+      },
+    });
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean })
+          .__mcodeHydrationComplete === true,
+    );
+    await setupChat(page, true);
+    await page.waitForSelector('[contenteditable="true"]', { timeout: 30_000 });
+
+    const editor = page.locator('[contenteditable="true"]').first();
+    await editor.click();
+    await page.keyboard.type("ship the feature");
+    await page.keyboard.press("Enter");
+
+    await expect.poll(() => readQueueLength(page, THREAD.id), { timeout: 5_000 })
+      .toBe(1);
+    expect(sentMessages).not.toContain("ship the feature");
+  });
+});

--- a/apps/web/e2e/goal-pill.spec.ts
+++ b/apps/web/e2e/goal-pill.spec.ts
@@ -31,27 +31,23 @@ const PILL_HTML = (label: string, condition: string | null, hint: string) => `
 <head>
   <meta charset="utf-8" />
   <style>
-    :root { color-scheme: dark; }
-    body { margin: 0; padding: 24px; background: #0a0a0a; font-family: ui-sans-serif, system-ui; color: #fafafa; font-size: 14px; }
-    .border-border\\/60 { border-color: rgba(115, 115, 115, 0.6); }
-    .bg-muted\\/30 { background: rgba(38, 38, 38, 0.3); }
-    .text-muted-foreground { color: #a1a1aa; }
-    .text-foreground { color: #fafafa; }
-    .text-foreground\\/80 { color: rgba(250, 250, 250, 0.8); }
-    .opacity-80 { opacity: 0.8; }
+    :root { color-scheme: dark; --primary: #f0a800; --foreground: #fafafa; --muted: #a1a1aa; }
+    body { margin: 0; padding: 24px; background: #0a0a0a; font-family: ui-sans-serif, system-ui; color: var(--foreground); font-size: 14px; }
   </style>
 </head>
 <body>
-  <div class="flex items-start gap-2.5 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm"
-       style="display:flex;align-items:flex-start;gap:10px;border-radius:6px;border-width:1px;border-style:solid;padding:8px 12px;">
-    <svg data-testid="target-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mt-0.5 shrink-0 text-muted-foreground" style="margin-top:2px;flex-shrink:0;">
-      <circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>
-    </svg>
-    <div class="min-w-0 flex-1 text-muted-foreground leading-relaxed" style="min-width:0;flex:1 1 0;line-height:1.6;">
-      <span class="font-medium text-foreground" style="font-weight:500;">${label}</span>
-      ${condition ? `<span class="ml-1.5 text-foreground/80" style="margin-left:6px;">&ldquo;${condition}&rdquo;</span>` : ""}
-      <span class="ml-1.5 text-xs opacity-80" style="margin-left:6px;font-size:12px;opacity:0.8;">${hint}</span>
+  <div data-testid="goal-pill" role="note" aria-label="${condition ? `${label}: ${condition}` : label}"
+       style="display:flex;align-items:center;gap:12px;padding:8px 0;">
+    <div style="flex:1 1 0;height:1px;background:rgba(240,168,0,0.4);"></div>
+    <div style="display:flex;min-width:0;align-items:baseline;gap:10px;">
+      <svg data-testid="target-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;align-self:center;color:var(--primary);">
+        <circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>
+      </svg>
+      <span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:0.2em;color:var(--primary);">${label}</span>
+      ${condition ? `<span style="font-family:ui-serif,Georgia,serif;font-size:14px;font-style:italic;line-height:1.4;color:var(--foreground);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">&ldquo;${condition}&rdquo;</span>` : ""}
+      <span style="flex-shrink:0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:9.5px;text-transform:uppercase;letter-spacing:0.18em;color:rgba(161,161,170,0.7);">${hint}</span>
     </div>
+    <div style="flex:1 1 0;height:1px;background:rgba(240,168,0,0.4);"></div>
   </div>
 </body>
 </html>

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -23,6 +23,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { cn } from "@/lib/utils";
 import { isWindows } from "@/lib/platform";
 import { isCursorPermissionLockedToFull } from "@/lib/cursor-permission";
+import { isGoalControlCommand } from "@/lib/goal-command";
 import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, supportsUltrathink, supports1MContextWindow, supportsThinkingToggle, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels, providerSupportsReasoningLevels } from "@/lib/model-registry";
 import { ModelSelector } from "./ModelSelector";
 import { ModeSelector, ALL_MODE_OPTIONS } from "./ModeSelector";
@@ -1641,7 +1642,22 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     // Skip when composing a branch (`branchFromMessageId`) or a brand-new thread
     // (`isNewThread`) - both target a *different* thread and must not enqueue
     // on the parent thread that happens to be currently running.
-    if (isAgentRunning && threadId && !branchFromMessageId && !isNewThread) {
+    //
+    // Also skip for `/goal` control-form commands (`clear`, `reset`, `show`,
+    // bare `/goal`). When a goal is active the agent's Stop hook blocks the
+    // turn from ending until the goal is met - which means `session.turnComplete`
+    // never fires and the queue never drains. Queueing `/goal clear` here would
+    // deadlock: the only way to clear the goal is to send `/goal clear`, but
+    // that message would sit in the queue waiting for a turn that cannot
+    // complete. The server intercept handles these control forms synchronously
+    // without invoking the provider, so they are safe to send mid-turn.
+    if (
+      isAgentRunning &&
+      threadId &&
+      !branchFromMessageId &&
+      !isNewThread &&
+      !isGoalControlCommand(trimmed)
+    ) {
       const captureRows = buildAttachedBrowserCaptures(attachments);
       const { content: injectedContent, display: displayInjected } = await injectFileContent(trimmed);
       let content: string;

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -43,6 +43,127 @@ function parseGoalStatus(content: string): {
   return null;
 }
 
+/**
+ * Detect a user-typed /goal SET form (`/goal <condition>` with non-empty,
+ * non-control argument). The server rewrites the wire payload into a
+ * directive and dispatches it to the agent without emitting a separate
+ * assistant "Goal set: ..." status message, so the pill must render off
+ * the user's own message. Returns null for control forms (clear, reset,
+ * show, empty) — those still get an assistant-side pill from the server.
+ */
+function parseUserGoalCommand(content: string): { condition: string } | null {
+  const m = /^\s*\/goal\b\s*([\s\S]*)$/.exec(content);
+  if (!m) return null;
+  const arg = m[1].trim();
+  if (arg === "") return null;
+  const lower = arg.toLowerCase();
+  if (lower === "clear" || lower === "reset" || lower === "show") return null;
+  return { condition: arg };
+}
+
+/**
+ * Hairline chapter-break rendering for /goal command notices. Used by both
+ * the user-typed SET form and assistant-emitted SHOW/CLEAR confirmations.
+ * Mirrors the existing system-message divider pattern (hairline + glyph +
+ * caption) but tinted with the amber `primary` accent so /goal events read
+ * as structural marks rather than card chips in the transcript.
+ *
+ * Layout (collapsed): ─── ◎ GOAL SET "<condition>" /GOAL CLEAR ─── (truncated)
+ * Layout (expanded):  ─── ◎ GOAL SET /GOAL CLEAR ───
+ *                          "<condition wrapping across multiple lines>"
+ *
+ * The condition is a button that toggles expansion so long directives stay
+ * readable. `dir="auto"` lets the browser pick reading order from the
+ * content itself so RTL or mixed-script conditions render naturally.
+ * `[overflow-wrap:anywhere]` allows breaking inside long unbroken tokens
+ * (URLs, hashes) that ordinary `break-words` would leave to overflow.
+ */
+function GoalPill({ label, condition, hint }: { label: string; condition?: string; hint: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const labelEl = (
+    <span className="font-mono text-[10.5px] uppercase tracking-[0.2em] text-primary">
+      {label}
+    </span>
+  );
+  const hintEl = (
+    <span className="shrink-0 font-mono text-[9.5px] uppercase tracking-[0.18em] text-muted-foreground/70">
+      {hint}
+    </span>
+  );
+  const iconEl = (
+    <Target
+      data-testid="target-icon"
+      size={12}
+      className="shrink-0 self-center text-primary"
+      aria-hidden="true"
+    />
+  );
+
+  if (expanded && condition) {
+    return (
+      <div
+        className="flex items-start gap-3 py-2"
+        data-testid="goal-pill"
+        data-expanded="true"
+        role="note"
+        aria-label={`${label}: ${condition}`}
+      >
+        <div className="mt-2 h-px flex-1 bg-primary/40" />
+        <div className="flex min-w-0 flex-col items-start gap-1.5">
+          <div className="flex items-baseline gap-2.5">
+            {iconEl}
+            {labelEl}
+            {hintEl}
+          </div>
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            aria-expanded="true"
+            aria-label="Collapse goal condition"
+            dir="auto"
+            className="cursor-pointer text-left font-serif text-[14px] italic leading-snug text-foreground [overflow-wrap:anywhere] hover:text-foreground/80"
+          >
+            &ldquo;{condition}&rdquo;
+          </button>
+        </div>
+        <div className="mt-2 h-px flex-1 bg-primary/40" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center gap-3 py-2"
+      data-testid="goal-pill"
+      data-expanded="false"
+      role="note"
+      aria-label={condition ? `${label}: ${condition}` : label}
+    >
+      <div className="h-px flex-1 bg-primary/40" />
+      <div className="flex min-w-0 items-baseline gap-2.5">
+        {iconEl}
+        {labelEl}
+        {condition && (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            aria-expanded="false"
+            aria-label="Expand full goal condition"
+            title={condition}
+            dir="auto"
+            className="min-w-0 cursor-pointer truncate text-left font-serif text-[14px] italic leading-snug text-foreground hover:text-foreground/80"
+          >
+            &ldquo;{condition}&rdquo;
+          </button>
+        )}
+        {hintEl}
+      </div>
+      <div className="h-px flex-1 bg-primary/40" />
+    </div>
+  );
+}
+
 function parseAgentError(content: string): string | null {
   try {
     const parsed = JSON.parse(content) as { __type?: string; message?: string };
@@ -307,19 +428,24 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
   if (message.role === "assistant") {
     const goal = parseGoalStatus(textContent);
     if (goal) {
-      return (
-        <div className="flex items-start gap-2.5 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm">
-          <Target size={14} className="mt-0.5 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1 text-muted-foreground leading-relaxed">
-            <span className="font-medium text-foreground">{goal.label}</span>
-            {goal.condition && (
-              <span className="ml-1.5 text-foreground/80">&ldquo;{goal.condition}&rdquo;</span>
-            )}
-            <span className="ml-1.5 text-xs opacity-80">{goal.hint}</span>
-          </div>
-        </div>
-      );
+      return <GoalPill label={goal.label} condition={goal.condition} hint={goal.hint} />;
     }
+  }
+
+  // User-typed `/goal <condition>` SET form. AgentService rewrites the wire
+  // payload into a directive prompt and dispatches it to the agent without
+  // emitting a separate assistant status message, so the only place we can
+  // anchor the pill is the user's own message. Control forms (clear/show)
+  // still get an assistant-side pill from the server, so they fall through
+  // to the normal user bubble below.
+  const userGoal = message.role === "user" ? parseUserGoalCommand(textContent) : null;
+  const hasAttachments = imageAttachments.length > 0 || fileAttachments.length > 0;
+  // Without attachments the pill replaces the whole bubble (chapter-break
+  // full-width). With attachments we keep the user's images/files visible
+  // and render the pill alongside, so the directive is not "stolen" from
+  // the attachments the user intentionally sent with it.
+  if (message.role === "user" && userGoal && !hasAttachments) {
+    return <GoalPill label="Goal set" condition={userGoal.condition} hint="/goal clear to remove" />;
   }
 
   const isUser = message.role === "user";
@@ -376,7 +502,7 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
               </div>
             )}
 
-          {textContent.trim() && (
+          {textContent.trim() && !userGoal && (
             <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
               <Suspense fallback={null}>
                 <LazyMarkdownContent content={textContent} isStreaming={false} variant="user" />
@@ -397,12 +523,15 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
                 onReply(message.id, textContent.trim() || fallback, "user");
               }} />}
               {onBranch && <BranchButton onClick={() => onBranch(message.id)} />}
-              {textContent.trim() && <CopyButton content={textContent} />}
+              {textContent.trim() && !userGoal && <CopyButton content={textContent} />}
             </div>
             <span className="font-mono text-[10px] tabular-nums text-muted-foreground/55">{formattedTime}</span>
           </div>
         </div>
         </div>
+        {userGoal && (
+          <GoalPill label="Goal set" condition={userGoal.condition} hint="/goal clear to remove" />
+        )}
         <ImageAttachmentLightbox
           open={imagePreview !== null}
           onOpenChange={(open) => {

--- a/apps/web/src/lib/__tests__/goal-command.test.ts
+++ b/apps/web/src/lib/__tests__/goal-command.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { isGoalControlCommand } from "../goal-command";
+
+describe("isGoalControlCommand", () => {
+  it.each([
+    ["/goal"],
+    ["/goal "],
+    ["  /goal  "],
+    ["/goal clear"],
+    ["/goal CLEAR"],
+    ["/goal  clear  "],
+    ["/goal reset"],
+    ["/goal Reset"],
+    ["/goal show"],
+    ["/goal SHOW"],
+  ])("recognises %j as a control-form command", (text) => {
+    expect(isGoalControlCommand(text)).toBe(true);
+  });
+
+  it.each([
+    ["/goal ship the feature"],
+    ["/goal cleartheworld"], // not a control verb
+    ["/goal reset everything"], // SET with leading 'reset'
+    ["/goalclear"], // missing word boundary
+    ["goal clear"], // missing slash
+    [""],
+    ["just text"],
+    ["/plan"],
+  ])("returns false for %j", (text) => {
+    expect(isGoalControlCommand(text)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/goal-command.ts
+++ b/apps/web/src/lib/goal-command.ts
@@ -1,0 +1,32 @@
+/**
+ * Predicates for `/goal` slash-command routing on the composer side.
+ *
+ * Why the composer needs to know about goal semantics: when a goal is active
+ * the agent's Stop hook blocks turn end until the goal is satisfied. If the
+ * user then types `/goal clear`, the composer would normally enqueue the
+ * message (because the agent is "running") and wait for `session.turnComplete`
+ * to drain the queue — but turnComplete never fires while the goal blocks,
+ * producing a deadlock where the user can never clear the goal they set.
+ *
+ * Control-form commands (`/goal`, `/goal clear`, `/goal reset`, `/goal show`)
+ * are handled by the server's `AgentService` intercept synchronously without
+ * any provider invocation. They are always safe to send directly — even
+ * mid-turn — because clearing the goal frees the next Stop event to return
+ * cleanly and ends the live turn naturally right after.
+ */
+
+/**
+ * Returns `true` when `text` is a `/goal` control-form command that the
+ * server intercept will short-circuit without dispatching to the agent.
+ * Matches the `isControl` rule in `agent-service.ts` (case-insensitive
+ * argument, leading/trailing whitespace tolerated).
+ *
+ * Returns `false` for the SET form (`/goal <condition>`) — those still need
+ * the normal send path so the directive reaches the provider.
+ */
+export function isGoalControlCommand(text: string): boolean {
+  const match = /^\s*\/goal\b\s*([\s\S]*)$/.exec(text);
+  if (!match) return false;
+  const arg = match[1].trim().toLowerCase();
+  return arg === "" || arg === "clear" || arg === "reset" || arg === "show";
+}


### PR DESCRIPTION
## What

Combines two related `/goal` fixes that touch overlapping code:

1. **Restore the `/goal` pill** in the chat transcript and harden it for long conditions and attachment-bearing commands.
2. **Fix the queue deadlock** so `/goal clear` typed mid-turn actually clears the goal instead of sitting in the composer queue forever.

## Why

### 1. Pill restoration
The SDK Stop-hook refactor in #467 made the user-typed `/goal <condition>` SET form dispatch-only — the server rewrites the wire payload into a directive prompt and dispatches it to the agent without emitting a separate "Goal set: ..." assistant status message. The existing pill renderer keyed on that assistant message, so it stopped appearing for SET (but still rendered for SHOW / CLEAR, which the server continues to emit).

Two real-world cases also needed hardening:
- Long conditions overflowed the truncate or wrapped awkwardly across the bubble.
- `/goal X` with attachments previously hid the user's images/files entirely because the early-return swallowed the whole message.

### 2. Queue deadlock
When a goal is active and the user sends `/goal clear` (or `/goal show`, `/goal reset`, or bare `/goal`), the message got silently stuck in the composer queue: no "Goal cleared" pill ever rendered, no `Ended` event fired, and the agent kept spinning forever.

The cause was a deadlock between two correctly-behaving components:
1. The Claude provider's Stop hook (`claude-provider.ts:710-727`) keeps the agent's turn alive while a goal is unmet.
2. The composer (`Composer.tsx:1644`) enqueued every message while `isAgentRunning` was true.
3. The queue (`threadStore.ts:2360`) only drains on `session.turnComplete`, intentionally not on `session.ended` ("so explicit stops don't drain the queue").

So the only command that could free the agent was the one that could never reach the agent. Pressing Stop didn't help — `session.ended` doesn't drain the queue either. The user had no way out.

## Key changes

### Pill (commit `9d065b4`)
- Detect the user-typed SET form on the user's own message via `parseUserGoalCommand`; control forms (`clear`, `show`) keep their assistant-side path unchanged.
- Replace the card-chip pill with a shared `GoalPill` component using an editorial hairline (chapter-break) shape — amber primary hairlines, mono small-caps label, serif italic condition, mono small-caps hint — to mirror the existing system-message divider pattern.
- Long-text handling: condition is a button that toggles between collapsed single-line truncate (with native `title` tooltip) and expanded multi-line block using `[overflow-wrap:anywhere]`; `dir="auto"` picks reading order from the content for RTL / mixed-script directives.
- Attachment-preserving render: early-return chapter-break only fires when no attachments are present. With attachments, the user's images/files render in their normal right-aligned column, the literal `/goal X` text bubble and copy button are suppressed (since the pill is the visible representation), and the pill emits below as a full-width chapter mark.

### Queue bypass (commits `7a6bf68`, `b5aacac`)
- New predicate `isGoalControlCommand` in `apps/web/src/lib/goal-command.ts` that mirrors the server's `isControl` rule (`agent-service.ts:329`): matches `/goal`, `/goal clear`, `/goal reset`, `/goal show` (case-insensitive, whitespace-tolerant).
- One-line guard in `Composer.handleSend` queue path: `&& !isGoalControlCommand(trimmed)`.
- Colocated unit test plus Playwright E2E spec (`goal-clear-bypass-queue.spec.ts`) covering both halves of the routing rule.

Control-form commands are handled synchronously by the server's `AgentService` intercept without invoking the provider, so bypassing the queue is safe mid-turn. Clearing the goal lets the SDK's next Stop event return `{}` cleanly, and the live turn ends naturally right after.

## Configuration changes

None.

## Test plan

- [x] `bun run verify` green — 1201 / 1201 unit tests, typecheck, lint
- [x] `bun run e2e` green — 149 passed, 3 skipped, 0 failed (~20.5 min)
- [x] Focused goal specs — `goal-pill.spec.ts` (5/5) + `goal-clear-bypass-queue.spec.ts` (2/2) pass together
- [ ] Manual: send `/goal write a clean PR`, confirm hairline pill renders
- [ ] Manual: send a `/goal <300-char condition>`, click the condition to expand, verify it wraps cleanly inside the hairlines
- [ ] Manual: drag an image into composer, type `/goal stay focused`, send — verify the image still renders and the pill emits below it
- [ ] Manual: send `/goal show` and `/goal clear`, verify both still render via the assistant-side path
- [ ] Manual repro of deadlock: set `/goal X`, wait until agent is mid-loop, send `/goal clear` → "Goal cleared" pill appears immediately, agent ends its turn

## Related issues/PRs

- Supersedes #474 (folded in as commit `9d065b4`)
- Follow-up to #467 (SDK Stop-hook refactor)