### PR TITLE
refactor: agent provider + handoff architecture overhaul (E, A, B, D, F)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,26 @@ default provider. Handoff generation is **not** a utility-provider use case;
 handoffs route through the originating thread's own provider via the B/A/D
 pipeline.
 
+### Session runtime
+The per-Provider service that owns the uniform persistent-CLI-session
+lifecycle: the session pool, the lazy idle-eviction timer (60s sweep, 10min
+default TTL) with a `lastUsedAt + isBusy` guard, Windows `JobObject`
+attachment, the env snapshot, lazy spawn, resume-then-fallback, and the
+graceful-interrupt-then-hard-kill (`taskkill /T /F` on Windows) close. It
+treats per-session state as opaque (`SessionRuntime<TState>`) so the same
+lifecycle serves every Provider. Each Provider holds its own instance; the
+runtime is not shared, keeping per-session state type-isolated.
+
+### Protocol adapter
+The per-Provider seam carrying the protocol-specific I/O the Session runtime
+delegates to: `spawn` (returning the session state plus any child PIDs the
+runtime should attach/kill), `isBusy` (the eviction guard), `interrupt`
+(protocol-level graceful stop), `close` (provider teardown short of the OS
+kill), and `isStale` (whether a pooled session must be discarded before
+reuse). Each Provider *is* its own Protocol adapter (the Provider class
+implements the interface); composition with the Session runtime, not
+inheritance.
+
 ## Workspaces and worktrees
 
 ### Workspace

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -266,10 +266,24 @@ what hidden messages exclude themselves from in user-visible queries.
 ## Handoff
 
 ### Handoff
-A markdown document summarizing the parent thread, written to disk and
-inlined into the child thread's first provider turn so the new agent picks
-up with the parent's context. The handoff replaces what would otherwise be a
-verbose transcript replay.
+A markdown document summarizing the parent thread so a forked child picks up
+with the parent's context, replacing a verbose transcript replay. Delivered
+**off-band by default**: the full document is written to a stable OS temp path,
+and the child's first-Turn inline prompt carries only a small payload (a pointer
+to that file, a 2-3 sentence graceful-degradation summary, and the child's first
+user message). The child Reads the full document on its first Turn under a
+one-shot Scoped pre-grant, so Handoff quality is no longer capped by the child
+Provider's per-Turn input budget. The full document is retained at the temp path
+until garbage collection so the user can inspect it later.
+
+### Scoped pre-grant
+A pipeline-issued permission bypass authorising the child to `Read` exactly one
+file (its Handoff document) on exactly one Turn (its first), consumed once. It
+is **path-scoped** (only that file), **Turn-scoped** (does not survive into the
+second Turn), and **one-shot** (a second Read of the same path on the same Turn
+is not pre-granted). It bypasses the Thread's `permissionMode` only for that
+single Read. A pipeline guarantee that makes the Handoff feel invisible — not a
+user-configurable Hook.
 
 ### Handoff pipeline
 The orchestration layer that produces a handoff for a given fork. Routes
@@ -310,6 +324,14 @@ Injects hidden turns directly into the parent thread's session. Used when
 the provider declares `sessionForkOnResume: "mutating"` (Cursor today).
 Cleaned up with a disregard turn.
 
+> **Retirement pending.** Path A (the `MutatingForker`) is queued for removal
+> once Cursor's `loadSession` is verified to carry parent context across
+> stop/resume without the hidden-turn-then-disregard dance. The verification
+> (launch Cursor, send a Turn, stop, resume, send a follow-up, confirm context
+> carried) has not been run, so `MutatingForker` and the `"mutating"` value are
+> retained as the safe default. If it passes, Cursor moves to `CleanForker` (or
+> `DeterministicForker`) and the ladder reduces to B and D.
+
 ### Path D (deterministic)
 Local builder that produces the handoff from message rows without invoking
 any provider. Used as the universal fallback. Lowest fidelity but always
@@ -320,36 +342,34 @@ A label on a produced handoff artifact (`"B" | "A" | "D"`) identifying which
 path generated it. Stored in `handoff.json` for diagnostics and the
 fallback banner copy.
 
-## Modes and budgets
+## Handoff delivery
 
-### Full mode
-The default handoff structure produced by path B / A when the child
-provider's per-turn input window is large enough (≥ 8000 characters).
-Includes the model's choice of sections. The prompt does not enforce a
-fixed list.
+Handoffs are delivered **off-band by default**: the full document lives at a
+stable OS temp path and the child Reads it on its first Turn under a one-shot
+Scoped pre-grant (see the `Handoff` and `Scoped pre-grant` terms above). Because
+the document body never has to fit inside the child's per-Turn input window, the
+legacy sizing concepts are retired:
 
-### Minimal mode
-Compact handoff structure triggered when the child provider's
-`maxInputCharactersPerTurn` is below 8000 (Cursor's 4000-char floor today).
-Drops ancillary sections to keep the inlined doc within budget.
+- **Full / Minimal mode** — removed. There is no per-budget mode switch; the
+  document is always the complete handoff. (`HandoffMeta.mode` is retained as the
+  constant `"full"` for back-compat with older `handoff.json` provenance.)
+- **Character budget** — removed as a handoff doc-body sizing driver. The inline
+  first-Turn payload (pointer + short summary + user message) is small by
+  construction.
+- **Overflow** — removed. The off-band temp file *is* the document, not a spill
+  of whatever exceeded an inline budget.
 
-### Character budget
-The size constraint applied to the inlined portion of a handoff. Sourced
-from the child provider's declared `maxInputCharactersPerTurn`, minus
-reserved overhead for system prompt + the user's first message. Used as
-characters, not tokens. Tokens vary per model and are not portable.
-
-### Overflow
-The portion of a handoff that exceeds the inline budget. Written to the
-user's OS temp directory at
-`os.tmpdir()/mcode-handoff-overflow-<threadId>-<ts>.md` with a pointer
-embedded in the inlined version. The next agent can `Read` it on demand.
+`maxInputCharactersPerTurn` remains declared per Provider but is **decorative**
+for Handoff purposes after this change.
 
 ## Provider capabilities
 
 ### Session fork behavior
-Declared per provider as `"clean" | "mutating" | "unsupported"`. Determines
-which ladder path the orchestrator dispatches to:
+Declared per provider as `"clean" | "mutating" | "unsupported"`. **Metadata
+only** since each Provider now carries a `forker: SessionForker` that the
+pipeline dispatches through (`provider.forker.fork(req)`); this label is used
+for `handoff.json` provenance and the fallback banner copy, and historically
+mapped to ladder paths as:
 
 - **clean**: `resume:` spawns a fork without mutating the original (Claude)
 - **mutating**: `resume:` mutates the session forward (Cursor today)
@@ -358,8 +378,8 @@ which ladder path the orchestrator dispatches to:
 
 ### Per-turn input cap
 The maximum input characters a provider accepts per turn. Declared as
-`maxInputCharactersPerTurn`. Drives both the handoff budget and the
-mode (full vs minimal) selection.
+`maxInputCharactersPerTurn`. Decorative for Handoff purposes since Handoff
+delivery went off-band (see `Handoff delivery`); retained as Provider metadata.
 
 ## Internal / hidden state
 

--- a/apps/server/src/__tests__/agent-service-turn-started.test.ts
+++ b/apps/server/src/__tests__/agent-service-turn-started.test.ts
@@ -42,7 +42,7 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
   let taskRepo: TaskRepo;
   let svc: AgentService;
   let providerStub: EventEmitter & Partial<IAgentProvider> & {
-    sendMessage: ReturnType<typeof vi.fn>;
+    sendTurn: ReturnType<typeof vi.fn>;
   };
   let capturedEvents: AgentEvent[];
   // Snapshot of capturedEvents.length taken synchronously when the provider's
@@ -70,12 +70,11 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       // Snapshot capturedEvents.length synchronously on entry: this is the
       // load-bearing ordering signal. If the emit happened BEFORE the call
       // entered (correct order), this will be >= 1.
-      sendMessage: vi.fn(() => {
+      sendTurn: vi.fn(() => {
         eventsLengthAtSendMessageEntry = capturedEvents.length;
         return new Promise<void>(() => {});
       }),
       stopSession: vi.fn(),
-      setSdkSessionId: vi.fn(),
       shutdown: vi.fn(),
     });
     providerStub.on("event", (e: AgentEvent) => capturedEvents.push(e));
@@ -179,8 +178,8 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
 
     expect(svc.activeThreadIds()).toContain(thread.id);
 
-    // Provider.sendMessage must have been invoked. Confirms the emit happened
-    // during sendMessage flow, not via some other path.
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
+    // Provider.sendTurn must have been invoked. Confirms the emit happened
+    // during sendTurn flow, not via some other path.
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/src/__tests__/agent-service-turn-started.test.ts
+++ b/apps/server/src/__tests__/agent-service-turn-started.test.ts
@@ -17,6 +17,7 @@ import { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
 import { TurnSnapshotRepo } from "../repositories/turn-snapshot-repo";
 import { TaskRepo } from "../repositories/task-repo";
 import { AgentService } from "../services/agent-service";
+import { NarrativeStore } from "../services/narrative-store";
 import type { GitService } from "../services/git-service";
 import type { AttachmentService } from "../services/attachment-service";
 import type { SnapshotService } from "../services/snapshot-service";
@@ -128,8 +129,6 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       attachmentServiceStub,
       registryStub,
       threadServiceStub,
-      toolCallRecordRepo,
-      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
       { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
       turnSnapshotRepo,
       snapshotServiceStub,
@@ -139,8 +138,16 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       settingsServiceStub,
       availabilityStub,
       { markAnswered: vi.fn(), isAnswered: vi.fn(() => false), listAnsweredForThread: vi.fn(() => []) } as unknown as import("../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../repositories/plan-repo.js").PlanRepo,
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(
+        messageRepo,
+        toolCallRecordRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
+      ),
     );
   });
 

--- a/apps/server/src/__tests__/claude-provider-assistant-boundary.test.ts
+++ b/apps/server/src/__tests__/claude-provider-assistant-boundary.test.ts
@@ -81,13 +81,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-final",
+      threadId: "thread-boundary-final",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -122,13 +124,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-preamble",
+      threadId: "thread-boundary-preamble",
       message: "read file",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -162,13 +166,15 @@ describe("ClaudeProvider AssistantMessageBoundary from stop_reason", () => {
       if (e.type === AgentEventType.AssistantMessageBoundary) boundaries.push(e);
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-boundary-no-text",
+      threadId: "thread-boundary-no-text",
       message: "go",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 

--- a/apps/server/src/__tests__/claude-provider-eviction.test.ts
+++ b/apps/server/src/__tests__/claude-provider-eviction.test.ts
@@ -69,13 +69,15 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
   it("does NOT evict a session while a tool_use is still pending", async () => {
     mockQuery.mockImplementation(makeToolUseStream());
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t1",
+      threadId: "t1",
       message: "run something long",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     await vi.advanceTimersByTimeAsync(100);
@@ -120,13 +122,15 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
       });
     });
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t2",
+      threadId: "t2",
       message: "run",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     await vi.advanceTimersByTimeAsync(100);

--- a/apps/server/src/__tests__/claude-provider-eviction.test.ts
+++ b/apps/server/src/__tests__/claude-provider-eviction.test.ts
@@ -83,9 +83,12 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
     await vi.advanceTimersByTimeAsync(100);
     await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
 
+    // Session lifecycle now lives in the SessionRuntime; the provider's
+    // `isBusy` adapter method keeps a session with pending tool_use out of
+    // idle eviction (logging the skip), so the session must still be live.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sessions = (provider as any).sessions as Map<string, unknown>;
-    expect(sessions.has("mcode-t1")).toBe(true);
+    const runtime = (provider as any).runtime as { get: (id: string) => unknown };
+    expect(runtime.get("mcode-t1")).toBeDefined();
     const { logger } = await import("@mcode/shared");
     expect(logger.debug).toHaveBeenCalledWith(
       "Skipping eviction: pending tool calls",
@@ -142,8 +145,9 @@ describe("ClaudeProvider idle eviction with pending tool_use (#291)", () => {
     // Now advance past the idle window
     await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
 
+    // The runtime's idle sweep evicts a non-busy session once its TTL lapses.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sessions = (provider as any).sessions as Map<string, unknown>;
-    expect(sessions.has("mcode-t2")).toBe(false);
+    const runtime = (provider as any).runtime as { get: (id: string) => unknown };
+    expect(runtime.get("mcode-t2")).toBeUndefined();
   });
 });

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -90,21 +90,25 @@ describe("ClaudeProvider permission mode changes", () => {
   });
 
   it("reuses the session when permissionMode is unchanged", async () => {
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-a",
+      threadId: "thread-a",
       message: "first",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-a",
+      threadId: "thread-a",
       message: "second",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // One underlying sdk subprocess for both messages.
@@ -112,21 +116,25 @@ describe("ClaudeProvider permission mode changes", () => {
   });
 
   it("tears down and respawns the session when permissionMode changes", async () => {
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-b",
+      threadId: "thread-b",
       message: "first",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
     });
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-b",
+      threadId: "thread-b",
       message: "second",
       cwd: process.cwd(),
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // The SDK subprocess is respawned because permissionMode is fixed at spawn.

--- a/apps/server/src/__tests__/claude-provider-queue.test.ts
+++ b/apps/server/src/__tests__/claude-provider-queue.test.ts
@@ -89,13 +89,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
     // First send establishes the session
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-t1",
+      threadId: "t1",
       message: "first",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Simulate race by closing the queue directly
@@ -105,13 +107,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
 
     // Second send on same sessionId: push hits a closed queue
     await expect(
-      provider.sendMessage({
+      provider.sendTurn({
         sessionId: "mcode-t1",
+        threadId: "t1",
         message: "second",
         cwd: "/tmp",
         model: "claude-sonnet-4-6",
-        resume: false,
         permissionMode: "default",
+        interactionMode: "build",
+        providerOptions: {},
       }),
     ).rejects.toThrow(/closed/i);
 
@@ -148,13 +152,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
     // First send establishes the session
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-overflow",
+      threadId: "overflow",
       message: "first",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Saturate the queue: MAX_QUEUE_DEPTH is 20, so push many more than that.
@@ -162,13 +168,15 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     let overflowErr: Error | undefined;
     for (let i = 0; i < 25; i++) {
       try {
-        await provider.sendMessage({
+        await provider.sendTurn({
           sessionId: "mcode-overflow",
+          threadId: "overflow",
           message: `msg-${i}`,
           cwd: "/tmp",
           model: "claude-sonnet-4-6",
-          resume: false,
           permissionMode: "default",
+          interactionMode: "build",
+          providerOptions: {},
         });
       } catch (e) {
         overflowErr = e as Error;

--- a/apps/server/src/__tests__/claude-provider-queue.test.ts
+++ b/apps/server/src/__tests__/claude-provider-queue.test.ts
@@ -102,7 +102,7 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
 
     // Simulate race by closing the queue directly
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const entry = (provider as any).sessions.get("mcode-t1");
+    const entry = (provider as any).runtime.get("mcode-t1") as { closeQueue: () => void };
     entry.closeQueue();
 
     // Second send on same sessionId: push hits a closed queue
@@ -190,8 +190,8 @@ describe("ClaudeProvider sendMessage on closed queue (#292)", () => {
     // Critical behavior: the session entry must still exist so the next
     // delivery is not forced into a full cold-start.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sessions = (provider as any).sessions as Map<string, unknown>;
-    expect(sessions.has("mcode-overflow")).toBe(true);
+    const runtime = (provider as any).runtime as { get: (id: string) => unknown };
+    expect(runtime.get("mcode-overflow")).toBeDefined();
 
     // And an Error event surfaced to the caller, but with the raw overflow
     // message (not the "session was shutting down" closed-session wording).

--- a/apps/server/src/__tests__/claude-provider-result-error.test.ts
+++ b/apps/server/src/__tests__/claude-provider-result-error.test.ts
@@ -63,13 +63,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string; error?: string }> = [];
     provider.on("event", (e: { type: string; error?: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-1",
+      threadId: "thread-1",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     // Allow the stream loop microtasks to drain
@@ -92,13 +94,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string }> = [];
     provider.on("event", (e: { type: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-2",
+      threadId: "thread-2",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 
@@ -115,13 +119,15 @@ describe("ClaudeProvider result is_error handling (#293)", () => {
     const events: Array<{ type: string; error?: string; content?: string }> = [];
     provider.on("event", (e: { type: string; error?: string; content?: string }) => events.push(e));
 
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId: "mcode-thread-3",
+      threadId: "thread-3",
       message: "hi",
       cwd: "/tmp",
       model: "claude-sonnet-4-6",
-      resume: false,
       permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
     });
     await new Promise((r) => setTimeout(r, 10));
 

--- a/apps/server/src/__tests__/claude-provider-scoped-pre-grant.test.ts
+++ b/apps/server/src/__tests__/claude-provider-scoped-pre-grant.test.ts
@@ -1,0 +1,142 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Verifies the off-band handoff bypass in ClaudeProvider.canUseTool (PRD #538):
+ * a Read pre-granted via ScopedPreGrantService is auto-allowed without emitting
+ * a permission_request, and all other tool calls fall through to the normal
+ * permission flow unchanged.
+ *
+ * The fake SDK captures the `canUseTool` callback passed to query() so the test
+ * can invoke it directly (the real SDK only calls it when the model requests a
+ * tool, which this lightweight mock does not simulate).
+ */
+function makeFakeSdkQuery(captured: { canUseTool?: Function }) {
+  return ({
+    prompt,
+    options,
+  }: {
+    prompt: AsyncIterable<unknown>;
+    options: Record<string, unknown>;
+  }) => {
+    captured.canUseTool = options.canUseTool as Function;
+    const iterator = prompt[Symbol.asyncIterator]();
+    const generator: AsyncGenerator<Record<string, unknown>, void> = {
+      async next() {
+        const userMsg = await iterator.next();
+        if (userMsg.done) {
+          return { value: undefined as unknown as Record<string, unknown>, done: true };
+        }
+        return {
+          value: {
+            type: "result",
+            is_error: false,
+            result: "ok",
+            usage: { input_tokens: 1, output_tokens: 1 },
+            modelUsage: {},
+          },
+          done: false,
+        };
+      },
+      async return() {
+        return { value: undefined as unknown as Record<string, unknown>, done: true };
+      },
+      async throw(e: unknown) {
+        throw e;
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    Object.assign(generator, {
+      setModel: vi.fn(async () => {}),
+      interrupt: vi.fn(async () => {}),
+      close: vi.fn(() => {}),
+    });
+    return generator;
+  };
+}
+
+const { captured, mockQuery } = vi.hoisted(() => {
+  const captured: { canUseTool?: Function } = {};
+  return { captured, mockQuery: vi.fn() };
+});
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mockQuery,
+}));
+
+vi.mock("@mcode/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcode/shared")>();
+  return {
+    ...actual,
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+});
+
+import { ClaudeProvider } from "../providers/claude/claude-provider";
+import { ScopedPreGrantService } from "../services/scoped-pre-grant";
+import { stubEnvService } from "./stub-env-service.js";
+import { stubJobObject } from "./stub-job-object.js";
+
+describe("ClaudeProvider scoped pre-grant (off-band handoff Read)", () => {
+  let provider: ClaudeProvider;
+  let scopedPreGrant: ScopedPreGrantService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.canUseTool = undefined;
+    mockQuery.mockImplementation(makeFakeSdkQuery(captured));
+    scopedPreGrant = new ScopedPreGrantService();
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject(), scopedPreGrant);
+  });
+
+  async function startTurn(threadId: string): Promise<void> {
+    await provider.sendTurn({
+      sessionId: `mcode-${threadId}`,
+      threadId,
+      message: "hello",
+      cwd: process.cwd(),
+      model: "claude-sonnet-4-6",
+      // supervised => SDK "default": tool calls would normally prompt.
+      permissionMode: "supervised",
+      interactionMode: "build",
+      providerOptions: {},
+    });
+  }
+
+  it("auto-allows a pre-granted Read without emitting a permission_request", async () => {
+    const threadId = "thread-grant";
+    const grantedPath = "/tmp/mcode-handoff-thread-grant-123.md";
+    scopedPreGrant.issue({ threadId, toolName: "Read", path: grantedPath });
+
+    await startTurn(threadId);
+    expect(captured.canUseTool).toBeTypeOf("function");
+
+    const permissionEvents: unknown[] = [];
+    provider.on("permission_request", (e) => permissionEvents.push(e));
+
+    const result = await captured.canUseTool!("Read", { path: grantedPath }, {});
+    expect(result).toEqual({ behavior: "allow", updatedInput: { path: grantedPath } });
+    expect(permissionEvents).toHaveLength(0);
+    // One-shot: the grant is consumed and not active afterwards.
+    expect(scopedPreGrant.hasActiveGrant(threadId)).toBe(false);
+  });
+
+  it("does not bypass a Read of a different path (emits a permission_request)", async () => {
+    const threadId = "thread-other";
+    scopedPreGrant.issue({ threadId, toolName: "Read", path: "/tmp/granted.md" });
+
+    await startTurn(threadId);
+    const permissionEvents: unknown[] = [];
+    provider.on("permission_request", (e) => permissionEvents.push(e));
+
+    // Invoke with a non-granted path; the callback awaits a user decision, so
+    // race it against a tick to confirm it emitted a request rather than
+    // returning an immediate allow.
+    const decision = captured.canUseTool!("Read", { path: "/tmp/other.md" }, {});
+    await Promise.resolve();
+    expect(permissionEvents).toHaveLength(1);
+    void decision; // left pending; no resolution needed for this assertion
+  });
+});

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -66,6 +66,7 @@ vi.mock("@github/copilot-sdk", () => ({
 import which from "which";
 import { CopilotProvider } from "../providers/copilot/copilot-provider.js";
 import { stubEnvService } from "./stub-env-service.js";
+import { stubJobObject } from "./stub-job-object.js";
 
 /** Minimal SettingsService stub. */
 function makeSettingsService(cliPath = "") {
@@ -111,7 +112,7 @@ describe("CopilotProvider bootstrap", () => {
       });
       (which as unknown as Mock).mockResolvedValue("/usr/bin/node");
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
       await provider.listModels();
 
       // which was called to find the real node binary
@@ -128,7 +129,7 @@ describe("CopilotProvider bootstrap", () => {
         configurable: true,
       });
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
       await provider.listModels();
 
       // which should not be called when not in Electron
@@ -146,7 +147,7 @@ describe("CopilotProvider bootstrap", () => {
         },
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
       await provider.listModels();
 
       const opts = MockCopilotClient.mock.calls[0]?.[0];
@@ -160,7 +161,7 @@ describe("CopilotProvider bootstrap", () => {
         },
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
       await provider.listModels();
 
       const opts = MockCopilotClient.mock.calls[0]?.[0] ?? {};
@@ -170,7 +171,7 @@ describe("CopilotProvider bootstrap", () => {
 
   describe("client reuse", () => {
     it("reuses healthy connected client", async () => {
-      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
 
       await provider.listModels();
       mockClient.getState.mockReturnValue("connected");
@@ -189,7 +190,7 @@ describe("CopilotProvider bootstrap", () => {
         new Error("CLI server exited with code 1"),
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
 
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
@@ -217,7 +218,7 @@ describe("CopilotProvider bootstrap", () => {
         new Error("Could not find @github/copilot"),
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
 
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
@@ -271,7 +272,7 @@ async function runWithMockSession(
     mockSession.fire("session.idle");
   });
 
-  const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+  const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
   const events: AgentEvent[] = [];
   provider.on("event", (e: AgentEvent) => events.push(e));
 
@@ -286,7 +287,26 @@ async function runWithMockSession(
     permissionMode: "auto",
   });
 
+  // The first turn now runs via a queueMicrotask inside the runtime-backed
+  // spawn (it registers SDK handlers then awaits session.send()), so it has not
+  // emitted by the time sendTurn resolves. Wait for the turn's terminal "ended"
+  // event before reading the collected events.
+  await waitForEnded(events);
+
   return { events };
+}
+
+/**
+ * Resolve once an "ended" AgentEvent has been pushed, or after a bounded number
+ * of event-loop ticks. The runtime schedules the first turn on a microtask and
+ * runTurn awaits the async session.send(), so several ticks must drain before
+ * the turn settles.
+ */
+async function waitForEnded(events: AgentEvent[]): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (events.some((e) => e.type === "ended")) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -415,7 +435,7 @@ describe("CopilotProvider.complete()", () => {
       mockSession.fire("session.idle");
     });
 
-    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
     const result = await provider.complete("Generate PR draft", "gpt-4.1", "/tmp");
 
     expect(result).toBe(jsonResponse);
@@ -433,7 +453,7 @@ describe("CopilotProvider.complete()", () => {
       mockSession.fire("session.idle");
     });
 
-    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
     const result = await provider.complete("Generate PR draft", "gpt-4.1", "/tmp");
 
     expect(result).toBe('{"title":"feat: x","body":"b"}');
@@ -448,7 +468,7 @@ describe("CopilotProvider.complete()", () => {
       mockSession.fire("session.error", { message: "Model not available" });
     });
 
-    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
 
     await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
       "Model not available",
@@ -464,7 +484,7 @@ describe("CopilotProvider.complete()", () => {
       mockSession.fire("session.idle");
     });
 
-    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
 
     await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
       "no text content",
@@ -477,7 +497,7 @@ describe("CopilotProvider.complete()", () => {
     mockClient.createSession.mockResolvedValue(mockSession);
     mockSession.send.mockRejectedValue(new Error("network error"));
 
-    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
 
     await expect(provider.complete("prompt", "gpt-4.1", "/tmp")).rejects.toThrow(
       "network error",
@@ -580,7 +600,7 @@ describe("CopilotProvider.listModels() cache", () => {
       { id: "gpt-4.1", name: "GPT-4.1", capabilities: {}, billing: {} },
     ]);
 
-    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
 
     const first = await provider.listModels();
     const second = await provider.listModels();
@@ -596,7 +616,7 @@ describe("CopilotProvider.listModels() cache", () => {
       { id: "gpt-4.1", name: "GPT-4.1", capabilities: {}, billing: {} },
     ]);
 
-    const provider = new CopilotProvider(makeSettingsService() as any, stubEnvService());
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
 
     await provider.listModels();
     // Advance past the 10-minute TTL

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -194,12 +194,14 @@ describe("CopilotProvider bootstrap", () => {
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
 
-      await provider.sendMessage({
+      await provider.sendTurn({
         sessionId: "mcode-test1",
+        threadId: "test1",
         message: "hello",
         cwd: "/tmp",
         model: "gpt-4o",
-        resume: false,
+        interactionMode: "build",
+        providerOptions: {},
         permissionMode: "auto",
       });
 
@@ -220,12 +222,14 @@ describe("CopilotProvider bootstrap", () => {
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
 
-      await provider.sendMessage({
+      await provider.sendTurn({
         sessionId: "mcode-test2",
+        threadId: "test2",
         message: "hello",
         cwd: "/tmp",
         model: "gpt-4o",
-        resume: false,
+        interactionMode: "build",
+        providerOptions: {},
         permissionMode: "auto",
       });
 
@@ -271,12 +275,14 @@ async function runWithMockSession(
   const events: AgentEvent[] = [];
   provider.on("event", (e: AgentEvent) => events.push(e));
 
-  await provider.sendMessage({
+  await provider.sendTurn({
     sessionId,
+    threadId: sessionId.replace(/^mcode-/, ""),
     message: "hello",
     cwd: "/tmp",
     model: "gpt-4o",
-    resume: false,
+    interactionMode: "build",
+    providerOptions: {},
     permissionMode: "auto",
   });
 

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -307,6 +307,7 @@ async function waitForEnded(events: AgentEvent[]): Promise<void> {
     if (events.some((e) => e.type === "ended")) return;
     await new Promise((r) => setTimeout(r, 0));
   }
+  throw new Error("waitForEnded timed out waiting for 'ended' event");
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/__tests__/model-cache-service.test.ts
+++ b/apps/server/src/__tests__/model-cache-service.test.ts
@@ -16,7 +16,7 @@ function makeProvider(models: ProviderModelInfo[]) {
   return {
     id: "test-provider",
     listModels: vi.fn().mockResolvedValue(models),
-    sendMessage: vi.fn(),
+    sendTurn: vi.fn(),
     cancelSession: vi.fn(),
     shutdown: vi.fn(),
   };
@@ -163,7 +163,7 @@ describe("ModelCacheService", () => {
     const provider = {
       id: "cursor",
       listModels: vi.fn().mockReturnValue(listPromise),
-      sendMessage: vi.fn(),
+      sendTurn: vi.fn(),
       cancelSession: vi.fn(),
       shutdown: vi.fn(),
     };
@@ -191,7 +191,7 @@ describe("ModelCacheService", () => {
   it("throws when fetching from a provider that does not implement listModels", async () => {
     const provider = {
       id: "no-list",
-      sendMessage: vi.fn(),
+      sendTurn: vi.fn(),
       cancelSession: vi.fn(),
       shutdown: vi.fn(),
     };

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -48,6 +48,7 @@ import { SettingsService } from "./services/settings-service";
 import { GitWatcherService } from "./services/git-watcher-service";
 import { SkillWatcherService } from "./services/skill-watcher-service";
 import { MemoryPressureService } from "./services/memory-pressure-service";
+import { ScopedPreGrantService } from "./services/scoped-pre-grant";
 import { CleanupWorker } from "./services/cleanup-worker";
 import { PrDraftService } from "./services/pr-draft-service";
 import {
@@ -343,6 +344,14 @@ export function setupContainer(mcodeDir: string): typeof container {
     { useClass: MemoryPressureService },
     { lifecycle: Lifecycle.Singleton },
   );
+  container.register(
+    ScopedPreGrantService,
+    { useClass: ScopedPreGrantService },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register("ScopedPreGrantService", {
+    useFactory: (c) => c.resolve(ScopedPreGrantService),
+  });
   container.register(
     CleanupWorker,
     { useClass: CleanupWorker },

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -33,6 +33,7 @@ import { ProviderRegistry } from "./providers/provider-registry";
 import { WorkspaceService } from "./services/workspace-service";
 import { ThreadService } from "./services/thread-service";
 import { AgentService } from "./services/agent-service";
+import { NarrativeStore } from "./services/narrative-store";
 import { GitService } from "./services/git-service";
 import { GithubService } from "./services/github-service";
 import { FileService } from "./services/file-service";
@@ -266,6 +267,14 @@ export function setupContainer(mcodeDir: string): typeof container {
     { useClass: AttachmentService },
     { lifecycle: Lifecycle.Singleton },
   );
+  container.register(
+    NarrativeStore,
+    { useClass: NarrativeStore },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register("NarrativeStore", {
+    useFactory: (c) => c.resolve(NarrativeStore),
+  });
   container.register(
     AgentService,
     { useClass: AgentService },

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -20,6 +20,7 @@ import { PtyPidRegistry } from "./services/pty-pid-registry";
 import { WorkspaceService } from "./services/workspace-service";
 import { ThreadService } from "./services/thread-service";
 import { AgentService } from "./services/agent-service";
+import { NarrativeStore } from "./services/narrative-store";
 import { GitService } from "./services/git-service";
 import { GithubService } from "./services/github-service";
 import { FileService } from "./services/file-service";
@@ -177,6 +178,7 @@ const providerAvailability = container.resolve(ProviderAvailabilityService);
 const toolCallRecordRepo = container.resolve(ToolCallRecordRepo);
 const thoughtSegmentRepo = container.resolve(ThoughtSegmentRepo);
 const hookExecutionRepo = container.resolve(HookExecutionRepo);
+const narrativeStore = container.resolve(NarrativeStore);
 const turnSnapshotRepo = container.resolve(TurnSnapshotRepo);
 const snapshotService = container.resolve(SnapshotService);
 const settingsService = container.resolve(SettingsService);
@@ -459,6 +461,7 @@ const { httpServer, wss } = createWsServer({
   toolCallRecordRepo,
   thoughtSegmentRepo,
   hookExecutionRepo,
+  narrativeStore,
   turnSnapshotRepo,
   snapshotService,
   settingsService,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -366,7 +366,7 @@ for (const provider of providerRegistry.resolveAll()) {
     if (event.type === AgentEventType.ToolUse && event.toolName !== "Agent") {
       // SDK omitted parent_tool_use_id; fill from turn buffer fallback when unique running Agent (see narrative-pipeline.md).
       if (!event.parentToolCallId) {
-        const parentId = agentService.getCurrentParentToolCallId(event.threadId);
+        const parentId = narrativeStore.getCurrentParentToolCallId(event.threadId);
         if (parentId) {
           enrichedEvent = { ...event, parentToolCallId: parentId };
         }

--- a/apps/server/src/providers/claude/__tests__/side-channel-sessionless.test.ts
+++ b/apps/server/src/providers/claude/__tests__/side-channel-sessionless.test.ts
@@ -50,7 +50,13 @@ function makeProvider() {
   const provider = Object.create(ClaudeProvider.prototype) as ClaudeProvider;
   (provider as any).envService = makeEnvService();
   (provider as any).jobObject = makeJobObject();
-  (provider as any).sessions = new Map();
+  // The constructor is bypassed (Object.create) to avoid spawning. After the
+  // SessionRuntime migration, runSideChannelQuery reads parent liveness via
+  // this.runtime.get(...), so provide a Map-backed runtime stub. The
+  // `sessions` map remains the seeding surface used by withLiveParentSession.
+  const sessions = new Map();
+  (provider as any).sessions = sessions;
+  (provider as any).runtime = { get: (id: string) => sessions.get(id) };
   (provider as any).emitter = { emit: vi.fn(), on: vi.fn() };
   return provider;
 }

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -13,6 +13,7 @@ import { logger } from "@mcode/shared";
 import { AgentEventType, isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   ContextWindowMode,
@@ -300,26 +301,32 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
   }
 
   /** Start or continue a session by sending a message via the SDK. */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    contextWindowMode?: ContextWindowMode;
-    thinking?: boolean;
-    maxBudgetUsd?: number;
-    maxTurns?: number;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"claude">): Promise<void> {
+    // Seed the resume id so doSendMessage's sdkSessionIds lookup resolves it.
+    // `resumeFrom` defined ⇒ resume that SDK session; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
+    const params = {
+      sessionId: req.sessionId,
+      message: req.message,
+      cwd: req.cwd,
+      model: req.model,
+      fallbackModel: req.fallbackModel,
+      resume: req.resumeFrom !== undefined,
+      permissionMode: req.permissionMode,
+      attachments: req.attachments,
+      reasoningLevel: req.reasoningLevel,
+      contextWindowMode: req.providerOptions.contextWindowMode,
+      thinking: req.providerOptions.thinking,
+      maxBudgetUsd: req.maxBudgetUsd,
+      maxTurns: req.maxTurns,
+    };
     try {
       await this.doSendMessage(params);
     } catch (e: unknown) {
-      logger.error("sendMessage error", {
-        sessionId: params.sessionId,
+      logger.error("sendTurn error", {
+        sessionId: req.sessionId,
         error: String(e),
       });
       throw e;
@@ -2006,11 +2013,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
-
   /**
    * Install a goal on a session. The next Stop event from the SDK will be
    * blocked with a "Goal not yet met" reason until {@link clearGoal} is
@@ -2165,6 +2167,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
    * callback captures ExitPlanMode calls instead of denying them.
    * When disabled (or after capture), the model's ExitPlanMode calls
    * are denied silently.
+   *
+   * Off-interface (like setGoal/clearGoal): no longer an IAgentProvider member;
+   * AgentService invokes it on the concrete ClaudeProvider via a cast. The
+   * question-vs-answer plan distinction cannot be carried by the binary
+   * TurnRequest.interactionMode, so this Claude-only arming stays explicit.
    */
   setPlanAnswerMode(threadId: string, enabled: boolean): void {
     if (enabled) {

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -34,6 +34,8 @@ import { AnthropicHeaderUsageSource } from "./usage/header-usage-source.js";
 import { CompositeUsageSource } from "./usage/composite-usage-source.js";
 import { EnvService } from "../../services/env-service.js";
 import { JobObject } from "../../services/job-object.js";
+import { SessionRuntime } from "../../services/session-runtime.js";
+import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import { listDirectChildren } from "../../services/process-kill.js";
 
 /**
@@ -63,14 +65,21 @@ function restoreProcessEnv(backup: Record<string, string | undefined>): void {
   }
 }
 
-/** Idle TTL before a session is evicted (10 minutes). */
-const IDLE_TTL_MS = 10 * 60 * 1000;
-/** How often to check for idle sessions (1 minute). */
-const EVICTION_INTERVAL_MS = 60 * 1000;
 /** Max queued messages before push() warns and drops. */
 const MAX_QUEUE_DEPTH = 20;
 
-interface SessionEntry {
+/**
+ * Per-session state owned by the {@link SessionRuntime}. Holds the live SDK
+ * `query`, its prompt-queue handles, and the per-turn bookkeeping the stream
+ * loop and eviction guard read. The runtime owns eviction timing and JobObject/
+ * kill; `lastUsedAt` is retained here because the stream loop and
+ * `resolvePermission` stamp it so SDK activity and user attention count.
+ */
+interface ClaudeSessionState {
+  /** Session id this state belongs to; lets adapter methods reference provider maps. */
+  sessionId: string;
+  /** Working directory the SDK subprocess was spawned with. */
+  cwd: string;
   query: Query;
   pushMessage: (msg: SDKUserMessage) => void;
   closeQueue: () => void;
@@ -93,8 +102,8 @@ interface SessionEntry {
   /** When true, the finally block in startStreamLoop should not emit an "ended" event. */
   suppressEnded?: boolean;
   /** Tool-use IDs whose matching tool_result has not yet been received.
-   *  While this set is non-empty, evictIdleSessions() must skip the session
-   *  regardless of how long it has been since an SDK message arrived. */
+   *  While this set is non-empty, `isBusy` returns true so the runtime's idle
+   *  eviction skips the session regardless of how long the SDK has been quiet. */
   pendingToolUses: Set<string>;
   /**
    * True once the first tool call for this sendMessage query has been registered.
@@ -227,16 +236,44 @@ export function detectFallbackModel(
 /** Max time to wait on a resume side-channel before falling back to sessionless. */
 const SIDE_CHANNEL_RESUME_PROBE_MS = 20_000;
 
+/**
+ * Per-turn payload staged from `sendTurn`/`doSendMessage` to `spawn`. The
+ * runtime's `acquire` only hands back state, so the prompt, resume flag, and
+ * SDK options for a freshly-spawned session's first turn are carried here keyed
+ * by sessionId. Mirrors the Codex provider's `pendingSpawnTurns`.
+ */
+interface PendingSpawnTurn {
+  prompt: SDKUserMessage;
+  /** Whether this spawn should resume an existing SDK session id. */
+  resume: boolean;
+  /** SDK session id to resume from (only consulted when `resume` is true). */
+  resumeId: string;
+  /** Raw uuid (threadId) used as the `sessionId` option on a fresh (non-resume) spawn. */
+  uuid: string;
+  /** Fully-built SDK query options sans the resume/sessionId discriminator. */
+  baseOptions: Record<string, unknown>;
+  /**
+   * Bare model id (no `[1m]` suffix) stored on the session state so
+   * detectFallbackModel compares against the dated snapshot ids the SDK reports.
+   */
+  resolvedModel: string;
+  /** Context window mode the session was spawned with; gates the in-place reuse check. */
+  contextWindowMode: ContextWindowMode | undefined;
+}
+
 /** Claude Agent SDK adapter implementing IAgentProvider with prompt queue pattern. */
 @injectable()
-export class ClaudeProvider extends EventEmitter implements IAgentProvider {
+export class ClaudeProvider extends EventEmitter implements IAgentProvider, ProtocolAdapter<ClaudeSessionState> {
   readonly id: ProviderId = "claude";
   /** Claude supports one-shot text completion via sdkQuery with maxTurns: 1. */
   readonly supportsCompletion = true;
   readonly sessionForkOnResume = "clean" as const;
   readonly maxInputCharactersPerTurn = 180_000;
 
-  private sessions = new Map<string, SessionEntry>();
+  /** Owns the session pool, idle eviction (with busy guard), and JobObject/kill. */
+  private readonly runtime: SessionRuntime<ClaudeSessionState>;
+  /** Per-turn payload staged for `spawn` to run a fresh session's first turn. */
+  private pendingSpawnTurns = new Map<string, PendingSpawnTurn>();
   private sdkSessionIds = new Map<string, string>();
   /**
    * Active goals keyed by sessionId (mcode-${threadId}). When set, the SDK
@@ -266,7 +303,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       resolve: (decision: PermissionDecision) => void;
     }
   >();
-  private evictionTimer: ReturnType<typeof setInterval> | null = null;
   private lastSessionCostUsd?: number;
   private lastServiceTier?: "standard" | "priority" | "batch";
   private lastNumTurns?: number;
@@ -281,6 +317,10 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     @inject("JobObject") private readonly jobObject: JobObject,
   ) {
     super();
+    this.runtime = new SessionRuntime<ClaudeSessionState>(this, {
+      jobObject: this.jobObject,
+      envService: this.envService,
+    });
   }
 
   /**
@@ -464,7 +504,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     // Resolve model from the parent thread's active session if available,
     // falling back to the default claude-sonnet model.
     const parentSessionId = `mcode-${args.parentThreadId}`;
-    const hasLiveParentSession = this.sessions.has(parentSessionId);
+    const hasLiveParentSession = this.runtime.get(parentSessionId) !== undefined;
 
     // Path B-prime: after a server restart (or when the user forks without
     // sending a new message on the parent), the SDK subprocess is not running
@@ -484,7 +524,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       );
     }
 
-    const model = this.sessions.get(parentSessionId)?.model ?? DEFAULT_CLAUDE_MODEL;
+    const model = this.runtime.get(parentSessionId)?.model ?? DEFAULT_CLAUDE_MODEL;
 
     const backup = snapshotProcessEnv();
     // Cap resume attempts so a hung subprocess does not consume the full
@@ -748,14 +788,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       thinking,
     } = params;
 
-    if (!this.evictionTimer) {
-      this.evictionTimer = setInterval(
-        () => this.evictIdleSessions(),
-        EVICTION_INTERVAL_MS,
-      );
-    }
-
-    const existing = this.sessions.get(sessionId);
+    const existing = this.runtime.get(sessionId);
     const isBypass = permissionMode === "full";
     const sdkPermissionMode = isBypass
       ? ("bypassPermissions" as const)
@@ -780,42 +813,31 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         ? await this.buildMultimodalMessage(finalMessage, attachments, sessionId)
         : toUserMessage(finalMessage, sessionId);
 
-    if (existing) {
-      // Permission mode is fixed at SDK subprocess spawn. setPermissionMode()
-      // cannot enter bypassPermissions without the --dangerously-skip-permissions
-      // flag at spawn time (mutually exclusive with canUseTool), so we match
-      // the codex provider's teardown-and-respawn pattern here. The new session
-      // resumes the same conversation via the persisted sdkSessionIds entry.
-      if (existing.permissionMode !== permissionMode) {
-        logger.info("permissionMode changed, recreating session", {
-          sessionId,
-          from: existing.permissionMode,
-          to: permissionMode,
-        });
-        existing.suppressEnded = true;
-        existing.closeQueue();
-        existing.query.close();
-        this.sessions.delete(sessionId);
-        return this.doSendMessage(params);
-      }
+    // A live session whose spawn-fixed parameters (permissionMode or
+    // contextWindowMode) still match the request can be reused in place: the
+    // model can be hot-swapped via setModel() and the prompt pushed onto the
+    // existing queue. A mismatch is detected by `isStale`, so `acquire` would
+    // discard and respawn anyway; tearing it down here (with `suppressEnded`)
+    // keeps the stream loop quiet and falls through to the fresh-spawn path,
+    // which resumes the same conversation via the persisted sdkSessionIds entry.
+    const reusable =
+      existing !== undefined &&
+      existing.permissionMode === permissionMode &&
+      existing.contextWindowMode === contextWindowMode;
 
-      // Context window mode is part of the model slug at spawn time, so the SDK
-      // subprocess must be torn down and respawned when the user toggles 200k/1M.
-      // setModel() can change the model ID but cannot toggle the [1m] suffix beta
-      // header, which is only attached at session creation.
-      if (existing.contextWindowMode !== contextWindowMode) {
-        logger.info("contextWindowMode changed, recreating session", {
-          sessionId,
-          from: existing.contextWindowMode,
-          to: contextWindowMode,
-        });
-        existing.suppressEnded = true;
-        existing.closeQueue();
-        existing.query.close();
-        this.sessions.delete(sessionId);
-        return this.doSendMessage(params);
-      }
+    if (existing && !reusable) {
+      logger.info("Session spawn parameters changed, recreating session", {
+        sessionId,
+        permissionMode: { from: existing.permissionMode, to: permissionMode },
+        contextWindowMode: { from: existing.contextWindowMode, to: contextWindowMode },
+      });
+      // Suppress the teardown's Ended emit; the fresh session takes over the id.
+      existing.suppressEnded = true;
+      await this.runtime.stop(sessionId);
+    }
 
+    if (existing && reusable) {
+      this.runtime.recordUsage(sessionId);
       existing.lastUsedAt = Date.now();
 
       if (existing.model !== resolvedModel) {
@@ -838,10 +860,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                 err instanceof Error ? err.message : String(err),
             },
           );
+          // Respawn fresh (no resume) after a setModel failure. Suppress the
+          // teardown Ended and fall through to the fresh-spawn path with a
+          // resume:false stage so the new subprocess starts a clean session.
           existing.suppressEnded = true;
-          existing.closeQueue();
-          existing.query.close();
-          this.sessions.delete(sessionId);
+          await this.runtime.stop(sessionId);
           return this.doSendMessage({ ...params, resume: false });
         }
       }
@@ -867,11 +890,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
             error: "Message could not be delivered: session was shutting down. Please try again.",
           } satisfies AgentEvent);
           // Drop the stale entry so the next send creates a fresh session.
-          // Safe to delete here even if startStreamLoop is mid-iteration: its
-          // finally block guards with `current?.query === q` before re-deleting,
-          // so a second delete is a no-op and the terminal Ended event still
-          // fires via the `(!current || current.query === q)` condition.
-          this.sessions.delete(sessionId);
+          // Safe even if startStreamLoop is mid-iteration: its finally block
+          // guards with `current?.query === q` before re-deleting, so a second
+          // stop is a no-op and the terminal Ended event still fires via the
+          // `(!current || current.query === q)` condition.
+          await this.runtime.stop(sessionId);
         } else {
           // Transient overflow: surface via Error event but keep the session.
           logger.warn("Prompt queue full on existing session", {
@@ -1069,6 +1092,125 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         }],
       },
     };
+    // Stage the per-turn payload so `spawn` can build the SDK query, start the
+    // stream loop, and push this prompt as the fresh session's first turn.
+    // `spawn` discriminates resume vs. fresh via these staged fields.
+    const stageTurn = (doResume: boolean): void => {
+      this.pendingSpawnTurns.set(sessionId, {
+        prompt,
+        resume: doResume,
+        resumeId,
+        uuid,
+        baseOptions,
+        resolvedModel,
+        contextWindowMode,
+      });
+    };
+
+    // Spawn fresh through the runtime. Resume-failure detection needs its
+    // listeners registered BEFORE `acquire` runs `spawn` (which starts the
+    // stream loop), otherwise a `_resumeFailed` emit could race ahead of the
+    // listener attach across the `await acquire` boundary.
+    const runSpawn = async (doResume: boolean): Promise<"ok" | "stopped" | "retry"> => {
+      stageTurn(doResume);
+
+      let retryPromise: Promise<boolean> | undefined;
+      let resumeHandler: (() => void) | null = null;
+      let doneHandler: (() => void) | null = null;
+      const failedEvent = `_resumeFailed:${sessionId}`;
+      const doneEvent = `_streamDone:${sessionId}`;
+      if (doResume) {
+        retryPromise = new Promise<boolean>((resolve) => {
+          resumeHandler = () => resolve(true);
+          doneHandler = () => resolve(false);
+          this.once(failedEvent, resumeHandler);
+          this.once(doneEvent, doneHandler);
+        });
+      }
+
+      try {
+        await this.runtime.acquire({
+          sessionId,
+          threadId: tid,
+          cwd: resolvedCwd,
+          permissionMode,
+          resumeFrom: doResume ? resumeId : undefined,
+        });
+      } catch (err) {
+        if (resumeHandler) this.removeListener(failedEvent, resumeHandler);
+        if (doneHandler) this.removeListener(doneEvent, doneHandler);
+        this.pendingSpawnTurns.delete(sessionId);
+        throw err;
+      }
+      this.runtime.recordUsage(sessionId);
+
+      // A stop requested while the spawn was in flight: tear it down now.
+      if (this.pendingStops.delete(sessionId)) {
+        logger.info("Pending stop consumed, tearing down new session", {
+          sessionId,
+        });
+        if (resumeHandler) this.removeListener(failedEvent, resumeHandler);
+        if (doneHandler) this.removeListener(doneEvent, doneHandler);
+        await this.runtime.stop(sessionId);
+        // TurnStarted was already emitted by AgentService before calling the
+        // provider, so the frontend thinks the agent is running. Emit Ended
+        // to clear that state.
+        this.emit("event", {
+          type: AgentEventType.Ended,
+          threadId: tid,
+        } satisfies AgentEvent);
+        return "stopped";
+      }
+
+      if (!doResume || !retryPromise) return "ok";
+
+      let needsRetry: boolean;
+      try {
+        needsRetry = await retryPromise;
+      } finally {
+        // Guarantee both listeners are removed regardless of how the
+        // promise settled (resolve, reject, or upstream cancellation).
+        if (resumeHandler) this.removeListener(failedEvent, resumeHandler);
+        if (doneHandler) this.removeListener(doneEvent, doneHandler);
+      }
+
+      if (!needsRetry) return "ok";
+
+      logger.info("Resume failed, falling back to fresh query()", { sessionId });
+      this.sdkSessionIds.delete(sessionId);
+      // Discard the resume session so `acquire` spawns a fresh one. The failed
+      // resume already suppressed its own Ended via the stream loop.
+      await this.runtime.stop(sessionId);
+      return "retry";
+    };
+
+    const first = await runSpawn(resume);
+    if (first === "retry") {
+      await runSpawn(false);
+    }
+  }
+
+  /**
+   * Spawns a fresh Claude SDK session for the staged turn: builds the prompt
+   * queue, launches `sdkQuery` inside the env snapshot window, surfaces any new
+   * child PID to the runtime (which attaches it to the Windows JobObject and
+   * hard-kills it on stop — Claude's converged taskkill), starts the stream
+   * loop, and pushes the first prompt.
+   *
+   * Returns the discovered child PIDs (Windows only; the Claude SDK does not
+   * expose the subprocess PID directly, so they are recovered by diffing the
+   * server's direct children across the spawn). On non-Windows the array is
+   * empty and JobObject/taskkill are no-ops.
+   */
+  async spawn(args: SpawnArgs): Promise<SpawnResult<ClaudeSessionState>> {
+    const { sessionId, cwd } = args;
+    const staged = this.pendingSpawnTurns.get(sessionId);
+    if (!staged) {
+      throw new Error(`Claude spawn called with no staged turn for session ${sessionId}`);
+    }
+    this.pendingSpawnTurns.delete(sessionId);
+
+    const { prompt, resume, resumeId, uuid, baseOptions, resolvedModel, contextWindowMode } = staged;
     const options = resume
       ? { ...baseOptions, resume: resumeId }
       : { ...baseOptions, sessionId: uuid };
@@ -1079,8 +1221,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       sessionId,
       resume,
       resumeId,
-      model: resolvedModel,
-      cwd: resolvedCwd,
+      cwd,
     });
 
     let beforePids: Set<number> | undefined;
@@ -1095,11 +1236,22 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
 
     const q = this.withSdkSpawnEnv(() => sdkQuery({ prompt: queue.iterable, options }));
 
+    // Discover the newly-spawned child PID(s) so the runtime can JobObject-
+    // attach and taskkill them. Mirrors the old `labelSdkSubprocess` diff, but
+    // returns the PIDs to the runtime instead of attaching inline.
+    let pids: number[] = [];
     if (beforePids) {
-      void this.labelSdkSubprocess(beforePids);
+      try {
+        const after = await listDirectChildren(process.pid);
+        pids = after.filter((c) => !beforePids!.has(c.pid)).map((c) => c.pid);
+      } catch {
+        // Best-effort: process enumeration can fail transiently.
+      }
     }
 
-    const entry: SessionEntry = {
+    const state: ClaudeSessionState = {
+      sessionId,
+      cwd,
       query: q,
       pushMessage: queue.push,
       closeQueue: queue.close,
@@ -1107,124 +1259,63 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       // boundary so detectFallbackModel can compare against the dated snapshot
       // IDs the SDK reports in modelUsage.
       model: resolvedModel,
-      permissionMode,
+      permissionMode: args.permissionMode,
       contextWindowMode,
       lastUsedAt: Date.now(),
       pendingToolUses: new Set<string>(),
       hasFiredToolThisTurn: false,
     };
-    this.sessions.set(sessionId, entry);
 
-    // A stop was requested while sendMessage was still in flight (race
-    // between concurrent agent.send and agent.stop RPCs). Tear down
-    // immediately so the agent never starts.
-    if (this.pendingStops.delete(sessionId)) {
-      logger.info("Pending stop consumed, tearing down new session", {
-        sessionId,
+    // Start the stream loop and push the first prompt. The loop is async and
+    // reads `this.runtime.get(sessionId)` lazily on each SDK message; by the
+    // time the first message yields, `acquire` has stored `state` in the pool
+    // (the runtime stores it synchronously the moment this `spawn` resolves).
+    this.startStreamLoop(sessionId, q);
+    queue.push(prompt);
+
+    return { state, pids };
+  }
+
+  /**
+   * Eviction guard: a session is busy while a tool_use awaits its result, OR
+   * while it has a pending permission request the user may still answer (the
+   * user could be on another thread). Both keep the session out of idle
+   * eviction regardless of how long the SDK has been quiet.
+   */
+  isBusy(state: ClaudeSessionState): boolean {
+    if (state.pendingToolUses.size > 0) {
+      logger.debug("Skipping eviction: pending tool calls", {
+        sessionId: state.sessionId,
+        pending: state.pendingToolUses.size,
       });
-      this.sessions.delete(sessionId);
-      entry.closeQueue();
-      entry.query.close();
-      // TurnStarted was already emitted by AgentService before calling the
-      // provider, so the frontend thinks the agent is running. Emit Ended
-      // to clear that state.
-      this.emit("event", {
-        type: AgentEventType.Ended,
-        threadId: tid,
-      } satisfies AgentEvent);
-      return;
+      return true;
     }
+    const tid = state.sessionId.startsWith("mcode-")
+      ? state.sessionId.slice(6)
+      : state.sessionId;
+    return [...this.pendingPermissions.values()].some((p) => p.threadId === tid);
+  }
 
-    if (resume) {
-      const failedEvent = `_resumeFailed:${sessionId}`;
-      const doneEvent = `_streamDone:${sessionId}`;
+  /** Graceful protocol interrupt: close the prompt queue so the SDK iterator ends. */
+  interrupt(state: ClaudeSessionState): void {
+    state.closeQueue();
+  }
 
-      let resumeHandler: (() => void) | null = null;
-      let doneHandler: (() => void) | null = null;
+  /** Provider teardown: close the SDK query handle. */
+  close(state: ClaudeSessionState): void {
+    state.query.close();
+  }
 
-      const retryPromise = new Promise<boolean>((resolve) => {
-        resumeHandler = () => resolve(true);
-        doneHandler = () => resolve(false);
-        this.once(failedEvent, resumeHandler);
-        this.once(doneEvent, doneHandler);
-      });
-
-      this.startStreamLoop(sessionId, q);
-      queue.push(prompt);
-
-      let needsRetry: boolean;
-      try {
-        needsRetry = await retryPromise;
-      } finally {
-        // Guarantee both listeners are removed regardless of how the
-        // promise settled (resolve, reject, or upstream cancellation).
-        if (resumeHandler) this.removeListener(failedEvent, resumeHandler);
-        if (doneHandler) this.removeListener(doneEvent, doneHandler);
-      }
-
-      if (needsRetry) {
-        logger.info("Resume failed, falling back to fresh query()", {
-          sessionId,
-        });
-        this.sdkSessionIds.delete(sessionId);
-
-        const freshQueue = createPromptQueue();
-        const freshOptions = { ...baseOptions, sessionId: uuid };
-
-        let freshBeforePids: Set<number> | undefined;
-        if (this.jobObject.isWindowsJob) {
-          try {
-            const children = await listDirectChildren(process.pid);
-            freshBeforePids = new Set(children.map((c) => c.pid));
-          } catch {
-            // Best-effort
-          }
-        }
-
-        const freshQ = this.withSdkSpawnEnv(() =>
-          sdkQuery({
-            prompt: freshQueue.iterable,
-            options: freshOptions,
-          }),
-        );
-
-        if (freshBeforePids) {
-          void this.labelSdkSubprocess(freshBeforePids);
-        }
-        const freshEntry: SessionEntry = {
-          query: freshQ,
-          pushMessage: freshQueue.push,
-          closeQueue: freshQueue.close,
-          model: resolvedModel,
-          permissionMode,
-          contextWindowMode,
-          lastUsedAt: Date.now(),
-          pendingToolUses: new Set<string>(),
-          hasFiredToolThisTurn: false,
-        };
-        this.sessions.set(sessionId, freshEntry);
-
-        if (this.pendingStops.delete(sessionId)) {
-          logger.info("Pending stop consumed on resume fallback", {
-            sessionId,
-          });
-          this.sessions.delete(sessionId);
-          freshEntry.closeQueue();
-          freshEntry.query.close();
-          this.emit("event", {
-            type: AgentEventType.Ended,
-            threadId: tid,
-          } satisfies AgentEvent);
-          return;
-        }
-
-        this.startStreamLoop(sessionId, freshQ);
-        freshQueue.push(prompt);
-      }
-    } else {
-      this.startStreamLoop(sessionId, q);
-      queue.push(prompt);
-    }
+  /**
+   * A pooled session must be discarded before reuse when its spawn-fixed
+   * parameters changed. permissionMode is fixed at SDK spawn (bypass vs.
+   * default), and contextWindowMode is encoded into the model slug at spawn,
+   * so either change forces a respawn. `doSendMessage` detects the same
+   * mismatch and tears the session down explicitly (with `suppressEnded`)
+   * before reaching `acquire`; this is the runtime-side backstop.
+   */
+  isStale(state: ClaudeSessionState, args: { cwd: string; permissionMode: string }): boolean {
+    return state.permissionMode !== args.permissionMode;
   }
 
   /** Run the stream loop for a query, mapping SDK events to AgentEvent types. */
@@ -1291,7 +1382,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         };
 
         for await (const msg of q) {
-          const entry = this.sessions.get(sessionId);
+          const entry = this.runtime.get(sessionId);
           if (entry) entry.lastUsedAt = Date.now();
 
           const anyMsg = msg as Record<string, unknown>;
@@ -1418,7 +1509,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                   }
                   if (toolId) {
                     emittedToolUseIds.add(toolId);
-                    const entry = this.sessions.get(sessionId);
+                    const entry = this.runtime.get(sessionId);
                     if (entry) {
                       entry.pendingToolUses.add(toolId);
                       entry.hasFiredToolThisTurn = true;
@@ -1664,7 +1755,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
               }
               if (toolId) {
                 emittedToolUseIds.add(toolId);
-                const entry = this.sessions.get(sessionId);
+                const entry = this.runtime.get(sessionId);
                 if (entry) {
                   entry.pendingToolUses.add(toolId);
                   entry.hasFiredToolThisTurn = true;
@@ -1717,7 +1808,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                 isError: Boolean(anyMsg.is_error),
               } satisfies AgentEvent);
               if (toolUseId) {
-                const entry = this.sessions.get(sessionId);
+                const entry = this.runtime.get(sessionId);
                 entry?.pendingToolUses.delete(toolUseId);
               }
               break;
@@ -1767,7 +1858,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
                   // (pendingToolUses empty) AND at least one tool has fired this
                   // turn — distinguishing post-tool final-response text from
                   // pre-tool preamble, both of which have pendingToolUses===0.
-                  const sessionEntry = this.sessions.get(sessionId);
+                  const sessionEntry = this.runtime.get(sessionId);
                   const isFinalResponse =
                     sessionEntry !== undefined &&
                     sessionEntry.pendingToolUses.size === 0 &&
@@ -1852,7 +1943,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         // non-zero after its stdin is closed, which propagates here as a
         // thrown exit error. That exit is expected, not a user-visible crash,
         // because a fresh session has already taken over the sessionId.
-        const current = this.sessions.get(sessionId);
+        const current = this.runtime.get(sessionId);
         const superseded =
           (current !== undefined && current.query !== q) ||
           current?.suppressEnded === true;
@@ -1873,9 +1964,12 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
           } satisfies AgentEvent);
         }
       } finally {
-        const current = this.sessions.get(sessionId);
+        const current = this.runtime.get(sessionId);
         if (current?.query === q) {
-          this.sessions.delete(sessionId);
+          // The SDK subprocess has exited; drop the dead session from the pool.
+          // `runtime.stop` also best-effort taskkills the (already-gone) PIDs,
+          // which is harmless. Fire-and-forget: the stream loop is unwinding.
+          void this.runtime.stop(sessionId);
         }
         logger.info("Session stream ended", { sessionId });
         this.emit(`_streamDone:${sessionId}`);
@@ -1887,28 +1981,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
         }
       }
     })();
-  }
-
-  /**
-   * Discover and label new child PIDs spawned by sdkQuery().
-   * Compares direct children of the server process before and after the spawn.
-   * Best-effort: races with other concurrent spawns are tolerated because
-   * labelling a wrong process is harmless (the description is overwritten
-   * on the next setDescription call for that PID).
-   */
-  private async labelSdkSubprocess(beforePids: Set<number>): Promise<void> {
-    if (!this.jobObject.isWindowsJob) return;
-    try {
-      const after = await listDirectChildren(process.pid);
-      for (const child of after) {
-        if (!beforePids.has(child.pid)) {
-          this.jobObject.assign(child.pid);
-          this.jobObject.setDescription(child.pid, "Mcode Agent: Claude");
-        }
-      }
-    } catch {
-      // Best-effort: process enumeration can fail transiently
-    }
   }
 
   /** Build a multimodal SDKUserMessage from text and attachments. */
@@ -1983,36 +2055,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     };
   }
 
-  /** Evict sessions that have been idle longer than IDLE_TTL_MS. */
-  private evictIdleSessions(): void {
-    const now = Date.now();
-    for (const [sessionId, entry] of this.sessions) {
-      if (now - entry.lastUsedAt > IDLE_TTL_MS) {
-        // Skip sessions with in-flight tool calls: a long-running tool (build,
-        // test suite, large file op) may not emit any SDK message for minutes.
-        if (entry.pendingToolUses.size > 0) {
-          logger.debug("Skipping eviction: pending tool calls", {
-            sessionId,
-            pending: entry.pendingToolUses.size,
-          });
-          continue;
-        }
-        // Never evict a session that is actively awaiting a user permission response —
-        // the user may be on another thread and is about to respond.
-        const tid = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
-        const hasPending = [...this.pendingPermissions.values()].some(
-          (p) => p.threadId === tid,
-        );
-        if (hasPending) continue;
-
-        logger.info("Evicting idle session", { sessionId });
-        this.sessions.delete(sessionId);
-        entry.closeQueue();
-        entry.query.close();
-      }
-    }
-  }
-
   /**
    * Install a goal on a session. The next Stop event from the SDK will be
    * blocked with a "Goal not yet met" reason until {@link clearGoal} is
@@ -2046,11 +2088,14 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       }
     }
     this.goalsBySession.delete(sessionId);
-    const entry = this.sessions.get(sessionId);
+    const entry = this.runtime.get(sessionId);
     if (entry) {
-      this.sessions.delete(sessionId);
-      entry.closeQueue();
-      entry.query.close();
+      // The runtime's stop runs interrupt (closeQueue) → close (query.close) →
+      // hard taskkill of the spawned PID. Fire-and-forget; callers that need to
+      // await the subprocess exit use waitForSessionExit.
+      void this.runtime.stop(sessionId).catch((err: unknown) => {
+        logger.warn("Claude stopSession failed", { sessionId, error: String(err) });
+      });
     } else {
       // Session not yet created (sendMessage still in flight). Record the
       // stop so doSendMessage tears the session down immediately after
@@ -2086,16 +2131,19 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
       const timer = setTimeout(done, timeoutMs);
       this.once(`_streamDone:${sessionId}`, done);
 
-      const entry = this.sessions.get(sessionId);
+      const entry = this.runtime.get(sessionId);
       if (!entry) {
         // No active session — resolve immediately without waiting.
         done();
         return;
       }
 
-      this.sessions.delete(sessionId);
-      entry.closeQueue();
-      entry.query.close();
+      // Stop through the runtime (interrupt → close → taskkill). The interrupt
+      // closes the prompt queue, ending the SDK iterator, so the stream loop's
+      // finally emits `_streamDone`, which resolves the wait above.
+      void this.runtime.stop(sessionId).catch((err: unknown) => {
+        logger.warn("Claude waitForSessionExit stop failed", { sessionId, error: String(err) });
+      });
     });
   }
 
@@ -2137,7 +2185,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
     // Reset the session's idle timer so the 10-minute eviction clock starts
     // from the moment the user responds, not from when the request was sent.
     const sessionId = `mcode-${entry.threadId}`;
-    const session = this.sessions.get(sessionId);
+    const session = this.runtime.get(sessionId);
     if (session) session.lastUsedAt = Date.now();
 
     entry.resolve(decision);
@@ -2183,27 +2231,21 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider {
 
   /** Tear down all sessions and release resources. */
   shutdown(): void {
-    if (this.evictionTimer) {
-      clearInterval(this.evictionTimer);
-      this.evictionTimer = null;
-    }
-    // Drain all pending permission requests so their promises settle
+    // Drain all pending permission requests so their promises settle. Do this
+    // before the runtime stops sessions so any in-flight canUseTool awaits
+    // unblock and the SDK iterators can wind down cleanly.
     for (const [requestId, entry] of this.pendingPermissions) {
       this.pendingPermissions.delete(requestId);
       entry.resolve("cancelled");
       this.emit("permission_resolved", { requestId, decision: "cancelled" as const });
     }
-    for (const [sessionId, entry] of this.sessions) {
-      if (entry.pendingToolUses.size > 0) {
-        logger.warn("Shutting down session with pending tool calls", {
-          sessionId,
-          pending: entry.pendingToolUses.size,
-        });
-      }
-      entry.closeQueue();
-      entry.query.close();
-    }
-    this.sessions.clear();
+    // The runtime stops every session (interrupt → close → taskkill) and
+    // clears its eviction timer. Fire-and-forget: shutdown is synchronous and
+    // the provider-owned maps below are cleared immediately.
+    void this.runtime.shutdown().catch((err: unknown) => {
+      logger.warn("Claude runtime shutdown failed", { error: String(err) });
+    });
+    this.pendingSpawnTurns.clear();
     this.sdkSessionIds.clear();
     this.goalsBySession.clear();
     logger.info("ClaudeProvider shutdown complete");

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -37,6 +37,8 @@ import { JobObject } from "../../services/job-object.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import { listDirectChildren } from "../../services/process-kill.js";
+import { CleanForker } from "../../services/handoff/session-forker.js";
+import type { SessionForker } from "@mcode/contracts";
 
 /**
  * Default model slug used for side-channel and fallback paths.
@@ -269,6 +271,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
   readonly supportsCompletion = true;
   readonly sessionForkOnResume = "clean" as const;
   readonly maxInputCharactersPerTurn = 180_000;
+  /** Path B (+ B-prime) forker; calls this provider's runSideChannelQuery. */
+  readonly forker: SessionForker = new CleanForker(this);
 
   /** Owns the session pool, idle eviction (with busy guard), and JobObject/kill. */
   private readonly runtime: SessionRuntime<ClaudeSessionState>;

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1146,16 +1146,32 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
       let retryPromise: Promise<boolean> | undefined;
       let resumeHandler: (() => void) | null = null;
       let doneHandler: (() => void) | null = null;
+      let okHandler: (() => void) | null = null;
       const failedEvent = `_resumeFailed:${sessionId}`;
       const doneEvent = `_streamDone:${sessionId}`;
+      const okEvent = `_resumeOk:${sessionId}`;
       if (doResume) {
+        // Resolve true → fall back to a fresh query; false → proceed.
+        // `_resumeOk` fires when the resumed turn is confirmed live (the first
+        // non-result event arrived) so a SUCCESSFUL resume releases the waiter
+        // immediately instead of hanging until the stream ends. `_streamDone`
+        // remains a backstop for a resume turn that completes before emitting
+        // any non-result event. `_resumeFailed` still drives the fallback.
         retryPromise = new Promise<boolean>((resolve) => {
           resumeHandler = () => resolve(true);
           doneHandler = () => resolve(false);
+          okHandler = () => resolve(false);
           this.once(failedEvent, resumeHandler);
           this.once(doneEvent, doneHandler);
+          this.once(okEvent, okHandler);
         });
       }
+
+      const removeResumeListeners = (): void => {
+        if (resumeHandler) this.removeListener(failedEvent, resumeHandler);
+        if (doneHandler) this.removeListener(doneEvent, doneHandler);
+        if (okHandler) this.removeListener(okEvent, okHandler);
+      };
 
       try {
         await this.runtime.acquire({
@@ -1166,8 +1182,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
           resumeFrom: doResume ? resumeId : undefined,
         });
       } catch (err) {
-        if (resumeHandler) this.removeListener(failedEvent, resumeHandler);
-        if (doneHandler) this.removeListener(doneEvent, doneHandler);
+        removeResumeListeners();
         this.pendingSpawnTurns.delete(sessionId);
         throw err;
       }
@@ -1178,8 +1193,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
         logger.info("Pending stop consumed, tearing down new session", {
           sessionId,
         });
-        if (resumeHandler) this.removeListener(failedEvent, resumeHandler);
-        if (doneHandler) this.removeListener(doneEvent, doneHandler);
+        removeResumeListeners();
         await this.runtime.stop(sessionId);
         // TurnStarted was already emitted by AgentService before calling the
         // provider, so the frontend thinks the agent is running. Emit Ended
@@ -1197,10 +1211,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
       try {
         needsRetry = await retryPromise;
       } finally {
-        // Guarantee both listeners are removed regardless of how the
+        // Guarantee all listeners are removed regardless of how the
         // promise settled (resolve, reject, or upstream cancellation).
-        if (resumeHandler) this.removeListener(failedEvent, resumeHandler);
-        if (doneHandler) this.removeListener(doneEvent, doneHandler);
+        removeResumeListeners();
       }
 
       if (!needsRetry) return "ok";
@@ -1418,6 +1431,12 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
 
           if (!sessionInitialized && anyMsg.type !== "result") {
             sessionInitialized = true;
+            // A resumed session is now confirmed live (the first non-result
+            // event arrived without a "No conversation found" error). Release
+            // the resume waiter in `runSpawn(true)` so `sendTurn` proceeds
+            // without blocking until the whole stream completes. Harmless on
+            // fresh spawns: no listener is registered there.
+            this.emit(`_resumeOk:${sessionId}`);
           }
 
           // Capture SDK session ID

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -34,6 +34,7 @@ import { AnthropicHeaderUsageSource } from "./usage/header-usage-source.js";
 import { CompositeUsageSource } from "./usage/composite-usage-source.js";
 import { EnvService } from "../../services/env-service.js";
 import { JobObject } from "../../services/job-object.js";
+import { ScopedPreGrantService } from "../../services/scoped-pre-grant.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import { listDirectChildren } from "../../services/process-kill.js";
@@ -319,6 +320,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
   constructor(
     @inject(EnvService) private readonly envService: EnvService,
     @inject("JobObject") private readonly jobObject: JobObject,
+    // Optional with a default so existing `new ClaudeProvider(env, job)` test
+    // call sites keep working; DI always supplies the shared singleton so the
+    // pipeline-issued handoff grants are visible here.
+    @inject(ScopedPreGrantService)
+    private readonly scopedPreGrant: ScopedPreGrantService = new ScopedPreGrantService(),
   ) {
     super();
     this.runtime = new SessionRuntime<ClaudeSessionState>(this, {
@@ -974,6 +980,25 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
               behavior: "deny" as const,
               message: "Plan mode is not active. Continue with the user's request normally.",
             };
+          }
+
+          // Off-band handoff (PRD #538): if the pipeline pre-granted a one-shot
+          // Read of this exact path for this thread, auto-allow it without
+          // prompting, bypassing permissionMode. tryConsume is path-scoped and
+          // one-shot, so this never widens authority beyond the single handoff
+          // doc. All other permission behaviour is unchanged.
+          if (toolName === "Read") {
+            const readPath = typeof input?.path === "string" ? input.path : undefined;
+            if (
+              readPath !== undefined &&
+              this.scopedPreGrant.tryConsume({ threadId: tid, toolName: "Read", path: readPath })
+            ) {
+              logger.debug("canUseTool: auto-allowing pre-granted handoff Read", {
+                threadId: tid,
+                path: readPath,
+              });
+              return { behavior: "allow" as const, updatedInput: input };
+            }
           }
 
           const requestId = crypto.randomUUID();

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -15,7 +15,35 @@ import { stubEnvService } from "../../../__tests__/stub-env-service.js";
  * stopSession drain, shutdown drain. They do NOT spawn a codex child
  * process; we call handleApprovalRequest directly as if CodexAppServer
  * had invoked our handler.
+ *
+ * Session lifecycle now lives in the held SessionRuntime. The provider holds
+ * `runtime`, whose private `sessions` pool keys `sessionId -> { state, pids,
+ * lastUsedAt }`. `seedSession` plants a fake-server state directly in that pool
+ * so the permission-drain paths have something to iterate without spawning a
+ * real child.
  */
+function seedSession(
+  provider: CodexProvider,
+  sessionId: string,
+  threadId: string,
+  state: Record<string, unknown>,
+): { kill: ReturnType<typeof vi.fn> } {
+  const fullState: Record<string, unknown> = {
+    sessionId,
+    threadId,
+    runTurnSeq: 0,
+    pendingTurnId: null,
+    ...state,
+  };
+  const pool = (
+    provider as unknown as {
+      runtime: { sessions: Map<string, { state: unknown; pids: number[]; lastUsedAt: number }> };
+    }
+  ).runtime.sessions;
+  pool.set(sessionId, { state: fullState, pids: [], lastUsedAt: (state.lastUsedAt as number) ?? Date.now() });
+  return fullState.server as { kill: ReturnType<typeof vi.fn> };
+}
+
 describe("CodexProvider permission flow", () => {
   let provider: CodexProvider;
   const threadId = "thread-abc";
@@ -26,12 +54,12 @@ describe("CodexProvider permission flow", () => {
     // settingsService and jobObject are unused for these paths; pass minimal stubs.
     provider = new CodexProvider(
       { get: async () => ({ provider: { cli: { codex: "codex" } } }) } as never,
-      { assign: vi.fn() } as never,
+      { assign: vi.fn(), isWindowsJob: false } as never,
       stubEnvService() as never,
     );
     // Pre-register a session entry so drain logic has something to iterate.
-    (provider as unknown as { sessions: Map<string, unknown> }).sessions.set(sessionId, {
-      server: { kill: vi.fn().mockResolvedValue(undefined), isAlive: true },
+    seedSession(provider, sessionId, threadId, {
+      server: { kill: vi.fn().mockResolvedValue(undefined), interruptTurn: vi.fn().mockResolvedValue(undefined), isAlive: true },
       mapper: { reset: vi.fn() },
       lastUsedAt: Date.now() - 1000,
       sandboxMode: "workspace-write",
@@ -139,13 +167,11 @@ describe("CodexProvider permission flow", () => {
     provider.on("permission_resolved", (p) => resolved.push(p as never));
 
     // Re-register session with a fake server that we can drive fatal from.
-    const sessions = (provider as unknown as {
-      sessions: Map<string, { server: unknown; lastUsedAt: number; sandboxMode: string; mapper: unknown }>;
-    }).sessions;
     const fakeServer = new (require("events").EventEmitter)();
     fakeServer.kill = vi.fn().mockResolvedValue(undefined);
+    fakeServer.interruptTurn = vi.fn().mockResolvedValue(undefined);
     fakeServer.isAlive = true;
-    sessions.set(sessionId, {
+    seedSession(provider, sessionId, threadId, {
       server: fakeServer,
       mapper: { reset: vi.fn() },
       lastUsedAt: Date.now(),
@@ -173,27 +199,31 @@ describe("CodexProvider permission flow", () => {
     expect(resolved[0].decision).toBe("cancelled");
   });
 
-  it("evictIdleSessions skips sessions that have pending permissions", () => {
-    // Force the session's lastUsedAt well past the idle threshold.
-    const sessions = (provider as unknown as {
-      sessions: Map<string, { lastUsedAt: number; server: { kill: () => Promise<void> } }>;
-    }).sessions;
-    const existing = sessions.get(sessionId)!;
-    existing.lastUsedAt = Date.now() - 60 * 60 * 1000; // 1 hour ago
+  it("runtime eviction spares a session with a turn in flight (busy guard)", async () => {
+    // The runtime owns idle eviction now and consults the adapter's isBusy
+    // guard. A pending permission only ever exists mid-turn, so the converged
+    // guard derives busyness from pendingTurnId: a turn in flight => not evicted.
+    const runtime = (
+      provider as unknown as {
+        runtime: {
+          sessions: Map<string, { state: { pendingTurnId: string | null }; lastUsedAt: number }>;
+          evictIdle: () => Promise<void>;
+        };
+      }
+    ).runtime;
+    const entry = runtime.sessions.get(sessionId)!;
+    entry.lastUsedAt = Date.now() - 60 * 60 * 1000; // 1 hour ago
+    entry.state.pendingTurnId = "turn-1"; // a turn is in flight => busy
 
-    // Queue a pending permission on the same thread.
-    void (provider as unknown as {
-      handleApprovalRequest: (s: string, t: string, r: unknown) => Promise<unknown>;
-    }).handleApprovalRequest(sessionId, threadId, {
-      rpcId: 99,
-      method: "item/commandExecution/requestApproval",
-      params: { command: "x", cwd: "/" },
-    });
+    await runtime.evictIdle();
 
-    (provider as unknown as { evictIdleSessions: () => void }).evictIdleSessions();
+    // Busy session must survive the sweep regardless of idle time.
+    expect(runtime.sessions.has(sessionId)).toBe(true);
 
-    // Session must NOT have been evicted while a permission is pending.
-    expect(sessions.has(sessionId)).toBe(true);
+    // Once the turn settles (pendingTurnId cleared) the same idle session is evictable.
+    entry.state.pendingTurnId = null;
+    await runtime.evictIdle();
+    expect(runtime.sessions.has(sessionId)).toBe(false);
   });
 
   it("drains pending permissions when sendMessage detects a permission mode swap", async () => {

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -221,13 +221,15 @@ describe("CodexProvider permission flow", () => {
     };
 
     vi.useRealTimers();
-    await provider.sendMessage({
+    await provider.sendTurn({
       sessionId,
+      threadId,
       message: "hi",
       cwd: "/",
       model: "gpt-5",
-      resume: false,
       permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: {},
     });
 
     const response = await pendingPromise;

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -16,6 +16,8 @@ import { logger } from "@mcode/shared";
 import { SettingsService } from "../../services/settings-service.js";
 import { JobObject } from "../../services/job-object.js";
 import { EnvService } from "../../services/env-service.js";
+import { SessionRuntime } from "../../services/session-runtime.js";
+import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import type {
   IAgentProvider,
   TurnRequest,
@@ -39,10 +41,6 @@ import {
 } from "./codex-permission-mapper.js";
 import type { TurnInputPart, CodexNotification } from "./codex-types.js";
 
-/** Idle TTL before a session is evicted (10 minutes). */
-const IDLE_TTL_MS = 10 * 60 * 1000;
-/** How often to check for idle sessions (1 minute). */
-const EVICTION_INTERVAL_MS = 60 * 1000;
 /**
  * Maximum wall-clock idle between Codex app-server notifications while
  * waiting for `turn/completed`. The timer resets on every notification so
@@ -59,7 +57,18 @@ class CodexTurnSupersededError extends Error {
   }
 }
 
-interface SessionEntry {
+/**
+ * Per-session state owned by the {@link SessionRuntime}. Holds the live
+ * app-server, its event mapper, and the turn-sequencing bookkeeping that the
+ * provider's `runTurn` reads. The runtime owns eviction timing, but
+ * `lastUsedAt` is retained here because `resolvePermission` stamps it so user
+ * attention on a permission card counts as activity.
+ */
+interface CodexSessionState {
+  /** Session id this state belongs to; lets `close`/drain reference provider-owned maps. */
+  sessionId: string;
+  /** Thread id derived from the session id; reused for event emission on teardown. */
+  threadId: string;
   server: CodexAppServer;
   mapper: CodexEventMapper;
   lastUsedAt: number;
@@ -122,7 +131,7 @@ function toCodexEffort(level?: ReasoningLevel): string | undefined {
 
 /** Codex provider adapter implementing IAgentProvider with a persistent app-server process per session. */
 @injectable()
-export class CodexProvider extends EventEmitter implements IAgentProvider {
+export class CodexProvider extends EventEmitter implements IAgentProvider, ProtocolAdapter<CodexSessionState> {
   readonly id: ProviderId = "codex";
   /** Codex CLI is an agentic tool with no one-shot text completion mode. */
   readonly supportsCompletion = false;
@@ -134,16 +143,25 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     return CODEX_STATIC_MODELS.map((m) => ({ ...m }));
   }
 
-  private sessions = new Map<string, SessionEntry>();
+  /** Owns the session pool, idle eviction (with busy guard), and JobObject/kill. */
+  private readonly runtime: SessionRuntime<CodexSessionState>;
   private sdkSessionIds = new Map<string, string>();
   /**
    * Session IDs for which a stop was requested before the session was created.
    * Checked after session creation; if found the session is torn down immediately.
    */
   private pendingStops = new Set<string>();
-  private evictionTimer: ReturnType<typeof setInterval> | null = null;
   /** Pending host-side permission approvals keyed by requestId. */
   private pendingPermissions = new Map<string, PendingPermissionEntry>();
+  /**
+   * Turn input + options carried from `sendTurn` to `spawn` so a freshly
+   * spawned session can run its first turn. The runtime's `acquire` only hands
+   * back the state, so the per-turn payload is staged here keyed by sessionId.
+   */
+  private pendingSpawnTurns = new Map<
+    string,
+    { input: string | TurnInputPart[]; turnOptions: { model?: string; effort?: string; serviceTier?: string } }
+  >();
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
@@ -151,6 +169,10 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     @inject(EnvService) private readonly envService: EnvService,
   ) {
     super();
+    this.runtime = new SessionRuntime<CodexSessionState>(this, {
+      jobObject: this.jobObject,
+      envService: this.envService,
+    });
   }
 
   /**
@@ -170,22 +192,12 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
       sessionId, message, cwd, model, permissionMode,
       reasoningLevel, attachments,
     } = req;
-    const resume = req.resumeFrom !== undefined;
     const codexFastMode = req.providerOptions.fastMode;
 
     const input = buildCodexInput(message, attachments);
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
 
-    if (!this.evictionTimer) {
-      this.evictionTimer = setInterval(
-        () => this.evictIdleSessions(),
-        EVICTION_INTERVAL_MS,
-      );
-    }
-
     const sandbox = permissionMode === "full" ? "danger-full-access" : "workspace-write";
-    const approvalPolicy = permissionMode === "full" ? "never" : "on-request";
-    const existing = this.sessions.get(sessionId);
 
     const useFastTier =
       codexFastMode !== undefined
@@ -199,62 +211,115 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
       ...(fastServiceTier && { serviceTier: fastServiceTier }),
     };
 
-    if (existing) {
-      // Resilience: the cached SessionEntry may point at a dead app-server
-      // (codex CLI idle-killed, host suspend/resume, or the "exit" event has
-      // not yet drained the EventEmitter queue). Reusing a dead server makes
-      // the next user message hang on a turn/start RPC until the 30s timeout
-      // fires, surfaced to the user as a generic timeout error. Detect the
-      // dead-server case and fall through to a clean respawn instead.
-      if (!existing.server.isAlive) {
-        logger.info("Codex session was dead; respawning", { sessionId });
-        this.drainPending((e) => e.sessionId === sessionId);
-        this.sessions.delete(sessionId);
-      } else if (existing.sandboxMode === sandbox) {
-        // Same permission mode - reuse the running session
-        existing.lastUsedAt = Date.now();
-        existing.mapper.reset();
-        void this.runTurn(sessionId, threadId, existing.server, input, turnOptions);
-        return;
-      } else {
-      // Permission mode changed - kill the old session so we can start fresh with the correct sandbox
+    // Permission-mode change requires a fresh thread, not just a respawn: the
+    // resumed thread would inherit the old sandbox. Clearing the stored SDK
+    // thread ID and draining the stale session is Codex-specific bookkeeping
+    // the runtime cannot do, so handle it here before acquiring.
+    const existing = this.runtime.get(sessionId);
+    if (existing && existing.server.isAlive && existing.sandboxMode !== sandbox) {
       logger.info("Codex session restarted due to permission mode change", {
         sessionId,
         from: existing.sandboxMode,
         to: sandbox,
       });
-      // Drain pending permissions for this session before kill. The app-server's
-      // graceful exit path suppresses the "fatal" emit (killRequested=true), so
-      // attachFatalDrain won't fire here; cancel any open cards explicitly so
-      // the UI doesn't keep a stale amber dot on an orphaned request.
+      // Drain synchronously here (not only via close()) so approval cards
+      // clear deterministically even if the version check below aborts before
+      // `acquire` discards the stale session. The app-server's graceful exit
+      // suppresses the "fatal" emit, so the fatal-drain listener will not fire.
       this.drainPending((e) => e.sessionId === sessionId);
-      this.sessions.delete(sessionId);
-      // Clear the stored SDK thread ID so the new session starts fresh rather than
-      // resuming the old thread (which would inherit the old sandbox mode).
+      // Clear the stored SDK thread id so the respawn starts a fresh thread
+      // rather than resuming the old one (which would inherit the old sandbox).
       this.sdkSessionIds.delete(sessionId);
-      existing.server.kill().catch((err: unknown) => {
+      // Eagerly tear the stale session down so a later abort (e.g. a failed
+      // version check below) cannot leave a wrong-sandbox process alive.
+      // `acquire` then spawns fresh. Fire-and-forget: permissions are already
+      // drained above, so the async close has nothing left to resolve.
+      void this.runtime.stop(sessionId).catch((err: unknown) => {
         logger.warn("Codex session kill on permission change failed", { error: String(err) });
       });
+    }
+
+    // Version check only when starting a new session (cached in codex-version
+    // per CLI path). Reusing a live, mode-matched session skips this. Emit
+    // user-facing errors and abort before touching the runtime so a bad CLI
+    // never spawns a child.
+    const reusable = existing && existing.server.isAlive && existing.sandboxMode === sandbox;
+    if (!reusable) {
+      const versionResult = checkCodexVersion(cliPath);
+      if (!versionResult.ok) {
+        this.emit("event", { type: AgentEventType.Error, threadId, error: versionResult.error } satisfies AgentEvent);
+        this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+        return;
+      }
+
+      if (!meetsMinVersion(versionResult.version, "0.37.0")) {
+        const errorMsg = `Codex CLI version ${versionResult.version} is not supported. Minimum required: 0.37.0. Update with: npm install -g @openai/codex`;
+        this.emit("event", { type: AgentEventType.Error, threadId, error: errorMsg } satisfies AgentEvent);
+        this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+        return;
       }
     }
 
-    // Version check only when starting a new session (cached in codex-version per CLI path).
-    const versionResult = checkCodexVersion(cliPath);
-    if (!versionResult.ok) {
-      this.emit("event", { type: AgentEventType.Error, threadId, error: versionResult.error } satisfies AgentEvent);
+    // Stage the per-turn payload so `spawn` can run the first turn of a fresh
+    // session; reuse reads it directly below. Keyed by sessionId.
+    this.pendingSpawnTurns.set(sessionId, { input, turnOptions });
+
+    let state: CodexSessionState;
+    try {
+      state = await this.runtime.acquire({
+        sessionId,
+        threadId,
+        cwd,
+        permissionMode,
+        resumeFrom:
+          req.resumeFrom !== undefined ? this.sdkSessionIds.get(sessionId) : undefined,
+      });
+    } catch (e: unknown) {
+      this.pendingSpawnTurns.delete(sessionId);
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      logger.error("CodexAppServer start failed", { sessionId, error: errorMessage });
+      this.emit("event", { type: AgentEventType.Error, threadId, error: errorMessage } satisfies AgentEvent);
+      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      return;
+    }
+    this.runtime.recordUsage(sessionId);
+
+    // A stop requested before the session finished spawning: tear it down now.
+    if (this.pendingStops.delete(sessionId)) {
+      logger.info("Pending stop consumed, tearing down new Codex session", { sessionId });
+      this.pendingSpawnTurns.delete(sessionId);
+      void this.runtime.stop(sessionId);
       this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
       return;
     }
 
-    if (!meetsMinVersion(versionResult.version, "0.37.0")) {
-      const errorMsg = `Codex CLI version ${versionResult.version} is not supported. Minimum required: 0.37.0. Update with: npm install -g @openai/codex`;
-      this.emit("event", { type: AgentEventType.Error, threadId, error: errorMsg } satisfies AgentEvent);
-      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+    // Reuse path: `spawn` did not run because the session already existed, so
+    // the staged turn is still pending. Reset the mapper and run it here.
+    if (reusable && this.pendingSpawnTurns.delete(sessionId)) {
+      state.lastUsedAt = Date.now();
+      state.mapper.reset();
+      void this.runTurn(sessionId, threadId, state.server, input, turnOptions);
       return;
     }
+  }
 
-    const resumeId = this.sdkSessionIds.get(sessionId);
-    const attemptResume = !!(resume && resumeId);
+  /**
+   * Spawns a fresh Codex app-server session: version-checked CLI launch, the
+   * JSON-RPC handshake, mapper + event wiring, and the first turn for the
+   * staged payload. Returns an empty `pids` array because {@link CodexAppServer}
+   * keeps its child PID private and attaches it to the Windows JobObject
+   * itself; the runtime's JobObject/taskkill are therefore best-effort no-ops
+   * for Codex and teardown is delegated to `server.kill()` in {@link close}.
+   */
+  async spawn(args: SpawnArgs): Promise<SpawnResult<CodexSessionState>> {
+    const settings = await this.settingsService.get();
+    const cliPath = settings.provider.cli.codex || "codex";
+    const { sessionId, threadId, cwd, permissionMode, resumeFrom } = args;
+
+    const sandbox = permissionMode === "full" ? "danger-full-access" : "workspace-write";
+    const approvalPolicy = permissionMode === "full" ? "never" : "on-request";
+
+    const attemptResume = !!resumeFrom;
 
     // Only register the handler in supervised mode. The CodexAppServer
     // ignores approvalHandler when approvalPolicy === "never" (auto-approve
@@ -265,15 +330,17 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     const server = new CodexAppServer({
       cliPath,
       workingDirectory: cwd,
-      model: model || undefined,
+      // The model passed at thread/start is carried on the turn payload too;
+      // settings drive it indirectly via the staged turnOptions.
+      model: undefined,
       sandbox,
       approvalPolicy,
-      resumeThreadId: attemptResume ? resumeId : undefined,
+      resumeThreadId: attemptResume ? resumeFrom : undefined,
       approvalHandler: supervised
         ? (req) => this.handleApprovalRequest(sessionId, threadId, req)
         : undefined,
       jobObject: this.jobObject,
-      getSpawnEnv: () => this.envService.getEnv(),
+      getSpawnEnv: () => args.env,
     });
 
     const mapper = new CodexEventMapper(threadId);
@@ -282,7 +349,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
       const n = notification as { method?: string; params?: Record<string, unknown> };
       if (n.method === "turn/started") {
         const turn = n.params?.turn as { id?: string } | undefined;
-        const entry = this.sessions.get(sessionId);
+        const entry = this.runtime.get(sessionId);
         if (entry && turn?.id) entry.pendingTurnId = turn.id;
       }
       const events = mapper.mapNotification(notification as CodexNotification);
@@ -308,26 +375,20 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
       logger.error("CodexAppServer fatal", { sessionId, error });
       this.emit("event", { type: AgentEventType.Error, threadId, error } satisfies AgentEvent);
       this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-      this.sessions.delete(sessionId);
+      void this.runtime.stop(sessionId);
     });
 
     this.attachFatalDrain(sessionId, server);
 
     server.on("exit", () => {
       if (!server.isAlive) {
-        this.sessions.delete(sessionId);
+        void this.runtime.stop(sessionId);
       }
     });
 
-    try {
-      await server.start();
-    } catch (e: unknown) {
-      const errorMessage = e instanceof Error ? e.message : String(e);
-      logger.error("CodexAppServer start failed", { sessionId, error: errorMessage });
-      this.emit("event", { type: AgentEventType.Error, threadId, error: errorMessage } satisfies AgentEvent);
-      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-      return;
-    }
+    // Propagates start failures to the runtime, which surfaces them to the
+    // `acquire` caller in `sendTurn` (emits Error/Ended there).
+    await server.start();
 
     if (server.resumeFailed) {
       logger.warn("Codex session context lost; resume failed, started fresh thread", { sessionId });
@@ -347,26 +408,58 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
       } satisfies AgentEvent);
     }
 
-    this.sessions.set(sessionId, {
+    const state: CodexSessionState = {
+      sessionId,
+      threadId,
       server,
       mapper,
       lastUsedAt: Date.now(),
       sandboxMode: sandbox,
       runTurnSeq: 0,
       pendingTurnId: null,
-    });
+    };
 
-    if (this.pendingStops.delete(sessionId)) {
-      logger.info("Pending stop consumed, tearing down new Codex session", { sessionId });
-      void server.kill().catch((err: unknown) => {
-        logger.warn("Codex pending-stop kill failed", { sessionId, error: String(err) });
+    // Run the first turn for the staged payload. `sendTurn` consults
+    // `pendingStops` after `acquire` returns; only fire the turn if no stop
+    // raced in. The runtime stores the state before this resolves, so
+    // `runTurn`'s `this.runtime.get(sessionId)` sees it.
+    const staged = this.pendingSpawnTurns.get(sessionId);
+    if (staged && !this.pendingStops.has(sessionId)) {
+      this.pendingSpawnTurns.delete(sessionId);
+      queueMicrotask(() => {
+        if (this.runtime.get(sessionId) !== state) return;
+        void this.runTurn(sessionId, threadId, server, staged.input, staged.turnOptions);
       });
-      this.sessions.delete(sessionId);
-      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-      return;
     }
 
-    void this.runTurn(sessionId, threadId, server, input, turnOptions);
+    return { state, pids: [] };
+  }
+
+  /** Eviction guard: a turn is in flight while `pendingTurnId` is set. */
+  isBusy(state: CodexSessionState): boolean {
+    return state.pendingTurnId != null;
+  }
+
+  /** Graceful protocol interrupt of the in-flight turn (does not kill the process). */
+  async interrupt(state: CodexSessionState): Promise<void> {
+    await state.server.interruptTurn();
+  }
+
+  /**
+   * Provider teardown: drain pending permissions for this session as
+   * cancelled (so orphaned approval cards clear), then kill the app-server.
+   * Drives every teardown path (stop, shutdown, eviction, stale-discard).
+   */
+  async close(state: CodexSessionState): Promise<void> {
+    this.drainPending((e) => e.sessionId === state.sessionId);
+    await state.server.kill();
+  }
+
+  /** A pooled session must be discarded before reuse if the process died or the sandbox/permission mode changed. */
+  isStale(state: CodexSessionState, args: { cwd: string; permissionMode: string }): boolean {
+    if (!state.server.isAlive) return true;
+    const sandbox = args.permissionMode === "full" ? "danger-full-access" : "workspace-write";
+    return state.sandboxMode !== sandbox;
   }
 
   /**
@@ -381,7 +474,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     input: string | TurnInputPart[],
     turnOptions?: { model?: string; effort?: string; serviceTier?: string },
   ): Promise<void> {
-    const entry = this.sessions.get(sessionId);
+    const entry = this.runtime.get(sessionId);
     if (!entry) return;
 
     entry.abortPendingTurnWait?.();
@@ -468,6 +561,12 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
         this.emit("event", { type: AgentEventType.Error, threadId, error: errorMessage } satisfies AgentEvent);
       }
     } finally {
+      if (seq === entry.runTurnSeq) {
+        // The turn for this seq has settled: clear the in-flight marker so the
+        // runtime's busy guard (`isBusy` reads `pendingTurnId`) stops sparing
+        // the session from idle eviction. A superseding turn owns its own id.
+        entry.pendingTurnId = null;
+      }
       if (!serverDied && seq === entry.runTurnSeq && !endedEmitted) {
         endedEmitted = true;
         this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
@@ -520,7 +619,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     this.pendingPermissions.delete(requestId);
 
     // Reset idle timer on the owning session so user attention counts as activity.
-    const session = this.sessions.get(entry.sessionId);
+    this.runtime.recordUsage(entry.sessionId);
+    const session = this.runtime.get(entry.sessionId);
     if (session) session.lastUsedAt = Date.now();
 
     const response = mapDecisionToCodexResponse(entry.method, decision, entry.params);
@@ -571,54 +671,40 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Evicts sessions that have been idle longer than IDLE_TTL_MS. Sessions with pending permissions are spared. */
-  private evictIdleSessions(): void {
-    const now = Date.now();
-    // Build the set of sessionIds with at least one pending permission once
-    // rather than iterating the map per session.
-    const hasPending = new Set<string>();
-    for (const entry of this.pendingPermissions.values()) {
-      hasPending.add(entry.sessionId);
-    }
-    for (const [sessionId, entry] of this.sessions) {
-      if (hasPending.has(sessionId)) continue;
-      if (now - entry.lastUsedAt > IDLE_TTL_MS) {
-        logger.info("Evicted idle Codex session", { sessionId });
-        void entry.server.kill();
-        this.sessions.delete(sessionId);
-      }
-    }
-  }
-
-
-  /** Kills a running session's subprocess and cancels any pending permissions for its thread. */
+  /**
+   * Kills a running session's subprocess and cancels any pending permissions
+   * for its thread. The runtime's `stop` runs `interrupt` → `close` (which
+   * drains permissions for the session, see {@link close}) → hard kill. When
+   * the session has not spawned yet, record the intent so `sendTurn`/`spawn`
+   * tear it down on arrival.
+   */
   stopSession(sessionId: string): void {
-    const entry = this.sessions.get(sessionId);
-    // Drain first so handler promises resolve with the cancel response BEFORE
-    // we kill(). That way the app-server sees the cancel decision, interrupts
-    // the turn cleanly, and there is no race with the process exiting.
-    this.drainPending((e) => e.sessionId === sessionId);
-    if (entry) {
-      void entry.server.kill();
-      this.sessions.delete(sessionId);
+    const exists = this.runtime.get(sessionId) !== undefined;
+    if (exists) {
+      void this.runtime.stop(sessionId).catch((err: unknown) => {
+        logger.warn("Codex stopSession failed", { sessionId, error: String(err) });
+      });
     } else {
+      // Drain any pending permissions for a session still mid-spawn so cards
+      // clear immediately; close() will not run until/unless the session lands.
+      this.drainPending((e) => e.sessionId === sessionId);
       this.pendingStops.add(sessionId);
+      this.pendingSpawnTurns.delete(sessionId);
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
     }
   }
 
   /** Tears down all sessions, drains pending permissions, and stops the eviction timer. */
   shutdown(): void {
-    if (this.evictionTimer) {
-      clearInterval(this.evictionTimer);
-      this.evictionTimer = null;
-    }
+    // Drain everything up front: `runtime.shutdown` stops each session
+    // (close drains per-session), but draining all here also clears any
+    // permissions whose session never landed in the pool.
     this.drainPending(() => true);
-    for (const [, entry] of this.sessions) {
-      void entry.server.kill();
-    }
-    this.sessions.clear();
+    void this.runtime.shutdown().catch((err: unknown) => {
+      logger.warn("Codex runtime shutdown failed", { error: String(err) });
+    });
     this.sdkSessionIds.clear();
+    this.pendingSpawnTurns.clear();
     logger.info("CodexProvider shutdown complete");
   }
 }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -18,6 +18,7 @@ import { JobObject } from "../../services/job-object.js";
 import { EnvService } from "../../services/env-service.js";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   AgentEvent,
@@ -157,26 +158,20 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
    * For new sessions, spawns a subprocess and runs the JSON-RPC handshake first.
    * The method returns immediately; events stream via the `event` EventEmitter channel.
    */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /** When true, pass OpenAI fast service tier; when false, standard. Undefined uses global settings. */
-    codexFastMode?: boolean;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"codex">): Promise<void> {
     const settings = await this.settingsService.get();
     const cliPath = settings.provider.cli.codex || "codex";
 
+    // `resumeFrom` defined ⇒ resume that Codex thread; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
     const {
-      sessionId, message, cwd, model, resume, permissionMode,
-      reasoningLevel, attachments, codexFastMode,
-    } = params;
+      sessionId, message, cwd, model, permissionMode,
+      reasoningLevel, attachments,
+    } = req;
+    const resume = req.resumeFrom !== undefined;
+    const codexFastMode = req.providerOptions.fastMode;
 
     const input = buildCodexInput(message, attachments);
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
@@ -595,10 +590,6 @@ export class CodexProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Pre-loads an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
 
   /** Kills a running session's subprocess and cancels any pending permissions for its thread. */
   stopSession(sessionId: string): void {

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -18,8 +18,10 @@ import { JobObject } from "../../services/job-object.js";
 import { EnvService } from "../../services/env-service.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
+import { DeterministicForker } from "../../services/handoff/session-forker.js";
 import type {
   IAgentProvider,
+  SessionForker,
   TurnRequest,
   ProviderId,
   ReasoningLevel,
@@ -137,6 +139,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, Proto
   readonly supportsCompletion = false;
   readonly sessionForkOnResume = "unsupported" as const;
   readonly maxInputCharactersPerTurn = 16_000;
+  /** Path D forker; Codex cannot fork a session, so handoffs are deterministic. */
+  readonly forker: SessionForker = new DeterministicForker();
 
   /** Returns the static Codex model catalog. Codex does not support dynamic model discovery. */
   async listModels(): Promise<ProviderModelInfo[]> {

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -25,6 +25,7 @@ import { SettingsService } from "../../services/settings-service.js";
 import { EnvService } from "../../services/env-service.js";
 import type {
   IAgentProvider,
+  TurnRequest,
   ProviderId,
   ReasoningLevel,
   AgentEvent,
@@ -465,19 +466,23 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   private contextWindowBySession = new Map<string, number>();
 
   /** Start or continue a session by sending a message via the Copilot SDK. When `copilotAgent` is provided, routes the session to the appropriate built-in mode or custom agent before sending. */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /** Copilot sub-agent name. Built-in modes: "interactive" | "plan" | "autopilot". Custom: any YAML agent name. */
-    copilotAgent?: string;
-  }): Promise<void> {
+  async sendTurn(req: TurnRequest<"copilot">): Promise<void> {
+    // `resumeFrom` defined ⇒ resume that SDK session; undefined ⇒ fresh.
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
+    }
+    const params = {
+      sessionId: req.sessionId,
+      message: req.message,
+      cwd: req.cwd,
+      model: req.model,
+      fallbackModel: req.fallbackModel,
+      resume: req.resumeFrom !== undefined,
+      permissionMode: req.permissionMode,
+      attachments: req.attachments,
+      reasoningLevel: req.reasoningLevel,
+      copilotAgent: req.providerOptions.agent,
+    };
     try {
       await this.doSendMessage(params);
     } catch (e: unknown) {
@@ -940,11 +945,6 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         this.contextWindowBySession.delete(sessionId);
       }
     }
-  }
-
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
   }
 
   /** Disconnect and remove an active session, or record a pending stop if the session hasn't been created yet. */

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -23,6 +23,9 @@ import { discoverCopilotAgents, COPILOT_DEFAULT_AGENTS } from "./copilot-agent-d
 import { logger } from "@mcode/shared";
 import { SettingsService } from "../../services/settings-service.js";
 import { EnvService } from "../../services/env-service.js";
+import { JobObject } from "../../services/job-object.js";
+import { SessionRuntime } from "../../services/session-runtime.js";
+import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import type {
   IAgentProvider,
   TurnRequest,
@@ -121,24 +124,31 @@ function inferModelGroup(modelId: string): string | undefined {
   return undefined;
 }
 
-/** Idle TTL before a session is evicted (10 minutes). */
-const IDLE_TTL_MS = 10 * 60 * 1000;
-/** How often to check for idle sessions (1 minute). */
-const EVICTION_INTERVAL_MS = 60 * 1000;
-
 /** Names of built-in Copilot session modes, derived from COPILOT_DEFAULT_AGENTS. */
 const BUILTIN_MODE_NAMES = new Set<"interactive" | "plan" | "autopilot">(
   COPILOT_DEFAULT_AGENTS.map((a) => a.name as "interactive" | "plan" | "autopilot"),
 );
 
-interface SessionEntry {
+/**
+ * Per-session state owned by the {@link SessionRuntime}. Holds the live Copilot
+ * SDK session plus the turn-active flag the runtime's busy guard reads. Copilot
+ * exposes no native busy signal, so `turnActive` is the provider-maintained
+ * substitute: set true while a turn runs, false when it settles.
+ */
+interface CopilotSessionState {
   session: CopilotSession;
   lastUsedAt: number;
+  /**
+   * True while a turn is in flight. The SDK has no busy signal, so the provider
+   * toggles this in `runTurn` to give the runtime's idle-eviction guard a real
+   * busy check (the drift this migration converges).
+   */
+  turnActive: boolean;
 }
 
 /** GitHub Copilot SDK adapter implementing IAgentProvider with callback-based event mapping. */
 @injectable()
-export class CopilotProvider extends EventEmitter implements IAgentProvider {
+export class CopilotProvider extends EventEmitter implements IAgentProvider, ProtocolAdapter<CopilotSessionState> {
   readonly id: ProviderId = "copilot";
   readonly supportsCompletion = true;
   readonly sessionForkOnResume = "unsupported" as const;
@@ -148,14 +158,21 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   private lastCliPath: string | undefined;
   /** Cached result of `which("node")` so we don't re-probe PATH on every rebuild. */
   private cachedNodePath: string | null | undefined;
-  private sessions = new Map<string, SessionEntry>();
+  /** Owns the session pool, idle eviction (now with a real busy guard via `isBusy`), and JobObject/kill. */
+  private readonly runtime: SessionRuntime<CopilotSessionState>;
   private sdkSessionIds = new Map<string, string>();
   /**
    * Session IDs for which a stop was requested before the session was created.
    * Checked after session creation; if found the session is torn down immediately.
    */
   private pendingStops = new Set<string>();
-  private evictionTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Per-turn payload carried from `sendTurn` to `spawn` so a freshly spawned
+   * session can run its first turn. The runtime's `acquire` only returns the
+   * state, so the turn message and agent routing are staged here keyed by
+   * sessionId.
+   */
+  private pendingSpawnTurns = new Map<string, { message: string; model?: string; copilotAgent?: string }>();
   /** Serialises concurrent refreshClient() calls so only one rebuild runs at a time. */
   private clientStartLock: Promise<void> = Promise.resolve();
 
@@ -166,9 +183,14 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
+    @inject("JobObject") private readonly jobObject: JobObject,
     @inject(EnvService) private readonly envService: EnvService,
   ) {
     super();
+    this.runtime = new SessionRuntime<CopilotSessionState>(this, {
+      jobObject: this.jobObject,
+      envService: this.envService,
+    });
   }
 
   /**
@@ -538,44 +560,80 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
   }): Promise<void> {
     await this.refreshClient();
 
-    const { sessionId, message, cwd, model, resume, copilotAgent } = params;
-
-    if (!this.evictionTimer) {
-      this.evictionTimer = setInterval(
-        () => this.evictIdleSessions(),
-        EVICTION_INTERVAL_MS,
-      );
-    }
-
+    const { sessionId, message, cwd, model, permissionMode, resume, copilotAgent } = params;
     const threadId = this.toThreadId(sessionId);
 
-    // Double-checked locking: re-read after the async refreshClient() await so
-    // concurrent sendMessage calls that both passed the first check don't each
-    // create a new SDK session for the same sessionId.
-    const existing = this.sessions.get(sessionId);
-    if (existing) {
-      existing.lastUsedAt = Date.now();
-      // Apply agent routing so mid-thread agent changes take effect on cached sessions.
-      if (copilotAgent) {
-        if (BUILTIN_MODE_NAMES.has(copilotAgent as "interactive" | "plan" | "autopilot")) {
-          await existing.session.rpc.mode.set({ mode: copilotAgent as "interactive" | "plan" | "autopilot" });
-          logger.info("CopilotProvider: set built-in mode on cached session", { sessionId, mode: copilotAgent });
-        } else {
-          await existing.session.rpc.agent.select({ name: copilotAgent });
-          logger.info("CopilotProvider: selected custom agent on cached session", { sessionId, agent: copilotAgent });
-        }
-      }
-      // Abort in-flight turn by sending a new message on the existing session.
-      // The previous runTurn promise will resolve when session.idle fires.
-      void this.runTurn(sessionId, threadId, existing.session, message);
-      return;
+    // Re-read after the async refreshClient() await so concurrent sends that
+    // both passed the first check don't each create a new SDK session for the
+    // same sessionId.
+    const existing = this.runtime.get(sessionId);
+
+    // Stage the per-turn options (model, agent routing) so `spawn` can build a
+    // fresh session correctly. The turn itself is run here after `acquire`
+    // (uniformly for fresh and reuse paths) so it never races the runtime's
+    // post-spawn pool write.
+    this.pendingSpawnTurns.set(sessionId, { message, model, copilotAgent });
+
+    let state: CopilotSessionState;
+    try {
+      state = await this.runtime.acquire({
+        sessionId,
+        threadId,
+        cwd,
+        permissionMode,
+        resumeFrom: resume ? this.sdkSessionIds.get(sessionId) : undefined,
+      });
+    } catch (e: unknown) {
+      this.pendingSpawnTurns.delete(sessionId);
+      throw e;
     }
+    this.pendingSpawnTurns.delete(sessionId);
+    this.runtime.recordUsage(sessionId);
+
+    // A stop requested before the session finished spawning: `spawn` already
+    // tore it down and emitted Ended, so do not run the turn.
+    if (this.pendingStops.has(sessionId)) return;
+
+    state.lastUsedAt = Date.now();
+
+    // Reuse path: `spawn` did not run, so apply agent routing here so mid-thread
+    // agent changes take effect on the cached session. (Fresh sessions get
+    // routing applied in `spawn` when first created.)
+    if (existing && copilotAgent) {
+      if (BUILTIN_MODE_NAMES.has(copilotAgent as "interactive" | "plan" | "autopilot")) {
+        await state.session.rpc.mode.set({ mode: copilotAgent as "interactive" | "plan" | "autopilot" });
+        logger.info("CopilotProvider: set built-in mode on cached session", { sessionId, mode: copilotAgent });
+      } else {
+        await state.session.rpc.agent.select({ name: copilotAgent });
+        logger.info("CopilotProvider: selected custom agent on cached session", { sessionId, agent: copilotAgent });
+      }
+    }
+
+    // Run the turn. Sending a new message on an existing session implicitly
+    // aborts any in-flight turn; the prior runTurn promise resolves on idle.
+    void this.runTurn(sessionId, threadId, state.session, message);
+  }
+
+  /**
+   * Spawns a fresh Copilot SDK session: creates (or resumes) the session,
+   * applies agent routing, and captures the SDK session id. The first turn is
+   * run by the `doSendMessage` caller after the runtime stores this state, so
+   * `spawn` does not run it (avoiding a race with the runtime's pool write).
+   * Returns an empty `pids` array because the Copilot SDK manages its own
+   * subprocess and never exposes the PID; the runtime's JobObject/`taskkill`
+   * are therefore best-effort no-ops for Copilot, and teardown is delegated to
+   * `session.disconnect()` in {@link close}.
+   */
+  async spawn(args: SpawnArgs): Promise<SpawnResult<CopilotSessionState>> {
+    const { sessionId, threadId, cwd, resumeFrom } = args;
 
     const client = this.client;
     if (!client) {
       throw new Error("Copilot client not available");
     }
-    const sdkSessionId = this.sdkSessionIds.get(sessionId);
+
+    const staged = this.pendingSpawnTurns.get(sessionId);
+    const copilotAgent = staged?.copilotAgent;
 
     let session: CopilotSession;
 
@@ -594,7 +652,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         prompt: "",
       }));
 
-    // TODO(#258): respect params.permissionMode. Currently approveAll is used
+    // TODO(#258): respect args.permissionMode. Currently approveAll is used
     // unconditionally because the Copilot SDK does not expose per-action gating.
     // Until the SDK adds granular permission control, all tool actions are
     // approved automatically regardless of the thread's permissionMode setting.
@@ -602,7 +660,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     const skillDirs = userSkillDirectories();
     const sessionBase = {
       onPermissionRequest: approveAll,
-      model: model || undefined,
+      model: staged?.model || undefined,
       workingDirectory: cwd,
       enableConfigDiscovery: true,
       ...(customAgents.length > 0 && { customAgents }),
@@ -610,10 +668,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       ...(userInstructions && { systemMessage: { content: userInstructions } }),
     };
 
-    if (resume && sdkSessionId) {
+    if (resumeFrom) {
       try {
-        session = await client.resumeSession(sdkSessionId, sessionBase);
-        logger.info("Resumed Copilot session", { sessionId, sdkSessionId });
+        session = await client.resumeSession(resumeFrom, sessionBase);
+        logger.info("Resumed Copilot session", { sessionId, sdkSessionId: resumeFrom });
       } catch (err) {
         logger.warn("CopilotProvider: resume failed, starting fresh session", {
           sessionId,
@@ -650,21 +708,65 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
       } satisfies AgentEvent);
     }
 
-    const entry: SessionEntry = {
+    const state: CopilotSessionState = {
       session,
       lastUsedAt: Date.now(),
+      turnActive: false,
     };
-    this.sessions.set(sessionId, entry);
 
-    if (this.pendingStops.delete(sessionId)) {
+    if (this.pendingStops.has(sessionId)) {
       logger.info("Pending stop consumed, tearing down new Copilot session", { sessionId });
-      entry.session.disconnect().catch(() => {});
-      this.sessions.delete(sessionId);
+      session.disconnect().catch(() => {});
       this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-      return;
     }
 
-    void this.runTurn(sessionId, threadId, session, message);
+    return { state, pids: [] };
+  }
+
+  /**
+   * Eviction guard: a turn is in flight while `turnActive` is true. Copilot has
+   * no native busy signal, so `runTurn` toggles this flag; this converges the
+   * busy guard the old TTL-only eviction lacked.
+   */
+  isBusy(state: CopilotSessionState): boolean {
+    return state.turnActive;
+  }
+
+  /** Graceful protocol interrupt: disconnect the SDK session. Guarded so a double-disconnect is harmless. */
+  async interrupt(state: CopilotSessionState): Promise<void> {
+    try {
+      await state.session.disconnect();
+    } catch (err) {
+      logger.debug("CopilotProvider: interrupt disconnect failed (session may already be down)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Provider teardown. Copilot has no separate hard kill; `disconnect()` is the
+   * teardown. The runtime calls `interrupt` then `close`, both of which
+   * disconnect, so this is guarded against a double-disconnect.
+   */
+  async close(state: CopilotSessionState): Promise<void> {
+    try {
+      await state.session.disconnect();
+    } catch (err) {
+      logger.debug("CopilotProvider: close disconnect failed (session may already be down)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Whether a pooled session must be discarded before reuse. The Copilot SDK
+   * exposes no reliable per-session liveness getter and the original provider
+   * performed no cwd/model/agent staleness check before reuse (a dead session
+   * surfaces as `session.error`, which evicts it from the pool). Mirror that:
+   * never force-discard here, preserving the prior reuse behavior.
+   */
+  isStale(_state: CopilotSessionState, _args: { cwd: string; permissionMode: string }): boolean {
+    return false;
   }
 
   /**
@@ -678,6 +780,11 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     session: CopilotSession,
     message: string,
   ): Promise<void> {
+    // Mark the session busy so the runtime's idle-eviction guard spares it for
+    // the duration of the turn (Copilot has no native busy signal).
+    const turnState = this.runtime.get(sessionId);
+    if (turnState) turnState.turnActive = true;
+
     // Track per-tool start times to derive elapsedSeconds for toolProgress events.
     const toolStartTimes = new Map<string, number>();
 
@@ -698,8 +805,9 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         // assistant.message_delta - streaming text chunk
         unsubscribers.push(
           session.on("assistant.message_delta", (event) => {
-            const entry = this.sessions.get(sessionId);
+            const entry = this.runtime.get(sessionId);
             if (entry) entry.lastUsedAt = Date.now();
+            this.runtime.recordUsage(sessionId);
 
             this.emit("event", {
               type: "textDelta",
@@ -838,7 +946,9 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
 
         // session.error - provider-level error; resolve so cleanup runs.
         // Also evict the session entry so the next sendMessage creates a fresh
-        // session rather than reusing a potentially dead one.
+        // session rather than reusing a potentially dead one. The turn is
+        // settling, so clear `turnActive` before stopping so the runtime's
+        // busy guard does not block teardown.
         unsubscribers.push(
           session.on("session.error", (event) => {
             this.emit("event", {
@@ -846,8 +956,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
               threadId,
               error: event.data.message,
             } satisfies AgentEvent);
-            this.sessions.delete(sessionId);
+            const errored = this.runtime.get(sessionId);
+            if (errored) errored.turnActive = false;
             this.contextWindowBySession.delete(sessionId);
+            void this.runtime.stop(sessionId);
             resolve();
           }),
         );
@@ -918,6 +1030,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
         error: errorMessage,
       } satisfies AgentEvent);
     } finally {
+      // The turn has settled: clear the busy marker so the runtime's idle
+      // eviction (which reads `isBusy` → `turnActive`) can reclaim the session.
+      const settled = this.runtime.get(sessionId);
+      if (settled) settled.turnActive = false;
       // Deregister all per-turn handlers to prevent memory leaks across turns
       for (const unsub of unsubscribers) {
         unsub();
@@ -929,59 +1045,32 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Evict sessions that have been idle longer than IDLE_TTL_MS. */
-  private evictIdleSessions(): void {
-    const now = Date.now();
-    for (const [sessionId, entry] of this.sessions) {
-      if (now - entry.lastUsedAt > IDLE_TTL_MS) {
-        logger.info("Evicting idle Copilot session", { sessionId });
-        entry.session.disconnect().catch((err) =>
-          logger.warn("CopilotProvider: error disconnecting evicted session", {
-            sessionId,
-            error: String(err),
-          }),
-        );
-        this.sessions.delete(sessionId);
-        this.contextWindowBySession.delete(sessionId);
-      }
-    }
-  }
-
-  /** Disconnect and remove an active session, or record a pending stop if the session hasn't been created yet. */
+  /**
+   * Disconnect and remove an active session, or record a pending stop if the
+   * session hasn't been created yet. The runtime's `stop` runs `interrupt` →
+   * `close` (both disconnect the SDK session, guarded) → hard kill (a no-op for
+   * Copilot, whose PID the SDK hides).
+   */
   stopSession(sessionId: string): void {
     this.contextWindowBySession.delete(sessionId);
-    const entry = this.sessions.get(sessionId);
-    if (entry) {
-      entry.session.disconnect().catch((err) =>
-        logger.warn("CopilotProvider: error disconnecting stopped session", {
-          sessionId,
-          error: String(err),
-        }),
+    if (this.runtime.get(sessionId) !== undefined) {
+      void this.runtime.stop(sessionId).catch((err: unknown) =>
+        logger.warn("CopilotProvider: stopSession failed", { sessionId, error: String(err) }),
       );
-      this.sessions.delete(sessionId);
     } else {
       this.pendingStops.add(sessionId);
+      this.pendingSpawnTurns.delete(sessionId);
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
     }
   }
 
   /** Tear down all sessions, stop the client, and release resources. */
   shutdown(): void {
-    if (this.evictionTimer) {
-      clearInterval(this.evictionTimer);
-      this.evictionTimer = null;
-    }
-
-    for (const [sessionId, entry] of this.sessions) {
-      entry.session.disconnect().catch((err) =>
-        logger.warn("CopilotProvider: error disconnecting session during shutdown", {
-          sessionId,
-          error: String(err),
-        }),
-      );
-    }
-    this.sessions.clear();
+    void this.runtime.shutdown().catch((err: unknown) =>
+      logger.warn("CopilotProvider: runtime shutdown failed", { error: String(err) }),
+    );
     this.sdkSessionIds.clear();
+    this.pendingSpawnTurns.clear();
     this.contextWindowBySession.clear();
 
     if (this.client) {

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -595,8 +595,19 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
     this.runtime.recordUsage(sessionId);
 
     // A stop requested before the session finished spawning: `spawn` already
-    // tore it down and emitted Ended, so do not run the turn.
-    if (this.pendingStops.has(sessionId)) return;
+    // disconnected the SDK session and emitted Ended, so do not run the turn.
+    // `spawn` does not evict the runtime pool entry, and `isStale` always
+    // returns false, so without this the disconnected (dead) session would be
+    // reused on the next turn. Evict it now.
+    if (this.pendingStops.has(sessionId)) {
+      void this.runtime.stop(sessionId).catch((err: unknown) =>
+        logger.debug("CopilotProvider: stop of pending-stop session failed", {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      return;
+    }
 
     state.lastUsedAt = Date.now();
 

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -26,8 +26,10 @@ import { EnvService } from "../../services/env-service.js";
 import { JobObject } from "../../services/job-object.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
+import { DeterministicForker } from "../../services/handoff/session-forker.js";
 import type {
   IAgentProvider,
+  SessionForker,
   TurnRequest,
   ProviderId,
   ReasoningLevel,
@@ -153,6 +155,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
   readonly supportsCompletion = true;
   readonly sessionForkOnResume = "unsupported" as const;
   readonly maxInputCharactersPerTurn = 16_000;
+  /** Path D forker; Copilot cannot fork a session, so handoffs are deterministic. */
+  readonly forker: SessionForker = new DeterministicForker();
 
   private client: CopilotClient | null = null;
   private lastCliPath: string | undefined;

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -32,11 +32,13 @@ import { MessageRepo } from "../../repositories/message-repo.js";
 import { JobObject } from "../../services/job-object.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
+import { MutatingForker } from "../../services/handoff/session-forker.js";
 import {
   AgentEventType,
   CURSOR_STATIC_MODEL_FALLBACK,
   getCatalogEntry,
 } from "@mcode/contracts";
+import type { SessionForker } from "@mcode/contracts";
 import type {
   AttachmentMeta,
   AgentEvent,
@@ -145,6 +147,8 @@ export class CursorProvider
   readonly supportsCompletion = false;
   readonly sessionForkOnResume = "mutating" as const;
   readonly maxInputCharactersPerTurn = 4_000;
+  /** Path A forker; calls this provider's runHiddenTurn on the parent session. */
+  readonly forker: SessionForker = new MutatingForker(this);
 
   /** Owns the session pool, idle eviction (with busy guard), and JobObject/kill. */
   private readonly runtime: SessionRuntime<CursorSessionState>;

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -7,7 +7,7 @@
  */
 
 import { injectable, inject } from "tsyringe";
-import { spawn, execFile, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -30,6 +30,8 @@ import { SkillService } from "../../services/skill-service.js";
 import { EnvService } from "../../services/env-service.js";
 import { MessageRepo } from "../../repositories/message-repo.js";
 import { JobObject } from "../../services/job-object.js";
+import { SessionRuntime } from "../../services/session-runtime.js";
+import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import {
   AgentEventType,
   CURSOR_STATIC_MODEL_FALLBACK,
@@ -85,7 +87,6 @@ import { cursorTaskExtToAgentEvents } from "./cursor-acp-task.js";
 import { extractCursorCreatePlanMarkdown } from "./cursor-create-plan.js";
 
 const CURSOR_STDERR_TAIL_MAX = 48;
-const EVICTION_INTERVAL_MS = 60 * 1000;
 
 function cursorCliProbeBinaries(settings: Settings): string[] {
   const configured = settings.provider.cli.cursor?.trim();
@@ -124,15 +125,29 @@ interface CursorAcpSessionEntry {
   pendingUserStopAbort: boolean;
 }
 
+/**
+ * Per-session state owned by the {@link SessionRuntime}. Identical to the rich
+ * ACP session entry the provider has always carried (child process, ACP
+ * connection, logical session id, in-flight turn state, the serialized turn
+ * chain, sticky-instruction pacing, stderr tail). The runtime now owns the
+ * pool, idle eviction (with the `activeTurnState` busy guard), JobObject
+ * attachment, and the hard `taskkill` of the child PID surfaced from `spawn`.
+ */
+type CursorSessionState = CursorAcpSessionEntry;
+
 /** Cursor ACP (Agent Communication Protocol) adapter implementing IAgentProvider via a MCP subprocess per session. */
 @injectable()
-export class CursorProvider extends EventEmitter implements IAgentProvider {
+export class CursorProvider
+  extends EventEmitter
+  implements IAgentProvider, ProtocolAdapter<CursorSessionState>
+{
   readonly id: ProviderId = "cursor";
   readonly supportsCompletion = false;
   readonly sessionForkOnResume = "mutating" as const;
   readonly maxInputCharactersPerTurn = 4_000;
 
-  private sessions = new Map<string, CursorAcpSessionEntry>();
+  /** Owns the session pool, idle eviction (with busy guard), and JobObject/kill. */
+  private readonly runtime: SessionRuntime<CursorSessionState>;
   private sdkSessionIds = new Map<string, string>();
   /**
    * Session IDs for which a stop was requested before the session was created.
@@ -142,7 +157,13 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   private pendingPermissions = new Map<string, PendingAcpPermission>();
   /** Threads in Mcode plan-questions phase; disables Cursor ask_question auto-picks. */
   private planQuestionModeThreads = new Set<string>();
-  private evictionTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Mcode session ids the runtime currently holds. The runtime owns the pool
+   * but exposes only `get(id)`, so the provider mirrors the live id set to be
+   * able to iterate sessions (e.g. sticky-instruction invalidation). Populated
+   * in `spawn`, pruned in `close`.
+   */
+  private liveSessionIds = new Set<string>();
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
@@ -152,6 +173,11 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     @inject(MessageRepo) private readonly messageRepo: MessageRepo,
   ) {
     super();
+    this.runtime = new SessionRuntime<CursorSessionState>(this, {
+      jobObject: this.jobObject,
+      envService: this.envService,
+      idleTtlMs: this.settingsService.get().provider.cursor.idleSessionTtlMinutes * 60 * 1000,
+    });
   }
 
   /** Lists models by running `cursor-agent models` (falls back when discovery fails). */
@@ -188,7 +214,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       this.sdkSessionIds.set(sessionId, req.resumeFrom);
     }
 
-    const pm: "full" | "default" = permissionMode === "full" ? "full" : "default";
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
 
     // interactionMode absorbs the retired setPlanQuestionMode: a plan-mode Turn
@@ -200,47 +225,38 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       this.planQuestionModeThreads.delete(threadId);
     }
 
-    if (!this.evictionTimer) {
-      this.evictionTimer = setInterval(() => this.evictIdleSessions(), EVICTION_INTERVAL_MS);
+    let entry: CursorSessionState;
+    try {
+      // The runtime discards a stale pooled session (dead child / cwd /
+      // permission-mode mismatch — see `isStale`) and spawns a fresh one,
+      // attaching the child PID to the Windows JobObject from the returned pids.
+      entry = await this.runtime.acquire({
+        sessionId,
+        threadId,
+        cwd,
+        permissionMode,
+        resumeFrom: resume ? this.sdkSessionIds.get(sessionId) : undefined,
+      });
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      logger.error("Cursor ACP spawn failed", { sessionId, error: errMsg });
+      this.emit("event", { type: AgentEventType.Error, threadId, error: errMsg } satisfies AgentEvent);
+      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      return;
     }
 
-    const settings = this.settingsService.get();
-    let entry = this.sessions.get(sessionId);
-    if (entry) {
-      const dead =
-        entry.child.exitCode != null ||
-        entry.child.signalCode != null;
-      const mismatch = entry.permissionMode !== pm || entry.cwd !== cwd;
-      if (mismatch || dead) {
-        await this.teardownSessionEntry(sessionId, entry, false);
-        entry = undefined;
-      }
+    // A stop requested before the session finished spawning: tear it down now.
+    if (this.pendingStops.delete(sessionId)) {
+      logger.info("Pending stop consumed, tearing down new Cursor session", { sessionId });
+      void this.runtime.stop(sessionId);
+      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      return;
     }
 
-    if (!entry) {
-      try {
-        entry = await this.spawnChild(sessionId, threadId, cwd, pm, settings);
-        this.sessions.set(sessionId, entry);
-
-        if (this.pendingStops.delete(sessionId)) {
-          logger.info("Pending stop consumed, tearing down new Cursor session", { sessionId });
-          this.sessions.delete(sessionId);
-          await this.teardownSessionEntry(sessionId, entry, false);
-          this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-          return;
-        }
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        logger.error("Cursor ACP spawn failed", { sessionId, error: errMsg });
-        this.emit("event", { type: AgentEventType.Error, threadId, error: errMsg } satisfies AgentEvent);
-        this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-        return;
-      }
-    }
-
+    this.runtime.recordUsage(sessionId);
     entry.lastUsedAt = Date.now();
     const scheduled = entry.turnChain.then(() =>
-      this.runTurn(entry!, { message, model, resume, attachments }),
+      this.runTurn(entry, { message, model, resume, attachments }),
     );
     entry.turnChain = scheduled.then(
       () => {},
@@ -250,9 +266,17 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   }
 
 
-  /** Cancel the active ACP session. Records a pending stop if the session hasn't been created yet. */
+  /**
+   * Cancel the active ACP session. Once the logical ACP session is open, a stop
+   * issues a graceful ACP cancel (and flags `pendingUserStopAbort` when a prompt
+   * is in flight so the in-progress turn settles as a user stop) — the runtime
+   * is not torn down, the warm session stays pooled for the next turn, matching
+   * prior behavior. When the entry exists but the ACP session has not opened
+   * yet, hand it to `runtime.stop` (interrupt → close → hard kill). Records a
+   * pending stop if the session has not spawned at all.
+   */
   stopSession(sessionId: string): void {
-    const entry = this.sessions.get(sessionId);
+    const entry = this.runtime.get(sessionId);
     this.cancelPendingForThread(sessionId);
     if (entry?.acpSessionId && entry.activeTurnState) {
       entry.pendingUserStopAbort = true;
@@ -262,8 +286,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     } else if (entry) {
       // Entry exists but ACP session hasn't opened yet; tear down immediately.
       const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
-      this.sessions.delete(sessionId);
-      void this.teardownSessionEntry(sessionId, entry, false);
+      void this.runtime.stop(sessionId);
       this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
     } else {
       this.pendingStops.add(sessionId);
@@ -274,17 +297,13 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
 
   /** Tear down all sessions, cancel pending permissions, and stop the eviction timer. */
   shutdown(): void {
-    if (this.evictionTimer) {
-      clearInterval(this.evictionTimer);
-      this.evictionTimer = null;
-    }
     this.drainAllPendingCancelled();
-    for (const [id, entry] of this.sessions) {
-      void this.teardownSessionEntry(id, entry, false);
-    }
-    this.sessions.clear();
+    void this.runtime.shutdown().catch((err: unknown) => {
+      logger.warn("Cursor runtime shutdown failed", { error: String(err) });
+    });
     this.planQuestionModeThreads.clear();
     this.sdkSessionIds.clear();
+    this.liveSessionIds.clear();
     logger.info("CursorProvider shutdown complete");
   }
 
@@ -314,8 +333,9 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
    * sticky Cursor preambles can pick up regenerated skill inventories.
    */
   onSkillRegistryDebouncedInvalidation(): void {
-    for (const e of this.sessions.values()) {
-      e.stickyHeavyInstructionsSent = false;
+    for (const id of this.liveSessionIds) {
+      const e = this.runtime.get(id);
+      if (e) e.stickyHeavyInstructionsSent = false;
     }
   }
 
@@ -342,6 +362,63 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       }
     }
     this.pendingPermissions.clear();
+  }
+
+  /**
+   * Spawns a fresh Cursor ACP session for the runtime: launches the
+   * `cursor-agent acp` subprocess (probing CLI candidates), runs the ACP
+   * `initialize`/`authenticate` handshake, then opens the logical ACP session
+   * (`session/load` on resume, falling back to `session/new`). Returns the
+   * child PID in `pids` so the runtime attaches it to the Windows JobObject and
+   * hard-`taskkill`s it on close — the provider no longer does either inline.
+   */
+  async spawn(args: SpawnArgs): Promise<SpawnResult<CursorSessionState>> {
+    const { sessionId, threadId, cwd, permissionMode, resumeFrom } = args;
+    const pm: "full" | "default" = permissionMode === "full" ? "full" : "default";
+    const settings = this.settingsService.get();
+    const state = await this.spawnChild(sessionId, threadId, cwd, pm, settings);
+
+    // Open the logical ACP session up front so reuse paths see a ready
+    // `acpSessionId`. `runTurn`'s own `openLogicalSession` call then early-returns.
+    await this.openLogicalSession(state, resumeFrom !== undefined);
+
+    this.liveSessionIds.add(sessionId);
+    return { state, pids: state.child.pid != null ? [state.child.pid] : [] };
+  }
+
+  /** Eviction guard: a turn is in flight while `activeTurnState` is set. */
+  isBusy(state: CursorSessionState): boolean {
+    return state.activeTurnState != null;
+  }
+
+  /**
+   * Graceful protocol interrupt: ACP `session/cancel` for the open logical
+   * session. Does not kill the child — the runtime's hard kill handles the OS
+   * process via the surfaced PID.
+   */
+  async interrupt(state: CursorSessionState): Promise<void> {
+    state.pendingUserStopAbort = false;
+    if (state.acpSessionId) {
+      await state.connection.cancel({ sessionId: state.acpSessionId }).catch(() => {});
+    }
+  }
+
+  /**
+   * Provider teardown that is not the OS kill: cancel any pending permissions
+   * for this session (so orphaned approval cards clear) and drop it from the
+   * live-id mirror. The child process is killed by the runtime's hard kill.
+   */
+  close(state: CursorSessionState): void {
+    this.cancelPendingForThread(state.mcodeSessionId);
+    this.liveSessionIds.delete(state.mcodeSessionId);
+  }
+
+  /** A pooled session must be discarded before reuse if the child died or the cwd/permission mode changed. */
+  isStale(state: CursorSessionState, args: { cwd: string; permissionMode: string }): boolean {
+    const dead = state.child.exitCode != null || state.child.signalCode != null;
+    if (dead) return true;
+    const pm: "full" | "default" = args.permissionMode === "full" ? "full" : "default";
+    return state.permissionMode !== pm || state.cwd !== args.cwd;
   }
 
   private async spawnChild(
@@ -387,10 +464,8 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       throw new Error("Failed to spawn cursor-agent: stdio pipes unavailable");
     }
 
-    if (child.pid) {
-      this.jobObject.assign(child.pid);
-      this.jobObject.setDescription(child.pid, "Mcode Agent: Cursor");
-    }
+    // JobObject attach + hard kill are now owned by the SessionRuntime, which
+    // acts on the PID this method surfaces through `spawn`'s `pids`.
 
     const out = Writable.toWeb(child.stdin) as WritableStream<Uint8Array>;
     const inp = Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>;
@@ -440,7 +515,10 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
 
     child.on("exit", () => {
       this.cancelPendingForThread(mcodeSessionId);
-      this.sessions.delete(mcodeSessionId);
+      // The child died unexpectedly; ask the runtime to drop the pooled entry
+      // (runs interrupt → close → hard kill of the already-dead PID, all no-ops
+      // here beyond removing it from the pool).
+      void this.runtime.stop(mcodeSessionId);
     });
 
     const initResult = await connection.initialize({
@@ -906,42 +984,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  private async teardownSessionEntry(
-    mcodeSessionId: string,
-    entry: CursorAcpSessionEntry,
-    clearStoredSdkId: boolean,
-  ): Promise<void> {
-    this.cancelPendingForThread(mcodeSessionId);
-    entry.pendingUserStopAbort = false;
-    if (entry.acpSessionId) {
-      await entry.connection.cancel({ sessionId: entry.acpSessionId }).catch(() => {});
-    }
-    try {
-      entry.child.kill();
-    } catch {
-      /* ignore */
-    }
-    if (process.platform === "win32" && entry.child.pid) {
-      await new Promise<void>((resolve) => {
-        execFile(
-          "taskkill",
-          ["/T", "/F", "/PID", String(entry.child.pid)],
-          () => resolve(),
-        );
-      });
-    }
-    if (clearStoredSdkId) {
-      this.sdkSessionIds.delete(mcodeSessionId);
-    }
-  }
-
-  private sessionHasPendingPermissions(mcodeSessionId: string): boolean {
-    for (const p of this.pendingPermissions.values()) {
-      if (p.mcodeSessionId === mcodeSessionId) return true;
-    }
-    return false;
-  }
-
   /**
    * Runs two hidden prompt/reply pairs on the parent thread's active Cursor session
    * to extract a handoff summary without surfacing them in the UI.
@@ -959,7 +1001,7 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   }): Promise<string> {
     const { parentThreadId, prompt, abortSignal } = args;
     const sessionKey = `mcode-${parentThreadId}`;
-    const entry = this.sessions.get(sessionKey);
+    const entry = this.runtime.get(sessionKey);
     if (!entry) {
       throw new Error(`No active Cursor session for parent thread: ${parentThreadId}`);
     }
@@ -1041,19 +1083,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
       return resolveCursorAssistantMessageContent(turnState.accumulator);
     } finally {
       entry.activeTurnState = null;
-    }
-  }
-
-  private evictIdleSessions(): void {
-    const settings = this.settingsService.get();
-    const ttlMs = settings.provider.cursor.idleSessionTtlMinutes * 60 * 1000;
-    const now = Date.now();
-    for (const [id, entry] of this.sessions) {
-      if (entry.activeTurnState) continue;
-      if (now - entry.lastUsedAt <= ttlMs) continue;
-      if (this.sessionHasPendingPermissions(id)) continue;
-      void this.teardownSessionEntry(id, entry, true);
-      this.sessions.delete(id);
     }
   }
 }

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -384,7 +384,20 @@ export class CursorProvider
 
     // Open the logical ACP session up front so reuse paths see a ready
     // `acpSessionId`. `runTurn`'s own `openLogicalSession` call then early-returns.
-    await this.openLogicalSession(state, resumeFrom !== undefined);
+    // If the handshake throws, the runtime never received the child's pid, so
+    // it cannot kill it on `stop`. Tear the child down here before rethrowing
+    // so the subprocess does not leak.
+    try {
+      await this.openLogicalSession(state, resumeFrom !== undefined);
+    } catch (err) {
+      this.liveSessionIds.delete(sessionId);
+      try {
+        state.child.kill();
+      } catch {
+        /* best-effort: the child may already be gone */
+      }
+      throw err;
+    }
 
     this.liveSessionIds.add(sessionId);
     return { state, pids: state.child.pid != null ? [state.child.pid] : [] };

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -39,11 +39,11 @@ import type {
   AttachmentMeta,
   AgentEvent,
   IAgentProvider,
+  TurnRequest,
   PermissionDecision,
   PermissionRequest,
   ProviderId,
   ProviderModelInfo,
-  ReasoningLevel,
   Settings,
 } from "@mcode/contracts";
 import {
@@ -170,32 +170,35 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
   }
 
   /** Queues an ACP `session/prompt` on the session subprocess (serialized per thread). */
-  async sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-  }): Promise<void> {
-    void params.fallbackModel;
-    void params.reasoningLevel;
+  async sendTurn(req: TurnRequest<"cursor">): Promise<void> {
+    void req.fallbackModel;
+    void req.reasoningLevel;
 
     const {
       sessionId,
       message,
       cwd,
       model,
-      resume,
       permissionMode,
       attachments,
-    } = params;
+    } = req;
+    // `resumeFrom` defined ⇒ resume the stored ACP session; undefined ⇒ fresh.
+    const resume = req.resumeFrom !== undefined;
+    if (req.resumeFrom !== undefined) {
+      this.sdkSessionIds.set(sessionId, req.resumeFrom);
+    }
 
     const pm: "full" | "default" = permissionMode === "full" ? "full" : "default";
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
+
+    // interactionMode absorbs the retired setPlanQuestionMode: a plan-mode Turn
+    // suppresses Cursor's native auto-answer of ask_question; build clears it.
+    // The flag is re-derived every Turn, so it is authoritative per Turn.
+    if (req.interactionMode === "plan") {
+      this.planQuestionModeThreads.add(threadId);
+    } else {
+      this.planQuestionModeThreads.delete(threadId);
+    }
 
     if (!this.evictionTimer) {
       this.evictionTimer = setInterval(() => this.evictIdleSessions(), EVICTION_INTERVAL_MS);
@@ -246,10 +249,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     await scheduled;
   }
 
-  /** Pre-load an SDK session ID mapping (e.g. from the database on startup). */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
-    this.sdkSessionIds.set(sessionId, sdkSessionId);
-  }
 
   /** Cancel the active ACP session. Records a pending stop if the session hasn't been created yet. */
   stopSession(sessionId: string): void {
@@ -272,14 +271,6 @@ export class CursorProvider extends EventEmitter implements IAgentProvider {
     }
   }
 
-  /** Toggle Mcode plan-questions phase for Cursor ask_question handling. */
-  setPlanQuestionMode(threadId: string, enabled: boolean): void {
-    if (enabled) {
-      this.planQuestionModeThreads.add(threadId);
-    } else {
-      this.planQuestionModeThreads.delete(threadId);
-    }
-  }
 
   /** Tear down all sessions, cancel pending permissions, and stop the eviction timer. */
   shutdown(): void {

--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Thread, IProviderRegistry } from "@mcode/contracts";
 import { AgentService } from "../agent-service.js";
+import { NarrativeStore } from "../narrative-store.js";
 import { ProviderAvailabilityService } from "../provider-availability-service.js";
 import { ProviderDisabledError } from "../provider-availability-errors.js";
 import type { ThreadRepo } from "../../repositories/thread-repo.js";
@@ -170,8 +171,6 @@ function buildService({
     attachmentService,
     providerRegistry,
     threadService,
-    toolCallRecordRepo,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
     { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
@@ -185,6 +184,12 @@ function buildService({
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(
+        messageRepo,
+        toolCallRecordRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+      ),
   );
 }
 

--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -184,6 +184,7 @@ function buildService({
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
   );
 }
 

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -9,10 +9,10 @@ import { ThreadRepo } from "../../repositories/thread-repo.js";
 import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import { MessageRepo } from "../../repositories/message-repo.js";
 import { PlanQuestionAnswersRepo } from "../../repositories/plan-question-answers-repo.js";
-import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
 import { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo.js";
 import { TaskRepo } from "../../repositories/task-repo.js";
 import { AgentService } from "../agent-service.js";
+import { NarrativeStore } from "../narrative-store.js";
 import { ProviderAvailabilityService } from "../provider-availability-service.js";
 import type { GitService } from "../git-service.js";
 import type { AttachmentService } from "../attachment-service.js";
@@ -38,7 +38,6 @@ function buildService(db: Database.Database) {
   const workspaceRepo = container.resolve(WorkspaceRepo);
   const messageRepo = container.resolve(MessageRepo);
   const planQuestionAnswersRepo = container.resolve(PlanQuestionAnswersRepo);
-  const toolCallRecordRepo = container.resolve(ToolCallRecordRepo);
   const turnSnapshotRepo = container.resolve(TurnSnapshotRepo);
   const taskRepo = container.resolve(TaskRepo);
 
@@ -104,8 +103,6 @@ function buildService(db: Database.Database) {
     attachmentService,
     providerRegistry,
     threadService,
-    toolCallRecordRepo,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
     { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
@@ -119,6 +116,7 @@ function buildService(db: Database.Database) {
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      container.resolve(NarrativeStore),
   );
 
   return { svc, threadRepo, workspaceRepo, messageRepo, providerStub };

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -118,6 +118,7 @@ function buildService(db: Database.Database) {
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
   );
 
   return { svc, threadRepo, workspaceRepo, messageRepo, providerStub };

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -27,7 +27,7 @@ import { broadcast } from "../../transport/push.js";
 
 /**
  * Build an AgentService with a Claude-shaped provider stub that records
- * setGoal/clearGoal/sendMessage so we can assert which path the /goal
+ * setGoal/clearGoal/sendTurn so we can assert which path the /goal
  * intercept took (control short-circuit vs SET fall-through).
  */
 function buildService(db: Database.Database) {
@@ -56,10 +56,9 @@ function buildService(db: Database.Database) {
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendMessage: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
+    sendTurn: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
       () => Promise.resolve(),
     ),
-    setSdkSessionId: vi.fn(),
     setGoal: vi.fn<(sid: string, condition: string) => void>(),
     clearGoal: vi.fn<(sid: string) => void>(),
     getGoal: vi.fn<(sid: string) => string | undefined>(() => undefined),
@@ -157,8 +156,8 @@ describe("AgentService.sendMessage — /goal command", () => {
 
     // Provider was actually called — this is the regression the user hit
     // where /goal <condition> set the hook but never started the agent.
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
-    const sentMessage = providerStub.sendMessage.mock.calls[0][0].message;
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
+    const sentMessage = providerStub.sendTurn.mock.calls[0][0].message;
     expect(sentMessage).toContain("analyse this branch");
     expect(sentMessage.toLowerCase()).toContain("directive");
 
@@ -183,7 +182,7 @@ describe("AgentService.sendMessage — /goal command", () => {
     );
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
-    expect(providerStub.sendMessage).not.toHaveBeenCalled();
+    expect(providerStub.sendTurn).not.toHaveBeenCalled();
 
     // Confirmation pill persisted as an assistant message.
     const { messages } = messageRepo.listByThread(thread.id, 100);
@@ -213,7 +212,7 @@ describe("AgentService.sendMessage — /goal command", () => {
       "claude",
     );
 
-    expect(providerStub.sendMessage).not.toHaveBeenCalled();
+    expect(providerStub.sendTurn).not.toHaveBeenCalled();
     expect(providerStub.setGoal).not.toHaveBeenCalled();
 
     const { messages } = messageRepo.listByThread(thread.id, 100);
@@ -237,7 +236,7 @@ describe("AgentService.sendMessage — /goal command", () => {
 
     // Provider was still called with the raw text (no rewrite, no goal install).
     expect(providerStub.setGoal).not.toHaveBeenCalled();
-    expect(providerStub.sendMessage).toHaveBeenCalledTimes(1);
-    expect(providerStub.sendMessage.mock.calls[0][0].message).toBe("/goal something");
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
+    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal something");
   });
 });

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -167,6 +167,7 @@ function build(): Built {
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
   );
   service.init();
   // Prime per-thread state without running sendMessage's full path.

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "events";
 import { AgentEventType } from "@mcode/contracts";
 import type { Thread, IProviderRegistry, Message } from "@mcode/contracts";
 import { AgentService } from "../agent-service.js";
+import { NarrativeStore } from "../narrative-store.js";
 import type { ThreadRepo } from "../../repositories/thread-repo.js";
 import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import type { MessageRepo } from "../../repositories/message-repo.js";
@@ -145,6 +146,15 @@ function build(): Built {
     prepare: vi.fn(() => ({ run: vi.fn() })),
   } as unknown as import("better-sqlite3").Database;
 
+  // The narrative write seam lives in NarrativeStore; build it from the same
+  // repo mocks so the bulkCreate spies observe what AgentService delegates.
+  const narrativeStore = new NarrativeStore(
+    messageRepo,
+    toolCallRecordRepo,
+    thoughtSegmentRepo,
+    hookExecutionRepo,
+  );
+
   const service = new AgentService(
     threadRepo,
     workspaceRepo,
@@ -153,8 +163,6 @@ function build(): Built {
     attachmentService,
     providerRegistry,
     threadService,
-    toolCallRecordRepo,
-    thoughtSegmentRepo,
     hookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
@@ -168,16 +176,14 @@ function build(): Built {
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      narrativeStore,
   );
   service.init();
-  // Prime per-thread state without running sendMessage's full path.
-  (service as any).turnToolCalls.set(THREAD_ID, []);
-  (service as any).turnSortCounters.set(THREAD_ID, 0);
-  (service as any).agentCallStack.set(THREAD_ID, []);
-  (service as any).turnOpenThought.set(THREAD_ID, null);
-  (service as any).turnThoughts.set(THREAD_ID, []);
-  (service as any).turnOpenHooks.set(THREAD_ID, new Map());
-  (service as any).turnHooks.set(THREAD_ID, []);
+  // Prime per-thread state without running sendMessage's full path. The buffers
+  // now live in NarrativeStore; seed them via the same public entry points
+  // sendMessage uses (beginTurn + resetTurnCounters).
+  narrativeStore.beginTurn(THREAD_ID);
+  narrativeStore.resetTurnCounters(THREAD_ID);
   return { service, providerEmitter, thoughtBulk, hookBulk, toolBulk };
 }
 

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -73,8 +73,7 @@ interface Built {
 function build(): Built {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
-  (providerEmitter as any).sendMessage = vi.fn(() => Promise.resolve());
-  (providerEmitter as any).setSdkSessionId = vi.fn();
+  (providerEmitter as any).sendTurn = vi.fn(() => Promise.resolve());
 
   const threadRepo = {
     findById: vi.fn(() => thread),

--- a/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
@@ -116,6 +116,7 @@ function buildService(db: Database.Database) {
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
   );
 
   return { svc, threadRepo, workspaceRepo, messageRepo, planQuestionAnswersRepo };

--- a/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
@@ -51,14 +51,15 @@ function buildService(db: Database.Database) {
   } as unknown as AttachmentService;
 
   // Provider stub: extends EventEmitter (matches real provider shape) and
-  // resolves sendMessage immediately so the turn "completes" without I/O.
+  // resolves sendTurn immediately so the turn "completes" without I/O.
   const providerStub = Object.assign(new EventEmitter(), {
     id: "claude" as const,
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendMessage: vi.fn(() => Promise.resolve()),
-    setSdkSessionId: vi.fn(),
+    sendTurn: vi.fn(() => Promise.resolve()),
+    // Claude-concrete off-interface method invoked by armPlanGenerationTurn via cast.
+    setPlanAnswerMode: vi.fn(),
   });
   const providerRegistry = {
     resolve: vi.fn(() => providerStub),

--- a/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
@@ -8,10 +8,10 @@ import { ThreadRepo } from "../../repositories/thread-repo.js";
 import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import { MessageRepo } from "../../repositories/message-repo.js";
 import { PlanQuestionAnswersRepo } from "../../repositories/plan-question-answers-repo.js";
-import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
 import { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo.js";
 import { TaskRepo } from "../../repositories/task-repo.js";
 import { AgentService } from "../agent-service.js";
+import { NarrativeStore } from "../narrative-store.js";
 import { ProviderAvailabilityService } from "../provider-availability-service.js";
 import type { GitService } from "../git-service.js";
 import type { AttachmentService } from "../attachment-service.js";
@@ -37,7 +37,6 @@ function buildService(db: Database.Database) {
   const workspaceRepo = container.resolve(WorkspaceRepo);
   const messageRepo = container.resolve(MessageRepo);
   const planQuestionAnswersRepo = container.resolve(PlanQuestionAnswersRepo);
-  const toolCallRecordRepo = container.resolve(ToolCallRecordRepo);
   const turnSnapshotRepo = container.resolve(TurnSnapshotRepo);
   const taskRepo = container.resolve(TaskRepo);
 
@@ -102,8 +101,6 @@ function buildService(db: Database.Database) {
     attachmentService,
     providerRegistry,
     threadService,
-    toolCallRecordRepo,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
     { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
@@ -117,6 +114,7 @@ function buildService(db: Database.Database) {
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      container.resolve(NarrativeStore),
   );
 
   return { svc, threadRepo, workspaceRepo, messageRepo, planQuestionAnswersRepo };

--- a/apps/server/src/services/__tests__/agent-service-snapshot-flag.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-snapshot-flag.test.ts
@@ -181,6 +181,7 @@ function buildService(opts: BuildServiceOptions = {}): {
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
   );
 
   return { svc, turnSnapshotRepo, snapshotService, db, runSpy };

--- a/apps/server/src/services/__tests__/agent-service-snapshot-flag.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-snapshot-flag.test.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Thread, IProviderRegistry } from "@mcode/contracts";
 import { AgentService } from "../agent-service.js";
+import { NarrativeStore } from "../narrative-store.js";
 import type { ThreadRepo } from "../../repositories/thread-repo.js";
 import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import type { MessageRepo } from "../../repositories/message-repo.js";
@@ -167,8 +168,6 @@ function buildService(opts: BuildServiceOptions = {}): {
     attachmentService,
     providerRegistry,
     threadService,
-    toolCallRecordRepo,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
     { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
@@ -182,6 +181,12 @@ function buildService(opts: BuildServiceOptions = {}): {
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(
+        messageRepo,
+        toolCallRecordRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+      ),
   );
 
   return { svc, turnSnapshotRepo, snapshotService, db, runSpy };

--- a/apps/server/src/services/__tests__/agent-service-stack-fallback.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-stack-fallback.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
 import type { Thread, IProviderRegistry } from "@mcode/contracts";
 import { AgentService } from "../agent-service.js";
+import { NarrativeStore } from "../narrative-store.js";
 import type { ThreadRepo } from "../../repositories/thread-repo.js";
 import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import type { MessageRepo } from "../../repositories/message-repo.js";
@@ -125,6 +126,13 @@ function minimalService(): AgentService {
     prepare: vi.fn(() => ({ run: vi.fn() })),
   } as unknown as import("better-sqlite3").Database;
 
+  const narrativeStore = new NarrativeStore(
+    messageRepo,
+    toolCallRecordRepo,
+    thoughtSegmentRepo,
+    hookExecutionRepo,
+  );
+
   return new AgentService(
     threadRepo,
     workspaceRepo,
@@ -133,8 +141,6 @@ function minimalService(): AgentService {
     attachmentService,
     providerRegistry,
     threadService,
-    toolCallRecordRepo,
-    thoughtSegmentRepo,
     hookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
@@ -148,16 +154,22 @@ function minimalService(): AgentService {
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      narrativeStore,
   );
 }
 
-/** Minimal buffer row shape for `getStackDerivedParentFallback` inspection. */
+/**
+ * Seed the in-turn buffers directly on the NarrativeStore (which now owns the
+ * agentCallStack + tool-call buffer the fallback rule reads) so we can probe
+ * `getCurrentParentToolCallId`'s exactly-one-running-Agent semantics.
+ */
 function seedThreadState(
   service: AgentService,
   stack: string[],
   bufferRows: BufferedToolRow[],
 ): void {
-  (service as unknown as { agentCallStack: Map<string, string[]> }).agentCallStack.set(
+  const narrativeStore = (service as unknown as { narrativeStore: NarrativeStore }).narrativeStore;
+  (narrativeStore as unknown as { agentCallStack: Map<string, string[]> }).agentCallStack.set(
     THREAD_ID,
     stack,
   );
@@ -172,7 +184,7 @@ function seedThreadState(
     parentToolCallId: undefined as string | undefined,
     _rawToolInput: {} as Record<string, unknown>,
   }));
-  (service as unknown as { turnToolCalls: Map<string, typeof fullRows> }).turnToolCalls.set(
+  (narrativeStore as unknown as { turnToolCalls: Map<string, typeof fullRows> }).turnToolCalls.set(
     THREAD_ID,
     fullRows,
   );

--- a/apps/server/src/services/__tests__/agent-service-stack-fallback.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-stack-fallback.test.ts
@@ -147,6 +147,7 @@ function minimalService(): AgentService {
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
   );
 }
 

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -196,6 +196,7 @@ function buildService(): {
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
   );
 
   return { service, providerEmitter, memoryPressureService: memoryPressureService as MemoryPressureService & { markActive: ReturnType<typeof vi.fn>; markIdle: ReturnType<typeof vi.fn> } };

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -75,9 +75,8 @@ function buildService(): {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
 
-  // sendMessage() and setSdkSessionId() are called on the resolved provider
-  (providerEmitter as any).sendMessage = vi.fn(() => Promise.resolve());
-  (providerEmitter as any).setSdkSessionId = vi.fn();
+  // sendTurn() is called on the resolved provider
+  (providerEmitter as any).sendTurn = vi.fn(() => Promise.resolve());
 
   const threadRepo = {
     findById: vi.fn(() => thread),

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "events";
 import { AgentEventType } from "@mcode/contracts";
 import type { AgentEvent, Thread, IProviderRegistry } from "@mcode/contracts";
 import { AgentService } from "../agent-service.js";
+import { NarrativeStore } from "../narrative-store.js";
 import type { ThreadRepo } from "../../repositories/thread-repo.js";
 import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import type { MessageRepo } from "../../repositories/message-repo.js";
@@ -182,8 +183,6 @@ function buildService(): {
     attachmentService,
     providerRegistry,
     threadService,
-    toolCallRecordRepo,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
     { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
@@ -197,6 +196,12 @@ function buildService(): {
       { orchestrate: vi.fn() } as any,
       { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(
+        messageRepo,
+        toolCallRecordRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+      ),
   );
 
   return { service, providerEmitter, memoryPressureService: memoryPressureService as MemoryPressureService & { markActive: ReturnType<typeof vi.fn>; markIdle: ReturnType<typeof vi.fn> } };

--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -1,0 +1,117 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../../store/database";
+import { MessageRepo } from "../../repositories/message-repo";
+import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo";
+import { ThoughtSegmentRepo } from "../../repositories/thought-segment-repo";
+import { HookExecutionRepo } from "../../repositories/hook-execution-repo";
+import { NarrativeStore } from "../narrative-store";
+
+/** Seed a workspace + thread so message/record foreign keys are satisfied. */
+function seedThread(db: Database.Database): string {
+  const now = new Date().toISOString();
+  db.prepare(
+    "INSERT INTO workspaces (id, name, path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+  ).run("ws-1", "Test", "/tmp/test", now, now);
+  db.prepare(
+    "INSERT INTO threads (id, workspace_id, title, branch, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run("thread-1", "ws-1", "Test thread", "main", now, now);
+  return "thread-1";
+}
+
+function insertMessage(
+  db: Database.Database,
+  id: string,
+  role: string,
+  content: string,
+  sequence: number,
+): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(id, "thread-1", role, content, now, sequence);
+}
+
+describe("NarrativeStore.load (read seam)", () => {
+  let db: Database.Database;
+  let store: NarrativeStore;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    seedThread(db);
+    store = new NarrativeStore(
+      new MessageRepo(db),
+      new ToolCallRecordRepo(db),
+      new ThoughtSegmentRepo(db),
+      new HookExecutionRepo(db),
+    );
+  });
+
+  it("returns one list interleaved by (sequence, sortOrder), final response as the message body", () => {
+    // One assistant message: preamble narration (0), tool call (1), hook (2),
+    // final-response segment (3). The body must surface at sortOrder 3.
+    insertMessage(db, "m1", "assistant", "Final answer text.", 1);
+    new ThoughtSegmentRepo(db).bulkCreate([
+      { messageId: "m1", text: "Let me look.", startedAt: "t", endedAt: "t", sortOrder: 0 },
+      { messageId: "m1", text: "Final answer text.", startedAt: "t", endedAt: "t", sortOrder: 3, isFinalResponse: 1 },
+    ]);
+    new ToolCallRecordRepo(db).bulkCreate([
+      { messageId: "m1", toolName: "Read", inputSummary: "f.ts", outputSummary: "ok", status: "completed", sortOrder: 1 },
+    ]);
+    new HookExecutionRepo(db).bulkCreate([
+      { messageId: "m1", hookName: "PreToolUse", toolName: "Read", phase: "pre", payload: "{}", durationMs: 1, didBlock: false, startedAt: "t", endedAt: "t", sortOrder: 2 },
+    ]);
+
+    const entries = store.load("thread-1");
+
+    expect(entries.map((e) => e.kind)).toEqual([
+      "narrationSegment", // sortOrder 0
+      "toolCall", // 1
+      "hook", // 2
+      "assistantMessage", // 3 (final response as body)
+    ]);
+    const body = entries.find((e) => e.kind === "assistantMessage");
+    expect(body && body.kind === "assistantMessage" && body.body).toBe("Final answer text.");
+    // The final-response segment is NOT also emitted as a narration row.
+    const narrations = entries.filter((e) => e.kind === "narrationSegment");
+    expect(narrations).toHaveLength(1);
+    expect(narrations[0].kind === "narrationSegment" && narrations[0].record.text).toBe("Let me look.");
+  });
+
+  it("orders entries across messages by sequence, and skips user/system messages", () => {
+    insertMessage(db, "u1", "user", "do the thing", 1);
+    insertMessage(db, "m1", "assistant", "first answer", 2);
+    insertMessage(db, "sys1", "system", "Context compacted", 3);
+    insertMessage(db, "m2", "assistant", "second answer", 4);
+    const tools = new ToolCallRecordRepo(db);
+    tools.bulkCreate([
+      { messageId: "m1", toolName: "Read", inputSummary: "a", outputSummary: "ok", status: "completed", sortOrder: 0 },
+    ]);
+    tools.bulkCreate([
+      { messageId: "m2", toolName: "Bash", inputSummary: "ls", outputSummary: "ok", status: "completed", sortOrder: 0 },
+    ]);
+
+    const entries = store.load("thread-1");
+
+    // Only assistant narrative; user + system rows excluded.
+    expect(entries.every((e) => e.sequence === 2 || e.sequence === 4)).toBe(true);
+    // All of message seq=2's entries precede all of seq=4's entries.
+    const seqs = entries.map((e) => e.sequence);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    // m1 (seq 2): toolCall then assistantMessage (body sorts last, no final seg → MAX).
+    const seq2 = entries.filter((e) => e.sequence === 2);
+    expect(seq2.map((e) => e.kind)).toEqual(["toolCall", "assistantMessage"]);
+  });
+
+  it("places the assistant body last when there is no final-response segment", () => {
+    insertMessage(db, "m1", "assistant", "answer with no tagged final segment", 1);
+    new ToolCallRecordRepo(db).bulkCreate([
+      { messageId: "m1", toolName: "Read", inputSummary: "a", outputSummary: "ok", status: "completed", sortOrder: 0 },
+      { messageId: "m1", toolName: "Edit", inputSummary: "b", outputSummary: "ok", status: "completed", sortOrder: 1 },
+    ]);
+
+    const entries = store.load("thread-1");
+    expect(entries.map((e) => e.kind)).toEqual(["toolCall", "toolCall", "assistantMessage"]);
+  });
+});

--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -115,3 +115,239 @@ describe("NarrativeStore.load (read seam)", () => {
     expect(entries.map((e) => e.kind)).toEqual(["toolCall", "toolCall", "assistantMessage"]);
   });
 });
+
+/**
+ * Write-seam integration tests. These drive the NarrativeStore enrichment +
+ * classification + persistence methods directly with synthetic events and
+ * assert on the persisted rows (via `load` / repos), guarding the six
+ * narrative-pipeline traps on the server side. The store is backed by a real
+ * in-memory SQLite DB so `persistNarrative` exercises actual bulk inserts.
+ */
+describe("NarrativeStore write seam (server-side traps)", () => {
+  const THREAD = "thread-1";
+  let db: Database.Database;
+  let store: NarrativeStore;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    seedThread(db);
+    store = new NarrativeStore(
+      new MessageRepo(db),
+      new ToolCallRecordRepo(db),
+      new ThoughtSegmentRepo(db),
+      new HookExecutionRepo(db),
+    );
+  });
+
+  /** Seed an assistant message row so persistNarrative's FK targets exist. */
+  function seedAssistantMessage(id: string, content: string, sequence: number): void {
+    insertMessage(db, id, "assistant", content, sequence);
+  }
+
+  function toolUse(toolCallId: string, toolName: string, parentToolCallId?: string) {
+    return { toolCallId, toolName, toolInput: {}, parentToolCallId };
+  }
+
+  describe("Trap 1: parent_tool_use_id is authoritative for parallel sub-agents", () => {
+    it("attributes each child to its SDK-supplied parent across 4 parallel Agents", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+
+      // Four Agents dispatched in parallel; the stack ends [a1,a2,a3,a4].
+      for (const id of ["a1", "a2", "a3", "a4"]) {
+        store.bufferToolCall(THREAD, toolUse(id, "Agent"));
+      }
+      // Each child carries its own SDK parent_tool_use_id. The naive LIFO peek
+      // would clump them all under a4; the SDK value must win instead.
+      store.bufferToolCall(THREAD, toolUse("c1", "Read", "a1"));
+      store.bufferToolCall(THREAD, toolUse("c2", "Read", "a2"));
+      store.bufferToolCall(THREAD, toolUse("c3", "Read", "a3"));
+      store.bufferToolCall(THREAD, toolUse("c4", "Read", "a4"));
+
+      const byId = new Map(
+        store.getBufferedToolCalls(THREAD).map((b) => [b.toolCallId, b.parentToolCallId]),
+      );
+      expect(byId.get("c1")).toBe("a1");
+      expect(byId.get("c2")).toBe("a2");
+      expect(byId.get("c3")).toBe("a3");
+      expect(byId.get("c4")).toBe("a4");
+      // Agent rows themselves never get a parent.
+      expect(byId.get("a1")).toBeUndefined();
+    });
+
+    it("falls back to the only running Agent when the SDK omits the parent", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, toolUse("solo", "Agent"));
+
+      // SDK omitted parentToolCallId; exactly one Agent is running → attributed.
+      expect(store.getCurrentParentToolCallId(THREAD)).toBe("solo");
+      const childParent = store.bufferToolCall(THREAD, toolUse("child", "Read"));
+      expect(childParent).toBe("solo");
+    });
+
+    it("returns undefined when two Agents are running (ambiguous fallback)", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, toolUse("a1", "Agent"));
+      store.bufferToolCall(THREAD, toolUse("a2", "Agent"));
+
+      expect(store.getCurrentParentToolCallId(THREAD)).toBeUndefined();
+      const childParent = store.bufferToolCall(THREAD, toolUse("child", "Read"));
+      expect(childParent).toBeUndefined();
+    });
+  });
+
+  describe("Trap 2: agentCallStack lifecycle", () => {
+    it("does NOT clear the stack on openOrExtendThought (textDelta analogue)", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, toolUse("solo", "Agent"));
+
+      // A sub-agent streams text mid-flight; the fallback parent must survive.
+      store.openOrExtendThought(THREAD, "thinking out loud");
+      expect(store.getCurrentParentToolCallId(THREAD)).toBe("solo");
+      expect(store.bufferToolCall(THREAD, toolUse("child", "Read"))).toBe("solo");
+    });
+
+    it("pops the Agent from the stack on its toolResult", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, toolUse("solo", "Agent"));
+      expect(store.getCurrentParentToolCallId(THREAD)).toBe("solo");
+
+      store.updateBufferedToolCallOutput(THREAD, "solo", "done", false);
+      // Agent finished → no running Agent → coordinator tools do not inherit it.
+      expect(store.getCurrentParentToolCallId(THREAD)).toBeUndefined();
+    });
+
+    it("clears the whole stack on the final Message event", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, toolUse("a1", "Agent"));
+      store.bufferToolCall(THREAD, toolUse("a2", "Agent"));
+
+      store.clearAgentStackOnMessage(THREAD);
+      expect(store.getCurrentParentToolCallId(THREAD)).toBeUndefined();
+    });
+  });
+
+  describe("Trap 3 (server analogue): buffers reset at beginTurn, survive through persist", () => {
+    it("resets buffered tool calls on a fresh beginTurn", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, toolUse("tc-1", "Read"));
+      expect(store.getBufferedToolCalls(THREAD)).toHaveLength(1);
+
+      // New turn starts → previous trail cleared.
+      store.beginTurn(THREAD);
+      expect(store.getBufferedToolCalls(THREAD)).toHaveLength(0);
+    });
+
+    it("keeps buffers populated through persistNarrative until clearTurn", () => {
+      seedAssistantMessage("m1", "final body", 1);
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, toolUse("tc-1", "Read"));
+
+      const result = store.persistNarrative(THREAD, "m1", "final body", false);
+      expect(result.toolCallCount).toBe(1);
+      // Buffers are NOT cleared by persistNarrative.
+      expect(store.getBufferedToolCalls(THREAD)).toHaveLength(1);
+
+      store.clearTurn(THREAD);
+      expect(store.getBufferedToolCalls(THREAD)).toHaveLength(0);
+    });
+  });
+
+  describe("Classification precedence + is_final_response safety net", () => {
+    it("drops the open thought when the boundary reports a final response (tool-free turn)", () => {
+      seedAssistantMessage("m1", "Tool-free final answer", 1);
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.openOrExtendThought(THREAD, "Tool-free final answer");
+      // end_turn-style boundary → final response → drop, never persisted.
+      store.dropOpenThought(THREAD);
+
+      store.persistNarrative(THREAD, "m1", "Tool-free final answer", false);
+      expect(new ThoughtSegmentRepo(db).listByMessage("m1")).toHaveLength(0);
+    });
+
+    it("persists preamble as a thought when the boundary reports tool_use (non-final)", () => {
+      seedAssistantMessage("m1", "", 1);
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.openOrExtendThought(THREAD, "Let me check that file.");
+      // tool_use stop_reason → close as preamble.
+      store.closeOpenThought(THREAD);
+      store.bufferToolCall(THREAD, toolUse("tc-read", "Read"));
+
+      store.persistNarrative(THREAD, "m1", "", false);
+      const thoughts = new ThoughtSegmentRepo(db).listByMessage("m1");
+      expect(thoughts).toHaveLength(1);
+      expect(thoughts[0].text).toBe("Let me check that file.");
+      expect(thoughts[0].is_final_response ?? 0).toBe(0);
+    });
+
+    it("tags the tail thought is_final_response via suffix-match when text equals the body", () => {
+      const body = "FULL USER-FACING REPLY";
+      seedAssistantMessage("m1", body, 1);
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.openOrExtendThought(THREAD, body);
+      // No boundary fired (older/reconnect path) → suffix-match must catch it.
+      store.persistNarrative(THREAD, "m1", body, false);
+
+      const thoughts = new ThoughtSegmentRepo(db).listByMessage("m1");
+      expect(thoughts).toHaveLength(1);
+      expect(thoughts[0].is_final_response).toBe(1);
+      // load() surfaces the body as assistantMessage, not a duplicate narration.
+      const entries = store.load(THREAD);
+      expect(entries.filter((e) => e.kind === "narrationSegment")).toHaveLength(0);
+      const msg = entries.find((e) => e.kind === "assistantMessage");
+      expect(msg && msg.kind === "assistantMessage" && msg.body).toBe(body);
+    });
+
+    it("orders a preamble thought before its following tool call via the shared sort counter", () => {
+      seedAssistantMessage("m1", "", 1);
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.openOrExtendThought(THREAD, "I will read.");
+      // The ToolUse handler closes the open thought before buffering the call,
+      // so the thought sorts strictly before it (sort 0 < 1).
+      store.closeOpenThought(THREAD);
+      store.bufferToolCall(THREAD, toolUse("tc-1", "Read"));
+      store.openOrExtendThought(THREAD, "Now respond.");
+
+      store.persistNarrative(THREAD, "m1", "", false);
+      const thoughts = new ThoughtSegmentRepo(db).listByMessage("m1");
+      const tools = new ToolCallRecordRepo(db).listByMessage("m1");
+      expect(thoughts.map((t) => [t.text, t.sort_order])).toEqual([
+        ["I will read.", 0],
+        ["Now respond.", 2],
+      ]);
+      expect(tools[0].sort_order).toBe(1);
+    });
+  });
+
+  describe("Trap 6: counting data preserved (semantics unchanged)", () => {
+    it("persists every top-level tool call including Agent rows, so step counts are derivable", () => {
+      seedAssistantMessage("m1", "", 1);
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, toolUse("r1", "Read"));
+      store.bufferToolCall(THREAD, toolUse("r2", "Read"));
+      store.bufferToolCall(THREAD, toolUse("r3", "Read"));
+      store.bufferToolCall(THREAD, toolUse("ag", "Agent"));
+
+      const { toolCallCount } = store.persistNarrative(THREAD, "m1", "", false);
+      expect(toolCallCount).toBe(4);
+
+      const tools = new ToolCallRecordRepo(db).listByMessage("m1");
+      // All four top-level calls persisted; the Agent is one of the four, not a fifth.
+      const topLevel = tools.filter((t) => t.parent_tool_call_id == null);
+      expect(topLevel).toHaveLength(4);
+      expect(topLevel.filter((t) => t.tool_name === "Agent")).toHaveLength(1);
+    });
+  });
+});

--- a/apps/server/src/services/__tests__/scoped-pre-grant.test.ts
+++ b/apps/server/src/services/__tests__/scoped-pre-grant.test.ts
@@ -1,0 +1,50 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolve } from "node:path";
+import { ScopedPreGrantService } from "../scoped-pre-grant";
+
+const T = "child-thread-1";
+const DOC = resolve("/tmp/mcode-handoff-child-thread-1-123.md");
+const OTHER = resolve("/tmp/secrets.env");
+
+describe("ScopedPreGrantService", () => {
+  let svc: ScopedPreGrantService;
+  beforeEach(() => {
+    svc = new ScopedPreGrantService();
+    svc.issue({ threadId: T, toolName: "Read", path: DOC });
+  });
+
+  it("path-scoped: grants the exact path, denies any other path", () => {
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: OTHER })).toBe(false);
+    // a sibling/parent dir is NOT covered (no prefix matching)
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: resolve("/tmp") })).toBe(false);
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: DOC })).toBe(true);
+  });
+
+  it("path-scoped: matches across separator/././ normalisation", () => {
+    const messy = "/tmp/./sub/../mcode-handoff-child-thread-1-123.md";
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: messy })).toBe(true);
+  });
+
+  it("tool-scoped: a different tool on the same path is not pre-granted", () => {
+    expect(svc.tryConsume({ threadId: T, toolName: "Edit", path: DOC })).toBe(false);
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: DOC })).toBe(true);
+  });
+
+  it("one-shot: a second Read of the same path on the same Turn is not pre-granted", () => {
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: DOC })).toBe(true);
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: DOC })).toBe(false);
+  });
+
+  it("thread-scoped: a different thread's Read is not pre-granted", () => {
+    expect(svc.tryConsume({ threadId: "other-thread", toolName: "Read", path: DOC })).toBe(false);
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: DOC })).toBe(true);
+  });
+
+  it("turn-scoped: clear() drops the grant so it does not survive into the next Turn", () => {
+    expect(svc.hasActiveGrant(T)).toBe(true);
+    svc.clear(T);
+    expect(svc.hasActiveGrant(T)).toBe(false);
+    expect(svc.tryConsume({ threadId: T, toolName: "Read", path: DOC })).toBe(false);
+  });
+});

--- a/apps/server/src/services/__tests__/session-runtime.test.ts
+++ b/apps/server/src/services/__tests__/session-runtime.test.ts
@@ -114,6 +114,40 @@ describe("SessionRuntime", () => {
     expect(rt.size).toBe(0);
   });
 
+  it("dedups concurrent acquire() for the same session into a single spawn", async () => {
+    // A slow adapter whose spawn does not resolve until we release it, so both
+    // acquire() calls are genuinely in flight at the same time.
+    let releaseSpawn!: () => void;
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve;
+    });
+    let spawnCount = 0;
+    const slowAdapter: ProtocolAdapter<FakeState> = {
+      async spawn(args: SpawnArgs): Promise<SpawnResult<FakeState>> {
+        spawnCount++;
+        await spawnGate;
+        return {
+          state: { id: args.sessionId, cwd: args.cwd, permissionMode: args.permissionMode, busy: false, dead: false },
+          pids: [],
+        };
+      },
+      isBusy: () => false,
+      interrupt: () => {},
+      close: () => {},
+      isStale: () => false,
+    };
+    const rt = makeRuntime(slowAdapter as FakeAdapter);
+
+    const p1 = rt.acquire({ ...ACQUIRE, sessionId: "s" });
+    const p2 = rt.acquire({ ...ACQUIRE, sessionId: "s" });
+    releaseSpawn();
+    const [a, b] = await Promise.all([p1, p2]);
+
+    expect(spawnCount).toBe(1);
+    expect(a).toBe(b);
+    expect(rt.size).toBe(1);
+  });
+
   it("shutdown() stops all sessions and clears the eviction timer", async () => {
     const rt = makeRuntime(adapter);
     await rt.acquire({ ...ACQUIRE, sessionId: "s1" });

--- a/apps/server/src/services/__tests__/session-runtime.test.ts
+++ b/apps/server/src/services/__tests__/session-runtime.test.ts
@@ -1,0 +1,129 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { SessionRuntime } from "../session-runtime";
+import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../session-runtime";
+
+/** Per-session state for the fake adapter. */
+interface FakeState {
+  id: string;
+  cwd: string;
+  permissionMode: string;
+  busy: boolean;
+  dead: boolean;
+}
+
+/** Records every adapter call so tests can assert on lifecycle ordering. */
+class FakeAdapter implements ProtocolAdapter<FakeState> {
+  calls: string[] = [];
+  spawnEnvs: Array<Record<string, string>> = [];
+  nextPids: number[] = [];
+
+  async spawn(args: SpawnArgs): Promise<SpawnResult<FakeState>> {
+    this.calls.push(`spawn:${args.sessionId}`);
+    this.spawnEnvs.push(args.env);
+    return {
+      state: { id: args.sessionId, cwd: args.cwd, permissionMode: args.permissionMode, busy: false, dead: false },
+      pids: this.nextPids,
+    };
+  }
+  isBusy(state: FakeState): boolean {
+    return state.busy;
+  }
+  interrupt(state: FakeState): void {
+    this.calls.push(`interrupt:${state.id}`);
+  }
+  close(state: FakeState): void {
+    this.calls.push(`close:${state.id}`);
+  }
+  isStale(state: FakeState, args: { cwd: string; permissionMode: string }): boolean {
+    return state.dead || state.cwd !== args.cwd || state.permissionMode !== args.permissionMode;
+  }
+}
+
+const jobObject = { isWindowsJob: false, assign: vi.fn(), setDescription: vi.fn() } as unknown as import("../job-object").JobObject;
+const envService = { getEnv: () => ({ MCODE_TEST: "1" }) } as unknown as import("../env-service").EnvService;
+
+function makeRuntime(adapter: FakeAdapter, idleTtlMs = 1000): SessionRuntime<FakeState> {
+  return new SessionRuntime<FakeState>(adapter, { jobObject, envService, idleTtlMs });
+}
+
+const ACQUIRE = { sessionId: "s1", threadId: "t1", cwd: "/repo", permissionMode: "full" };
+
+describe("SessionRuntime", () => {
+  let adapter: FakeAdapter;
+
+  beforeEach(() => {
+    adapter = new FakeAdapter();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("spawns lazily on first acquire and reuses the pooled session on the second", async () => {
+    const rt = makeRuntime(adapter);
+    const a = await rt.acquire(ACQUIRE);
+    const b = await rt.acquire(ACQUIRE);
+    expect(a).toBe(b);
+    expect(adapter.calls.filter((c) => c.startsWith("spawn")).length).toBe(1);
+    expect(rt.size).toBe(1);
+  });
+
+  it("passes the EnvService-snapshotted env to spawn", async () => {
+    const rt = makeRuntime(adapter);
+    await rt.acquire(ACQUIRE);
+    expect(adapter.spawnEnvs[0]).toEqual({ MCODE_TEST: "1" });
+  });
+
+  it("discards a stale session and respawns before reuse", async () => {
+    const rt = makeRuntime(adapter);
+    const first = await rt.acquire(ACQUIRE);
+    first.dead = true; // simulate a dead process
+    const second = await rt.acquire(ACQUIRE);
+    expect(second).not.toBe(first);
+    expect(adapter.calls).toEqual([
+      "spawn:s1",
+      "interrupt:s1", // stop() of the stale session
+      "close:s1",
+      "spawn:s1",
+    ]);
+  });
+
+  it("evicts an idle, non-busy session after the TTL", async () => {
+    const rt = makeRuntime(adapter, 1000);
+    await rt.acquire(ACQUIRE);
+    await vi.advanceTimersByTimeAsync(1001 + 60_000); // past TTL, next sweep
+    expect(rt.size).toBe(0);
+    expect(adapter.calls).toContain("close:s1");
+  });
+
+  it("never evicts a busy session even past the TTL (converged busy guard)", async () => {
+    const rt = makeRuntime(adapter, 1000);
+    const state = await rt.acquire(ACQUIRE);
+    state.busy = true;
+    await vi.advanceTimersByTimeAsync(1001 + 60_000 * 3); // several sweeps
+    expect(rt.size).toBe(1); // survived because isBusy() is true
+  });
+
+  it("stop() runs interrupt then close in order", async () => {
+    const rt = makeRuntime(adapter);
+    await rt.acquire(ACQUIRE);
+    await rt.stop("s1");
+    expect(adapter.calls).toEqual(["spawn:s1", "interrupt:s1", "close:s1"]);
+    expect(rt.size).toBe(0);
+  });
+
+  it("shutdown() stops all sessions and clears the eviction timer", async () => {
+    const rt = makeRuntime(adapter);
+    await rt.acquire({ ...ACQUIRE, sessionId: "s1" });
+    await rt.acquire({ ...ACQUIRE, sessionId: "s2" });
+    await rt.shutdown();
+    expect(rt.size).toBe(0);
+    expect(adapter.calls.filter((c) => c.startsWith("close")).sort()).toEqual(["close:s1", "close:s2"]);
+    // Timer cleared: advancing time triggers no further sweeps/spawns.
+    const before = adapter.calls.length;
+    await vi.advanceTimersByTimeAsync(60_000 * 5);
+    expect(adapter.calls.length).toBe(before);
+  });
+});

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -17,6 +17,7 @@ import type {
   ReasoningLevel,
   ContextWindowMode,
   IProviderRegistry,
+  TurnRequest,
   AgentEvent,
   ProviderId,
   InteractionMode,
@@ -481,9 +482,10 @@ export class AgentService {
     if (planAction === "revise") {
       this.armPlanGenerationTurn(threadId);
       wirePayload = `${wirePayload}\n\n${this.buildPlanOutputInstructions()}`;
-    } else if (planAction === "implement") {
-      this.setPlanQuestionModeOnProvider(threadId, false);
     }
+    // The retired setPlanQuestionMode toggle is gone: Cursor derives plan-question
+    // suppression from each Turn's interactionMode at sendTurn. An "implement"
+    // turn dispatches as "build", which clears the flag.
 
     const effectiveInteractionMode =
       planAction === "revise" || planAction === "implement"
@@ -492,7 +494,6 @@ export class AgentService {
 
     if (effectiveInteractionMode === "plan") {
       this.planParsers.set(threadId, new PlanQuestionParser());
-      this.setPlanQuestionModeOnProvider(threadId, true);
       if (providerWireOverride === undefined) {
         wirePayload = this.buildPlanPrompt(wirePayload);
       }
@@ -597,11 +598,10 @@ export class AgentService {
     // Only treat as resume if there is actually a session to resume.
     const isResume = nextSeq > 1 && !!thread.sdk_session_id;
 
-    // Hydrate SDK session ID mapping for resume
-    if (isResume && thread.sdk_session_id) {
-      const sdkProvider = this.providerRegistry.resolve(effectiveProvider);
-      sdkProvider.setSdkSessionId(sessionName, thread.sdk_session_id);
-    }
+    // Resume signal: defined ⇒ resume that SDK session, undefined ⇒ fresh.
+    // Replaces the former setSdkSessionId(...) + resume:true two-step dance.
+    const resumeFrom: string | undefined =
+      isResume && thread.sdk_session_id ? thread.sdk_session_id : undefined;
 
     const resolvedProvider = this.providerRegistry.resolve(effectiveProvider);
 
@@ -636,24 +636,36 @@ export class AgentService {
       });
     }
 
+    // Provider-specific knobs are walled into providerOptions, keyed by the
+    // resolved Provider. The orchestrator picks both the Provider and its
+    // matching options together; the cast at the sendTurn boundary is the one
+    // controlled point where the runtime selection meets the union type.
+    const providerOptions =
+      effectiveProvider === "claude"
+        ? { contextWindowMode: effectiveContextWindowMode, thinking: effectiveThinking }
+        : effectiveProvider === "codex"
+          ? { fastMode: effectiveCodexFastMode }
+          : effectiveProvider === "copilot"
+            ? { agent: effectiveCopilotAgent }
+            : {};
+
     try {
-      await resolvedProvider.sendMessage({
+      await resolvedProvider.sendTurn({
         sessionId: sessionName,
+        threadId,
         message: providerMessage,
         cwd,
         model: resolvedModel,
         fallbackModel,
-        resume: isResume,
         permissionMode,
+        interactionMode: effectiveInteractionMode ?? "build",
         attachments: persisted.length > 0 ? persisted : undefined,
         reasoningLevel,
-        contextWindowMode: effectiveContextWindowMode,
-        thinking: effectiveThinking,
-        ...(effectiveProvider === "codex" && { codexFastMode: effectiveCodexFastMode }),
         ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
         ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
-        copilotAgent: effectiveCopilotAgent,
-      });
+        resumeFrom,
+        providerOptions,
+      } as TurnRequest);
       logger.info("Message sent via provider", {
         threadId,
         session: sessionName,
@@ -1892,7 +1904,6 @@ export class AgentService {
           this.pendingPlanOutputs.delete(event.threadId);
           this.pendingExitPlanMarkdown.delete(event.threadId);
           this.planCapturedThisTurn.delete(event.threadId);
-          this.setPlanQuestionModeOnProvider(event.threadId, false);
         }
 
         if (event.type === AgentEventType.Compacting && event.active) {
@@ -1964,7 +1975,6 @@ export class AgentService {
           this.pendingPlanOutputs.delete(event.threadId);
           this.pendingExitPlanMarkdown.delete(event.threadId);
           this.planCapturedThisTurn.delete(event.threadId);
-          this.setPlanQuestionModeOnProvider(event.threadId, false);
         }
       });
     }
@@ -2049,22 +2059,21 @@ export class AgentService {
   private armPlanGenerationTurn(threadId: string): void {
     this.planOutputParsers.set(threadId, new PlanOutputParser());
     this.planCapturedThisTurn.delete(threadId);
-    this.setPlanQuestionModeOnProvider(threadId, false);
 
+    // Claude ExitPlanMode capture is a Claude-only concern that the binary
+    // TurnRequest.interactionMode cannot carry (it would conflate the
+    // question-generation turn with the answer/revise turn). It stays an
+    // off-interface arming on the concrete ClaudeProvider, invoked via a cast
+    // like setGoal/clearGoal. The revise/answer turn dispatches with
+    // interactionMode "build", so Cursor's per-Turn question mode clears itself.
     const thread = this.threadRepo.findById(threadId);
     const effectiveProvider = (thread?.provider as ProviderId) ?? "claude";
-    const provider = this.providerRegistry.resolve(effectiveProvider);
-    provider.setPlanAnswerMode?.(threadId, true);
-  }
-
-  /** Toggle native question UI suppression on the active provider. */
-  private setPlanQuestionModeOnProvider(threadId: string, enabled: boolean): void {
-    const thread = this.threadRepo.findById(threadId);
-    if (!thread) return;
-    const provider = this.providerRegistry.resolve(
-      (thread.provider as ProviderId) ?? "claude",
-    );
-    provider.setPlanQuestionMode?.(threadId, enabled);
+    if (effectiveProvider === "claude") {
+      const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
+        setPlanAnswerMode: (threadId: string, enabled: boolean) => void;
+      };
+      claudeProvider.setPlanAnswerMode(threadId, true);
+    }
   }
 
   /** Persist one plan version and broadcast, skipping duplicate captures per turn. */

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -6,7 +6,6 @@
  */
 
 import { injectable, inject, delay } from "tsyringe";
-import { randomUUID } from "crypto";
 import { existsSync, statSync } from "fs";
 import { writeFile } from "fs/promises";
 import { tmpdir } from "os";
@@ -31,9 +30,8 @@ import type {
 import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { MessageRepo } from "../repositories/message-repo";
-import { ToolCallRecordRepo, type CreateToolCallRecordInput } from "../repositories/tool-call-record-repo";
-import { ThoughtSegmentRepo, type CreateThoughtSegmentInput } from "../repositories/thought-segment-repo";
 import { HookExecutionRepo, type CreateHookExecutionInput } from "../repositories/hook-execution-repo";
+import { NarrativeStore } from "./narrative-store.js";
 import { TurnSnapshotRepo } from "../repositories/turn-snapshot-repo";
 import type Database from "better-sqlite3";
 import { TaskRepo } from "../repositories/task-repo";
@@ -142,11 +140,6 @@ function buildOffBandHandoffPrompt(tempPath: string, markdown: string, userMessa
   ].join("\n");
 }
 
-/** Buffered tool call with raw input preserved for deferred summarization. */
-interface BufferedToolCall extends CreateToolCallRecordInput {
-  _rawToolInput?: Record<string, unknown>;
-}
-
 /** Orchestrates agent sessions, message sending, and event forwarding. */
 @injectable()
 export class AgentService {
@@ -158,39 +151,13 @@ export class AgentService {
   private lastContextWindowByThread = new Map<string, number>();
   /** Tracks threads where compaction is currently in progress to guard DB persistence in turnComplete. */
   private compactionInProgressByThread = new Set<string>();
-  /** Per-thread buffer of tool calls accumulated during the current turn. */
-  private turnToolCalls = new Map<string, BufferedToolCall[]>();
+  /**
+   * Per-thread narrative buffers (tool calls, agentCallStack, thoughts, hooks,
+   * sort counter) and their enrichment + classification + persistence logic
+   * live in {@link NarrativeStore}. AgentService delegates the write seam to it.
+   */
   /** Per-thread ref_before captured at sendMessage time. */
   private turnRefBefore = new Map<string, { ref: string; cwd: string }>();
-  /** Stack of active Agent tool call IDs per thread (for nesting inference). */
-  private agentCallStack = new Map<string, string[]>();
-  /** Per-thread sort counter shared across tool calls, thought segments, and hook executions. */
-  private turnSortCounters = new Map<string, number>();
-  /** In-flight thought segment being accumulated from consecutive textDelta events, per thread. */
-  private turnOpenThought = new Map<
-    string,
-    { id: string; text: string; startedAt: string; sortOrder: number } | null
-  >();
-  /** Closed thought segments awaiting persistence at turn end, per thread. */
-  private turnThoughts = new Map<string, CreateThoughtSegmentInput[]>();
-  /** In-flight hook executions keyed by hookName, per thread. HookCompleted carries no toolName, so hookName alone matches. */
-  private turnOpenHooks = new Map<
-    string,
-    Map<
-      string,
-      {
-        id: string;
-        hookName: string;
-        toolName: string | null;
-        phase: string;
-        payload: string;
-        startedAt: string;
-        sortOrder: number;
-      }
-    >
-  >();
-  /** Closed hook executions awaiting persistence at turn end, per thread. */
-  private turnHooks = new Map<string, CreateHookExecutionInput[]>();
   /** Threads currently running persistTurn to prevent concurrent calls. */
   private persistingThreads = new Set<string>();
   /**
@@ -236,8 +203,6 @@ export class AgentService {
     private readonly providerRegistry: IProviderRegistry,
     @inject(delay(() => ThreadService))
     private readonly threadService: ThreadService,
-    @inject(ToolCallRecordRepo) private readonly toolCallRecordRepo: ToolCallRecordRepo,
-    @inject(ThoughtSegmentRepo) private readonly thoughtSegmentRepo: ThoughtSegmentRepo,
     @inject(HookExecutionRepo) private readonly hookExecutionRepo: HookExecutionRepo,
     @inject(TurnSnapshotRepo) private readonly turnSnapshotRepo: TurnSnapshotRepo,
     @inject(SnapshotService) private readonly snapshotService: SnapshotService,
@@ -257,6 +222,8 @@ export class AgentService {
     private readonly handoffStorage: HandoffStorage,
     @inject(ScopedPreGrantService)
     private readonly scopedPreGrant: ScopedPreGrantService,
+    @inject(NarrativeStore)
+    private readonly narrativeStore: NarrativeStore,
   ) {}
 
   /**
@@ -570,13 +537,8 @@ export class AgentService {
         error: err instanceof Error ? err.message : String(err),
       });
     }
-    this.turnToolCalls.set(threadId, []);
-    this.turnSortCounters.set(threadId, 0);
-    this.agentCallStack.set(threadId, []);
-    this.turnOpenThought.set(threadId, null);
-    this.turnThoughts.set(threadId, []);
-    this.turnOpenHooks.set(threadId, new Map());
-    this.turnHooks.set(threadId, []);
+    this.narrativeStore.beginTurn(threadId);
+    this.narrativeStore.resetTurnCounters(threadId);
 
     // Initialize context tracking from the previous turn's final count.
     // For resume turns, last_context_tokens is the authoritative count from
@@ -1469,34 +1431,13 @@ export class AgentService {
     // clearTurnState already called inside persistTurn
   }
 
-  /** Get the current parent tool call ID for a thread's active Agent nesting. */
-  getCurrentParentToolCallId(threadId: string): string | undefined {
-    return this.getStackDerivedParentFallback(threadId);
-  }
-
   /**
-   * Single running Agent on the stack (buffer `status === "running"`) can
-   * serve as a parent fallback when the SDK omits `parent_tool_use_id`.
-   * Zero or multiple running Agents means the fallback is ambiguous (parallel
-   * dispatch, nested agents, or coordinator work after children); return
-   * undefined so tools do not attach under the wrong subagent row.
+   * Get the current parent tool call ID for a thread's active Agent nesting.
+   * Delegates to {@link NarrativeStore} which owns the agentCallStack and the
+   * "exactly one running Agent" fallback rule (narrative-pipeline.md Trap 1).
    */
-  private getStackDerivedParentFallback(threadId: string): string | undefined {
-    const stack = this.agentCallStack.get(threadId) ?? [];
-    if (stack.length === 0) return undefined;
-
-    const buffer = this.turnToolCalls.get(threadId) ?? [];
-    const runningAgentIds: string[] = [];
-    for (const agentId of stack) {
-      const row = buffer.find(
-        (b) => b.toolCallId === agentId && b.toolName === "Agent",
-      );
-      if (row?.status === "running") {
-        runningAgentIds.push(agentId);
-      }
-    }
-
-    return runningAgentIds.length === 1 ? runningAgentIds[0] : undefined;
+  getCurrentParentToolCallId(threadId: string): string | undefined {
+    return this.narrativeStore.getCurrentParentToolCallId(threadId);
   }
 
   /**
@@ -1507,7 +1448,7 @@ export class AgentService {
     threadId: string,
     parentToolCallId: string,
   ): string {
-    const buffer = this.turnToolCalls.get(threadId) ?? [];
+    const buffer = this.narrativeStore.getBufferedToolCalls(threadId);
     let current: string | undefined = parentToolCallId;
 
     while (current) {
@@ -1597,22 +1538,10 @@ export class AgentService {
           // open a ThoughtSegment for them: that would cause the text to appear
           // twice (once as a dimmed thought block, once as the assistant message).
           if (!event.isFinalResponse) {
-            // Open or extend the current thought segment. Sort order is allocated lazily
-            // on first delta so consecutive deltas keep the same slot; the slot is taken
-            // BEFORE any following tool call's sort order, matching the live client builder.
-            const open = this.turnOpenThought.get(event.threadId);
-            if (!open) {
-              const sortOrder = this.turnSortCounters.get(event.threadId) ?? 0;
-              this.turnSortCounters.set(event.threadId, sortOrder + 1);
-              this.turnOpenThought.set(event.threadId, {
-                id: randomUUID(),
-                text: event.delta,
-                startedAt: new Date().toISOString(),
-                sortOrder,
-              });
-            } else {
-              open.text += event.delta;
-            }
+            // Open or extend the current thought segment. NarrativeStore allocates
+            // the sort order lazily on the first delta so consecutive deltas keep
+            // the same slot, taken BEFORE any following tool call's sort order.
+            this.narrativeStore.openOrExtendThought(event.threadId, event.delta);
           }
           const parser = this.planParsers.get(event.threadId);
           if (parser) {
@@ -1681,11 +1610,8 @@ export class AgentService {
           }
           // A Message event marks the end of the turn. Any Agent calls still
           // on the stack are implicitly done - clear the stack so the next turn
-          // starts clean.
-          const stackOnMessage = this.agentCallStack.get(event.threadId);
-          if (stackOnMessage && stackOnMessage.length > 0) {
-            stackOnMessage.length = 0;
-          }
+          // starts clean (narrative-pipeline.md Trap 2 end-of-turn clear).
+          this.narrativeStore.clearAgentStackOnMessage(event.threadId);
 
           // Persist any pending plan-output extracted from streamed text deltas.
           // Guarded on event.messageId so it only runs when the assistant message
@@ -1766,14 +1692,14 @@ export class AgentService {
           // Otherwise the message ended with a non-finalizing stop_reason such
           // as `tool_use`; close the thought so it persists as preamble.
           if (event.isFinalResponse) {
-            this.dropOpenThought(event.threadId);
+            this.narrativeStore.dropOpenThought(event.threadId);
           } else {
-            this.closeOpenThought(event.threadId);
+            this.narrativeStore.closeOpenThought(event.threadId);
           }
         }
 
         if (event.type === AgentEventType.ToolUse) {
-          this.closeOpenThought(event.threadId);
+          this.narrativeStore.closeOpenThought(event.threadId);
           this.bufferToolCall(event.threadId, event);
         }
 
@@ -1781,77 +1707,40 @@ export class AgentService {
           // Late hooks (TurnComplete already seen) bypass the in-turn buffer.
           // They will be persisted directly in the paired HookCompleted handler.
           if (this.turnCompleteSeenByThread.has(event.threadId)) {
-            const sortOrder = this.turnSortCounters.get(event.threadId) ?? 0;
-            this.turnSortCounters.set(event.threadId, sortOrder + 1);
-            // Use turnOpenHooks as a scratch pad so HookCompleted can still pair
-            // with the HookStarted record even for late hooks.
-            const lateMap =
-              this.turnOpenHooks.get(event.threadId) ??
-              new Map<
-                string,
-                {
-                  id: string;
-                  hookName: string;
-                  toolName: string | null;
-                  phase: string;
-                  payload: string;
-                  startedAt: string;
-                  sortOrder: number;
-                }
-              >();
-            lateMap.set(event.hookName, {
-              id: randomUUID(),
+            const sortOrder = this.narrativeStore.nextSortOrder(event.threadId);
+            // Use the open-hook map as a scratch pad so HookCompleted can still
+            // pair with the HookStarted record even for late hooks.
+            this.narrativeStore.openHook(event.threadId, {
               hookName: event.hookName,
               toolName: event.toolName ?? null,
               // Post-turn hooks are always tagged "stop" regardless of hookType
               // because they fire after the SDK result message.
               phase: "stop",
               payload: JSON.stringify({ hookType: "stop", toolName: null }),
-              startedAt: new Date().toISOString(),
               sortOrder,
             });
-            this.turnOpenHooks.set(event.threadId, lateMap);
           } else {
-            const sortOrder = this.turnSortCounters.get(event.threadId) ?? 0;
-            this.turnSortCounters.set(event.threadId, sortOrder + 1);
+            const sortOrder = this.narrativeStore.nextSortOrder(event.threadId);
             // Close any open thought so the hook sorts after the text that preceded it,
             // mirroring the tool-call branch.
-            this.closeOpenThought(event.threadId);
-            const map =
-              this.turnOpenHooks.get(event.threadId) ??
-              new Map<
-                string,
-                {
-                  id: string;
-                  hookName: string;
-                  toolName: string | null;
-                  phase: string;
-                  payload: string;
-                  startedAt: string;
-                  sortOrder: number;
-                }
-              >();
-            map.set(event.hookName, {
-              id: randomUUID(),
+            this.narrativeStore.closeOpenThought(event.threadId);
+            this.narrativeStore.openHook(event.threadId, {
               hookName: event.hookName,
               toolName: event.toolName ?? null,
               phase: event.hookType,
               payload: JSON.stringify({ hookType: event.hookType, toolName: event.toolName ?? null }),
-              startedAt: new Date().toISOString(),
               sortOrder,
             });
-            this.turnOpenHooks.set(event.threadId, map);
           }
         }
 
         if (event.type === AgentEventType.HookCompleted) {
-          const map = this.turnOpenHooks.get(event.threadId);
-          const open = map?.get(event.hookName);
-          if (open && map) {
+          const open = this.narrativeStore.peekOpenHook(event.threadId, event.hookName);
+          if (open) {
+            const endedAt = new Date().toISOString();
             // Late hook: persist immediately to the last message row and
             // broadcast a HookCompleted event with persistedMessageId.
             if (this.turnCompleteSeenByThread.has(event.threadId)) {
-              const endedAt = new Date().toISOString();
               this.flushLateHook(event.threadId, {
                 id: open.id,
                 hookName: open.hookName,
@@ -1864,11 +1753,8 @@ export class AgentService {
                 endedAt,
                 sortOrder: open.sortOrder,
               });
-              map.delete(event.hookName);
             } else {
-              const endedAt = new Date().toISOString();
-              const list = this.turnHooks.get(event.threadId) ?? [];
-              list.push({
+              this.narrativeStore.pushClosedHook(event.threadId, {
                 id: open.id,
                 messageId: "",
                 hookName: open.hookName,
@@ -1881,14 +1767,13 @@ export class AgentService {
                 endedAt,
                 sortOrder: open.sortOrder,
               });
-              this.turnHooks.set(event.threadId, list);
-              map.delete(event.hookName);
             }
+            this.narrativeStore.removeOpenHook(event.threadId, event.hookName);
           }
         }
 
         if (event.type === AgentEventType.ToolResult) {
-          this.updateBufferedToolCallOutput(event.threadId, event.toolCallId, event.output, event.isError);
+          this.narrativeStore.updateBufferedToolCallOutput(event.threadId, event.toolCallId, event.output, event.isError);
         }
 
         if (event.type === AgentEventType.TurnStarted) {
@@ -1903,8 +1788,7 @@ export class AgentService {
           // hooks can attach to the previous turn. Re-seeding them here rather
           // than in clearTurnState ensures a fresh counter for each new turn
           // while late hooks from the prior turn can still increment the old one.
-          this.turnSortCounters.set(event.threadId, 0);
-          this.agentCallStack.set(event.threadId, []);
+          this.narrativeStore.resetTurnCounters(event.threadId);
           this.turnCompleteSeenByThread.delete(event.threadId);
         }
 
@@ -2249,39 +2133,12 @@ ${userMessage}`;
   }
 
   /**
-   * Close any in-flight thought segment for the thread and push it onto the
-   * closed-thoughts list. Called before a tool call begins (so the thought
-   * sorts strictly before the tool) and during turn-end drain.
+   * Buffer a tool call event into the narrative write seam, then perform the
+   * non-narrative side effect AgentService still owns: persisting TodoWrite
+   * task state for reconnect hydration. The narrative buffer + agentCallStack
+   * push + parent attribution (narrative-pipeline.md Trap 1) live in
+   * {@link NarrativeStore.bufferToolCall}, which returns the attributed parent.
    */
-  private closeOpenThought(threadId: string): void {
-    const open = this.turnOpenThought.get(threadId);
-    if (!open) return;
-    const list = this.turnThoughts.get(threadId) ?? [];
-    list.push({
-      id: open.id,
-      messageId: "",
-      text: open.text,
-      startedAt: open.startedAt,
-      endedAt: new Date().toISOString(),
-      sortOrder: open.sortOrder,
-    });
-    this.turnThoughts.set(threadId, list);
-    this.turnOpenThought.set(threadId, null);
-  }
-
-  /**
-   * Discards the open thought without persisting it.
-   *
-   * Called when `AssistantMessageBoundary` reports `isFinalResponse: true` —
-   * the streamed text was actually the final assistant response and will be
-   * persisted via the `Message` event, so keeping the matching thought row
-   * would duplicate the body as a ThoughtBlock in the narrative.
-   */
-  private dropOpenThought(threadId: string): void {
-    this.turnOpenThought.set(threadId, null);
-  }
-
-  /** Buffer a tool call event for later persistence. */
   private bufferToolCall(
     threadId: string,
     event: {
@@ -2291,47 +2148,7 @@ ${userMessage}`;
       parentToolCallId?: string;
     },
   ): void {
-    const buffer = this.turnToolCalls.get(threadId) ?? [];
-    const sortOrder = this.turnSortCounters.get(threadId) ?? 0;
-    this.turnSortCounters.set(threadId, sortOrder + 1);
-
-    const stack = this.agentCallStack.get(threadId) ?? [];
-    // Prefer the SDK-provided parent_tool_use_id on the event (set by the
-    // provider). Parallel subagents require it; stack fallback aligns with
-    // `getCurrentParentToolCallId` / index.ts enrichment.
-    const parentToolCallId =
-      event.toolName === "Agent"
-        ? undefined
-        : event.parentToolCallId ?? this.getStackDerivedParentFallback(threadId);
-    // Diagnostic: trace parent attribution when a mismatch is suspected.
-    if (event.toolName !== "Agent" && parentToolCallId) {
-      logger.debug("bufferToolCall: parent attribution", {
-        threadId,
-        toolCallId: event.toolCallId,
-        toolName: event.toolName,
-        sdkParent: event.parentToolCallId ?? null,
-        stackDepth: stack.length,
-        attributed: parentToolCallId,
-        source: event.parentToolCallId ? "sdk" : "stack-fallback",
-      });
-    }
-    if (event.toolName === "Agent") {
-      stack.push(event.toolCallId);
-      this.agentCallStack.set(threadId, stack);
-    }
-
-    buffer.push({
-      toolCallId: event.toolCallId,
-      messageId: "",
-      toolName: event.toolName,
-      inputSummary: "", // Deferred to persistTurn
-      outputSummary: "",
-      status: "running",
-      sortOrder,
-      parentToolCallId,
-      _rawToolInput: event.toolInput,
-    });
-    this.turnToolCalls.set(threadId, buffer);
+    const parentToolCallId = this.narrativeStore.bufferToolCall(threadId, event);
 
     // Persist TodoWrite state for hydration on reconnect
     if (event.toolName === "TodoWrite") {
@@ -2377,35 +2194,6 @@ ${userMessage}`;
             });
           }
         }
-      }
-    }
-  }
-
-  /** Update a buffered tool call with its output when result arrives. */
-  private updateBufferedToolCallOutput(
-    threadId: string,
-    toolCallId: string,
-    output: string,
-    isError: boolean,
-  ): void {
-    const stack = this.agentCallStack.get(threadId) ?? [];
-    const stackIdx = stack.indexOf(toolCallId);
-    if (stackIdx >= 0) {
-      stack.splice(stackIdx, 1);
-      this.agentCallStack.set(threadId, stack);
-      logger.debug("updateBufferedToolCallOutput: popped Agent from stack", {
-        threadId,
-        toolCallId,
-        remainingDepth: stack.length,
-      });
-    }
-
-    const buffer = this.turnToolCalls.get(threadId) ?? [];
-    for (let i = buffer.length - 1; i >= 0; i--) {
-      if (buffer[i].toolCallId === toolCallId) {
-        buffer[i].outputSummary = output.slice(0, 500);
-        buffer[i].status = isError ? "failed" : "completed";
-        break;
       }
     }
   }
@@ -2503,141 +2291,41 @@ ${userMessage}`;
     } satisfies AgentEvent);
   }
 
-  /** Persist buffered tool calls and snapshot to DB, then push turn.persisted. */
+  /**
+   * Persist the turn: the narrative rows (tool calls, thoughts, hooks) are
+   * persisted by {@link NarrativeStore.persistNarrative}; AgentService retains
+   * the turn-level concerns — the git turn_snapshot, the files_changed flag,
+   * and the `turn.persisted` broadcast — then clears the per-turn state.
+   */
   private async persistTurn(threadId: string, isError = false): Promise<void> {
     if (this.persistingThreads.has(threadId)) return;
     this.persistingThreads.add(threadId);
     try {
-      const buffer = this.turnToolCalls.get(threadId) ?? [];
+      const bufferedCount = this.narrativeStore.getBufferedToolCalls(threadId).length;
 
       const { messages } = this.messageRepo.listByThread(threadId, 1);
       if (messages.length === 0) {
-        if (buffer.length > 0) {
+        if (bufferedCount > 0) {
           logger.warn("Discarding buffered tool calls: no messages found", {
             threadId,
-            toolCallCount: buffer.length,
+            toolCallCount: bufferedCount,
           });
         }
         this.clearTurnState(threadId);
         return;
       }
-      const messageId = messages[messages.length - 1].id;
+      const lastMessage = messages[messages.length - 1];
+      const messageId = lastMessage.id;
       // Record the message ID so late hooks (Stop/SessionEnd) arriving after
       // this point can attach to the correct persisted row.
       this.lastPersistedMessageIdByThread.set(threadId, messageId);
 
-      for (const tc of buffer) {
-        if (tc.status === "running") {
-          // Tools still running when the turn ends were interrupted, not failed.
-          // A tool that actually errored already has status "failed" from
-          // updateBufferedToolCallOutput.
-          tc.status = isError ? "cancelled" : "completed";
-        }
-        tc.messageId = messageId;
-
-        // Deferred summarization: compute inputSummary from raw tool input
-        if (!tc.inputSummary && tc._rawToolInput) {
-          tc.inputSummary = this.summarizeInput(tc.toolName, tc._rawToolInput);
-          delete tc._rawToolInput;
-        }
-      }
-
-      if (buffer.length > 0) {
-        try {
-          this.toolCallRecordRepo.bulkCreate(buffer);
-        } catch (err) {
-          logger.error("Failed to persist tool call records", {
-            threadId,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-
-      // Drain any in-flight thought / hook before persisting so a turn that ends
-      // without a trailing tool call still records its tail thought + hook.
-      this.closeOpenThought(threadId);
-      const openHookMap = this.turnOpenHooks.get(threadId);
-      if (openHookMap && openHookMap.size > 0) {
-        const list = this.turnHooks.get(threadId) ?? [];
-        const endedAt = new Date().toISOString();
-        for (const open of openHookMap.values()) {
-          list.push({
-            id: open.id,
-            messageId: "",
-            hookName: open.hookName,
-            toolName: open.toolName,
-            phase: open.phase,
-            payload: open.payload,
-            durationMs: Date.parse(endedAt) - Date.parse(open.startedAt),
-            didBlock: false,
-            startedAt: open.startedAt,
-            endedAt,
-            sortOrder: open.sortOrder,
-          });
-        }
-        this.turnHooks.set(threadId, list);
-        openHookMap.clear();
-      }
-
-      const rawThoughts = (this.turnThoughts.get(threadId) ?? []).map((t) => ({
-        ...t,
+      const { toolCallCount } = this.narrativeStore.persistNarrative(
+        threadId,
         messageId,
-      }));
-      const thoughts = rawThoughts;
-      if (thoughts.length > 0) {
-        // Suffix-match safeguard: the last chronological thought segment whose
-        // text (trimmed) is a suffix of the assistant message body is the
-        // final user-facing response — tag it so the client doesn't render it
-        // as a ThoughtBlock.  This catches provider edge cases and tool-free
-        // turns where the provider cannot set isFinalResponse at stream time.
-        const msgContent = messages[messages.length - 1].content ?? "";
-        const msgTrimmed = msgContent.trim();
-        if (msgTrimmed.length > 0) {
-          // Identify the last segment by sortOrder (suffix guard targets the tail).
-          let maxSortOrder = -Infinity;
-          for (const t of thoughts) {
-            if (t.sortOrder > maxSortOrder) maxSortOrder = t.sortOrder;
-          }
-          for (const t of thoughts) {
-            const segTrimmed = t.text.trim();
-            if (segTrimmed.length === 0) continue;
-            if (segTrimmed === msgTrimmed) {
-              t.isFinalResponse = 1;
-              continue;
-            }
-            if (
-              t.sortOrder === maxSortOrder &&
-              (t.isFinalResponse === 1 || msgTrimmed.endsWith(segTrimmed))
-            ) {
-              t.isFinalResponse = 1;
-            }
-          }
-        }
-
-        try {
-          this.thoughtSegmentRepo.bulkCreate(thoughts);
-        } catch (err) {
-          logger.error("Failed to persist thought segments", {
-            threadId,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-
-      const hooks = (this.turnHooks.get(threadId) ?? []).map((h) => ({
-        ...h,
-        messageId,
-      }));
-      if (hooks.length > 0) {
-        try {
-          this.hookExecutionRepo.bulkCreate(hooks);
-        } catch (err) {
-          logger.error("Failed to persist hook executions", {
-            threadId,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
+        lastMessage.content ?? "",
+        isError,
+      );
 
       let filesChanged: string[] = [];
       const refData = this.turnRefBefore.get(threadId);
@@ -2677,7 +2365,7 @@ ${userMessage}`;
       broadcast("turn.persisted", {
         threadId,
         messageId,
-        toolCallCount: buffer.length,
+        toolCallCount,
         filesChanged,
       });
 
@@ -2689,15 +2377,12 @@ ${userMessage}`;
 
   /** Clear per-turn buffering state. */
   private clearTurnState(threadId: string): void {
-    this.turnToolCalls.delete(threadId);
     this.turnRefBefore.delete(threadId);
-    // turnSortCounters and agentCallStack are reset in the TurnStarted handler
-    // so late hooks that arrive after clearTurnState can still increment the
-    // sort counter for the completed turn.
-    this.turnOpenThought.delete(threadId);
-    this.turnThoughts.delete(threadId);
-    this.turnOpenHooks.delete(threadId);
-    this.turnHooks.delete(threadId);
+    // The narrative buffers live in NarrativeStore. Its sort counter and
+    // agentCallStack are reset in the TurnStarted handler (not here) so late
+    // hooks that arrive after clearTurnState can still increment the completed
+    // turn's sort counter.
+    this.narrativeStore.clearTurn(threadId);
     this.persistingThreads.delete(threadId);
   }
 
@@ -2738,25 +2423,6 @@ ${userMessage}`;
       break;
     }
     return map;
-  }
-
-  /** Generate a human-readable summary of tool input. */
-  private summarizeInput(toolName: string, input: Record<string, unknown>): string {
-    switch (toolName) {
-      case "Read":
-      case "Edit":
-      case "Write":
-        return String(input.file_path ?? input.filePath ?? "");
-      case "Bash":
-        return String(input.command ?? "").slice(0, 200);
-      case "Grep":
-      case "Glob":
-        return String(input.pattern ?? "");
-      case "Agent":
-        return String(input.description ?? "").slice(0, 100);
-      default:
-        return JSON.stringify(input).slice(0, 200);
-    }
   }
 
   /** Stop all active agent sessions (for graceful shutdown). */

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -8,6 +8,8 @@
 import { injectable, inject, delay } from "tsyringe";
 import { randomUUID } from "crypto";
 import { existsSync, statSync } from "fs";
+import { writeFile } from "fs/promises";
+import { tmpdir } from "os";
 import { isAbsolute } from "path";
 import { logger } from "@mcode/shared";
 import { AgentEventType } from "@mcode/contracts";
@@ -58,6 +60,7 @@ import { buildHandoffContent, buildConversationReplay, replayBudgetChars, resolv
 import { PLAN_ANSWER_MESSAGE_PREFIX } from "@mcode/contracts";
 import { HandoffPipelineService } from "./handoff/handoff-pipeline.js";
 import { HandoffStorage } from "./handoff/handoff-storage.js";
+import { ScopedPreGrantService } from "./scoped-pre-grant.js";
 import type { AttachmentSource } from "./handoff/handoff-storage.js";
 import type { HandoffArtifact } from "./handoff/handoff-types.js";
 import { classifyProviderError } from "./handoff/error-classifier.js";
@@ -96,6 +99,47 @@ function findLastIndex<T>(arr: T[], predicate: (item: T) => boolean): number {
     if (predicate(arr[i])) return i;
   }
   return -1;
+}
+
+/**
+ * Derive a short (<=2-3 sentence) graceful-degradation summary from the full
+ * handoff markdown. Uses the first non-heading, non-empty paragraph so the
+ * child still has minimal orientation even if it never reads the temp file
+ * (e.g. the file is swept, or the Read is denied). Capped so the inline prompt
+ * stays small by construction.
+ */
+function deriveHandoffSummary(markdown: string): string {
+  const SUMMARY_CAP = 280;
+  const firstParagraph = markdown
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .find((block) => block.length > 0 && !block.startsWith("#") && !block.startsWith("---"));
+  const summary = (firstParagraph ?? "").replace(/\s+/g, " ").trim();
+  if (!summary) {
+    return "A handoff document describing the parent thread's context is available at the path above; read it before continuing.";
+  }
+  return summary.length > SUMMARY_CAP ? `${summary.slice(0, SUMMARY_CAP).trimEnd()}...` : summary;
+}
+
+/**
+ * Build the small inline first-Turn prompt for off-band handoff delivery: a
+ * pointer line to the full doc on disk, a short graceful-degradation summary,
+ * then the child's first user message. The child is pre-granted a one-shot
+ * Read of the pointed-to file (see ScopedPreGrantService) so it can pull the
+ * full context without prompting. Kept small by construction so it fits any
+ * provider's per-turn input window.
+ */
+function buildOffBandHandoffPrompt(tempPath: string, markdown: string, userMessage: string): string {
+  return [
+    "You are continuing work handed off from a previous thread.",
+    `The full handoff document is on this machine at: ${tempPath}`,
+    "Read that file first with the Read tool to load the complete context (you are pre-authorized to read it once without prompting). Summary if the file is unavailable:",
+    deriveHandoffSummary(markdown),
+    "",
+    "---",
+    "",
+    userMessage,
+  ].join("\n");
 }
 
 /** Buffered tool call with raw input preserved for deferred summarization. */
@@ -211,6 +255,8 @@ export class AgentService {
     private readonly handoffPipeline: HandoffPipelineService,
     @inject(HandoffStorage)
     private readonly handoffStorage: HandoffStorage,
+    @inject(ScopedPreGrantService)
+    private readonly scopedPreGrant: ScopedPreGrantService,
   ) {}
 
   /**
@@ -1199,15 +1245,43 @@ export class AgentService {
         providerErrorOnGenerate: artifact.meta.providerErrorOnGenerate,
       });
 
-      // Store an internal-only system message at seq 1 as a DB anchor for the handoff.
-      // isInternal=true keeps it off the UI render path.
+      // Store an internal-only system message at seq 1 as a DB anchor for the
+      // handoff. We keep the FULL markdown here (not the pointer): it is not
+      // budget-bound, and a complete anchor lets reload reconstruct the doc even
+      // if the OS temp file has been swept. isInternal=true keeps it off the UI
+      // render path.
       this.messageRepo.create(
         thread.id, "system", artifact.markdown, 1,
         undefined, undefined, undefined, undefined, /* isInternal */ true,
       );
 
-      // Append the user's new message so the provider receives full context + the prompt.
-      providerWireOverride = `${artifact.markdown}\n\n---\n\n${content}`;
+      // Off-band delivery (PRD #538): write the FULL handoff doc to a stable OS
+      // temp path and shrink the child's inline first-Turn prompt to a small
+      // pointer + graceful-degradation summary + the user's message. Issue a
+      // ScopedPreGrant so the child can Read that one file on its first Turn
+      // without prompting, regardless of permissionMode.
+      const handoffTempPath = join(
+        tmpdir(),
+        `mcode-handoff-${thread.id}-${Date.now()}.md`,
+      );
+      try {
+        await writeFile(handoffTempPath, artifact.markdown, "utf8");
+        this.scopedPreGrant.issue({
+          threadId: thread.id,
+          toolName: "Read",
+          path: handoffTempPath,
+        });
+        providerWireOverride = buildOffBandHandoffPrompt(handoffTempPath, artifact.markdown, content);
+      } catch (writeErr) {
+        // If the temp write fails we cannot pre-grant a Read, so fall back to
+        // inlining the full doc (legacy behaviour) — the fork still succeeds.
+        logger.warn("Off-band handoff write failed; inlining full doc", {
+          threadId: thread.id,
+          handoffTempPath,
+          error: writeErr instanceof Error ? writeErr.message : String(writeErr),
+        });
+        providerWireOverride = `${artifact.markdown}\n\n---\n\n${content}`;
+      }
     } catch (pipelineErr) {
       // Re-check child thread existence before writing any fallback artifacts.
       // The thread may have been hard-deleted between pipeline start and failure
@@ -1899,6 +1973,9 @@ export class AgentService {
           } else {
             this.clearTurnState(event.threadId);
           }
+          // Turn-scoped cleanup of any one-shot handoff Read grant when the
+          // first Turn errors out before completing normally.
+          this.scopedPreGrant.clear(event.threadId);
           this.planParsers.delete(event.threadId);
           this.planOutputParsers.delete(event.threadId);
           this.pendingPlanOutputs.delete(event.threadId);
@@ -1970,6 +2047,9 @@ export class AgentService {
 
         if (event.type === AgentEventType.Ended) {
           this.trackSessionEnded(event.threadId);
+          // Turn-scoped cleanup of any one-shot handoff Read grant. No-op on
+          // later turns since the grant is already gone (consumed or cleared).
+          this.scopedPreGrant.clear(event.threadId);
           this.planParsers.delete(event.threadId);
           this.planOutputParsers.delete(event.threadId);
           this.pendingPlanOutputs.delete(event.threadId);

--- a/apps/server/src/services/handoff/__tests__/fork-flow.e2e.test.ts
+++ b/apps/server/src/services/handoff/__tests__/fork-flow.e2e.test.ts
@@ -21,6 +21,12 @@ import { HandoffPipelineService } from "../handoff-pipeline.js";
 import { HandoffStorage } from "../handoff-storage.js";
 import type { HandoffArtifact } from "../handoff-types.js";
 import { classifyProviderError } from "../error-classifier.js";
+import { CleanForker } from "../session-forker.js";
+
+/** Wrap a Claude-like mock (with runSideChannelQuery) in a real CleanForker. */
+function withCleanForker<T extends { runSideChannelQuery: (...a: any[]) => any }>(p: T) {
+  return { ...p, forker: new CleanForker(p as any) };
+}
 
 // ---------------------------------------------------------------------------
 // Mock the push broadcast so the pipeline's callers don't need a real WS server.
@@ -103,13 +109,14 @@ describe("fork flow with handoff pipeline (e2e)", () => {
   it("path B success persists artifact to disk with generatedBy=provider and ladderStep=B", async () => {
     const deps = makeDeps((id) => {
       if (id === "claude") {
-        return {
+        return withCleanForker({
           sessionForkOnResume: "clean",
           maxInputCharactersPerTurn: 180_000,
+          id: "claude",
           runSideChannelQuery: vi.fn(async () =>
             "# Handoff\n\n## Goal\nComplete the refactor.\n\n## Context\nSome context.",
           ),
-        };
+        });
       }
       return null;
     });
@@ -227,9 +234,10 @@ describe("fork flow with handoff pipeline (e2e)", () => {
   });
 
   it("path B quota failure (429) falls to D and artifact has ladderStep=D", async () => {
-    const deps = makeDeps((_id) => ({
+    const deps = makeDeps((_id) => withCleanForker({
       sessionForkOnResume: "clean",
       maxInputCharactersPerTurn: 180_000,
+      id: "claude",
       runSideChannelQuery: vi.fn(async () => {
         throw Object.assign(new Error("rate limited"), { status: 429 });
       }),

--- a/apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts
@@ -2,6 +2,25 @@ import "reflect-metadata";
 import { describe, expect, it, vi } from "vitest";
 import type { IProviderRegistry } from "@mcode/contracts";
 import { HandoffPipelineService } from "../handoff-pipeline.js";
+import { CleanForker, MutatingForker, DeterministicForker } from "../session-forker.js";
+
+/**
+ * Wrap a partial Claude-like mock (with runSideChannelQuery) in a real
+ * CleanForker so tests exercise the new forker dispatch end-to-end.
+ */
+function withCleanForker<T extends { runSideChannelQuery: (...a: any[]) => any }>(p: T) {
+  return { ...p, forker: new CleanForker(p as any) };
+}
+
+/** Wrap a Cursor-like mock (with runHiddenTurn) in a real MutatingForker. */
+function withMutatingForker<T extends { runHiddenTurn: (...a: any[]) => any }>(p: T) {
+  return { ...p, forker: new MutatingForker(p as any) };
+}
+
+/** Attach a DeterministicForker to a provider with no fork capability. */
+function withDeterministicForker<T extends object>(p: T) {
+  return { ...p, forker: new DeterministicForker() };
+}
 
 function mkDeps() {
   const parent = { id: "t_parent", title: "X", provider: "claude", sdk_session_id: "sdk_1", deleted_at: null, workspace_id: "ws_1", worktree_path: null } as any;
@@ -38,11 +57,12 @@ describe("HandoffPipelineService.orchestrate", () => {
     const deps = mkDeps();
     deps.providerRegistry.resolve = vi.fn((id: string) => {
       if (id === "claude") {
-        return {
+        return withCleanForker({
           sessionForkOnResume: "clean",
           maxInputCharactersPerTurn: 180_000,
+          id: "claude",
           runSideChannelQuery: vi.fn(async () => "# Handoff\n\n## Goal\nX"),
-        };
+        });
       }
       return null;
     });
@@ -54,9 +74,10 @@ describe("HandoffPipelineService.orchestrate", () => {
 
   it("path B quota failure falls directly to D, skipping A", async () => {
     const deps = mkDeps();
-    deps.providerRegistry.resolve = vi.fn(() => ({
+    deps.providerRegistry.resolve = vi.fn(() => withCleanForker({
       sessionForkOnResume: "clean",
       maxInputCharactersPerTurn: 180_000,
+      id: "claude",
       runSideChannelQuery: vi.fn(async () => {
         throw Object.assign(new Error("rate limited"), { status: 429 });
       }),
@@ -69,9 +90,10 @@ describe("HandoffPipelineService.orchestrate", () => {
 
   it("mutating-resume provider uses path A and minimal mode", async () => {
     const deps = mkDeps();
-    deps.providerRegistry.resolve = vi.fn(() => ({
+    deps.providerRegistry.resolve = vi.fn(() => withMutatingForker({
       sessionForkOnResume: "mutating",
       maxInputCharactersPerTurn: 4_000,
+      id: "cursor",
       runHiddenTurn: vi.fn(async () => "# Handoff\n\n## Goal\nX"),
     }));
     const svc = HandoffPipelineService.forTesting(deps);
@@ -85,9 +107,10 @@ describe("HandoffPipelineService.orchestrate", () => {
 
   it("unsupported-resume provider skips to D with reason null", async () => {
     const deps = mkDeps();
-    deps.providerRegistry.resolve = vi.fn(() => ({
+    deps.providerRegistry.resolve = vi.fn(() => withDeterministicForker({
       sessionForkOnResume: "unsupported",
       maxInputCharactersPerTurn: 16_000,
+      id: "codex",
     }));
     const svc = HandoffPipelineService.forTesting(deps);
     const r = await svc.orchestrate({
@@ -105,11 +128,12 @@ describe("HandoffPipelineService.orchestrate", () => {
     // Override parent to have no session id
     const parentNoSession = { id: "t_parent", title: "X", provider: "claude", sdk_session_id: null, deleted_at: null, workspace_id: "ws_1", worktree_path: null };
     deps.threadRepo.findById = vi.fn(async (id) => (id === "t_parent" ? parentNoSession : null));
-    const provider = {
+    const provider = withCleanForker({
       sessionForkOnResume: "clean",
       maxInputCharactersPerTurn: 180_000,
+      id: "claude",
       runSideChannelQuery: vi.fn(async () => "should not be called"),
-    };
+    });
     deps.providerRegistry.resolve = vi.fn(() => provider);
     const svc = HandoffPipelineService.forTesting(deps);
     const r = await svc.orchestrate(BASE_REQ);
@@ -124,9 +148,10 @@ describe("HandoffPipelineService.orchestrate", () => {
     const deps = mkDeps();
     // Provider that rejects immediately when its signal is already aborted,
     // simulating what a real provider does when the 60s AbortController fires.
-    deps.providerRegistry.resolve = vi.fn(() => ({
+    deps.providerRegistry.resolve = vi.fn(() => withCleanForker({
       sessionForkOnResume: "clean",
       maxInputCharactersPerTurn: 180_000,
+      id: "claude",
       runSideChannelQuery: vi.fn(async (args: { abortSignal?: AbortSignal }) => {
         if (args.abortSignal?.aborted) {
           throw Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
@@ -166,9 +191,10 @@ describe("HandoffPipelineService.orchestrate", () => {
 
     const deps = mkDeps();
     let callCount = 0;
-    deps.providerRegistry.resolve = vi.fn(() => ({
+    deps.providerRegistry.resolve = vi.fn(() => withMutatingForker({
       sessionForkOnResume: "mutating",
       maxInputCharactersPerTurn: 180_000,
+      id: "cursor",
       runHiddenTurn: vi.fn(async () => {
         const idx = ++callCount;
         order.push(idx);

--- a/apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts
@@ -88,10 +88,12 @@ describe("HandoffPipelineService.orchestrate", () => {
     expect(r.meta.providerErrorOnGenerate).toBe("quota");
   });
 
-  it("mutating-resume provider uses path A and minimal mode", async () => {
+  it("mutating-resume provider uses path A; mode is always full after off-band delivery", async () => {
     const deps = mkDeps();
     deps.providerRegistry.resolve = vi.fn(() => withMutatingForker({
       sessionForkOnResume: "mutating",
+      // A small child cap no longer downgrades the doc: off-band delivery
+      // (PRD #538) retired the minimal mode and the per-turn char budget.
       maxInputCharactersPerTurn: 4_000,
       id: "cursor",
       runHiddenTurn: vi.fn(async () => "# Handoff\n\n## Goal\nX"),
@@ -102,7 +104,7 @@ describe("HandoffPipelineService.orchestrate", () => {
       childProviderId: "cursor",
     });
     expect(r.meta.ladderStep).toBe("A");
-    expect(r.meta.mode).toBe("minimal");
+    expect(r.meta.mode).toBe("full");
   });
 
   it("unsupported-resume provider skips to D with reason null", async () => {

--- a/apps/server/src/services/handoff/__tests__/handoff-prompt.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-prompt.test.ts
@@ -1,25 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildHandoffPrompt, pickHandoffMode, computeBudgetChars, truncateAtSectionBoundary } from "../handoff-prompt.js";
-
-describe("pickHandoffMode", () => {
-  it("returns minimal when child cap < 8000", () => {
-    expect(pickHandoffMode(4_000)).toBe("minimal");
-    expect(pickHandoffMode(7_999)).toBe("minimal");
-  });
-  it("returns full at or above 8000", () => {
-    expect(pickHandoffMode(8_000)).toBe("full");
-    expect(pickHandoffMode(180_000)).toBe("full");
-  });
-});
-
-describe("computeBudgetChars", () => {
-  it("subtracts reserved overhead from cap", () => {
-    expect(computeBudgetChars(180_000)).toBeGreaterThan(170_000);
-  });
-  it("floors at 1000 minimum", () => {
-    expect(computeBudgetChars(1_500)).toBe(1_000);
-  });
-});
+import { buildHandoffPrompt } from "../handoff-prompt.js";
 
 describe("buildHandoffPrompt", () => {
   const baseInput = {
@@ -27,12 +7,11 @@ describe("buildHandoffPrompt", () => {
     parentThreadTitle: "Database migration design",
     forkMessageExcerpt: "We should use Postgres because...",
     childProviderId: "claude",
-    childMaxInputCharacters: 180_000,
     userFollowUpMessage: "what about feature X?",
   };
 
   it("quotes the /handoff skill instructions verbatim", () => {
-    const p = buildHandoffPrompt({ ...baseInput, mode: "full" });
+    const p = buildHandoffPrompt(baseInput);
     expect(p).toContain("Write a handoff document summarising the current conversation so a fresh agent can continue the work.");
     expect(p).toContain(`Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.`);
     expect(p).toContain("Do not duplicate content already captured in other artifacts");
@@ -41,62 +20,37 @@ describe("buildHandoffPrompt", () => {
   });
 
   it("handles missing follow-up message by saying so explicitly", () => {
-    const p = buildHandoffPrompt({ ...baseInput, mode: "full", userFollowUpMessage: "" });
+    const p = buildHandoffPrompt({ ...baseInput, userFollowUpMessage: "" });
     expect(p).toMatch(/has not provided a follow-up message yet/i);
     expect(p).toMatch(/no skill arguments/i);
   });
 
-  it("expresses budget in characters not tokens", () => {
-    const p = buildHandoffPrompt({ ...baseInput, mode: "minimal", childMaxInputCharacters: 4000 });
-    expect(p.toLowerCase()).toContain("character");
-    expect(p.toLowerCase()).not.toContain("token");
+  it("asks for a complete doc with no character cap (off-band delivery)", () => {
+    const p = buildHandoffPrompt(baseInput);
+    // The full-vs-minimal mode, the per-turn character budget, and the
+    // overflow/truncation guard were retired by off-band delivery (PRD #538).
+    expect(p.toLowerCase()).toContain("off-band");
+    expect(p.toLowerCase()).toContain("no character cap");
+    expect(p.toLowerCase()).not.toMatch(/less than or equal to \d/);
+    expect(p.toLowerCase()).not.toContain("output mode:");
   });
 
   it("frames user-msg fork as retry, assistant-msg fork as follow-up about assistant reply", () => {
-    const userFork = buildHandoffPrompt({ ...baseInput, mode: "full", forkAnchorRole: "user" });
+    const userFork = buildHandoffPrompt({ ...baseInput, forkAnchorRole: "user" });
     expect(userFork).toMatch(/retry this question/i);
-    const asstFork = buildHandoffPrompt({ ...baseInput, mode: "full", forkAnchorRole: "assistant" });
+    const asstFork = buildHandoffPrompt({ ...baseInput, forkAnchorRole: "assistant" });
     expect(asstFork).toMatch(/follow-up about what the assistant just said/i);
   });
 
   it("includes the user's follow-up message in the prompt", () => {
-    const p = buildHandoffPrompt({ ...baseInput, mode: "full" });
+    const p = buildHandoffPrompt(baseInput);
     expect(p).toContain("what about feature X?");
   });
 
   it("instructs the model to return markdown as response text, not call tools", () => {
-    const p = buildHandoffPrompt({ ...baseInput, mode: "full" });
+    const p = buildHandoffPrompt(baseInput);
     expect(p).toMatch(/return.*handoff.*document.*response/i);
     expect(p).toMatch(/do not call any tools/i);
     expect(p).toMatch(/do not write to disk/i);
-  });
-});
-
-describe("truncateAtSectionBoundary", () => {
-  it("keeps the doc intact when under budget", () => {
-    const md = "## Goal\nDo something.\n\n## Open items\n- Item 1\n";
-    expect(truncateAtSectionBoundary(md, 1000)).toBe(md);
-  });
-
-  it("truncates at the last complete H2 boundary when one exists past halfway", () => {
-    const part1 = "## Goal\nSome goal text here.\n\n";
-    const part2 = "## Open items\nItem 1\nItem 2\n\n";
-    const part3 = "## Files in play\nMany files listed here to push over budget.";
-    const md = part1 + part2 + part3;
-    // Budget is tight enough to cut part3 but large enough that the H2 is past halfway
-    const budget = part1.length + part2.length + 5;
-    const result = truncateAtSectionBoundary(md, budget);
-    expect(result).not.toContain("Files in play");
-    expect(result).toContain("Open items");
-    // Must not end with a dangling "## " prefix
-    expect(result.endsWith("## ")).toBe(false);
-  });
-
-  it("falls back to hard truncate when no H2 is past the halfway point", () => {
-    // Only an H2 very near the beginning; the budget covers more than 2x that point
-    const md = "## Goal\nX\n" + "a".repeat(900);
-    const budget = 500;
-    const result = truncateAtSectionBoundary(md, budget);
-    expect(result.length).toBe(budget);
   });
 });

--- a/apps/server/src/services/handoff/__tests__/path-d-deterministic.test.ts
+++ b/apps/server/src/services/handoff/__tests__/path-d-deterministic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { runPathDDeterministic, type PathDInput } from "../path-d-deterministic.js";
+import { parseHandoffJson } from "@mcode/contracts";
 import type { Thread, Message, ToolCallRecord, ThoughtSegmentRecord } from "@mcode/contracts";
 
 const parent = {
@@ -196,6 +197,27 @@ describe("runPathDDeterministic", () => {
       const long = "X".repeat(5000);
       const a = await runPathDDeterministic({ ...BASE, compactSummary: long });
       expect(a.markdown).toContain(long);
+    });
+
+    it("escapes HTML comment terminators in metadata so the marker round-trips", async () => {
+      // A parent title containing `-->` would otherwise close the HTML comment
+      // early and break the embedded JSON block.
+      const evilTitle = 'Fix bug --> done <!-- sneaky';
+      const a = await runPathDDeterministic({
+        ...BASE,
+        parentThread: { ...parent, title: evilTitle } as unknown as Thread,
+      });
+      // The metadata block must not contain a raw `-->` or `<!--` terminator.
+      const markerIdx = a.markdown.indexOf("<!-- mcode-handoff");
+      const jsonBlock = a.markdown.slice(markerIdx + "<!-- mcode-handoff".length);
+      const closeIdx = jsonBlock.lastIndexOf("-->");
+      expect(closeIdx).toBeGreaterThan(0);
+      const innerJson = jsonBlock.slice(0, closeIdx);
+      expect(innerJson).not.toContain("-->");
+      // The parser still restores the original title (\u003e parses back to >).
+      const parsed = parseHandoffJson(a.markdown);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.parentTitle).toBe(evilTitle);
     });
   });
 });

--- a/apps/server/src/services/handoff/__tests__/path-d-deterministic.test.ts
+++ b/apps/server/src/services/handoff/__tests__/path-d-deterministic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { runPathDDeterministic } from "../path-d-deterministic.js";
-import type { Thread, Message } from "@mcode/contracts";
+import { runPathDDeterministic, type PathDInput } from "../path-d-deterministic.js";
+import type { Thread, Message, ToolCallRecord, ThoughtSegmentRecord } from "@mcode/contracts";
 
 const parent = {
   id: "t_parent",
@@ -13,6 +13,7 @@ const parent = {
   worktree_path: null,
   worktree_managed: true,
   sdk_session_id: null,
+  last_compact_summary: null,
 } as unknown as Thread;
 
 const messages: Message[] = [
@@ -27,36 +28,174 @@ const messages: Message[] = [
     id: "m_2",
     thread_id: "t_parent",
     role: "assistant",
-    content: "Yes because...",
+    content: "Yes because it scales.",
     sequence: 2,
   } as unknown as Message,
 ];
 
+function mkTool(over: Partial<ToolCallRecord>): ToolCallRecord {
+  return {
+    id: "tc_1",
+    message_id: "m_2",
+    parent_tool_call_id: null,
+    tool_name: "Read",
+    input_summary: "src/index.ts",
+    output_summary: "...",
+    status: "completed",
+    started_at: "2026-01-01T00:00:00Z",
+    completed_at: "2026-01-01T00:00:01Z",
+    sort_order: 0,
+    ...over,
+  };
+}
+
+function mkThought(over: Partial<ThoughtSegmentRecord>): ThoughtSegmentRecord {
+  return {
+    id: "ts_1",
+    message_id: "m_2",
+    text: "Considering the schema migration order.",
+    started_at: "2026-01-01T00:00:00Z",
+    ended_at: "2026-01-01T00:00:01Z",
+    sort_order: 0,
+    is_final_response: 0,
+    ...over,
+  };
+}
+
+const BASE: PathDInput = {
+  parentThread: parent,
+  messagesUpToFork: messages,
+  forkedFromMessageId: "m_2",
+  forkAnchorRole: "assistant",
+  childThreadId: "t_child",
+  reason: null,
+};
+
 describe("runPathDDeterministic", () => {
-  it("produces a HandoffArtifact with ladderStep D + generatedBy deterministic", async () => {
-    const a = await runPathDDeterministic({
-      parentThread: parent,
-      messagesUpToFork: messages,
-      forkedFromMessageId: "m_2",
-      forkAnchorRole: "assistant",
-      childThreadId: "t_child",
-      reason: "quota",
-    });
+  it("always tags ladderStep D, generatedBy deterministic, and matches characterCount", async () => {
+    const a = await runPathDDeterministic({ ...BASE, reason: "quota" });
     expect(a.meta.ladderStep).toBe("D");
     expect(a.meta.generatedBy).toBe("deterministic");
     expect(a.meta.providerErrorOnGenerate).toBe("quota");
+    expect(a.meta.characterCount).toBe(a.markdown.length);
     expect(a.markdown.length).toBeGreaterThan(0);
   });
 
-  it("characterCount matches markdown length", async () => {
-    const a = await runPathDDeterministic({
-      parentThread: parent,
-      messagesUpToFork: messages,
-      forkedFromMessageId: "m_2",
-      forkAnchorRole: "assistant",
-      childThreadId: "t_child",
-      reason: null,
+  it("is deterministic for fixed input (modulo generatedAt)", async () => {
+    const input: PathDInput = {
+      ...BASE,
+      compactSummary: "We migrated the users table.",
+      toolCallRecords: [mkTool({}), mkTool({ id: "tc_2", tool_name: "Edit", sort_order: 1 })],
+      thoughtSegments: [mkThought({})],
+      filesChanged: ["a.ts", "b.ts"],
+    };
+    const a = await runPathDDeterministic(input);
+    const b = await runPathDDeterministic(input);
+    const strip = (m: string) => m; // markdown body has no timestamps
+    expect(strip(a.markdown)).toBe(strip(b.markdown));
+  });
+
+  describe("section presence", () => {
+    it("(a) no tool calls: omits Recent tool activity", async () => {
+      const a = await runPathDDeterministic({ ...BASE, toolCallRecords: [] });
+      expect(a.markdown).not.toContain("## Recent tool activity");
     });
-    expect(a.meta.characterCount).toBe(a.markdown.length);
+
+    it("(b) many tool calls: includes Recent tool activity with each tool", async () => {
+      const tools = Array.from({ length: 6 }, (_, i) =>
+        mkTool({ id: `tc_${i}`, tool_name: `Tool${i}`, sort_order: i }),
+      );
+      const a = await runPathDDeterministic({ ...BASE, toolCallRecords: tools });
+      expect(a.markdown).toContain("## Recent tool activity");
+      for (let i = 0; i < 6; i++) expect(a.markdown).toContain(`Tool${i}`);
+    });
+
+    it("(c) no compact summary: falls back to Recent context heading", async () => {
+      const a = await runPathDDeterministic({ ...BASE, compactSummary: null });
+      expect(a.markdown).not.toContain("## Summary");
+      expect(a.markdown).toContain("## Recent context");
+    });
+
+    it("(d) present compact summary: uses Summary heading and includes the text", async () => {
+      const a = await runPathDDeterministic({ ...BASE, compactSummary: "Migrated users table." });
+      expect(a.markdown).toContain("## Summary");
+      expect(a.markdown).toContain("Migrated users table.");
+    });
+
+    it("(e1) present filesChanged: includes Recent files changed section", async () => {
+      const a = await runPathDDeterministic({ ...BASE, filesChanged: ["x.ts", "y.ts"] });
+      expect(a.markdown).toContain("## Recent files changed");
+      expect(a.markdown).toContain("- x.ts");
+      expect(a.markdown).toContain("- y.ts");
+    });
+
+    it("(e2) absent filesChanged: omits Recent files changed section", async () => {
+      const a = await runPathDDeterministic({ ...BASE, filesChanged: [] });
+      expect(a.markdown).not.toContain("## Recent files changed");
+    });
+
+    it("(f1) present fork-anchor body with a compact summary: renders Fork-anchor context", async () => {
+      const a = await runPathDDeterministic({
+        ...BASE,
+        compactSummary: "Summary here.",
+        forkAnchorBody: "The anchor message body.",
+      });
+      expect(a.markdown).toContain("## Fork-anchor context");
+      expect(a.markdown).toContain("The anchor message body.");
+    });
+
+    it("(f2) fork-anchor body used as goal when no compact summary: no separate section", async () => {
+      const a = await runPathDDeterministic({
+        ...BASE,
+        compactSummary: null,
+        forkAnchorBody: "The anchor body becomes the goal.",
+      });
+      expect(a.markdown).toContain("## Recent context");
+      expect(a.markdown).toContain("The anchor body becomes the goal.");
+      expect(a.markdown).not.toContain("## Fork-anchor context");
+    });
+
+    it("(f3) absent fork-anchor body: no Fork-anchor context section", async () => {
+      const a = await runPathDDeterministic({
+        ...BASE,
+        compactSummary: "Summary only.",
+        forkAnchorBody: null,
+      });
+      expect(a.markdown).not.toContain("## Fork-anchor context");
+    });
+
+    it("narration highlights: includes non-final segments, excludes final-response", async () => {
+      const a = await runPathDDeterministic({
+        ...BASE,
+        thoughtSegments: [
+          mkThought({ id: "n1", text: "planning step", is_final_response: 0 }),
+          mkThought({ id: "n2", text: "final answer", is_final_response: 1 }),
+        ],
+      });
+      expect(a.markdown).toContain("## Narration / reasoning highlights");
+      expect(a.markdown).toContain("planning step");
+      expect(a.markdown).not.toContain("- final answer");
+    });
+
+    it("empty everything: still produces a valid doc with title and metadata marker", async () => {
+      const a = await runPathDDeterministic({
+        parentThread: parent,
+        messagesUpToFork: [],
+        forkedFromMessageId: "m_x",
+        forkAnchorRole: "user",
+        childThreadId: "t_child",
+        reason: null,
+      });
+      expect(a.markdown).toContain("# Handoff (deterministic)");
+      expect(a.meta.ladderStep).toBe("D");
+      expect(a.markdown).not.toContain("## Recent tool activity");
+      expect(a.markdown).not.toContain("## Narration");
+    });
+
+    it("preserves full summary without 2000-char truncation", async () => {
+      const long = "X".repeat(5000);
+      const a = await runPathDDeterministic({ ...BASE, compactSummary: long });
+      expect(a.markdown).toContain(long);
+    });
   });
 });

--- a/apps/server/src/services/handoff/__tests__/session-forker.test.ts
+++ b/apps/server/src/services/handoff/__tests__/session-forker.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ForkRequest } from "@mcode/contracts";
+import type { Thread, Message } from "@mcode/contracts";
+import { CleanForker, DeterministicForker, MutatingForker } from "../session-forker.js";
+
+const parent = {
+  id: "t_parent",
+  workspace_id: "w_1",
+  title: "DB migration",
+  branch: "main",
+  provider: "claude",
+  model: "claude-opus-4-7",
+  status: "active",
+  worktree_path: null,
+  worktree_managed: true,
+  sdk_session_id: "sdk_1",
+} as unknown as Thread;
+
+const messages: Message[] = [
+  { id: "m_1", thread_id: "t_parent", role: "user", content: "Should we use Postgres?", sequence: 1 } as unknown as Message,
+  { id: "m_2", thread_id: "t_parent", role: "assistant", content: "Yes because...", sequence: 2 } as unknown as Message,
+];
+
+function baseReq(overrides: Partial<ForkRequest> = {}): ForkRequest {
+  return {
+    parentThreadId: "t_parent",
+    forkedFromMessageId: "m_2",
+    forkAnchorRole: "assistant",
+    prompt: "Generate a handoff.",
+    cwd: "/tmp/cwd",
+    parentSdkSessionId: "sdk_1",
+    conversationHistory: "User: hi\nAssistant: hello",
+    messagesUpToFork: messages,
+    parentThread: parent,
+    childThreadId: "t_child",
+    ...overrides,
+  };
+}
+
+describe("DeterministicForker", () => {
+  it("produces a path-D artifact from the message replay", async () => {
+    const forker = new DeterministicForker();
+    const artifact = await forker.fork(baseReq({ forkReason: "quota" }));
+
+    expect(artifact.meta.ladderStep).toBe("D");
+    expect(artifact.meta.generatedBy).toBe("deterministic");
+    expect(artifact.meta.providerErrorOnGenerate).toBe("quota");
+    expect(artifact.meta.childThreadId).toBe("t_child");
+    expect(artifact.meta.characterCount).toBe(artifact.markdown.length);
+    expect(artifact.markdown.length).toBeGreaterThan(0);
+  });
+
+  it("defaults forkReason to null when omitted (path D was the only option)", async () => {
+    const forker = new DeterministicForker();
+    const artifact = await forker.fork(baseReq());
+    expect(artifact.meta.providerErrorOnGenerate).toBeNull();
+  });
+});
+
+describe("CleanForker", () => {
+  it("delegates to runSideChannelQuery and wraps a path-B artifact", async () => {
+    const runSideChannelQuery = vi.fn(async (args: { parentSdkSessionId: string; cwd: string }) => {
+      void args;
+      return "# Handoff\n\n## Goal\nX";
+    });
+    const forker = new CleanForker({ id: "claude", runSideChannelQuery });
+    const artifact = await forker.fork(baseReq());
+
+    expect(runSideChannelQuery).toHaveBeenCalledOnce();
+    const args = runSideChannelQuery.mock.calls[0][0];
+    expect(args.parentSdkSessionId).toBe("sdk_1");
+    expect(args.cwd).toBe("/tmp/cwd");
+    expect(artifact.meta.ladderStep).toBe("B");
+    expect(artifact.meta.generatedBy).toBe("provider");
+  });
+
+  it("passes an empty session id through when parentSdkSessionId is missing (B-prime)", async () => {
+    const runSideChannelQuery = vi.fn(async (args: { parentSdkSessionId: string }) => {
+      void args;
+      return "# Handoff";
+    });
+    const forker = new CleanForker({ id: "claude", runSideChannelQuery });
+    await forker.fork(baseReq({ parentSdkSessionId: null }));
+    const args = runSideChannelQuery.mock.calls[0][0];
+    expect(args.parentSdkSessionId).toBe("");
+  });
+});
+
+describe("MutatingForker", () => {
+  it("delegates to runHiddenTurn and wraps a path-A artifact", async () => {
+    const runHiddenTurn = vi.fn(async () => "# Handoff\n\n## Goal\nX");
+    const forker = new MutatingForker({ id: "cursor", runHiddenTurn });
+    const artifact = await forker.fork(baseReq());
+
+    expect(runHiddenTurn).toHaveBeenCalledOnce();
+    expect(artifact.meta.ladderStep).toBe("A");
+    expect(artifact.meta.generatedBy).toBe("provider");
+  });
+});

--- a/apps/server/src/services/handoff/handoff-pipeline.ts
+++ b/apps/server/src/services/handoff/handoff-pipeline.ts
@@ -21,6 +21,8 @@ import { logger } from "@mcode/shared";
 import { ThreadRepo } from "../../repositories/thread-repo.js";
 import { MessageRepo } from "../../repositories/message-repo.js";
 import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
+import { ThoughtSegmentRepo } from "../../repositories/thought-segment-repo.js";
 import { classifyProviderError } from "./error-classifier.js";
 import { buildHandoffPrompt, computeBudgetChars, pickHandoffMode, truncateAtSectionBoundary } from "./handoff-prompt.js";
 import { DeterministicForker } from "./session-forker.js";
@@ -30,6 +32,9 @@ import type {
   IAgentProvider,
   IProviderRegistry,
   ProviderId,
+  ToolCallRecord,
+  ThoughtSegmentRecord,
+  Message,
 } from "@mcode/contracts";
 /**
  * Render an Error-shaped value for structured logging. Winston cannot
@@ -79,6 +84,19 @@ interface IMessageRepo {
 interface IWorkspaceRepo {
   findById(id: string): Promise<any> | any;
 }
+interface IToolCallRecordRepo {
+  listByMessage(messageId: string): Promise<ToolCallRecord[]> | ToolCallRecord[];
+}
+interface IThoughtSegmentRepo {
+  listByMessage(messageId: string): Promise<ThoughtSegmentRecord[]> | ThoughtSegmentRecord[];
+}
+
+/**
+ * How many of the parent thread's most recent assistant messages to mine for
+ * tool-call / narration / files-changed signals when composing a deterministic
+ * (path-D) handoff. Bounded so a long thread doesn't produce an unwieldy doc.
+ */
+const RECENT_ASSISTANT_MESSAGES_FOR_D = 5;
 
 /**
  * Timeout for side-channel and hidden-turn provider calls, in milliseconds.
@@ -107,6 +125,8 @@ export class HandoffPipelineService {
     @inject(MessageRepo) private readonly messageRepo: IMessageRepo,
     @inject("IProviderRegistry") private readonly providerRegistry: Pick<IProviderRegistry, "resolve">,
     @inject(WorkspaceRepo) private readonly workspaceRepo: IWorkspaceRepo,
+    @inject(ToolCallRecordRepo) private readonly toolCallRecordRepo: IToolCallRecordRepo,
+    @inject(ThoughtSegmentRepo) private readonly thoughtSegmentRepo: IThoughtSegmentRepo,
   ) {}
 
   /**
@@ -118,6 +138,8 @@ export class HandoffPipelineService {
     messageRepo: IMessageRepo;
     providerRegistry: Pick<IProviderRegistry, "resolve">;
     workspaceRepo?: IWorkspaceRepo;
+    toolCallRecordRepo?: IToolCallRecordRepo;
+    thoughtSegmentRepo?: IThoughtSegmentRepo;
   }): HandoffPipelineService {
     const svc = Object.create(HandoffPipelineService.prototype) as HandoffPipelineService;
     (svc as any).threadRepo = deps.threadRepo;
@@ -125,6 +147,12 @@ export class HandoffPipelineService {
     (svc as any).providerRegistry = deps.providerRegistry;
     (svc as any).workspaceRepo = deps.workspaceRepo ?? {
       findById: async () => ({ path: process.cwd() }),
+    };
+    (svc as any).toolCallRecordRepo = deps.toolCallRecordRepo ?? {
+      listByMessage: () => [],
+    };
+    (svc as any).thoughtSegmentRepo = deps.thoughtSegmentRepo ?? {
+      listByMessage: () => [],
     };
     // Initialize instance fields that aren't set via the constructor (Object.create
     // bypasses field initializers).
@@ -182,6 +210,11 @@ export class HandoffPipelineService {
     const replayBudget = computeBudgetChars(childCap);
     const conversationHistory = buildConversationReplay(messagesUpToFork, replayBudget, null);
 
+    // Pre-gather the deterministic (path-D) signals from the parent thread so
+    // DeterministicForker stays stateless. These are no-ops for provider paths
+    // (B/A) — the forkers simply ignore the extra fields.
+    const deterministicInputs = await this.gatherDeterministicInputs(parent, messagesUpToFork, forkMsg);
+
     const forkReq: ForkRequest = {
       parentThreadId: req.parentThreadId,
       forkedFromMessageId: req.forkedFromMessageId,
@@ -193,6 +226,7 @@ export class HandoffPipelineService {
       messagesUpToFork,
       parentThread: parent,
       childThreadId: req.childThreadId,
+      ...deterministicInputs,
     };
 
     // Providers that cannot fork a session (capability "unsupported") or a
@@ -239,6 +273,61 @@ export class HandoffPipelineService {
       return this.withPathALock(req.parentThreadId, runFork);
     }
     return runFork();
+  }
+
+  /**
+   * Gather the deterministic-handoff (path-D) signals that already exist in the
+   * database: the parent thread's last compact summary, the fork-anchor message
+   * body, recent tool-call / narration records, and the de-duplicated files
+   * changed across recent messages. Returned as a partial ForkRequest so the
+   * orchestrator can spread it onto the request. Failures degrade gracefully —
+   * a missing record just means an omitted section, never a fork failure.
+   */
+  private async gatherDeterministicInputs(
+    parent: any,
+    messagesUpToFork: Message[],
+    forkMsg: Message,
+  ): Promise<Pick<ForkRequest, "compactSummary" | "forkAnchorBody" | "toolCallRecords" | "thoughtSegments" | "filesChanged">> {
+    const compactSummary: string | null = parent.last_compact_summary ?? null;
+    const forkAnchorBody: string | null = forkMsg?.content ?? null;
+
+    // Mine the most recent assistant messages up to the fork for structured
+    // activity. Tool calls / narration are keyed by assistant message id.
+    const recentAssistant = messagesUpToFork
+      .filter((m) => m.role === "assistant")
+      .slice(-RECENT_ASSISTANT_MESSAGES_FOR_D);
+
+    const toolCallRecords: ToolCallRecord[] = [];
+    const thoughtSegments: ThoughtSegmentRecord[] = [];
+    for (const m of recentAssistant) {
+      try {
+        toolCallRecords.push(...(await this.toolCallRecordRepo.listByMessage(m.id)));
+      } catch {
+        // Tolerate repo errors; the section is simply omitted.
+      }
+      try {
+        thoughtSegments.push(...(await this.thoughtSegmentRepo.listByMessage(m.id)));
+      } catch {
+        // Tolerate repo errors; the section is simply omitted.
+      }
+    }
+
+    // Aggregate files_changed across recent messages, de-duplicated and in
+    // first-seen order. files_changed is stored as a JSON array of strings.
+    const seen = new Set<string>();
+    const filesChanged: string[] = [];
+    for (const m of messagesUpToFork) {
+      const fc = (m as { files_changed?: unknown }).files_changed;
+      if (!Array.isArray(fc)) continue;
+      for (const f of fc) {
+        if (typeof f === "string" && !seen.has(f)) {
+          seen.add(f);
+          filesChanged.push(f);
+        }
+      }
+    }
+
+    return { compactSummary, forkAnchorBody, toolCallRecords, thoughtSegments, filesChanged };
   }
 
   /**

--- a/apps/server/src/services/handoff/handoff-pipeline.ts
+++ b/apps/server/src/services/handoff/handoff-pipeline.ts
@@ -1,14 +1,16 @@
 /**
- * Orchestrates the B->A->D ladder for chat fork handoff generation.
+ * Orchestrates chat fork handoff generation by delegating to each provider's
+ * {@link SessionForker}.
  *
- * The dispatch routes on the parent provider's `sessionForkOnResume` capability:
- * - "clean"       : path B (side-channel resume)
- * - "mutating"    : path A (hidden turn on the parent thread)
- * - "unsupported" or null parent.sdk_session_id : path D (deterministic) directly
+ * The pipeline builds a {@link ForkRequest} and calls `provider.forker.fork(req)`.
+ * Each provider owns the strategy: CleanForker (Claude, path B), MutatingForker
+ * (Cursor, path A), or DeterministicForker (Codex/Copilot, path D). The
+ * `sessionForkOnResume` field is now metadata only (provenance + the path-A
+ * mutex decision), not the dispatch key.
  *
- * On any provider failure classified by error-classifier as quota/auth/
- * context-overflow/fatal, the pipeline falls through to D rather than
- * attempting the next ladder step (the next step would hit the same wall).
+ * On a classified non-retryable provider error (quota/auth/context-overflow/
+ * fatal) or a timeout, the pipeline falls back to a shared DeterministicForker
+ * (path D) rather than retrying — the same wall would be hit again.
  */
 
 import { tmpdir } from "os";
@@ -21,9 +23,10 @@ import { MessageRepo } from "../../repositories/message-repo.js";
 import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import { classifyProviderError } from "./error-classifier.js";
 import { buildHandoffPrompt, computeBudgetChars, pickHandoffMode, truncateAtSectionBoundary } from "./handoff-prompt.js";
-import { runPathDDeterministic } from "./path-d-deterministic.js";
+import { DeterministicForker } from "./session-forker.js";
 import { buildConversationReplay } from "../handoff-builder.js";
 import type {
+  ForkRequest,
   IAgentProvider,
   IProviderRegistry,
   ProviderId,
@@ -58,8 +61,6 @@ function describeError(err: unknown): Record<string, unknown> {
 
 import type {
   HandoffArtifact,
-  HandoffMeta,
-  HandoffMode,
   HandoffRequest,
   LadderStep,
 } from "./handoff-types.js";
@@ -94,6 +95,13 @@ export class HandoffPipelineService {
    */
   private readonly pathALocks = new Map<string, Promise<void>>();
 
+  /**
+   * Cross-forker fallback. The pipeline delegates to a provider's own forker
+   * first; on a classified non-retryable error or timeout it falls back to this
+   * deterministic forker (path D).
+   */
+  private readonly deterministicForker = new DeterministicForker();
+
   constructor(
     @inject(ThreadRepo) private readonly threadRepo: IThreadRepo,
     @inject(MessageRepo) private readonly messageRepo: IMessageRepo,
@@ -118,8 +126,10 @@ export class HandoffPipelineService {
     (svc as any).workspaceRepo = deps.workspaceRepo ?? {
       findById: async () => ({ path: process.cwd() }),
     };
-    // Initialize instance-field Maps that aren't set via the constructor.
+    // Initialize instance fields that aren't set via the constructor (Object.create
+    // bypasses field initializers).
     (svc as any).pathALocks = new Map<string, Promise<void>>();
+    (svc as any).deterministicForker = new DeterministicForker();
     return svc;
   }
 
@@ -166,114 +176,69 @@ export class HandoffPipelineService {
     const capability: string = parentProvider?.sessionForkOnResume ?? "unsupported";
     const parentSdkSession: string | null = parent.sdk_session_id ?? null;
 
-    // Path B: side-channel query against the parent provider's existing session.
-    // Requires sdk_session_id because the side-channel must resume the correct
-    // provider conversation state.
-    if (capability === "clean" && parentProvider?.runSideChannelQuery && parentSdkSession) {
+    // Build a budgeted history replay so that if a clean-resume session fails
+    // (e.g. after a server restart), the provider can retry without `resume:`
+    // and still produce a high-fidelity path-B result.
+    const replayBudget = computeBudgetChars(childCap);
+    const conversationHistory = buildConversationReplay(messagesUpToFork, replayBudget, null);
+
+    const forkReq: ForkRequest = {
+      parentThreadId: req.parentThreadId,
+      forkedFromMessageId: req.forkedFromMessageId,
+      forkAnchorRole: req.forkAnchorRole,
+      prompt,
+      cwd: parentCwd,
+      parentSdkSessionId: parentSdkSession,
+      conversationHistory,
+      messagesUpToFork,
+      parentThread: parent,
+      childThreadId: req.childThreadId,
+    };
+
+    // Providers that cannot fork a session (capability "unsupported") or a
+    // clean-resume provider with no session id to resume go straight to the
+    // deterministic forker. The DeterministicForker is also the cross-forker
+    // fallback below.
+    const canProviderFork =
+      !!parentProvider &&
+      ((capability === "clean" && !!parentSdkSession) || capability === "mutating");
+    if (!canProviderFork) {
+      return this.deterministicForker.fork({ ...forkReq, forkReason: null });
+    }
+
+    // Path A (mutating) must be serialized per parent thread because each
+    // hidden turn mutates provider session state. Path B (clean) does not.
+    const runFork = async (): Promise<HandoffArtifact> => {
       const abort = new AbortController();
       const timer = setTimeout(() => abort.abort(), PROVIDER_CALL_TIMEOUT_MS);
       try {
-        // Build a budgeted history replay so that if the session-resume fails
-        // (e.g. after a server restart), the provider can retry without `resume:`
-        // and still produce a high-fidelity path-B result.
-        const replayBudget = computeBudgetChars(childCap);
-        const conversationHistory = buildConversationReplay(messagesUpToFork, replayBudget, null);
-
-        let text: string = await parentProvider.runSideChannelQuery({
-          parentThreadId: req.parentThreadId,
-          parentSdkSessionId: parentSdkSession,
-          prompt,
-          abortSignal: abort.signal,
-          conversationHistory,
-          cwd: parentCwd,
-        });
-        text = await this.applyBudgetGuard(text, childCap, "B", req.childThreadId);
-        return this.buildProviderArtifact(req, parent, text, "B", mode);
+        const artifact = await parentProvider!.forker.fork({ ...forkReq, abortSignal: abort.signal });
+        // Apply the child's input budget to provider output, then stamp the
+        // budget-driven mode (forkers return mode "full" by default).
+        const guarded = await this.applyBudgetGuard(
+          artifact.markdown,
+          childCap,
+          artifact.meta.ladderStep,
+          req.childThreadId,
+        );
+        return { markdown: guarded, meta: { ...artifact.meta, mode, characterCount: guarded.length } };
       } catch (err) {
         if ((abort.signal as AbortSignal).aborted) {
-          logger.warn("Handoff path B timed out; falling to D", { threadId: req.parentThreadId });
-          return runPathDDeterministic({
-            parentThread: parent,
-            messagesUpToFork,
-            forkedFromMessageId: req.forkedFromMessageId,
-            forkAnchorRole: req.forkAnchorRole,
-            childThreadId: req.childThreadId,
-            reason: "transient",
-          });
+          logger.warn("Handoff provider fork timed out; falling to D", { threadId: req.parentThreadId });
+          return this.deterministicForker.fork({ ...forkReq, forkReason: "transient" });
         }
         const cls = classifyProviderError(err);
-        logger.warn("Handoff path B failed", { error: describeError(err), cls, threadId: req.parentThreadId });
-        return runPathDDeterministic({
-          parentThread: parent,
-          messagesUpToFork,
-          forkedFromMessageId: req.forkedFromMessageId,
-          forkAnchorRole: req.forkAnchorRole,
-          childThreadId: req.childThreadId,
-          reason: cls,
-        });
+        logger.warn("Handoff provider fork failed", { error: describeError(err), cls, threadId: req.parentThreadId });
+        return this.deterministicForker.fork({ ...forkReq, forkReason: cls });
       } finally {
         clearTimeout(timer);
       }
-    }
+    };
 
-    // Path A: hidden turn injected into the parent's mutable session.
-    // sdk_session_id is NOT required here because runHiddenTurn creates its own
-    // ephemeral turn rather than resuming an existing session; the hidden turn
-    // is a no-op if the parent has never started a session (the provider will
-    // simply have no prior context to draw from, which is acceptable -- path D
-    // will produce an equivalent result in that case). We intentionally do not
-    // gate path A on sdk_session_id to avoid blocking providers that defer
-    // session creation until the first real turn.
-    const runHiddenTurn = parentProvider?.runHiddenTurn?.bind(parentProvider);
-    if (capability === "mutating" && runHiddenTurn) {
-      return this.withPathALock(req.parentThreadId, async () => {
-        const abort = new AbortController();
-        const timer = setTimeout(() => abort.abort(), PROVIDER_CALL_TIMEOUT_MS);
-        try {
-          let text: string = await runHiddenTurn({
-            parentThreadId: req.parentThreadId,
-            prompt,
-            abortSignal: abort.signal,
-          });
-          text = await this.applyBudgetGuard(text, childCap, "A", req.childThreadId);
-          return this.buildProviderArtifact(req, parent, text, "A", mode);
-        } catch (err) {
-          if ((abort.signal as AbortSignal).aborted) {
-            logger.warn("Handoff path A timed out; falling to D", { threadId: req.parentThreadId });
-            return runPathDDeterministic({
-              parentThread: parent,
-              messagesUpToFork,
-              forkedFromMessageId: req.forkedFromMessageId,
-              forkAnchorRole: req.forkAnchorRole,
-              childThreadId: req.childThreadId,
-              reason: "transient",
-            });
-          }
-          const cls = classifyProviderError(err);
-          logger.warn("Handoff path A failed", { error: describeError(err), cls, threadId: req.parentThreadId });
-          return runPathDDeterministic({
-            parentThread: parent,
-            messagesUpToFork,
-            forkedFromMessageId: req.forkedFromMessageId,
-            forkAnchorRole: req.forkAnchorRole,
-            childThreadId: req.childThreadId,
-            reason: cls,
-          });
-        } finally {
-          clearTimeout(timer);
-        }
-      });
+    if (capability === "mutating") {
+      return this.withPathALock(req.parentThreadId, runFork);
     }
-
-    // Path D: deterministic fallback for unsupported providers or missing sessions
-    return runPathDDeterministic({
-      parentThread: parent,
-      messagesUpToFork: messages,
-      forkedFromMessageId: req.forkedFromMessageId,
-      forkAnchorRole: req.forkAnchorRole,
-      childThreadId: req.childThreadId,
-      reason: null,
-    });
+    return runFork();
   }
 
   /**
@@ -362,33 +327,5 @@ export class HandoffPipelineService {
       `  ${overflowPath}`,
       "Use the Read tool to access it for additional context on the parent thread.",
     ].join("\n");
-  }
-
-  /** Builds a provider-generated artifact with the given ladder step and mode. */
-  private buildProviderArtifact(
-    req: HandoffRequest,
-    parent: any,
-    markdownBody: string,
-    step: LadderStep,
-    mode: HandoffMode,
-  ): HandoffArtifact {
-    const meta: HandoffMeta = {
-      schemaVersion: 1,
-      parentThreadId: req.parentThreadId,
-      forkedFromMessageId: req.forkedFromMessageId,
-      forkAnchorRole: req.forkAnchorRole,
-      childThreadId: req.childThreadId,
-      generatedBy: "provider",
-      provider: parent.provider,
-      ladderStep: step,
-      mode,
-      generatedAt: new Date().toISOString(),
-      characterCount: markdownBody.length,
-      parentSdkSessionId: parent.sdk_session_id ?? null,
-      providerErrorOnGenerate: null,
-      regenerationHistory: [],
-      attachments: [],
-    };
-    return { markdown: markdownBody, meta };
   }
 }

--- a/apps/server/src/services/handoff/handoff-pipeline.ts
+++ b/apps/server/src/services/handoff/handoff-pipeline.ts
@@ -13,9 +13,6 @@
  * (path D) rather than retrying — the same wall would be hit again.
  */
 
-import { tmpdir } from "os";
-import { writeFile } from "fs/promises";
-import { join as pathJoin } from "path";
 import { inject, injectable } from "tsyringe";
 import { logger } from "@mcode/shared";
 import { ThreadRepo } from "../../repositories/thread-repo.js";
@@ -24,7 +21,7 @@ import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
 import { ThoughtSegmentRepo } from "../../repositories/thought-segment-repo.js";
 import { classifyProviderError } from "./error-classifier.js";
-import { buildHandoffPrompt, computeBudgetChars, pickHandoffMode, truncateAtSectionBoundary } from "./handoff-prompt.js";
+import { buildHandoffPrompt } from "./handoff-prompt.js";
 import { DeterministicForker } from "./session-forker.js";
 import { buildConversationReplay } from "../handoff-builder.js";
 import type {
@@ -67,7 +64,6 @@ function describeError(err: unknown): Record<string, unknown> {
 import type {
   HandoffArtifact,
   HandoffRequest,
-  LadderStep,
 } from "./handoff-types.js";
 
 /**
@@ -104,6 +100,14 @@ const RECENT_ASSISTANT_MESSAGES_FOR_D = 5;
  * 60s was too tight after server restarts on Windows.
  */
 const PROVIDER_CALL_TIMEOUT_MS = 120_000;
+
+/**
+ * Character cap for the conversation-history replay used as the clean-resume
+ * B-prime fallback body sent to the PARENT provider's side-channel. Sizes the
+ * parent's resume input, not the child's delivery (which is off-band), so it is
+ * a fixed generous value rather than a function of the child's per-turn window.
+ */
+const REPLAY_BUDGET_CHARS = 100_000;
 
 @injectable()
 export class HandoffPipelineService {
@@ -179,10 +183,6 @@ export class HandoffPipelineService {
     const parentCwd: string = parent.worktree_path ?? workspace.path;
 
     const parentProvider = this.tryResolveProvider(parent.provider);
-    const childProvider = this.tryResolveProvider(req.childProviderId);
-    const childCap: number = childProvider?.maxInputCharactersPerTurn ?? 16_000;
-    const mode = pickHandoffMode(childCap);
-
     const messages = await this.messageRepo.listIncludingInternal(req.parentThreadId);
     const forkIndex = messages.findIndex((m: any) => m.id === req.forkedFromMessageId);
     if (forkIndex === -1) throw new Error(`Fork message ${req.forkedFromMessageId} not in parent`);
@@ -192,12 +192,10 @@ export class HandoffPipelineService {
     const forkMsg = messagesUpToFork[forkIndex];
 
     const prompt = buildHandoffPrompt({
-      mode,
       forkAnchorRole: req.forkAnchorRole,
       parentThreadTitle: parent.title,
       forkMessageExcerpt: forkMsg.content,
       childProviderId: req.childProviderId,
-      childMaxInputCharacters: childCap,
       userFollowUpMessage: req.userFollowUpMessage,
     });
 
@@ -206,9 +204,11 @@ export class HandoffPipelineService {
 
     // Build a budgeted history replay so that if a clean-resume session fails
     // (e.g. after a server restart), the provider can retry without `resume:`
-    // and still produce a high-fidelity path-B result.
-    const replayBudget = computeBudgetChars(childCap);
-    const conversationHistory = buildConversationReplay(messagesUpToFork, replayBudget, null);
+    // and still produce a high-fidelity path-B result. This budget sizes the
+    // PARENT provider's side-channel resume body (not the child's delivery,
+    // which is off-band), so it is a fixed generous cap rather than a function
+    // of the child provider's per-turn input window.
+    const conversationHistory = buildConversationReplay(messagesUpToFork, REPLAY_BUDGET_CHARS, null);
 
     // Pre-gather the deterministic (path-D) signals from the parent thread so
     // DeterministicForker stays stateless. These are no-ops for provider paths
@@ -246,16 +246,14 @@ export class HandoffPipelineService {
       const abort = new AbortController();
       const timer = setTimeout(() => abort.abort(), PROVIDER_CALL_TIMEOUT_MS);
       try {
+        // Off-band delivery (PRD #538): the full doc ships to the child via a
+        // temp file, so there is no inline budget to enforce here. Return the
+        // provider's markdown verbatim with the constant "full" mode.
         const artifact = await parentProvider!.forker.fork({ ...forkReq, abortSignal: abort.signal });
-        // Apply the child's input budget to provider output, then stamp the
-        // budget-driven mode (forkers return mode "full" by default).
-        const guarded = await this.applyBudgetGuard(
-          artifact.markdown,
-          childCap,
-          artifact.meta.ladderStep,
-          req.childThreadId,
-        );
-        return { markdown: guarded, meta: { ...artifact.meta, mode, characterCount: guarded.length } };
+        return {
+          markdown: artifact.markdown,
+          meta: { ...artifact.meta, mode: "full", characterCount: artifact.markdown.length },
+        };
       } catch (err) {
         if ((abort.signal as AbortSignal).aborted) {
           logger.warn("Handoff provider fork timed out; falling to D", { threadId: req.parentThreadId });
@@ -361,60 +359,5 @@ export class HandoffPipelineService {
       this.pathALocks.delete(threadId);
       release();
     }
-  }
-
-  /**
-   * Validates provider output against the child's input budget. When the
-   * provider overshoots by more than 15%, writes the full doc to OS temp dir
-   * and returns a truncated inline version with a pointer to the overflow file.
-   * Falls back to a hard truncation with a comment if the temp write fails.
-   */
-  private async applyBudgetGuard(
-    text: string,
-    childCap: number,
-    step: LadderStep,
-    childThreadId: string,
-  ): Promise<string> {
-    const budget = computeBudgetChars(childCap);
-
-    // Within budget — return as-is.
-    if (text.length <= budget * 1.15) return text;
-
-    logger.warn("Provider exceeded handoff budget; truncating + overflowing to temp", {
-      produced: text.length,
-      budget,
-      ladderStep: step,
-      threadId: childThreadId,
-    });
-
-    // Generate overflow filename in OS temp dir. Format mirrors the
-    // /handoff skill's convention (timestamped, slugged).
-    const ts = new Date().toISOString().replace(/[:.]/g, "-");
-    const overflowPath = pathJoin(tmpdir(), `mcode-handoff-overflow-${childThreadId}-${ts}.md`);
-
-    try {
-      // Write the FULL doc to temp so the next agent can Read it on demand.
-      await writeFile(overflowPath, text, "utf8");
-    } catch (err) {
-      logger.warn("Failed to write handoff overflow to temp; continuing with hard truncation only", {
-        overflowPath,
-        err: err instanceof Error ? err.message : String(err),
-      });
-      return truncateAtSectionBoundary(text, budget) + "\n\n<!-- handoff truncated at budget; overflow write failed -->";
-    }
-
-    // Truncate the inline version, leaving room for the pointer block.
-    const POINTER_BUDGET = 400;
-    const inlinedBudget = budget - POINTER_BUDGET;
-    const truncated = truncateAtSectionBoundary(text, inlinedBudget);
-
-    return [
-      truncated,
-      "",
-      "## Detailed context (overflow)",
-      "The parent thread's full handoff exceeded the inline budget. The complete doc is on the user's filesystem at:",
-      `  ${overflowPath}`,
-      "Use the Read tool to access it for additional context on the parent thread.",
-    ].join("\n");
   }
 }

--- a/apps/server/src/services/handoff/handoff-prompt.ts
+++ b/apps/server/src/services/handoff/handoff-prompt.ts
@@ -1,56 +1,24 @@
 /**
  * Builds the side-channel prompt that the parent's provider session executes
  * to produce a handoff document. Vendors the /handoff skill instructions and
- * tailors them with fork context, mode (full/minimal), and a character budget
- * derived from the child provider's per-turn input cap.
+ * tailors them with fork context.
+ *
+ * Off-band delivery (PRD #538) retired the full-vs-minimal mode selection, the
+ * child-input character budget, and the >115% truncation/overflow guard: the
+ * full doc is now written to an OS temp file and the child reads it on demand
+ * via a one-shot ScopedPreGrant, so doc-body sizing no longer needs to fit a
+ * provider's per-turn input window. The prompt therefore asks for a complete,
+ * self-contained document with no character cap.
  */
 
-import type { ForkAnchorRole, HandoffMode } from "./handoff-types.js";
-
-const MINIMAL_MODE_THRESHOLD_CHARS = 8_000;
-const RESERVED_SYSTEM_PROMPT_CHARS = 1_000;
-const RESERVED_USER_FIRST_MESSAGE_CHARS = 500;
-const RESERVED_OVERHEAD_CHARS = 500;
-const MIN_HANDOFF_BUDGET = 1_000;
-
-/**
- * Pick mode based on child provider's per-turn cap. Minimal is triggered
- * when the cap is too tight to host the full structured doc.
- */
-export function pickHandoffMode(childMaxInputCharacters: number): HandoffMode {
-  return childMaxInputCharacters < MINIMAL_MODE_THRESHOLD_CHARS ? "minimal" : "full";
-}
-
-/**
- * Truncates markdown at the last complete H2 (`## `) section boundary at or
- * before maxChars. Falls back to a hard slice when no usable H2 exists past
- * the halfway point, to avoid returning an empty or near-empty document.
- */
-export function truncateAtSectionBoundary(md: string, maxChars: number): string {
-  if (md.length <= maxChars) return md;
-  const slice = md.slice(0, maxChars);
-  const lastH2 = slice.lastIndexOf("\n## ");
-  return lastH2 > maxChars * 0.5 ? slice.slice(0, lastH2) : slice;
-}
-
-/** Character budget the handoff doc should target. */
-export function computeBudgetChars(childMaxInputCharacters: number): number {
-  const budget =
-    childMaxInputCharacters -
-    RESERVED_SYSTEM_PROMPT_CHARS -
-    RESERVED_USER_FIRST_MESSAGE_CHARS -
-    RESERVED_OVERHEAD_CHARS;
-  return Math.max(budget, MIN_HANDOFF_BUDGET);
-}
+import type { ForkAnchorRole } from "./handoff-types.js";
 
 /** Input arguments for building the handoff prompt sent to the parent provider session. */
 export interface HandoffPromptInput {
-  mode: HandoffMode;
   forkAnchorRole: ForkAnchorRole;
   parentThreadTitle: string;
   forkMessageExcerpt: string;
   childProviderId: string;
-  childMaxInputCharacters: number;
   /**
    * The user's new follow-up message in the fork composer. Passed to the
    * side-channel so the prompt can tell the model what the child agent is
@@ -66,8 +34,7 @@ export interface HandoffPromptInput {
  * passes `tools: []`, so the model must not be asked to write files.
  */
 export function buildHandoffPrompt(input: HandoffPromptInput): string {
-  const { mode, forkAnchorRole, parentThreadTitle, forkMessageExcerpt, childProviderId, userFollowUpMessage } = input;
-  const budget = computeBudgetChars(input.childMaxInputCharacters);
+  const { forkAnchorRole, parentThreadTitle, forkMessageExcerpt, childProviderId, userFollowUpMessage } = input;
 
   const anchorFraming =
     forkAnchorRole === "user"
@@ -107,10 +74,9 @@ export function buildHandoffPrompt(input: HandoffPromptInput): string {
     argumentBlock,
     "",
     "## Output constraints (mcode-specific)",
-    `- Target output: less than or equal to ${budget} characters (string.length, by character count not word count).`,
-    `- Output mode: ${mode}${mode === "minimal" ? " (the next provider has a small per-turn input window, so be concise but preserve the concrete facts that matter for the follow-up)" : ""}.`,
+    "- Write a complete, self-contained document. There is no character cap: mcode delivers the full doc to the next agent off-band (written to a file the agent reads on demand), so prefer completeness over brevity while staying focused on what matters for the follow-up.",
     "- Return the complete handoff document as your assistant text response.",
-    "- Do NOT call any tools. Do NOT write to disk. mcode handles persistence; if your output exceeds the budget, mcode automatically overflows the full doc to the user's OS temp dir.",
+    "- Do NOT call any tools. Do NOT write to disk. mcode handles persistence.",
     "- Do NOT include YAML frontmatter (the pipeline injects that).",
     "- Begin your response directly with the document's first heading.",
   ].join("\n");

--- a/apps/server/src/services/handoff/handoff-types.ts
+++ b/apps/server/src/services/handoff/handoff-types.ts
@@ -1,63 +1,22 @@
 /**
  * Shared types for the chat fork handoff pipeline.
  *
- * The B/A/D ladder, mode selection, error classification, and the on-disk
- * artifact shape all reference these types. Importing modules use them to
- * avoid restating literal unions.
+ * These now live canonically in `@mcode/contracts` (providers/session-forker)
+ * so the {@link IAgentProvider} interface can reference the forker contract.
+ * This module re-exports them and adds the pipeline-only {@link HandoffRequest}
+ * so existing server-side imports keep working unchanged.
  */
 
-/** Which step of the B→A→D ladder produced the handoff. */
-export type LadderStep = "B" | "A" | "D";
+export type {
+  LadderStep,
+  HandoffMode,
+  ForkAnchorRole,
+  ProviderErrorClass,
+  HandoffMeta,
+  HandoffArtifact,
+} from "@mcode/contracts";
 
-/** Full handoff has all sections; minimal targets sub-8000-char child providers. */
-export type HandoffMode = "full" | "minimal";
-
-/** Whether the parent message at the fork point was authored by the user or assistant. */
-export type ForkAnchorRole = "user" | "assistant";
-
-/** Classified provider error returned during path-B/A attempts. */
-export type ProviderErrorClass =
-  | "quota"             // 429, rate-limit, billing-exhausted
-  | "auth"              // 401, expired credentials
-  | "context-overflow"  // input too large for the model
-  | "transient"         // network blip, 5xx, retry-once is reasonable
-  | "fatal"             // provider misconfigured, model removed, etc.
-  | "clean";            // no error
-
-/** What the pipeline writes to handoff.json. */
-export interface HandoffMeta {
-  schemaVersion: 1;
-  parentThreadId: string;
-  forkedFromMessageId: string;
-  forkAnchorRole: ForkAnchorRole;
-  childThreadId: string;
-  generatedBy: "provider" | "deterministic";
-  provider: string | null;
-  ladderStep: LadderStep;
-  mode: HandoffMode;
-  generatedAt: string;
-  characterCount: number;
-  parentSdkSessionId: string | null;
-  providerErrorOnGenerate: ProviderErrorClass | null;
-  regenerationHistory: Array<{
-    at: string;
-    ladderStep: LadderStep;
-    reason: ProviderErrorClass | "user-requested";
-  }>;
-  attachments: Array<{
-    id: string;
-    originalName: string;
-    sha256: string;
-    mime: string;
-    parentMessageId: string;
-  }>;
-}
-
-/** Returned by every ladder step. The pipeline writes both to disk. */
-export interface HandoffArtifact {
-  markdown: string;
-  meta: HandoffMeta;
-}
+import type { ForkAnchorRole } from "@mcode/contracts";
 
 /** Input to the pipeline's orchestrate() method. */
 export interface HandoffRequest {

--- a/apps/server/src/services/handoff/path-d-deterministic.ts
+++ b/apps/server/src/services/handoff/path-d-deterministic.ts
@@ -153,7 +153,15 @@ export async function runPathDDeterministic(input: PathDInput): Promise<HandoffA
     openTasks: [] as Array<{ content: string; status: string }>,
   };
 
-  const markdown = `${body}\n\n${HANDOFF_MARKER}\n${JSON.stringify(metadata, null, 2)}\n-->\n`;
+  // Escape HTML comment terminators in the embedded JSON. User/project strings
+  // (titles, branches, paths) can contain `-->`, which would close the comment
+  // early. `\u003e` is JSON-safe: JSON.parse restores it to `>`, so the marker
+  // parser still round-trips. Also neutralise `<!--` to avoid nested-comment
+  // ambiguity in HTML renderers.
+  const metadataJson = JSON.stringify(metadata, null, 2)
+    .replace(/-->/g, "--\\u003e")
+    .replace(/<!--/g, "\\u003c!--");
+  const markdown = `${body}\n\n${HANDOFF_MARKER}\n${metadataJson}\n-->\n`;
 
   const meta: HandoffMeta = {
     schemaVersion: 1,

--- a/apps/server/src/services/handoff/path-d-deterministic.ts
+++ b/apps/server/src/services/handoff/path-d-deterministic.ts
@@ -1,14 +1,22 @@
 /**
  * Path D of the chat fork handoff ladder.
  *
- * Wraps the existing deterministic handoff-builder so the orchestrator can
- * treat all three paths (B, A, D) uniformly. The legacy builder produces
- * prose for the system message; this adapter wraps it in the new metadata
- * shape and tags the source as `deterministic`.
+ * The deterministic builder composes a thorough Markdown handoff document from
+ * signals that already exist in the database — compact summary, fork-anchor
+ * message body, recent tool activity, narration/reasoning highlights, and the
+ * files changed across recent parent messages. It runs with no budget pressure
+ * (candidate F delivers the budgeted off-band copy separately) so the
+ * deterministic fallback is competitive with provider-generated summaries.
+ *
+ * The document is stateless and pure: every input is pre-gathered by the
+ * pipeline and passed in via {@link PathDInput}. Empty sections are omitted so
+ * the output adapts gracefully to whatever data the parent thread happened to
+ * produce. The artifact keeps the canonical HandoffArtifact shape with
+ * `ladderStep: "D"` and `generatedBy: "deterministic"`.
  */
 
-import type { Thread, Message } from "@mcode/contracts";
-import { buildHandoffContent } from "../handoff-builder.js";
+import type { Thread, Message, ToolCallRecord, ThoughtSegmentRecord } from "@mcode/contracts";
+import { HANDOFF_MARKER } from "@mcode/contracts";
 import type { HandoffArtifact, HandoffMeta, ForkAnchorRole, ProviderErrorClass } from "./handoff-types.js";
 
 /** Input data required to produce a deterministic path-D handoff artifact. */
@@ -20,29 +28,133 @@ export interface PathDInput {
   childThreadId: string;
   /** Why D ran instead of B/A. null when D was the only viable path. */
   reason: ProviderErrorClass | null;
+  /** Parent thread's most recent compact summary, if any. Primary Goal source. */
+  compactSummary?: string | null;
+  /** Body of the fork-anchor message; rendered as fork-anchor context. */
+  forkAnchorBody?: string | null;
+  /** Recent tool-call records from the parent's latest assistant messages. */
+  toolCallRecords?: ToolCallRecord[];
+  /** Recent narration/reasoning segments from the parent's latest messages. */
+  thoughtSegments?: ThoughtSegmentRecord[];
+  /** De-duplicated files changed across recent parent messages. */
+  filesChanged?: string[];
+}
+
+/** Max narration highlights surfaced so reasoning context stays focused. */
+const MAX_NARRATION_HIGHLIGHTS = 8;
+
+/**
+ * Render the structured Markdown body (everything above the metadata comment).
+ * Each section is emitted only when its source data is present, so the document
+ * shape is a deterministic function of which inputs were supplied.
+ */
+function renderBody(input: PathDInput): string {
+  const {
+    parentThread,
+    messagesUpToFork,
+    forkAnchorRole,
+    compactSummary,
+    forkAnchorBody,
+    toolCallRecords,
+    thoughtSegments,
+    filesChanged,
+  } = input;
+
+  const lines: string[] = [];
+  lines.push("# Handoff (deterministic)");
+  lines.push("");
+  lines.push(`You are continuing work from a previous thread titled "${parentThread.title}".`);
+  const modelInfo = parentThread.model ? ` ${parentThread.model}` : "";
+  lines.push(`The previous thread used${modelInfo} on branch ${parentThread.branch}.`);
+
+  // Goal / summary: prefer the model-generated compact summary, then the
+  // fork-anchor body, then the last assistant message. No truncation.
+  const lastAssistant = [...messagesUpToFork].reverse().find((m) => m.role === "assistant");
+  const goal =
+    (compactSummary && compactSummary.trim()) ||
+    (forkAnchorBody && forkAnchorBody.trim()) ||
+    (lastAssistant?.content?.trim() ?? "");
+  if (goal) {
+    const heading = compactSummary && compactSummary.trim() ? "## Summary" : "## Recent context";
+    lines.push("");
+    lines.push(heading);
+    lines.push("");
+    lines.push(goal);
+  }
+
+  if (filesChanged && filesChanged.length > 0) {
+    lines.push("");
+    lines.push("## Recent files changed");
+    lines.push("");
+    for (const f of filesChanged) {
+      lines.push(`- ${f}`);
+    }
+  }
+
+  const tools = (toolCallRecords ?? []).filter((t) => t.tool_name);
+  if (tools.length > 0) {
+    lines.push("");
+    lines.push("## Recent tool activity");
+    lines.push("");
+    for (const t of tools) {
+      const summary = t.input_summary?.trim();
+      const status = t.status && t.status !== "completed" ? ` (${t.status})` : "";
+      lines.push(`- ${t.tool_name}${status}${summary ? `: ${summary}` : ""}`);
+    }
+  }
+
+  const highlights = (thoughtSegments ?? [])
+    .filter((s) => (s.is_final_response ?? 0) === 0 && s.text?.trim())
+    .slice(0, MAX_NARRATION_HIGHLIGHTS);
+  if (highlights.length > 0) {
+    lines.push("");
+    lines.push("## Narration / reasoning highlights");
+    lines.push("");
+    for (const s of highlights) {
+      lines.push(`- ${s.text.trim()}`);
+    }
+  }
+
+  // Fork-anchor context: surface the anchor body distinctly when it wasn't
+  // already used as the Goal source (i.e. a compact summary took that slot).
+  const anchor = forkAnchorBody && forkAnchorBody.trim();
+  const anchorUsedAsGoal = !(compactSummary && compactSummary.trim()) && !!anchor;
+  if (anchor && !anchorUsedAsGoal) {
+    lines.push("");
+    lines.push(`## Fork-anchor context (${forkAnchorRole} message)`);
+    lines.push("");
+    lines.push(anchor);
+  }
+
+  return lines.join("\n");
 }
 
 /**
- * Produce a HandoffArtifact using the legacy deterministic builder.
+ * Produce a HandoffArtifact by composing a thorough deterministic document from
+ * the pre-gathered parent-thread signals in {@link PathDInput}.
  * Used when provider-generated handoffs are not available (quota, auth,
  * context-overflow, transient failure with no retry, or unsupported provider).
  */
 export async function runPathDDeterministic(input: PathDInput): Promise<HandoffArtifact> {
-  const { parentThread, messagesUpToFork, forkedFromMessageId, forkAnchorRole, childThreadId, reason } = input;
+  const { parentThread, forkedFromMessageId, forkAnchorRole, childThreadId, reason } = input;
 
-  const lastAssistant = [...messagesUpToFork].reverse().find((m) => m.role === "assistant");
-  const lastAssistantText = lastAssistant?.content ?? null;
+  const body = renderBody(input);
 
-  const prose = buildHandoffContent({
-    parentThread,
-    forkMessageId: forkedFromMessageId,
-    lastAssistantText,
-    recentFilesChanged: [],
-    openTasks: [],
+  const metadata = {
+    parentThreadId: parentThread.id,
+    parentTitle: parentThread.title,
+    forkedFromMessageId,
+    sourceProvider: parentThread.provider,
+    sourceModel: parentThread.model,
+    sourceBranch: parentThread.branch,
+    sourceWorktreePath: parentThread.worktree_path,
     sourceHead: null,
-  });
+    recentFilesChanged: input.filesChanged ?? [],
+    openTasks: [] as Array<{ content: string; status: string }>,
+  };
 
-  const markdown = `# Handoff (deterministic)\n\n${prose}\n`;
+  const markdown = `${body}\n\n${HANDOFF_MARKER}\n${JSON.stringify(metadata, null, 2)}\n-->\n`;
+
   const meta: HandoffMeta = {
     schemaVersion: 1,
     parentThreadId: parentThread.id,

--- a/apps/server/src/services/handoff/session-forker.ts
+++ b/apps/server/src/services/handoff/session-forker.ts
@@ -139,6 +139,11 @@ export class DeterministicForker implements SessionForker {
       forkAnchorRole: req.forkAnchorRole,
       childThreadId: req.childThreadId,
       reason: req.forkReason ?? null,
+      compactSummary: req.compactSummary ?? null,
+      forkAnchorBody: req.forkAnchorBody ?? null,
+      toolCallRecords: req.toolCallRecords,
+      thoughtSegments: req.thoughtSegments,
+      filesChanged: req.filesChanged,
     });
   }
 }

--- a/apps/server/src/services/handoff/session-forker.ts
+++ b/apps/server/src/services/handoff/session-forker.ts
@@ -1,0 +1,144 @@
+/**
+ * Per-Provider session forkers for the chat fork handoff pipeline.
+ *
+ * Replaces the B/A/D dispatch that lived inline in
+ * {@link HandoffPipelineService.orchestrate}. Each provider owns a `forker`
+ * (see {@link IAgentProvider.forker}) that knows how to produce a handoff
+ * artifact for that provider's session-fork semantics:
+ *
+ * - {@link CleanForker} (Claude, path B + B-prime): runs a side-channel query
+ *   against a forked copy of the parent session.
+ * - {@link MutatingForker} (Cursor, path A): runs a hidden turn on the parent's
+ *   mutable session.
+ * - {@link DeterministicForker} (path D): stateless replay-based builder, also
+ *   the pipeline's cross-forker fallback when a provider fork fails.
+ *
+ * The forkers call the providers' concrete `runSideChannelQuery` /
+ * `runHiddenTurn` methods directly. Those methods are intentionally off the
+ * {@link IAgentProvider} interface now — only the forkers reach them.
+ */
+
+import type { ForkRequest, HandoffArtifact, HandoffMeta, SessionForker } from "@mcode/contracts";
+import { runPathDDeterministic } from "./path-d-deterministic.js";
+
+export type { ForkRequest, SessionForker } from "@mcode/contracts";
+
+/**
+ * Structural shape of the Claude provider's concrete `runSideChannelQuery`.
+ * Kept narrow so the forker does not depend on the full provider class.
+ */
+interface CleanForkCapable {
+  runSideChannelQuery(args: {
+    parentThreadId: string;
+    parentSdkSessionId: string;
+    prompt: string;
+    abortSignal?: AbortSignal;
+    conversationHistory?: string;
+    cwd: string;
+  }): Promise<string>;
+  readonly id: string;
+}
+
+/**
+ * Structural shape of the Cursor provider's concrete `runHiddenTurn`.
+ */
+interface MutatingForkCapable {
+  runHiddenTurn(args: {
+    parentThreadId: string;
+    prompt: string;
+    abortSignal?: AbortSignal;
+  }): Promise<string>;
+  readonly id: string;
+}
+
+/**
+ * Build a provider-generated artifact (path B or A) with the given ladder step.
+ * Mode is decided by the pipeline (budget-driven) and stamped here; the
+ * forkers do not own mode selection.
+ */
+function buildProviderArtifact(
+  req: ForkRequest,
+  markdownBody: string,
+  step: "B" | "A",
+): HandoffArtifact {
+  const parent = req.parentThread;
+  const meta: HandoffMeta = {
+    schemaVersion: 1,
+    parentThreadId: req.parentThreadId,
+    forkedFromMessageId: req.forkedFromMessageId,
+    forkAnchorRole: req.forkAnchorRole,
+    childThreadId: req.childThreadId,
+    generatedBy: "provider",
+    provider: parent.provider,
+    ladderStep: step,
+    mode: "full",
+    generatedAt: new Date().toISOString(),
+    characterCount: markdownBody.length,
+    parentSdkSessionId: parent.sdk_session_id ?? null,
+    providerErrorOnGenerate: null,
+    regenerationHistory: [],
+    attachments: [],
+  };
+  return { markdown: markdownBody, meta };
+}
+
+/**
+ * Path B (+ B-prime) forker for clean-resume providers (Claude). Runs a
+ * one-shot side-channel query against a forked copy of the parent session. If
+ * `parentSdkSessionId` is missing the provider's own sessionless B-prime
+ * fallback (driven by `conversationHistory`) still produces a path-B result.
+ */
+export class CleanForker implements SessionForker {
+  constructor(private readonly provider: CleanForkCapable) {}
+
+  /** Produce a path-B handoff via the provider's side-channel query. */
+  async fork(req: ForkRequest): Promise<HandoffArtifact> {
+    const text = await this.provider.runSideChannelQuery({
+      parentThreadId: req.parentThreadId,
+      parentSdkSessionId: req.parentSdkSessionId ?? "",
+      prompt: req.prompt,
+      abortSignal: req.abortSignal,
+      conversationHistory: req.conversationHistory,
+      cwd: req.cwd,
+    });
+    return buildProviderArtifact(req, text, "B");
+  }
+}
+
+/**
+ * Path A forker for mutating-resume providers (Cursor). Runs a hidden turn on
+ * the parent thread's mutable session. The pipeline serializes concurrent
+ * calls per parent thread because each hidden turn mutates session state.
+ */
+export class MutatingForker implements SessionForker {
+  constructor(private readonly provider: MutatingForkCapable) {}
+
+  /** Produce a path-A handoff via the provider's hidden turn. */
+  async fork(req: ForkRequest): Promise<HandoffArtifact> {
+    const text = await this.provider.runHiddenTurn({
+      parentThreadId: req.parentThreadId,
+      prompt: req.prompt,
+      abortSignal: req.abortSignal,
+    });
+    return buildProviderArtifact(req, text, "A");
+  }
+}
+
+/**
+ * Path D forker: stateless, replay-based deterministic builder. Used directly
+ * by providers that cannot fork a session (Codex, Copilot) and as the
+ * pipeline's cross-forker fallback when a provider fork fails or times out.
+ */
+export class DeterministicForker implements SessionForker {
+  /** Produce a path-D handoff from the parent message replay. */
+  async fork(req: ForkRequest): Promise<HandoffArtifact> {
+    return runPathDDeterministic({
+      parentThread: req.parentThread,
+      messagesUpToFork: req.messagesUpToFork,
+      forkedFromMessageId: req.forkedFromMessageId,
+      forkAnchorRole: req.forkAnchorRole,
+      childThreadId: req.childThreadId,
+      reason: req.forkReason ?? null,
+    });
+  }
+}

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -1,0 +1,90 @@
+/**
+ * NarrativeStore — single home for the narrative pipeline's read side (and,
+ * after the candidate-A write-seam extraction, its enrichment + classification
+ * + persistence too).
+ *
+ * Read seam: {@link NarrativeStore.load} returns one chronologically-ordered
+ * list of {@link NarrativeEntry} for a thread, interleaving assistant message
+ * bodies, tool calls, narration segments, and hooks by (sequence, sortOrder).
+ * The client renders this list in payload order, so reloaded turns no longer
+ * race two hydration streams (the old `message.list` + `narrative.list` pair)
+ * and Tool calls never render before the assistant message body.
+ */
+import { injectable, inject } from "tsyringe";
+import type { NarrativeEntry, TurnRange } from "@mcode/contracts";
+import { MessageRepo } from "../repositories/message-repo";
+import { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
+import { ThoughtSegmentRepo } from "../repositories/thought-segment-repo";
+import { HookExecutionRepo } from "../repositories/hook-execution-repo";
+
+/** Default number of recent messages hydrated when no range is supplied. */
+const DEFAULT_LOAD_LIMIT = 200;
+
+@injectable()
+export class NarrativeStore {
+  constructor(
+    @inject(MessageRepo) private readonly messageRepo: MessageRepo,
+    @inject(ToolCallRecordRepo) private readonly toolCallRecordRepo: ToolCallRecordRepo,
+    @inject(ThoughtSegmentRepo) private readonly thoughtSegmentRepo: ThoughtSegmentRepo,
+    @inject(HookExecutionRepo) private readonly hookExecutionRepo: HookExecutionRepo,
+  ) {}
+
+  /**
+   * Load a thread's persisted narrative as one chronologically-ordered list.
+   *
+   * Entries are ordered by `(message.sequence, sortOrder)`. For each assistant
+   * message, the final-response narration segment is surfaced as the
+   * `assistantMessage` entry (carrying the message body and that segment's
+   * sort order) rather than as a separate narration row, so the final response
+   * is the message body and never appears as a duplicate preamble. Preamble
+   * narration, tool calls, and hooks for the same message interleave by their
+   * own sort order. User and system messages are not narrative and are skipped.
+   */
+  load(threadId: string, range?: TurnRange): NarrativeEntry[] {
+    const { messages } = this.messageRepo.listByThread(
+      threadId,
+      range?.limit ?? DEFAULT_LOAD_LIMIT,
+      range?.before,
+    );
+
+    const entries: NarrativeEntry[] = [];
+    for (const m of messages) {
+      if (m.role !== "assistant") continue;
+
+      const tools = this.toolCallRecordRepo.listByMessage(m.id);
+      const thoughts = this.thoughtSegmentRepo.listByMessage(m.id);
+      const hooks = this.hookExecutionRepo.listByMessage(m.id);
+
+      const finalSeg = thoughts.find((t) => (t.is_final_response ?? 0) !== 0);
+      entries.push({
+        kind: "assistantMessage",
+        messageId: m.id,
+        sequence: m.sequence,
+        body: m.content,
+        // Body sorts where its final-response segment sat; absent (tool-free
+        // or older rows) it sorts after this message's other entries.
+        sortOrder: finalSeg?.sort_order ?? Number.MAX_SAFE_INTEGER,
+      });
+
+      for (const t of tools) {
+        entries.push({ kind: "toolCall", sequence: m.sequence, sortOrder: t.sort_order, record: t });
+      }
+      for (const seg of thoughts) {
+        if ((seg.is_final_response ?? 0) !== 0) continue; // already the assistantMessage body
+        entries.push({
+          kind: "narrationSegment",
+          sequence: m.sequence,
+          sortOrder: seg.sort_order,
+          record: seg,
+        });
+      }
+      for (const h of hooks) {
+        entries.push({ kind: "hook", sequence: m.sequence, sortOrder: h.sort_order, record: h });
+      }
+    }
+
+    return entries.sort(
+      (a, b) => a.sequence - b.sequence || a.sortOrder - b.sortOrder,
+    );
+  }
+}

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -9,19 +9,106 @@
  * The client renders this list in payload order, so reloaded turns no longer
  * race two hydration streams (the old `message.list` + `narrative.list` pair)
  * and Tool calls never render before the assistant message body.
+ *
+ * Write seam: this store owns the per-turn buffers (tool calls, the
+ * `agentCallStack`, the open/closed thought segments, hook executions, and the
+ * shared sort counter) and the enrichment + classification + persistence logic
+ * that AgentService used to inline. The six narrative-pipeline traps documented
+ * in `docs/guides/narrative-pipeline.md` are enforced here:
+ *
+ * - Trap 1: {@link bufferToolCall} prefers the SDK `parent_tool_use_id` and only
+ *   falls back to {@link getCurrentParentToolCallId} when exactly one Agent on
+ *   the stack is still running.
+ * - Trap 2: the `agentCallStack` is mutated only by {@link bufferToolCall}
+ *   (push on Agent), {@link updateBufferedToolCallOutput} (pop on Agent result),
+ *   and {@link clearAgentStackOnMessage} (clear at end of turn). Never on
+ *   textDelta — the textDelta thought handling in {@link openOrExtendThought}
+ *   never touches the stack.
+ * - Trap 3: the volatile buffers are reset at turn start ({@link beginTurn} +
+ *   {@link resetTurnCounters}) and survive through {@link persistNarrative};
+ *   they are cleared only by {@link clearTurn}.
+ * - Classification precedence + the `is_final_response` suffix-match safety net
+ *   live in {@link dropOpenThought}/{@link closeOpenThought} and
+ *   {@link persistNarrative}.
+ * - Trap 6: counting semantics are owned by the client; this store preserves
+ *   the persisted rows verbatim and changes no counts.
  */
 import { injectable, inject } from "tsyringe";
+import { randomUUID } from "crypto";
+import { logger } from "@mcode/shared";
 import type { NarrativeEntry, TurnRange } from "@mcode/contracts";
 import { MessageRepo } from "../repositories/message-repo";
-import { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
-import { ThoughtSegmentRepo } from "../repositories/thought-segment-repo";
-import { HookExecutionRepo } from "../repositories/hook-execution-repo";
+import {
+  ToolCallRecordRepo,
+  type CreateToolCallRecordInput,
+} from "../repositories/tool-call-record-repo";
+import {
+  ThoughtSegmentRepo,
+  type CreateThoughtSegmentInput,
+} from "../repositories/thought-segment-repo";
+import {
+  HookExecutionRepo,
+  type CreateHookExecutionInput,
+} from "../repositories/hook-execution-repo";
 
 /** Default number of recent messages hydrated when no range is supplied. */
 const DEFAULT_LOAD_LIMIT = 200;
 
+/** Buffered tool call with raw input preserved for deferred summarization. */
+export interface BufferedToolCall extends CreateToolCallRecordInput {
+  _rawToolInput?: Record<string, unknown>;
+}
+
+/** In-flight thought segment accumulated from consecutive textDelta events. */
+interface OpenThought {
+  id: string;
+  text: string;
+  startedAt: string;
+  sortOrder: number;
+}
+
+/** In-flight hook execution awaiting its paired HookCompleted. */
+export interface OpenHook {
+  id: string;
+  hookName: string;
+  toolName: string | null;
+  phase: string;
+  payload: string;
+  startedAt: string;
+  sortOrder: number;
+}
+
+/** Tool-use event shape consumed by {@link NarrativeStore.bufferToolCall}. */
+export interface BufferToolCallEvent {
+  toolCallId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  parentToolCallId?: string;
+}
+
+/** Result of persisting a turn's narrative rows. */
+export interface PersistNarrativeResult {
+  /** Number of buffered tool calls written (drives the turn.persisted count). */
+  toolCallCount: number;
+}
+
 @injectable()
 export class NarrativeStore {
+  /** Per-thread buffer of tool calls accumulated during the current turn. */
+  private turnToolCalls = new Map<string, BufferedToolCall[]>();
+  /** Stack of active Agent tool call IDs per thread (for nesting inference). */
+  private agentCallStack = new Map<string, string[]>();
+  /** Per-thread sort counter shared across tool calls, thoughts, and hooks. */
+  private turnSortCounters = new Map<string, number>();
+  /** In-flight thought segment being accumulated from textDelta events, per thread. */
+  private turnOpenThought = new Map<string, OpenThought | null>();
+  /** Closed thought segments awaiting persistence at turn end, per thread. */
+  private turnThoughts = new Map<string, CreateThoughtSegmentInput[]>();
+  /** In-flight hook executions keyed by hookName, per thread. */
+  private turnOpenHooks = new Map<string, Map<string, OpenHook>>();
+  /** Closed hook executions awaiting persistence at turn end, per thread. */
+  private turnHooks = new Map<string, CreateHookExecutionInput[]>();
+
   constructor(
     @inject(MessageRepo) private readonly messageRepo: MessageRepo,
     @inject(ToolCallRecordRepo) private readonly toolCallRecordRepo: ToolCallRecordRepo,
@@ -86,5 +173,437 @@ export class NarrativeStore {
     return entries.sort(
       (a, b) => a.sequence - b.sequence || a.sortOrder - b.sortOrder,
     );
+  }
+
+  // ----------------------------------------------------------------------
+  // Write seam
+  // ----------------------------------------------------------------------
+
+  /**
+   * Reset the volatile per-turn buffers at the START of a turn (Trap 3). Mirrors
+   * the seeding AgentService used to do in its `sendMessage`/turnStarted prelude.
+   * Note: the sort counter and Agent stack are reset separately via
+   * {@link resetTurnCounters} on the TurnStarted event so late hooks from the
+   * prior turn can still increment the old counter.
+   */
+  beginTurn(threadId: string): void {
+    this.turnToolCalls.set(threadId, []);
+    this.turnOpenThought.set(threadId, null);
+    this.turnThoughts.set(threadId, []);
+    this.turnOpenHooks.set(threadId, new Map());
+    this.turnHooks.set(threadId, []);
+  }
+
+  /**
+   * Reset the per-turn sort counter and Agent stack. Called from the
+   * TurnStarted handler rather than {@link beginTurn} so a fresh counter is
+   * available for each new turn while late hooks from the prior turn can still
+   * increment the old one (see {@link clearTurn}).
+   */
+  resetTurnCounters(threadId: string): void {
+    this.turnSortCounters.set(threadId, 0);
+    this.agentCallStack.set(threadId, []);
+  }
+
+  /** Allocate the next shared sort order for the thread's current turn. */
+  nextSortOrder(threadId: string): number {
+    const sortOrder = this.turnSortCounters.get(threadId) ?? 0;
+    this.turnSortCounters.set(threadId, sortOrder + 1);
+    return sortOrder;
+  }
+
+  /**
+   * Open or extend the in-flight thought segment from a non-final `textDelta`.
+   * The sort order is allocated lazily on the first delta so consecutive deltas
+   * keep the same slot, taken BEFORE any following tool call's slot — matching
+   * the live client builder. Never touches the `agentCallStack` (Trap 2).
+   */
+  openOrExtendThought(threadId: string, delta: string): void {
+    const open = this.turnOpenThought.get(threadId);
+    if (!open) {
+      const sortOrder = this.nextSortOrder(threadId);
+      this.turnOpenThought.set(threadId, {
+        id: randomUUID(),
+        text: delta,
+        startedAt: new Date().toISOString(),
+        sortOrder,
+      });
+    } else {
+      open.text += delta;
+    }
+  }
+
+  /**
+   * Close any in-flight thought segment for the thread and push it onto the
+   * closed-thoughts list. Called before a tool call begins (so the thought
+   * sorts strictly before the tool) and during turn-end drain.
+   */
+  closeOpenThought(threadId: string): void {
+    const open = this.turnOpenThought.get(threadId);
+    if (!open) return;
+    const list = this.turnThoughts.get(threadId) ?? [];
+    list.push({
+      id: open.id,
+      messageId: "",
+      text: open.text,
+      startedAt: open.startedAt,
+      endedAt: new Date().toISOString(),
+      sortOrder: open.sortOrder,
+    });
+    this.turnThoughts.set(threadId, list);
+    this.turnOpenThought.set(threadId, null);
+  }
+
+  /**
+   * Discards the open thought without persisting it.
+   *
+   * Called when `AssistantMessageBoundary` reports `isFinalResponse: true` —
+   * the streamed text was actually the final assistant response and will be
+   * persisted via the `Message` event, so keeping the matching thought row
+   * would duplicate the body as a ThoughtBlock in the narrative.
+   */
+  dropOpenThought(threadId: string): void {
+    this.turnOpenThought.set(threadId, null);
+  }
+
+  /**
+   * Get the current parent tool call ID for a thread's active Agent nesting.
+   * This is the fallback consulted by `index.ts` enrichment and
+   * {@link bufferToolCall} when the SDK omits `parent_tool_use_id` (Trap 1).
+   */
+  getCurrentParentToolCallId(threadId: string): string | undefined {
+    return this.getStackDerivedParentFallback(threadId);
+  }
+
+  /**
+   * A single running Agent on the stack (buffer `status === "running"`) can
+   * serve as a parent fallback when the SDK omits `parent_tool_use_id`.
+   * Zero or multiple running Agents means the fallback is ambiguous (parallel
+   * dispatch, nested agents, or coordinator work after children); return
+   * undefined so tools do not attach under the wrong subagent row.
+   */
+  private getStackDerivedParentFallback(threadId: string): string | undefined {
+    const stack = this.agentCallStack.get(threadId) ?? [];
+    if (stack.length === 0) return undefined;
+
+    const buffer = this.turnToolCalls.get(threadId) ?? [];
+    const runningAgentIds: string[] = [];
+    for (const agentId of stack) {
+      const row = buffer.find(
+        (b) => b.toolCallId === agentId && b.toolName === "Agent",
+      );
+      if (row?.status === "running") {
+        runningAgentIds.push(agentId);
+      }
+    }
+
+    return runningAgentIds.length === 1 ? runningAgentIds[0] : undefined;
+  }
+
+  /**
+   * Buffer a tool call event for later persistence and return the parent tool
+   * call ID attributed to it. The SDK `parent_tool_use_id` wins; the stack
+   * fallback fills in only when exactly one Agent is still running (Trap 1).
+   * Agent calls are pushed onto the `agentCallStack` (Trap 2 push site).
+   */
+  bufferToolCall(threadId: string, event: BufferToolCallEvent): string | undefined {
+    const buffer = this.turnToolCalls.get(threadId) ?? [];
+    const sortOrder = this.nextSortOrder(threadId);
+
+    const stack = this.agentCallStack.get(threadId) ?? [];
+    // Prefer the SDK-provided parent_tool_use_id on the event (set by the
+    // provider). Parallel subagents require it; stack fallback aligns with
+    // `getCurrentParentToolCallId` / index.ts enrichment.
+    const parentToolCallId =
+      event.toolName === "Agent"
+        ? undefined
+        : event.parentToolCallId ?? this.getStackDerivedParentFallback(threadId);
+    // Diagnostic: trace parent attribution when a mismatch is suspected.
+    if (event.toolName !== "Agent" && parentToolCallId) {
+      logger.debug("bufferToolCall: parent attribution", {
+        threadId,
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        sdkParent: event.parentToolCallId ?? null,
+        stackDepth: stack.length,
+        attributed: parentToolCallId,
+        source: event.parentToolCallId ? "sdk" : "stack-fallback",
+      });
+    }
+    if (event.toolName === "Agent") {
+      stack.push(event.toolCallId);
+      this.agentCallStack.set(threadId, stack);
+    }
+
+    buffer.push({
+      toolCallId: event.toolCallId,
+      messageId: "",
+      toolName: event.toolName,
+      inputSummary: "", // Deferred to persistNarrative
+      outputSummary: "",
+      status: "running",
+      sortOrder,
+      parentToolCallId,
+      _rawToolInput: event.toolInput,
+    });
+    this.turnToolCalls.set(threadId, buffer);
+
+    return parentToolCallId;
+  }
+
+  /**
+   * Update a buffered tool call with its output when its result arrives, and
+   * pop the call from the `agentCallStack` if it was an Agent (Trap 2 pop site).
+   */
+  updateBufferedToolCallOutput(
+    threadId: string,
+    toolCallId: string,
+    output: string,
+    isError: boolean,
+  ): void {
+    const stack = this.agentCallStack.get(threadId) ?? [];
+    const stackIdx = stack.indexOf(toolCallId);
+    if (stackIdx >= 0) {
+      stack.splice(stackIdx, 1);
+      this.agentCallStack.set(threadId, stack);
+      logger.debug("updateBufferedToolCallOutput: popped Agent from stack", {
+        threadId,
+        toolCallId,
+        remainingDepth: stack.length,
+      });
+    }
+
+    const buffer = this.turnToolCalls.get(threadId) ?? [];
+    for (let i = buffer.length - 1; i >= 0; i--) {
+      if (buffer[i].toolCallId === toolCallId) {
+        buffer[i].outputSummary = output.slice(0, 500);
+        buffer[i].status = isError ? "failed" : "completed";
+        break;
+      }
+    }
+  }
+
+  /**
+   * Clear the whole Agent stack when a final `Message` event arrives — the turn
+   * is over and any Agent calls still on the stack are implicitly done (Trap 2
+   * end-of-turn clear). No-ops when the stack is already empty.
+   */
+  clearAgentStackOnMessage(threadId: string): void {
+    const stack = this.agentCallStack.get(threadId);
+    if (stack && stack.length > 0) {
+      stack.length = 0;
+    }
+  }
+
+  /** Snapshot of the thread's buffered tool calls (read-only inspection). */
+  getBufferedToolCalls(threadId: string): readonly BufferedToolCall[] {
+    return this.turnToolCalls.get(threadId) ?? [];
+  }
+
+  /**
+   * Record an in-flight hook execution (HookStarted). The caller supplies the
+   * already-allocated sort order (the late-hook path in AgentService allocates
+   * it before deciding routing). Returns the generated row id.
+   */
+  openHook(
+    threadId: string,
+    hook: { hookName: string; toolName: string | null; phase: string; payload: string; sortOrder: number },
+  ): string {
+    const map = this.turnOpenHooks.get(threadId) ?? new Map<string, OpenHook>();
+    const id = randomUUID();
+    map.set(hook.hookName, {
+      id,
+      hookName: hook.hookName,
+      toolName: hook.toolName,
+      phase: hook.phase,
+      payload: hook.payload,
+      startedAt: new Date().toISOString(),
+      sortOrder: hook.sortOrder,
+    });
+    this.turnOpenHooks.set(threadId, map);
+    return id;
+  }
+
+  /** Look up (without removing) an open hook by name. */
+  peekOpenHook(threadId: string, hookName: string): OpenHook | undefined {
+    return this.turnOpenHooks.get(threadId)?.get(hookName);
+  }
+
+  /** Remove an open hook by name (after it has been completed or flushed). */
+  removeOpenHook(threadId: string, hookName: string): void {
+    this.turnOpenHooks.get(threadId)?.delete(hookName);
+  }
+
+  /** Push a completed hook execution onto the closed-hooks list for persistence. */
+  pushClosedHook(threadId: string, hook: CreateHookExecutionInput): void {
+    const list = this.turnHooks.get(threadId) ?? [];
+    list.push(hook);
+    this.turnHooks.set(threadId, list);
+  }
+
+  /**
+   * Persist the buffered narrative rows (tool calls, thoughts, hooks) for a
+   * completed turn against `messageId`, tagging the final-response thought via
+   * the `is_final_response` suffix-match safety net. Drains the in-flight
+   * thought and any open hooks first so a turn that ends without a trailing
+   * tool call still records its tail. Returns the tool-call count for the
+   * `turn.persisted` broadcast that AgentService still owns.
+   *
+   * The volatile buffers are NOT cleared here (Trap 3) — call {@link clearTurn}
+   * after the turn-level persistence (snapshots, broadcast) completes.
+   */
+  persistNarrative(
+    threadId: string,
+    messageId: string,
+    messageContent: string,
+    isError: boolean,
+  ): PersistNarrativeResult {
+    const buffer = this.turnToolCalls.get(threadId) ?? [];
+
+    for (const tc of buffer) {
+      if (tc.status === "running") {
+        // Tools still running when the turn ends were interrupted, not failed.
+        // A tool that actually errored already has status "failed" from
+        // updateBufferedToolCallOutput.
+        tc.status = isError ? "cancelled" : "completed";
+      }
+      tc.messageId = messageId;
+
+      // Deferred summarization: compute inputSummary from raw tool input.
+      if (!tc.inputSummary && tc._rawToolInput) {
+        tc.inputSummary = this.summarizeInput(tc.toolName, tc._rawToolInput);
+        delete tc._rawToolInput;
+      }
+    }
+
+    if (buffer.length > 0) {
+      try {
+        this.toolCallRecordRepo.bulkCreate(buffer);
+      } catch (err) {
+        logger.error("Failed to persist tool call records", {
+          threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Drain any in-flight thought / hook before persisting so a turn that ends
+    // without a trailing tool call still records its tail thought + hook.
+    this.closeOpenThought(threadId);
+    const openHookMap = this.turnOpenHooks.get(threadId);
+    if (openHookMap && openHookMap.size > 0) {
+      const list = this.turnHooks.get(threadId) ?? [];
+      const endedAt = new Date().toISOString();
+      for (const open of openHookMap.values()) {
+        list.push({
+          id: open.id,
+          messageId: "",
+          hookName: open.hookName,
+          toolName: open.toolName,
+          phase: open.phase,
+          payload: open.payload,
+          durationMs: Date.parse(endedAt) - Date.parse(open.startedAt),
+          didBlock: false,
+          startedAt: open.startedAt,
+          endedAt,
+          sortOrder: open.sortOrder,
+        });
+      }
+      this.turnHooks.set(threadId, list);
+      openHookMap.clear();
+    }
+
+    const thoughts = (this.turnThoughts.get(threadId) ?? []).map((t) => ({
+      ...t,
+      messageId,
+    }));
+    if (thoughts.length > 0) {
+      // Suffix-match safeguard: the last chronological thought segment whose
+      // text (trimmed) is a suffix of the assistant message body is the
+      // final user-facing response — tag it so the client doesn't render it
+      // as a ThoughtBlock.  This catches provider edge cases and tool-free
+      // turns where the provider cannot set isFinalResponse at stream time.
+      const msgTrimmed = (messageContent ?? "").trim();
+      if (msgTrimmed.length > 0) {
+        // Identify the last segment by sortOrder (suffix guard targets the tail).
+        let maxSortOrder = -Infinity;
+        for (const t of thoughts) {
+          if (t.sortOrder > maxSortOrder) maxSortOrder = t.sortOrder;
+        }
+        for (const t of thoughts) {
+          const segTrimmed = t.text.trim();
+          if (segTrimmed.length === 0) continue;
+          if (segTrimmed === msgTrimmed) {
+            t.isFinalResponse = 1;
+            continue;
+          }
+          if (
+            t.sortOrder === maxSortOrder &&
+            (t.isFinalResponse === 1 || msgTrimmed.endsWith(segTrimmed))
+          ) {
+            t.isFinalResponse = 1;
+          }
+        }
+      }
+
+      try {
+        this.thoughtSegmentRepo.bulkCreate(thoughts);
+      } catch (err) {
+        logger.error("Failed to persist thought segments", {
+          threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    const hooks = (this.turnHooks.get(threadId) ?? []).map((h) => ({
+      ...h,
+      messageId,
+    }));
+    if (hooks.length > 0) {
+      try {
+        this.hookExecutionRepo.bulkCreate(hooks);
+      } catch (err) {
+        logger.error("Failed to persist hook executions", {
+          threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return { toolCallCount: buffer.length };
+  }
+
+  /**
+   * Clear the per-turn narrative buffers this store owns. The sort counter and
+   * Agent stack are intentionally NOT cleared here — they are reset in the
+   * TurnStarted handler so late hooks that arrive after this point can still
+   * increment the completed turn's counter (mirrors the old clearTurnState).
+   */
+  clearTurn(threadId: string): void {
+    this.turnToolCalls.delete(threadId);
+    this.turnOpenThought.delete(threadId);
+    this.turnThoughts.delete(threadId);
+    this.turnOpenHooks.delete(threadId);
+    this.turnHooks.delete(threadId);
+  }
+
+  /** Generate a human-readable summary of tool input. */
+  private summarizeInput(toolName: string, input: Record<string, unknown>): string {
+    switch (toolName) {
+      case "Read":
+      case "Edit":
+      case "Write":
+        return String(input.file_path ?? input.filePath ?? "");
+      case "Bash":
+        return String(input.command ?? "").slice(0, 200);
+      case "Grep":
+      case "Glob":
+        return String(input.pattern ?? "");
+      case "Agent":
+        return String(input.description ?? "").slice(0, 100);
+      default:
+        return JSON.stringify(input).slice(0, 200);
+    }
   }
 }

--- a/apps/server/src/services/scoped-pre-grant.ts
+++ b/apps/server/src/services/scoped-pre-grant.ts
@@ -1,0 +1,81 @@
+/**
+ * ScopedPreGrant — a narrow, one-shot permission bypass the handoff pipeline
+ * issues so a freshly forked child can Read its Handoff document on its first
+ * Turn without prompting the user, regardless of the Thread's `permissionMode`.
+ *
+ * The grant is deliberately the smallest authority that makes the Handoff feel
+ * invisible (PRD user stories 3 and 4):
+ *  - **Path-scoped:** authorises exactly ONE absolute file path. No prefix or
+ *    directory matching — a different path is not covered.
+ *  - **Turn-scoped:** valid only until the granted Turn ends. {@link clear} is
+ *    called when the child's first Turn completes, so the grant never survives
+ *    into a second Turn.
+ *  - **One-shot:** the first matching consume marks it used; a second Read of
+ *    the same path on the same Turn is NOT pre-granted (falls back to the
+ *    normal permission flow).
+ *
+ * This is a pipeline guarantee, not a user-configurable Hook, and it bypasses
+ * `permissionMode` only for the single granted Read.
+ */
+import { resolve } from "node:path";
+import { injectable } from "tsyringe";
+
+interface ScopedGrant {
+  /** Tool the grant authorises (always "Read" today). */
+  toolName: string;
+  /** The single absolute path authorised, resolved for stable comparison. */
+  resolvedPath: string;
+  /** One-shot latch: set on first successful consume. */
+  used: boolean;
+}
+
+/** Normalise a path so grant issuance and consumption compare equal. */
+function normalizePath(p: string): string {
+  // resolve() collapses separators and `.`/`..`; lower-case the drive/letters
+  // on Windows where the filesystem is case-insensitive.
+  const resolved = resolve(p);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+@injectable()
+export class ScopedPreGrantService {
+  /** threadId -> active grants for that thread's current granted Turn. */
+  private readonly grantsByThread = new Map<string, ScopedGrant[]>();
+
+  /**
+   * Authorise a one-shot Read of `path` on `threadId`'s next Turn. Call
+   * {@link clear} when that Turn ends to enforce Turn-scoping.
+   */
+  issue(args: { threadId: string; toolName: string; path: string }): void {
+    const list = this.grantsByThread.get(args.threadId) ?? [];
+    list.push({ toolName: args.toolName, resolvedPath: normalizePath(args.path), used: false });
+    this.grantsByThread.set(args.threadId, list);
+  }
+
+  /**
+   * Try to consume a grant for a tool call. Returns true (and latches the grant
+   * used) only when an UNUSED grant for this thread matches the tool name and
+   * the exact resolved path. Path-scoped, one-shot.
+   */
+  tryConsume(args: { threadId: string; toolName: string; path: string }): boolean {
+    const list = this.grantsByThread.get(args.threadId);
+    if (!list || list.length === 0) return false;
+    const target = normalizePath(args.path);
+    const grant = list.find(
+      (g) => !g.used && g.toolName === args.toolName && g.resolvedPath === target,
+    );
+    if (!grant) return false;
+    grant.used = true; // one-shot
+    return true;
+  }
+
+  /** Turn-scoped cleanup: drop every grant for a thread when its granted Turn ends. */
+  clear(threadId: string): void {
+    this.grantsByThread.delete(threadId);
+  }
+
+  /** Whether a thread currently has any unused grant (diagnostics/tests). */
+  hasActiveGrant(threadId: string): boolean {
+    return (this.grantsByThread.get(threadId) ?? []).some((g) => !g.used);
+  }
+}

--- a/apps/server/src/services/session-runtime.ts
+++ b/apps/server/src/services/session-runtime.ts
@@ -1,0 +1,235 @@
+/**
+ * SessionRuntime — the uniform persistent-CLI-session lifecycle shared by every
+ * Provider, parameterised over an opaque per-session state `TState`.
+ *
+ * Candidate B of the agent provider overhaul concentrates the lifecycle that
+ * the four Providers (Claude, Cursor, Codex, Copilot) had each hand-rolled and
+ * drifted on: a session pool, a lazy 60s idle-eviction timer with a real
+ * `lastUsedAt + isBusy` guard, Windows `JobObject` attachment, env snapshot via
+ * `EnvService`, lazy spawn, and a graceful-interrupt-then-hard-`taskkill /T /F`
+ * close. The runtime owns all of it; the {@link ProtocolAdapter} supplies only
+ * the protocol-specific I/O. Composition, not inheritance: each Provider holds
+ * its own `SessionRuntime<TState>` and implements its own `ProtocolAdapter`.
+ *
+ * Convergence is the point. Before this, Codex/Copilot evicted on TTL alone
+ * (no busy guard), only Cursor used `taskkill /T /F`, and Codex/Copilot did not
+ * directly attach spawned PIDs to the JobObject. By moving JobObject attachment
+ * and the hard kill into the runtime — acting on the PIDs the adapter surfaces
+ * from `spawn` — every Provider gets the same correctness.
+ */
+import { execFile } from "node:child_process";
+import { logger } from "@mcode/shared";
+import type { JobObject } from "./job-object";
+import type { EnvService } from "./env-service";
+
+/** Default idle TTL before an unused, non-busy session is evicted. */
+const DEFAULT_IDLE_TTL_MS = 10 * 60 * 1000;
+/** How often the lazy eviction timer sweeps the pool. */
+const EVICTION_INTERVAL_MS = 60 * 1000;
+
+/** Arguments the runtime hands to {@link ProtocolAdapter.spawn}. */
+export interface SpawnArgs {
+  sessionId: string;
+  threadId: string;
+  cwd: string;
+  permissionMode: string;
+  /** SDK session id to resume from; undefined starts a fresh session. */
+  resumeFrom?: string;
+  /** Merged child environment, snapshotted by the runtime via EnvService. */
+  env: Record<string, string>;
+}
+
+/**
+ * Result of spawning a session: the opaque state plus any child PIDs the
+ * runtime should attach to the Windows JobObject and `taskkill` on hard close.
+ * Providers whose SDK hides the subprocess PID return an empty `pids` array;
+ * JobObject/taskkill are then best-effort no-ops for that session.
+ */
+export interface SpawnResult<TState> {
+  state: TState;
+  pids: number[];
+}
+
+/** The protocol-specific I/O for one Provider. The Provider class implements this. */
+export interface ProtocolAdapter<TState> {
+  /** Spawn a fresh session for `sessionId`. */
+  spawn(args: SpawnArgs): Promise<SpawnResult<TState>>;
+  /** Eviction guard: true while the session has work in flight (mid-turn). */
+  isBusy(state: TState): boolean;
+  /** Protocol-level graceful interrupt (queue close / interruptTurn / disconnect / cancel). */
+  interrupt(state: TState): Promise<void> | void;
+  /** Provider-level teardown that is not the OS kill (close handles, drain). */
+  close(state: TState): Promise<void> | void;
+  /** Whether a pooled session must be discarded before reuse (dead process, or cwd/permissionMode mismatch). */
+  isStale(state: TState, args: { cwd: string; permissionMode: string }): boolean;
+}
+
+/** Internal pool entry: opaque state plus the bookkeeping the runtime owns. */
+interface PoolEntry<TState> {
+  state: TState;
+  pids: number[];
+  lastUsedAt: number;
+}
+
+/**
+ * Owns the lifecycle for one Provider's sessions. Per-Provider instance so
+ * `TState` stays type-isolated.
+ */
+export class SessionRuntime<TState> {
+  private readonly sessions = new Map<string, PoolEntry<TState>>();
+  private evictionTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly idleTtlMs: number;
+
+  constructor(
+    private readonly adapter: ProtocolAdapter<TState>,
+    private readonly deps: { jobObject: JobObject; envService: EnvService; idleTtlMs?: number },
+  ) {
+    this.idleTtlMs = deps.idleTtlMs ?? DEFAULT_IDLE_TTL_MS;
+  }
+
+  /**
+   * Get the live session for `sessionId`, spawning lazily if absent and
+   * discarding a stale one first. Starts the eviction timer on first use and
+   * stamps `lastUsedAt`.
+   */
+  async acquire(args: {
+    sessionId: string;
+    threadId: string;
+    cwd: string;
+    permissionMode: string;
+    resumeFrom?: string;
+  }): Promise<TState> {
+    this.ensureEvictionTimer();
+
+    const existing = this.sessions.get(args.sessionId);
+    if (existing) {
+      if (this.adapter.isStale(existing.state, { cwd: args.cwd, permissionMode: args.permissionMode })) {
+        await this.stop(args.sessionId);
+      } else {
+        existing.lastUsedAt = Date.now();
+        return existing.state;
+      }
+    }
+
+    const env = this.deps.envService.getEnv();
+    const { state, pids } = await this.adapter.spawn({ ...args, env });
+
+    // Converged JobObject attachment: every Provider's spawned PIDs join the
+    // Windows job so a server crash tears the whole tree down.
+    if (this.deps.jobObject.isWindowsJob) {
+      for (const pid of pids) {
+        this.deps.jobObject.assign(pid);
+        this.deps.jobObject.setDescription(pid, `mcode session ${args.sessionId}`);
+      }
+    }
+
+    this.sessions.set(args.sessionId, { state, pids, lastUsedAt: Date.now() });
+    return state;
+  }
+
+  /** The live state for `sessionId`, or undefined. */
+  get(sessionId: string): TState | undefined {
+    return this.sessions.get(sessionId)?.state;
+  }
+
+  /** Stamp `lastUsedAt` so an in-progress session is not evicted. */
+  recordUsage(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (entry) entry.lastUsedAt = Date.now();
+  }
+
+  /** Number of live sessions (diagnostics/tests). */
+  get size(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Stop one session: graceful protocol interrupt, then provider close, then
+   * the converged hard kill (`taskkill /T /F` on Windows) for any surfaced PID.
+   */
+  async stop(sessionId: string): Promise<void> {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    this.sessions.delete(sessionId);
+    try {
+      await this.adapter.interrupt(entry.state);
+    } catch (err) {
+      logger.warn("SessionRuntime interrupt failed", { sessionId, error: errMsg(err) });
+    }
+    try {
+      await this.adapter.close(entry.state);
+    } catch (err) {
+      logger.warn("SessionRuntime close failed", { sessionId, error: errMsg(err) });
+    }
+    await this.hardKill(entry.pids);
+  }
+
+  /** Stop every session and clear the eviction timer. */
+  async shutdown(): Promise<void> {
+    if (this.evictionTimer) {
+      clearInterval(this.evictionTimer);
+      this.evictionTimer = null;
+    }
+    const ids = [...this.sessions.keys()];
+    await Promise.all(ids.map((id) => this.stop(id)));
+  }
+
+  private ensureEvictionTimer(): void {
+    if (this.evictionTimer) return;
+    this.evictionTimer = setInterval(() => {
+      void this.evictIdle();
+    }, EVICTION_INTERVAL_MS);
+    // Do not keep the process alive solely for eviction sweeps.
+    this.evictionTimer.unref?.();
+  }
+
+  /**
+   * Evict sessions idle beyond the TTL. The converged guard: a session is never
+   * evicted while `adapter.isBusy(state)` is true, regardless of idle time.
+   */
+  private async evictIdle(): Promise<void> {
+    const now = Date.now();
+    const toEvict: string[] = [];
+    for (const [sessionId, entry] of this.sessions) {
+      if (now - entry.lastUsedAt <= this.idleTtlMs) continue;
+      if (this.adapter.isBusy(entry.state)) continue;
+      toEvict.push(sessionId);
+    }
+    for (const sessionId of toEvict) {
+      logger.info("SessionRuntime evicting idle session", { sessionId });
+      await this.stop(sessionId);
+    }
+  }
+
+  /**
+   * Converged hard kill. On Windows, `taskkill /T /F /PID` via `execFile` tears
+   * down the whole process tree (Node's `child.kill()` misses grandchildren on
+   * Windows). Elsewhere, `process.kill`. No-op for sessions without a PID.
+   */
+  private async hardKill(pids: number[]): Promise<void> {
+    await Promise.all(
+      pids.map(
+        (pid) =>
+          new Promise<void>((resolve) => {
+            if (process.platform === "win32") {
+              execFile("taskkill", ["/T", "/F", "/PID", String(pid)], (err) => {
+                if (err) logger.debug("taskkill failed (process may have exited)", { pid, error: errMsg(err) });
+                resolve();
+              });
+            } else {
+              try {
+                process.kill(pid);
+              } catch (err) {
+                logger.debug("process.kill failed (process may have exited)", { pid, error: errMsg(err) });
+              }
+              resolve();
+            }
+          }),
+      ),
+    );
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/server/src/services/session-runtime.ts
+++ b/apps/server/src/services/session-runtime.ts
@@ -77,6 +77,12 @@ interface PoolEntry<TState> {
  */
 export class SessionRuntime<TState> {
   private readonly sessions = new Map<string, PoolEntry<TState>>();
+  /**
+   * In-flight spawns keyed by sessionId. Dedups overlapping `acquire` calls for
+   * the same session: the first miss creates the spawn promise, later callers
+   * await it instead of spawning a second process.
+   */
+  private readonly pendingSpawns = new Map<string, Promise<TState>>();
   private evictionTimer: ReturnType<typeof setInterval> | null = null;
   private readonly idleTtlMs: number;
 
@@ -111,20 +117,34 @@ export class SessionRuntime<TState> {
       }
     }
 
-    const env = this.deps.envService.getEnv();
-    const { state, pids } = await this.adapter.spawn({ ...args, env });
+    // Dedup concurrent spawns: a second overlapping `acquire` for the same
+    // sessionId must not call `adapter.spawn` again and start a second process.
+    const inFlight = this.pendingSpawns.get(args.sessionId);
+    if (inFlight) return inFlight;
 
-    // Converged JobObject attachment: every Provider's spawned PIDs join the
-    // Windows job so a server crash tears the whole tree down.
-    if (this.deps.jobObject.isWindowsJob) {
-      for (const pid of pids) {
-        this.deps.jobObject.assign(pid);
-        this.deps.jobObject.setDescription(pid, `mcode session ${args.sessionId}`);
+    const spawnPromise = (async () => {
+      const env = this.deps.envService.getEnv();
+      const { state, pids } = await this.adapter.spawn({ ...args, env });
+
+      // Converged JobObject attachment: every Provider's spawned PIDs join the
+      // Windows job so a server crash tears the whole tree down.
+      if (this.deps.jobObject.isWindowsJob) {
+        for (const pid of pids) {
+          this.deps.jobObject.assign(pid);
+          this.deps.jobObject.setDescription(pid, `mcode session ${args.sessionId}`);
+        }
       }
-    }
 
-    this.sessions.set(args.sessionId, { state, pids, lastUsedAt: Date.now() });
-    return state;
+      this.sessions.set(args.sessionId, { state, pids, lastUsedAt: Date.now() });
+      return state;
+    })();
+
+    this.pendingSpawns.set(args.sessionId, spawnPromise);
+    try {
+      return await spawnPromise;
+    } finally {
+      this.pendingSpawns.delete(args.sessionId);
+    }
   }
 
   /** The live state for `sessionId`, or undefined. */

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -32,6 +32,7 @@ import type { SkillService } from "../services/skill-service";
 import type { TerminalService } from "../services/terminal-service";
 import type { MessageRepo } from "../repositories/message-repo";
 import type { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
+import type { NarrativeStore } from "../services/narrative-store";
 import type { ThoughtSegmentRepo } from "../repositories/thought-segment-repo";
 import type { HookExecutionRepo } from "../repositories/hook-execution-repo";
 import type { TurnSnapshotRepo } from "../repositories/turn-snapshot-repo";
@@ -73,6 +74,8 @@ export interface RouterDeps {
   toolCallRecordRepo: ToolCallRecordRepo;
   thoughtSegmentRepo: ThoughtSegmentRepo;
   hookExecutionRepo: HookExecutionRepo;
+  /** Single-source ordered narrative reader backing the `turn.load` RPC. */
+  narrativeStore: NarrativeStore;
   turnSnapshotRepo: TurnSnapshotRepo;
   snapshotService: SnapshotService;
   settingsService: SettingsService;
@@ -611,6 +614,8 @@ async function dispatch(
       return deps.toolCallRecordRepo.listByMessage(params.messageId);
     case "toolCallRecord.listByParent":
       return deps.toolCallRecordRepo.listByParent(params.parentToolCallId);
+    case "turn.load":
+      return deps.narrativeStore.load(params.threadId, params.range);
     case "narrative.list":
       return {
         tools: deps.toolCallRecordRepo.listByMessage(params.messageId),

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -622,21 +622,6 @@ async function dispatch(
         thoughts: deps.thoughtSegmentRepo.listByMessage(params.messageId),
         hooks: deps.hookExecutionRepo.listByMessage(params.messageId),
       };
-    case "narrative.listBatch": {
-      // Resolve each messageId in a single synchronous loop (SQLite is
-      // single-threaded; parallelism here would context-switch the event loop
-      // without any actual concurrency benefit). The result is a plain object
-      // keyed by messageId so the client can index directly.
-      const batchResult: Record<string, { tools: unknown[]; thoughts: unknown[]; hooks: unknown[] }> = {};
-      for (const mid of params.messageIds) {
-        batchResult[mid] = {
-          tools: deps.toolCallRecordRepo.listByMessage(mid),
-          thoughts: deps.thoughtSegmentRepo.listByMessage(mid),
-          hooks: deps.hookExecutionRepo.listByMessage(mid),
-        };
-      }
-      return batchResult;
-    }
 
     // Thread tasks
     case "thread.getTasks":

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -152,6 +152,7 @@ export const mockTransport: McodeTransport = {
   listToolCallRecordsByParent: vi.fn().mockResolvedValue([]),
   listNarrative: vi.fn().mockResolvedValue({ tools: [], thoughts: [], hooks: [] }),
   listNarrativeBatch: vi.fn().mockResolvedValue({}),
+  loadTurn: vi.fn().mockResolvedValue([]),
   getThreadTasks: vi.fn().mockResolvedValue(null),
   getThreadPlans: vi.fn().mockResolvedValue([]),
   getSnapshotDiff: vi.fn().mockResolvedValue(""),

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -151,7 +151,6 @@ export const mockTransport: McodeTransport = {
   listToolCallRecords: vi.fn().mockResolvedValue([]),
   listToolCallRecordsByParent: vi.fn().mockResolvedValue([]),
   listNarrative: vi.fn().mockResolvedValue({ tools: [], thoughts: [], hooks: [] }),
-  listNarrativeBatch: vi.fn().mockResolvedValue({}),
   loadTurn: vi.fn().mockResolvedValue([]),
   getThreadTasks: vi.fn().mockResolvedValue(null),
   getThreadPlans: vi.fn().mockResolvedValue([]),

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -93,6 +93,7 @@ function resetStores() {
   (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue(null);
   (mockTransport.getThreadPlans as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   (mockTransport.listNarrativeBatch as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  (mockTransport.loadTurn as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
   useWorkspaceStore.setState({
     threads: [
@@ -239,7 +240,7 @@ describe("ThreadHydrator", () => {
     expect(getTestActiveMessages()).toEqual([msgB]);
   });
 
-  it("falls back to per-message narrative fetches when batch RPC fails", async () => {
+  it("falls back to per-message narrative fetches when turn.load fails", async () => {
     const assistant = createMockMessage({
       id: "asst-1",
       thread_id: THREAD_A,
@@ -250,8 +251,8 @@ describe("ThreadHydrator", () => {
       messages: [msgA, assistant],
       hasMore: false,
     });
-    (mockTransport.listNarrativeBatch as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("batch unsupported"),
+    (mockTransport.loadTurn as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("turn.load unsupported"),
     );
     const listNarrativeSpy = vi.spyOn(mockTransport, "listNarrative");
 

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -92,7 +92,6 @@ function resetStores() {
   (mockTransport.listPendingPermissions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue(null);
   (mockTransport.getThreadPlans as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-  (mockTransport.listNarrativeBatch as ReturnType<typeof vi.fn>).mockResolvedValue({});
   (mockTransport.loadTurn as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
   useWorkspaceStore.setState({

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -12,11 +12,13 @@ import {
 import type { ThreadRecord } from "@/stores/thread-record";
 import type {
   HydrateMode,
+  NarrativeBatchResult,
   ThreadHydratorDeps,
   ThreadHydratorOptions,
   ThreadHydratorTransport,
   ThreadHydratorWriteState,
 } from "./types";
+import type { NarrativeEntry } from "@mcode/contracts";
 import { snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
 
@@ -270,7 +272,16 @@ export class ThreadHydrator {
     }
   }
 
-  /** Eager-prefetch persisted narrative for the last N assistant messages. */
+  /**
+   * Eager-hydrate persisted narrative for the thread via the single
+   * server-ordered `turn.load` call, then group the flat {@link NarrativeEntry}
+   * list back into the per-message {@link NarrativeBatchResult} shape that
+   * `narrativeByMessage` consumers expect (back-compat is intentional).
+   *
+   * On `turn.load` rejection we leave the lazy per-message
+   * `loadNarrativeForMessage` (`narrative.list`) path to fill in, so hydration
+   * never crashes on a transport failure.
+   */
   private prefetchNarratives(threadId: string, messages: import("@/transport").Message[]): void {
     const lastAssistants = messages.filter((m) => m.role === "assistant").slice(-NARRATIVE_PREFETCH_BATCH);
     const narrativeByMessage = getThreadRecord(this.deps.getState().records, threadId).narrativeByMessage;
@@ -281,25 +292,72 @@ export class ThreadHydrator {
     if (idsToFetch.length === 0) return;
 
     void this.transport()
-      .listNarrativeBatch(idsToFetch)
-      .then((batchRes) => {
+      .loadTurn(threadId)
+      .then((entries) => {
+        const grouped = groupNarrativeEntriesByMessage(entries);
         this.deps.setState((state: ThreadHydratorWriteState) => {
           if (!state.records.has(threadId)) return {};
           const rec = getThreadRecord(state.records, threadId);
+          // Preserve already-loaded entries: only commit messages we still need.
+          const next = { ...rec.narrativeByMessage };
+          for (const id of idsToFetch) {
+            next[id] = grouped[id] ?? { tools: [], thoughts: [], hooks: [] };
+          }
           return {
             records: patchThreadRecord(state.records, threadId, {
-              narrativeByMessage: { ...rec.narrativeByMessage, ...batchRes },
+              narrativeByMessage: next,
             }),
           };
         });
       })
       .catch((err) => {
-        console.warn("[narrative] listNarrativeBatch failed, falling back", err);
+        console.warn("[narrative] turn.load failed, falling back to lazy narrative.list", err);
         for (const m of lastAssistants) {
           void this.deps.loadNarrativeForMessage(m.id);
         }
       });
   }
+}
+
+/**
+ * Group a flat, server-ordered {@link NarrativeEntry} list into the legacy
+ * per-message {@link NarrativeBatchResult} shape keyed by `message_id`.
+ *
+ * `assistantMessage` entries are skipped: their body already lives on the
+ * message row, so they do not belong in `narrativeByMessage`. The server
+ * already orders entries by (sequence, sortOrder), so per-message arrays
+ * preserve that order without re-sorting here.
+ */
+export function groupNarrativeEntriesByMessage(
+  entries: NarrativeEntry[],
+): NarrativeBatchResult {
+  const grouped: NarrativeBatchResult = {};
+  const bucket = (messageId: string): NarrativeBatchResult[string] => {
+    let entry = grouped[messageId];
+    if (!entry) {
+      entry = { tools: [], thoughts: [], hooks: [] };
+      grouped[messageId] = entry;
+    }
+    return entry;
+  };
+
+  for (const entry of entries) {
+    switch (entry.kind) {
+      case "toolCall":
+        bucket(entry.record.message_id).tools.push(entry.record);
+        break;
+      case "narrationSegment":
+        bucket(entry.record.message_id).thoughts.push(entry.record);
+        break;
+      case "hook":
+        bucket(entry.record.message_id).hooks.push(entry.record);
+        break;
+      case "assistantMessage":
+        break;
+    }
+  }
+
+  return grouped;
 }
 
 /** Module-scoped hydrator instance registered by threadStore at init. */

--- a/apps/web/src/lib/thread-hydrator/types.ts
+++ b/apps/web/src/lib/thread-hydrator/types.ts
@@ -1,5 +1,5 @@
 import type { Message, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord } from "@/transport";
-import type { TurnSnapshot, PermissionRequest, PlanRecord } from "@mcode/contracts";
+import type { TurnSnapshot, PermissionRequest, PlanRecord, NarrativeEntry } from "@mcode/contracts";
 import type { TaskItem } from "@/stores/taskStore";
 import type { PlanQuestion } from "@mcode/contracts";
 import type { ThreadRecord } from "@/stores/thread-record";
@@ -36,6 +36,7 @@ export interface ThreadHydratorTransport {
   listSnapshots(threadId: string): Promise<TurnSnapshot[]>;
   listNarrativeBatch(messageIds: string[]): Promise<NarrativeBatchResult>;
   listNarrative(messageId: string): Promise<NarrativeBatchResult[string]>;
+  loadTurn(threadId: string): Promise<NarrativeEntry[]>;
   listPendingPermissions(threadId: string): Promise<PermissionRequest[]>;
   getThreadTasks(
     threadId: string,

--- a/apps/web/src/lib/thread-hydrator/types.ts
+++ b/apps/web/src/lib/thread-hydrator/types.ts
@@ -34,7 +34,6 @@ export type NarrativeBatchResult = Record<
 export interface ThreadHydratorTransport {
   getMessages(threadId: string, limit: number, before?: number): Promise<PaginatedMessages>;
   listSnapshots(threadId: string): Promise<TurnSnapshot[]>;
-  listNarrativeBatch(messageIds: string[]): Promise<NarrativeBatchResult>;
   listNarrative(messageId: string): Promise<NarrativeBatchResult[string]>;
   loadTurn(threadId: string): Promise<NarrativeEntry[]>;
   listPendingPermissions(threadId: string): Promise<PermissionRequest[]>;

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -329,12 +329,6 @@ export interface McodeTransport {
     thoughts: ThoughtSegmentRecord[];
     hooks: HookExecutionRecord[];
   }>;
-  /** Batch fetch narratives for multiple messages in one round-trip. */
-  listNarrativeBatch(messageIds: string[]): Promise<Record<string, {
-    tools: ToolCallRecord[];
-    thoughts: ThoughtSegmentRecord[];
-    hooks: HookExecutionRecord[];
-  }>>;
   /** Fetch a thread's full server-ordered narrative as a flat, chronological list. */
   loadTurn(threadId: string): Promise<import("@mcode/contracts").NarrativeEntry[]>;
 

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -335,6 +335,8 @@ export interface McodeTransport {
     thoughts: ThoughtSegmentRecord[];
     hooks: HookExecutionRecord[];
   }>>;
+  /** Fetch a thread's full server-ordered narrative as a flat, chronological list. */
+  loadTurn(threadId: string): Promise<import("@mcode/contracts").NarrativeEntry[]>;
 
   /** Fetch persisted task list for a thread (from last TodoWrite). */
   getThreadTasks(threadId: string): Promise<Array<{ content: string; status: "pending" | "in_progress" | "completed" | "cancelled"; group?: string }> | null>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -666,12 +666,6 @@ export function createWsTransport(
         thoughts: ThoughtSegmentRecord[];
         hooks: HookExecutionRecord[];
       }>("narrative.list", { messageId }),
-    listNarrativeBatch: (messageIds) =>
-      rpc<Record<string, {
-        tools: ToolCallRecord[];
-        thoughts: ThoughtSegmentRecord[];
-        hooks: HookExecutionRecord[];
-      }>>("narrative.listBatch", { messageIds }),
     loadTurn: (threadId) =>
       rpc<import("@mcode/contracts").NarrativeEntry[]>("turn.load", { threadId }),
 

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -672,6 +672,8 @@ export function createWsTransport(
         thoughts: ThoughtSegmentRecord[];
         hooks: HookExecutionRecord[];
       }>>("narrative.listBatch", { messageIds }),
+    loadTurn: (threadId) =>
+      rpc<import("@mcode/contracts").NarrativeEntry[]>("turn.load", { threadId }),
 
     // Thread tasks
     getThreadTasks: (threadId: string) =>

--- a/docs/guides/narrative-pipeline.md
+++ b/docs/guides/narrative-pipeline.md
@@ -8,7 +8,12 @@ the specific traps we hit so the next person doesn't trip on them.
 If you are about to touch any of these files, **read this first**:
 
 - `apps/server/src/providers/claude/claude-provider.ts` (event source)
-- `apps/server/src/services/agent-service.ts` (event enrichment + persistence)
+- `apps/server/src/services/narrative-store.ts` (write seam: enrichment +
+  classification + persistence; owns the per-turn buffers and the
+  `agentCallStack`. Also owns the read seam, `load`.)
+- `apps/server/src/services/agent-service.ts` (event dispatch; delegates the
+  write seam to NarrativeStore and retains turn-level concerns — turn snapshots,
+  `turn.persisted` broadcast, late-hook flushing)
 - `apps/server/src/index.ts` (broadcast layer)
 - `apps/web/src/stores/threadStore.ts` (client volatile state lifecycle)
 - `apps/web/src/components/chat/narrative/*` (renderers)
@@ -25,10 +30,12 @@ SDK message (parent_tool_use_id on top level)
 claude-provider.ts emits AgentEvent { type: "toolUse", parentToolCallId? }
     │
     ▼
-agent-service.ts bufferToolCall (writes to turnToolCalls for later persist)
+agent-service.ts ToolUse handler → narrative-store.ts bufferToolCall
+  (writes to the per-turn tool-call buffer for later persist)
     │
     ▼
-index.ts on("event") enriches missing parentToolCallId via agentCallStack
+index.ts on("event") enriches missing parentToolCallId via
+  narrativeStore.getCurrentParentToolCallId (agentCallStack fallback)
     │
     ▼
 broadcast("agent.event", enrichedEvent)
@@ -74,9 +81,9 @@ misclassified preamble or duplicate assistant bodies:
    thought segment on `session.assistantMessageBoundary`. Final response text
    stays in `streamingByThread` and renders via the `streaming-response`
    virtual slot, not `thoughtSegmentsByThread`.
-4. **Persist suffix match** — `agent-service.ts` tags the last matching
-   thought row `is_final_response` before DB insert as a safety net for
-   older rows or reconnect gaps.
+4. **Persist suffix match** — `narrative-store.ts` `persistNarrative` tags the
+   last matching thought row `is_final_response` before DB insert as a safety
+   net for older rows or reconnect gaps.
 
 **Don't break this:** dropping the boundary handler or counting thought
 segments in `NarrativeIndicator.stepCount` will diverge live counts from
@@ -105,10 +112,11 @@ SDK doesn't surface this field (older paths, edge cases).
 - `claude-provider.ts` reads `anyMsg.parent_tool_use_id` and forwards it as
   `parentToolCallId` on the `ToolUse` event.
 - `index.ts` checks `if (event.parentToolCallId)` first — if set,
-  leave it. Only falls back to `agentService.getCurrentParentToolCallId`
+  leave it. Only falls back to `narrativeStore.getCurrentParentToolCallId`
   when the SDK omitted it.
-- `agent-service.ts bufferToolCall` does the same dance for the persistence
-  buffer: SDK value wins, stack is a fallback.
+- `narrative-store.ts bufferToolCall` does the same dance for the persistence
+  buffer: SDK value wins, stack is a fallback. (AgentService's `bufferToolCall`
+  is a thin wrapper that delegates here, then persists TodoWrite task state.)
 
 **Stack fallback contract:** `getCurrentParentToolCallId` does **not** return
 `stack[stack.length - 1]`. It only returns a parent when **exactly one** Agent
@@ -143,8 +151,10 @@ child `toolUse` events to lose their fallback parent ID.
 2. When a final `Message` event arrives (turn over — clear the whole stack).
 3. When the session ends.
 
-**Never on `textDelta`. Never on streaming events.** See the explanatory
-comment in `agent-service.ts:1009-1014`.
+**Never on `textDelta`. Never on streaming events.** The stack now lives on
+`narrative-store.ts`; its `openOrExtendThought` (the textDelta path) never
+touches `agentCallStack`. See the explanatory comment in the AgentService
+`TextDelta` handler.
 
 ---
 

--- a/docs/guides/provider-architecture.md
+++ b/docs/guides/provider-architecture.md
@@ -2,6 +2,24 @@
 
 All agent providers must use a **persistent process per session**, not per-turn spawning.
 
+## Shared lifecycle: SessionRuntime + ProtocolAdapter
+
+The uniform session lifecycle lives in `apps/server/src/services/session-runtime.ts`.
+Each Provider holds its own `SessionRuntime<TState>` and implements
+`ProtocolAdapter<TState>` (composition, not inheritance). The runtime owns the
+session pool, the lazy 60s idle-eviction timer with a `lastUsedAt + isBusy`
+guard, Windows `JobObject` attachment, the `EnvService` env snapshot, and the
+graceful-interrupt-then-`taskkill /T /F` hard close — acting on the child PIDs
+the adapter's `spawn` surfaces. The adapter supplies only `spawn`, `isBusy`,
+`interrupt`, `close`, and `isStale`.
+
+When adding a Provider, implement the `ProtocolAdapter` seam on the Provider
+class and construct a `SessionRuntime` in its constructor; the pool, eviction,
+JobObject, and hard-kill come for free. Do not hand-roll a session map or an
+eviction timer. If the SDK hides the subprocess PID, return an empty `pids`
+array from `spawn` and the runtime's JobObject/taskkill become best-effort
+no-ops for that Provider (document it).
+
 Both the Claude and Codex providers were originally built with per-turn process spawning
 (via their respective SDKs). Both suffered the same reliability issues: stdin pipe timing
 failures on Windows, abort signal races, and opaque error messages from stderr status lines

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -61,6 +61,9 @@ export type { ThoughtSegmentRecord } from "./models/thought-segment.js";
 export { HookExecutionRecordSchema } from "./models/hook-execution.js";
 export type { HookExecutionRecord } from "./models/hook-execution.js";
 
+export { NarrativeEntrySchema, TurnRangeSchema } from "./models/narrative-entry.js";
+export type { NarrativeEntry, TurnRange } from "./models/narrative-entry.js";
+
 export { TurnSnapshotSchema } from "./models/turn-snapshot.js";
 export type { TurnSnapshot } from "./models/turn-snapshot.js";
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -279,6 +279,8 @@ export type {
   IAgentProvider,
   ICompletionCapable,
   IProviderRegistry,
+  TurnRequest,
+  ProviderOptionsByProvider,
 } from "./providers/interfaces.js";
 
 export * from "./providers/catalog.js";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -299,6 +299,17 @@ export {
 export type { ProviderModelInfo } from "./providers/models.js";
 export { isCompletionCapable } from "./providers/interfaces.js";
 
+export type {
+  SessionForker,
+  ForkRequest,
+  HandoffArtifact,
+  HandoffMeta,
+  HandoffMode,
+  LadderStep,
+  ForkAnchorRole,
+  ProviderErrorClass,
+} from "./providers/session-forker.js";
+
 export {
   TurnUsageSchema,
   QuotaCategorySchema,

--- a/packages/contracts/src/models/narrative-entry.ts
+++ b/packages/contracts/src/models/narrative-entry.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { ToolCallRecordSchema } from "./tool-call-record.js";
+import { ThoughtSegmentRecordSchema } from "./thought-segment.js";
+import { HookExecutionRecordSchema } from "./hook-execution.js";
+
+/**
+ * One entry in a Turn's chronological narrative, as returned by the
+ * `turn.load` RPC. The server orders entries so the client renders in source
+ * order without merging separate per-message streams client-side. This is the
+ * single-source hydration that fixes the page-load ordering bug where Tool
+ * calls rendered before the assistant message body.
+ *
+ * `sortOrder` is the within-message ordinal lifted from the underlying record
+ * (`sort_order`); the assistant message body carries the `sortOrder` of its
+ * final-response segment so the body interleaves correctly with tool calls.
+ */
+export const NarrativeEntrySchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("assistantMessage"),
+    messageId: z.string(),
+    sequence: z.number(),
+    body: z.string(),
+    sortOrder: z.number(),
+  }),
+  z.object({
+    kind: z.literal("toolCall"),
+    sequence: z.number(),
+    sortOrder: z.number(),
+    record: ToolCallRecordSchema,
+  }),
+  z.object({
+    kind: z.literal("narrationSegment"),
+    sequence: z.number(),
+    sortOrder: z.number(),
+    record: ThoughtSegmentRecordSchema,
+  }),
+  z.object({
+    kind: z.literal("hook"),
+    sequence: z.number(),
+    sortOrder: z.number(),
+    record: HookExecutionRecordSchema,
+  }),
+]);
+
+/** One chronologically-ordered narrative entry returned by `turn.load`. */
+export type NarrativeEntry = z.infer<typeof NarrativeEntrySchema>;
+
+/**
+ * Optional load window for `turn.load`. Omit for the thread's recent narrative;
+ * pass a sequence cursor for pagination. Mirrors `message.list` paging.
+ */
+export const TurnRangeSchema = z.object({
+  limit: z.number().optional(),
+  before: z.number().optional(),
+});
+
+/** Optional load window for the `turn.load` RPC. */
+export type TurnRange = z.infer<typeof TurnRangeSchema>;

--- a/packages/contracts/src/models/narrative-entry.ts
+++ b/packages/contracts/src/models/narrative-entry.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
 import { ToolCallRecordSchema } from "./tool-call-record.js";
 import { ThoughtSegmentRecordSchema } from "./thought-segment.js";
 import { HookExecutionRecordSchema } from "./hook-execution.js";
@@ -14,45 +15,49 @@ import { HookExecutionRecordSchema } from "./hook-execution.js";
  * (`sort_order`); the assistant message body carries the `sortOrder` of its
  * final-response segment so the body interleaves correctly with tool calls.
  */
-export const NarrativeEntrySchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("assistantMessage"),
-    messageId: z.string(),
-    sequence: z.number(),
-    body: z.string(),
-    sortOrder: z.number(),
-  }),
-  z.object({
-    kind: z.literal("toolCall"),
-    sequence: z.number(),
-    sortOrder: z.number(),
-    record: ToolCallRecordSchema,
-  }),
-  z.object({
-    kind: z.literal("narrationSegment"),
-    sequence: z.number(),
-    sortOrder: z.number(),
-    record: ThoughtSegmentRecordSchema,
-  }),
-  z.object({
-    kind: z.literal("hook"),
-    sequence: z.number(),
-    sortOrder: z.number(),
-    record: HookExecutionRecordSchema,
-  }),
-]);
+export const NarrativeEntrySchema = lazySchema(() =>
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("assistantMessage"),
+      messageId: z.string(),
+      sequence: z.number(),
+      body: z.string(),
+      sortOrder: z.number(),
+    }),
+    z.object({
+      kind: z.literal("toolCall"),
+      sequence: z.number(),
+      sortOrder: z.number(),
+      record: ToolCallRecordSchema,
+    }),
+    z.object({
+      kind: z.literal("narrationSegment"),
+      sequence: z.number(),
+      sortOrder: z.number(),
+      record: ThoughtSegmentRecordSchema,
+    }),
+    z.object({
+      kind: z.literal("hook"),
+      sequence: z.number(),
+      sortOrder: z.number(),
+      record: HookExecutionRecordSchema,
+    }),
+  ]),
+);
 
 /** One chronologically-ordered narrative entry returned by `turn.load`. */
-export type NarrativeEntry = z.infer<typeof NarrativeEntrySchema>;
+export type NarrativeEntry = z.infer<ReturnType<typeof NarrativeEntrySchema>>;
 
 /**
  * Optional load window for `turn.load`. Omit for the thread's recent narrative;
  * pass a sequence cursor for pagination. Mirrors `message.list` paging.
  */
-export const TurnRangeSchema = z.object({
-  limit: z.number().optional(),
-  before: z.number().optional(),
-});
+export const TurnRangeSchema = lazySchema(() =>
+  z.object({
+    limit: z.number().optional(),
+    before: z.number().optional(),
+  }),
+);
 
 /** Optional load window for the `turn.load` RPC. */
-export type TurnRange = z.infer<typeof TurnRangeSchema>;
+export type TurnRange = z.infer<ReturnType<typeof TurnRangeSchema>>;

--- a/packages/contracts/src/providers/__tests__/turn-request.type-test.ts
+++ b/packages/contracts/src/providers/__tests__/turn-request.type-test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import type { TurnRequest } from "../interfaces.js";
+
+/**
+ * These assertions are compile-time first: if the discriminated `providerOptions`
+ * bag stops walling knobs by Provider, the file fails to typecheck and
+ * `bun run verify` breaks. The runtime bodies are trivial so Vitest registers
+ * the file as a passing suite.
+ */
+describe("TurnRequest providerOptions discrimination", () => {
+  it("accepts Claude knobs on a claude request", () => {
+    const req: TurnRequest<"claude"> = {
+      sessionId: "mcode-t1",
+      threadId: "t1",
+      message: "hi",
+      cwd: "/tmp",
+      model: "claude-sonnet-4-6",
+      permissionMode: "full",
+      interactionMode: "build",
+      providerOptions: { contextWindowMode: "1m", thinking: true },
+    };
+    expect(req.providerOptions.contextWindowMode).toBe("1m");
+  });
+
+  it("requires an empty bag for knob-less providers", () => {
+    const req: TurnRequest<"cursor"> = {
+      sessionId: "mcode-t2",
+      threadId: "t2",
+      message: "hi",
+      cwd: "/tmp",
+      model: "cursor-default",
+      permissionMode: "default",
+      interactionMode: "plan",
+      providerOptions: {},
+    };
+    expect(req.providerOptions).toEqual({});
+  });
+
+  it("walls off cross-provider knobs (negative case via @ts-expect-error)", () => {
+    const bad: TurnRequest<"claude"> = {
+      sessionId: "mcode-t3",
+      threadId: "t3",
+      message: "hi",
+      cwd: "/tmp",
+      model: "claude-sonnet-4-6",
+      permissionMode: "full",
+      interactionMode: "build",
+      // @ts-expect-error fastMode is a Codex knob, not valid on a Claude request
+      providerOptions: { fastMode: true },
+    };
+    void bad;
+    expect(true).toBe(true);
+  });
+});

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "../events/agent-event.js";
+import type { InteractionMode } from "../models/enums.js";
 import type { AttachmentMeta } from "../models/attachment.js";
 import type { PermissionDecision, PermissionRequest } from "../models/permission.js";
 import type { ContextWindowMode, ReasoningLevel } from "../models/settings.js";
@@ -13,6 +14,61 @@ export type ProviderId = "claude" | "codex" | "gemini" | "copilot" | "cursor" | 
 
 /** How a provider's `resume` mechanism behaves when used to fork a session. */
 export type SessionForkBehavior = "clean" | "mutating" | "unsupported";
+
+/**
+ * Per-Provider knobs that ride on a {@link TurnRequest}, keyed by {@link ProviderId}.
+ * Generic call sites cannot reach into the wrong Provider's knobs because the
+ * field type is selected by the request's `P` type parameter.
+ */
+export interface ProviderOptionsByProvider {
+  /** Claude: context-window tier and the Haiku thinking toggle. */
+  claude: { contextWindowMode?: ContextWindowMode; thinking?: boolean };
+  /** Codex: request the OpenAI fast service tier. */
+  codex: { fastMode?: boolean };
+  /** Copilot: sub-agent name ("interactive" | "plan" | "autopilot" | custom YAML name). */
+  copilot: { agent?: string };
+  cursor: Record<string, never>;
+  gemini: Record<string, never>;
+  opencode: Record<string, never>;
+}
+
+/**
+ * The per-Turn value object passed to {@link IAgentProvider.sendTurn}.
+ * `P` selects the Provider-specific `providerOptions` shape.
+ *
+ * Top-level fields are generic per-Turn inputs and knobs the user may change
+ * between Turns. Provider-specific knobs live only in `providerOptions`.
+ */
+export interface TurnRequest<P extends ProviderId = ProviderId> {
+  /** SDK session name, currently `mcode-${threadId}`. */
+  sessionId: string;
+  /** Owning thread id. */
+  threadId: string;
+  /** User input text (already wire-wrapped by the orchestrator when needed). */
+  message: string;
+  attachments?: AttachmentMeta[];
+  /** Working directory: the thread's effective worktree or workspace path. */
+  cwd: string;
+  model: string;
+  /** Fallback model if the primary is unavailable. Undefined disables fallback. */
+  fallbackModel?: string;
+  permissionMode: string;
+  /** Per-Turn interaction state. Plan suppresses Cursor's native auto-answer. */
+  interactionMode: InteractionMode;
+  reasoningLevel?: ReasoningLevel;
+  /** USD budget cap for this Turn. Undefined or 0 disables. */
+  maxBudgetUsd?: number;
+  /** Max agent turns for this Turn. Undefined or 0 disables. */
+  maxTurns?: number;
+  /**
+   * SDK session id to resume from. When defined the Provider resumes that
+   * session; when undefined it starts fresh. Replaces the previous
+   * `setSdkSessionId(...)` + `resume: true` two-step dance.
+   */
+  resumeFrom?: string;
+  /** Provider-specific knobs, walled off by `P`. Required; empty-knob Providers pass `{}`. */
+  providerOptions: ProviderOptionsByProvider[P];
+}
 
 /** A pluggable agent backend that can run sessions and emit events. */
 export interface IAgentProvider {
@@ -44,52 +100,16 @@ export interface IAgentProvider {
    */
   readonly maxInputCharactersPerTurn: number;
 
-  /** Start or continue a session by sending a message. */
-  sendMessage(params: {
-    sessionId: string;
-    message: string;
-    cwd: string;
-    model: string;
-    /** Fallback model to use if the primary model is unavailable. Undefined disables fallback. */
-    fallbackModel?: string;
-    resume: boolean;
-    permissionMode: string;
-    attachments?: AttachmentMeta[];
-    reasoningLevel?: ReasoningLevel;
-    /**
-     * Per-thread context window selection. "1m" appends `[1m]` to the model
-     * slug at the SDK boundary so the SDK attaches the 1M-context beta header.
-     * Undefined falls back to the model's default 200k window.
-     * Honored only by Claude provider; ignored by Codex/Gemini/Copilot.
-     */
-    contextWindowMode?: ContextWindowMode;
-    /**
-     * Boolean thinking toggle for models that expose it (Haiku 4.5).
-     * Undefined and non-Haiku models ignore this field.
-     */
-    thinking?: boolean;
-    /** USD budget cap for this session. Provider stops if exceeded. Undefined or 0 disables. */
-    maxBudgetUsd?: number;
-    /** Maximum agent turns for this session. Provider stops after this count. Undefined or 0 disables. */
-    maxTurns?: number;
-    /**
-     * Codex: request OpenAI fast tier when true. Undefined lets the provider read global settings.
-     */
-    codexFastMode?: boolean;
-    /**
-     * Copilot-specific: name of the sub-agent to activate for this session.
-     * Built-in modes: "interactive" | "plan" | "autopilot".
-     * Custom agents: any name defined in user/project YAML config.
-     * Ignored by non-Copilot providers.
-     */
-    copilotAgent?: string;
-  }): void | Promise<void>;
+  /**
+   * Start or continue a Turn. The {@link TurnRequest} carries all per-Turn
+   * input, knobs, the resume signal (`resumeFrom`), and Provider-specific
+   * options (`providerOptions`). Replaces the former 15-parameter
+   * `sendMessage` call.
+   */
+  sendTurn(req: TurnRequest): Promise<void>;
 
   /** Abort a running session. */
   stopSession(sessionId: string): void;
-
-  /** Store the SDK-assigned session ID for later resume. */
-  setSdkSessionId(sessionId: string, sdkSessionId: string): void;
 
   /** Tear down all sessions and release resources. */
   shutdown(): void;
@@ -160,15 +180,6 @@ export interface IAgentProvider {
   on(event: "permission_resolved", handler: (payload: { requestId: string; decision: PermissionDecision }) => void): void;
   /** Subscribe to ExitPlanMode capture events (Claude SDK plan output). */
   on(event: "exit_plan_mode", handler: (payload: { threadId: string; planMarkdown: string }) => void): void;
-
-  /** Mark a thread as expecting a plan output (enables ExitPlanMode capture). */
-  setPlanAnswerMode?(threadId: string, enabled: boolean): void;
-
-  /**
-   * Mark a thread as in the plan-questions phase. Providers with native question
-   * UIs (Cursor) should not auto-answer while this is active.
-   */
-  setPlanQuestionMode?(threadId: string, enabled: boolean): void;
 }
 
 /**

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -5,6 +5,7 @@ import type { PermissionDecision, PermissionRequest } from "../models/permission
 import type { ContextWindowMode, ReasoningLevel } from "../models/settings.js";
 import type { ProviderModelInfo } from "./models.js";
 import type { ProviderUsageInfo } from "./usage.js";
+import type { SessionForker } from "./session-forker.js";
 
 /**
  * Identifier for a supported AI provider.
@@ -81,13 +82,25 @@ export interface IAgentProvider {
   readonly supportsCompletion: boolean;
 
   /**
-   * How the provider's `resume` mechanism behaves when used to fork a session
-   * for side-channel queries (e.g. handoff generation):
+   * How the provider's `resume` mechanism behaves when used to fork a session.
+   * Now metadata only (provenance + UI banner) — it no longer drives handoff
+   * dispatch. The handoff pipeline delegates to {@link forker} instead:
    * - "clean": resuming creates a forked session; the original session is unaffected.
    * - "mutating": resuming mutates the original session's forward history.
    * - "unsupported": resuming is not supported or not yet verified.
    */
   readonly sessionForkOnResume: SessionForkBehavior;
+
+  /**
+   * The session-fork strategy for this provider's handoff generation. The
+   * handoff pipeline calls `provider.forker.fork(req)` instead of branching on
+   * {@link sessionForkOnResume}. Clean-resume providers use CleanForker (path
+   * B), mutating providers use MutatingForker (path A), and providers that
+   * cannot fork a session use DeterministicForker (path D). The forkers reach
+   * the providers' concrete side-channel / hidden-turn methods directly; those
+   * methods are intentionally not on this interface.
+   */
+  readonly forker: SessionForker;
 
   /**
    * Maximum input characters the provider accepts per turn, across all roles
@@ -128,47 +141,6 @@ export interface IAgentProvider {
 
   /** Return all pending permission requests for a given thread. */
   listPendingPermissions?(threadId: string): PermissionRequest[];
-
-  /**
-   * Run a one-shot query against a forked copy of the parent's session.
-   * Only providers with `sessionForkOnResume === "clean"` implement this.
-   * The returned string is the assistant's final text output.
-   *
-   * Throws a provider-specific error on failure. The pipeline classifies via
-   * classifyProviderError.
-   */
-  runSideChannelQuery?(args: {
-    parentThreadId: string;
-    parentSdkSessionId: string;
-    prompt: string;
-    abortSignal?: AbortSignal;
-    /**
-     * Conversation history as plain text (budgeted replay). When provided and
-     * the session-resume call fails with a session-missing error, the provider
-     * retries without `resume:` by baking this history into the prompt so the
-     * caller still gets a path-B result rather than falling to path D.
-     */
-    conversationHistory?: string;
-    /**
-     * Working directory for the side-channel SDK call. Must be the parent
-     * thread's effective worktree (worktree_path if set, otherwise the workspace
-     * path). The provider sees the same filesystem state the parent had.
-     */
-    cwd: string;
-  }): Promise<string>;
-
-  /**
-   * Run a hidden turn on the parent thread's session. Persists both the
-   * request and the assistant reply with isInternal=1. Only providers with
-   * `sessionForkOnResume === "mutating"` implement this. After the hidden
-   * turn the implementation MUST send a second hidden turn instructing the
-   * model to disregard the handoff request and continue normally.
-   */
-  runHiddenTurn?(args: {
-    parentThreadId: string;
-    prompt: string;
-    abortSignal?: AbortSignal;
-  }): Promise<string>;
 
   /** Subscribe to agent events. */
   on(event: "event", handler: (event: AgentEvent) => void): void;

--- a/packages/contracts/src/providers/session-forker.ts
+++ b/packages/contracts/src/providers/session-forker.ts
@@ -16,8 +16,13 @@ import type { Message, Thread, ToolCallRecord, ThoughtSegmentRecord } from "../i
 /** Which step of the B->A->D ladder produced the handoff. */
 export type LadderStep = "B" | "A" | "D";
 
-/** Full handoff has all sections; minimal targets sub-8000-char child providers. */
-export type HandoffMode = "full" | "minimal";
+/**
+ * Handoff doc mode. Retained as a constant `"full"` for provenance/frontmatter
+ * stability after off-band delivery (PRD #538) retired the full-vs-minimal
+ * sizing selection. The child receives a small pointer + summary inline and
+ * reads the full doc off-band, so doc-body sizing no longer drives a mode.
+ */
+export type HandoffMode = "full";
 
 /** Whether the parent message at the fork point was authored by the user or assistant. */
 export type ForkAnchorRole = "user" | "assistant";

--- a/packages/contracts/src/providers/session-forker.ts
+++ b/packages/contracts/src/providers/session-forker.ts
@@ -11,7 +11,7 @@
  * existing server-side imports keep working unchanged.
  */
 
-import type { Message, Thread } from "../index.js";
+import type { Message, Thread, ToolCallRecord, ThoughtSegmentRecord } from "../index.js";
 
 /** Which step of the B->A->D ladder produced the handoff. */
 export type LadderStep = "B" | "A" | "D";
@@ -95,6 +95,35 @@ export interface ForkRequest {
    */
   forkReason?: ProviderErrorClass | null;
   abortSignal?: AbortSignal;
+  /**
+   * Parent thread's most recent compact summary, if one exists. Pre-gathered by
+   * the pipeline so {@link DeterministicForker} stays stateless. Used as the
+   * primary Goal/summary source for the deterministic (path-D) handoff doc.
+   */
+  compactSummary?: string | null;
+  /**
+   * Body of the fork-anchor message (the message identified by
+   * `forkedFromMessageId`). Pre-gathered by the pipeline; rendered as the
+   * fork-anchor context section and used as a summary fallback.
+   */
+  forkAnchorBody?: string | null;
+  /**
+   * Recent tool-call records from the parent thread's latest assistant
+   * messages. Pre-gathered by the pipeline; summarized into a "Recent tool
+   * activity" section of the deterministic doc.
+   */
+  toolCallRecords?: ToolCallRecord[];
+  /**
+   * Recent narration/reasoning segments from the parent thread's latest
+   * assistant messages. Pre-gathered by the pipeline; surfaced as
+   * "Narration / reasoning highlights".
+   */
+  thoughtSegments?: ThoughtSegmentRecord[];
+  /**
+   * Files changed across the parent thread's recent messages, de-duplicated.
+   * Pre-gathered by the pipeline from each message's `files_changed` JSON.
+   */
+  filesChanged?: string[];
 }
 
 /**

--- a/packages/contracts/src/providers/session-forker.ts
+++ b/packages/contracts/src/providers/session-forker.ts
@@ -1,0 +1,107 @@
+/**
+ * Session-fork contract for the chat fork handoff pipeline.
+ *
+ * The B/A/D ladder is no longer dispatched inline in the handoff pipeline.
+ * Instead every {@link IAgentProvider} exposes a `forker` whose `fork(req)`
+ * produces a {@link HandoffArtifact}. This module is the canonical home for
+ * the artifact shape and the forker contract so the provider interface (which
+ * lives in this package) can reference them without depending on the server.
+ *
+ * The server's `services/handoff/handoff-types.ts` re-exports these so
+ * existing server-side imports keep working unchanged.
+ */
+
+import type { Message, Thread } from "../index.js";
+
+/** Which step of the B->A->D ladder produced the handoff. */
+export type LadderStep = "B" | "A" | "D";
+
+/** Full handoff has all sections; minimal targets sub-8000-char child providers. */
+export type HandoffMode = "full" | "minimal";
+
+/** Whether the parent message at the fork point was authored by the user or assistant. */
+export type ForkAnchorRole = "user" | "assistant";
+
+/** Classified provider error returned during path-B/A attempts. */
+export type ProviderErrorClass =
+  | "quota"             // 429, rate-limit, billing-exhausted
+  | "auth"              // 401, expired credentials
+  | "context-overflow"  // input too large for the model
+  | "transient"         // network blip, 5xx, retry-once is reasonable
+  | "fatal"             // provider misconfigured, model removed, etc.
+  | "clean";            // no error
+
+/** What the pipeline writes to handoff.json. */
+export interface HandoffMeta {
+  schemaVersion: 1;
+  parentThreadId: string;
+  forkedFromMessageId: string;
+  forkAnchorRole: ForkAnchorRole;
+  childThreadId: string;
+  generatedBy: "provider" | "deterministic";
+  provider: string | null;
+  ladderStep: LadderStep;
+  mode: HandoffMode;
+  generatedAt: string;
+  characterCount: number;
+  parentSdkSessionId: string | null;
+  providerErrorOnGenerate: ProviderErrorClass | null;
+  regenerationHistory: Array<{
+    at: string;
+    ladderStep: LadderStep;
+    reason: ProviderErrorClass | "user-requested";
+  }>;
+  attachments: Array<{
+    id: string;
+    originalName: string;
+    sha256: string;
+    mime: string;
+    parentMessageId: string;
+  }>;
+}
+
+/** Returned by every forker. The pipeline writes both fields to disk. */
+export interface HandoffArtifact {
+  markdown: string;
+  meta: HandoffMeta;
+}
+
+/**
+ * Provider-agnostic input to {@link SessionForker.fork}. The handoff pipeline
+ * builds one from the parent thread + sliced message history and hands it to
+ * the resolved provider's forker.
+ */
+export interface ForkRequest {
+  parentThreadId: string;
+  forkedFromMessageId: string;
+  forkAnchorRole: ForkAnchorRole;
+  prompt: string;
+  cwd: string;
+  parentSdkSessionId?: string | null;
+  /**
+   * Conversation history as plain text (budgeted replay). Used by clean-resume
+   * providers as the sessionless B-prime fallback body.
+   */
+  conversationHistory?: string;
+  /** Parent messages up to the fork point, for the deterministic builder. */
+  messagesUpToFork: Message[];
+  /** Full parent thread row; the deterministic builder needs its metadata. */
+  parentThread: Thread;
+  /** The forked child thread id, threaded through to the artifact metadata. */
+  childThreadId: string;
+  /**
+   * Why a deterministic fork is running, when it runs as a fallback. null when
+   * the deterministic forker is the only viable path (e.g. unsupported provider).
+   */
+  forkReason?: ProviderErrorClass | null;
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * A provider-specific strategy that turns a {@link ForkRequest} into a
+ * {@link HandoffArtifact}. Implemented server-side by CleanForker (path B),
+ * MutatingForker (path A), and DeterministicForker (path D).
+ */
+export interface SessionForker {
+  fork(req: ForkRequest): Promise<HandoffArtifact>;
+}

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -587,22 +587,6 @@ export const WS_METHODS = lazySchema(() => ({
       hooks: z.array(HookExecutionRecordSchema),
     }),
   },
-  /**
-   * Batch variant of `narrative.list`. Returns a map of messageId →
-   * narrative records in a single round-trip. Replaces the 20-parallel-RPC
-   * prefetch pattern in threadStore with one call.
-   */
-  "narrative.listBatch": {
-    params: z.object({ messageIds: z.array(z.string()) }),
-    result: z.record(
-      z.string(),
-      z.object({
-        tools: z.array(ToolCallRecordSchema),
-        thoughts: z.array(ThoughtSegmentRecordSchema),
-        hooks: z.array(HookExecutionRecordSchema),
-      }),
-    ),
-  },
   "thread.getTasks": {
     params: z.object({ threadId: z.string() }),
     result: z

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -8,6 +8,7 @@ import { MAX_ATTACHMENTS } from "../models/file-types.js";
 import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { ThoughtSegmentRecordSchema } from "../models/thought-segment.js";
 import { HookExecutionRecordSchema } from "../models/hook-execution.js";
+import { NarrativeEntrySchema, TurnRangeSchema } from "../models/narrative-entry.js";
 import { GitBranchSchema, WorktreeSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
 import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema, ChecksStatusSchema } from "../github.js";
@@ -565,6 +566,17 @@ export const WS_METHODS = lazySchema(() => ({
   "toolCallRecord.listByParent": {
     params: z.object({ parentToolCallId: z.string() }),
     result: z.array(ToolCallRecordSchema),
+  },
+  /**
+   * Single-source hydration for a thread's persisted narrative: returns one
+   * chronologically-ordered list of entries (assistant message bodies, tool
+   * calls, narration segments, hooks) interleaved by (sequence, sortOrder).
+   * Replaces the race-prone `message.list` + `narrative.list` pair so reloaded
+   * turns render in source order (Tool calls never precede the assistant body).
+   */
+  "turn.load": {
+    params: z.object({ threadId: z.string(), range: TurnRangeSchema.optional() }),
+    result: z.array(NarrativeEntrySchema),
   },
   /** Replay the full persisted narrative (tools, thoughts, hooks) for an assistant message. */
   "narrative.list": {

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -575,8 +575,8 @@ export const WS_METHODS = lazySchema(() => ({
    * turns render in source order (Tool calls never precede the assistant body).
    */
   "turn.load": {
-    params: z.object({ threadId: z.string(), range: TurnRangeSchema.optional() }),
-    result: z.array(NarrativeEntrySchema),
+    params: z.object({ threadId: z.string(), range: TurnRangeSchema().optional() }),
+    result: z.array(NarrativeEntrySchema()),
   },
   /** Replay the full persisted narrative (tools, thoughts, hooks) for an assistant message. */
   "narrative.list": {


### PR DESCRIPTION
## What

Lands the five-candidate agent provider + handoff overhaul from the architecture review (E, A, B, D, F) onto one branch. Largely a refactor: it deepens module boundaries and converges Provider behaviour without changing the product surface, plus two user-facing fixes (off-band handoff delivery and page-load narrative ordering).

## Why

The agent layer had a 2,689-line `AgentService`, ~70% duplicated session-lifecycle code across the four Providers (with accidental drift), a 15-parameter per-Turn Provider call that leaked every Provider's knobs to every call site, a handoff capped by the child's per-Turn input budget, and a page-reload bug where Tool calls rendered before the assistant message. See #538 for the full PRD.

## Key Changes

- **E - TurnRequest:** `IAgentProvider.sendMessage(...15 params)` becomes `sendTurn(req: TurnRequest<P>)`. Per-Provider knobs ride in a discriminated `providerOptions` bag; `resumeFrom` replaces the `setSdkSessionId` + `resume:true` dance; `interactionMode` absorbs `setPlanQuestionMode`. (`setPlanAnswerMode` relocated off the interface to `ClaudeProvider` as a concrete method - the binary `interactionMode` cannot carry the question-vs-answer ExitPlanMode distinction; documented in-PR.)
- **A - NarrativeStore:** one server module owns the write seam (parent-id enrichment, `AssistantMessageBoundary` classification, persistence - moved out of `AgentService`) and the read seam (one ordered `turn.load` RPC). The client hydrates from that single ordered source, fixing the page-load render-ordering bug. All six narrative-pipeline traps preserved + covered by new integration tests.
- **B - SessionRuntime + ProtocolAdapter:** all four Providers now hold a `SessionRuntime<TState>` and implement `ProtocolAdapter<TState>` (composition). Converges the accidental drift: Codex/Copilot gain a real `isBusy` guard, all Providers gain `JobObject` attachment + Windows `taskkill /T /F` via the runtime.
- **D - SessionForker:** the B/A/D handoff dispatch becomes `provider.forker.fork(req)` with `CleanForker`/`MutatingForker`/`DeterministicForker` and an explicit deterministic cross-forker fallback. `runSideChannelQuery`/`runHiddenTurn` leave `IAgentProvider`.
- **F - Handoff fidelity:** the handoff is delivered off-band by default (full doc to a stable OS temp path; small inline pointer + summary), the child Reads it on its first Turn under a one-shot, path-scoped, Turn-scoped `ScopedPreGrant`, and the deterministic Path-D builder now composes from `last_compact_summary`, tool-call records, narration segments, files changed, and the fork-anchor body. Full/Minimal mode, Character budget, and Overflow retire.
- **CONTEXT.md** gains `Session runtime`, `Protocol adapter`, `Scoped pre-grant`, off-band `Handoff`, `Handoff delivery`, and the Path-A retirement-pending note.

## CONTEXT.md terms implemented

Turn / `TurnRequest`, Plan mode + Build mode (per-Turn), Provider, Session runtime, Protocol adapter, Handoff (off-band), Scoped pre-grant, Handoff delivery, the B/A/D ladder (now forker adapters), Path D (deterministic builder).

## User stories satisfied (from #538)

8, 9, 10 (narrative ordering/trail) - A; 11, 12, 20, 21, 22 (per-Turn knobs, typed call, providerOptions, resumeFrom) - E; 13-17, 19, 25, 28 (resume, Windows cleanup, idle eviction, uniform lifecycle, isolated lifecycle tests, drift convergence) - B; 23, 26 (typed forker selection, isolated deterministic builder) - D; 1-7, 24, 27, 29 (full off-band context, scoped pre-grant, deterministic fidelity, single read seam, CONTEXT.md) - A+F. Story 18/30 (Cursor clean-resume / Path-A retirement) is deferred - see below.

## Verification

- `bun run verify` fast gate (typecheck 5/5 packages + lint): passes.
- Server unit suite: 1105 pass; web suite: 88 pass. The only failures are the 7 `snapshot-service.integration` tests, which time out at the 10s hook limit under sandbox git latency (unrelated to this work; they pass at a 60s timeout).

## Deferred / follow-ups (not blockers)

- **F-A:** the live Cursor stop/resume verification could not run in the dev sandbox, so `MutatingForker` is kept (the PRD's safe default) and marked retirement-pending in CONTEXT.md.
- Two pre-existing, unrelated issues surfaced during QA and were filed separately, not patched here: Codex cold-start initialize timeout (#541) and Copilot CLI cross-platform discovery (#542).

Closes #538

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782659469&installation_id=129163861&pr_number=543&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F543&signature=4f8fe7c13467c6037d85db6b28cd8f6c3afbbb05cf03fa79ee34d7a274a6a958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Off‑band handoff delivery (full document via stable temp file) for more reliable forks.
  * One‑shot scoped pre‑grant permission for secure, path‑scoped file access during handoffs.
  * Turn‑level narrative loading so UIs can fetch a thread’s full ordered narrative.

* **Improvements**
  * Simplified, unified handoff paths (deterministic / clean / mutating) and clearer prompt behavior.
  * Centralized narrative pipeline for more accurate tool-call attribution, thought tracking, and persistence.
  * More robust session lifecycle handling and quieter idle eviction/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->