### PR TITLE
docs: preview error-state + tab-discard design (ADR 0002 + glossary)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -409,6 +409,58 @@ within their own provider's context window. Distinct from a fork handoff,
 though the orchestrator does consult `last_compact_summary` when building a
 deterministic path-D handoff.
 
+## In-app browser preview
+
+### Preview
+The embedded in-app browser panel that renders a web URL or a local file
+alongside a thread. Distinct from opening the page in the user's external
+browser. The preview is **thread-scoped**: each thread keeps its own set of
+tabs.
+
+### Preview tab
+One navigable page within the preview, belonging to a thread. A thread can
+hold several tabs; exactly one is the active tab at a time.
+
+### Active tab
+The preview tab currently shown to the user. The other tabs in the thread
+are background tabs.
+
+### Panel visibility
+Whether the preview panel is currently in view. When the user collapses or
+navigates away from the preview, the panel is **hidden** even though its
+tabs still exist. Visibility is distinct from which tab is active: the active
+tab of a hidden panel is not on screen.
+
+### Warm tab
+A preview tab that holds a live page in memory and is instant to view.
+Background warm tabs keep their page intact (scroll position, form input)
+but are throttled while not in view.
+
+### Cold tab (discarded tab)
+A preview tab reduced to placeholder information - its title, URL, and
+favicon - with its in-memory page released to reclaim memory. Reopening a
+cold tab reloads the page from scratch, so scroll position and form input do
+not survive. This is the same idea modern browsers call a *discarded* or
+*sleeping* tab; Mcode uses **cold** / **discarded**, never "disabled".
+
+### Tab discard
+Demoting a warm tab to cold to save memory. The inverse - showing a cold tab
+again - is **re-warming**, which reloads the page. The active tab is never
+discarded while the panel is visible; once the panel is hidden it may be
+discarded like any other tab.
+
+### Preview page state
+The status of a preview tab's page from the user's point of view:
+**loading**, **loaded**, **error**, or **discarded**. Exactly one applies at
+a time.
+
+### Preview error state
+The page state shown when a tab fails to display a live page: the site is
+unreachable (network or TLS failure), the server returned an HTTP error
+(404, 500, and similar), the local file is missing, or the page crashed. The
+user is offered recovery actions (retry, edit the address, go back, open
+externally) rather than a raw browser error page.
+
 ## App-side extensibility
 
 Three end-user-facing extensibility surfaces inside the running Mcode app.

--- a/docs/adr/0002-preview-tab-discard-policy.md
+++ b/docs/adr/0002-preview-tab-discard-policy.md
@@ -1,0 +1,82 @@
+---
+status: accepted
+---
+
+# Preview tabs are discarded (renderer killed), not frozen, and the active tab is protected only while the panel is visible
+
+## Context
+
+The in-app browser preview keeps a live renderer per tab. Background tabs are
+already throttled (`setBackgroundThrottling(true)`), but nothing ever releases a
+background tab's renderer, and hiding the panel or switching threads leaves
+renderers resident. Warm-tab count is unbounded, so a session that visits several
+pages or threads accumulates renderer processes and blows the < 150MB idle-memory
+target.
+
+We want modern-browser "memory saver" behaviour. Two questions drove real
+trade-offs:
+
+1. **Discard vs freeze.** A frozen tab keeps its renderer (instant resume, state
+   intact) but frees little memory. A discarded tab kills the renderer (reclaims
+   the memory) but reloads on return, losing scroll position and form input.
+2. **When is the active tab safe to reclaim?** The active tab is what the user is
+   looking at, so it must stay warm - but only while the panel is actually on
+   screen.
+
+A prior attempt at idle teardown was removed in #454 because a `ResizeObserver`
+flapped the panel's `visible` flag on every SPA in-page navigation, hiding and
+re-showing the view and causing reload churn. That history constrains any
+time-based reclaim we add.
+
+## Decision
+
+Reclaim memory by **discarding** background tabs (kill the renderer, keep a cold
+placeholder of title/URL/favicon), not by freezing them. Re-warming reloads the
+page; scroll and form state are intentionally not preserved. This matches Chrome
+Memory Saver / Edge sleeping-tabs discard semantics.
+
+The discard policy is a pure function of (warm tabs, active thread/tab, panel
+visibility, clock). It is visibility-aware:
+
+- **Panel visible:** the active tab is protected and never discarded. Background
+  tabs are discarded only after an idle threshold; the warm-tab count cap is **not**
+  enforced, so the user's working set stays snappy.
+- **Panel hidden:** the active tab loses its protection and competes like any other
+  tab. After an idle delay the warm set is trimmed to the N most-recently-used tabs
+  (steady state = N warm, as a fast-reopen cache, not zero).
+
+Time-based reclaim carries **hysteresis**: a discard scheduled when the panel hides
+is cancelled if the panel reappears within the window. This is the direct mitigation
+for the #454 flap class.
+
+## Considered Options
+
+- **Freeze instead of discard (rejected).** Preserves scroll/form state, but a frozen
+  renderer still holds most of its memory, so it does not meet the idle-memory target -
+  the entire reason for the feature.
+- **Discard everything to zero when hidden (rejected).** Maximum reclaim, but every
+  reopen reloads even the tab the user just left. Keeping N warm as a reopen cache is
+  the better point on the curve.
+- **Enforce the count cap while visible too (rejected).** Would discard a background
+  tab the user is actively toggling between, reloading it on return mid-task. The cap
+  is a hidden-panel concern; while visible, idle-eviction alone bounds the set.
+- **Discard the active tab the instant the panel hides (rejected).** Reintroduces the
+  #454 churn: the `visible` flag is known to flap. Hysteresis plus an idle delay is
+  required.
+
+## Consequences
+
+- Re-warming a tab is a full reload. Scroll position, form input, and in-page client
+  state do not survive a discard. This is by design; preserving them would require a
+  freeze (insufficient memory savings) or heavyweight state serialization (separate,
+  larger effort).
+- A discarded `file:` preview whose file was deleted re-warms into the preview error
+  state (file-not-found). Discard and error handling compose through the same page
+  state.
+- The policy must persist a tab's validated current URL before disposing its renderer,
+  or re-warm loads a blank page. The window-teardown park path already models this.
+- The thresholds (warm-tab count N, background idle, hidden-panel idle) are user
+  settings, not constants, so the memory/responsiveness balance is tunable without code
+  changes.
+- If a future product decision wants scroll/form preservation, it is a freeze tier
+  layered on top - not a reversal of this decision - and should be recorded separately.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,41 @@ Issues and PRDs for this repo live as GitHub issues at [Mzeey-Empire/mcode](http
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
+## Issue relationships and dependencies
+
+When a plan spans an epic and several features, wire the relationships natively. Native links are the source of truth; the epic body carries a human-readable view of them.
+
+- **Type by title prefix + label**: `epic: …` (label `epic`) for the parent, `feat: …` (label `feat`) for vertical slices. Children reference the parent with a `## Parent` section (`#<epic>`) and list blockers under `## Blocked by`.
+- **Epic body carries a `## Sequencing` ASCII graph** so the order is readable at a glance: `↓` for sequential, `←→ … - can parallel` for parallel-safe slices, `└──┬──┘` for join points. This mirrors the native links; it does not replace them.
+- **Do not put priority / estimate / type in the body** — those are project fields and labels. The body starts with `## Description` (or the skill's template) and the relationship sections.
+
+`gh` has no native command for sub-issues or dependencies, so use the API.
+
+**Get an issue's GraphQL node id:**
+
+```bash
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){id}}}' \
+  -f o=Mzeey-Empire -f r=mcode -F n=<number> --jq '.data.repository.issue.id'
+```
+
+**Link a sub-issue to its parent** (needs the `sub_issues` feature header):
+
+```bash
+gh api graphql -H "GraphQL-Features: sub_issues" \
+  -f query='mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,subIssueId:$c}){issue{number}}}' \
+  -f p=<parent-node-id> -f c=<child-node-id>
+```
+
+**Add a blocked-by dependency** (REST; uses the numeric `.id`, not the issue number):
+
+```bash
+BLOCKER_ID=$(gh api repos/Mzeey-Empire/mcode/issues/<blocker-number> --jq '.id')
+gh api --method POST repos/Mzeey-Empire/mcode/issues/<blocked-number>/dependencies/blocked_by \
+  -F issue_id=$BLOCKER_ID
+```
+
+Publish issues in dependency order (blockers first) so the real numbers exist before you reference them. Verify with the response fields `parent_issue_url` (sub-issue set) and `issue_dependencies_summary.blocked_by` (dependency set).
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -21,13 +21,20 @@ When a plan spans an epic and several features, wire the relationships natively.
 - **Epic body carries a `## Sequencing` ASCII graph** so the order is readable at a glance: `↓` for sequential, `←→ … - can parallel` for parallel-safe slices, `└──┬──┘` for join points. This mirrors the native links; it does not replace them.
 - **Do not put priority / estimate / type in the body** — those are project fields and labels. The body starts with `## Description` (or the skill's template) and the relationship sections.
 
-`gh` has no native command for sub-issues or dependencies, so use the API.
+`gh` has no native command for sub-issues or dependencies, so use the API. REST
+calls use the `{owner}/{repo}` placeholder, which `gh api` fills from the current
+clone. GraphQL has no such placeholder, so derive the owner and repo once and
+reuse them:
+
+```bash
+read -r OWNER REPO < <(gh repo view --json owner,name --jq '"\(.owner.login) \(.name)"')
+```
 
 **Get an issue's GraphQL node id:**
 
 ```bash
 gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){id}}}' \
-  -f o=Mzeey-Empire -f r=mcode -F n=<number> --jq '.data.repository.issue.id'
+  -f o="$OWNER" -f r="$REPO" -F n=<number> --jq '.data.repository.issue.id'
 ```
 
 **Link a sub-issue to its parent** (needs the `sub_issues` feature header):
@@ -41,12 +48,22 @@ gh api graphql -H "GraphQL-Features: sub_issues" \
 **Add a blocked-by dependency** (REST; uses the numeric `.id`, not the issue number):
 
 ```bash
-BLOCKER_ID=$(gh api repos/Mzeey-Empire/mcode/issues/<blocker-number> --jq '.id')
-gh api --method POST repos/Mzeey-Empire/mcode/issues/<blocked-number>/dependencies/blocked_by \
+BLOCKER_ID=$(gh api repos/{owner}/{repo}/issues/<blocker-number> --jq '.id')
+gh api --method POST repos/{owner}/{repo}/issues/<blocked-number>/dependencies/blocked_by \
   -F issue_id=$BLOCKER_ID
 ```
 
-Publish issues in dependency order (blockers first) so the real numbers exist before you reference them. Verify with the response fields `parent_issue_url` (sub-issue set) and `issue_dependencies_summary.blocked_by` (dependency set).
+Publish issues in dependency order (blockers first) so the real numbers exist before you reference them, then verify the links:
+
+```bash
+# Sub-issue set? -> prints the parent number
+gh api graphql -H "GraphQL-Features: sub_issues" \
+  -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){parentIssue{number}}}}' \
+  -f o="$OWNER" -f r="$REPO" -F n=<child-number> --jq '.data.repository.issue.parentIssue.number'
+
+# Dependency set? -> prints the blocked-by count
+gh api repos/{owner}/{repo}/issues/<blocked-number> --jq '.issue_dependencies_summary.blocked_by'
+```
 
 ## When a skill says "publish to the issue tracker"
 


### PR DESCRIPTION
## What

Documents the design for in-app browser preview error states and memory-saver (discarded) tabs ahead of implementation.

- Adds an **in-app browser preview** glossary section to `CONTEXT.md` (Preview, Preview tab, Active tab, Panel visibility, Warm/Cold tab, Tab discard, Preview page state, Preview error state).
- Adds **ADR 0002 - preview tab discard policy**: discard (kill renderer) not freeze; visibility-aware active-tab protection; trim to N most-recently-used only when the panel is hidden; reload-loses-state semantics; hysteresis to mitigate the #454 ResizeObserver flap; thresholds as settings.

## Why

The preview has zero error handling today (blank surface / raw Chromium error page) and leaks renderers, blowing the < 150MB idle-memory target. These docs lock the contract so the implementation work can proceed against agreed vocabulary and a recorded decision.

## Key changes

- `CONTEXT.md` - new glossary section (no implementation detail, no thresholds).
- `docs/adr/0002-preview-tab-discard-policy.md` - new ADR (accepted).

## Related issues

Implementation tracked under the epic:
- Epic #552 - preview error states + memory-saver tabs
- #553 - feat: page-status state model (blocks the other two)
- #554 - feat: preview error states (blocked by #553)
- #555 - feat: memory-saver tabs (blocked by #553)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783095495&installation_id=129163861&pr_number=556&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F556&signature=51fe8e6adbb7028d38cf1b4314729b2210839017d718c69b5abf858a43246762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an in-app browser preview glossary defining preview, tabs, active/visible states, warm/cold tabs, and error states.
  * Added an architecture decision record describing the tab memory-saver policy: preview tabs are discarded (renderer killed) under visibility-aware rules; discarded tabs fully reload and may lose scroll/form state.
  * Added issue-tracking conventions for linking and sequencing related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->