### PR TITLE
perf(verify): run typecheck, lint, tests concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "sync:cursor-models": "bun apps/server/scripts/sync-cursor-models-snapshot.ts",
     "verify": "node scripts/agent/verify-tests.mjs",
     "verify:e2e": "node scripts/agent/verify-e2e.mjs",
-    "verify:all": "node scripts/agent/verify-all.mjs"
+    "verify:all": "node scripts/agent/verify-all.mjs",
+    "test:scripts": "node --test scripts/agent/__tests__/"
   },
   "devDependencies": {
     "@types/node": "^22.19.17",

--- a/scripts/agent/__tests__/verify-tests.test.mjs
+++ b/scripts/agent/__tests__/verify-tests.test.mjs
@@ -1,0 +1,208 @@
+/**
+ * Tests for the parallel verify orchestrator.
+ * Uses Node's built-in test runner (`node:test`) so no extra dev dep is
+ * required. Run with `node --test scripts/agent/__tests__/`.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execSync, spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DEFAULT_PHASES,
+  hasCodeChanges,
+  runPhase,
+  runPhasesInParallel,
+} from "../verify-tests.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = resolve(__dirname, "..", "verify-tests.mjs");
+
+// Node binary used to spawn deterministic, cross-platform test phases.
+const NODE = process.execPath;
+
+/**
+ * Build a phase that runs a snippet of JS through `node -e`. Always passes
+ * `shell: false` so Windows cmd.exe quoting does not garble the snippet —
+ * the absolute node path means no shell wrapping is needed.
+ */
+function nodePhase(name, code) {
+  return { name, command: NODE, args: ["-e", code], shell: false };
+}
+
+test("runPhase resolves with code 0 and captured stdout for a successful command", async () => {
+  const result = await runPhase(nodePhase("echo", "console.log('hello-stdout')"));
+
+  assert.equal(result.name, "echo");
+  assert.equal(result.code, 0);
+  assert.match(result.output, /hello-stdout/);
+  assert.ok(result.durationMs >= 0);
+});
+
+test("runPhase preserves the child's non-zero exit code", async () => {
+  const result = await runPhase(nodePhase("fail", "process.exit(7)"));
+
+  assert.equal(result.code, 7);
+});
+
+test("runPhase captures stderr output as part of the buffered phase log", async () => {
+  const result = await runPhase(nodePhase("stderr", "console.error('boom')"));
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /boom/);
+});
+
+test("runPhase resolves (does not throw) when the command cannot be spawned", async () => {
+  const result = await runPhase({
+    name: "missing",
+    command: "this-binary-does-not-exist-xyz123",
+    args: [],
+    shell: false,
+  });
+
+  assert.notEqual(result.code, 0);
+});
+
+test("runPhasesInParallel returns aggregate code 0 when every phase passes", async () => {
+  const lines = [];
+  const { code, results } = await runPhasesInParallel(
+    [
+      nodePhase("alpha", "console.log('A')"),
+      nodePhase("beta", "console.log('B')"),
+      nodePhase("gamma", "console.log('C')"),
+    ],
+    { printer: (line) => lines.push(line) },
+  );
+
+  assert.equal(code, 0);
+  assert.equal(results.length, 3);
+  for (const r of results) assert.equal(r.code, 0);
+});
+
+test("runPhasesInParallel returns the first failing phase's code when any phase fails", async () => {
+  const { code, results } = await runPhasesInParallel(
+    [
+      nodePhase("ok", "console.log('a')"),
+      nodePhase("bad", "process.exit(3)"),
+      nodePhase("also-bad", "process.exit(5)"),
+    ],
+    { printer: () => {} },
+  );
+
+  assert.equal(code, 3);
+  // All phases run even though one (or more) failed.
+  assert.equal(results.length, 3);
+  assert.equal(results.find((r) => r.name === "ok").code, 0);
+  assert.equal(results.find((r) => r.name === "bad").code, 3);
+  assert.equal(results.find((r) => r.name === "also-bad").code, 5);
+});
+
+test("runPhasesInParallel prints buffered output in declared order, not finish order", async () => {
+  const lines = [];
+  // Phase A is intentionally slower than phase B. Output for A must still
+  // print before B's output because A is listed first.
+  await runPhasesInParallel(
+    [
+      nodePhase("A_slow", "setTimeout(function(){console.log('AAA')},150)"),
+      nodePhase("B_fast", "console.log('BBB')"),
+    ],
+    { printer: (line) => lines.push(line) },
+  );
+
+  const combined = lines.join("\n");
+  const idxA = combined.indexOf("AAA");
+  const idxB = combined.indexOf("BBB");
+  assert.ok(idxA >= 0, "expected A output in printed lines");
+  assert.ok(idxB >= 0, "expected B output in printed lines");
+  assert.ok(idxA < idxB, `A output should print before B output (got A@${idxA}, B@${idxB})`);
+});
+
+test("runPhasesInParallel actually runs phases concurrently (wall time ≈ max, not sum)", async () => {
+  const sleepMs = 400;
+  const start = Date.now();
+  const sleepCode = `setTimeout(function(){},${sleepMs})`;
+  await runPhasesInParallel(
+    [
+      nodePhase("s1", sleepCode),
+      nodePhase("s2", sleepCode),
+      nodePhase("s3", sleepCode),
+    ],
+    { printer: () => {} },
+  );
+  const elapsed = Date.now() - start;
+
+  // Sequential would be ~3 * sleepMs = 1200ms. Concurrent should be well
+  // under 2x sleep even on slow CI. Generous bound to avoid flakiness.
+  assert.ok(
+    elapsed < sleepMs * 2.5,
+    `expected concurrent execution (~${sleepMs}ms), got ${elapsed}ms`,
+  );
+});
+
+test("DEFAULT_PHASES wires the three required phases for `bun run verify`", () => {
+  const names = DEFAULT_PHASES.map((p) => p.name);
+  assert.deepEqual(names, ["Typecheck", "Lint", "Unit Tests"]);
+  for (const phase of DEFAULT_PHASES) {
+    assert.equal(phase.command, "bun");
+    assert.equal(phase.args[0], "run");
+  }
+});
+
+test("hasCodeChanges is exported and returns a boolean for the current repo", () => {
+  const result = hasCodeChanges();
+  assert.equal(typeof result, "boolean");
+});
+
+test("script exits 0 with skip message when run in a clean repo with no code changes", async () => {
+  const tmp = mkdtempSync(resolve(tmpdir(), "verify-orchestrator-"));
+  try {
+    const gitOpts = { cwd: tmp, stdio: "ignore" };
+    execSync("git init -q -b main", gitOpts);
+    execSync('git config user.email "t@t"', gitOpts);
+    execSync('git config user.name "t"', gitOpts);
+    execSync("git config commit.gpgsign false", gitOpts);
+    writeFileSync(resolve(tmp, "README.md"), "ok\n");
+    execSync("git add README.md", gitOpts);
+    execSync('git commit -q -m "init"', gitOpts);
+
+    const { code, stdout } = await runScript(SCRIPT_PATH, tmp);
+
+    assert.equal(code, 0, `expected exit 0, got ${code}. output:\n${stdout}`);
+    assert.match(
+      stdout,
+      /skipping verification/i,
+      "expected early-exit bypass to log a skip message",
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Spawns the verify script in a given directory and resolves with its
+ * combined output and exit code.
+ *
+ * @param {string} scriptPath
+ * @param {string} cwd
+ * @returns {Promise<{ code: number, stdout: string }>}
+ */
+function runScript(scriptPath, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd,
+      env: { ...process.env },
+    });
+    let stdout = "";
+    child.stdout.on("data", (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on("data", (d) => {
+      stdout += d.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 0, stdout }));
+  });
+}

--- a/scripts/agent/__tests__/verify-tests.test.mjs
+++ b/scripts/agent/__tests__/verify-tests.test.mjs
@@ -187,7 +187,7 @@ test("script exits 0 with skip message when run in a clean repo with no code cha
  *
  * @param {string} scriptPath
  * @param {string} cwd
- * @returns {Promise<{ code: number, stdout: string }>}
+ * @returns {Promise<{ code: number, stdout: string, signal: NodeJS.Signals | null }>}
  */
 function runScript(scriptPath, cwd) {
   return new Promise((resolve, reject) => {
@@ -203,6 +203,11 @@ function runScript(scriptPath, cwd) {
       stdout += d.toString();
     });
     child.on("error", reject);
-    child.on("close", (code) => resolve({ code: code ?? 0, stdout }));
+    // Signal-terminated runs report `code === null`. Treat them as failure
+    // (exit 1) so abnormal termination is never silently treated as success;
+    // expose the signal so callers can disambiguate if needed.
+    child.on("close", (code, signal) =>
+      resolve({ code: code === null ? 1 : code, stdout, signal }),
+    );
   });
 }

--- a/scripts/agent/verify-tests.mjs
+++ b/scripts/agent/verify-tests.mjs
@@ -1,26 +1,42 @@
 #!/usr/bin/env node
 /**
- * Cross-platform verification script: typecheck + lint + unit tests.
- * Skips verification when no code changes are detected (brainstorming-only sessions).
+ * Cross-platform verification orchestrator: typecheck + lint + unit tests
+ * spawned as concurrent child processes. Per-phase stdout/stderr is buffered
+ * and printed sequentially after every phase resolves, so the combined log
+ * stays readable instead of interleaving three streams of output.
+ *
+ * Skips verification entirely when no code changes are detected
+ * (brainstorming-only sessions).
+ *
+ * External interface: exit 0 when every phase passes (or when there are no
+ * code changes to verify); exit non-zero when any phase fails. The Codex
+ * (`scripts/agent/hooks/codex-stop.mjs`) and Cursor
+ * (`scripts/agent/hooks/cursor-stop.mjs`) wrappers depend on this contract.
  */
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
-function run(cmd, opts = {}) {
-  execSync(cmd, { stdio: "inherit", ...opts });
-}
+const isWindows = process.platform === "win32";
 
-/** Returns true when the branch has code changes (committed or uncommitted). */
-function hasCodeChanges() {
+/**
+ * Detects whether the current branch has code-relevant changes.
+ *
+ * Checks (in order): uncommitted diff against HEAD, untracked files, and
+ * committed changes against the merge-base with `main`. Returns true on any
+ * git error so verification still runs in unusual states (detached HEAD,
+ * shallow clone, missing main branch).
+ *
+ * @returns {boolean} True if any code file differs from the baseline.
+ */
+export function hasCodeChanges() {
   const codeGlob = '"*.ts" "*.tsx" "*.js" "*.jsx" "*.mts" "*.cts" "*.mjs" "*.cjs"';
 
-  // Check uncommitted changes (staged + unstaged)
   try {
     execSync(`git diff --quiet HEAD -- ${codeGlob}`, { stdio: "ignore" });
   } catch {
     return true;
   }
 
-  // Check untracked files
   try {
     const untracked = execSync(
       `git ls-files --others --exclude-standard -- ${codeGlob}`,
@@ -31,7 +47,6 @@ function hasCodeChanges() {
     return true;
   }
 
-  // Check committed changes on this branch vs main
   try {
     const mergeBase = execSync("git merge-base HEAD main", {
       encoding: "utf-8",
@@ -42,25 +57,140 @@ function hasCodeChanges() {
     ).trim();
     if (diff.length > 0) return true;
   } catch {
-    // Not on a branch or no main; run verification to be safe
     return true;
   }
 
   return false;
 }
 
-if (!hasCodeChanges()) {
-  console.log("=== No code changes detected, skipping verification ===");
-  process.exit(0);
+/**
+ * @typedef {Object} PhaseSpec
+ * @property {string}   name     Human-readable phase label (e.g. "Typecheck").
+ * @property {string}   command  Executable to spawn (e.g. "bun").
+ * @property {string[]} [args]   Arguments passed to the command.
+ * @property {string}   [cwd]    Working directory. Defaults to process.cwd().
+ * @property {NodeJS.ProcessEnv} [env] Environment overrides. Defaults to process.env.
+ * @property {boolean}  [shell]  Spawn through a shell. Defaults to true on
+ *                               Windows so bare names like "bun" resolve via
+ *                               PATH and `.cmd` shims; false on POSIX.
+ */
+
+/**
+ * @typedef {Object} PhaseResult
+ * @property {string} name        The phase label.
+ * @property {number} code        Exit code (0 = success). Spawn errors yield 1.
+ * @property {string} output      Merged stdout + stderr captured during the run.
+ * @property {number} durationMs  Wall-clock duration in milliseconds.
+ */
+
+/**
+ * Spawns a single verification phase and buffers its combined output.
+ *
+ * Always resolves (never rejects) so `Promise.all` over a set of phases
+ * waits for every phase to complete even when one fails. A spawn error
+ * is folded into the resolved value with code 1 and an explanatory line
+ * appended to `output`.
+ *
+ * @param {PhaseSpec} spec
+ * @returns {Promise<PhaseResult>}
+ */
+export function runPhase({
+  name,
+  command,
+  args = [],
+  cwd = process.cwd(),
+  env = process.env,
+  shell = isWindows,
+}) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    // `shell: true` on Windows is the default so bare names like "bun"
+    // resolve through PATH and `.cmd` shims work. Callers that already
+    // pass an absolute executable path (e.g. tests using process.execPath)
+    // can opt out via `shell: false` to skip shell-quoting pitfalls.
+    const child = spawn(command, args, { cwd, env, shell });
+    let output = "";
+    child.stdout.on("data", (d) => {
+      output += d.toString();
+    });
+    child.stderr.on("data", (d) => {
+      output += d.toString();
+    });
+    child.on("error", (err) => {
+      output += `\n[spawn error] ${err.message}\n`;
+      resolve({ name, code: 1, output, durationMs: Date.now() - start });
+    });
+    child.on("close", (code) => {
+      resolve({ name, code: code ?? 1, output, durationMs: Date.now() - start });
+    });
+  });
 }
 
-console.log("=== Typecheck ===");
-run("bun run typecheck");
+/**
+ * Runs the supplied phases concurrently, then prints each phase's buffered
+ * output in the order the phases were given (not the order they finished).
+ *
+ * Aggregation rule: returns the exit code of the first failing phase, or 0
+ * if every phase succeeded. A failure in one phase does not cancel the
+ * others; every phase runs to completion before this resolves.
+ *
+ * @param {PhaseSpec[]} phases
+ * @param {{ printer?: (line: string) => void }} [options]
+ * @returns {Promise<{ code: number, results: PhaseResult[] }>}
+ */
+export async function runPhasesInParallel(phases, { printer = console.log } = {}) {
+  const results = await Promise.all(phases.map((phase) => runPhase(phase)));
 
-console.log("=== Lint ===");
-run("bun run lint");
+  let aggregateCode = 0;
+  for (const result of results) {
+    const status = result.code === 0 ? "PASS" : "FAIL";
+    const secs = (result.durationMs / 1000).toFixed(1);
+    printer(`\n=== ${result.name} [${status}] (${secs}s) ===`);
+    const trimmed = result.output.replace(/\s+$/g, "");
+    if (trimmed.length > 0) printer(trimmed);
+    if (result.code !== 0 && aggregateCode === 0) {
+      aggregateCode = result.code;
+    }
+  }
 
-console.log("=== Unit Tests ===");
-run("bun run test");
+  return { code: aggregateCode, results };
+}
 
-console.log("\n=== All checks passed ===");
+/** Default phases executed by `bun run verify`. */
+export const DEFAULT_PHASES = [
+  { name: "Typecheck", command: "bun", args: ["run", "typecheck"] },
+  { name: "Lint", command: "bun", args: ["run", "lint"] },
+  { name: "Unit Tests", command: "bun", args: ["run", "test"] },
+];
+
+/**
+ * Entry point. Gates on `hasCodeChanges`, then orchestrates the default
+ * phases and exits with the aggregate code.
+ */
+async function main() {
+  if (!hasCodeChanges()) {
+    console.log("=== No code changes detected, skipping verification ===");
+    process.exit(0);
+  }
+
+  console.log("=== Running typecheck, lint, unit tests in parallel ===");
+  const startedAt = Date.now();
+  const { code } = await runPhasesInParallel(DEFAULT_PHASES);
+  const totalSecs = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+  if (code === 0) {
+    console.log(`\n=== All checks passed in ${totalSecs}s ===`);
+  } else {
+    console.log(`\n=== Verification failed in ${totalSecs}s ===`);
+  }
+  process.exit(code);
+}
+
+// Run main only when invoked directly. The module is also imported by tests
+// in `scripts/agent/__tests__/`, which exercise the exported helpers without
+// triggering the full pipeline.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main();
+}


### PR DESCRIPTION
## What

Rewrite `scripts/agent/verify-tests.mjs` to spawn typecheck, lint, and unit tests as concurrent child processes via `spawn` + `Promise.all`. Per-phase stdout/stderr is buffered and printed sequentially in declared order after every phase resolves, so the combined log stays readable instead of interleaving three streams.

## Why

`bun run verify` runs every turn on the agent stop hook. The old script ran the three phases sequentially via `execSync` with `stdio: inherit`, so wall time was the sum of all three even when no phase depended on another. With cold caches this is the dominant cost in the agent edit→verify loop.

This is **Module B** of the parent perf initiative (#526). It composes with the incremental typecheck and ESLint cache (#532, already merged) so the wins compound.

## Key Changes

- `scripts/agent/verify-tests.mjs` — rewrite as a parallel orchestrator. Exports `hasCodeChanges`, `runPhase`, `runPhasesInParallel`, `DEFAULT_PHASES`. Main is gated behind a direct-invocation check so tests can import without triggering the pipeline.
- Aggregation: first failing phase's exit code wins; every phase runs to completion before the result is reported.
- `hasCodeChanges()` early-exit bypass preserved.
- External contract (exit 0 = pass / non-zero = fail) unchanged, so `scripts/agent/hooks/{codex,cursor}-stop.mjs` keep working without edits.
- `scripts/agent/__tests__/verify-tests.test.mjs` — new tests using Node's built-in `node:test` runner (zero new deps). 11 tests cover phase spawning, exit-code aggregation, output ordering (slow-first / fast-second still prints in declared order), concurrency proof (3 × 400 ms sleeps complete well under sequential time), and the early-exit bypass (spawned against a temp clean git repo).
- `package.json` — add `test:scripts` script: `node --test scripts/agent/__tests__/`.

## Benchmarks

Per the protocol in #526. Measured on this machine, fresh worktree, single run.

| Scenario | Before (sequential) | After (parallel) | Delta |
|---|---|---|---|
| Cold typecheck + lint | 6.77s + 2.36s = 9.13s | ≈ max(6.77s, 2.36s) ≈ 6.8s | -26% |
| Warm (turbo cache hit) | 0.40s + 0.40s = 0.80s | ≈ 0.40s | -50% |
| Full cold (typecheck + lint + test) | 6.77 + 2.36 + 240.5 ≈ 249.6s | 243.7s | -2% |

The full-cold delta is small because the test phase dominates (~240s on this branch — note the pre-existing `snapshot-service.integration.test.ts` hook timeouts add ~70s of wasted wall time; verified those failures reproduce identically on the unmodified branch via `git stash`, so they are unrelated to this change). On hot caches and on the typecheck+lint pair the parallel wins are immediate. The full-pipeline win grows naturally as test selection (Module D) and the fast gate (Module E) land.

## Test plan

- [x] `node --test scripts/agent/__tests__/verify-tests.test.mjs` → 11/11 pass
- [x] `bun run verify` end-to-end on this branch runs all three phases concurrently and exits with the aggregate code
- [x] Codex / Cursor wrappers unchanged; external interface verified (subprocess call + exit-code contract)
- [x] Pre-existing test failures (`snapshot-service.integration.test.ts`) confirmed to exist on main, not introduced here

Closes #528
Part of #526

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782596506&installation_id=129163861&pr_number=534&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F534&signature=8679a83a0ad11b69371645cdf2e7df6d4c4f18541c99370a64b39ed8f2dd9536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the verification workflow: phase execution, parallelism, deterministic output ordering, error handling, and an integration scenario for a no-change repository.

* **Chores**
  * Refactored the verification tool to run phases concurrently with buffered, non-interleaved output and improved cross-platform behavior.
  * Added a package test script to run the verification tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->