### PR TITLE
fix(web): PR button flash and stale PR on thread switch

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -407,7 +407,12 @@ for (const provider of providerRegistry.resolveAll()) {
               || thread.pr_status?.toLowerCase() !== pr.state.toLowerCase();
             if (stateChanged) {
               threadService.linkPr(thread.id, pr.number, pr.state);
-              const prPayload = { threadId: thread.id, prNumber: pr.number, prStatus: pr.state };
+              const prPayload = {
+                threadId: thread.id,
+                prNumber: pr.number,
+                prStatus: pr.state,
+                prUrl: pr.url,
+              };
               broadcast("thread.prLinked", prPayload);
               portPush.send("thread.prLinked", prPayload);
             }

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -62,12 +62,19 @@ export class GithubService {
     }
   }
 
-  /** Look up the PR associated with a branch in the given working directory. */
+  /**
+   * Look up the most recently created PR for a branch in any state (open, merged, closed).
+   *
+   * Uses `gh pr list --state all` instead of `gh pr view` so that:
+   * - Closed/merged PRs are returned (not silenced by the default open-only filter).
+   * - When multiple PRs exist for the same branch, the newest one (highest number) is
+   *   returned first, matching GitHub API's default `created_at DESC` sort order.
+   */
   getBranchPr(branch: string, cwd: string): Promise<PrInfo | null> {
     return new Promise((resolve) => {
       execFile(
         "gh",
-        ["pr", "view", branch, "--json", "number,url,state"],
+        ["pr", "list", "--head", branch, "--state", "all", "--limit", "1", "--json", "number,url,state"],
         { cwd, encoding: "utf-8", timeout: 10_000, windowsHide: true },
         (error, stdout) => {
           if (error || !stdout) {
@@ -75,12 +82,14 @@ export class GithubService {
             return;
           }
           try {
-            const data = JSON.parse(stdout) as {
+            const items = JSON.parse(stdout) as Array<{
               number?: number;
               url?: string;
               state?: string;
-            };
+            }>;
+            const data = items[0];
             if (
+              data &&
               typeof data.number === "number" &&
               typeof data.url === "string"
             ) {

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -65,10 +65,11 @@ export class GithubService {
   /**
    * Look up the most recently created PR for a branch in any state (open, merged, closed).
    *
-   * Uses `gh pr list --state all` instead of `gh pr view` so that:
-   * - Closed/merged PRs are returned (not silenced by the default open-only filter).
-   * - When multiple PRs exist for the same branch, the newest one (highest number) is
-   *   returned first, matching GitHub API's default `created_at DESC` sort order.
+   * Uses `gh pr list --head <branch> --state all --limit 1` instead of `gh pr view` so that:
+   * - `--head` filters to PRs whose head branch matches exactly (view uses positional lookup).
+   * - `--state all` includes closed/merged PRs (view defaults to open only).
+   * - `--limit 1` takes the first result; gh returns PRs newest-first (`createdAt DESC`),
+   *   so the highest-numbered PR is always returned when multiple exist for the branch.
    */
   getBranchPr(branch: string, cwd: string): Promise<PrInfo | null> {
     return new Promise((resolve) => {

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -329,7 +329,7 @@ async function dispatch(
       if (needsCheck.length === 0) return [];
       const workspace = deps.workspaceService.findById(params.workspaceId);
       if (!workspace) return [];
-      const results: Array<{ threadId: string; prNumber: number; prStatus: string }> = [];
+      const results: Array<{ threadId: string; prNumber: number; prStatus: string; prUrl: string }> = [];
       await Promise.allSettled(
         needsCheck.map(async (t) => {
           const pr = await deps.githubService.getBranchPr(t.branch, workspace.path);
@@ -338,8 +338,10 @@ async function dispatch(
             const statusChanged = t.pr_status?.toLowerCase() !== pr.state.toLowerCase();
             if (numberChanged || statusChanged) {
               deps.threadService.linkPr(t.id, pr.number, pr.state);
-              results.push({ threadId: t.id, prNumber: pr.number, prStatus: pr.state });
             }
+            // Always include prUrl in results so the client can populate
+            // prUrlsByThreadId, even when pr_number/pr_status are unchanged.
+            results.push({ threadId: t.id, prNumber: pr.number, prStatus: pr.state, prUrl: pr.url });
             // Start CI watching if PR is not in terminal state.
             // Unwatch first when the PR number changed so the watcher targets the new PR.
             const prState = pr.state.toLowerCase();
@@ -858,6 +860,7 @@ async function dispatch(
         threadId: params.threadId,
         prNumber: result.number,
         prStatus: "OPEN",
+        prUrl: result.url,
       });
 
       // Replace any stale watcher (e.g. previous PR on this thread) before registering the new one.

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -253,15 +253,20 @@ export function ChecksPopover({
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
-      {/* Render the trigger AS the inner button (passed via children) instead of
-       * wrapping it. Wrapping in a <button> nests buttons (invalid HTML); wrapping
-       * in a <span> drops base-ui's native-button semantics and warns. The render
-       * prop tells base-ui to clone the child element and merge in its own props
-       * (onClick, aria-haspopup, refs) — the inner <button> stays a real button. */}
+      {/* Render the trigger as a transparent <span> (display: contents) wrapping
+       * the real <button> passed via children. The default nativeButton={true}
+       * expects the rendered element to BE a <button>, but rendering as a button
+       * here would nest two real buttons (invalid HTML). nativeButton={false} is
+       * the documented escape hatch: base-ui adds role="button" + tabindex + key
+       * handling on the span, and the click bubbles from the inner button up to
+       * the span where base-ui's open handler fires. */}
       <PopoverTrigger
-        render={children as React.ReactElement}
+        render={<span style={{ display: "contents" }} />}
+        nativeButton={false}
         aria-label="View CI check details"
-      />
+      >
+        {children}
+      </PopoverTrigger>
       <PopoverContent side="bottom" align="start" sideOffset={8} className="w-[340px] p-0 overflow-hidden">
         {/* Header chrome */}
         <div className={cn("px-4 pt-3.5 pb-3", visual.surface)}>

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -254,7 +254,7 @@ export function ChecksPopover({
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger
-        className="inline-flex cursor-pointer"
+        render={<span style={{ display: "contents" }} />}
         aria-label="View CI check details"
       >
         {children}

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -253,12 +253,15 @@ export function ChecksPopover({
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
+      {/* Render the trigger AS the inner button (passed via children) instead of
+       * wrapping it. Wrapping in a <button> nests buttons (invalid HTML); wrapping
+       * in a <span> drops base-ui's native-button semantics and warns. The render
+       * prop tells base-ui to clone the child element and merge in its own props
+       * (onClick, aria-haspopup, refs) — the inner <button> stays a real button. */}
       <PopoverTrigger
-        render={<span style={{ display: "contents" }} />}
+        render={children as React.ReactElement}
         aria-label="View CI check details"
-      >
-        {children}
-      </PopoverTrigger>
+      />
       <PopoverContent side="bottom" align="start" sideOffset={8} className="w-[340px] p-0 overflow-hidden">
         {/* Header chrome */}
         <div className={cn("px-4 pt-3.5 pb-3", visual.surface)}>

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -53,11 +53,12 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
   const storePr = thread.pr_number != null && cachedPrUrl
     ? { number: thread.pr_number, url: cachedPrUrl, state: thread.pr_status ?? "OPEN" }
     : null;
-  // When polledPr and storePr have different numbers, storePr is the freshly
-  // created PR and polledPr is stale (not yet caught up). Prefer storePr.
-  const pr = (storePr != null && polledPr?.url && polledPr.number !== storePr.number)
-    ? storePr
-    : (polledPr?.url ? polledPr : null) ?? storePr;
+  // When numbers differ, prefer the higher PR number (most recently created).
+  // storePr may be freshly created (polledPr not caught up yet) or stale from DB
+  // (polledPr discovered a newer PR). Higher number = correct choice in both cases.
+  const pr = polledPr?.url
+    ? (storePr && storePr.number > polledPr.number ? storePr : polledPr)
+    : storePr;
 
   // Check if the branch has commits ahead of main (disable Create PR when it doesn't)
   const hasCommitsAhead = useHasCommitsAhead(

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -647,6 +647,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
             return;
           }
           const resultMap = new Map(results.map((r) => [r.threadId, r]));
+          const urlPatch: Record<string, string> = {};
+          for (const r of results) {
+            if (r.prUrl) urlPatch[r.threadId] = r.prUrl;
+          }
           set((state) => ({
             threads: state.threads.map((t) => {
               const match = resultMap.get(t.id);
@@ -654,6 +658,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
               // null prNumber means the stale PR was cleared server-side
               return { ...t, pr_number: match.prNumber, pr_status: match.prStatus };
             }),
+            prUrlsByThreadId: { ...state.prUrlsByThreadId, ...urlPatch },
           }));
         }).catch(() => {});
       }

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -651,15 +651,27 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
           for (const r of results) {
             if (r.prUrl) urlPatch[r.threadId] = r.prUrl;
           }
-          set((state) => ({
-            threads: state.threads.map((t) => {
+          set((state) => {
+            const nextThreads = state.threads.map((t) => {
               const match = resultMap.get(t.id);
               if (!match) return t;
+              // Return the same reference when nothing changed so Zustand
+              // selectors don't see a false-positive identity change.
+              if (t.pr_number === match.prNumber && t.pr_status === match.prStatus) return t;
               // null prNumber means the stale PR was cleared server-side
               return { ...t, pr_number: match.prNumber, pr_status: match.prStatus };
-            }),
-            prUrlsByThreadId: { ...state.prUrlsByThreadId, ...urlPatch },
-          }));
+            });
+            // Only produce a new prUrlsByThreadId object when URLs actually changed.
+            const hasNewUrls = Object.entries(urlPatch).some(
+              ([id, url]) => state.prUrlsByThreadId[id] !== url,
+            );
+            return {
+              threads: nextThreads,
+              prUrlsByThreadId: hasNewUrls
+                ? { ...state.prUrlsByThreadId, ...urlPatch }
+                : state.prUrlsByThreadId,
+            };
+          });
         }).catch(() => {});
       }
     } catch (e) {

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -239,7 +239,7 @@ export interface McodeTransport {
   markThreadViewed(threadId: string): Promise<void>;
   /** Scan threads for stale or missing PR data and refresh their state. Returns updated PR state
    * for all affected threads. A null prNumber/prStatus signals the PR was cleared (stale data removed). */
-  syncThreadPrs(workspaceId: string): Promise<Array<{ threadId: string; prNumber: number | null; prStatus: string | null }>>;
+  syncThreadPrs(workspaceId: string): Promise<Array<{ threadId: string; prNumber: number | null; prStatus: string | null; prUrl: string | null }>>;
 
   // Message queries
   /**

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -41,7 +41,7 @@ function approxBase64DecodedBytes(encoded: string): number {
  * - Reconnect-gap banners are emitted from ws-transport after `terminal.reattach` RPC
  *   (there is no `terminal.reconnectGap` push channel on the server)
  * - `thread.status` -- thread status changes reflected in threadStore
- * - `thread.prLinked` -- PR detected for a thread, updates pr_number/pr_status
+ * - `thread.prLinked` -- PR detected for a thread, updates pr_number/pr_status and prUrlsByThreadId
  * - `thread.checksUpdated` -- CI check status polled for a thread's PR, updates checksById
  * - `thread.modelUpdated` -- thread model and provider synced after a message send (multi-client)
  * - `files.changed` -- invalidates the file autocomplete cache

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -220,15 +220,17 @@ export function startPushListeners(): void {
   // thread.prLinked: a PR was detected and linked to a thread
   unsubs.push(
     pushEmitter.on("thread.prLinked", (data) => {
-      const { threadId, prNumber, prStatus } = data as {
+      const { threadId, prNumber, prStatus, prUrl } = data as {
         threadId: string;
         prNumber: number;
         prStatus: string;
+        prUrl: string;
       };
       useWorkspaceStore.setState((ws) => ({
         threads: ws.threads.map((t) =>
           t.id === threadId ? { ...t, pr_number: prNumber, pr_status: prStatus } : t,
         ),
+        prUrlsByThreadId: { ...ws.prUrlsByThreadId, [threadId]: prUrl },
       }));
     }),
   );

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -485,7 +485,7 @@ export function createWsTransport(
       }),
     markThreadViewed: (threadId) => rpc<void>("thread.markViewed", { threadId }),
     syncThreadPrs: (workspaceId) =>
-      rpc<Array<{ threadId: string; prNumber: number; prStatus: string }>>("thread.syncPrs", { workspaceId }),
+      rpc<Array<{ threadId: string; prNumber: number; prStatus: string; prUrl: string }>>("thread.syncPrs", { workspaceId }),
 
     // Git
     listBranches: (workspaceId) => rpc<GitBranch[]>("git.listBranches", { workspaceId }),

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -36,6 +36,7 @@ export const WS_CHANNELS = {
     threadId: z.string(),
     prNumber: z.number(),
     prStatus: z.string(),
+    prUrl: z.string(),
   }),
   "thread.checksUpdated": z.object({
     threadId: z.string(),

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -36,6 +36,7 @@ export const WS_CHANNELS = {
     threadId: z.string(),
     prNumber: z.number(),
     prStatus: z.string(),
+    /** Non-nullable: this event only fires once a PR URL is confirmed. */
     prUrl: z.string(),
   }),
   "thread.checksUpdated": z.object({

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -258,6 +258,7 @@ export const WS_METHODS = lazySchema(() => ({
       /** null signals the PR was cleared from this thread (stale data removed). */
       prNumber: z.number().nullable(),
       prStatus: z.string().nullable(),
+      prUrl: z.string().nullable(),
     })),
   },
   /** Search threads across all workspaces by title substring, with optional status/provider filters and sort order. */


### PR DESCRIPTION
## What
Fix two bugs in the PR/CI header button that affected thread switching and workspaces with multiple closed PRs on the same branch.

## Why
**Bug 1 — PR button flash on thread switch:** `prUrlsByThreadId` was only written by `recordPrCreated()` (called from `CreatePrDialog`). PRs discovered by `syncPrs` or the `prLinked` push event had no URL entry, so when `useBranchPr` correctly reset to `null` on branch change (its stale-data guard), `storePr` was also null — causing the header to flash "Create PR" until the next poll completed. The project view sidebar kept its CI state because it reads from `checksById`, which is populated by a separate push channel unaffected by branch resets.

**Bug 2 — Old PR shown instead of newest:** `getBranchPr` used `gh pr view <branch>` which defaults to open PRs only and returns a single JSON object, so closed/merged PRs were invisible. The selection logic in `HeaderActions` also unconditionally preferred `storePr` when numbers differed, which broke when `storePr` held a stale DB entry and `polledPr` had found a newer one.

## Key Changes
- Plumb `prUrl` through `thread.syncPrs` RPC response and `thread.prLinked` push event so `prUrlsByThreadId` is populated for all threads, not just ones created via the dialog in the current session
- Switch `getBranchPr` from `gh pr view <branch>` to `gh pr list --head <branch> --state all --limit 1` so closed/merged PRs are visible and the newest (highest-numbered) PR is always returned
- Fix PR selection logic in `HeaderActions` to prefer the higher PR number rather than unconditionally preferring `storePr`
- Add reference-equality guards in the `syncPrs` store handler so Zustand selectors don't see false-positive identity changes every 30 seconds when nothing has changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782272095&installation_id=129163861&pr_number=514&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F514&signature=0c60747b8525ab72243df951155133b279a37711eebffbbcab0c3d5f95a046e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Threads now store and surface PR URLs for clearer PR linkage and visibility.
  * Background sync and real-time events include PR URLs so the UI receives and persists PR links.

* **Bug Fixes**
  * PR selection logic updated to prefer the higher/more recent PR when multiple sources exist.
  * Branch PR lookup improved to reliably return the most recently created matching PR.
  * UI state updates optimized to avoid unnecessary re-renders.
  * Popover trigger adjusted to prevent invalid nested button markup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->