### PR TITLE
feat(preview): in-panel error states for failed loads

### DIFF
--- a/apps/desktop/src/main/__tests__/classify-load-result.test.ts
+++ b/apps/desktop/src/main/__tests__/classify-load-result.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { classifyLoadResult, crashError } from "../preview/classify-load-result.js";
+
+describe("classifyLoadResult", () => {
+  it("returns 'ok' for a clean main-frame load (no error code, no http error)", () => {
+    expect(classifyLoadResult(true, 0, "", 200, "https://x.test")).toBe("ok");
+  });
+
+  it("classifies main-frame HTTP 404 as http with status and 'Page not found'", () => {
+    const r = classifyLoadResult(true, 0, "", 404, "https://x.test/missing");
+    expect(r).toEqual({ kind: "http", status: 404, message: "Page not found" });
+  });
+
+  it("classifies a generic 4xx as http with a neutral message", () => {
+    const r = classifyLoadResult(true, 0, "", 403, "https://x.test/forbidden");
+    expect(r).toEqual({ kind: "http", status: 403, message: "The site returned an error" });
+  });
+
+  it("classifies main-frame HTTP 5xx as http with 'The site had an error'", () => {
+    const r = classifyLoadResult(true, 0, "", 503, "https://x.test");
+    expect(r).toEqual({ kind: "http", status: 503, message: "The site had an error" });
+  });
+
+  it("returns 'ok' for ERR_ABORTED (-3): redirects and user cancels are not failures", () => {
+    expect(classifyLoadResult(true, -3, "ERR_ABORTED", 0, "https://x.test")).toBe("ok");
+  });
+
+  it("returns 'ok' for any sub-frame failure so the whole page is not blanked", () => {
+    expect(classifyLoadResult(false, -105, "ERR_NAME_NOT_RESOLVED", 0, "https://ad.test")).toBe(
+      "ok",
+    );
+    // Even a sub-frame HTTP error must not blank the page.
+    expect(classifyLoadResult(false, 0, "", 500, "https://ad.test")).toBe("ok");
+  });
+
+  it("classifies ERR_FILE_NOT_FOUND (-6) as file-not-found and carries the code", () => {
+    const r = classifyLoadResult(true, -6, "ERR_FILE_NOT_FOUND", 0, "file:///gone.html");
+    expect(r).toEqual({
+      kind: "file-not-found",
+      code: "ERR_FILE_NOT_FOUND",
+      message: "File no longer exists",
+    });
+  });
+
+  it("classifies DNS / offline errors as network and surfaces the net-error code", () => {
+    const r = classifyLoadResult(true, -105, "ERR_NAME_NOT_RESOLVED", 0, "https://nope.test");
+    expect(r).toEqual({
+      kind: "network",
+      code: "ERR_NAME_NOT_RESOLVED",
+      message: "Can't reach this site",
+    });
+  });
+
+  it("classifies an unknown negative net error on the main frame as network", () => {
+    const r = classifyLoadResult(true, -2, "ERR_FAILED", 0, "https://x.test");
+    expect(r).toEqual({ kind: "network", code: "ERR_FAILED", message: "Can't reach this site" });
+  });
+
+  it("prefers the HTTP status when both an http error and a benign code are present", () => {
+    const r = classifyLoadResult(true, 0, "", 404, "https://x.test");
+    expect(r).toEqual({ kind: "http", status: 404, message: "Page not found" });
+  });
+});
+
+describe("crashError", () => {
+  it("builds a crash error with 'This page crashed'", () => {
+    expect(crashError()).toEqual({ kind: "crash", message: "This page crashed" });
+  });
+});

--- a/apps/desktop/src/main/__tests__/page-status-reducer.test.ts
+++ b/apps/desktop/src/main/__tests__/page-status-reducer.test.ts
@@ -41,6 +41,17 @@ describe("pageStatusReducer", () => {
     expect(errored.error).toEqual(ERR);
   });
 
+  it("load-error adopts the failed URL when carried, so the panel can show it", () => {
+    const loading = pageStatusReducer(initialPageStatus(), { type: "load-start" });
+    const errored = pageStatusReducer(loading, {
+      type: "load-error",
+      error: { kind: "network", message: "Can't reach this site" },
+      url: "https://nope.test",
+    });
+    expect(errored.phase).toBe("error");
+    expect(errored.url).toBe("https://nope.test");
+  });
+
   it("error -> loading on retry (load-start)", () => {
     const errored = { url: "https://x.test", title: null, favicon: null, phase: "error" as const, error: ERR };
     const retry = pageStatusReducer(errored, { type: "load-start" });

--- a/apps/desktop/src/main/preview/classify-load-result.ts
+++ b/apps/desktop/src/main/preview/classify-load-result.ts
@@ -1,0 +1,85 @@
+/**
+ * Single source of truth for "did this preview load fail, and how". Pure: maps
+ * the raw signals the host gets from a guest WebContents (HTTP status from
+ * `did-navigate`, Chromium net error codes from `did-fail-load` /
+ * `did-fail-provisional-load`) onto the shared {@link PreviewPageError} shape.
+ *
+ * The reducer and renderer never re-derive failure; they consume the result of
+ * this function so error copy and detection stay in one place.
+ */
+
+import type { PreviewPageError } from "@mcode/contracts";
+
+/** Chromium net error: the load was deliberately aborted (redirect, user cancel). */
+const ERR_ABORTED = -3;
+/** Chromium net error: a `file:` target did not exist on disk. */
+const ERR_FILE_NOT_FOUND = -6;
+
+/** Per-kind plain-language copy. The classifier is the only place these live. */
+const COPY = {
+  notFound: "Page not found",
+  serverError: "The site had an error",
+  httpOther: "The site returned an error",
+  network: "Can't reach this site",
+  fileMissing: "File no longer exists",
+  crash: "This page crashed",
+} as const;
+
+/**
+ * Classifies a load outcome.
+ *
+ * @param isMainFrame Whether the event came from the top-level frame. Sub-frame
+ *   failures never blank the whole preview, so they always classify as `"ok"`.
+ * @param errorCode Chromium net error code from a `did-fail-load` event, or `0`
+ *   when the signal is an HTTP status (from `did-navigate`).
+ * @param errorDescription Chromium's net-error name (e.g.
+ *   `ERR_NAME_NOT_RESOLVED`); surfaced as the diagnostic `code` for the
+ *   developer audience on network/file failures.
+ * @param httpStatus The committed response status from `did-navigate`, or `0`
+ *   when none (provisional failure before a response).
+ * @param _url The URL that was loading; carried to keep the signature stable
+ *   for callers and future scheme-specific rules.
+ * @returns `"ok"` when the load did not fail, else a classified
+ *   {@link PreviewPageError}.
+ */
+export function classifyLoadResult(
+  isMainFrame: boolean,
+  errorCode: number,
+  errorDescription: string,
+  httpStatus: number,
+  _url: string,
+): "ok" | PreviewPageError {
+  // A sub-frame (ad iframe, embedded widget) failing must not blank the page.
+  if (!isMainFrame) return "ok";
+
+  // HTTP errors win: the navigation committed a response, so the status is the
+  // authoritative signal even if a benign code rode alongside it.
+  if (httpStatus >= 400) {
+    return { kind: "http", status: httpStatus, message: httpMessage(httpStatus) };
+  }
+
+  // Redirects and user-initiated cancels surface as ERR_ABORTED; not a failure.
+  if (errorCode === 0 || errorCode === ERR_ABORTED) return "ok";
+
+  const code = errorDescription.length > 0 ? errorDescription : undefined;
+
+  if (errorCode === ERR_FILE_NOT_FOUND) {
+    return { kind: "file-not-found", code, message: COPY.fileMissing };
+  }
+
+  // Any other main-frame load error (DNS, offline, connection refused/reset,
+  // generic ERR_FAILED) reads to the user as "can't reach this site".
+  return { kind: "network", code, message: COPY.network };
+}
+
+/** Builds the crash error surfaced when a guest renderer process is gone. */
+export function crashError(): PreviewPageError {
+  return { kind: "crash", message: COPY.crash };
+}
+
+/** Maps an HTTP error status onto its plain-language headline. */
+function httpMessage(status: number): string {
+  if (status === 404) return COPY.notFound;
+  if (status >= 500) return COPY.serverError;
+  return COPY.httpOther;
+}

--- a/apps/desktop/src/main/preview/page-status-reducer.ts
+++ b/apps/desktop/src/main/preview/page-status-reducer.ts
@@ -19,8 +19,13 @@ export type PageStatusEvent =
   | { type: "favicon"; favicon: string | null }
   /** did-stop-loading / did-finish-load: settle to loaded (unless already error). */
   | { type: "load-stop" }
-  /** Classified failure (W1): enter error and clear the loading affordance. */
-  | { type: "load-error"; error: PreviewPageError }
+  /**
+   * Classified failure (W1): enter error and clear the loading affordance.
+   * `url` carries the failed address (from did-fail-load's validatedURL) so the
+   * error panel can show it and offer "Open in browser" / "Edit URL" even when
+   * the navigation never committed a URL.
+   */
+  | { type: "load-error"; error: PreviewPageError; url?: string | null }
   /** Memory-saver eviction (W3): enter discarded, keep cold chrome. */
   | { type: "discard" }
   /** Tab/thread switch: replace the whole status with the activated tab's chrome. */
@@ -61,7 +66,13 @@ export function pageStatusReducer(
     case "load-stop":
       return prev.phase === "error" ? prev : { ...prev, phase: "loaded" };
     case "load-error":
-      return { ...prev, phase: "error", favicon: null, error: event.error };
+      return {
+        ...prev,
+        url: event.url !== undefined ? event.url : prev.url,
+        phase: "error",
+        favicon: null,
+        error: event.error,
+      };
     case "discard":
       return { ...prev, phase: "discarded" };
     case "reset":

--- a/apps/desktop/src/main/preview/preview-lifecycle.ts
+++ b/apps/desktop/src/main/preview/preview-lifecycle.ts
@@ -23,6 +23,7 @@ import {
 import { removeEpPickHighlighter, abortOverlayCapture } from "./preview-overlay.js";
 import { pushPreviewConsoleLine } from "./preview-capture.js";
 import { validateResumeUrl, trustMainProcessFileNavigation } from "./preview-local-file.js";
+import { classifyLoadResult, crashError } from "./classify-load-result.js";
 
 /**
  * Injected into every guest document so preview scrollbars match the app shell on Windows
@@ -77,6 +78,8 @@ export function detachViewListeners(view: WebContentsView): void {
   view.webContents.removeAllListeners("page-title-updated");
   view.webContents.removeAllListeners("page-favicon-updated");
   view.webContents.removeAllListeners("did-finish-load");
+  view.webContents.removeAllListeners("did-fail-load");
+  view.webContents.removeAllListeners("did-fail-provisional-load");
   view.webContents.removeAllListeners("did-start-loading");
   view.webContents.removeAllListeners("did-stop-loading");
   view.webContents.removeAllListeners("console-message");
@@ -216,9 +219,14 @@ export function ensureTabView(
     })();
   });
 
-  const forwardNav = () => {
+  const forwardNav = (httpStatus = 0) => {
     if (win.isDestroyed() || view.webContents.isDestroyed()) return;
     const url = view.webContents.getURL();
+    // Chromium commits its internal error document at a chrome-error:// URL when
+    // a provisional load fails. Adopting that as the navigated URL would clobber
+    // the error we just classified (the `navigated` reducer case clears error),
+    // so leave the page-status untouched and let load-error own the surface.
+    if (url.startsWith("chrome-error:")) return;
     void (async () => {
       if (win.isDestroyed() || view.webContents.isDestroyed()) return;
       const persisted = await validateResumeUrl(isAllowedPreviewUrl(url) ? url : null);
@@ -235,6 +243,12 @@ export function ensureTabView(
           url: url.length > 0 ? url : null,
           title,
         });
+        // A committed response with a 4xx/5xx status is a main-frame HTTP error.
+        // Classify after navigated so the error rides on the real URL/title.
+        const result = classifyLoadResult(true, 0, "", httpStatus, url);
+        if (result !== "ok") {
+          applyPageStatus(win, s, { type: "load-error", error: result });
+        }
       }
     })();
   };
@@ -251,8 +265,12 @@ export function ensureTabView(
     }
   };
 
-  view.webContents.on("did-navigate", forwardNav);
-  view.webContents.on("did-navigate-in-page", forwardNav);
+  // did-navigate carries the committed main-frame HTTP status as its third arg;
+  // did-navigate-in-page (hash/pushState) has no response, so it stays at 0.
+  view.webContents.on("did-navigate", (_e, _url, httpResponseCode: number) => {
+    forwardNav(typeof httpResponseCode === "number" ? httpResponseCode : 0);
+  });
+  view.webContents.on("did-navigate-in-page", () => forwardNav());
   view.webContents.on("page-title-updated", forwardTitle);
   view.webContents.on("page-favicon-updated", (_e, urls: string[]) => {
     tab.faviconUrl = urls[0] ?? null;
@@ -267,6 +285,34 @@ export function ensureTabView(
       void injectPreviewScrollbarStyles(s);
     }
   });
+
+  // Network / file / DNS failures. Main-frame only so a failing sub-resource
+  // iframe never blanks the whole preview; ERR_ABORTED (-3) from a redirect or
+  // user cancel is swallowed inside classifyLoadResult.
+  const forwardLoadError = (
+    errorCode: number,
+    errorDescription: string,
+    validatedURL: string,
+    isMainFrame: boolean,
+  ) => {
+    if (win.isDestroyed() || view.webContents.isDestroyed()) return;
+    if (!isActiveView()) return;
+    const result = classifyLoadResult(isMainFrame, errorCode, errorDescription, 0, validatedURL);
+    if (result === "ok") return;
+    // Carry the failed address so the panel can show it and offer Open in
+    // browser / Edit URL; only adopt real preview URLs (never chrome-error).
+    const failedUrl = isAllowedPreviewUrl(validatedURL) ? validatedURL : undefined;
+    applyPageStatus(win, s, { type: "load-error", error: result, url: failedUrl });
+  };
+  view.webContents.on("did-fail-load", (_e, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    forwardLoadError(errorCode, errorDescription, validatedURL, isMainFrame);
+  });
+  view.webContents.on(
+    "did-fail-provisional-load",
+    (_e, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      forwardLoadError(errorCode, errorDescription, validatedURL, isMainFrame);
+    },
+  );
 
   const forwardLoadingStart = () => {
     if (win.isDestroyed() || view.webContents.isDestroyed()) return;
@@ -323,7 +369,9 @@ export function ensureTabView(
     if (now - s.lastCrashRecoveryAt < CRASH_COOLDOWN_MS) {
       logger.warn("Preview: crash recovery skipped (cooldown active)");
       if (!win.isDestroyed()) {
-        setPreviewLoading(win, s, false);
+        // No auto-recovery this cycle: surface the crash so the user sees a
+        // "This page crashed" panel with Retry instead of a blank surface.
+        applyPageStatus(win, s, { type: "load-error", error: crashError() });
       }
       return;
     }

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -272,9 +272,11 @@ export function registerNavigationHandlers(): void {
     }
     // The view was torn down (e.g. a renderer crash surfaced as an error panel,
     // and the crash-cooldown skipped auto-recovery). Retry must re-create the
-    // view and reload the last URL rather than no-op.
-    const url = s.resumePreviewUrl;
-    if (!url || !s.lastBounds) return;
+    // view rather than no-op. A fresh tab can crash before it ever navigated, so
+    // resumePreviewUrl may be null; fall back to a blank guest so Retry still
+    // remounts a working surface instead of leaving the error panel stuck.
+    if (!s.lastBounds) return;
+    const url = s.resumePreviewUrl ?? "about:blank";
     const view = ensureView(win, s);
     view.setBounds(s.lastBounds);
     mountView(win, view);

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -264,9 +264,23 @@ export function registerNavigationHandlers(): void {
     const win = BrowserWindow.fromWebContents(_event.sender);
     if (!win || win.isDestroyed()) return;
     const s = getSession(win);
-    if (!s.view || s.view.webContents.isDestroyed()) return;
+    if (s.view && !s.view.webContents.isDestroyed()) {
+      setPreviewLoading(win, s, true);
+      s.view.webContents.reload();
+      resetIdle(win, s);
+      return;
+    }
+    // The view was torn down (e.g. a renderer crash surfaced as an error panel,
+    // and the crash-cooldown skipped auto-recovery). Retry must re-create the
+    // view and reload the last URL rather than no-op.
+    const url = s.resumePreviewUrl;
+    if (!url || !s.lastBounds) return;
+    const view = ensureView(win, s);
+    view.setBounds(s.lastBounds);
+    mountView(win, view);
     setPreviewLoading(win, s, true);
-    s.view.webContents.reload();
+    trustMainProcessFileNavigation(s, url);
+    void view.webContents.loadURL(url);
     resetIdle(win, s);
   });
 

--- a/apps/desktop/src/main/preview/preview-session.ts
+++ b/apps/desktop/src/main/preview/preview-session.ts
@@ -303,6 +303,7 @@ function pageStatusEqual(a: PreviewPageStatus, b: PreviewPageStatus): boolean {
     a.phase === b.phase &&
     a.error?.kind === b.error?.kind &&
     a.error?.status === b.error?.status &&
+    a.error?.code === b.error?.code &&
     a.error?.message === b.error?.message
   );
 }

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -159,6 +159,56 @@ async function injectPreviewBridge(page: Page): Promise<void> {
 }
 
 /**
+ * Layer an error page-status over the base bridge: after {@link injectPreviewBridge}
+ * sets `window.desktopBridge.preview`, override the methods the error panel
+ * touches so onPageStatus emits `phase: "error"`, navigation history is
+ * configurable, and Retry / Open in browser are observable via window counters.
+ */
+async function injectErrorBridge(
+  page: Page,
+  opts: { url: string | null; canGoBack: boolean },
+): Promise<void> {
+  await page.addInitScript((o) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any;
+    const preview = w.desktopBridge.preview;
+    w.__mcodePreview = { reload: 0, openExternal: 0 };
+    preview.onPageStatus = (
+      cb: (s: {
+        url: string | null;
+        title: string | null;
+        favicon: string | null;
+        phase: "loading" | "loaded" | "error" | "discarded";
+        error?: { kind: string; status?: number; code?: string; message: string };
+      }) => void,
+    ) => {
+      cb({
+        url: o.url,
+        title: null,
+        favicon: null,
+        phase: "error",
+        error: {
+          kind: "network",
+          code: "ERR_NAME_NOT_RESOLVED",
+          message: "Can't reach this site",
+        },
+      });
+      return () => undefined;
+    };
+    preview.getNavigationState = () =>
+      Promise.resolve({ canGoBack: o.canGoBack, canGoForward: false });
+    preview.reload = () => {
+      w.__mcodePreview.reload += 1;
+      return Promise.resolve();
+    };
+    preview.openExternal = () => {
+      w.__mcodePreview.openExternal += 1;
+      return Promise.resolve();
+    };
+  }, opts);
+}
+
+/**
  * Open the app at a thread so the right panel can be revealed for preview tests.
  * Returns once the thread view is rendered and ready for shortcut input.
  */
@@ -317,5 +367,68 @@ test.describe("PreviewPanel — chrome with mocked bridge", () => {
     // Flip the dock to the right; splitter should re-orient.
     await page.getByLabel("Dock to right").click();
     await expect(splitter).toHaveAttribute("aria-orientation", "vertical");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — preview error states (W1)
+// ---------------------------------------------------------------------------
+
+test.describe("PreviewPanel — error states", () => {
+  test("surfaces a failed load with copy and the distilled recovery actions", async ({ page }) => {
+    await injectPreviewBridge(page);
+    await injectErrorBridge(page, { url: "https://nope.test", canGoBack: true });
+    await openAppAtThread(page);
+    await openPreviewTab(page);
+
+    const panel = page.getByTestId("preview-error-panel");
+    await expect(panel).toBeVisible();
+    await expect(page.getByTestId("preview-error-headline")).toHaveText(
+      "Can't reach this site",
+    );
+    // Distilled to the essentials: Retry (primary) + Go back (history exists).
+    await expect(panel.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(panel.getByRole("button", { name: "Go back" })).toBeVisible();
+    // Redundant-with-chrome actions were removed: the omnibox is the URL editor
+    // and the toolbar owns Open-in-system-browser.
+    await expect(panel.getByRole("button", { name: "Edit URL" })).toHaveCount(0);
+    await expect(panel.getByRole("button", { name: "Open in browser" })).toHaveCount(0);
+    // Diagnostic code is shown for the developer audience.
+    await expect(panel.getByText(/ERR_NAME_NOT_RESOLVED/)).toBeVisible();
+  });
+
+  test("Retry reloads the failed page", async ({ page }) => {
+    await injectPreviewBridge(page);
+    await injectErrorBridge(page, { url: "https://nope.test", canGoBack: true });
+    await openAppAtThread(page);
+    await openPreviewTab(page);
+
+    await page.getByTestId("preview-error-retry").click();
+    await expect
+      .poll(() => page.evaluate(() => (window as unknown as { __mcodePreview: { reload: number } }).__mcodePreview.reload))
+      .toBeGreaterThan(0);
+  });
+
+  test("Go back is hidden when the guest has no history", async ({ page }) => {
+    await injectPreviewBridge(page);
+    await injectErrorBridge(page, { url: "https://nope.test", canGoBack: false });
+    await openAppAtThread(page);
+    await openPreviewTab(page);
+
+    const panel = page.getByTestId("preview-error-panel");
+    await expect(panel.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(panel.getByRole("button", { name: "Go back" })).toHaveCount(0);
+  });
+
+  test("renders the panel for a file failure with Retry only (no history)", async ({ page }) => {
+    await injectPreviewBridge(page);
+    await injectErrorBridge(page, { url: "file:///gone.html", canGoBack: false });
+    await openAppAtThread(page);
+    await openPreviewTab(page);
+
+    const panel = page.getByTestId("preview-error-panel");
+    await expect(panel).toBeVisible();
+    await expect(panel.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(panel.getByRole("button", { name: "Go back" })).toHaveCount(0);
   });
 });

--- a/apps/web/src/components/panels/PreviewErrorPanel.tsx
+++ b/apps/web/src/components/panels/PreviewErrorPanel.tsx
@@ -53,13 +53,20 @@ export function PreviewErrorPanel({
   // HTTP failures lead with the status; network/file failures with the
   // Chromium net-error code. The dev audience uses this to triage.
   const diagnostic = error.status ? String(error.status) : (error.code ?? null);
+  // Join only the present parts so the line never trails a dangling separator
+  // when one side is absent (a crash has no status/code; a provisional failure
+  // never committed a URL).
+  const diagnosticLine = [diagnostic, url].filter(Boolean).join(" \u00b7 ");
   return (
     <div
       data-testid="preview-error-panel"
       role="alert"
-      className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+      className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center motion-safe:animate-in motion-safe:fade-in"
     >
-      <Icon className="size-8 text-muted-foreground/40" aria-hidden />
+      {/* Clay-tinted per the system's errored-state color (matches the sidebar
+          thread dot and the omnibox navError line) so the failure registers at
+          a glance, kept muted to stay quiet rather than a loud alert chip. */}
+      <Icon className="size-8 text-destructive/70" aria-hidden />
       <div className="space-y-1">
         <p
           data-testid="preview-error-headline"
@@ -67,10 +74,9 @@ export function PreviewErrorPanel({
         >
           {error.message}
         </p>
-        {url || diagnostic ? (
+        {diagnosticLine ? (
           <p className="max-w-md truncate font-mono text-[11px] text-muted-foreground">
-            {diagnostic ? `${diagnostic} \u00b7 ` : ""}
-            {url}
+            {diagnosticLine}
           </p>
         ) : null}
       </div>

--- a/apps/web/src/components/panels/PreviewErrorPanel.tsx
+++ b/apps/web/src/components/panels/PreviewErrorPanel.tsx
@@ -1,0 +1,91 @@
+import {
+  ArrowLeft,
+  FileX,
+  RefreshCw,
+  ServerCrash,
+  TriangleAlert,
+  WifiOff,
+  type LucideIcon,
+} from "lucide-react";
+import type { PreviewPageError } from "@mcode/contracts";
+import { Button } from "@/components/ui/button";
+
+/** Per-kind glyph for the error headline. */
+const ERROR_ICON: Record<PreviewPageError["kind"], LucideIcon> = {
+  http: TriangleAlert,
+  network: WifiOff,
+  "file-not-found": FileX,
+  crash: ServerCrash,
+};
+
+/** Props for {@link PreviewErrorPanel}. */
+export interface PreviewErrorPanelProps {
+  /** Classified failure that put the preview into its error phase. */
+  readonly error: PreviewPageError;
+  /** URL that failed to load; shown as diagnostic context under the headline. */
+  readonly url: string | null;
+  /** Whether the guest has back history; gates the secondary "Go back" action. */
+  readonly canBack: boolean;
+  /** Reload the failed page. */
+  readonly onRetry: () => void;
+  /** Navigate the guest back one entry. */
+  readonly onGoBack: () => void;
+}
+
+/**
+ * In-chrome error surface shown (Approach A) when the native preview view is
+ * hidden because a load failed. Names the failure in plain language, shows the
+ * diagnostic code/URL for triage, and offers the one canonical recovery —
+ * Retry — plus Go back when there is history to return to.
+ *
+ * Editing the address and opening in the system browser are intentionally NOT
+ * here: the omnibox directly above is the URL editor, and the toolbar already
+ * owns "Open in system browser" (which is meaningless on an unreachable site).
+ */
+export function PreviewErrorPanel({
+  error,
+  url,
+  canBack,
+  onRetry,
+  onGoBack,
+}: PreviewErrorPanelProps) {
+  const Icon = ERROR_ICON[error.kind];
+  // HTTP failures lead with the status; network/file failures with the
+  // Chromium net-error code. The dev audience uses this to triage.
+  const diagnostic = error.status ? String(error.status) : (error.code ?? null);
+  return (
+    <div
+      data-testid="preview-error-panel"
+      role="alert"
+      className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+    >
+      <Icon className="size-8 text-muted-foreground/40" aria-hidden />
+      <div className="space-y-1">
+        <p
+          data-testid="preview-error-headline"
+          className="text-sm font-medium text-foreground"
+        >
+          {error.message}
+        </p>
+        {url || diagnostic ? (
+          <p className="max-w-md truncate font-mono text-[11px] text-muted-foreground">
+            {diagnostic ? `${diagnostic} \u00b7 ` : ""}
+            {url}
+          </p>
+        ) : null}
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-1.5">
+        <Button size="sm" onClick={onRetry} data-testid="preview-error-retry">
+          <RefreshCw aria-hidden />
+          Retry
+        </Button>
+        {canBack ? (
+          <Button size="sm" variant="outline" onClick={onGoBack}>
+            <ArrowLeft aria-hidden />
+            Go back
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -6,6 +6,7 @@ import { usePreviewDesignModeStore } from "@/stores/previewDesignModeStore";
 import { usePreviewFocusStore } from "@/stores/previewFocusStore";
 import { SmartOmnibox } from "./SmartOmnibox";
 import { PreviewToolbar } from "./PreviewToolbar";
+import { PreviewErrorPanel } from "./PreviewErrorPanel";
 import { PREVIEW_TABPANEL_ID, PreviewTabBar } from "./PreviewTabBar";
 import { PreviewPerfHud } from "./PreviewPerfHud";
 import { PreviewDevDock } from "./PreviewDevDock";
@@ -91,7 +92,17 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
       ...ts,
       tabs: ts.tabs.map((t) =>
         t.id === ts.activeTabId
-          ? { ...t, title: status.title, url: status.url, faviconUrl: status.favicon }
+          ? {
+              // Fall back to the tab's own chrome when the live page-status
+              // field is null. The per-thread reset blanks pageStatus on a
+              // thread/url change without the warm guest re-emitting its title,
+              // so overlaying null here would clobber the active tab's real
+              // title and the bar would read "New tab" over a loaded page.
+              ...t,
+              title: status.title ?? t.title,
+              url: status.url ?? t.url,
+              faviconUrl: status.favicon ?? t.faviconUrl,
+            }
           : t,
       ),
     };
@@ -271,6 +282,8 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
   }
 
   const hasLoadedPage = bridge.storedUrl.trim().length > 0;
+  const pageError =
+    bridge.pageStatus.phase === "error" ? bridge.pageStatus.error : undefined;
 
   return (
     <div
@@ -391,7 +404,19 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
               <span>{CAPTURE_KIND_LABEL[lastCapture]}</span>
             </div>
           ) : null}
-          {!hasLoadedPage && !bridge.previewLoading ? (
+          {pageError ? (
+            // Approach A: the native view is hidden (bridge syncs visible:false
+            // while phase === "error"), so this HTML panel owns the surface and
+            // names the failure with recovery actions.
+            <PreviewErrorPanel
+              error={pageError}
+              url={bridge.pageStatus.url}
+              canBack={bridge.canBack}
+              onRetry={() => void bridge.onRetry()}
+              onGoBack={() => void bridge.onGoBack()}
+            />
+          ) : null}
+          {!hasLoadedPage && !bridge.previewLoading && !pageError ? (
             // Empty state teaches what becomes available once a URL loads.
             // hasLoadedPage gates every capture/design action; without this hint
             // a first-timer lands on a bare Globe and never discovers the picker,

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../hooks/usePreviewBridge", () => ({
     previewLoading: false,
     pageTitle: null,
     faviconUrl: null,
+    pageStatus: { url: null, title: null, favicon: null, phase: "loaded" },
     storedUrl: "",
     pushSync: vi.fn(),
     refreshNav: vi.fn(),
@@ -27,7 +28,22 @@ vi.mock("../hooks/usePreviewBridge", () => ({
     onReload: vi.fn(),
     onOpenExternal: vi.fn(),
     onNavigate: vi.fn(),
+    onRetry: vi.fn(),
   }),
+}));
+
+// usePreviewTabs is controllable per-test so we can exercise the tab bar's
+// active-tab overlay. Defaults to no tab set (bar renders nothing).
+const tabsState = vi.hoisted(() => ({
+  current: {
+    tabSet: null as unknown,
+    newTab: () => {},
+    activateTab: () => {},
+    closeTab: () => {},
+  },
+}));
+vi.mock("../hooks/usePreviewTabs", () => ({
+  usePreviewTabs: () => tabsState.current,
 }));
 
 vi.mock("../hooks/usePreviewCapture", () => ({
@@ -73,6 +89,15 @@ describe("PreviewPanel — unavailable state", () => {
 
 describe("PreviewPanel — full panel state", () => {
   beforeEach(() => {
+    // The tab bar's useHorizontalScrollEdges observes layout; jsdom lacks it.
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).desktopBridge = {
       preview: {
@@ -92,6 +117,7 @@ describe("PreviewPanel — full panel state", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).desktopBridge = undefined;
   });
@@ -125,5 +151,37 @@ describe("PreviewPanel — full panel state", () => {
       ),
     ).not.toThrow();
     expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+  });
+
+  it("keeps the active tab's title when the live page-status is blank", () => {
+    // Simulates the post-reset window: pageStatus is all-null (see the mocked
+    // usePreviewBridge above) while the warm tab still carries its real title.
+    // The overlay must fall back to the tab's own title, not read "New tab".
+    tabsState.current = {
+      ...tabsState.current,
+      tabSet: {
+        threadId: "thread-1",
+        activeTabId: "tab-1",
+        tabs: [
+          {
+            id: "tab-1",
+            threadId: "thread-1",
+            title: "Google",
+            url: "https://www.google.com/search?q=google",
+            faviconUrl: null,
+            warm: true,
+            active: true,
+          },
+        ],
+      },
+    };
+
+    render(<PreviewPanel threadId="thread-1" />);
+
+    const tab = screen.getByTestId("preview-tab");
+    expect(tab).toHaveTextContent("Google");
+    expect(tab).not.toHaveTextContent("New tab");
+
+    tabsState.current = { ...tabsState.current, tabSet: null };
   });
 });

--- a/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
+++ b/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
@@ -260,6 +260,24 @@ describe("usePreviewBridge", () => {
     expect(mockPreview.openExternal).toHaveBeenCalledOnce();
   });
 
+  describe("error recovery actions", () => {
+    it("onRetry reloads the failed page and clears any nav error", async () => {
+      const mockPreview = makeMockPreview();
+      window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
+
+      const { result } = renderHook(() =>
+        usePreviewBridge({ threadId: "t-1", workspaceId: "ws-1", surfaceRef: makeSurfaceRef() }),
+      );
+
+      await act(async () => {
+        await result.current.onRetry();
+      });
+
+      expect(mockPreview.reload).toHaveBeenCalledOnce();
+      expect(result.current.navError).toBeNull();
+    });
+  });
+
   describe("onNavigate", () => {
     it("calls preview.navigate with the given URL", async () => {
       const mockPreview = makeMockPreview();

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -64,6 +64,8 @@ export interface PreviewBridgeState {
   readonly onOpenExternal: () => Promise<void>;
   /** Navigate the preview to the given URL or file path. */
   readonly onNavigate: (url: string) => void;
+  /** Recover from an error state by reloading the failed page. */
+  readonly onRetry: () => Promise<void>;
 }
 
 /**
@@ -88,6 +90,13 @@ export function usePreviewBridge({
   const previewLoading = pageStatus.phase === "loading";
   const pageTitle = pageStatus.title;
   const faviconUrl = pageStatus.favicon;
+
+  // Approach A seam: while the page is in an error phase we hide the native
+  // WebContentsView (which paints above all HTML) so the in-chrome HTML error
+  // panel is visible. pushSync reads this ref to force visible:false; the
+  // phase-change effect below re-syncs on every transition into/out of error.
+  const phaseRef = useRef(pageStatus.phase);
+  phaseRef.current = pageStatus.phase;
 
   const workspacePath = useWorkspaceStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.path ?? null,
@@ -130,7 +139,9 @@ export function usePreviewBridge({
       if (!preview) return;
       const el = surfaceRef.current;
       const hint = storedUrlRef.current.trim() || null;
-      if (!visible || !el) {
+      // Keep the native view hidden while an error panel owns the surface.
+      const effectiveVisible = visible && phaseRef.current !== "error";
+      if (!effectiveVisible || !el) {
         await preview.sync({
           visible: false,
           bounds: null,
@@ -169,6 +180,23 @@ export function usePreviewBridge({
       const url = status.url;
       const isReal =
         !!url && !url.startsWith("chrome-error://") && !url.startsWith("about:");
+      if (status.phase === "error") {
+        // Surface the error without persisting the failed URL into the
+        // per-thread store: writing it would change storedUrl and retrigger the
+        // [threadId, storedUrl] reset effect below, clobbering this error back
+        // to a blank "loaded" status before the panel ever renders. The omnibox
+        // still shows a real failed address (for Edit URL); a chrome-error/about
+        // surface reads as "nothing loaded" so its title/favicon are dropped.
+        if (isReal) {
+          setInputUrl(url);
+          setPageStatus(status);
+        } else {
+          setInputUrl("");
+          setPageStatus({ ...status, title: null, favicon: null });
+        }
+        void refreshNav();
+        return;
+      }
       if (isReal) {
         useDiffStore.getState().setPreviewUrlForThread(threadId, url);
         setInputUrl(url);
@@ -199,6 +227,12 @@ export function usePreviewBridge({
       void pushSyncRef.current(true);
     }
   }, [suppressionCount]);
+
+  // Re-sync the native view on every error<->non-error transition: hide it when
+  // an error panel takes over, re-show it when a retry clears the error.
+  useEffect(() => {
+    void pushSyncRef.current(true);
+  }, [pageStatus.phase]);
 
   useEffect(() => {
     const preview = window.desktopBridge?.preview;
@@ -263,6 +297,11 @@ export function usePreviewBridge({
     await preview.openExternal();
   }, []);
 
+  const onRetry = useCallback(async () => {
+    setNavError(null);
+    await onReload();
+  }, [onReload]);
+
   const onNavigate = useCallback(
     (url: string) => {
       const preview = window.desktopBridge?.preview;
@@ -297,5 +336,6 @@ export function usePreviewBridge({
     onReload,
     onOpenExternal,
     onNavigate,
+    onRetry,
   };
 }

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -229,10 +229,12 @@ export function usePreviewBridge({
   }, [suppressionCount]);
 
   // Re-sync the native view on every error<->non-error transition: hide it when
-  // an error panel takes over, re-show it when a retry clears the error.
+  // an error panel takes over, re-show it when a retry clears the error. Defer to
+  // suppression: a load completing while a dialog/overlay is open must not reshow
+  // the BrowserView above it, so respect suppressionCount instead of forcing true.
   useEffect(() => {
-    void pushSyncRef.current(true);
-  }, [pageStatus.phase]);
+    void pushSyncRef.current(suppressionCount === 0);
+  }, [pageStatus.phase, suppressionCount]);
 
   useEffect(() => {
     const preview = window.desktopBridge?.preview;

--- a/packages/contracts/src/models/preview-page-status.ts
+++ b/packages/contracts/src/models/preview-page-status.ts
@@ -11,6 +11,7 @@ export const PREVIEW_PAGE_STATUS_STRING_MAX = {
   title: 240,
   favicon: 4096,
   message: 500,
+  code: 120,
 } as const;
 
 /** Load phase of the active preview tab. */
@@ -28,6 +29,12 @@ export const PreviewPageErrorSchema = lazySchema(() =>
   z.object({
     kind: z.enum(["http", "network", "file-not-found", "crash"]),
     status: z.number().int().optional(),
+    /**
+     * Diagnostic code shown to the (developer) audience in the error panel:
+     * the Chromium net-error name for network/file failures
+     * (e.g. `ERR_NAME_NOT_RESOLVED`). HTTP failures use {@link status} instead.
+     */
+    code: z.string().max(PREVIEW_PAGE_STATUS_STRING_MAX.code).optional(),
     message: z.string().max(PREVIEW_PAGE_STATUS_STRING_MAX.message),
   }),
 );


### PR DESCRIPTION
## What
Detect preview navigation failures and show a clear in-panel message with recovery actions, instead of a blank surface or Chromium's raw error page.

## Why
When a URL or local file fails to load in the embedded browser preview (404, 5xx, unresolved host, deleted file, crashed renderer), the preview previously showed nothing useful and gave no way to recover. This is W1 of the preview error-states epic; it builds on the page-status state model (W2) that already landed.

## Key Changes
- `classifyLoadResult`: one pure classifier that maps HTTP status and Chromium net errors to `http` / `network` / `file-not-found` / `crash`. Sub-frame failures and `ERR_ABORTED` are treated as non-failures so a failing iframe never blanks the whole page.
- Lifecycle wiring: read `did-navigate` `httpResponseCode`, handle `did-fail-load` / `did-fail-provisional-load` (main-frame only, registered in `detachViewListeners`), and classify `render-process-gone` as a crash while preserving the 30s auto-recovery cooldown. `reload` re-creates a torn-down view so Retry works after a crash.
- `PreviewErrorPanel` (Approach A): hide the native `WebContentsView` and render an HTML panel with per-kind plain-language copy, Retry (primary), and Go back (only when history exists). A diagnostic line shows the HTTP status or net-error code for triage.
- The failed URL and code flow through the page-status reducer so the panel can show them even when the navigation never committed.
- Fix: the active tab no longer reads "New tab" over a loaded page. The tab bar falls back to the tab's own title when the live page-status is momentarily blank after a thread/url reset.

## Tests
- Unit: `classifyLoadResult` (404/5xx, -3, sub-frame, file-not-found, network code, crash, success), page-status reducer, `usePreviewBridge`, `PreviewPanel` (including the tab-title regression), contracts schema.
- e2e (`preview-chrome.spec.ts`): drive a failing navigation and assert the message, Retry, conditional Go back, the diagnostic code, and that Retry reloads.
- `bun run verify`: typecheck, lint, and the changed packages pass. The only failing suite is the pre-existing `apps/server` `snapshot-service.integration` git-hook timeout flake on Windows, which is unrelated to this change (no server files touched).

Closes #554
Related to #552

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783134090&installation_id=129163861&pr_number=561&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F561&signature=3fcc877c7763c045b7e3beee3b86e2b4f6c291e0a179bf7f13fec953bb71a7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app error panel for preview load failures showing message, diagnostic code/status and failed URL; primary “Retry” and optional “Go back” actions.
  * Retry clears the error and attempts reload; UI avoids showing native preview during error.

* **Bug Fixes**
  * Better handling of main-frame vs sub-frame failures, renderer crashes, and HTTP/file/network distinctions.
  * Prevents adopting internal error URLs and preserves tab titles when live page status is blank.

* **Tests**
  * Added unit and E2E tests covering error classification, UI, and recovery flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->