### PR TITLE
fix(handoff): use sessionless path B-prime for stale parent sessions

### DIFF
--- a/apps/server/src/providers/claude/__tests__/side-channel-sessionless.test.ts
+++ b/apps/server/src/providers/claude/__tests__/side-channel-sessionless.test.ts
@@ -4,7 +4,9 @@
  * When `resume:` fails because the SDK's process-local session cache is empty
  * (typically after a server restart), `runSideChannelQuery` should transparently
  * retry without `resume:` when `conversationHistory` is supplied, keeping path B
- * alive instead of forcing a fall to path D.
+ * alive instead of forcing a fall to path D. When the parent has no live SDK
+ * subprocess at all, it should skip resume entirely and use sessionless path
+ * B-prime on the first call.
  *
  * NOTE: ClaudeProvider injects EnvService via tsyringe DI and spawns real SDK
  * subprocesses; unit-testing it end-to-end requires mocking both the DI
@@ -63,9 +65,49 @@ function makeAsyncIterable(messages: Record<string, unknown>[]) {
   })();
 }
 
+/** Mark the parent thread as having a live SDK subprocess (resume path eligible). */
+function withLiveParentSession(provider: ClaudeProvider, threadId = "t_parent") {
+  (provider as any).sessions.set(`mcode-${threadId}`, {
+    query: { close: vi.fn() },
+    pushMessage: vi.fn(),
+    closeQueue: vi.fn(),
+    model: "claude-sonnet-4-6",
+    permissionMode: "default",
+    contextWindowMode: undefined,
+    lastUsedAt: Date.now(),
+    pendingToolUses: new Set<string>(),
+  });
+}
+
 describe("runSideChannelQuery sessionless fallback", () => {
   beforeEach(() => {
     mockQuery.mockReset();
+  });
+
+  it("uses sessionless path immediately when parent has no live SDK session", async () => {
+    const successResult = [
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "# Handoff\n\n## Goal\nStale session fork" }],
+        },
+      },
+    ];
+    mockQuery.mockReturnValueOnce(makeAsyncIterable(successResult));
+
+    const provider = makeProvider();
+    const result = await (provider as any).runSideChannelQuery({
+      parentThreadId: "t_parent",
+      parentSdkSessionId: "sdk_abc123",
+      prompt: "Generate a handoff document.",
+      conversationHistory: "User: hello\nAssistant: hi there",
+      cwd: "/tmp/test-cwd",
+    });
+
+    expect(result).toBe("# Handoff\n\n## Goal\nStale session fork");
+    // Must not attempt resume when no live parent session exists.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0][0].options).not.toHaveProperty("resume");
   });
 
   it("returns the second call's text when the first call fails with session-missing error and history is provided", async () => {
@@ -92,6 +134,7 @@ describe("runSideChannelQuery sessionless fallback", () => {
       .mockReturnValueOnce(makeAsyncIterable(successResult));
 
     const provider = makeProvider();
+    withLiveParentSession(provider);
     const result = await (provider as any).runSideChannelQuery({
       parentThreadId: "t_parent",
       parentSdkSessionId: "sdk_abc123",

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -223,6 +223,9 @@ export function detectFallbackModel(
   return usedModels[0] ?? null;
 }
 
+/** Max time to wait on a resume side-channel before falling back to sessionless. */
+const SIDE_CHANNEL_RESUME_PROBE_MS = 20_000;
+
 /** Claude Agent SDK adapter implementing IAgentProvider with prompt queue pattern. */
 @injectable()
 export class ClaudeProvider extends EventEmitter implements IAgentProvider {
@@ -452,9 +455,38 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     // Resolve model from the parent thread's active session if available,
     // falling back to the default claude-sonnet model.
     const parentSessionId = `mcode-${args.parentThreadId}`;
+    const hasLiveParentSession = this.sessions.has(parentSessionId);
+
+    // Path B-prime: after a server restart (or when the user forks without
+    // sending a new message on the parent), the SDK subprocess is not running
+    // even though sdk_session_id is still in SQLite. Resume on a cold subprocess
+    // often hangs until the pipeline abort fires, leaving no time for the
+    // sessionless retry. Skip resume and bake message history into the prompt.
+    if (!hasLiveParentSession && args.conversationHistory) {
+      logger.info("Claude side-channel: no live parent session, using sessionless path B-prime", {
+        threadId: args.parentThreadId,
+      });
+      return await this.runSideChannelQuerySessionless(
+        args.conversationHistory,
+        prompt,
+        abortSignal,
+        args.parentThreadId,
+        cwd,
+      );
+    }
+
     const model = this.sessions.get(parentSessionId)?.model ?? DEFAULT_CLAUDE_MODEL;
 
     const backup = snapshotProcessEnv();
+    // Cap resume attempts so a hung subprocess does not consume the full
+    // pipeline timeout before sessionless path B-prime can run.
+    const resumeProbe = args.conversationHistory ? new AbortController() : null;
+    let resumeProbeTimer: ReturnType<typeof setTimeout> | undefined;
+    if (resumeProbe && abortSignal && !abortSignal.aborted) {
+      resumeProbeTimer = setTimeout(() => resumeProbe.abort(), SIDE_CHANNEL_RESUME_PROBE_MS);
+      abortSignal.addEventListener("abort", () => resumeProbe.abort(), { once: true });
+    }
+
     try {
       const merged = this.envService.getEnv();
       for (const [k, v] of Object.entries(merged)) {
@@ -464,17 +496,19 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       const queue = createPromptQueue();
       const ephemeralId = `side-channel-${crypto.randomUUID()}`;
 
+      const sdkAbortSource = resumeProbe?.signal ?? abortSignal;
+
       // The SDK takes an AbortController, not a bare AbortSignal. We cannot
       // overwrite `signal` on a real AbortController (it is a getter-only
       // property and Object.assign throws on modern Node). Instead, create a
       // fresh controller and forward aborts from the caller's signal to it.
       let sdkAbortController: AbortController | undefined;
-      if (abortSignal) {
+      if (sdkAbortSource) {
         sdkAbortController = new AbortController();
-        if (abortSignal.aborted) {
+        if (sdkAbortSource.aborted) {
           sdkAbortController.abort();
         } else {
-          abortSignal.addEventListener("abort", () => sdkAbortController?.abort(), { once: true });
+          sdkAbortSource.addEventListener("abort", () => sdkAbortController?.abort(), { once: true });
         }
       }
 
@@ -535,6 +569,23 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       if (!assistantText) throw new Error("Claude side-channel query returned empty output");
       return assistantText.trim();
     } catch (err) {
+      const resumeProbeTimedOut =
+        resumeProbe?.signal.aborted === true && abortSignal && !abortSignal.aborted;
+
+      // Resume hung before the pipeline timeout. Retry sessionless while budget remains.
+      if (resumeProbeTimedOut && args.conversationHistory) {
+        logger.info("Claude side-channel: resume probe timed out, retrying without resume", {
+          threadId: args.parentThreadId,
+        });
+        return await this.runSideChannelQuerySessionless(
+          args.conversationHistory,
+          args.prompt,
+          abortSignal,
+          args.parentThreadId,
+          args.cwd,
+        );
+      }
+
       // Detect session-not-found / expired errors. Includes the actual SDK
       // phrase "No conversation found with session ID: ..." seen in user logs.
       const msg = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
@@ -564,6 +615,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       }
       throw err;
     } finally {
+      if (resumeProbeTimer) clearTimeout(resumeProbeTimer);
       restoreProcessEnv(backup);
     }
   }

--- a/apps/server/src/services/handoff/handoff-pipeline.ts
+++ b/apps/server/src/services/handoff/handoff-pipeline.ts
@@ -79,8 +79,12 @@ interface IWorkspaceRepo {
   findById(id: string): Promise<any> | any;
 }
 
-/** Timeout for side-channel and hidden-turn provider calls, in milliseconds. */
-const PROVIDER_CALL_TIMEOUT_MS = 60_000;
+/**
+ * Timeout for side-channel and hidden-turn provider calls, in milliseconds.
+ * Handoff generation includes a cold SDK subprocess start plus model inference;
+ * 60s was too tight after server restarts on Windows.
+ */
+const PROVIDER_CALL_TIMEOUT_MS = 120_000;
 
 @injectable()
 export class HandoffPipelineService {


### PR DESCRIPTION
## What
Fix fork handoffs timing out and falling to deterministic path D after a server restart when the parent thread has no live SDK subprocess.

## Why
After restarting Mcode, users could fork from an existing Claude thread without sending a new message on the parent first. Path B attempted `resume:` on a cold SDK subprocess, hung for the full timeout, and fell to path D instead of generating a provider handoff via the /handoff skill.

## Key Changes
- Skip `resume:` and use path B-prime (sessionless side-channel with baked-in message history) when the parent has no live SDK subprocess
- Add a 20s resume probe timeout with sessionless fallback when resume hangs but history is available
- Raise the handoff pipeline provider timeout from 60s to 120s for cold SDK startup plus model inference
- Add regression tests for the stale-session fork path

## Test plan
- [x] `cd apps/server && bunx vitest run src/services/handoff src/providers/claude/__tests__/side-channel-sessionless.test.ts` (48/48 passed)
- [x] Manual: restart Mcode, fork from a stale parent thread without sending a message, confirm path B succeeds and server log shows `using sessionless path B-prime`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782148724&installation_id=129163861&pr_number=501&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F501&signature=52b3c0ff4d8f9cece7214c3bc59c20bc035af628345837fbe3c53b6fe78ab60d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced side-channel resume behavior to automatically fall back to sessionless mode when parent session is unavailable.
  * Increased provider-call timeout from 60 to 120 seconds for improved reliability during side-channel operations.

* **Tests**
  * Expanded test coverage for session fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->