### PR TITLE
fix(chat): preserve narration on thread swap + session resilience

### DIFF
--- a/apps/server/src/__tests__/agent-service-session-invalidated.test.ts
+++ b/apps/server/src/__tests__/agent-service-session-invalidated.test.ts
@@ -1,0 +1,154 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EventEmitter } from "events";
+import type Database from "better-sqlite3";
+import { AgentEventType } from "@mcode/contracts";
+import type {
+  AgentEvent,
+  IAgentProvider,
+  IProviderRegistry,
+  ProviderId,
+} from "@mcode/contracts";
+import { openMemoryDatabase } from "../store/database";
+import { ThreadRepo } from "../repositories/thread-repo";
+import { WorkspaceRepo } from "../repositories/workspace-repo";
+import { MessageRepo } from "../repositories/message-repo";
+import { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
+import { TurnSnapshotRepo } from "../repositories/turn-snapshot-repo";
+import { TaskRepo } from "../repositories/task-repo";
+import { AgentService } from "../services/agent-service";
+import { NarrativeStore } from "../services/narrative-store";
+import type { GitService } from "../services/git-service";
+import type { AttachmentService } from "../services/attachment-service";
+import type { SnapshotService } from "../services/snapshot-service";
+import type { MemoryPressureService } from "../services/memory-pressure-service";
+import type { ThreadService } from "../services/thread-service";
+import type { SettingsService } from "../services/settings-service";
+import type { ProviderAvailabilityService } from "../services/provider-availability-service";
+
+/**
+ * Verifies the poison-pill recovery wiring: when the Claude provider abandons an
+ * unresumable session (emitting a System `sdk_session_invalidated` event), the
+ * service clears the thread's persisted `sdk_session_id` so the next turn spawns
+ * a fresh session instead of resuming the broken transcript forever.
+ */
+describe("AgentService clears sdk_session_id on session invalidation", () => {
+  let db: Database.Database;
+  let threadRepo: ThreadRepo;
+  let workspaceRepo: WorkspaceRepo;
+  let messageRepo: MessageRepo;
+  let toolCallRecordRepo: ToolCallRecordRepo;
+  let turnSnapshotRepo: TurnSnapshotRepo;
+  let taskRepo: TaskRepo;
+  let svc: AgentService;
+  let providerStub: EventEmitter & Partial<IAgentProvider>;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    threadRepo = new ThreadRepo(db);
+    workspaceRepo = new WorkspaceRepo(db);
+    messageRepo = new MessageRepo(db);
+    toolCallRecordRepo = new ToolCallRecordRepo(db);
+    turnSnapshotRepo = new TurnSnapshotRepo(db);
+    taskRepo = new TaskRepo(db);
+
+    providerStub = Object.assign(new EventEmitter(), {
+      id: "claude" as ProviderId,
+      supportsCompletion: false,
+      sessionForkOnResume: "unsupported" as const,
+      maxInputCharactersPerTurn: 16_000,
+      sendTurn: vi.fn(() => new Promise<void>(() => {})),
+      stopSession: vi.fn(),
+      shutdown: vi.fn(),
+    });
+
+    const registryStub: IProviderRegistry = {
+      resolve: () => providerStub as unknown as IAgentProvider,
+      resolveAll: () => [providerStub as unknown as IAgentProvider],
+      shutdown: () => {},
+    };
+
+    const gitServiceStub = {
+      resolveWorkingDir: vi.fn(() => process.cwd()),
+    } as unknown as GitService;
+    const attachmentServiceStub = {
+      persist: vi.fn(async () => ({ stored: [], persisted: [] })),
+    } as unknown as AttachmentService;
+    const snapshotServiceStub = {
+      captureRef: vi.fn(async () => "ref-before-sha"),
+    } as unknown as SnapshotService;
+    const memoryPressureServiceStub = {
+      markActive: vi.fn(),
+      markIdle: vi.fn(),
+    } as unknown as MemoryPressureService;
+    const settingsServiceStub = {
+      get: vi.fn(async () => ({
+        model: { defaults: { fallbackId: undefined } },
+        agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
+      })),
+    } as unknown as SettingsService;
+    const threadServiceStub = {} as unknown as ThreadService;
+    const availabilityStub = {
+      assertUsable: vi.fn(),
+    } as unknown as ProviderAvailabilityService;
+
+    svc = new AgentService(
+      threadRepo,
+      workspaceRepo,
+      messageRepo,
+      gitServiceStub,
+      attachmentServiceStub,
+      registryStub,
+      threadServiceStub,
+      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
+      turnSnapshotRepo,
+      snapshotServiceStub,
+      db,
+      memoryPressureServiceStub,
+      taskRepo,
+      settingsServiceStub,
+      availabilityStub,
+      { markAnswered: vi.fn(), isAnswered: vi.fn(() => false), listAnsweredForThread: vi.fn(() => []) } as unknown as import("../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../repositories/plan-repo.js").PlanRepo,
+      { orchestrate: vi.fn() } as any,
+      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(
+        messageRepo,
+        toolCallRecordRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
+      ),
+    );
+    svc.init();
+  });
+
+  it("nulls sdk_session_id when a sdk_session_invalidated event arrives", () => {
+    const workspace = workspaceRepo.create("test-ws", process.cwd());
+    const thread = threadRepo.create(workspace.id, "Test Thread", "direct", "main", true, "claude");
+    threadRepo.updateSdkSessionId(thread.id, "poison-sid");
+    expect(threadRepo.findById(thread.id)?.sdk_session_id).toBe("poison-sid");
+
+    providerStub.emit("event", {
+      type: AgentEventType.System,
+      threadId: thread.id,
+      subtype: "sdk_session_invalidated",
+    } satisfies AgentEvent);
+
+    expect(threadRepo.findById(thread.id)?.sdk_session_id).toBeNull();
+  });
+
+  it("leaves sdk_session_id intact for an unrelated System subtype", () => {
+    const workspace = workspaceRepo.create("test-ws", process.cwd());
+    const thread = threadRepo.create(workspace.id, "Test Thread", "direct", "main", true, "claude");
+    threadRepo.updateSdkSessionId(thread.id, "keep-sid");
+
+    providerStub.emit("event", {
+      type: AgentEventType.System,
+      threadId: thread.id,
+      subtype: "session_restarted",
+    } satisfies AgentEvent);
+
+    expect(threadRepo.findById(thread.id)?.sdk_session_id).toBe("keep-sid");
+  });
+});

--- a/apps/server/src/__tests__/unrecoverable-thinking-block-error.test.ts
+++ b/apps/server/src/__tests__/unrecoverable-thinking-block-error.test.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata";
+import { describe, it, expect } from "vitest";
+import { isUnrecoverableThinkingBlockError } from "../providers/claude/claude-provider.js";
+
+describe("isUnrecoverableThinkingBlockError", () => {
+  it("matches the API 400 about unmodifiable thinking blocks", () => {
+    const result =
+      'API Error: 400 {"type":"error","error":{"type":"invalid_request_error",' +
+      '"message":"messages.3.content.63: `thinking` or `redacted_thinking` blocks ' +
+      'in the latest assistant message cannot be modified. These blocks must remain ' +
+      'as they were in the original response."},"request_id":"req_011CbXbo4WBwX9JhUhPi1L6r"}';
+    expect(isUnrecoverableThinkingBlockError(result)).toBe(true);
+  });
+
+  it("matches the redacted_thinking-only phrasing", () => {
+    const result =
+      "messages.5.content.2: `redacted_thinking` blocks in the latest assistant " +
+      "message cannot be modified.";
+    expect(isUnrecoverableThinkingBlockError(result)).toBe(true);
+  });
+
+  it("does not match the resume 'No conversation found' error", () => {
+    expect(
+      isUnrecoverableThinkingBlockError("No conversation found with session ID: abc"),
+    ).toBe(false);
+  });
+
+  it("does not match an unrelated 400", () => {
+    expect(
+      isUnrecoverableThinkingBlockError(
+        'API Error: 400 {"type":"invalid_request_error","message":"max_tokens too large"}',
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match an empty or non-string payload", () => {
+    expect(isUnrecoverableThinkingBlockError("")).toBe(false);
+    expect(isUnrecoverableThinkingBlockError(undefined)).toBe(false);
+  });
+});

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -104,6 +104,12 @@ interface ClaudeSessionState {
   lastUsedAt: number;
   /** When true, the finally block in startStreamLoop should not emit an "ended" event. */
   suppressEnded?: boolean;
+  /**
+   * Set when a resume of this session's transcript hit an unrecoverable API
+   * state (see {@link isUnrecoverableThinkingBlockError}). A poisoned entry is
+   * never reused: the next send tears it down and spawns a fresh session.
+   */
+  poisoned?: boolean;
   /** Tool-use IDs whose matching tool_result has not yet been received.
    *  While this set is non-empty, `isBusy` returns true so the runtime's idle
    *  eviction skips the session regardless of how long the SDK has been quiet. */
@@ -236,8 +242,29 @@ export function detectFallbackModel(
   return usedModels[0] ?? null;
 }
 
+/**
+ * Detects the Anthropic API 400 that bricks a resumable session: with extended
+ * thinking on, `thinking`/`redacted_thinking` blocks must be replayed unmodified
+ * on every subsequent request. When a stored assistant turn's thinking block is
+ * altered (e.g. by SDK-side context compaction during a long tool-use run), the
+ * API rejects every resume of that transcript with this message, so the thread
+ * is permanently stuck until the session is abandoned.
+ *
+ * @param resultText - the SDK result payload's `result` string (the error text
+ *   lives there, not in the `errors` array, for this class of failure)
+ */
+export function isUnrecoverableThinkingBlockError(resultText: unknown): boolean {
+  if (typeof resultText !== "string") return false;
+  return /`?(?:thinking|redacted_thinking)`?[^]*?blocks in the latest assistant message cannot be modified/.test(
+    resultText,
+  );
+}
+
 /** Max time to wait on a resume side-channel before falling back to sessionless. */
 const SIDE_CHANNEL_RESUME_PROBE_MS = 20_000;
+
+/** Bytes of subprocess stderr retained per session for crash diagnostics. */
+const STDERR_CAPTURE_LIMIT = 8_000;
 
 /**
  * Per-turn payload staged from `sendTurn`/`doSendMessage` to `spawn`. The
@@ -280,6 +307,14 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
   /** Per-turn payload staged for `spawn` to run a fresh session's first turn. */
   private pendingSpawnTurns = new Map<string, PendingSpawnTurn>();
   private sdkSessionIds = new Map<string, string>();
+  /**
+   * Tail of the most recent stderr emitted by each session's Claude Code
+   * subprocess, capped at {@link STDERR_CAPTURE_LIMIT}. The SDK's process-exit
+   * error carries only the exit code (no stderr), so without this a crash
+   * surfaces as the opaque "process exited with code 1". Captured here and
+   * attached to the Error event when the stream throws.
+   */
+  private recentStderr = new Map<string, string>();
   /**
    * Active goals keyed by sessionId (mcode-${threadId}). When set, the SDK
    * Stop hook installed in baseOptions blocks the agent from ending its turn
@@ -832,6 +867,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
     // which resumes the same conversation via the persisted sdkSessionIds entry.
     const reusable =
       existing !== undefined &&
+      existing.poisoned !== true &&
       existing.permissionMode === permissionMode &&
       existing.contextWindowMode === contextWindowMode;
 
@@ -1253,9 +1289,20 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
     this.pendingSpawnTurns.delete(sessionId);
 
     const { prompt, resume, resumeId, uuid, baseOptions, resolvedModel, contextWindowMode } = staged;
+
+    // Capture the subprocess stderr tail so a non-zero exit (which the SDK
+    // reports as a bare "process exited with code N") carries the actual CLI
+    // error instead of an opaque code. Reset per spawn so a crash is never
+    // attributed stale output from a prior turn on the same session.
+    this.recentStderr.delete(sessionId);
+    const captureStderr = (data: string): void => {
+      const next = ((this.recentStderr.get(sessionId) ?? "") + data).slice(-STDERR_CAPTURE_LIMIT);
+      this.recentStderr.set(sessionId, next);
+    };
+
     const options = resume
-      ? { ...baseOptions, resume: resumeId }
-      : { ...baseOptions, sessionId: uuid };
+      ? { ...baseOptions, resume: resumeId, stderr: captureStderr }
+      : { ...baseOptions, sessionId: uuid, stderr: captureStderr };
 
     const queue = createPromptQueue();
 
@@ -1586,6 +1633,33 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
 
             case "result": {
               if (anyMsg.is_error === true) {
+                // Poison-pill recovery: an unmodifiable-thinking-block 400 means
+                // this session's stored transcript can never be resumed again.
+                // Abandon the session (forget the resume id, mark the live entry
+                // poisoned so it is not reused, and tell AgentService to clear
+                // the persisted sdk_session_id) so the next send starts fresh,
+                // instead of looping the same 400 forever.
+                if (isUnrecoverableThinkingBlockError(anyMsg.result)) {
+                  logger.warn("Claude session poisoned by unmodifiable thinking block; abandoning session", {
+                    sessionId,
+                    threadId,
+                  });
+                  this.sdkSessionIds.delete(sessionId);
+                  const poisonedEntry = this.runtime.get(sessionId);
+                  if (poisonedEntry) poisonedEntry.poisoned = true;
+                  // Surface the reset as a quiet system-message hairline in the
+                  // transcript (handled client-side), not a red error card. The
+                  // same event also clears the persisted sdk_session_id server-side.
+                  this.emit("event", {
+                    type: AgentEventType.System,
+                    threadId,
+                    subtype: "sdk_session_invalidated",
+                  } satisfies AgentEvent);
+                  lastAssistantText = "";
+                  lastStreamInputTokens = undefined;
+                  awaitingResume = false;
+                  break;
+                }
                 // The "No conversation found" resume-recovery branch above
                 // handles its own flow and returns early; any other is_error
                 // result lands here and must be surfaced as an Error event
@@ -1995,6 +2069,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
         const superseded =
           (current !== undefined && current.query !== q) ||
           current?.suppressEnded === true;
+        // The SDK's process-exit error omits stderr; attach the captured tail
+        // so "process exited with code 1" becomes actionable.
+        const stderrTail = this.recentStderr.get(sessionId)?.trim();
         if (superseded) {
           logger.debug("SDK stream error suppressed (session superseded)", {
             sessionId,
@@ -2004,14 +2081,18 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, Prot
           logger.error("SDK stream error", {
             sessionId,
             error: errorMessage,
+            ...(stderrTail ? { stderr: stderrTail } : {}),
           });
           this.emit("event", {
             type: AgentEventType.Error,
             threadId,
-            error: errorMessage,
+            error: stderrTail
+              ? `${errorMessage}\n\nClaude Code stderr (tail):\n${stderrTail}`
+              : errorMessage,
           } satisfies AgentEvent);
         }
       } finally {
+        this.recentStderr.delete(sessionId);
         const current = this.runtime.get(sessionId);
         if (current?.query === q) {
           // The SDK subprocess has exited; drop the dead session from the pool.

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1926,6 +1926,18 @@ export class AgentService {
                 error: err instanceof Error ? err.message : String(err),
               });
             }
+          } else if (event.subtype === "sdk_session_invalidated") {
+            // The provider abandoned an unresumable session (poison-pill 400).
+            // Clear the persisted id so the next turn spawns fresh rather than
+            // resuming the broken transcript.
+            try {
+              this.threadRepo.clearSdkSessionId(event.threadId);
+            } catch (err) {
+              logger.warn("Failed to clear sdk_session_id", {
+                threadId: event.threadId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
           }
         }
 

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -56,6 +56,29 @@ describe("handleAgentEvent branches", () => {
     expect(getTestThreadError("thread-1")).toBe("Out of tokens");
   });
 
+  it("session.system sdk_session_invalidated appends a reset hairline message", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.system",
+      params: { subtype: "sdk_session_invalidated" },
+    });
+
+    const messages = getTestActiveMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("system");
+    expect(messages[0].content).toBe(
+      "Session reset. Earlier context cleared. Send again to continue.",
+    );
+  });
+
+  it("session.system with an unknown subtype appends no message", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.system",
+      params: { subtype: "some_other_subtype" },
+    });
+
+    expect(getTestActiveMessages()).toHaveLength(0);
+  });
+
   it("session.turnComplete without streaming content clears state only", () => {
     useThreadStore.getState().handleAgentEvent("thread-1", {
       method: "session.turnComplete",

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1719,21 +1719,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     // Avoid duplicate submissions while a placeholder thread is still materializing.
     if (isThreadScaffold) return;
 
-    // Guard against sending a slash command that the active provider doesn't support.
-    // This catches the case where the user typed a command, changed providers, and
-    // then sent without selecting a valid replacement from the popup.
-    const slashMatch = trimmed.match(/^\/(\S+)/);
-    if (slashMatch) {
-      const cmdName = slashMatch[1];
-      const exists = slashCommand.allCommands.some((c) => c.name === cmdName);
-      if (!exists && !slashCommand.isLoading) {
-        useToastStore
-          .getState()
-          .show("error", "Unknown command", `/${cmdName} is not available for this provider`);
-        return;
-      }
-    }
-
     // ---- Handoff queue path: child thread context is still being generated ----
     // When the handoff document hasn't landed yet, queue the message locally and
     // fire it automatically once the status transitions to ready or fallback.

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -438,13 +438,13 @@ export const MessageBubble = memo(function MessageBubble({ message, onBranch, on
     }
 
     return (
-      <div className="flex items-center gap-3 py-2">
-        <div className="h-px flex-1 bg-border" />
+      <div className="flex items-center gap-3 py-2" role="note">
+        <div className="h-px flex-1 bg-border" aria-hidden="true" />
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          <RotateCcw size={12} />
+          <RotateCcw size={12} aria-hidden="true" />
           <span>{message.content}</span>
         </div>
-        <div className="h-px flex-1 bg-border" />
+        <div className="h-px flex-1 bg-border" aria-hidden="true" />
       </div>
     );
   }

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -4,6 +4,7 @@ import {
   getTestThreadStreaming,
   getTestThreadToolCalls,
   getTestThreadLoadEpoch,
+  getTestThreadAgentStartTime,
   readActiveThreadField,
 } from "@/stores/thread-store-test-utils";
 /**
@@ -196,6 +197,35 @@ describe("ThreadHydrator", () => {
 
     expect(getTestThreadStreaming(THREAD_A)).toBe("partial...");
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+  });
+
+  it("preserves volatile state for a running thread on cache hit", async () => {
+    resetThreadStoreForTests({
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map<string, ThreadRecord>([
+        [
+          THREAD_A,
+          {
+            ...createEmptyThreadRecord(),
+            streaming: "partial...",
+            agentStartTime: 1234,
+            toolCalls: [
+              { id: "tc1", toolName: "bash", toolInput: {}, output: null, isError: false, isComplete: false },
+            ],
+          },
+        ],
+      ]),
+    });
+    // A stale snapshot — e.g. from a sidebar hover prefetch that captured
+    // messages but no in-flight narration — must not clobber the live timeline.
+    cacheRecord(THREAD_A, makeCachedRecord());
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(mockTransport.getMessages).not.toHaveBeenCalled();
+    expect(getTestThreadStreaming(THREAD_A)).toBe("partial...");
+    expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+    expect(getTestThreadAgentStartTime(THREAD_A)).toBe(1234);
   });
 
   it("does not commit stale RPC results after a cross-thread race", async () => {

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -142,6 +142,21 @@ export class ThreadHydrator {
   private restoreFromCache(threadId: string, cached: ThreadRecord): void {
     this.deps.setState((state: ThreadHydratorWriteState) => {
       const current = getThreadRecord(state.records, threadId);
+      // The cache snapshot predates in-flight narration, so for a running
+      // thread the live record wins (mirrors fetchAndCommit's isRunning guard).
+      const isRunning = state.runningThreadIds.has(threadId);
+      const liveVolatile: Partial<ThreadRecord> = isRunning
+        ? {
+            toolCalls: current.toolCalls,
+            thoughtSegments: current.thoughtSegments,
+            hooks: current.hooks,
+            streaming: current.streaming,
+            streamingPreview: current.streamingPreview,
+            agentStartTime: current.agentStartTime,
+            currentTurnMessageId: current.currentTurnMessageId,
+            isCompacting: current.isCompacting,
+          }
+        : {};
       return {
         records: patchThreadRecord(state.records, threadId, {
           ...cached,
@@ -152,6 +167,7 @@ export class ThreadHydrator {
           lastHydratedAt: current.lastHydratedAt,
           permissions: current.permissions,
           settings: this.deps.getWorkspaceThreadSettings(threadId),
+          ...liveVolatile,
         }),
         currentThreadId: threadId,
       };

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1276,12 +1276,23 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
     if (method === "session.system") {
       const subtype = params.subtype as string;
-      if (subtype === "session_restarted") {
+      // Both subtypes render as the quiet system-message hairline chapter-break.
+      // `session_restarted`: the SDK silently restarted (lost in-memory context).
+      // `sdk_session_invalidated`: a poison-pill provider state forced a reset;
+      // the persisted sdk_session_id is cleared server-side so the next send
+      // starts fresh. Terse, technical copy; no apology, no vendor-blame.
+      const systemNotice =
+        subtype === "session_restarted"
+          ? "Session restarted. The agent no longer has context from earlier messages."
+          : subtype === "sdk_session_invalidated"
+            ? "Session reset. Earlier context cleared. Send again to continue."
+            : null;
+      if (systemNotice) {
         const message: Message = {
           id: crypto.randomUUID(),
           thread_id: threadId,
           role: "system",
-          content: "Session restarted. The agent no longer has context from earlier messages.",
+          content: systemNotice,
           tool_calls: null,
           files_changed: null,
           cost_usd: null,


### PR DESCRIPTION
## What
Three related-but-distinct reliability fixes around running threads and the Claude provider, bundled on this branch:

1. **Narration survives thread swaps.** Swapping away from a running thread and back no longer wipes its in-flight tool calls and thoughts.
2. **Slash-prefixed messages send.** The composer no longer blocks messages that start with a slash.
3. **Sessions self-heal.** A thread whose provider session becomes unresumable now resets quietly and starts fresh on the next send instead of looping the same error forever.

## Why
1. `restoreFromCache` overwrote a running thread's live narration with a stale cached snapshot. Because the thinking indicator reads a separate `runningThreadIds` set, the timeline disappeared while the spinner stayed, looking like the thread had silently lost its work. The cache-miss path already guarded running threads; the cache-hit path did not.
2. A send-time guard rejected any message whose text began with an unrecognised slash command. Its regex treated every leading slash token as a command, so `//`, paths like `/etc/hosts`, and other text were blocked. Slash commands are forwarded to the provider verbatim anyway, so the guard only ever blocked valid input.
3. With extended thinking on, a long tool-use run can leave a stored assistant turn whose thinking blocks the API later refuses to replay. Every resume of that transcript returned the same 400, permanently bricking the thread.

## Key Changes
- `thread-hydrator`: cache-hit restore preserves live volatile narration for running threads (mirrors the cache-miss guard).
- `Composer`: removed the slash-command send guard; the autocomplete popup still guides valid commands.
- `claude-provider`: detect the unrecoverable thinking-block 400, abandon the poisoned session (drop resume id, mark the entry poisoned so it is not reused), and emit a session-invalidated event.
- `agent-service`: clears the persisted `sdk_session_id` on invalidation so the next send spawns fresh.
- `threadStore`: renders the reset as the existing quiet system-message hairline, not a red error card.
- `MessageBubble`: same accessibility treatment on the system-message divider as the goal-notice divider.
- `claude-provider`: capture the Claude Code subprocess stderr tail and attach it to the Error event, since the SDK reports a non-zero exit with no stderr.

## Test plan
- [ ] `bun run verify` passes (run locally; in CI sandbox the `snapshot-service.integration` suite times out on git-subprocess spawning, unrelated to this change)
- [x] thread-hydrator unit suite (cache-hit running-thread preservation) green
- [x] server detector + session-invalidation suites green
- [x] threadStore `agent-event-branches` (reset hairline) green
- [ ] Manual: run a test-provider thread, swap away and back mid-run, confirm narration persists
- [ ] Manual: send a `/unknown` or `//` message and confirm it is delivered

## Open / follow-up (not in this PR)
- The reset hairline is client-side only (not persisted across a full reload). Durable persistence is a follow-up.
- A subprocess `exited with code 1` crash on a fresh session is still under investigation; the stderr capture here is the instrumentation to surface its cause, not a fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782891054&installation_id=129163861&pr_number=546&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F546&signature=a49b941eacbb32cf9aa99e3eac87c987aa31890e128bc10e4327c12cbdc6678c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session recovery when Claude encounters unmodifiable thinking block errors; sessions are now properly invalidated with user-visible reset messages.
  * Enhanced state preservation for active conversations during cache restoration.

* **Improvements**
  * Better error diagnostics with subprocess error capture.
  * Removed redundant pre-send validation for slash commands.

* **Accessibility**
  * Enhanced system message semantics with improved accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->