### PR TITLE
fix(web): fix browser preview navigation and tooltip positioning

### DIFF
--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { MarkdownContent } from "../components/chat/MarkdownContent";
 import { CodeBlock } from "../components/chat/CodeBlock";
 import { useWorkspaceStore } from "../stores/workspaceStore";
+import { useDiffStore } from "../stores/diffStore";
 import { createMockWorkspace } from "./mocks/transport";
 
 // Mock CodeBlock to avoid shiki/worker dependencies
@@ -119,6 +120,7 @@ describe("MarkdownContent workspace preview navigation", () => {
       activeWorkspaceId: null,
       activeThreadId: null,
     });
+    useDiffStore.setState({ previewUrlByThread: {} });
   });
 
   it("passes workspace path when opening mcode-workspace link with ctrl+click", async () => {
@@ -196,7 +198,7 @@ describe("MarkdownContent workspace preview navigation", () => {
     });
   });
 
-  it("falls back to openExternalUrl when preview.navigate is missing after ctrl+click", async () => {
+  it("stores URL for preview sync when preview.navigate is missing on ctrl+click", async () => {
     const mockOpenExternal = vi.fn();
     const ws = createMockWorkspace({ id: "ws-fallback", path: "/tmp/ws-fallback" });
     useWorkspaceStore.setState({
@@ -215,13 +217,14 @@ describe("MarkdownContent workspace preview navigation", () => {
     await act(async () => {
       fireEvent.click(link!, { ctrlKey: true });
     });
-    await waitFor(() => {
-      expect(mockOpenExternal).toHaveBeenCalledWith("mcode-workspace:///page.html", "/tmp/ws-fallback");
-    });
+    // URL stored for the sync mechanism; no external fallback
+    expect(useDiffStore.getState().previewUrlByThread["thread-fallback"])
+      .toBe("mcode-workspace:///page.html");
+    expect(mockOpenExternal).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("falls back to openExternalUrl when preview.navigate rejects", async () => {
+  it("silently catches navigate rejection on ctrl+click without external fallback", async () => {
     const mockOpenExternal = vi.fn();
     const nav = vi.fn().mockRejectedValue(new Error("nav failed"));
     const ws = createMockWorkspace({ id: "ws-rej", path: "/tmp/ws-rej" });
@@ -241,9 +244,14 @@ describe("MarkdownContent workspace preview navigation", () => {
     await act(async () => {
       fireEvent.click(link!, { ctrlKey: true });
     });
+    // URL stored for the sync mechanism
+    expect(useDiffStore.getState().previewUrlByThread["thread-rej"])
+      .toBe("https://example.com/x");
+    // Navigate was attempted but rejection is silently caught; no external fallback
     await waitFor(() => {
-      expect(mockOpenExternal).toHaveBeenCalledWith("https://example.com/x");
+      expect(nav).toHaveBeenCalled();
     });
+    expect(mockOpenExternal).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -171,9 +171,9 @@ function makeStaticComponents(variant: "assistant" | "user", workspacePath: stri
       );
       if (!showHint) return anchor;
       return (
-        <Tooltip trackCursorAxis="both">
+        <Tooltip>
           <TooltipTrigger render={anchor} />
-          <TooltipContent className="text-xs">{previewHint}</TooltipContent>
+          <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
         </Tooltip>
       );
     },
@@ -265,7 +265,7 @@ function makeComponents(
             <code
               role="link"
               tabIndex={0}
-              className={`${codeClass} ${linkClass}`}
+              className={`${codeClass} ${linkClass} whitespace-nowrap`}
               onClick={(e) => handleLinkClick(e, text)}
               onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e, text); }}
             >
@@ -274,9 +274,9 @@ function makeComponents(
           );
           if (!hasPreview()) return codeEl;
           return (
-            <Tooltip trackCursorAxis="both">
+            <Tooltip>
               <TooltipTrigger render={codeEl} />
-              <TooltipContent className="text-xs">{previewHint}</TooltipContent>
+              <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
             </Tooltip>
           );
         }
@@ -290,7 +290,7 @@ function makeComponents(
             <code
               role="link"
               tabIndex={0}
-              className={`${codeClass} ${linkClass}`}
+              className={`${codeClass} ${linkClass} whitespace-nowrap`}
               onClick={(e) => handleLinkClick(e, previewUrl)}
               onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e, previewUrl); }}
             >
@@ -299,9 +299,9 @@ function makeComponents(
           );
           if (!hasPreview()) return codeEl;
           return (
-            <Tooltip trackCursorAxis="both">
+            <Tooltip>
               <TooltipTrigger render={codeEl} />
-              <TooltipContent className="text-xs">{previewHint}</TooltipContent>
+              <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
             </Tooltip>
           );
         }

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -73,30 +73,22 @@ function handleLinkClick(e: React.MouseEvent | React.KeyboardEvent, url: string)
   if (isModifierClick && hasPreview()) {
     const threadId = useWorkspaceStore.getState().activeThreadId;
     if (threadId) {
-      const { showRightPanel, setRightPanelTab } = useDiffStore.getState();
+      const { showRightPanel, setRightPanelTab, setPreviewUrlForThread } =
+        useDiffStore.getState();
+      // Store the URL before opening the panel so that:
+      // 1. usePreviewBridge populates the omnibox immediately via storedUrl
+      // 2. pushSync sends it as resumeUrlHint, letting the main process load
+      //    the page once BrowserView bounds are established
+      setPreviewUrlForThread(threadId, url);
       showRightPanel(threadId);
       setRightPanelTab(threadId, "preview");
-      // Defer navigation so React can re-render and sync BrowserView bounds
+      // Fire-and-forget navigate for the already-open-panel case (bounds
+      // already synced). For a freshly mounted panel the sync handler's
+      // resumeUrlHint path handles navigation after bounds arrive.
       setTimeout(() => {
-        const fallback = (): void => {
-          if (isMcodeWorkspacePreviewUrl(url)) {
-            void window.desktopBridge?.openExternalUrl?.(url, workspacePath ?? undefined);
-          } else {
-            window.desktopBridge?.openExternalUrl?.(url);
-          }
-        };
-        const navigatePromise = window.desktopBridge?.preview?.navigate?.(url, workspacePath);
-        if (!navigatePromise) {
-          fallback();
-          return;
-        }
-        void navigatePromise
-          .then((r) => {
-            if (!r?.ok) fallback();
-          })
-          .catch(() => {
-            fallback();
-          });
+        void window.desktopBridge?.preview
+          ?.navigate?.(url, workspacePath ?? undefined)
+          ?.catch(() => {});
       }, 0);
       return;
     }

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -171,9 +171,9 @@ function makeStaticComponents(variant: "assistant" | "user", workspacePath: stri
       );
       if (!showHint) return anchor;
       return (
-        <Tooltip>
+        <Tooltip trackCursorAxis="both">
           <TooltipTrigger render={anchor} />
-          <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+          <TooltipContent className="text-xs">{previewHint}</TooltipContent>
         </Tooltip>
       );
     },
@@ -274,9 +274,9 @@ function makeComponents(
           );
           if (!hasPreview()) return codeEl;
           return (
-            <Tooltip>
+            <Tooltip trackCursorAxis="both">
               <TooltipTrigger render={codeEl} />
-              <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+              <TooltipContent className="text-xs">{previewHint}</TooltipContent>
             </Tooltip>
           );
         }
@@ -299,9 +299,9 @@ function makeComponents(
           );
           if (!hasPreview()) return codeEl;
           return (
-            <Tooltip>
+            <Tooltip trackCursorAxis="both">
               <TooltipTrigger render={codeEl} />
-              <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+              <TooltipContent className="text-xs">{previewHint}</TooltipContent>
             </Tooltip>
           );
         }

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -7,6 +7,7 @@ import {
   looksLikeWorkspaceRelativeFileRef,
 } from "@mcode/contracts";
 import { CodeBlock } from "./CodeBlock";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { resolveCodeBlockLanguage } from "@/lib/resolve-code-block-language";
 import { useDiffStore } from "@/stores/diffStore";
 import { isMac } from "@/lib/platform";
@@ -148,10 +149,9 @@ function makeStaticComponents(variant: "assistant" | "user", workspacePath: stri
           safeHref.startsWith("https:") ||
           isMcodeWorkspacePreviewUrl(safeHref));
       const showHint = isPreviewable && hasPreview();
-      return (
+      const anchor = (
         <a
           href={safeHref}
-          title={showHint ? previewHint : undefined}
           className={linkClass}
           target="_blank"
           rel="noopener noreferrer"
@@ -168,6 +168,13 @@ function makeStaticComponents(variant: "assistant" | "user", workspacePath: stri
         >
           {children}
         </a>
+      );
+      if (!showHint) return anchor;
+      return (
+        <Tooltip>
+          <TooltipTrigger render={anchor} />
+          <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+        </Tooltip>
       );
     },
     blockquote: ({ children }: { children?: React.ReactNode }) => (
@@ -254,17 +261,23 @@ function makeComponents(
           const linkClass = isUser
             ? "text-primary-foreground underline decoration-dotted hover:opacity-80 cursor-pointer"
             : "text-primary underline decoration-dotted hover:text-primary cursor-pointer";
-          return (
+          const codeEl = (
             <code
               role="link"
               tabIndex={0}
-              title={hasPreview() ? previewHint : undefined}
               className={`${codeClass} ${linkClass}`}
               onClick={(e) => handleLinkClick(e, text)}
               onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e, text); }}
             >
               {children}
             </code>
+          );
+          if (!hasPreview()) return codeEl;
+          return (
+            <Tooltip>
+              <TooltipTrigger render={codeEl} />
+              <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+            </Tooltip>
           );
         }
 
@@ -273,17 +286,23 @@ function makeComponents(
           const linkClass = isUser
             ? "text-primary-foreground underline decoration-dotted hover:opacity-80 cursor-pointer"
             : "text-primary underline decoration-dotted hover:text-primary cursor-pointer";
-          return (
+          const codeEl = (
             <code
               role="link"
               tabIndex={0}
-              title={hasPreview() ? previewHint : undefined}
               className={`${codeClass} ${linkClass}`}
               onClick={(e) => handleLinkClick(e, previewUrl)}
               onKeyDown={(e) => { if (e.key === "Enter") handleLinkClick(e, previewUrl); }}
             >
               {children}
             </code>
+          );
+          if (!hasPreview()) return codeEl;
+          return (
+            <Tooltip>
+              <TooltipTrigger render={codeEl} />
+              <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+            </Tooltip>
           );
         }
 


### PR DESCRIPTION
## What
Fix the in-app browser preview so clicking links actually loads content, populates the omnibox, and shows a properly positioned tooltip hint.

## Why
`handleLinkClick` called `preview.navigate` directly via `setTimeout(0)`, racing the ResizeObserver->RAF->pushSync chain that establishes BrowserView bounds. On fresh panels the navigate IPC arrived before bounds existed, so content never loaded and the URL never reached the omnibox. Additionally, the dev script had a duplicate `killProcessTree` declaration preventing `bun run dev:desktop` from starting.

## Key Changes
- Store the preview URL in Zustand (`setPreviewUrlForThread`) before opening the panel, so `usePreviewBridge` populates the omnibox via `storedUrl` and `pushSync` carries the URL as `resumeUrlHint`
- Remove the external-browser fallback on Ctrl+click since the intent is always the embedded preview
- Replace native `title` attribute with the app's `Tooltip` component for the preview hint on links and inline code spans
- Add `whitespace-nowrap` to clickable code spans so the tooltip has a single bounding rect to anchor against
- Remove duplicate `killProcessTree` declaration in `dev-electron.mjs` (the shared import already handles Windows)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782263772&installation_id=129163861&pr_number=507&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F507&signature=e67eed82ecbd559b8933672e85813aed1ac2650958af04c6563c64c35dc2436f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Preview hints for Ctrl/Cmd+click navigation now display as tooltips for better visibility and user guidance.
  * Enhanced preview navigation behavior with improved error handling when preview attempts fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->