### PR TITLE
docs(product): add PRODUCT.md and refresh design context

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,13 +1,15 @@
 # Design Context
 
 ## Target Audience
-**Developers.** Specifically: people who already build software for a living and use Mcode as their daily AI agent orchestration desktop app.
+**Developers.** Specifically: people who already build software for a living and use Mcode as their daily AI agent orchestration desktop app — late evenings, multiple agents running in parallel, the app kept open on a second monitor next to the editor.
 
 ## Use Cases
 - Driving long-running coding agents across multiple worktrees and threads in parallel
-- Reviewing diffs, commits, task progress, and tool-call traces produced by those agents
+- Reviewing per-turn diffs, commits, task progress, and tool-call traces produced by those agents
 - Switching rapidly between projects and threads (sidebar is on-screen all day)
-- Composing prompts with branch/worktree/mode controls visible upfront, not buried
+- Composing prompts with branch / worktree / mode controls visible upfront, not buried
+- Drafting in **Plan mode** before letting the agent execute in **Build mode**
+- Capturing browser screenshots and regions straight into the next prompt via the preview panel
 - Extended evening / late-night sessions with the app open in the foreground
 
 ## Brand Personality / Tone
@@ -16,18 +18,38 @@
 - **Information-dense**: developers tolerate (and prefer) tight layouts with mono / tabular numerics. Don't pad with marketing-style whitespace.
 - **Technical register in copy**: "Errored", "Idle", "Empty" — not softened consumer language.
 - **No emoji decoration**, no hand-holding empty states. Typographic glyphs (◌, ⊘, ⊕, ⌂) carry empty states.
-- **Keyboard-first**: shortcuts (F2 rename, Enter to navigate, slash commands) are first-class, not hidden.
+- **Keyboard-first**: shortcuts (F2 rename, Cmd+1..9 thread switch, Cmd+K palette, slash commands) are first-class, not hidden.
+- **Glance, not read**: the user's attention is rationed. A status dot they can read at flick-speed is worth more than a paragraph of agent prose.
 
 ## Established Aesthetic
-- **Theme**: warm amber primary (hue 75) with sage (`--diff-add-strong`, hue 145) for additions/completed state and clay (`--diff-remove-strong`, hue 25) for removals/errored state. Dark and light themes both supported; warm tinting throughout.
-- **Typography**: Public Sans for UI, mono for SHAs / counts / timestamps / status labels. Mono small-caps with `tracking-[0.16em–0.18em]` for section headings.
+- **Theme**: warm amber primary (hue 75) with sage (`--diff-add-strong`, hue 145) for additions / completed state and clay (`--diff-remove-strong`, hue 25) for removals / errored state. Dark theme is the **primary canvas** (the app is used in the evening). Light theme uses warm 0.005-chroma neutrals; dark theme uses a matte cool 260-hue surface with the same warm amber accent on top.
+- **Typography**: Public Sans for UI, mono (SF Mono / Cascadia / Consolas) for SHAs / counts / timestamps / status labels. Mono small-caps with `tracking-[0.16em–0.18em]` for section headings.
+- **Tonal lift instead of dividers**: floating panels sit a few percent above `--page` so separation reads as light, not lines. Reach for tonal separation before reaching for `border`.
 - **Status indicators**: 1.5–2px dots in tokenized colors, never raw `bg-yellow-500` / `bg-green-500`.
 - **Selection**: row-fill with `bg-accent`, never a side-stripe border (`border-l > 1px` is banned per impeccable).
 - **No nested guide rails** (`border-l border-border/50 pl-2` for tree indentation): use indentation alone.
-- **Empty states**: glyph (28px font-mono `text-muted-foreground/15`) + small-caps mono caption (10.5px `tracking-[0.18em]` `text-muted-foreground/40`).
+- **Empty states**: glyph (28px font-mono `text-muted-foreground/15`) plus small-caps mono caption (10.5px `tracking-[0.18em]` `text-muted-foreground/40`).
 - **Active counts / running indicators**: pulsing 6px `bg-primary` dots; tabular-nums for any numeric meta.
 
+## Surfaces
+- **Sidebar** — projects and threads tree, drag-reorderable, status dot per thread. The thing the user scans first, every time.
+- **Conversation (ChatView)** — narrative timeline of turns. Moving toward a **Whisper aesthetic**: prose-first rendering, vertical timeline rail reserved for nested sub-agent groups only. See `project_narrative_whisper.md` and commit c906a265.
+- **Composer** — the user's only input surface. Treat as a **drafting surface**, not a chat box. Owns mode (Plan / Build), branch, worktree, attachments, model, reasoning level. Drafts persist across thread switches.
+- **Plan-mode wizard** — when Plan mode activates, the composer transforms into a structured question wizard (`PlanQuestionWizard`). Use the wizard motion system already in `index.css` (`animate-wizard-*`); do not invent new curves.
+- **Preview panel** — embedded browser. Has a **Design mode** toggle (gates the main submit button until exited) and a **Capture dock** for region / element / full-page captures that land in the composer. Tools split into "main" (omnibox, tabs) and "dev / debug" (capture, design pill, page context); see `project_preview_toolbar_devdebug_split.md`.
+- **Diff panel** — per-turn file tree on the left, side-by-side / unified / whole-file Markdown preview on the right. Side-rail file actions stay left-aligned so icons remain visible when collapsed (commit 632f3cac).
+- **Command palette (Cmd+K)** — the keyboard discovery surface. Slash commands, settings, actions.
+- **Right panel** — terminal lives here as a tab (commit 39336e66). Other auxiliary tabs are siblings, never nested.
+- **Settings** — appearance, performance, model context overrides, provider keys, permission modes. Schema is nested JSON, max 3 levels (see `docs/guides/settings-schema.md`).
+
 ## Constraints
-- React + Zustand + Tailwind 4 + shadcn/ui primitives in `apps/web/src/components/ui/`
+- React 19 + Zustand + Tailwind 4 + shadcn/ui primitives in `apps/web/src/components/ui/`
 - Shiki syntax highlighting runs in a worker; new lang grammars must be declared in `optimizeDeps`
 - Frontend bundle target < 2MB gzipped, app idle memory < 150MB
+- Every animation in `index.css` has a `prefers-reduced-motion` override; new motion must too
+- Cross-package changes require `bun run verify` to pass (typecheck + lint + unit). See `docs/guides/agent-workflow.md`
+
+## Where to Go Deeper
+- **`docs/guides/ui-design-spec.md`** — the full designer-facing spec (11 sections, banned patterns, the "AI made this" test). Read once before any non-trivial UI work.
+- **`PRODUCT.md`** — what Mcode is, who it's for, the wedge, the non-goals. Read when scoping a feature, not when polishing one.
+- **`CONTEXT.md`** — domain glossary. Read before naming things.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -84,8 +84,9 @@ A user with Mcode open sees, in priority order:
 | **Plan-mode wizard** | When Plan mode is active, the composer transforms into a step-by-step question flow before any work begins. | Structured planning, not free-form chat. |
 | **Preview panel** | Embedded browser pointed at the running app. Has a **design mode** (manual inspection, gates the main submit button) and a **capture dock** (screenshot regions or elements into the composer). | Visual loop without leaving the app. |
 | **Diff panel** | Per-turn file changes, side-rail to open in editor, whole-file Markdown preview. | Reviewing what the agent did is the second most common action after sending a prompt. |
-| **Command palette** | Cmd+K. Slash commands, settings, actions. | The keyboard discovery surface. |
+| **Command palette** | Cmd+K. Slash commands, actions, and a jump to Settings. | The keyboard discovery surface. |
 | **Right panel** | Terminal as a tab; other auxiliary tabs alongside. | Drop into a shell without leaving the workspace. |
+| **Settings** | Appearance, performance, model context overrides, provider keys, permission modes. Reached from the sidebar or the command palette. | Configuration without leaving the workspace. |
 
 ## 7. What Mcode Doesn't Do
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,136 @@
+# Product
+
+*For contributors. The README tells you what Mcode is in a sentence. This document tells you why it exists, who it serves, what jobs it does, and the lines we choose not to cross. Read it once before you scope a feature.*
+
+---
+
+## 1. What Mcode Is
+
+Mcode is a desktop app for running coding agents — many at a time, across many projects, against many branches. You point it at a folder, pick a provider (Claude, Codex, Copilot, Cursor, OpenCode), and you get a workspace where each conversation is a thread, each thread can have its own git worktree, and every tool call the agent makes is visible in real time.
+
+It is not a chat client and it is not a wrapper. The CLIs already work. Mcode exists because *running eight agents in parallel from a terminal is unworkable* — you lose track of which one finished, which one errored, which branch each one is on, which diff each one produced. Mcode is the orchestration surface that sits above all of them.
+
+## 2. Who It's For
+
+One person, holding their attention:
+
+- **Senior developers** who already use coding agents daily and have hit the wall of "how do I keep five of these going without losing my mind?"
+- **Solo founders and indie engineers** running parallel experiments across multiple repos.
+- **Power users** who keep an editor, a terminal, a browser, and a notes app open simultaneously and want Mcode to fit next to those, not replace them.
+
+Not for:
+
+- People who have never used Claude Code, Cursor, or Codex from a terminal. The mental model is too dense.
+- Teams looking for ticket tracking, code review, or PR workflow inside the app.
+- People who want a single chat box with no concept of branches, threads, or worktrees.
+
+## 3. The Jobs Mcode Does
+
+In rough order of frequency:
+
+| Job | What happens | Why Mcode beats the CLI |
+|-----|--------------|-------------------------|
+| Run an agent on a fresh branch | Pick provider, choose **New worktree** mode, type the prompt, submit. A worktree is provisioned and the agent starts. | One action vs. five terminal commands. The worktree is named, tracked, listed. |
+| Track multiple agents at once | Sidebar shows every thread across every project with a status dot (idle / running / errored). | A terminal cannot show eight sessions at a glance. |
+| Review what an agent did | Diff panel renders per-turn file changes; side-rail jumps straight to the file in the user's editor. | The CLI's diff output scrolls past and is gone. |
+| Follow up on a previous run | Fork a thread from any message, or attach a new thread to an existing worktree. | The CLI has no concept of "continue from message N." |
+| Hand work between providers | Fork a Claude thread into a Cursor thread; a generated handoff doc carries context across. | Provider sessions don't talk to each other. Mcode's B/A/D ladder bridges them. |
+| Inspect an agent's web preview | Preview panel renders the running app; captures regions or full screenshots straight into the next prompt. | No tab-flipping; the screenshot lands in the composer ready to send. |
+| Plan before doing | Plan mode produces a structured plan and a question wizard before the agent edits anything. | The CLI just starts editing. |
+
+## 4. The Wedge
+
+The thing Mcode does that nothing else does:
+
+> **It treats each agent run as a first-class object with state — branch, worktree, transcript, diff, status — that you can scan in one second.**
+
+A Claude Code terminal session has no object. It's an ephemeral stream of text. When you start a second one, you're juggling two terminals. Five sessions and you're lost.
+
+Mcode says: *every conversation is a thread, every thread has metadata, every thread sits on the sidebar with a dot showing its state.* Once you commit to that abstraction, everything else falls out — worktree isolation, fork and handoff, per-turn diffs, the preview panel, the command palette. They all reinforce one principle: **the agent's work is something you can hold and reason about, not just talk to.**
+
+## 5. Product Principles
+
+Five things that decide ambiguous design or scope calls:
+
+### 1. The glance matters more than the conversation.
+
+Most of the time, the user is not reading the agent's reply. They're glancing at the sidebar to see what's done, what's running, what errored. Optimize for the glance. A status dot you can read at flick-speed is worth more than a paragraph of agent prose.
+
+### 2. Density over discovery.
+
+Developers tolerate small type, tight rows, packed columns. Don't add tooltips to teach them what icons mean — they'll learn it once. Don't wrap things in cards to "make them feel safe." Tight is correct.
+
+### 3. The agent is a peer, not an oracle.
+
+The user is in charge. They edit the prompts, they pick the branch, they choose when to fork, they decide what to ship. The agent runs; the user steers. Mcode does not narrate the agent's wisdom or hide its mistakes — it shows what happened, exactly, in the order it happened.
+
+### 4. Keyboard first, mouse fallback.
+
+Every action has a keystroke. F2 renames in place, Cmd+1..9 switches threads, Cmd+K opens the palette, slash commands fire from the composer. If you design a feature without a keyboard path, you haven't finished it.
+
+### 5. Quiet over loud.
+
+The interface rewards inactivity. When nothing is happening, the app looks calm. When something is happening, exactly one element changes — a dot pulses, a row enters, a number ticks. Nothing else moves. Decoration that competes with the data is hostile.
+
+## 6. The Surfaces
+
+A user with Mcode open sees, in priority order:
+
+| Surface | What it does | Why it earns its space |
+|---------|--------------|------------------------|
+| **Sidebar** | Projects, threads, status dots, drag-reorder | The thing the user scans first, every time. |
+| **Conversation** | Narrative timeline of turns, tool calls, narration segments. Read-only — replies go through the composer. | The agent's stream, made legible. |
+| **Composer** | Drafting surface at the bottom of the conversation. Owns mode (Plan / Build), branch, worktree, attachments, model, reasoning level. Persists drafts across thread switches. | The user's only input. Treat it like a workbench. |
+| **Plan-mode wizard** | When Plan mode is active, the composer transforms into a step-by-step question flow before any work begins. | Structured planning, not free-form chat. |
+| **Preview panel** | Embedded browser pointed at the running app. Has a **design mode** (manual inspection, gates the main submit button) and a **capture dock** (screenshot regions or elements into the composer). | Visual loop without leaving the app. |
+| **Diff panel** | Per-turn file changes, side-rail to open in editor, whole-file Markdown preview. | Reviewing what the agent did is the second most common action after sending a prompt. |
+| **Command palette** | Cmd+K. Slash commands, settings, actions. | The keyboard discovery surface. |
+| **Right panel** | Terminal as a tab; other auxiliary tabs alongside. | Drop into a shell without leaving the workspace. |
+
+## 7. What Mcode Doesn't Do
+
+Explicit non-goals. Saying no to these is what keeps the surface coherent.
+
+- **No ticket tracking.** GitHub Issues, Linear, Jira exist. We point at them; we don't replace them.
+- **No code review workflow.** PRs happen on GitHub. The diff panel is for *the agent's work in flight*, not for reviewing teammates' PRs.
+- **No team features.** Mcode is a personal tool. Multi-user, shared workspaces, role-based access are out of scope.
+- **No marketing surface.** No dashboards, no "stats", no "your week in Mcode." The app is a tool, not a thing to look at.
+- **No model abstraction layer.** We do not reinvent the provider SDKs. We adapt to them. If Claude releases a new feature, we surface it. We do not pretend providers are interchangeable when they aren't.
+- **No cloud sync, no accounts, no telemetry.** State lives on disk. Threads, worktrees, settings — all local.
+- **No mid-turn chat with the user.** The agent does not ask clarifying questions during a turn. We disallow the `AskUserQuestion` SDK tool (commit 58e1fc39). Plan mode is the structured place for clarification.
+
+## 8. Where We Are
+
+The roadmap lives on a GitHub Project board. Four broad phases, executed solo:
+
+1. **Foundations** — multi-provider runtime, worktree isolation, narrative timeline. *Largely shipped.*
+2. **The orchestration loop** — fork and handoff (B/A/D ladder), plan mode, per-turn diffs, preview panel. *In flight.*
+3. **The drafting surface** — composer as workbench, slash commands, skills, hooks. *In flight.*
+4. **Polish and integrations** — auto-updater, signing, packaging, deeper editor integration. *Backlog.*
+
+In flight as of May 2026:
+
+- **Whisper narrative redesign** — prose-first rendering, vertical rail reserved for nested tool calls. See commit c906a265.
+- **Preview panel refinements** — capture dock, design-mode pill, split between main toolbar and dev / debug tools. See commit 91e37a36.
+- **Plan-mode wizard** — composer takeover, durable lifecycle, structured question flow. See commit 82fd5eb2.
+- **Cursor handoff via provider-generated path** — B/A/D ladder with sessionless B-prime fallback. See commits fb4e7123 and 8bc66d23.
+
+## 9. How to Read the Other Docs
+
+| Doc | When to open it |
+|-----|----------------|
+| `README.md` | Install, run, prerequisites. |
+| `AGENTS.md` | Repo conventions, workflow gates, where `bun run verify` lives. |
+| `CONTEXT.md` | Domain glossary. If you don't know what a "worktree" or "narration segment" means here, read this first. |
+| `ARCHITECTURE.md` | IPC flow, data model, directory layout. |
+| `docs/guides/ui-design-spec.md` | Designer-facing spec. How Mcode should look and feel. |
+| `.impeccable.md` | Condensed design context for LLMs doing UI work. Mirrors the spec but optimized for code-generating agents. |
+| `docs/specs/` | Formal product specs for individual features (markdown rendering, usage tracking, context window, sort order). |
+
+## 10. The Product Test
+
+Before shipping a feature, hold it against three questions:
+
+1. **Does it earn its pixels?** If it adds chrome without making the glance faster or the loop tighter, cut it.
+2. **Does it sound like Mcode in copy?** "Errored", "Idle", "Empty" — not "Oops, something went wrong." Marketing voice in the diff is a bug.
+3. **Would a senior developer at 11pm thank you for this, or scroll past it?** That's the audience. That's the test.


### PR DESCRIPTION
## What

Adds a contributor-facing `PRODUCT.md` and refreshes `.impeccable.md` to fold in recent product/UX shifts.

## Why

The repo had a thorough designer-facing spec (`docs/guides/ui-design-spec.md`) and a condensed design context for LLMs (`.impeccable.md`), but no top-level product brief. A new contributor reading the README and `AGENTS.md` could understand *how to work on Mcode* without ever learning *what Mcode is for, who it serves, or what it explicitly refuses to do*. `PRODUCT.md` fills that gap.

`.impeccable.md` was also missing the surfaces and modes that landed in the last few months — Plan/Build, Whisper narrative, preview capture dock, per-turn diff side-rail. Refreshed so design-time agents have a current map.

## Key changes

**`PRODUCT.md` (new)**
- Who Mcode is for and who it isn't
- The 7 jobs Mcode does and why each one beats the CLI
- The wedge: *each agent run is a first-class object you can scan in one second*
- 5 product principles (glance > conversation, density > discovery, agent as peer, keyboard first, quiet over loud)
- Surfaces map, 7 explicit non-goals, current 4-phase roadmap with in-flight commit references
- 3-question product test for scoping new features

**`.impeccable.md` (refresh)**
- New **Surfaces** section: Sidebar, Conversation, Composer, Plan wizard, Preview, Diff, Palette, Right panel, Settings
- "Glance, not read" added to brand personality
- Plan/Build mode terminology (reflects #515 rename)
- Whisper narrative aesthetic noted on the Conversation surface (#484, #496)
- Preview capture dock and design-mode pill noted (#517)
- Cross-links to `PRODUCT.md` and the design spec

## Configuration changes

None.

## Related

- Folds in: #484 (Whisper narrative), #496 (plan-mode wizard), #515 (build/chat rename), #517 (preview redesign), #498 (diff side-rail), #499 (handoff B/A/D ladder)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782462265&installation_id=129163861&pr_number=518&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F518&signature=fff27a05b0ed598d150ff0d9f4af28685bf40f1a8627753108b8fb3bbf1f7bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded developer workflow and UI design spec with detailed use-case guidance (diff/review flows, mode switching, prompt composition, capture workflows) plus comprehensive aesthetic rules, UI surface definitions, and performance/motion expectations.
  * Added product documentation outlining positioning, interaction model, core principles, non-goals, roadmap status, related references, and a product test checklist for evaluating features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->