### PR TITLE
fix(auto-updater): suppress transient DNS errors from update banner

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater-channel.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater-channel.test.ts
@@ -38,7 +38,12 @@ vi.mock("@mcode/shared", () => ({
   getMcodeDir: vi.fn().mockReturnValue("/tmp/mcode"),
 }));
 
-import { applyChannelConfig, applyReleaseLineSwitch, isCrossChannelDowngrade } from "../auto-updater";
+import {
+  applyChannelConfig,
+  applyReleaseLineSwitch,
+  isCrossChannelDowngrade,
+  isTransientNetworkError,
+} from "../auto-updater";
 
 describe("applyChannelConfig", () => {
   beforeEach(() => {
@@ -163,6 +168,47 @@ describe("isCrossChannelDowngrade", () => {
         latestStable: "0.11.1",
       }),
     ).toBe(false);
+  });
+});
+
+describe("isTransientNetworkError", () => {
+  it("classifies Chromium net::ERR_NAME_NOT_RESOLVED as transient", () => {
+    // Regression: this was surfaced as a scary red "Update failed" banner
+    // when the app launched before WiFi reconnected. See UpdateBanner.tsx.
+    expect(isTransientNetworkError(new Error("net::ERR_NAME_NOT_RESOLVED"))).toBe(true);
+  });
+
+  it("classifies other Chromium connectivity errors as transient", () => {
+    expect(isTransientNetworkError(new Error("net::ERR_INTERNET_DISCONNECTED"))).toBe(true);
+    expect(isTransientNetworkError(new Error("net::ERR_CONNECTION_RESET"))).toBe(true);
+    expect(isTransientNetworkError(new Error("net::ERR_TIMED_OUT"))).toBe(true);
+    expect(isTransientNetworkError(new Error("net::ERR_PROXY_CONNECTION_FAILED"))).toBe(true);
+  });
+
+  it("classifies Node POSIX socket/DNS codes as transient", () => {
+    const err = Object.assign(new Error("getaddrinfo ENOTFOUND github.com"), {
+      code: "ENOTFOUND",
+    });
+    expect(isTransientNetworkError(err)).toBe(true);
+
+    const econn = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    expect(isTransientNetworkError(econn)).toBe(true);
+
+    const etimeout = Object.assign(new Error("read ETIMEDOUT"), { code: "ETIMEDOUT" });
+    expect(isTransientNetworkError(etimeout)).toBe(true);
+  });
+
+  it("does not classify real update failures as transient", () => {
+    expect(isTransientNetworkError(new Error("HttpError: 404"))).toBe(false);
+    expect(isTransientNetworkError(new Error("signature verification failed"))).toBe(false);
+    expect(isTransientNetworkError(new Error("Cannot find latest.yml"))).toBe(false);
+    expect(isTransientNetworkError(new Error("Cannot parse update info"))).toBe(false);
+  });
+
+  it("handles non-Error inputs without throwing", () => {
+    expect(isTransientNetworkError(undefined)).toBe(false);
+    expect(isTransientNetworkError(null)).toBe(false);
+    expect(isTransientNetworkError("net::ERR_NAME_NOT_RESOLVED")).toBe(true);
   });
 });
 

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -22,6 +22,55 @@ import { SettingsSchema as BundledSettingsSchema } from "@mcode/contracts";
 /** Use snapshot-provided schema when available (V8 snapshot pre-initializes Zod). */
 const SettingsSchema = globalThis.__v8Snapshot?.contracts?.SettingsSchema ?? BundledSettingsSchema;
 
+/**
+ * Connectivity-class error tokens that should NOT surface as a red
+ * "Update failed" banner. These are transient: WiFi reconnecting, VPN flap,
+ * captive portal, IPv6 resolver hiccup, brief DNS outage. The next periodic
+ * check will succeed without user intervention, so the right UX is to stay
+ * quiet rather than alarm the user about a self-healing condition.
+ *
+ * Chromium `net::ERR_*` codes are emitted when the updater goes through
+ * Electron's net module; POSIX `E*` codes are emitted by Node-level DNS/socket
+ * failures (still possible inside electron-updater's HTTP layer on some paths).
+ */
+const TRANSIENT_NETWORK_TOKENS: readonly string[] = [
+  "ERR_NAME_NOT_RESOLVED",
+  "ERR_INTERNET_DISCONNECTED",
+  "ERR_NETWORK_CHANGED",
+  "ERR_PROXY_CONNECTION_FAILED",
+  "ERR_CONNECTION_RESET",
+  "ERR_CONNECTION_REFUSED",
+  "ERR_CONNECTION_TIMED_OUT",
+  "ERR_CONNECTION_ABORTED",
+  "ERR_CONNECTION_CLOSED",
+  "ERR_NETWORK_IO_SUSPENDED",
+  "ERR_TIMED_OUT",
+  "ERR_ADDRESS_UNREACHABLE",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ECONNABORTED",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+];
+
+/**
+ * True for connectivity-class failures that should be logged but not surfaced
+ * to the user as an update error. See `TRANSIENT_NETWORK_TOKENS` for the
+ * concrete set and the rationale.
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (typeof code === "string" && TRANSIENT_NETWORK_TOKENS.includes(code)) {
+    return true;
+  }
+  return TRANSIENT_NETWORK_TOKENS.some((token) => message.includes(token));
+}
+
 /** Map from user-friendly interval names to milliseconds. */
 const INTERVAL_MS_MAP: Record<string, number> = {
   "15min": 15 * 60 * 1000,
@@ -470,6 +519,14 @@ export function initAutoUpdater(): void {
 
   autoUpdater.on("error", (err) => {
     const message = err instanceof Error ? err.message : String(err);
+    if (isTransientNetworkError(err)) {
+      // Connectivity blips (DNS failure, captive portal, offline-at-launch)
+      // resolve themselves on the next periodic check. Log for diagnostics but
+      // do not flip the renderer to an error banner — see UpdateBanner.tsx.
+      console.warn("[auto-updater] Transient network failure, will retry:", message);
+      broadcastStatus({ state: "idle" });
+      return;
+    }
     console.error("[auto-updater] Error checking for updates:", message);
     broadcastStatus({ state: "error", message });
   });


### PR DESCRIPTION
## What
Stop showing a persistent red `Update failed: net::ERR_NAME_NOT_RESOLVED` banner when the auto-update check hits a transient network failure.

## Why
The 10-second-post-launch update check often fires before the network is fully up (WiFi reconnecting, VPN flap, captive portal, brief DNS outage). `electron-updater` surfaces the resulting Chromium `net::ERR_NAME_NOT_RESOLVED` as an error event, which our handler forwarded to the renderer as `state: "error"` — rendered by `UpdateBanner.tsx` as a full-width red banner. The next periodic check is 4 hours away by default, so the scary banner lingered over a self-healing condition. Real update failures became indistinguishable from a flaky WiFi connection.

## Key Changes
- `apps/desktop/src/main/auto-updater.ts`: new `isTransientNetworkError(err)` classifier covering Chromium `net::ERR_*` codes (`ERR_NAME_NOT_RESOLVED`, `ERR_INTERNET_DISCONNECTED`, `ERR_PROXY_CONNECTION_FAILED`, `ERR_CONNECTION_RESET`, `ERR_TIMED_OUT`, …) and POSIX socket codes (`ENOTFOUND`, `ECONNREFUSED`, `ETIMEDOUT`, …).
- The `autoUpdater.on("error", …)` handler now logs transient failures as warnings and broadcasts `state: "idle"` instead of `state: "error"`. The banner does not appear; the next periodic check retries silently.
- Genuine failures (signature verification, malformed feed, server 4xx/5xx) still surface as `state: "error"` and render the banner.
- 5 new regression tests in `auto-updater-channel.test.ts` covering both classes of error.

## Test plan
- [x] `bun run verify` — typecheck + lint + 1314 unit tests pass
- [ ] Manual: launch with WiFi off → no red banner; reconnect → next check succeeds
- [ ] Manual: real update available → banner still appears as before

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782247731&installation_id=129163861&pr_number=505&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F505&signature=b410e914398b44d7cfa47c4396d8f53b8bdd4d1ef89a87859e7f8a830083eae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved update mechanism to automatically retry on transient network failures instead of displaying errors to the user, making the update process more resilient to temporary connectivity issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->