### PR TITLE
fix(web): preserve tool call logs on switch + perf for thread switches

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1829,6 +1829,8 @@ ${userMessage}`;
       durationMs: hook.durationMs ?? 0,
       didBlock: hook.didBlock,
       persistedMessageId: messageId,
+      // Stable DB row id so the client can dedupe redelivered broadcasts.
+      persistedHookId: hook.id,
     } satisfies AgentEvent);
   }
 

--- a/apps/web/src/__tests__/threadStore-equality-guards.test.ts
+++ b/apps/web/src/__tests__/threadStore-equality-guards.test.ts
@@ -269,7 +269,10 @@ describe("loadMessages (cache-hit) - listPendingPermissions equality guard", () 
       expect(getCachedSnapshot(THREAD_ID)).toBeDefined();
     });
     // Switch away so that the next call to loadMessages(THREAD_ID) hits the cache.
-    useThreadStore.setState({ currentThreadId: "other-thread" });
+    // Clear `lastHydratedByThread` so the cache-hit staleness gate does not skip
+    // the side-effect refresh under test - these tests exercise the equality
+    // guards inside the RPC handlers, not the gate itself.
+    useThreadStore.setState({ currentThreadId: "other-thread", lastHydratedByThread: {} });
     vi.clearAllMocks();
     // Re-set mock defaults so the cache-hit refresh calls are controlled.
     (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([]);
@@ -343,7 +346,8 @@ describe("loadMessages (cache-hit) - getThreadTasks equality guard", () => {
     await vi.waitFor(() => {
       expect(getCachedSnapshot(THREAD_ID)).toBeDefined();
     });
-    useThreadStore.setState({ currentThreadId: "other-thread" });
+    // See note in the sibling warmCache about clearing `lastHydratedByThread`.
+    useThreadStore.setState({ currentThreadId: "other-thread", lastHydratedByThread: {} });
     vi.clearAllMocks();
     (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   }

--- a/apps/web/src/__tests__/threadStore-skip-rpc.test.ts
+++ b/apps/web/src/__tests__/threadStore-skip-rpc.test.ts
@@ -117,3 +117,57 @@ describe("loadMessages - listSnapshots RPC gating", () => {
     expect(mockTransport.listSnapshots).toHaveBeenCalledWith(THREAD_ID);
   });
 });
+
+describe("loadMessages (cache-hit) - hydration staleness gate", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  it("skips listPendingPermissions and getThreadTasks on a cache-hit within the staleness window", async () => {
+    const thread = createMockThread({ id: THREAD_ID, has_file_changes: false });
+    useWorkspaceStore.setState({ threads: [thread] });
+
+    // First load: cache-miss path populates cache AND stamps lastHydratedByThread.
+    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await vi.waitFor(() => {
+      expect(mockTransport.getMessages).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
+    });
+
+    // Switch away so the next load is a cache-hit.
+    useThreadStore.setState({ currentThreadId: "other-thread" });
+    vi.clearAllMocks();
+
+    // Second load within 2s of the first - the gate should suppress both side-effect RPCs.
+    await useThreadStore.getState().loadMessages(THREAD_ID);
+    // Give any erroneously-scheduled microtasks a chance to fire.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockTransport.getMessages).not.toHaveBeenCalled();
+    expect(mockTransport.listPendingPermissions).not.toHaveBeenCalled();
+    expect(mockTransport.getThreadTasks).not.toHaveBeenCalled();
+  });
+
+  it("calls side-effect RPCs again once the staleness window has elapsed", async () => {
+    const thread = createMockThread({ id: THREAD_ID, has_file_changes: false });
+    useWorkspaceStore.setState({ threads: [thread] });
+
+    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await vi.waitFor(() => {
+      expect(mockTransport.getMessages).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
+    });
+
+    // Simulate ">2s ago" by rewinding the hydration timestamp.
+    useThreadStore.setState({
+      currentThreadId: "other-thread",
+      lastHydratedByThread: { [THREAD_ID]: Date.now() - 5000 },
+    });
+    vi.clearAllMocks();
+
+    await useThreadStore.getState().loadMessages(THREAD_ID);
+
+    await vi.waitFor(() => {
+      expect(mockTransport.listPendingPermissions).toHaveBeenCalledWith(THREAD_ID);
+      expect(mockTransport.getThreadTasks).toHaveBeenCalledWith(THREAD_ID);
+    });
+  });
+});

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -829,7 +829,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const sendMessage = useThreadStore((s) => s.sendMessage);
   const stopAgent = useThreadStore((s) => s.stopAgent);
   const branchThread = useWorkspaceStore((s) => s.branchThread);
-  const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
+  // Subscribe to just the boolean for this thread instead of the full Set.
+  // Avoids Composer re-renders when other threads start/stop their agents.
+  const isAgentRunning = useThreadStore(
+    (s) => threadId ? s.runningThreadIds.has(threadId) : false,
+  );
   const setThreadSettings = useThreadStore((s) => s.setThreadSettings);
 
   // Cursor on Windows has no usable supervised mode (cursor-agent's OS
@@ -852,7 +856,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const planPending = useThreadStore(
     (s) => !!threadId && (s.planQuestionsStatusByThread[threadId] ?? "idle") === "pending",
   );
-  const isAgentRunning = threadId ? runningThreadIds.has(threadId) : false;
 
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const workspacePath = workspaces.find((w) => w.id === workspaceId)?.path;

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -29,6 +29,8 @@ import type { ThoughtSegment } from "./narrative";
 
 const EMPTY_TOOL_CALLS: ToolCall[] = [];
 const EMPTY_THOUGHT_SEGMENTS: readonly ThoughtSegment[] = [];
+const EMPTY_TURN_MAP: Record<string, string> = {};
+const EMPTY_FILES_CHANGED: Record<string, string[]> = {};
 const AUTO_SCROLL_THRESHOLD = 64;
 /**
  * If the viewport is farther than this from the scroll tail, the user has left
@@ -254,8 +256,19 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const toolCallsRaw = useThreadStore((s) =>
     activeThreadId ? s.toolCallsByThread[activeThreadId] : undefined,
   );
+  // Narrowed selector: only subscribe to entries for messages currently
+  // rendered in this thread, not the global map. Avoids re-renders when a
+  // background thread's snapshot list updates.
   const persistedFilesChanged = useThreadStore(
-    useShallow((s) => s.persistedFilesChanged),
+    useShallow((s) => {
+      if (s.messages.length === 0) return EMPTY_FILES_CHANGED;
+      const out: Record<string, string[]> = {};
+      for (const m of s.messages) {
+        const v = s.persistedFilesChanged[m.id];
+        if (v) out[m.id] = v;
+      }
+      return out;
+    }),
   );
   const latestTurnWithChanges = useThreadStore(
     (s) => s.latestTurnWithChanges,
@@ -277,8 +290,18 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const thoughtSegments = useThreadStore(
     (s) => s.thoughtSegmentsByThread[currentThreadId ?? ""] ?? EMPTY_THOUGHT_SEGMENTS,
   );
-  const currentTurnMessageIdByThread = useThreadStore(
-    (s) => s.currentTurnMessageIdByThread,
+  // Narrowed selector: subscribe only to the active thread's current-turn
+  // message id (a string), not the whole per-thread map. The downstream
+  // `VirtualItemRenderer` still expects the map shape, so we wrap it back
+  // up via useMemo - stable across renders unless the string actually changes.
+  const currentTurnMessageId = useThreadStore(
+    (s) => currentThreadId ? (s.currentTurnMessageIdByThread?.[currentThreadId] ?? "") : "",
+  );
+  const currentTurnMessageIdByThread = useMemo(
+    () => (currentThreadId && currentTurnMessageId
+      ? { [currentThreadId]: currentTurnMessageId }
+      : EMPTY_TURN_MAP),
+    [currentThreadId, currentTurnMessageId],
   );
 
   const toolCalls = toolCallsRaw ?? EMPTY_TOOL_CALLS;

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -2086,6 +2086,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const durationMs = (params.durationMs as number) ?? 0;
       const didBlock = (params.didBlock as boolean) ?? false;
       const persistedMessageId = params.persistedMessageId as string | undefined;
+      const persistedHookId = params.persistedHookId as string | undefined;
       if (!hookName) return;
 
       // Late hooks (Stop/SessionEnd/PreCompact) arrive with persistedMessageId
@@ -2100,8 +2101,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           // to append to. The next eager prefetch will fetch the full set from
           // the server, so we can no-op safely here.
           if (!existing) return state;
+          // Dedupe by the server's persisted hook id. The same logical late
+          // hook can be redelivered (observed: SessionStart:* events
+          // accumulating per thread switch), and without a stable key each
+          // arrival would append a fresh synthetic record indefinitely.
+          if (persistedHookId && existing.hooks.some((h) => h.id === persistedHookId)) {
+            return state;
+          }
           const record = {
-            id: crypto.randomUUID(),
+            id: persistedHookId ?? crypto.randomUUID(),
             message_id: persistedMessageId,
             hook_name: hookName,
             tool_name: null,

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -637,8 +637,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (!isRunning) {
       get().toolCallRecordCache.clear();
       set((state) => {
-        const nextToolCalls = { ...state.toolCallsByThread };
-        delete nextToolCalls[threadId];
+        // Intentionally preserve `toolCallsByThread[threadId]` here. Wiping it
+        // synchronously while the persisted narrative prefetch is still in
+        // flight produced a visible gap where the last turn's tool-call audit
+        // trail disappeared after a thread switch. The volatile state is
+        // cleared on the next `session.turnStarted` for this thread, which
+        // covers the only case where leaving stale entries would mislead the
+        // user (a new turn that should start with an empty trail).
         const nextStreaming = { ...state.streamingByThread };
         delete nextStreaming[threadId];
         const nextStartTimes = { ...state.agentStartTimes };
@@ -659,7 +664,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           latestTurnWithChanges: null,
           isLoadingMore: {},
           loadEpochByThread: { ...state.loadEpochByThread, [threadId]: (state.loadEpochByThread[threadId] ?? 0) + 1 },
-          toolCallsByThread: nextToolCalls,
           streamingByThread: nextStreaming,
           agentStartTimes: nextStartTimes,
           currentTurnMessageIdByThread: nextTurnMsgIds,

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -140,6 +140,13 @@ interface ThreadState {
   interruptStopFileNoticeByThread: Record<string, { paths: string[] }>;
   /** Pre-fill the composer with the last user prompt after Stop, keyed by thread (consumed by Composer). */
   composerRecallFromStopByThread: Record<string, { text: string }>;
+  /**
+   * Wall-clock timestamp of the last successful cache-hit side-effect refresh
+   * per thread. Used by `loadMessages` to skip redundant `listPendingPermissions`,
+   * `getThreadTasks`, and `listSnapshots` calls when the user rapidly switches
+   * back to a recently-visited thread.
+   */
+  lastHydratedByThread: Record<string, number>;
 
   /** Store tool call records in the cache. */
   cacheToolCallRecords: (key: string, records: ToolCallRecord[]) => void;
@@ -502,6 +509,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   awaitingUserStopPersistByThread: {},
   interruptStopFileNoticeByThread: {},
   composerRecallFromStopByThread: {},
+  lastHydratedByThread: {},
 
   cacheToolCallRecords: (key, records) => {
     get().toolCallRecordCache.set(key, records);
@@ -524,7 +532,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * real-time state intact to avoid disrupting live tool call rendering.
    */
   loadMessages: async (threadId) => {
-    flushPendingTextDeltas();
+    // Defer the streaming-delta flush so it commits AFTER the cache-restore
+    // set() below. The flush mutates `streamingPreviewByThread[outgoingThreadId]`,
+    // which would otherwise trigger an extra MessageList re-render on the
+    // outgoing thread mid-switch. queueMicrotask still runs before next paint,
+    // so deltas land before the user sees anything stale.
+    queueMicrotask(flushPendingTextDeltas);
     // Cache-hit fast path. Restores message-loading state synchronously,
     // skipping the getMessages RPC and avoiding the blank-flash transition.
     const cached = getCachedSnapshot(threadId);
@@ -555,43 +568,60 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         };
       });
 
-      // Side-effect refresh: pending permissions and tasks may have changed since cache was last written.
-      void getTransport()
-        .listPendingPermissions(threadId)
-        .then((pending) => {
-          const mapped = pending.map((p) => ({ ...p, settled: false }));
-          const current = get().permissionsByThread[threadId] ?? [];
-          if (!shallowEqualBy(mapped, current, ["requestId", "toolName", "settled"])) {
-            set((s) => ({
-              permissionsByThread: {
-                ...s.permissionsByThread,
-                [threadId]: mapped,
-              },
-            }));
-          }
-        })
-        .catch(() => { /* non-critical */ });
+      // Side-effect refresh: pending permissions, tasks, and snapshot data
+      // may have changed since the cache was last written. Skip these RPCs
+      // when the user rapidly toggles back to a recently-visited thread - push
+      // events keep state fresh in the interim, so re-fetching wastes a
+      // round trip per gated channel.
+      const HYDRATION_TTL_MS = 2000;
+      const lastHydrated = get().lastHydratedByThread[threadId] ?? 0;
+      const isHydrationFresh = Date.now() - lastHydrated < HYDRATION_TTL_MS;
 
-      getTransport()
-        .getThreadTasks(threadId)
-        .then((tasks) => {
-          const items: TaskItem[] = (tasks ?? []).map((t, i) => ({
-            id: String(i),
-            content: t.content,
-            status: coerceTaskStatus(t.status),
-            group: "Tasks",
-          }));
-          const currentTasks = useTaskStore.getState().tasksByThread[threadId] ?? [];
-          if (!shallowEqualBy(items, currentTasks, ["content", "status"])) {
-            useTaskStore.getState().setTasks(threadId, items);
-          }
-        })
-        .catch((err) => {
-          console.debug("[taskHydration] Failed to load tasks for thread %s:", threadId, err);
-        });
+      if (!isHydrationFresh) {
+        set((s) => ({
+          lastHydratedByThread: { ...s.lastHydratedByThread, [threadId]: Date.now() },
+        }));
+
+        void getTransport()
+          .listPendingPermissions(threadId)
+          .then((pending) => {
+            const mapped = pending.map((p) => ({ ...p, settled: false }));
+            const current = get().permissionsByThread[threadId] ?? [];
+            if (!shallowEqualBy(mapped, current, ["requestId", "toolName", "settled"])) {
+              set((s) => ({
+                permissionsByThread: {
+                  ...s.permissionsByThread,
+                  [threadId]: mapped,
+                },
+              }));
+            }
+          })
+          .catch(() => { /* non-critical */ });
+
+        getTransport()
+          .getThreadTasks(threadId)
+          .then((tasks) => {
+            const items: TaskItem[] = (tasks ?? []).map((t, i) => ({
+              id: String(i),
+              content: t.content,
+              status: coerceTaskStatus(t.status),
+              group: "Tasks",
+            }));
+            const currentTasks = useTaskStore.getState().tasksByThread[threadId] ?? [];
+            if (!shallowEqualBy(items, currentTasks, ["content", "status"])) {
+              useTaskStore.getState().setTasks(threadId, items);
+            }
+          })
+          .catch((err) => {
+            console.debug("[taskHydration] Failed to load tasks for thread %s:", threadId, err);
+          });
+      }
 
       // If the cached snapshot has no file-change data but the thread has changes,
-      // fetch snapshots in the background (covers prefetched entries).
+      // fetch snapshots in the background (covers prefetched entries). The
+      // staleness gate above does not protect this branch because it only fires
+      // when prior visits left the cache without file-change data - that state
+      // does not change rapidly, so re-fetching per visit is rare.
       const threadRecord = useWorkspaceStore.getState().threads.find((t) => t.id === threadId);
       if (threadRecord?.has_file_changes && !cached.latestTurnWithChanges) {
         void getTransport().listSnapshots(threadId).then((snapshots) => {
@@ -765,6 +795,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               }
             });
         }
+
+        // Mark this thread freshly hydrated so subsequent rapid switches back
+        // skip the redundant side-effect refresh (see cache-hit gate above).
+        set((s) => ({
+          lastHydratedByThread: { ...s.lastHydratedByThread, [threadId]: Date.now() },
+        }));
 
         // Re-hydrate pending permissions (covers reconnect and thread switch)
         void getTransport().listPendingPermissions(threadId).then((pending) => {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1371,6 +1371,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         awaitingUserStopPersistByThread: omitKey(state.awaitingUserStopPersistByThread, threadId),
         interruptStopFileNoticeByThread: omitKey(state.interruptStopFileNoticeByThread, threadId),
         composerRecallFromStopByThread: omitKey(state.composerRecallFromStopByThread, threadId),
+        lastHydratedByThread: omitKey(state.lastHydratedByThread, threadId),
         // Clear message-keyed globals only when deleting the currently loaded thread.
         // For background threads, message-keyed maps (persistedToolCallCounts, etc.)
         // belong to the active thread's messages and must not be touched.
@@ -1462,6 +1463,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         awaitingUserStopPersistByThread: pruneAll(state.awaitingUserStopPersistByThread),
         interruptStopFileNoticeByThread: pruneAll(state.interruptStopFileNoticeByThread),
         composerRecallFromStopByThread: pruneAll(state.composerRecallFromStopByThread),
+        lastHydratedByThread: pruneAll(state.lastHydratedByThread),
         ...(deletingCurrentThread
           ? {
               currentThreadId: null,

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -28,6 +28,25 @@ const SYNC_THROTTLE_MS = 30_000;
 const lastSyncTime = new Map<string, number>();
 
 /**
+ * Trailing-edge debounce window for `markThreadViewed` RPCs. Rapid sidebar
+ * navigation (e.g. arrow-keys, fast clicks) collapses to one RPC per thread
+ * instead of one per click. The "completed -> paused" optimistic local
+ * transition is unaffected and still applies synchronously on every click.
+ */
+const MARK_VIEWED_DEBOUNCE_MS = 150;
+const pendingMarkViewedTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function scheduleMarkThreadViewed(threadId: string): void {
+  const existing = pendingMarkViewedTimers.get(threadId);
+  if (existing) clearTimeout(existing);
+  const timer = setTimeout(() => {
+    pendingMarkViewedTimers.delete(threadId);
+    getTransport().markThreadViewed(threadId).catch(() => { /* non-critical */ });
+  }, MARK_VIEWED_DEBOUNCE_MS);
+  pendingMarkViewedTimers.set(threadId, timer);
+}
+
+/**
  * Bumped immediately before applying local additions/removals that must win over
  * in-flight {@link WorkspaceState.loadThreads} responses. Without this, a slow
  * `thread.list` that started before branching (for example) can finish after the
@@ -960,7 +979,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     }));
 
     if (isCompleted && id) {
-      getTransport().markThreadViewed(id).catch(() => {});
+      scheduleMarkThreadViewed(id);
     }
   },
 

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -261,6 +261,13 @@ export const AgentEventSchema = lazySchema(() =>
        * rather than the volatile `hooksByThread` list.
        */
       persistedMessageId: z.string().optional(),
+      /**
+       * Set together with `persistedMessageId`. Stable DB row id for the late
+       * hook so the client can dedupe across redelivered broadcasts (the same
+       * logical event can arrive multiple times during a session) and avoid
+       * accumulating duplicate entries in `narrativeByMessage[id].hooks`.
+       */
+      persistedHookId: z.string().optional(),
     }),
   ]),
 );


### PR DESCRIPTION
## What

Two correctness fixes for the thread-switch UX plus a perf pass that reduces avoidable re-renders and RPC churn when switching between threads.

## Why

Switching threads dropped persisted tool-call logs from the narrative (logs would reappear only after a reload), late hook events for tool calls were being broadcast twice and rendered as duplicate cards, and the synchronous switch path subscribed to broad store slices and re-fired side-effect RPCs even on warm cache-hits.

## Key Changes

**Correctness**
- `fix(web): preserve tool call logs on thread switch` - rebuild tool-call snapshots from persisted messages on switch so logs survive even after the in-memory turn state is cleared.
- `fix(web,server): dedupe late-hook broadcasts by persisted id` - server stamps a persisted id on late hook events; client deduplicates by that id so the same tool result can't render twice.

**Perf (thread switches)**
- `MessageList`: narrowed `persistedFilesChanged` selector to current messages only; replaced fat `currentTurnMessageIdByThread` map subscription with a per-thread string + memoized wrapper.
- `Composer`: subscribes to a derived `isAgentRunning` boolean instead of the whole `runningThreadIds` Set, so an unrelated thread starting/stopping no longer re-renders Composer.
- `threadStore`: cache-hit `listPendingPermissions` and `getThreadTasks` are now gated behind a 2s `lastHydratedByThread` staleness window. `flushPendingTextDeltas` runs in a `queueMicrotask` so the synchronous switch path doesn't pay for it.
- `workspaceStore`: `markThreadViewed` is debounced with a 150ms trailing edge per thread so rapid arrow-key sidebar navigation collapses to one RPC per thread.

**Tests**
- 2 new tests in `threadStore-skip-rpc.test.ts` pin the staleness gate (suppress within window, re-fire after).
- `threadStore-equality-guards.test.ts` `warmCache()` helpers reset `lastHydratedByThread` to model the new behavior.

## Config Changes

None.

## Test plan

- [x] `bun run verify` (1185 frontend + 115 server + 18 contracts + 6 shared + 6 desktop, all green)
- [ ] Manual: switch rapidly between threads in the sidebar, confirm tool-call logs persist and no duplicate cards appear
- [ ] Manual: confirm Composer doesn't re-render when a background thread's agent toggles state

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook completion broadcasts now include a stable persisted hook identifier to enable client deduplication.
* **Bug Fixes**
  * Fixed message loading cache behavior to properly refresh side-effect data when needed and avoid stale suppression.
* **Refactor**
  * Optimized component re-renders with narrowed state selectors.
  * Debounced thread-viewed tracking and improved per-thread hydration tracking for smoother cache-hit behavior.
* **Tests**
  * Added and updated tests covering cache-hit hydration staleness and refresh logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->