### PR TITLE
perf(verify): tiered verification with fast gate for agent stop hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/agent/verify-tests.mjs"
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/agent/verify-fast.mjs"
           }
         ]
       }

--- a/docs/guides/agent-workflow.md
+++ b/docs/guides/agent-workflow.md
@@ -42,15 +42,26 @@ digraph workflow {
 
 ## Verify (mandatory, enforced)
 
-```bash
-bun run verify
-```
+Verification has two tiers. The stop hook runs the **fast gate** on every
+turn so type errors and lint violations surface in seconds; the **full gate**
+runs at commit time and adds the unit-test suite on top.
 
-Runs typecheck, lint, and unit tests. All three must pass with zero errors.
-The Stop hook runs this automatically when you try to finish a turn. If it
-fails, you get the error output and must fix before you can stop.
+| Tier | When it runs | What it runs | How to invoke |
+|------|--------------|--------------|---------------|
+| Fast gate | Every agent stop hook | Typecheck + Lint (parallel) | `node scripts/agent/verify-fast.mjs` |
+| Full gate | Before committing | Typecheck + Lint + Tests (parallel) | `bun run verify` |
 
-Do not run `tsc --noEmit` or test commands individually. Use `bun run verify`.
+Both tiers share the same `hasCodeChanges()` early-exit bypass, so
+brainstorming-only sessions with no code edits skip verification entirely.
+
+The Stop hook calls the fast gate automatically when you try to finish a
+turn. If typecheck or lint fails, you get the error output and must fix
+before you can stop. **Before committing**, run `bun run verify` yourself
+to exercise the full gate, including the unit tests. The fast gate alone
+does not certify a commit.
+
+Do not run `tsc --noEmit` or test commands individually. Use the tier
+appropriate for what you are doing.
 
 ## Visual Verify (when UI changes + Playwright MCP available)
 
@@ -88,10 +99,14 @@ evidence that checks passed.
 
 ## Before You Declare Done
 
-- [ ] `bun run verify` passes
+- [ ] `bun run verify` (the full gate, including unit tests) passes
 - [ ] UI changes verified visually (if Playwright MCP available)
 - [ ] E2E tests pass (if applicable)
 - [ ] No browser console errors on affected pages
+
+The fast gate that the stop hook ran during the turn is not sufficient on
+its own — it skips the unit test phase. Run `bun run verify` explicitly
+before committing.
 
 ## Enforcement
 

--- a/scripts/agent/__tests__/verify-fast.test.mjs
+++ b/scripts/agent/__tests__/verify-fast.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Tests for the fast-gate verify orchestrator.
+ *
+ * The fast gate runs only typecheck + lint (no tests) and is what the agent
+ * stop hooks invoke on every turn. The full gate (verify-tests.mjs) still
+ * runs at `bun run verify` time. These tests verify the fast gate's
+ * external contract: the phase set, exit-code aggregation, and the shared
+ * `hasCodeChanges()` early-exit bypass.
+ *
+ * Uses Node's built-in test runner (`node:test`) so no extra dev dep is
+ * required. Run with `node --test scripts/agent/__tests__/`.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execSync, spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  FAST_PHASES,
+  runPhasesInParallel,
+} from "../verify-fast.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = resolve(__dirname, "..", "verify-fast.mjs");
+
+const NODE = process.execPath;
+
+/**
+ * Build a phase that runs a snippet of JS through `node -e`. `shell: false`
+ * keeps Windows cmd.exe quoting from garbling the snippet.
+ */
+function nodePhase(name, code) {
+  return { name, command: NODE, args: ["-e", code], shell: false };
+}
+
+test("FAST_PHASES wires only typecheck and lint (no tests)", () => {
+  const names = FAST_PHASES.map((p) => p.name);
+  assert.deepEqual(names, ["Typecheck", "Lint"]);
+  for (const phase of FAST_PHASES) {
+    assert.equal(phase.command, "bun");
+    assert.equal(phase.args[0], "run");
+  }
+  // Explicitly assert the test phase is absent: this is the defining
+  // difference between the fast gate and the full gate.
+  const hasTestPhase = FAST_PHASES.some((p) =>
+    p.args.some((arg) => arg === "test" || arg === "tests"),
+  );
+  assert.equal(hasTestPhase, false, "fast gate must not include a test phase");
+});
+
+test("FAST_PHASES is a strict subset of the full gate phase set", async () => {
+  const { DEFAULT_PHASES } = await import("../verify-tests.mjs");
+  const fastNames = new Set(FAST_PHASES.map((p) => p.name));
+  const fullNames = new Set(DEFAULT_PHASES.map((p) => p.name));
+  for (const name of fastNames) {
+    assert.ok(
+      fullNames.has(name),
+      `fast phase ${name} should also appear in DEFAULT_PHASES`,
+    );
+  }
+  assert.ok(
+    fullNames.size > fastNames.size,
+    "full gate should include strictly more phases than the fast gate",
+  );
+});
+
+test("runPhasesInParallel exits non-zero when typecheck fails", async () => {
+  const { code } = await runPhasesInParallel(
+    [
+      nodePhase("Typecheck", "process.exit(2)"),
+      nodePhase("Lint", "process.exit(0)"),
+    ],
+    { printer: () => {} },
+  );
+
+  assert.notEqual(code, 0, "fast gate must propagate typecheck failure");
+});
+
+test("runPhasesInParallel exits non-zero when lint fails", async () => {
+  const { code } = await runPhasesInParallel(
+    [
+      nodePhase("Typecheck", "process.exit(0)"),
+      nodePhase("Lint", "process.exit(4)"),
+    ],
+    { printer: () => {} },
+  );
+
+  assert.notEqual(code, 0, "fast gate must propagate lint failure");
+});
+
+test("script exits 0 with skip message when run in a clean repo with no code changes", async () => {
+  const tmp = mkdtempSync(resolve(tmpdir(), "verify-fast-"));
+  try {
+    const gitOpts = { cwd: tmp, stdio: "ignore" };
+    execSync("git init -q -b main", gitOpts);
+    execSync('git config user.email "t@t"', gitOpts);
+    execSync('git config user.name "t"', gitOpts);
+    execSync("git config commit.gpgsign false", gitOpts);
+    writeFileSync(resolve(tmp, "README.md"), "ok\n");
+    execSync("git add README.md", gitOpts);
+    execSync('git commit -q -m "init"', gitOpts);
+
+    const { code, stdout } = await runScript(SCRIPT_PATH, tmp);
+
+    assert.equal(code, 0, `expected exit 0, got ${code}. output:\n${stdout}`);
+    assert.match(
+      stdout,
+      /skipping verification/i,
+      "expected early-exit bypass to log a skip message",
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Spawns the verify-fast script in a given directory and resolves with its
+ * combined output and exit code.
+ *
+ * @param {string} scriptPath
+ * @param {string} cwd
+ * @returns {Promise<{ code: number, stdout: string, signal: NodeJS.Signals | null }>}
+ */
+function runScript(scriptPath, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd,
+      env: { ...process.env },
+    });
+    let stdout = "";
+    child.stdout.on("data", (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on("data", (d) => {
+      stdout += d.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) =>
+      resolve({ code: code === null ? 1 : code, stdout, signal }),
+    );
+  });
+}

--- a/scripts/agent/hooks/codex-stop.mjs
+++ b/scripts/agent/hooks/codex-stop.mjs
@@ -1,15 +1,18 @@
 #!/usr/bin/env node
 /**
  * Codex Stop hook wrapper.
- * Runs verify-tests.mjs and returns Codex's expected JSON response:
- * {"decision":"approve"} to continue, {"decision":"block","reason":"..."} to block.
+ * Runs verify-fast.mjs (typecheck + lint only, the fast gate) and returns
+ * Codex's expected JSON response: {"decision":"approve"} to continue,
+ * {"decision":"block","reason":"..."} to block. The full gate (typecheck +
+ * lint + tests) runs at `bun run verify` time, not on every stop. See
+ * docs/guides/agent-workflow.md for the two-tier model.
  */
 import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const verifyScript = resolve(__dirname, "..", "verify-tests.mjs");
+const verifyScript = resolve(__dirname, "..", "verify-fast.mjs");
 
 try {
   execSync(`node "${verifyScript}"`, { stdio: "pipe" });
@@ -18,6 +21,6 @@ try {
   const output = ((err?.stderr ?? err?.stdout) || "").toString().slice(-500);
   console.log(JSON.stringify({
     decision: "block",
-    reason: `verify-tests failed: ${output.replace(/\n/g, " ").trim()}`,
+    reason: `verify-fast failed: ${output.replace(/\n/g, " ").trim()}`,
   }));
 }

--- a/scripts/agent/hooks/cursor-stop.mjs
+++ b/scripts/agent/hooks/cursor-stop.mjs
@@ -1,20 +1,22 @@
 #!/usr/bin/env node
 /**
  * Cursor Stop hook wrapper.
- * Runs verify-tests.mjs and translates the result for Cursor:
- * exit 0 = allow, exit 2 = block.
+ * Runs verify-fast.mjs (typecheck + lint only, the fast gate) and translates
+ * the result for Cursor: exit 0 = allow, exit 2 = block. The full gate
+ * (typecheck + lint + tests) runs at `bun run verify` time, not on every
+ * stop. See docs/guides/agent-workflow.md for the two-tier model.
  */
 import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const verifyScript = resolve(__dirname, "..", "verify-tests.mjs");
+const verifyScript = resolve(__dirname, "..", "verify-fast.mjs");
 
 try {
   execSync(`node "${verifyScript}"`, { stdio: "inherit" });
   process.exit(0);
 } catch (err) {
-  console.error("BLOCK: verify-tests failed. Fix the errors before finishing.");
+  console.error("BLOCK: verify-fast failed. Fix the errors before finishing.");
   process.exit(2);
 }

--- a/scripts/agent/verify-fast.mjs
+++ b/scripts/agent/verify-fast.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform fast-gate verification orchestrator: typecheck + lint only.
+ *
+ * This is the *fast gate* in the two-tier verification model documented in
+ * `docs/guides/agent-workflow.md`. Agent stop hooks (Claude, Cursor, Codex)
+ * invoke this on every turn to give type errors and lint violations sub-10s
+ * feedback. The full gate (`scripts/agent/verify-tests.mjs`, exposed as
+ * `bun run verify`) additionally runs the unit tests and is the canonical
+ * pre-commit check.
+ *
+ * Reuses the parallel phase orchestrator and `hasCodeChanges()` early-exit
+ * bypass from `verify-tests.mjs` so the two gates stay behaviorally
+ * consistent — the only difference between them is the phase set.
+ *
+ * External interface: exit 0 when typecheck and lint both pass (or when
+ * there are no code changes to verify); exit non-zero when either fails.
+ * The Codex (`scripts/agent/hooks/codex-stop.mjs`) and Cursor
+ * (`scripts/agent/hooks/cursor-stop.mjs`) wrappers depend on this contract.
+ */
+import { pathToFileURL } from "node:url";
+
+import {
+  hasCodeChanges,
+  runPhasesInParallel,
+} from "./verify-tests.mjs";
+
+/**
+ * Phases executed by the fast gate. Intentionally excludes the unit-test
+ * phase — that is the defining difference between this gate and the full
+ * gate. See the module docstring for context.
+ */
+export const FAST_PHASES = [
+  { name: "Typecheck", command: "bun", args: ["run", "typecheck"] },
+  { name: "Lint", command: "bun", args: ["run", "lint"] },
+];
+
+// Re-export `runPhasesInParallel` so callers (including the test suite) can
+// import the orchestrator from either module without coupling to the file
+// that happens to define it.
+export { runPhasesInParallel };
+
+/**
+ * Entry point. Gates on `hasCodeChanges`, then orchestrates the fast phases
+ * and exits with the aggregate code.
+ */
+async function main() {
+  if (!hasCodeChanges()) {
+    console.log("=== No code changes detected, skipping verification ===");
+    process.exit(0);
+  }
+
+  console.log("=== Running typecheck and lint in parallel (fast gate) ===");
+  const startedAt = Date.now();
+  const { code } = await runPhasesInParallel(FAST_PHASES);
+  const totalSecs = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+  if (code === 0) {
+    console.log(`\n=== Fast gate passed in ${totalSecs}s ===`);
+  } else {
+    console.log(`\n=== Fast gate failed in ${totalSecs}s ===`);
+  }
+  process.exit(code);
+}
+
+// Run main only when invoked directly. The module is also imported by
+// tests in `scripts/agent/__tests__/` which exercise the exported phase
+// set and the shared orchestrator without triggering the full pipeline.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main();
+}


### PR DESCRIPTION
## What

Split agent verification into two tiers:

- **Fast gate** (`scripts/agent/verify-fast.mjs`): typecheck + lint in parallel. Wired into every agent stop hook (Claude, Cursor, Codex).
- **Full gate** (`scripts/agent/verify-tests.mjs`, still `bun run verify`): typecheck + lint + tests in parallel. Canonical pre-commit check.

## Why

Stop hooks ran the full `verify-tests.mjs` (typecheck + lint + ~1000 unit tests) on every turn. On this machine that takes ~170s of wall time on a warm cache, which throttles the agent edit/verify loop and frequently approaches the 120s Codex/Cursor hook timeout. The fast gate gives type errors and lint violations sub-2s feedback while keeping the full suite for commit-time.

## Key Changes

- New `scripts/agent/verify-fast.mjs` reuses `hasCodeChanges()` and `runPhasesInParallel()` from `verify-tests.mjs` so the gates share the early-exit bypass and orchestrator. Only the phase set differs.
- New `scripts/agent/__tests__/verify-fast.test.mjs` covers: typecheck + lint as the only phases (no tests), strict-subset invariant against `DEFAULT_PHASES`, non-zero exit on typecheck/lint failure, and the `hasCodeChanges` skip path.
- `.claude/settings.json`, `scripts/agent/hooks/cursor-stop.mjs`, `scripts/agent/hooks/codex-stop.mjs` now invoke `verify-fast.mjs`.
- `docs/guides/agent-workflow.md` documents the two-tier model. The "before you declare done" checklist references the full gate explicitly.

## Benchmarks

Protocol per Mzeey-Empire/mcode#526: 3 runs, warm cache (turbo + tsbuildinfo + ESLint cache populated from prior runs on this branch). Wall-clock from `time node …`.

| Scenario (stop-hook invocation) | Before (`verify-tests.mjs`) | After (`verify-fast.mjs`) | Delta |
|---------------------------------|-----------------------------|---------------------------|-------|
| Warm cache, ~20-file diff       | 168s, 171s, 478s (median 171s) | 1.49s, 1.53s, 1.60s (median 1.53s) | -99% |

Run 3 of the before benchmark hit a transient OS/disk hiccup (~8 min wall); medians use runs 1–2.

The before run hits 7 failing unit tests in `apps/server/src/__tests__/snapshot-service.integration.test.ts` (10s `beforeEach` hook timeout on `createGitRepo()`). These are pre-existing and unrelated to this change — the full-gate wall time is reported regardless because it represents what the stop hook waited for. The fast gate is unaffected because it does not run tests.

## Tests

```
$ node --test scripts/agent/__tests__/*.test.mjs
✔ FAST_PHASES wires only typecheck and lint (no tests)
✔ FAST_PHASES is a strict subset of the full gate phase set
✔ runPhasesInParallel exits non-zero when typecheck fails
✔ runPhasesInParallel exits non-zero when lint fails
✔ script exits 0 with skip message when run in a clean repo with no code changes
… 11 pre-existing verify-tests tests …
ℹ tests 16
ℹ pass 16
ℹ fail 0
```

Fast-gate run from this branch:

```
$ node scripts/agent/verify-fast.mjs
=== Running typecheck and lint in parallel (fast gate) ===
=== Typecheck [PASS] (0.9s) ===
=== Lint [PASS] (1.0s) ===
=== Fast gate passed in 1.0s ===
```

Closes Mzeey-Empire/mcode#530

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782602561&installation_id=129163861&pr_number=536&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F536&signature=fe7e0aaad5a012f72272df0a541daf922531736ba0b47a356d9df20418029648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a fast-gate verification process for agent workflows, reducing verification time by running typecheck and lint checks only.

* **Documentation**
  * Updated agent workflow guide with formalized two-tier verification system and enhanced pre-commit verification checklist.

* **Tests**
  * Added test suite validating the fast-gate verification process and parallel phase execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->