### PR TITLE
fix(preview): sync native view on thread switch when panel bounds unchanged

### DIFF
--- a/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
+++ b/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
@@ -513,6 +513,35 @@ describe("usePreviewBridge", () => {
     });
   });
 
+  describe("thread switch", () => {
+    it("calls preview.sync with the new threadId immediately when threadId changes", async () => {
+      const mockPreview = makeMockPreview();
+      window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
+
+      const surfaceRef = makeSurfaceRef();
+      const { rerender } = renderHook(
+        ({ threadId }: { threadId: string }) =>
+          usePreviewBridge({ threadId, workspaceId: "ws-1", surfaceRef }),
+        { initialProps: { threadId: "t-1" } },
+      );
+
+      // Flush the initial RAF so t-1's mount sync fires.
+      await flushRaf();
+      mockPreview.sync.mockClear();
+
+      // Switch to a different thread.
+      await act(async () => {
+        rerender({ threadId: "t-2" });
+      });
+
+      // The new threadId effect must fire synchronously (no RAF needed) so
+      // the native layer swaps views even when panel bounds are unchanged.
+      expect(mockPreview.sync).toHaveBeenCalledWith(
+        expect.objectContaining({ visible: true, threadId: "t-2" }),
+      );
+    });
+  });
+
   describe("ResizeObserver effect", () => {
     it("observes the surface element", () => {
       const mockPreview = makeMockPreview();

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -100,6 +100,14 @@ export function usePreviewBridge({
     setNavError(null);
   }, [threadId, storedUrl]);
 
+  // Notify the native layer whenever the owning thread changes. The
+  // ResizeObserver effect (primary sync driver) has empty deps and only fires
+  // on layout changes — a thread switch with identical panel bounds would
+  // otherwise leave the previous thread's WebContentsView visible.
+  useEffect(() => {
+    void pushSyncRef.current(true);
+  }, [threadId]);
+
   const refreshNav = useCallback(async () => {
     const preview = window.desktopBridge?.preview;
     if (!preview) return;


### PR DESCRIPTION
## What
When both threads have the preview tab open and the user switches between them, the preview panel now correctly shows the new thread's page instead of staying on the previous thread's content.

## Why
`usePreviewBridge` drives the native `WebContentsView` swap via `pushSync`, which is called from a `ResizeObserver` effect with empty `[]` deps. That effect only fires on component mount and layout changes. A thread switch that leaves the panel at identical dimensions never triggered `preview:sync`, so the Electron main process never received the new `threadId` and kept the old thread's view mounted.

The omnibox showed the correct URL because it reads from the Zustand store directly (a separate `useEffect([threadId, storedUrl])`), creating the misleading symptom: right URL text, wrong visual page.

## Key Changes
- Added `useEffect([threadId])` in `usePreviewBridge` that calls `pushSyncRef.current(true)` on every thread change, ensuring the native layer always receives a `preview:sync` with the current `threadId` even when panel bounds are stable
- Added regression test that rerenders the hook with a new `threadId` and asserts `preview.sync` is called immediately (no RAF or ResizeObserver flush required)

Closes #507

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782266434&installation_id=129163861&pr_number=508&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F508&signature=6c92ac3b1b21fa3169a6d08f84b618e438ba7027991f677cbb9dd7524dca6188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview synchronization when switching between threads, ensuring the view properly updates to display thread-specific content.

* **Tests**
  * Added test coverage to verify correct preview behavior when the thread context changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->