### PR TITLE
feat: treat direct-mode threads as non-PR-able

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,6 +75,18 @@ Worktrees are persistent and removed manually. When a user deletes a
 thread, an option to delete its worktree is offered alongside; the
 worktree can also be kept and reused for future threads.
 
+### PR-able thread
+A thread the app can open a pull request from. A thread is PR-able only
+when it runs in an isolated worktree; direct-mode threads are never
+PR-able, because they run against the workspace's main checkout and there
+is nothing to open a pull request from. This single notion gates every PR
+affordance: the thread-row PR icon, the chat header's Create PR button,
+and the background PR and commits-ahead polling. A non-PR-able thread
+shows its branch/agent status instead of a PR glyph, offers no Create PR
+button, and is never polled against GitHub, even if a PR number happens to
+be attached to it. A user who wants a pull request from local work creates
+a worktree.
+
 ## Composer
 
 ### Composer mode

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -68,7 +68,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     workspace_id: "ws-1",
     title: "Test Thread",
     status: "active",
-    mode: "direct",
+    mode: "worktree",
     worktree_path: null,
     branch: "feat/my-feature",
     worktree_managed: false,
@@ -139,7 +139,7 @@ describe("HeaderActions - Create PR button", () => {
     mockUseHasCommitsAhead.mockReturnValue(null);
   });
 
-  it("shows Create PR button on a feature branch", () => {
+  it("shows Create PR button on a worktree thread", () => {
     mockUseHasCommitsAhead.mockReturnValue(true);
     render(<HeaderActions thread={makeThread()} />);
     const btn = screen.getByRole("button", { name: /create pr/i });
@@ -168,9 +168,12 @@ describe("HeaderActions - Create PR button", () => {
     expect(btn).not.toBeDisabled();
   });
 
-  it("does not show Create PR button on main branch", () => {
+  it("shows Create PR button on a worktree thread regardless of branch name", () => {
+    // The gate is mode-based, not branch-based: a worktree thread that happens
+    // to sit on a branch named "main" is still PR-able.
+    mockUseHasCommitsAhead.mockReturnValue(true);
     render(<HeaderActions thread={makeThread({ branch: "main" })} />);
-    expect(screen.queryByRole("button", { name: /create pr/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create pr/i })).toBeInTheDocument();
   });
 
   it("does not show Create PR button when PR already exists", () => {
@@ -192,5 +195,44 @@ describe("HeaderActions - Create PR button", () => {
     render(<HeaderActions thread={makeThread()} />);
     const btn = screen.getByRole("button", { name: /create pr/i });
     expect(btn).not.toHaveAttribute("title");
+  });
+});
+
+describe("HeaderActions - PR-ability gating by mode", () => {
+  beforeEach(() => {
+    const state = defaultWorkspaceState();
+    mockWorkspaceSelector.mockImplementation(
+      (selector: (s: unknown) => unknown) => selector(state),
+    );
+    mockUseBranchPr.mockReturnValue(null);
+    mockUseHasCommitsAhead.mockReturnValue(true);
+  });
+
+  it("does not show the Create PR button for a direct-mode thread", () => {
+    render(<HeaderActions thread={makeThread({ mode: "direct" })} />);
+    expect(screen.queryByRole("button", { name: /create pr/i })).not.toBeInTheDocument();
+  });
+
+  it("does not mount the create-PR dialog for a direct-mode thread", () => {
+    render(<HeaderActions thread={makeThread({ mode: "direct" })} />);
+    expect(screen.queryByTestId("create-pr-dialog")).not.toBeInTheDocument();
+  });
+
+  it("mounts the create-PR dialog for a worktree thread", () => {
+    render(<HeaderActions thread={makeThread({ mode: "worktree" })} />);
+    expect(screen.getByTestId("create-pr-dialog")).toBeInTheDocument();
+  });
+
+  it("skips PR polling for a direct-mode thread", () => {
+    render(<HeaderActions thread={makeThread({ mode: "direct", branch: "feat/x" })} />);
+    // Non-PR-able threads must not poll GitHub: both hooks receive null inputs.
+    expect(mockUseBranchPr).toHaveBeenCalledWith(null, expect.anything());
+    expect(mockUseHasCommitsAhead).toHaveBeenCalledWith("", null, undefined);
+  });
+
+  it("polls GitHub for a worktree thread", () => {
+    render(<HeaderActions thread={makeThread({ mode: "worktree", branch: "feat/x" })} />);
+    expect(mockUseBranchPr).toHaveBeenCalledWith("feat/x", expect.anything());
+    expect(mockUseHasCommitsAhead).toHaveBeenCalledWith("ws-1", "feat/x", "thread-1");
   });
 });

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -8,6 +8,7 @@ import { useHasCommitsAhead } from "@/hooks/useHasCommitsAhead";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore } from "@/stores/diffStore";
 import { executeCommand } from "@/lib/command-registry";
+import { isPrable } from "@/lib/is-prable";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Thread } from "@/transport";
@@ -32,10 +33,12 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
   // Determine the path to open: worktree path if available, otherwise workspace root
   const dirPath = thread.worktree_path ?? workspace?.path ?? null;
 
-  // Only poll for PRs on feature branches (not main/master)
+  // PR affordances only apply to PR-able (worktree) threads. A direct-mode
+  // thread runs against the main checkout and can never have a PR through this
+  // app, so we render no PR UI and skip all GitHub polling for it.
   const cwd = workspace?.path ?? null;
-  const shouldPollPr = thread.branch !== "main" && thread.branch !== "master";
-  const polledPr = useBranchPr(shouldPollPr ? thread.branch : null, cwd);
+  const prable = isPrable(thread);
+  const polledPr = useBranchPr(prable ? thread.branch : null, cwd);
 
   // polledPr is the live source of truth for state (OPEN / MERGED / CLOSED).
   // The store-backed entry fills the window right after creation, before the first
@@ -62,9 +65,9 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
 
   // Check if the branch has commits ahead of main (disable Create PR when it doesn't)
   const hasCommitsAhead = useHasCommitsAhead(
-    shouldPollPr ? thread.workspace_id : "",
-    shouldPollPr ? thread.branch : null,
-    shouldPollPr ? thread.id : undefined,
+    prable ? thread.workspace_id : "",
+    prable ? thread.branch : null,
+    prable ? thread.id : undefined,
   );
 
   // Sync polled PR state back to the workspace store so the project tree
@@ -149,7 +152,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
     <div className="flex items-center justify-between gap-0.5">
       {dirPath && (
         <div className="flex items-center gap-0.5 bg-muted/20 rounded-md px-1 py-0.5">
-          {shouldPollPr && (
+          {prable && (
             <PrSplitButton
               pr={pr}
               hasCommitsAhead={hasCommitsAhead}
@@ -240,7 +243,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
         </TooltipContent>
       </Tooltip>
 
-      {shouldPollPr && (
+      {prable && (
         <CreatePrDialog
           open={createPrOpen}
           onOpenChange={setCreatePrOpen}

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -427,6 +427,7 @@ describe("ProjectTree action-required indicator", () => {
     currentThread = makeThread({
       id: "thread-pending",
       status: "active",
+      mode: "worktree",
       pr_number: 42,
       pr_status: "open",
     });
@@ -447,6 +448,7 @@ describe("ProjectTree action-required indicator", () => {
     currentThread = makeThread({
       id: "thread-pending",
       status: "active",
+      mode: "worktree",
       pr_number: 42,
       pr_status: "open",
     });
@@ -473,6 +475,7 @@ describe("ProjectTree action-required indicator", () => {
     currentThread = {
       ...makeThread({
         id: "thread-pending",
+        mode: "worktree",
         pr_number: 42,
         pr_status: "open",
       }),
@@ -503,5 +506,78 @@ describe("ProjectTree action-required indicator", () => {
 
     const chip = screen.getByLabelText("0 of 1 checks done");
     expect(chip.className).not.toContain("opacity-[0.72]");
+  });
+});
+
+describe("ProjectTree PR-ability gating by mode", () => {
+  function renderWithThread(
+    thread: Thread,
+    checks: Record<string, { aggregate: string; runs: unknown[] }> = {},
+  ) {
+    vi.mocked(useWorkspaceStore).mockImplementation(
+      ((selector: (s: unknown) => unknown) =>
+        selector({
+          workspaces: [WORKSPACE],
+          activeWorkspaceId: "ws-1",
+          activeThreadId: null,
+          threads: [thread],
+          checksById: checks,
+          loadWorkspaces: vi.fn(),
+          loadThreads: vi.fn(),
+          setActiveWorkspace: vi.fn(),
+          setActiveThread: vi.fn(),
+          createWorkspace: vi.fn(),
+          deleteWorkspace: vi.fn(),
+          deleteThread: vi.fn(),
+          setPendingNewThread: vi.fn(),
+          updateThreadTitle: vi.fn(),
+          loadWorktrees: vi.fn(),
+          worktrees: [],
+          worktreesLoadedForWorkspace: null,
+          error: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        })) as any,
+    );
+    return render(<ProjectTree />);
+  }
+
+  beforeEach(() => {
+    threadStoreOverrides.permissionsByThread = undefined;
+    threadStoreOverrides.runningThreadIds = undefined;
+    window.localStorage.setItem("mcode-expanded-projects", JSON.stringify({ "ws-1": true }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("renders no PR icon for a direct-mode thread even when a pr_number is attached", () => {
+    renderWithThread(makeThread({ mode: "direct", pr_number: 42, pr_status: "open" }));
+    expect(screen.queryByTitle(/PR #42/)).toBeNull();
+  });
+
+  it("renders the PR icon and number badge for a worktree thread with a pr_number", () => {
+    renderWithThread(makeThread({ mode: "worktree", pr_number: 42, pr_status: "open" }));
+    expect(screen.getByTitle(/PR #42/)).toBeInTheDocument();
+    expect(screen.getByText("#42")).toBeInTheDocument();
+  });
+
+  it("renders the merged PR visual for a worktree thread", () => {
+    renderWithThread(makeThread({ mode: "worktree", pr_number: 42, pr_status: "merged" }));
+    expect(screen.getByTitle(/PR #42 \u2013 merged/)).toBeInTheDocument();
+  });
+
+  it("hides the CI chip for a direct-mode thread even when checks are present", () => {
+    renderWithThread(
+      makeThread({ mode: "direct", pr_number: 42, pr_status: "open" }),
+      {
+        "thread-1": {
+          aggregate: "pending",
+          runs: [{ name: "build", status: "in_progress", conclusion: null }],
+        },
+      },
+    );
+    expect(screen.queryByLabelText(/checks done/i)).toBeNull();
   });
 });

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -32,6 +32,7 @@ import { Switch } from "@/components/ui/switch";
 import { relativeTime } from "@/lib/time";
 import { schedulePrefetch, cancelPrefetch } from "@/lib/thread-hydrator/prefetch-scheduler";
 import { getStatusDisplay, getNotificationDot } from "@/lib/thread-status";
+import { isPrable } from "@/lib/is-prable";
 import { getBreakdown, getCiVisual, CI_ICON_STROKE } from "@/lib/ci-status";
 import type { ChecksStatus } from "@mcode/contracts";
 import type { Workspace, Thread } from "@/transport/types";
@@ -1150,6 +1151,10 @@ function VirtualizedThreadList({
         const { thread, depth } = treeItems[virtualItem.index];
         const status = getStatusDisplay(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
         const isEditing = inlineEdit?.threadId === thread.id;
+        // Only PR-able (worktree) threads surface PR affordances. A direct-mode
+        // thread shows its branch/agent status, never a PR icon, even if a PR
+        // number happens to be attached.
+        const prable = isPrable(thread);
         // Worktree thread whose directory no longer exists on disk.
         // Only check threads from the workspace whose worktrees are loaded — comparing
         // against a different workspace's worktree list would produce false positives.
@@ -1220,7 +1225,7 @@ function VirtualizedThreadList({
                     scaffoldDim,
                   )}
                 >
-                {thread.pr_number != null ? (() => {
+                {prable && thread.pr_number != null ? (() => {
                   const { Icon: PrIcon, color: prColor } = getPrVisual(thread.pr_status);
                   const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
                   // Only the agent signal lives on the PR icon — a top-right dot.
@@ -1308,7 +1313,7 @@ function VirtualizedThreadList({
                   </Tooltip>
                 )}
                 </div>
-                {!isEditing && thread.pr_number != null && checksById[thread.id] && (
+                {!isEditing && prable && thread.pr_number != null && checksById[thread.id] && (
                   <CiChip checks={checksById[thread.id]} />
                 )}
                 {!isEditing && (
@@ -1318,7 +1323,7 @@ function VirtualizedThreadList({
                       scaffoldDim,
                     )}
                   >
-                    {thread.pr_number != null && (
+                    {prable && thread.pr_number != null && (
                       <span className="mr-1 opacity-80">#{thread.pr_number}</span>
                     )}
                     {relativeTime(thread.updated_at)}

--- a/apps/web/src/lib/__tests__/is-prable.test.ts
+++ b/apps/web/src/lib/__tests__/is-prable.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { isPrable } from "../is-prable";
+
+describe("isPrable", () => {
+  it("returns true for a worktree-mode thread", () => {
+    expect(isPrable({ mode: "worktree" })).toBe(true);
+  });
+
+  it("returns false for a direct-mode thread", () => {
+    expect(isPrable({ mode: "direct" })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/is-prable.ts
+++ b/apps/web/src/lib/is-prable.ts
@@ -1,0 +1,14 @@
+import type { Thread } from "@/transport";
+
+/**
+ * Returns whether a thread can have a pull request through this app.
+ *
+ * A thread is PR-able only when it runs in an isolated worktree. Direct-mode
+ * (local) threads run against the workspace's main checkout and are never
+ * PR-able: there is nothing to open a pull request from. This is the single
+ * source of truth shared by the sidebar thread list and the chat header so the
+ * two surfaces can never disagree about whether to show PR affordances.
+ */
+export function isPrable(thread: Pick<Thread, "mode">): boolean {
+  return thread.mode === "worktree";
+}


### PR DESCRIPTION
## What
Local (direct-mode) threads no longer surface pull-request affordances. The thread-row PR icon, the chat header's "Create PR" button and dialog, and the background PR/commits-ahead polling are all gated behind a single mode-based predicate. Worktree threads are unchanged.

## Why
A direct-mode thread runs against the workspace's main checkout - there is nothing to open a pull request from (you cannot PR `main` into `main`). The old gate was also brittle and inconsistent: the chat header hid PR actions with a hardcoded `main`/`master` name check (wrong for repos whose default branch is `develop`/`trunk`), while the thread-row PR icon had no default-branch guard at all and appeared whenever a `pr_number` was attached. This unifies the rule in one place so the sidebar and header can never disagree.

## Key Changes
- Add `isPrable(thread)` predicate (`apps/web/src/lib/is-prable.ts`): `true` only when `thread.mode === "worktree"`. Single source of truth shared by both surfaces.
- `HeaderActions`: replace the `branch !== "main" && branch !== "master"` gate with `isPrable(thread)`, driving the PR split button, the create-PR dialog, and both polling hooks. Direct-mode threads neither render PR UI nor poll GitHub.
- `ProjectTree`: gate the PR icon, CI chip, and `#N` badge behind `isPrable(thread)`. Direct-mode threads show their branch/agent status dot even when a `pr_number` is attached; worktree threads keep the icon, merged/closed visuals, CI chip, and badge.
- Add the "PR-able thread" entry to the `CONTEXT.md` glossary.
- Tests: new `isPrable` unit test plus mode-gating coverage in `HeaderActions` and `ProjectTree` (31 tests, all green).

## Config Changes
None. No contract, schema, or migration change - keys off the existing `Thread.mode` field.

Closes #588

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783515909&installation_id=129163861&pr_number=591&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F591&signature=0e6b1b4c5e2c5f1d62fe54447ded544b83e3e6c6c71a07daf140ac88313213ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request features including creation buttons, PR status icons, and related UI elements now correctly gate visibility based on thread type, ensuring these options only display for compatible thread modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->