### PR TITLE
perf: incremental typecheck, ESLint cache, turbo cleanup

### DIFF
--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -17,7 +17,9 @@
     "sourceMap": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
   },
   "include": ["src/main/**/*"],
   "exclude": ["node_modules", "dist", "src/main/__tests__"]

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -7,7 +7,10 @@
     "declarationMap": false,
     // dist-tsc is only an esbuild input. Per-file .source maps race `tsc --watch` on Windows
     // (esbuild can read an empty .map mid-write) and break the desktop dev bundle.
-    "sourceMap": false
+    "sourceMap": false,
+    // Distinct buildinfo path so the dev:desktop emit pass (this config) doesn't clobber the
+    // typecheck pass (base tsconfig.json) that ships with the same tsBuildInfoFile.
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo.build"
   },
   "exclude": ["node_modules", "dist", "dist-tsc", "src/__tests__"]
 }

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -20,7 +20,9 @@
     "rootDir": "src",
     "outDir": "dist",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "src/__tests__"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
+    "lint": "eslint . --cache --cache-location node_modules/.cache/.eslintcache",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "preview": "vite preview",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -16,6 +16,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -18,7 +18,9 @@
     "noFallthroughCasesInSwitch": true,
     "noEmit": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "src/__tests__"]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -18,7 +18,9 @@
     "noFallthroughCasesInSwitch": true,
     "noEmit": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/turbo.json
+++ b/turbo.json
@@ -9,11 +9,9 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
-    "test": {
-      "dependsOn": ["^build"]
-    },
+    "test": {},
     "typecheck": {
-      "dependsOn": ["^build"]
+      "outputs": ["node_modules/.cache/tsbuildinfo"]
     },
     "lint": {}
   }


### PR DESCRIPTION
## What

Foundation optimizations that make every `bun run verify` faster on repeat runs. Three config-only changes shipped together because they share a single benchmark run and have no logic to test independently.

## Why

Typecheck and lint dominate agent and developer feedback loops. Incremental compilation and ESLint caching cut repeat-run times significantly. The phantom `^build` dependency on `test` and `typecheck` turbo tasks added unnecessary serialization since upstream packages have no build script.

## Key changes

- **Incremental TypeScript:** Added `incremental: true` and `tsBuildInfoFile: ./node_modules/.cache/tsbuildinfo` to all 5 tsconfig.json files
- **ESLint cache:** Updated `apps/web` lint script to `eslint . --cache --cache-location node_modules/.cache/.eslintcache`
- **Turbo cleanup:** Removed `dependsOn: ["^build"]` from `test` and `typecheck` tasks; added `outputs: ["node_modules/.cache/tsbuildinfo"]` to `typecheck`

## Benchmark

| Phase | Cold (1st run) | Warm (2nd run) | Speedup |
|-------|---------------|----------------|---------|
| Typecheck | 19.97s | 8.48s | 57% faster |
| Lint | 28.10s | 17.64s | 37% faster |

## Verification

- `turbo run typecheck --dry` confirms no phantom `^build` dependencies
- Typecheck: 5/5 packages pass
- Lint: passes clean
- Tests: 154 files, 1373 tests pass

Closes #527
Relates to #526

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782579211&installation_id=129163861&pr_number=532&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F532&signature=a0ba9c541b391c62c17b9c9c8171228d4be782888ba281c8e58ba80dd200a473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build performance by enabling incremental compilation and centralized build-info caching across apps and packages.
  * Enabled lint caching to speed up code checks.
  * Adjusted task dependency/configuration to reduce redundant rebuilds and added separate build-info for server builds to prevent cache conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->