### PR TITLE
fix(claude): disallow AskUserQuestion SDK tool to prevent session stall

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -600,7 +600,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       // ExitPlanMode tools conflict because Mcode has no UI to handle
       // the SDK's "Exit plan mode?" confirmation, causing the model to
       // get stuck.
-      disallowedTools: ["EnterPlanMode", "ExitPlanMode"],
+      // AskUserQuestion is also disallowed: in chat mode the model can
+      // ask questions in plain text, and in plan mode Mcode uses its own
+      // PlanQuestionWizard.  The SDK tool has no result handler here, so
+      // calling it stalls the session indefinitely.
+      disallowedTools: ["EnterPlanMode", "ExitPlanMode", "AskUserQuestion"],
       permissionMode: sdkPermissionMode,
       canUseTool: (async (
         toolName: string,


### PR DESCRIPTION
## What

Adds `AskUserQuestion` to the Claude provider's `disallowedTools` list.

## Why

The Claude Agent SDK's `AskUserQuestion` tool blocks the session indefinitely - the SDK waits for a tool result (user input) that Mcode never sends back. The session hangs at "Working..." with no way to recover.

## Key changes

- Added `"AskUserQuestion"` to `disallowedTools` in `claude-provider.ts` alongside the existing `EnterPlanMode`/`ExitPlanMode` entries
- In chat mode the model asks questions in plain text; in plan mode `PlanQuestionWizard` handles clarifying questions - neither needs the SDK tool

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved stalling behavior in chat and plan interactions by disabling a tool that was causing performance issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->