### PR TITLE
fix(web): restore right panel resize on terminal tab

### DIFF
--- a/apps/web/e2e/right-panel-terminal-resize.spec.ts
+++ b/apps/web/e2e/right-panel-terminal-resize.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { Thread } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-panel-resize",
+  name: "Panel Resize",
+  path: "/tmp/panel-resize",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+function makeThread(id: string, title: string): Thread {
+  return {
+    id,
+    workspace_id: WORKSPACE.id,
+    title,
+    status: "paused",
+    mode: "direct",
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+  };
+}
+
+const THREAD = makeThread("thread-resize", "Resize Thread");
+
+/** Reads the stored right-panel width for a thread from diffStore. */
+async function getRightPanelWidth(page: Page, threadId: string): Promise<number> {
+  return page.evaluate((tid) => {
+    const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+    const diffStore = stores.find((s: unknown) => {
+      const st = (s as { getState: () => Record<string, unknown> }).getState();
+      return "getRightPanel" in st;
+    });
+    if (!diffStore) return 0;
+    const panel = (
+      diffStore as { getState: () => { getRightPanel: (id: string) => { width: number } } }
+    )
+      .getState()
+      .getRightPanel(tid);
+    return panel.width;
+  }, threadId);
+}
+
+/** Opens the right-panel terminal tab and mounts a PTY for the thread. */
+async function openTerminalWithPty(page: Page, threadId: string): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread, tid }) => {
+      const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const wsStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "activeThreadId" in st && "threads" in st;
+      });
+      if (wsStore) {
+        (wsStore as { setState: (p: unknown) => void }).setState({
+          workspaces: [workspace],
+          activeWorkspaceId: workspace.id,
+          threads: [thread],
+          activeThreadId: tid,
+        });
+      }
+
+      const diffStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "showRightPanel" in st && "setRightPanelTab" in st;
+      });
+      if (diffStore) {
+        const api = (
+          diffStore as {
+            getState: () => {
+              showRightPanel: (id: string) => void;
+              setRightPanelTab: (id: string, tab: string) => void;
+            };
+          }
+        ).getState();
+        api.showRightPanel(tid);
+        api.setRightPanelTab(tid, "terminal");
+      }
+
+      const termStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "addTerminal" in st;
+      });
+      if (termStore) {
+        (
+          termStore as {
+            getState: () => { addTerminal: (a: string, b: string, c?: string) => void };
+          }
+        )
+          .getState()
+          .addTerminal(tid, `pty-${tid}`, "bash");
+      }
+    },
+    { workspace: WORKSPACE, thread: THREAD, tid: threadId },
+  );
+}
+
+test.describe("Right panel resize with terminal tab", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [THREAD],
+      "terminal.create": { ptyId: "pty-thread-resize", shell: "bash" },
+      "terminal.resize": true,
+      "terminal.kill": true,
+      "terminal.killByThread": true,
+      "settings.get": getDefaultSettings(),
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1920, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+  });
+
+  test("drag handle resizes panel while terminal tab is active", async ({ page }) => {
+    await openTerminalWithPty(page, THREAD.id);
+
+    await expect(page.locator(".xterm")).toBeVisible({ timeout: 15_000 });
+
+    const handle = page.locator('[role="separator"][aria-orientation="vertical"].cursor-col-resize');
+    await expect(handle).toBeVisible();
+    const box = await handle.boundingBox();
+    expect(box, "vertical resize handle must be visible").not.toBeNull();
+
+    const widthBefore = await getRightPanelWidth(page, THREAD.id);
+    expect(widthBefore).toBeGreaterThan(0);
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x - 80, box!.y + box!.height / 2, { steps: 8 });
+    await page.mouse.up();
+
+    await expect
+      .poll(() => getRightPanelWidth(page, THREAD.id), { timeout: 3_000 })
+      .not.toBe(widthBefore);
+  });
+});

--- a/apps/web/src/__tests__/right-panel-resize.test.ts
+++ b/apps/web/src/__tests__/right-panel-resize.test.ts
@@ -1,0 +1,15 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+
+const RIGHT_PANEL_SRC = readFileSync(
+  new URL("../components/panels/RightPanel.tsx", import.meta.url),
+  "utf-8",
+);
+
+describe("RightPanel resize handle stacking", () => {
+  it("keeps the col-resize handle above the terminal tab layer", () => {
+    expect(RIGHT_PANEL_SRC).toMatch(/z-20[^"]*cursor-col-resize/);
+    expect(RIGHT_PANEL_SRC).toMatch(/activeTab === "terminal" && "z-10"/);
+  });
+});

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -234,7 +234,7 @@ export function RightPanel() {
         role="separator"
         aria-orientation="vertical"
         tabIndex={0}
-        className="absolute left-0 top-0 bottom-0 z-10 flex w-3 cursor-col-resize justify-center bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        className="absolute left-0 top-0 bottom-0 z-20 flex w-3 cursor-col-resize justify-center bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         onMouseDown={onDragStart}
         onDoubleClick={() => {
           const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;


### PR DESCRIPTION
## What
Restore the right panel drag handle when the Terminal tab is active.

## Why
After the terminal moved into the right panel, its content layer used the same z-index as the resize handle. The terminal layer sat on top and blocked mouse events, so the panel could not be resized on that tab.

## Key Changes
- Raise the right panel drag handle from z-10 to z-20 so it stacks above the terminal tab layer
- Add a Playwright E2E test that drags the handle with the terminal tab open
- Add a unit test that guards the z-index stacking contract in RightPanel.tsx

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782149520&installation_id=129163861&pr_number=502&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F502&signature=35d7a3ddb63b89c26a726389982309f16b8d7ca7dcb4ac0548d5d0a6cf365e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the stacking order of the right-panel resize handle to ensure proper visibility and interaction when the terminal tab is active.

* **Tests**
  * Added end-to-end tests to verify right-panel resize behavior with active terminal tabs.
  * Added unit tests to validate right-panel styling and layering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->