### PR TITLE
E: TurnRequest

### DIFF
--- a/apps/server/src/__tests__/agent-service-turn-started.test.ts
+++ b/apps/server/src/__tests__/agent-service-turn-started.test.ts
@@ -42,7 +42,7 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
   let taskRepo: TaskRepo;
   let svc: AgentService;
   let providerStub: EventEmitter & Partial<IAgentProvider> & {
-    sendMessage: ReturnType<typeof vi.fn>;
+    sendTurn: ReturnType<typeof vi.fn>;
   };
   let capturedEvents: AgentEvent[];
   // Snapshot of capturedEvents.length taken synchronously when the provider's
@@ -70,12 +70,11 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       // Snapshot capturedEvents.length synchronously on entry: this is the
       // load-bearing ordering signal. If the emit happened BEFORE the call
       // entered (correct order), this will be >= 1.
-      sendMessage: vi.fn(() => {
+      sendTurn: vi.fn(() => {
         eventsLengthAtSendMessageEntry = capturedEvents.length;
         return new Promise<void>(() => {});
       }),
       stopSession: vi.fn(),
-      setSdkSessionId: vi.fn(),
       shutdown: vi.fn(),
     });
     providerStub.on("event", (e: AgentEvent) => capturedEvents.push(e));
@@ -179,8 +178,8 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
 
     expect(svc.activeThreadIds()).toContain(thread.id);
 
-    // Provider.sendMessage must have been invoked. Confirms the emit happened
-    // during sendMessage flow, not via some other path.
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
+    // Provider.sendTurn must have been invoked. Confirms the emit happened
+    // during sendTurn flow, not via some other path.
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/src/__tests__/claude-provider-assistant-boundary.test.ts
+++ b/apps/server/src/__tests__/claude-provider-assistant-boundary.test.ts
@@ -81,13 +81,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-final",
+      threadId: "thread-boundary-final",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -122,13 +124,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-preamble",
+      threadId: "thread-boundary-preamble",
       message: "read file",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -162,13 +166,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-no-text",
+      threadId: "thread-boundary-no-text",
       message: "go",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 

--- a/apps/server/src/__tests__/claude-provider-eviction.test.ts
+++ b/apps/server/src/__tests__/claude-provider-eviction.test.ts
@@ -69,13 +69,15 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
   it("does NOT evict a session while a tool_use is still pending", async () => {
     mockQuery.mockImplementation(makeToolUseStream());
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t1",
+      threadId: "t1",
       message: "run something long",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     await vi.advanceTimersByTimeAsync(100);
@@ -120,13 +122,15 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
       });
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t2",
+      threadId: "t2",
       message: "run",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     await vi.advanceTimersByTimeAsync(100);

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -90,21 +90,25 @@ describe("ClaudeProvider permission mode changes", () => {
   });
 
   it("reuses the session when permissionMode is unchanged", async () => {
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-a",
+      threadId: "thread-a",
       message: "first",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-a",
+      threadId: "thread-a",
       message: "second",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // One underlying sdk subprocess for both messages.
@@ -112,21 +116,25 @@ describe("ClaudeProvider permission mode changes", () => {
   });
 
   it("tears down and respawns the session when permissionMode changes", async () => {
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-b",
+      threadId: "thread-b",
       message: "first",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-b",
+      threadId: "thread-b",
       message: "second",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // The SDK subprocess is respawned because permissionMode is fixed at spawn.

--- a/apps/server/src/__tests__/claude-provider-queue.test.ts
+++ b/apps/server/src/__tests__/claude-provider-queue.test.ts
@@ -89,13 +89,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
     // First send establishes the session
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t1",
+      threadId: "t1",
       message: "first",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Simulate race by closing the queue directly
@@ -105,13 +107,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
 
     // Second send on same sessionId: push hits a closed queue
     await expect(
-      provider.sendMessage({
+      provider.sendTurn({
         sessionId: "mcode-t1",
+        threadId: "t1",
         message: "second",
         cwd: "/tmp",
         model: "claude-sonnet-4-6",
-        resume: false,
         permissionMode: "default",
+        interactionMode: "build",
+        providerOptions: {},
       }),
     ).rejects.toThrow(/closed/i);
 
@@ -148,13 +152,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
     // First send establishes the session
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-overflow",
+      threadId: "overflow",
       message: "first",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Saturate the queue: MAX_QUEUE_DEPTH is 20, so push many more than that.
@@ -162,13 +168,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     let overflowErr: Error | undefined;
     for (let i = 0; i < 25; i++) {
       try {
-        await provider.sendMessage({
+        await provider.sendTurn({
           sessionId: "mcode-overflow",
+          threadId: "overflow",
           message: `msg-${i}`,
           cwd: "/tmp",
           model: "claude-sonnet-4-6",
-          resume: false,
           permissionMode: "default",
+          interactionMode: "build",
+          providerOptions: {},
         });
       } catch (e) {
         overflowErr = e as Error;

--- a/apps/server/src/__tests__/claude-provider-result-error.test.ts
+++ b/apps/server/src/__tests__/claude-provider-result-error.test.ts
@@ -63,13 +63,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string; error?: string }> = [];
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-1",
+      threadId: "thread-1",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Allow the stream loop microtasks to drain
@@ -92,13 +94,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string }> = [];
     provider.on("event", (e: { type: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-2",
+      threadId: "thread-2",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -115,13 +119,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string; error?: string; content?: string }> = [];
     provider.on("event", (e: { type: string; error?: string; content?: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-3",
+      threadId: "thread-3",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -194,12 +194,14 @@ describe("CopilotProvider bootstrap", () => {
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
 
-      await provider.sendMessage({
+      await provider.sendTurn({
         sessionId: "mcode-test1",
+        threadId: "test1",
         message: "hello",
         cwd: "/tmp",
         model: "gpt-4o",
-        resume: false,
+        interactionMode: "build",
+        providerOptions: {},
         permissionMode: "auto",
       });
 
@@ -220,12 +222,14 @@ describe("CopilotProvider bootstrap", () => {
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
 
-      await provider.sendMessage({
+      await provider.sendTurn({
         sessionId: "mcode-test2",
+        threadId: "test2",
         message: "hello",
         cwd: "/tmp",
         model: "gpt-4o",
-        resume: false,
+        interactionMode: "build",
+        providerOptions: {},
         permissionMode: "auto",
       });
 
@@ -271,12 +275,14 @@ async function runWithMockSession(
   const events: AgentEvent[] = [];
   provider.on("event", (e: AgentEvent) => events.push(e));
 
-  await provider.sendMessage({
+  await provider.sendTurn({
     sessionId,
+    threadId: sessionId.replace(/^mcode-/, ""),
     message: "hello",
     cwd: "/tmp",
     model: "gpt-4o",
-    resume: false,
+    interactionMode: "build",
+    providerOptions: {},
     permissionMode: "auto",
   });
 

--- a/apps/server/src/__tests__/model-cache-service.test.ts
+++ b/apps/server/src/__tests__/model-cache-service.test.ts
@@ -16,7 +16,7 @@ function makeProvider(models: ProviderModelInfo[]) {
   return {
     id: "test-provider",
     listModels: vi.fn().mockResolvedValue(models),
-    sendMessage: vi.fn(),
+    sendTurn: vi.fn(),
     cancelSession: vi.fn(),
     shutdown: vi.fn(),
   };
@@ -163,7 +163,7 @@ describe("ModelCacheService", () => {
     const provider = {
       id: "cursor",
       listModels: vi.fn().mockReturnValue(listPromise),
-      sendMessage: vi.fn(),
+      sendTurn: vi.fn(),
       cancelSession: vi.fn(),
       shutdown: vi.fn(),
     };
@@ -191,7 +191,7 @@ describe("ModelCacheService", () => {
   it("throws when fetching from a provider that does not implement listModels", async () => {
     const provider = {
       id: "no-list",
-      sendMessage: vi.fn(),
+      sendTurn: vi.fn(),
       cancelSession: vi.fn(),
       shutdown: vi.fn(),
     };

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -13,6 +13,7 @@ import { logger } from "@mcode/shared";
 import { AgentEventType, isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   ContextWindowMode,
@@ -300,26 +301,32 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
   }
 
   /** Start or continue a session by sending a message via the SDK. */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    contextWindowMode?: ContextWindowMode;
-    thinking?: boolean;
-    maxBudgetUsd?: number;
-    maxTurns?: number;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"claude">): Promise<void> {
+    // Seed the resume id so doSendMessage's sdkSessionIds lookup resolves it.
+    // `resumeFrom` defined ⇒ resume that SDK session; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
+    const params = {
+      sessionId: req.sessionId,
+      message: req.message,
+      cwd: req.cwd,
+      model: req.model,
+      fallbackModel: req.fallbackModel,
+      resume: req.resumeFrom !== undefined,
+      permissionMode: req.permissionMode,
+      attachments: req.attachments,
+      reasoningLevel: req.reasoningLevel,
+      contextWindowMode: req.providerOptions.contextWindowMode,
+      thinking: req.providerOptions.thinking,
+      maxBudgetUsd: req.maxBudgetUsd,
+      maxTurns: req.maxTurns,
+    };
     try {
       await this.doSendMessage(params);
     } catch (e: unknown) {
-      logger.error("sendMessage error", {
-        sessionId: params.sessionId,
+      logger.error("sendTurn error", {
+        sessionId: req.sessionId,
         error: String(e),
       });
       throw e;
@@ -2006,11 +2013,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
-
   /**
    * Install a goal on a session. The next Stop event from the SDK will be
    * blocked with a "Goal not yet met" reason until {@link clearGoal} is
@@ -2165,6 +2167,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
    * callback captures ExitPlanMode calls instead of denying them.
    * When disabled (or after capture), the model's ExitPlanMode calls
    * are denied silently.
+   *
+   * Off-interface (like setGoal/clearGoal): no longer an IAgentProvider member;
+   * AgentService invokes it on the concrete ClaudeProvider via a cast. The
+   * question-vs-answer plan distinction cannot be carried by the binary
+   * TurnRequest.interactionMode, so this Claude-only arming stays explicit.
    */
   setPlanAnswerMode(threadId: string, enabled: boolean): void {
     if (enabled) {

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -221,13 +221,15 @@ describe("CodexProvider permission flow", () => {
     };
 
     vi.useRealTimers();
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId,
+      threadId,
       message: "hi",
       cwd: "/",
       model: "gpt-5",
-      resume: false,
       permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     const response = await pendingPromise;

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -18,6 +18,7 @@ import { JobObject } from "../../services/job-object.js";
 import { EnvService } from "../../services/env-service.js";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   AgentEvent,
@@ -157,26 +158,20 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
    * For new sessions, spawns a subprocess and runs the JSON-RPC handshake first.
    * The method returns immediately; events stream via the `event` EventEmitter channel.
    */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /** When true, pass OpenAI fast service tier; when false, standard. Undefined uses global settings. */
-    codexFastMode?: boolean;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"codex">): Promise<void> {
     const settings = await this.settingsService.get();
     const cliPath = settings.provider.cli.codex || "codex";
 
+    // `resumeFrom` defined ⇒ resume that Codex thread; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
     const {
-      sessionId, message, cwd, model, resume, permissionMode,
-      reasoningLevel, attachments, codexFastMode,
-    } = params;
+      sessionId, message, cwd, model, permissionMode,
+      reasoningLevel, attachments,
+    } = req;
+    const resume = req.resumeFrom !== undefined;
+    const codexFastMode = req.providerOptions.fastMode;
 
     const input = buildCodexInput(message, attachments);
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
@@ -595,10 +590,6 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Pre-loads an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
 
   /** Kills a running session's subprocess and cancels any pending permissions for its thread. */
   stopSession(sessionId: string): void {

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -25,6 +25,7 @@ import { SettingsService } from "../../services/settings-service.js";
 import { EnvService } from "../../services/env-service.js";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   AgentEvent,
@@ -465,19 +466,23 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   private contextWindowBySession = new Map<string, number>();
 
   /** Start or continue a session by sending a message via the Copilot SDK. When `copilotAgent` is provided, routes the session to the appropriate built-in mode or custom agent before sending. */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /** Copilot sub-agent name. Built-in modes: "interactive" | "plan" | "autopilot". Custom: any YAML agent name. */
-    copilotAgent?: string;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"copilot">): Promise<void> {
+    // `resumeFrom` defined ⇒ resume that SDK session; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
+    const params = {
+      sessionId: req.sessionId,
+      message: req.message,
+      cwd: req.cwd,
+      model: req.model,
+      fallbackModel: req.fallbackModel,
+      resume: req.resumeFrom !== undefined,
+      permissionMode: req.permissionMode,
+      attachments: req.attachments,
+      reasoningLevel: req.reasoningLevel,
+      copilotAgent: req.providerOptions.agent,
+    };
     try {
       await this.doSendMessage(params);
     } catch (e: unknown) {
@@ -940,11 +945,6 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         this.contextWindowBySession.delete(sessionId);
       }
     }
-  }
-
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
   }
 
   /** Disconnect and remove an active session, or record a pending stop if the session hasn't been created yet. */

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -39,11 +39,11 @@ import type {
   AttachmentMeta,
   AgentEvent,
   IAgentProvider,
+  TurnRequest,
   PermissionDecision,
   PermissionRequest,
   ProviderId,
   ProviderModelInfo,
-  ReasoningLevel,
   Settings,
 } from "@mcode/contracts";
 import {
@@ -170,32 +170,35 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   }
 
   /** Queues an ACP `session/prompt` on the session subprocess (serialized per thread). */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-  }): Promise<void> {
-    void params.fallbackModel;
-    void params.reasoningLevel;
+  async sendTurn(req: TurnRequest<"cursor">): Promise<void> {
+    void req.fallbackModel;
+    void req.reasoningLevel;
 
     const {
       sessionId,
       message,
       cwd,
       model,
-      resume,
       permissionMode,
       attachments,
-    } = params;
+    } = req;
+    // `resumeFrom` defined ⇒ resume the stored ACP session; undefined ⇒ fresh.
+    const resume = req.resumeFrom !== undefined;
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(sessionId, req.resumeFrom);
+    }
 
     const pm: "full" | "default" = permissionMode === "full" ? "full" : "default";
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
+
+    // interactionMode absorbs the retired setPlanQuestionMode: a plan-mode Turn
+    // suppresses Cursor's native auto-answer of ask_question; build clears it.
+    // The flag is re-derived every Turn, so it is authoritative per Turn.
+    if (req.interactionMode === "plan") {
+      this.planQuestionModeThreads.add(threadId);
+    } else {
+      this.planQuestionModeThreads.delete(threadId);
+    }
 
     if (!this.evictionTimer) {
       this.evictionTimer = setInterval(() => this.evictIdleSessions(), EVICTION_INTERVAL_MS);
@@ -246,10 +249,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     await scheduled;
   }
 
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
 
   /** Cancel the active ACP session. Records a pending stop if the session hasn't been created yet. */
   stopSession(sessionId: string): void {
@@ -272,14 +271,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Toggle Mcode plan-questions phase for Cursor ask_question handling. */
-  setPlanQuestionMode(threadId: string, enabled: boolean): void {
-    if (enabled) {
-      this.planQuestionModeThreads.add(threadId);
-    } else {
-      this.planQuestionModeThreads.delete(threadId);
-    }
-  }
 
   /** Tear down all sessions, cancel pending permissions, and stop the eviction timer. */
   shutdown(): void {

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -27,7 +27,7 @@ import { broadcast } from "../../transport/push.js";
 
 /**
  * Build an AgentService with a Claude-shaped provider stub that records
- * setGoal/clearGoal/sendMessage so we can assert which path the /goal
+ * setGoal/clearGoal/sendTurn so we can assert which path the /goal
  * intercept took (control short-circuit vs SET fall-through).
  */
 function buildService(db: Database.Database) {
@@ -56,10 +56,9 @@ function buildService(db: Database.Database) {
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendMessage: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
+    sendTurn: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
       () => Promise.resolve(),
     ),
-    setSdkSessionId: vi.fn(),
     setGoal: vi.fn<(sid: string, condition: string) => void>(),
     clearGoal: vi.fn<(sid: string) => void>(),
     getGoal: vi.fn<(sid: string) => string | undefined>(() => undefined),
@@ -157,8 +156,8 @@ describe("AgentService.sendMessage — /goal command", () => {
 
     // Provider was actually called — this is the regression the user hit
     // where /goal <condition> set the hook but never started the agent.
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
-    const sentMessage = providerStub.sendMessage.mock.calls[0][0].message;
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
+    const sentMessage = providerStub.sendTurn.mock.calls[0][0].message;
     expect(sentMessage).toContain("analyse this branch");
     expect(sentMessage.toLowerCase()).toContain("directive");
 
@@ -183,7 +182,7 @@ describe("AgentService.sendMessage — /goal command", () => {
     );
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
-    expect(providerStub.sendMessage).not.toHaveBeenCalled();
+    expect(providerStub.sendTurn).not.toHaveBeenCalled();
 
     // Confirmation pill persisted as an assistant message.
     const { messages } = messageRepo.listByThread(thread.id, 100);
@@ -213,7 +212,7 @@ describe("AgentService.sendMessage — /goal command", () => {
       "claude",
     );
 
-    expect(providerStub.sendMessage).not.toHaveBeenCalled();
+    expect(providerStub.sendTurn).not.toHaveBeenCalled();
     expect(providerStub.setGoal).not.toHaveBeenCalled();
 
     const { messages } = messageRepo.listByThread(thread.id, 100);
@@ -237,7 +236,7 @@ describe("AgentService.sendMessage — /goal command", () => {
 
     // Provider was still called with the raw text (no rewrite, no goal install).
     expect(providerStub.setGoal).not.toHaveBeenCalled();
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
-    expect(providerStub.sendMessage.mock.calls[0][0].message).toBe("/goal something");
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
+    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal something");
   });
 });

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -73,8 +73,7 @@ interface Built {
 function build(): Built {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
-  (providerEmitter as any).sendMessage = vi.fn(() => Promise.resolve());
-  (providerEmitter as any).setSdkSessionId = vi.fn();
+  (providerEmitter as any).sendTurn = vi.fn(() => Promise.resolve());
 
   const threadRepo = {
     findById: vi.fn(() => thread),

--- a/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
@@ -51,14 +51,15 @@ function buildService(db: Database.Database) {
   } as unknown as AttachmentService;
 
   // Provider stub: extends EventEmitter (matches real provider shape) and
-  // resolves sendMessage immediately so the turn "completes" without I/O.
+  // resolves sendTurn immediately so the turn "completes" without I/O.
   const providerStub = Object.assign(new EventEmitter(), {
     id: "claude" as const,
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendMessage: vi.fn(() => Promise.resolve()),
-    setSdkSessionId: vi.fn(),
+    sendTurn: vi.fn(() => Promise.resolve()),
+    // Claude-concrete off-interface method invoked by armPlanGenerationTurn via cast.
+    setPlanAnswerMode: vi.fn(),
   });
   const providerRegistry = {
     resolve: vi.fn(() => providerStub),

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -75,9 +75,8 @@ function buildService(): {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
 
-  // sendMessage() and setSdkSessionId() are called on the resolved provider
-  (providerEmitter as any).sendMessage = vi.fn(() => Promise.resolve());
-  (providerEmitter as any).setSdkSessionId = vi.fn();
+  // sendTurn() is called on the resolved provider
+  (providerEmitter as any).sendTurn = vi.fn(() => Promise.resolve());
 
   const threadRepo = {
     findById: vi.fn(() => thread),

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -17,6 +17,7 @@ import type {
   ReasoningLevel,
   ContextWindowMode,
   IProviderRegistry,
+  TurnRequest,
   AgentEvent,
   ProviderId,
   InteractionMode,
@@ -481,9 +482,10 @@ export class AgentService {
     if (planAction === "revise") {
       this.armPlanGenerationTurn(threadId);
       wirePayload = `${wirePayload}\n\n${this.buildPlanOutputInstructions()}`;
-    } else if (planAction === "implement") {
-      this.setPlanQuestionModeOnProvider(threadId, false);
     }
+    // The retired setPlanQuestionMode toggle is gone: Cursor derives plan-question
+    // suppression from each Turn's interactionMode at sendTurn. An "implement"
+    // turn dispatches as "build", which clears the flag.
 
     const effectiveInteractionMode =
       planAction === "revise" || planAction === "implement"
@@ -492,7 +494,6 @@ export class AgentService {
 
     if (effectiveInteractionMode === "plan") {
       this.planParsers.set(threadId, new PlanQuestionParser());
-      this.setPlanQuestionModeOnProvider(threadId, true);
       if (providerWireOverride === undefined) {
         wirePayload = this.buildPlanPrompt(wirePayload);
       }
@@ -597,11 +598,10 @@ export class AgentService {
     // Only treat as resume if there is actually a session to resume.
     const isResume = nextSeq > 1 && !!thread.sdk_session_id;
 
-    // Hydrate SDK session ID mapping for resume
-    if (isResume && thread.sdk_session_id) {
-      const sdkProvider = this.providerRegistry.resolve(effectiveProvider);
-      sdkProvider.setSdkSessionId(sessionName, thread.sdk_session_id);
-    }
+    // Resume signal: defined ⇒ resume that SDK session, undefined ⇒ fresh.
+    // Replaces the former setSdkSessionId(...) + resume:true two-step dance.
+    const resumeFrom: string | undefined =
+      isResume && thread.sdk_session_id ? thread.sdk_session_id : undefined;
 
     const resolvedProvider = this.providerRegistry.resolve(effectiveProvider);
 
@@ -636,24 +636,36 @@ export class AgentService {
       });
     }
 
+    // Provider-specific knobs are walled into providerOptions, keyed by the
+    // resolved Provider. The orchestrator picks both the Provider and its
+    // matching options together; the cast at the sendTurn boundary is the one
+    // controlled point where the runtime selection meets the union type.
+    const providerOptions =
+      effectiveProvider === "claude"
+        ? { contextWindowMode: effectiveContextWindowMode, thinking: effectiveThinking }
+        : effectiveProvider === "codex"
+          ? { fastMode: effectiveCodexFastMode }
+          : effectiveProvider === "copilot"
+            ? { agent: effectiveCopilotAgent }
+            : {};
+
     try {
-      await resolvedProvider.sendMessage({
+      await resolvedProvider.sendTurn({
         sessionId: sessionName,
+        threadId,
         message: providerMessage,
         cwd,
         model: resolvedModel,
         fallbackModel,
-        resume: isResume,
         permissionMode,
+        interactionMode: effectiveInteractionMode ?? "build",
         attachments: persisted.length > 0 ? persisted : undefined,
         reasoningLevel,
-        contextWindowMode: effectiveContextWindowMode,
-        thinking: effectiveThinking,
-        ...(effectiveProvider === "codex" && { codexFastMode: effectiveCodexFastMode }),
         ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
         ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
-        copilotAgent: effectiveCopilotAgent,
-      });
+        resumeFrom,
+        providerOptions,
+      } as TurnRequest);
       logger.info("Message sent via provider", {
         threadId,
         session: sessionName,
@@ -1892,7 +1904,6 @@ export class AgentService {
           this.pendingPlanOutputs.delete(event.threadId);
           this.pendingExitPlanMarkdown.delete(event.threadId);
           this.planCapturedThisTurn.delete(event.threadId);
-          this.setPlanQuestionModeOnProvider(event.threadId, false);
         }
 
         if (event.type === AgentEventType.Compacting && event.active) {
@@ -1964,7 +1975,6 @@ export class AgentService {
           this.pendingPlanOutputs.delete(event.threadId);
           this.pendingExitPlanMarkdown.delete(event.threadId);
           this.planCapturedThisTurn.delete(event.threadId);
-          this.setPlanQuestionModeOnProvider(event.threadId, false);
         }
       });
     }
@@ -2049,22 +2059,21 @@ export class AgentService {
   private armPlanGenerationTurn(threadId: string): void {
     this.planOutputParsers.set(threadId, new PlanOutputParser());
     this.planCapturedThisTurn.delete(threadId);
-    this.setPlanQuestionModeOnProvider(threadId, false);
 
+    // Claude ExitPlanMode capture is a Claude-only concern that the binary
+    // TurnRequest.interactionMode cannot carry (it would conflate the
+    // question-generation turn with the answer/revise turn). It stays an
+    // off-interface arming on the concrete ClaudeProvider, invoked via a cast
+    // like setGoal/clearGoal. The revise/answer turn dispatches with
+    // interactionMode "build", so Cursor's per-Turn question mode clears itself.
     const thread = this.threadRepo.findById(threadId);
     const effectiveProvider = (thread?.provider as ProviderId) ?? "claude";
-    const provider = this.providerRegistry.resolve(effectiveProvider);
-    provider.setPlanAnswerMode?.(threadId, true);
-  }
-
-  /** Toggle native question UI suppression on the active provider. */
-  private setPlanQuestionModeOnProvider(threadId: string, enabled: boolean): void {
-    const thread = this.threadRepo.findById(threadId);
-    if (!thread) return;
-    const provider = this.providerRegistry.resolve(
-      (thread.provider as ProviderId) ?? "claude",
-    );
-    provider.setPlanQuestionMode?.(threadId, enabled);
+    if (effectiveProvider === "claude") {
+      const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
+        setPlanAnswerMode: (threadId: string, enabled: boolean) => void;
+      };
+      claudeProvider.setPlanAnswerMode(threadId, true);
+    }
   }
 
   /** Persist one plan version and broadcast, skipping duplicate captures per turn. */

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -279,6 +279,8 @@ export type {
   IAgentProvider,
   ICompletionCapable,
   IProviderRegistry,
+  TurnRequest,
+  ProviderOptionsByProvider,
 } from "./providers/interfaces.js";
 
 export * from "./providers/catalog.js";

--- a/packages/contracts/src/providers/__tests__/turn-request.type-test.ts
+++ b/packages/contracts/src/providers/__tests__/turn-request.type-test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import type { TurnRequest } from "../interfaces.js";
+
+/**
+ * These assertions are compile-time first: if the discriminated `providerOptions`
+ * bag stops walling knobs by Provider, the file fails to typecheck and
+ * `bun run verify` breaks. The runtime bodies are trivial so Vitest registers
+ * the file as a passing suite.
+ */
+describe("TurnRequest providerOptions discrimination", () => {
+  it("accepts Claude knobs on a claude request", () => {
+    const req: TurnRequest<"claude"> = {
+      sessionId: "mcode-t1",
+      threadId: "t1",
+      message: "hi",
+      cwd: "/tmp",
+      model: "claude-sonnet-4-6",
+      permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: { contextWindowMode: "1m", thinking: true },
+    };
+    expect(req.providerOptions.contextWindowMode).toBe("1m");
+  });
+
+  it("requires an empty bag for knob-less providers", () => {
+    const req: TurnRequest<"cursor"> = {
+      sessionId: "mcode-t2",
+      threadId: "t2",
+      message: "hi",
+      cwd: "/tmp",
+      model: "cursor-default",
+      permissionMode: "default",
+      interactionMode: "plan",
+      providerOptions: {},
+    };
+    expect(req.providerOptions).toEqual({});
+  });
+
+  it("walls off cross-provider knobs (negative case via @ts-expect-error)", () => {
+    const bad: TurnRequest<"claude"> = {
+      sessionId: "mcode-t3",
+      threadId: "t3",
+      message: "hi",
+      cwd: "/tmp",
+      model: "claude-sonnet-4-6",
+      permissionMode: "full",
+      interactionMode: "build",
+      // @ts-expect-error fastMode is a Codex knob, not valid on a Claude request
+      providerOptions: { fastMode: true },
+    };
+    void bad;
+    expect(true).toBe(true);
+  });
+});

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "../events/agent-event.js";
+import type { InteractionMode } from "../models/enums.js";
 import type { AttachmentMeta } from "../models/attachment.js";
 import type { PermissionDecision, PermissionRequest } from "../models/permission.js";
 import type { ContextWindowMode, ReasoningLevel } from "../models/settings.js";
@@ -13,6 +14,61 @@ export type ProviderId = "claude" | "codex" | "gemini" | "copilot" | "cursor" | 
 
 /** How a provider's `resume` mechanism behaves when used to fork a session. */
 export type SessionForkBehavior = "clean" | "mutating" | "unsupported";
+
+/**
+ * Per-Provider knobs that ride on a {@link TurnRequest}, keyed by {@link ProviderId}.
+ * Generic call sites cannot reach into the wrong Provider's knobs because the
+ * field type is selected by the request's `P` type parameter.
+ */
+export interface ProviderOptionsByProvider {
+  /** Claude: context-window tier and the Haiku thinking toggle. */
+  claude: { contextWindowMode?: ContextWindowMode; thinking?: boolean };
+  /** Codex: request the OpenAI fast service tier. */
+  codex: { fastMode?: boolean };
+  /** Copilot: sub-agent name ("interactive" | "plan" | "autopilot" | custom YAML name). */
+  copilot: { agent?: string };
+  cursor: Record<string, never>;
+  gemini: Record<string, never>;
+  opencode: Record<string, never>;
+}
+
+/**
+ * The per-Turn value object passed to {@link IAgentProvider.sendTurn}.
+ * `P` selects the Provider-specific `providerOptions` shape.
+ *
+ * Top-level fields are generic per-Turn inputs and knobs the user may change
+ * between Turns. Provider-specific knobs live only in `providerOptions`.
+ */
+export interface TurnRequest<P extends ProviderId = ProviderId> {
+  /** SDK session name, currently `mcode-${threadId}`. */
+  sessionId: string;
+  /** Owning thread id. */
+  threadId: string;
+  /** User input text (already wire-wrapped by the orchestrator when needed). */
+  message: string;
+  attachments?: AttachmentMeta[];
+  /** Working directory: the thread's effective worktree or workspace path. */
+  cwd: string;
+  model: string;
+  /** Fallback model if the primary is unavailable. Undefined disables fallback. */
+  fallbackModel?: string;
+  permissionMode: string;
+  /** Per-Turn interaction state. Plan suppresses Cursor's native auto-answer. */
+  interactionMode: InteractionMode;
+  reasoningLevel?: ReasoningLevel;
+  /** USD budget cap for this Turn. Undefined or 0 disables. */
+  maxBudgetUsd?: number;
+  /** Max agent turns for this Turn. Undefined or 0 disables. */
+  maxTurns?: number;
+  /**
+   * SDK session id to resume from. When defined the Provider resumes that
+   * session; when undefined it starts fresh. Replaces the previous
+   * `setSdkSessionId(...)` + `resume: true` two-step dance.
+   */
+  resumeFrom?: string;
+  /** Provider-specific knobs, walled off by `P`. Required; empty-knob Providers pass `{}`. */
+  providerOptions: ProviderOptionsByProvider[P];
+}
 
 /** A pluggable agent backend that can run sessions and emit events. */
 export interface IAgentProvider {
@@ -44,52 +100,16 @@ export interface IAgentProvider {
    */
   readonly maxInputCharactersPerTurn: number;
 
-  /** Start or continue a session by sending a message. */
-  sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    /** Fallback model to use if the primary model is unavailable. Undefined disables fallback. */
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /**
-     * Per-thread context window selection. "1m" appends `[1m]` to the model
-     * slug at the SDK boundary so the SDK attaches the 1M-context beta header.
-     * Undefined falls back to the model's default 200k window.
-     * Honored only by Claude provider; ignored by Codex/Gemini/Copilot.
-     */
-    contextWindowMode?: ContextWindowMode;
-    /**
-     * Boolean thinking toggle for models that expose it (Haiku 4.5).
-     * Undefined and non-Haiku models ignore this field.
-     */
-    thinking?: boolean;
-    /** USD budget cap for this session. Provider stops if exceeded. Undefined or 0 disables. */
-    maxBudgetUsd?: number;
-    /** Maximum agent turns for this session. Provider stops after this count. Undefined or 0 disables. */
-    maxTurns?: number;
-    /**
-     * Codex: request OpenAI fast tier when true. Undefined lets the provider read global settings.
-     */
-    codexFastMode?: boolean;
-    /**
-     * Copilot-specific: name of the sub-agent to activate for this session.
-     * Built-in modes: "interactive" | "plan" | "autopilot".
-     * Custom agents: any name defined in user/project YAML config.
-     * Ignored by non-Copilot providers.
-     */
-    copilotAgent?: string;
-  }): void | Promise<void>;
+  /**
+   * Start or continue a Turn. The {@link TurnRequest} carries all per-Turn
+   * input, knobs, the resume signal (`resumeFrom`), and Provider-specific
+   * options (`providerOptions`). Replaces the former 15-parameter
+   * `sendMessage` call.
+   */
+  sendTurn(req: TurnRequest): Promise<void>;
 
   /** Abort a running session. */
   stopSession(sessionId: string): void;
-
-  /** Store the SDK-assigned session ID for later resume. */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void;
 
   /** Tear down all sessions and release resources. */
   shutdown(): void;
@@ -160,15 +180,6 @@ export interface IAgentProvider {
   on(event: "permission_resolved", handler: (payload: { requestId: string; decision: PermissionDecision }) => void): void;
   /** Subscribe to ExitPlanMode capture events (Claude SDK plan output). */
   on(event: "exit_plan_mode", handler: (payload: { threadId: string; planMarkdown: string }) => void): void;
-
-  /** Mark a thread as expecting a plan output (enables ExitPlanMode capture). */
-  setPlanAnswerMode?(threadId: string, enabled: boolean): void;
-
-  /**
-   * Mark a thread as in the plan-questions phase. Providers with native question
-   * UIs (Cursor) should not auto-answer while this is active.
-   */
-  setPlanQuestionMode?(threadId: string, enabled: boolean): void;
 }
 
 /**


### PR DESCRIPTION
## What
Replace the 15-parameter `IAgentProvider.sendMessage` with a typed `sendTurn(req: TurnRequest<P>)` value object, and wall per-Provider knobs behind a discriminated `providerOptions` bag.

## Why
Candidate E of the agent provider + handoff overhaul. Every Provider used to see every other Provider's knobs, AgentService had to know which knob applied where, and adding a knob widened the shared interface. Resume also needed a two-step dance (`setSdkSessionId` then `resume: true`) where the flag and the SDK session id could disagree.

## Key Changes
- `sendMessage(...15 params)` becomes `sendTurn(req: TurnRequest<P>)` across `IAgentProvider` and all four Providers (Claude, Cursor, Codex, Copilot).
- `ProviderOptionsByProvider` discriminates knobs by `ProviderId`: Claude `{ contextWindowMode?, thinking? }`, Codex `{ fastMode? }`, Copilot `{ agent? }`, others `Record<string, never>`. The `providerOptions` field is required.
- `resumeFrom?: string` replaces `setSdkSessionId(...)` plus `resume: true`. Defined resumes that SDK session; undefined starts fresh.
- `interactionMode: "plan" | "build"` rides on every Turn and absorbs the retired `setPlanQuestionMode` (Cursor derives auto-answer suppression per Turn).
- Three methods leave `IAgentProvider`: `setSdkSessionId`, `setPlanQuestionMode`, `setPlanAnswerMode`. `setPlanAnswerMode` relocates to `ClaudeProvider` as a concrete method invoked via cast (the same pattern as `setGoal`/`clearGoal`), because the binary `interactionMode` cannot carry the question-generation vs answer-generation ExitPlanMode distinction without changing plan-wizard behaviour.
- A compile-time test asserts the `providerOptions` bag rejects cross-Provider knobs.

## Design note
The PRD wording says `interactionMode` absorbs both plan methods. The code distinguishes three plan states (build; plan-question-generation, where Claude denies ExitPlanMode to force questions first; plan-answer-generation, where Claude captures it). Folding answer-mode into the binary would make the question turn capture early and skip the wizard, so `setPlanAnswerMode` was relocated off-interface rather than folded. All three methods still leave the shared interface, which is the stated goal.

## CONTEXT.md terms implemented
Turn, Plan mode and Build mode (as per-Turn states), Provider.

## User stories satisfied
20 (one typed value object), 21 (providerOptions discriminator keyed by Provider), 22 (single `resumeFrom` field), 11 and 12 (per-Turn interaction mode and knob changes apply on the next Turn).

## Verification
- Typecheck: 5 of 5 packages pass (forced, uncached).
- Lint: pass.
- Server unit suite: 1064 pass. The `snapshot-service.integration` git tests time out under this sandbox's slow git at the default 10s hook timeout and pass at 60s; they import nothing from this change.

Related to #538.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782608266&installation_id=129163861&pr_number=539&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F539&signature=9a32b7cf8c1785fcc79e1616cf0916fdbc8d7b9201faf803e48eb5aa269c136b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->