### PR TITLE
feat(preview): memory-saver tabs (discard idle background previews)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -466,3 +466,11 @@ lifecycle within a thread. Two kinds today:
 
 Distinct from the dev-tooling stop hook under `AGENTS.md` (the harness
 verification gate for contributors).
+
+## In-app browser preview
+
+### Discarded tab (memory saver)
+A background preview tab whose renderer has been killed to reclaim memory,
+keeping only a cold placeholder (title, URL, favicon). Reopening reloads the
+page; scroll position and form state are not preserved. Governed by
+`preview.memorySaver.*` settings and ADR 0002.

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -141,6 +141,7 @@ vi.mock("node:fs/promises", async () => {
 
 import { BrowserWindow } from "electron";
 import { registerPreviewBrowserHandlers, disposePreviewForWindow } from "../preview/index.js";
+import { sessions } from "../preview/preview-session.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -961,6 +962,65 @@ describe("preview-browser", () => {
         tabId: "",
       });
       expect(r2.ok).toBe(false);
+    });
+  });
+
+  describe("memory-saver hysteresis (#454 guard)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("cancels the scheduled hidden discard when the panel reappears within the window", async () => {
+      const win = createWindow();
+
+      // Create 3 warm tabs on separate threads at T=0 so they are old enough
+      // (> hiddenIdleMs = 60s) to be eligible for discard during the hidden sweep.
+      // Each thread switch keeps the previous thread's WebContentsView warm (alive)
+      // but unmounts it, so collectWarmTabs sees 4 live views total.
+      await showPreview(win, { threadId: "hys-t1" });
+      await showPreview(win, { threadId: "hys-t2" });
+      await showPreview(win, { threadId: "hys-t3" });
+
+      // Advance time past hiddenIdleMs so the 3 idle tabs become overflow-eligible.
+      await vi.advanceTimersByTimeAsync(65_000);
+
+      // Bring in a 4th thread (MRU; its lastActiveAt = now = T+65s). This thread
+      // is what will be "active" at hide time.
+      await showPreview(win, { threadId: "hys-t4" });
+      expect(createdViews.length).toBeGreaterThanOrEqual(4);
+
+      // Hide -> schedules a hidden discard timer (default hiddenIdleMs = 60s).
+      // With 4 warm tabs and maxWarm=3, the oldest (one of t1/t2/t3) sits in the
+      // overflow slot and would be discarded when the timer fires.
+      await hidePreview(win, { threadId: "hys-t4" });
+
+      // The synchronous timer handle must be set immediately after hiding; this is
+      // the only state we can inspect deterministically (the discard callback is a
+      // floating Promise and cannot be reliably awaited in a fake-timer environment).
+      const s = sessions.get(win.id)!;
+      expect(s.discardHiddenTimer).not.toBeNull();
+
+      // Re-show before the timer elapses -> onPreviewVisible cancels discardHiddenTimer.
+      await showPreview(win, { threadId: "hys-t4" });
+
+      // Primary discriminating assertion: hysteresis guard set the handle to null
+      // synchronously. Without the re-show call this would still be non-null and
+      // the timer would fire after hiddenIdleMs, discarding the overflow tab.
+      expect(s.discardHiddenTimer).toBeNull();
+
+      // Advance well past hiddenIdleMs; the cancelled timer must not fire.
+      await vi.advanceTimersByTimeAsync(120_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      for (const v of createdViews) {
+        expect(v.webContents.close).not.toHaveBeenCalled();
+      }
     });
   });
 

--- a/apps/desktop/src/main/__tests__/select-tabs-to-discard.test.ts
+++ b/apps/desktop/src/main/__tests__/select-tabs-to-discard.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectTabsToDiscard,
+  type WarmTabRef,
+  type DiscardConfig,
+} from "../preview/select-tabs-to-discard.js";
+
+const CONFIG: DiscardConfig = { maxWarm: 3, bgIdleMs: 300_000, hiddenIdleMs: 60_000 };
+const NOW = 10_000_000;
+
+/** Helper: a warm tab whose last activation was `idleMs` before NOW. */
+function tab(id: string, idleMs: number, threadId = "t1"): WarmTabRef {
+  return { tabId: id, threadId, lastActiveAt: NOW - idleMs };
+}
+
+describe("selectTabsToDiscard — panel visible", () => {
+  it("never discards the active tab even when idle past bgIdleMs", () => {
+    const tabs = [tab("active", 999_999), tab("bg", 10_000)];
+    const out = selectTabsToDiscard(tabs, "t1", "active", true, NOW, CONFIG);
+    expect(out).not.toContain("active");
+  });
+
+  it("discards a background tab idle >= bgIdleMs", () => {
+    const tabs = [tab("active", 0), tab("bg", 300_000)];
+    const out = selectTabsToDiscard(tabs, "t1", "active", true, NOW, CONFIG);
+    expect(out).toEqual(["bg"]);
+  });
+
+  it("keeps a background tab idle < bgIdleMs", () => {
+    const tabs = [tab("active", 0), tab("bg", 299_999)];
+    const out = selectTabsToDiscard(tabs, "t1", "active", true, NOW, CONFIG);
+    expect(out).toEqual([]);
+  });
+
+  it("does NOT enforce the count cap while visible", () => {
+    const tabs = Array.from({ length: 10 }, (_, i) => tab(`t${i}`, 1_000));
+    const out = selectTabsToDiscard(tabs, "t1", "t0", true, NOW, CONFIG);
+    expect(out).toEqual([]);
+  });
+
+  it("discards background tabs across threads when idle", () => {
+    const tabs = [tab("a", 0, "t1"), tab("b", 400_000, "t2")];
+    const out = selectTabsToDiscard(tabs, "t1", "a", true, NOW, CONFIG);
+    expect(out).toEqual(["b"]);
+  });
+});
+
+describe("selectTabsToDiscard — panel hidden", () => {
+  it("trims to the maxWarm most-recently-used tabs", () => {
+    const tabs = [
+      tab("mru1", 70_000),
+      tab("mru2", 80_000),
+      tab("mru3", 90_000),
+      tab("lru1", 100_000),
+      tab("lru2", 110_000),
+    ];
+    const out = selectTabsToDiscard(tabs, "t1", "mru1", false, NOW, CONFIG);
+    expect(out.sort()).toEqual(["lru1", "lru2"]);
+  });
+
+  it("does NOT protect the active tab when hidden", () => {
+    const tabs = [
+      tab("active", 200_000),
+      tab("b", 70_000),
+      tab("c", 71_000),
+      tab("d", 72_000),
+    ];
+    const out = selectTabsToDiscard(tabs, "t1", "active", false, NOW, CONFIG);
+    expect(out).toEqual(["active"]);
+  });
+
+  it("keeps everything when warm count <= maxWarm", () => {
+    const tabs = [tab("a", 200_000), tab("b", 300_000)];
+    const out = selectTabsToDiscard(tabs, "t1", "a", false, NOW, CONFIG);
+    expect(out).toEqual([]);
+  });
+
+  it("grants overflow tabs hiddenIdleMs grace before discarding", () => {
+    const tabs = [
+      tab("a", 0),
+      tab("b", 1_000),
+      tab("c", 2_000),
+      tab("overflow", 30_000),
+    ];
+    const out = selectTabsToDiscard(tabs, "t1", "a", false, NOW, CONFIG);
+    expect(out).toEqual([]);
+  });
+
+  it("works with null active identifiers (pure cap behavior)", () => {
+    const tabs = [tab("a", 70_000), tab("b", 80_000), tab("c", 90_000), tab("d", 100_000)];
+    const out = selectTabsToDiscard(tabs, null, null, false, NOW, CONFIG);
+    expect(out).toEqual(["d"]);
+  });
+});
+
+describe("selectTabsToDiscard — edges", () => {
+  it("returns [] for no warm tabs", () => {
+    expect(selectTabsToDiscard([], "t1", "x", true, NOW, CONFIG)).toEqual([]);
+    expect(selectTabsToDiscard([], "t1", "x", false, NOW, CONFIG)).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/preview/preview-discard-scheduler.ts
+++ b/apps/desktop/src/main/preview/preview-discard-scheduler.ts
@@ -98,59 +98,67 @@ export async function runDiscardSweep(
   config: DiscardConfig,
 ): Promise<void> {
   if (win.isDestroyed()) return;
-  const warm = collectWarmTabs(s);
-  setPerf("warmInactiveRuntimeCount", warm.length);
-  if (warm.length === 0) return;
+  if (s.discardSweepInProgress) return;
+  s.discardSweepInProgress = true;
+  try {
+    const warm = collectWarmTabs(s);
+    setPerf("warmInactiveRuntimeCount", warm.length);
+    if (warm.length === 0) return;
 
-  const ids = selectTabsToDiscard(
-    warm,
-    s.lastPreviewThreadId,
-    activeTabIdOf(s),
-    visible,
-    Date.now(),
-    config,
-  );
-  if (ids.length === 0) return;
+    const ids = selectTabsToDiscard(
+      warm,
+      s.lastPreviewThreadId,
+      activeTabIdOf(s),
+      visible,
+      Date.now(),
+      config,
+    );
+    if (ids.length === 0) return;
 
-  let activeThreadTouched = false;
-  for (const id of ids) {
-    const located = locateTab(s, id);
-    if (!located) continue;
-    const { set, tab } = located;
+    let activeThreadTouched = false;
+    for (const id of ids) {
+      const located = locateTab(s, id);
+      if (!located) continue;
+      const { set, tab } = located;
 
-    // Persist the validated current URL before disposing (ADR 0002).
-    if (tab.view && !tab.view.webContents.isDestroyed()) {
-      try {
-        const live = tab.view.webContents.getURL();
-        const safe = await validateResumeUrl(isAllowedPreviewUrl(live) ? live : null);
-        if (safe) tab.resumeUrl = safe;
-      } catch {
-        /* guest may be tearing down; keep the last known resumeUrl */
+      // Persist the validated current URL before disposing (ADR 0002).
+      if (tab.view && !tab.view.webContents.isDestroyed()) {
+        try {
+          const live = tab.view.webContents.getURL();
+          const safe = await validateResumeUrl(isAllowedPreviewUrl(live) ? live : null);
+          if (safe) tab.resumeUrl = safe;
+        } catch {
+          /* guest may be tearing down; keep the last known resumeUrl */
+        }
       }
+      if (win.isDestroyed()) return;
+
+      const wasActiveTab =
+        tab.threadId === s.lastPreviewThreadId && set.activeTabId === tab.id;
+
+      disposeTabView(win, s, tab);
+      bumpPerf("inactiveTabBudgetEvictions");
+
+      // The active tab can only be dropped when hidden; surface it through the
+      // single page-status channel so the reducer records phase: 'discarded'.
+      if (wasActiveTab) applyPageStatus(win, s, { type: "discard" });
+      if (tab.threadId === s.lastPreviewThreadId) activeThreadTouched = true;
     }
-    if (win.isDestroyed()) return;
 
-    const wasActiveTab =
-      tab.threadId === s.lastPreviewThreadId && set.activeTabId === tab.id;
-
-    disposeTabView(win, s, tab);
-    bumpPerf("inactiveTabBudgetEvictions");
-
-    // The active tab can only be dropped when hidden; surface it through the
-    // single page-status channel so the reducer records phase: 'discarded'.
-    if (wasActiveTab) applyPageStatus(win, s, { type: "discard" });
-    if (tab.threadId === s.lastPreviewThreadId) activeThreadTouched = true;
-  }
-
-  setPerf("warmInactiveRuntimeCount", collectWarmTabs(s).length);
-  if (activeThreadTouched && s.lastPreviewThreadId) {
-    emitTabsUpdated(win, s, s.lastPreviewThreadId);
+    setPerf("warmInactiveRuntimeCount", collectWarmTabs(s).length);
+    if (activeThreadTouched && s.lastPreviewThreadId) {
+      emitTabsUpdated(win, s, s.lastPreviewThreadId);
+    }
+  } finally {
+    s.discardSweepInProgress = false;
   }
 }
 
 /**
  * Panel became visible: cancel any pending hidden-discard (hysteresis) and
- * start the background-idle sweep if it is not already running.
+ * start the background-idle sweep if it is not already running. The sweep
+ * interval is fixed at start time, so a `bgIdleMs` settings change only takes
+ * effect after the panel is next hidden and reshown.
  */
 export function onPreviewVisible(win: BrowserWindow, s: PreviewSession): void {
   if (s.discardHiddenTimer) {
@@ -193,16 +201,4 @@ export function onPreviewHidden(win: BrowserWindow, s: PreviewSession): void {
   }, cfg.hiddenIdleMs);
   bumpPerf("inactiveTabSuspendScheduled");
   logger.info("Preview: hidden discard scheduled", { hiddenIdleMs: cfg.hiddenIdleMs });
-}
-
-/** Cancels both discard timers. Called on window park/dispose. */
-export function clearDiscardTimers(s: PreviewSession): void {
-  if (s.discardSweepTimer) {
-    clearInterval(s.discardSweepTimer);
-    s.discardSweepTimer = null;
-  }
-  if (s.discardHiddenTimer) {
-    clearTimeout(s.discardHiddenTimer);
-    s.discardHiddenTimer = null;
-  }
 }

--- a/apps/desktop/src/main/preview/preview-discard-scheduler.ts
+++ b/apps/desktop/src/main/preview/preview-discard-scheduler.ts
@@ -1,0 +1,208 @@
+/**
+ * Per-session memory-saver scheduler (ADR 0002). Runs the pure
+ * `selectTabsToDiscard` policy on a sweep interval while the panel is visible
+ * and on a single delayed timer after the panel hides, then disposes the
+ * returned tabs' renderers after persisting each tab's validated URL.
+ *
+ * Hysteresis: the hidden timer is cancelled when the panel reappears, the
+ * direct mitigation for the #454 ResizeObserver `visible`-flag flap.
+ */
+
+import { BrowserWindow } from "electron";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getMcodeDir, logger } from "@mcode/shared";
+import { SettingsSchema as BundledSettingsSchema } from "@mcode/contracts";
+import {
+  selectTabsToDiscard,
+  type WarmTabRef,
+  type DiscardConfig,
+} from "./select-tabs-to-discard.js";
+import {
+  applyPageStatus,
+  emitTabsUpdated,
+  isAllowedPreviewUrl,
+  type PreviewSession,
+  type TabState,
+  type ThreadTabSet,
+} from "./preview-session.js";
+import { disposeTabView } from "./preview-lifecycle.js";
+import { validateResumeUrl } from "./preview-local-file.js";
+import { bumpPerf, setPerf } from "./preview-perf.js";
+
+/** Mirror server-manager's snapshot-aware schema resolution for packaged builds. */
+const SettingsSchema =
+  globalThis.__v8Snapshot?.contracts?.SettingsSchema ?? BundledSettingsSchema;
+
+/** Fallback thresholds when settings.json is missing or unparseable (matches schema defaults). */
+const DEFAULT_CONFIG: DiscardConfig = {
+  maxWarm: 3,
+  bgIdleMs: 300_000,
+  hiddenIdleMs: 60_000,
+};
+
+/** Floor for the visible-panel sweep interval so we never spin too hot. */
+const SWEEP_INTERVAL_FLOOR_MS = 15_000;
+
+/** Reads `preview.memorySaver.*` from settings.json, falling back to defaults. */
+export function readMemorySaverConfig(): DiscardConfig {
+  try {
+    const raw = readFileSync(join(getMcodeDir(), "settings.json"), "utf-8");
+    const parsed = SettingsSchema().safeParse(JSON.parse(raw));
+    if (parsed.success) {
+      const ms = parsed.data.preview.memorySaver;
+      return { maxWarm: ms.maxWarm, bgIdleMs: ms.bgIdleMs, hiddenIdleMs: ms.hiddenIdleMs };
+    }
+  } catch {
+    /* missing / unreadable / invalid JSON -> defaults */
+  }
+  return DEFAULT_CONFIG;
+}
+
+/** Enumerates every warm tab across all threads in the session. */
+function collectWarmTabs(s: PreviewSession): WarmTabRef[] {
+  const out: WarmTabRef[] = [];
+  for (const set of s.tabsByThread.values()) {
+    for (const tab of set.tabs) {
+      if (tab.view && !tab.view.webContents.isDestroyed()) {
+        out.push({ tabId: tab.id, threadId: tab.threadId, lastActiveAt: tab.lastActiveAt });
+      }
+    }
+  }
+  return out;
+}
+
+/** Active tab id of the active preview thread, or null. */
+function activeTabIdOf(s: PreviewSession): string | null {
+  if (!s.lastPreviewThreadId) return null;
+  return s.tabsByThread.get(s.lastPreviewThreadId)?.activeTabId ?? null;
+}
+
+/** Locates a tab by id across all threads. */
+function locateTab(s: PreviewSession, tabId: string): { set: ThreadTabSet; tab: TabState } | null {
+  for (const set of s.tabsByThread.values()) {
+    const tab = set.tabs.find((t) => t.id === tabId);
+    if (tab) return { set, tab };
+  }
+  return null;
+}
+
+/**
+ * Runs the policy once and disposes the selected tabs. Persists each tab's
+ * validated live URL before killing its renderer so re-warm reloads the page.
+ */
+export async function runDiscardSweep(
+  win: BrowserWindow,
+  s: PreviewSession,
+  visible: boolean,
+  config: DiscardConfig,
+): Promise<void> {
+  if (win.isDestroyed()) return;
+  const warm = collectWarmTabs(s);
+  setPerf("warmInactiveRuntimeCount", warm.length);
+  if (warm.length === 0) return;
+
+  const ids = selectTabsToDiscard(
+    warm,
+    s.lastPreviewThreadId,
+    activeTabIdOf(s),
+    visible,
+    Date.now(),
+    config,
+  );
+  if (ids.length === 0) return;
+
+  let activeThreadTouched = false;
+  for (const id of ids) {
+    const located = locateTab(s, id);
+    if (!located) continue;
+    const { set, tab } = located;
+
+    // Persist the validated current URL before disposing (ADR 0002).
+    if (tab.view && !tab.view.webContents.isDestroyed()) {
+      try {
+        const live = tab.view.webContents.getURL();
+        const safe = await validateResumeUrl(isAllowedPreviewUrl(live) ? live : null);
+        if (safe) tab.resumeUrl = safe;
+      } catch {
+        /* guest may be tearing down; keep the last known resumeUrl */
+      }
+    }
+    if (win.isDestroyed()) return;
+
+    const wasActiveTab =
+      tab.threadId === s.lastPreviewThreadId && set.activeTabId === tab.id;
+
+    disposeTabView(win, s, tab);
+    bumpPerf("inactiveTabBudgetEvictions");
+
+    // The active tab can only be dropped when hidden; surface it through the
+    // single page-status channel so the reducer records phase: 'discarded'.
+    if (wasActiveTab) applyPageStatus(win, s, { type: "discard" });
+    if (tab.threadId === s.lastPreviewThreadId) activeThreadTouched = true;
+  }
+
+  setPerf("warmInactiveRuntimeCount", collectWarmTabs(s).length);
+  if (activeThreadTouched && s.lastPreviewThreadId) {
+    emitTabsUpdated(win, s, s.lastPreviewThreadId);
+  }
+}
+
+/**
+ * Panel became visible: cancel any pending hidden-discard (hysteresis) and
+ * start the background-idle sweep if it is not already running.
+ */
+export function onPreviewVisible(win: BrowserWindow, s: PreviewSession): void {
+  if (s.discardHiddenTimer) {
+    clearTimeout(s.discardHiddenTimer);
+    s.discardHiddenTimer = null;
+    bumpPerf("inactiveTabSuspendCancelled");
+  }
+  if (s.discardSweepTimer) return;
+  const cfg = readMemorySaverConfig();
+  const interval = Math.max(SWEEP_INTERVAL_FLOOR_MS, Math.floor(cfg.bgIdleMs / 2));
+  s.discardSweepTimer = setInterval(() => {
+    void runDiscardSweep(win, s, true, readMemorySaverConfig());
+  }, interval);
+  bumpPerf("inactiveTabSuspendScheduled");
+}
+
+/**
+ * Panel hidden: stop the sweep and schedule a single delayed trim. Stamps the
+ * active tab fresh so the tab the user just left survives as part of the MRU
+ * working set. The timer is cancelled by `onPreviewVisible` if the panel
+ * returns within `hiddenIdleMs` (the #454 flap mitigation).
+ */
+export function onPreviewHidden(win: BrowserWindow, s: PreviewSession): void {
+  if (s.discardSweepTimer) {
+    clearInterval(s.discardSweepTimer);
+    s.discardSweepTimer = null;
+  }
+  if (s.discardHiddenTimer) return;
+
+  const activeId = activeTabIdOf(s);
+  if (activeId) {
+    const located = locateTab(s, activeId);
+    if (located) located.tab.lastActiveAt = Date.now();
+  }
+
+  const cfg = readMemorySaverConfig();
+  s.discardHiddenTimer = setTimeout(() => {
+    s.discardHiddenTimer = null;
+    void runDiscardSweep(win, s, false, readMemorySaverConfig());
+  }, cfg.hiddenIdleMs);
+  bumpPerf("inactiveTabSuspendScheduled");
+  logger.info("Preview: hidden discard scheduled", { hiddenIdleMs: cfg.hiddenIdleMs });
+}
+
+/** Cancels both discard timers. Called on window park/dispose. */
+export function clearDiscardTimers(s: PreviewSession): void {
+  if (s.discardSweepTimer) {
+    clearInterval(s.discardSweepTimer);
+    s.discardSweepTimer = null;
+  }
+  if (s.discardHiddenTimer) {
+    clearTimeout(s.discardHiddenTimer);
+    s.discardHiddenTimer = null;
+  }
+}

--- a/apps/desktop/src/main/preview/preview-lifecycle.ts
+++ b/apps/desktop/src/main/preview/preview-lifecycle.ts
@@ -453,6 +453,9 @@ export function hidePreview(win: BrowserWindow, s: PreviewSession): void {
 export function parkPreview(win: BrowserWindow, s: PreviewSession): void {
   logger.info("Preview: view parked (destroyed)", { url: s.resumePreviewUrl });
   hidePreview(win, s);
+  // Inline to avoid a lifecycle <-> scheduler import cycle.
+  if (s.discardSweepTimer) { clearInterval(s.discardSweepTimer); s.discardSweepTimer = null; }
+  if (s.discardHiddenTimer) { clearTimeout(s.discardHiddenTimer); s.discardHiddenTimer = null; }
   // Save the active tab's URL before disposing so a later restore can reload.
   if (s.view && !s.view.webContents.isDestroyed()) {
     try {

--- a/apps/desktop/src/main/preview/preview-lifecycle.ts
+++ b/apps/desktop/src/main/preview/preview-lifecycle.ts
@@ -372,6 +372,7 @@ export function ensureView(win: BrowserWindow, s: PreviewSession): WebContentsVi
     resumeUrl: null,
     title: null,
     faviconUrl: null,
+    lastActiveAt: Date.now(),
   };
   const view = ensureTabView(win, s, synthetic);
   s.view = view;

--- a/apps/desktop/src/main/preview/preview-lifecycle.ts
+++ b/apps/desktop/src/main/preview/preview-lifecycle.ts
@@ -16,6 +16,7 @@ import {
   getActiveTab,
   sessions,
   clearIdle,
+  clearDiscardTimers,
   applyPageStatus,
   setPreviewLoading,
   isAllowedPreviewUrl,
@@ -453,9 +454,7 @@ export function hidePreview(win: BrowserWindow, s: PreviewSession): void {
 export function parkPreview(win: BrowserWindow, s: PreviewSession): void {
   logger.info("Preview: view parked (destroyed)", { url: s.resumePreviewUrl });
   hidePreview(win, s);
-  // Inline to avoid a lifecycle <-> scheduler import cycle.
-  if (s.discardSweepTimer) { clearInterval(s.discardSweepTimer); s.discardSweepTimer = null; }
-  if (s.discardHiddenTimer) { clearTimeout(s.discardHiddenTimer); s.discardHiddenTimer = null; }
+  clearDiscardTimers(s);
   // Save the active tab's URL before disposing so a later restore can reload.
   if (s.view && !s.view.webContents.isDestroyed()) {
     try {

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -28,6 +28,7 @@ import {
   trustMainProcessFileNavigation,
 } from "./preview-local-file.js";
 import { isMcodeWorkspacePreviewUrl } from "@mcode/contracts";
+import { onPreviewHidden, onPreviewVisible } from "./preview-discard-scheduler.js";
 
 /**
  * True when `input` looks like a bare host (e.g. `example.com`, `sub.x.io/path`,
@@ -79,6 +80,7 @@ export function registerNavigationHandlers(): void {
       bumpPerf("setPanelBoundsCalls");
       if (!payload.visible || !b || b.width < 4 || b.height < 4) {
         hidePreview(win, s);
+        onPreviewHidden(win, s);
         return;
       }
 
@@ -165,6 +167,7 @@ export function registerNavigationHandlers(): void {
         }
       }
       resetIdle(win, s);
+      onPreviewVisible(win, s);
     },
   );
 

--- a/apps/desktop/src/main/preview/preview-session.ts
+++ b/apps/desktop/src/main/preview/preview-session.ts
@@ -61,6 +61,10 @@ export interface ThreadTabSet {
 export interface PreviewSession {
   view: WebContentsView | null;
   idleTimer: NodeJS.Timeout | null;
+  /** Recurring sweep timer that evicts idle background tabs while the panel is visible. */
+  discardSweepTimer: NodeJS.Timeout | null;
+  /** One-shot timer scheduled when the panel hides; trims the warm set unless cancelled (hysteresis). */
+  discardHiddenTimer: NodeJS.Timeout | null;
   /** Last shell-reported bounds so navigate can attach the view before the next sync tick. */
   lastBounds: Bounds | null;
   /**
@@ -138,6 +142,8 @@ export function getSession(win: BrowserWindow): PreviewSession {
     s = {
       view: null,
       idleTimer: null,
+      discardSweepTimer: null,
+      discardHiddenTimer: null,
       lastBounds: null,
       resumePreviewUrl: null,
       scrollbarCssKey: null,
@@ -280,6 +286,22 @@ export function applyPageStatus(
   bumpPerf("stateEmitCalls");
   try {
     win.webContents.send("preview:page-status", next);
+  } catch {
+    bumpPerf("stateEmitSkips");
+  }
+}
+
+/**
+ * Sends the active-thread tab set to the renderer on `preview:tabs-updated`.
+ * Used by the discard scheduler so the tab bar reflects freshly-discarded
+ * (cold) tabs. Mirrors the emit in preview-tabs.ts but rebuilds from session
+ * state rather than a pre-synced set.
+ */
+export function emitTabsUpdated(win: BrowserWindow, s: PreviewSession, threadId: string): void {
+  if (win.isDestroyed()) return;
+  bumpPerf("stateEmitCalls");
+  try {
+    win.webContents.send("preview:tabs-updated", toBrowserTabSet(s, threadId));
   } catch {
     bumpPerf("stateEmitSkips");
   }

--- a/apps/desktop/src/main/preview/preview-session.ts
+++ b/apps/desktop/src/main/preview/preview-session.ts
@@ -65,6 +65,8 @@ export interface PreviewSession {
   discardSweepTimer: NodeJS.Timeout | null;
   /** One-shot timer scheduled when the panel hides; trims the warm set unless cancelled (hysteresis). */
   discardHiddenTimer: NodeJS.Timeout | null;
+  /** True while a discard sweep is mid-flight; prevents overlapping async sweeps. */
+  discardSweepInProgress: boolean;
   /** Last shell-reported bounds so navigate can attach the view before the next sync tick. */
   lastBounds: Bounds | null;
   /**
@@ -144,6 +146,7 @@ export function getSession(win: BrowserWindow): PreviewSession {
       idleTimer: null,
       discardSweepTimer: null,
       discardHiddenTimer: null,
+      discardSweepInProgress: false,
       lastBounds: null,
       resumePreviewUrl: null,
       scrollbarCssKey: null,
@@ -250,6 +253,18 @@ export function syncActiveTabFromSession(s: PreviewSession): void {
   if (s.view && !s.view.webContents.isDestroyed()) {
     const t = s.view.webContents.getTitle();
     tab.title = t && t.length > 0 ? t : tab.title;
+  }
+}
+
+/** Cancels both memory-saver discard timers (sweep interval + hidden one-shot). */
+export function clearDiscardTimers(s: PreviewSession): void {
+  if (s.discardSweepTimer) {
+    clearInterval(s.discardSweepTimer);
+    s.discardSweepTimer = null;
+  }
+  if (s.discardHiddenTimer) {
+    clearTimeout(s.discardHiddenTimer);
+    s.discardHiddenTimer = null;
   }
 }
 

--- a/apps/desktop/src/main/preview/preview-session.ts
+++ b/apps/desktop/src/main/preview/preview-session.ts
@@ -43,6 +43,8 @@ export interface TabState {
   resumeUrl: string | null;
   title: string | null;
   faviconUrl: string | null;
+  /** Epoch ms when this tab was last activated. Drives memory-saver LRU ordering (ADR 0002). */
+  lastActiveAt: number;
 }
 
 /** Per-thread tab set: an ordered list plus the id of the mounted tab. */
@@ -176,6 +178,7 @@ export function ensureThreadTabSet(s: PreviewSession, threadId: string): ThreadT
       resumeUrl: isActiveThread ? s.resumePreviewUrl : null,
       title: null,
       faviconUrl: isActiveThread ? (s.lastFavicons[0] ?? null) : null,
+      lastActiveAt: Date.now(),
     };
     set = { threadId, tabs: [firstTab], activeTabId: tabId };
     s.tabsByThread.set(threadId, set);
@@ -198,6 +201,7 @@ export function getActiveTab(s: PreviewSession, threadId: string): TabState {
       resumeUrl: null,
       title: null,
       faviconUrl: null,
+      lastActiveAt: Date.now(),
     };
     set.tabs.push(tab);
     set.activeTabId = id;

--- a/apps/desktop/src/main/preview/preview-tabs.ts
+++ b/apps/desktop/src/main/preview/preview-tabs.ts
@@ -68,6 +68,7 @@ function activateTabView(
   s: PreviewSession,
   tab: TabState,
 ): void {
+  tab.lastActiveAt = Date.now();
   // Unmount whatever's currently mounted for this session (the prior active
   // tab's view). Keep its webContents alive so switching back is instant.
   if (s.view && s.view !== tab.view) {
@@ -165,6 +166,7 @@ export function registerTabHandlers(): void {
         resumeUrl: null,
         title: null,
         faviconUrl: null,
+        lastActiveAt: Date.now(),
       });
 
       if (activate && tid === s.lastPreviewThreadId) {
@@ -256,6 +258,7 @@ export function registerTabHandlers(): void {
           resumeUrl: null,
           title: null,
           faviconUrl: null,
+          lastActiveAt: Date.now(),
         };
         set.tabs.push(fallback);
         set.activeTabId = fallbackId;

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -110,6 +110,7 @@ export function registerWebviewAdoptHandlers(): void {
           resumeUrl: wc.getURL() || null,
           title: wc.getTitle() || null,
           faviconUrl: null,
+          lastActiveAt: Date.now(),
         };
         set.tabs.push(tab);
       }

--- a/apps/desktop/src/main/preview/select-tabs-to-discard.ts
+++ b/apps/desktop/src/main/preview/select-tabs-to-discard.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure memory-saver discard policy for the embedded preview (ADR 0002).
+ *
+ * Decides which warm preview tabs to discard given the current warm set, which
+ * tab is active, whether the panel is visible, the clock, and the tunable
+ * thresholds. No Electron or session state: callers map the result back to
+ * concrete tabs and dispose them.
+ */
+
+/** A warm (live-renderer) preview tab considered for discard. */
+export interface WarmTabRef {
+  /** Stable tab id (unique across threads). */
+  readonly tabId: string;
+  /** Owning thread id. */
+  readonly threadId: string;
+  /** Epoch ms when the tab was last activated; drives LRU ordering. */
+  readonly lastActiveAt: number;
+}
+
+/** Tunable thresholds, sourced from `preview.memorySaver.*` settings. */
+export interface DiscardConfig {
+  /** Most-recently-used warm tabs kept when the panel is hidden. */
+  readonly maxWarm: number;
+  /** Idle ms before a background tab is discarded while the panel is visible. */
+  readonly bgIdleMs: number;
+  /** Idle ms an overflow tab must exceed before it is trimmed when hidden. */
+  readonly hiddenIdleMs: number;
+}
+
+/**
+ * Returns the ids of warm tabs to discard. See ADR 0002:
+ * - Visible: active tab protected, no count cap, background tabs dropped after `bgIdleMs`.
+ * - Hidden: active loses protection; warm set trimmed to the `maxWarm` MRU tabs,
+ *   each overflow tab dropped once idle past `hiddenIdleMs`.
+ *
+ * Pure: never mutates its inputs.
+ */
+export function selectTabsToDiscard(
+  warmTabs: readonly WarmTabRef[],
+  activeThreadId: string | null,
+  activeTabId: string | null,
+  visible: boolean,
+  now: number,
+  config: DiscardConfig,
+): string[] {
+  const isActive = (t: WarmTabRef): boolean =>
+    activeThreadId !== null &&
+    activeTabId !== null &&
+    t.threadId === activeThreadId &&
+    t.tabId === activeTabId;
+
+  if (visible) {
+    return warmTabs
+      .filter((t) => !isActive(t) && now - t.lastActiveAt >= config.bgIdleMs)
+      .map((t) => t.tabId);
+  }
+
+  // Hidden: rank by recency, keep the top `maxWarm`, discard the idle overflow.
+  const byMru = [...warmTabs].sort((a, b) => b.lastActiveAt - a.lastActiveAt);
+  const overflow = byMru.slice(Math.max(0, config.maxWarm));
+  return overflow
+    .filter((t) => now - t.lastActiveAt >= config.hiddenIdleMs)
+    .map((t) => t.tabId);
+}

--- a/apps/web/src/components/settings/sections/PerformanceSection.tsx
+++ b/apps/web/src/components/settings/sections/PerformanceSection.tsx
@@ -78,7 +78,7 @@ export function PerformanceSection() {
             step={30_000}
             value={bgIdleMs}
             onCommit={(v) => void update({ preview: { memorySaver: { bgIdleMs: v } } })}
-            formatValue={(v) => `${Math.round(v / 60_000)} min`}
+            formatValue={(v) => `${(v / 60_000).toFixed(1).replace(/\.0$/, "")} min`}
           />
         </SettingRow>
         <SettingRow

--- a/apps/web/src/components/settings/sections/PerformanceSection.tsx
+++ b/apps/web/src/components/settings/sections/PerformanceSection.tsx
@@ -5,12 +5,15 @@ import { SectionHeading } from "../SectionHeading";
 
 /**
  * Performance settings section. Exposes runtime-tunable knobs that affect
- * memory and latency trade-offs: server V8 heap size and the in-memory
- * thread cache size.
+ * memory and latency trade-offs: server V8 heap size, thread cache size, and
+ * preview memory-saver tab controls (warm tab limit and idle discard timers).
  */
 export function PerformanceSection() {
   const threadCacheSize = useSettingsStore((s) => s.settings.performance.threadCacheSize);
   const heapMb = useSettingsStore((s) => s.settings.server.memory.heapMb);
+  const maxWarm = useSettingsStore((s) => s.settings.preview.memorySaver.maxWarm);
+  const bgIdleMs = useSettingsStore((s) => s.settings.preview.memorySaver.bgIdleMs);
+  const hiddenIdleMs = useSettingsStore((s) => s.settings.preview.memorySaver.hiddenIdleMs);
   const update = useSettingsStore((s) => s.update);
 
   return (
@@ -48,6 +51,48 @@ export function PerformanceSection() {
             value={heapMb}
             onCommit={(v) => void update({ server: { memory: { heapMb: v } } })}
             formatValue={(v) => `${v} MB`}
+          />
+        </SettingRow>
+        <SettingRow
+          label="Warm preview tabs"
+          configKey="preview.memorySaver.maxWarm"
+          hint="Most-recently-used background browser tabs kept in memory while the preview panel is hidden. Others are discarded and reload when reopened."
+        >
+          <RangeControl
+            min={1}
+            max={20}
+            step={1}
+            value={maxWarm}
+            onCommit={(v) => void update({ preview: { memorySaver: { maxWarm: v } } })}
+            formatValue={(v) => `${v} tab${v === 1 ? "" : "s"}`}
+          />
+        </SettingRow>
+        <SettingRow
+          label="Background idle before discard"
+          configKey="preview.memorySaver.bgIdleMs"
+          hint="How long an unfocused preview tab can sit idle (while the panel is visible) before its renderer is discarded to save memory."
+        >
+          <RangeControl
+            min={30_000}
+            max={3_600_000}
+            step={30_000}
+            value={bgIdleMs}
+            onCommit={(v) => void update({ preview: { memorySaver: { bgIdleMs: v } } })}
+            formatValue={(v) => `${Math.round(v / 60_000)} min`}
+          />
+        </SettingRow>
+        <SettingRow
+          label="Hidden-panel trim delay"
+          configKey="preview.memorySaver.hiddenIdleMs"
+          hint="After the preview panel is hidden, how long to wait before trimming the warm set down to the limit above. A short reshow cancels the trim."
+        >
+          <RangeControl
+            min={5_000}
+            max={600_000}
+            step={5_000}
+            value={hiddenIdleMs}
+            onCommit={(v) => void update({ preview: { memorySaver: { hiddenIdleMs: v } } })}
+            formatValue={(v) => `${Math.round(v / 1_000)}s`}
           />
         </SettingRow>
       </div>

--- a/docs/adr/0002-preview-tab-discard-policy.md
+++ b/docs/adr/0002-preview-tab-discard-policy.md
@@ -1,0 +1,82 @@
+---
+status: accepted
+---
+
+# Preview tabs are discarded (renderer killed), not frozen, and the active tab is protected only while the panel is visible
+
+## Context
+
+The in-app browser preview keeps a live renderer per tab. Background tabs are
+already throttled (`setBackgroundThrottling(true)`), but nothing ever releases a
+background tab's renderer, and hiding the panel or switching threads leaves
+renderers resident. Warm-tab count is unbounded, so a session that visits several
+pages or threads accumulates renderer processes and blows the < 150MB idle-memory
+target.
+
+We want modern-browser "memory saver" behaviour. Two questions drove real
+trade-offs:
+
+1. **Discard vs freeze.** A frozen tab keeps its renderer (instant resume, state
+   intact) but frees little memory. A discarded tab kills the renderer (reclaims
+   the memory) but reloads on return, losing scroll position and form input.
+2. **When is the active tab safe to reclaim?** The active tab is what the user is
+   looking at, so it must stay warm - but only while the panel is actually on
+   screen.
+
+A prior attempt at idle teardown was removed in #454 because a `ResizeObserver`
+flapped the panel's `visible` flag on every SPA in-page navigation, hiding and
+re-showing the view and causing reload churn. That history constrains any
+time-based reclaim we add.
+
+## Decision
+
+Reclaim memory by **discarding** background tabs (kill the renderer, keep a cold
+placeholder of title/URL/favicon), not by freezing them. Re-warming reloads the
+page; scroll and form state are intentionally not preserved. This matches Chrome
+Memory Saver / Edge sleeping-tabs discard semantics.
+
+The discard policy is a pure function of (warm tabs, active thread/tab, panel
+visibility, clock). It is visibility-aware:
+
+- **Panel visible:** the active tab is protected and never discarded. Background
+  tabs are discarded only after an idle threshold; the warm-tab count cap is **not**
+  enforced, so the user's working set stays snappy.
+- **Panel hidden:** the active tab loses its protection and competes like any other
+  tab. After an idle delay the warm set is trimmed to the N most-recently-used tabs
+  (steady state = N warm, as a fast-reopen cache, not zero).
+
+Time-based reclaim carries **hysteresis**: a discard scheduled when the panel hides
+is cancelled if the panel reappears within the window. This is the direct mitigation
+for the #454 flap class.
+
+## Considered Options
+
+- **Freeze instead of discard (rejected).** Preserves scroll/form state, but a frozen
+  renderer still holds most of its memory, so it does not meet the idle-memory target -
+  the entire reason for the feature.
+- **Discard everything to zero when hidden (rejected).** Maximum reclaim, but every
+  reopen reloads even the tab the user just left. Keeping N warm as a reopen cache is
+  the better point on the curve.
+- **Enforce the count cap while visible too (rejected).** Would discard a background
+  tab the user is actively toggling between, reloading it on return mid-task. The cap
+  is a hidden-panel concern; while visible, idle-eviction alone bounds the set.
+- **Discard the active tab the instant the panel hides (rejected).** Reintroduces the
+  #454 churn: the `visible` flag is known to flap. Hysteresis plus an idle delay is
+  required.
+
+## Consequences
+
+- Re-warming a tab is a full reload. Scroll position, form input, and in-page client
+  state do not survive a discard. This is by design; preserving them would require a
+  freeze (insufficient memory savings) or heavyweight state serialization (separate,
+  larger effort).
+- A discarded `file:` preview whose file was deleted re-warms into the preview error
+  state (file-not-found). Discard and error handling compose through the same page
+  state.
+- The policy must persist a tab's validated current URL before disposing its renderer,
+  or re-warm loads a blank page. The window-teardown park path already models this.
+- The thresholds (warm-tab count N, background idle, hidden-panel idle) are user
+  settings, not constants, so the memory/responsiveness balance is tunable without code
+  changes.
+- If a future product decision wants scroll/form preservation, it is a freeze tier
+  layered on top - not a reversal of this decision - and should be recorded separately.

--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -29,6 +29,9 @@ Per-setting reference for Mcode's `settings.json`. For schema conventions and st
 | `worktree.naming.aiConfirmation` | boolean | `true` | - | - | Prompt before using AI-generated branch names |
 | `performance.threadCacheSize` | integer | `10` | 1-25 | - | Number of threads to keep in memory for instant switching. Lower values reduce memory use; values ≤ 3 mean most thread switches reload from the server. Takes effect immediately. |
 | `server.memory.heapMb` | integer | `512` | 64-8192 | `MCODE_SERVER_HEAP_MB` | V8 max old space for the server process (MB) |
+| `preview.memorySaver.maxWarm` | integer | `3` | 1-20 | - | Most-recently-used background preview tabs kept warm while the panel is hidden. Others are discarded (renderer freed) and reload on reopen. |
+| `preview.memorySaver.bgIdleMs` | integer | `300000` | 30000-3600000 | - | Idle time (ms) before a background preview tab is discarded while the panel is visible. |
+| `preview.memorySaver.hiddenIdleMs` | integer | `60000` | 5000-600000 | - | Idle time (ms) after the preview panel hides before the warm set is trimmed to `maxWarm`. A reshow within the window cancels the trim. |
 | `provider.cli.codex` | string | `""` | - | - | Path to the Codex CLI binary. When empty, mcode looks for `codex` on the system PATH. |
 | `provider.cli.claude` | string | `""` | - | - | Path to the Claude Code CLI binary. When empty, mcode looks for `claude` on the system PATH. |
 | `provider.cursor.alwaysSendFullInstructions` | boolean | `false` | - | - | When true, Cursor ACP sends full stitched workspace guidance and the skill catalogue on every turn instead of sticky shortening (largest prompts). |

--- a/packages/contracts/src/models/__tests__/settings.test.ts
+++ b/packages/contracts/src/models/__tests__/settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getDefaultSettings, PartialSettingsSchema } from "../settings.js";
+import { getDefaultSettings, PartialSettingsSchema, SettingsSchema } from "../settings.js";
 
 describe("settings.provider.enabled", () => {
   it("defaults claude/codex/copilot to true and others to false", () => {
@@ -15,6 +15,27 @@ describe("settings.provider.enabled", () => {
       provider: { enabled: { codex: false } },
     });
     expect(parsed.provider?.enabled?.codex).toBe(false);
+  });
+});
+
+describe("preview.memorySaver", () => {
+  it("applies ADR 0002 defaults", () => {
+    const s = SettingsSchema().parse({});
+    expect(s.preview.memorySaver.maxWarm).toBe(3);
+    expect(s.preview.memorySaver.bgIdleMs).toBe(300_000);
+    expect(s.preview.memorySaver.hiddenIdleMs).toBe(60_000);
+  });
+
+  it("accepts a partial override without backfilling siblings", () => {
+    const p = PartialSettingsSchema().parse({
+      preview: { memorySaver: { maxWarm: 5 } },
+    });
+    expect(p.preview?.memorySaver?.maxWarm).toBe(5);
+    expect(p.preview?.memorySaver?.bgIdleMs).toBeUndefined();
+  });
+
+  it("rejects out-of-range maxWarm", () => {
+    expect(SettingsSchema().safeParse({ preview: { memorySaver: { maxWarm: 0 } } }).success).toBe(false);
   });
 });
 

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -403,6 +403,27 @@ export const SettingsSchema = lazySchema(() =>
       })
       .default({}),
 
+    /** In-app browser preview settings. */
+    preview: z
+      .object({
+        /**
+         * Memory-saver discard policy (ADR 0002). Thresholds are milliseconds.
+         * Background preview tabs are discarded (renderer freed) and reload on
+         * reopen; the active tab stays warm while the panel is visible.
+         */
+        memorySaver: z
+          .object({
+            /** Most-recently-used warm tabs kept when the panel is hidden. */
+            maxWarm: z.number().int().min(1).max(20).default(3),
+            /** Idle time before a background tab is discarded while the panel is visible (ms). */
+            bgIdleMs: z.number().int().min(30_000).max(3_600_000).default(300_000),
+            /** Idle time after the panel hides before the warm set is trimmed (ms). */
+            hiddenIdleMs: z.number().int().min(5_000).max(600_000).default(60_000),
+          })
+          .default({}),
+      })
+      .default({}),
+
     /** App auto-update settings. */
     updates: z
       .object({
@@ -593,6 +614,17 @@ export const PartialSettingsSchema = lazySchema(() =>
     performance: z
       .object({
         threadCacheSize: z.number().int().min(1).max(50).optional(),
+      })
+      .optional(),
+    preview: z
+      .object({
+        memorySaver: z
+          .object({
+            maxWarm: z.number().int().min(1).max(20).optional(),
+            bgIdleMs: z.number().int().min(30_000).max(3_600_000).optional(),
+            hiddenIdleMs: z.number().int().min(5_000).max(600_000).optional(),
+          })
+          .optional(),
       })
       .optional(),
     updates: z


### PR DESCRIPTION
## What

Discard idle background browser-preview tabs to reclaim renderer memory, Chrome Memory Saver / Edge sleeping-tabs style. A discarded tab keeps a cold placeholder (title, URL, favicon) and reloads when reopened; the active tab stays warm while the preview panel is visible.

## Why

Every page or thread visited left a live renderer behind, and nothing reclaimed a background tab's memory. A long session accumulated renderer processes and pushed the app past its < 150MB idle-memory target. This is the W3 slice of epic #552, backed by ADR 0002.

## Key Changes

- **Pure policy** `selectTabsToDiscard(warmTabs, activeThreadId, activeTabId, visible, now, config)`. Panel visible: active tab protected, no count cap, background tabs discarded after `bgIdleMs`. Panel hidden: active loses protection, warm set trimmed to the `maxWarm` most-recently-used tabs once idle past `hiddenIdleMs`.
- **Discard scheduler** runs the policy on a sweep interval while visible and a single delayed timer when hidden. Hysteresis: a discard scheduled on panel-hide is cancelled if the panel reappears within the window (mitigates the #454 ResizeObserver visible-flag flap). A re-entrancy guard prevents overlapping async sweeps.
- **`lastActiveAt`** added to `TabState`, stamped on activate, drives LRU ordering.
- Each tab's validated URL is persisted before its renderer is disposed, so re-warm reloads via the existing first-mount load path. Re-warm is a full reload; scroll and form state are intentionally not preserved (ADR 0002).
- Three new settings `preview.memorySaver.{maxWarm, bgIdleMs, hiddenIdleMs}` (defaults 3 / 5min / 60s) with Performance-section UI controls.
- Discarded state flows through the existing W2 `preview:page-status` reducer as `phase: 'discarded'`.
- ADR 0002, settings reference, and a CONTEXT.md glossary term.

## Tests

- Unit tests cover the full ADR 0002 policy matrix (visible vs hidden, active protection, cap-only-when-hidden, idle thresholds, LRU).
- Integration test guards the #454 hysteresis regression (hide then reshow cancels the scheduled discard).
- `bun run verify` passes (typecheck, lint, feature tests). The only failures are the pre-existing `@mcode/server` snapshot-service integration Windows flake (git-setup hook timeouts), unrelated to this branch.

## Follow-up (non-blocking)

`readMemorySaverConfig` reads `settings.json` per sweep tick. At the most aggressive `bgIdleMs` (30s, giving 15s sweeps) that is frequent; a small cache could be added later.

Closes #555
Related to #552

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783150417&installation_id=129163861&pr_number=562&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F562&signature=2930155c4325b2c0730b6998becd42db087d603d9be39dadfda52da72b3349a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->