### PR TITLE
docs(adr): no in-app multi-engine browser preview

### DIFF
--- a/docs/adr/0003-no-in-app-multi-engine-browser-preview.md
+++ b/docs/adr/0003-no-in-app-multi-engine-browser-preview.md
@@ -1,0 +1,56 @@
+# No in-app multi-engine (Firefox/WebKit) browser preview
+
+Status: accepted
+
+We will **not** build multi-engine browser preview inside Mcode (issue #452, closed
+wontfix). The in-app preview stays Chromium-only via Electron's `WebContentsView`.
+Cross-browser verification is served by launching the user's **real installed
+browser** ("Open in browser", already on the roadmap via #554), not by embedding or
+bundling Firefox/WebKit.
+
+## Why
+
+The motivating goal is cross-browser **verification** ("does my page render the same
+in Firefox/WebKit"), not cross-browser embedding. Embedding a non-Chromium engine in
+the panel is categorically impossible, and every workaround is dominated by simpler
+options:
+
+- **No desktop Gecko embedding exists.** `GeckoView` is Android-only and Mozilla has
+  no desktop plans. WebKit is embeddable only as the *system* engine (WKWebView on
+  macOS, WebKitGTK on Linux); there is no first-class embeddable WebKit on Windows.
+  Electron `WebContentsView`/`<webview>` are Chromium-only.
+- **A Playwright-launched headed window can't be docked or positioned.** Playwright
+  exposes no cross-engine window-bounds API (`Browser.setWindowBounds` is
+  Chromium-only; WebKit ignores it; Firefox moves only the viewport). It would float
+  as a separate, unpositionable window.
+- **A Playwright headed window adds little.** It drives only Playwright's *pinned,
+  non-real* Firefox/WebKit builds, so it benefits only users who lack the real
+  browser (i.e. WebKit on Windows/Linux). If the user has Safari/Firefox, the real
+  browser is strictly better; if they don't, a static in-panel screenshot covers the
+  same case more cheaply.
+- **The category leaders hit the same wall.** Polypane, Sizzy, and Responsively all
+  render Chromium-only; Polypane (whose author asked Mozilla directly) ships "Portal"
+  to open and sync the page in the user's *real* browsers rather than embedding.
+
+The whole preview tooling surface (capture, design-mode inspect, region/element pick,
+and the Codex browser-use bridge over `webContents.debugger` CDP) is Chromium/CDP
+coupled and does not port to non-Chromium engines regardless.
+
+## Considered and rejected
+
+- **`PreviewEngine` abstraction + bundled Playwright engines in managed windows**
+  (the original #452 plan): impossible to dock, pinned non-real builds, 100-300MB
+  per-engine downloads, a full parallel host-side implementation of every preview
+  feature against the Playwright `Page` API. Not worth the benefit.
+- **Static in-panel engine screenshots** (headless Playwright render -> image in the
+  panel): the cleanest in-app option and the only way to show WebKit on Windows/Linux,
+  but still carries the per-engine download (the no-API-keys rule rules out cloud
+  screenshot services). Parked as a possible opt-in plugin, not built now.
+
+## The only proper path (out of scope)
+
+True multi-engine support belongs in a **dedicated standalone developer-browser
+product** with an owner responsible for keeping each engine on par with Chrome, Edge,
+Safari, and Firefox. If that ever exists, Mcode could integrate it as a **plugin** that
+launches engine instances, or expose those engines to the **agent** for browser use.
+Both are future, separate efforts, not a fix for #452.


### PR DESCRIPTION
## What

Add ADR 0003 recording the decision not to build multi-engine (Firefox/WebKit) browser preview inside Mcode, and close #452.

## Why

#452 proposed adding Firefox and WebKit preview via a `PreviewEngine` abstraction and bundled Playwright engines in managed windows. Grilling that model against Electron and Playwright reality showed the benefit does not justify the cost, and the core approach is not achievable:

- No desktop Gecko embedding exists (`GeckoView` is Android-only; Mozilla has no desktop plans). WebKit is embeddable only as the system engine (WKWebView on macOS, WebKitGTK on Linux), with none on Windows. Electron `WebContentsView`/`<webview>` are Chromium-only.
- A Playwright headed window cannot be docked or positioned (no cross-engine window-bounds API) and drives only pinned, non-real engine builds, so it benefits only users who lack the real browser.
- The leading dev browsers (Polypane, Sizzy, Responsively) all render Chromium-only; Polypane opens and syncs the user's real browsers rather than embedding.
- The existing preview tooling (capture, design-mode, element/region pick, Codex browser-use over CDP) is Chromium/CDP-coupled and would not port.

Cross-browser verification is served instead by launching the user's real installed browser, already covered by the "Open in browser" action landing in #554.

## Key Changes

- Add `docs/adr/0003-no-in-app-multi-engine-browser-preview.md` (numbered 0003 to avoid colliding with #552's reserved ADR 0002).

Closes #452

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783107128&installation_id=129163861&pr_number=560&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F560&signature=5e4d5284c9e11eb94b0bc0fe72f7a49ed52601f5b4b27447b9e157e3da206fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture documentation clarifying that in-app browser preview is Chromium-only; cross-browser verification uses the user's installed browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->