### PR TITLE
fix(web): open ctrl+click links in preview without replacing active tab

### DIFF
--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -98,22 +98,56 @@ describe("MarkdownContent link handling", () => {
 
 describe("MarkdownContent workspace preview navigation", () => {
   let mockNavigate: ReturnType<typeof vi.fn>;
+  let mockCreate: ReturnType<typeof vi.fn>;
+  let showRightPanel: ReturnType<typeof vi.fn>;
+  let setRightPanelTab: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     mockNavigate = vi.fn().mockResolvedValue({ ok: true });
+    mockCreate = vi.fn().mockResolvedValue({ ok: true, data: { tabId: "tab-2", tabs: {} } });
+    showRightPanel = vi.fn();
+    setRightPanelTab = vi.fn();
     const ws = createMockWorkspace({ id: "ws-prev", path: "/tmp/ws-preview-test" });
     useWorkspaceStore.setState({
       workspaces: [ws],
       activeWorkspaceId: ws.id,
       activeThreadId: "thread-prev",
     });
+    useDiffStore.setState({
+      showRightPanel,
+      setRightPanelTab,
+      setPreviewUrlForThread: vi.fn(),
+    } as Partial<ReturnType<typeof useDiffStore.getState>>);
     window.desktopBridge = {
       openExternalUrl: vi.fn(),
-      preview: { navigate: mockNavigate },
+      preview: {
+        navigate: mockNavigate,
+        tabs: {
+          create: mockCreate,
+          list: vi.fn().mockResolvedValue({
+            ok: true,
+            data: {
+              threadId: "thread-prev",
+              activeTabId: "tab-1",
+              tabs: [{
+                id: "tab-1",
+                threadId: "thread-prev",
+                title: "Example",
+                url: "https://example.com",
+                faviconUrl: null,
+                warm: true,
+                active: true,
+              }],
+            },
+          }),
+        },
+      },
     } as unknown as typeof window.desktopBridge;
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     delete (window as unknown as Record<string, unknown>).desktopBridge;
     useWorkspaceStore.setState({
       workspaces: [],
@@ -123,20 +157,21 @@ describe("MarkdownContent workspace preview navigation", () => {
     useDiffStore.setState({ previewUrlByThread: {} });
   });
 
-  it("passes workspace path when opening mcode-workspace link with ctrl+click", async () => {
+  it("creates a new preview tab and navigates on ctrl+click", async () => {
     const { container } = render(<MarkdownContent content="[doc](mcode-workspace:///sub/page.html)" />);
     const link = container.querySelector("a");
     expect(link).toBeTruthy();
-    expect(link).toHaveAttribute("href", "mcode-workspace:///sub/page.html");
     await act(async () => {
       fireEvent.click(link!, { ctrlKey: true });
+      await vi.runAllTimersAsync();
     });
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        "mcode-workspace:///sub/page.html",
-        "/tmp/ws-preview-test",
-      );
-    });
+    expect(showRightPanel).toHaveBeenCalledWith("thread-prev");
+    expect(setRightPanelTab).toHaveBeenCalledWith("thread-prev", "preview");
+    expect(mockCreate).toHaveBeenCalledWith("thread-prev", true);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "mcode-workspace:///sub/page.html",
+      "/tmp/ws-preview-test",
+    );
   });
 
   it("rewrites relative html link to mcode-workspace for navigation", async () => {
@@ -145,13 +180,13 @@ describe("MarkdownContent workspace preview navigation", () => {
     expect(link).toBeTruthy();
     await act(async () => {
       fireEvent.click(link!, { ctrlKey: true });
+      await vi.runAllTimersAsync();
     });
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        "mcode-workspace:///sub/page.html",
-        "/tmp/ws-preview-test",
-      );
-    });
+    expect(mockCreate).toHaveBeenCalledWith("thread-prev", true);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "mcode-workspace:///sub/page.html",
+      "/tmp/ws-preview-test",
+    );
   });
 
   it("opens mcode-workspace in the default browser on plain click", async () => {
@@ -189,26 +224,45 @@ describe("MarkdownContent workspace preview navigation", () => {
     expect(el).toBeTruthy();
     await act(async () => {
       fireEvent.click(el!, { ctrlKey: true });
+      await vi.runAllTimersAsync();
     });
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        "mcode-workspace:///report.html",
-        "/tmp/ws-preview-test",
-      );
-    });
+    expect(mockCreate).toHaveBeenCalledWith("thread-prev", true);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "mcode-workspace:///report.html",
+      "/tmp/ws-preview-test",
+    );
   });
 
   it("stores URL for preview sync when preview.navigate is missing on ctrl+click", async () => {
-    const mockOpenExternal = vi.fn();
-    const ws = createMockWorkspace({ id: "ws-fallback", path: "/tmp/ws-fallback" });
-    useWorkspaceStore.setState({
-      workspaces: [ws],
-      activeWorkspaceId: ws.id,
-      activeThreadId: "thread-fallback",
-    });
+    const setPreviewUrlForThread = vi.fn();
+    useDiffStore.setState({
+      showRightPanel,
+      setRightPanelTab,
+      setPreviewUrlForThread,
+    } as Partial<ReturnType<typeof useDiffStore.getState>>);
     window.desktopBridge = {
-      openExternalUrl: mockOpenExternal,
-      preview: {},
+      openExternalUrl: vi.fn(),
+      preview: {
+        tabs: {
+          create: mockCreate,
+          list: vi.fn().mockResolvedValue({
+            ok: true,
+            data: {
+              threadId: "thread-prev",
+              activeTabId: "tab-1",
+              tabs: [{
+                id: "tab-1",
+                threadId: "thread-prev",
+                title: null,
+                url: null,
+                faviconUrl: null,
+                warm: true,
+                active: true,
+              }],
+            },
+          }),
+        },
+      },
     } as unknown as typeof window.desktopBridge;
 
     const { container } = render(<MarkdownContent content="[doc](mcode-workspace:///page.html)" />);
@@ -216,42 +270,32 @@ describe("MarkdownContent workspace preview navigation", () => {
     expect(link).toBeTruthy();
     await act(async () => {
       fireEvent.click(link!, { ctrlKey: true });
+      await vi.runAllTimersAsync();
     });
-    // URL stored for the sync mechanism; no external fallback
-    expect(useDiffStore.getState().previewUrlByThread["thread-fallback"])
-      .toBe("mcode-workspace:///page.html");
-    expect(mockOpenExternal).not.toHaveBeenCalled();
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(setPreviewUrlForThread).toHaveBeenCalledWith(
+      "thread-prev",
+      "mcode-workspace:///page.html",
+    );
   });
 
-  it("silently catches navigate rejection on ctrl+click without external fallback", async () => {
-    const mockOpenExternal = vi.fn();
-    const nav = vi.fn().mockRejectedValue(new Error("nav failed"));
-    const ws = createMockWorkspace({ id: "ws-rej", path: "/tmp/ws-rej" });
-    useWorkspaceStore.setState({
-      workspaces: [ws],
-      activeWorkspaceId: ws.id,
-      activeThreadId: "thread-rej",
-    });
-    window.desktopBridge = {
-      openExternalUrl: mockOpenExternal,
-      preview: { navigate: nav },
-    } as unknown as typeof window.desktopBridge;
+  it("stores URL when navigate rejects on ctrl+click", async () => {
+    const setPreviewUrlForThread = vi.fn();
+    useDiffStore.setState({
+      showRightPanel,
+      setRightPanelTab,
+      setPreviewUrlForThread,
+    } as Partial<ReturnType<typeof useDiffStore.getState>>);
+    mockNavigate.mockRejectedValue(new Error("nav failed"));
 
     const { container } = render(<MarkdownContent content="[doc](https://example.com/x)" />);
     const link = container.querySelector("a");
     expect(link).toBeTruthy();
     await act(async () => {
       fireEvent.click(link!, { ctrlKey: true });
+      await vi.runAllTimersAsync();
     });
-    // URL stored for the sync mechanism
-    expect(useDiffStore.getState().previewUrlByThread["thread-rej"])
-      .toBe("https://example.com/x");
-    // Navigate was attempted but rejection is silently caught; no external fallback
-    await waitFor(() => {
-      expect(nav).toHaveBeenCalled();
-    });
-    expect(mockOpenExternal).not.toHaveBeenCalled();
+    expect(setPreviewUrlForThread).toHaveBeenCalledWith("thread-prev", "https://example.com/x");
+    expect(mockNavigate).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -7,6 +7,7 @@ import { getTransport } from "@/transport";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { getCiVisual, getBreakdown, getLeadRunningName, CI_ICON_STROKE } from "@/lib/ci-status";
 import type { ChecksStatus, CheckRun } from "@mcode/contracts";
+import { openGitHubUrl } from "@/lib/open-url-in-preview";
 
 /** Props for {@link ChecksPopover}. */
 interface ChecksPopoverProps {
@@ -185,29 +186,21 @@ export function ChecksPopover({
     }
   }, [threadId]);
 
-  const handleOpenGitHub = useCallback(() => {
-    try {
-      const parsed = new URL(prUrl);
-      if (parsed.protocol === "https:" && parsed.hostname === "github.com") {
-        window.desktopBridge?.openExternalUrl(prUrl);
-      }
-    } catch {
-      // Invalid URL - do nothing
-    }
-  }, [prUrl]);
+  const handleOpenGitHub = useCallback(
+    (event: React.MouseEvent) => {
+      openGitHubUrl(prUrl, threadId, event);
+    },
+    [prUrl, threadId],
+  );
 
   // Deep-link into GitHub's PR checks tab so devs can jump straight to the run logs
   // from the failing-lane header. Uses the same protocol/host guard as handleOpenGitHub.
-  const handleOpenChecksTab = useCallback(() => {
-    try {
-      const parsed = new URL(prUrl);
-      if (parsed.protocol === "https:" && parsed.hostname === "github.com") {
-        window.desktopBridge?.openExternalUrl(`${prUrl}/checks`);
-      }
-    } catch {
-      // Invalid URL - do nothing
-    }
-  }, [prUrl]);
+  const handleOpenChecksTab = useCallback(
+    (event: React.MouseEvent) => {
+      openGitHubUrl(`${prUrl}/checks`, threadId, event);
+    },
+    [prUrl, threadId],
+  );
 
   // Group runs by lane, ordered by priority.
   const laned = useMemo(() => {

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -11,6 +11,7 @@ import { executeCommand } from "@/lib/command-registry";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Thread } from "@/transport";
+import { openGitHubUrl } from "@/lib/open-url-in-preview";
 
 /** Props for {@link HeaderActions}. */
 interface HeaderActionsProps {
@@ -137,16 +138,12 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
     }
   }, [thread?.id]);
 
-  const handleOpenPr = useCallback((url: string) => {
-    try {
-      const parsed = new URL(url);
-      if (parsed.protocol === "https:" && parsed.hostname === "github.com") {
-        window.desktopBridge?.openExternalUrl(url);
-      }
-    } catch {
-      // Invalid URL, ignore
-    }
-  }, []);
+  const handleOpenPr = useCallback(
+    (url: string, event?: React.MouseEvent) => {
+      openGitHubUrl(url, thread.id, event);
+    },
+    [thread.id],
+  );
 
   return (
     <div className="flex items-center justify-between gap-0.5">

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -10,8 +10,12 @@ import {
 import { CodeBlock } from "./CodeBlock";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { resolveCodeBlockLanguage } from "@/lib/resolve-code-block-language";
-import { useDiffStore } from "@/stores/diffStore";
 import { isMac } from "@/lib/platform";
+import {
+  isModifierClick,
+  isPreviewableUrl,
+  openUrlInPreview,
+} from "@/lib/open-url-in-preview";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 /** Pass through workspace preview URLs; otherwise use react-markdown's default sanitizer. */
@@ -54,45 +58,26 @@ function hasPreview(): boolean {
   return !!window.desktopBridge?.preview;
 }
 
-/**
- * Looks up the on-disk path for the active workspace so the desktop preview
- * can resolve relative files and `mcode-workspace:` URLs.
- */
-function getWorkspacePathForPreview(): string | null {
+/** Active workspace path for resolving preview URLs. */
+function getActiveWorkspacePath(): string | null {
   const { activeWorkspaceId, workspaces } = useWorkspaceStore.getState();
   if (!activeWorkspaceId) return null;
   return workspaces.find((w) => w.id === activeWorkspaceId)?.path ?? null;
 }
 
 /**
- * Handles a click on a previewable URL. Ctrl/Cmd+click opens in the embedded
- * preview when available; a normal click opens in the system default browser.
+ * Handles a click on a previewable URL. Ctrl/Cmd+click opens in a new embedded
+ * preview tab when available; a normal click opens in the system default browser.
  */
 function handleLinkClick(e: React.MouseEvent | React.KeyboardEvent, url: string): void {
   e.preventDefault();
 
-  const workspacePath = getWorkspacePathForPreview();
-  const isModifierClick = e.ctrlKey || e.metaKey;
-  if (isModifierClick && hasPreview()) {
+  const workspacePath = getActiveWorkspacePath();
+
+  if (isModifierClick(e) && hasPreview()) {
     const threadId = useWorkspaceStore.getState().activeThreadId;
     if (threadId) {
-      const { showRightPanel, setRightPanelTab, setPreviewUrlForThread } =
-        useDiffStore.getState();
-      // Store the URL before opening the panel so that:
-      // 1. usePreviewBridge populates the omnibox immediately via storedUrl
-      // 2. pushSync sends it as resumeUrlHint, letting the main process load
-      //    the page once BrowserView bounds are established
-      setPreviewUrlForThread(threadId, url);
-      showRightPanel(threadId);
-      setRightPanelTab(threadId, "preview");
-      // Fire-and-forget navigate for the already-open-panel case (bounds
-      // already synced). For a freshly mounted panel the sync handler's
-      // resumeUrlHint path handles navigation after bounds arrive.
-      setTimeout(() => {
-        void window.desktopBridge?.preview
-          ?.navigate?.(url, workspacePath ?? undefined)
-          ?.catch(() => {});
-      }, 0);
+      openUrlInPreview({ url, threadId, workspacePath });
       return;
     }
   }
@@ -145,11 +130,7 @@ function makeStaticComponents(variant: "assistant" | "user", workspacePath: stri
       const linkClass = isUser
         ? "text-primary-foreground underline hover:opacity-80"
         : "text-primary underline hover:text-primary";
-      const isPreviewable =
-        !!safeHref &&
-        (safeHref.startsWith("http:") ||
-          safeHref.startsWith("https:") ||
-          isMcodeWorkspacePreviewUrl(safeHref));
+      const isPreviewable = !!safeHref && isPreviewableUrl(safeHref);
       const showHint = isPreviewable && hasPreview();
       const anchor = (
         <a

--- a/apps/web/src/components/chat/PrSplitButton.test.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.test.tsx
@@ -58,7 +58,10 @@ describe("PrSplitButton", () => {
     const onOpenPr = vi.fn();
     render(<PrSplitButton pr={openPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={onOpenPr} />);
     fireEvent.click(screen.getByText("PR #42"));
-    expect(onOpenPr).toHaveBeenCalledWith("https://github.com/o/r/pull/42");
+    expect(onOpenPr).toHaveBeenCalledWith(
+      "https://github.com/o/r/pull/42",
+      expect.objectContaining({ type: "click" }),
+    );
   });
 
   // ── PR merged ──────────────────────────────────────────────────────────────
@@ -103,7 +106,10 @@ describe("PrSplitButton", () => {
     render(<PrSplitButton pr={mergedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={onOpenPr} />);
     fireEvent.click(screen.getByRole("button", { name: /open pr menu/i }));
     fireEvent.click(screen.getByText(/view on github/i));
-    expect(onOpenPr).toHaveBeenCalledWith("https://github.com/o/r/pull/42");
+    expect(onOpenPr).toHaveBeenCalledWith(
+      "https://github.com/o/r/pull/42",
+      expect.objectContaining({ type: "click" }),
+    );
   });
 
   // ── PR closed ──────────────────────────────────────────────────────────────

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/ci-status";
 import { registerCommand } from "@/lib/command-registry";
 import type { ChecksStatus } from "@mcode/contracts";
+import { isModifierClick } from "@/lib/open-url-in-preview";
 
 /** Props for {@link PrSplitButton}. */
 interface PrSplitButtonProps {
@@ -28,8 +29,8 @@ interface PrSplitButtonProps {
   hasCommitsAhead: boolean | null;
   /** Called when the user wants to open CreatePrDialog. */
   onCreatePr: () => void;
-  /** Called with the PR URL when the user wants to open it in the browser. */
-  onOpenPr: (url: string) => void;
+  /** Called with the PR URL when the user wants to open it in the browser or preview. */
+  onOpenPr: (url: string, event?: React.MouseEvent) => void;
   /** CI check status for this thread, if available. */
   checks?: ChecksStatus | null;
   /** Thread ID for manual refresh via ChecksPopover. */
@@ -190,6 +191,18 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
             ? "Pull request closed"
             : "Pull request open";
 
+  const handlePrimaryClick = (event: React.MouseEvent) => {
+    if (isModifierClick(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+      onOpenPr(pr.url, event);
+      return;
+    }
+    if (!usePopover) {
+      onOpenPr(pr.url, event);
+    }
+  };
+
   const primaryButton = (
     <button
       type="button"
@@ -201,7 +214,7 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
         !showChevron && "rounded-r",
       )}
       title={titleAttr}
-      onClick={usePopover ? undefined : () => onOpenPr(pr.url)}
+      onClick={handlePrimaryClick}
     >
       <Github size={12} className="opacity-70 shrink-0" />
       <span className="text-foreground/85">{label}</span>
@@ -278,7 +291,7 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" sideOffset={4} className="min-w-[170px] text-xs">
               <DropdownMenuItem
-                onClick={() => onOpenPr(pr.url)}
+                onClick={(e) => onOpenPr(pr.url, e)}
                 className="text-foreground/75 gap-2"
               >
                 <Github size={11} className="opacity-75" />

--- a/apps/web/src/lib/__tests__/open-url-in-preview.test.ts
+++ b/apps/web/src/lib/__tests__/open-url-in-preview.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  isModifierClick,
+  isPreviewableUrl,
+  isEmptyPreviewTabUrl,
+  openUrlInPreview,
+  openGitHubUrl,
+} from "../open-url-in-preview";
+import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { createMockWorkspace } from "@/__tests__/mocks/transport";
+
+describe("isModifierClick", () => {
+  it("returns true for ctrl+click", () => {
+    expect(isModifierClick({ ctrlKey: true, metaKey: false })).toBe(true);
+  });
+
+  it("returns true for cmd+click", () => {
+    expect(isModifierClick({ ctrlKey: false, metaKey: true })).toBe(true);
+  });
+
+  it("returns false for plain click", () => {
+    expect(isModifierClick({ ctrlKey: false, metaKey: false })).toBe(false);
+  });
+});
+
+describe("isPreviewableUrl", () => {
+  it("accepts https URLs", () => {
+    expect(isPreviewableUrl("https://example.com")).toBe(true);
+  });
+
+  it("accepts mcode-workspace URLs", () => {
+    expect(isPreviewableUrl("mcode-workspace:///page.html")).toBe(true);
+  });
+
+  it("rejects mailto URLs", () => {
+    expect(isPreviewableUrl("mailto:test@example.com")).toBe(false);
+  });
+});
+
+describe("isEmptyPreviewTabUrl", () => {
+  it("treats null, blank, and about: URLs as empty", () => {
+    expect(isEmptyPreviewTabUrl(null)).toBe(true);
+    expect(isEmptyPreviewTabUrl("")).toBe(true);
+    expect(isEmptyPreviewTabUrl("about:blank")).toBe(true);
+  });
+
+  it("treats loaded http(s) URLs as non-empty", () => {
+    expect(isEmptyPreviewTabUrl("https://example.com")).toBe(false);
+  });
+});
+
+function mockTabList(activeUrl: string | null) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    data: {
+      threadId: "thread-1",
+      activeTabId: "tab-1",
+      tabs: [
+        {
+          id: "tab-1",
+          threadId: "thread-1",
+          title: activeUrl ? "Loaded" : null,
+          url: activeUrl,
+          faviconUrl: null,
+          warm: true,
+          active: true,
+        },
+      ],
+    },
+  });
+}
+
+describe("openUrlInPreview", () => {
+  let mockCreate: ReturnType<typeof vi.fn>;
+  let mockNavigate: ReturnType<typeof vi.fn>;
+  let showRightPanel: ReturnType<typeof vi.fn>;
+  let setRightPanelTab: ReturnType<typeof vi.fn>;
+  let setPreviewUrlForThread: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockCreate = vi.fn().mockResolvedValue({ ok: true, data: { tabId: "tab-2", tabs: {} } });
+    mockNavigate = vi.fn().mockResolvedValue({ ok: true });
+    showRightPanel = vi.fn();
+    setRightPanelTab = vi.fn();
+    setPreviewUrlForThread = vi.fn();
+
+    useDiffStore.setState({
+      showRightPanel,
+      setRightPanelTab,
+      setPreviewUrlForThread,
+    } as Partial<ReturnType<typeof useDiffStore.getState>>);
+
+    const ws = createMockWorkspace({ id: "ws-1", path: "/tmp/workspace" });
+    useWorkspaceStore.setState({
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      activeThreadId: "thread-1",
+    });
+
+    window.desktopBridge = {
+      preview: {
+        tabs: { create: mockCreate, list: mockTabList("https://example.com") },
+        navigate: mockNavigate,
+      },
+    } as unknown as typeof window.desktopBridge;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
+    useWorkspaceStore.setState({
+      workspaces: [],
+      activeWorkspaceId: null,
+      activeThreadId: null,
+    });
+  });
+
+  it("creates a new tab then navigates when the active tab already has a page", async () => {
+    openUrlInPreview({ url: "https://example.com/pr/1", threadId: "thread-1" });
+    await vi.runAllTimersAsync();
+
+    expect(showRightPanel).toHaveBeenCalledWith("thread-1");
+    expect(setRightPanelTab).toHaveBeenCalledWith("thread-1", "preview");
+    expect(mockCreate).toHaveBeenCalledWith("thread-1", true);
+    expect(mockNavigate).toHaveBeenCalledWith("https://example.com/pr/1", "/tmp/workspace");
+    expect(setPreviewUrlForThread).not.toHaveBeenCalled();
+  });
+
+  it("reuses an empty active tab instead of creating another", async () => {
+    window.desktopBridge = {
+      preview: {
+        tabs: { create: mockCreate, list: mockTabList(null) },
+        navigate: mockNavigate,
+      },
+    } as unknown as typeof window.desktopBridge;
+
+    openUrlInPreview({ url: "https://example.com/pr/1", threadId: "thread-1" });
+    await vi.runAllTimersAsync();
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(setPreviewUrlForThread).toHaveBeenCalledWith("thread-1", "https://example.com/pr/1");
+    expect(mockNavigate).toHaveBeenCalledWith("https://example.com/pr/1", "/tmp/workspace");
+  });
+
+  it("navigates active tab without creating when newTab is false", async () => {
+    openUrlInPreview({
+      url: "https://example.com",
+      threadId: "thread-1",
+      newTab: false,
+    });
+    await vi.runAllTimersAsync();
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(setPreviewUrlForThread).toHaveBeenCalledWith("thread-1", "https://example.com");
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it("falls back to window.open when preview bridge is missing", () => {
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
+    const mockOpen = vi.fn();
+    vi.stubGlobal("open", mockOpen);
+
+    openUrlInPreview({ url: "https://example.com", threadId: "thread-1" });
+
+    expect(mockOpen).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
+    vi.unstubAllGlobals();
+  });
+
+  it("stores URL when navigate rejects", async () => {
+    mockNavigate.mockRejectedValue(new Error("no-bounds"));
+    window.desktopBridge = {
+      preview: {
+        tabs: { create: mockCreate, list: mockTabList("https://example.com") },
+        navigate: mockNavigate,
+      },
+    } as unknown as typeof window.desktopBridge;
+
+    openUrlInPreview({ url: "https://example.com", threadId: "thread-1" });
+    await vi.runAllTimersAsync();
+
+    expect(setPreviewUrlForThread).toHaveBeenCalledWith("thread-1", "https://example.com");
+  });
+});
+
+describe("openGitHubUrl", () => {
+  let mockOpenExternal: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockOpenExternal = vi.fn();
+    window.desktopBridge = {
+      openExternalUrl: mockOpenExternal,
+      preview: {
+        tabs: {
+          create: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+          list: mockTabList("https://github.com/org/repo/pull/1"),
+        },
+        navigate: vi.fn().mockResolvedValue({ ok: true }),
+      },
+    } as unknown as typeof window.desktopBridge;
+
+    useDiffStore.setState({
+      showRightPanel: vi.fn(),
+      setRightPanelTab: vi.fn(),
+      setPreviewUrlForThread: vi.fn(),
+    } as Partial<ReturnType<typeof useDiffStore.getState>>);
+
+    useWorkspaceStore.setState({ activeThreadId: "thread-1", workspaces: [], activeWorkspaceId: null });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
+  });
+
+  it("opens in system browser on plain click", () => {
+    openGitHubUrl("https://github.com/org/repo/pull/1", "thread-1");
+    expect(mockOpenExternal).toHaveBeenCalledWith("https://github.com/org/repo/pull/1");
+  });
+
+  it("opens in preview on ctrl+click", async () => {
+    const mockCreate = vi.mocked(window.desktopBridge!.preview!.tabs!.create);
+    openGitHubUrl(
+      "https://github.com/org/repo/pull/1",
+      "thread-1",
+      { ctrlKey: true, metaKey: false },
+    );
+    await vi.runAllTimersAsync();
+    expect(mockOpenExternal).not.toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/__tests__/open-url-in-preview.test.ts
+++ b/apps/web/src/lib/__tests__/open-url-in-preview.test.ts
@@ -220,6 +220,21 @@ describe("openGitHubUrl", () => {
     expect(mockOpenExternal).toHaveBeenCalledWith("https://github.com/org/repo/pull/1");
   });
 
+  it("falls back to window.open when desktopBridge is missing on plain click", () => {
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
+    const mockOpen = vi.fn();
+    vi.stubGlobal("open", mockOpen);
+
+    openGitHubUrl("https://github.com/org/repo/pull/1", "thread-1");
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      "https://github.com/org/repo/pull/1",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    vi.unstubAllGlobals();
+  });
+
   it("opens in preview on ctrl+click", async () => {
     const mockCreate = vi.mocked(window.desktopBridge!.preview!.tabs!.create);
     openGitHubUrl(

--- a/apps/web/src/lib/open-url-in-preview.ts
+++ b/apps/web/src/lib/open-url-in-preview.ts
@@ -1,0 +1,160 @@
+import { isMcodeWorkspacePreviewUrl } from "@mcode/contracts";
+import type { BrowserTabInfo } from "@mcode/contracts";
+import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+/** Returns true when the event is a Ctrl+click (Windows/Linux) or Cmd+click (macOS). */
+export function isModifierClick(e: { ctrlKey: boolean; metaKey: boolean }): boolean {
+  return e.ctrlKey || e.metaKey;
+}
+
+/** Whether a URL can be loaded in the embedded preview panel. */
+export function isPreviewableUrl(url: string): boolean {
+  const trimmed = url.trim();
+  if (isMcodeWorkspacePreviewUrl(trimmed)) return true;
+  try {
+    const { protocol } = new URL(trimmed);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+/** Options for {@link openUrlInPreview}. */
+export interface OpenUrlInPreviewOptions {
+  /** URL to load in the preview panel. */
+  url: string;
+  /** Thread that owns the preview session. */
+  threadId: string;
+  /** Workspace root used to resolve relative paths and mcode-workspace URLs. */
+  workspacePath?: string | null;
+  /**
+   * When true (default), opens in a new preview tab so the active tab keeps
+   * its current page.
+   */
+  newTab?: boolean;
+}
+
+function resolveWorkspacePath(explicit: string | null | undefined): string | null {
+  if (explicit !== undefined) return explicit;
+  const { activeWorkspaceId, workspaces } = useWorkspaceStore.getState();
+  if (!activeWorkspaceId) return null;
+  return workspaces.find((w) => w.id === activeWorkspaceId)?.path ?? null;
+}
+
+/**
+ * True when a preview tab has no real page loaded yet. Mirrors the host-side
+ * `guestUrlNeedsHttpRestore` check so empty tabs are reused instead of spawning
+ * another blank tab.
+ */
+export function isEmptyPreviewTabUrl(url: string | null | undefined): boolean {
+  if (!url || url.trim().length === 0) return true;
+  const lower = url.trim().toLowerCase();
+  if (lower === "about:blank") return true;
+  if (lower.startsWith("about:")) return true;
+  if (lower.startsWith("chrome-error:")) return true;
+  return false;
+}
+
+/** Resolves the active tab from a tab set snapshot. */
+function findActiveTab(
+  tabs: readonly BrowserTabInfo[],
+  activeTabId: string | null,
+): BrowserTabInfo | undefined {
+  if (activeTabId) {
+    const byId = tabs.find((t) => t.id === activeTabId);
+    if (byId) return byId;
+  }
+  return tabs.find((t) => t.active);
+}
+
+/**
+ * Returns whether a modifier-open should create a new preview tab. Reuses the
+ * active tab when it is still blank; opens a new tab when the active tab already
+ * has a page loaded.
+ */
+async function shouldOpenInNewTab(
+  threadId: string,
+  tabsApi: NonNullable<NonNullable<typeof window.desktopBridge>["preview"]>["tabs"],
+): Promise<boolean> {
+  if (!tabsApi?.list) return false;
+
+  const listed = await tabsApi.list(threadId);
+  if (!listed.ok) return true;
+
+  const active = findActiveTab(listed.data.tabs, listed.data.activeTabId);
+  if (!active) return false;
+
+  return !isEmptyPreviewTabUrl(active.url);
+}
+
+/**
+ * Opens a URL in the embedded browser preview, optionally in a new tab so the
+ * current preview tab keeps its page.
+ */
+export function openUrlInPreview({
+  url,
+  threadId,
+  workspacePath,
+  newTab = true,
+}: OpenUrlInPreviewOptions): void {
+  if (!isPreviewableUrl(url)) return;
+
+  const preview = window.desktopBridge?.preview;
+  if (!preview) {
+    window.open(url, "_blank", "noopener,noreferrer");
+    return;
+  }
+
+  const wsPath = resolveWorkspacePath(workspacePath);
+  const { showRightPanel, setRightPanelTab, setPreviewUrlForThread } = useDiffStore.getState();
+  showRightPanel(threadId);
+  setRightPanelTab(threadId, "preview");
+
+  const run = async (): Promise<void> => {
+    const openInNewTab = newTab && (await shouldOpenInNewTab(threadId, preview.tabs));
+
+    if (openInNewTab && preview.tabs?.create) {
+      await preview.tabs.create(threadId, true);
+    } else if (!openInNewTab) {
+      setPreviewUrlForThread(threadId, url);
+    }
+
+    if (preview.navigate) {
+      try {
+        await preview.navigate(url, wsPath ?? undefined);
+      } catch {
+        setPreviewUrlForThread(threadId, url);
+      }
+    } else {
+      setPreviewUrlForThread(threadId, url);
+    }
+  };
+
+  // Defer until the preview panel has mounted and reported bounds.
+  setTimeout(() => {
+    void run();
+  }, 0);
+}
+
+/**
+ * Opens a GitHub HTTPS URL in the system browser when plain-clicked, or in the
+ * embedded preview (new tab) when Ctrl/Cmd+clicked.
+ */
+export function openGitHubUrl(
+  url: string,
+  threadId: string,
+  event?: { ctrlKey: boolean; metaKey: boolean },
+): void {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") return;
+    if (event && isModifierClick(event)) {
+      openUrlInPreview({ url, threadId });
+      return;
+    }
+    window.desktopBridge?.openExternalUrl(url);
+  } catch {
+    // Invalid URL - do nothing
+  }
+}

--- a/apps/web/src/lib/open-url-in-preview.ts
+++ b/apps/web/src/lib/open-url-in-preview.ts
@@ -153,7 +153,11 @@ export function openGitHubUrl(
       openUrlInPreview({ url, threadId });
       return;
     }
-    window.desktopBridge?.openExternalUrl(url);
+    if (window.desktopBridge?.openExternalUrl) {
+      void window.desktopBridge.openExternalUrl(url);
+    } else {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
   } catch {
     // Invalid URL - do nothing
   }


### PR DESCRIPTION
## What
Ctrl/Cmd+click on markdown links and PR links now opens the embedded browser preview instead of the system browser. When the active preview tab already has a page loaded, the link opens in a new tab. When the active tab is still blank, the link loads there.

## Why
Users expect modifier-click to open links in the in-app preview without losing the page they already have loaded. PR links in the chat header and checks popover had no modifier-click support at all.

## Key changes
- Add `openUrlInPreview` and `openGitHubUrl` helpers in `apps/web/src/lib/open-url-in-preview.ts`
- Markdown links: Ctrl/Cmd+click routes through the helper (new tab when active tab has content)
- PR header button and checks popover: Ctrl/Cmd+click opens in preview; plain click unchanged
- Reuse an empty active preview tab instead of always creating a second blank tab
- Unit tests for the helper and updated component tests (57 passing in affected specs)

## Configuration changes
None

## Test plan
- [x] Unit tests: `open-url-in-preview.test.ts`, `MarkdownContent.test.tsx`, `PrSplitButton.test.tsx`
- [ ] Manual: load a page in preview tab 1, Ctrl+click a chat link, confirm tab 2 opens and tab 1 is unchanged
- [ ] Manual: with an empty active preview tab, Ctrl+click a link, confirm it loads in that tab (no extra tab)
- [ ] Manual: plain click on PR links still opens system browser or checks popover
- [ ] Manual: Ctrl+click PR header and checks popover View on GitHub opens in preview

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783091998&installation_id=129163861&pr_number=551&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F551&signature=0d3da14aadc3147ff854546d7117ed9d8242464ff5fa593b9478062c75569d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modifier-click (Ctrl/Cmd+click) opens links in the embedded preview panel and preserves workspace context.
  * Improved preview behavior: smarter tab reuse/creation and reliable fallbacks when previewing fails.

* **Bug Fixes**
  * More consistent GitHub link handling and preview navigation, including modifier-click vs normal-click behavior.

* **Tests**
  * Expanded test coverage for preview navigation, URL-opening flows, and modifier-click interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->