### PR TITLE
feat(right-panel): glanceable tab status, drag-handle fixes, terminal auto-start

### DIFF
--- a/apps/web/e2e/right-panel-tab-status.spec.ts
+++ b/apps/web/e2e/right-panel-tab-status.spec.ts
@@ -1,0 +1,258 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { Thread, TurnSnapshot } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-tab-status",
+  name: "Tab Status",
+  path: "/tmp/tab-status",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+function makeThread(id: string, title: string): Thread {
+  return {
+    id,
+    workspace_id: WORKSPACE.id,
+    title,
+    status: "paused",
+    mode: "direct",
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+  };
+}
+
+const THREAD = makeThread("thread-tab-status", "Tab Status Thread");
+
+/** Two completed of five parent tasks → Scope reads "2/5". */
+const TASKS = [
+  { id: "t1", content: "Map data sources", status: "completed", group: "Tasks" },
+  { id: "t2", content: "Build tab status", status: "completed", group: "Tasks" },
+  { id: "t3", content: "Wire freshness", status: "in_progress", group: "Tasks" },
+  { id: "t4", content: "Fix drag handle", status: "pending", group: "Tasks" },
+  { id: "t5", content: "Verify in browser", status: "pending", group: "Tasks" },
+] as const;
+
+function makeSnapshot(id: string, files: string[]): TurnSnapshot {
+  return {
+    id,
+    message_id: `m-${id}`,
+    thread_id: THREAD.id,
+    ref_before: "aaaaaaa",
+    ref_after: "bbbbbbb",
+    files_changed: files,
+    worktree_path: null,
+    created_at: now,
+  };
+}
+
+/** Two snapshots covering four distinct files → Changes reads "4". */
+const SNAPSHOTS = [
+  makeSnapshot("s1", ["RightPanel.tsx", "diffStore.ts"]),
+  makeSnapshot("s2", ["index.css", "RightPanel.tsx", "App.tsx"]),
+];
+
+/**
+ * Seeds workspace, thread, tasks, and snapshots into the live stores, then
+ * opens the right panel on the given tab. Mirrors the store-poking pattern used
+ * by right-panel-terminal-resize.spec.ts.
+ */
+async function seedPanel(page: Page, tab: "tasks" | "changes"): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread, tid, snapshots, tab }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) =>
+        (s as { getState: () => Record<string, unknown> }).getState();
+
+      const wsStore = stores.find((s) => "activeThreadId" in getState(s) && "threads" in getState(s));
+      if (wsStore) {
+        (wsStore as { setState: (p: unknown) => void }).setState({
+          workspaces: [workspace],
+          activeWorkspaceId: workspace.id,
+          threads: [thread],
+          activeThreadId: tid,
+        });
+      }
+
+      const diffStore = stores.find(
+        (s) => "showRightPanel" in getState(s) && "setSnapshots" in getState(s),
+      );
+      if (diffStore) {
+        const api = (
+          diffStore as {
+            getState: () => {
+              setSnapshots: (id: string, snaps: unknown) => void;
+              showRightPanel: (id: string) => void;
+              setRightPanelTab: (id: string, t: string) => void;
+            };
+          }
+        ).getState();
+        api.setSnapshots(tid, snapshots);
+        api.showRightPanel(tid);
+        api.setRightPanelTab(tid, tab);
+      }
+    },
+    { workspace: WORKSPACE, thread: THREAD, tid: THREAD.id, snapshots: SNAPSHOTS, tab },
+  );
+}
+
+/** Appends one snapshot with a new file so the cumulative file count grows. */
+async function addSnapshotWithNewFile(page: Page): Promise<void> {
+  await page.evaluate((tid) => {
+    const stores: unknown[] =
+      (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+    const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+    const diffStore = stores.find((s) => "setSnapshots" in getState(s));
+    if (!diffStore) return;
+    const api = (
+      diffStore as {
+        getState: () => {
+          snapshotsByThread: Record<string, unknown[]>;
+          setSnapshots: (id: string, snaps: unknown) => void;
+        };
+      }
+    ).getState();
+    const existing = api.snapshotsByThread[tid] ?? [];
+    const fresh = {
+      id: "s3",
+      message_id: "m-s3",
+      thread_id: tid,
+      ref_before: "ccccccc",
+      ref_after: "ddddddd",
+      files_changed: ["TabStatus.tsx"],
+      worktree_path: null,
+      created_at: new Date().toISOString(),
+    };
+    api.setSnapshots(tid, [...existing, fresh]);
+  }, THREAD.id);
+}
+
+test.describe("Right panel tab status", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [THREAD],
+      // The auxiliary hydrator loads tasks from this RPC on thread activation;
+      // returning them here (rather than poking the store) avoids a race where
+      // the hydrator's default empty result overwrites a seeded task list.
+      "thread.getTasks": TASKS,
+      "snapshot.listByThread": SNAPSHOTS,
+      "settings.get": getDefaultSettings(),
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1920, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+  });
+
+  test("tabs show scope progress, change count, and the active-tab lamp", async ({ page }, testInfo) => {
+    await seedPanel(page, "tasks");
+
+    const scopeTab = page.getByRole("button", { name: /Scope/ });
+    const changesTab = page.getByRole("button", { name: /Changes/ });
+    await expect(scopeTab).toBeVisible();
+
+    // Scope progress (2 completed of 5) and Changes file count (4 distinct).
+    await expect(scopeTab).toContainText("2/5");
+    await expect(changesTab).toContainText("4");
+
+    // The active tab carries the amber lamp; the sliding indicator is present.
+    await expect(scopeTab).toHaveClass(/text-primary/);
+    await expect(page.getByTestId("tab-indicator")).toBeAttached();
+
+    await page.screenshot({ path: testInfo.outputPath("scope-active.png") });
+
+    // Switching tabs moves the lamp to Changes.
+    await changesTab.click();
+    await expect(changesTab).toHaveClass(/text-primary/);
+    await expect(scopeTab).not.toHaveClass(/text-primary/);
+
+    await page.screenshot({ path: testInfo.outputPath("changes-active.png") });
+  });
+
+  test("changes tab pulses fresh when new files land while viewing another tab", async ({ page }) => {
+    // Open on Scope so the Changes tab is inactive; this also baselines the
+    // current file count so pre-existing changes do not pulse.
+    await seedPanel(page, "tasks");
+
+    const changesTab = page.getByRole("button", { name: /Changes/ });
+    await expect(changesTab).toContainText("4");
+    await expect(changesTab.locator(".changes-fresh-ring")).toHaveCount(0);
+
+    // A new turn lands while the user is on Scope → Changes goes fresh.
+    await addSnapshotWithNewFile(page);
+    await expect(changesTab).toContainText("5");
+    await expect(changesTab.locator(".changes-fresh-ring")).toBeVisible();
+
+    // Viewing Changes clears the freshness signal.
+    await changesTab.click();
+    await expect(changesTab.locator(".changes-fresh-ring")).toHaveCount(0);
+  });
+
+  test("changes badge caps the count for very large diffs", async ({ page }) => {
+    // Seed on Scope (Changes inactive) so the DiffPanel does not refetch and
+    // overwrite the large snapshot we poke in below.
+    await seedPanel(page, "tasks");
+
+    await page.evaluate((tid) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+      const diffStore = stores.find((s) => "setSnapshots" in getState(s));
+      if (!diffStore) return;
+      const files = Array.from({ length: 200 }, (_, i) => `src/file-${i}.ts`);
+      (
+        diffStore as { getState: () => { setSnapshots: (id: string, snaps: unknown) => void } }
+      )
+        .getState()
+        .setSnapshots(tid, [
+          {
+            id: "big",
+            message_id: "m-big",
+            thread_id: tid,
+            ref_before: "aaaaaaa",
+            ref_after: "bbbbbbb",
+            files_changed: files,
+            worktree_path: null,
+            created_at: new Date().toISOString(),
+          },
+        ]);
+    }, THREAD.id);
+
+    // 200 distinct files renders as the capped label, not "200".
+    const changesTab = page.getByRole("button", { name: /Changes/ });
+    await expect(changesTab).toContainText("99+");
+  });
+});

--- a/apps/web/e2e/right-panel-terminal-autostart.spec.ts
+++ b/apps/web/e2e/right-panel-terminal-autostart.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { Thread } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-term-autostart",
+  name: "Autostart WS",
+  path: "/tmp/term-autostart",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+function makeThread(id: string, title: string): Thread {
+  return {
+    id,
+    workspace_id: WORKSPACE.id,
+    title,
+    status: "paused",
+    mode: "direct",
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+  };
+}
+
+const THREAD = makeThread("thread-term-autostart", "Autostart Thread");
+
+/** Reads the number of terminals the store holds for a thread. */
+async function terminalCount(page: Page, threadId: string): Promise<number> {
+  return page.evaluate((tid) => {
+    const stores: unknown[] =
+      (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+    const termStore = stores.find(
+      (s) => "addTerminal" in (s as { getState: () => Record<string, unknown> }).getState(),
+    );
+    if (!termStore) return -1;
+    const terminals = (
+      termStore as { getState: () => { terminals: Record<string, unknown[]> } }
+    ).getState().terminals[tid];
+    return terminals ? terminals.length : 0;
+  }, threadId);
+}
+
+async function openPanelOnScope(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread, tid }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+      const wsStore = stores.find((s) => "activeThreadId" in getState(s) && "threads" in getState(s));
+      (wsStore as { setState: (p: unknown) => void } | undefined)?.setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: [thread],
+        activeThreadId: tid,
+      });
+      const diffStore = stores.find((s) => "showRightPanel" in getState(s));
+      if (diffStore) {
+        const api = (
+          diffStore as {
+            getState: () => {
+              showRightPanel: (id: string) => void;
+              setRightPanelTab: (id: string, t: string) => void;
+            };
+          }
+        ).getState();
+        api.showRightPanel(tid);
+        api.setRightPanelTab(tid, "tasks");
+      }
+    },
+    { workspace: WORKSPACE, thread: THREAD, tid: THREAD.id },
+  );
+}
+
+test.describe("Right panel terminal auto-start", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [THREAD],
+      "terminal.create": { ptyId: "pty-term-autostart", shell: "bash" },
+      "terminal.resize": true,
+      "terminal.kill": true,
+      "terminal.killByThread": true,
+      "settings.get": getDefaultSettings(),
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1920, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+  });
+
+  test("clicking the Terminal tab auto-starts a shell", async ({ page }) => {
+    await openPanelOnScope(page);
+
+    // No terminals before the tab is opened.
+    expect(await terminalCount(page, THREAD.id)).toBe(0);
+
+    await page.getByRole("button", { name: "Terminal", exact: true }).click();
+
+    // Opening the tab spawns one without the user clicking "New terminal".
+    await expect.poll(() => terminalCount(page, THREAD.id), { timeout: 5_000 }).toBe(1);
+    await expect(page.getByText("No terminals")).toHaveCount(0);
+  });
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -12,7 +12,6 @@ import { ShortcutHelpDialog } from "@/components/ShortcutHelpDialog";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { resizeRecordCache } from "@/lib/thread-hydrator/record-cache";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useTerminalStore } from "@/stores/terminalStore";
 import { useDiffStore } from "@/stores/diffStore";
 import { usePreviewDockStore } from "@/stores/previewDockStore";
 import { usePreviewFocusStore } from "@/stores/previewFocusStore";
@@ -21,7 +20,6 @@ import { initShortcuts } from "@/lib/shortcuts";
 import { registerCommand } from "@/lib/command-registry";
 import { setContext } from "@/lib/context-tracker";
 import { startPushListeners, stopPushListeners } from "@/transport/ws-events";
-import { getTransport } from "@/transport";
 import { useIdleReclamation } from "@/hooks/useIdleReclamation";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ToastContainer } from "@/components/Toast";
@@ -44,13 +42,6 @@ const LazyCommandPalette = lazy(async () => {
   const m = await import("@/components/palette/CommandPalette");
   return { default: m.CommandPalette };
 });
-
-/**
- * Tracks threads for which a PTY creation RPC is already in flight.
- * Prevents duplicate terminals when Ctrl+J is pressed rapidly or when
- * the toggle fires twice before the first creation resolves.
- */
-const terminalCreationInFlight = new Set<string>();
 
 /** Root application component. Initializes WS transport and push listeners. */
 export function App() {
@@ -198,7 +189,6 @@ export function App() {
           const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
             useDiffStore.getState();
           const panel = getRightPanel(tid);
-          const isOpening = !panel.visible || panel.activeTab !== "terminal";
           if (!panel.visible) {
             showRightPanel(tid);
             setRightPanelTab(tid, "terminal");
@@ -207,39 +197,8 @@ export function App() {
           } else {
             hideRightPanel(tid);
           }
-          // Auto-create a terminal when opening the tab with none.
-          if (isOpening && !terminalCreationInFlight.has(tid)) {
-            const termStore = useTerminalStore.getState();
-            const terminals = termStore.terminals[tid];
-            if (!terminals || terminals.length === 0) {
-              terminalCreationInFlight.add(tid);
-              try {
-                const transport = getTransport();
-                transport
-                  .terminalCreate(tid)
-                  .then(({ ptyId, shell }) => {
-                    terminalCreationInFlight.delete(tid);
-                    const rightPanel = useDiffStore.getState().getRightPanel(tid);
-                    // Panel was closed while creation was in flight — dispose the orphaned PTY.
-                    if (!rightPanel.visible || rightPanel.activeTab !== "terminal") {
-                      transport.terminalKill(ptyId).catch(() => {});
-                      return;
-                    }
-                    const currentTerminals = useTerminalStore.getState().terminals[tid];
-                    if (!currentTerminals || currentTerminals.length === 0) {
-                      useTerminalStore.getState().addTerminal(tid, ptyId, shell);
-                    } else {
-                      transport.terminalKill(ptyId).catch(() => {});
-                    }
-                  })
-                  .catch(() => {
-                    terminalCreationInFlight.delete(tid);
-                  });
-              } catch {
-                terminalCreationInFlight.delete(tid);
-              }
-            }
-          }
+          // Terminal creation on open is handled by RightPanel's
+          // ensureTerminalForThread effect (fires for every open path).
         },
       }),
       registerCommand({

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -1,5 +1,6 @@
+import type { LucideIcon } from "lucide-react";
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ListChecks, Diff, Globe, Terminal, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -10,6 +11,7 @@ import {
   PANEL_WIDE_WIDTH,
   createDefaultRightPanelState,
   getDefaultPanelWidthPx,
+  type RightPanelTab,
 } from "@/stores/diffStore";
 import { ScopeSplitPane } from "./ScopeSplitPane";
 import { DiffPanel } from "@/components/diff";
@@ -17,7 +19,160 @@ import { PreviewPanel } from "@/components/panels/PreviewPanel";
 import { TerminalTabContent } from "@/components/terminal/TerminalTabContent";
 import { TerminalPoolSlot } from "@/components/terminal/TerminalPoolSlotContext";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { ensureTerminalForThread } from "@/lib/ensure-terminal";
 import { cn } from "@/lib/utils";
+
+/** Static definition of a right-panel tab: id, label, and icon. */
+interface TabDef {
+  readonly id: RightPanelTab;
+  readonly label: string;
+  readonly icon: LucideIcon;
+}
+
+/** The four right-panel tabs, in display order. */
+const TABS: readonly TabDef[] = [
+  { id: "tasks", label: "Scope", icon: ListChecks },
+  { id: "changes", label: "Changes", icon: Diff },
+  { id: "preview", label: "Preview", icon: Globe },
+  { id: "terminal", label: "Terminal", icon: Terminal },
+];
+
+/**
+ * Below this rendered panel width (px) the tab strip drops inactive labels to
+ * icon-only so four tabs plus their status never crowd at the 384px floor. The
+ * active tab keeps its label; every tab keeps its status glyph.
+ */
+const COMPACT_TAB_WIDTH = 440;
+
+/**
+ * Past this many changed files the Changes badge renders "{cap}+" instead of
+ * the exact number. The glance only needs "a lot"; an exact 3-4 digit count
+ * adds width without information and would grow the tab on large diffs. Only
+ * the rendered label is capped — the underlying count stays exact so freshness
+ * detection still registers further growth above the cap.
+ */
+const CHANGES_COUNT_CAP = 99;
+
+/**
+ * Tracks whether the Changes tab has unreviewed new files for the active
+ * thread. In-session only (the diff store is not persisted): the first time a
+ * thread is seen, the current file count becomes the baseline so pre-existing
+ * changes do not pulse. While the Changes tab is active the baseline tracks the
+ * live count (you are looking at it, nothing is "new"); otherwise a count above
+ * the baseline marks the tab fresh until it is next viewed.
+ */
+function useChangesFreshness(
+  threadId: string | null,
+  fileCount: number,
+  isChangesActive: boolean,
+): boolean {
+  const seenByThread = useRef<Map<string, number>>(new Map());
+  const [fresh, setFresh] = useState(false);
+
+  useEffect(() => {
+    if (!threadId) {
+      setFresh(false);
+      return;
+    }
+    const seen = seenByThread.current;
+    const baseline = seen.get(threadId);
+    if (baseline === undefined || isChangesActive) {
+      seen.set(threadId, fileCount);
+      setFresh(false);
+      return;
+    }
+    setFresh(fileCount > baseline);
+  }, [threadId, fileCount, isChangesActive]);
+
+  return fresh;
+}
+
+/** Aggregate task completion across a thread's parent tasks. */
+interface ScopeProgress {
+  readonly done: number;
+  readonly total: number;
+}
+
+/**
+ * Per-tab glance status rendered beside the label: Scope task progress and the
+ * Changes file count. Returns null for tabs with nothing to report so a calm
+ * tab stays a bare label. Terminal and Preview carry no status yet (their
+ * running/errored state is not surfaced per-thread).
+ */
+function TabStatus({
+  tab,
+  active,
+  scope,
+  changesCount,
+  changesFresh,
+}: {
+  tab: RightPanelTab;
+  active: boolean;
+  scope: ScopeProgress;
+  changesCount: number;
+  changesFresh: boolean;
+}) {
+  if (tab === "tasks") {
+    if (scope.total === 0) return null;
+    const complete = scope.done === scope.total;
+    return (
+      <span
+        className={cn(
+          "font-mono text-[10px] font-medium tabular-nums tracking-normal",
+          complete
+            ? "text-[var(--diff-add-strong)]"
+            : active
+              ? "text-current"
+              : "text-muted-foreground",
+        )}
+      >
+        {scope.done}/{scope.total}
+      </span>
+    );
+  }
+  if (tab === "changes") {
+    if (changesCount === 0) return null;
+    const label = changesCount > CHANGES_COUNT_CAP ? `${CHANGES_COUNT_CAP}+` : String(changesCount);
+    return (
+      <span
+        className={cn(
+          "font-mono text-[10px] font-medium tabular-nums tracking-normal",
+          changesFresh
+            ? "changes-fresh-ring text-primary"
+            : active
+              ? "text-current"
+              : "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+    );
+  }
+  return null;
+}
+
+/**
+ * Accessible name for a tab, carrying its glance status as text so screen
+ * readers get the same signal sighted users read from the count and the amber
+ * freshness color. Also keeps the name complete when narrow mode hides the
+ * visible label.
+ */
+function tabAccessibleLabel(
+  tab: RightPanelTab,
+  scope: ScopeProgress,
+  changesCount: number,
+  changesFresh: boolean,
+): string {
+  if (tab === "tasks") {
+    return scope.total > 0 ? `Scope, ${scope.done} of ${scope.total} tasks done` : "Scope";
+  }
+  if (tab === "changes") {
+    if (changesCount === 0) return "Changes";
+    const files = `${changesCount} ${changesCount === 1 ? "file" : "files"} changed`;
+    return `Changes, ${files}${changesFresh ? ", new since last viewed" : ""}`;
+  }
+  return tab === "preview" ? "Preview" : "Terminal";
+}
 
 /** Right-side panel with tabs for Tasks, Changes, and Preview. */
 export function RightPanel() {
@@ -87,6 +242,88 @@ export function RightPanel() {
   const wouldCrampChat =
     panelWidth + CHAT_COMFORT_MIN + SIDEBAR_BUFFER + LAYOUT_GAPS > viewportWidth;
   const isOverlay = !isWide || wouldCrampChat;
+
+  // Tab-strip glance status. Scope progress counts completed and cancelled
+  // tasks as settled (a dropped task is no longer pending work); Changes counts
+  // distinct files across every turn snapshot (the cumulative working-tree diff
+  // the user reviews and ships).
+  const scope = useMemo<ScopeProgress>(() => {
+    const total = parentTasks.length;
+    const done = parentTasks.filter(
+      (t) => t.status === "completed" || t.status === "cancelled",
+    ).length;
+    return { done, total };
+  }, [parentTasks]);
+
+  const snapshots = useDiffStore((s) =>
+    activeThreadId ? s.snapshotsByThread[activeThreadId] : undefined,
+  );
+  const changesCount = useMemo(() => {
+    if (!snapshots || snapshots.length === 0) return 0;
+    const files = new Set<string>();
+    for (const snap of snapshots) {
+      for (const file of snap.files_changed) files.add(file);
+    }
+    return files.size;
+  }, [snapshots]);
+
+  const isChangesActive = panelVisible && activeTab === "changes";
+  const changesFresh = useChangesFreshness(activeThreadId, changesCount, isChangesActive);
+
+  // Drop inactive tab labels when the rendered panel is narrow. Overlay mode
+  // renders at min(panelWidth, 90vw), so measure against that.
+  const renderedTabWidth = isOverlay
+    ? Math.min(panelWidth, viewportWidth * 0.9)
+    : panelWidth;
+  const compactTabs = renderedTabWidth < COMPACT_TAB_WIDTH;
+
+  // Active-tab underline indicator. Measured imperatively (rather than derived
+  // from layout) so it slides between tabs whose widths vary with their status.
+  const headerRef = useRef<HTMLDivElement>(null);
+  const tablistRef = useRef<HTMLDivElement>(null);
+  const indicatorRef = useRef<HTMLSpanElement>(null);
+  const measureIndicator = useCallback(() => {
+    const header = headerRef.current;
+    const indicator = indicatorRef.current;
+    const active = tablistRef.current?.querySelector<HTMLElement>('[data-tab-active="true"]');
+    if (!header || !indicator) return;
+    // Drive the slide with a GPU-composited transform (translate + scaleX off a
+    // 1px base) rather than animating left/width, so the underline never
+    // triggers layout. scaleX(0) parks it invisibly when there is no target.
+    if (!active) {
+      indicator.style.transform = "scaleX(0)";
+      return;
+    }
+    const headerRect = header.getBoundingClientRect();
+    const activeRect = active.getBoundingClientRect();
+    if (activeRect.width === 0) {
+      indicator.style.transform = "scaleX(0)";
+      return;
+    }
+    const offset = activeRect.left - headerRect.left;
+    indicator.style.transform = `translateX(${offset}px) scaleX(${activeRect.width})`;
+  }, []);
+  useLayoutEffect(() => {
+    measureIndicator();
+  }, [measureIndicator, activeTab, panelVisible, compactTabs, scope, changesCount]);
+  useEffect(() => {
+    const list = tablistRef.current;
+    if (!list || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => measureIndicator());
+    ro.observe(list);
+    return () => ro.disconnect();
+  }, [measureIndicator]);
+
+  // Anticipate the next step: opening the Terminal tab spawns a shell when the
+  // thread has none, so the user lands in a ready terminal instead of an empty
+  // pane. Gated on visibility so a hidden (persisted) terminal tab never spawns
+  // in the background, and intentionally not gated on the terminal count so
+  // killing the last terminal does not immediately respawn one.
+  useEffect(() => {
+    if (panelVisible && activeTab === "terminal" && activeThreadId) {
+      ensureTerminalForThread(activeThreadId);
+    }
+  }, [panelVisible, activeTab, activeThreadId]);
 
   // Close on Escape when overlaid.
   useEffect(() => {
@@ -249,8 +486,9 @@ export function RightPanel() {
       <div
         role="separator"
         aria-orientation="vertical"
+        aria-label="Resize panel"
         tabIndex={0}
-        className="absolute left-0 top-0 bottom-0 z-20 flex w-3 cursor-col-resize justify-center bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        className="group absolute inset-y-0 left-0 z-20 flex w-3 cursor-col-resize items-stretch justify-center focus:outline-none"
         onMouseDown={onDragStart}
         onDoubleClick={() => {
           const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
@@ -274,64 +512,53 @@ export function RightPanel() {
           }
         }}
       >
+        {/* Grip: transparent at rest (the panel's radius and shadow already
+            separate it from the chat — a resting hairline is redundant and
+            reads as a stray line). It brightens on hover, focus, and active
+            drag. Inset vertically (my-2.5) so it clears the panel's rounded
+            corners instead of being clipped by overflow-hidden. */}
         <span
-          className="pointer-events-none h-full w-px shrink-0 rounded-none bg-border/45"
           aria-hidden
+          className="pointer-events-none my-2.5 w-px shrink-0 rounded-full bg-transparent transition-colors group-hover:bg-border group-focus-visible:w-0.5 group-focus-visible:bg-ring group-active:w-0.5 group-active:bg-muted-foreground/60"
         />
       </div>
 
-      {/* Tab header */}
-      <div className="flex-none border-b border-border/40">
+      {/* Tab header. The active tab is marked by Filament Amber text and a 2px
+          amber underline that slides between tabs (the One Lamp Rule applied to
+          tab selection); each tab carries a glance status beside its label. */}
+      <div ref={headerRef} className="relative flex-none border-b border-border/40">
         <div className="flex h-11 items-center justify-between px-3">
-          <div className="flex items-center gap-0.5">
-            <button
-              type="button"
-              onClick={() => setRightPanelTab(activeThreadId!, "tasks")}
-              className={`flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-[10px] font-semibold tracking-[0.16em] uppercase transition-colors ${
-                activeTab === "tasks"
-                  ? "text-foreground bg-muted/50"
-                  : "text-foreground/70 hover:text-foreground"
-              }`}
-            >
-              <ListChecks size={12} />
-              Scope
-            </button>
-            <button
-              type="button"
-              onClick={() => setRightPanelTab(activeThreadId!, "changes")}
-              className={`flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-[10px] font-semibold tracking-[0.16em] uppercase transition-colors ${
-                activeTab === "changes"
-                  ? "text-foreground bg-muted/50"
-                  : "text-foreground/70 hover:text-foreground"
-              }`}
-            >
-              <Diff size={12} />
-              Changes
-            </button>
-            <button
-              type="button"
-              onClick={() => setRightPanelTab(activeThreadId!, "preview")}
-              className={`flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-[10px] font-semibold tracking-[0.16em] uppercase transition-colors ${
-                activeTab === "preview"
-                  ? "text-foreground bg-muted/50"
-                  : "text-foreground/70 hover:text-foreground"
-              }`}
-            >
-              <Globe size={12} />
-              Preview
-            </button>
-            <button
-              type="button"
-              onClick={() => setRightPanelTab(activeThreadId!, "terminal")}
-              className={`flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-[10px] font-semibold tracking-[0.16em] uppercase transition-colors ${
-                activeTab === "terminal"
-                  ? "text-foreground bg-muted/50"
-                  : "text-foreground/70 hover:text-foreground"
-              }`}
-            >
-              <Terminal size={12} />
-              Terminal
-            </button>
+          <div ref={tablistRef} className="flex items-center gap-0.5">
+            {TABS.map((tab) => {
+              const isActive = activeTab === tab.id;
+              const Icon = tab.icon;
+              const showLabel = isActive || !compactTabs;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  data-tab-active={isActive ? "true" : undefined}
+                  aria-pressed={isActive}
+                  aria-label={tabAccessibleLabel(tab.id, scope, changesCount, changesFresh)}
+                  title={tab.label}
+                  onClick={() => setRightPanelTab(activeThreadId!, tab.id)}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-[10px] font-semibold tracking-[0.16em] uppercase transition-colors",
+                    isActive ? "text-primary" : "text-foreground/70 hover:text-foreground",
+                  )}
+                >
+                  <Icon size={12} />
+                  {showLabel && <span>{tab.label}</span>}
+                  <TabStatus
+                    tab={tab.id}
+                    active={isActive}
+                    scope={scope}
+                    changesCount={changesCount}
+                    changesFresh={changesFresh}
+                  />
+                </button>
+              );
+            })}
           </div>
           <Button
             variant="ghost"
@@ -348,6 +575,12 @@ export function RightPanel() {
             <X size={11} />
           </Button>
         </div>
+        <span
+          ref={indicatorRef}
+          data-testid="tab-indicator"
+          aria-hidden
+          className="pointer-events-none absolute bottom-0 left-0 h-0.5 w-px origin-left rounded-full bg-primary transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
+        />
       </div>
 
       {/* Tab content — DiffPanel and terminal pool stay mounted (stacked) so

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -240,6 +240,24 @@
   }
 }
 
+/* Changes-tab freshness ring: a short amber pulse that fires when new changed
+ * files land while the user is on another tab, then settles to the steady
+ * amber count. Two iterations so it registers without nagging. */
+@keyframes changes-fresh-ring {
+  0% { box-shadow: 0 0 0 0 color-mix(in oklch, var(--primary), transparent 45%); }
+  70% { box-shadow: 0 0 0 6px color-mix(in oklch, var(--primary), transparent 100%); }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+.changes-fresh-ring {
+  animation: changes-fresh-ring 1.8s cubic-bezier(0.4, 0, 0.6, 1) 2;
+  border-radius: var(--radius-sm);
+}
+@media (prefers-reduced-motion: reduce) {
+  .changes-fresh-ring {
+    animation: none;
+  }
+}
+
 /* ─────────────────────────────────────────────────────────────────────────
  * Plan-question wizard motion system.
  *

--- a/apps/web/src/lib/ensure-terminal.ts
+++ b/apps/web/src/lib/ensure-terminal.ts
@@ -1,0 +1,56 @@
+import { useDiffStore } from "@/stores/diffStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+import { getTransport } from "@/transport";
+
+/**
+ * Threads with an in-flight terminal creation. Shared module-level guard so
+ * concurrent triggers (tab click, the mod+j keybinding, React strict-mode
+ * double-invoked effects) spawn at most one terminal per thread.
+ */
+const creationInFlight = new Set<string>();
+
+/**
+ * Spawns a terminal for the thread when it has none, so opening the Terminal
+ * tab lands the user in a ready shell instead of an empty pane (the "anticipate
+ * the next step" product principle).
+ *
+ * No-op when a terminal already exists or a creation is already in flight. If
+ * the Terminal tab is no longer the visible target by the time the PTY is ready
+ * (the user closed the panel or switched tabs mid-creation), the orphaned PTY
+ * is killed rather than added to the store.
+ *
+ * @param threadId - The thread to ensure a terminal for.
+ */
+export function ensureTerminalForThread(threadId: string): void {
+  if (creationInFlight.has(threadId)) return;
+  const existing = useTerminalStore.getState().terminals[threadId];
+  if (existing && existing.length > 0) return;
+
+  creationInFlight.add(threadId);
+  try {
+    const transport = getTransport();
+    transport
+      .terminalCreate(threadId)
+      .then(({ ptyId, shell }) => {
+        creationInFlight.delete(threadId);
+        const panel = useDiffStore.getState().getRightPanel(threadId);
+        // Panel closed or tab switched while creation was in flight — dispose
+        // the orphaned PTY instead of adding a terminal nobody asked to see.
+        if (!panel.visible || panel.activeTab !== "terminal") {
+          transport.terminalKill(ptyId).catch(() => {});
+          return;
+        }
+        const current = useTerminalStore.getState().terminals[threadId];
+        if (!current || current.length === 0) {
+          useTerminalStore.getState().addTerminal(threadId, ptyId, shell);
+        } else {
+          transport.terminalKill(ptyId).catch(() => {});
+        }
+      })
+      .catch(() => {
+        creationInFlight.delete(threadId);
+      });
+  } catch {
+    creationInFlight.delete(threadId);
+  }
+}


### PR DESCRIPTION
## What

Make the right-panel tab strip readable at a glance, fix two drag-handle bugs, and auto-start a shell when the Terminal tab opens.

## Why

The tab strip was inert: you had to click into Changes to learn files changed, or into Terminal to learn a shell errored, which fights the product's glance-first principle. The drag handle showed a stray amber/white hairline and clipped its grip at the panel's rounded corners. Opening the Terminal tab left an empty pane until you clicked "New terminal", which broke the "anticipate the next step" feel.

## Key Changes

- **Tab status:** Scope shows task progress (N/M, sage at complete); Changes shows the distinct changed-file count with an amber freshness pulse when new files land while you are on another tab. Counts render as `99+` on large diffs, but the underlying count stays exact so freshness still fires above the cap.
- **Active-tab lamp:** amber label plus a GPU-composited underline that slides between tabs (`transform`, not `left`/`width`; reduced-motion safe). Inactive labels collapse to icon-only below the 384px floor.
- **Drag-handle fixes:** dropped the always-on hairline (tonal lift already separates the panel), the grip now reveals on hover/focus/drag in a neutral tone, and it is inset so it clears the rounded corners instead of being clipped.
- **Terminal auto-start:** opening the Terminal tab spawns a shell via a shared `ensureTerminalForThread` helper, so every open path (click, `mod+j`, palette, restore) lands in a ready terminal. Killing the last terminal does not respawn one.
- **Accessibility:** tabs expose `aria-pressed` and a text `aria-label`, so status and freshness are not color-only and the name stays complete in narrow mode.
- **Tests:** e2e coverage for tab status, freshness, the large-diff cap, and terminal auto-start. Full `bun run verify` (1452 unit tests) passes.

## Config Changes

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783177602&installation_id=129163861&pr_number=570&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F570&signature=18ed0fe455ef9677daf745c9d8af0963e41c036b5b1e02e6647a7b3247711426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Right panel tabs now display dynamic status indicators—task progress counts, file counts, and a visual "fresh" indicator when new changes arrive.
  * Terminal now auto-creates when switching to the Terminal tab.
  * Active tab highlighted with a sliding underline indicator.

* **Tests**
  * Added E2E tests for right panel tab status and terminal auto-start functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->