### PR TITLE
fix(settings): accept legacy agent.defaults.mode chat on load

### DIFF
--- a/packages/contracts/src/__tests__/settings.test.ts
+++ b/packages/contracts/src/__tests__/settings.test.ts
@@ -148,6 +148,31 @@ describe("SettingsSchema", () => {
     });
   });
 
+  describe("agent.defaults.mode", () => {
+    it("normalizes legacy chat to build", () => {
+      const result = SettingsSchema().parse({
+        agent: { defaults: { mode: "chat" } },
+      });
+      expect(result.agent.defaults.mode).toBe("build");
+    });
+
+    it("accepts build, plan, and agent unchanged", () => {
+      for (const mode of ["build", "plan", "agent"] as const) {
+        const result = SettingsSchema().parse({
+          agent: { defaults: { mode } },
+        });
+        expect(result.agent.defaults.mode).toBe(mode);
+      }
+    });
+
+    it("rejects unknown mode values", () => {
+      const result = SettingsSchema().safeParse({
+        agent: { defaults: { mode: "unknown" } },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe("model.defaults.thinking", () => {
     it("accepts thinking true", () => {
       const result = SettingsSchema().parse({

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -16,11 +16,12 @@ export type Theme = z.infer<typeof ThemeSchema>;
  *
  * Extends the base InteractionMode with an "agent" option that grants
  * autonomous multi-step execution capabilities.
+ *
+ * Accepts legacy `"chat"` from pre-rename settings files and normalizes it to `"build"`.
  */
-export const AgentDefaultModeSchema = z.enum([
-  ...InteractionModeSchema.options,
-  "agent",
-]);
+export const AgentDefaultModeSchema = z
+  .enum([...InteractionModeSchema.options, "agent", "chat"])
+  .transform((mode) => (mode === "chat" ? "build" : mode));
 /** Default agent interaction mode value. */
 export type AgentDefaultMode = z.infer<typeof AgentDefaultModeSchema>;
 


### PR DESCRIPTION
## What

Normalize legacy `agent.defaults.mode: "chat"` to `"build"` when parsing settings.json.

## Why

PR #515 renamed InteractionMode `chat` to `build`. Existing user settings still store `"chat"`, which made Zod validation fail and the server returned defaults on every load.

## Key changes

- Extend `AgentDefaultModeSchema` to accept `"chat"` and transform it to `"build"`
- Add regression tests for legacy value, current values, and invalid modes

## Configuration changes

None.

## Related issues/PRs

Relates to #515

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782464353&installation_id=129163861&pr_number=520&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F520&signature=645b4d5e6a23f541900e5ecd2b7572eca1e44ce38f82ca03ce103fd1ee5a5f09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced backward compatibility by supporting legacy "chat" mode in agent settings, which is now normalized to the "build" mode.

* **Tests**
  * Added test suite verifying mode validation, legacy value handling, and rejection of unknown mode values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->