### PR TITLE
fix(dev): kill full process tree on Windows to release ports

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -12,7 +12,7 @@
  */
 
 import { context, build } from "esbuild";
-import { spawn } from "child_process";
+import { spawn, spawnSync } from "child_process";
 import { watch } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -22,6 +22,27 @@ import {
   resolveServerTscBin,
   copyClaudeSdkCliNextTo,
 } from "../../../scripts/build-server-dev-bundle.mjs";
+
+/**
+ * Kill a child process and its entire process tree.
+ *
+ * On Windows, child.kill() only terminates the direct subprocess (e.g. bun),
+ * leaving grandchildren (e.g. the Vite server spawned by bun) as orphans that
+ * continue holding their network ports across dev sessions. taskkill /F /T
+ * kills the full tree atomically before returning.
+ *
+ * @param {import("child_process").ChildProcess | null} child
+ */
+function killTree(child) {
+  if (!child?.pid) return;
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/F", "/T", "/PID", String(child.pid)], {
+      stdio: "ignore",
+    });
+  } else {
+    child.kill();
+  }
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
@@ -220,7 +241,7 @@ let electronProcess = null;
 /** Spawn (or restart) the Electron process. */
 function spawnElectron() {
   if (electronProcess) {
-    electronProcess.kill();
+    killTree(electronProcess);
     electronProcess = null;
   }
 
@@ -312,7 +333,7 @@ function cleanup() {
   }
 
   if (serverTscWatch) {
-    serverTscWatch.kill();
+    killTree(serverTscWatch);
     serverTscWatch = null;
   }
 
@@ -321,12 +342,12 @@ function cleanup() {
   }
 
   if (electronProcess) {
-    electronProcess.kill();
+    killTree(electronProcess);
     electronProcess = null;
   }
 
   if (viteProcess) {
-    viteProcess.kill();
+    killTree(viteProcess);
     viteProcess = null;
   }
 }

--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -12,7 +12,7 @@
  */
 
 import { context, build } from "esbuild";
-import { spawn, spawnSync } from "child_process";
+import { spawn } from "child_process";
 import { watch } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -22,27 +22,7 @@ import {
   resolveServerTscBin,
   copyClaudeSdkCliNextTo,
 } from "../../../scripts/build-server-dev-bundle.mjs";
-
-/**
- * Kill a child process and its entire process tree.
- *
- * On Windows, child.kill() only terminates the direct subprocess (e.g. bun),
- * leaving grandchildren (e.g. the Vite server spawned by bun) as orphans that
- * continue holding their network ports across dev sessions. taskkill /F /T
- * kills the full tree atomically before returning.
- *
- * @param {import("child_process").ChildProcess | null} child
- */
-function killTree(child) {
-  if (!child?.pid) return;
-  if (process.platform === "win32") {
-    spawnSync("taskkill", ["/F", "/T", "/PID", String(child.pid)], {
-      stdio: "ignore",
-    });
-  } else {
-    child.kill();
-  }
-}
+import { killProcessTree } from "../../../scripts/kill-process-tree.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
@@ -66,7 +46,7 @@ const shared = {
 /**
  * Spawn `tsc --watch` so server source edits re-emit apps/server/dist-tsc.
  *
- * @returns Detached subprocess handle (caller must `.kill()` on shutdown).
+ * @returns Detached subprocess handle (caller must kill via killProcessTree on shutdown).
  */
 function startServerTscWatch() {
   const tscBin = resolveServerTscBin(serverRoot);
@@ -241,7 +221,7 @@ let electronProcess = null;
 /** Spawn (or restart) the Electron process. */
 function spawnElectron() {
   if (electronProcess) {
-    killTree(electronProcess);
+    killProcessTree(electronProcess);
     electronProcess = null;
   }
 
@@ -333,7 +313,7 @@ function cleanup() {
   }
 
   if (serverTscWatch) {
-    killTree(serverTscWatch);
+    killProcessTree(serverTscWatch);
     serverTscWatch = null;
   }
 
@@ -342,12 +322,12 @@ function cleanup() {
   }
 
   if (electronProcess) {
-    killTree(electronProcess);
+    killProcessTree(electronProcess);
     electronProcess = null;
   }
 
   if (viteProcess) {
-    killTree(viteProcess);
+    killProcessTree(viteProcess);
     viteProcess = null;
   }
 }

--- a/scripts/dev-web.mjs
+++ b/scripts/dev-web.mjs
@@ -16,6 +16,7 @@ import { resolve, dirname } from "node:path";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { rebuildServerDevBundle } from "./build-server-dev-bundle.mjs";
+import { killProcessTree } from "./kill-process-tree.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, "..");
@@ -152,19 +153,19 @@ const vite = spawn("bun", ["run", "dev"], {
 
 // Clean shutdown: kill both on exit
 function cleanup() {
-  server.kill();
-  vite.kill();
+  killProcessTree(server);
+  killProcessTree(vite);
 }
 
 process.on("SIGINT", cleanup);
 process.on("SIGTERM", cleanup);
 server.on("exit", () => {
   if (!serverFailed) {
-    vite.kill();
+    killProcessTree(vite);
     process.exit();
   }
 });
 vite.on("exit", () => {
-  server.kill();
+  killProcessTree(server);
   process.exit();
 });

--- a/scripts/kill-process-tree.mjs
+++ b/scripts/kill-process-tree.mjs
@@ -1,0 +1,30 @@
+/**
+ * Platform-aware process tree termination for dev orchestration scripts.
+ *
+ * On Windows, child.kill() only terminates the direct subprocess (e.g. bun),
+ * leaving grandchildren (e.g. the Vite server spawned by bun) as orphans that
+ * continue holding their network ports across dev sessions.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/** Max wait for taskkill to propagate through a deep process tree. */
+export const TASKKILL_TIMEOUT_MS = 5_000;
+
+/**
+ * Kill a child process and its entire process tree.
+ *
+ * @param {import("node:child_process").ChildProcess | null | undefined} child
+ */
+export function killProcessTree(child) {
+  if (!child?.pid) return;
+
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/T", "/F", "/PID", String(child.pid)], {
+      stdio: "ignore",
+      timeout: TASKKILL_TIMEOUT_MS,
+    });
+  } else {
+    child.kill();
+  }
+}


### PR DESCRIPTION
## What

Replace bare `child.kill()` calls in the dev orchestration script with a `killTree()` helper that uses `taskkill /F /T /PID` on Windows.

## Why

On Windows, `child.kill()` issues `TerminateProcess()` against only the direct child process (e.g. `bun`). Grandchildren spawned by that process -- most importantly the Vite dev server launched by `bun run dev` -- are orphaned and keep holding their ports. After each close/restart cycle another Vite instance accumulates, causing the port-exhaustion cascade reported:

```
[web] Port 5173 is in use, trying another one...
[web] Port 5174 is in use, trying another one...
... (5173-5192)
```

`taskkill /F /T /PID` kills the full process tree atomically. `spawnSync` is used so the call completes before `process.exit()` is reached. On Unix, `child.kill()` is retained because SIGTERM propagates to the process group naturally.

## Key Changes

- Add `killTree(child)` helper: `taskkill /F /T` on win32, `child.kill()` elsewhere
- Replace all 4 `.kill()` call sites: `viteProcess`, `electronProcess` (in both `cleanup()` and `spawnElectron()`), and `serverTscWatch`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781912732&installation_id=129163861&pr_number=488&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F488&signature=75723f6ed6fb804170272b6372c6ae75b54447d52783f78078a126b58e835aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved development environment stability by introducing a platform-aware process cleanup mechanism for dev workflows.
  * Ensures spawned processes are reliably terminated on restart and shutdown across Windows and Unix-like systems.
  * Prevents resource leaks and stray background processes that could interfere with subsequent development sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->