### PR TITLE
fix(chat): stop sticky user bar flicker at scroll clip boundary

### DIFF
--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -52,6 +52,8 @@ const WHEEL_UP_FOLLOW_PAUSE_MS = 750;
 const OVERSCAN = 8;
 const DEFAULT_ITEM_HEIGHT = 80;
 const PAGINATION_THRESHOLD = 200;
+/** Top inset on the scroll container when the sticky user bar is hidden (`pt-4`). */
+const MESSAGE_LIST_TOP_PADDING_PX = 16;
 /**
  * Initial-load reveal is gated on the inner list height stabilizing across frames.
  * TanStack Virtual measures rows asynchronously after mount, so `scrollHeight`
@@ -263,6 +265,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const prevScrollTopRef = useRef(0);
   /** Ref mirror of sticky-user-message visibility to avoid redundant setState on scroll. */
   const showStickyUserMessageRef = useRef(false);
+  /** Previous effective top padding; used to compensate scrollTop when padding changes. */
+  const prevStickyTopInsetRef = useRef(MESSAGE_LIST_TOP_PADDING_PX);
   const [showStickyUserMessage, setShowStickyUserMessage] = useState(false);
   /** Reserved top inset while the sticky user-message bar is visible. */
   const [stickyBarHeight, setStickyBarHeight] = useState(0);
@@ -343,6 +347,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       stickyTarget.id,
       stickyTarget.itemIndex,
       virtualizerInstance,
+      showStickyUserMessageRef.current,
     );
     if (shouldShowSticky !== showStickyUserMessageRef.current) {
       showStickyUserMessageRef.current = shouldShowSticky;
@@ -823,6 +828,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       showStickyUserMessageRef.current = false;
       setShowStickyUserMessage(false);
       setStickyBarHeight(0);
+      prevStickyTopInsetRef.current = MESSAGE_LIST_TOP_PADDING_PX;
     }
 
     if (loading) {
@@ -1067,6 +1073,22 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
         ? stickyBarHeight
         : STICKY_USER_MESSAGE_ESTIMATED_HEIGHT
       : 0;
+
+  const effectiveStickyTopInset =
+    stickyReservedTop > 0 ? stickyReservedTop : MESSAGE_LIST_TOP_PADDING_PX;
+
+  // When the sticky bar reserves more top padding, bump scrollTop so the transcript
+  // does not jump and re-trigger visibility at the clip boundary (padding feedback loop).
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el || !isPositioned) return;
+    const delta = effectiveStickyTopInset - prevStickyTopInsetRef.current;
+    if (delta !== 0) {
+      el.scrollTop = Math.max(0, el.scrollTop + delta);
+      prevScrollTopRef.current = el.scrollTop;
+    }
+    prevStickyTopInsetRef.current = effectiveStickyTopInset;
+  }, [effectiveStickyTopInset, isPositioned]);
 
   return (
     <div className="relative h-full" data-testid="message-list">

--- a/apps/web/src/components/chat/__tests__/sticky-user-message-visibility.test.ts
+++ b/apps/web/src/components/chat/__tests__/sticky-user-message-visibility.test.ts
@@ -103,4 +103,61 @@ describe("shouldShowStickyUserMessage", () => {
       }),
     ).toBe(true);
   });
+
+  describe("virtualizer fallback hysteresis (no DOM node)", () => {
+    const scrollTop = 240;
+
+    function containerWithoutDom(): HTMLDivElement {
+      const container = document.createElement("div");
+      Object.defineProperty(container, "clientHeight", { value: 400 });
+      Object.defineProperty(container, "scrollTop", { value: scrollTop, writable: true });
+      return container;
+    }
+
+    /** Virtual row for item 0 whose bottom edge sits `bottomPx` below the viewport top. */
+    function virtualizerAtMessageBottom(bottomPx: number): {
+      getVirtualItems: () => ReadonlyArray<{ index: number; start: number; size: number }>;
+    } {
+      const rowEnd = scrollTop + bottomPx;
+      return {
+        getVirtualItems: () => [{ index: 0, start: rowEnd - 52, size: 52 }],
+      };
+    }
+
+    it("returns false when the virtual row is only partially clipped at the top", () => {
+      const container = containerWithoutDom();
+      const virtualizer = virtualizerAtMessageBottom(12);
+
+      expect(
+        shouldShowStickyUserMessage(container, "msg-1", 0, virtualizer, false),
+      ).toBe(false);
+    });
+
+    it("returns true when the virtual row bottom is at the hide-in-view boundary and sticky is already on", () => {
+      const container = containerWithoutDom();
+      const virtualizer = virtualizerAtMessageBottom(STICKY_HIDE_IN_VIEW_PX);
+
+      expect(
+        shouldShowStickyUserMessage(container, "msg-1", 0, virtualizer, true),
+      ).toBe(true);
+    });
+
+    it("returns false when the virtual row bottom is just past the hide-in-view boundary", () => {
+      const container = containerWithoutDom();
+      const virtualizer = virtualizerAtMessageBottom(STICKY_HIDE_IN_VIEW_PX + 1);
+
+      expect(
+        shouldShowStickyUserMessage(container, "msg-1", 0, virtualizer, true),
+      ).toBe(false);
+    });
+
+    it("returns true when the virtual row is fully above the show threshold", () => {
+      const container = containerWithoutDom();
+      const virtualizer = virtualizerAtMessageBottom(-(STICKY_SHOW_ABOVE_VIEWPORT_PX + 1));
+
+      expect(
+        shouldShowStickyUserMessage(container, "msg-1", 0, virtualizer, false),
+      ).toBe(true);
+    });
+  });
 });

--- a/apps/web/src/components/chat/__tests__/sticky-user-message-visibility.test.ts
+++ b/apps/web/src/components/chat/__tests__/sticky-user-message-visibility.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldShowStickyUserMessage } from "../sticky-user-message-visibility";
+import {
+  shouldShowStickyUserMessage,
+  STICKY_HIDE_IN_VIEW_PX,
+  STICKY_SHOW_ABOVE_VIEWPORT_PX,
+} from "../sticky-user-message-visibility";
 
 describe("shouldShowStickyUserMessage", () => {
   it("returns false when the message is still visible in the viewport", () => {
@@ -33,10 +37,58 @@ describe("shouldShowStickyUserMessage", () => {
     container.getBoundingClientRect = () =>
       ({ top: 0, bottom: 400, left: 0, right: 300, width: 300, height: 400, x: 0, y: 0, toJSON: () => ({}) });
     message.getBoundingClientRect = () =>
-      ({ top: -40, bottom: -1, left: 0, right: 300, width: 300, height: 39, x: 0, y: -40, toJSON: () => ({}) });
+      ({
+        top: -48,
+        bottom: -(STICKY_SHOW_ABOVE_VIEWPORT_PX + 1),
+        left: 0,
+        right: 300,
+        width: 300,
+        height: 39,
+        x: 0,
+        y: -48,
+        toJSON: () => ({}),
+      });
 
     expect(
       shouldShowStickyUserMessage(container, "msg-1", 0, { getVirtualItems: () => [] }),
+    ).toBe(true);
+  });
+
+  it("returns false when the message is only partially clipped at the top", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "clientHeight", { value: 400 });
+    Object.defineProperty(container, "scrollTop", { value: 240, writable: true });
+
+    const message = document.createElement("div");
+    message.setAttribute("data-message-id", "msg-1");
+    container.appendChild(message);
+
+    container.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 400, left: 0, right: 300, width: 300, height: 400, x: 0, y: 0, toJSON: () => ({}) });
+    message.getBoundingClientRect = () =>
+      ({ top: -10, bottom: 12, left: 0, right: 300, width: 300, height: 22, x: 0, y: -10, toJSON: () => ({}) });
+
+    expect(
+      shouldShowStickyUserMessage(container, "msg-1", 0, { getVirtualItems: () => [] }),
+    ).toBe(false);
+  });
+
+  it("keeps the sticky bar on through partial clip when already visible", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "clientHeight", { value: 400 });
+    Object.defineProperty(container, "scrollTop", { value: 240, writable: true });
+
+    const message = document.createElement("div");
+    message.setAttribute("data-message-id", "msg-1");
+    container.appendChild(message);
+
+    container.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 400, left: 0, right: 300, width: 300, height: 400, x: 0, y: 0, toJSON: () => ({}) });
+    message.getBoundingClientRect = () =>
+      ({ top: -10, bottom: STICKY_HIDE_IN_VIEW_PX, left: 0, right: 300, width: 300, height: 22, x: 0, y: -10, toJSON: () => ({}) });
+
+    expect(
+      shouldShowStickyUserMessage(container, "msg-1", 0, { getVirtualItems: () => [] }, true),
     ).toBe(true);
   });
 

--- a/apps/web/src/components/chat/sticky-user-message-visibility.ts
+++ b/apps/web/src/components/chat/sticky-user-message-visibility.ts
@@ -4,14 +4,30 @@ export interface StickyVisibilityVirtualizer {
 }
 
 /**
+ * Message bottom must be at least this far above the viewport top before the sticky
+ * bar turns on (avoids toggling while the bubble is only partially clipped).
+ */
+export const STICKY_SHOW_ABOVE_VIEWPORT_PX = 8;
+
+/**
+ * Message bottom must be at least this far below the viewport top before the sticky
+ * bar turns off (avoids toggling when reserved top padding nudges the bubble back in).
+ */
+export const STICKY_HIDE_IN_VIEW_PX = 4;
+
+/**
  * Returns true when the last user message has scrolled fully above the list viewport
  * and the sticky preview should pin at the top.
+ *
+ * @param currentlySticky - When true, keeps the bar visible through partial clip until
+ *   the message is clearly back in the viewport (hysteresis).
  */
 export function shouldShowStickyUserMessage(
   container: HTMLElement,
   messageId: string,
   itemIndex: number,
   virtualizer: StickyVisibilityVirtualizer,
+  currentlySticky = false,
 ): boolean {
   const viewportHeight = container.clientHeight;
   const scrollTop = container.scrollTop;
@@ -22,10 +38,13 @@ export function shouldShowStickyUserMessage(
     const msgRect = domEl.getBoundingClientRect();
     const relativeTop = msgRect.top - containerRect.top;
     const relativeBottom = msgRect.bottom - containerRect.top;
-    if (relativeBottom > 0 && relativeTop < viewportHeight) {
+    if (relativeBottom > STICKY_HIDE_IN_VIEW_PX && relativeTop < viewportHeight) {
       return false;
     }
-    return relativeBottom <= 0;
+    if (currentlySticky) {
+      return relativeBottom <= STICKY_HIDE_IN_VIEW_PX;
+    }
+    return relativeBottom <= -STICKY_SHOW_ABOVE_VIEWPORT_PX;
   }
 
   const visible = virtualizer.getVirtualItems();
@@ -40,5 +59,8 @@ export function shouldShowStickyUserMessage(
   if (!match) return false;
 
   const messageBottom = match.start + match.size - scrollTop;
-  return messageBottom <= 0;
+  if (currentlySticky) {
+    return messageBottom <= STICKY_HIDE_IN_VIEW_PX;
+  }
+  return messageBottom <= -STICKY_SHOW_ABOVE_VIEWPORT_PX;
 }


### PR DESCRIPTION
## What
Fixed chat view flicker when scrolling up through a long assistant reply as the last user message clips at the top of the viewport.

## Why
The sticky user bar toggled on at `relativeBottom <= 0` and reserved ~56px top padding without moving `scrollTop`. That nudged the bubble back into view, hid the bar, dropped padding, and repeated.

## Key changes
- Hysteresis on sticky visibility (show when fully above viewport, hold through partial clip)
- Compensate `scrollTop` when effective top inset changes (16px vs sticky height)
- Unit tests for partial clip and hysteresis at the boundary

## Configuration changes
None.

## Related issues/PRs
Relates to #523 (sticky last user message bar)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783072839&installation_id=129163861&pr_number=548&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F548&signature=da170dcaf2cecd9439d697df784f3ae544a8fc0dd6d5535d3e42d3ccdc240b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced flicker and false toggles of the sticky user-message preview during scrolling, including correct scroll adjustment when the reserved top space changes or on thread switches.
* **Tests**
  * Added boundary and fallback tests covering show/hide thresholds and virtualizer scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->