### PR TITLE
docs(agents): trim AGENTS.md, route through CONTEXT.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,19 +17,6 @@ Performant AI agent orchestration desktop app built with Electron + TypeScript.
 Run `bun run setup` to bootstrap from a fresh clone.
 Run `bun run doctor` to verify all prerequisites are installed.
 
-## Supported Agent Harnesses
-
-This repo is configured for four agent harnesses. All four read `AGENTS.md` (Claude Code via `CLAUDE.md` which re-exports it), share the same `.env`-edit block and Stop-hook verify, and load the Playwright MCP for visual verification.
-
-| Harness | Config | Stop hook | MCP | Slash commands |
-|---------|--------|-----------|-----|----------------|
-| Claude Code | `.claude/settings.json`, `.claude/agents/`, `.claude/commands/`, `CLAUDE.md` | `scripts/agent/verify-tests.mjs` | `.mcp.json` | `.claude/commands/` (auto) |
-| Cursor | `.cursor/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/cursor-stop.mjs` | `.cursor/mcp.json` | `.cursor/commands/` (auto) |
-| Codex | `.codex/hooks.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` | `.mcp.json` | `.codex/prompts/` → install once with `node scripts/agent/install-codex-prompts.mjs` (copies to `~/.codex/prompts/`) |
-| OpenCode | `.opencode/opencode.json`, `AGENTS.md` | `scripts/agent/hooks/codex-stop.mjs` (shared; Codex-compatible JSON contract) | `.opencode/opencode.json` | `.opencode/command/` (auto) |
-
-All four harnesses expose the same six commands: `/verify`, `/verify-e2e`, `/verify-e2e-desktop`, `/demo`, `/demo-desktop`, `/review-pr`. Claude Code additionally has specialized subagents under `.claude/agents/` (`frontend-engineer`, `backend-engineer`, `qa-engineer`, `security-reviewer`). The shell equivalents are documented in `docs/agents/runtime.md` § Common Workflows.
-
 ## Agent skills
 
 Per-repo configuration for the engineering skills (`to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, `zoom-out`). These tell the skills how this repo tracks issues, what labels to apply during triage, and where domain docs live.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,17 @@
 
 Performant AI agent orchestration desktop app built with Electron + TypeScript.
 
-For system architecture, data model, IPC flow, and diagrams, see **[ARCHITECTURE.md](ARCHITECTURE.md)**.
+## Start here
 
-## Runtime Contract
-
-Before working on this repo, read **[docs/agents/runtime.md](docs/agents/runtime.md)** for
-the canonical list of startup commands, environment variables, runtime artifact locations,
-and agent write boundaries.
+1. **[CONTEXT.md](CONTEXT.md)** — domain glossary. Read first. Defines providers,
+   workspaces, worktrees, composer modes (Direct / New worktree / Existing worktree),
+   interaction modes (Plan / Build), threads, turns, narration segments, the handoff
+   B/A/D ladder, and the app-side extensibility surfaces (Skill / Slash command / Hook).
+   Most product terms in this repo are defined there, not in code.
+2. **[ARCHITECTURE.md](ARCHITECTURE.md)** — system architecture, data model, IPC flow,
+   directory layout, diagrams.
+3. **[docs/agents/runtime.md](docs/agents/runtime.md)** — canonical startup commands,
+   environment variables, runtime artifact locations, agent write boundaries.
 
 Run `bun run setup` to bootstrap from a fresh clone.
 Run `bun run doctor` to verify all prerequisites are installed.
@@ -30,84 +34,15 @@ All four harnesses expose the same six commands: `/verify`, `/verify-e2e`, `/ver
 
 Per-repo configuration for the engineering skills (`to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, `zoom-out`). These tell the skills how this repo tracks issues, what labels to apply during triage, and where domain docs live.
 
-### Issue tracker
+- **Issue tracker:** GitHub Issues at [Mzeey-Empire/mcode](https://github.com/Mzeey-Empire/mcode) via the `gh` CLI. See [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
+- **Triage labels:** Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See [`docs/agents/triage-labels.md`](docs/agents/triage-labels.md).
+- **Domain docs:** Single-context: [`CONTEXT.md`](CONTEXT.md) + `docs/adr/`. See [`docs/agents/domain.md`](docs/agents/domain.md).
 
-GitHub Issues at [Mzeey-Empire/mcode](https://github.com/Mzeey-Empire/mcode) via the `gh` CLI. See [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
+## Code Style
 
-### Triage labels
+Always add JSDoc/TSDoc docstrings to all exported functions, components, types, and interfaces. AI-powered code reviews depend on these for context. At minimum include a one-line summary of what the symbol does.
 
-Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See [`docs/agents/triage-labels.md`](docs/agents/triage-labels.md).
-
-### Domain docs
-
-Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See [`docs/agents/domain.md`](docs/agents/domain.md).
-
-## Directory Structure
-
-```text
-packages/
-├── contracts/                  # Shared types and Zod schemas (zero runtime deps)
-│   └── src/
-│       ├── models/             # Workspace, Thread, Message, Attachment, enums
-│       ├── events/             # AgentEvent discriminated union
-│       ├── ws/                 # WebSocket RPC methods, push channels, protocol types
-│       ├── providers/          # IAgentProvider, IProviderRegistry, ProviderId
-│       ├── git.ts              # GitBranch, WorktreeInfo schemas
-│       ├── github.ts           # PrInfo, PrDetail schemas
-│       └── skills.ts           # SkillInfo schema
-├── shared/                     # Runtime utilities shared across packages
-│   └── src/
-│       ├── logging/            # Winston logger with daily rotation
-│       ├── paths/              # Mcode data directory resolution
-│       └── git/                # Branch name sanitization, validation
-
-apps/
-├── server/                     # Standalone Node.js HTTP + WebSocket server
-│   └── src/
-│       ├── index.ts            # HTTP + WS server entry point
-│       ├── container.ts        # tsyringe DI composition root
-│       ├── services/           # Business logic (agent, thread, git, terminal, etc.)
-│       ├── providers/          # AI provider adapters
-│       │   ├── claude/         # Claude Agent SDK adapter
-│       │   └── provider-registry.ts
-│       ├── repositories/       # Data access (workspace, thread, message)
-│       ├── store/              # SQLite setup and migrations
-│       └── transport/          # WebSocket server, RPC router, push broadcasting
-├── desktop/                    # Thin Electron shell (~500 lines)
-│   └── src/main/
-│       ├── main.ts             # Window, native IPC, lifecycle
-│       ├── preload.ts          # contextBridge: desktopBridge + getPathForFile
-│       └── server-manager.ts   # Server child process lifecycle
-├── web/                        # React SPA (connects via WebSocket)
-│   └── src/
-│       ├── app/                # Routes and providers
-│       ├── components/         # UI components (sidebar, chat, terminal, diff)
-│       ├── stores/             # Zustand state management
-│       ├── transport/          # WebSocket RPC client + push events
-│       │   ├── ws-transport.ts # WebSocket RPC client + reconnection
-│       │   ├── ws-events.ts    # Push channel listeners
-│       │   └── desktop-bridge.d.ts # Type declarations for native bridge
-│       └── lib/                # Utilities and types
-docs/plans/                     # Design and planning docs (gitignored)
-```
-
-## Composer Status Bar
-
-The `Composer` component (`apps/web/src/components/chat/Composer.tsx`) renders a status bar below the text input with mode and branch controls. The layout depends on the selected `ComposerMode`:
-
-| Mode | Left | Right |
-|------|------|-------|
-| Direct | `ModeSelector` | `BranchPicker` |
-| New worktree | `ModeSelector` | `BranchPicker` → `NamingModeSelector` → `BranchNameInput` |
-| Existing worktree | `ModeSelector` | `WorktreePicker` |
-| Locked (existing thread) | `ModeSelector` (locked) | `BranchPicker` (locked, read-only) |
-
-Key components:
-- **`BranchPicker`** – searchable branch dropdown, used in both direct and worktree modes
-- **`ModeSelector`** – switches between Local / New worktree / Existing worktree
-- **`NamingModeSelector`** – toggles Auto / Custom branch naming
-- **`BranchNameInput`** – shows auto-generated or editable branch name
-- **`WorktreePicker`** – searchable dropdown for existing worktrees
+Comments explain **why**, not **what**. The code itself shows what it does.
 
 ## UI Components
 
@@ -119,78 +54,41 @@ That guide's **Testing UI Changes** section lists the triggers that require a Pl
 
 Before touching the Claude provider event pipeline, the agent-service, the `threadStore` tool-call lifecycle, or anything under `apps/web/src/components/chat/narrative/`, read **[docs/guides/narrative-pipeline.md](docs/guides/narrative-pipeline.md)**. It documents the end-to-end event flow and six specific traps (parent-id attribution for parallel sub-agents, `agentCallStack` lifecycle, volatile-state lifetime through `turn.persisted`, the DOM-mutation anti-pattern for the typing cursor, wall-clock snapshots in React, and the intentional step/sub-agent count overlap) that have already caused regressions on this codebase.
 
-## Code Style
-
-Always add JSDoc/TSDoc docstrings to all exported functions, components, types, and interfaces. AI-powered code reviews depend on these for context. At minimum include a one-line summary of what the symbol does.
-
-## Zod Schemas in `packages/contracts`
-
-All non-trivial Zod schemas must be wrapped with `lazySchema` to defer construction until first use, reducing module-load cost.
-
-```ts
-import { lazySchema } from "../utils/lazySchema.js";
-
-export const MySchema = lazySchema(() =>
-  z.object({ ... }),
-);
-
-export type MyType = z.infer<ReturnType<typeof MySchema>>;
-```
-
-Call sites invoke the schema as a function: `MySchema()`. See `AgentEventSchema`, `SettingsSchema`, and `WS_METHODS` for examples.
-
 ## Cross-Package Changes
 
-This is a monorepo. When changing a function signature, return type, or shared interface, you must typecheck ALL packages that import it, not just the one you modified. Use `grep` to find all call sites across the monorepo before considering the change complete.
-
-```sh
-# Typecheck all packages after cross-cutting changes
-(cd apps/server && npx tsc --noEmit)
-(cd apps/web && npx tsc --noEmit)
-(cd apps/desktop && npx tsc --noEmit)
-```
-
-## Commit Guidelines
-
-Use [Conventional Commits](https://www.conventionalcommits.org/).
-Types: feat, fix, refactor, docs, test, chore, perf, ci
-
-Keep commits atomic. Each commit represents one logical change.
+This is a monorepo. When you change a function signature, return type, or shared interface, every package that imports it must still typecheck. Re-run `bun run verify` (it typechecks every package). Do not run `tsc --noEmit` per package — the workflow gate in [`docs/guides/agent-workflow.md`](docs/guides/agent-workflow.md) is the source of truth.
 
 ## Settings
 
 When adding or modifying user-facing settings, follow the schema conventions in **[docs/guides/settings-schema.md](docs/guides/settings-schema.md)**. All settings use nested JSON with a max depth of 3 levels. See **[docs/settings/reference.md](docs/settings/reference.md)** for the full settings reference.
 
-## Shiki in the Web Worker
-
-Syntax highlighting runs in `apps/web/src/workers/shiki.worker.ts` via `@shikijs/langs/*` dynamic imports. Language grammars are lazy-loaded on demand and registered with a singleton highlighter.
-
-**Do not add new `@shikijs/langs/*` imports without also declaring them in `optimizeDeps` in `apps/web/vite.config.ts`.** Vite's dep pre-bundler discovers dynamic imports at runtime in dev mode — any grammar not listed upfront causes Vite to re-run its optimizer mid-session, which forces a full page reload. To avoid this, either:
-
-- Add the new lang to `optimizeDeps.include` (pre-bundle it at startup), or
-- Keep all shiki packages under `optimizeDeps.exclude` (skip bundling entirely — what shiki's own docs recommend)
-
-## Provider Architecture Convention
+## Provider Architecture
 
 See **[docs/guides/provider-architecture.md](docs/guides/provider-architecture.md)**.
 
+## Zod schemas in `packages/contracts`
+
+Wrap non-trivial schemas with `lazySchema` to defer construction until first use.
+Call sites invoke the schema as a function: `MySchema()`. See `AgentEventSchema`,
+`SettingsSchema`, and `WS_METHODS` for examples.
+
 ## Child process environment (server)
 
-Integrated terminals and provider subprocesses use **`EnvService`** plus **`ProtectedEnvStore`** and **`ShellEnvResolver`** under `apps/server/src/services/`. Keys prefixed with `MCODE_`, `ELECTRON_`, or `BETTER_SQLITE3_` are snapshotted at server boot and always win over shell or registry resolution. For one-off internal variables without those prefixes, call `ProtectedEnvStore.protect("NAME")` during server startup before spawning children.
+Integrated terminals and provider subprocesses use `EnvService` plus
+`ProtectedEnvStore` and `ShellEnvResolver` under `apps/server/src/services/`. Keys
+prefixed with `MCODE_`, `ELECTRON_`, or `BETTER_SQLITE3_` are snapshotted at
+server boot and always win over shell or registry resolution. For one-off internal
+variables without those prefixes, call `ProtectedEnvStore.protect("NAME")` during
+server startup before spawning children.
 
-## Key Documentation
+## Subsystem guides
 
-- **Architecture:** [ARCHITECTURE.md](ARCHITECTURE.md)
-- **Electron docs:** https://www.electronjs.org/docs
-- **esbuild docs:** https://esbuild.github.io/
-- **better-sqlite3 docs:** https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md
-- **tsyringe docs:** https://github.com/microsoft/tsyringe
-- **shadcn/ui docs:** https://ui.shadcn.com/
-- **Tailwind CSS 4:** https://tailwindcss.com/docs
-- **Codex provider docs:** `apps/server/src/providers/codex/` - uses `codex app-server` JSON-RPC 2.0 protocol (see ARCHITECTURE.md)
-- **Chat fork handoff:** [docs/guides/chat-fork-handoff.md](docs/guides/chat-fork-handoff.md)
+- **Database migrations / branch-specific DBs:** [`docs/guides/db-migrations.md`](docs/guides/db-migrations.md)
+- **Shiki worker (syntax highlighting):** [`docs/guides/shiki-worker.md`](docs/guides/shiki-worker.md)
+- **Chat fork handoff:** [`docs/guides/chat-fork-handoff.md`](docs/guides/chat-fork-handoff.md)
+- **Codex provider (`codex app-server` JSON-RPC 2.0):** `apps/server/src/providers/codex/` and `ARCHITECTURE.md`
 
-## Performance Requirements
+## Performance targets
 
 | Metric | Target |
 |--------|--------|
@@ -200,58 +98,6 @@ Integrated terminals and provider subprocesses use **`EnvService`** plus **`Prot
 | App startup to usable | < 2 seconds |
 | Frontend bundle size | < 2MB gzipped |
 
-## Database Migrations
-
-Migrations are managed by [Drizzle Kit](https://orm.drizzle.team/docs/kit-overview).
-The declarative schema lives in `apps/server/src/store/schema.ts`. Generated SQL
-files live under `apps/server/drizzle/`.
-
-```sh
-cd apps/server
-
-bun run db:generate    # Emit SQL from schema edits (review before commit)
-bun run db:migrate     # Apply pending migrations via drizzle-kit (needs DB URL config for CLI)
-bun run db:push        # Push schema directly (dev only; can be destructive)
-bun run db:studio      # Drizzle Studio (visual browser)
-```
-
-App startup runs Drizzle `migrate()` programmatically against the user's SQLite file,
-including legacy `_migrations` detection (`bootstrapDrizzle`) so existing installs
-upgrade without manual steps.
-
-**Branch-specific databases (development):** In a linked git worktree (where `.git` is a file pointing at the common git dir), dev mode uses `<toplevel>/.mcode-local/mcode.db` inside that checkout so schemas stay with the worktree.
-
-When developing in the primary repo directory (`main` checkout with `.git/` as a directory), `NODE_ENV` is not `production` and `MCODE_GIT_BRANCH` is set (or detected via `git rev-parse`), the DB file is `<mcodeDir>/dbs/dev-<hash>.db` instead of `<mcodeDir>/mcode.db`. Production stays on `~/.mcode/mcode.db`.
-
-**Known limitation:** Drizzle's `migrate()` wraps each migration in a transaction.
-SQLite ignores `PRAGMA foreign_keys` inside transactions, so Drizzle Kit's generated
-`PRAGMA foreign_keys=OFF` statements are silently no-ops. This is harmless for tables
-with no inbound FK references (the current state). If a future migration needs to
-rebuild a table that other tables reference via FK, the SQL must be split into a
-separate non-transactional step or applied manually outside `migrate()`.
-
-## Testing
-
-- **Unit tests:** `bun run test` from root (Vitest, runs in apps/web and apps/desktop)
-- **E2E tests:** `cd apps/web && bun run e2e` (Playwright, requires `bun run dev:web` or auto-starts)
-- **E2E headed:** `cd apps/web && bun run e2e:headed` (opens browser to watch)
-- **Screenshots:** E2E tests save screenshots to `apps/web/e2e/screenshots/` for visual verification
-
 ## Agent Development Workflow
 
 @docs/guides/agent-workflow.md
-
-## Worktrees
-
-Feature work uses git worktrees for isolation. Create them with:
-
-```sh
-git worktree add .worktrees/<name> -b <branch-name> main
-```
-
-Clean up finished worktrees with:
-
-```sh
-git worktree remove .worktrees/<name>
-git worktree prune
-```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ bun run dev:desktop
 
 ## Documentation
 
+**Working on this codebase (humans or AI agents)?** Start here:
+
+- **[AGENTS.md](AGENTS.md)** - Repo-wide conventions, harness setup, workflow gates. Routes to everything else.
+- **[CONTEXT.md](CONTEXT.md)** - Domain glossary (providers, threads, forks, worktrees, handoff pipeline). Read before naming or reasoning about product concepts.
+
+**Reference docs:**
+
 - **[Architecture](ARCHITECTURE.md)** - System design, data model, IPC flow, and diagrams
 - **[Provider architecture](docs/guides/provider-architecture.md)** - How providers are wired up
 - **[Settings reference](docs/settings/reference.md)** - All configurable settings

--- a/docs/guides/db-migrations.md
+++ b/docs/guides/db-migrations.md
@@ -1,0 +1,39 @@
+# Database Migrations
+
+Migrations are managed by [Drizzle Kit](https://orm.drizzle.team/docs/kit-overview).
+The declarative schema lives in `apps/server/src/store/schema.ts`. Generated SQL
+files live under `apps/server/drizzle/`.
+
+```sh
+cd apps/server
+
+bun run db:generate    # Emit SQL from schema edits (review before commit)
+bun run db:migrate     # Apply pending migrations via drizzle-kit (needs DB URL config for CLI)
+bun run db:push        # Push schema directly (dev only; can be destructive)
+bun run db:studio      # Drizzle Studio (visual browser)
+```
+
+App startup runs Drizzle `migrate()` programmatically against the user's SQLite file,
+including legacy `_migrations` detection (`bootstrapDrizzle`) so existing installs
+upgrade without manual steps.
+
+## Branch-specific databases (development)
+
+In a linked git worktree (where `.git` is a file pointing at the common git dir),
+dev mode uses `<toplevel>/.mcode-local/mcode.db` inside that checkout so schemas
+stay with the worktree.
+
+When developing in the primary repo directory (`main` checkout with `.git/` as a
+directory), `NODE_ENV` is not `production` and `MCODE_GIT_BRANCH` is set (or
+detected via `git rev-parse`), the DB file is `<mcodeDir>/dbs/dev-<hash>.db`
+instead of `<mcodeDir>/mcode.db`. Production stays on `~/.mcode/mcode.db`.
+
+## Known limitation: FK pragmas inside transactions
+
+Drizzle's `migrate()` wraps each migration in a transaction. SQLite ignores
+`PRAGMA foreign_keys` inside transactions, so Drizzle Kit's generated
+`PRAGMA foreign_keys=OFF` statements are silently no-ops. This is harmless for
+tables with no inbound FK references (the current state). If a future migration
+needs to rebuild a table that other tables reference via FK, the SQL must be
+split into a separate non-transactional step or applied manually outside
+`migrate()`.

--- a/docs/guides/shiki-worker.md
+++ b/docs/guides/shiki-worker.md
@@ -1,0 +1,18 @@
+# Shiki in the Web Worker
+
+Syntax highlighting runs in `apps/web/src/workers/shiki.worker.ts` via
+`@shikijs/langs/*` dynamic imports. Language grammars are lazy-loaded on demand
+and registered with a singleton highlighter.
+
+## Rule
+
+**Do not add new `@shikijs/langs/*` imports without also declaring them in
+`optimizeDeps` in `apps/web/vite.config.ts`.**
+
+Vite's dep pre-bundler discovers dynamic imports at runtime in dev mode. Any
+grammar not listed upfront causes Vite to re-run its optimizer mid-session,
+which forces a full page reload. To avoid this, either:
+
+- Add the new lang to `optimizeDeps.include` (pre-bundle it at startup), or
+- Keep all shiki packages under `optimizeDeps.exclude` (skip bundling entirely;
+  this is what shiki's own docs recommend).


### PR DESCRIPTION
## What

Trim `AGENTS.md` from 257 to 99 lines, add a "Start here" pointer that routes new agents to `CONTEXT.md` first, relocate two subsystem docs to their own guides, and update `README.md` so contributors and AI agents land on `AGENTS.md` and `CONTEXT.md` on first read.

## Why

`AGENTS.md` had drifted into a mix of canonical conventions, duplicated content from `CONTEXT.md` / `ARCHITECTURE.md` / the workflow doc, third-party documentation URLs, and one section (`Cross-Package Changes`) that actively contradicted the enforced workflow gate. New agents joining the repo had no clear entry order: nothing told them to read `CONTEXT.md` first, and a parallel-agent orientation test showed three fresh subagents bypassing `AGENTS.md` entirely in favour of spelunking `README.md` and source.

## Key Changes

**`AGENTS.md` (193 deletions, 39 insertions):**
- Added "Start here" block pointing to `CONTEXT.md` then `ARCHITECTURE.md` then `docs/agents/runtime.md`.
- Removed sections now owned elsewhere: Composer Status Bar (in `CONTEXT.md`), Directory Structure (in `ARCHITECTURE.md`), Commit Guidelines (in user-level `CLAUDE.md`), Testing block (in `docs/guides/agent-workflow.md`), Worktrees shell snippets (in `docs/agents/runtime.md`), third-party documentation URL list.
- Fixed Cross-Package Changes to point at the workflow gate instead of recommending `npx tsc --noEmit` per package.
- Consolidated Agent skills into a single bullet list.

**New subsystem guides:**
- `docs/guides/db-migrations.md` (Drizzle commands, branch-specific dev DBs, FK pragma limitation).
- `docs/guides/shiki-worker.md` (the `optimizeDeps` trap that forces a full page reload).

**`README.md`:** Documentation section leads with `AGENTS.md` and `CONTEXT.md` so the first doc any human or AI agent reads routes them to the canonical entry point.

## Notes

- All content removed from `AGENTS.md` was either duplicated elsewhere already or relocated to a dedicated guide. Nothing was lost.
- Spotted but not fixed (out of scope): typo in `README.md` clone URL on line 30 (`Mzeey-Emipre` should be `Mzeey-Empire`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782271109&installation_id=129163861&pr_number=513&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F513&signature=eb233b2841ed11e9c22179b0c207065c9af0e321c8217fdb88998b0d138a0830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved onboarding documentation with streamlined "Start here" section and clearer guidance for working on the codebase
  * Added new guide for database migration workflows and setup
  * Added new guide for syntax highlighting in web workers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->