### PR TITLE
feat(desktop): gate DevTools to dev desktop and auto-open docked

### DIFF
--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -117,6 +117,8 @@ export default async function afterPack(context) {
       // Reset it so the binary can launch before electron-builder codesigns.
       resetAdHocDarwinSignature: electronPlatformName === "darwin" || electronPlatformName === "mas",
       [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: true,
+      // Packaged apps must not expose Node/V8 inspector on the main binary.
+      [FuseV1Options.EnableNodeCliInspectArguments]: false,
     });
 
     console.log("[after-pack] V8 snapshot fuse enabled");

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -70,17 +70,40 @@ export default async function afterPack(context) {
   console.log("[after-pack] Built renamed server binary");
 
   // -------------------------------------------------------------------------
-  // Step 2: V8 snapshot copy + fuse flip (skip if snapshot not generated).
+  // Step 2: V8 snapshot copy + fuse flip.
   // This runs AFTER the server binary copy so only the main Electron binary
-  // (used for the GUI) gets the fuse — not the ELECTRON_RUN_AS_NODE copy.
+  // (used for the GUI) gets the fuses — not the ELECTRON_RUN_AS_NODE copy.
+  //
+  // The snapshot copy is conditional on the snapshot file existing, but the
+  // fuse flip is always performed so that EnableNodeCliInspectArguments is
+  // disabled on every packaged build regardless of snapshot presence.
   // -------------------------------------------------------------------------
 
-  if (!existsSync(snapshotFile)) {
-    console.log("[after-pack] No snapshot found, skipping fuse configuration");
-  } else {
-    let snapshotDest;
-    let electronBinary;
+  const hasSnapshot = existsSync(snapshotFile);
 
+  // Resolve the main Electron binary path — needed for the fuse flip whether
+  // or not a snapshot was generated.
+  let electronBinary;
+  if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
+    // @electron/fuses expects the main executable, not the framework binary.
+    // It resolves to the framework internally; passing the framework path
+    // causes double Frameworks/ resolution (ENOENT).
+    electronBinary = join(
+      appOutDir,
+      `${context.packager.appInfo.productFilename}.app`,
+      "Contents", "MacOS", context.packager.appInfo.productFilename,
+    );
+  } else if (electronPlatformName === "win32") {
+    electronBinary = join(
+      appOutDir,
+      `${context.packager.appInfo.productFilename}.exe`,
+    );
+  } else {
+    electronBinary = join(appOutDir, context.packager.executableName);
+  }
+
+  if (hasSnapshot) {
+    let snapshotDest;
     if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
       const frameworkDir = join(
         appOutDir,
@@ -88,39 +111,29 @@ export default async function afterPack(context) {
         "Contents/Frameworks/Electron Framework.framework/Resources",
       );
       snapshotDest = join(frameworkDir, "browser_v8_context_snapshot.bin");
-      // @electron/fuses expects the main executable, not the framework binary.
-      // It resolves to the framework internally; passing the framework path
-      // causes double Frameworks/ resolution (ENOENT).
-      electronBinary = join(
-        appOutDir,
-        `${context.packager.appInfo.productFilename}.app`,
-        "Contents", "MacOS", context.packager.appInfo.productFilename,
-      );
-    } else if (electronPlatformName === "win32") {
-      snapshotDest = join(appOutDir, "browser_v8_context_snapshot.bin");
-      electronBinary = join(
-        appOutDir,
-        `${context.packager.appInfo.productFilename}.exe`,
-      );
     } else {
       snapshotDest = join(appOutDir, "browser_v8_context_snapshot.bin");
-      electronBinary = join(appOutDir, context.packager.executableName);
     }
-
     console.log(`[after-pack] Copying snapshot to ${snapshotDest}`);
     copyFileSync(snapshotFile, snapshotDest);
-
-    console.log(`[after-pack] Flipping V8 snapshot fuse on ${electronBinary}`);
-    await flipFuses(electronBinary, {
-      version: FuseVersion.V1,
-      // On ARM64 macOS, flipping fuses invalidates the ad-hoc code signature.
-      // Reset it so the binary can launch before electron-builder codesigns.
-      resetAdHocDarwinSignature: electronPlatformName === "darwin" || electronPlatformName === "mas",
-      [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: true,
-      // Packaged apps must not expose Node/V8 inspector on the main binary.
-      [FuseV1Options.EnableNodeCliInspectArguments]: false,
-    });
-
-    console.log("[after-pack] V8 snapshot fuse enabled");
+  } else {
+    console.log("[after-pack] No snapshot found, skipping snapshot copy");
   }
+
+  console.log(`[after-pack] Flipping security fuses on ${electronBinary}`);
+  await flipFuses(electronBinary, {
+    version: FuseVersion.V1,
+    // On ARM64 macOS, flipping fuses invalidates the ad-hoc code signature.
+    // Reset it so the binary can launch before electron-builder codesigns.
+    resetAdHocDarwinSignature: electronPlatformName === "darwin" || electronPlatformName === "mas",
+    // Only enable the browser-process V8 snapshot fuse when the snapshot was
+    // actually copied into the app bundle; otherwise Electron crashes trying
+    // to load a missing file.
+    [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: hasSnapshot,
+    // Packaged apps must not expose Node/V8 inspector on the main binary.
+    // This runs unconditionally — independent of snapshot presence.
+    [FuseV1Options.EnableNodeCliInspectArguments]: false,
+  });
+
+  console.log("[after-pack] Security fuses applied");
 }

--- a/apps/desktop/src/main/__tests__/is-desktop-dev.test.ts
+++ b/apps/desktop/src/main/__tests__/is-desktop-dev.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("electron", () => ({
+  app: { isPackaged: false },
+}));
+
+describe("isDesktopDev", () => {
+  const originalRendererUrl = process.env.ELECTRON_RENDERER_URL;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.ELECTRON_RENDERER_URL;
+  });
+
+  afterEach(() => {
+    if (originalRendererUrl === undefined) {
+      delete process.env.ELECTRON_RENDERER_URL;
+    } else {
+      process.env.ELECTRON_RENDERER_URL = originalRendererUrl;
+    }
+  });
+
+  it("is true when unpackaged and ELECTRON_RENDERER_URL is set", async () => {
+    process.env.ELECTRON_RENDERER_URL = "http://localhost:5173";
+    const { isDesktopDev } = await import("../is-desktop-dev.js");
+    expect(isDesktopDev()).toBe(true);
+  });
+
+  it("is false when ELECTRON_RENDERER_URL is unset", async () => {
+    const { isDesktopDev } = await import("../is-desktop-dev.js");
+    expect(isDesktopDev()).toBe(false);
+  });
+
+  it("is false when the app is packaged even if ELECTRON_RENDERER_URL is set", async () => {
+    vi.doMock("electron", () => ({
+      app: { isPackaged: true },
+    }));
+    process.env.ELECTRON_RENDERER_URL = "http://localhost:5173";
+    const { isDesktopDev } = await import("../is-desktop-dev.js");
+    expect(isDesktopDev()).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/is-desktop-dev.ts
+++ b/apps/desktop/src/main/is-desktop-dev.ts
@@ -1,0 +1,10 @@
+import { app } from "electron";
+
+/**
+ * True when the desktop app is running the dev orchestration flow
+ * (`bun run dev:desktop`), which sets `ELECTRON_RENDERER_URL` to the Vite dev
+ * server. Packaged installs and local `bun run prod` never set that variable.
+ */
+export function isDesktopDev(): boolean {
+  return !app.isPackaged && !!process.env.ELECTRON_RENDERER_URL;
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -44,6 +44,7 @@ import { setupSpellcheck } from "./spellcheck.js";
 import { registerPreviewBrowserHandlers, disposePreviewForWindow } from "./preview/index.js";
 import { startBrowserUseBridge, disposeBrowserUseBridge } from "./browser-use/index.js";
 import { resolveMcodeWorkspacePreviewUrl } from "./preview/preview-local-file.js";
+import { isDesktopDev } from "./is-desktop-dev.js";
 
 // Isolate dev's Electron userData (cache, cookies, localStorage, IndexedDB)
 // from the installed prod build. Without this, both share %APPDATA%/Mcode/
@@ -270,6 +271,9 @@ function createWindow(): void {
       // process risks; the will-attach-webview hook below clamps webPreferences
       // and we never expose nodeIntegrationInSubFrames.
       webviewTag: true,
+      // Chromium DevTools only in `bun run dev:desktop` (ELECTRON_RENDERER_URL).
+      // Packaged releases and local `bun run prod` keep DevTools disabled.
+      devTools: isDesktopDev(),
     },
   });
 
@@ -297,6 +301,7 @@ function createWindow(): void {
     webPreferences.nodeIntegration = false;
     webPreferences.contextIsolation = true;
     webPreferences.sandbox = true;
+    webPreferences.devTools = false;
     delete (webPreferences as { preload?: string }).preload;
     delete (webPreferences as { preloadURL?: string }).preloadURL;
     params.partition = "persist:mcode-preview";
@@ -335,6 +340,14 @@ function createWindow(): void {
     mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL);
   } else {
     mainWindow.loadFile(join(__dirname, "../renderer/index.html"));
+  }
+
+  if (isDesktopDev()) {
+    mainWindow.webContents.once("did-finish-load", () => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.openDevTools({ mode: "right" });
+      }
+    });
   }
 }
 

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -16,6 +16,7 @@ import { resolve, join, dirname } from "path";
 import { getMcodeDir } from "@mcode/shared";
 import { SettingsSchema as BundledSettingsSchema } from "@mcode/contracts";
 import { resolveServerBinary } from "./server-binary-resolver.js";
+import { isDesktopDev } from "./is-desktop-dev.js";
 
 /** Use snapshot-provided schema when available (V8 snapshot pre-initializes Zod). */
 const SettingsSchema = globalThis.__v8Snapshot?.contracts?.SettingsSchema ?? BundledSettingsSchema;
@@ -60,9 +61,8 @@ function getServerPaths(): {
  *  - Packaged installed app (app.isPackaged):  19700-19799
  * The standalone server defaults to 19400 via MCODE_PORT.
  */
-const isDev = !!process.env.ELECTRON_RENDERER_URL;
-const PORT_MIN = app.isPackaged ? 19700 : isDev ? 19500 : 19600;
-const PORT_MAX = app.isPackaged ? 19800 : isDev ? 19600 : 19700;
+const PORT_MIN = app.isPackaged ? 19700 : isDesktopDev() ? 19500 : 19600;
+const PORT_MAX = app.isPackaged ? 19800 : isDesktopDev() ? 19600 : 19700;
 
 /** Interval (ms) between health-check polls during startup. */
 const HEALTH_POLL_INTERVAL = 200;
@@ -330,7 +330,7 @@ export class ServerManager {
         MCODE_VERSION: app.getVersion(),
       };
 
-      if (isDev && !process.env.MCODE_GIT_BRANCH) {
+      if (isDesktopDev() && !process.env.MCODE_GIT_BRANCH) {
         try {
           const branch = execSync("git rev-parse --abbrev-ref HEAD", {
             encoding: "utf-8",
@@ -347,7 +347,7 @@ export class ServerManager {
         env.MCODE_GIT_BRANCH = process.env.MCODE_GIT_BRANCH;
       }
 
-      if (isDev && !process.env.MCODE_GIT_TOPLEVEL) {
+      if (isDesktopDev() && !process.env.MCODE_GIT_TOPLEVEL) {
         try {
           const top = execSync("git rev-parse --show-toplevel", {
             encoding: "utf-8",
@@ -382,7 +382,7 @@ export class ServerManager {
 
       // In production, route stderr to a log file so crashes are diagnosable.
       // Dev mode inherits stdio for immediate console visibility.
-      const stderrStream = isDev
+      const stderrStream = isDesktopDev()
         ? undefined
         : createWriteStream(SERVER_LOG_PATH, { flags: "w" });
 
@@ -400,7 +400,7 @@ export class ServerManager {
           cwd,
           env,
           detached: true,
-          stdio: isDev ? "inherit" : ["ignore", "ignore", stderrStream ? "pipe" : "ignore"],
+          stdio: isDesktopDev() ? "inherit" : ["ignore", "ignore", stderrStream ? "pipe" : "ignore"],
         });
       } catch (err) {
         stderrStream?.destroy();
@@ -410,7 +410,7 @@ export class ServerManager {
       this.serverProcess = child;
 
       // Pipe stderr to the log file when running packaged
-      if (!isDev && stderrStream && child.stderr) {
+      if (!isDesktopDev() && stderrStream && child.stderr) {
         child.stderr.pipe(stderrStream);
       }
 


### PR DESCRIPTION
## What
Disable Chromium DevTools in packaged and prod desktop builds, and auto-open DevTools docked on the right when running `bun run dev:desktop`.

## Why
Production installs should not expose the renderer debugger. Desktop development should open DevTools automatically so engineers do not need a manual step on every launch.

## Key Changes
- Add `isDesktopDev()` helper keyed on `ELECTRON_RENDERER_URL` (set only by `dev-electron.mjs`)
- Set `webPreferences.devTools` to false outside dev desktop; block DevTools on preview webviews
- Auto-open DevTools with `mode: "right"` after the renderer loads in dev desktop
- Disable `EnableNodeCliInspectArguments` on the packaged Electron binary in `after-pack.mjs`
- Unit tests for `isDesktopDev()`

## Test plan
- [ ] `bun run dev:desktop`: DevTools opens docked on the right
- [ ] Packaged build / `bun run prod`: DevTools unavailable (F12 blocked)
- [ ] `cd apps/desktop && bun run typecheck && bunx vitest run src/main/__tests__/is-desktop-dev.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781940290&installation_id=129163861&pr_number=497&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F497&signature=a8e4d1761a55447341182e9c5bd863e9183c83db29b8b15c257d8f4833cbf61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Packaged apps further lock down Node/V8 inspector exposure for improved runtime safety.
* **Behavior**
  * DevTools are enabled only in development; disabled in packaged/production runs.
  * Startup behavior now reliably distinguishes dev vs. packaged runs to ensure appropriate runtime modes.
* **Tests**
  * Added test coverage for development-environment detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->