### PR TITLE
A (part 1): NarrativeStore read seam + single-source turn.load hydration

### DIFF
--- a/apps/server/src/__tests__/agent-service-turn-started.test.ts
+++ b/apps/server/src/__tests__/agent-service-turn-started.test.ts
@@ -42,7 +42,7 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
   let taskRepo: TaskRepo;
   let svc: AgentService;
   let providerStub: EventEmitter & Partial<IAgentProvider> & {
-    sendMessage: ReturnType<typeof vi.fn>;
+    sendTurn: ReturnType<typeof vi.fn>;
   };
   let capturedEvents: AgentEvent[];
   // Snapshot of capturedEvents.length taken synchronously when the provider's
@@ -70,12 +70,11 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       // Snapshot capturedEvents.length synchronously on entry: this is the
       // load-bearing ordering signal. If the emit happened BEFORE the call
       // entered (correct order), this will be >= 1.
-      sendMessage: vi.fn(() => {
+      sendTurn: vi.fn(() => {
         eventsLengthAtSendMessageEntry = capturedEvents.length;
         return new Promise<void>(() => {});
       }),
       stopSession: vi.fn(),
-      setSdkSessionId: vi.fn(),
       shutdown: vi.fn(),
     });
     providerStub.on("event", (e: AgentEvent) => capturedEvents.push(e));
@@ -179,8 +178,8 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
 
     expect(svc.activeThreadIds()).toContain(thread.id);
 
-    // Provider.sendMessage must have been invoked. Confirms the emit happened
-    // during sendMessage flow, not via some other path.
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
+    // Provider.sendTurn must have been invoked. Confirms the emit happened
+    // during sendTurn flow, not via some other path.
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/src/__tests__/claude-provider-assistant-boundary.test.ts
+++ b/apps/server/src/__tests__/claude-provider-assistant-boundary.test.ts
@@ -81,13 +81,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-final",
+      threadId: "thread-boundary-final",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -122,13 +124,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-preamble",
+      threadId: "thread-boundary-preamble",
       message: "read file",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -162,13 +166,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-no-text",
+      threadId: "thread-boundary-no-text",
       message: "go",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 

--- a/apps/server/src/__tests__/claude-provider-eviction.test.ts
+++ b/apps/server/src/__tests__/claude-provider-eviction.test.ts
@@ -69,13 +69,15 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
   it("does NOT evict a session while a tool_use is still pending", async () => {
     mockQuery.mockImplementation(makeToolUseStream());
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t1",
+      threadId: "t1",
       message: "run something long",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     await vi.advanceTimersByTimeAsync(100);
@@ -120,13 +122,15 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
       });
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t2",
+      threadId: "t2",
       message: "run",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     await vi.advanceTimersByTimeAsync(100);

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -90,21 +90,25 @@ describe("ClaudeProvider permission mode changes", () => {
   });
 
   it("reuses the session when permissionMode is unchanged", async () => {
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-a",
+      threadId: "thread-a",
       message: "first",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-a",
+      threadId: "thread-a",
       message: "second",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // One underlying sdk subprocess for both messages.
@@ -112,21 +116,25 @@ describe("ClaudeProvider permission mode changes", () => {
   });
 
   it("tears down and respawns the session when permissionMode changes", async () => {
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-b",
+      threadId: "thread-b",
       message: "first",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-b",
+      threadId: "thread-b",
       message: "second",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // The SDK subprocess is respawned because permissionMode is fixed at spawn.

--- a/apps/server/src/__tests__/claude-provider-queue.test.ts
+++ b/apps/server/src/__tests__/claude-provider-queue.test.ts
@@ -89,13 +89,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
     // First send establishes the session
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t1",
+      threadId: "t1",
       message: "first",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Simulate race by closing the queue directly
@@ -105,13 +107,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
 
     // Second send on same sessionId: push hits a closed queue
     await expect(
-      provider.sendMessage({
+      provider.sendTurn({
         sessionId: "mcode-t1",
+        threadId: "t1",
         message: "second",
         cwd: "/tmp",
         model: "claude-sonnet-4-6",
-        resume: false,
         permissionMode: "default",
+        interactionMode: "build",
+        providerOptions: {},
       }),
     ).rejects.toThrow(/closed/i);
 
@@ -148,13 +152,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
     // First send establishes the session
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-overflow",
+      threadId: "overflow",
       message: "first",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Saturate the queue: MAX_QUEUE_DEPTH is 20, so push many more than that.
@@ -162,13 +168,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     let overflowErr: Error | undefined;
     for (let i = 0; i < 25; i++) {
       try {
-        await provider.sendMessage({
+        await provider.sendTurn({
           sessionId: "mcode-overflow",
+          threadId: "overflow",
           message: `msg-${i}`,
           cwd: "/tmp",
           model: "claude-sonnet-4-6",
-          resume: false,
           permissionMode: "default",
+          interactionMode: "build",
+          providerOptions: {},
         });
       } catch (e) {
         overflowErr = e as Error;

--- a/apps/server/src/__tests__/claude-provider-result-error.test.ts
+++ b/apps/server/src/__tests__/claude-provider-result-error.test.ts
@@ -63,13 +63,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string; error?: string }> = [];
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-1",
+      threadId: "thread-1",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Allow the stream loop microtasks to drain
@@ -92,13 +94,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string }> = [];
     provider.on("event", (e: { type: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-2",
+      threadId: "thread-2",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -115,13 +119,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string; error?: string; content?: string }> = [];
     provider.on("event", (e: { type: string; error?: string; content?: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-3",
+      threadId: "thread-3",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -194,12 +194,14 @@ describe("CopilotProvider bootstrap", () => {
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
 
-      await provider.sendMessage({
+      await provider.sendTurn({
         sessionId: "mcode-test1",
+        threadId: "test1",
         message: "hello",
         cwd: "/tmp",
         model: "gpt-4o",
-        resume: false,
+        interactionMode: "build",
+        providerOptions: {},
         permissionMode: "auto",
       });
 
@@ -220,12 +222,14 @@ describe("CopilotProvider bootstrap", () => {
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
 
-      await provider.sendMessage({
+      await provider.sendTurn({
         sessionId: "mcode-test2",
+        threadId: "test2",
         message: "hello",
         cwd: "/tmp",
         model: "gpt-4o",
-        resume: false,
+        interactionMode: "build",
+        providerOptions: {},
         permissionMode: "auto",
       });
 
@@ -271,12 +275,14 @@ async function runWithMockSession(
   const events: AgentEvent[] = [];
   provider.on("event", (e: AgentEvent) => events.push(e));
 
-  await provider.sendMessage({
+  await provider.sendTurn({
     sessionId,
+    threadId: sessionId.replace(/^mcode-/, ""),
     message: "hello",
     cwd: "/tmp",
     model: "gpt-4o",
-    resume: false,
+    interactionMode: "build",
+    providerOptions: {},
     permissionMode: "auto",
   });
 

--- a/apps/server/src/__tests__/model-cache-service.test.ts
+++ b/apps/server/src/__tests__/model-cache-service.test.ts
@@ -16,7 +16,7 @@ function makeProvider(models: ProviderModelInfo[]) {
   return {
     id: "test-provider",
     listModels: vi.fn().mockResolvedValue(models),
-    sendMessage: vi.fn(),
+    sendTurn: vi.fn(),
     cancelSession: vi.fn(),
     shutdown: vi.fn(),
   };
@@ -163,7 +163,7 @@ describe("ModelCacheService", () => {
     const provider = {
       id: "cursor",
       listModels: vi.fn().mockReturnValue(listPromise),
-      sendMessage: vi.fn(),
+      sendTurn: vi.fn(),
       cancelSession: vi.fn(),
       shutdown: vi.fn(),
     };
@@ -191,7 +191,7 @@ describe("ModelCacheService", () => {
   it("throws when fetching from a provider that does not implement listModels", async () => {
     const provider = {
       id: "no-list",
-      sendMessage: vi.fn(),
+      sendTurn: vi.fn(),
       cancelSession: vi.fn(),
       shutdown: vi.fn(),
     };

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -33,6 +33,7 @@ import { ProviderRegistry } from "./providers/provider-registry";
 import { WorkspaceService } from "./services/workspace-service";
 import { ThreadService } from "./services/thread-service";
 import { AgentService } from "./services/agent-service";
+import { NarrativeStore } from "./services/narrative-store";
 import { GitService } from "./services/git-service";
 import { GithubService } from "./services/github-service";
 import { FileService } from "./services/file-service";
@@ -266,6 +267,14 @@ export function setupContainer(mcodeDir: string): typeof container {
     { useClass: AttachmentService },
     { lifecycle: Lifecycle.Singleton },
   );
+  container.register(
+    NarrativeStore,
+    { useClass: NarrativeStore },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register("NarrativeStore", {
+    useFactory: (c) => c.resolve(NarrativeStore),
+  });
   container.register(
     AgentService,
     { useClass: AgentService },

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -20,6 +20,7 @@ import { PtyPidRegistry } from "./services/pty-pid-registry";
 import { WorkspaceService } from "./services/workspace-service";
 import { ThreadService } from "./services/thread-service";
 import { AgentService } from "./services/agent-service";
+import { NarrativeStore } from "./services/narrative-store";
 import { GitService } from "./services/git-service";
 import { GithubService } from "./services/github-service";
 import { FileService } from "./services/file-service";
@@ -177,6 +178,7 @@ const providerAvailability = container.resolve(ProviderAvailabilityService);
 const toolCallRecordRepo = container.resolve(ToolCallRecordRepo);
 const thoughtSegmentRepo = container.resolve(ThoughtSegmentRepo);
 const hookExecutionRepo = container.resolve(HookExecutionRepo);
+const narrativeStore = container.resolve(NarrativeStore);
 const turnSnapshotRepo = container.resolve(TurnSnapshotRepo);
 const snapshotService = container.resolve(SnapshotService);
 const settingsService = container.resolve(SettingsService);
@@ -459,6 +461,7 @@ const { httpServer, wss } = createWsServer({
   toolCallRecordRepo,
   thoughtSegmentRepo,
   hookExecutionRepo,
+  narrativeStore,
   turnSnapshotRepo,
   snapshotService,
   settingsService,

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -13,6 +13,7 @@ import { logger } from "@mcode/shared";
 import { AgentEventType, isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   ContextWindowMode,
@@ -300,26 +301,32 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
   }
 
   /** Start or continue a session by sending a message via the SDK. */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    contextWindowMode?: ContextWindowMode;
-    thinking?: boolean;
-    maxBudgetUsd?: number;
-    maxTurns?: number;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"claude">): Promise<void> {
+    // Seed the resume id so doSendMessage's sdkSessionIds lookup resolves it.
+    // `resumeFrom` defined ⇒ resume that SDK session; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
+    const params = {
+      sessionId: req.sessionId,
+      message: req.message,
+      cwd: req.cwd,
+      model: req.model,
+      fallbackModel: req.fallbackModel,
+      resume: req.resumeFrom !== undefined,
+      permissionMode: req.permissionMode,
+      attachments: req.attachments,
+      reasoningLevel: req.reasoningLevel,
+      contextWindowMode: req.providerOptions.contextWindowMode,
+      thinking: req.providerOptions.thinking,
+      maxBudgetUsd: req.maxBudgetUsd,
+      maxTurns: req.maxTurns,
+    };
     try {
       await this.doSendMessage(params);
     } catch (e: unknown) {
-      logger.error("sendMessage error", {
-        sessionId: params.sessionId,
+      logger.error("sendTurn error", {
+        sessionId: req.sessionId,
         error: String(e),
       });
       throw e;
@@ -2006,11 +2013,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
-
   /**
    * Install a goal on a session. The next Stop event from the SDK will be
    * blocked with a "Goal not yet met" reason until {@link clearGoal} is
@@ -2165,6 +2167,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
    * callback captures ExitPlanMode calls instead of denying them.
    * When disabled (or after capture), the model's ExitPlanMode calls
    * are denied silently.
+   *
+   * Off-interface (like setGoal/clearGoal): no longer an IAgentProvider member;
+   * AgentService invokes it on the concrete ClaudeProvider via a cast. The
+   * question-vs-answer plan distinction cannot be carried by the binary
+   * TurnRequest.interactionMode, so this Claude-only arming stays explicit.
    */
   setPlanAnswerMode(threadId: string, enabled: boolean): void {
     if (enabled) {

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -221,13 +221,15 @@ describe("CodexProvider permission flow", () => {
     };
 
     vi.useRealTimers();
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId,
+      threadId,
       message: "hi",
       cwd: "/",
       model: "gpt-5",
-      resume: false,
       permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     const response = await pendingPromise;

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -18,6 +18,7 @@ import { JobObject } from "../../services/job-object.js";
 import { EnvService } from "../../services/env-service.js";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   AgentEvent,
@@ -157,26 +158,20 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
    * For new sessions, spawns a subprocess and runs the JSON-RPC handshake first.
    * The method returns immediately; events stream via the `event` EventEmitter channel.
    */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /** When true, pass OpenAI fast service tier; when false, standard. Undefined uses global settings. */
-    codexFastMode?: boolean;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"codex">): Promise<void> {
     const settings = await this.settingsService.get();
     const cliPath = settings.provider.cli.codex || "codex";
 
+    // `resumeFrom` defined ⇒ resume that Codex thread; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
     const {
-      sessionId, message, cwd, model, resume, permissionMode,
-      reasoningLevel, attachments, codexFastMode,
-    } = params;
+      sessionId, message, cwd, model, permissionMode,
+      reasoningLevel, attachments,
+    } = req;
+    const resume = req.resumeFrom !== undefined;
+    const codexFastMode = req.providerOptions.fastMode;
 
     const input = buildCodexInput(message, attachments);
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
@@ -595,10 +590,6 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Pre-loads an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
 
   /** Kills a running session's subprocess and cancels any pending permissions for its thread. */
   stopSession(sessionId: string): void {

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -25,6 +25,7 @@ import { SettingsService } from "../../services/settings-service.js";
 import { EnvService } from "../../services/env-service.js";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   AgentEvent,
@@ -465,19 +466,23 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   private contextWindowBySession = new Map<string, number>();
 
   /** Start or continue a session by sending a message via the Copilot SDK. When `copilotAgent` is provided, routes the session to the appropriate built-in mode or custom agent before sending. */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /** Copilot sub-agent name. Built-in modes: "interactive" | "plan" | "autopilot". Custom: any YAML agent name. */
-    copilotAgent?: string;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"copilot">): Promise<void> {
+    // `resumeFrom` defined ⇒ resume that SDK session; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
+    const params = {
+      sessionId: req.sessionId,
+      message: req.message,
+      cwd: req.cwd,
+      model: req.model,
+      fallbackModel: req.fallbackModel,
+      resume: req.resumeFrom !== undefined,
+      permissionMode: req.permissionMode,
+      attachments: req.attachments,
+      reasoningLevel: req.reasoningLevel,
+      copilotAgent: req.providerOptions.agent,
+    };
     try {
       await this.doSendMessage(params);
     } catch (e: unknown) {
@@ -940,11 +945,6 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         this.contextWindowBySession.delete(sessionId);
       }
     }
-  }
-
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
   }
 
   /** Disconnect and remove an active session, or record a pending stop if the session hasn't been created yet. */

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -39,11 +39,11 @@ import type {
   AttachmentMeta,
   AgentEvent,
   IAgentProvider,
+  TurnRequest,
   PermissionDecision,
   PermissionRequest,
   ProviderId,
   ProviderModelInfo,
-  ReasoningLevel,
   Settings,
 } from "@mcode/contracts";
 import {
@@ -170,32 +170,35 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   }
 
   /** Queues an ACP `session/prompt` on the session subprocess (serialized per thread). */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-  }): Promise<void> {
-    void params.fallbackModel;
-    void params.reasoningLevel;
+  async sendTurn(req: TurnRequest<"cursor">): Promise<void> {
+    void req.fallbackModel;
+    void req.reasoningLevel;
 
     const {
       sessionId,
       message,
       cwd,
       model,
-      resume,
       permissionMode,
       attachments,
-    } = params;
+    } = req;
+    // `resumeFrom` defined ⇒ resume the stored ACP session; undefined ⇒ fresh.
+    const resume = req.resumeFrom !== undefined;
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(sessionId, req.resumeFrom);
+    }
 
     const pm: "full" | "default" = permissionMode === "full" ? "full" : "default";
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
+
+    // interactionMode absorbs the retired setPlanQuestionMode: a plan-mode Turn
+    // suppresses Cursor's native auto-answer of ask_question; build clears it.
+    // The flag is re-derived every Turn, so it is authoritative per Turn.
+    if (req.interactionMode === "plan") {
+      this.planQuestionModeThreads.add(threadId);
+    } else {
+      this.planQuestionModeThreads.delete(threadId);
+    }
 
     if (!this.evictionTimer) {
       this.evictionTimer = setInterval(() => this.evictIdleSessions(), EVICTION_INTERVAL_MS);
@@ -246,10 +249,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     await scheduled;
   }
 
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
 
   /** Cancel the active ACP session. Records a pending stop if the session hasn't been created yet. */
   stopSession(sessionId: string): void {
@@ -272,14 +271,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Toggle Mcode plan-questions phase for Cursor ask_question handling. */
-  setPlanQuestionMode(threadId: string, enabled: boolean): void {
-    if (enabled) {
-      this.planQuestionModeThreads.add(threadId);
-    } else {
-      this.planQuestionModeThreads.delete(threadId);
-    }
-  }
 
   /** Tear down all sessions, cancel pending permissions, and stop the eviction timer. */
   shutdown(): void {

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -27,7 +27,7 @@ import { broadcast } from "../../transport/push.js";
 
 /**
  * Build an AgentService with a Claude-shaped provider stub that records
- * setGoal/clearGoal/sendMessage so we can assert which path the /goal
+ * setGoal/clearGoal/sendTurn so we can assert which path the /goal
  * intercept took (control short-circuit vs SET fall-through).
  */
 function buildService(db: Database.Database) {
@@ -56,10 +56,9 @@ function buildService(db: Database.Database) {
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendMessage: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
+    sendTurn: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
       () => Promise.resolve(),
     ),
-    setSdkSessionId: vi.fn(),
     setGoal: vi.fn<(sid: string, condition: string) => void>(),
     clearGoal: vi.fn<(sid: string) => void>(),
     getGoal: vi.fn<(sid: string) => string | undefined>(() => undefined),
@@ -157,8 +156,8 @@ describe("AgentService.sendMessage — /goal command", () => {
 
     // Provider was actually called — this is the regression the user hit
     // where /goal <condition> set the hook but never started the agent.
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
-    const sentMessage = providerStub.sendMessage.mock.calls[0][0].message;
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
+    const sentMessage = providerStub.sendTurn.mock.calls[0][0].message;
     expect(sentMessage).toContain("analyse this branch");
     expect(sentMessage.toLowerCase()).toContain("directive");
 
@@ -183,7 +182,7 @@ describe("AgentService.sendMessage — /goal command", () => {
     );
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
-    expect(providerStub.sendMessage).not.toHaveBeenCalled();
+    expect(providerStub.sendTurn).not.toHaveBeenCalled();
 
     // Confirmation pill persisted as an assistant message.
     const { messages } = messageRepo.listByThread(thread.id, 100);
@@ -213,7 +212,7 @@ describe("AgentService.sendMessage — /goal command", () => {
       "claude",
     );
 
-    expect(providerStub.sendMessage).not.toHaveBeenCalled();
+    expect(providerStub.sendTurn).not.toHaveBeenCalled();
     expect(providerStub.setGoal).not.toHaveBeenCalled();
 
     const { messages } = messageRepo.listByThread(thread.id, 100);
@@ -237,7 +236,7 @@ describe("AgentService.sendMessage — /goal command", () => {
 
     // Provider was still called with the raw text (no rewrite, no goal install).
     expect(providerStub.setGoal).not.toHaveBeenCalled();
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
-    expect(providerStub.sendMessage.mock.calls[0][0].message).toBe("/goal something");
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
+    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal something");
   });
 });

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -73,8 +73,7 @@ interface Built {
 function build(): Built {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
-  (providerEmitter as any).sendMessage = vi.fn(() => Promise.resolve());
-  (providerEmitter as any).setSdkSessionId = vi.fn();
+  (providerEmitter as any).sendTurn = vi.fn(() => Promise.resolve());
 
   const threadRepo = {
     findById: vi.fn(() => thread),

--- a/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
@@ -51,14 +51,15 @@ function buildService(db: Database.Database) {
   } as unknown as AttachmentService;
 
   // Provider stub: extends EventEmitter (matches real provider shape) and
-  // resolves sendMessage immediately so the turn "completes" without I/O.
+  // resolves sendTurn immediately so the turn "completes" without I/O.
   const providerStub = Object.assign(new EventEmitter(), {
     id: "claude" as const,
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendMessage: vi.fn(() => Promise.resolve()),
-    setSdkSessionId: vi.fn(),
+    sendTurn: vi.fn(() => Promise.resolve()),
+    // Claude-concrete off-interface method invoked by armPlanGenerationTurn via cast.
+    setPlanAnswerMode: vi.fn(),
   });
   const providerRegistry = {
     resolve: vi.fn(() => providerStub),

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -75,9 +75,8 @@ function buildService(): {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
 
-  // sendMessage() and setSdkSessionId() are called on the resolved provider
-  (providerEmitter as any).sendMessage = vi.fn(() => Promise.resolve());
-  (providerEmitter as any).setSdkSessionId = vi.fn();
+  // sendTurn() is called on the resolved provider
+  (providerEmitter as any).sendTurn = vi.fn(() => Promise.resolve());
 
   const threadRepo = {
     findById: vi.fn(() => thread),

--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -1,0 +1,117 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../../store/database";
+import { MessageRepo } from "../../repositories/message-repo";
+import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo";
+import { ThoughtSegmentRepo } from "../../repositories/thought-segment-repo";
+import { HookExecutionRepo } from "../../repositories/hook-execution-repo";
+import { NarrativeStore } from "../narrative-store";
+
+/** Seed a workspace + thread so message/record foreign keys are satisfied. */
+function seedThread(db: Database.Database): string {
+  const now = new Date().toISOString();
+  db.prepare(
+    "INSERT INTO workspaces (id, name, path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+  ).run("ws-1", "Test", "/tmp/test", now, now);
+  db.prepare(
+    "INSERT INTO threads (id, workspace_id, title, branch, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run("thread-1", "ws-1", "Test thread", "main", now, now);
+  return "thread-1";
+}
+
+function insertMessage(
+  db: Database.Database,
+  id: string,
+  role: string,
+  content: string,
+  sequence: number,
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(id, "thread-1", role, content, now, sequence);
+}
+
+describe("NarrativeStore.load (read seam)", () => {
+  let db: Database.Database;
+  let store: NarrativeStore;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    seedThread(db);
+    store = new NarrativeStore(
+      new MessageRepo(db),
+      new ToolCallRecordRepo(db),
+      new ThoughtSegmentRepo(db),
+      new HookExecutionRepo(db),
+    );
+  });
+
+  it("returns one list interleaved by (sequence, sortOrder), final response as the message body", () => {
+    // One assistant message: preamble narration (0), tool call (1), hook (2),
+    // final-response segment (3). The body must surface at sortOrder 3.
+    insertMessage(db, "m1", "assistant", "Final answer text.", 1);
+    new ThoughtSegmentRepo(db).bulkCreate([
+      { messageId: "m1", text: "Let me look.", startedAt: "t", endedAt: "t", sortOrder: 0 },
+      { messageId: "m1", text: "Final answer text.", startedAt: "t", endedAt: "t", sortOrder: 3, isFinalResponse: 1 },
+    ]);
+    new ToolCallRecordRepo(db).bulkCreate([
+      { messageId: "m1", toolName: "Read", inputSummary: "f.ts", outputSummary: "ok", status: "completed", sortOrder: 1 },
+    ]);
+    new HookExecutionRepo(db).bulkCreate([
+      { messageId: "m1", hookName: "PreToolUse", toolName: "Read", phase: "pre", payload: "{}", durationMs: 1, didBlock: false, startedAt: "t", endedAt: "t", sortOrder: 2 },
+    ]);
+
+    const entries = store.load("thread-1");
+
+    expect(entries.map((e) => e.kind)).toEqual([
+      "narrationSegment", // sortOrder 0
+      "toolCall", // 1
+      "hook", // 2
+      "assistantMessage", // 3 (final response as body)
+    ]);
+    const body = entries.find((e) => e.kind === "assistantMessage");
+    expect(body && body.kind === "assistantMessage" && body.body).toBe("Final answer text.");
+    // The final-response segment is NOT also emitted as a narration row.
+    const narrations = entries.filter((e) => e.kind === "narrationSegment");
+    expect(narrations).toHaveLength(1);
+    expect(narrations[0].kind === "narrationSegment" && narrations[0].record.text).toBe("Let me look.");
+  });
+
+  it("orders entries across messages by sequence, and skips user/system messages", () => {
+    insertMessage(db, "u1", "user", "do the thing", 1);
+    insertMessage(db, "m1", "assistant", "first answer", 2);
+    insertMessage(db, "sys1", "system", "Context compacted", 3);
+    insertMessage(db, "m2", "assistant", "second answer", 4);
+    const tools = new ToolCallRecordRepo(db);
+    tools.bulkCreate([
+      { messageId: "m1", toolName: "Read", inputSummary: "a", outputSummary: "ok", status: "completed", sortOrder: 0 },
+    ]);
+    tools.bulkCreate([
+      { messageId: "m2", toolName: "Bash", inputSummary: "ls", outputSummary: "ok", status: "completed", sortOrder: 0 },
+    ]);
+
+    const entries = store.load("thread-1");
+
+    // Only assistant narrative; user + system rows excluded.
+    expect(entries.every((e) => e.sequence === 2 || e.sequence === 4)).toBe(true);
+    // All of message seq=2's entries precede all of seq=4's entries.
+    const seqs = entries.map((e) => e.sequence);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    // m1 (seq 2): toolCall then assistantMessage (body sorts last, no final seg → MAX).
+    const seq2 = entries.filter((e) => e.sequence === 2);
+    expect(seq2.map((e) => e.kind)).toEqual(["toolCall", "assistantMessage"]);
+  });
+
+  it("places the assistant body last when there is no final-response segment", () => {
+    insertMessage(db, "m1", "assistant", "answer with no tagged final segment", 1);
+    new ToolCallRecordRepo(db).bulkCreate([
+      { messageId: "m1", toolName: "Read", inputSummary: "a", outputSummary: "ok", status: "completed", sortOrder: 0 },
+      { messageId: "m1", toolName: "Edit", inputSummary: "b", outputSummary: "ok", status: "completed", sortOrder: 1 },
+    ]);
+
+    const entries = store.load("thread-1");
+    expect(entries.map((e) => e.kind)).toEqual(["toolCall", "toolCall", "assistantMessage"]);
+  });
+});

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -17,6 +17,7 @@ import type {
   ReasoningLevel,
   ContextWindowMode,
   IProviderRegistry,
+  TurnRequest,
   AgentEvent,
   ProviderId,
   InteractionMode,
@@ -481,9 +482,10 @@ export class AgentService {
     if (planAction === "revise") {
       this.armPlanGenerationTurn(threadId);
       wirePayload = `${wirePayload}\n\n${this.buildPlanOutputInstructions()}`;
-    } else if (planAction === "implement") {
-      this.setPlanQuestionModeOnProvider(threadId, false);
     }
+    // The retired setPlanQuestionMode toggle is gone: Cursor derives plan-question
+    // suppression from each Turn's interactionMode at sendTurn. An "implement"
+    // turn dispatches as "build", which clears the flag.
 
     const effectiveInteractionMode =
       planAction === "revise" || planAction === "implement"
@@ -492,7 +494,6 @@ export class AgentService {
 
     if (effectiveInteractionMode === "plan") {
       this.planParsers.set(threadId, new PlanQuestionParser());
-      this.setPlanQuestionModeOnProvider(threadId, true);
       if (providerWireOverride === undefined) {
         wirePayload = this.buildPlanPrompt(wirePayload);
       }
@@ -597,11 +598,10 @@ export class AgentService {
     // Only treat as resume if there is actually a session to resume.
     const isResume = nextSeq > 1 && !!thread.sdk_session_id;
 
-    // Hydrate SDK session ID mapping for resume
-    if (isResume && thread.sdk_session_id) {
-      const sdkProvider = this.providerRegistry.resolve(effectiveProvider);
-      sdkProvider.setSdkSessionId(sessionName, thread.sdk_session_id);
-    }
+    // Resume signal: defined ⇒ resume that SDK session, undefined ⇒ fresh.
+    // Replaces the former setSdkSessionId(...) + resume:true two-step dance.
+    const resumeFrom: string | undefined =
+      isResume && thread.sdk_session_id ? thread.sdk_session_id : undefined;
 
     const resolvedProvider = this.providerRegistry.resolve(effectiveProvider);
 
@@ -636,24 +636,36 @@ export class AgentService {
       });
     }
 
+    // Provider-specific knobs are walled into providerOptions, keyed by the
+    // resolved Provider. The orchestrator picks both the Provider and its
+    // matching options together; the cast at the sendTurn boundary is the one
+    // controlled point where the runtime selection meets the union type.
+    const providerOptions =
+      effectiveProvider === "claude"
+        ? { contextWindowMode: effectiveContextWindowMode, thinking: effectiveThinking }
+        : effectiveProvider === "codex"
+          ? { fastMode: effectiveCodexFastMode }
+          : effectiveProvider === "copilot"
+            ? { agent: effectiveCopilotAgent }
+            : {};
+
     try {
-      await resolvedProvider.sendMessage({
+      await resolvedProvider.sendTurn({
         sessionId: sessionName,
+        threadId,
         message: providerMessage,
         cwd,
         model: resolvedModel,
         fallbackModel,
-        resume: isResume,
         permissionMode,
+        interactionMode: effectiveInteractionMode ?? "build",
         attachments: persisted.length > 0 ? persisted : undefined,
         reasoningLevel,
-        contextWindowMode: effectiveContextWindowMode,
-        thinking: effectiveThinking,
-        ...(effectiveProvider === "codex" && { codexFastMode: effectiveCodexFastMode }),
         ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
         ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
-        copilotAgent: effectiveCopilotAgent,
-      });
+        resumeFrom,
+        providerOptions,
+      } as TurnRequest);
       logger.info("Message sent via provider", {
         threadId,
         session: sessionName,
@@ -1892,7 +1904,6 @@ export class AgentService {
           this.pendingPlanOutputs.delete(event.threadId);
           this.pendingExitPlanMarkdown.delete(event.threadId);
           this.planCapturedThisTurn.delete(event.threadId);
-          this.setPlanQuestionModeOnProvider(event.threadId, false);
         }
 
         if (event.type === AgentEventType.Compacting && event.active) {
@@ -1964,7 +1975,6 @@ export class AgentService {
           this.pendingPlanOutputs.delete(event.threadId);
           this.pendingExitPlanMarkdown.delete(event.threadId);
           this.planCapturedThisTurn.delete(event.threadId);
-          this.setPlanQuestionModeOnProvider(event.threadId, false);
         }
       });
     }
@@ -2049,22 +2059,21 @@ export class AgentService {
   private armPlanGenerationTurn(threadId: string): void {
     this.planOutputParsers.set(threadId, new PlanOutputParser());
     this.planCapturedThisTurn.delete(threadId);
-    this.setPlanQuestionModeOnProvider(threadId, false);
 
+    // Claude ExitPlanMode capture is a Claude-only concern that the binary
+    // TurnRequest.interactionMode cannot carry (it would conflate the
+    // question-generation turn with the answer/revise turn). It stays an
+    // off-interface arming on the concrete ClaudeProvider, invoked via a cast
+    // like setGoal/clearGoal. The revise/answer turn dispatches with
+    // interactionMode "build", so Cursor's per-Turn question mode clears itself.
     const thread = this.threadRepo.findById(threadId);
     const effectiveProvider = (thread?.provider as ProviderId) ?? "claude";
-    const provider = this.providerRegistry.resolve(effectiveProvider);
-    provider.setPlanAnswerMode?.(threadId, true);
-  }
-
-  /** Toggle native question UI suppression on the active provider. */
-  private setPlanQuestionModeOnProvider(threadId: string, enabled: boolean): void {
-    const thread = this.threadRepo.findById(threadId);
-    if (!thread) return;
-    const provider = this.providerRegistry.resolve(
-      (thread.provider as ProviderId) ?? "claude",
-    );
-    provider.setPlanQuestionMode?.(threadId, enabled);
+    if (effectiveProvider === "claude") {
+      const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
+        setPlanAnswerMode: (threadId: string, enabled: boolean) => void;
+      };
+      claudeProvider.setPlanAnswerMode(threadId, true);
+    }
   }
 
   /** Persist one plan version and broadcast, skipping duplicate captures per turn. */

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -1,0 +1,90 @@
+/**
+ * NarrativeStore — single home for the narrative pipeline's read side (and,
+ * after the candidate-A write-seam extraction, its enrichment + classification
+ * + persistence too).
+ *
+ * Read seam: {@link NarrativeStore.load} returns one chronologically-ordered
+ * list of {@link NarrativeEntry} for a thread, interleaving assistant message
+ * bodies, tool calls, narration segments, and hooks by (sequence, sortOrder).
+ * The client renders this list in payload order, so reloaded turns no longer
+ * race two hydration streams (the old `message.list` + `narrative.list` pair)
+ * and Tool calls never render before the assistant message body.
+ */
+import { injectable, inject } from "tsyringe";
+import type { NarrativeEntry, TurnRange } from "@mcode/contracts";
+import { MessageRepo } from "../repositories/message-repo";
+import { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
+import { ThoughtSegmentRepo } from "../repositories/thought-segment-repo";
+import { HookExecutionRepo } from "../repositories/hook-execution-repo";
+
+/** Default number of recent messages hydrated when no range is supplied. */
+const DEFAULT_LOAD_LIMIT = 200;
+
+@injectable()
+export class NarrativeStore {
+  constructor(
+    @inject(MessageRepo) private readonly messageRepo: MessageRepo,
+    @inject(ToolCallRecordRepo) private readonly toolCallRecordRepo: ToolCallRecordRepo,
+    @inject(ThoughtSegmentRepo) private readonly thoughtSegmentRepo: ThoughtSegmentRepo,
+    @inject(HookExecutionRepo) private readonly hookExecutionRepo: HookExecutionRepo,
+  ) {}
+
+  /**
+   * Load a thread's persisted narrative as one chronologically-ordered list.
+   *
+   * Entries are ordered by `(message.sequence, sortOrder)`. For each assistant
+   * message, the final-response narration segment is surfaced as the
+   * `assistantMessage` entry (carrying the message body and that segment's
+   * sort order) rather than as a separate narration row, so the final response
+   * is the message body and never appears as a duplicate preamble. Preamble
+   * narration, tool calls, and hooks for the same message interleave by their
+   * own sort order. User and system messages are not narrative and are skipped.
+   */
+  load(threadId: string, range?: TurnRange): NarrativeEntry[] {
+    const { messages } = this.messageRepo.listByThread(
+      threadId,
+      range?.limit ?? DEFAULT_LOAD_LIMIT,
+      range?.before,
+    );
+
+    const entries: NarrativeEntry[] = [];
+    for (const m of messages) {
+      if (m.role !== "assistant") continue;
+
+      const tools = this.toolCallRecordRepo.listByMessage(m.id);
+      const thoughts = this.thoughtSegmentRepo.listByMessage(m.id);
+      const hooks = this.hookExecutionRepo.listByMessage(m.id);
+
+      const finalSeg = thoughts.find((t) => (t.is_final_response ?? 0) !== 0);
+      entries.push({
+        kind: "assistantMessage",
+        messageId: m.id,
+        sequence: m.sequence,
+        body: m.content,
+        // Body sorts where its final-response segment sat; absent (tool-free
+        // or older rows) it sorts after this message's other entries.
+        sortOrder: finalSeg?.sort_order ?? Number.MAX_SAFE_INTEGER,
+      });
+
+      for (const t of tools) {
+        entries.push({ kind: "toolCall", sequence: m.sequence, sortOrder: t.sort_order, record: t });
+      }
+      for (const seg of thoughts) {
+        if ((seg.is_final_response ?? 0) !== 0) continue; // already the assistantMessage body
+        entries.push({
+          kind: "narrationSegment",
+          sequence: m.sequence,
+          sortOrder: seg.sort_order,
+          record: seg,
+        });
+      }
+      for (const h of hooks) {
+        entries.push({ kind: "hook", sequence: m.sequence, sortOrder: h.sort_order, record: h });
+      }
+    }
+
+    return entries.sort(
+      (a, b) => a.sequence - b.sequence || a.sortOrder - b.sortOrder,
+    );
+  }
+}

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -32,6 +32,7 @@ import type { SkillService } from "../services/skill-service";
 import type { TerminalService } from "../services/terminal-service";
 import type { MessageRepo } from "../repositories/message-repo";
 import type { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
+import type { NarrativeStore } from "../services/narrative-store";
 import type { ThoughtSegmentRepo } from "../repositories/thought-segment-repo";
 import type { HookExecutionRepo } from "../repositories/hook-execution-repo";
 import type { TurnSnapshotRepo } from "../repositories/turn-snapshot-repo";
@@ -73,6 +74,8 @@ export interface RouterDeps {
   toolCallRecordRepo: ToolCallRecordRepo;
   thoughtSegmentRepo: ThoughtSegmentRepo;
   hookExecutionRepo: HookExecutionRepo;
+  /** Single-source ordered narrative reader backing the `turn.load` RPC. */
+  narrativeStore: NarrativeStore;
   turnSnapshotRepo: TurnSnapshotRepo;
   snapshotService: SnapshotService;
   settingsService: SettingsService;
@@ -611,6 +614,8 @@ async function dispatch(
       return deps.toolCallRecordRepo.listByMessage(params.messageId);
     case "toolCallRecord.listByParent":
       return deps.toolCallRecordRepo.listByParent(params.parentToolCallId);
+    case "turn.load":
+      return deps.narrativeStore.load(params.threadId, params.range);
     case "narrative.list":
       return {
         tools: deps.toolCallRecordRepo.listByMessage(params.messageId),

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -152,6 +152,7 @@ export const mockTransport: McodeTransport = {
   listToolCallRecordsByParent: vi.fn().mockResolvedValue([]),
   listNarrative: vi.fn().mockResolvedValue({ tools: [], thoughts: [], hooks: [] }),
   listNarrativeBatch: vi.fn().mockResolvedValue({}),
+  loadTurn: vi.fn().mockResolvedValue([]),
   getThreadTasks: vi.fn().mockResolvedValue(null),
   getThreadPlans: vi.fn().mockResolvedValue([]),
   getSnapshotDiff: vi.fn().mockResolvedValue(""),

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -93,6 +93,7 @@ function resetStores() {
   (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue(null);
   (mockTransport.getThreadPlans as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   (mockTransport.listNarrativeBatch as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  (mockTransport.loadTurn as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
   useWorkspaceStore.setState({
     threads: [
@@ -239,7 +240,7 @@ describe("ThreadHydrator", () => {
     expect(getTestActiveMessages()).toEqual([msgB]);
   });
 
-  it("falls back to per-message narrative fetches when batch RPC fails", async () => {
+  it("falls back to per-message narrative fetches when turn.load fails", async () => {
     const assistant = createMockMessage({
       id: "asst-1",
       thread_id: THREAD_A,
@@ -250,8 +251,8 @@ describe("ThreadHydrator", () => {
       messages: [msgA, assistant],
       hasMore: false,
     });
-    (mockTransport.listNarrativeBatch as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("batch unsupported"),
+    (mockTransport.loadTurn as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("turn.load unsupported"),
     );
     const listNarrativeSpy = vi.spyOn(mockTransport, "listNarrative");
 

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -12,11 +12,13 @@ import {
 import type { ThreadRecord } from "@/stores/thread-record";
 import type {
   HydrateMode,
+  NarrativeBatchResult,
   ThreadHydratorDeps,
   ThreadHydratorOptions,
   ThreadHydratorTransport,
   ThreadHydratorWriteState,
 } from "./types";
+import type { NarrativeEntry } from "@mcode/contracts";
 import { snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
 
@@ -270,7 +272,16 @@ export class ThreadHydrator {
     }
   }
 
-  /** Eager-prefetch persisted narrative for the last N assistant messages. */
+  /**
+   * Eager-hydrate persisted narrative for the thread via the single
+   * server-ordered `turn.load` call, then group the flat {@link NarrativeEntry}
+   * list back into the per-message {@link NarrativeBatchResult} shape that
+   * `narrativeByMessage` consumers expect (back-compat is intentional).
+   *
+   * On `turn.load` rejection we leave the lazy per-message
+   * `loadNarrativeForMessage` (`narrative.list`) path to fill in, so hydration
+   * never crashes on a transport failure.
+   */
   private prefetchNarratives(threadId: string, messages: import("@/transport").Message[]): void {
     const lastAssistants = messages.filter((m) => m.role === "assistant").slice(-NARRATIVE_PREFETCH_BATCH);
     const narrativeByMessage = getThreadRecord(this.deps.getState().records, threadId).narrativeByMessage;
@@ -281,25 +292,72 @@ export class ThreadHydrator {
     if (idsToFetch.length === 0) return;
 
     void this.transport()
-      .listNarrativeBatch(idsToFetch)
-      .then((batchRes) => {
+      .loadTurn(threadId)
+      .then((entries) => {
+        const grouped = groupNarrativeEntriesByMessage(entries);
         this.deps.setState((state: ThreadHydratorWriteState) => {
           if (!state.records.has(threadId)) return {};
           const rec = getThreadRecord(state.records, threadId);
+          // Preserve already-loaded entries: only commit messages we still need.
+          const next = { ...rec.narrativeByMessage };
+          for (const id of idsToFetch) {
+            next[id] = grouped[id] ?? { tools: [], thoughts: [], hooks: [] };
+          }
           return {
             records: patchThreadRecord(state.records, threadId, {
-              narrativeByMessage: { ...rec.narrativeByMessage, ...batchRes },
+              narrativeByMessage: next,
             }),
           };
         });
       })
       .catch((err) => {
-        console.warn("[narrative] listNarrativeBatch failed, falling back", err);
+        console.warn("[narrative] turn.load failed, falling back to lazy narrative.list", err);
         for (const m of lastAssistants) {
           void this.deps.loadNarrativeForMessage(m.id);
         }
       });
   }
+}
+
+/**
+ * Group a flat, server-ordered {@link NarrativeEntry} list into the legacy
+ * per-message {@link NarrativeBatchResult} shape keyed by `message_id`.
+ *
+ * `assistantMessage` entries are skipped: their body already lives on the
+ * message row, so they do not belong in `narrativeByMessage`. The server
+ * already orders entries by (sequence, sortOrder), so per-message arrays
+ * preserve that order without re-sorting here.
+ */
+export function groupNarrativeEntriesByMessage(
+  entries: NarrativeEntry[],
+): NarrativeBatchResult {
+  const grouped: NarrativeBatchResult = {};
+  const bucket = (messageId: string): NarrativeBatchResult[string] => {
+    let entry = grouped[messageId];
+    if (!entry) {
+      entry = { tools: [], thoughts: [], hooks: [] };
+      grouped[messageId] = entry;
+    }
+    return entry;
+  };
+
+  for (const entry of entries) {
+    switch (entry.kind) {
+      case "toolCall":
+        bucket(entry.record.message_id).tools.push(entry.record);
+        break;
+      case "narrationSegment":
+        bucket(entry.record.message_id).thoughts.push(entry.record);
+        break;
+      case "hook":
+        bucket(entry.record.message_id).hooks.push(entry.record);
+        break;
+      case "assistantMessage":
+        break;
+    }
+  }
+
+  return grouped;
 }
 
 /** Module-scoped hydrator instance registered by threadStore at init. */

--- a/apps/web/src/lib/thread-hydrator/types.ts
+++ b/apps/web/src/lib/thread-hydrator/types.ts
@@ -1,5 +1,5 @@
 import type { Message, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord } from "@/transport";
-import type { TurnSnapshot, PermissionRequest, PlanRecord } from "@mcode/contracts";
+import type { TurnSnapshot, PermissionRequest, PlanRecord, NarrativeEntry } from "@mcode/contracts";
 import type { TaskItem } from "@/stores/taskStore";
 import type { PlanQuestion } from "@mcode/contracts";
 import type { ThreadRecord } from "@/stores/thread-record";
@@ -36,6 +36,7 @@ export interface ThreadHydratorTransport {
   listSnapshots(threadId: string): Promise<TurnSnapshot[]>;
   listNarrativeBatch(messageIds: string[]): Promise<NarrativeBatchResult>;
   listNarrative(messageId: string): Promise<NarrativeBatchResult[string]>;
+  loadTurn(threadId: string): Promise<NarrativeEntry[]>;
   listPendingPermissions(threadId: string): Promise<PermissionRequest[]>;
   getThreadTasks(
     threadId: string,

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -335,6 +335,8 @@ export interface McodeTransport {
     thoughts: ThoughtSegmentRecord[];
     hooks: HookExecutionRecord[];
   }>>;
+  /** Fetch a thread's full server-ordered narrative as a flat, chronological list. */
+  loadTurn(threadId: string): Promise<import("@mcode/contracts").NarrativeEntry[]>;
 
   /** Fetch persisted task list for a thread (from last TodoWrite). */
   getThreadTasks(threadId: string): Promise<Array<{ content: string; status: "pending" | "in_progress" | "completed" | "cancelled"; group?: string }> | null>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -672,6 +672,8 @@ export function createWsTransport(
         thoughts: ThoughtSegmentRecord[];
         hooks: HookExecutionRecord[];
       }>>("narrative.listBatch", { messageIds }),
+    loadTurn: (threadId) =>
+      rpc<import("@mcode/contracts").NarrativeEntry[]>("turn.load", { threadId }),
 
     // Thread tasks
     getThreadTasks: (threadId: string) =>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -61,6 +61,9 @@ export type { ThoughtSegmentRecord } from "./models/thought-segment.js";
 export { HookExecutionRecordSchema } from "./models/hook-execution.js";
 export type { HookExecutionRecord } from "./models/hook-execution.js";
 
+export { NarrativeEntrySchema, TurnRangeSchema } from "./models/narrative-entry.js";
+export type { NarrativeEntry, TurnRange } from "./models/narrative-entry.js";
+
 export { TurnSnapshotSchema } from "./models/turn-snapshot.js";
 export type { TurnSnapshot } from "./models/turn-snapshot.js";
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -279,6 +279,8 @@ export type {
   IAgentProvider,
   ICompletionCapable,
   IProviderRegistry,
+  TurnRequest,
+  ProviderOptionsByProvider,
 } from "./providers/interfaces.js";
 
 export * from "./providers/catalog.js";

--- a/packages/contracts/src/models/narrative-entry.ts
+++ b/packages/contracts/src/models/narrative-entry.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { ToolCallRecordSchema } from "./tool-call-record.js";
+import { ThoughtSegmentRecordSchema } from "./thought-segment.js";
+import { HookExecutionRecordSchema } from "./hook-execution.js";
+
+/**
+ * One entry in a Turn's chronological narrative, as returned by the
+ * `turn.load` RPC. The server orders entries so the client renders in source
+ * order without merging separate per-message streams client-side. This is the
+ * single-source hydration that fixes the page-load ordering bug where Tool
+ * calls rendered before the assistant message body.
+ *
+ * `sortOrder` is the within-message ordinal lifted from the underlying record
+ * (`sort_order`); the assistant message body carries the `sortOrder` of its
+ * final-response segment so the body interleaves correctly with tool calls.
+ */
+export const NarrativeEntrySchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("assistantMessage"),
+    messageId: z.string(),
+    sequence: z.number(),
+    body: z.string(),
+    sortOrder: z.number(),
+  }),
+  z.object({
+    kind: z.literal("toolCall"),
+    sequence: z.number(),
+    sortOrder: z.number(),
+    record: ToolCallRecordSchema,
+  }),
+  z.object({
+    kind: z.literal("narrationSegment"),
+    sequence: z.number(),
+    sortOrder: z.number(),
+    record: ThoughtSegmentRecordSchema,
+  }),
+  z.object({
+    kind: z.literal("hook"),
+    sequence: z.number(),
+    sortOrder: z.number(),
+    record: HookExecutionRecordSchema,
+  }),
+]);
+
+/** One chronologically-ordered narrative entry returned by `turn.load`. */
+export type NarrativeEntry = z.infer<typeof NarrativeEntrySchema>;
+
+/**
+ * Optional load window for `turn.load`. Omit for the thread's recent narrative;
+ * pass a sequence cursor for pagination. Mirrors `message.list` paging.
+ */
+export const TurnRangeSchema = z.object({
+  limit: z.number().optional(),
+  before: z.number().optional(),
+});
+
+/** Optional load window for the `turn.load` RPC. */
+export type TurnRange = z.infer<typeof TurnRangeSchema>;

--- a/packages/contracts/src/providers/__tests__/turn-request.type-test.ts
+++ b/packages/contracts/src/providers/__tests__/turn-request.type-test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import type { TurnRequest } from "../interfaces.js";
+
+/**
+ * These assertions are compile-time first: if the discriminated `providerOptions`
+ * bag stops walling knobs by Provider, the file fails to typecheck and
+ * `bun run verify` breaks. The runtime bodies are trivial so Vitest registers
+ * the file as a passing suite.
+ */
+describe("TurnRequest providerOptions discrimination", () => {
+  it("accepts Claude knobs on a claude request", () => {
+    const req: TurnRequest<"claude"> = {
+      sessionId: "mcode-t1",
+      threadId: "t1",
+      message: "hi",
+      cwd: "/tmp",
+      model: "claude-sonnet-4-6",
+      permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: { contextWindowMode: "1m", thinking: true },
+    };
+    expect(req.providerOptions.contextWindowMode).toBe("1m");
+  });
+
+  it("requires an empty bag for knob-less providers", () => {
+    const req: TurnRequest<"cursor"> = {
+      sessionId: "mcode-t2",
+      threadId: "t2",
+      message: "hi",
+      cwd: "/tmp",
+      model: "cursor-default",
+      permissionMode: "default",
+      interactionMode: "plan",
+      providerOptions: {},
+    };
+    expect(req.providerOptions).toEqual({});
+  });
+
+  it("walls off cross-provider knobs (negative case via @ts-expect-error)", () => {
+    const bad: TurnRequest<"claude"> = {
+      sessionId: "mcode-t3",
+      threadId: "t3",
+      message: "hi",
+      cwd: "/tmp",
+      model: "claude-sonnet-4-6",
+      permissionMode: "full",
+      interactionMode: "build",
+      // @ts-expect-error fastMode is a Codex knob, not valid on a Claude request
+      providerOptions: { fastMode: true },
+    };
+    void bad;
+    expect(true).toBe(true);
+  });
+});

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "../events/agent-event.js";
+import type { InteractionMode } from "../models/enums.js";
 import type { AttachmentMeta } from "../models/attachment.js";
 import type { PermissionDecision, PermissionRequest } from "../models/permission.js";
 import type { ContextWindowMode, ReasoningLevel } from "../models/settings.js";
@@ -13,6 +14,61 @@ export type ProviderId = "claude" | "codex" | "gemini" | "copilot" | "cursor" | 
 
 /** How a provider's `resume` mechanism behaves when used to fork a session. */
 export type SessionForkBehavior = "clean" | "mutating" | "unsupported";
+
+/**
+ * Per-Provider knobs that ride on a {@link TurnRequest}, keyed by {@link ProviderId}.
+ * Generic call sites cannot reach into the wrong Provider's knobs because the
+ * field type is selected by the request's `P` type parameter.
+ */
+export interface ProviderOptionsByProvider {
+  /** Claude: context-window tier and the Haiku thinking toggle. */
+  claude: { contextWindowMode?: ContextWindowMode; thinking?: boolean };
+  /** Codex: request the OpenAI fast service tier. */
+  codex: { fastMode?: boolean };
+  /** Copilot: sub-agent name ("interactive" | "plan" | "autopilot" | custom YAML name). */
+  copilot: { agent?: string };
+  cursor: Record<string, never>;
+  gemini: Record<string, never>;
+  opencode: Record<string, never>;
+}
+
+/**
+ * The per-Turn value object passed to {@link IAgentProvider.sendTurn}.
+ * `P` selects the Provider-specific `providerOptions` shape.
+ *
+ * Top-level fields are generic per-Turn inputs and knobs the user may change
+ * between Turns. Provider-specific knobs live only in `providerOptions`.
+ */
+export interface TurnRequest<P extends ProviderId = ProviderId> {
+  /** SDK session name, currently `mcode-${threadId}`. */
+  sessionId: string;
+  /** Owning thread id. */
+  threadId: string;
+  /** User input text (already wire-wrapped by the orchestrator when needed). */
+  message: string;
+  attachments?: AttachmentMeta[];
+  /** Working directory: the thread's effective worktree or workspace path. */
+  cwd: string;
+  model: string;
+  /** Fallback model if the primary is unavailable. Undefined disables fallback. */
+  fallbackModel?: string;
+  permissionMode: string;
+  /** Per-Turn interaction state. Plan suppresses Cursor's native auto-answer. */
+  interactionMode: InteractionMode;
+  reasoningLevel?: ReasoningLevel;
+  /** USD budget cap for this Turn. Undefined or 0 disables. */
+  maxBudgetUsd?: number;
+  /** Max agent turns for this Turn. Undefined or 0 disables. */
+  maxTurns?: number;
+  /**
+   * SDK session id to resume from. When defined the Provider resumes that
+   * session; when undefined it starts fresh. Replaces the previous
+   * `setSdkSessionId(...)` + `resume: true` two-step dance.
+   */
+  resumeFrom?: string;
+  /** Provider-specific knobs, walled off by `P`. Required; empty-knob Providers pass `{}`. */
+  providerOptions: ProviderOptionsByProvider[P];
+}
 
 /** A pluggable agent backend that can run sessions and emit events. */
 export interface IAgentProvider {
@@ -44,52 +100,16 @@ export interface IAgentProvider {
    */
   readonly maxInputCharactersPerTurn: number;
 
-  /** Start or continue a session by sending a message. */
-  sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    /** Fallback model to use if the primary model is unavailable. Undefined disables fallback. */
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /**
-     * Per-thread context window selection. "1m" appends `[1m]` to the model
-     * slug at the SDK boundary so the SDK attaches the 1M-context beta header.
-     * Undefined falls back to the model's default 200k window.
-     * Honored only by Claude provider; ignored by Codex/Gemini/Copilot.
-     */
-    contextWindowMode?: ContextWindowMode;
-    /**
-     * Boolean thinking toggle for models that expose it (Haiku 4.5).
-     * Undefined and non-Haiku models ignore this field.
-     */
-    thinking?: boolean;
-    /** USD budget cap for this session. Provider stops if exceeded. Undefined or 0 disables. */
-    maxBudgetUsd?: number;
-    /** Maximum agent turns for this session. Provider stops after this count. Undefined or 0 disables. */
-    maxTurns?: number;
-    /**
-     * Codex: request OpenAI fast tier when true. Undefined lets the provider read global settings.
-     */
-    codexFastMode?: boolean;
-    /**
-     * Copilot-specific: name of the sub-agent to activate for this session.
-     * Built-in modes: "interactive" | "plan" | "autopilot".
-     * Custom agents: any name defined in user/project YAML config.
-     * Ignored by non-Copilot providers.
-     */
-    copilotAgent?: string;
-  }): void | Promise<void>;
+  /**
+   * Start or continue a Turn. The {@link TurnRequest} carries all per-Turn
+   * input, knobs, the resume signal (`resumeFrom`), and Provider-specific
+   * options (`providerOptions`). Replaces the former 15-parameter
+   * `sendMessage` call.
+   */
+  sendTurn(req: TurnRequest): Promise<void>;
 
   /** Abort a running session. */
   stopSession(sessionId: string): void;
-
-  /** Store the SDK-assigned session ID for later resume. */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void;
 
   /** Tear down all sessions and release resources. */
   shutdown(): void;
@@ -160,15 +180,6 @@ export interface IAgentProvider {
   on(event: "permission_resolved", handler: (payload: { requestId: string; decision: PermissionDecision }) => void): void;
   /** Subscribe to ExitPlanMode capture events (Claude SDK plan output). */
   on(event: "exit_plan_mode", handler: (payload: { threadId: string; planMarkdown: string }) => void): void;
-
-  /** Mark a thread as expecting a plan output (enables ExitPlanMode capture). */
-  setPlanAnswerMode?(threadId: string, enabled: boolean): void;
-
-  /**
-   * Mark a thread as in the plan-questions phase. Providers with native question
-   * UIs (Cursor) should not auto-answer while this is active.
-   */
-  setPlanQuestionMode?(threadId: string, enabled: boolean): void;
 }
 
 /**

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -8,6 +8,7 @@ import { MAX_ATTACHMENTS } from "../models/file-types.js";
 import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { ThoughtSegmentRecordSchema } from "../models/thought-segment.js";
 import { HookExecutionRecordSchema } from "../models/hook-execution.js";
+import { NarrativeEntrySchema, TurnRangeSchema } from "../models/narrative-entry.js";
 import { GitBranchSchema, WorktreeSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
 import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema, ChecksStatusSchema } from "../github.js";
@@ -565,6 +566,17 @@ export const WS_METHODS = lazySchema(() => ({
   "toolCallRecord.listByParent": {
     params: z.object({ parentToolCallId: z.string() }),
     result: z.array(ToolCallRecordSchema),
+  },
+  /**
+   * Single-source hydration for a thread's persisted narrative: returns one
+   * chronologically-ordered list of entries (assistant message bodies, tool
+   * calls, narration segments, hooks) interleaved by (sequence, sortOrder).
+   * Replaces the race-prone `message.list` + `narrative.list` pair so reloaded
+   * turns render in source order (Tool calls never precede the assistant body).
+   */
+  "turn.load": {
+    params: z.object({ threadId: z.string(), range: TurnRangeSchema.optional() }),
+    result: z.array(NarrativeEntrySchema),
   },
   /** Replay the full persisted narrative (tools, thoughts, hooks) for an assistant message. */
   "narrative.list": {


### PR DESCRIPTION
## What
Introduce a server-side `NarrativeStore` read seam and a single `turn.load` RPC that returns one chronologically-ordered narrative list, and switch client hydration to it. This is the read-side half of candidate A; the write-seam extraction (moving `bufferToolCall` / `agentCallStack` / classification / `persistTurn` out of `agent-service.ts` into `NarrativeStore`) follows in a focused part-2 PR.

## Why
On page reload the client assembled the persisted narrative from two race-prone hydration RPCs (`message.list` + `narrative.listBatch`), which let narrative items render out of source order. A single server-ordered source removes the race. Sidecar tables and `messages.tool_calls` are untouched (module/render-layer change, not a schema reshape).

## Key Changes
- `NarrativeEntry` discriminated union (`assistantMessage` | `toolCall` | `narrationSegment` | `hook`) and `turn.load` RPC in `@mcode/contracts`.
- `NarrativeStore.load(threadId, range?)` returns entries ordered by `(sequence, sortOrder)`; the final-response narration segment is surfaced as the `assistantMessage` body (never a duplicate narration row). DI-registered; wired as `turn.load` in the ws-router.
- Client hydration (`thread-hydrator`) fetches the persisted narrative via one `turn.load` call instead of `narrative.listBatch`; `narrative.list` stays as the lazy per-message fallback. Live volatile maps and `session.*` handlers untouched (the six narrative traps are unchanged).

## Out of scope / follow-up (part 2)
- Write-seam move into `NarrativeStore` (enrichment + `AssistantMessageBoundary` classification + persistence) with the six-trap integration suite.
- Deeper `virtual-items` unification + Playwright render-order E2E. Live Playwright could not run in this environment (port 5173 occupied; backend better-sqlite3 is unsupported under Bun), so verification here is via unit + integration tests.

## CONTEXT.md terms implemented
Turn, Tool call, Sub-agent, Narration segment, Final response, Message.

## User stories satisfied
8 (source-order render via single-source hydration), 9 (persisted trail reappears on reload), 27 (one `turn.load` RPC, no two-RPC race). Partial toward 24 (read seam done; write seam in part 2).

## Verification
- Typecheck: 5/5 packages pass.
- Server: `NarrativeStore.load` integration tests (ordering, final-response surfacing, cross-message sequence, user/system exclusion) pass.
- Web: 88 unit tests pass (narrative + thread-hydrator + stores).

Related to #538.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782610922&installation_id=129163861&pr_number=540&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F540&signature=2268913cd5c3b2f9ec4c227ba41ffcc0fbfa4cf6d6f467e2cf5f990125b0d368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->