### PR TITLE
perf(verify): scope unit tests to changed files via vitest related

### DIFF
--- a/docs/guides/agent-workflow.md
+++ b/docs/guides/agent-workflow.md
@@ -52,7 +52,8 @@ fails, you get the error output and must fix before you can stop.
 
 Do not run `tsc --noEmit` or test commands individually. Use `bun run verify`.
 
-**Test scope.** `bun run verify` always runs every unit test (the full gate).
+**Test scope.** `bun run verify` runs the full unit-test gate whenever
+verification runs (it still skips entirely when no code changes are detected).
 The Stop hook calls `verify-tests.mjs` directly without `--full`, so it scopes
 each workspace's vitest run to tests related to the changed files
 (`vitest related <files> --run`) for fast feedback. Any change inside

--- a/docs/guides/agent-workflow.md
+++ b/docs/guides/agent-workflow.md
@@ -52,6 +52,14 @@ fails, you get the error output and must fix before you can stop.
 
 Do not run `tsc --noEmit` or test commands individually. Use `bun run verify`.
 
+**Test scope.** `bun run verify` always runs every unit test (the full gate).
+The Stop hook calls `verify-tests.mjs` directly without `--full`, so it scopes
+each workspace's vitest run to tests related to the changed files
+(`vitest related <files> --run`) for fast feedback. Any change inside
+`packages/contracts` or `packages/shared` falls back to the full suite because
+those packages are imported across the repo and vitest's related-file import
+graph is per-project.
+
 ## Visual Verify (when UI changes + Playwright MCP available)
 
 If Playwright MCP is connected and the change affects UI:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "state:reset": "node scripts/state-reset.mjs",
     "db:info": "bun scripts/db-info.mjs",
     "sync:cursor-models": "bun apps/server/scripts/sync-cursor-models-snapshot.ts",
-    "verify": "node scripts/agent/verify-tests.mjs",
+    "verify": "node scripts/agent/verify-tests.mjs --full",
     "verify:e2e": "node scripts/agent/verify-e2e.mjs",
     "verify:all": "node scripts/agent/verify-all.mjs",
     "test:scripts": "node --test scripts/agent/__tests__/"

--- a/scripts/agent/__tests__/verify-tests.test.mjs
+++ b/scripts/agent/__tests__/verify-tests.test.mjs
@@ -13,9 +13,12 @@ import { fileURLToPath } from "node:url";
 
 import {
   DEFAULT_PHASES,
+  FULL_TEST_PHASE,
+  getChangedFiles,
   hasCodeChanges,
   runPhase,
   runPhasesInParallel,
+  selectTestPhases,
 } from "../verify-tests.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -179,6 +182,119 @@ test("script exits 0 with skip message when run in a clean repo with no code cha
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
+});
+
+test("selectTestPhases falls back to the full suite when a packages/contracts file changed", () => {
+  const phases = selectTestPhases(["packages/contracts/src/index.ts"]);
+
+  assert.equal(phases.length, 1);
+  assert.equal(phases[0].name, FULL_TEST_PHASE.name);
+  assert.deepEqual(phases[0].args, FULL_TEST_PHASE.args);
+});
+
+test("selectTestPhases falls back to the full suite when a packages/shared file changed", () => {
+  const phases = selectTestPhases([
+    "apps/web/src/foo.ts",
+    "packages/shared/src/model-effort/index.ts",
+  ]);
+
+  assert.equal(phases.length, 1);
+  assert.equal(phases[0].name, FULL_TEST_PHASE.name);
+});
+
+test("selectTestPhases scopes a single apps/web change to that workspace's vitest related run", () => {
+  const phases = selectTestPhases(["apps/web/src/components/foo.tsx"]);
+
+  assert.equal(phases.length, 1);
+  const [phase] = phases;
+  assert.match(phase.name, /apps\/web/);
+  assert.equal(phase.cwd.endsWith("apps/web") || phase.cwd.endsWith("apps\\web"), true);
+  // Vitest 4: `vitest related <files> --run`. `--run` opts out of watch mode.
+  assert.equal(phase.command, "bunx");
+  assert.equal(phase.args[0], "vitest");
+  assert.equal(phase.args[1], "related");
+  assert.ok(phase.args.includes("--run"), `expected --run in args, got ${phase.args.join(" ")}`);
+  // The changed file is forwarded (path is relative to the package root).
+  assert.ok(
+    phase.args.some((a) => a.endsWith("foo.tsx")),
+    `expected the changed file in args, got ${phase.args.join(" ")}`,
+  );
+});
+
+test("selectTestPhases buckets multi-workspace changes into one phase per workspace", () => {
+  const phases = selectTestPhases([
+    "apps/web/src/a.ts",
+    "apps/web/src/b.ts",
+    "apps/server/src/c.ts",
+  ]);
+
+  assert.equal(phases.length, 2);
+  const names = phases.map((p) => p.name);
+  assert.ok(names.some((n) => n.includes("apps/web")));
+  assert.ok(names.some((n) => n.includes("apps/server")));
+  // The apps/web phase carries both of its changed files as positional args
+  // to `vitest related`, with `--run` somewhere in the same arg list.
+  const web = phases.find((p) => p.name.includes("apps/web"));
+  // Files are everything between `related` and `--run`.
+  const startIdx = web.args.indexOf("related") + 1;
+  const endIdx = web.args.indexOf("--run");
+  const related = web.args.slice(startIdx, endIdx);
+  assert.equal(related.length, 2);
+  assert.ok(related.some((a) => a.endsWith("a.ts")));
+  assert.ok(related.some((a) => a.endsWith("b.ts")));
+});
+
+test("selectTestPhases returns no phases when changes only touch workspaces without tests (e.g., scripts/)", () => {
+  const phases = selectTestPhases(["scripts/agent/foo.mjs", "docs/guides/x.md"]);
+  assert.deepEqual(phases, []);
+});
+
+test("selectTestPhases returns the full suite when changedFiles is null (git-error fallback)", () => {
+  const phases = selectTestPhases(null);
+  assert.equal(phases.length, 1);
+  assert.equal(phases[0].name, FULL_TEST_PHASE.name);
+});
+
+test("getChangedFiles returns null OR an array of paths from the current repo", () => {
+  const result = getChangedFiles();
+  assert.ok(result === null || Array.isArray(result));
+  if (Array.isArray(result)) {
+    for (const f of result) assert.equal(typeof f, "string");
+  }
+});
+
+test("getChangedFiles reports a code file edited in a fresh git repo", () => {
+  const tmp = mkdtempSync(resolve(tmpdir(), "verify-getchanged-"));
+  try {
+    const gitOpts = { cwd: tmp, stdio: "ignore" };
+    execSync("git init -q -b main", gitOpts);
+    execSync('git config user.email "t@t"', gitOpts);
+    execSync('git config user.name "t"', gitOpts);
+    execSync("git config commit.gpgsign false", gitOpts);
+    writeFileSync(resolve(tmp, "README.md"), "ok\n");
+    execSync("git add README.md", gitOpts);
+    execSync('git commit -q -m "init"', gitOpts);
+    // Add an uncommitted code file to be detected by `getChangedFiles`.
+    writeFileSync(resolve(tmp, "edited.ts"), "export const a = 1;\n");
+    execSync("git add edited.ts", gitOpts);
+
+    const files = getChangedFiles({ cwd: tmp });
+    assert.ok(Array.isArray(files), "expected array, got " + files);
+    assert.ok(files.includes("edited.ts"), `expected "edited.ts" in ${files.join(",")}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("--full flag forces the full test suite regardless of changed files", async () => {
+  // Drive the script with a tiny fixture where only apps/web/src/foo.ts was
+  // edited. Without --full, that would scope to apps/web vitest --related;
+  // with --full, the orchestrator runs `bun run test` directly.
+  // We exercise this indirectly: the exported planner should honor a
+  // `forceFull` option even when scoping is possible.
+  const phases = selectTestPhases(["apps/web/src/foo.ts"], { forceFull: true });
+  assert.equal(phases.length, 1);
+  assert.equal(phases[0].name, FULL_TEST_PHASE.name);
 });
 
 /**

--- a/scripts/agent/verify-tests.mjs
+++ b/scripts/agent/verify-tests.mjs
@@ -13,7 +13,7 @@
  * (`scripts/agent/hooks/codex-stop.mjs`) and Cursor
  * (`scripts/agent/hooks/cursor-stop.mjs`) wrappers depend on this contract.
  */
-import { execSync, spawn } from "node:child_process";
+import { execFileSync, execSync, spawn } from "node:child_process";
 import { resolve as resolvePath } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -83,17 +83,17 @@ export function getChangedFiles({ cwd = process.cwd() } = {}) {
     }
   };
 
-  // Use execFileSync-like behavior by routing each git invocation through
-  // execSync but passing the glob list as separate path args to git itself.
-  // `git -- <pathspecs>` accepts shell-style globs without shell interpretation.
-  const gitGlob = CODE_GLOB_ARGS.join(" ");
+  // Pass git pathspecs as argv (not a single shell-interpolated string) so
+  // POSIX shells do not glob-expand `*.ts` etc. before git sees them. git
+  // interprets the pathspec globs internally regardless of the OS.
 
   try {
     collect(
-      execSync(`git diff --name-only HEAD -- ${gitGlob}`, {
-        cwd,
-        encoding: "utf-8",
-      }),
+      execFileSync(
+        "git",
+        ["diff", "--name-only", "HEAD", "--", ...CODE_GLOB_ARGS],
+        { cwd, encoding: "utf-8" },
+      ),
     );
   } catch {
     return null;
@@ -101,26 +101,28 @@ export function getChangedFiles({ cwd = process.cwd() } = {}) {
 
   try {
     collect(
-      execSync(`git ls-files --others --exclude-standard -- ${gitGlob}`, {
-        cwd,
-        encoding: "utf-8",
-      }),
+      execFileSync(
+        "git",
+        ["ls-files", "--others", "--exclude-standard", "--", ...CODE_GLOB_ARGS],
+        { cwd, encoding: "utf-8" },
+      ),
     );
   } catch {
     return null;
   }
 
   try {
-    const mergeBase = execSync("git merge-base HEAD main", {
+    const mergeBase = execFileSync("git", ["merge-base", "HEAD", "main"], {
       cwd,
       encoding: "utf-8",
     }).trim();
     if (mergeBase.length > 0) {
       collect(
-        execSync(`git diff --name-only ${mergeBase} HEAD -- ${gitGlob}`, {
-          cwd,
-          encoding: "utf-8",
-        }),
+        execFileSync(
+          "git",
+          ["diff", "--name-only", mergeBase, "HEAD", "--", ...CODE_GLOB_ARGS],
+          { cwd, encoding: "utf-8" },
+        ),
       );
     }
   } catch {

--- a/scripts/agent/verify-tests.mjs
+++ b/scripts/agent/verify-tests.mjs
@@ -14,9 +14,33 @@
  * (`scripts/agent/hooks/cursor-stop.mjs`) wrappers depend on this contract.
  */
 import { execSync, spawn } from "node:child_process";
+import { resolve as resolvePath } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const isWindows = process.platform === "win32";
+
+// Workspaces that run vitest. Tests are scoped per-workspace because vitest's
+// `--related` traces import graphs within a single project, not across the
+// monorepo. Order matters only for output readability; iteration uses Set.
+const TESTABLE_WORKSPACES = ["apps/web", "apps/server", "packages/contracts", "packages/shared"];
+
+// Edits in these workspaces force a full test run: their exported types and
+// runtime modules are imported across the whole repo, so vitest's --related
+// graph in a single downstream package cannot prove what is or isn't safe.
+const SHARED_WORKSPACES = ["packages/contracts", "packages/shared"];
+
+// Glob applied to every git diff / ls-files call. Mirrors the file types that
+// the verify orchestrator considers "code" for change detection.
+const CODE_GLOB_ARGS = [
+  "*.ts",
+  "*.tsx",
+  "*.js",
+  "*.jsx",
+  "*.mts",
+  "*.cts",
+  "*.mjs",
+  "*.cjs",
+];
 
 /**
  * Detects whether the current branch has code-relevant changes.
@@ -29,38 +53,81 @@ const isWindows = process.platform === "win32";
  * @returns {boolean} True if any code file differs from the baseline.
  */
 export function hasCodeChanges() {
-  const codeGlob = '"*.ts" "*.tsx" "*.js" "*.jsx" "*.mts" "*.cts" "*.mjs" "*.cjs"';
+  const files = getChangedFiles();
+  // null = git-error fallback. Treat as "changed" so verification still runs.
+  if (files === null) return true;
+  return files.length > 0;
+}
+
+/**
+ * Enumerates code files that differ from the merge-base with `main`, including
+ * uncommitted (staged + unstaged + untracked) edits.
+ *
+ * Returns `null` when git is unavailable or the merge-base cannot be resolved
+ * (detached HEAD, shallow clone, missing `main`). Callers MUST treat `null` as
+ * a fallback signal (run the full test suite), not as "no changes".
+ *
+ * Paths are returned relative to the repo root using forward slashes (git's
+ * native output), with duplicates removed.
+ *
+ * @param {{ cwd?: string }} [options]
+ * @returns {string[] | null}
+ */
+export function getChangedFiles({ cwd = process.cwd() } = {}) {
+  const seen = new Set();
+  const collect = (raw) => {
+    if (!raw) return;
+    for (const line of raw.split(/\r?\n/)) {
+      const f = line.trim();
+      if (f.length > 0) seen.add(f);
+    }
+  };
+
+  // Use execFileSync-like behavior by routing each git invocation through
+  // execSync but passing the glob list as separate path args to git itself.
+  // `git -- <pathspecs>` accepts shell-style globs without shell interpretation.
+  const gitGlob = CODE_GLOB_ARGS.join(" ");
 
   try {
-    execSync(`git diff --quiet HEAD -- ${codeGlob}`, { stdio: "ignore" });
+    collect(
+      execSync(`git diff --name-only HEAD -- ${gitGlob}`, {
+        cwd,
+        encoding: "utf-8",
+      }),
+    );
   } catch {
-    return true;
+    return null;
   }
 
   try {
-    const untracked = execSync(
-      `git ls-files --others --exclude-standard -- ${codeGlob}`,
-      { encoding: "utf-8" },
-    ).trim();
-    if (untracked.length > 0) return true;
+    collect(
+      execSync(`git ls-files --others --exclude-standard -- ${gitGlob}`, {
+        cwd,
+        encoding: "utf-8",
+      }),
+    );
   } catch {
-    return true;
+    return null;
   }
 
   try {
     const mergeBase = execSync("git merge-base HEAD main", {
+      cwd,
       encoding: "utf-8",
     }).trim();
-    const diff = execSync(
-      `git diff --name-only ${mergeBase} HEAD -- ${codeGlob}`,
-      { encoding: "utf-8" },
-    ).trim();
-    if (diff.length > 0) return true;
+    if (mergeBase.length > 0) {
+      collect(
+        execSync(`git diff --name-only ${mergeBase} HEAD -- ${gitGlob}`, {
+          cwd,
+          encoding: "utf-8",
+        }),
+      );
+    }
   } catch {
-    return true;
+    return null;
   }
 
-  return false;
+  return Array.from(seen);
 }
 
 /**
@@ -156,26 +223,141 @@ export async function runPhasesInParallel(phases, { printer = console.log } = {}
   return { code: aggregateCode, results };
 }
 
-/** Default phases executed by `bun run verify`. */
+/**
+ * Phase that runs every workspace's unit tests via the root `bun run test`
+ * (which fans out through turbo). Used as the shared-package fallback and
+ * when `--full` is passed.
+ */
+export const FULL_TEST_PHASE = {
+  name: "Unit Tests",
+  command: "bun",
+  args: ["run", "test"],
+};
+
+/** Default phases used when callers don't need scoped test selection. */
 export const DEFAULT_PHASES = [
   { name: "Typecheck", command: "bun", args: ["run", "typecheck"] },
   { name: "Lint", command: "bun", args: ["run", "lint"] },
-  { name: "Unit Tests", command: "bun", args: ["run", "test"] },
+  FULL_TEST_PHASE,
 ];
 
 /**
- * Entry point. Gates on `hasCodeChanges`, then orchestrates the default
+ * Plans the unit-test phases for a given set of changed files.
+ *
+ * Rules (in order):
+ *   - `forceFull: true` or a null/missing file list → run the full suite.
+ *     (`null` from `getChangedFiles` means git failed; the safe move is to
+ *     run everything.)
+ *   - Any change inside a shared workspace (`packages/contracts` or
+ *     `packages/shared`) → run the full suite. Their exports flow everywhere.
+ *   - Otherwise → one `vitest related <file...> --run` phase per testable
+ *     workspace that owns at least one changed file. Files in workspaces
+ *     without a test runner (`apps/desktop`, `scripts/`, `docs/`, …) are
+ *     dropped because nothing in this repo's vitest setup would run them.
+ *
+ * Returning `[]` means "no tests need to run for this diff" - the typecheck
+ * and lint phases still execute.
+ *
+ * @param {string[] | null} changedFiles Paths relative to repo root, or
+ *   `null` to signal a git-error fallback.
+ * @param {{ forceFull?: boolean, cwd?: string }} [options]
+ * @returns {PhaseSpec[]}
+ */
+export function selectTestPhases(changedFiles, { forceFull = false, cwd = process.cwd() } = {}) {
+  if (forceFull || changedFiles === null) return [FULL_TEST_PHASE];
+
+  // Empty diff -> no test phases. (`hasCodeChanges` gates the orchestrator
+  // before this point, so an empty array here means the only changes were
+  // non-code files like Markdown.)
+  if (changedFiles.length === 0) return [];
+
+  const isShared = changedFiles.some((f) =>
+    SHARED_WORKSPACES.some((ws) => f === ws || f.startsWith(ws + "/")),
+  );
+  if (isShared) return [FULL_TEST_PHASE];
+
+  /** @type {Map<string, string[]>} workspace → files relative to repo root */
+  const buckets = new Map();
+  for (const file of changedFiles) {
+    const ws = TESTABLE_WORKSPACES.find((w) => file === w || file.startsWith(w + "/"));
+    if (!ws) continue;
+    const list = buckets.get(ws);
+    if (list) {
+      list.push(file);
+    } else {
+      buckets.set(ws, [file]);
+    }
+  }
+
+  /** @type {PhaseSpec[]} */
+  const phases = [];
+  for (const [ws, files] of buckets) {
+    // Strip the workspace prefix so vitest receives paths relative to its cwd.
+    const rel = files.map((f) => f.slice(ws.length + 1));
+    phases.push({
+      name: `Unit Tests (${ws})`,
+      command: "bunx",
+      // Vitest 4 exposes related-file scoping as a subcommand:
+      //   vitest related <files> --run
+      // The `--run` flag opts out of the watch mode that `related` defaults
+      // to. `bunx` resolves the workspace-local vitest binary, picking up
+      // each package's own vitest config (setup files, environment, etc.).
+      args: ["vitest", "related", ...rel, "--run"],
+      cwd: resolvePath(cwd, ws),
+    });
+  }
+  return phases;
+}
+
+/**
+ * Builds the parallel phase list for a given diff: typecheck and lint
+ * unchanged, tests scoped via `selectTestPhases`.
+ *
+ * @param {string[] | null} changedFiles
+ * @param {{ forceFull?: boolean, cwd?: string }} [options]
+ * @returns {PhaseSpec[]}
+ */
+export function buildPhases(changedFiles, options = {}) {
+  return [
+    { name: "Typecheck", command: "bun", args: ["run", "typecheck"] },
+    { name: "Lint", command: "bun", args: ["run", "lint"] },
+    ...selectTestPhases(changedFiles, options),
+  ];
+}
+
+/**
+ * Entry point. Gates on `hasCodeChanges`, then orchestrates the planned
  * phases and exits with the aggregate code.
+ *
+ * CLI: pass `--full` to force the full test suite even when only a single
+ * downstream file changed. `bun run verify` passes this flag so the
+ * full-gate semantics survive the changed-file optimization.
  */
 async function main() {
-  if (!hasCodeChanges()) {
+  const forceFull = process.argv.includes("--full");
+  const changedFiles = getChangedFiles();
+
+  // When git works AND the diff is empty (no code-relevant changes), skip
+  // the entire pipeline. Use `getChangedFiles` directly here (instead of
+  // `hasCodeChanges`) so we reuse the file list for `buildPhases` below
+  // without re-running git.
+  if (changedFiles !== null && changedFiles.length === 0) {
     console.log("=== No code changes detected, skipping verification ===");
     process.exit(0);
   }
 
-  console.log("=== Running typecheck, lint, unit tests in parallel ===");
+  const phases = buildPhases(changedFiles, { forceFull });
+
+  const testPhaseCount = phases.length - 2; // minus typecheck + lint
+  const scope = forceFull || changedFiles === null
+    ? "full suite"
+    : testPhaseCount === 1 && phases[2] === FULL_TEST_PHASE
+      ? "full suite (shared-package fallback)"
+      : `${testPhaseCount} scoped vitest phase(s)`;
+  console.log(`=== Running typecheck, lint, ${scope} in parallel ===`);
+
   const startedAt = Date.now();
-  const { code } = await runPhasesInParallel(DEFAULT_PHASES);
+  const { code } = await runPhasesInParallel(phases);
   const totalSecs = ((Date.now() - startedAt) / 1000).toFixed(1);
 
   if (code === 0) {


### PR DESCRIPTION
## What

Extends the parallel verify orchestrator (added in #534) with changed-file test
scoping so the agent stop-hook path (`node scripts/agent/verify-tests.mjs`)
runs only the tests that depend on the files an agent actually edited.

`bun run verify` (the human-/commit-time entry) is unchanged: it now passes
`--full` to the orchestrator and runs every unit test, every time.

## Why

A flat full-suite run on every stop hook is the dominant cost in the agent
edit-verify-edit loop. Editing a single leaf file in `apps/web/src/` cold-runs
all 1410 unit tests across 160 files. Scoping vitest to the per-project import
graph cuts that to whatever actually depends on the edited file.

Closes #529. Builds on #534. Parent PRD: #526.

## Key Changes

- `scripts/agent/verify-tests.mjs`
  - New `getChangedFiles({ cwd })` enumerates code-relevant changes
    (uncommitted + untracked + committed vs. merge-base with `main`).
    Returns `null` on git error (callers treat that as "run everything").
  - New `selectTestPhases(changedFiles, { forceFull, cwd })` plans phases:
    - `forceFull` or `null` files → one full `bun run test` phase.
    - Any change in `packages/contracts` or `packages/shared` → full suite
      (vitest's related-file graph is per-project, so cross-package edits
      cannot be reasoned about safely).
    - Otherwise → one `bunx vitest related <files> --run` phase per
      affected testable workspace (`apps/web`, `apps/server`,
      `packages/contracts`, `packages/shared`).
    - Diffs that only touch non-testable areas (`scripts/`, `docs/`,
      `apps/desktop/`) emit no test phases.
  - `main()` accepts `--full` to force the full suite regardless of diff
    and prints a scope summary at startup.
- `package.json` — `bun run verify` now passes `--full`, preserving the
  commit-time full-gate semantics.
- `scripts/agent/__tests__/verify-tests.test.mjs` — 10 new tests cover
  every branch of `selectTestPhases`, including the shared-package
  fallback, multi-workspace bucketing, the no-test-workspace skip, the
  `null` fallback, and `forceFull`. Also covers `getChangedFiles` against
  a fresh git repo fixture.
- `docs/guides/agent-workflow.md` — documents the split: scoped on stop
  hook, full on `bun run verify`, shared-package fallback.

## Benchmarks

Measured on Windows 11 / Node 24.14.1 / Bun 1.3.11. 3 runs per scenario,
median reported. Scenario: edit one leaf file (`apps/web/src/components/ui/badge.tsx`)
and run only the apps/web unit-test phase.

| Scenario                                  | Before (median) | After (median) | Delta |
|-------------------------------------------|-----------------|----------------|-------|
| apps/web unit tests (`bun run test`)      | 141s            | n/a            | n/a   |
| Scoped (`vitest related badge.tsx --run`) | n/a             | 23.5s          | -83%  |

Test counts: full = 1410 tests across 160 files. Scoped on badge.tsx = 65
tests across 13 files (the components that transitively import the badge).

Raw runs:

```
Full apps/web:   175s, 130s, 141s   → median 141s
Scoped badge:    24.7s, 23.5s, 22.4s → median 23.5s
```

Other test phases (typecheck, lint) are unchanged by this PR.

## Test plan

- [x] `node --test scripts/agent/__tests__/` — 20/20 pass
- [x] Manual orchestrator run with scoped path (no-test workspace change) — skips test phases
- [x] Manual orchestrator run with `--full` — runs `bun run test`
- [x] `bunx vitest related <file> --run` works against the workspace-local vitest

Related to #526.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782603212&installation_id=129163861&pr_number=537&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F537&signature=c96433f92ffed4c703ccc3b5cbcc1d248d731954c6815110f02a9ceeea209ec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification now scopes test runs to affected workspaces; when changes are detected it runs targeted tests for faster feedback.
  * The top-level verify command now defaults to running the full unit-test gate when verification runs.

* **Documentation**
  * Guide updated to clarify differences in test scope and behavior between the top-level verify command and the Stop hook.

* **Tests**
  * Added comprehensive tests for change detection and test-phase planning logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mzeey-Empire/mcode/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->