### PR TITLE
fix(diff): left-align side-rail buttons so icons stay visible when collapsed

### DIFF
--- a/apps/web/src/components/diff/SideRail.tsx
+++ b/apps/web/src/components/diff/SideRail.tsx
@@ -185,7 +185,12 @@ export function SideRail({
 /** Shared classes for the rail's button structure — used by both RailButton
  *  and the inline DropdownMenu trigger so they remain visually identical. */
 const RAIL_BUTTON_CLASS = [
-  "relative flex min-h-[30px] w-full items-center gap-2.5",
+  // `justify-start` overrides the shadcn Button default `justify-center`.
+  // The label span keeps its `whitespace-nowrap` width even when faded out,
+  // so centering the row would push the icon left of the collapsed rail's
+  // `w-8` frame and hide it. Left-anchoring keeps the icon at the same x
+  // position whether the rail is collapsed or expanded.
+  "relative flex min-h-[30px] w-full items-center justify-start gap-2.5",
   "px-3 py-1 text-left font-mono text-[10.5px] uppercase tracking-[0.04em]",
   "transition-colors text-muted-foreground hover:bg-muted/50 hover:text-foreground",
   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-ring/55",


### PR DESCRIPTION
## What
Left-align the diff side-rail action buttons so their icons remain visible when the rail is in its collapsed 32px state.

## Why
The shadcn `Button` default `justify-center` was centering each row (icon + gap + label) inside the rail. The label span keeps its `whitespace-nowrap` width even when faded out, so the row is wider than the collapsed `w-8` (32px) frame. Centering pushed the icon past the left edge into the clipped overflow region — users saw an empty rail with no icons until they hovered.

## Key Changes
- `apps/web/src/components/diff/SideRail.tsx`: add `justify-start` to `RAIL_BUTTON_CLASS` and comment the override rationale.

## Test plan
- [x] `bun run vitest run src/components/diff/__tests__/SideRail.test.tsx` — 8/8 pass
- [x] `bun run verify` — typecheck + lint clean; unit suite 1088/1089 (single unrelated Windows vitest worker-startup timeout in `message-cap.test.ts`)
- [ ] Visual check: collapsed rail shows Diff / Copy-path / Open icons aligned at the left edge; hover expands without horizontal jump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782352472&installation_id=129163861&pr_number=516&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F516&signature=defdd993a0c605e98eb15309a9488aa3582e2728ad507010b88f8d52e67eaa29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved sidebar button alignment consistency. The rail button content now maintains stable positioning when the sidebar expands and collapses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->