### PR TITLE
refactor(server): lift HandoffCoordinator out of AgentService

### DIFF
--- a/apps/server/src/__tests__/agent-service-session-invalidated.test.ts
+++ b/apps/server/src/__tests__/agent-service-session-invalidated.test.ts
@@ -110,8 +110,7 @@ describe("AgentService clears sdk_session_id on session invalidation", () => {
       availabilityStub,
       { markAnswered: vi.fn(), isAnswered: vi.fn(() => false), listAnsweredForThread: vi.fn(() => []) } as unknown as import("../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       new NarrativeStore(
         messageRepo,

--- a/apps/server/src/__tests__/agent-service-turn-started.test.ts
+++ b/apps/server/src/__tests__/agent-service-turn-started.test.ts
@@ -139,8 +139,7 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       availabilityStub,
       { markAnswered: vi.fn(), isAnswered: vi.fn(() => false), listAnsweredForThread: vi.fn(() => []) } as unknown as import("../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       new NarrativeStore(
         messageRepo,

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -43,6 +43,7 @@ import { TerminalService } from "./services/terminal-service";
 import { AttachmentService } from "./services/attachment-service";
 import { HandoffStorage } from "./services/handoff/handoff-storage.js";
 import { HandoffPipelineService } from "./services/handoff/handoff-pipeline.js";
+import { HandoffCoordinator } from "./services/handoff/handoff-coordinator.js";
 import { SnapshotService } from "./services/snapshot-service";
 import { SettingsService } from "./services/settings-service";
 import { GitWatcherService } from "./services/git-watcher-service";
@@ -319,6 +320,11 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(
     HandoffPipelineService,
     { useClass: HandoffPipelineService },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    HandoffCoordinator,
+    { useClass: HandoffCoordinator },
     { lifecycle: Lifecycle.Singleton },
   );
   container.register(

--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -181,8 +181,7 @@ function buildService({
     availability,
     planQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       new NarrativeStore(
         messageRepo,

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -113,8 +113,7 @@ function buildService(db: Database.Database) {
     availability,
     planQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       container.resolve(NarrativeStore),
   );

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -173,8 +173,7 @@ function build(): Built {
     availability,
     planQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       narrativeStore,
   );

--- a/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
@@ -111,8 +111,7 @@ function buildService(db: Database.Database) {
     availability,
     planQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       container.resolve(NarrativeStore),
   );

--- a/apps/server/src/services/__tests__/agent-service-snapshot-flag.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-snapshot-flag.test.ts
@@ -178,8 +178,7 @@ function buildService(opts: BuildServiceOptions = {}): {
     availability,
     { markAnswered: vi.fn(), isAnswered: vi.fn(() => false), listAnsweredForThread: vi.fn(() => []) } as unknown as import("../../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       new NarrativeStore(
         messageRepo,

--- a/apps/server/src/services/__tests__/agent-service-stack-fallback.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-stack-fallback.test.ts
@@ -151,8 +151,7 @@ function minimalService(): AgentService {
     availability,
     planQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       narrativeStore,
   );

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -193,8 +193,7 @@ function buildService(): {
     availability,
     planQuestionAnswersRepo,
       { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { orchestrate: vi.fn() } as any,
-      { write: vi.fn(), copyAttachments: vi.fn(() => []), deleteThreadFiles: vi.fn() } as any,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
       { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       new NarrativeStore(
         messageRepo,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -7,8 +7,6 @@
 
 import { injectable, inject, delay } from "tsyringe";
 import { existsSync, statSync } from "fs";
-import { writeFile } from "fs/promises";
-import { tmpdir } from "os";
 import { isAbsolute } from "path";
 import { logger } from "@mcode/shared";
 import { AgentEventType } from "@mcode/contracts";
@@ -54,17 +52,9 @@ import {
 import { PlanQuestionParser } from "./plan-question-parser.js";
 import { PlanOutputParser } from "./plan-output-parser.js";
 import { PlanRepo } from "../repositories/plan-repo";
-import { buildHandoffContent, buildConversationReplay, replayBudgetChars, resolveForkSnapshot } from "./handoff-builder.js";
 import { PLAN_ANSWER_MESSAGE_PREFIX } from "@mcode/contracts";
-import { HandoffPipelineService } from "./handoff/handoff-pipeline.js";
-import { HandoffStorage } from "./handoff/handoff-storage.js";
+import { HandoffCoordinator } from "./handoff/handoff-coordinator.js";
 import { ScopedPreGrantService } from "./scoped-pre-grant.js";
-import type { AttachmentSource } from "./handoff/handoff-storage.js";
-import type { HandoffArtifact } from "./handoff/handoff-types.js";
-import { classifyProviderError } from "./handoff/error-classifier.js";
-import { getMcodeDir } from "@mcode/shared";
-import { join } from "path";
-import { storedAttachmentSuffix } from "@mcode/contracts";
 import { normalizeAgentProviderError } from "./provider-agent-error-normalize.js";
 
 /**
@@ -89,55 +79,6 @@ function truncateTitle(content: string): string {
   const lastSpace = truncated.lastIndexOf(" ");
   const cutPoint = lastSpace > 0 ? lastSpace : 50;
   return truncated.slice(0, cutPoint) + "...";
-}
-
-/** Array.findLastIndex polyfill for ES2022 targets that lack it. */
-function findLastIndex<T>(arr: T[], predicate: (item: T) => boolean): number {
-  for (let i = arr.length - 1; i >= 0; i--) {
-    if (predicate(arr[i])) return i;
-  }
-  return -1;
-}
-
-/**
- * Derive a short (<=2-3 sentence) graceful-degradation summary from the full
- * handoff markdown. Uses the first non-heading, non-empty paragraph so the
- * child still has minimal orientation even if it never reads the temp file
- * (e.g. the file is swept, or the Read is denied). Capped so the inline prompt
- * stays small by construction.
- */
-function deriveHandoffSummary(markdown: string): string {
-  const SUMMARY_CAP = 280;
-  const firstParagraph = markdown
-    .split(/\n{2,}/)
-    .map((block) => block.trim())
-    .find((block) => block.length > 0 && !block.startsWith("#") && !block.startsWith("---"));
-  const summary = (firstParagraph ?? "").replace(/\s+/g, " ").trim();
-  if (!summary) {
-    return "A handoff document describing the parent thread's context is available at the path above; read it before continuing.";
-  }
-  return summary.length > SUMMARY_CAP ? `${summary.slice(0, SUMMARY_CAP).trimEnd()}...` : summary;
-}
-
-/**
- * Build the small inline first-Turn prompt for off-band handoff delivery: a
- * pointer line to the full doc on disk, a short graceful-degradation summary,
- * then the child's first user message. The child is pre-granted a one-shot
- * Read of the pointed-to file (see ScopedPreGrantService) so it can pull the
- * full context without prompting. Kept small by construction so it fits any
- * provider's per-turn input window.
- */
-function buildOffBandHandoffPrompt(tempPath: string, markdown: string, userMessage: string): string {
-  return [
-    "You are continuing work handed off from a previous thread.",
-    `The full handoff document is on this machine at: ${tempPath}`,
-    "Read that file first with the Read tool to load the complete context (you are pre-authorized to read it once without prompting). Summary if the file is unavailable:",
-    deriveHandoffSummary(markdown),
-    "",
-    "---",
-    "",
-    userMessage,
-  ].join("\n");
 }
 
 /** Orchestrates agent sessions, message sending, and event forwarding. */
@@ -216,10 +157,8 @@ export class AgentService {
     @inject(PlanQuestionAnswersRepo)
     private readonly planQuestionAnswersRepo: PlanQuestionAnswersRepo,
     @inject(PlanRepo) private readonly planRepo: PlanRepo,
-    @inject(HandoffPipelineService)
-    private readonly handoffPipeline: HandoffPipelineService,
-    @inject(HandoffStorage)
-    private readonly handoffStorage: HandoffStorage,
+    @inject(HandoffCoordinator)
+    private readonly handoffCoordinator: HandoffCoordinator,
     @inject(ScopedPreGrantService)
     private readonly scopedPreGrant: ScopedPreGrantService,
     @inject(NarrativeStore)
@@ -1138,230 +1077,18 @@ export class AgentService {
         : thread.codex_fast_mode,
     };
 
-    // Derive the fork anchor role for the pipeline.
-    const forkAnchorRole = forkMessage.role === "user" ? "user" : "assistant";
-
-    // Orchestrate the handoff pipeline (B->A->D ladder). On failure, fall back to the
-    // legacy inline replay so the fork always succeeds.
-    let providerWireOverride: string;
-
-    // Signal to clients that the handoff is in progress so the UI can show a spinner
-    // before the artifact lands.
-    broadcast("thread.handoff", { threadId: thread.id, status: "generating" });
-
-    try {
-      const artifact = await this.handoffPipeline.orchestrate({
-        parentThreadId,
-        forkedFromMessageId: resolvedForkMessageId,
-        forkAnchorRole,
-        childThreadId: thread.id,
-        childProviderId: provider,
-        userFollowUpMessage: content,
-      });
-
-      // Copy attachments from parent messages within the fork range into the child thread's dir.
-      // StoredAttachment has no path field; files live at {mcodeDir}/attachments/{threadId}/{id}{ext}.
-      const parentAttachmentsDir = join(getMcodeDir(), "attachments", parentThreadId);
-      const attachmentSources: AttachmentSource[] = [];
-      for (const msg of forkedMessages) {
-        if (!msg.attachments) continue;
-        for (const att of msg.attachments) {
-          const ext = storedAttachmentSuffix(att.mimeType);
-          const absolutePath = join(parentAttachmentsDir, `${att.id}${ext}`);
-          if (!existsSync(absolutePath)) {
-            logger.warn("createBranchedThread: parent attachment not found on disk, skipping", {
-              attachmentId: att.id,
-              parentThreadId,
-              absolutePath,
-            });
-            continue;
-          }
-          attachmentSources.push({
-            id: att.id,
-            absolutePath,
-            originalName: att.name,
-            mime: att.mimeType,
-            parentMessageId: msg.id,
-          });
-        }
-      }
-
-      if (attachmentSources.length > 0) {
-        artifact.meta.attachments = await this.handoffStorage.copyAttachments(thread.id, attachmentSources);
-      }
-
-      // Guard against the child thread being hard-deleted between orchestration
-      // start and artifact write (e.g. rapid user delete during a slow path B).
-      const childCheck = this.threadRepo.findById(thread.id);
-      if (!childCheck || childCheck.deleted_at) {
-        logger.info("Child thread vanished mid-handoff; dropping artifact", { childThreadId: thread.id });
-        throw new Error("Child thread deleted before handoff artifact could be written");
-      }
-
-      await this.handoffStorage.write(thread.id, artifact);
-
-      broadcast("thread.handoff", {
-        threadId: thread.id,
-        status: artifact.meta.ladderStep === "D" ? "fallback" : "ready",
-        ladderStep: artifact.meta.ladderStep,
-        providerErrorOnGenerate: artifact.meta.providerErrorOnGenerate,
-      });
-
-      // Store an internal-only system message at seq 1 as a DB anchor for the
-      // handoff. We keep the FULL markdown here (not the pointer): it is not
-      // budget-bound, and a complete anchor lets reload reconstruct the doc even
-      // if the OS temp file has been swept. isInternal=true keeps it off the UI
-      // render path.
-      this.messageRepo.create(
-        thread.id, "system", artifact.markdown, 1,
-        undefined, undefined, undefined, undefined, /* isInternal */ true,
-      );
-
-      // Off-band delivery (PRD #538): write the FULL handoff doc to a stable OS
-      // temp path and shrink the child's inline first-Turn prompt to a small
-      // pointer + graceful-degradation summary + the user's message. Issue a
-      // ScopedPreGrant so the child can Read that one file on its first Turn
-      // without prompting, regardless of permissionMode.
-      const handoffTempPath = join(
-        tmpdir(),
-        `mcode-handoff-${thread.id}-${Date.now()}.md`,
-      );
-      try {
-        await writeFile(handoffTempPath, artifact.markdown, "utf8");
-        this.scopedPreGrant.issue({
-          threadId: thread.id,
-          toolName: "Read",
-          path: handoffTempPath,
-        });
-        providerWireOverride = buildOffBandHandoffPrompt(handoffTempPath, artifact.markdown, content);
-      } catch (writeErr) {
-        // If the temp write fails we cannot pre-grant a Read, so fall back to
-        // inlining the full doc (legacy behaviour) — the fork still succeeds.
-        logger.warn("Off-band handoff write failed; inlining full doc", {
-          threadId: thread.id,
-          handoffTempPath,
-          error: writeErr instanceof Error ? writeErr.message : String(writeErr),
-        });
-        providerWireOverride = `${artifact.markdown}\n\n---\n\n${content}`;
-      }
-    } catch (pipelineErr) {
-      // Re-check child thread existence before writing any fallback artifacts.
-      // The thread may have been hard-deleted between pipeline start and failure
-      // (e.g. rapid user delete during a slow path B), in which case proceeding
-      // would produce FK errors, stale files, or a misleading fallback event.
-      const childRecheck = this.threadRepo.findById(thread.id);
-      if (!childRecheck || childRecheck.deleted_at) {
-        logger.info("Child thread vanished mid-handoff; aborting fallback", {
-          childThreadId: thread.id,
-        });
-        throw pipelineErr;
-      }
-
-      // Classify the error so we know how to label the artifact and log usefully.
-      const errClass = classifyProviderError(pipelineErr);
-      logger.warn("createBranchedThread: handoff pipeline failed, falling back to legacy replay", {
-        threadId: thread.id,
-        parentThreadId,
-        errClass,
-        error: pipelineErr instanceof Error ? pipelineErr.message : String(pipelineErr),
-        stack: pipelineErr instanceof Error ? pipelineErr.stack : undefined,
-      });
-
-      // Notify clients that the handoff fell back to the deterministic legacy replay.
-      // The pipeline itself threw, so treat as the classified error (or fatal if clean).
-      broadcast("thread.handoff", {
-        threadId: thread.id,
-        status: "fallback",
-        ladderStep: "D" as const,
-        providerErrorOnGenerate: errClass === "clean" ? ("fatal" as const) : errClass,
-      });
-
-      // Legacy fallback: build handoff content + conversation replay inline.
-      const lastAssistantMsg = [...forkedMessages].reverse().find((m) => m.role === "assistant");
-      const lastAssistantText = lastAssistantMsg?.content ?? null;
-      const allSnapshots = this.turnSnapshotRepo.listByThread(parentThreadId);
-      const forkedMessageIds = new Set(forkedMessages.map((m) => m.id));
-      const forkSnapshot = resolveForkSnapshot(allSnapshots, forkedMessageIds);
-      const recentFilesChanged: string[] = forkSnapshot?.files_changed ?? [];
-      const sourceHead = forkSnapshot?.ref_after ?? null;
-      const rawTasks = this.taskRepo.get(parentThreadId);
-      const openTasks = (rawTasks ?? []).map((t) => ({ content: t.content, status: t.status }));
-      const handoffContent = buildHandoffContent({
-        parentThread,
-        forkMessageId: resolvedForkMessageId,
-        lastAssistantText,
-        recentFilesChanged,
-        openTasks,
-        sourceHead,
-      });
-
-      // isInternal=true keeps this off the UI render path, consistent with the
-      // pipeline path's system message (written below after replay is built).
-      // NOTE: we write this placeholder now; the legacy replay is stored via
-      // providerWireOverride, not as a second system message.
-      this.messageRepo.create(
-        thread.id, "system", handoffContent, 1,
-        undefined, undefined, undefined, undefined, /* isInternal */ true,
-      );
-
-      const budget = replayBudgetChars(model);
-      let compactSummary: string | null = null;
-      if (parentThread.last_compact_summary) {
-        const lastForkCompactionIdx = findLastIndex(
-          forkedMessages,
-          (m) => m.role === "system" && m.content === "Context compacted",
-        );
-        if (lastForkCompactionIdx !== -1) {
-          const { messages: postForkWindow } = this.messageRepo.listByThread(parentThreadId, 100);
-          const postForkCompaction = postForkWindow.some(
-            (m) =>
-              m.role === "system" &&
-              m.content === "Context compacted" &&
-              m.sequence > forkMessage.sequence,
-          );
-          if (!postForkCompaction) {
-            compactSummary = parentThread.last_compact_summary;
-          }
-        }
-      }
-      const replay = buildConversationReplay(forkedMessages, budget, compactSummary);
-      const replayHeader = `You are continuing work from a previous thread titled "${parentThread.title}". Here is the conversation history up to the fork point:\n\n`;
-      providerWireOverride = replay ? `${replayHeader}${replay}\n\n---\n\n${content}` : content;
-
-      // Persist a HandoffArtifact so "View doc" has something to read.
-      // The markdown is the full replay that will be sent to the provider.
-      const legacyMarkdown = (replay ? `${replayHeader}${replay}` : handoffContent).trim();
-      const legacyArtifact: HandoffArtifact = {
-        markdown: legacyMarkdown,
-        meta: {
-          schemaVersion: 1,
-          parentThreadId,
-          forkedFromMessageId: resolvedForkMessageId,
-          forkAnchorRole,
-          childThreadId: thread.id,
-          generatedBy: "deterministic",
-          provider: parentThread.provider,
-          ladderStep: "D",
-          mode: "full",
-          generatedAt: new Date().toISOString(),
-          characterCount: legacyMarkdown.length,
-          parentSdkSessionId: parentThread.sdk_session_id ?? null,
-          providerErrorOnGenerate: errClass === "clean" ? "fatal" : errClass,
-          regenerationHistory: [],
-          attachments: [],
-        },
-      };
-      try {
-        await this.handoffStorage.write(thread.id, legacyArtifact);
-      } catch (storageErr) {
-        // Non-fatal: the fork still succeeds via providerWireOverride; View doc
-        // will show "not available" rather than blocking the user.
-        logger.warn("Failed to persist legacy handoff artifact (View doc will be unavailable)", {
-          threadId: thread.id,
-          storageError: storageErr instanceof Error ? storageErr.message : String(storageErr),
-        });
-      }
-    }
+    // Delegate handoff path selection (B/A/D) and the legacy-replay fallback to
+    // the coordinator. It owns artifact persistence, the seq-1 anchor, off-band
+    // delivery, and returns the provider-only first-turn payload.
+    const { providerWireOverride } = await this.handoffCoordinator.deliverHandoff({
+      parentThread,
+      childThreadId: thread.id,
+      childProvider: provider,
+      forkMessage,
+      forkedMessages,
+      userMessage: content,
+      model,
+    });
 
     // In plan mode, wrap so the provider receives buildPlanPrompt(handoff + userPrompt).
     // The DB still stores the clean user prompt at seq 2 (written by sendMessage).

--- a/apps/server/src/services/handoff/__tests__/handoff-coordinator.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-coordinator.test.ts
@@ -1,0 +1,182 @@
+import "reflect-metadata";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { broadcast } from "../../../transport/push";
+import { HandoffCoordinator } from "../handoff-coordinator.js";
+import type { HandoffArtifact, LadderStep, ProviderErrorClass } from "@mcode/contracts";
+
+// The coordinator broadcasts UI handoff-status events as part of path selection
+// ("generating" -> "ready"/"fallback"). Mock the push module so tests can assert
+// which path ran without a live transport.
+vi.mock("../../../transport/push", () => ({ broadcast: vi.fn() }));
+const broadcastMock = vi.mocked(broadcast);
+
+/** Build a pipeline-produced artifact for a given ladder step. */
+function mkArtifact(
+  ladderStep: LadderStep,
+  providerErrorOnGenerate: ProviderErrorClass | null = null,
+): HandoffArtifact {
+  const markdown = "# Handoff\n\nThis paragraph orients the child on the parent thread's goal.";
+  return {
+    markdown,
+    meta: {
+      schemaVersion: 1,
+      parentThreadId: "t_parent",
+      forkedFromMessageId: "m_fork",
+      forkAnchorRole: "user",
+      childThreadId: "t_child",
+      generatedBy: ladderStep === "D" ? "deterministic" : "provider",
+      provider: "claude",
+      ladderStep,
+      mode: "full",
+      generatedAt: new Date().toISOString(),
+      characterCount: markdown.length,
+      parentSdkSessionId: "sdk_1",
+      providerErrorOnGenerate,
+      regenerationHistory: [],
+      attachments: [],
+    },
+  };
+}
+
+function mkDeps() {
+  return {
+    handoffPipeline: { orchestrate: vi.fn(async () => mkArtifact("B")) },
+    handoffStorage: {
+      write: vi.fn(async () => "artifact_ulid"),
+      copyAttachments: vi.fn(async () => []),
+    },
+    scopedPreGrant: { issue: vi.fn() },
+    // Child thread is present and not deleted by default.
+    threadRepo: { findById: vi.fn(() => ({ id: "t_child", deleted_at: null }) as any) },
+    messageRepo: {
+      create: vi.fn(() => ({}) as any),
+      listByThread: vi.fn(() => ({ messages: [], hasMore: false }) as any),
+    },
+    turnSnapshotRepo: { listByThread: vi.fn(() => []) },
+    taskRepo: { get: vi.fn(() => []) },
+  };
+}
+
+const PARENT_THREAD = {
+  id: "t_parent",
+  title: "Parent Thread",
+  provider: "claude",
+  sdk_session_id: "sdk_1",
+  last_compact_summary: null,
+  deleted_at: null,
+} as any;
+
+const FORK_MESSAGE = { id: "m_fork", role: "user", sequence: 5, content: "do the thing" } as any;
+
+const FORKED_MESSAGES = [
+  { id: "m1", role: "user", content: "hi", sequence: 1, attachments: null },
+  { id: "m2", role: "assistant", content: "working on it", sequence: 2, attachments: null },
+  FORK_MESSAGE,
+] as any;
+
+function mkInput() {
+  return {
+    parentThread: PARENT_THREAD,
+    childThreadId: "t_child",
+    childProvider: "claude" as const,
+    forkMessage: FORK_MESSAGE,
+    forkedMessages: FORKED_MESSAGES,
+    userMessage: "continue the work please",
+    model: "claude-sonnet-4-6",
+  };
+}
+
+/** Find the last `thread.handoff` broadcast payload. */
+function lastHandoffStatus() {
+  const calls = broadcastMock.mock.calls.filter((c) => c[0] === "thread.handoff");
+  return calls[calls.length - 1]?.[1] as any;
+}
+
+describe("HandoffCoordinator.deliverHandoff", () => {
+  beforeEach(() => {
+    broadcastMock.mockClear();
+  });
+
+  it("path B: persists the artifact, broadcasts ready, anchors the full doc, delivers off-band", async () => {
+    const deps = mkDeps();
+    deps.handoffPipeline.orchestrate = vi.fn(async () => mkArtifact("B"));
+    const coordinator = HandoffCoordinator.forTesting(deps);
+
+    const { providerWireOverride } = await coordinator.deliverHandoff(mkInput());
+
+    // The pipeline ran with the derived fork anchor role.
+    expect(deps.handoffPipeline.orchestrate).toHaveBeenCalledWith(
+      expect.objectContaining({ forkAnchorRole: "user", childThreadId: "t_child", childProviderId: "claude" }),
+    );
+    // Artifact persisted, status "ready" (not fallback).
+    expect(deps.handoffStorage.write).toHaveBeenCalledWith("t_child", expect.objectContaining({ meta: expect.objectContaining({ ladderStep: "B" }) }));
+    expect(lastHandoffStatus()).toMatchObject({ status: "ready", ladderStep: "B" });
+    // Seq-1 anchor holds the FULL markdown, internal-only.
+    expect(deps.messageRepo.create).toHaveBeenCalledWith(
+      "t_child", "system", expect.stringContaining("# Handoff"), 1,
+      undefined, undefined, undefined, undefined, true,
+    );
+    // Off-band delivery: pointer prompt names the temp file and carries the user message.
+    expect(deps.scopedPreGrant.issue).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "t_child", toolName: "Read" }),
+    );
+    expect(providerWireOverride).toContain("mcode-handoff-t_child-");
+    expect(providerWireOverride).toContain("continue the work please");
+  });
+
+  it("path A: a mutating-provider artifact still broadcasts ready and delivers off-band", async () => {
+    const deps = mkDeps();
+    deps.handoffPipeline.orchestrate = vi.fn(async () => mkArtifact("A"));
+    const coordinator = HandoffCoordinator.forTesting(deps);
+
+    const { providerWireOverride } = await coordinator.deliverHandoff(mkInput());
+
+    expect(lastHandoffStatus()).toMatchObject({ status: "ready", ladderStep: "A" });
+    expect(providerWireOverride).toContain("mcode-handoff-t_child-");
+  });
+
+  it("path D (pipeline-produced): broadcasts fallback with ladderStep D but still uses off-band delivery", async () => {
+    const deps = mkDeps();
+    deps.handoffPipeline.orchestrate = vi.fn(async () => mkArtifact("D", "quota"));
+    const coordinator = HandoffCoordinator.forTesting(deps);
+
+    const { providerWireOverride } = await coordinator.deliverHandoff(mkInput());
+
+    expect(deps.handoffStorage.write).toHaveBeenCalledWith("t_child", expect.objectContaining({ meta: expect.objectContaining({ ladderStep: "D" }) }));
+    expect(lastHandoffStatus()).toMatchObject({ status: "fallback", ladderStep: "D", providerErrorOnGenerate: "quota" });
+    // A pipeline-produced D is NOT the legacy replay: it ships the doc off-band.
+    expect(providerWireOverride).toContain("mcode-handoff-t_child-");
+  });
+
+  it("legacy-replay fallback: when the pipeline throws, builds a deterministic replay and persists a D artifact", async () => {
+    const deps = mkDeps();
+    deps.handoffPipeline.orchestrate = vi.fn(async () => {
+      throw Object.assign(new Error("rate limited"), { status: 429 });
+    });
+    const coordinator = HandoffCoordinator.forTesting(deps);
+
+    const { providerWireOverride } = await coordinator.deliverHandoff(mkInput());
+
+    // Fallback path runs: status fallback, error classified from the thrown error.
+    expect(lastHandoffStatus()).toMatchObject({ status: "fallback", ladderStep: "D", providerErrorOnGenerate: "quota" });
+    // The provider receives the inline conversation replay, NOT an off-band pointer.
+    expect(providerWireOverride).toContain('continuing work from a previous thread titled "Parent Thread"');
+    expect(providerWireOverride).not.toContain("mcode-handoff-t_child-");
+    expect(providerWireOverride).toContain("continue the work please");
+    // A deterministic D artifact is persisted so "View doc" has something to read.
+    expect(deps.handoffStorage.write).toHaveBeenCalledWith(
+      "t_child",
+      expect.objectContaining({ meta: expect.objectContaining({ generatedBy: "deterministic", ladderStep: "D", providerErrorOnGenerate: "quota" }) }),
+    );
+  });
+
+  it("throws when the child thread vanishes mid-handoff (does not write an artifact)", async () => {
+    const deps = mkDeps();
+    deps.handoffPipeline.orchestrate = vi.fn(async () => mkArtifact("B"));
+    deps.threadRepo.findById = vi.fn(() => null as any);
+    const coordinator = HandoffCoordinator.forTesting(deps);
+
+    await expect(coordinator.deliverHandoff(mkInput())).rejects.toThrow();
+    expect(deps.handoffStorage.write).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/handoff/handoff-coordinator.ts
+++ b/apps/server/src/services/handoff/handoff-coordinator.ts
@@ -1,0 +1,389 @@
+/**
+ * Orchestrates branch-thread handoff delivery: selects the B/A/D ladder path
+ * via {@link HandoffPipelineService}, persists the resulting artifact, writes
+ * the seq-1 DB anchor, performs off-band delivery, and falls back to a legacy
+ * inline conversation replay when the pipeline throws. Lifted out of
+ * `AgentService.createBranchedThread` so path selection lives next to the
+ * handoff mechanics it drives.
+ */
+
+import { injectable, inject } from "tsyringe";
+import { existsSync } from "fs";
+import { writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { logger, getMcodeDir } from "@mcode/shared";
+import { storedAttachmentSuffix } from "@mcode/contracts";
+import type { Thread, Message, ProviderId } from "@mcode/contracts";
+import { ThreadRepo } from "../../repositories/thread-repo";
+import { MessageRepo } from "../../repositories/message-repo";
+import { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo";
+import { TaskRepo } from "../../repositories/task-repo";
+import { broadcast } from "../../transport/push";
+import {
+  buildHandoffContent,
+  buildConversationReplay,
+  replayBudgetChars,
+  resolveForkSnapshot,
+} from "../handoff-builder.js";
+import { HandoffPipelineService } from "./handoff-pipeline.js";
+import { HandoffStorage } from "./handoff-storage.js";
+import type { AttachmentSource } from "./handoff-storage.js";
+import type { HandoffArtifact } from "./handoff-types.js";
+import { classifyProviderError } from "./error-classifier.js";
+import { ScopedPreGrantService } from "../scoped-pre-grant.js";
+
+/** Array.findLastIndex polyfill for ES2022 targets that lack it. */
+function findLastIndex<T>(arr: T[], predicate: (item: T) => boolean): number {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (predicate(arr[i])) return i;
+  }
+  return -1;
+}
+
+/**
+ * Derive a short (<=2-3 sentence) graceful-degradation summary from the full
+ * handoff markdown. Uses the first non-heading, non-empty paragraph so the
+ * child still has minimal orientation even if it never reads the temp file
+ * (e.g. the file is swept, or the Read is denied). Capped so the inline prompt
+ * stays small by construction.
+ */
+function deriveHandoffSummary(markdown: string): string {
+  const SUMMARY_CAP = 280;
+  const firstParagraph = markdown
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .find((block) => block.length > 0 && !block.startsWith("#") && !block.startsWith("---"));
+  const summary = (firstParagraph ?? "").replace(/\s+/g, " ").trim();
+  if (!summary) {
+    return "A handoff document describing the parent thread's context is available at the path above; read it before continuing.";
+  }
+  return summary.length > SUMMARY_CAP ? `${summary.slice(0, SUMMARY_CAP).trimEnd()}...` : summary;
+}
+
+/**
+ * Build the small inline first-Turn prompt for off-band handoff delivery: a
+ * pointer line to the full doc on disk, a short graceful-degradation summary,
+ * then the child's first user message. The child is pre-granted a one-shot
+ * Read of the pointed-to file (see ScopedPreGrantService) so it can pull the
+ * full context without prompting. Kept small by construction so it fits any
+ * provider's per-turn input window.
+ */
+function buildOffBandHandoffPrompt(tempPath: string, markdown: string, userMessage: string): string {
+  return [
+    "You are continuing work handed off from a previous thread.",
+    `The full handoff document is on this machine at: ${tempPath}`,
+    "Read that file first with the Read tool to load the complete context (you are pre-authorized to read it once without prompting). Summary if the file is unavailable:",
+    deriveHandoffSummary(markdown),
+    "",
+    "---",
+    "",
+    userMessage,
+  ].join("\n");
+}
+
+/** Inputs needed to run a branch-thread handoff for one child thread. */
+export interface HandoffDeliveryInput {
+  /** The parent thread being forked from. */
+  parentThread: Thread;
+  /** The already-created child thread's id. */
+  childThreadId: string;
+  /** The child thread's provider (drives the pipeline's path selection). */
+  childProvider: ProviderId;
+  /** The parent message at the fork anchor (id, role, sequence read from it). */
+  forkMessage: Message;
+  /** Parent messages up to and including the fork anchor, ascending. */
+  forkedMessages: Message[];
+  /** The child's first user message. */
+  userMessage: string;
+  /** The child's model id (sizes the legacy replay budget). */
+  model: string;
+}
+
+/** Result of {@link HandoffCoordinator.deliverHandoff}. */
+export interface HandoffDeliveryResult {
+  /** Provider-only first-turn payload (off-band pointer prompt or legacy replay). */
+  providerWireOverride: string;
+}
+
+/**
+ * Owns branch-thread handoff path selection (B/A/D) and the legacy-replay
+ * fallback. AgentService delegates branch-thread handoff delivery here.
+ */
+@injectable()
+export class HandoffCoordinator {
+  constructor(
+    @inject(HandoffPipelineService)
+    private readonly handoffPipeline: HandoffPipelineService,
+    @inject(HandoffStorage)
+    private readonly handoffStorage: HandoffStorage,
+    @inject(ScopedPreGrantService)
+    private readonly scopedPreGrant: ScopedPreGrantService,
+    @inject(ThreadRepo) private readonly threadRepo: ThreadRepo,
+    @inject(MessageRepo) private readonly messageRepo: MessageRepo,
+    @inject(TurnSnapshotRepo) private readonly turnSnapshotRepo: TurnSnapshotRepo,
+    @inject(TaskRepo) private readonly taskRepo: TaskRepo,
+  ) {}
+
+  /**
+   * Test-friendly factory that bypasses DI. Accepts a plain deps object so
+   * unit tests can pass fakes for the handoff mechanics without a container.
+   */
+  static forTesting(deps: {
+    handoffPipeline: Pick<HandoffPipelineService, "orchestrate">;
+    handoffStorage: Pick<HandoffStorage, "write" | "copyAttachments">;
+    scopedPreGrant: Pick<ScopedPreGrantService, "issue">;
+    threadRepo: Pick<ThreadRepo, "findById">;
+    messageRepo: Pick<MessageRepo, "create" | "listByThread">;
+    turnSnapshotRepo: Pick<TurnSnapshotRepo, "listByThread">;
+    taskRepo: Pick<TaskRepo, "get">;
+  }): HandoffCoordinator {
+    const svc = Object.create(HandoffCoordinator.prototype) as HandoffCoordinator;
+    (svc as any).handoffPipeline = deps.handoffPipeline;
+    (svc as any).handoffStorage = deps.handoffStorage;
+    (svc as any).scopedPreGrant = deps.scopedPreGrant;
+    (svc as any).threadRepo = deps.threadRepo;
+    (svc as any).messageRepo = deps.messageRepo;
+    (svc as any).turnSnapshotRepo = deps.turnSnapshotRepo;
+    (svc as any).taskRepo = deps.taskRepo;
+    return svc;
+  }
+
+  /**
+   * Run the B/A/D ladder (or legacy-replay fallback) for one child thread and
+   * return the provider wire override for its first turn. Throws if the child
+   * thread vanishes mid-handoff, so the caller aborts the branch.
+   */
+  async deliverHandoff(input: HandoffDeliveryInput): Promise<HandoffDeliveryResult> {
+    const { parentThread, childThreadId, childProvider, forkMessage, forkedMessages, userMessage, model } = input;
+    const parentThreadId = parentThread.id;
+    const resolvedForkMessageId = forkMessage.id;
+
+    // Derive the fork anchor role for the pipeline.
+    const forkAnchorRole = forkMessage.role === "user" ? "user" : "assistant";
+
+    // Orchestrate the handoff pipeline (B->A->D ladder). On failure, fall back to the
+    // legacy inline replay so the fork always succeeds.
+    let providerWireOverride: string;
+
+    // Signal to clients that the handoff is in progress so the UI can show a spinner
+    // before the artifact lands.
+    broadcast("thread.handoff", { threadId: childThreadId, status: "generating" });
+
+    try {
+      const artifact = await this.handoffPipeline.orchestrate({
+        parentThreadId,
+        forkedFromMessageId: resolvedForkMessageId,
+        forkAnchorRole,
+        childThreadId,
+        childProviderId: childProvider,
+        userFollowUpMessage: userMessage,
+      });
+
+      // Copy attachments from parent messages within the fork range into the child thread's dir.
+      // StoredAttachment has no path field; files live at {mcodeDir}/attachments/{threadId}/{id}{ext}.
+      const parentAttachmentsDir = join(getMcodeDir(), "attachments", parentThreadId);
+      const attachmentSources: AttachmentSource[] = [];
+      for (const msg of forkedMessages) {
+        if (!msg.attachments) continue;
+        for (const att of msg.attachments) {
+          const ext = storedAttachmentSuffix(att.mimeType);
+          const absolutePath = join(parentAttachmentsDir, `${att.id}${ext}`);
+          if (!existsSync(absolutePath)) {
+            logger.warn("deliverHandoff: parent attachment not found on disk, skipping", {
+              attachmentId: att.id,
+              parentThreadId,
+              absolutePath,
+            });
+            continue;
+          }
+          attachmentSources.push({
+            id: att.id,
+            absolutePath,
+            originalName: att.name,
+            mime: att.mimeType,
+            parentMessageId: msg.id,
+          });
+        }
+      }
+
+      if (attachmentSources.length > 0) {
+        artifact.meta.attachments = await this.handoffStorage.copyAttachments(childThreadId, attachmentSources);
+      }
+
+      // Guard against the child thread being hard-deleted between orchestration
+      // start and artifact write (e.g. rapid user delete during a slow path B).
+      const childCheck = this.threadRepo.findById(childThreadId);
+      if (!childCheck || childCheck.deleted_at) {
+        logger.info("Child thread vanished mid-handoff; dropping artifact", { childThreadId });
+        throw new Error("Child thread deleted before handoff artifact could be written");
+      }
+
+      await this.handoffStorage.write(childThreadId, artifact);
+
+      broadcast("thread.handoff", {
+        threadId: childThreadId,
+        status: artifact.meta.ladderStep === "D" ? "fallback" : "ready",
+        ladderStep: artifact.meta.ladderStep,
+        providerErrorOnGenerate: artifact.meta.providerErrorOnGenerate,
+      });
+
+      // Store an internal-only system message at seq 1 as a DB anchor for the
+      // handoff. We keep the FULL markdown here (not the pointer): it is not
+      // budget-bound, and a complete anchor lets reload reconstruct the doc even
+      // if the OS temp file has been swept. isInternal=true keeps it off the UI
+      // render path.
+      this.messageRepo.create(
+        childThreadId, "system", artifact.markdown, 1,
+        undefined, undefined, undefined, undefined, /* isInternal */ true,
+      );
+
+      // Off-band delivery (PRD #538): write the FULL handoff doc to a stable OS
+      // temp path and shrink the child's inline first-Turn prompt to a small
+      // pointer + graceful-degradation summary + the user's message. Issue a
+      // ScopedPreGrant so the child can Read that one file on its first Turn
+      // without prompting, regardless of permissionMode.
+      const handoffTempPath = join(
+        tmpdir(),
+        `mcode-handoff-${childThreadId}-${Date.now()}.md`,
+      );
+      try {
+        await writeFile(handoffTempPath, artifact.markdown, "utf8");
+        this.scopedPreGrant.issue({
+          threadId: childThreadId,
+          toolName: "Read",
+          path: handoffTempPath,
+        });
+        providerWireOverride = buildOffBandHandoffPrompt(handoffTempPath, artifact.markdown, userMessage);
+      } catch (writeErr) {
+        // If the temp write fails we cannot pre-grant a Read, so fall back to
+        // inlining the full doc (legacy behaviour) — the fork still succeeds.
+        logger.warn("Off-band handoff write failed; inlining full doc", {
+          threadId: childThreadId,
+          handoffTempPath,
+          error: writeErr instanceof Error ? writeErr.message : String(writeErr),
+        });
+        providerWireOverride = `${artifact.markdown}\n\n---\n\n${userMessage}`;
+      }
+    } catch (pipelineErr) {
+      // Re-check child thread existence before writing any fallback artifacts.
+      // The thread may have been hard-deleted between pipeline start and failure
+      // (e.g. rapid user delete during a slow path B), in which case proceeding
+      // would produce FK errors, stale files, or a misleading fallback event.
+      const childRecheck = this.threadRepo.findById(childThreadId);
+      if (!childRecheck || childRecheck.deleted_at) {
+        logger.info("Child thread vanished mid-handoff; aborting fallback", {
+          childThreadId,
+        });
+        throw pipelineErr;
+      }
+
+      // Classify the error so we know how to label the artifact and log usefully.
+      const errClass = classifyProviderError(pipelineErr);
+      logger.warn("deliverHandoff: handoff pipeline failed, falling back to legacy replay", {
+        threadId: childThreadId,
+        parentThreadId,
+        errClass,
+        error: pipelineErr instanceof Error ? pipelineErr.message : String(pipelineErr),
+        stack: pipelineErr instanceof Error ? pipelineErr.stack : undefined,
+      });
+
+      // Notify clients that the handoff fell back to the deterministic legacy replay.
+      // The pipeline itself threw, so treat as the classified error (or fatal if clean).
+      broadcast("thread.handoff", {
+        threadId: childThreadId,
+        status: "fallback",
+        ladderStep: "D" as const,
+        providerErrorOnGenerate: errClass === "clean" ? ("fatal" as const) : errClass,
+      });
+
+      // Legacy fallback: build handoff content + conversation replay inline.
+      const lastAssistantMsg = [...forkedMessages].reverse().find((m) => m.role === "assistant");
+      const lastAssistantText = lastAssistantMsg?.content ?? null;
+      const allSnapshots = this.turnSnapshotRepo.listByThread(parentThreadId);
+      const forkedMessageIds = new Set(forkedMessages.map((m) => m.id));
+      const forkSnapshot = resolveForkSnapshot(allSnapshots, forkedMessageIds);
+      const recentFilesChanged: string[] = forkSnapshot?.files_changed ?? [];
+      const sourceHead = forkSnapshot?.ref_after ?? null;
+      const rawTasks = this.taskRepo.get(parentThreadId);
+      const openTasks = (rawTasks ?? []).map((t) => ({ content: t.content, status: t.status }));
+      const handoffContent = buildHandoffContent({
+        parentThread,
+        forkMessageId: resolvedForkMessageId,
+        lastAssistantText,
+        recentFilesChanged,
+        openTasks,
+        sourceHead,
+      });
+
+      // isInternal=true keeps this off the UI render path, consistent with the
+      // pipeline path's system message (written below after replay is built).
+      // NOTE: we write this placeholder now; the legacy replay is stored via
+      // providerWireOverride, not as a second system message.
+      this.messageRepo.create(
+        childThreadId, "system", handoffContent, 1,
+        undefined, undefined, undefined, undefined, /* isInternal */ true,
+      );
+
+      const budget = replayBudgetChars(model);
+      let compactSummary: string | null = null;
+      if (parentThread.last_compact_summary) {
+        const lastForkCompactionIdx = findLastIndex(
+          forkedMessages,
+          (m) => m.role === "system" && m.content === "Context compacted",
+        );
+        if (lastForkCompactionIdx !== -1) {
+          const { messages: postForkWindow } = this.messageRepo.listByThread(parentThreadId, 100);
+          const postForkCompaction = postForkWindow.some(
+            (m) =>
+              m.role === "system" &&
+              m.content === "Context compacted" &&
+              m.sequence > forkMessage.sequence,
+          );
+          if (!postForkCompaction) {
+            compactSummary = parentThread.last_compact_summary;
+          }
+        }
+      }
+      const replay = buildConversationReplay(forkedMessages, budget, compactSummary);
+      const replayHeader = `You are continuing work from a previous thread titled "${parentThread.title}". Here is the conversation history up to the fork point:\n\n`;
+      providerWireOverride = replay ? `${replayHeader}${replay}\n\n---\n\n${userMessage}` : userMessage;
+
+      // Persist a HandoffArtifact so "View doc" has something to read.
+      // The markdown is the full replay that will be sent to the provider.
+      const legacyMarkdown = (replay ? `${replayHeader}${replay}` : handoffContent).trim();
+      const legacyArtifact: HandoffArtifact = {
+        markdown: legacyMarkdown,
+        meta: {
+          schemaVersion: 1,
+          parentThreadId,
+          forkedFromMessageId: resolvedForkMessageId,
+          forkAnchorRole,
+          childThreadId,
+          generatedBy: "deterministic",
+          provider: parentThread.provider,
+          ladderStep: "D",
+          mode: "full",
+          generatedAt: new Date().toISOString(),
+          characterCount: legacyMarkdown.length,
+          parentSdkSessionId: parentThread.sdk_session_id ?? null,
+          providerErrorOnGenerate: errClass === "clean" ? "fatal" : errClass,
+          regenerationHistory: [],
+          attachments: [],
+        },
+      };
+      try {
+        await this.handoffStorage.write(childThreadId, legacyArtifact);
+      } catch (storageErr) {
+        // Non-fatal: the fork still succeeds via providerWireOverride; View doc
+        // will show "not available" rather than blocking the user.
+        logger.warn("Failed to persist legacy handoff artifact (View doc will be unavailable)", {
+          threadId: childThreadId,
+          storageError: storageErr instanceof Error ? storageErr.message : String(storageErr),
+        });
+      }
+    }
+
+    return { providerWireOverride };
+  }
+}


### PR DESCRIPTION
## What
Extract branch-thread handoff orchestration (the B/A/D ladder path selection plus the legacy-replay fallback) from `AgentService.createBranchedThread` into a dedicated `HandoffCoordinator` service.

## Why
`createBranchedThread` had grown to own handoff path selection, artifact persistence, the seq-1 anchor, off-band delivery, and the legacy replay fallback inline. Lifting this into a focused service groups path selection next to the handoff mechanics it drives and removes ~273 lines from `agent-service.ts`. Behavior is unchanged.

## Key Changes
- Add `HandoffCoordinator.deliverHandoff(...)`: runs the pipeline, copies attachments, persists the artifact, writes the seq-1 anchor, does off-band delivery, and falls back to legacy inline replay when the pipeline throws. Returns `{ providerWireOverride }` for the child's first turn.
- `createBranchedThread` now delegates to `handoffCoordinator.deliverHandoff(...)` instead of inlining the logic. Constructor takes `handoffCoordinator` in place of `handoffPipeline` + `handoffStorage`.
- Register `HandoffCoordinator` as a DI singleton in `container.ts`.
- Add 5 vertical-slice tests covering paths B, A, pipeline-produced D, legacy-replay fallback, and the child-vanished error.
- Update 9 `agent-service-*` test files to construct the service with the coordinator fake.

## Config Changes
None

Closes #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783509201&installation_id=129163861&pr_number=585&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F585&signature=a614cbca323ef3abb8c60de65449b1d3514f373cfbe165bc80105c685241e4ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced handoff coordination system for thread branching with multiple delivery paths and improved error handling and fallback mechanisms.

* **Refactor**
  * Consolidated handoff orchestration logic into a dedicated coordinator service for better maintainability.

* **Tests**
  * Added comprehensive test suite validating handoff delivery across multiple scenarios including fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->