### PR TITLE
fix(web): restore CI spinners and sidebar status dot animations

### DIFF
--- a/apps/web/e2e/architecture.spec.ts
+++ b/apps/web/e2e/architecture.spec.ts
@@ -768,9 +768,9 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
     const statusDot = threadRow.locator("span.rounded-full").first();
 
     // Before the signal fires, the dot must NOT carry the running classes.
-    // Running state maps to `bg-primary animate-pulse` per apps/web/src/lib/thread-status.ts:83.
+    // Running state maps to `bg-primary status-pulse` per apps/web/src/lib/thread-status.ts.
     await expect(statusDot).not.toHaveClass(/bg-primary/);
-    await expect(statusDot).not.toHaveClass(/animate-pulse/);
+    await expect(statusDot).not.toHaveClass(/status-pulse/);
 
     await page.screenshot({
       path: "e2e/screenshots/running-signal-before.png",
@@ -804,7 +804,7 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
     // After injection the store should flag the thread as running and the
     // sidebar dot should flip to the primary/pulsing state.
     await expect(statusDot).toHaveClass(/bg-primary/);
-    await expect(statusDot).toHaveClass(/animate-pulse/);
+    await expect(statusDot).toHaveClass(/status-pulse/);
 
     // Also confirm the store side-effect (handleAgentEvent wrote the id).
     const isRunning = await page.evaluate(

--- a/apps/web/e2e/sidebar-action-required.spec.ts
+++ b/apps/web/e2e/sidebar-action-required.spec.ts
@@ -135,7 +135,7 @@ test.describe("sidebar action-required indicator", () => {
     await expect(indicator).toBeVisible();
     await expect(indicator).toHaveClass(/ring-amber-500/);
     await expect(indicator).toHaveClass(/bg-transparent/);
-    await expect(indicator).toHaveClass(/animate-pulse/);
+    await expect(indicator).toHaveClass(/status-pulse/);
   });
 
   test("does not show the ring indicator when no permission is pending", async ({

--- a/apps/web/e2e/sidebar-interrupted-state.spec.ts
+++ b/apps/web/e2e/sidebar-interrupted-state.spec.ts
@@ -114,7 +114,7 @@ test.describe("Sidebar: interrupted thread state", () => {
 
     // Must show amber (not idle grey, not primary blue).
     await expect(statusDot).toHaveClass(/amber/);
-    await expect(statusDot).toHaveClass(/animate-pulse/);
+    await expect(statusDot).toHaveClass(/status-pulse/);
     // Must NOT look like a running thread.
     await expect(statusDot).not.toHaveClass(/bg-primary/);
 
@@ -162,7 +162,7 @@ test.describe("Sidebar: interrupted thread state", () => {
 
     // After resume the dot must switch to primary running indicator.
     await expect(statusDot).toHaveClass(/bg-primary/);
-    await expect(statusDot).toHaveClass(/animate-pulse/);
+    await expect(statusDot).toHaveClass(/status-pulse/);
     await expect(statusDot).not.toHaveClass(/amber/);
 
     await page.screenshot({

--- a/apps/web/e2e/spinner-animation.spec.ts
+++ b/apps/web/e2e/spinner-animation.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+
+/** Sample computed transform on an element to detect CSS animation motion. */
+async function sampleTransform(page: import("@playwright/test").Page, selector: string) {
+  return page.$eval(selector, (el) => {
+    const style = getComputedStyle(el);
+    return {
+      animationName: style.animationName,
+      transform: style.transform,
+    };
+  });
+}
+
+test.describe("status indicator animations", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => {
+      const spin = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      spin.id = "spin";
+      spin.setAttribute("class", "status-spin");
+      spin.setAttribute("width", "16");
+      spin.setAttribute("height", "16");
+      spin.setAttribute("viewBox", "0 0 24 24");
+      spin.innerHTML = '<circle cx="12" cy="12" r="10" stroke="currentColor" fill="none" />';
+      document.body.appendChild(spin);
+
+      const pulse = document.createElement("span");
+      pulse.id = "pulse";
+      pulse.className = "status-pulse";
+      pulse.textContent = "blob";
+      document.body.appendChild(pulse);
+    });
+  });
+
+  test("status-spin rotates loader icons", async ({ page }) => {
+    const first = await sampleTransform(page, "#spin");
+    await page.waitForTimeout(400);
+    const second = await sampleTransform(page, "#spin");
+
+    expect(first.animationName).not.toBe("none");
+    expect(first.animationName).toContain("spin");
+    expect(second.transform).not.toBe(first.transform);
+  });
+
+  test("status-pulse animates agent dots", async ({ page }) => {
+    const name = await page.$eval("#pulse", (el) => getComputedStyle(el).animationName);
+    expect(name).not.toBe("none");
+    expect(name).toContain("pulse");
+  });
+
+  test("prefers-reduced-motion disables status indicator motion", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    const spin = await sampleTransform(page, "#spin");
+    const pulse = await page.$eval("#pulse", (el) => getComputedStyle(el).animationName);
+    expect(spin.animationName).toBe("none");
+    expect(pulse).toBe("none");
+  });
+
+  test("status classes ship in app css on first load", async ({ page }) => {
+    const cssText = await page.evaluate(() => {
+      const chunks: string[] = [];
+      for (const sheet of Array.from(document.styleSheets)) {
+        try {
+          for (const rule of Array.from(sheet.cssRules ?? [])) {
+            chunks.push(rule.cssText);
+          }
+        } catch {
+          // Cross-origin stylesheets are not readable.
+        }
+      }
+      return chunks.join("\n");
+    });
+
+    expect(cssText).toMatch(/\.status-spin\s*\{[^}]*animation:[^}]*spin/);
+    expect(cssText).toMatch(/\.status-pulse\s*\{[^}]*animation:[^}]*pulse/);
+  });
+});

--- a/apps/web/src/__tests__/thread-status.test.ts
+++ b/apps/web/src/__tests__/thread-status.test.ts
@@ -44,7 +44,7 @@ describe("getStatusDisplay", () => {
     expect(result.label).toBe("");
     expect(result.color).toContain("primary");
     expect(result.dotClass).toContain("bg-primary");
-    expect(result.dotClass).toContain("animate-pulse");
+    expect(result.dotClass).toContain("status-pulse");
   });
 
   it("errored status returns Errored with diff-remove-strong color", () => {
@@ -68,7 +68,7 @@ describe("getStatusDisplay", () => {
     const result = getStatusDisplay(makeThread(), true, true);
     expect(result.shape).toBe("ring");
     expect(result.dotClass).toContain("ring-amber-500");
-    expect(result.dotClass).toContain("animate-pulse");
+    expect(result.dotClass).toContain("status-pulse");
     expect(result.dotClass).toContain("bg-transparent");
     expect(result.color).toBe("text-amber-500");
   });
@@ -104,14 +104,14 @@ describe("getStatusDisplay", () => {
     expect(result.label).toBe("Interrupted");
     expect(result.color).toContain("amber");
     expect(result.dotClass).toContain("amber");
-    expect(result.dotClass).toContain("animate-pulse");
+    expect(result.dotClass).toContain("status-pulse");
     expect(result.shape).toBe("solid");
   });
 
   it("interrupted thread shows running indicator when agent is live (resume in progress)", () => {
     const result = getStatusDisplay(makeThread({ status: "interrupted" }), true);
     expect(result.dotClass).toContain("bg-primary");
-    expect(result.dotClass).toContain("animate-pulse");
+    expect(result.dotClass).toContain("status-pulse");
   });
 });
 

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -87,7 +87,7 @@ function RunIcon({ run }: { run: CheckRun }) {
       className={cn(
         Meta.iconClass,
         "shrink-0",
-        lane === "running" && "motion-safe:animate-spin",
+        lane === "running" && "status-spin",
       )}
       strokeWidth={CI_ICON_STROKE}
     />
@@ -268,7 +268,7 @@ export function ChecksPopover({
               className={cn(
                 "shrink-0 mt-0.5",
                 visual.color,
-                checks.aggregate === "pending" && "motion-safe:animate-spin",
+                checks.aggregate === "pending" && "status-spin",
               )}
               strokeWidth={CI_ICON_STROKE}
             />
@@ -320,7 +320,7 @@ export function ChecksPopover({
                     size={10}
                     className={cn(
                       meta.iconClass,
-                      lane === "running" && "motion-safe:animate-spin",
+                      lane === "running" && "status-spin",
                     )}
                     strokeWidth={CI_ICON_STROKE}
                   />
@@ -399,7 +399,7 @@ export function ChecksPopover({
                   <RefreshCw
                     size={10}
                     strokeWidth={CI_ICON_STROKE}
-                    className={cn(refreshing && "motion-safe:animate-spin")}
+                    className={cn(refreshing && "status-spin")}
                   />
                 </Button>
               </>

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -68,7 +68,7 @@ function ProgressPills({ checks }: { checks: ChecksStatus }) {
           className={cn(
             "h-[5px] w-[5px] rounded-full transition-colors",
             slot === "fail" && "bg-[var(--diff-remove-strong)]",
-            slot === "run" && "bg-primary motion-safe:animate-pulse",
+            slot === "run" && "bg-primary status-pulse",
             slot === "pass" && "bg-[var(--diff-add-strong)]",
             slot === "other" && "bg-muted-foreground/40",
           )}
@@ -214,7 +214,7 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
               size={11}
               className={cn(
                 "shrink-0",
-                aggregate === "pending" && "motion-safe:animate-spin",
+                aggregate === "pending" && "status-spin",
               )}
               strokeWidth={CI_ICON_STROKE}
             />
@@ -229,7 +229,7 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
       )}
 
       {/* Indeterminate bottom-edge progress strip when running.
-       * Wrapped in motion-safe so reduced-motion users don't see a stationary
+       * Wrapped in motion-reduce:hidden so reduced-motion users don't see a stationary
        * partial bar (which would look like a broken progress indicator).
        * The Loader icon already conveys pending state without motion. */}
       {aggregate === "pending" && (

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -384,7 +384,7 @@ describe("ProjectTree action-required indicator", () => {
     const indicator = screen.getByLabelText("Action required");
     expect(indicator.className).toContain("ring-amber-500");
     expect(indicator.className).toContain("bg-transparent");
-    expect(indicator.className).toContain("animate-pulse");
+    expect(indicator.className).toContain("status-pulse");
   });
 
   it("renders a solid dot (no action-required label) when there is no pending permission", () => {

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -990,7 +990,7 @@ const CiChip = memo(function CiChip({ checks }: { checks: ChecksStatus }) {
       <Icon
         size={9}
         strokeWidth={CI_ICON_STROKE}
-        className={cn("shrink-0", agg === "pending" && "motion-safe:animate-spin")}
+        className={cn("shrink-0", agg === "pending" && "status-spin")}
       />
       <span>{text}</span>
     </span>
@@ -1047,7 +1047,7 @@ const WorkspaceCiRollupChip = memo(function WorkspaceCiRollupChip({
       <Icon
         size={9}
         strokeWidth={CI_ICON_STROKE}
-        className={cn("shrink-0", agg === "pending" && "motion-safe:animate-spin")}
+        className={cn("shrink-0", agg === "pending" && "status-spin")}
       />
       <span>{count}</span>
     </span>
@@ -1238,7 +1238,7 @@ function VirtualizedThreadList({
                               ? "-top-1 -right-1 h-2 w-2"
                               : "-top-0.5 -right-0.5 h-1.5 w-1.5 ring-1 ring-background",
                             agentDot.dotClass,
-                            agentDot.animate && "motion-safe:animate-pulse",
+                            agentDot.animate && "status-pulse",
                           )}
                         />
                       )}
@@ -1490,7 +1490,7 @@ const ProjectNode = memo(function ProjectNode({
               render={
                 <span
                   aria-hidden="true"
-                  className="shrink-0 h-1.5 w-1.5 rounded-full bg-primary animate-pulse"
+                  className="shrink-0 h-1.5 w-1.5 rounded-full bg-primary status-pulse"
                 />
               }
             />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -209,6 +209,22 @@
   }
 }
 
+/* CI rails, check popovers, and sidebar agent dots — explicit classes so status
+ * motion never depends on Tailwind variant JIT (motion-safe:* can be absent on
+ * first paint in dev). Keyframes come from the tailwindcss import above. */
+.status-spin {
+  animation: spin 1s linear infinite;
+}
+.status-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .status-spin,
+  .status-pulse {
+    animation: none;
+  }
+}
+
 @keyframes flash-highlight {
   0% { background-color: color-mix(in oklch, var(--primary), transparent 85%); }
   100% { background-color: transparent; }

--- a/apps/web/src/lib/thread-status.ts
+++ b/apps/web/src/lib/thread-status.ts
@@ -75,7 +75,7 @@ export function getStatusDisplay(
     return {
       label: "",
       color: "text-amber-500",
-      dotClass: "ring-2 ring-inset ring-amber-500 bg-transparent animate-pulse",
+      dotClass: "ring-2 ring-inset ring-amber-500 bg-transparent status-pulse",
       shape: "ring",
     };
   }
@@ -84,7 +84,7 @@ export function getStatusDisplay(
     return {
       label: "",
       color: "text-primary/90",
-      dotClass: "bg-primary animate-pulse",
+      dotClass: "bg-primary status-pulse",
       shape: "solid",
     };
   }
@@ -109,7 +109,7 @@ export function getStatusDisplay(
       return {
         label: "Interrupted",
         color: "text-amber-500/90",
-        dotClass: "bg-amber-500/85 animate-pulse",
+        dotClass: "bg-amber-500/85 status-pulse",
         shape: "solid",
       };
     default:


### PR DESCRIPTION
## What
Restore spinning CI check icons and pulsing sidebar status dots that stopped animating after the CI status UI overhaul.

## Why
The CI overhaul switched status indicators to \motion-safe:animate-*\ Tailwind variants. Those utilities are generated by Tailwind JIT and were missing on first paint in dev, so Loader2 icons and PR overlay blobs rendered as static shapes. Explicit CSS classes fix the regression without depending on variant JIT timing.

## Key Changes
- Add \.status-spin\ and \.status-pulse\ to \index.css\ (same pattern as \.animate-ci-slide\)
- Migrate ChecksPopover, PrSplitButton, ProjectTree, and thread-status to the new classes
- Update unit and E2E assertions; add \spinner-animation.spec.ts\ regression coverage

## Test plan
- [x] \un run test src/__tests__/thread-status.test.ts src/components/sidebar/ProjectTree.test.tsx\ (33 passed)
- [x] \
px playwright test e2e/spinner-animation.spec.ts e2e/sidebar-interrupted-state.spec.ts\ (6 passed)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782260997&installation_id=129163861&pr_number=506&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F506&signature=0972416ab36cb21d3ae07372dbd99ef3767c093c83f5e41bd3e0d72da3068257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored animation utilities for status indicators (dots, spinners, refresh buttons) to improve consistency and reduce-motion accessibility support.
  * Updated E2E tests and unit tests to reflect new animation class implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->