### PR TITLE
feat(web): auto-expand latest turn diffs in By Turn view

### DIFF
--- a/apps/web/src/__tests__/TurnTimeline.expand.test.tsx
+++ b/apps/web/src/__tests__/TurnTimeline.expand.test.tsx
@@ -1,0 +1,140 @@
+import { StrictMode } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TurnSnapshot } from "@mcode/contracts";
+import { TurnTimeline } from "../components/diff/TurnTimeline";
+
+// Mock the transport so FileEntry's lazy diff load resolves immediately.
+vi.mock("@/transport", () => ({
+  getTransport: () => ({
+    getSnapshotDiff: vi.fn().mockResolvedValue("@@ -0,0 +1 @@\n+hello\n"),
+    getCumulativeDiff: vi.fn().mockResolvedValue(""),
+    getCommitDiff: vi.fn().mockResolvedValue(""),
+  }),
+}));
+
+// Mock heavy diff renderers to keep tests fast and avoid unrelated failures.
+vi.mock("../components/diff/UnifiedDiff", () => ({
+  UnifiedDiff: ({ lines }: { lines: unknown[] }) => (
+    <div data-testid="unified-diff">{lines.length} lines</div>
+  ),
+}));
+vi.mock("../components/diff/SideBySideDiff", () => ({
+  SideBySideDiff: () => <div data-testid="side-by-side-diff" />,
+}));
+vi.mock("../components/diff/DiffPreview", () => ({
+  DiffPreview: () => <div data-testid="diff-preview" />,
+}));
+
+/** Minimal snapshot factory. */
+function snap(id: string, files: string[]): TurnSnapshot {
+  return {
+    id,
+    thread_id: "t1",
+    ref_before: "aaa",
+    ref_after: "bbb",
+    files_changed: files,
+    created_at: new Date().toISOString(),
+  } as TurnSnapshot;
+}
+
+describe("TurnTimeline auto-expand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("expands the latest turn by default", () => {
+    const snapshots = [
+      snap("s1", ["a.ts"]),
+      snap("s2", ["b.ts", "c.ts"]),
+    ];
+
+    render(<TurnTimeline snapshots={snapshots} />);
+
+    // The latest turn (s2, rendered first after reverse) should have aria-expanded=true
+    const buttons = screen.getAllByRole("button", { expanded: true });
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+
+    // Its content region should be visible (the file list is rendered)
+    const contentRegion = document.getElementById("turn-entry-content-s2");
+    expect(contentRegion).toBeTruthy();
+  });
+
+  it("keeps older turns collapsed", () => {
+    const snapshots = [
+      snap("s1", ["a.ts"]),
+      snap("s2", ["b.ts"]),
+    ];
+
+    render(<TurnTimeline snapshots={snapshots} />);
+
+    // The older turn (s1) should not have its content rendered
+    const contentRegion = document.getElementById("turn-entry-content-s1");
+    expect(contentRegion).toBeNull();
+  });
+
+  it("keeps the latest turn expanded across re-renders with new snapshots", () => {
+    const initial = [snap("s1", ["a.ts"])];
+    const { rerender } = render(<TurnTimeline snapshots={initial} />);
+
+    // s1 is the latest and should be expanded
+    expect(document.getElementById("turn-entry-content-s1")).toBeTruthy();
+
+    // A new turn arrives — s2 becomes the latest
+    const updated = [snap("s1", ["a.ts"]), snap("s2", ["b.ts"])];
+    rerender(<TurnTimeline snapshots={updated} />);
+
+    // s2 should now be expanded (latest)
+    expect(document.getElementById("turn-entry-content-s2")).toBeTruthy();
+  });
+
+  it("auto-expands file diffs inside the latest turn", async () => {
+    const snapshots = [snap("s1", ["readme.md"])];
+
+    render(<TurnTimeline snapshots={snapshots} />);
+
+    // The turn content region should be visible
+    const contentRegion = document.getElementById("turn-entry-content-s1");
+    expect(contentRegion).toBeTruthy();
+
+    // The file entry inside the latest turn should also start expanded,
+    // triggering a diff load. Wait for the mocked transport to resolve.
+    const diffEl = await screen.findByTestId("unified-diff");
+    expect(diffEl).toBeTruthy();
+  });
+
+  it("does NOT auto-expand file diffs in older turns", () => {
+    const snapshots = [
+      snap("s1", ["a.ts"]),
+      snap("s2", ["b.ts"]),
+    ];
+
+    render(<TurnTimeline snapshots={snapshots} />);
+
+    // The older turn (s1) should be collapsed entirely
+    const contentRegion = document.getElementById("turn-entry-content-s1");
+    expect(contentRegion).toBeNull();
+
+    // No diff should be rendered for older turn files
+    const diffs = screen.queryAllByTestId("unified-diff");
+    // Only 1 diff (from the latest turn s2), not 2
+    expect(diffs.length).toBeLessThanOrEqual(1);
+  });
+
+  it("auto-expands file diffs under React StrictMode (double-invoke)", async () => {
+    const snapshots = [snap("s1", ["readme.md"])];
+
+    render(
+      <StrictMode>
+        <TurnTimeline snapshots={snapshots} />
+      </StrictMode>,
+    );
+
+    // StrictMode double-invokes effects on mount. The first invocation's
+    // fetch is cancelled by cleanup; the second must start a fresh fetch
+    // that completes. If the ref guard isn't reset in cleanup, the diff
+    // stays stuck on loading dots forever.
+    const diffEl = await screen.findByTestId("unified-diff");
+    expect(diffEl).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -20,6 +20,8 @@ interface FileEntryProps {
    * parent-path suffix is suppressed (the folder header above carries it).
    */
   depth?: number;
+  /** When true the diff starts expanded on mount (used for the latest turn). */
+  defaultExpanded?: boolean;
 }
 
 /** Extract the basename from a file path. */
@@ -59,15 +61,20 @@ type DiffState = null | { loading: true } | { loading: false; data: string };
  * Diff is loaded lazily on the first expand.
  * Large diffs (>200 lines) are truncated with a "Show all N lines" button.
  */
-export function FileEntry({ filePath, source, id, depth = 0 }: FileEntryProps) {
+export function FileEntry({ filePath, source, id, depth = 0, defaultExpanded: defaultExpandedProp = false }: FileEntryProps) {
   const nested = depth > 0;
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpandedProp);
   const [showAllLines, setShowAllLines] = useState(false);
   const [previewMode, setPreviewMode] = useState(false);
-  const [diffState, setDiffState] = useState<DiffState>(null);
+  // Initialise from the Zustand cache so diffs survive panel close/reopen.
+  const cachedDiff = useDiffStore((s) => s.inlineDiffCache[`${source}:${id}:${filePath}`]);
+  const [diffState, setDiffState] = useState<DiffState>(
+    () => (cachedDiff !== undefined ? { loading: false, data: cachedDiff } : null),
+  );
   const renderMode = useDiffStore((s) => s.renderMode);
-  // Tracks whether a load has been kicked off so the effect doesn't cancel itself
-  // when diffState transitions from null → {loading:true}
+  // Tracks whether a load has been kicked off in this effect lifecycle.
+  // Reset in cleanup so React StrictMode's second invocation can start a
+  // fresh, non-cancelled fetch (the first is cancelled by cleanup).
   const loadStartedRef = useRef(false);
 
   const { basename, parent, ext, language, isMarkdown } = useMemo(() => {
@@ -77,10 +84,9 @@ export function FileEntry({ filePath, source, id, depth = 0 }: FileEntryProps) {
     return { basename: bn, parent: pr, ext: ex, language: langFromPath(filePath), isMarkdown: isMarkdownFile(filePath) };
   }, [filePath]);
 
-  // Load diff lazily on first expand. Uses a ref guard so that the state
-  // transition to {loading:true} doesn't re-trigger cleanup and cancel the fetch.
+  // Load diff lazily on first expand. Skips if the diff is already cached.
   useEffect(() => {
-    if (!expanded || loadStartedRef.current) return;
+    if (!expanded || loadStartedRef.current || (diffState !== null && !diffState.loading)) return;
     loadStartedRef.current = true;
 
     let cancelled = false;
@@ -100,7 +106,10 @@ export function FileEntry({ filePath, source, id, depth = 0 }: FileEntryProps) {
             ? await transport.getCommitDiff(workspaceId, id, filePath)
             : "";
         }
-        if (!cancelled) setDiffState({ loading: false, data: result });
+        if (!cancelled) {
+          setDiffState({ loading: false, data: result });
+          useDiffStore.getState().cacheInlineDiff(source, id, filePath, result);
+        }
       } catch {
         if (!cancelled) setDiffState({ loading: false, data: "" });
       }
@@ -109,6 +118,7 @@ export function FileEntry({ filePath, source, id, depth = 0 }: FileEntryProps) {
     void load();
     return () => {
       cancelled = true;
+      loadStartedRef.current = false;
     };
   }, [expanded, source, id, filePath]);
 
@@ -120,18 +130,15 @@ export function FileEntry({ filePath, source, id, depth = 0 }: FileEntryProps) {
     [diffState],
   );
 
-  const stats = useMemo(
-    () =>
-      lines.reduce(
-        (acc, l) => {
-          if (l.type === "add") acc.additions++;
-          else if (l.type === "remove") acc.deletions++;
-          return acc;
-        },
-        { additions: 0, deletions: 0 },
-      ),
-    [lines],
-  );
+  const stats = useMemo(() => {
+    let additions = 0;
+    let deletions = 0;
+    for (const l of lines) {
+      if (l.type === "add") additions++;
+      else if (l.type === "remove") deletions++;
+    }
+    return { additions, deletions };
+  }, [lines]);
 
   const isLoaded = diffState !== null && !diffState.loading;
   const isLargeDiff = lines.length > LARGE_DIFF_THRESHOLD;
@@ -192,7 +199,7 @@ export function FileEntry({ filePath, source, id, depth = 0 }: FileEntryProps) {
           )}
         </span>
 
-        {/* Stats: proportion bar + counts. The bar gives an at-a-glance sense of net impact. */}
+        {/* Stats: proportion bar + counts. Shown after the diff loads. */}
         {isLoaded && (stats.additions > 0 || stats.deletions > 0) && (
           <span className="flex shrink-0 items-center gap-2 font-mono text-[10px] tabular-nums">
             <span className="flex h-[3px] w-12 items-stretch overflow-hidden rounded-full bg-border/40">

--- a/apps/web/src/components/diff/FileList.tsx
+++ b/apps/web/src/components/diff/FileList.tsx
@@ -9,6 +9,8 @@ interface FileListProps {
   files: string[];
   source: SelectedFile["source"];
   id: string;
+  /** When true every file entry starts expanded (used for the latest turn). */
+  defaultFilesExpanded?: boolean;
 }
 
 /**
@@ -16,7 +18,7 @@ interface FileListProps {
  * Single-child folder chains are compressed (e.g., `src/stores/__tests__/`).
  * Folders sort before files; both alphabetical within their group.
  */
-export function FileList({ files, source, id }: FileListProps) {
+export function FileList({ files, source, id, defaultFilesExpanded = false }: FileListProps) {
   const tree = useMemo(() => buildFileTree(files), [files]);
 
   if (files.length === 0) {
@@ -28,7 +30,7 @@ export function FileList({ files, source, id }: FileListProps) {
   return (
     <div className="flex flex-col">
       {tree.map((node) => (
-        <TreeNodeRenderer key={nodeKey(node)} node={node} depth={0} source={source} id={id} />
+        <TreeNodeRenderer key={nodeKey(node)} node={node} depth={0} source={source} id={id} defaultExpanded={defaultFilesExpanded} />
       ))}
     </div>
   );
@@ -45,16 +47,16 @@ function TreeNodeRenderer({
   depth,
   source,
   id,
+  defaultExpanded,
 }: {
   node: TreeNode;
   depth: number;
   source: SelectedFile["source"];
   id: string;
+  defaultExpanded?: boolean;
 }) {
   if (node.type === "file") {
-    // depth 0 = file at the root of the input (no folder above it) → render flat.
-    // depth > 0 = file inside a folder → render nested (suppress redundant parent path).
-    return <FileEntry filePath={node.path} source={source} id={id} depth={depth} />;
+    return <FileEntry filePath={node.path} source={source} id={id} depth={depth} defaultExpanded={defaultExpanded} />;
   }
 
   return (
@@ -66,6 +68,7 @@ function TreeNodeRenderer({
           depth={depth + 1}
           source={source}
           id={id}
+          defaultExpanded={defaultExpanded}
         />
       ))}
     </FolderEntry>

--- a/apps/web/src/components/diff/TurnEntry.tsx
+++ b/apps/web/src/components/diff/TurnEntry.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { TurnSnapshot } from "@mcode/contracts";
 import { FileList } from "./FileList";
 
@@ -6,18 +6,32 @@ import { FileList } from "./FileList";
 interface TurnEntryProps {
   snapshot: TurnSnapshot;
   turnNumber: number;
+  /** When true the accordion starts expanded (used for the latest turn). */
+  defaultExpanded?: boolean;
 }
 
 /**
  * Single turn accordion. Leading element is an oversized ordinal — the page's
  * primary navigational rhythm. Expansion is a typographic chevron, not a heavy
  * plus/minus glyph.
+ *
+ * When `defaultExpanded` is set, the turn opens on mount so the file list is
+ * visible without a click (used for the latest turn in the By Turn view).
  */
-export function TurnEntry({ snapshot, turnNumber }: TurnEntryProps) {
-  const [expanded, setExpanded] = useState(false);
+export function TurnEntry({ snapshot, turnNumber, defaultExpanded = false }: TurnEntryProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  // Sync when defaultExpanded transitions to true (e.g. a new turn arrives
+  // and this entry becomes the latest, or snapshots load after mount).
+  // useState only reads its initializer on first mount.
+  useEffect(() => {
+    if (defaultExpanded) setExpanded(true);
+  }, [defaultExpanded]);
+
   const fileCount = snapshot.files_changed.length;
   const ordinal = String(turnNumber).padStart(2, "0");
   const contentId = `turn-entry-content-${snapshot.id}`;
+
 
   return (
     <div className={`border-b border-border/15 ${expanded ? "bg-muted/[0.04]" : ""}`}>
@@ -54,7 +68,12 @@ export function TurnEntry({ snapshot, turnNumber }: TurnEntryProps) {
 
       {expanded && (
         <div id={contentId} className="pb-1">
-          <FileList files={snapshot.files_changed} source="snapshot" id={snapshot.id} />
+          <FileList
+            files={snapshot.files_changed}
+            source="snapshot"
+            id={snapshot.id}
+            defaultFilesExpanded={defaultExpanded}
+          />
         </div>
       )}
     </div>

--- a/apps/web/src/components/diff/TurnTimeline.tsx
+++ b/apps/web/src/components/diff/TurnTimeline.tsx
@@ -25,10 +25,17 @@ export function TurnTimeline({ snapshots }: TurnTimelineProps) {
     );
   }
 
+  const reversed = [...withFiles].reverse();
+
   return (
     <div className="flex flex-col">
-      {[...withFiles].reverse().map(({ snapshot, turnNumber }) => (
-        <TurnEntry key={snapshot.id} snapshot={snapshot} turnNumber={turnNumber} />
+      {reversed.map(({ snapshot, turnNumber }, i) => (
+        <TurnEntry
+          key={snapshot.id}
+          snapshot={snapshot}
+          turnNumber={turnNumber}
+          defaultExpanded={i === 0}
+        />
       ))}
     </div>
   );

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -310,7 +310,8 @@ export function RightPanel() {
         </div>
       </div>
 
-      {/* Tab content */}
+      {/* Tab content — DiffPanel stays mounted (hidden) so turn expand
+          state and loaded diffs survive tab switches. */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {activeTab === "tasks" && (
           <>
@@ -318,7 +319,9 @@ export function RightPanel() {
             <TaskPanel />
           </>
         )}
-        {activeTab === "changes" && <DiffPanel />}
+        <div className={activeTab === "changes" ? "flex flex-1 flex-col min-h-0" : "hidden"}>
+          <DiffPanel />
+        </div>
         {activeTab === "preview" && (
           <PreviewPanel threadId={activeThreadId} workspaceId={activeWorkspaceId} />
         )}

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -93,6 +93,11 @@ interface DiffState {
   commitsByThread: Record<string, GitCommit[]>;
   /** Whether commits are currently loading, keyed by thread ID. */
   commitsLoadingByThread: Record<string, boolean>;
+  /**
+   * Inline diff cache keyed by `"source:id:filePath"`. Survives component
+   * unmounts (panel close/reopen, tab switches) so diffs aren't re-fetched.
+   */
+  inlineDiffCache: Record<string, string>;
   /** Currently selected file for diff viewing. */
   selectedFile: SelectedFile | null;
   /** Raw unified diff text for the selected file. */
@@ -131,6 +136,10 @@ interface DiffState {
   setSummaryRecord: (record: DiffState["summaryRecord"]) => void;
   /** Set summary loading state. */
   setSummaryLoading: (loading: boolean) => void;
+  /** Cache a fetched inline diff so it survives component unmounts. */
+  cacheInlineDiff: (source: string, id: string, filePath: string, data: string) => void;
+  /** Retrieve a cached inline diff, or undefined if not cached. */
+  getCachedInlineDiff: (source: string, id: string, filePath: string) => string | undefined;
   /** Persist the omnibox URL for a thread's embedded preview. */
   setPreviewUrlForThread: (threadId: string, url: string) => void;
   clearThread: (threadId: string) => void;
@@ -147,6 +156,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   snapshotsLoadingByThread: {},
   commitsByThread: {},
   commitsLoadingByThread: {},
+  inlineDiffCache: {},
   selectedFile: null,
   diffContent: null,
   diffLoading: false,
@@ -227,6 +237,12 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   setDiffLoading: (loading) => set({ diffLoading: loading }),
   setSummaryRecord: (record) => set({ summaryRecord: record }),
   setSummaryLoading: (loading) => set({ summaryLoading: loading }),
+  cacheInlineDiff: (source, id, filePath, data) =>
+    set((s) => ({
+      inlineDiffCache: { ...s.inlineDiffCache, [`${source}:${id}:${filePath}`]: data },
+    })),
+  getCachedInlineDiff: (source, id, filePath) =>
+    get().inlineDiffCache[`${source}:${id}:${filePath}`],
   setPreviewUrlForThread: (threadId, url) =>
     set((s) => ({
       previewUrlByThread: { ...s.previewUrlByThread, [threadId]: url },


### PR DESCRIPTION
## What

The By Turn diff view now auto-expands the latest turn and its file diffs so users see changes immediately without clicking.

## Why

Opening the Changes tab previously showed a collapsed list of turns - the user had to click the turn, then click each file to see the diff. This added friction to the most common workflow (reviewing the latest change).

## Key changes

- **TurnTimeline** passes `defaultExpanded={i === 0}` to the newest turn after reversing
- **TurnEntry** accepts `defaultExpanded` with a `useEffect` sync so new turn arrivals also auto-expand
- **FileList / FileEntry** thread `defaultExpanded` through the folder tree so file diffs open automatically
- **RightPanel** keeps DiffPanel mounted via CSS `hidden` instead of conditional rendering, preserving expand state and loaded diffs across tab switches
- **FileEntry** resets `loadStartedRef` in effect cleanup to fix a React StrictMode bug where double-invoked mount effects left diffs stuck on loading dots
- **diffStore** adds `inlineDiffCache` (keyed by `source:id:filePath`) so fetched diffs persist across panel close/reopen without re-fetching

## Test plan

- [ ] Open Changes tab on a thread with turns - latest turn and its file diffs should be expanded with content visible
- [ ] Switch to Tasks tab and back - diffs should still be visible (no reload)
- [ ] Close the panel and reopen - diffs should render instantly from cache
- [ ] Older turns should remain collapsed
- [ ] New turn arriving should auto-expand as the latest
- [ ] `bun run verify` passes (1189 tests, including 6 StrictMode-specific auto-expand tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Latest turn now automatically expands by default for immediate visibility.
  * File diffs within the latest turn auto-expand on load.
  * Inline diff content is cached in memory, reducing reload time when navigating between files.
  * Diff panel state persists when switching tabs, preserving expanded content across navigation.

* **Tests**
  * Added comprehensive test suite validating auto-expand behavior across turns and file diffs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->