### PR TITLE
docs(agents): configure per-repo skill metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,22 @@ This repo is configured for four agent harnesses. All four read `AGENTS.md` (Cla
 
 All four harnesses expose the same six commands: `/verify`, `/verify-e2e`, `/verify-e2e-desktop`, `/demo`, `/demo-desktop`, `/review-pr`. Claude Code additionally has specialized subagents under `.claude/agents/` (`frontend-engineer`, `backend-engineer`, `qa-engineer`, `security-reviewer`). The shell equivalents are documented in `docs/agents/runtime.md` § Common Workflows.
 
+## Agent skills
+
+Per-repo configuration for the engineering skills (`to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, `zoom-out`). These tell the skills how this repo tracks issues, what labels to apply during triage, and where domain docs live.
+
+### Issue tracker
+
+GitHub Issues at [Mzeey-Empire/mcode](https://github.com/Mzeey-Empire/mcode) via the `gh` CLI. See [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See [`docs/agents/triage-labels.md`](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See [`docs/agents/domain.md`](docs/agents/domain.md).
+
 ## Directory Structure
 
 ```text

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,39 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — Mcode's domain glossary (thread, fork, handoff, provider terms, etc.)
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Mcode is a single-context repo:
+
+```
+/
+├── CONTEXT.md            ← project-wide glossary
+├── docs/adr/             ← architectural decision records
+└── apps/, packages/      ← source
+```
+
+Even though Mcode is a monorepo (`apps/server`, `apps/web`, `apps/desktop`, `packages/contracts`, `packages/shared`), domain terms like `Thread`, `Message`, `Workspace`, `AgentEvent`, `Provider`, `Handoff` are intentionally shared across packages via `packages/contracts`. They belong in a single project-wide glossary.
+
+If you ever start seeing naming collisions across packages (e.g. "Session" meaning different things in server vs. web), revisit `/setup-matt-pocock-skills` to migrate to a multi-context layout with `CONTEXT-MAP.md`.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids — e.g. say "Fork" not "Branch" when referring to chat-thread branching (the glossary explicitly notes this rename).
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_
+
+`docs/adr/` doesn't exist yet; ADRs will appear as they get written by `/grill-with-docs` or by hand.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues at [Mzeey-Empire/mcode](https://github.com/Mzeey-Empire/mcode). Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's GitHub issue tracker.
+
+| Canonical role    | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Only `wontfix` exists in the repo today. The other four labels will be created the first time a `triage` run needs to apply them (or you can pre-create with `gh label create <name>`).
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## What

Adds an `Agent skills` section to `AGENTS.md` and three new docs under `docs/agents/` that tell engineering skills how this repo tracks issues, labels triage, and structures domain docs.

## Why

Skills like `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, and `improve-codebase-architecture` need per-repo configuration to function. Without it they have to ask every time which tracker to file against, which labels to apply, and where to look for domain language. This commit answers those questions once so the skills can run unattended.

## Key Changes

- `AGENTS.md` — new `## Agent skills` section between "Supported Agent Harnesses" and "Directory Structure" with pointers to the three docs
- `docs/agents/issue-tracker.md` — GitHub Issues via the `gh` CLI, with the conventions skills should use to create, read, label, comment on, and close issues
- `docs/agents/triage-labels.md` — canonical five-role mapping (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). Only `wontfix` currently exists on the repo; the others will be created on first use
- `docs/agents/domain.md` — declares Mcode as single-context (one `CONTEXT.md` at the repo root, shared across the monorepo), with guidance on glossary vocabulary and ADR conflict flagging

No code changes. `bun run verify` skipped (no code paths affected).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782172204&installation_id=129163861&pr_number=504&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F504&signature=1d97e07a7f8ff28c2758b447f98acf62a157800a5b2336082b8410fdb1148805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub issue tracker conventions for creating, viewing, and managing issues.
  * Added triage label mapping for consistent issue classification.
  * Added guidance for consuming domain documentation resources.
  * Updated agent skills configuration documentation with repo-specific integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->