### PR TITLE
chore(hooks): chain .githooks to global co-author stripping hooks

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+# --- chained-to-global-hooks ---
+GLOBAL_HOOK="$HOME/.git-hooks/post-commit"
+if [ -x "$GLOBAL_HOOK" ]; then
+    "$GLOBAL_HOOK" "$@"
+fi

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,6 @@
+#!/bin/sh
+# --- chained-to-global-hooks ---
+GLOBAL_HOOK="$HOME/.git-hooks/prepare-commit-msg"
+if [ -x "$GLOBAL_HOOK" ]; then
+    "$GLOBAL_HOOK" "$@"
+fi


### PR DESCRIPTION
## What

Adds `prepare-commit-msg` and `post-commit` hooks to `.githooks/` that chain to the user-level hooks at `~/.git-hooks/`.

## Why

This repo sets `core.hooksPath = .githooks`, which bypasses the global `~/.git-templates` hooks directory. Without chaining hooks in place, the user-level co-author stripping hooks never run in this repo, and AI co-author lines leak into commits.

## Key changes

- `.githooks/prepare-commit-msg` - chains to `~/.git-hooks/prepare-commit-msg` if executable
- `.githooks/post-commit` - chains to `~/.git-hooks/post-commit` if executable
- Both hooks are safe to re-install (idempotent via `# --- chained-to-global-hooks ---` marker)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782464458&installation_id=129163861&pr_number=521&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F521&signature=b76c1cfaf02e8b0948aa8503f9f99ae371681d571130a34e0cdb349a99e58954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Git hooks configuration to enable custom global commit workflow integration for development processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->