### PR TITLE
feat(preview): page-status state model (single channel + reducer)

### DIFF
--- a/apps/desktop/src/main/__tests__/page-status-reducer.test.ts
+++ b/apps/desktop/src/main/__tests__/page-status-reducer.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { pageStatusReducer, initialPageStatus } from "../preview/page-status-reducer.js";
+import type { PreviewPageError } from "@mcode/contracts";
+
+const ERR: PreviewPageError = { kind: "http", status: 404, message: "Page not found" };
+
+describe("pageStatusReducer", () => {
+  it("starts loaded with empty chrome", () => {
+    expect(initialPageStatus()).toEqual({
+      url: null,
+      title: null,
+      favicon: null,
+      phase: "loaded",
+    });
+  });
+
+  it("load-start enters loading and clears favicon + error", () => {
+    const prev = { url: "https://a.test", title: "A", favicon: "f", phase: "error" as const, error: ERR };
+    const next = pageStatusReducer(prev, { type: "load-start" });
+    expect(next.phase).toBe("loading");
+    expect(next.favicon).toBeNull();
+    expect(next.error).toBeUndefined();
+    // url/title carry across until navigated fires.
+    expect(next.url).toBe("https://a.test");
+    expect(next.title).toBe("A");
+  });
+
+  it("loading -> loaded via load-stop", () => {
+    const loading = pageStatusReducer(initialPageStatus(), { type: "load-start", url: "https://x.test" });
+    expect(loading.phase).toBe("loading");
+    const loaded = pageStatusReducer(loading, { type: "load-stop" });
+    expect(loaded.phase).toBe("loaded");
+    expect(loaded.url).toBe("https://x.test");
+  });
+
+  it("loading -> error via load-error, clearing the loading affordance and favicon", () => {
+    const loading = pageStatusReducer(initialPageStatus(), { type: "load-start", url: "https://x.test" });
+    const errored = pageStatusReducer(loading, { type: "load-error", error: ERR });
+    expect(errored.phase).toBe("error");
+    expect(errored.favicon).toBeNull();
+    expect(errored.error).toEqual(ERR);
+  });
+
+  it("error -> loading on retry (load-start)", () => {
+    const errored = { url: "https://x.test", title: null, favicon: null, phase: "error" as const, error: ERR };
+    const retry = pageStatusReducer(errored, { type: "load-start" });
+    expect(retry.phase).toBe("loading");
+    expect(retry.error).toBeUndefined();
+  });
+
+  it("load-stop does not override an error phase", () => {
+    const errored = { url: "https://x.test", title: null, favicon: null, phase: "error" as const, error: ERR };
+    const after = pageStatusReducer(errored, { type: "load-stop" });
+    expect(after.phase).toBe("error");
+  });
+
+  it("loaded -> discarded via discard, keeping cold chrome", () => {
+    const loaded = { url: "https://x.test", title: "X", favicon: "fav", phase: "loaded" as const };
+    const discarded = pageStatusReducer(loaded, { type: "discard" });
+    expect(discarded.phase).toBe("discarded");
+    expect(discarded.url).toBe("https://x.test");
+    expect(discarded.title).toBe("X");
+    expect(discarded.favicon).toBe("fav");
+  });
+
+  it("discarded -> loading on re-warm (load-start)", () => {
+    const discarded = { url: "https://x.test", title: "X", favicon: "fav", phase: "discarded" as const };
+    const rewarm = pageStatusReducer(discarded, { type: "load-start", url: "https://x.test" });
+    expect(rewarm.phase).toBe("loading");
+  });
+
+  it("navigated sets url, keeps phase, and only overwrites title when non-empty", () => {
+    const loading = pageStatusReducer(initialPageStatus(), { type: "load-start" });
+    const nav = pageStatusReducer(loading, { type: "navigated", url: "https://y.test", title: "Y" });
+    expect(nav.url).toBe("https://y.test");
+    expect(nav.title).toBe("Y");
+    expect(nav.phase).toBe("loading");
+    const navEmptyTitle = pageStatusReducer(nav, { type: "navigated", url: "https://y.test/2", title: "" });
+    expect(navEmptyTitle.title).toBe("Y");
+  });
+
+  it("title and favicon events patch only their field", () => {
+    const base = { url: "https://x.test", title: "X", favicon: null, phase: "loaded" as const };
+    expect(pageStatusReducer(base, { type: "title", title: "New" }).title).toBe("New");
+    expect(pageStatusReducer(base, { type: "favicon", favicon: "fav" }).favicon).toBe("fav");
+  });
+
+  it("reset replaces the whole status", () => {
+    const replacement = { url: "https://z.test", title: "Z", favicon: "zf", phase: "loaded" as const };
+    expect(pageStatusReducer(initialPageStatus(), { type: "reset", status: replacement })).toEqual(replacement);
+  });
+});

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -235,17 +235,19 @@ describe("preview-browser", () => {
       expect(view.webContents.close).not.toHaveBeenCalled();
     });
 
-    it("sends loading-state false when hiding", async () => {
+    it("sends a non-loading page-status when hiding", async () => {
       const win = createWindow();
       await showPreview(win);
       win.webContents.send.mockClear();
 
       await hidePreview(win);
 
-      expect(win.webContents.send).toHaveBeenCalledWith(
-        "preview:loading-state",
-        { loading: false },
+      const statusCalls = win.webContents.send.mock.calls.filter(
+        ([channel]) => channel === "preview:page-status",
       );
+      expect(statusCalls.length).toBeGreaterThan(0);
+      const last = statusCalls[statusCalls.length - 1]![1] as { phase: string };
+      expect(last.phase).not.toBe("loading");
     });
   });
 
@@ -905,10 +907,10 @@ describe("preview-browser", () => {
       }
     });
 
-    it("activating a brand-new blank tab pushes did-navigate with empty URL", async () => {
-      // Regression: a blank new tab must emit a did-navigate event with url=''
-      // so the renderer clears its omnibox; otherwise the previous tab's URL
-      // bleeds visually into the new tab.
+    it("activating a brand-new blank tab pushes a page-status with null URL", async () => {
+      // Regression: a blank new tab must emit a page-status whose url is null so
+      // the renderer clears its omnibox; otherwise the previous tab's URL bleeds
+      // visually into the new tab.
       const win = createWindow();
       await showPreview(win, { threadId: "thread-A", url: "https://prev.test" });
       const firstView = createdViews[0]!;
@@ -921,13 +923,12 @@ describe("preview-browser", () => {
       });
       expect(created.ok).toBe(true);
 
-      // Find the preview:did-navigate emission for the brand-new tab.
-      const navCalls = win.webContents.send.mock.calls.filter(
-        ([channel]) => channel === "preview:did-navigate",
+      const statusCalls = win.webContents.send.mock.calls.filter(
+        ([channel]) => channel === "preview:page-status",
       );
-      expect(navCalls.length).toBeGreaterThan(0);
-      const lastNav = navCalls[navCalls.length - 1]![1] as { url: string };
-      expect(lastNav.url).toBe("");
+      expect(statusCalls.length).toBeGreaterThan(0);
+      const last = statusCalls[statusCalls.length - 1]![1] as { url: string | null };
+      expect(last.url).toBeNull();
     });
 
     it("activating a brand-new tab uses its own fresh WebContentsView (no reload of old)", async () => {

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -199,24 +199,17 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     releaseBrowserCaptureSpills(paths: readonly string[]): Promise<void> {
       return ipcRenderer.invoke("preview:release-browser-capture-spill", [...paths]);
     },
-    onDidNavigate(callback: (payload: { url: string; title: string; favicon?: string | null }) => void) {
-      const listener = (_event: unknown, payload: { url: string; title: string; favicon?: string | null }) =>
-        callback(payload);
-      ipcRenderer.on("preview:did-navigate", listener);
-      return () => ipcRenderer.removeListener("preview:did-navigate", listener);
-    },
-    /** Subscribe to guest webContents loading spin (did-start / did-stop loading). */
-    onLoadingState(callback: (payload: { loading: boolean }) => void) {
-      const listener = (_event: unknown, payload: { loading: boolean }) => callback(payload);
-      ipcRenderer.on("preview:loading-state", listener);
-      return () => ipcRenderer.removeListener("preview:loading-state", listener);
-    },
-    /** Subscribe to favicon updates from the guest webContents. */
-    onDidUpdateFavicon(callback: (payload: { favicon: string | null }) => void) {
-      const listener = (_event: unknown, payload: { favicon: string | null }) =>
-        callback(payload);
-      ipcRenderer.on("preview:did-update-favicon", listener);
-      return () => ipcRenderer.removeListener("preview:did-update-favicon", listener);
+    /**
+     * Subscribe to the single page-status channel: the full PreviewPageStatus
+     * (url, title, favicon, phase, error?) emitted once per change for the
+     * active tab. Replaces the old loading-state / did-navigate /
+     * did-update-favicon trio.
+     */
+    onPageStatus(callback: (status: import("@mcode/contracts").PreviewPageStatus) => void) {
+      const listener = (_event: unknown, status: import("@mcode/contracts").PreviewPageStatus) =>
+        callback(status);
+      ipcRenderer.on("preview:page-status", listener);
+      return () => ipcRenderer.removeListener("preview:page-status", listener);
     },
     /** Cancel any in-progress capture operation (region or element-pick). */
     cancelCapture(): Promise<void> {

--- a/apps/desktop/src/main/preview/page-status-reducer.ts
+++ b/apps/desktop/src/main/preview/page-status-reducer.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure reducer for the embedded preview's page state. This is the only place
+ * `PreviewPageStatus` transitions; navigation, title, favicon, loading, error,
+ * and discard all flow through here so the host emits one consistent object on
+ * the single `preview:page-status` channel.
+ */
+
+import type { PreviewPageStatus, PreviewPageError } from "@mcode/contracts";
+
+/** Discrete inputs the host derives from guest webContents events. */
+export type PageStatusEvent =
+  /** did-start-loading / navigate kickoff: enter loading, clear favicon + error. */
+  | { type: "load-start"; url?: string | null }
+  /** did-navigate / did-navigate-in-page: adopt the committed URL (and title). */
+  | { type: "navigated"; url: string | null; title?: string | null }
+  /** page-title-updated. */
+  | { type: "title"; title: string | null }
+  /** page-favicon-updated. */
+  | { type: "favicon"; favicon: string | null }
+  /** did-stop-loading / did-finish-load: settle to loaded (unless already error). */
+  | { type: "load-stop" }
+  /** Classified failure (W1): enter error and clear the loading affordance. */
+  | { type: "load-error"; error: PreviewPageError }
+  /** Memory-saver eviction (W3): enter discarded, keep cold chrome. */
+  | { type: "discard" }
+  /** Tab/thread switch: replace the whole status with the activated tab's chrome. */
+  | { type: "reset"; status: PreviewPageStatus };
+
+/** Blank starting status: nothing loaded, no spinner. */
+export function initialPageStatus(): PreviewPageStatus {
+  return { url: null, title: null, favicon: null, phase: "loaded" };
+}
+
+/** Returns the next status for `event`. Pure: never mutates `prev`. */
+export function pageStatusReducer(
+  prev: PreviewPageStatus,
+  event: PageStatusEvent,
+): PreviewPageStatus {
+  switch (event.type) {
+    case "load-start":
+      return {
+        url: event.url !== undefined ? event.url : prev.url,
+        title: prev.title,
+        favicon: null,
+        phase: "loading",
+      };
+    case "navigated":
+      return {
+        ...prev,
+        url: event.url,
+        title:
+          event.title !== undefined && event.title !== null && event.title.length > 0
+            ? event.title
+            : prev.title,
+        error: undefined,
+      };
+    case "title":
+      return { ...prev, title: event.title };
+    case "favicon":
+      return { ...prev, favicon: event.favicon };
+    case "load-stop":
+      return prev.phase === "error" ? prev : { ...prev, phase: "loaded" };
+    case "load-error":
+      return { ...prev, phase: "error", favicon: null, error: event.error };
+    case "discard":
+      return { ...prev, phase: "discarded" };
+    case "reset":
+      return event.status;
+  }
+}

--- a/apps/desktop/src/main/preview/preview-lifecycle.ts
+++ b/apps/desktop/src/main/preview/preview-lifecycle.ts
@@ -16,10 +16,9 @@ import {
   getActiveTab,
   sessions,
   clearIdle,
-  sendPreviewLoading,
+  applyPageStatus,
+  setPreviewLoading,
   isAllowedPreviewUrl,
-  syncActiveTabFromSession,
-  toBrowserTabSet,
 } from "./preview-session.js";
 import { removeEpPickHighlighter, abortOverlayCapture } from "./preview-overlay.js";
 import { pushPreviewConsoleLine } from "./preview-capture.js";
@@ -196,7 +195,7 @@ export function ensureTabView(
       const safe = await validateResumeUrl(navigationUrl);
       if (safe) {
         trustMainProcessFileNavigation(s, safe);
-        if (isActiveView()) sendPreviewLoading(win, true);
+        if (isActiveView()) setPreviewLoading(win, s, true);
         try {
           await view.webContents.loadURL(safe);
         } catch {
@@ -206,7 +205,7 @@ export function ensureTabView(
         tab.resumeUrl = null;
         if (isActiveView()) {
           s.resumePreviewUrl = null;
-          sendPreviewLoading(win, true);
+          setPreviewLoading(win, s, true);
         }
         try {
           await view.webContents.loadURL("about:blank");
@@ -231,42 +230,36 @@ export function ensureTabView(
       // Only the active view drives the shell omnibox + session mirror.
       if (isActiveView()) {
         s.resumePreviewUrl = persisted;
-        win.webContents.send("preview:did-navigate", {
-          url,
+        applyPageStatus(win, s, {
+          type: "navigated",
+          url: url.length > 0 ? url : null,
           title,
-          favicon: s.lastFavicons[0] ?? null,
         });
-        syncActiveTabFromSession(s);
-      }
-      // Tab list pushes are cheap; emit so the bar refreshes title/url
-      // for inactive tabs too.
-      if (s.lastPreviewThreadId) {
-        win.webContents.send(
-          "preview:tabs-updated",
-          toBrowserTabSet(s, s.lastPreviewThreadId),
-        );
       }
     })();
   };
 
+  // page-title-updated must NOT run validateResumeUrl (P1): a title change does
+  // not change the URL, so re-stat'ing the file path on every title event is
+  // pure waste. Patch only the title field.
+  const forwardTitle = () => {
+    if (win.isDestroyed() || view.webContents.isDestroyed()) return;
+    const title = view.webContents.getTitle();
+    tab.title = title && title.length > 0 ? title : tab.title;
+    if (isActiveView() && !win.isDestroyed()) {
+      applyPageStatus(win, s, { type: "title", title });
+    }
+  };
+
   view.webContents.on("did-navigate", forwardNav);
   view.webContents.on("did-navigate-in-page", forwardNav);
-  view.webContents.on("page-title-updated", forwardNav);
+  view.webContents.on("page-title-updated", forwardTitle);
   view.webContents.on("page-favicon-updated", (_e, urls: string[]) => {
     tab.faviconUrl = urls[0] ?? null;
     if (win.isDestroyed()) return;
     if (isActiveView()) {
       s.lastFavicons = urls;
-      win.webContents.send("preview:did-update-favicon", {
-        favicon: urls[0] ?? null,
-      });
-      syncActiveTabFromSession(s);
-    }
-    if (s.lastPreviewThreadId) {
-      win.webContents.send(
-        "preview:tabs-updated",
-        toBrowserTabSet(s, s.lastPreviewThreadId),
-      );
+      applyPageStatus(win, s, { type: "favicon", favicon: urls[0] ?? null });
     }
   });
   view.webContents.on("did-finish-load", () => {
@@ -278,14 +271,14 @@ export function ensureTabView(
   const forwardLoadingStart = () => {
     if (win.isDestroyed() || view.webContents.isDestroyed()) return;
     if (!isActiveView()) return;
+    // The load-start reducer case clears the favicon as part of entering loading.
     s.lastFavicons = [];
-    win.webContents.send("preview:did-update-favicon", { favicon: null });
-    sendPreviewLoading(win, true);
+    applyPageStatus(win, s, { type: "load-start" });
   };
   const forwardLoadingStop = () => {
     if (win.isDestroyed() || view.webContents.isDestroyed()) return;
     if (!isActiveView()) return;
-    sendPreviewLoading(win, false);
+    applyPageStatus(win, s, { type: "load-stop" });
   };
   view.webContents.on("did-start-loading", forwardLoadingStart);
   view.webContents.on("did-stop-loading", forwardLoadingStop);
@@ -330,7 +323,7 @@ export function ensureTabView(
     if (now - s.lastCrashRecoveryAt < CRASH_COOLDOWN_MS) {
       logger.warn("Preview: crash recovery skipped (cooldown active)");
       if (!win.isDestroyed()) {
-        sendPreviewLoading(win, false);
+        setPreviewLoading(win, s, false);
       }
       return;
     }
@@ -343,7 +336,7 @@ export function ensureTabView(
       s.view = fresh;
       if (s.lastBounds) fresh.setBounds(s.lastBounds);
       mountView(win, fresh);
-      sendPreviewLoading(win, true);
+      setPreviewLoading(win, s, true);
       trustMainProcessFileNavigation(s, url);
       void fresh.webContents.loadURL(url);
     }
@@ -446,7 +439,7 @@ export function hidePreview(win: BrowserWindow, s: PreviewSession): void {
     unmountView(win, s.view);
   }
   if (!win.isDestroyed()) {
-    sendPreviewLoading(win, false);
+    setPreviewLoading(win, s, false);
   }
 }
 

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -13,7 +13,8 @@ import {
   isAllowedHttpUrl,
   isAllowedPreviewUrl,
   resetIdle,
-  sendPreviewLoading,
+  applyPageStatus,
+  setPreviewLoading,
   syncActiveTabFromSession,
 } from "./preview-session.js";
 import { ensureView, hidePreview, mountView, unmountView } from "./preview-lifecycle.js";
@@ -139,7 +140,7 @@ export function registerNavigationHandlers(): void {
             switchedThread,
             threadId: tid,
           });
-          sendPreviewLoading(win, true);
+          setPreviewLoading(win, s, true);
           if (restoreTarget.startsWith("file:")) {
             trustMainProcessFileNavigation(s, restoreTarget);
           }
@@ -147,17 +148,20 @@ export function registerNavigationHandlers(): void {
           if (activeTab) activeTab.resumeUrl = restoreTarget;
           s.resumePreviewUrl = restoreTarget;
         } else if (switchedThread && activeTab) {
-          // Warm tab on the new thread: just mirror its state onto the session
-          // so the omnibox shows the right URL without a network round-trip.
+          // Warm tab on the new thread: mirror its state onto the session so the
+          // omnibox shows the right URL without a network round-trip.
           s.resumePreviewUrl = activeTab.resumeUrl;
           s.lastFavicons = activeTab.faviconUrl ? [activeTab.faviconUrl] : [];
-          if (!win.isDestroyed()) {
-            win.webContents.send("preview:did-navigate", {
-              url: wc.getURL(),
-              title: wc.getTitle(),
+          const liveUrl = wc.getURL();
+          applyPageStatus(win, s, {
+            type: "reset",
+            status: {
+              url: liveUrl.length > 0 ? liveUrl : activeTab.resumeUrl,
+              title: wc.getTitle() || activeTab.title,
               favicon: activeTab.faviconUrl ?? null,
-            });
-          }
+              phase: "loaded",
+            },
+          });
         }
       }
       resetIdle(win, s);
@@ -218,7 +222,7 @@ export function registerNavigationHandlers(): void {
       view.setBounds(s.lastBounds);
       mountView(win, view);
       logger.info("Preview: user navigated", { url: target });
-      sendPreviewLoading(win, true);
+      setPreviewLoading(win, s, true);
       trustMainProcessFileNavigation(s, target);
       void view.webContents.loadURL(target);
       s.resumePreviewUrl = target;
@@ -234,7 +238,7 @@ export function registerNavigationHandlers(): void {
     const s = getSession(win);
     if (!s.view || s.view.webContents.isDestroyed()) return false;
     if (s.view.webContents.canGoBack()) {
-      sendPreviewLoading(win, true);
+      setPreviewLoading(win, s, true);
       s.view.webContents.goBack();
       resetIdle(win, s);
       return true;
@@ -248,7 +252,7 @@ export function registerNavigationHandlers(): void {
     const s = getSession(win);
     if (!s.view || s.view.webContents.isDestroyed()) return false;
     if (s.view.webContents.canGoForward()) {
-      sendPreviewLoading(win, true);
+      setPreviewLoading(win, s, true);
       s.view.webContents.goForward();
       resetIdle(win, s);
       return true;
@@ -261,7 +265,7 @@ export function registerNavigationHandlers(): void {
     if (!win || win.isDestroyed()) return;
     const s = getSession(win);
     if (!s.view || s.view.webContents.isDestroyed()) return;
-    sendPreviewLoading(win, true);
+    setPreviewLoading(win, s, true);
     s.view.webContents.reload();
     resetIdle(win, s);
   });

--- a/apps/desktop/src/main/preview/preview-session.ts
+++ b/apps/desktop/src/main/preview/preview-session.ts
@@ -5,7 +5,19 @@
 
 import { BrowserWindow, WebContentsView } from "electron";
 import { randomUUID } from "node:crypto";
-import type { AttachmentMeta, BrowserTabInfo, BrowserTabSet, McodeBrowserCaptureV2 } from "@mcode/contracts";
+import type {
+  AttachmentMeta,
+  BrowserTabInfo,
+  BrowserTabSet,
+  McodeBrowserCaptureV2,
+  PreviewPageStatus,
+} from "@mcode/contracts";
+import {
+  pageStatusReducer,
+  initialPageStatus,
+  type PageStatusEvent,
+} from "./page-status-reducer.js";
+import { bumpPerf } from "./preview-perf.js";
 
 /**
  * Result of a picture-reference capture; defined here so PreviewSession can reference
@@ -108,6 +120,8 @@ export interface PreviewSession {
    * threads' tabs carry only the resume URL/title/favicon needed to restore them.
    */
   tabsByThread: Map<string, ThreadTabSet>;
+  /** Single source of truth for the active tab's page chrome, emitted on `preview:page-status`. */
+  pageStatus: PreviewPageStatus;
 }
 
 /** Global map of window id -> preview session state. */
@@ -138,6 +152,7 @@ export function getSession(win: BrowserWindow): PreviewSession {
       lastCrashRecoveryAt: 0,
       trustedFileNavigationBudget: 0,
       tabsByThread: new Map(),
+      pageStatus: initialPageStatus(),
     };
     sessions.set(win.id, s);
   }
@@ -244,17 +259,52 @@ export function resetIdle(_win: BrowserWindow, s: PreviewSession): void {
 }
 
 /**
- * Tells the React shell to show or hide the loading affordance. The native
- * WebContentsView stacks above HTML, so the indicator lives in chrome above the
- * guest bounds rather than inside the surface div.
+ * Runs the page-status reducer for `event`, stores the result on the session,
+ * and emits the full {@link PreviewPageStatus} on `preview:page-status` when it
+ * changed. The single emit path that replaces the old loading/navigate/favicon
+ * channels.
  */
-export function sendPreviewLoading(win: BrowserWindow, loading: boolean): void {
+export function applyPageStatus(
+  win: BrowserWindow,
+  s: PreviewSession,
+  event: PageStatusEvent,
+): void {
+  const next = pageStatusReducer(s.pageStatus, event);
+  if (pageStatusEqual(s.pageStatus, next)) return;
+  s.pageStatus = next;
   if (win.isDestroyed()) return;
+  bumpPerf("stateEmitCalls");
   try {
-    win.webContents.send("preview:loading-state", { loading });
+    win.webContents.send("preview:page-status", next);
   } catch {
-    /* sender may be gone */
+    bumpPerf("stateEmitSkips");
   }
+}
+
+/**
+ * Convenience for the many call sites that only toggle the loading affordance.
+ * Routes through {@link applyPageStatus} so loading stays part of the single
+ * page-status channel.
+ */
+export function setPreviewLoading(
+  win: BrowserWindow,
+  s: PreviewSession,
+  loading: boolean,
+): void {
+  applyPageStatus(win, s, loading ? { type: "load-start" } : { type: "load-stop" });
+}
+
+/** Shallow equality so {@link applyPageStatus} emits at most once per real change. */
+function pageStatusEqual(a: PreviewPageStatus, b: PreviewPageStatus): boolean {
+  return (
+    a.url === b.url &&
+    a.title === b.title &&
+    a.favicon === b.favicon &&
+    a.phase === b.phase &&
+    a.error?.kind === b.error?.kind &&
+    a.error?.status === b.error?.status &&
+    a.error?.message === b.error?.message
+  );
 }
 
 /**

--- a/apps/desktop/src/main/preview/preview-tabs.ts
+++ b/apps/desktop/src/main/preview/preview-tabs.ts
@@ -28,7 +28,7 @@ import {
 } from "./preview-lifecycle.js";
 import {
   isAllowedPreviewUrl,
-  sendPreviewLoading,
+  applyPageStatus,
   type TabState,
 } from "./preview-session.js";
 import { trustMainProcessFileNavigation } from "./preview-local-file.js";
@@ -83,33 +83,35 @@ function activateTabView(
   if (s.lastBounds) view.setBounds(s.lastBounds);
   mountView(win, view);
 
+  let loadingKicked = false;
   if (isFirstMount && tab.resumeUrl && isAllowedPreviewUrl(tab.resumeUrl)) {
     // Brand-new view for a tab that already had a saved URL (e.g. thread
     // restore). Load it once; subsequent activates of the same tab skip this
     // entirely so the user keeps their scroll / form state.
-    sendPreviewLoading(win, true);
+    loadingKicked = true;
     if (tab.resumeUrl.startsWith("file:")) {
       trustMainProcessFileNavigation(s, tab.resumeUrl);
     }
     void view.webContents.loadURL(tab.resumeUrl);
   }
 
-  // Tell the renderer the newly-mounted tab's chrome state so the omnibox,
-  // title, and favicon update immediately on tab swap. Without this the
-  // user sees a stale URL/title until the next page event fires on the
-  // (warm) webContents - which may never happen for a long-lived page.
+  // Single page-status emit replaces the old loading-state + did-navigate +
+  // did-update-favicon trio. The phase reflects whether we just kicked off a
+  // load; without this the user sees a stale URL/title until the next page
+  // event fires on the (warm) webContents - which may never happen for a
+  // long-lived page.
   if (!win.isDestroyed()) {
     const wc = view.webContents;
     if (!wc.isDestroyed()) {
       const liveUrl = wc.getURL();
-      const liveTitle = wc.getTitle();
-      win.webContents.send("preview:did-navigate", {
-        url: liveUrl,
-        title: liveTitle,
-        favicon: tab.faviconUrl ?? null,
-      });
-      win.webContents.send("preview:did-update-favicon", {
-        favicon: tab.faviconUrl ?? null,
+      applyPageStatus(win, s, {
+        type: "reset",
+        status: {
+          url: loadingKicked ? tab.resumeUrl : (liveUrl.length > 0 ? liveUrl : null),
+          title: loadingKicked ? tab.title : (wc.getTitle() || null),
+          favicon: tab.faviconUrl ?? null,
+          phase: loadingKicked ? "loading" : "loaded",
+        },
       });
     }
   }

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -105,18 +105,23 @@ async function injectPreviewBridge(page: Page): Promise<void> {
       capturePageContext: () =>
         Promise.resolve({ ok: false, error: "no-preview" } as const),
       releaseBrowserCaptureSpills: noop,
-      // Fire onDidNavigate synchronously on subscribe with a fake URL so the
+      // Fire onPageStatus synchronously on subscribe with a fake URL so the
       // panel's hasLoadedPage state flips to true. The capture / design
       // buttons are now gated on hasLoadedPage to avoid no-op clicks on an
       // empty preview, which would otherwise leave the click-based tests
       // (Design aria-pressed, Exit pill, dock rows) firing against disabled
       // buttons.
-      onDidNavigate: (cb: (p: { url: string; title: string; favicon?: string | null }) => void) => {
-        cb({ url: "https://example.com", title: "Example", favicon: null });
+      onPageStatus: (
+        cb: (s: {
+          url: string | null;
+          title: string | null;
+          favicon: string | null;
+          phase: "loading" | "loaded" | "error" | "discarded";
+        }) => void,
+      ) => {
+        cb({ url: "https://example.com", title: "Example", favicon: null, phase: "loaded" });
         return () => undefined;
       },
-      onLoadingState: unsub,
-      onDidUpdateFavicon: unsub,
       cancelCapture: () => {
         if (pickResolver) {
           const resolver = pickResolver;

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Check, Globe } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePreviewDockStore, MIN_DOCK_SIZE, MAX_DOCK_SIZE } from "@/stores/previewDockStore";
@@ -79,6 +79,23 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
     onSuccess: onCaptureSuccess,
   });
   const tabs = usePreviewTabs(threadId);
+
+  // Page events flow through `preview:page-status`, not `preview:tabs-updated`
+  // (P2). Overlay the active tab's live chrome so its bar entry stays current
+  // without re-serializing the whole tab set on every navigation/favicon tick.
+  const displayTabSet = useMemo(() => {
+    const ts = tabs.tabSet;
+    if (!ts || !ts.activeTabId) return ts;
+    const status = bridge.pageStatus;
+    return {
+      ...ts,
+      tabs: ts.tabs.map((t) =>
+        t.id === ts.activeTabId
+          ? { ...t, title: status.title, url: status.url, faviconUrl: status.favicon }
+          : t,
+      ),
+    };
+  }, [tabs.tabSet, bridge.pageStatus]);
   // Each selector returns a stable primitive/function reference so Zustand
   // does not re-render on unrelated store mutations.
   const dock = usePreviewDockStore((s) => s.docks[threadId]) ?? {
@@ -261,7 +278,7 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
       className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
       <PreviewTabBar
-        tabSet={tabs.tabSet}
+        tabSet={displayTabSet}
         onNewTab={tabs.newTab}
         onActivate={tabs.activateTab}
         onClose={tabs.closeTab}

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -85,9 +85,7 @@ describe("PreviewPanel — full panel state", () => {
         getNavigationState: vi
           .fn()
           .mockResolvedValue({ canGoBack: false, canGoForward: false }),
-        onDidNavigate: vi.fn().mockReturnValue(() => {}),
-        onDidUpdateFavicon: vi.fn().mockReturnValue(() => {}),
-        onLoadingState: vi.fn().mockReturnValue(() => {}),
+        onPageStatus: vi.fn().mockReturnValue(() => {}),
         cancelCapture: vi.fn().mockResolvedValue(undefined),
       },
     };

--- a/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
+++ b/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/stores/workspaceStore", () => ({
   ),
 }));
 
-// Make useDiffStore.getState() available for the onDidNavigate handler.
+// Make useDiffStore.getState() available for the onPageStatus handler.
 import { useDiffStore } from "@/stores/diffStore";
 (useDiffStore as unknown as { getState: () => unknown }).getState = () => ({
   setPreviewUrlForThread: mockSetPreviewUrlForThread,

--- a/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
+++ b/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
@@ -59,9 +59,7 @@ function makeMockPreview() {
     reload: vi.fn().mockResolvedValue(undefined),
     openExternal: vi.fn().mockResolvedValue(undefined),
     getNavigationState: vi.fn().mockResolvedValue({ canGoBack: false, canGoForward: false }),
-    onDidNavigate: vi.fn().mockReturnValue(() => {}),
-    onLoadingState: vi.fn().mockReturnValue(() => {}),
-    onDidUpdateFavicon: vi.fn().mockReturnValue(() => {}),
+    onPageStatus: vi.fn().mockReturnValue(() => {}),
     cancelCapture: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -328,188 +326,93 @@ describe("usePreviewBridge", () => {
     });
   });
 
-  describe("onDidNavigate subscription", () => {
-    it("updates inputUrl and pageTitle when the navigate event fires", async () => {
+  describe("onPageStatus subscription", () => {
+    type StatusCb = (s: import("@mcode/contracts").PreviewPageStatus) => void;
+
+    function captureStatusCb(mockPreview: ReturnType<typeof makeMockPreview>) {
+      let cb: StatusCb | null = null;
+      mockPreview.onPageStatus.mockImplementation((fn: StatusCb) => {
+        cb = fn;
+        return () => {};
+      });
+      return () => cb;
+    }
+
+    it("derives inputUrl, pageTitle, faviconUrl, and previewLoading from status", async () => {
       const mockPreview = makeMockPreview();
-      let capturedCallback: ((p: { url: string; title?: string; favicon?: string }) => void) | null = null;
-
-      mockPreview.onDidNavigate.mockImplementation(
-        (cb: (p: { url: string; title?: string; favicon?: string }) => void) => {
-          capturedCallback = cb;
-          return () => {};
-        },
-      );
-
+      const getCb = captureStatusCb(mockPreview);
       window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
 
       const { result } = renderHook(() =>
-        usePreviewBridge({
-          threadId: "t-1",
-          workspaceId: "ws-1",
-          surfaceRef: makeSurfaceRef(),
-        }),
+        usePreviewBridge({ threadId: "t-1", workspaceId: "ws-1", surfaceRef: makeSurfaceRef() }),
       );
-
-      expect(capturedCallback).not.toBeNull();
+      expect(getCb()).not.toBeNull();
 
       await act(async () => {
-        capturedCallback!({ url: "https://example.com", title: "Example Page" });
+        getCb()!({
+          url: "https://example.com",
+          title: "Example Page",
+          favicon: "https://example.com/fav.ico",
+          phase: "loading",
+        });
       });
 
       expect(result.current.inputUrl).toBe("https://example.com");
       expect(result.current.pageTitle).toBe("Example Page");
+      expect(result.current.faviconUrl).toBe("https://example.com/fav.ico");
+      expect(result.current.previewLoading).toBe(true);
+
+      await act(async () => {
+        getCb()!({
+          url: "https://example.com",
+          title: "Example Page",
+          favicon: "https://example.com/fav.ico",
+          phase: "loaded",
+        });
+      });
+      expect(result.current.previewLoading).toBe(false);
     });
 
-    it("clears pageTitle and faviconUrl when the URL is a chrome-error:// URL", async () => {
+    it("clears title and favicon when the URL is a chrome-error:// URL", async () => {
       const mockPreview = makeMockPreview();
-      let capturedCallback: ((p: { url: string; title?: string; favicon?: string }) => void) | null = null;
-
-      // First set a valid navigate so title/favicon are set.
-      mockPreview.onDidNavigate.mockImplementation(
-        (cb: (p: { url: string; title?: string; favicon?: string }) => void) => {
-          capturedCallback = cb;
-          return () => {};
-        },
-      );
-
+      const getCb = captureStatusCb(mockPreview);
       window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
 
       const { result } = renderHook(() =>
-        usePreviewBridge({
-          threadId: "t-1",
-          workspaceId: "ws-1",
-          surfaceRef: makeSurfaceRef(),
-        }),
+        usePreviewBridge({ threadId: "t-1", workspaceId: "ws-1", surfaceRef: makeSurfaceRef() }),
       );
 
-      // Establish some state first.
       await act(async () => {
-        capturedCallback!({ url: "https://example.com", title: "Example", favicon: "https://example.com/fav.ico" });
+        getCb()!({
+          url: "https://example.com",
+          title: "Example",
+          favicon: "https://example.com/fav.ico",
+          phase: "loaded",
+        });
       });
-
       expect(result.current.pageTitle).toBe("Example");
 
-      // Now fire a chrome-error URL.
       await act(async () => {
-        capturedCallback!({ url: "chrome-error://chromewebdata", title: "Error" });
+        getCb()!({ url: "chrome-error://chromewebdata", title: "Error", favicon: null, phase: "error" });
       });
-
       expect(result.current.pageTitle).toBeNull();
       expect(result.current.faviconUrl).toBeNull();
     });
 
-    it("calls the cleanup function returned by onDidNavigate on unmount", async () => {
+    it("calls the cleanup function returned by onPageStatus on unmount", async () => {
       const cleanup = vi.fn();
       const mockPreview = makeMockPreview();
-      mockPreview.onDidNavigate.mockReturnValue(cleanup);
-
+      mockPreview.onPageStatus.mockReturnValue(cleanup);
       window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
 
       const { unmount } = renderHook(() =>
-        usePreviewBridge({
-          threadId: "t-1",
-          workspaceId: "ws-1",
-          surfaceRef: makeSurfaceRef(),
-        }),
+        usePreviewBridge({ threadId: "t-1", workspaceId: "ws-1", surfaceRef: makeSurfaceRef() }),
       );
 
       await act(async () => {
         unmount();
       });
-
       expect(cleanup).toHaveBeenCalled();
-    });
-  });
-
-  describe("onLoadingState subscription", () => {
-    it("updates previewLoading when the loading event fires", async () => {
-      const mockPreview = makeMockPreview();
-      let capturedCallback: ((p: { loading: boolean }) => void) | null = null;
-
-      mockPreview.onLoadingState.mockImplementation(
-        (cb: (p: { loading: boolean }) => void) => {
-          capturedCallback = cb;
-          return () => {};
-        },
-      );
-
-      window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
-
-      const { result } = renderHook(() =>
-        usePreviewBridge({
-          threadId: "t-1",
-          workspaceId: "ws-1",
-          surfaceRef: makeSurfaceRef(),
-        }),
-      );
-
-      expect(capturedCallback).not.toBeNull();
-
-      await act(async () => {
-        capturedCallback!({ loading: true });
-      });
-
-      expect(result.current.previewLoading).toBe(true);
-
-      await act(async () => {
-        capturedCallback!({ loading: false });
-      });
-
-      expect(result.current.previewLoading).toBe(false);
-    });
-
-    it("calls the cleanup from onLoadingState on unmount", async () => {
-      const cleanup = vi.fn();
-      const mockPreview = makeMockPreview();
-      mockPreview.onLoadingState.mockReturnValue(cleanup);
-
-      window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
-
-      const { unmount } = renderHook(() =>
-        usePreviewBridge({
-          threadId: "t-1",
-          workspaceId: "ws-1",
-          surfaceRef: makeSurfaceRef(),
-        }),
-      );
-
-      await act(async () => {
-        unmount();
-      });
-
-      expect(cleanup).toHaveBeenCalled();
-    });
-  });
-
-  describe("onDidUpdateFavicon subscription", () => {
-    it("updates faviconUrl when the favicon event fires", async () => {
-      const mockPreview = makeMockPreview();
-      let capturedCallback: ((p: { favicon: string }) => void) | null = null;
-
-      mockPreview.onDidUpdateFavicon.mockImplementation(
-        (cb: (p: { favicon: string }) => void) => {
-          capturedCallback = cb;
-          return () => {};
-        },
-      );
-
-      window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
-
-      const { result } = renderHook(() =>
-        usePreviewBridge({
-          threadId: "t-1",
-          workspaceId: "ws-1",
-          surfaceRef: makeSurfaceRef(),
-        }),
-      );
-
-      expect(capturedCallback).not.toBeNull();
-
-      await act(async () => {
-        capturedCallback!({ favicon: "https://example.com/favicon.ico" });
-      });
-
-      expect(result.current.faviconUrl).toBe("https://example.com/favicon.ico");
     });
   });
 

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -5,6 +5,7 @@ import {
   useState,
   type RefObject,
 } from "react";
+import type { PreviewPageStatus } from "@mcode/contracts";
 import { useDiffStore } from "@/stores/diffStore";
 import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -49,6 +50,8 @@ export interface PreviewBridgeState {
   readonly previewLoading: boolean;
   readonly pageTitle: string | null;
   readonly faviconUrl: string | null;
+  /** Full active-tab page status; the tab bar overlays its active entry from this. */
+  readonly pageStatus: PreviewPageStatus;
   /** Persisted URL for the current thread (Zustand store). */
   readonly storedUrl: string;
   /** Push current bounds and visibility to the native BrowserView. */
@@ -76,9 +79,15 @@ export function usePreviewBridge({
   const [navError, setNavError] = useState<string | null>(null);
   const [canBack, setCanBack] = useState(false);
   const [canFwd, setCanFwd] = useState(false);
-  const [previewLoading, setPreviewLoading] = useState(false);
-  const [pageTitle, setPageTitle] = useState<string | null>(null);
-  const [faviconUrl, setFaviconUrl] = useState<string | null>(null);
+  const [pageStatus, setPageStatus] = useState<PreviewPageStatus>(() => ({
+    url: null,
+    title: null,
+    favicon: null,
+    phase: "loaded",
+  }));
+  const previewLoading = pageStatus.phase === "loading";
+  const pageTitle = pageStatus.title;
+  const faviconUrl = pageStatus.favicon;
 
   const workspacePath = useWorkspaceStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.path ?? null,
@@ -95,8 +104,7 @@ export function usePreviewBridge({
 
   useEffect(() => {
     setInputUrl(storedUrl);
-    setPageTitle(null);
-    setFaviconUrl(null);
+    setPageStatus({ url: null, title: null, favicon: null, phase: "loaded" });
     setNavError(null);
   }, [threadId, storedUrl]);
 
@@ -156,44 +164,28 @@ export function usePreviewBridge({
 
   useEffect(() => {
     const preview = window.desktopBridge?.preview;
-    if (!preview) return;
-    const unsub = preview.onDidNavigate((p) => {
-      if (
-        p.url &&
-        !p.url.startsWith("chrome-error://") &&
-        !p.url.startsWith("about:")
-      ) {
-        useDiffStore.getState().setPreviewUrlForThread(threadId, p.url);
-        setInputUrl(p.url);
-        setPageTitle(p.title ?? null);
-        setFaviconUrl(p.favicon ?? null);
+    if (!preview?.onPageStatus) return;
+    const unsub = preview.onPageStatus((status) => {
+      const url = status.url;
+      const isReal =
+        !!url && !url.startsWith("chrome-error://") && !url.startsWith("about:");
+      if (isReal) {
+        useDiffStore.getState().setPreviewUrlForThread(threadId, url);
+        setInputUrl(url);
+        setPageStatus(status);
       } else {
-        // Empty URL or about:blank => brand-new / blank tab. Clear the
-        // omnibox AND the per-thread URL store so the previous tab's URL
-        // does not bleed into a freshly-activated blank tab.
+        // Blank / about: / chrome-error => brand-new or failed surface. Clear
+        // the omnibox AND the per-thread URL store so a stale URL does not
+        // bleed in, and suppress title/favicon so the chrome reads
+        // "nothing loaded".
         useDiffStore.getState().setPreviewUrlForThread(threadId, "");
         setInputUrl("");
-        setPageTitle(null);
-        setFaviconUrl(null);
+        setPageStatus({ ...status, title: null, favicon: null });
       }
       void refreshNav();
     });
     return unsub;
   }, [threadId, refreshNav]);
-
-  useEffect(() => {
-    const preview = window.desktopBridge?.preview;
-    if (!preview?.onDidUpdateFavicon) return;
-    return preview.onDidUpdateFavicon((p) => {
-      setFaviconUrl(p.favicon);
-    });
-  }, []);
-
-  useEffect(() => {
-    const preview = window.desktopBridge?.preview;
-    if (!preview) return;
-    return preview.onLoadingState((p) => setPreviewLoading(p.loading));
-  }, []);
 
   // Hide the native WebContentsView while any modal/dialog overlay is open
   // in the renderer. Without this the native view paints above all HTML and
@@ -296,6 +288,7 @@ export function usePreviewBridge({
     previewLoading,
     pageTitle,
     faviconUrl,
+    pageStatus,
     storedUrl,
     pushSync,
     refreshNav,

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -1,5 +1,5 @@
 import type { AttachmentMeta } from "./types";
-import type { BrowserPerfCounters, BrowserTabSet, McodeBrowserCapture } from "@mcode/contracts";
+import type { BrowserPerfCounters, BrowserTabSet, McodeBrowserCapture, PreviewPageStatus } from "@mcode/contracts";
 
 /** Discriminated union describing the auto-updater lifecycle state. */
 export type UpdateStatus =
@@ -103,11 +103,11 @@ interface PreviewBridge {
   capturePageContext(): Promise<PreviewContextReferenceResult>;
   /** Deletes workspace-relative preview spill files after the message was sent or the queue dropped them. */
   releaseBrowserCaptureSpills(paths: readonly string[]): Promise<void>;
-  onDidNavigate(callback: (payload: { url: string; title: string; favicon?: string | null }) => void): () => void;
-  /** Guest load lifecycle for shell chrome (BrowserView covers the surface div). */
-  onLoadingState(callback: (payload: { loading: boolean }) => void): () => void;
-  /** Subscribe to favicon updates from the guest webContents. */
-  onDidUpdateFavicon(callback: (payload: { favicon: string | null }) => void): () => void;
+  /**
+   * Single page-status channel for the active tab. The renderer holds one
+   * {@link PreviewPageStatus} and derives loading/title/favicon from it.
+   */
+  onPageStatus(callback: (status: PreviewPageStatus) => void): () => void;
   /** Cancel any in-progress capture operation (region or element-pick). */
   cancelCapture(): Promise<void>;
   /** Multi-tab control surface (Phase A of the in-app browser rewrite). */

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -150,6 +150,18 @@ export type {
 } from "./models/browser-tab.js";
 
 export {
+  PreviewPagePhaseSchema,
+  PreviewPageErrorSchema,
+  PreviewPageStatusSchema,
+  PREVIEW_PAGE_STATUS_STRING_MAX,
+} from "./models/preview-page-status.js";
+export type {
+  PreviewPagePhase,
+  PreviewPageError,
+  PreviewPageStatus,
+} from "./models/preview-page-status.js";
+
+export {
   BROWSER_USE_FRAME_HEADER_BYTES,
   BROWSER_USE_MAX_MESSAGE_BYTES,
   BROWSER_USE_METHODS,

--- a/packages/contracts/src/models/preview-page-status.ts
+++ b/packages/contracts/src/models/preview-page-status.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+
+/**
+ * Max lengths for {@link PreviewPageStatus} string fields. Enforced at the IPC
+ * boundary so a runaway page title or huge favicon/url cannot blow up renderer
+ * state. Mirrors BROWSER_TAB_INFO_STRING_MAX so tab and page-status agree.
+ */
+export const PREVIEW_PAGE_STATUS_STRING_MAX = {
+  url: 4096,
+  title: 240,
+  favicon: 4096,
+  message: 500,
+} as const;
+
+/** Load phase of the active preview tab. */
+export const PreviewPagePhaseSchema = lazySchema(() =>
+  z.enum(["loading", "loaded", "error", "discarded"]),
+);
+export type PreviewPagePhase = z.infer<ReturnType<typeof PreviewPagePhaseSchema>>;
+
+/**
+ * Classified load failure attached to a status whose phase is `error`.
+ * Populated by W1 (`classifyLoadResult`); defined here so the reducer and the
+ * renderer share one shape.
+ */
+export const PreviewPageErrorSchema = lazySchema(() =>
+  z.object({
+    kind: z.enum(["http", "network", "file-not-found", "crash"]),
+    status: z.number().int().optional(),
+    message: z.string().max(PREVIEW_PAGE_STATUS_STRING_MAX.message),
+  }),
+);
+export type PreviewPageError = z.infer<ReturnType<typeof PreviewPageErrorSchema>>;
+
+/**
+ * Full page state for the active preview tab, carried by the single
+ * `preview:page-status` channel. The renderer holds exactly one of these and
+ * derives loading/title/favicon from it.
+ */
+export const PreviewPageStatusSchema = lazySchema(() =>
+  z.object({
+    url: z.string().max(PREVIEW_PAGE_STATUS_STRING_MAX.url).nullable(),
+    title: z.string().max(PREVIEW_PAGE_STATUS_STRING_MAX.title).nullable(),
+    favicon: z.string().max(PREVIEW_PAGE_STATUS_STRING_MAX.favicon).nullable(),
+    phase: PreviewPagePhaseSchema(),
+    error: PreviewPageErrorSchema().optional(),
+  }),
+);
+export type PreviewPageStatus = z.infer<ReturnType<typeof PreviewPageStatusSchema>>;


### PR DESCRIPTION
## What
Collapse the preview's scattered per-page IPC channels into one host to renderer channel `preview:page-status`, driven by a single pure reducer. The renderer now holds one `PreviewPageStatus` object instead of separate loading, title, and favicon state.

## Why
The preview tracked active-tab page state across three channels (`preview:loading-state`, `preview:did-navigate`, `preview:did-update-favicon`) plus duplicated host and renderer state. Error and discard states could not compose through a single path. This is the foundation (W2) that the error-states (W1) and memory-saver-tabs (W3) features both emit through. It also folds in two perf fixes that ride the same path.

This is a behavior-preserving refactor: navigation, title, favicon, and loading look exactly as before, but flow through one channel.

## Key Changes
- New `PreviewPageStatus { url, title, favicon, phase, error? }` contract in `@mcode/contracts`.
- New pure reducer `pageStatusReducer(prev, event)` is the only place page state transitions. Covered by unit tests for every transition: loading to loaded, loading to error, error to loading (retry), loaded to discarded, discarded to loading (re-warm), and loading-clears-on-error.
- Host emits the full status on `preview:page-status` through one `applyPageStatus()` path; preload exposes `onPageStatus()`. The three old per-page channels are removed.
- Renderer bridge holds one status object and derives `previewLoading` / `pageTitle` / `faviconUrl`, so the panel and omnibox contract is unchanged.
- P1: `page-title-updated` no longer runs `validateResumeUrl` (lstat/realpath/stat). A title change does not change the URL, so the file-stat work was pure waste.
- P2: page events no longer re-serialize the full `BrowserTabSet`. The active tab's bar entry is overlaid from the live page status instead.

## Notes for reviewers
- Background-tab title/favicon updates no longer push live to the tab bar; they refresh on activate. This is a direct consequence of removing the per-event `tabs-updated` re-serialization (P2). Active-tab chrome stays live via the overlay, and W3 discards background tabs anyway.
- Native-BrowserView visual verification was not run: the preview guest view requires the Electron desktop runtime, which is unreachable through plain-browser Playwright. The mocked-bridge e2e spec (`preview-chrome`) is the closest functional coverage and passes (11/11).

## Test plan
- [x] Reducer unit tests: 11/11
- [x] Desktop preview integration: 63/63
- [x] `usePreviewBridge`: 21/21, `PreviewPanel`: 7/7
- [x] Preview e2e (`preview-chrome`): 11/11
- [x] Typecheck + lint + test for `@mcode/contracts`, `mcode-desktop`, `mcode-frontend`: green
- [ ] Full `bun run verify` is green except 7 pre-existing `apps/server` snapshot-service flakes (git-setup hook timeouts on Windows; this diff touches zero server files)

Closes #553
Related to #552

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783105752&installation_id=129163861&pr_number=557&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F557&signature=de43943d3a91947f0696c2505d1665879316bbe6b6358625614f5918d0432014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page state transitions in preview tabs with better handling of navigation, loading, error, and recovery scenarios.

* **Improvements**
  * Consolidated preview information delivery system for more reliable synchronization of page content details (URL, title, favicon) and loading states across the preview panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->