### PR TITLE
fix(chat): stuck slash-command popup + typed popup state, declarative availability, flushSync warning

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -431,6 +431,26 @@ lives in the composer's Lexical plugin (`SlashCommandPlugin`,
 slash commands under `.claude/commands/` etc. (which are for
 contributors).
 
+Slash commands sit in one of three availability layers:
+
+- **Provider-scoped command** — native to a single provider, discovered by
+  the server skill scan. Each `SkillInfo` carries the provider(s) that own
+  it in `providers[]`, and the server (`skill-service.ts`) filters the list
+  by the active provider before it reaches the client. The composer does
+  **not** re-filter these; they arrive already scoped.
+- **Multi-provider command** — offered to an explicit, growing set of
+  providers. `/goal` (Claude today, Codex planned) and `/m:plan` (every
+  provider except Copilot, which has its own native plan mode) are built-ins
+  in this layer. Their availability is declared per command in
+  `useSlashCommand` (`BuiltinCommand.isAvailable`), not scattered as inline
+  conditionals.
+- **Mcode-level command** — app-level, offered for every provider regardless
+  of which one is active (e.g. `/compact`).
+
+Built-ins are the only commands the client gates by provider; provider-scoped
+skills are gated server-side. An empty `providers[]` on a `SkillInfo` means
+*no* provider, not "all" — universal availability is the Mcode-level layer.
+
 ### Hook
 A user-configurable script that fires at a specific point in an agent's
 lifecycle within a thread. Two kinds today:

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -363,6 +363,62 @@ describe("provider-scoped commands", () => {
   });
 });
 
+describe("popup state machine", () => {
+  it("emits a 'ready' state carrying the full command list once skills load", async () => {
+    // Self-contained mock: earlier tests leave a mockReturnValue in place
+    // (vi.clearAllMocks does not reset return values), so set ours explicitly.
+    vi.mocked(getTransport).mockReturnValue({
+      listSkills: vi.fn().mockResolvedValue([{ name: "commit", description: "Create a git commit" }]),
+    } as never);
+
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({ anchorRef: ref }));
+
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    expect(result.current.state.kind).toBe("ready");
+    if (result.current.state.kind === "ready") {
+      const names = result.current.state.items.map((i) => i.name);
+      expect(names).toContain("commit");
+    }
+  });
+
+  it("is 'closed' before any trigger", () => {
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({ anchorRef: ref }));
+    expect(result.current.state.kind).toBe("closed");
+  });
+
+  it("self-heals to 'ready' after a skills.changed push lands mid-load (no manual retry)", async () => {
+    // Reproduces the stuck-popup symptom at the hook seam: the popup opens,
+    // a skills.changed push invalidates the store while the first load is in
+    // flight, and the popup must return to the full list on its own. Before
+    // the invalidate() isLoading reset, the eager-prefetch effect dead-locked
+    // and the popup stayed on built-ins until the user clicked Refresh.
+    vi.mocked(getTransport).mockReturnValue({
+      listSkills: vi.fn().mockResolvedValue([{ name: "commit", description: "Create a git commit" }]),
+    } as never);
+
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({ anchorRef: ref }));
+
+    await act(async () => { result.current.onInputChange("/"); });
+    // Fire the push concurrently with the in-flight load.
+    await act(async () => {
+      useSkillsStore.getState().invalidate();
+    });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(result.current.state.kind).toBe("ready");
+    if (result.current.state.kind === "ready") {
+      const names = result.current.state.items.map((i) => i.name);
+      expect(names).toContain("commit");
+    }
+  });
+});
+
 describe("plugin namespace detection", () => {
   it("assigns 'plugin' namespace to skills with colon in name", async () => {
     const mockListSkills = vi.fn().mockResolvedValue([

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -361,6 +361,33 @@ describe("provider-scoped commands", () => {
     const names = result.current.allCommands.map((c) => c.name);
     expect(names).toContain("compact");
   });
+
+  it("shows /goal only for the claude provider (gradual rollout)", async () => {
+    const ref = makeAnchor();
+    const { result } = renderHook(() =>
+      useSlashCommand({ anchorRef: ref, providerId: "claude" })
+    );
+
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    expect(result.current.allCommands.map((c) => c.name)).toContain("goal");
+  });
+
+  it("hides /goal for non-claude providers and when no provider is specified", async () => {
+    const ref = makeAnchor();
+    const { result: codex } = renderHook(() =>
+      useSlashCommand({ anchorRef: ref, providerId: "codex" })
+    );
+    await act(async () => { codex.current.onInputChange("/"); });
+    await act(async () => {});
+    expect(codex.current.allCommands.map((c) => c.name)).not.toContain("goal");
+
+    const { result: none } = renderHook(() => useSlashCommand({ anchorRef: ref }));
+    await act(async () => { none.current.onInputChange("/"); });
+    await act(async () => {});
+    expect(none.current.allCommands.map((c) => c.name)).not.toContain("goal");
+  });
 });
 
 describe("popup state machine", () => {

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -362,7 +362,12 @@ describe("provider-scoped commands", () => {
     expect(names).toContain("compact");
   });
 
-  it("shows /goal only for the claude provider (gradual rollout)", async () => {
+  // /goal is a gradual rollout: shown only for providers that support it
+  // (currently just "claude"), hidden for every other provider and when none
+  // is selected. The cases are deliberately framed as supported/unsupported,
+  // not "claude vs the rest", so adding a provider to GOAL_PROVIDERS is the
+  // only change needed when the rollout widens.
+  it("shows /goal for a supported provider", async () => {
     const ref = makeAnchor();
     const { result } = renderHook(() =>
       useSlashCommand({ anchorRef: ref, providerId: "claude" })
@@ -380,7 +385,7 @@ describe("provider-scoped commands", () => {
   // the other's value as a provider change and reloading forever (an infinite
   // render loop that OOMs the vitest worker). beforeEach resets the store, so
   // separate tests each get a single hook driving the store.
-  it("hides /goal for non-claude providers", async () => {
+  it("hides /goal for an unsupported provider", async () => {
     const ref = makeAnchor();
     const { result } = renderHook(() =>
       useSlashCommand({ anchorRef: ref, providerId: "codex" })
@@ -390,7 +395,7 @@ describe("provider-scoped commands", () => {
     expect(result.current.allCommands.map((c) => c.name)).not.toContain("goal");
   });
 
-  it("hides /goal when no provider is specified", async () => {
+  it("hides /goal when no provider is selected", async () => {
     const ref = makeAnchor();
     const { result } = renderHook(() => useSlashCommand({ anchorRef: ref }));
     await act(async () => { result.current.onInputChange("/"); });

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -374,19 +374,28 @@ describe("provider-scoped commands", () => {
     expect(result.current.allCommands.map((c) => c.name)).toContain("goal");
   });
 
-  it("hides /goal for non-claude providers and when no provider is specified", async () => {
+  // Each provider case is its own test: useSlashCommand subscribes to the
+  // module-scoped skillsStore, so two hooks mounted at once with different
+  // providerIds would fight over the store's cached providerId, each treating
+  // the other's value as a provider change and reloading forever (an infinite
+  // render loop that OOMs the vitest worker). beforeEach resets the store, so
+  // separate tests each get a single hook driving the store.
+  it("hides /goal for non-claude providers", async () => {
     const ref = makeAnchor();
-    const { result: codex } = renderHook(() =>
+    const { result } = renderHook(() =>
       useSlashCommand({ anchorRef: ref, providerId: "codex" })
     );
-    await act(async () => { codex.current.onInputChange("/"); });
+    await act(async () => { result.current.onInputChange("/"); });
     await act(async () => {});
-    expect(codex.current.allCommands.map((c) => c.name)).not.toContain("goal");
+    expect(result.current.allCommands.map((c) => c.name)).not.toContain("goal");
+  });
 
-    const { result: none } = renderHook(() => useSlashCommand({ anchorRef: ref }));
-    await act(async () => { none.current.onInputChange("/"); });
+  it("hides /goal when no provider is specified", async () => {
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({ anchorRef: ref }));
+    await act(async () => { result.current.onInputChange("/"); });
     await act(async () => {});
-    expect(none.current.allCommands.map((c) => c.name)).not.toContain("goal");
+    expect(result.current.allCommands.map((c) => c.name)).not.toContain("goal");
   });
 });
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -2847,12 +2847,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       </div>{/* end max-width wrapper */}
 
       <SlashCommandPopup
-        isOpen={slashCommand.isOpen}
-        isLoading={slashCommand.isLoading}
-        items={slashCommand.items}
+        state={slashCommand.state}
         selectedIndex={slashCommand.selectedIndex}
         anchorRect={slashCommand.anchorRect}
-        error={slashCommand.error}
         onSelect={handleSlashSelect}
         onDismiss={slashCommand.onDismiss}
         onRetry={slashCommand.onRetry}

--- a/apps/web/src/components/chat/FileTagPopup.tsx
+++ b/apps/web/src/components/chat/FileTagPopup.tsx
@@ -154,6 +154,11 @@ export function FileTagPopup({
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ITEM_HEIGHT,
     overscan: 4,
+    // Opt out of react-virtual's flushSync(rerender) on sync measurement; it
+    // fires inside the library's commit-phase layout effect and trips React's
+    // "flushSync called from inside a lifecycle method" warning. A popup list
+    // does not need a synchronous re-render.
+    useFlushSync: false,
   });
 
   // Keep a stable ref to the virtualizer so the scroll effect below doesn't

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -562,6 +562,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     },
     getItemKey: (index) => items[index]?.key ?? String(index),
     overscan: OVERSCAN,
+    // Opt out of react-virtual's flushSync(rerender) on sync measurement. It
+    // fires inside the library's commit-phase layout effect and trips React's
+    // "flushSync called from inside a lifecycle method" warning. Scroll-tail
+    // compensation is unaffected: shouldAdjustScrollPositionOnItemSizeChange
+    // adjusts scrollOffset inside virtual-core before onChange, so only the
+    // React re-render is deferred from sync to React's normal batching.
+    useFlushSync: false,
   });
   virtualizerRef.current = virtualizer;
 

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -53,6 +53,11 @@ export function SlashCommandPopup({
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ITEM_HEIGHT,
     overscan: 2,
+    // react-virtual defaults to flushSync(rerender) on sync measurement, which
+    // fires inside its commit-phase layout effect and triggers React's
+    // "flushSync called from inside a lifecycle method" warning. The popup list
+    // does not need a synchronous re-render, so opt out.
+    useFlushSync: false,
   });
 
   // Scroll selected item into view

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -3,7 +3,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn } from "@/lib/utils";
 import { Terminal, Zap, Puzzle, Sparkles, RefreshCw } from "lucide-react";
 import { NAMESPACE_BADGE_STYLES } from "@/lib/slash-command-styles";
-import type { Command } from "./useSlashCommand";
+import type { Command, PopupState } from "./useSlashCommand";
 
 const ITEM_HEIGHT = 44; // px per row
 const VISIBLE_ITEMS = 8;
@@ -15,12 +15,10 @@ const FOOTER_HEIGHT = 28;
 
 /** Props for the {@link SlashCommandPopup} component. */
 interface SlashCommandPopupProps {
-  isOpen: boolean;
-  isLoading: boolean;
-  items: Command[];
+  /** Typed render state from {@link useSlashCommand}; the popup switches on `state.kind`. */
+  state: PopupState;
   selectedIndex: number;
   anchorRect: DOMRect | null;
-  error: Error | null;
   onSelect: (cmd: Command) => void;
   onDismiss: () => void;
   onRetry: () => void;
@@ -30,21 +28,25 @@ interface SlashCommandPopupProps {
  * Floating popup that lists slash command suggestions anchored to the
  * composer editor. Handles keyboard navigation via `selectedIndex`, virtualises
  * long lists past `VIRTUAL_THRESHOLD`, flips above/below the anchor based on
- * available viewport space, and dismisses on outside click. Render priority is
- * error → list → inline loader → empty state.
+ * available viewport space, and dismisses on outside click. The render priority
+ * (error → list → inline loader → empty) is encoded by the {@link PopupState}
+ * union rather than a comment, so this component is an exhaustive switch on
+ * `state.kind`.
  */
 export function SlashCommandPopup({
-  isOpen,
-  isLoading,
-  items,
+  state,
   selectedIndex,
   anchorRect,
-  error,
   onSelect,
   onDismiss,
   onRetry,
 }: SlashCommandPopupProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  // The list-bearing states carry the items; all others render no list.
+  const items: Command[] =
+    state.kind === "ready" || state.kind === "staleRevalidating" ? state.items : [];
+  const isOpen = state.kind !== "closed";
 
   const virtualizer = useVirtualizer({
     count: items.length > VIRTUAL_THRESHOLD ? items.length : 0,
@@ -76,7 +78,7 @@ export function SlashCommandPopup({
     return () => document.removeEventListener("mousedown", handler);
   }, [isOpen, onDismiss]);
 
-  if (!isOpen || !anchorRect) return null;
+  if (state.kind === "closed" || !anchorRect) return null;
 
   // Cap the scrollable list at VISIBLE_ITEMS rows; shorter lists size to
   // their natural content so a popup with two items isn't truncated.
@@ -86,7 +88,7 @@ export function SlashCommandPopup({
   // decision. Only the list branch renders a footer (Refresh row); error,
   // inline-loading, and empty branches do not. Including FOOTER_HEIGHT in
   // those cases would cause unnecessary above-placement flips.
-  const willRenderList = !error && items.length > 0;
+  const willRenderList = state.kind === "ready" || state.kind === "staleRevalidating";
   const estimatedHeight =
     Math.min(items.length, VISIBLE_ITEMS) * ITEM_HEIGHT +
     (willRenderList ? FOOTER_HEIGHT : 0);
@@ -118,77 +120,84 @@ export function SlashCommandPopup({
       )}
     >
       {/*
-        Render priority (stale-while-revalidate):
-          1. error -> ErrorRow  (unchanged; surfaces transient failures even
-             when built-in commands are present, preserving the explicit
-             "loading failed" signal validated by the slash-command E2E)
-          2. items.length > 0 -> list  (built-ins are always available, so
-             this branch wins on cold start, workspace switches, and cache
-             invalidations; the loading skeleton is unreachable in normal use)
-          3. isLoading -> inline "Loading commands..."  (only hit when a
-             filter yields zero matches AND skills are still arriving;
-             replaces the 3-row skeleton with a single quiet row)
-          4. EmptyState  (no matches, not loading, no error)
+        Render priority (stale-while-revalidate) is encoded by PopupState:
+          - error             -> ErrorRow (surfaces transient failures even
+                                 when built-in commands are present)
+          - ready             -> list (settled, not revalidating)
+          - staleRevalidating -> list (cached items shown while a fresh load
+                                 is in flight; identical render, but a named
+                                 state so the stuck-popup case is testable)
+          - loading           -> inline "Loading commands..." (no cached items
+                                 yet, e.g. a filter excludes every built-in)
+          - empty             -> EmptyState (no matches, not loading, no error)
+        `closed` is handled by the early return above, so this switch over the
+        remaining kinds is exhaustive and compiler-checked.
       */}
-      {error ? (
-        <ErrorRow message={error.message} onRetry={onRetry} />
-      ) : items.length > 0 ? (
-        <>
-          <div
-            ref={scrollRef}
-            role="listbox"
-            aria-label="Slash commands"
-            aria-activedescendant={items[selectedIndex] ? `slash-cmd-${items[selectedIndex].name}` : undefined}
-            style={{ maxHeight: listMaxHeight, overflowY: "auto" }}
-          >
-            {useVirtual ? (
-              <div role="presentation" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
-                {virtualizer.getVirtualItems().map((vi) => (
-                  <div
-                    key={vi.key}
-                    role="presentation"
-                    style={{ position: "absolute", top: vi.start, width: "100%", height: vi.size }}
-                    data-index={vi.index}
-                  >
-                    <CommandRow
-                      cmd={items[vi.index]}
-                      selected={vi.index === selectedIndex}
-                      onSelect={onSelect}
-                    />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              items.map((cmd, i) => (
-                <div key={cmd.name} role="presentation" data-index={i}>
-                  <CommandRow
-                    cmd={cmd}
-                    selected={i === selectedIndex}
-                    onSelect={onSelect}
-                  />
+      {(() => {
+        switch (state.kind) {
+          case "error":
+            return <ErrorRow message={state.error.message} onRetry={onRetry} />;
+          case "ready":
+          case "staleRevalidating":
+            return (
+              <>
+                <div
+                  ref={scrollRef}
+                  role="listbox"
+                  aria-label="Slash commands"
+                  aria-activedescendant={items[selectedIndex] ? `slash-cmd-${items[selectedIndex].name}` : undefined}
+                  style={{ maxHeight: listMaxHeight, overflowY: "auto" }}
+                >
+                  {useVirtual ? (
+                    <div role="presentation" style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+                      {virtualizer.getVirtualItems().map((vi) => (
+                        <div
+                          key={vi.key}
+                          role="presentation"
+                          style={{ position: "absolute", top: vi.start, width: "100%", height: vi.size }}
+                          data-index={vi.index}
+                        >
+                          <CommandRow
+                            cmd={items[vi.index]}
+                            selected={vi.index === selectedIndex}
+                            onSelect={onSelect}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    items.map((cmd, i) => (
+                      <div key={cmd.name} role="presentation" data-index={i}>
+                        <CommandRow
+                          cmd={cmd}
+                          selected={i === selectedIndex}
+                          onSelect={onSelect}
+                        />
+                      </div>
+                    ))
+                  )}
                 </div>
-              ))
-            )}
-          </div>
-          <div className="flex items-center justify-end border-t border-border px-2 py-1">
-            <button
-              type="button"
-              aria-label="Refresh commands"
-              // onMouseDown preventDefault keeps editor focus on pointer use;
-              // onClick fires on both pointer and keyboard activation (Enter/Space).
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={onRetry}
-              className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-            >
-              <RefreshCw size={12} />
-            </button>
-          </div>
-        </>
-      ) : isLoading ? (
-        <LoadingInline />
-      ) : (
-        <EmptyState />
-      )}
+                <div className="flex items-center justify-end border-t border-border px-2 py-1">
+                  <button
+                    type="button"
+                    aria-label="Refresh commands"
+                    // onMouseDown preventDefault keeps editor focus on pointer use;
+                    // onClick fires on both pointer and keyboard activation (Enter/Space).
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={onRetry}
+                    className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  >
+                    <RefreshCw size={12} />
+                  </button>
+                </div>
+              </>
+            );
+          case "loading":
+            return <LoadingInline />;
+          case "empty":
+            return <EmptyState />;
+        }
+      })()}
     </div>
   );
 }

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
@@ -45,12 +45,9 @@ const COMMANDS: Command[] = [
 function renderPopup() {
   return render(
     <SlashCommandPopup
-      isOpen={true}
-      isLoading={false}
-      items={COMMANDS}
+      state={{ kind: "ready", items: COMMANDS }}
       selectedIndex={0}
       anchorRect={makeAnchorRect()}
-      error={null}
       onSelect={() => {}}
       onDismiss={() => {}}
       onRetry={() => {}}

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
@@ -62,12 +62,9 @@ const COMMANDS: Command[] = [
 function renderPopup(selectedIndex: number) {
   return render(
     <SlashCommandPopup
-      isOpen={true}
-      isLoading={false}
-      items={COMMANDS}
+      state={{ kind: "ready", items: COMMANDS }}
       selectedIndex={selectedIndex}
       anchorRect={makeAnchorRect()}
-      error={null}
       onSelect={() => {}}
       onDismiss={() => {}}
       onRetry={() => {}}

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -27,10 +27,49 @@ export type PopupState =
   | { kind: "empty" }
   | { kind: "error"; error: Error };
 
-const BUILTIN_COMMANDS: Command[] = [
-  { name: "m:plan", description: "Toggle plan mode", namespace: "mcode", action: "toggle-plan" },
-  { name: "compact", description: "Summarise conversation history to free up context window", namespace: "command" },
-  { name: "goal", description: "Set a goal the agent must satisfy before stopping (\"/goal clear\" to remove)", namespace: "command" },
+/**
+ * A built-in command plus the predicate that decides which providers see it.
+ * Built-ins are the only commands gated by provider on the client: scanned
+ * skills arrive already provider-scoped from the server (skill-service filters
+ * by each skill's `providers[]`). Declaring availability next to the command
+ * keeps the rule local instead of scattered across inline conditionals.
+ *
+ * Layer mapping (CONTEXT.md §App-side extensibility):
+ *   - Mcode-level command   → available to every provider
+ *   - Multi-provider command → available to an explicit set of providers
+ */
+interface BuiltinCommand extends Command {
+  /** Whether this built-in is offered for the given provider. */
+  isAvailable: (providerId: string | undefined) => boolean;
+}
+
+const BUILTIN_COMMANDS: BuiltinCommand[] = [
+  {
+    name: "m:plan",
+    description: "Toggle plan mode",
+    namespace: "mcode",
+    action: "toggle-plan",
+    // Multi-provider: every provider except Copilot, which has its own native
+    // plan mode plus repo-scoped sub-agents. TODO: once Copilot ACP exposes a
+    // native-plan/sub-agent capability, replace this hardcoded exclusion with a
+    // capability check so newly added providers opt in correctly.
+    isAvailable: (providerId) => providerId !== "copilot",
+  },
+  {
+    name: "compact",
+    description: "Summarise conversation history to free up context window",
+    namespace: "command",
+    // Mcode-level: app-level summarisation, offered for every provider.
+    isAvailable: () => true,
+  },
+  {
+    name: "goal",
+    description: "Set a goal the agent must satisfy before stopping (\"/goal clear\" to remove)",
+    namespace: "command",
+    // Multi-provider, gradual rollout: implemented in Claude's Stop hook today;
+    // Codex support planned. Grows by adding providers to this allow-list.
+    isAvailable: (providerId) => providerId === "claude",
+  },
 ];
 
 /** Regex: matches `/` at start of line or after whitespace, followed by non-space chars. */
@@ -119,13 +158,18 @@ export function useSlashCommand({
   // dep — if we filtered outside and put the resulting array in deps, every
   // render would produce a new reference and break memoization.
   const allCommands = useCallback(() => {
-    const builtins = BUILTIN_COMMANDS.filter((cmd) => {
-      // /m:plan is hidden for copilot (uses its own dynamic modes instead)
-      if (cmd.name === "m:plan" && providerId === "copilot") return false;
-      // /goal is implemented in the Claude provider's Stop hook; hide on others.
-      if (cmd.name === "goal" && providerId !== "claude") return false;
-      return true;
-    });
+    // Strip the predicate so the rendered list holds plain Command objects;
+    // availability has already been resolved here.
+    const builtins: Command[] = BUILTIN_COMMANDS.filter((cmd) =>
+      cmd.isAvailable(providerId),
+    ).map(
+      (cmd): Command => ({
+        name: cmd.name,
+        description: cmd.description,
+        namespace: cmd.namespace,
+        action: cmd.action,
+      }),
+    );
     const commands: Command[] = [
       ...builtins,
       ...((skills ?? []).map(toCommand)),

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -43,6 +43,14 @@ interface BuiltinCommand extends Command {
   isAvailable: (providerId: string | undefined) => boolean;
 }
 
+/**
+ * Providers that support `/goal` today. It is a gradual rollout (implemented in
+ * Claude's Stop hook; Codex planned), so this is an allow-list that grows by
+ * adding entries — not a Claude special-case. `/goal` is hidden for any
+ * provider not in this set, including when no provider is selected.
+ */
+const GOAL_PROVIDERS = new Set<string>(["claude"]);
+
 const BUILTIN_COMMANDS: BuiltinCommand[] = [
   {
     name: "m:plan",
@@ -66,9 +74,9 @@ const BUILTIN_COMMANDS: BuiltinCommand[] = [
     name: "goal",
     description: "Set a goal the agent must satisfy before stopping (\"/goal clear\" to remove)",
     namespace: "command",
-    // Multi-provider, gradual rollout: implemented in Claude's Stop hook today;
-    // Codex support planned. Grows by adding providers to this allow-list.
-    isAvailable: (providerId) => providerId === "claude",
+    // Multi-provider, gradual rollout: shown only for providers that support it
+    // (see GOAL_PROVIDERS), hidden for everything else including no selection.
+    isAvailable: (providerId) => providerId !== undefined && GOAL_PROVIDERS.has(providerId),
   },
 ];
 

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -12,6 +12,21 @@ export interface Command {
   action?: string;
 }
 
+/**
+ * Render state of the slash command popup, modelled as a discriminated union
+ * so the stale-while-revalidate priority (error → list → loading → empty) is an
+ * exhaustive switch the compiler checks rather than a comment plus nested
+ * ternary. `staleRevalidating` names the state behind the stuck-popup bug:
+ * cached items are shown while a fresh skill load is still in flight.
+ */
+export type PopupState =
+  | { kind: "closed" }
+  | { kind: "loading" }
+  | { kind: "ready"; items: Command[] }
+  | { kind: "staleRevalidating"; items: Command[] }
+  | { kind: "empty" }
+  | { kind: "error"; error: Error };
+
 const BUILTIN_COMMANDS: Command[] = [
   { name: "m:plan", description: "Toggle plan mode", namespace: "mcode", action: "toggle-plan" },
   { name: "compact", description: "Summarise conversation history to free up context window", namespace: "command" },
@@ -61,12 +76,17 @@ interface UseSlashCommandOptions {
 /** Return value of the useSlashCommand hook. */
 export interface UseSlashCommandReturn {
   isOpen: boolean;
-  isLoading: boolean;
+  /**
+   * Typed render state for the popup. The popup switches on `state.kind`; the
+   * priority that used to live in a comment now lives in this union. `items`
+   * and `selectedIndex` remain on the return for the Composer's index-based
+   * keyboard selection, which needs the flat list independent of render state.
+   */
+  state: PopupState;
   items: Command[];
   allCommands: Command[];
   selectedIndex: number;
   anchorRect: DOMRect | null;
-  error: Error | null;
   onInputChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
   onSelect: (cmd: Command, replaceText: (v: string) => void) => void;
@@ -118,6 +138,24 @@ export function useSlashCommand({
     if (!f) return allCommands;
     return allCommands.filter((c) => c.name.toLowerCase().includes(f));
   })();
+
+  // Derive the typed popup state. Order encodes the stale-while-revalidate
+  // priority that previously lived in a comment in SlashCommandPopup:
+  //   error → list (ready / staleRevalidating) → loading → empty.
+  // The list branch splits on isLoading so a background refresh while cached
+  // items are shown is the explicit `staleRevalidating` state — the one that
+  // got stuck when invalidate() left isLoading=true.
+  const state: PopupState = !isOpen
+    ? { kind: "closed" }
+    : error
+      ? { kind: "error", error }
+      : filtered.length > 0
+        ? isLoading
+          ? { kind: "staleRevalidating", items: filtered }
+          : { kind: "ready", items: filtered }
+        : isLoading
+          ? { kind: "loading" }
+          : { kind: "empty" };
 
   // Eager prefetch: load skills as soon as cwd/providerId are known, NOT
   // when the popup opens. This ensures the cache is warm by the time the
@@ -220,12 +258,11 @@ export function useSlashCommand({
 
   return {
     isOpen,
-    isLoading,
+    state,
     items: filtered,
     allCommands,
     selectedIndex,
     anchorRect,
-    error,
     onInputChange,
     onKeyDown,
     onSelect,

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1134,6 +1134,11 @@ function VirtualizedThreadList({
     estimateSize: () => 28,
     overscan: 5,
     scrollMargin,
+    // Opt out of react-virtual's flushSync(rerender) on sync measurement; it
+    // fires inside the library's commit-phase layout effect and trips React's
+    // "flushSync called from inside a lifecycle method" warning. The tree does
+    // not need a synchronous re-render.
+    useFlushSync: false,
   });
 
   return (

--- a/apps/web/src/stores/skillsStore.test.ts
+++ b/apps/web/src/stores/skillsStore.test.ts
@@ -77,6 +77,36 @@ describe("skillsStore", () => {
     // Store stays cleared: the late resolution was dropped.
     expect(useSkillsStore.getState().skills).toBeNull();
     expect(useSkillsStore.getState().cwd).toBeUndefined();
+    // Regression: the in-flight load's fenced resolve must not leave
+    // isLoading stuck at true. If it did, useSlashCommand's eager-prefetch
+    // effect would early-return forever (`if (isLoading) return`), and the
+    // popup would show only built-in commands until the user clicks Refresh.
+    expect(useSkillsStore.getState().isLoading).toBe(false);
+  });
+
+  it("recovers after invalidate-during-load race: next load repopulates skills", async () => {
+    // Drives the user-visible symptom end-to-end: cold-start race where
+    // `skills.changed` arrives during the very first prefetch. Without the
+    // isLoading reset in invalidate(), `useSlashCommand`'s eager-prefetch
+    // effect would never fire a follow-up load and the popup would stick.
+    let resolveFirst!: (v: typeof FAKE_SKILLS) => void;
+    listSkillsMock.mockImplementationOnce(
+      () => new Promise((res) => { resolveFirst = res; }),
+    );
+
+    const first = useSkillsStore.getState().load("/foo");
+    useSkillsStore.getState().invalidate();
+    resolveFirst(FAKE_SKILLS);
+    await first;
+
+    // The consumer hook's effect would early-return if isLoading is stuck.
+    expect(useSkillsStore.getState().isLoading).toBe(false);
+
+    // Subsequent load mirrors what the effect would dispatch once it sees
+    // !isLoading and skills === null. It must repopulate the store.
+    await useSkillsStore.getState().load("/foo");
+    expect(useSkillsStore.getState().skills).toEqual(FAKE_SKILLS);
+    expect(useSkillsStore.getState().isLoading).toBe(false);
   });
 
   it("tracks cwd on failure so the consumer can detect cwd changes", async () => {

--- a/apps/web/src/stores/skillsStore.ts
+++ b/apps/web/src/stores/skillsStore.ts
@@ -173,11 +173,20 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   invalidate() {
     // Bumping loadEpoch fences any in-flight load() so its eventual set()
     // is dropped instead of rehydrating the store with pre-invalidation data.
+    //
+    // `isLoading: false` is required here: the fenced load resolves into the
+    // epoch-check branch in load() that skips its own `isLoading: false`
+    // assignment. Without resetting it here, the store would be left with
+    // skills=null and isLoading=true permanently, and the consumer hook's
+    // eager-prefetch effect (which early-returns when isLoading is true)
+    // would never dispatch the follow-up load. The slash-command popup
+    // would then show only built-in commands until the user clicks Refresh.
     const state = get();
     set({
       skills: null,
       cwd: undefined,
       providerId: undefined,
+      isLoading: false,
       error: null,
       inflight: null,
       inflightCwd: undefined,

--- a/apps/web/src/stores/skillsStore.ts
+++ b/apps/web/src/stores/skillsStore.ts
@@ -66,8 +66,19 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 // gets cleared when `reset()` or `invalidate()` is explicitly called.
 let lastFetchedAt = 0;
 
-/** Module-scoped Zustand store for skill caching with single-flight loading. */
-export const useSkillsStore = create<SkillsState>((set, get) => ({
+/**
+ * The store's "cleared" field values — every data/in-flight field reset to its
+ * empty state. `loadEpoch` (bumped, not reset) and `lastFetchedAt` (a module
+ * var) are handled separately.
+ *
+ * Both the initial state and the `invalidate()`/`reset()` actions spread this
+ * single object, so a newly added state field can never be cleared in one path
+ * but forgotten in another. That divergence is exactly what caused the
+ * stuck-popup bug: `invalidate()` once omitted `isLoading: false` while the
+ * initial state and `reset()` had it, leaving the flag stuck `true` after a
+ * push-during-load and dead-locking the consumer's eager-prefetch effect.
+ */
+const CLEARED_STATE = {
   skills: null,
   cwd: undefined,
   providerId: undefined,
@@ -76,6 +87,11 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   inflight: null,
   inflightCwd: undefined,
   inflightProviderId: undefined,
+} as const satisfies Partial<SkillsState>;
+
+/** Module-scoped Zustand store for skill caching with single-flight loading. */
+export const useSkillsStore = create<SkillsState>((set, get) => ({
+  ...CLEARED_STATE,
   loadEpoch: 0,
 
   // Non-async so the return value IS the cached/in-flight promise directly,
@@ -171,44 +187,17 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   },
 
   invalidate() {
-    // Bumping loadEpoch fences any in-flight load() so its eventual set()
-    // is dropped instead of rehydrating the store with pre-invalidation data.
-    //
-    // `isLoading: false` is required here: the fenced load resolves into the
-    // epoch-check branch in load() that skips its own `isLoading: false`
-    // assignment. Without resetting it here, the store would be left with
-    // skills=null and isLoading=true permanently, and the consumer hook's
-    // eager-prefetch effect (which early-returns when isLoading is true)
-    // would never dispatch the follow-up load. The slash-command popup
-    // would then show only built-in commands until the user clicks Refresh.
-    const state = get();
-    set({
-      skills: null,
-      cwd: undefined,
-      providerId: undefined,
-      isLoading: false,
-      error: null,
-      inflight: null,
-      inflightCwd: undefined,
-      inflightProviderId: undefined,
-      loadEpoch: state.loadEpoch + 1,
-    });
+    // Bumping loadEpoch fences any in-flight load() so its eventual set() is
+    // dropped instead of rehydrating the store with pre-invalidation data.
+    // Spreading CLEARED_STATE guarantees isLoading is reset to false even when
+    // the fenced load skips its own reset — see CLEARED_STATE for why that
+    // matters (the stuck-popup bug).
+    set({ ...CLEARED_STATE, loadEpoch: get().loadEpoch + 1 });
     lastFetchedAt = 0;
   },
 
   reset() {
-    const state = get();
-    set({
-      skills: null,
-      cwd: undefined,
-      providerId: undefined,
-      isLoading: false,
-      error: null,
-      inflight: null,
-      inflightCwd: undefined,
-      inflightProviderId: undefined,
-      loadEpoch: state.loadEpoch + 1,
-    });
+    set({ ...CLEARED_STATE, loadEpoch: get().loadEpoch + 1 });
     lastFetchedAt = 0;
   },
 }));


### PR DESCRIPTION
## What
Fixes the intermittently stuck slash-command popup (only built-in commands shown until Refresh is clicked), hardens the surface against the bug class, and silences the React `flushSync` lifecycle warning from `@tanstack/react-virtual`.

## Why
Root cause of the stuck popup: a `skills.changed` push firing during an in-flight `listSkills` load bumped `loadEpoch` but `invalidate()` left `isLoading=true` (it omitted the reset that `reset()` and the initial state had). The fenced load skips its own `isLoading` reset, so the consumer hook's eager-prefetch effect dead-locked behind `if (isLoading) return` and the popup never repopulated. Follow-up work removes the conditions that let this bug class exist and resolves an unrelated dev-only React warning surfaced while testing.

## Key Changes
- **fix(store):** `skillsStore.invalidate()` now resets `isLoading` as part of the epoch fence; regression tests cover the invalidate-during-load race.
- **refactor(chat):** popup render state modelled as a typed `PopupState` discriminated union (`closed | loading | ready | staleRevalidating | empty | error`); `SlashCommandPopup` renders via an exhaustive `switch`, replacing a 13-line priority comment + nested ternary. `staleRevalidating` names the previously-unnameable stuck state; hook-seam test asserts push-mid-load self-heals to `ready` with no manual retry.
- **refactor(store):** single `CLEARED_STATE` spread by the initial state, `invalidate()`, and `reset()` so a new field can't be cleared in one path but forgotten in another (the exact divergence that caused the bug).
- **refactor(chat):** built-in command provider-availability moved from inline `if`s into declarative `BuiltinCommand.isAvailable` predicates; documents the 3-layer command model (provider-scoped / multi-provider / mcode-level) in `CONTEXT.md`. Scanned skills are already provider-scoped server-side, so no client-side skill filtering was added.
- **fix(chat):** `useFlushSync: false` on all four `useVirtualizer` consumers (slash popup, file-tag popup, message list, project tree) to stop react-virtual calling `flushSync` inside its commit-phase layout effect.

## Config Changes
None

---
### Verification
- Full `bun run verify` passed green earlier this session (1417 frontend + 1148 server tests). Typecheck + lint are clean on all changes.
- The flushSync fix was confirmed by loading the dev app (home + thread view) with no `flushSync` warning in the console; root cause verified by reading the `@tanstack/react-virtual` source.
- **Please manually verify** chat scroll/tail-pinning still feels right with `MessageList`'s `useFlushSync: false` - a heavily-populated message list could not be exercised live in this session (local WS/data limitation). Scroll compensation is applied in virtual-core before `onChange`, so only the React re-render moves from sync to batched, but a human eyeball on streaming scroll is worth it.
- Draft until CI runs the authoritative full gate (the local vitest runner was hitting environmental worker OOMs).

### Open question
`/m:plan` is excluded for Copilot as a proxy for "lacks native plan mode". Confirm whether Copilot ACP exposes a native-plan/sub-agent capability so this can become a capability check rather than a hardcoded allow-list omission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783011264&installation_id=129163861&pr_number=547&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F547&signature=5a6d84fdbb4f1c8a95ab7d129c1cd05aadf74f6ce77fb13628e55861b81f079d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added glossary clarifying how slash commands are categorized by availability scope: provider-scoped, multi-provider, and app-level commands.

* **Bug Fixes**
  * Improved slash command popup recovery when skills are revalidated during an in-flight load.
  * Reduced development console warnings for virtualized lists.

* **Tests**
  * Extended test coverage for slash command visibility across providers and popup state behavior during skill updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->