### PR TITLE
fix(server): make turn assistant-message write idempotent (#577)

### DIFF
--- a/apps/server/src/__tests__/message-repo.test.ts
+++ b/apps/server/src/__tests__/message-repo.test.ts
@@ -153,6 +153,48 @@ ORDER BY m.sequence ASC`,
     });
   });
 
+  describe("createAssistantIdempotent", () => {
+    it("inserts the assistant row with the supplied deterministic id", () => {
+      const msg = repo.createAssistantIdempotent({
+        id: "det-1",
+        threadId: "thread-1",
+        content: "answer",
+        sequence: 2,
+        model: "claude-sonnet-4-6",
+      });
+
+      expect(msg.id).toBe("det-1");
+      expect(msg.role).toBe("assistant");
+      const found = repo.findByIdInThread("thread-1", "det-1");
+      expect(found?.content).toBe("answer");
+      expect(found?.model).toBe("claude-sonnet-4-6");
+    });
+
+    it("is a no-op on a second write for the same id (insert-or-ignore)", () => {
+      repo.createAssistantIdempotent({
+        id: "det-1",
+        threadId: "thread-1",
+        content: "first",
+        sequence: 2,
+        model: null,
+      });
+      repo.createAssistantIdempotent({
+        id: "det-1",
+        threadId: "thread-1",
+        content: "second",
+        sequence: 3,
+        model: null,
+      });
+
+      const { messages } = repo.listByThread("thread-1", 10);
+      const assistantRows = messages.filter((m) => m.role === "assistant");
+      expect(assistantRows).toHaveLength(1);
+      // The original row wins; the ignored write does not overwrite it.
+      expect(assistantRows[0].content).toBe("first");
+      expect(assistantRows[0].sequence).toBe(2);
+    });
+  });
+
   describe("findByIdInThread", () => {
     it("returns the message matching the given id and thread", () => {
       repo.create("thread-1", "user", "first", 1);

--- a/apps/server/src/repositories/message-repo.ts
+++ b/apps/server/src/repositories/message-repo.ts
@@ -145,6 +145,57 @@ export class MessageRepo {
   }
 
   /**
+   * Insert an assistant message under a caller-supplied deterministic `id`,
+   * skipping the write when a row with that id already exists.
+   *
+   * This mirrors the `INSERT OR IGNORE` pattern the narrative tables use
+   * (see {@link ToolCallRecordRepo}). Because the turn's assistant message has a
+   * deterministic per-turn identity, a replayed write — a re-run finalize, a
+   * retry, or a reconnect replay — collapses onto the same id and is a no-op
+   * rather than a duplicate row. The first write wins; a later ignored write
+   * does not overwrite its content. The returned record reflects the supplied
+   * values (the caller already holds the deterministic id, so re-reading the
+   * stored row is unnecessary). Note: on an ignored write the returned
+   * `content`, `sequence`, and `timestamp` reflect this call's arguments, not
+   * the row already in the database — re-read from the DB if you need the
+   * authoritative stored values.
+   */
+  createAssistantIdempotent(input: {
+    id: string;
+    threadId: string;
+    content: string;
+    sequence: number;
+    model?: string | null;
+  }): Message {
+    const now = new Date().toISOString();
+    const modelValue = input.model ?? null;
+
+    this.db
+      .prepare(
+        "INSERT OR IGNORE INTO messages (id, thread_id, role, content, timestamp, sequence, model, is_internal) VALUES (?, ?, 'assistant', ?, ?, ?, ?, 0)",
+      )
+      .run(input.id, input.threadId, input.content, now, input.sequence, modelValue);
+
+    return {
+      id: input.id,
+      thread_id: input.threadId,
+      role: "assistant",
+      content: input.content,
+      tool_calls: null,
+      files_changed: null,
+      cost_usd: null,
+      tokens_used: null,
+      timestamp: now,
+      sequence: input.sequence,
+      attachments: null,
+      reply_to_message_id: null,
+      quoted_text: null,
+      model: modelValue,
+      is_internal: false,
+    };
+  }
+
+  /**
    * Return the last N messages for a thread in ascending sequence order.
    *
    * Uses a sub-select pattern: grab the last N rows by descending sequence,

--- a/apps/server/src/services/__tests__/turn-finalizer.test.ts
+++ b/apps/server/src/services/__tests__/turn-finalizer.test.ts
@@ -7,7 +7,7 @@ import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo";
 import { ThoughtSegmentRepo } from "../../repositories/thought-segment-repo";
 import { HookExecutionRepo } from "../../repositories/hook-execution-repo";
 import { NarrativeStore } from "../narrative-store";
-import { TurnFinalizer } from "../turn-finalizer";
+import { TurnFinalizer, deriveTurnAssistantMessageId } from "../turn-finalizer";
 import type { ThreadRepo } from "../../repositories/thread-repo";
 import type { SnapshotService } from "../snapshot-service";
 import type { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo";
@@ -175,6 +175,44 @@ describe("TurnFinalizer.finalize — turn outcome → tool-call status", () => {
     const tools = toolRepo.listByMessage(assistant!.id);
     expect(tools).toHaveLength(1);
     expect(tools[0].status).toBe("cancelled");
+  });
+
+  it("synthesizes the interrupted assistant row under a deterministic per-turn id", async () => {
+    // The flushed row's identity must derive from the turn's anchor (the
+    // preceding user message), not a fresh random id — so a replayed flush
+    // collapses onto the same row.
+    insertMessage(db, "u1", "user", "go", 1);
+    narrativeStore.beginTurn(THREAD);
+    narrativeStore.resetTurnCounters(THREAD);
+    finalizer.appendStreamingText(THREAD, "partial answer before stop");
+
+    await finalizer.finalize(THREAD, "cancelled");
+
+    const { messages } = new MessageRepo(db).listByThread(THREAD, 10);
+    const assistant = messages.find((m) => m.role === "assistant");
+    expect(assistant?.id).toBe(deriveTurnAssistantMessageId(THREAD, "u1"));
+  });
+
+  it("produces exactly one assistant row when finalize runs twice for one turn", async () => {
+    // Reconnect replay: the streamed deltas are re-accumulated and finalize is
+    // called a second time. Here the second flush is short-circuited by the
+    // existing "last row is already assistant" guard, so it never reaches the
+    // insert — this asserts the end-to-end "twice → one row" outcome. The
+    // deterministic-id + INSERT OR IGNORE collapse that backs this up at the DB
+    // layer is covered directly in message-repo.test.ts.
+    insertMessage(db, "u1", "user", "go", 1);
+    narrativeStore.beginTurn(THREAD);
+    narrativeStore.resetTurnCounters(THREAD);
+    finalizer.appendStreamingText(THREAD, "partial answer before stop");
+
+    await finalizer.finalize(THREAD, "cancelled");
+    // A replay re-buffers the same streamed text before the second finalize.
+    finalizer.appendStreamingText(THREAD, "partial answer before stop");
+    await finalizer.finalize(THREAD, "cancelled");
+
+    const { messages } = new MessageRepo(db).listByThread(THREAD, 10);
+    const assistantRows = messages.filter((m) => m.role === "assistant");
+    expect(assistantRows).toHaveLength(1);
   });
 
   it("is a no-op when a finalize is already in flight (re-entrancy guard)", async () => {

--- a/apps/server/src/services/turn-finalizer.ts
+++ b/apps/server/src/services/turn-finalizer.ts
@@ -17,6 +17,7 @@
  * the delegation methods below and reads it back through
  * {@link getLastPersistedMessageId}.
  */
+import { createHash } from "crypto";
 import { logger } from "@mcode/shared";
 import { AgentEventType } from "@mcode/contracts";
 import type { AgentEvent } from "@mcode/contracts";
@@ -33,6 +34,22 @@ import type { TurnOutcome } from "./turn-outcome";
 interface TurnRef {
   ref: string;
   cwd: string;
+}
+
+/**
+ * Derive the deterministic id for a turn's synthesized assistant message from
+ * the turn's anchor — the id of the message immediately preceding the assistant
+ * turn (normally the user message the assistant responds to), or a positional
+ * `seq:N` fallback when the thread has no prior message. Re-running the flush
+ * for the same turn collapses onto this id, so the
+ * {@link MessageRepo.createAssistantIdempotent} write is a no-op rather than a
+ * duplicate row — matching the `INSERT OR IGNORE` identity the narrative tables
+ * already key on.
+ */
+export function deriveTurnAssistantMessageId(threadId: string, anchorId: string): string {
+  return createHash("sha256")
+    .update(`${threadId}\u0000${anchorId}\u0000assistant`)
+    .digest("hex");
 }
 
 /** Owns the single fixed end-of-turn order shared by the completion, error, and cancellation paths. */
@@ -205,16 +222,16 @@ export class TurnFinalizer {
     try {
       const thread = this.threadRepo.findById(threadId);
       const modelForMessage = thread?.model ?? null;
-      const msg = this.messageRepo.create(
+      // Anchor the deterministic id on the preceding user message so a replayed
+      // flush for the same turn lands on the same row (insert-or-ignore no-op).
+      const anchorId = last ? last.id : `seq:${nextSeq}`;
+      const msg = this.messageRepo.createAssistantIdempotent({
+        id: deriveTurnAssistantMessageId(threadId, anchorId),
         threadId,
-        "assistant",
-        text,
-        nextSeq,
-        undefined,
-        undefined,
-        undefined,
-        modelForMessage,
-      );
+        content: text,
+        sequence: nextSeq,
+        model: modelForMessage,
+      });
       this.streamingAssistantTextByThread.delete(threadId);
       broadcast("agent.event", {
         type: AgentEventType.Message,


### PR DESCRIPTION
## What
Make the turn's synthesized assistant-message write idempotent in the `TurnFinalizer` flush path, so a replayed flush can no longer duplicate the assistant row.

## Why
Narrative rows (`tool_call_records`) already used `INSERT OR IGNORE` with stable ids, but the assistant message used a plain `INSERT` with a random UUID. A replayed flush (re-run finalize, retry, or reconnect replay) could therefore insert a duplicate assistant row. Issue #577 asked to close this write asymmetry.

## Key Changes
- Added `MessageRepo.createAssistantIdempotent` — `INSERT OR IGNORE` under a caller-supplied deterministic id, mirroring `ToolCallRecordRepo`. The first write wins; a later ignored write is a no-op.
- Added `deriveTurnAssistantMessageId(threadId, anchorId)` — derives a stable per-turn id via `sha256(threadId \0 anchorId \0 "assistant")`, anchored on the message preceding the assistant turn.
- `flushInterruptedAssistantMessage` now derives the id from the turn anchor and writes via `createAssistantIdempotent` instead of `create` + `randomUUID()`. The existing "last row is already assistant" guard remains as the first line of defense.
- Tests: repo-level double-write collapse (`message-repo.test.ts`), deterministic-id synthesis, and end-to-end "finalize twice -> one row" (`turn-finalizer.test.ts`).

## Config Changes
None

## Notes for reviewers
- No migration: existing assistant rows keep their random UUIDs; only newly synthesized rows get deterministic ids.
- Scope is the `TurnFinalizer` flush path only (per #576 framing, "behind the finalize seam"); the eager AgentService message-handler write is unchanged.

Closes #577

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783514617&installation_id=129163861&pr_number=590&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F590&signature=ffaef36ac0ab3ee59c31a7e4a9b0f9cc8fcaa0719ce11bf2944cb61bd494e0de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of message handling for interrupted streaming scenarios. Messages are now created idempotently, preventing duplicates when operations are retried or re-executed.

* **Tests**
  * Added comprehensive test coverage for idempotent message creation and interrupted stream flushing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->