### PR TITLE
perf(e2e): parallel workers + auto-detect existing dev server

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,
-  workers: 1,
+  workers: isCI ? 1 : 4,
   reporter: [["html", { outputFolder: "playwright-report" }]],
   use: {
     baseURL: BASE_URL,

--- a/scripts/agent/verify-e2e.mjs
+++ b/scripts/agent/verify-e2e.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 /**
  * Cross-platform E2E test runner.
- * Runs Playwright E2E tests from the apps/web directory.
+ * Probes the base URL for an already-running dev server; when found, sets
+ * PLAYWRIGHT_REUSE_WEB_SERVER=1 so Playwright attaches instead of cold-booting
+ * a fresh Vite server (saves ~30-60s per run for UI-iterating agents).
  */
 import { execSync } from "node:child_process";
+import { createConnection } from "node:net";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,5 +14,48 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../..");
 const webDir = resolve(repoRoot, "apps/web");
 
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:5173";
+
+/**
+ * Resolves to true when a TCP connection to `url`'s host:port completes within
+ * `timeoutMs`. A bare TCP probe is enough: Playwright's own readiness check
+ * still gates spec execution on the HTTP response, so we just need to know
+ * whether something is listening.
+ */
+function probeBaseUrl(url, timeoutMs = 1000) {
+  return new Promise((resolveProbe) => {
+    let host;
+    let port;
+    try {
+      const parsed = new URL(url);
+      host = parsed.hostname;
+      port = Number(parsed.port) || (parsed.protocol === "https:" ? 443 : 80);
+    } catch {
+      resolveProbe(false);
+      return;
+    }
+    const socket = createConnection({ host, port });
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolveProbe(ok);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(timeoutMs, () => finish(false));
+  });
+}
+
+const env = { ...process.env };
+const devServerUp = await probeBaseUrl(BASE_URL);
+if (devServerUp) {
+  console.log(`=== Dev server detected at ${BASE_URL}, reusing ===`);
+  env.PLAYWRIGHT_REUSE_WEB_SERVER = "1";
+} else {
+  console.log(`=== No dev server at ${BASE_URL}, Playwright will boot one ===`);
+}
+
 console.log("=== E2E Tests ===");
-execSync("bun run e2e", { stdio: "inherit", cwd: webDir });
+execSync("bun run e2e", { stdio: "inherit", cwd: webDir, env });

--- a/scripts/agent/verify-e2e.mjs
+++ b/scripts/agent/verify-e2e.mjs
@@ -54,6 +54,10 @@ if (devServerUp) {
   console.log(`=== Dev server detected at ${BASE_URL}, reusing ===`);
   env.PLAYWRIGHT_REUSE_WEB_SERVER = "1";
 } else {
+  // Explicitly clear in case the caller's shell exported it: an inherited
+  // truthy value plus no server listening would make Playwright skip its
+  // own boot and every spec would fail with ECONNREFUSED.
+  delete env.PLAYWRIGHT_REUSE_WEB_SERVER;
   console.log(`=== No dev server at ${BASE_URL}, Playwright will boot one ===`);
 }
 


### PR DESCRIPTION
## What

Two config-only e2e perf changes from Module F of #526:

1. **Parallel workers locally.** `playwright.config.ts` now runs `workers: 4` outside CI (CI stays at `workers: 1` for deterministic runs). The existing specs mock the WebSocket server, so there is no shared backend state to collide on.
2. **Reuse an already-running dev server.** `verify-e2e.mjs` does a 1s TCP probe of `localhost:5173` (or `PLAYWRIGHT_BASE_URL`) before launching Playwright. If something is listening, it exports `PLAYWRIGHT_REUSE_WEB_SERVER=1` so the existing config attaches to that server instead of cold-booting Vite. If nothing is listening, behavior is unchanged: Playwright boots its own server.

## Why

Closes #531. Agents iterating on UI typically have `bun run dev` open already, so cold-booting Vite on every `verify:e2e` run wastes 30-60s. Single-worker Playwright serializes 49 specs that have no shared state. Both are pure waste in the agent feedback loop.

## Key Changes

- `apps/web/playwright.config.ts:20` — `workers: 1` to `workers: isCI ? 1 : 4`
- `scripts/agent/verify-e2e.mjs` — added `probeBaseUrl()` (raw TCP via `node:net`) and the env-var hand-off to Playwright

## Verification

- `bun run verify` — typecheck and lint pass; 7 `snapshot-service.integration.test.ts` failures are pre-existing on `main` (hook timeout of 10s under load on Windows; file is byte-identical to `main` and passes in isolation with longer timeouts)
- **Warm path:** with `vite` running on :5173, `node scripts/agent/verify-e2e.mjs` prints `Dev server detected at http://localhost:5173, reusing` and reports `Running 246 tests using 4 workers` (parallelism active, env var picked up)
- **Cold path:** with no dev server, the script prints the fallback banner and Playwright boots its own server as before

### Benchmark caveat

I could not capture a clean before/after wall-clock table for the warm path on this run: a sibling-worktree spec (`usage-popover-visual.spec.ts`) hardcodes `baseURL: http://localhost:5174` and fails 79 tests when that external server is not running, which masks the parallelism win in the aggregate timer. Cold run with `workers: 4` finished the 165 non-:5174 specs in 8m54s on this machine. The reuse skip itself is a structural ~30-60s save on every run a developer already has `bun run dev` open for.

Closes #531
Related to #526

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782593143&installation_id=129163861&pr_number=533&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F533&signature=139f1e6991e73305284299570231fd1b6c6243b03c382dee79ac15596c1b5e0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E runner now detects and reuses an existing dev server to reduce startup time.
  * Test execution uses dynamic worker allocation (1 worker in CI, 4 locally) for faster local runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->