### PR TITLE
fix(cursor): recover from ACP connection closed mid-turn

### DIFF
--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-transient-retry.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-transient-retry.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
+  CURSOR_ACP_CONTINUE_AFTER_DISCONNECT_PROMPT,
+  buildCursorAcpContinueAfterDisconnectPrompt,
   isLikelyTransientCursorPromptFailure,
+  looksLikeAcpConnectionClosed,
   looksLikeUpstreamStreamCancel,
+  shouldSuppressCursorPromptError,
 } from "../cursor-acp-transient-retry.js";
 
 describe("isLikelyTransientCursorPromptFailure", () => {
@@ -22,6 +26,36 @@ describe("isLikelyTransientCursorPromptFailure", () => {
       ),
     ).toBe(true);
     expect(looksLikeUpstreamStreamCancel("[canceled] http/2 stream closed")).toBe(true);
+  });
+
+  it("treats ACP connection closed as transient for capped continue retry", () => {
+    expect(isLikelyTransientCursorPromptFailure("ACP connection closed")).toBe(true);
+    expect(looksLikeAcpConnectionClosed("ACP connection closed")).toBe(true);
+    expect(looksLikeAcpConnectionClosed("Error: ACP connection closed")).toBe(true);
+  });
+
+  it("suppresses ACP disconnect errors after explicit Stop", () => {
+    expect(
+      shouldSuppressCursorPromptError("ACP connection closed", {
+        pendingUserStopAbort: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuppressCursorPromptError("ACP connection closed", {
+        pendingUserStopAbort: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("exports a continue prompt for post-disconnect recovery", () => {
+    expect(CURSOR_ACP_CONTINUE_AFTER_DISCONNECT_PROMPT.length).toBeGreaterThan(10);
+  });
+
+  it("appends the interrupted user message to the continue retry prompt", () => {
+    const built = buildCursorAcpContinueAfterDisconnectPrompt("fix the login bug");
+    expect(built).toContain(CURSOR_ACP_CONTINUE_AFTER_DISCONNECT_PROMPT);
+    expect(built).toContain("Last message:");
+    expect(built).toContain("fix the login bug");
   });
 
   it("returns false for likely permanent client errors", () => {

--- a/apps/server/src/providers/cursor/cursor-acp-transient-retry.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-transient-retry.ts
@@ -2,6 +2,29 @@
  * Heuristics for detecting transient `session/prompt` failures worth a single retry.
  */
 
+/** Canonical `@agentclientprotocol/sdk` message when stdio to `cursor-agent acp` ends. */
+export const ACP_CONNECTION_CLOSED_MESSAGE = "ACP connection closed";
+
+/**
+ * User prompt sent once after respawning `cursor-agent` when an in-flight turn died
+ * from an unexpected ACP disconnect.
+ */
+export const CURSOR_ACP_CONTINUE_AFTER_DISCONNECT_PROMPT =
+  "Continue from where you left off. Resume the interrupted task without repeating work you already completed.";
+
+/**
+ * Builds the capped reconnect retry prompt: continue instruction plus the user's last message.
+ *
+ * @param originalMessage - The user text from the turn that was interrupted.
+ */
+export function buildCursorAcpContinueAfterDisconnectPrompt(originalMessage: string): string {
+  const trimmed = originalMessage.trim();
+  if (trimmed.length === 0) {
+    return CURSOR_ACP_CONTINUE_AFTER_DISCONNECT_PROMPT;
+  }
+  return `${CURSOR_ACP_CONTINUE_AFTER_DISCONNECT_PROMPT}\n\nLast message:\n${trimmed}`;
+}
+
 const TRANSIENT_RE = new RegExp(
   [
     "\\binternal\\s+server\\s+error\\b",
@@ -35,6 +58,29 @@ export function looksLikeUpstreamStreamCancel(message: string): boolean {
 }
 
 /**
+ * Returns true when the ACP SDK rejected a prompt because the subprocess stream closed.
+ *
+ * @param message - Serialized error (`Error.message` or stderr snippet).
+ */
+export function looksLikeAcpConnectionClosed(message: string): boolean {
+  return /\bacp connection closed\b/i.test(message);
+}
+
+/**
+ * Returns true when a prompt failure should not surface as a chat error (user Stop, etc.).
+ *
+ * @param message - Serialized error (`Error.message` or stderr snippet).
+ * @param flags - Turn-local intent flags from the provider.
+ */
+export function shouldSuppressCursorPromptError(
+  message: string,
+  flags: { pendingUserStopAbort: boolean },
+): boolean {
+  if (!flags.pendingUserStopAbort) return false;
+  return looksLikeUpstreamStreamCancel(message) || looksLikeAcpConnectionClosed(message);
+}
+
+/**
  * Returns whether a Cursor CLI `prompt` rejection likely indicates a retryable flake.
  *
  * Intentionally conservative: only obvious transport or generic HTTP outages qualify.
@@ -42,5 +88,9 @@ export function looksLikeUpstreamStreamCancel(message: string): boolean {
  * @param message - Serialized error (`Error.message` or stderr snippet).
  */
 export function isLikelyTransientCursorPromptFailure(message: string): boolean {
-  return TRANSIENT_RE.test(message) || looksLikeUpstreamStreamCancel(message);
+  return (
+    TRANSIENT_RE.test(message) ||
+    looksLikeUpstreamStreamCancel(message) ||
+    looksLikeAcpConnectionClosed(message)
+  );
 }

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -533,6 +533,9 @@ export class CursorProvider
     });
 
     child.on("exit", () => {
+      const pooled = this.runtime.get(mcodeSessionId);
+      // After ACP respawn, the same sessionId maps to a new child; ignore stale exits.
+      if (pooled?.child !== child) return;
       this.cancelPendingForThread(mcodeSessionId);
       // The child died unexpectedly; ask the runtime to drop the pooled entry
       // (runs interrupt → close → hard kill of the already-dead PID, all no-ops

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -77,8 +77,10 @@ import {
 import { resolveCursorStickyInstructionBlob } from "./cursor-acp-sticky-instructions.js";
 import { buildCursorAskQuestionExtResponse } from "./cursor-acp-ask-question.js";
 import {
-  looksLikeUpstreamStreamCancel,
+  buildCursorAcpContinueAfterDisconnectPrompt,
+  looksLikeAcpConnectionClosed,
   isLikelyTransientCursorPromptFailure,
+  shouldSuppressCursorPromptError,
 } from "./cursor-acp-transient-retry.js";
 import {
   shouldEmitCursorSessionTrace,
@@ -843,6 +845,51 @@ export class CursorProvider
     }
   }
 
+  /** Respawns `cursor-agent acp` after an unexpected disconnect and preserves turn pacing state. */
+  private async respawnCursorSessionAfterAcpClose(
+    dead: CursorAcpSessionEntry,
+  ): Promise<CursorAcpSessionEntry> {
+    const sessionId = dead.mcodeSessionId;
+    this.logAcpChildDisconnect(dead, "ACP connection closed");
+    await this.runtime.stop(sessionId);
+    const fresh = await this.runtime.acquire({
+      sessionId,
+      threadId: dead.threadId,
+      cwd: dead.cwd,
+      permissionMode: dead.permissionMode,
+      resumeFrom: this.sdkSessionIds.get(sessionId),
+    });
+    fresh.stickyHeavyInstructionsSent = dead.stickyHeavyInstructionsSent;
+    fresh.cursorPromptOrdinal = dead.cursorPromptOrdinal;
+    fresh.lastUsedAt = Date.now();
+    logger.info("Cursor ACP subprocess respawned after disconnect", {
+      threadId: fresh.threadId,
+      acpSessionId: this.sdkSessionIds.get(sessionId),
+      childPid: fresh.child.pid,
+    });
+    return fresh;
+  }
+
+  /** Logs child exit metadata when the ACP stdio stream closes mid-turn. */
+  private logAcpChildDisconnect(entry: CursorAcpSessionEntry, error: string): void {
+    const cursorCfg = this.settingsService.get().provider.cursor;
+    const stderrTail =
+      cursorCfg.verboseFailureLogs && entry.stderrTailLines.length > 0
+        ? entry.stderrTailLines.slice(-16)
+        : undefined;
+    logger.warn("Cursor ACP connection closed mid-turn", {
+      threadId: entry.threadId,
+      acpSessionId: entry.acpSessionId,
+      promptOrdinal: entry.cursorPromptOrdinal,
+      childPid: entry.child.pid,
+      childExitCode: entry.child.exitCode,
+      childSignalCode: entry.child.signalCode,
+      verboseFailureLogs: cursorCfg.verboseFailureLogs,
+      stderrTail,
+      error,
+    });
+  }
+
   private async runTurn(
     entry: CursorAcpSessionEntry,
     opts: {
@@ -854,58 +901,79 @@ export class CursorProvider
   ): Promise<void> {
     const { message, model, resume, attachments } = opts;
     const cursorCfg = this.settingsService.get().provider.cursor;
+    let currentEntry = entry;
+    let promptMessage = message;
+    let promptAttachments = attachments;
+    const originalUserMessage = message;
+    const originalAttachments = attachments;
+    let isContinueRetry = false;
+    let instructionMarkdown: string | undefined;
+    let instructionMarkdownReady = false;
     try {
-      await this.openLogicalSession(entry, resume);
-      await this.applyModel(entry, model);
-
-      entry.stderrTailLines.length = 0;
-
-      entry.cursorPromptOrdinal += 1;
+      currentEntry.cursorPromptOrdinal += 1;
       if (
         !cursorCfg.alwaysSendFullInstructions &&
         cursorCfg.fullPreambleEveryNTurns > 0 &&
-        entry.cursorPromptOrdinal % cursorCfg.fullPreambleEveryNTurns === 0
+        currentEntry.cursorPromptOrdinal % cursorCfg.fullPreambleEveryNTurns === 0
       ) {
-        entry.stickyHeavyInstructionsSent = false;
+        currentEntry.stickyHeavyInstructionsSent = false;
       }
-
-      const guidance = buildCursorAgentGuidanceMarkdown(entry.cwd);
-      const skillsBlock = formatCursorSkillsAndCommandsForPrompt(
-        this.skillService.list(entry.cwd, "cursor"),
-      );
-      const instructionParts = [guidance, skillsBlock].filter(
-        (s): s is string => typeof s === "string" && s.length > 0,
-      );
-      const combined =
-        instructionParts.length > 0 ? instructionParts.join("\n\n---\n\n") : undefined;
-
-      let instructionMarkdown: string | undefined;
-
-      if (cursorCfg.alwaysSendFullInstructions) {
-        instructionMarkdown = combined ?? readCursorUserInstructions();
-      } else {
-        const { instructionMarkdown: blob, markHeavyCommitted } = resolveCursorStickyInstructionBlob({
-          combinedGuidanceAndSkillsMarkdown: combined,
-          readFallbackAgents: readCursorUserInstructions,
-          stickyHeavyCommitted: entry.stickyHeavyInstructionsSent,
-        });
-        instructionMarkdown = blob;
-        if (markHeavyCommitted) {
-          entry.stickyHeavyInstructionsSent = true;
-        }
-      }
-
-      const blocks = buildCursorAcpPromptBlocks(message, attachments, instructionMarkdown);
 
       const maxAttempts = cursorCfg.retryTransientFailuresOnce ? 2 : 1;
       let promptResponse: Awaited<ReturnType<ClientSideConnection["prompt"]>>;
       let attempt = 0;
       for (;;) {
+        await this.openLogicalSession(currentEntry, resume);
+        await this.applyModel(currentEntry, model);
+        currentEntry.stderrTailLines.length = 0;
+
+        let blocks;
+        if (isContinueRetry) {
+          blocks = buildCursorAcpPromptBlocks(
+            promptMessage,
+            promptAttachments,
+            undefined,
+          );
+        } else {
+          if (!instructionMarkdownReady) {
+            const guidance = buildCursorAgentGuidanceMarkdown(currentEntry.cwd);
+            const skillsBlock = formatCursorSkillsAndCommandsForPrompt(
+              this.skillService.list(currentEntry.cwd, "cursor"),
+            );
+            const instructionParts = [guidance, skillsBlock].filter(
+              (s): s is string => typeof s === "string" && s.length > 0,
+            );
+            const combined =
+              instructionParts.length > 0 ? instructionParts.join("\n\n---\n\n") : undefined;
+
+            if (cursorCfg.alwaysSendFullInstructions) {
+              instructionMarkdown = combined ?? readCursorUserInstructions();
+            } else {
+              const { instructionMarkdown: blob, markHeavyCommitted } =
+                resolveCursorStickyInstructionBlob({
+                  combinedGuidanceAndSkillsMarkdown: combined,
+                  readFallbackAgents: readCursorUserInstructions,
+                  stickyHeavyCommitted: currentEntry.stickyHeavyInstructionsSent,
+                });
+              instructionMarkdown = blob;
+              if (markHeavyCommitted) {
+                currentEntry.stickyHeavyInstructionsSent = true;
+              }
+            }
+            instructionMarkdownReady = true;
+          }
+          blocks = buildCursorAcpPromptBlocks(
+            promptMessage,
+            promptAttachments,
+            instructionMarkdown,
+          );
+        }
+
         try {
           attempt += 1;
-          entry.activeTurnState = createCursorAcpTurnState();
-          promptResponse = await entry.connection.prompt({
-            sessionId: entry.acpSessionId,
+          currentEntry.activeTurnState = createCursorAcpTurnState();
+          promptResponse = await currentEntry.connection.prompt({
+            sessionId: currentEntry.acpSessionId,
             prompt: blocks,
           });
           break;
@@ -913,7 +981,7 @@ export class CursorProvider
           const raw = attemptErr instanceof Error ? attemptErr.message : String(attemptErr);
           // Do not retry after explicit Stop; cancel-like errors are expected and a
           // second prompt would fight the user's abort.
-          if (entry.pendingUserStopAbort) {
+          if (currentEntry.pendingUserStopAbort) {
             throw attemptErr;
           }
           if (
@@ -923,19 +991,26 @@ export class CursorProvider
           ) {
             throw attemptErr;
           }
+          if (looksLikeAcpConnectionClosed(raw)) {
+            currentEntry = await this.respawnCursorSessionAfterAcpClose(currentEntry);
+            promptMessage = buildCursorAcpContinueAfterDisconnectPrompt(originalUserMessage);
+            promptAttachments = originalAttachments;
+            isContinueRetry = true;
+            continue;
+          }
           logger.warn("Cursor ACP prompt retry after transient CLI failure", {
-            threadId: entry.threadId,
+            threadId: currentEntry.threadId,
             attempt,
             error: raw,
           });
         }
       }
 
-      const text = resolveCursorAssistantMessageContent(entry.activeTurnState.accumulator);
+      const text = resolveCursorAssistantMessageContent(currentEntry.activeTurnState.accumulator);
       if (text.length > 0) {
         this.emit("event", {
           type: AgentEventType.Message,
-          threadId: entry.threadId,
+          threadId: currentEntry.threadId,
           content: text,
           tokens: null,
         } satisfies AgentEvent);
@@ -944,7 +1019,7 @@ export class CursorProvider
       const usage = promptResponse.usage;
       this.emit("event", {
         type: AgentEventType.TurnComplete,
-        threadId: entry.threadId,
+        threadId: currentEntry.threadId,
         reason: promptResponse.stopReason,
         costUsd: null,
         tokensIn: usage?.inputTokens ?? 0,
@@ -952,52 +1027,56 @@ export class CursorProvider
         providerId: "cursor",
       } satisfies AgentEvent);
 
-      this.emit("event", { type: AgentEventType.Ended, threadId: entry.threadId } satisfies AgentEvent);
+      this.emit("event", { type: AgentEventType.Ended, threadId: currentEntry.threadId } satisfies AgentEvent);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      const userStoppedStream =
-        entry.pendingUserStopAbort && looksLikeUpstreamStreamCancel(errMsg);
+      const userStoppedStream = shouldSuppressCursorPromptError(errMsg, {
+        pendingUserStopAbort: currentEntry.pendingUserStopAbort,
+      });
       const stderrTail =
-        cursorCfg.verboseFailureLogs && entry.stderrTailLines.length > 0
-          ? entry.stderrTailLines.slice(-16)
+        cursorCfg.verboseFailureLogs && currentEntry.stderrTailLines.length > 0
+          ? currentEntry.stderrTailLines.slice(-16)
           : undefined;
       if (!userStoppedStream) {
         logger.error("Cursor ACP prompt failed", {
-          threadId: entry.threadId,
-          stickyHeavyCommitted: entry.stickyHeavyInstructionsSent,
-          promptOrdinal: entry.cursorPromptOrdinal,
-          acpSessionId: entry.acpSessionId,
+          threadId: currentEntry.threadId,
+          stickyHeavyCommitted: currentEntry.stickyHeavyInstructionsSent,
+          promptOrdinal: currentEntry.cursorPromptOrdinal,
+          acpSessionId: currentEntry.acpSessionId,
           verboseFailureLogs: cursorCfg.verboseFailureLogs,
+          childPid: currentEntry.child.pid,
+          childExitCode: currentEntry.child.exitCode,
+          childSignalCode: currentEntry.child.signalCode,
           stderrTail,
           error: errMsg,
         });
         this.emit("event", {
           type: AgentEventType.Error,
-          threadId: entry.threadId,
+          threadId: currentEntry.threadId,
           error: errMsg,
         } satisfies AgentEvent);
       } else {
-        logger.info("Cursor prompt ended after Stop (stream cancel)", {
-          threadId: entry.threadId,
+        logger.info("Cursor prompt ended after Stop (expected disconnect)", {
+          threadId: currentEntry.threadId,
           errorSample: errMsg.slice(0, 200),
         });
         const interrupted =
-          entry.activeTurnState?.accumulator !== undefined
-            ? resolveCursorAssistantMessageContent(entry.activeTurnState.accumulator).trim()
+          currentEntry.activeTurnState?.accumulator !== undefined
+            ? resolveCursorAssistantMessageContent(currentEntry.activeTurnState.accumulator).trim()
             : "";
         if (interrupted.length > 0) {
           this.emit("event", {
             type: AgentEventType.Message,
-            threadId: entry.threadId,
+            threadId: currentEntry.threadId,
             content: interrupted,
             tokens: null,
           } satisfies AgentEvent);
         }
       }
-      this.emit("event", { type: AgentEventType.Ended, threadId: entry.threadId } satisfies AgentEvent);
+      this.emit("event", { type: AgentEventType.Ended, threadId: currentEntry.threadId } satisfies AgentEvent);
     } finally {
-      entry.activeTurnState = null;
-      entry.pendingUserStopAbort = false;
+      currentEntry.activeTurnState = null;
+      currentEntry.pendingUserStopAbort = false;
     }
   }
 


### PR DESCRIPTION
## What
Handle Cursor ACP disconnects during in-flight turns without surfacing a raw "ACP connection closed" error when recovery is possible.

## Why
Production logs showed cursor-agent subprocesses dying mid-prompt, leaving turns stuck with no thinking output and a confusing chat error toast.

## Key changes
- Suppress chat errors for ACP disconnect after explicit Stop (same as HTTP/2 stream cancel)
- On unexpected disconnect: respawn cursor-agent, retry once with a continue prompt plus the original user message and attachments
- Log child exit code, signal, PID, and stderr tail on disconnect for diagnosis
- Unit tests for ACP-closed heuristics and continue prompt builder

## Configuration changes
None. Reuses existing `provider.cursor.retryTransientFailuresOnce` (default true, max 2 attempts).

## Related issues/PRs
Relates to branch `fix/acp-closed-cursor` (production log diagnosis in Mcode desktop).

## Test plan
- [x] `apps/server` unit tests: cursor-acp-transient-retry (7 passed)
- [x] `apps/server` typecheck
- [ ] Manual: trigger Cursor turn, simulate subprocess kill, confirm silent continue retry and no error toast on success
- [ ] Manual: click Stop during Cursor turn, confirm no "ACP connection closed" toast

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783090990&installation_id=129163861&pr_number=550&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F550&signature=af695db651b42dc55e86f42bf16a57b5b1bddcc71a0f056dfb08ce40b4c18062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic recovery from unexpected assistant subprocess disconnects with respawn-and-continue so conversations can resume after transient failures.

* **Bug Fixes**
  * Better detection/classification of connection-closed failures as transient and improved error suppression during user stop/abort scenarios.
  * More robust handling of stale process exit events to prevent incorrect teardowns.

* **Tests**
  * Added tests covering connection-closed handling, suppression behavior, and continue-after-disconnect prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->