### PR TITLE
refactor: add IGoalCapable capability + extract GoalCommand (#574)

### DIFF
--- a/apps/server/src/commands/__tests__/goal-command.test.ts
+++ b/apps/server/src/commands/__tests__/goal-command.test.ts
@@ -1,0 +1,195 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import type { IAgentProvider, AgentEvent } from "@mcode/contracts";
+import { AgentEventType } from "@mcode/contracts";
+import { EventEmitter } from "events";
+import { openMemoryDatabase } from "../../store/database.js";
+import { MessageRepo } from "../../repositories/message-repo.js";
+import { GoalCommand } from "../goal-command.js";
+
+/** Seed a workspace + thread so message foreign keys are satisfied. */
+function seedThread(db: Database.Database): string {
+  const now = new Date().toISOString();
+  db.prepare(
+    "INSERT INTO workspaces (id, name, path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+  ).run("ws-1", "Test", "/tmp/test", now, now);
+  db.prepare(
+    "INSERT INTO threads (id, workspace_id, title, branch, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run("thread-1", "ws-1", "Test thread", "main", now, now);
+  return "thread-1";
+}
+
+/** A Claude-shaped fake that implements the goal capability. */
+function fakeGoalCapableProvider() {
+  return Object.assign(new EventEmitter(), {
+    id: "claude" as const,
+    setGoal: vi.fn<(sid: string, condition: string) => void>(),
+    clearGoal: vi.fn<(sid: string) => void>(),
+    getGoal: vi.fn<(sid: string) => string | undefined>(() => undefined),
+  }) as unknown as IAgentProvider & {
+    setGoal: ReturnType<typeof vi.fn>;
+    clearGoal: ReturnType<typeof vi.fn>;
+    getGoal: ReturnType<typeof vi.fn>;
+  };
+}
+
+/** A provider lacking the goal capability (e.g. codex/copilot). */
+function fakeNonGoalProvider() {
+  return Object.assign(new EventEmitter(), {
+    id: "codex" as const,
+  }) as unknown as IAgentProvider;
+}
+
+describe("GoalCommand", () => {
+  let db: Database.Database;
+  let messageRepo: MessageRepo;
+  let broadcast: ReturnType<typeof vi.fn>;
+  const threadId = "thread-1";
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    seedThread(db);
+    messageRepo = new MessageRepo(db);
+    broadcast = vi.fn();
+  });
+
+  function build(provider: IAgentProvider) {
+    return new GoalCommand(
+      provider,
+      { messageRepo, db },
+      broadcast as unknown as (channel: "agent.event", data: AgentEvent) => void,
+    );
+  }
+
+  describe("passthrough", () => {
+    it("returns passthrough for content that is not a /goal command", () => {
+      const cmd = build(fakeGoalCapableProvider());
+      expect(cmd.handle(threadId, "just a normal message").kind).toBe("passthrough");
+      expect(broadcast).not.toHaveBeenCalled();
+    });
+
+    it("returns passthrough when the provider lacks the goal capability", () => {
+      const provider = fakeNonGoalProvider();
+      const cmd = build(provider);
+
+      const outcome = cmd.handle(threadId, "/goal ship the feature");
+
+      expect(outcome.kind).toBe("passthrough");
+      // Nothing persisted or broadcast — the model sees the raw text.
+      expect(broadcast).not.toHaveBeenCalled();
+      const { messages } = messageRepo.listByThread(threadId, 100);
+      expect(messages).toHaveLength(0);
+    });
+  });
+
+  describe("SET form", () => {
+    it("rewrites the content into a directive and surfaces the pending goal", () => {
+      const cmd = build(fakeGoalCapableProvider());
+
+      const outcome = cmd.handle(threadId, "/goal analyse this branch");
+
+      expect(outcome.kind).toBe("rewrite");
+      if (outcome.kind !== "rewrite") throw new Error("expected rewrite");
+      expect(outcome.pendingGoal).toBe("analyse this branch");
+      // The wire payload becomes a directive that names the condition.
+      expect(outcome.content).toContain("analyse this branch");
+      expect(outcome.content.toLowerCase()).toContain("directive");
+      // SET does not persist or broadcast on its own — the caller owns the send.
+      expect(broadcast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("install / rollback", () => {
+    it("installGoal sets the goal on the provider keyed by the thread session", () => {
+      const provider = fakeGoalCapableProvider();
+      const cmd = build(provider);
+
+      cmd.installGoal(threadId, "ship the feature");
+
+      expect(provider.setGoal).toHaveBeenCalledWith(`mcode-${threadId}`, "ship the feature");
+    });
+
+    it("rollbackGoal clears the goal on the provider", () => {
+      const provider = fakeGoalCapableProvider();
+      const cmd = build(provider);
+
+      cmd.rollbackGoal(threadId);
+
+      expect(provider.clearGoal).toHaveBeenCalledWith(`mcode-${threadId}`);
+    });
+
+    it("install / rollback are no-ops on a non-capable provider", () => {
+      const cmd = build(fakeNonGoalProvider());
+      // Must not throw when the provider lacks the capability.
+      expect(() => cmd.installGoal(threadId, "x")).not.toThrow();
+      expect(() => cmd.rollbackGoal(threadId)).not.toThrow();
+    });
+  });
+
+  /** Collect agent events broadcast on the "agent.event" channel. */
+  function broadcastEvents(): AgentEvent[] {
+    return broadcast.mock.calls
+      .filter(([channel]) => channel === "agent.event")
+      .map(([, payload]) => payload as AgentEvent);
+  }
+
+  describe("SHOW form", () => {
+    it("reports the active goal and short-circuits the send", () => {
+      const provider = fakeGoalCapableProvider();
+      provider.getGoal.mockReturnValueOnce("ship the feature");
+      const cmd = build(provider);
+
+      const outcome = cmd.handle(threadId, "/goal");
+
+      expect(outcome.kind).toBe("handled");
+      expect(provider.setGoal).not.toHaveBeenCalled();
+
+      // Original "/goal" text persisted as the user row; goal echoed in the pill.
+      const { messages } = messageRepo.listByThread(threadId, 100);
+      expect(messages.find((m) => m.role === "user")?.content).toBe("/goal");
+      expect(messages.find((m) => m.role === "assistant")?.content).toContain(
+        "ship the feature",
+      );
+
+      // The composer clears its optimistic running state on Ended.
+      const events = broadcastEvents();
+      expect(events.some((e) => e.type === AgentEventType.Message)).toBe(true);
+      expect(events.some((e) => e.type === AgentEventType.Ended)).toBe(true);
+    });
+
+    it("reports no active goal when none is set", () => {
+      const provider = fakeGoalCapableProvider();
+      provider.getGoal.mockReturnValueOnce(undefined);
+      const cmd = build(provider);
+
+      const outcome = cmd.handle(threadId, "/goal show");
+
+      expect(outcome.kind).toBe("handled");
+      const { messages } = messageRepo.listByThread(threadId, 100);
+      expect(messages.find((m) => m.role === "assistant")?.content).toMatch(
+        /No active goal/,
+      );
+    });
+  });
+
+  describe("CLEAR form", () => {
+    it("clears the goal, persists a confirmation pill, and emits Ended", () => {
+      const provider = fakeGoalCapableProvider();
+      const cmd = build(provider);
+
+      const outcome = cmd.handle(threadId, "/goal clear");
+
+      expect(outcome.kind).toBe("handled");
+      expect(provider.clearGoal).toHaveBeenCalledWith(`mcode-${threadId}`);
+
+      const { messages } = messageRepo.listByThread(threadId, 100);
+      expect(messages.find((m) => m.role === "assistant")?.content).toMatch(
+        /Goal cleared/,
+      );
+
+      const events = broadcastEvents();
+      expect(events.some((e) => e.type === AgentEventType.Ended)).toBe(true);
+    });
+  });
+});

--- a/apps/server/src/commands/goal-command.ts
+++ b/apps/server/src/commands/goal-command.ts
@@ -1,0 +1,150 @@
+import type Database from "better-sqlite3";
+import {
+  type IAgentProvider,
+  type IGoalCapable,
+  type AgentEvent,
+  AgentEventType,
+  isGoalCapable,
+} from "@mcode/contracts";
+import type { MessageRepo } from "../repositories/message-repo.js";
+
+/** Broadcast function shape used to push agent events to connected clients. */
+type BroadcastFn = (channel: "agent.event", data: AgentEvent) => void;
+
+/** Repositories and database handle the command needs to persist its rows. */
+interface GoalCommandDeps {
+  readonly messageRepo: MessageRepo;
+  readonly db: Database.Database;
+}
+
+/**
+ * Result of routing a message through {@link GoalCommand.handle}:
+ * - `passthrough` — not a goal command (or the provider lacks the capability);
+ *   the caller forwards the original content to the model unchanged.
+ * - `handled` — a control form (show/clear) was fully serviced and persisted;
+ *   the caller should short-circuit the send.
+ * - `rewrite` — a SET form; the caller persists `content` as the wire payload
+ *   while keeping the original text for the transcript, then installs the goal.
+ */
+export type GoalCommandOutcome =
+  | { readonly kind: "passthrough" }
+  | { readonly kind: "handled" }
+  | { readonly kind: "rewrite"; readonly content: string; readonly pendingGoal: string };
+
+/** Matches `/goal`, optionally followed by an argument, across newlines. */
+const GOAL_COMMAND = /^\s*\/goal\b\s*(.*)$/s;
+
+/**
+ * Owns the `/goal` app-native command. Constructed per send with the resolved
+ * provider, the repositories, and the broadcast function; it holds no turn
+ * state. Any provider that implements {@link IGoalCapable} gets `/goal` for
+ * free; on a provider without it, every `/goal` is a passthrough so the model
+ * still sees what the user typed.
+ */
+export class GoalCommand {
+  /** The capable view of the provider, or null when it lacks goal support. */
+  private readonly capable: IGoalCapable | null;
+
+  constructor(
+    provider: IAgentProvider,
+    private readonly deps: GoalCommandDeps,
+    private readonly broadcast: BroadcastFn,
+  ) {
+    this.capable = isGoalCapable(provider) ? provider : null;
+  }
+
+  /** The session id the goal hook keys on, derived from the thread id. */
+  private sessionName(threadId: string): string {
+    return `mcode-${threadId}`;
+  }
+
+  /**
+   * Install the goal gate on the provider. Called by the send orchestrator as
+   * late as possible before dispatch so a failed preflight leaves no stale
+   * goal. A no-op when the provider lacks the capability.
+   */
+  installGoal(threadId: string, condition: string): void {
+    this.capable?.setGoal(this.sessionName(threadId), condition);
+  }
+
+  /**
+   * Tear the goal back out after a failed send so a hidden Stop-hook gate does
+   * not linger into the next turn. A no-op when the provider lacks the
+   * capability.
+   */
+  rollbackGoal(threadId: string): void {
+    this.capable?.clearGoal(this.sessionName(threadId));
+  }
+
+  /**
+   * Route a message. Returns {@link GoalCommandOutcome} describing how the
+   * caller should proceed.
+   */
+  handle(threadId: string, content: string): GoalCommandOutcome {
+    const match = GOAL_COMMAND.exec(content);
+    if (!match || !this.capable) {
+      return { kind: "passthrough" };
+    }
+
+    const arg = match[1].trim();
+    const lower = arg.toLowerCase();
+    const isControl =
+      arg === "" || lower === "show" || lower === "clear" || lower === "reset";
+
+    if (isControl) {
+      let replyText: string;
+      if (arg === "" || lower === "show") {
+        const current = this.capable.getGoal(this.sessionName(threadId));
+        replyText = current
+          ? `Active goal: "${current}". The agent will not stop until this condition is met. Use \`/goal clear\` to remove it.`
+          : `No active goal. Use \`/goal <condition>\` to set one.`;
+      } else {
+        this.capable.clearGoal(this.sessionName(threadId));
+        replyText = `Goal cleared. The agent may now end its turn normally.`;
+      }
+      this.persistControlReply(threadId, content, replyText);
+      return { kind: "handled" };
+    }
+
+    // SET form: rewrite the wire payload so the agent starts working on the
+    // condition immediately, while the caller pins the original text for the
+    // transcript. The actual setGoal() install is deferred to the caller (via
+    // installGoal) so a send failure can't leave a stale goal in the provider.
+    return {
+      kind: "rewrite",
+      pendingGoal: arg,
+      content:
+        `A goal has been set for this session: "${arg}". Treat this exactly ` +
+        `as your directive — start working toward it now. The session will not ` +
+        `stop until the goal is satisfied.`,
+    };
+  }
+
+  /**
+   * Persist the user message and a synthetic confirmation pill in one
+   * transaction, then broadcast the pill and an Ended event. Ended clears the
+   * composer's optimistic running state since no provider call ran.
+   */
+  private persistControlReply(threadId: string, userText: string, replyText: string): void {
+    const { messages: existing } = this.deps.messageRepo.listByThread(threadId, 1);
+    const baseSeq = existing.length > 0 ? existing[existing.length - 1].sequence : 0;
+    let assistantMsgId = "";
+    this.deps.db.transaction(() => {
+      this.deps.messageRepo.create(threadId, "user", userText, baseSeq + 1);
+      const a = this.deps.messageRepo.create(threadId, "assistant", replyText, baseSeq + 2);
+      assistantMsgId = a.id;
+    })();
+
+    this.broadcast("agent.event", {
+      type: AgentEventType.Message,
+      threadId,
+      content: replyText,
+      tokens: null,
+      messageId: assistantMsgId,
+    } satisfies AgentEvent);
+    this.broadcast("agent.event", {
+      type: AgentEventType.Ended,
+      threadId,
+    } satisfies AgentEvent);
+  }
+}

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -13,6 +13,7 @@ import { logger } from "@mcode/shared";
 import { AgentEventType, isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import type {
   IAgentProvider,
+  IGoalCapable,
   TurnRequest,
   ProviderId,
   ReasoningLevel,
@@ -293,7 +294,7 @@ interface PendingSpawnTurn {
 
 /** Claude Agent SDK adapter implementing IAgentProvider with prompt queue pattern. */
 @injectable()
-export class ClaudeProvider extends EventEmitter implements IAgentProvider, ProtocolAdapter<ClaudeSessionState> {
+export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoalCapable, ProtocolAdapter<ClaudeSessionState> {
   readonly id: ProviderId = "claude";
   /** Claude supports one-shot text completion via sdkQuery with maxTurns: 1. */
   readonly supportsCompletion = true;

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -62,8 +62,19 @@ function buildService(db: Database.Database) {
     clearGoal: vi.fn<(sid: string) => void>(),
     getGoal: vi.fn<(sid: string) => string | undefined>(() => undefined),
   });
+  // A provider lacking the goal capability (no setGoal/clearGoal/getGoal).
+  // `/goal` must pass through to this provider as plain text.
+  const nonGoalStub = Object.assign(new EventEmitter(), {
+    id: "codex" as const,
+    supportsCompletion: true,
+    sessionForkOnResume: "unsupported" as const,
+    maxInputCharactersPerTurn: 16_000,
+    sendTurn: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
+      () => Promise.resolve(),
+    ),
+  });
   const providerRegistry = {
-    resolve: vi.fn(() => providerStub),
+    resolve: vi.fn((id: string) => (id === "claude" ? providerStub : nonGoalStub)),
     resolveAll: vi.fn(() => []),
     shutdown: vi.fn(),
   } as unknown as IProviderRegistry;
@@ -119,7 +130,7 @@ function buildService(db: Database.Database) {
       container.resolve(NarrativeStore),
   );
 
-  return { svc, threadRepo, workspaceRepo, messageRepo, providerStub };
+  return { svc, threadRepo, workspaceRepo, messageRepo, providerStub, nonGoalStub };
 }
 
 describe("AgentService.sendMessage — /goal command", () => {
@@ -219,8 +230,8 @@ describe("AgentService.sendMessage — /goal command", () => {
     expect(assistantMsg?.content).toContain("ship the feature");
   });
 
-  it("non-Claude providers do not trigger the /goal intercept", async () => {
-    const { svc, providerStub } = buildService(db);
+  it("providers without the goal capability pass /goal through as plain text", async () => {
+    const { svc, providerStub, nonGoalStub } = buildService(db);
 
     await svc.sendMessage(
       thread.id,
@@ -229,13 +240,14 @@ describe("AgentService.sendMessage — /goal command", () => {
       "claude-sonnet-4-6",
       [],
       undefined,
-      // Force a different provider so the intercept regex stays inactive.
+      // A non-goal-capable provider so the capability probe returns passthrough.
       "codex",
     );
 
-    // Provider was still called with the raw text (no rewrite, no goal install).
+    // No goal install on the capable provider, and the non-capable provider
+    // received the raw text (no rewrite).
     expect(providerStub.setGoal).not.toHaveBeenCalled();
-    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
-    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal something");
+    expect(nonGoalStub.sendTurn).toHaveBeenCalledTimes(1);
+    expect(nonGoalStub.sendTurn.mock.calls[0][0].message).toBe("/goal something");
   });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -41,6 +41,7 @@ import { AttachmentService } from "./attachment-service";
 import { SnapshotService } from "./snapshot-service";
 import { MemoryPressureService } from "./memory-pressure-service";
 import { broadcast } from "../transport/push";
+import { GoalCommand } from "../commands/goal-command";
 // Lazy-imported to break circular dependency: AgentService -> ThreadService -> (shared repos)
 // Using delay() ensures tsyringe resolves ThreadService from the container at first access,
 // not at AgentService construction time.
@@ -309,114 +310,37 @@ export class AgentService {
       throw new Error(`Workspace not found: ${thread.workspace_id}`);
     }
 
-    // `/goal` chat-command interception. Three forms are recognised:
+    // `/goal` app-native command. The capability is probed through
+    // {@link GoalCapableProvider}: any provider that implements it gets `/goal`
+    // for free, and a provider without it passes the command through as plain
+    // text so the model still sees what the user typed.
     //
-    //   `/goal <condition>` — install a Stop hook for the condition AND
-    //                         immediately invoke the agent with the condition
-    //                         as its directive. The hook blocks the agent from
-    //                         ending its turn until the condition is satisfied.
-    //   `/goal clear`       — remove the active goal. No agent invocation.
-    //   `/goal` / `/goal show` — show the active goal. No agent invocation.
+    //   `/goal <condition>` — rewrite (SET): the wire payload becomes a
+    //                         directive and the goal is installed just before
+    //                         dispatch (see deferred install below).
+    //   `/goal clear`       — handled: remove the active goal, no dispatch.
+    //   `/goal` / `/goal show` — handled: show the active goal, no dispatch.
     //
-    // Only the Claude provider implements goals; on other providers the
-    // command is left as plain text so the model sees it.
-    //
-    // For SET form, we fall through to the normal sendMessage path with
-    // `content` rewritten to a directive prompt and `messageDisplayContent`
-    // pinned to the original `/goal …` text so the transcript shows what
-    // the user actually typed. For SHOW/CLEAR we short-circuit: persist the
-    // user message + a synthetic confirmation pill, then emit Ended so the
-    // composer can clear its optimistic "thinking" state.
-    // Deferred goal install for the SET form. Populated below and consumed
-    // immediately before `provider.sendMessage` runs, so a send failure
-    // can't leave a stale goal in the provider map. The catch block on the
-    // send also clears it as a belt-and-suspenders guard for failure paths
-    // between install and successful dispatch.
+    // Deferred goal install for the SET form: populated here and consumed
+    // immediately before `sendTurn` runs, so a send failure can't leave a
+    // stale goal in the provider map. The catch block on the send also clears
+    // it as a belt-and-suspenders guard for failures between install and
+    // successful dispatch.
     let pendingGoalInstall: string | null = null;
-
-    const goalMatch = effectiveProvider === "claude"
-      ? /^\s*\/goal\b\s*(.*)$/s.exec(content)
-      : null;
-    if (goalMatch) {
-      const arg = goalMatch[1].trim();
-      const lower = arg.toLowerCase();
-      const sessionName = `mcode-${threadId}`;
-      // Goal commands require the Claude provider to implement the goal
-      // API. Fail-fast if it doesn't — silently no-oping with `?.()` made
-      // the SET form *appear* to install a goal while leaving the Stop
-      // hook ungated, so the agent would just end its turn normally.
-      const rawProvider = this.providerRegistry.resolve("claude") as unknown as {
-        setGoal?: (sid: string, c: string) => void;
-        clearGoal?: (sid: string) => void;
-        getGoal?: (sid: string) => string | undefined;
-      };
-      if (
-        typeof rawProvider.setGoal !== "function" ||
-        typeof rawProvider.clearGoal !== "function" ||
-        typeof rawProvider.getGoal !== "function"
-      ) {
-        throw new Error("Claude provider does not implement /goal API");
-      }
-      const claudeProvider = rawProvider as {
-        setGoal: (sid: string, c: string) => void;
-        clearGoal: (sid: string) => void;
-        getGoal: (sid: string) => string | undefined;
-      };
-
-      const isControl = arg === "" || lower === "show" || lower === "clear" || lower === "reset";
-
-      if (isControl) {
-        let replyText: string;
-        if (arg === "" || lower === "show") {
-          const current = claudeProvider.getGoal(sessionName);
-          replyText = current
-            ? `Active goal: "${current}". The agent will not stop until this condition is met. Use \`/goal clear\` to remove it.`
-            : `No active goal. Use \`/goal <condition>\` to set one.`;
-        } else {
-          claudeProvider.clearGoal(sessionName);
-          replyText = `Goal cleared. The agent may now end its turn normally.`;
-        }
-
-        const { messages: existing } = this.messageRepo.listByThread(threadId, 1);
-        const baseSeq = existing.length > 0 ? existing[existing.length - 1].sequence : 0;
-        let userMsgId: string;
-        let assistantMsgId: string;
-        this.db.transaction(() => {
-          const u = this.messageRepo.create(threadId, "user", content, baseSeq + 1);
-          const a = this.messageRepo.create(threadId, "assistant", replyText, baseSeq + 2);
-          userMsgId = u.id;
-          assistantMsgId = a.id;
-        })();
-
-        broadcast("agent.event", {
-          type: AgentEventType.Message,
-          threadId,
-          content: replyText,
-          tokens: null,
-          messageId: assistantMsgId!,
-        } satisfies AgentEvent);
-        // Composer optimistically marks the thread as running on send and
-        // waits for Ended to clear it. Since no provider call ran, emit one
-        // here so the indicator clears.
-        broadcast("agent.event", {
-          type: AgentEventType.Ended,
-          threadId,
-        } satisfies AgentEvent);
-        logger.info("Handled /goal control command", { threadId, arg, userMsgId: userMsgId! });
-        return;
-      }
-
-      // SET form. Stash the install for after preflight/persistence and
-      // rewrite the wire payload so the agent starts working on the
-      // condition immediately. The actual setGoal() call is deferred to
-      // right before provider.sendMessage to avoid leaving a stale goal
-      // in the provider map if any of the intervening steps throw.
-      pendingGoalInstall = arg;
+    const goalCommand = new GoalCommand(
+      this.providerRegistry.resolve(effectiveProvider),
+      { messageRepo: this.messageRepo, db: this.db },
+      broadcast,
+    );
+    const goalOutcome = goalCommand.handle(threadId, content);
+    if (goalOutcome.kind === "handled") {
+      logger.info("Handled /goal control command", { threadId });
+      return;
+    }
+    if (goalOutcome.kind === "rewrite") {
+      pendingGoalInstall = goalOutcome.pendingGoal;
       messageDisplayContent = content;
-      content =
-        `A goal has been set for this session: "${arg}". Treat this exactly ` +
-        `as your directive — start working toward it now. The session will not ` +
-        `stop until the goal is satisfied.`;
+      content = goalOutcome.content;
     }
 
     const cwd = this.gitService.resolveWorkingDir(
@@ -629,15 +553,12 @@ export class AgentService {
     const providerMessage = providerWireOverride ?? wirePayload;
 
     // Install the deferred /goal hook gate now, as late as possible before
-    // dispatch. If sendMessage throws synchronously or rejects, the catch
-    // block below tears the goal back out so failures don't leave a hidden
-    // gate active. Only runs for Claude SET form (pendingGoalInstall is
-    // only populated in that branch above).
+    // dispatch. If sendTurn throws synchronously or rejects, the catch block
+    // below tears the goal back out so failures don't leave a hidden gate
+    // active. Only runs for the SET form (pendingGoalInstall is only populated
+    // when the goal command returned a rewrite).
     if (pendingGoalInstall !== null) {
-      const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
-        setGoal: (sid: string, c: string) => void;
-      };
-      claudeProvider.setGoal(`mcode-${threadId}`, pendingGoalInstall);
+      goalCommand.installGoal(threadId, pendingGoalInstall);
       logger.info("Goal installed; dispatching directive to provider", {
         threadId,
         goal: pendingGoalInstall,
@@ -689,10 +610,7 @@ export class AgentService {
       // Only runs when we got past the deferred install above.
       if (pendingGoalInstall !== null) {
         try {
-          const claudeProvider = this.providerRegistry.resolve("claude") as unknown as {
-            clearGoal: (sid: string) => void;
-          };
-          claudeProvider.clearGoal(`mcode-${threadId}`);
+          goalCommand.rollbackGoal(threadId);
         } catch (clearErr) {
           logger.warn("Failed to clear goal after failed send", {
             threadId,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -293,6 +293,7 @@ export type {
   SessionForkBehavior,
   IAgentProvider,
   ICompletionCapable,
+  IGoalCapable,
   IProviderRegistry,
   TurnRequest,
   ProviderOptionsByProvider,
@@ -309,7 +310,7 @@ export {
   ModelPolicyStateSchema,
 } from "./providers/models.js";
 export type { ProviderModelInfo } from "./providers/models.js";
-export { isCompletionCapable } from "./providers/interfaces.js";
+export { isCompletionCapable, isGoalCapable } from "./providers/interfaces.js";
 
 export type {
   SessionForker,

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -172,6 +172,35 @@ export function isCompletionCapable(provider: IAgentProvider): provider is IComp
   return provider.supportsCompletion === true && typeof (provider as ICompletionCapable).complete === "function";
 }
 
+/**
+ * Narrowed view of an agent provider that supports session goals. A goal
+ * installs a Stop-hook gate that blocks the provider from ending its turn
+ * until the goal is cleared. Use `isGoalCapable()` to narrow an
+ * `IAgentProvider` to this type before calling the goal methods.
+ */
+export interface IGoalCapable extends IAgentProvider {
+  /** Install a goal condition on a session. */
+  setGoal(sessionId: string, condition: string): void;
+  /** Remove the active goal so the next Stop event is allowed through. */
+  clearGoal(sessionId: string): void;
+  /** Return the active goal condition for a session, or undefined. */
+  getGoal(sessionId: string): string | undefined;
+}
+
+/**
+ * Type guard: returns true when the provider implements session goals.
+ * Narrows `IAgentProvider` to `IGoalCapable` so the goal methods are callable
+ * without casting. Replaces the former runtime cast + triple `typeof` guard.
+ */
+export function isGoalCapable(provider: IAgentProvider): provider is IGoalCapable {
+  const candidate = provider as Partial<IGoalCapable>;
+  return (
+    typeof candidate.setGoal === "function" &&
+    typeof candidate.clearGoal === "function" &&
+    typeof candidate.getGoal === "function"
+  );
+}
+
 /** Registry that resolves provider instances by ID. */
 export interface IProviderRegistry {
   /** Get a single provider by ID. Throws if not registered. */


### PR DESCRIPTION
## What

Express `/goal` support as an `IGoalCapable` capability interface and extract the command logic out of `agent-service` into a stateless `GoalCommand`.

## Why

`agent-service.sendMessage` gated `/goal` on a hard-coded `effectiveProvider === "claude"` check and reached the goal API through three `resolve("claude") as unknown` casts plus a triple `typeof` runtime guard. That coupled the orchestrator to one provider id and made the capability invisible to the type system. Closes #574.

## Key changes

- **`IGoalCapable` + `isGoalCapable`** (`packages/contracts`) — capability interface (`setGoal`, `clearGoal`, `getGoal`) and type guard, mirroring the existing `ICompletionCapable` / `isCompletionCapable` precedent.
- **`GoalCommand`** (`apps/server/src/commands/goal-command.ts`) — stateless command constructed per send from the resolved provider, repos, and broadcast fn. Probes capability once, routes set/show/clear, and exposes `installGoal` / `rollbackGoal` deferred-install seams.
- **`ClaudeProvider`** declares `implements IGoalCapable` for a compile-time guarantee (no runtime change).
- **`agent-service`** — removed the ~90-line inline block, the provider-id gate, the casts, and the triple guard; gating is now capability-based.
- **Tests** — 9 new `GoalCommand` tests (set / show / clear / passthrough against a fake capable provider) plus the agent-service test now uses a non-goal-capable stub for the codex path.

## Behaviour

No breaking changes. Any provider implementing `IGoalCapable` gets `/goal` for free; providers without it pass the command through as plain text so the model still sees the raw input. Codex remains non-goal-capable (intentional).

## Verification

- `bun run verify`: contracts + server typecheck/lint clean; 1177/1178 server tests pass. The single failure is a pre-existing `snapshot-service.integration` `beforeEach` git-repo timeout under parallel load — passes 10/10 in isolation, untouched by this change.
- All 13 goal tests green.

Closes #574

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783507936&installation_id=129163861&pr_number=582&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F582&signature=2b6b582b532d0b3e3931555c028c363666087cf07fd20e8f230ffc008cb01bb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/goal` command system allowing users to set, view, and clear session-specific goals throughout conversations
  * Supports `/goal <condition>` to define new goals, `/goal show` or `/goal` to display the current active goal, and `/goal clear` to remove goals
  * Goal management functionality is available for compatible AI providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->