### PR TITLE
refactor(contracts): rename InteractionMode value "chat" → "build"

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,11 +103,9 @@ The opposite of Plan mode: the thread state where the agent actually
 performs the work — editing files, running tools, making changes. The
 default for new threads when the user does not opt into Plan mode.
 
-> **Codebase mismatch (rename pending).** The `InteractionMode` enum still
-> uses the value `"chat"` for what the product calls "Build mode." A
-> follow-up rename to `"build"` is planned. Likewise, the
-> `AgentDefaultModeSchema` still exposes a deprecated third `"agent"`
-> value that should be dropped — the product has only Plan and Build.
+> **Codebase mismatch (rename pending).** The `AgentDefaultModeSchema`
+> still exposes a deprecated third `"agent"` value that should be dropped —
+> the product has only Plan and Build.
 
 ## Model configuration
 

--- a/apps/server/drizzle/0010_clever_skin.sql
+++ b/apps/server/drizzle/0010_clever_skin.sql
@@ -1,1 +1,1 @@
-UPDATE `threads` SET `interaction_mode` = 'build' WHERE `interaction_mode` = 'chat';--> statement-breakpoint
+UPDATE `threads` SET `interaction_mode` = 'build' WHERE `interaction_mode` = 'chat';

--- a/apps/server/drizzle/0010_clever_skin.sql
+++ b/apps/server/drizzle/0010_clever_skin.sql
@@ -1,0 +1,1 @@
+UPDATE `threads` SET `interaction_mode` = 'build' WHERE `interaction_mode` = 'chat';--> statement-breakpoint

--- a/apps/server/drizzle/meta/0010_snapshot.json
+++ b/apps/server/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1448 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "69cd7062-087d-4510-906a-cc20404a6f97",
+  "prevId": "ddfe5b0d-167f-4fa8-b3b3-69112c30fbe6",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diff_summaries": {
+      "name": "diff_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_turn_id": {
+          "name": "last_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_diff_summaries_thread": {
+          "name": "idx_diff_summaries_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "diff_summaries_thread_id_threads_id_fk": {
+          "name": "diff_summaries_thread_id_threads_id_fk",
+          "tableFrom": "diff_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_executions": {
+      "name": "hook_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hook_name": {
+          "name": "hook_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "did_block": {
+          "name": "did_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_hook_executions_message": {
+          "name": "idx_hook_executions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hook_executions_message_id_messages_id_fk": {
+          "name": "hook_executions_message_id_messages_id_fk",
+          "tableFrom": "hook_executions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plans_thread": {
+          "name": "idx_plans_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plans_thread_version": {
+          "name": "idx_plans_thread_version",
+          "columns": [
+            "thread_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plans_thread_id_threads_id_fk": {
+          "name": "plans_thread_id_threads_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_message_id_messages_id_fk": {
+          "name": "plans_message_id_messages_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thought_segments": {
+      "name": "thought_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_final_response": {
+          "name": "is_final_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thought_segments_message": {
+          "name": "idx_thought_segments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thought_segments_message_id_messages_id_fk": {
+          "name": "thought_segments_message_id_messages_id_fk",
+          "tableFrom": "thought_segments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codex_fast_mode": {
+          "name": "codex_fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1779405379838,
       "tag": "0009_plain_loki",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1779638400000,
+      "tag": "0010_clever_skin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -474,7 +474,7 @@ export class AgentService {
     // whether a provider content override exists. When branching (override present),
     // the override already carries the plan-wrapped stitched content; only wrap the
     // plain content when there is no override.
-    // Plan-tab implement/revise actions force chat mode so the prompt is not
+    // Plan-tab implement/revise actions force build mode so the prompt is not
     // re-wrapped with the question-generation template.
     let wirePayload = content;
 

--- a/apps/web/e2e/about-visual.spec.ts
+++ b/apps/web/e2e/about-visual.spec.ts
@@ -7,7 +7,7 @@ const SCREENSHOT_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "
 
 const MOCK_SETTINGS = {
   appearance: { theme: "dark" },
-  agent: { maxConcurrent: 3, defaults: { mode: "chat", permission: "supervised" } },
+  agent: { maxConcurrent: 3, defaults: { mode: "build", permission: "supervised" } },
   model: { defaults: { provider: "claude", id: "claude-sonnet-4-6", fallbackId: "claude-sonnet-4-6", reasoning: "high" } },
   provider: { cli: { codex: "", claude: "", copilot: "" } },
   prDraft: { provider: "", model: "" },

--- a/apps/web/e2e/qa-codex-reasoning.spec.ts
+++ b/apps/web/e2e/qa-codex-reasoning.spec.ts
@@ -11,7 +11,7 @@ let currentSettings = makeDefaultSettings("claude", "claude-sonnet-4-6", "high")
 function makeDefaultSettings(provider: string, modelId: string, reasoning: string) {
   return {
     appearance: { theme: "dark" },
-    agent: { maxConcurrent: 3, defaults: { mode: "chat", permission: "supervised" } },
+    agent: { maxConcurrent: 3, defaults: { mode: "build", permission: "supervised" } },
     model: {
       defaults: { provider, id: modelId, fallbackId: "claude-sonnet-4-6", reasoning },
     },

--- a/apps/web/e2e/reasoning-levels.spec.ts
+++ b/apps/web/e2e/reasoning-levels.spec.ts
@@ -9,7 +9,7 @@ import { mockWebSocketServer } from "./helpers/e2e-helpers";
 function makeSettings(modelId: string, reasoning = "high") {
   return {
     appearance: { theme: "dark" },
-    agent: { maxConcurrent: 3, defaults: { mode: "chat", permission: "supervised" } },
+    agent: { maxConcurrent: 3, defaults: { mode: "build", permission: "supervised" } },
     model: {
       defaults: {
         provider: "claude",

--- a/apps/web/e2e/settings-visual.spec.ts
+++ b/apps/web/e2e/settings-visual.spec.ts
@@ -8,7 +8,7 @@ const SCREENSHOT_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "
 // Default settings matching the schema
 const DEFAULT_SETTINGS = {
   appearance: { theme: "dark" },
-  agent: { maxConcurrent: 3, defaults: { mode: "chat", permission: "supervised" } },
+  agent: { maxConcurrent: 3, defaults: { mode: "build", permission: "supervised" } },
   model: {
     defaults: {
       provider: "claude",

--- a/apps/web/e2e/sidebar-action-required.spec.ts
+++ b/apps/web/e2e/sidebar-action-required.spec.ts
@@ -60,7 +60,7 @@ async function mockWebSocketServer(
   // returning null from settings.get causes an immediate crash.
   const defaultSettings = {
     appearance: { theme: "system" },
-    agent: { maxConcurrent: 5, defaults: { mode: "chat", permission: "full" }, guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
+    agent: { maxConcurrent: 5, defaults: { mode: "build", permission: "full" }, guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
     model: { defaults: { provider: "claude", id: "claude-opus-4-7", reasoning: "high", fallbackId: "claude-sonnet-4-6" } },
     terminal: { scrollback: 250 },
     notifications: { enabled: true },

--- a/apps/web/e2e/ui-improvements-floating.spec.ts
+++ b/apps/web/e2e/ui-improvements-floating.spec.ts
@@ -71,13 +71,13 @@ test.describe("Composer options — wide viewport (md+)", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
   });
 
-  test("renders Chat / Full access toggles inline and hides the overflow trigger", async ({ page }) => {
+  test("renders Build / Full access toggles inline and hides the overflow trigger", async ({ page }) => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
     await openComposerInNewThread(page);
 
     // Inline buttons are visible above the md breakpoint.
-    await expect(page.getByRole("button", { name: /^Chat$/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Build$/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Full access$/ })).toBeVisible();
 
     // The overflow trigger is reserved for narrow viewports.
@@ -98,8 +98,8 @@ test.describe("Composer options — narrow viewport (below md)", () => {
     await page.waitForLoadState("networkidle");
     await openComposerInNewThread(page);
 
-    // Inline Chat / Full access buttons collapse below md.
-    await expect(page.getByRole("button", { name: /^Chat$/ })).toHaveCount(0);
+    // Inline Build / Full access buttons collapse below md.
+    await expect(page.getByRole("button", { name: /^Build$/ })).toHaveCount(0);
     await expect(page.getByRole("button", { name: /^Full access$/ })).toHaveCount(0);
 
     const trigger = page.getByRole("button", { name: "Composer options" });
@@ -109,7 +109,7 @@ test.describe("Composer options — narrow viewport (below md)", () => {
     // Popover exposes grouped Mode + Permissions controls.
     await expect(page.getByText("Mode", { exact: true })).toBeVisible();
     await expect(page.getByText("Permissions", { exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Chat" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Build" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Plan" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Full" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Supervised" })).toBeVisible();
@@ -122,15 +122,15 @@ test.describe("Composer options — narrow viewport (below md)", () => {
 
     await page.getByRole("button", { name: "Composer options" }).click();
     const planBtn = page.getByRole("button", { name: "Plan" });
-    const chatBtn = page.getByRole("button", { name: "Chat" });
+    const buildBtn = page.getByRole("button", { name: "Build" });
 
-    await expect(chatBtn).toHaveAttribute("aria-pressed", "true");
+    await expect(buildBtn).toHaveAttribute("aria-pressed", "true");
     await expect(planBtn).toHaveAttribute("aria-pressed", "false");
 
     await planBtn.click();
 
     await expect(planBtn).toHaveAttribute("aria-pressed", "true");
-    await expect(chatBtn).toHaveAttribute("aria-pressed", "false");
+    await expect(buildBtn).toHaveAttribute("aria-pressed", "false");
   });
 
   test("Tasks panel row is hidden when the thread has no tasks", async ({ page }) => {

--- a/apps/web/src/__tests__/per-thread-settings.test.ts
+++ b/apps/web/src/__tests__/per-thread-settings.test.ts
@@ -61,7 +61,7 @@ describe("per-thread settings", () => {
 
     const settings = useThreadStore.getState().getThreadSettings("thread-null");
 
-    expect(settings.interactionMode).toBe("chat");
+    expect(settings.interactionMode).toBe("build");
     expect(settings.permissionMode).toBe("full");
     expect(settings.reasoningLevel).toBeUndefined();
     expect(settings.codexFastMode).toBeNull();
@@ -103,7 +103,7 @@ describe("per-thread settings", () => {
       settingsByThread: {
         "thread-override": {
           permissionMode: "full",
-          interactionMode: "chat",
+          interactionMode: "build",
           reasoningLevel: undefined,
         },
       },
@@ -112,7 +112,7 @@ describe("per-thread settings", () => {
     const settings = useThreadStore.getState().getThreadSettings("thread-override");
 
     expect(settings.permissionMode).toBe("full");
-    expect(settings.interactionMode).toBe("chat");
+    expect(settings.interactionMode).toBe("build");
     expect(settings.reasoningLevel).toBeUndefined();
   });
 
@@ -143,11 +143,11 @@ describe("per-thread settings", () => {
     });
 
     // Set only interactionMode
-    useThreadStore.getState().setThreadSettings("thread-1", { interactionMode: "chat" });
+    useThreadStore.getState().setThreadSettings("thread-1", { interactionMode: "build" });
 
     // Other settings should be preserved from DB, not cleared
     const settings = useThreadStore.getState().getThreadSettings("thread-1");
-    expect(settings.interactionMode).toBe("chat");
+    expect(settings.interactionMode).toBe("build");
     expect(settings.reasoningLevel).toBe("high");
     expect(settings.permissionMode).toBe("supervised");
   });
@@ -156,7 +156,7 @@ describe("per-thread settings", () => {
     const thread = createMockThread({
       id: "thread-sync",
       reasoning_level: null,
-      interaction_mode: "chat",
+      interaction_mode: "build",
       permission_mode: "supervised",
     });
     useWorkspaceStore.setState({ threads: [thread] });
@@ -175,7 +175,7 @@ describe("per-thread settings", () => {
     const thread = createMockThread({
       id: "thread-sync-2",
       reasoning_level: "max",
-      interaction_mode: "chat",
+      interaction_mode: "build",
       permission_mode: "supervised",
       copilot_agent: "code",
     });
@@ -212,7 +212,7 @@ describe("per-thread settings", () => {
     expect(updated?.copilot_agent).toBeNull();
   });
 
-  it("sendPlanAction implement switches interaction mode to chat", async () => {
+  it("sendPlanAction implement switches interaction mode to build", async () => {
     const thread = createMockThread({
       id: "thread-implement",
       interaction_mode: "plan",
@@ -225,17 +225,17 @@ describe("per-thread settings", () => {
       "implement",
     );
 
-    expect(useThreadStore.getState().getThreadSettings("thread-implement").interactionMode).toBe("chat");
+    expect(useThreadStore.getState().getThreadSettings("thread-implement").interactionMode).toBe("build");
     expect(
       useWorkspaceStore.getState().threads.find((t) => t.id === "thread-implement")?.interaction_mode,
-    ).toBe("chat");
+    ).toBe("build");
     expect(mockTransport.updateThreadSettings).toHaveBeenCalledWith(
       "thread-implement",
-      expect.objectContaining({ interactionMode: "chat" }),
+      expect.objectContaining({ interactionMode: "build" }),
     );
 
     const calls = vi.mocked(mockTransport.sendMessage).mock.calls;
     const sendCall = calls[calls.length - 1];
-    expect(sendCall?.[8]).toBe("chat");
+    expect(sendCall?.[8]).toBe("build");
   });
 });

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -477,7 +477,7 @@ describe("Workspace Behavior", () => {
         forkedFromMessageId: "msg-parent",
         permissionMode: "supervised",
         reasoningLevel: "max",
-        interactionMode: "chat",
+        interactionMode: "build",
         contextWindow: "1m",
         thinking: true,
       });

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -5,7 +5,7 @@ import type { PermissionMode, InteractionMode, AttachmentMeta } from "@/transpor
 import { PERMISSION_MODES, INTERACTION_MODES, getTransport } from "@/transport";
 import {
   ArrowUp,
-  MessageSquare,
+  Hammer,
   FileEdit,
   Lock,
   Unlock,
@@ -208,17 +208,17 @@ function ComposerOptionsMenu({
           <Button
             variant="ghost"
             size="xs"
-            onClick={() => onModeChange(INTERACTION_MODES.CHAT)}
-            aria-pressed={mode === INTERACTION_MODES.CHAT}
+            onClick={() => onModeChange(INTERACTION_MODES.BUILD)}
+            aria-pressed={mode === INTERACTION_MODES.BUILD}
             className={cn(
               "h-auto flex-1 gap-1.5 rounded-[5px] px-2 py-1 text-xs font-medium hover:bg-transparent",
-              mode === INTERACTION_MODES.CHAT
+              mode === INTERACTION_MODES.BUILD
                 ? "bg-background text-foreground shadow-sm hover:bg-background"
                 : "text-muted-foreground hover:text-foreground",
             )}
           >
-            <MessageSquare size={12} />
-            Chat
+            <Hammer size={12} />
+            Build
           </Button>
           <Button
             variant="ghost"
@@ -357,15 +357,15 @@ function InlineComposerOptions({
             <Button
               variant="ghost"
               size="xs"
-              onClick={() => onModeChange(mode === INTERACTION_MODES.CHAT ? INTERACTION_MODES.PLAN : INTERACTION_MODES.CHAT)}
+              onClick={() => onModeChange(mode === INTERACTION_MODES.BUILD ? INTERACTION_MODES.PLAN : INTERACTION_MODES.BUILD)}
               className="gap-1.5 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
             >
-              {mode === INTERACTION_MODES.CHAT ? <MessageSquare size={14} /> : <FileEdit size={14} />}
-              <span className="text-sm">{mode === INTERACTION_MODES.CHAT ? "Chat" : "Plan"}</span>
+              {mode === INTERACTION_MODES.BUILD ? <Hammer size={14} /> : <FileEdit size={14} />}
+              <span className="text-sm">{mode === INTERACTION_MODES.BUILD ? "Build" : "Plan"}</span>
             </Button>
           }
         />
-        <TooltipContent>{mode === INTERACTION_MODES.CHAT ? "Chat mode" : "Plan mode"}</TooltipContent>
+        <TooltipContent>{mode === INTERACTION_MODES.BUILD ? "Build mode" : "Plan mode"}</TooltipContent>
       </Tooltip>
 
       {permissionLocked ? (
@@ -471,7 +471,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   // provider from the model ID alone is ambiguous and routes to the wrong backend.
   const [provider, setProvider] = useState<string>(getDefaultProviderId());
   const [reasoning, setReasoning] = useState<ReasoningLevel>(getDefaultReasoningLevel());
-  const [mode, setMode] = useState<InteractionMode>(INTERACTION_MODES.CHAT);
+  const [mode, setMode] = useState<InteractionMode>(INTERACTION_MODES.BUILD);
   const [copilotAgent, setCopilotAgent] = useState<string | null>(null);
   // Per-thread overrides; null/undefined means inherit from settings default.
   const [contextWindow, setContextWindow] = useState<ContextWindowMode | null>(null);
@@ -581,7 +581,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     setReasoning(normalizeReasoningLevelForModel(validModelId, settingsDefaultReasoning));
 
     if (!agentSettingsTouchedRef.current) {
-      setMode(settingsDefaultMode === "plan" ? INTERACTION_MODES.PLAN : INTERACTION_MODES.CHAT);
+      setMode(settingsDefaultMode === "plan" ? INTERACTION_MODES.PLAN : INTERACTION_MODES.BUILD);
       setAccess(settingsDefaultPermission);
     }
   }, [settingsLoaded, settingsDefaultModelId, settingsDefaultProvider, settingsDefaultReasoning, settingsDefaultMode, settingsDefaultPermission, threadId]);
@@ -711,11 +711,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         setMode(
           nextThread?.interaction_mode === "plan"
             ? INTERACTION_MODES.PLAN
-            : nextThread?.interaction_mode === "chat"
-              ? INTERACTION_MODES.CHAT
+            : nextThread?.interaction_mode === "build"
+              ? INTERACTION_MODES.BUILD
               : globalSettings.agent.defaults.mode === "plan"
                 ? INTERACTION_MODES.PLAN
-                : INTERACTION_MODES.CHAT,
+                : INTERACTION_MODES.BUILD,
         );
         setAccess(
           nextThread?.permission_mode
@@ -746,7 +746,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       // Reset mode/access to persisted defaults
       agentSettingsTouchedRef.current = false;
       const { settings } = useSettingsStore.getState();
-      setMode(settings.agent.defaults.mode === "plan" ? INTERACTION_MODES.PLAN : INTERACTION_MODES.CHAT);
+      setMode(settings.agent.defaults.mode === "plan" ? INTERACTION_MODES.PLAN : INTERACTION_MODES.BUILD);
       setAccess(settings.agent.defaults.permission);
       setCopilotAgent(null);
       setContextWindow(null);
@@ -777,14 +777,14 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const threadRecordInteractionMode = useWorkspaceStore((s) => {
     if (!threadId) return undefined;
     const mode = s.threads.find((t) => t.id === threadId)?.interaction_mode;
-    return mode === "plan" || mode === "chat" ? mode : undefined;
+    return mode === "plan" || mode === "build" ? mode : undefined;
   });
 
   // Sync mode when thread settings change in-place (e.g. Plan tab Implement).
   useEffect(() => {
     if (!threadId) return;
     const resolved = persistedInteractionMode ?? threadRecordInteractionMode;
-    if (resolved === INTERACTION_MODES.PLAN || resolved === INTERACTION_MODES.CHAT) {
+    if (resolved === INTERACTION_MODES.PLAN || resolved === INTERACTION_MODES.BUILD) {
       setMode(resolved);
     }
   }, [threadId, persistedInteractionMode, threadRecordInteractionMode]);
@@ -979,7 +979,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       if (action === "toggle-plan") {
         const next =
           mode === INTERACTION_MODES.PLAN
-            ? INTERACTION_MODES.CHAT
+            ? INTERACTION_MODES.BUILD
             : INTERACTION_MODES.PLAN;
         setMode(next);
         if (threadId) void setThreadSettings(threadId, { interactionMode: next });

--- a/apps/web/src/components/settings/sections/AgentSection.tsx
+++ b/apps/web/src/components/settings/sections/AgentSection.tsx
@@ -41,7 +41,7 @@ export function AgentSection() {
         <SegControl
           options={[
             { value: "plan", label: "Plan" },
-            { value: "chat", label: "Chat" },
+            { value: "build", label: "Build" },
             { value: "agent", label: "Agent", disabled: true, title: "Coming soon" },
           ]}
           value={mode}

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1738,8 +1738,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       usePlanStore.getState().setGenerating(threadId, true);
     } else if (action === "implement") {
       // Implementation runs in build mode; leave plan mode so the composer
-      // label and future sends match the execution phase.
-      void get().setThreadSettings(threadId, { interactionMode: INTERACTION_MODES.BUILD });
+      // label and future sends match the execution phase. Await the
+      // persistence RPC and abort the implement turn on failure so the
+      // local UI cannot diverge from the stored thread row (a stale row
+      // would flip the thread back to Plan on reload).
+      const persisted = await get().setThreadSettings(threadId, {
+        interactionMode: INTERACTION_MODES.BUILD,
+      });
+      if (!persisted) return;
     }
 
     await get().sendMessage(

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -388,7 +388,7 @@ export function countActiveSubagentCalls(calls: ToolCall[] | undefined): number 
 
 const DEFAULT_THREAD_SETTINGS: ThreadSettings = {
   permissionMode: PERMISSION_MODES.FULL,
-  interactionMode: INTERACTION_MODES.CHAT,
+  interactionMode: INTERACTION_MODES.BUILD,
 };
 
 /** Maximum entries in the tool call record LRU cache. */
@@ -1737,9 +1737,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (action === "revise") {
       usePlanStore.getState().setGenerating(threadId, true);
     } else if (action === "implement") {
-      // Implementation runs in chat mode; leave plan mode so the composer
+      // Implementation runs in build mode; leave plan mode so the composer
       // label and future sends match the execution phase.
-      void get().setThreadSettings(threadId, { interactionMode: INTERACTION_MODES.CHAT });
+      void get().setThreadSettings(threadId, { interactionMode: INTERACTION_MODES.BUILD });
     }
 
     await get().sendMessage(

--- a/docs/guides/settings-schema.md
+++ b/docs/guides/settings-schema.md
@@ -30,7 +30,7 @@ If a category has multiple settings that share a common qualifier, group them un
   "agent": {
     "maxConcurrent": 5,
     "defaults": {
-      "mode": "chat",
+      "mode": "build",
       "permission": "full"
     }
   }
@@ -40,7 +40,7 @@ If a category has multiple settings that share a common qualifier, group them un
 {
   "agent": {
     "maxConcurrent": 5,
-    "defaultMode": "chat",
+    "defaultMode": "build",
     "defaultPermission": "full"
   }
 }
@@ -115,7 +115,7 @@ When adding a new setting, ask these questions in order:
   "agent": {
     "maxConcurrent": 5,
     "defaults": {
-      "mode": "chat",                  // "plan" | "chat" | "agent"
+      "mode": "build",                 // "plan" | "build" | "agent"
       "permission": "full"             // "full" | "supervised"
     },
     "guardrails": {

--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -10,7 +10,7 @@ Per-setting reference for Mcode's `settings.json`. For schema conventions and st
 |---------|------|---------|-------|-------------|-------------|
 | `appearance.theme` | enum | `"system"` | `"system"` \| `"dark"` \| `"light"` | - | Color theme preference |
 | `agent.maxConcurrent` | integer | `5` | > 0 | - | Maximum concurrent agent sessions |
-| `agent.defaults.mode` | enum | `"chat"` | `"plan"` \| `"chat"` \| `"agent"` | - | Default interaction mode for new agents |
+| `agent.defaults.mode` | enum | `"build"` | `"plan"` \| `"build"` \| `"agent"` | - | Default interaction mode for new agents |
 | `agent.defaults.permission` | enum | `"full"` | `"full"` \| `"supervised"` | - | Default permission mode for new agents |
 | `agent.guardrails.maxBudgetUsd` | number | `0` | >= 0 | - | Stop the agent when session cost exceeds this USD amount. `0` disables. Claude only. |
 | `agent.guardrails.maxTurns` | integer | `0` | >= 0 | - | Stop the agent after this many turns. `0` disables. Claude only. |

--- a/packages/contracts/src/models/enums.ts
+++ b/packages/contracts/src/models/enums.ts
@@ -40,16 +40,16 @@ export const PERMISSION_MODES = {
 
 /**
  * Interaction mode for agent sessions.
- * - "chat": normal conversation with full tool access
+ * - "build": execution mode with full tool access (edits, runs, makes changes)
  * - "plan": read-only planning mode (no writes or execution)
  */
-export const InteractionModeSchema = z.enum(["chat", "plan"]);
+export const InteractionModeSchema = z.enum(["build", "plan"]);
 /** Interaction mode for agent sessions. */
 export type InteractionMode = z.infer<typeof InteractionModeSchema>;
 
 /** Constant lookup for interaction modes. */
 export const INTERACTION_MODES = {
-  CHAT: "chat" as const,
+  BUILD: "build" as const,
   PLAN: "plan" as const,
 } satisfies Record<string, InteractionMode>;
 

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -116,7 +116,7 @@ export const SettingsSchema = lazySchema(() =>
         defaults: z
           .object({
             /** Default interaction mode. */
-            mode: AgentDefaultModeSchema.default("chat"),
+            mode: AgentDefaultModeSchema.default("build"),
             /** Default permission mode. */
             permission: PermissionModeSchema.default("full"),
           })


### PR DESCRIPTION
## What

Rename the `InteractionMode` enum value `"chat"` → `"build"` end-to-end. Schema, settings default, DB rows, composer UI, transport types, unit tests, e2e fixtures, and docs all flip in one PR.

## Why

The product surface calls this mode **Build**, but the codebase value was `"chat"`. Inside an app that is entirely a chat UI, "Chat mode" reads as "the mode where you can chat with the agent" — a meaningless distinction. The mismatch was tracked as a rename-pending callout in `CONTEXT.md`.

## Key Changes

- `InteractionModeSchema` flips to `z.enum(["build", "plan"])`; `INTERACTION_MODES.CHAT` → `INTERACTION_MODES.BUILD`.
- `AgentDefaultModeSchema.default("build")`.
- Drizzle migration `0010_clever_skin` updates existing `thread.interaction_mode = 'chat'` rows to `'build'`. The DB column stays nullable text (matches sibling thread settings; default resolved at the contract layer).
- Composer mode picker label becomes **Build**; icon swaps `MessageSquare` → `Hammer` for clearer construct-vs-draft pairing against Plan's `FileEdit`.
- Settings picker SegControl, `threadStore` default, agent-service comments, unit-test fixtures and assertions, 6 e2e specs, `docs/guides/settings-schema.md`, and `docs/settings/reference.md` all updated.
- `CONTEXT.md` rename-pending callout for `InteractionMode` removed. The separate `AgentDefaultMode` `"agent"` callout is intentionally kept — it tracks #511.
- No backwards-compat shims.

## Verification

- `bun run typecheck` passes (5/5 packages).
- Modified unit tests pass: `per-thread-settings.test.ts` (12/12), `workspace-behavior.test.ts` (18/18).
- Affected e2e spec passes: `ui-improvements-floating.spec.ts` (12/12).
- Reviewed across 4 lenses (correctness, quality, security, performance); all real findings landed in this commit before the push.

Closes #510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782319339&installation_id=129163861&pr_number=515&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F515&signature=d57e90e0a7a34ae42e051d78d61197109536fefad8e4cb8dc38be30f9fad05e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default interaction mode changed from Chat to Build across the app (composer, controls, settings); new and placeholder threads now initialize in Build.
  * Database migration applied to align existing threads with the new default.

* **Tests**
  * End-to-end and unit tests updated to reflect Build as the default mode and UI expectations.

* **Documentation**
  * Settings docs and schema examples updated to show Build as the default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->