### PR TITLE
fix(web): scope inline diff cache by threadId

### DIFF
--- a/apps/web/src/__tests__/TurnTimeline.expand.test.tsx
+++ b/apps/web/src/__tests__/TurnTimeline.expand.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { TurnSnapshot } from "@mcode/contracts";
 import { TurnTimeline } from "../components/diff/TurnTimeline";
+import { useDiffStore } from "../stores/diffStore";
 
 // Mock the transport so FileEntry's lazy diff load resolves immediately.
 vi.mock("@/transport", () => ({
@@ -41,6 +42,7 @@ function snap(id: string, files: string[]): TurnSnapshot {
 describe("TurnTimeline auto-expand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useDiffStore.setState({ inlineDiffCache: {} });
   });
 
   it("expands the latest turn by default", () => {

--- a/apps/web/src/components/diff/CommitEntry.tsx
+++ b/apps/web/src/components/diff/CommitEntry.tsx
@@ -7,6 +7,8 @@ import { FileList } from "./FileList";
 /** Props for CommitEntry. */
 interface CommitEntryProps {
   commit: GitCommit;
+  /** Thread that owns this commit, used to scope the inline diff cache. */
+  threadId: string;
 }
 
 /** Format ISO date to a compact relative string. */
@@ -35,7 +37,7 @@ function getInitials(author: string): string {
  * Single commit row. Avatar is a quiet typographic mark (initials in muted square),
  * not a colored chip. Hierarchy: SHA (mono leading) → message → time.
  */
-export function CommitEntry({ commit }: CommitEntryProps) {
+export function CommitEntry({ commit, threadId }: CommitEntryProps) {
   const [expanded, setExpanded] = useState(false);
   const [files, setFiles] = useState<string[] | null>(null);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
@@ -122,7 +124,7 @@ export function CommitEntry({ commit }: CommitEntryProps) {
               No files changed
             </p>
           ) : (
-            <FileList files={files} source="commit" id={commit.sha} />
+            <FileList files={files} source="commit" id={commit.sha} threadId={threadId} />
           )}
         </div>
       )}

--- a/apps/web/src/components/diff/CommitsView.tsx
+++ b/apps/web/src/components/diff/CommitsView.tsx
@@ -94,7 +94,7 @@ export function CommitsView() {
   return (
     <div className="flex flex-col">
       {commits.map((commit) => (
-        <CommitEntry key={commit.sha} commit={commit} />
+        <CommitEntry key={commit.sha} commit={commit} threadId={activeThreadId!} />
       ))}
     </div>
   );

--- a/apps/web/src/components/diff/CumulativeView.tsx
+++ b/apps/web/src/components/diff/CumulativeView.tsx
@@ -43,7 +43,7 @@ export function CumulativeView({ snapshots, threadId }: CumulativeViewProps) {
           file{files.length !== 1 ? "s" : ""} · {snapshots.length} turn{snapshots.length !== 1 ? "s" : ""}
         </span>
       </div>
-      <FileList files={files} source="cumulative" id={threadId} />
+      <FileList files={files} source="cumulative" id={threadId} threadId={threadId} />
     </div>
   );
 }

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -79,6 +79,17 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
   // fresh, non-cancelled fetch (the first is cancelled by cleanup).
   const loadStartedRef = useRef(false);
 
+  // Reset local state when the cache identity changes so a reused component
+  // instance doesn't show stale content from a previous identity.
+  const cacheKey = `${threadId}:${source}:${id}:${filePath}`;
+  useEffect(() => {
+    const cached = useDiffStore.getState().inlineDiffCache[cacheKey];
+    setDiffState(cached !== undefined ? { loading: false, data: cached } : null);
+    setShowAllLines(false);
+    setPreviewMode(false);
+    loadStartedRef.current = false;
+  }, [cacheKey]);
+
   const { basename, parent, ext, language, isMarkdown } = useMemo(() => {
     const bn = getFileBasename(filePath);
     const pr = getParentDir(filePath);

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -15,6 +15,8 @@ interface FileEntryProps {
   filePath: string;
   source: SelectedFile["source"];
   id: string;
+  /** Thread that owns this file, used to scope the inline diff cache. */
+  threadId: string;
   /**
    * Indentation depth when rendered inside a folder tree. When > 0, the
    * parent-path suffix is suppressed (the folder header above carries it).
@@ -61,13 +63,13 @@ type DiffState = null | { loading: true } | { loading: false; data: string };
  * Diff is loaded lazily on the first expand.
  * Large diffs (>200 lines) are truncated with a "Show all N lines" button.
  */
-export function FileEntry({ filePath, source, id, depth = 0, defaultExpanded: defaultExpandedProp = false }: FileEntryProps) {
+export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultExpanded: defaultExpandedProp = false }: FileEntryProps) {
   const nested = depth > 0;
   const [expanded, setExpanded] = useState(defaultExpandedProp);
   const [showAllLines, setShowAllLines] = useState(false);
   const [previewMode, setPreviewMode] = useState(false);
   // Initialise from the Zustand cache so diffs survive panel close/reopen.
-  const cachedDiff = useDiffStore((s) => s.inlineDiffCache[`${source}:${id}:${filePath}`]);
+  const cachedDiff = useDiffStore((s) => s.inlineDiffCache[`${threadId}:${source}:${id}:${filePath}`]);
   const [diffState, setDiffState] = useState<DiffState>(
     () => (cachedDiff !== undefined ? { loading: false, data: cachedDiff } : null),
   );
@@ -108,7 +110,7 @@ export function FileEntry({ filePath, source, id, depth = 0, defaultExpanded: de
         }
         if (!cancelled) {
           setDiffState({ loading: false, data: result });
-          useDiffStore.getState().cacheInlineDiff(source, id, filePath, result);
+          useDiffStore.getState().cacheInlineDiff(threadId, source, id, filePath, result);
         }
       } catch {
         if (!cancelled) setDiffState({ loading: false, data: "" });
@@ -120,7 +122,7 @@ export function FileEntry({ filePath, source, id, depth = 0, defaultExpanded: de
       cancelled = true;
       loadStartedRef.current = false;
     };
-  }, [expanded, source, id, filePath]);
+  }, [expanded, source, id, filePath, threadId]);
 
   const lines = useMemo(
     () =>

--- a/apps/web/src/components/diff/FileList.tsx
+++ b/apps/web/src/components/diff/FileList.tsx
@@ -9,6 +9,8 @@ interface FileListProps {
   files: string[];
   source: SelectedFile["source"];
   id: string;
+  /** Thread that owns these files, used to scope the inline diff cache. */
+  threadId: string;
   /** When true every file entry starts expanded (used for the latest turn). */
   defaultFilesExpanded?: boolean;
 }
@@ -18,7 +20,7 @@ interface FileListProps {
  * Single-child folder chains are compressed (e.g., `src/stores/__tests__/`).
  * Folders sort before files; both alphabetical within their group.
  */
-export function FileList({ files, source, id, defaultFilesExpanded = false }: FileListProps) {
+export function FileList({ files, source, id, threadId, defaultFilesExpanded = false }: FileListProps) {
   const tree = useMemo(() => buildFileTree(files), [files]);
 
   if (files.length === 0) {
@@ -30,7 +32,7 @@ export function FileList({ files, source, id, defaultFilesExpanded = false }: Fi
   return (
     <div className="flex flex-col">
       {tree.map((node) => (
-        <TreeNodeRenderer key={nodeKey(node)} node={node} depth={0} source={source} id={id} defaultExpanded={defaultFilesExpanded} />
+        <TreeNodeRenderer key={nodeKey(node)} node={node} depth={0} source={source} id={id} threadId={threadId} defaultExpanded={defaultFilesExpanded} />
       ))}
     </div>
   );
@@ -47,16 +49,18 @@ function TreeNodeRenderer({
   depth,
   source,
   id,
+  threadId,
   defaultExpanded,
 }: {
   node: TreeNode;
   depth: number;
   source: SelectedFile["source"];
   id: string;
+  threadId: string;
   defaultExpanded?: boolean;
 }) {
   if (node.type === "file") {
-    return <FileEntry filePath={node.path} source={source} id={id} depth={depth} defaultExpanded={defaultExpanded} />;
+    return <FileEntry filePath={node.path} source={source} id={id} threadId={threadId} depth={depth} defaultExpanded={defaultExpanded} />;
   }
 
   return (
@@ -68,6 +72,7 @@ function TreeNodeRenderer({
           depth={depth + 1}
           source={source}
           id={id}
+          threadId={threadId}
           defaultExpanded={defaultExpanded}
         />
       ))}

--- a/apps/web/src/components/diff/TurnEntry.tsx
+++ b/apps/web/src/components/diff/TurnEntry.tsx
@@ -72,6 +72,7 @@ export function TurnEntry({ snapshot, turnNumber, defaultExpanded = false }: Tur
             files={snapshot.files_changed}
             source="snapshot"
             id={snapshot.id}
+            threadId={snapshot.thread_id}
             defaultFilesExpanded={defaultExpanded}
           />
         </div>

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -94,8 +94,9 @@ interface DiffState {
   /** Whether commits are currently loading, keyed by thread ID. */
   commitsLoadingByThread: Record<string, boolean>;
   /**
-   * Inline diff cache keyed by `"source:id:filePath"`. Survives component
-   * unmounts (panel close/reopen, tab switches) so diffs aren't re-fetched.
+   * Inline diff cache keyed by `"threadId:source:id:filePath"`. Survives
+   * component unmounts (panel close/reopen, tab switches) so diffs aren't
+   * re-fetched. Scoped by thread to prevent cross-thread collisions.
    */
   inlineDiffCache: Record<string, string>;
   /** Currently selected file for diff viewing. */
@@ -137,9 +138,9 @@ interface DiffState {
   /** Set summary loading state. */
   setSummaryLoading: (loading: boolean) => void;
   /** Cache a fetched inline diff so it survives component unmounts. */
-  cacheInlineDiff: (source: string, id: string, filePath: string, data: string) => void;
+  cacheInlineDiff: (threadId: string, source: string, id: string, filePath: string, data: string) => void;
   /** Retrieve a cached inline diff, or undefined if not cached. */
-  getCachedInlineDiff: (source: string, id: string, filePath: string) => string | undefined;
+  getCachedInlineDiff: (threadId: string, source: string, id: string, filePath: string) => string | undefined;
   /** Persist the omnibox URL for a thread's embedded preview. */
   setPreviewUrlForThread: (threadId: string, url: string) => void;
   clearThread: (threadId: string) => void;
@@ -237,12 +238,12 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   setDiffLoading: (loading) => set({ diffLoading: loading }),
   setSummaryRecord: (record) => set({ summaryRecord: record }),
   setSummaryLoading: (loading) => set({ summaryLoading: loading }),
-  cacheInlineDiff: (source, id, filePath, data) =>
+  cacheInlineDiff: (threadId, source, id, filePath, data) =>
     set((s) => ({
-      inlineDiffCache: { ...s.inlineDiffCache, [`${source}:${id}:${filePath}`]: data },
+      inlineDiffCache: { ...s.inlineDiffCache, [`${threadId}:${source}:${id}:${filePath}`]: data },
     })),
-  getCachedInlineDiff: (source, id, filePath) =>
-    get().inlineDiffCache[`${source}:${id}:${filePath}`],
+  getCachedInlineDiff: (threadId, source, id, filePath) =>
+    get().inlineDiffCache[`${threadId}:${source}:${id}:${filePath}`],
   setPreviewUrlForThread: (threadId, url) =>
     set((s) => ({
       previewUrlByThread: { ...s.previewUrlByThread, [threadId]: url },
@@ -262,6 +263,13 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       const previewUrls = { ...state.previewUrlByThread };
       delete previewUrls[threadId];
 
+      // Evict inline diff cache entries scoped to this thread.
+      const prefix = `${threadId}:`;
+      const inlineDiffCache: Record<string, string> = {};
+      for (const [key, value] of Object.entries(state.inlineDiffCache)) {
+        if (!key.startsWith(prefix)) inlineDiffCache[key] = value;
+      }
+
       // Only clear the global selection when it belongs to the deleted thread.
       const selectionBelongsToThread = state.selectedFile?.threadId === threadId;
       const summaryBelongsToThread = state.summaryRecord?.threadId === threadId;
@@ -273,6 +281,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         commitsLoadingByThread: commitsLoading,
         rightPanelByThread: rightPanels,
         previewUrlByThread: previewUrls,
+        inlineDiffCache,
         ...(selectionBelongsToThread
           ? { selectedFile: null, diffContent: null, diffLoading: false }
           : {}),


### PR DESCRIPTION
## What

Addresses three CodeRabbit review findings from #476 that were missed before merge.

## Why

The inline diff cache used `source:id:filePath` as keys, which could collide across threads. Thread deletion also leaked stale cache entries, and tests shared cache state between runs.

## Key changes

- Prefix all `inlineDiffCache` keys with `threadId` to prevent cross-thread collisions
- Thread `threadId` prop through `TurnEntry` → `FileList` → `FileEntry` and `CommitsView` → `CommitEntry` → `FileList`
- Evict cache entries matching the deleted thread's prefix in `clearThread`
- Reset `inlineDiffCache` in test `beforeEach` for proper test isolation

## Related issues/PRs

Relates to #476

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Isolated inline diff cache per thread to prevent stale or cross-thread diffs when switching views.

* **Tests**
  * Improved test setup so lazy diff loading behaves deterministically during test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->