### PR TITLE
feat(copilot): cross-platform ordered CLI resolver (#542)

### DIFF
--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -63,6 +63,31 @@ vi.mock("@github/copilot-sdk", () => ({
   approveAll: vi.fn(),
 }));
 
+// Mock the CLI resolver so provider tests never shell out (npm/which/powershell).
+// Default: configured path resolves verbatim; otherwise a fixed npm-global entry.
+const { resolveCopilotCliMock } = vi.hoisted(() => ({
+  resolveCopilotCliMock: vi.fn((ctx?: { configuredPath?: string }) =>
+    ctx?.configuredPath?.trim()
+      ? { source: "configured", entry: ctx.configuredPath.trim(), version: null }
+      : { source: "npm-global", entry: "/global/@github/copilot/index.js", version: "1.0.24" },
+  ),
+}));
+
+vi.mock("../providers/copilot/copilot-cli-resolver.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../providers/copilot/copilot-cli-resolver.js")>();
+  return {
+    ...actual,
+    resolveCopilotCli: resolveCopilotCliMock,
+    createNodeResolverIO: vi.fn(() => ({
+      exists: () => false,
+      readFile: () => null,
+      exec: () => null,
+      platform: process.platform,
+    })),
+  };
+});
+
 import which from "which";
 import { CopilotProvider } from "../providers/copilot/copilot-provider.js";
 import { stubEnvService } from "./stub-env-service.js";
@@ -135,7 +160,19 @@ describe("CopilotProvider bootstrap", () => {
       // which should not be called when not in Electron
       expect(which).not.toHaveBeenCalled();
       const ctorCall = MockCopilotClient.mock.calls[0]?.[0] ?? {};
-      expect(ctorCall.cliPath).toBeUndefined();
+      expect(ctorCall.cliPath).toBe("/global/@github/copilot/index.js");
+    });
+
+    it("passes the resolver's index.js entry to the SDK as cliPath", async () => {
+      resolveCopilotCliMock.mockReturnValueOnce({
+        source: "npm-global",
+        entry: "/global/@github/copilot/index.js",
+        version: "1.0.24",
+      });
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      await provider.listModels();
+      const ctorCall = MockCopilotClient.mock.calls[0]?.[0];
+      expect(ctorCall?.cliPath).toBe("/global/@github/copilot/index.js");
     });
   });
 
@@ -237,6 +274,34 @@ describe("CopilotProvider bootstrap", () => {
       const errorEvt = events.find((e) => e.type === "error");
       expect(errorEvt).toBeDefined();
       expect(errorEvt?.type === "error" && errorEvt.error).toContain("npm install");
+    });
+
+    it("emits the resolver's not-found message when the CLI cannot be resolved", async () => {
+      resolveCopilotCliMock.mockReturnValueOnce({
+        source: "not-found",
+        entry: null,
+        version: null,
+        message: "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot",
+      });
+
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      const events: AgentEvent[] = [];
+      provider.on("event", (e: AgentEvent) => events.push(e));
+
+      await provider.sendTurn({
+        sessionId: "mcode-test3",
+        threadId: "test3",
+        message: "hello",
+        cwd: "/tmp",
+        model: "gpt-4o",
+        interactionMode: "build",
+        providerOptions: {},
+        permissionMode: "auto",
+      });
+
+      const errorEvt = events.find((e) => e.type === "error");
+      expect(errorEvt).toBeDefined();
+      expect(errorEvt?.type === "error" && errorEvt.error).toContain("npm install -g @github/copilot");
     });
   });
 });

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -88,6 +88,19 @@ vi.mock("../providers/copilot/copilot-cli-resolver.js", async (importOriginal) =
   };
 });
 
+/** Resets the CLI resolver mock to its default successful resolution. */
+function resetResolverMock(): void {
+  resolveCopilotCliMock.mockImplementation((ctx?: { configuredPath?: string }) =>
+    ctx?.configuredPath?.trim()
+      ? { source: "configured", entry: ctx.configuredPath.trim(), version: null }
+      : { source: "npm-global", entry: "/global/@github/copilot/index.js", version: "1.0.24" },
+  );
+}
+
+beforeEach(() => {
+  resetResolverMock();
+});
+
 import which from "which";
 import { CopilotProvider } from "../providers/copilot/copilot-provider.js";
 import { stubEnvService } from "./stub-env-service.js";
@@ -302,6 +315,32 @@ describe("CopilotProvider bootstrap", () => {
       const errorEvt = events.find((e) => e.type === "error");
       expect(errorEvt).toBeDefined();
       expect(errorEvt?.type === "error" && errorEvt.error).toContain("npm install -g @github/copilot");
+    });
+
+    it("returns an empty model list when the CLI cannot be resolved", async () => {
+      resolveCopilotCliMock.mockReturnValueOnce({
+        source: "not-found",
+        entry: null,
+        version: null,
+        message: "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot",
+      });
+
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      await expect(provider.listModels()).resolves.toEqual([]);
+    });
+
+    it("throws the resolver install message from complete() when the CLI cannot be resolved", async () => {
+      resolveCopilotCliMock.mockReturnValueOnce({
+        source: "not-found",
+        entry: null,
+        version: null,
+        message: "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot",
+      });
+
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      await expect(provider.complete("hello", "gpt-4o", "/tmp")).rejects.toThrow(
+        "npm install -g @github/copilot",
+      );
     });
   });
 });

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
@@ -115,6 +115,23 @@ describe("resolveCopilotCli", () => {
     const io = fakeIO({ platform: "linux", exec: { "which copilot": "/usr/local/bin/copilot" } });
     expect(resolveCopilotCli({}, io).source).toBe("not-found");
   });
+
+  it("disambiguates gh copilot when only the gh extension is present", () => {
+    const io = fakeIO({ platform: "linux", exec: { "gh extension list": "github/gh-copilot  v1.0.0" } });
+    const res = resolveCopilotCli({}, io);
+    expect(res.source).toBe("not-found");
+    if (res.source === "not-found") {
+      expect(res.message).toContain("gh copilot");
+      expect(res.message).toContain("@github/copilot");
+    }
+  });
+
+  it("omits the gh-copilot note when the extension is absent", () => {
+    const res = resolveCopilotCli({}, fakeIO({ platform: "linux" }));
+    if (res.source === "not-found") {
+      expect(res.message).not.toContain("gh copilot");
+    }
+  });
 });
 
 export { fakeIO };

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
@@ -32,6 +32,26 @@ describe("resolveCopilotCli", () => {
       expect(res.message).toContain("npm install -g @github/copilot");
     }
   });
+
+  it("uses the configured path verbatim and probes its version", () => {
+    const io = fakeIO({
+      platform: "win32",
+      exec: { "C:/tools/copilot.cmd --version": "GitHub Copilot CLI 1.0.24." },
+    });
+    const res = resolveCopilotCli({ configuredPath: "C:/tools/copilot.cmd" }, io);
+    expect(res).toMatchObject({ source: "configured", entry: "C:/tools/copilot.cmd", version: "1.0.24" });
+  });
+
+  it("trusts the configured path even when --version yields no semver", () => {
+    const io = fakeIO({ platform: "linux", exec: { "/usr/bin/copilot --version": "weird output" } });
+    const res = resolveCopilotCli({ configuredPath: "/usr/bin/copilot" }, io);
+    expect(res).toMatchObject({ source: "configured", entry: "/usr/bin/copilot", version: null });
+  });
+
+  it("ignores a blank configured path and falls through", () => {
+    const res = resolveCopilotCli({ configuredPath: "   " }, fakeIO({}));
+    expect(res.source).toBe("not-found");
+  });
 });
 
 export { fakeIO };

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { join } from "node:path";
 import { resolveCopilotCli, type ResolverIO } from "./copilot-cli-resolver.js";
 
 /** Builds a seeded ResolverIO. `exec` keys are `[command, ...args].join(" ")`. */
@@ -51,6 +52,33 @@ describe("resolveCopilotCli", () => {
   it("ignores a blank configured path and falls through", () => {
     const res = resolveCopilotCli({ configuredPath: "   " }, fakeIO({}));
     expect(res.source).toBe("not-found");
+  });
+
+  it("resolves @github/copilot via npm root -g to index.js, version from package.json", () => {
+    const pkgDir = join("/global", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "linux",
+      exec: { "npm root -g": "/global" },
+      files: { [join(pkgDir, "package.json")]: JSON.stringify({ version: "1.0.24" }) },
+      existsExtra: [entry],
+    });
+    const res = resolveCopilotCli({}, io);
+    expect(res).toMatchObject({ source: "npm-global", entry, version: "1.0.24" });
+  });
+
+  it("falls through when npm root -g resolves but index.js is absent", () => {
+    const pkgDir = join("/global", "@github", "copilot");
+    const io = fakeIO({
+      platform: "linux",
+      exec: { "npm root -g": "/global" },
+      files: { [join(pkgDir, "package.json")]: JSON.stringify({ version: "1.0.24" }) },
+    });
+    expect(resolveCopilotCli({}, io).source).toBe("not-found");
+  });
+
+  it("falls through when npm is unavailable", () => {
+    expect(resolveCopilotCli({}, fakeIO({ platform: "linux" })).source).toBe("not-found");
   });
 });
 

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { resolveCopilotCli, type ResolverIO } from "./copilot-cli-resolver.js";
+
+/** Builds a seeded ResolverIO. `exec` keys are `[command, ...args].join(" ")`. */
+function fakeIO(opts: {
+  platform?: NodeJS.Platform;
+  files?: Record<string, string>;
+  existsExtra?: string[];
+  exec?: Record<string, string | null>;
+}): ResolverIO {
+  const files = opts.files ?? {};
+  const existsSet = new Set([...Object.keys(files), ...(opts.existsExtra ?? [])]);
+  const execMap = opts.exec ?? {};
+  return {
+    platform: opts.platform ?? "linux",
+    exists: (p) => existsSet.has(p),
+    readFile: (p) => (p in files ? files[p]! : null),
+    exec: (command, args) => {
+      const key = [command, ...args].join(" ");
+      return key in execMap ? execMap[key]! : null;
+    },
+  };
+}
+
+describe("resolveCopilotCli", () => {
+  it("returns not-found with the @github/copilot install command when nothing resolves", () => {
+    const res = resolveCopilotCli({}, fakeIO({ platform: "linux" }));
+    expect(res.source).toBe("not-found");
+    expect(res.entry).toBeNull();
+    expect(res.version).toBeNull();
+    if (res.source === "not-found") {
+      expect(res.message).toContain("npm install -g @github/copilot");
+    }
+  });
+});
+
+export { fakeIO };

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
@@ -80,6 +80,41 @@ describe("resolveCopilotCli", () => {
   it("falls through when npm is unavailable", () => {
     expect(resolveCopilotCli({}, fakeIO({ platform: "linux" })).source).toBe("not-found");
   });
+
+  it("follows a win32 .ps1 shim to the adjacent package index.js (PowerShell-aware)", () => {
+    const binDir = join("C:/scoop/bin");
+    const shim = join(binDir, "copilot.ps1");
+    const pkgDir = join(binDir, "node_modules", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "win32",
+      exec: { "powershell -NoProfile -Command (Get-Command copilot).Source": shim },
+      files: { [join(pkgDir, "package.json")]: JSON.stringify({ version: "1.0.24" }) },
+      existsExtra: [entry],
+    });
+    const res = resolveCopilotCli({}, io);
+    expect(res).toMatchObject({ source: "path-shim", entry, version: "1.0.24" });
+  });
+
+  it("resolves via posix which, following to the adjacent package index.js", () => {
+    const binDir = "/usr/local/bin";
+    const shim = join(binDir, "copilot");
+    const pkgDir = join(binDir, "node_modules", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "linux",
+      exec: { "which copilot": shim },
+      files: { [join(pkgDir, "package.json")]: JSON.stringify({ version: "1.0.24" }) },
+      existsExtra: [entry],
+    });
+    const res = resolveCopilotCli({}, io);
+    expect(res).toMatchObject({ source: "path-shim", entry, version: "1.0.24" });
+  });
+
+  it("falls through when the shim has no adjacent package", () => {
+    const io = fakeIO({ platform: "linux", exec: { "which copilot": "/usr/local/bin/copilot" } });
+    expect(resolveCopilotCli({}, io).source).toBe("not-found");
+  });
 });
 
 export { fakeIO };

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { join } from "node:path";
-import { resolveCopilotCli, type ResolverIO } from "./copilot-cli-resolver.js";
+import {
+  resolveCopilotCli,
+  clearResolutionCache,
+  formatCopilotNotFoundMessage,
+  type CopilotCliResolverIO,
+} from "./copilot-cli-resolver.js";
 
 /** Builds a seeded ResolverIO. `exec` keys are `[command, ...args].join(" ")`. */
 function fakeIO(opts: {
@@ -8,7 +13,7 @@ function fakeIO(opts: {
   files?: Record<string, string>;
   existsExtra?: string[];
   exec?: Record<string, string | null>;
-}): ResolverIO {
+}): CopilotCliResolverIO {
   const files = opts.files ?? {};
   const existsSet = new Set([...Object.keys(files), ...(opts.existsExtra ?? [])]);
   const execMap = opts.exec ?? {};
@@ -23,7 +28,29 @@ function fakeIO(opts: {
   };
 }
 
+const COPILOT_PKG = (version: string) =>
+  JSON.stringify({ name: "@github/copilot", version });
+
+/** Help text that satisfies the SDK capability probe via documented flags. */
+const SDK_COMPAT_HELP = "  --headless  Run the CLI as a headless server";
+
+/** Help text for 1.x CLIs that document `--acp` instead of `--headless`. */
+const SDK_ACP_HELP = "  --acp  Start as Agent Client Protocol server";
+
+/** Adds `--help` entries for CLI paths that should pass the SDK capability check. */
+function withSdkHelp(exec: Record<string, string | null>, entries: string[]): Record<string, string | null> {
+  const out = { ...exec };
+  for (const entry of entries) {
+    out[`${entry} --help`] = SDK_COMPAT_HELP;
+  }
+  return out;
+}
+
 describe("resolveCopilotCli", () => {
+  beforeEach(() => {
+    clearResolutionCache();
+  });
+
   it("returns not-found with the @github/copilot install command when nothing resolves", () => {
     const res = resolveCopilotCli({}, fakeIO({ platform: "linux" }));
     expect(res.source).toBe("not-found");
@@ -35,18 +62,66 @@ describe("resolveCopilotCli", () => {
   });
 
   it("uses the configured path verbatim and probes its version", () => {
+    const configured = "C:/tools/copilot.cmd";
     const io = fakeIO({
       platform: "win32",
-      exec: { "C:/tools/copilot.cmd --version": "GitHub Copilot CLI 1.0.24." },
+      existsExtra: [configured],
+      exec: withSdkHelp(
+        { [`${configured} --version`]: "GitHub Copilot CLI 1.0.24." },
+        [configured],
+      ),
     });
-    const res = resolveCopilotCli({ configuredPath: "C:/tools/copilot.cmd" }, io);
-    expect(res).toMatchObject({ source: "configured", entry: "C:/tools/copilot.cmd", version: "1.0.24" });
+    const res = resolveCopilotCli({ configuredPath: configured }, io);
+    expect(res).toMatchObject({ source: "configured", entry: configured, version: "1.0.24" });
   });
 
-  it("trusts the configured path even when --version yields no semver", () => {
-    const io = fakeIO({ platform: "linux", exec: { "/usr/bin/copilot --version": "weird output" } });
-    const res = resolveCopilotCli({ configuredPath: "/usr/bin/copilot" }, io);
-    expect(res).toMatchObject({ source: "configured", entry: "/usr/bin/copilot", version: null });
+  it("trusts the configured path when --version yields no semver", () => {
+    const configured = "/usr/bin/copilot";
+    const io = fakeIO({
+      platform: "linux",
+      existsExtra: [configured],
+      exec: withSdkHelp(
+        { [`${configured} --version`]: "weird output" },
+        [configured],
+      ),
+    });
+    const res = resolveCopilotCli({ configuredPath: configured }, io);
+    expect(res).toMatchObject({ source: "configured", entry: configured, version: null });
+  });
+
+  it("rejects configured paths with shell metacharacters", () => {
+    const res = resolveCopilotCli({ configuredPath: "copilot.cmd & calc.exe" }, fakeIO({}));
+    expect(res.source).toBe("not-found");
+    if (res.source === "not-found") {
+      expect(res.message).toContain("invalid characters");
+    }
+  });
+
+  it("falls through when the configured path is missing and npm-global resolves", () => {
+    const pkgDir = join("/global", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "linux",
+      exec: withSdkHelp({ "npm root -g": "/global" }, [entry]),
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("1.0.24") },
+      existsExtra: [entry],
+    });
+    const res = resolveCopilotCli({ configuredPath: "/missing/copilot" }, io);
+    expect(res).toMatchObject({ source: "npm-global", entry, version: "1.0.24" });
+  });
+
+  it("falls through when the configured path does not respond to --version", () => {
+    const configured = "/usr/bin/copilot";
+    const pkgDir = join("/global", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "linux",
+      existsExtra: [configured, entry],
+      exec: withSdkHelp({ "npm root -g": "/global" }, [entry]),
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("1.0.24") },
+    });
+    const res = resolveCopilotCli({ configuredPath: configured }, io);
+    expect(res).toMatchObject({ source: "npm-global", entry, version: "1.0.24" });
   });
 
   it("ignores a blank configured path and falls through", () => {
@@ -59,12 +134,48 @@ describe("resolveCopilotCli", () => {
     const entry = join(pkgDir, "index.js");
     const io = fakeIO({
       platform: "linux",
-      exec: { "npm root -g": "/global" },
-      files: { [join(pkgDir, "package.json")]: JSON.stringify({ version: "1.0.24" }) },
+      exec: withSdkHelp({ "npm root -g": "/global" }, [entry]),
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("1.0.24") },
       existsExtra: [entry],
     });
     const res = resolveCopilotCli({}, io);
     expect(res).toMatchObject({ source: "npm-global", entry, version: "1.0.24" });
+  });
+
+  it("accepts 1.x when version qualifies even if --help only lists --acp", () => {
+    const pkgDir = join("/global", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "linux",
+      exec: {
+        "npm root -g": "/global",
+        [`${entry} --help`]: SDK_ACP_HELP,
+      },
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("1.0.56") },
+      existsExtra: [entry],
+    });
+    const res = resolveCopilotCli({}, io);
+    expect(res).toMatchObject({ source: "npm-global", entry, version: "1.0.56" });
+  });
+
+  it("rejects an SDK-incompatible CLI below the minimum 0.0.x build", () => {
+    const pkgDir = join("/global", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "linux",
+      exec: {
+        "npm root -g": "/global",
+        [`${entry} --help`]: "Usage: copilot [options] [command]",
+      },
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("0.0.330") },
+      existsExtra: [entry],
+    });
+    const res = resolveCopilotCli({}, io);
+    expect(res.source).toBe("not-found");
+    if (res.source === "not-found") {
+      expect(res.message).toContain("0.0.330");
+      expect(res.message).toContain("npm install -g @github/copilot@latest");
+    }
   });
 
   it("falls through when npm root -g resolves but index.js is absent", () => {
@@ -72,7 +183,19 @@ describe("resolveCopilotCli", () => {
     const io = fakeIO({
       platform: "linux",
       exec: { "npm root -g": "/global" },
-      files: { [join(pkgDir, "package.json")]: JSON.stringify({ version: "1.0.24" }) },
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("1.0.24") },
+    });
+    expect(resolveCopilotCli({}, io).source).toBe("not-found");
+  });
+
+  it("falls through when package.json name is not @github/copilot", () => {
+    const pkgDir = join("/global", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "linux",
+      exec: { "npm root -g": "/global" },
+      files: { [join(pkgDir, "package.json")]: JSON.stringify({ name: "evil-pkg", version: "1.0.0" }) },
+      existsExtra: [entry],
     });
     expect(resolveCopilotCli({}, io).source).toBe("not-found");
   });
@@ -88,8 +211,26 @@ describe("resolveCopilotCli", () => {
     const entry = join(pkgDir, "index.js");
     const io = fakeIO({
       platform: "win32",
-      exec: { "powershell -NoProfile -Command (Get-Command copilot).Source": shim },
-      files: { [join(pkgDir, "package.json")]: JSON.stringify({ version: "1.0.24" }) },
+      exec: withSdkHelp(
+        { "powershell -NoProfile -Command (Get-Command copilot).Source": shim },
+        [entry],
+      ),
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("1.0.24") },
+      existsExtra: [entry],
+    });
+    const res = resolveCopilotCli({}, io);
+    expect(res).toMatchObject({ source: "path-shim", entry, version: "1.0.24" });
+  });
+
+  it("falls back to where.exe on win32 when PowerShell does not resolve copilot", () => {
+    const binDir = join("C:/tools/bin");
+    const shim = join(binDir, "copilot.cmd");
+    const pkgDir = join(binDir, "node_modules", "@github", "copilot");
+    const entry = join(pkgDir, "index.js");
+    const io = fakeIO({
+      platform: "win32",
+      exec: withSdkHelp({ "where copilot": shim }, [entry]),
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("1.0.24") },
       existsExtra: [entry],
     });
     const res = resolveCopilotCli({}, io);
@@ -103,8 +244,8 @@ describe("resolveCopilotCli", () => {
     const entry = join(pkgDir, "index.js");
     const io = fakeIO({
       platform: "linux",
-      exec: { "which copilot": shim },
-      files: { [join(pkgDir, "package.json")]: JSON.stringify({ version: "1.0.24" }) },
+      exec: withSdkHelp({ "which copilot": shim }, [entry]),
+      files: { [join(pkgDir, "package.json")]: COPILOT_PKG("1.0.24") },
       existsExtra: [entry],
     });
     const res = resolveCopilotCli({}, io);
@@ -131,6 +272,23 @@ describe("resolveCopilotCli", () => {
     if (res.source === "not-found") {
       expect(res.message).not.toContain("gh copilot");
     }
+  });
+
+  it("reuses cached resolution within the TTL", () => {
+    const io = fakeIO({ platform: "linux" });
+    const first = resolveCopilotCli({}, io);
+    const second = resolveCopilotCli({}, io);
+    expect(first).toEqual(second);
+  });
+});
+
+describe("formatCopilotNotFoundMessage", () => {
+  it("includes gh copilot disambiguation when requested", () => {
+    expect(formatCopilotNotFoundMessage(true)).toContain("gh copilot");
+  });
+
+  it("omits gh copilot disambiguation when absent", () => {
+    expect(formatCopilotNotFoundMessage(false)).not.toContain("gh copilot");
   });
 });
 

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.test.ts
@@ -97,6 +97,17 @@ describe("resolveCopilotCli", () => {
     }
   });
 
+  it("accepts configured paths with spaces and parentheses", () => {
+    const configured = "C:\\Program Files (x86)\\GitHub\\copilot\\index.js";
+    const io = fakeIO({
+      platform: "win32",
+      exec: { [`${configured} --version`]: "GitHub Copilot CLI 1.0.57." },
+      existsExtra: [configured],
+    });
+    const res = resolveCopilotCli({ configuredPath: configured }, io);
+    expect(res).toMatchObject({ source: "configured", entry: configured, version: "1.0.57" });
+  });
+
   it("falls through when the configured path is missing and npm-global resolves", () => {
     const pkgDir = join("/global", "@github", "copilot");
     const entry = join(pkgDir, "index.js");

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.ts
@@ -57,8 +57,23 @@ function parseVersion(out: string): string | null {
   return m ? m[1]! : null;
 }
 
+/**
+ * 1. User-configured path. Highest priority, never overridden, trusted verbatim
+ *    (the SDK's own existsSync gate validates it). The --version probe only
+ *    supplies the version for display.
+ */
+const configuredStrategy: Strategy = {
+  source: "configured",
+  resolve(ctx, io) {
+    const p = ctx.configuredPath?.trim();
+    if (!p) return null;
+    const out = io.exec(p, ["--version"]);
+    return { entry: p, version: out ? parseVersion(out) : null };
+  },
+};
+
 /** Strategy table, tried in priority order. Append a row to add a future route. */
-const STRATEGIES: Strategy[] = [];
+const STRATEGIES: Strategy[] = [configuredStrategy];
 
 /** Builds the not-found resolution, disambiguating `@github/copilot` from `gh copilot`. */
 function notFound(io: ResolverIO): CopilotCliNotFound {

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.ts
@@ -111,8 +111,37 @@ const npmGlobalStrategy: Strategy = {
   },
 };
 
+/** Returns the first command source on PATH: PowerShell-aware on win32, `which` on posix. */
+function locateOnPath(io: ResolverIO): string | null {
+  if (io.platform === "win32") {
+    // `where.exe` cannot see ExternalScript/.ps1 shims; Get-Command can. Prefer
+    // it, fall back to `where` for .cmd/.exe shims.
+    const viaPwsh = io.exec("powershell", ["-NoProfile", "-Command", "(Get-Command copilot).Source"]);
+    if (viaPwsh) return viaPwsh.split(/\r?\n/)[0]?.trim() ?? null;
+    const viaWhere = io.exec("where", ["copilot"]);
+    return viaWhere ? (viaWhere.split(/\r?\n/)[0]?.trim() ?? null) : null;
+  }
+  const viaWhich = io.exec("which", ["copilot"]);
+  return viaWhich ? (viaWhich.split(/\r?\n/)[0]?.trim() ?? null) : null;
+}
+
+/**
+ * 3. PATH/shim fallback. Resolves `copilot` on PATH (PowerShell-aware on win32
+ *    so .ps1 ExternalScripts are visible), then follows to the adjacent
+ *    `node_modules/@github/copilot/index.js`. Covers non-standard layouts the
+ *    npm-global root does not surface.
+ */
+const pathShimStrategy: Strategy = {
+  source: "path-shim",
+  resolve(_ctx, io) {
+    const shim = locateOnPath(io);
+    if (!shim) return null;
+    return resolvePackageEntry(join(dirname(shim), "node_modules", "@github", "copilot"), io);
+  },
+};
+
 /** Strategy table, tried in priority order. Append a row to add a future route. */
-const STRATEGIES: Strategy[] = [configuredStrategy, npmGlobalStrategy];
+const STRATEGIES: Strategy[] = [configuredStrategy, npmGlobalStrategy, pathShimStrategy];
 
 /** Builds the not-found resolution, disambiguating `@github/copilot` from `gh copilot`. */
 function notFound(io: ResolverIO): CopilotCliNotFound {

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.ts
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+
+/** Which discovery strategy produced a resolution (for diagnostics + banner copy). */
+export type CopilotCliSource = "configured" | "npm-global" | "path-shim";
+
+/** A successful resolution: an absolute, spawnable entry plus the detected version. */
+export interface CopilotCliFound {
+  source: CopilotCliSource;
+  /** Absolute path passed to the SDK as `cliPath` (the CLI's index.js, or the configured path). */
+  entry: string;
+  /** Detected version (e.g. "1.0.24"), or null when it could not be read. */
+  version: string | null;
+}
+
+/** No strategy resolved; carries a user-facing install message. */
+export interface CopilotCliNotFound {
+  source: "not-found";
+  entry: null;
+  version: null;
+  message: string;
+}
+
+/** The outcome of resolving the Copilot CLI: a found entry or a not-found message. */
+export type CopilotCliResolution = CopilotCliFound | CopilotCliNotFound;
+
+/** Filesystem/process access behind one seam so the resolver is testable without spawning. */
+export interface ResolverIO {
+  /** True when a path exists on disk. */
+  exists(p: string): boolean;
+  /** UTF-8 file contents, or null when unreadable. */
+  readFile(p: string): string | null;
+  /** Run a command; trimmed stdout, or null on spawn error / non-zero exit. */
+  exec(command: string, args: string[]): string | null;
+  /** Host platform; selects the win32 vs posix PATH branch. */
+  platform: NodeJS.Platform;
+}
+
+/** Inputs the resolver needs from the caller. */
+export interface ResolveContext {
+  /** The user-configured CLI path (`settings.provider.cli.copilot`), if any. */
+  configuredPath?: string;
+}
+
+interface Strategy {
+  source: CopilotCliSource;
+  resolve(ctx: ResolveContext, io: ResolverIO): { entry: string; version: string | null } | null;
+}
+
+/** Semver triplet matcher (matches "1.0.24" in "GitHub Copilot CLI 1.0.24."). */
+const VERSION_RE = /\b(\d+\.\d+\.\d+)(?!\.\d)/;
+
+/** Extracts a semver triplet from `<entry> --version` output, or null. */
+function parseVersion(out: string): string | null {
+  const m = out.match(VERSION_RE);
+  return m ? m[1]! : null;
+}
+
+/** Strategy table, tried in priority order. Append a row to add a future route. */
+const STRATEGIES: Strategy[] = [];
+
+/** Builds the not-found resolution, disambiguating `@github/copilot` from `gh copilot`. */
+function notFound(io: ResolverIO): CopilotCliNotFound {
+  const ghExts = io.exec("gh", ["extension", "list"]);
+  const hasGhCopilot = ghExts != null && /copilot/i.test(ghExts);
+  const base =
+    "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot\n\n" +
+    "Or set a custom path in Settings > Provider > Copilot CLI path.";
+  const disambig = hasGhCopilot
+    ? "\n\nNote: the `gh copilot` GitHub CLI extension is installed, which is different " +
+      "from the `@github/copilot` npm package Mcode needs."
+    : "";
+  return { source: "not-found", entry: null, version: null, message: base + disambig };
+}
+
+/**
+ * Resolves the Copilot CLI by trying each strategy in priority order and using
+ * the first that yields an existing entry. Returns a not-found resolution with
+ * an install message when none succeed. Reports a raw version only; min-version
+ * policy is intentionally not handled here (see ADR-0001).
+ */
+export function resolveCopilotCli(ctx: ResolveContext, io: ResolverIO): CopilotCliResolution {
+  for (const strategy of STRATEGIES) {
+    const r = strategy.resolve(ctx, io);
+    if (r) return { source: strategy.source, entry: r.entry, version: r.version };
+  }
+  return notFound(io);
+}
+
+/** Real adapter: Node fs + spawnSync. `shell:true` on win32 resolves `.cmd`/`.ps1` shims for probes. */
+export function createNodeResolverIO(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): ResolverIO {
+  return {
+    platform,
+    exists: (p) => existsSync(p),
+    readFile: (p) => {
+      try {
+        return readFileSync(p, "utf8");
+      } catch {
+        return null;
+      }
+    },
+    exec: (command, args) => {
+      const r = spawnSync(command, args, {
+        encoding: "utf8",
+        timeout: 5000,
+        windowsHide: true,
+        shell: platform === "win32",
+        env,
+      });
+      if (r.error || r.status !== 0) return null;
+      const out = (r.stdout ?? "").trim();
+      return out.length > 0 ? out : null;
+    },
+  };
+}

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.ts
@@ -72,8 +72,47 @@ const configuredStrategy: Strategy = {
   },
 };
 
+/**
+ * Resolves a `@github/copilot` package directory to its absolute `index.js`
+ * entry (the JS entry point the SDK runs with node) and version. Returns null
+ * when the package's `index.js` is missing. Shared by the npm-global and
+ * path-shim strategies so the entry and version come from the same package.
+ */
+function resolvePackageEntry(
+  pkgDir: string,
+  io: ResolverIO,
+): { entry: string; version: string | null } | null {
+  const entry = join(pkgDir, "index.js");
+  if (!io.exists(entry)) return null;
+  const raw = io.readFile(join(pkgDir, "package.json"));
+  let version: string | null = null;
+  if (raw) {
+    try {
+      const pkg = JSON.parse(raw) as { version?: string };
+      version = typeof pkg.version === "string" ? pkg.version : null;
+    } catch {
+      version = null;
+    }
+  }
+  return { entry, version };
+}
+
+/**
+ * 2. `@github/copilot` resolved via `npm root -g`. The primary auto-discovery
+ *    route: it finds the global install the SDK's own search misses, and yields
+ *    the absolute index.js the SDK runs with node.
+ */
+const npmGlobalStrategy: Strategy = {
+  source: "npm-global",
+  resolve(_ctx, io) {
+    const root = io.exec("npm", ["root", "-g"]);
+    if (!root) return null;
+    return resolvePackageEntry(join(root, "@github", "copilot"), io);
+  },
+};
+
 /** Strategy table, tried in priority order. Append a row to add a future route. */
-const STRATEGIES: Strategy[] = [configuredStrategy];
+const STRATEGIES: Strategy[] = [configuredStrategy, npmGlobalStrategy];
 
 /** Builds the not-found resolution, disambiguating `@github/copilot` from `gh copilot`. */
 function notFound(io: ResolverIO): CopilotCliNotFound {

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
+import { meetsMinVersion } from "../codex/codex-version.js";
 
 /** Which discovery strategy produced a resolution (for diagnostics + banner copy). */
 export type CopilotCliSource = "configured" | "npm-global" | "path-shim";
@@ -26,7 +27,7 @@ export interface CopilotCliNotFound {
 export type CopilotCliResolution = CopilotCliFound | CopilotCliNotFound;
 
 /** Filesystem/process access behind one seam so the resolver is testable without spawning. */
-export interface ResolverIO {
+export interface CopilotCliResolverIO {
   /** True when a path exists on disk. */
   exists(p: string): boolean;
   /** UTF-8 file contents, or null when unreadable. */
@@ -37,16 +38,31 @@ export interface ResolverIO {
   platform: NodeJS.Platform;
 }
 
+/** @deprecated Use {@link CopilotCliResolverIO}. */
+export type ResolverIO = CopilotCliResolverIO;
+
 /** Inputs the resolver needs from the caller. */
-export interface ResolveContext {
+export interface CopilotCliResolveContext {
   /** The user-configured CLI path (`settings.provider.cli.copilot`), if any. */
   configuredPath?: string;
 }
 
+/** @deprecated Use {@link CopilotCliResolveContext}. */
+export type ResolveContext = CopilotCliResolveContext;
+
 interface Strategy {
   source: CopilotCliSource;
-  resolve(ctx: ResolveContext, io: ResolverIO): { entry: string; version: string | null } | null;
+  resolve(ctx: CopilotCliResolveContext, io: CopilotCliResolverIO): { entry: string; version: string | null } | null;
 }
+
+/** Shell metacharacters that must not appear in a CLI path passed to `shell: true`. */
+const SHELL_METACHAR_RE = /[;&|`$(){}!<>"'\s\n\r]/;
+
+/** TTL for cached resolution results (5 minutes). */
+const RESOLUTION_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Cached resolution results keyed by trimmed configured path (empty string for auto-discovery). */
+const resolutionCache = new Map<string, { resolution: CopilotCliResolution; checkedAt: number }>();
 
 /** Semver triplet matcher (matches "1.0.24" in "GitHub Copilot CLI 1.0.24."). */
 const VERSION_RE = /\b(\d+\.\d+\.\d+)(?!\.\d)/;
@@ -57,30 +73,68 @@ function parseVersion(out: string): string | null {
   return m ? m[1]! : null;
 }
 
+/** Minimum 0.0.x build that accepts the SDK's programmatic spawn flags. */
+const MIN_COPILOT_CLI_0X = "0.0.403";
+
+/** Minimum 1.x line accepted for SDK integration (headless may be omitted from --help). */
+const MIN_COPILOT_CLI_1X = "1.0.0";
+
 /**
- * 1. User-configured path. Highest priority, never overridden, trusted verbatim
- *    (the SDK's own existsSync gate validates it). The --version probe only
- *    supplies the version for display.
+ * True when the located CLI can host the Copilot SDK. Uses semver first because
+ * 1.x builds support `--headless` at runtime even when `--help` only lists `--acp`.
  */
-const configuredStrategy: Strategy = {
-  source: "configured",
-  resolve(ctx, io) {
-    const p = ctx.configuredPath?.trim();
-    if (!p) return null;
-    const out = io.exec(p, ["--version"]);
-    return { entry: p, version: out ? parseVersion(out) : null };
-  },
-};
+function supportsSdkCompatibleCli(
+  entry: string,
+  version: string | null,
+  io: CopilotCliResolverIO,
+): boolean {
+  if (version) {
+    if (meetsMinVersion(version, MIN_COPILOT_CLI_1X)) return true;
+    if (meetsMinVersion(version, MIN_COPILOT_CLI_0X)) return true;
+  }
+  const help = io.exec(entry, ["--help"]);
+  if (help != null && (/--headless\b/.test(help) || /--acp\b/.test(help))) return true;
+  return false;
+}
+
+/**
+ * Returns a not-found resolution when the located CLI is too old for the SDK.
+ */
+function tooOldForSdk(
+  entry: string,
+  version: string | null,
+  io: CopilotCliResolverIO,
+): CopilotCliNotFound | null {
+  if (supportsSdkCompatibleCli(entry, version, io)) return null;
+  return {
+    source: "not-found",
+    entry: null,
+    version: null,
+    message: formatCopilotUpgradeMessage(version),
+  };
+}
+
+/**
+ * User-facing message when a located CLI is too old for the Copilot SDK.
+ */
+export function formatCopilotUpgradeMessage(version: string | null): string {
+  const versionLabel = version ?? "unknown";
+  return (
+    `GitHub Copilot CLI ${versionLabel} is too old for Mcode. ` +
+    `Update to ${MIN_COPILOT_CLI_1X} or newer (or ${MIN_COPILOT_CLI_0X}+ on the 0.0.x line).\n\n` +
+    "Update with: npm install -g @github/copilot@latest"
+  );
+}
 
 /**
  * Resolves a `@github/copilot` package directory to its absolute `index.js`
  * entry (the JS entry point the SDK runs with node) and version. Returns null
- * when the package's `index.js` is missing. Shared by the npm-global and
- * path-shim strategies so the entry and version come from the same package.
+ * when the package's `index.js` is missing or the package name does not match.
+ * Shared by the npm-global and path-shim strategies.
  */
 function resolvePackageEntry(
   pkgDir: string,
-  io: ResolverIO,
+  io: CopilotCliResolverIO,
 ): { entry: string; version: string | null } | null {
   const entry = join(pkgDir, "index.js");
   if (!io.exists(entry)) return null;
@@ -88,19 +142,47 @@ function resolvePackageEntry(
   let version: string | null = null;
   if (raw) {
     try {
-      const pkg = JSON.parse(raw) as { version?: string };
+      const pkg = JSON.parse(raw) as { name?: string; version?: string };
+      if (pkg.name !== "@github/copilot") return null;
       version = typeof pkg.version === "string" ? pkg.version : null;
     } catch {
-      version = null;
+      return null;
     }
+  } else {
+    return null;
   }
   return { entry, version };
 }
 
 /**
+ * Attempts configured-path resolution. Returns not-found for invalid shell
+ * metacharacters, null to fall through when the path is missing or unreachable,
+ * or a configured resolution when the path exists and responds to `--version`.
+ */
+function tryConfiguredPath(
+  configuredPath: string,
+  io: CopilotCliResolverIO,
+): CopilotCliFound | CopilotCliNotFound | null {
+  if (SHELL_METACHAR_RE.test(configuredPath)) {
+    return {
+      source: "not-found",
+      entry: null,
+      version: null,
+      message:
+        `GitHub Copilot CLI path contains invalid characters: "${configuredPath}". ` +
+        "Check the path in Settings > Provider > Copilot CLI path.",
+    };
+  }
+  if (!io.exists(configuredPath)) return null;
+  const out = io.exec(configuredPath, ["--version"]);
+  if (!out) return null;
+  return { source: "configured", entry: configuredPath, version: parseVersion(out) };
+}
+
+/**
  * 2. `@github/copilot` resolved via `npm root -g`. The primary auto-discovery
- *    route: it finds the global install the SDK's own search misses, and yields
- *    the absolute index.js the SDK runs with node.
+ * route: it finds the global install the SDK's own search misses, and yields
+ * the absolute index.js the SDK runs with node.
  */
 const npmGlobalStrategy: Strategy = {
   source: "npm-global",
@@ -112,7 +194,7 @@ const npmGlobalStrategy: Strategy = {
 };
 
 /** Returns the first command source on PATH: PowerShell-aware on win32, `which` on posix. */
-function locateOnPath(io: ResolverIO): string | null {
+function locateOnPath(io: CopilotCliResolverIO): string | null {
   if (io.platform === "win32") {
     // `where.exe` cannot see ExternalScript/.ps1 shims; Get-Command can. Prefer
     // it, fall back to `where` for .cmd/.exe shims.
@@ -127,9 +209,9 @@ function locateOnPath(io: ResolverIO): string | null {
 
 /**
  * 3. PATH/shim fallback. Resolves `copilot` on PATH (PowerShell-aware on win32
- *    so .ps1 ExternalScripts are visible), then follows to the adjacent
- *    `node_modules/@github/copilot/index.js`. Covers non-standard layouts the
- *    npm-global root does not surface.
+ * so .ps1 ExternalScripts are visible), then follows to the adjacent
+ * `node_modules/@github/copilot/index.js`. Covers non-standard layouts the
+ * npm-global root does not surface.
  */
 const pathShimStrategy: Strategy = {
   source: "path-shim",
@@ -140,42 +222,112 @@ const pathShimStrategy: Strategy = {
   },
 };
 
-/** Strategy table, tried in priority order. Append a row to add a future route. */
-const STRATEGIES: Strategy[] = [configuredStrategy, npmGlobalStrategy, pathShimStrategy];
+/** Auto-discovery strategies, tried in priority order after configured-path handling. */
+const AUTO_STRATEGIES: Strategy[] = [npmGlobalStrategy, pathShimStrategy];
 
 /** Builds the not-found resolution, disambiguating `@github/copilot` from `gh copilot`. */
-function notFound(io: ResolverIO): CopilotCliNotFound {
+function notFound(io: CopilotCliResolverIO): CopilotCliNotFound {
   const ghExts = io.exec("gh", ["extension", "list"]);
   const hasGhCopilot = ghExts != null && /copilot/i.test(ghExts);
-  const base =
-    "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot\n\n" +
-    "Or set a custom path in Settings > Provider > Copilot CLI path.";
-  const disambig = hasGhCopilot
-    ? "\n\nNote: the `gh copilot` GitHub CLI extension is installed, which is different " +
-      "from the `@github/copilot` npm package Mcode needs."
-    : "";
-  return { source: "not-found", entry: null, version: null, message: base + disambig };
+  return {
+    source: "not-found",
+    entry: null,
+    version: null,
+    message: formatCopilotNotFoundMessage(hasGhCopilot),
+  };
 }
 
 /**
- * Resolves the Copilot CLI by trying each strategy in priority order and using
- * the first that yields an existing entry. Returns a not-found resolution with
- * an install message when none succeed. Reports a raw version only; min-version
- * policy is intentionally not handled here (see ADR-0001).
+ * Returns the user-facing install message when the Copilot CLI cannot be used.
+ * When `hasGhCopilot` is omitted, probes `gh extension list` via `io`.
  */
-export function resolveCopilotCli(ctx: ResolveContext, io: ResolverIO): CopilotCliResolution {
-  for (const strategy of STRATEGIES) {
+export function formatCopilotNotFoundMessage(
+  hasGhCopilot?: boolean,
+  io?: CopilotCliResolverIO,
+): string {
+  let ghInstalled = hasGhCopilot;
+  if (ghInstalled === undefined && io != null) {
+    const ghExts = io.exec("gh", ["extension", "list"]);
+    ghInstalled = ghExts != null && /copilot/i.test(ghExts);
+  }
+  ghInstalled ??= false;
+  const base =
+    "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot\n\n" +
+    "Or set a custom path in Settings > Provider > Copilot CLI path.";
+  const disambig = ghInstalled === true
+    ? "\n\nNote: the `gh copilot` GitHub CLI extension is installed, which is different " +
+      "from the `@github/copilot` npm package Mcode needs."
+    : "";
+  return base + disambig;
+}
+
+/** Cache key for resolution results: trimmed configured path, or empty for auto-discovery. */
+function resolutionCacheKey(ctx: CopilotCliResolveContext): string {
+  return ctx.configuredPath?.trim() ?? "";
+}
+
+/**
+ * Resolves the Copilot CLI by trying configured path first, then auto-discovery
+ * strategies in priority order. Returns a not-found resolution with an install
+ * message when none succeed. Reports a raw version only; min-version policy is
+ * intentionally not handled here (see ADR-0001).
+ */
+export function resolveCopilotCli(
+  ctx: CopilotCliResolveContext,
+  io: CopilotCliResolverIO,
+): CopilotCliResolution {
+  const cacheKey = resolutionCacheKey(ctx);
+  const cached = resolutionCache.get(cacheKey);
+  if (cached && Date.now() - cached.checkedAt < RESOLUTION_CACHE_TTL_MS) {
+    return cached.resolution;
+  }
+
+  const configured = ctx.configuredPath?.trim();
+  let resolution: CopilotCliResolution;
+  if (configured) {
+    const configuredResult = tryConfiguredPath(configured, io);
+    if (configuredResult?.source === "not-found") {
+      resolution = configuredResult;
+    } else if (configuredResult) {
+      resolution = configuredResult;
+    } else {
+      resolution = resolveAutoDiscovery(ctx, io);
+    }
+  } else {
+    resolution = resolveAutoDiscovery(ctx, io);
+  }
+
+  if (resolution.source !== "not-found") {
+    const outdated = tooOldForSdk(resolution.entry, resolution.version, io);
+    if (outdated) resolution = outdated;
+  }
+
+  resolutionCache.set(cacheKey, { resolution, checkedAt: Date.now() });
+  return resolution;
+}
+
+/** Runs npm-global and path-shim strategies, falling back to not-found. */
+function resolveAutoDiscovery(
+  ctx: CopilotCliResolveContext,
+  io: CopilotCliResolverIO,
+): CopilotCliResolution {
+  for (const strategy of AUTO_STRATEGIES) {
     const r = strategy.resolve(ctx, io);
     if (r) return { source: strategy.source, entry: r.entry, version: r.version };
   }
   return notFound(io);
 }
 
+/** Clears cached resolution results. Exposed for testing only. */
+export function clearResolutionCache(): void {
+  resolutionCache.clear();
+}
+
 /** Real adapter: Node fs + spawnSync. `shell:true` on win32 resolves `.cmd`/`.ps1` shims for probes. */
 export function createNodeResolverIO(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
-): ResolverIO {
+): CopilotCliResolverIO {
   return {
     platform,
     exists: (p) => existsSync(p),

--- a/apps/server/src/providers/copilot/copilot-cli-resolver.ts
+++ b/apps/server/src/providers/copilot/copilot-cli-resolver.ts
@@ -55,8 +55,8 @@ interface Strategy {
   resolve(ctx: CopilotCliResolveContext, io: CopilotCliResolverIO): { entry: string; version: string | null } | null;
 }
 
-/** Shell metacharacters that must not appear in a CLI path passed to `shell: true`. */
-const SHELL_METACHAR_RE = /[;&|`$(){}!<>"'\s\n\r]/;
+/** Shell control characters that must not appear in a CLI path passed to `shell: true`. */
+const SHELL_METACHAR_RE = /[;&|`$<>\"'\n\r]/;
 
 /** TTL for cached resolution results (5 minutes). */
 const RESOLUTION_CACHE_TTL_MS = 5 * 60 * 1000;

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -165,6 +165,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
 
   private client: CopilotClient | null = null;
   private lastCliPath: string | undefined;
+  /** Last CLI resolution; surfaced as a user-facing error when not-found. */
+  private lastResolution: CopilotCliResolution | null = null;
   /** Cached result of `which("node")` so we don't re-probe PATH on every rebuild. */
   private cachedNodePath: string | null | undefined;
   /** Owns the session pool, idle eviction (now with a real busy guard via `isBusy`), and JobObject/kill. */

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -20,6 +20,11 @@ import { EventEmitter } from "events";
 import { CopilotClient, approveAll } from "@github/copilot-sdk";
 import type { CopilotSession, ModelInfo } from "@github/copilot-sdk";
 import { discoverCopilotAgents, COPILOT_DEFAULT_AGENTS } from "./copilot-agent-discovery.js";
+import {
+  resolveCopilotCli,
+  createNodeResolverIO,
+  type CopilotCliResolution,
+} from "./copilot-cli-resolver.js";
 import { logger } from "@mcode/shared";
 import { SettingsService } from "../../services/settings-service.js";
 import { EnvService } from "../../services/env-service.js";
@@ -303,6 +308,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
 
     const client = this.client;
     if (!client) {
+      if (this.lastResolution?.source === "not-found") return [];
       throw new Error("Copilot client not available");
     }
 
@@ -408,17 +414,31 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
 
     opts.env = { ...this.envService.getEnv() };
 
-    // User-configured CLI path takes priority over all other resolution.
-    if (configuredCliPath) {
-      opts.cliPath = configuredCliPath;
+    // Ordered resolution: configured path > npm-global index.js > PATH/shim follow.
+    const resolution = resolveCopilotCli(
+      { configuredPath: configuredCliPath },
+      createNodeResolverIO(this.envService.getEnv(), process.platform),
+    );
+    this.lastResolution = resolution;
+    if (resolution.source === "not-found") {
+      // Leave this.client null; sendTurn/listModels translate lastResolution
+      // into a user-facing error via the existing error seam.
+      logger.warn("CopilotProvider: CLI not found", { message: resolution.message });
+      this.lastCliPath = configuredCliPath;
+      return;
     }
+    opts.cliPath = resolution.entry;
+    logger.info("CopilotProvider: resolved CLI", {
+      source: resolution.source,
+      version: resolution.version ?? "unknown",
+    });
 
     // Electron fix: resolve the real node binary path once. The SDK's
     // getNodeExecPath() reads process.execPath to spawn .js CLI files,
     // but in Electron that returns electron.exe which cannot host the
     // CLI's server mode. We temporarily override process.execPath during
     // client.start() and also prepend node's directory to PATH.
-    if (process.versions.electron && !configuredCliPath) {
+    if (process.versions.electron && resolution.source !== "configured") {
       if (this.cachedNodePath === undefined) {
         this.cachedNodePath = await which("node", { nothrow: true });
         if (!this.cachedNodePath) {
@@ -566,6 +586,14 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
 
     const { sessionId, message, cwd, model, permissionMode, resume, copilotAgent } = params;
     const threadId = this.toThreadId(sessionId);
+
+    // The CLI could not be resolved during refreshClient; surface the resolver's
+    // install message via the existing error seam (mirrors Codex's abort-before-spawn).
+    if (this.lastResolution?.source === "not-found") {
+      this.emit("event", { type: "error", threadId, error: this.lastResolution.message } satisfies AgentEvent);
+      this.emit("event", { type: "ended", threadId } satisfies AgentEvent);
+      return;
+    }
 
     // Re-read after the async refreshClient() await so concurrent sends that
     // both passed the first check don't each create a new SDK session for the

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -407,16 +407,6 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
       return;
     }
 
-    // Skip re-probing when settings are unchanged and the last resolution was
-    // not-found (resolver cache also avoids repeated spawnSync on its own).
-    if (
-      configuredCliPath === this.lastCliPath &&
-      this.client === null &&
-      this.lastResolution?.source === "not-found"
-    ) {
-      return;
-    }
-
     if (this.client) {
       await this.client.stop().catch((err) =>
         logger.warn("CopilotProvider: error stopping old client", { error: String(err) }),

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -23,6 +23,8 @@ import { discoverCopilotAgents, COPILOT_DEFAULT_AGENTS } from "./copilot-agent-d
 import {
   resolveCopilotCli,
   createNodeResolverIO,
+  formatCopilotNotFoundMessage,
+  formatCopilotUpgradeMessage,
   type CopilotCliResolution,
 } from "./copilot-cli-resolver.js";
 import { logger } from "@mcode/shared";
@@ -211,6 +213,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
    */
   async complete(prompt: string, model: string, cwd: string): Promise<string> {
     await this.refreshClient();
+    const notFoundMessage = this.cliNotFoundMessage();
+    if (notFoundMessage) throw new Error(notFoundMessage);
     const client = this.client;
     if (!client) {
       throw new Error("Copilot client not available");
@@ -329,6 +333,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
         await this.refreshClient();
         const freshClient = this.client as CopilotClient | null;
         if (!freshClient) {
+          if (this.lastResolution?.source === "not-found") return [];
           throw new Error("Copilot client not available after reconnect");
         }
         sdkModels = await freshClient.listModels();
@@ -358,7 +363,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
   async getUsage(): Promise<ProviderUsageInfo> {
     try {
       await this.refreshClient();
-      const result = await this.client!.rpc.account.getQuota();
+      if (this.lastResolution?.source === "not-found" || !this.client) {
+        return { providerId: "copilot", quotaCategories: [] };
+      }
+      const result = await this.client.rpc.account.getQuota();
       const categories = result?.quotaSnapshots
         ? normalizeQuotaSnapshots(result.quotaSnapshots)
         : [];
@@ -399,6 +407,16 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
       return;
     }
 
+    // Skip re-probing when settings are unchanged and the last resolution was
+    // not-found (resolver cache also avoids repeated spawnSync on its own).
+    if (
+      configuredCliPath === this.lastCliPath &&
+      this.client === null &&
+      this.lastResolution?.source === "not-found"
+    ) {
+      return;
+    }
+
     if (this.client) {
       await this.client.stop().catch((err) =>
         logger.warn("CopilotProvider: error stopping old client", { error: String(err) }),
@@ -410,11 +428,15 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
 
     const opts: {
       cliPath?: string;
+      cliArgs?: string[];
       githubToken?: string;
       env?: Record<string, string | undefined>;
     } = {};
 
     opts.env = { ...this.envService.getEnv() };
+    // Pin the CLI version the resolver selected; without this the launcher can
+    // delegate to a newer build in ~/.copilot/pkg that breaks the SDK contract.
+    opts.cliArgs = ["--no-auto-update"];
 
     // Ordered resolution: configured path > npm-global index.js > PATH/shim follow.
     const resolution = resolveCopilotCli(
@@ -487,22 +509,45 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
     // Electron fix: the SDK reads process.execPath to spawn the CLI .js file.
     // In Electron that returns electron.exe, causing the CLI to exit immediately.
     // Temporarily override process.execPath with the real node binary.
-    if (process.versions.electron && this.cachedNodePath) {
-      const origExecPath = process.execPath;
-      process.execPath = this.cachedNodePath;
-      try {
+    const needsElectronExecPathOverride =
+      process.versions.electron && resolution.source !== "configured" && this.cachedNodePath;
+    try {
+      if (needsElectronExecPathOverride) {
+        const origExecPath = process.execPath;
+        process.execPath = this.cachedNodePath!;
+        try {
+          await client.start();
+        } finally {
+          process.execPath = origExecPath;
+        }
+      } else {
         await client.start();
-      } finally {
-        process.execPath = origExecPath;
       }
-    } else {
-      await client.start();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("--headless") || msg.includes("unknown option")) {
+        this.lastResolution = {
+          source: "not-found",
+          entry: null,
+          version: null,
+          message: formatCopilotUpgradeMessage(resolution.version),
+        };
+        this.lastCliPath = configuredCliPath;
+        logger.warn("CopilotProvider: CLI too old for SDK", { message: this.lastResolution.message });
+        return;
+      }
+      throw err;
     }
     // Assign only after start() succeeds so a failed startup never leaves
     // a stale non-started client on the instance.
     this.client = client;
     this.lastCliPath = configuredCliPath;
     logger.info("CopilotProvider: client started", { state: client.getState() });
+  }
+
+  /** Returns the resolver install message when the CLI could not be resolved. */
+  private cliNotFoundMessage(): string | null {
+    return this.lastResolution?.source === "not-found" ? this.lastResolution.message : null;
   }
 
   /** Strip the "mcode-" session prefix to derive the threadId used in emitted AgentEvents. */
@@ -558,10 +603,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
       }
 
       if (msg.includes("Could not find @github/copilot")) {
-        const userMsg =
-          "GitHub Copilot package not found.\n\n" +
-          "Install it with: npm install -g @github/copilot\n\n" +
-          "Or set a custom path in Settings > Provider > Copilot CLI path.";
+        const userMsg = formatCopilotNotFoundMessage(
+          undefined,
+          createNodeResolverIO(this.envService.getEnv(), process.platform),
+        );
         this.emit("event", { type: "error", threadId, error: userMsg } satisfies AgentEvent);
         this.emit("event", { type: "ended", threadId } satisfies AgentEvent);
         return;

--- a/docs/adr/0001-per-provider-cli-discovery-shared-version-policy.md
+++ b/docs/adr/0001-per-provider-cli-discovery-shared-version-policy.md
@@ -1,0 +1,48 @@
+---
+status: accepted
+---
+
+# Provider CLI discovery is per-provider; version policy is the one provider-blind seam
+
+## Context
+
+Issue #542 adds an ordered Copilot CLI resolver because the `@github/copilot-sdk`'s
+narrow 14-path search misses common installs (npm-global, Windows `.ps1`
+ExternalScript shims). While shaping it we asked whether CLI discovery and version
+checking should be unified into one resolver shared across every provider (Claude,
+Cursor, Codex, OpenCode, Copilot), anticipating a future need for minimum-supported
+versions and "please update your provider" prompts.
+
+## Decision
+
+Discovery stays per-provider. Each provider keeps its own mechanism for locating its
+CLI and probing its version, and returns a raw version string plus the discovery
+source. Discovery makes no min-version judgment.
+
+The only genuinely provider-blind concern is version policy: comparing a detected
+version against a per-provider floor and phrasing the update prompt. That logic
+already exists as Codex's pure `meetsMinVersion` (`codex-version.ts`). It is promoted
+to a shared module only when a second provider needs the update-prompt UX. The shared
+policy receives each provider's version and floor; it never holds or discovers them.
+
+## Considered Options
+
+- **Unified cross-provider discovery resolver (rejected).** It would have exactly one
+  real adapter today (Copilot is the only provider with a discovery problem; Codex
+  resolves via the configured path or PATH), so the seam is hypothetical. It also
+  lands discovery in `packages/shared`, where the verify gate forces the full
+  unit-test suite on every edit. Discovery churns constantly during development, so
+  this makes verification slower, not faster.
+- **Per-provider discovery, shared version policy (accepted).** Keeps discovery deep
+  and locally testable in `apps/server`, on the scoped `vitest related` path. The
+  provider-blind comparator is the real two-adapter seam (Codex today, Copilot next),
+  and it carries almost nothing, so its rare presence in a shared package is cheap.
+
+## Consequences
+
+- The Copilot resolver returns `{ entry, version, source }` and stops. It must not
+  bake in a floor or a min-version comparison.
+- When minimum-supported-version enforcement is wanted for a second provider, extract
+  `meetsMinVersion` plus the floors table and update-prompt copy into a small shared
+  version-policy module fed by each provider's raw version. Do not merge the discovery
+  resolvers.


### PR DESCRIPTION
## What

Add a cross-platform, ordered resolver for the `@github/copilot` CLI so the Copilot provider finds real-world installs the SDK's narrow 14-path search misses.

## Why

Users with `@github/copilot` installed globally (or behind a Windows `.ps1` ExternalScript shim) hit `Could not find @github/copilot package` even though `copilot` runs in their shell and the package resolves via Node. Mcode only honoured the user-configured CLI path; when empty it deferred entirely to the SDK's narrow `node_modules` search. See #542.

## Key Changes

- New deep, isolated `copilot-cli-resolver.ts`: one `resolveCopilotCli(ctx, io)` entry, all filesystem and process access behind an injected `ResolverIO` seam so strategies are tested with seeded inputs and never spawn.
- Ordered, data-driven strategy table, first spawnable entry wins:
  1. user-configured path (validated with `--version`; invalid paths fall through),
  2. `@github/copilot` via `npm root -g` to the absolute `index.js` the SDK runs with node,
  3. PATH/shim follow (PowerShell-aware on win32 so `.ps1` ExternalScripts are visible) to the adjacent package.
- Version reported from the same resolution that found the entry, so the detected CLI and reported version cannot disagree.
- SDK compatibility uses semver (`>= 1.0.0` or `>= 0.0.403`) with `--help` fallback (`--headless` or `--acp`) so 1.x CLIs are not rejected when help omits `--headless`.
- Shell-metacharacter guard on configured paths, 5-minute resolution cache, unified not-found/upgrade messages, and provider short-circuits when CLI is missing or incompatible.
- `doRefreshClient` consumes the resolver and re-gates the Electron node-exec override on the resolved source.
- ADR-0001 records why discovery stays per-provider and why version policy is the only provider-blind seam (deferred until a second provider needs it).

## Testing

- 52 resolver + provider unit tests pass in CI (every strategy across win32 and posix, configured/npm-global/path-shim/not-found, gh-copilot disambiguation, SDK compatibility, provider error flows).
- Fast gate (typecheck + lint) green on latest commit.
- Pre-existing, unrelated: `snapshot-service.integration.test.ts` fails on this Windows host via git-setup `beforeEach` hook timeouts; reproduces in isolation with no involvement from this change.

Closes #542

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782694339&installation_id=129163861&pr_number=544&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F544&signature=6ed9b0a9a24ceb7683ca5334c769e180a261ca13bcae96463402d8f21df6f846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Copilot CLI discovery with multiple detection strategies and improved version validation

* **Bug Fixes**
  * Graceful handling of missing or incompatible Copilot CLI with clear error messages and setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->