### PR TITLE
fix(chat): never show loading skeleton for slash commands

### DIFF
--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -13,6 +13,7 @@ const VIRTUAL_THRESHOLD = 20; // use virtual scroll only above this count
 // placement calculation; the rendered footer remains naturally sized.
 const FOOTER_HEIGHT = 28;
 
+/** Props for the {@link SlashCommandPopup} component. */
 interface SlashCommandPopupProps {
   isOpen: boolean;
   isLoading: boolean;
@@ -25,6 +26,13 @@ interface SlashCommandPopupProps {
   onRetry: () => void;
 }
 
+/**
+ * Floating popup that lists slash command suggestions anchored to the
+ * composer editor. Handles keyboard navigation via `selectedIndex`, virtualises
+ * long lists past `VIRTUAL_THRESHOLD`, flips above/below the anchor based on
+ * available viewport space, and dismisses on outside click. Render priority is
+ * error → list → inline loader → empty state.
+ */
 export function SlashCommandPopup({
   isOpen,
   isLoading,
@@ -74,11 +82,14 @@ export function SlashCommandPopup({
   // their natural content so a popup with two items isn't truncated.
   const listMaxHeight = VISIBLE_ITEMS * ITEM_HEIGHT;
 
-  // Estimate the rendered popup height (list rows + footer) only for the
-  // above/below placement decision. The outer wrapper itself has no maxHeight
-  // so it grows to fit list + footer without clipping the last row.
+  // Estimate the rendered popup height for the above/below placement
+  // decision. Only the list branch renders a footer (Refresh row); error,
+  // inline-loading, and empty branches do not. Including FOOTER_HEIGHT in
+  // those cases would cause unnecessary above-placement flips.
+  const willRenderList = !error && items.length > 0;
   const estimatedHeight =
-    Math.min(items.length, VISIBLE_ITEMS) * ITEM_HEIGHT + FOOTER_HEIGHT;
+    Math.min(items.length, VISIBLE_ITEMS) * ITEM_HEIGHT +
+    (willRenderList ? FOOTER_HEIGHT : 0);
   const spaceAbove = anchorRect.top;
   const placeAbove = spaceAbove > estimatedHeight + 8;
 

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -8,6 +8,10 @@ import type { Command } from "./useSlashCommand";
 const ITEM_HEIGHT = 44; // px per row
 const VISIBLE_ITEMS = 8;
 const VIRTUAL_THRESHOLD = 20; // use virtual scroll only above this count
+// Footer (Refresh row) intrinsic height: border-t (1px) + py-1 (8px) + icon
+// button height (~20px). Used to estimate popup height for the above/below
+// placement calculation; the rendered footer remains naturally sized.
+const FOOTER_HEIGHT = 28;
 
 interface SlashCommandPopupProps {
   isOpen: boolean;
@@ -66,16 +70,22 @@ export function SlashCommandPopup({
 
   if (!isOpen || !anchorRect) return null;
 
-  // Position: default above the anchor rect, flip below if not enough space
+  // Cap the scrollable list at VISIBLE_ITEMS rows; shorter lists size to
+  // their natural content so a popup with two items isn't truncated.
+  const listMaxHeight = VISIBLE_ITEMS * ITEM_HEIGHT;
+
+  // Estimate the rendered popup height (list rows + footer) only for the
+  // above/below placement decision. The outer wrapper itself has no maxHeight
+  // so it grows to fit list + footer without clipping the last row.
+  const estimatedHeight =
+    Math.min(items.length, VISIBLE_ITEMS) * ITEM_HEIGHT + FOOTER_HEIGHT;
   const spaceAbove = anchorRect.top;
-  const maxHeight = Math.min(VISIBLE_ITEMS * ITEM_HEIGHT, items.length * ITEM_HEIGHT || ITEM_HEIGHT * 2);
-  const placeAbove = spaceAbove > maxHeight + 8;
+  const placeAbove = spaceAbove > estimatedHeight + 8;
 
   const style: React.CSSProperties = {
     position: "fixed",
     left: anchorRect.left,
     width: Math.max(anchorRect.width, 320),
-    maxHeight,
     ...(placeAbove
       ? { bottom: window.innerHeight - anchorRect.top + 4 }
       : { top: anchorRect.bottom + 4 }),
@@ -96,20 +106,29 @@ export function SlashCommandPopup({
         "animate-in fade-in-0 zoom-in-95 duration-[120ms]",
       )}
     >
-      {isLoading ? (
-        <SkeletonRows />
-      ) : error ? (
+      {/*
+        Render priority (stale-while-revalidate):
+          1. error -> ErrorRow  (unchanged; surfaces transient failures even
+             when built-in commands are present, preserving the explicit
+             "loading failed" signal validated by the slash-command E2E)
+          2. items.length > 0 -> list  (built-ins are always available, so
+             this branch wins on cold start, workspace switches, and cache
+             invalidations; the loading skeleton is unreachable in normal use)
+          3. isLoading -> inline "Loading commands..."  (only hit when a
+             filter yields zero matches AND skills are still arriving;
+             replaces the 3-row skeleton with a single quiet row)
+          4. EmptyState  (no matches, not loading, no error)
+      */}
+      {error ? (
         <ErrorRow message={error.message} onRetry={onRetry} />
-      ) : items.length === 0 ? (
-        <EmptyState />
-      ) : (
+      ) : items.length > 0 ? (
         <>
           <div
             ref={scrollRef}
             role="listbox"
             aria-label="Slash commands"
             aria-activedescendant={items[selectedIndex] ? `slash-cmd-${items[selectedIndex].name}` : undefined}
-            style={{ maxHeight, overflowY: "auto" }}
+            style={{ maxHeight: listMaxHeight, overflowY: "auto" }}
           >
             {useVirtual ? (
               <div role="presentation" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
@@ -154,6 +173,10 @@ export function SlashCommandPopup({
             </button>
           </div>
         </>
+      ) : isLoading ? (
+        <LoadingInline />
+      ) : (
+        <EmptyState />
       )}
     </div>
   );
@@ -221,18 +244,25 @@ function CommandRow({
   );
 }
 
-function SkeletonRows() {
+/**
+ * Single-row "Loading commands..." indicator. Replaces the previous 3-row
+ * skeleton-shimmer block. The skeleton was visually noisy and triggered on
+ * every cold start, workspace switch, and cache-invalidation push; with the
+ * stale-while-revalidate render order in this component plus the eager
+ * prefetch in `useSlashCommand`, this branch should only be reachable when
+ * the user has typed a filter that excludes every cached built-in AND a
+ * skill load is still in flight -- an exceedingly rare combination.
+ */
+function LoadingInline() {
   return (
-    <div aria-busy="true" aria-label="Loading commands" className="p-1">
-      {[0, 1, 2].map((i) => (
-        <div key={i} className="flex items-center gap-3 px-3 py-2">
-          <div className="h-5 w-5 rounded bg-muted animate-pulse" />
-          <div className="flex flex-1 flex-col gap-1">
-            <div className="h-3 w-24 rounded bg-muted animate-pulse" />
-            <div className="h-2 w-40 rounded bg-muted animate-pulse" />
-          </div>
-        </div>
-      ))}
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      role="status"
+      className="flex items-center gap-3 px-3 py-2"
+    >
+      <span className="flex h-5 w-5 flex-shrink-0" />
+      <span className="text-sm text-muted-foreground">Loading commands...</span>
     </div>
   );
 }

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -119,25 +119,29 @@ export function useSlashCommand({
     return allCommands.filter((c) => c.name.toLowerCase().includes(f));
   })();
 
-  // Trigger a load when the popup opens AND either (a) we have no skills,
-  // or (b) the current workspace's cwd differs from the cached cwd. The
-  // store now tracks `cwd` for both successful and failed loads, so a
-  // mismatch is the right signal — without this, switching workspaces
-  // would keep showing the previous workspace's commands forever.
+  // Eager prefetch: load skills as soon as cwd/providerId are known, NOT
+  // when the popup opens. This ensures the cache is warm by the time the
+  // user types `/`, so the popup renders the full list on first paint and
+  // the loading skeleton is never visible.
+  //
+  // Conditions to trigger a load:
+  //   - cwd differs from the cached cwd (workspace switch)
+  //   - providerId differs (provider switch)
+  //   - skills are null and no prior error (cold start)
   //
   // The `!error` gate prevents an infinite retry loop on persistent
   // failures: when cwd is unchanged, recovery happens via `onRetry`.
   // When cwd changes, we always load (treating it as a fresh workspace,
   // ignoring any prior error from the old one).
   useEffect(() => {
-    if (!isOpen || isLoading) return;
+    if (isLoading) return;
     const cwdChanged = cachedCwd !== cwd;
     const providerChanged = cachedProviderId !== providerId;
     const noSkills = skills === null;
     if (cwdChanged || providerChanged || (noSkills && !error)) {
       load(cwd, providerId).catch(() => { /* surfaced via `error` */ });
     }
-  }, [isOpen, skills, cachedCwd, cachedProviderId, cwd, providerId, isLoading, error, load]);
+  }, [skills, cachedCwd, cachedProviderId, cwd, providerId, isLoading, error, load]);
 
   const onInputChange = useCallback(
     (value: string) => {


### PR DESCRIPTION
## What
The slash command popup (triggered by typing `/` in the composer) no longer flashes a heavy 3-row shimmer skeleton on cold start, workspace switches, provider switches, cache invalidations, or TTL expiry. It also no longer crops its own content when the list is short.

## Why
The previous behavior:
- Skills were loaded lazily, only after the popup opened (`!isOpen` gate). Every first-time open paid the network round-trip behind a skeleton.
- The popup's render priority placed `isLoading -> SkeletonRows` ahead of the items list, so even when built-ins (`/m:plan`, `/compact`, `/goal`) were available, a shimmer block hid them.
- A `skills.changed` push event blanked the cache and re-showed the skeleton every time.
- `maxHeight` was clamped to `items.length * ITEM_HEIGHT` and applied to the outer wrapper. A 2-item popup capped at 88px lost its second row once the ~28px footer pushed content past the cap (see report screenshot in the linked issue).

The fix makes the skeleton structurally unreachable in normal use and lets short lists render without truncation.

## Key Changes
- `useSlashCommand`: drop the `!isOpen` gate; skills now prefetch as soon as `cwd` / `providerId` are known, so the cache is warm by the time the user types `/`.
- `SlashCommandPopup`: new render precedence `error -> list (items > 0) -> inline loader -> empty`. Built-ins always populate items, so the list branch wins on every common path.
- Replace the 3-row shimmer `SkeletonRows` with a single quiet `LoadingInline` row, only reachable when the user's filter excludes every cached built-in AND a load is still in flight.
- Drop `maxHeight` from the outer popup wrapper so it grows to fit list + footer naturally; cap the inner scroll list at `VISIBLE_ITEMS * ITEM_HEIGHT` so long lists still scroll at 8 rows.
- Adjust the above/below placement estimate to include the footer height, so the popup doesn't get pushed off-screen when there's only room for the list.

## Config Changes
None.

## Test Plan
- [x] `bun x tsc -p . --noEmit` (apps/web) — clean
- [x] `bun x vitest run src/stores/skillsStore.test.ts` — 11/11 pass (invalidate, single-flight, epoch fencing, retry-after-disconnect, provider-scoped cache)
- [x] Wider `bun run test` — 917 passed, 5 skipped, 0 assertion failures (2 worker-startup timeouts unrelated to this change)
- [ ] Manual: type `/` in the composer on a cold Electron launch — verify list paints immediately, no shimmer
- [ ] Manual: switch workspaces, type `/` — verify stale list shows during refetch, then swaps in new commands; no shimmer
- [ ] Manual: trigger a `skills.changed` push event (edit a `~/.claude/skills/*` file) — verify popup keeps showing commands during background refresh
- [ ] Manual: open popup with only built-in commands available — verify both rows visible with full descriptions, footer not clipped
- [ ] Existing E2E `apps/web/e2e/slash-command-popup.spec.ts` (01-05) — should still pass; in particular test 03 (`error response surfaces ErrorRow`) preserved because error precedence wins over the items branch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash commands now prefetch data proactively based on context for faster responses.

* **Bug Fixes**
  * Improved popup placement and sizing for more accurate positioning.
  * Error messages in the slash command menu are surfaced more reliably.

* **Performance & Accessibility**
  * Streamlined loading UI: replaced multi-row loader with a single inline, accessible status indicator (aria-live/aria-busy).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->