### PR TITLE
fix(chat): preserve multiline user messages and trim edge whitespace

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.0",
     "shiki": "^4.0.2",

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -318,6 +318,15 @@ describe("MarkdownContent variant styling", () => {
         undefined,
       );
     });
+
+    it("preserves composer line breaks as visible breaks", () => {
+      const { container } = render(
+        <MarkdownContent content={"q1 hey\nq2 hello"} variant="user" />,
+      );
+      expect(container.querySelector("br")).toBeTruthy();
+      expect(container.textContent).toContain("q1 hey");
+      expect(container.textContent).toContain("q2 hello");
+    });
   });
 });
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -103,14 +103,12 @@ function buildAttachedBrowserCaptures(list: PendingAttachment[]): AttachedBrowse
   return rows;
 }
 
-/** Decide which caption is stored for the chat bubble vs what is sent over the agent wire. */
+/** Caption stored in the chat bubble and DB; trims edge whitespace, keeps internal newlines. */
 function resolveOutboundDisplayContent(
-  trimmed: string,
+  rawInput: string,
   displayInjected: string | undefined,
-  captureRows: AttachedBrowserCapture[],
-): string | undefined {
-  if (captureRows.length === 0) return displayInjected;
-  return displayInjected ?? trimmed;
+): string {
+  return (displayInjected ?? rawInput).trim();
 }
 
 /** `accept` list for the composer's hidden file input (mirrors {@link isFileSupported}). */
@@ -1203,7 +1201,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       attachmentsSnapshot: PendingAttachment[],
       inputSnapshot: string,
     ): Omit<QueuedMessage, "id" | "queuedAt"> => {
-      const cleaned = inputSnapshot.trim();
       const attachmentMetas: AttachmentMeta[] = attachmentsSnapshot.map((att) => ({
         id: att.id,
         name: att.name,
@@ -1211,9 +1208,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         sizeBytes: att.sizeBytes,
         sourcePath: att.filePath ?? "",
       }));
+      const trimmedInput = inputSnapshot.trim();
       return {
-        content: cleaned,
-        displayContent: cleaned,
+        content: trimmedInput,
+        displayContent: trimmedInput,
         attachments: attachmentMetas,
         model: modelId,
         permissionMode: access,
@@ -1636,9 +1634,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     editorRef.current?.focus();
   }, [addFiles]);
 
-  /** Resolve @file tags into injected content. */
-  const injectFileContent = useCallback(async (trimmed: string): Promise<{ content: string; display?: string }> => {
-    const refs = extractFileRefs(trimmed);
+  /** Resolve @file tags into injected content for the agent wire payload. */
+  const injectFileContent = useCallback(async (rawInput: string): Promise<{ content: string; display?: string }> => {
+    const refs = extractFileRefs(rawInput);
     if (refs.length > 0 && workspaceId) {
       try {
         const transport = getTransport();
@@ -1653,11 +1651,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         const validFiles = fileContents.filter(
           (f): f is { path: string; content: string } => f !== null,
         );
-        const injected = buildInjectedMessage(trimmed, validFiles);
-        return { content: injected, display: injected !== trimmed ? trimmed : undefined };
+        const injected = buildInjectedMessage(rawInput, validFiles);
+        return { content: injected, display: injected !== rawInput ? rawInput : undefined };
       } catch { /* fall through */ }
     }
-    return { content: trimmed };
+    return { content: rawInput };
   }, [workspaceId, threadId]);
 
   /** Collect attachment metadata for RPC and revoke preview URLs. */
@@ -1698,7 +1696,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   }, [attachments]);
 
   const handleSend = useCallback(async () => {
-    const trimmed = input.trim();
+    const rawInput = input;
+    const trimmed = rawInput.trim();
     if (trimmed.length === 0 && attachments.length === 0) {
       // Empty submit while editing a queued message = the user emptied it
       // intentionally. Treat as "remove from queue" instead of silently
@@ -1770,17 +1769,18 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       !isGoalControlCommand(trimmed)
     ) {
       const captureRows = buildAttachedBrowserCaptures(attachments);
-      const { content: injectedContent, display: displayInjected } = await injectFileContent(trimmed);
+      const { content: injectedContent, display: displayInjected } = await injectFileContent(rawInput);
       let content: string;
       try {
         content =
           captureRows.length === 0 ? injectedContent : appendBrowserCaptureFence(injectedContent, captureRows);
+        content = content.trim();
       } catch (e) {
         const msg = e instanceof Error ? e.message : "Invalid page preview payload";
         useToastStore.getState().show("error", "Could not send message", msg);
         return;
       }
-      const displayContentResolved = resolveOutboundDisplayContent(trimmed, displayInjected, captureRows);
+      const displayContentResolved = resolveOutboundDisplayContent(rawInput, displayInjected);
       const currentAttachments = collectAndClearAttachments();
       const browserCaptureSpillPaths = collectBrowserCaptureSpillPaths(captureRows);
 
@@ -1839,7 +1839,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       return;
     }
 
-    const { content: injectedContent, display: displayInjected } = await injectFileContent(trimmed);
+    const { content: injectedContent, display: displayInjected } = await injectFileContent(rawInput);
 
     // Validate worktree mode requirements
     if (isNewThread && newThreadMode === "worktree" && namingMode === "custom" && !customBranchName.trim()) {
@@ -1867,12 +1867,13 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     try {
       messageContent =
         captureRows.length === 0 ? injectedContent : appendBrowserCaptureFence(injectedContent, captureRows);
+      messageContent = messageContent.trim();
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Invalid page preview payload";
       useToastStore.getState().show("error", "Could not send message", msg);
       return;
     }
-    const outboundDisplay = resolveOutboundDisplayContent(trimmed, displayInjected, captureRows);
+    const outboundDisplay = resolveOutboundDisplayContent(rawInput, displayInjected);
 
     // ---- Normal send path ----
 
@@ -2011,11 +2012,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     setQueuedSend(null);
     useThreadStore.getState().sendMessage(
       threadId,
-      text,
+      text.trim(),
       modelId,
       access,
       undefined,
-      text,
+      text.trim(),
       reasoning,
       provider,
     );

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo, lazy, Suspense } from "react";
 import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import {
   isMcodeWorkspacePreviewUrl,
@@ -35,8 +36,9 @@ interface MarkdownContentProps {
   componentOverrides?: Partial<Components>;
 }
 
-/** Stable remark plugin list, hoisted to avoid re-creating on every render. */
-const plugins = [remarkGfm];
+/** GFM for assistant bubbles; user bubbles also enable single-newline line breaks. */
+const ASSISTANT_REMARK_PLUGINS = [remarkGfm];
+const USER_REMARK_PLUGINS = [remarkGfm, remarkBreaks];
 
 /** Lazy-loaded MermaidBlock - only fetched when a mermaid fence is encountered. */
 const LazyMermaidBlock = lazy(() => import("./MermaidBlock"));
@@ -367,8 +369,10 @@ export const MarkdownContent = memo(function MarkdownContent({
     [isStreaming, variant, workspacePath, componentOverrides],
   );
 
+  const remarkPlugins = variant === "user" ? USER_REMARK_PLUGINS : ASSISTANT_REMARK_PLUGINS;
+
   return (
-    <ReactMarkdown remarkPlugins={plugins} components={components} urlTransform={markdownUrlTransform}>
+    <ReactMarkdown remarkPlugins={remarkPlugins} components={components} urlTransform={markdownUrlTransform}>
       {content}
     </ReactMarkdown>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.1.0",
         "shiki": "^4.0.2",
@@ -1848,6 +1849,8 @@
 
     "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
 
+    "mdast-util-newline-to-break": ["mdast-util-newline-to-break@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-find-and-replace": "^3.0.0" } }, "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
@@ -2179,6 +2182,8 @@
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 


### PR DESCRIPTION
## What
User chat messages now trim leading/trailing whitespace for storage and display while preserving internal line breaks. User bubbles render composer newlines on separate lines instead of collapsing them into one line.

## Why
Composer input was trimmed before both the agent wire payload and the stored caption were built, which was unnecessary for display/DB. Separately, user bubbles rendered through standard markdown, which treats single newlines as spaces - so multi-line messages like \q1 hey\\nq2 hello\ appeared on one line.

## Key Changes
- Split composer send path: build file injection from raw input, trim edge whitespace for \displayContent\ and agent \content\
- Add \emark-breaks\ for user-variant markdown so single newlines render as visible line breaks
- Add unit test covering multiline user bubble rendering

## Config Changes
None

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782462913&installation_id=129163861&pr_number=519&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F519&signature=7e77e9b3def96e7d56ca2dbaca8d20b09e81b6e6a0fbed26a7f45f0000889aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->