### PR TITLE
fix(codex): suppress idle turn timeout from chat UI

### DIFF
--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -49,10 +49,11 @@ import type { TurnInputPart, CodexNotification, CodexTurnOptions, ReasoningEffor
  * active streams and tool output keep the turn alive; only a fully silent
  * stretch trips it. Set to 60s (matching Copilot's `COMPLETE_TIMEOUT_MS`) so a
  * stalled upstream turn — where `turn/completed` never arrives and the session
- * stays `isBusy`, exempt from idle eviction — surfaces a retryable error in
- * seconds instead of leaving the UI stuck "thinking" for half an hour. The
- * trade-off: a tool that runs silently (no output deltas) for longer than this
- * window will also trip it.
+ * stays `isBusy`, exempt from idle eviction — unblocks the UI in seconds instead
+ * of leaving it stuck "thinking" for half an hour. The trade-off: a tool that
+ * runs silently (no output deltas) for longer than this window will also trip
+ * it; that case is logged and suppressed from the chat UI (see
+ * {@link CodexTurnIdleTimeoutError}).
  */
 const TURN_TIMEOUT_MS = 60 * 1000;
 
@@ -61,6 +62,16 @@ class CodexTurnSupersededError extends Error {
   constructor() {
     super("Codex turn superseded");
     this.name = "CodexTurnSupersededError";
+  }
+}
+
+/** Internal: idle notification watchdog fired; ends the turn without a user error. */
+class CodexTurnIdleTimeoutError extends Error {
+  constructor() {
+    super(
+      `Codex turn timed out after ${TURN_TIMEOUT_MS / 1000}s with no app-server notifications`,
+    );
+    this.name = "CodexTurnIdleTimeoutError";
   }
 }
 
@@ -523,7 +534,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, Proto
           clearTimeout(activityTimer);
           activityTimer = setTimeout(() => {
             cleanup();
-            reject(new Error(`Codex turn timed out after ${TURN_TIMEOUT_MS / 1000}s with no app-server notifications`));
+            reject(new CodexTurnIdleTimeoutError());
           }, TURN_TIMEOUT_MS);
         };
 
@@ -576,6 +587,13 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, Proto
       });
     } catch (e: unknown) {
       if (e instanceof CodexTurnSupersededError) return;
+      if (e instanceof CodexTurnIdleTimeoutError) {
+        logger.debug("Codex turn idle timeout (suppressed from UI)", {
+          sessionId,
+          timeoutMs: TURN_TIMEOUT_MS,
+        });
+        return;
+      }
       if (!serverDied && seq === entry.runTurnSeq) {
         const errorMessage = e instanceof Error ? e.message : String(e);
         logger.error("Codex turn failed", { sessionId, error: errorMessage });


### PR DESCRIPTION
## What
Codex idle notification watchdog timeouts no longer emit a user-facing agent error.

## Why
The 60s idle timer often fires during long-running tools that produce no app-server notifications. That surfaced a misleading red error banner even when the turn was still healthy.

## Key changes
- Added internal `CodexTurnIdleTimeoutError` (same pattern as `CodexTurnSupersededError`)
- Idle timeout still clears the turn wait and emits `Ended` so the UI stops thinking
- Timeout details logged at debug only; no `AgentEventType.Error` to the client

## Configuration changes
None.

## Test plan
- [ ] Run a Codex turn with a tool silent for >60s; confirm no red agent_error banner
- [ ] Confirm the thread stops showing as running after the watchdog fires
- [ ] Confirm real Codex failures (CLI missing, app-server died) still show errors

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783073368&installation_id=129163861&pr_number=549&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F549&signature=51082c39fd24ce8985fbb5a4b684099f0cd3a1a8d732be66b3b1ca3ae83c83c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server timeout handling to better distinguish between idle periods and actual connection failures. The system now manages notification gaps more gracefully, reducing unnecessary error notifications during normal operation while maintaining proper diagnostic logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->