### PR TITLE
refactor(server): extract command dispatch to generic CommandRouter (#579)

### DIFF
--- a/apps/server/src/commands/__tests__/command-router.test.ts
+++ b/apps/server/src/commands/__tests__/command-router.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import type { IAgentProvider } from "@mcode/contracts";
+import { EventEmitter } from "events";
+import { CommandRouter } from "../command-router.js";
+import type { CommandContext, CommandOutcome, McodeCommand } from "../command-router.js";
+
+/** A bare provider stub; capability is decided by each command's probe. */
+function fakeProvider(id = "claude"): IAgentProvider {
+  return Object.assign(new EventEmitter(), { id }) as unknown as IAgentProvider;
+}
+
+/** Build a routing context for the given content and provider. */
+function ctx(content: string, provider: IAgentProvider = fakeProvider()): CommandContext {
+  return { threadId: "thread-1", content, provider };
+}
+
+/**
+ * A configurable fake command. `pattern` drives `matches`; `capability`
+ * (when supplied) drives `requiredCapability`; `outcome` is what `handle`
+ * returns. `handle` is a spy so tests can assert it did or did not run.
+ */
+function fakeCommand(opts: {
+  pattern: RegExp;
+  outcome: CommandOutcome;
+  capability?: (provider: IAgentProvider) => boolean;
+}): McodeCommand & { handle: ReturnType<typeof vi.fn> } {
+  const handle = vi.fn<(c: CommandContext) => CommandOutcome>(() => opts.outcome);
+  return {
+    matches: (content: string) => opts.pattern.test(content),
+    requiredCapability: opts.capability,
+    handle,
+  };
+}
+
+describe("CommandRouter", () => {
+  it("returns passthrough when no registered command matches", () => {
+    const cmd = fakeCommand({ pattern: /^\/goal\b/, outcome: { kind: "handled" } });
+    const router = new CommandRouter([cmd]);
+
+    const outcome = router.route(ctx("just a normal message"));
+
+    expect(outcome.kind).toBe("passthrough");
+    expect(cmd.handle).not.toHaveBeenCalled();
+  });
+
+  it("dispatches to a matching command and surfaces its handled outcome", () => {
+    const cmd = fakeCommand({ pattern: /^\/goal\b/, outcome: { kind: "handled" } });
+    const router = new CommandRouter([cmd]);
+
+    const routed = ctx("/goal clear");
+    const outcome = router.route(routed);
+
+    expect(outcome.kind).toBe("handled");
+    expect(cmd.handle).toHaveBeenCalledWith(routed);
+  });
+
+  it("surfaces a command's rewrite outcome with the rewritten content", () => {
+    const cmd = fakeCommand({
+      pattern: /^\/goal\b/,
+      outcome: { kind: "rewrite", content: "rewritten directive" },
+    });
+    const router = new CommandRouter([cmd]);
+
+    const outcome = router.route(ctx("/goal ship it"));
+
+    expect(outcome.kind).toBe("rewrite");
+    if (outcome.kind !== "rewrite") throw new Error("expected rewrite");
+    expect(outcome.content).toBe("rewritten directive");
+  });
+
+  it("returns passthrough without handling when the provider lacks the required capability", () => {
+    const cmd = fakeCommand({
+      pattern: /^\/goal\b/,
+      outcome: { kind: "handled" },
+      capability: () => false,
+    });
+    const router = new CommandRouter([cmd]);
+
+    const outcome = router.route(ctx("/goal ship it"));
+
+    expect(outcome.kind).toBe("passthrough");
+    expect(cmd.handle).not.toHaveBeenCalled();
+  });
+
+  it("handles the command when the provider satisfies the required capability", () => {
+    const capability = vi.fn(() => true);
+    const cmd = fakeCommand({
+      pattern: /^\/goal\b/,
+      outcome: { kind: "handled" },
+      capability,
+    });
+    const router = new CommandRouter([cmd]);
+
+    const provider = fakeProvider();
+    const outcome = router.route(ctx("/goal ship it", provider));
+
+    expect(outcome.kind).toBe("handled");
+    expect(capability).toHaveBeenCalledWith(provider);
+    expect(cmd.handle).toHaveBeenCalled();
+  });
+
+  it("dispatches to the first matching command in registration order", () => {
+    const first = fakeCommand({ pattern: /^\/goal\b/, outcome: { kind: "handled" } });
+    const second = fakeCommand({ pattern: /^\/goal\b/, outcome: { kind: "rewrite", content: "x" } });
+    const router = new CommandRouter([first, second]);
+
+    const outcome = router.route(ctx("/goal show"));
+
+    expect(outcome.kind).toBe("handled");
+    expect(first.handle).toHaveBeenCalled();
+    expect(second.handle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/commands/__tests__/goal-command.test.ts
+++ b/apps/server/src/commands/__tests__/goal-command.test.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from "events";
 import { openMemoryDatabase } from "../../store/database.js";
 import { MessageRepo } from "../../repositories/message-repo.js";
 import { GoalCommand } from "../goal-command.js";
+import type { CommandContext } from "../command-router.js";
 
 /** Seed a workspace + thread so message foreign keys are satisfied. */
 function seedThread(db: Database.Database): string {
@@ -54,26 +55,46 @@ describe("GoalCommand", () => {
     broadcast = vi.fn();
   });
 
-  function build(provider: IAgentProvider) {
+  function build() {
     return new GoalCommand(
-      provider,
       { messageRepo, db },
       broadcast as unknown as (channel: "agent.event", data: AgentEvent) => void,
     );
   }
 
+  /** Build a routing context for the given content and provider. */
+  function ctx(content: string, provider: IAgentProvider): CommandContext {
+    return { threadId, content, provider };
+  }
+
+  describe("matching and capability", () => {
+    it("matches /goal content and ignores other content", () => {
+      const cmd = build();
+      expect(cmd.matches("/goal ship it")).toBe(true);
+      expect(cmd.matches("/goal")).toBe(true);
+      expect(cmd.matches("just a normal message")).toBe(false);
+    });
+
+    it("requires the goal capability on the resolved provider", () => {
+      const cmd = build();
+      expect(cmd.requiredCapability(fakeGoalCapableProvider())).toBe(true);
+      expect(cmd.requiredCapability(fakeNonGoalProvider())).toBe(false);
+    });
+  });
+
   describe("passthrough", () => {
     it("returns passthrough for content that is not a /goal command", () => {
-      const cmd = build(fakeGoalCapableProvider());
-      expect(cmd.handle(threadId, "just a normal message").kind).toBe("passthrough");
+      const cmd = build();
+      expect(cmd.handle(ctx("just a normal message", fakeGoalCapableProvider())).kind).toBe(
+        "passthrough",
+      );
       expect(broadcast).not.toHaveBeenCalled();
     });
 
     it("returns passthrough when the provider lacks the goal capability", () => {
-      const provider = fakeNonGoalProvider();
-      const cmd = build(provider);
+      const cmd = build();
 
-      const outcome = cmd.handle(threadId, "/goal ship the feature");
+      const outcome = cmd.handle(ctx("/goal ship the feature", fakeNonGoalProvider()));
 
       expect(outcome.kind).toBe("passthrough");
       // Nothing persisted or broadcast — the model sees the raw text.
@@ -84,46 +105,29 @@ describe("GoalCommand", () => {
   });
 
   describe("SET form", () => {
-    it("rewrites the content into a directive and surfaces the pending goal", () => {
-      const cmd = build(fakeGoalCapableProvider());
+    it("rewrites the content into a directive and defers the goal install", () => {
+      const provider = fakeGoalCapableProvider();
+      const cmd = build();
 
-      const outcome = cmd.handle(threadId, "/goal analyse this branch");
+      const outcome = cmd.handle(ctx("/goal analyse this branch", provider));
 
       expect(outcome.kind).toBe("rewrite");
       if (outcome.kind !== "rewrite") throw new Error("expected rewrite");
-      expect(outcome.pendingGoal).toBe("analyse this branch");
       // The wire payload becomes a directive that names the condition.
       expect(outcome.content).toContain("analyse this branch");
       expect(outcome.content.toLowerCase()).toContain("directive");
-      // SET does not persist or broadcast on its own — the caller owns the send.
+      // SET does not persist, broadcast, or install on its own — the caller owns
+      // the send and runs the deferred lifecycle closures around it.
       expect(broadcast).not.toHaveBeenCalled();
-    });
-  });
+      expect(provider.setGoal).not.toHaveBeenCalled();
 
-  describe("install / rollback", () => {
-    it("installGoal sets the goal on the provider keyed by the thread session", () => {
-      const provider = fakeGoalCapableProvider();
-      const cmd = build(provider);
+      // onDispatch installs the goal keyed by the thread session.
+      outcome.onDispatch?.();
+      expect(provider.setGoal).toHaveBeenCalledWith(`mcode-${threadId}`, "analyse this branch");
 
-      cmd.installGoal(threadId, "ship the feature");
-
-      expect(provider.setGoal).toHaveBeenCalledWith(`mcode-${threadId}`, "ship the feature");
-    });
-
-    it("rollbackGoal clears the goal on the provider", () => {
-      const provider = fakeGoalCapableProvider();
-      const cmd = build(provider);
-
-      cmd.rollbackGoal(threadId);
-
+      // onRollback tears it back out after a failed send.
+      outcome.onRollback?.();
       expect(provider.clearGoal).toHaveBeenCalledWith(`mcode-${threadId}`);
-    });
-
-    it("install / rollback are no-ops on a non-capable provider", () => {
-      const cmd = build(fakeNonGoalProvider());
-      // Must not throw when the provider lacks the capability.
-      expect(() => cmd.installGoal(threadId, "x")).not.toThrow();
-      expect(() => cmd.rollbackGoal(threadId)).not.toThrow();
     });
   });
 
@@ -138,9 +142,9 @@ describe("GoalCommand", () => {
     it("reports the active goal and short-circuits the send", () => {
       const provider = fakeGoalCapableProvider();
       provider.getGoal.mockReturnValueOnce("ship the feature");
-      const cmd = build(provider);
+      const cmd = build();
 
-      const outcome = cmd.handle(threadId, "/goal");
+      const outcome = cmd.handle(ctx("/goal", provider));
 
       expect(outcome.kind).toBe("handled");
       expect(provider.setGoal).not.toHaveBeenCalled();
@@ -161,9 +165,9 @@ describe("GoalCommand", () => {
     it("reports no active goal when none is set", () => {
       const provider = fakeGoalCapableProvider();
       provider.getGoal.mockReturnValueOnce(undefined);
-      const cmd = build(provider);
+      const cmd = build();
 
-      const outcome = cmd.handle(threadId, "/goal show");
+      const outcome = cmd.handle(ctx("/goal show", provider));
 
       expect(outcome.kind).toBe("handled");
       const { messages } = messageRepo.listByThread(threadId, 100);
@@ -176,9 +180,9 @@ describe("GoalCommand", () => {
   describe("CLEAR form", () => {
     it("clears the goal, persists a confirmation pill, and emits Ended", () => {
       const provider = fakeGoalCapableProvider();
-      const cmd = build(provider);
+      const cmd = build();
 
-      const outcome = cmd.handle(threadId, "/goal clear");
+      const outcome = cmd.handle(ctx("/goal clear", provider));
 
       expect(outcome.kind).toBe("handled");
       expect(provider.clearGoal).toHaveBeenCalledWith(`mcode-${threadId}`);

--- a/apps/server/src/commands/command-router.ts
+++ b/apps/server/src/commands/command-router.ts
@@ -1,0 +1,76 @@
+import type { IAgentProvider } from "@mcode/contracts";
+
+/**
+ * Per-send context handed to a matched {@link McodeCommand}. The provider is
+ * the already-resolved instance for this turn; commands narrow it to a
+ * capability via their own type guard.
+ */
+export interface CommandContext {
+  readonly threadId: string;
+  readonly content: string;
+  readonly provider: IAgentProvider;
+}
+
+/**
+ * Result of routing a message through the {@link CommandRouter}:
+ * - `passthrough` — no command claimed the message (or the resolved provider
+ *   lacks the matched command's required capability); forward the original
+ *   content to the model unchanged.
+ * - `handled` — a command fully serviced the message; short-circuit the send.
+ * - `rewrite` — a command rewrote the wire payload; the caller sends `content`
+ *   instead of the original text, runs `onDispatch` just before dispatch, and
+ *   runs `onRollback` if the send fails. The lifecycle closures keep
+ *   command-specific side effects (e.g. installing a goal gate) out of the
+ *   router and the orchestrator.
+ */
+export type CommandOutcome =
+  | { readonly kind: "passthrough" }
+  | { readonly kind: "handled" }
+  | {
+      readonly kind: "rewrite";
+      readonly content: string;
+      readonly onDispatch?: () => void;
+      readonly onRollback?: () => void;
+    };
+
+/**
+ * A single mcode-native command. Implementations claim a content pattern via
+ * {@link matches}, optionally gate on a provider capability via
+ * {@link requiredCapability}, and service the message via {@link handle}.
+ */
+export interface McodeCommand {
+  /** Whether this command claims the given message content. */
+  matches(content: string): boolean;
+  /**
+   * Optional capability probe. When present and it returns false for the
+   * resolved provider, the router passes the message through untouched so the
+   * model still sees the raw text.
+   */
+  requiredCapability?(provider: IAgentProvider): boolean;
+  /** Service a claimed message and describe how the caller should proceed. */
+  handle(ctx: CommandContext): CommandOutcome;
+}
+
+/**
+ * Owns the mcode-native command namespace. Probes each registered command in
+ * registration order; the first to {@link McodeCommand.matches} claims the
+ * message. The capability probe lives here so provider differentiation is named
+ * in one place rather than branched per command.
+ */
+export class CommandRouter {
+  constructor(private readonly commands: readonly McodeCommand[]) {}
+
+  /** Route a message to the first matching command, or passthrough. */
+  route(ctx: CommandContext): CommandOutcome {
+    for (const command of this.commands) {
+      if (!command.matches(ctx.content)) {
+        continue;
+      }
+      if (command.requiredCapability && !command.requiredCapability(ctx.provider)) {
+        return { kind: "passthrough" };
+      }
+      return command.handle(ctx);
+    }
+    return { kind: "passthrough" };
+  }
+}

--- a/apps/server/src/commands/goal-command.ts
+++ b/apps/server/src/commands/goal-command.ts
@@ -1,12 +1,12 @@
 import type Database from "better-sqlite3";
 import {
   type IAgentProvider,
-  type IGoalCapable,
   type AgentEvent,
   AgentEventType,
   isGoalCapable,
 } from "@mcode/contracts";
 import type { MessageRepo } from "../repositories/message-repo.js";
+import type { CommandContext, CommandOutcome, McodeCommand } from "./command-router.js";
 
 /** Broadcast function shape used to push agent events to connected clients. */
 type BroadcastFn = (channel: "agent.event", data: AgentEvent) => void;
@@ -17,72 +17,49 @@ interface GoalCommandDeps {
   readonly db: Database.Database;
 }
 
-/**
- * Result of routing a message through {@link GoalCommand.handle}:
- * - `passthrough` — not a goal command (or the provider lacks the capability);
- *   the caller forwards the original content to the model unchanged.
- * - `handled` — a control form (show/clear) was fully serviced and persisted;
- *   the caller should short-circuit the send.
- * - `rewrite` — a SET form; the caller persists `content` as the wire payload
- *   while keeping the original text for the transcript, then installs the goal.
- */
-export type GoalCommandOutcome =
-  | { readonly kind: "passthrough" }
-  | { readonly kind: "handled" }
-  | { readonly kind: "rewrite"; readonly content: string; readonly pendingGoal: string };
-
 /** Matches `/goal`, optionally followed by an argument, across newlines. */
 const GOAL_COMMAND = /^\s*\/goal\b\s*(.*)$/s;
 
 /**
- * Owns the `/goal` app-native command. Constructed per send with the resolved
- * provider, the repositories, and the broadcast function; it holds no turn
- * state. Any provider that implements {@link IGoalCapable} gets `/goal` for
- * free; on a provider without it, every `/goal` is a passthrough so the model
- * still sees what the user typed.
+ * The `/goal` app-native command. Holds only server-lifetime deps; the resolved
+ * provider arrives per send via {@link CommandContext}. Any provider that
+ * implements the goal capability gets `/goal` for free, which the router gates
+ * through {@link requiredCapability}; on a provider without it the router passes
+ * the command through so the model still sees what the user typed.
  */
-export class GoalCommand {
-  /** The capable view of the provider, or null when it lacks goal support. */
-  private readonly capable: IGoalCapable | null;
-
+export class GoalCommand implements McodeCommand {
   constructor(
-    provider: IAgentProvider,
     private readonly deps: GoalCommandDeps,
     private readonly broadcast: BroadcastFn,
-  ) {
-    this.capable = isGoalCapable(provider) ? provider : null;
-  }
+  ) {}
 
   /** The session id the goal hook keys on, derived from the thread id. */
   private sessionName(threadId: string): string {
     return `mcode-${threadId}`;
   }
 
-  /**
-   * Install the goal gate on the provider. Called by the send orchestrator as
-   * late as possible before dispatch so a failed preflight leaves no stale
-   * goal. A no-op when the provider lacks the capability.
-   */
-  installGoal(threadId: string, condition: string): void {
-    this.capable?.setGoal(this.sessionName(threadId), condition);
+  /** Whether the content is a `/goal` invocation. */
+  matches(content: string): boolean {
+    return GOAL_COMMAND.test(content);
+  }
+
+  /** `/goal` is only meaningful on a provider that supports goal gating. */
+  requiredCapability(provider: IAgentProvider): boolean {
+    return isGoalCapable(provider);
   }
 
   /**
-   * Tear the goal back out after a failed send so a hidden Stop-hook gate does
-   * not linger into the next turn. A no-op when the provider lacks the
-   * capability.
+   * Route a `/goal` message. Returns {@link CommandOutcome} describing how the
+   * caller should proceed. The SET form rewrites the wire payload and defers the
+   * actual goal install to the returned {@link CommandOutcome.onDispatch} so a
+   * send failure can't leave a stale goal in the provider; `onRollback` tears it
+   * back out.
    */
-  rollbackGoal(threadId: string): void {
-    this.capable?.clearGoal(this.sessionName(threadId));
-  }
-
-  /**
-   * Route a message. Returns {@link GoalCommandOutcome} describing how the
-   * caller should proceed.
-   */
-  handle(threadId: string, content: string): GoalCommandOutcome {
+  handle(ctx: CommandContext): CommandOutcome {
+    const { threadId, content } = ctx;
     const match = GOAL_COMMAND.exec(content);
-    if (!match || !this.capable) {
+    const capable = isGoalCapable(ctx.provider) ? ctx.provider : null;
+    if (!match || !capable) {
       return { kind: "passthrough" };
     }
 
@@ -94,12 +71,12 @@ export class GoalCommand {
     if (isControl) {
       let replyText: string;
       if (arg === "" || lower === "show") {
-        const current = this.capable.getGoal(this.sessionName(threadId));
+        const current = capable.getGoal(this.sessionName(threadId));
         replyText = current
           ? `Active goal: "${current}". The agent will not stop until this condition is met. Use \`/goal clear\` to remove it.`
           : `No active goal. Use \`/goal <condition>\` to set one.`;
       } else {
-        this.capable.clearGoal(this.sessionName(threadId));
+        capable.clearGoal(this.sessionName(threadId));
         replyText = `Goal cleared. The agent may now end its turn normally.`;
       }
       this.persistControlReply(threadId, content, replyText);
@@ -108,15 +85,18 @@ export class GoalCommand {
 
     // SET form: rewrite the wire payload so the agent starts working on the
     // condition immediately, while the caller pins the original text for the
-    // transcript. The actual setGoal() install is deferred to the caller (via
-    // installGoal) so a send failure can't leave a stale goal in the provider.
+    // transcript. The setGoal() install is deferred to onDispatch (run by the
+    // caller just before sendTurn) so a send failure can't leave a stale goal;
+    // onRollback clears it if the send fails.
+    const session = this.sessionName(threadId);
     return {
       kind: "rewrite",
-      pendingGoal: arg,
       content:
         `A goal has been set for this session: "${arg}". Treat this exactly ` +
         `as your directive — start working toward it now. The session will not ` +
         `stop until the goal is satisfied.`,
+      onDispatch: () => capable.setGoal(session, arg),
+      onRollback: () => capable.clearGoal(session),
     };
   }
 

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -179,6 +179,31 @@ describe("AgentService.sendMessage — /goal command", () => {
     expect(userMsg?.content).toBe("/goal analyse this branch");
   });
 
+  it("rolls the installed goal back when the send fails so no Stop-hook gate lingers", async () => {
+    const { svc, providerStub } = buildService(db);
+    providerStub.sendTurn.mockRejectedValueOnce(new Error("provider boom"));
+
+    // sendMessage swallows the send failure (emits an error event, marks the
+    // thread errored) rather than rejecting, so this resolves normally.
+    await svc.sendMessage(
+      thread.id,
+      "/goal analyse this branch",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+
+    // onDispatch installed the goal just before the failing send...
+    expect(providerStub.setGoal).toHaveBeenCalledWith(
+      `mcode-${thread.id}`,
+      "analyse this branch",
+    );
+    // ...and the catch ran onRollback so the gate does not leak into the next turn.
+    expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
+  });
+
   it("/goal clear short-circuits — clears the goal, does NOT invoke the provider, emits Ended", async () => {
     const { svc, providerStub, messageRepo } = buildService(db);
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -42,6 +42,7 @@ import { SnapshotService } from "./snapshot-service";
 import { MemoryPressureService } from "./memory-pressure-service";
 import { broadcast } from "../transport/push";
 import { GoalCommand } from "../commands/goal-command";
+import { CommandRouter } from "../commands/command-router";
 // Lazy-imported to break circular dependency: AgentService -> ThreadService -> (shared repos)
 // Using delay() ensures tsyringe resolves ThreadService from the container at first access,
 // not at AgentService construction time.
@@ -108,6 +109,13 @@ export class AgentService {
    */
   private readonly turnFinalizer: TurnFinalizer;
   /**
+   * Owns the mcode-native command namespace (`/goal`, ...). Dispatches each
+   * send through registered `McodeCommand`s before the message reaches the
+   * provider, so the app-interpreted / provider-passed boundary is named in
+   * one place rather than branched inline.
+   */
+  private readonly commandRouter: CommandRouter;
+  /**
    * Threads whose `TurnComplete` event has already been processed but whose
    * finalize may still be in-flight or have already finished.
    * Set when `TurnComplete` is handled; cleared on `TurnStarted` so the
@@ -168,6 +176,9 @@ export class AgentService {
       this.turnSnapshotRepo,
       this.db,
     );
+    this.commandRouter = new CommandRouter([
+      new GoalCommand({ messageRepo: this.messageRepo, db: this.db }, broadcast),
+    ]);
   }
 
   /**
@@ -253,37 +264,36 @@ export class AgentService {
       throw new Error(`Workspace not found: ${thread.workspace_id}`);
     }
 
-    // `/goal` app-native command. The capability is probed through
-    // {@link GoalCapableProvider}: any provider that implements it gets `/goal`
-    // for free, and a provider without it passes the command through as plain
-    // text so the model still sees what the user typed.
+    // Route the message through the mcode-native command namespace before it
+    // reaches the provider. The router probes each command's required
+    // capability and passes through when the resolved provider lacks it, so the
+    // model still sees the raw text on providers without the capability.
     //
-    //   `/goal <condition>` — rewrite (SET): the wire payload becomes a
-    //                         directive and the goal is installed just before
-    //                         dispatch (see deferred install below).
-    //   `/goal clear`       — handled: remove the active goal, no dispatch.
-    //   `/goal` / `/goal show` — handled: show the active goal, no dispatch.
+    //   handled     — a control form was fully serviced; short-circuit the send.
+    //   rewrite     — the wire payload was rewritten (e.g. `/goal <condition>`);
+    //                 fall through and run the lifecycle closures around the
+    //                 send (onDispatch just before, onRollback on failure).
+    //   passthrough — forward the original content to the model unchanged.
     //
-    // Deferred goal install for the SET form: populated here and consumed
-    // immediately before `sendTurn` runs, so a send failure can't leave a
-    // stale goal in the provider map. The catch block on the send also clears
-    // it as a belt-and-suspenders guard for failures between install and
-    // successful dispatch.
-    let pendingGoalInstall: string | null = null;
-    const goalCommand = new GoalCommand(
-      this.providerRegistry.resolve(effectiveProvider),
-      { messageRepo: this.messageRepo, db: this.db },
-      broadcast,
-    );
-    const goalOutcome = goalCommand.handle(threadId, content);
-    if (goalOutcome.kind === "handled") {
-      logger.info("Handled /goal control command", { threadId });
+    // onDispatch is deferred to immediately before `sendTurn` so a send failure
+    // can't leave a stale side effect (e.g. a goal gate) on the provider; the
+    // catch block runs onRollback as a belt-and-suspenders guard.
+    let pendingDispatch: (() => void) | null = null;
+    let pendingRollback: (() => void) | null = null;
+    const commandOutcome = this.commandRouter.route({
+      threadId,
+      content,
+      provider: this.providerRegistry.resolve(effectiveProvider),
+    });
+    if (commandOutcome.kind === "handled") {
+      logger.info("Handled mcode-native command", { threadId });
       return;
     }
-    if (goalOutcome.kind === "rewrite") {
-      pendingGoalInstall = goalOutcome.pendingGoal;
+    if (commandOutcome.kind === "rewrite") {
+      pendingDispatch = commandOutcome.onDispatch ?? null;
+      pendingRollback = commandOutcome.onRollback ?? null;
       messageDisplayContent = content;
-      content = goalOutcome.content;
+      content = commandOutcome.content;
     }
 
     const cwd = this.gitService.resolveWorkingDir(
@@ -495,16 +505,14 @@ export class AgentService {
 
     const providerMessage = providerWireOverride ?? wirePayload;
 
-    // Install the deferred /goal hook gate now, as late as possible before
-    // dispatch. If sendTurn throws synchronously or rejects, the catch block
-    // below tears the goal back out so failures don't leave a hidden gate
-    // active. Only runs for the SET form (pendingGoalInstall is only populated
-    // when the goal command returned a rewrite).
-    if (pendingGoalInstall !== null) {
-      goalCommand.installGoal(threadId, pendingGoalInstall);
-      logger.info("Goal installed; dispatching directive to provider", {
+    // Run the command's deferred dispatch side effect now, as late as possible
+    // before dispatch. If sendTurn throws synchronously or rejects, the catch
+    // block below runs the rollback so failures don't leave a hidden side
+    // effect active. Only set for a rewrite outcome that supplied onDispatch.
+    if (pendingDispatch !== null) {
+      pendingDispatch();
+      logger.info("Command side effect installed; dispatching to provider", {
         threadId,
-        goal: pendingGoalInstall,
       });
     }
 
@@ -548,14 +556,14 @@ export class AgentService {
       if (this.activeSessionIds.size === 0) {
         this.memoryPressureService.markIdle();
       }
-      // Roll the just-installed goal back so a failed send doesn't leave a
-      // hidden Stop-hook gate active on the next (possibly unrelated) turn.
-      // Only runs when we got past the deferred install above.
-      if (pendingGoalInstall !== null) {
+      // Roll the just-installed command side effect back so a failed send
+      // doesn't leave a hidden gate (e.g. a Stop-hook goal) active on the next
+      // (possibly unrelated) turn. Only runs when we got past onDispatch above.
+      if (pendingRollback !== null) {
         try {
-          goalCommand.rollbackGoal(threadId);
+          pendingRollback();
         } catch (clearErr) {
-          logger.warn("Failed to clear goal after failed send", {
+          logger.warn("Failed to roll back command side effect after failed send", {
             threadId,
             error: clearErr instanceof Error ? clearErr.message : String(clearErr),
           });


### PR DESCRIPTION
## What
Replace the inline `/goal` handling in `AgentService` with a generic `CommandRouter` that dispatches each send through registered `McodeCommand`s before the message reaches the provider.

## Why
Seams the app-interpreted / provider-passed boundary into one named place ahead of the broader command-plugin refactor (#572). Approved as seam-prep even though #579's original go/no-go gate (a second mcode-native command, or a provider-id capability gate to delete) wasn't strictly met — `GoalCommand` already probed capabilities structurally via `isGoalCapable`, so there was no provider-id branching to remove.

## Key changes
- **`commands/command-router.ts`** (new) - `McodeCommand` interface (`matches` / optional `requiredCapability` / `handle`), `CommandContext`, `CommandOutcome` union (`passthrough` / `handled` / `rewrite` with optional `onDispatch`/`onRollback` lifecycle closures), and a first-match-wins `CommandRouter` that probes capability before `handle`.
- **`commands/goal-command.ts`** - now `implements McodeCommand`; capability probe moved to `requiredCapability(provider)`; `installGoal`/`rollbackGoal` refactored into `onDispatch`/`onRollback` closures so command-specific side effects stay out of the router and orchestrator.
- **`services/agent-service.ts`** - owns a `CommandRouter`; inline `/goal` block replaced with `commandRouter.route(ctx)`; generic `pendingDispatch`/`pendingRollback` run around `sendTurn` (dispatch just before, rollback on failure).

## Review fixes (this session)
- Fixed a broken `{@link McodeCommand}` doc reference in `agent-service.ts` (type not imported; importing solely for the link would trip `no-unused-vars`).
- Added an `AgentService` integration test for the **rollback-on-failed-send** path — a failed send must not leave a stale Stop-hook goal gate active on the next turn. The 4 prior integration tests covered SET / clear / show / passthrough but not this safety path.

## Verification
- `bun run verify` typecheck + lint pass; 1206/1207 unit tests pass.
- The single failure (`skill-watcher-service.test.ts` debounce timing) is pre-existing environmental flakiness under parallel load — passes 8/8 in isolation and imports nothing this PR touches.

## Related issues/PRs
- Closes #579
- Relates to #572

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783514472&installation_id=129163861&pr_number=589&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F589&signature=bb0520195789f627a18785f8463f8a34f0ffd02dcae26fc64f8c1eeaac09bd09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Goals now properly roll back when message send fails, preventing goal state leakage into subsequent turns.

* **Infrastructure**
  * Introduced command routing abstraction to enable future extensibility of mcode-native commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->