### PR TITLE
feat(cursor): clean side-channel forking (path B)

### DIFF
--- a/apps/server/src/providers/cursor/__tests__/cursor-side-channel.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-side-channel.test.ts
@@ -1,0 +1,146 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../../../store/database.js";
+import { ThreadRepo } from "../../../repositories/thread-repo.js";
+import { MessageRepo } from "../../../repositories/message-repo.js";
+import { CursorProvider } from "../cursor-provider.js";
+import type { SettingsService } from "../../../services/settings-service.js";
+import type { SkillService } from "../../../services/skill-service.js";
+import type { EnvService } from "../../../services/env-service.js";
+import type { JobObject } from "../../../services/job-object.js";
+import type { Client } from "@agentclientprotocol/sdk";
+import type { ForkRequest } from "@mcode/contracts";
+
+/**
+ * Slice 1 proof: forking a Cursor thread runs the handoff through the clean
+ * side-channel (path B) and leaves the parent's canonical session untouched -
+ * zero new `is_internal` rows and an unchanged max sequence - while still
+ * producing a non-empty handoff for the child.
+ */
+describe("Cursor clean side-channel fork", () => {
+  let db: Database.Database;
+  let threadRepo: ThreadRepo;
+  let messageRepo: MessageRepo;
+  let provider: CursorProvider;
+
+  const SUMMARY = "Parent was fixing the auth middleware; tests added next.";
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    threadRepo = new ThreadRepo(db);
+    messageRepo = new MessageRepo(db);
+
+    db.prepare("INSERT INTO workspaces (id, name, path) VALUES (?, ?, ?)").run(
+      "ws-1",
+      "test",
+      "/tmp/test",
+    );
+
+    const settingsStub = {
+      get: () => ({ provider: { cursor: { idleSessionTtlMinutes: 30 }, cli: {} } }),
+    } as unknown as SettingsService;
+    const skillStub = {} as unknown as SkillService;
+    const envStub = { getEnv: () => ({}) } as unknown as EnvService;
+    const jobStub = {} as unknown as JobObject;
+
+    provider = new CursorProvider(settingsStub, skillStub, envStub, jobStub, messageRepo);
+
+    // Replace the real `cursor-agent acp` spawn with a fake transport that
+    // streams a summary chunk back through the client (no subprocess, no
+    // events). `prompt` mimics the agent answering on the loaded session id.
+    (provider as unknown as { sideChannelConnector: unknown }).sideChannelConnector = (args: {
+      cwd: string;
+      client: Client;
+    }) => {
+      let loadedSessionId = "";
+      return Promise.resolve({
+        loadSession: (a: { sessionId: string }) => {
+          loadedSessionId = a.sessionId;
+          return Promise.resolve({});
+        },
+        prompt: async () => {
+          await args.client.sessionUpdate({
+            sessionId: loadedSessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: SUMMARY },
+            },
+          });
+          return {};
+        },
+        dispose: () => {},
+      });
+    };
+  });
+
+  it("produces a path-B handoff without mutating the parent session", async () => {
+    const parent = threadRepo.create("ws-1", "Fix auth bug", "direct", "main", true, "cursor");
+    messageRepo.create(parent.id, "user", "Fix the auth bug", 1);
+    messageRepo.create(parent.id, "assistant", "Fixed the middleware.", 2);
+    threadRepo.updateSdkSessionId(parent.id, "cursor-parent-session");
+    const seededParent = threadRepo.findById(parent.id)!;
+
+    const child = threadRepo.create("ws-1", "Branch: add tests", "direct", "main", true, "cursor", {
+      parentThreadId: parent.id,
+      forkedFromMessageId: "msg-2",
+    });
+
+    const beforeRows = messageRepo.listIncludingInternal(parent.id);
+    const beforeInternalCount = beforeRows.filter((m) => m.is_internal).length;
+    const beforeMaxSequence = Math.max(...beforeRows.map((m) => m.sequence));
+
+    const req: ForkRequest = {
+      parentThreadId: parent.id,
+      forkedFromMessageId: "msg-2",
+      forkAnchorRole: "assistant",
+      prompt: "Summarize the parent thread for handoff.",
+      cwd: "/tmp/test",
+      parentSdkSessionId: seededParent.sdk_session_id,
+      conversationHistory: "user: Fix the auth bug\nassistant: Fixed the middleware.",
+      messagesUpToFork: [],
+      parentThread: seededParent,
+      childThreadId: child.id,
+    };
+
+    const artifact = await provider.forker.fork(req);
+
+    expect(artifact.markdown).toContain(SUMMARY);
+    expect(artifact.markdown.length).toBeGreaterThan(0);
+    expect(artifact.meta.ladderStep).toBe("B");
+    expect(artifact.meta.generatedBy).toBe("provider");
+
+    const afterRows = messageRepo.listIncludingInternal(parent.id);
+    const afterInternalCount = afterRows.filter((m) => m.is_internal).length;
+    const afterMaxSequence = Math.max(...afterRows.map((m) => m.sequence));
+
+    expect(afterInternalCount).toBe(beforeInternalCount);
+    expect(afterInternalCount).toBe(0);
+    expect(afterRows).toHaveLength(beforeRows.length);
+    expect(afterMaxSequence).toBe(beforeMaxSequence);
+  });
+
+  it("degrades to a transient error (path-D trigger) when the parent has no session", async () => {
+    const parent = threadRepo.create("ws-1", "No session", "direct", "main", true, "cursor");
+    messageRepo.create(parent.id, "user", "Do a thing", 1);
+    const seededParent = threadRepo.findById(parent.id)!;
+    const child = threadRepo.create("ws-1", "child", "direct", "main", true, "cursor", {
+      parentThreadId: parent.id,
+      forkedFromMessageId: "msg-1",
+    });
+
+    const req: ForkRequest = {
+      parentThreadId: parent.id,
+      forkedFromMessageId: "msg-1",
+      forkAnchorRole: "user",
+      prompt: "Summarize.",
+      cwd: "/tmp/test",
+      parentSdkSessionId: null,
+      messagesUpToFork: [],
+      parentThread: seededParent,
+      childThreadId: child.id,
+    };
+
+    await expect(provider.forker.fork(req)).rejects.toMatchObject({ code: "ETIMEDOUT" });
+  });
+});

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -32,7 +32,8 @@ import { MessageRepo } from "../../repositories/message-repo.js";
 import { JobObject } from "../../services/job-object.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
-import { MutatingForker } from "../../services/handoff/session-forker.js";
+import { CleanForker } from "../../services/handoff/session-forker.js";
+import { killProcessTree } from "../../services/process-kill.js";
 import {
   AgentEventType,
   CURSOR_STATIC_MODEL_FALLBACK,
@@ -92,6 +93,40 @@ import { extractCursorCreatePlanMarkdown } from "./cursor-create-plan.js";
 
 const CURSOR_STDERR_TAIL_MAX = 48;
 
+/**
+ * Wrap a message as a transient (ETIMEDOUT) error. `classifyProviderError` maps
+ * ETIMEDOUT to the "transient" bucket, so the handoff pipeline falls cleanly to
+ * the deterministic path (D) instead of treating a missing/unresumable session
+ * as a permanent failure.
+ */
+function transientHandoffError(message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = "ETIMEDOUT";
+  return err;
+}
+
+/**
+ * Minimal transport surface the clean side-channel needs from a throwaway ACP
+ * connection: reconstruct the parent session, run one prompt, then dispose. The
+ * assistant text is read off the local accumulator, so neither return value is
+ * inspected here.
+ */
+interface CursorSideChannelTransport {
+  loadSession(args: { cwd: string; mcpServers: never[]; sessionId: string }): Promise<unknown>;
+  prompt(args: { sessionId: string; prompt: { type: "text"; text: string }[] }): Promise<unknown>;
+  dispose(): Promise<void> | void;
+}
+
+/**
+ * Factory that opens a throwaway ACP transport wired to a non-emitting client.
+ * Defaulted to the real `cursor-agent acp` spawn and overridable in tests so the
+ * clean-fork invariants can be asserted without a live subprocess.
+ */
+type CursorSideChannelConnector = (args: {
+  cwd: string;
+  client: Client;
+}) => Promise<CursorSideChannelTransport>;
+
 function cursorCliProbeBinaries(settings: Settings): string[] {
   const configured = settings.provider.cli.cursor?.trim();
   return configured ? [configured] : [getCatalogEntry("cursor").cliBinary, "agent"];
@@ -147,10 +182,18 @@ export class CursorProvider
 {
   readonly id: ProviderId = "cursor";
   readonly supportsCompletion = false;
-  readonly sessionForkOnResume = "mutating" as const;
+  readonly sessionForkOnResume = "clean" as const;
   readonly maxInputCharactersPerTurn = 4_000;
-  /** Path A forker; calls this provider's runHiddenTurn on the parent session. */
-  readonly forker: SessionForker = new MutatingForker(this);
+  /** Path B forker; calls this provider's runSideChannelQuery on a forked copy of the parent session. */
+  readonly forker: SessionForker = new CleanForker(this);
+
+  /**
+   * Opens the throwaway ACP transport for {@link runSideChannelQuery}. Defaults
+   * to the real subprocess spawn; tests override it to assert the clean-fork
+   * invariants without launching `cursor-agent`.
+   */
+  private sideChannelConnector: CursorSideChannelConnector = (args) =>
+    this.createSideChannelTransport(args);
 
   /** Owns the session pool, idle eviction (with busy guard), and JobObject/kill. */
   private readonly runtime: SessionRuntime<CursorSessionState>;
@@ -543,6 +586,17 @@ export class CursorProvider
       void this.runtime.stop(mcodeSessionId);
     });
 
+    await this.acpHandshake(connection, threadId);
+
+    return entry as CursorAcpSessionEntry;
+  }
+
+  /**
+   * Runs the ACP `initialize` handshake and a best-effort `authenticate` on a
+   * fresh connection. Shared by the pooled session spawn and the throwaway
+   * side-channel transport.
+   */
+  private async acpHandshake(connection: ClientSideConnection, threadId: string): Promise<void> {
     const initResult = await connection.initialize({
       protocolVersion: PROTOCOL_VERSION,
       clientInfo: { name: "mcode", title: "Mcode", version: "0.0.1" },
@@ -562,8 +616,6 @@ export class CursorProvider
         });
       });
     }
-
-    return entry as CursorAcpSessionEntry;
   }
 
   private buildAcpClient(entry: CursorAcpSessionEntry): Client {
@@ -1183,5 +1235,177 @@ export class CursorProvider
     } finally {
       entry.activeTurnState = null;
     }
+  }
+
+  /**
+   * Clean side-channel handoff query (path B). Reconstructs the parent thread's
+   * persisted Cursor session into a throwaway ACP connection, runs the summary
+   * prompt against that fork, and returns the assistant text. It writes nothing
+   * to the parent thread's `messages` table and emits no provider events, so the
+   * canonical session is left exactly as it was. The throwaway subprocess is
+   * killed before returning.
+   *
+   * Because loading the same session id into a second connection branches the
+   * conversation rather than advancing the canonical server-side session, the
+   * parent is never mutated — this is the primitive that retires the path-A
+   * hidden-turn dance ({@link runHiddenTurn}).
+   *
+   * Falls back to a transient (path-D) error when there is no persisted session
+   * to reconstruct, the load fails, or the fork produces no text — the pipeline
+   * then builds a deterministic handoff instead of mutating the parent.
+   * `conversationHistory` (the sessionless B-prime body Claude uses) is not
+   * consumed here: the slice's contract is a clean reconstruction of the
+   * persisted session, so a missing/unresumable session degrades to path D.
+   */
+  async runSideChannelQuery(args: {
+    parentThreadId: string;
+    parentSdkSessionId: string;
+    prompt: string;
+    abortSignal?: AbortSignal;
+    conversationHistory?: string;
+    cwd: string;
+  }): Promise<string> {
+    const { parentThreadId, parentSdkSessionId, prompt, abortSignal, cwd } = args;
+    void args.conversationHistory; // sessionless B-prime fallback is out of scope for this slice.
+
+    if (!parentSdkSessionId) {
+      throw transientHandoffError(
+        `No persisted Cursor session for parent thread ${parentThreadId}; cannot run clean side-channel query`,
+      );
+    }
+    if (abortSignal?.aborted) {
+      throw transientHandoffError("Cursor side-channel query aborted before start");
+    }
+
+    // Populated from session updates only; never emitted, so the parent thread
+    // gains no rows and the UI timeline sees nothing.
+    const turnState = createCursorAcpTurnState();
+    const todoSnapshot = createCursorTodoSnapshot();
+    const sideChannelThreadId = `sidechannel-${randomUUID()}`;
+
+    const client: Client = {
+      // A summary query needs no tools, and a throwaway side-channel must never
+      // mutate the user's workspace; deny every permission request.
+      requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
+      sessionUpdate: async (params: SessionNotification) => {
+        if (params.sessionId !== parentSdkSessionId) return;
+        // Map for the accumulator side effect; discard the events (no emission).
+        mapCursorAcpSessionNotification(params, sideChannelThreadId, turnState, todoSnapshot);
+      },
+      readTextFile: async (r) => ({ content: this.safeReadWorkspaceFile(cwd, r.path) }),
+      writeTextFile: async () => {
+        throw new Error("Cursor side-channel is read-only");
+      },
+      extMethod: async () => ({}),
+      extNotification: async () => {},
+    };
+
+    let transport: CursorSideChannelTransport;
+    try {
+      transport = await this.sideChannelConnector({ cwd, client });
+    } catch (err) {
+      throw transientHandoffError(
+        `Failed to open Cursor side-channel connection: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const onAbort = (): void => {
+      void transport.dispose();
+    };
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      try {
+        await transport.loadSession({ cwd, mcpServers: [], sessionId: parentSdkSessionId });
+      } catch (err) {
+        throw transientHandoffError(
+          `Cursor side-channel could not reconstruct parent session ${parentSdkSessionId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      await transport.prompt({
+        sessionId: parentSdkSessionId,
+        prompt: [{ type: "text", text: prompt }],
+      });
+
+      const text = resolveCursorAssistantMessageContent(turnState.accumulator).trim();
+      if (!text) {
+        throw transientHandoffError("Cursor side-channel query returned empty output");
+      }
+      return text;
+    } finally {
+      abortSignal?.removeEventListener("abort", onAbort);
+      await transport.dispose();
+    }
+  }
+
+  /**
+   * Default {@link sideChannelConnector}: spawns a fresh `cursor-agent acp`
+   * subprocess, runs the ACP handshake, and returns a transport that wraps the
+   * connection plus a process-tree kill on dispose. The subprocess is never
+   * registered with the session pool, so it cannot disturb the parent thread's
+   * pooled session.
+   */
+  private async createSideChannelTransport(args: {
+    cwd: string;
+    client: Client;
+  }): Promise<CursorSideChannelTransport> {
+    const { cwd, client } = args;
+    const settings = this.settingsService.get();
+    const cliCandidates = cursorCliProbeBinaries(settings);
+
+    let child: ChildProcess | null = null;
+    let lastErr: unknown = null;
+    for (const cliPath of cliCandidates) {
+      try {
+        const candidate = spawn(cliPath, buildCursorAcpArgs({ permissionMode: "default" }), {
+          stdio: ["pipe", "pipe", "pipe"],
+          cwd,
+          shell: process.platform === "win32",
+          env: this.envService.getEnv(),
+        });
+        if (!candidate.stdin || !candidate.stdout) {
+          throw new Error("Failed to spawn cursor-agent: stdio pipes unavailable");
+        }
+        child = candidate;
+        break;
+      } catch (e) {
+        lastErr = e;
+        const m = e instanceof Error ? e.message : String(e);
+        if (/Failed to spawn cursor-agent/i.test(m)) continue;
+        break;
+      }
+    }
+    if (!child?.stdin || !child.stdout) {
+      throw lastErr instanceof Error
+        ? lastErr
+        : new Error(String(lastErr ?? "Failed to spawn cursor-agent (side-channel)"));
+    }
+
+    // Read the pipes off `child` directly: the guard above narrows
+    // `child.stdin`/`child.stdout` on that exact reference, a narrowing that
+    // would not survive being aliased through another binding.
+    const out = Writable.toWeb(child.stdin) as WritableStream<Uint8Array>;
+    const inp = Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>;
+    const spawned = child;
+    const stream = ndJsonStream(out, inp);
+    const connection = new ClientSideConnection(() => client, stream);
+    await this.acpHandshake(connection, "cursor-side-channel");
+
+    return {
+      loadSession: (a) => connection.loadSession(a),
+      prompt: (a) => connection.prompt(a),
+      dispose: async () => {
+        try {
+          if (spawned.pid != null) await killProcessTree(spawned.pid);
+        } catch {
+          /* best-effort: the subprocess may already be gone */
+        }
+        try {
+          spawned.kill();
+        } catch {
+          /* best-effort: the subprocess may already be gone */
+        }
+      },
+    };
   }
 }

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -1309,8 +1309,16 @@ export class CursorProvider
       );
     }
 
+    // Dispose exactly once: an abort during loadSession/prompt and the finally
+    // block both reach for teardown, so the first caller owns it and the other
+    // awaits the same promise rather than racing a second kill.
+    let disposal: Promise<void> | null = null;
+    const disposeOnce = (): Promise<void> => {
+      if (!disposal) disposal = Promise.resolve(transport.dispose());
+      return disposal;
+    };
     const onAbort = (): void => {
-      void transport.dispose();
+      void disposeOnce();
     };
     abortSignal?.addEventListener("abort", onAbort, { once: true });
     try {
@@ -1334,7 +1342,7 @@ export class CursorProvider
       return text;
     } finally {
       abortSignal?.removeEventListener("abort", onAbort);
-      await transport.dispose();
+      await disposeOnce();
     }
   }
 


### PR DESCRIPTION
## What
Fork a Cursor thread by reconstructing the parent's persisted session into a throwaway ACP side-channel (path B) to build the handoff, instead of mutating the parent with a hidden turn (path A).

## Why
Path A advanced the parent's canonical Cursor session to produce a fork summary, leaving `is_internal` rows and bumping the message sequence. Slice 1 of F-A proves a clean alternative: a throwaway connection that loads the same session id branches the conversation rather than advancing it, so the parent is left exactly as it was. This is the primitive that retires the hidden-turn dance.

## Key Changes
- Add `runSideChannelQuery` to `CursorProvider`: loads the parent's persisted session into a throwaway `cursor-agent acp` connection, runs the summary prompt, returns the assistant text, and disposes the subprocess. Emits **zero** provider events, so the global agent-service subscriber persists nothing to the parent thread.
- Add `createSideChannelTransport` (the default connector) with process-tree kill on dispose; injectable via `sideChannelConnector` for tests.
- Extract `acpHandshake`, shared by the pooled session spawn and the side-channel transport.
- Rewire the Cursor forker `MutatingForker` -> `CleanForker`; flip `sessionForkOnResume` to `"clean"`.
- Missing/unresumable session or empty output raises a transient (`ETIMEDOUT`) error, so the pipeline degrades cleanly to path D.
- `MutatingForker` / `runHiddenTurn` retained as the Slice 2 rollback path.
- Integration test: forks a Cursor thread against a real in-memory DB and asserts the clean-parent invariant (zero `is_internal` rows added, row count and max sequence unchanged) plus a non-empty path-B handoff; a second case asserts the no-session path throws the transient path-D trigger.

## Config Changes
None

Closes #558

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783165460&installation_id=129163861&pr_number=569&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F569&signature=484f8f5b95e00a6fa28e6e8fb873efc21da2b19e65658cb1b4c8fad98a193c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clean side-channel forking flow that preserves the parent session and can run throwaway summary queries without mutating parent state.

* **Bug Fixes**
  * Improved transient error detection and handling for fork/hand-off operations.

* **Tests**
  * Added tests covering clean side-channel forking, summary streaming, and timeout/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->