### PR TITLE
feat(server): skip DB write for empty turns via TurnSubstance predicate

### DIFF
--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -290,7 +290,11 @@ describe("AgentService narrative persistence", () => {
   it("persists late hooks (arriving after persistTurn) attached to the last message id", async () => {
     const { providerEmitter, hookBulk } = build();
 
-    // Emit TurnComplete first to simulate the SDK result arriving before hooks.
+    // The turn must have substance so TurnFinalizer materializes an assistant
+    // row to attach the late hook to (#578: empty turns leave no row). A streamed
+    // body satisfies the TurnSubstance predicate.
+    providerEmitter.emit("event", { type: AgentEventType.TextDelta, threadId: THREAD_ID, delta: "Done." });
+    // Emit TurnComplete to simulate the SDK result arriving before hooks.
     providerEmitter.emit("event", {
       type: AgentEventType.TurnComplete,
       threadId: THREAD_ID,
@@ -330,6 +334,42 @@ describe("AgentService narrative persistence", () => {
     expect(lateHooks[0].messageId).toBe(MSG_ID);
     expect(lateHooks[0].phase).toBe("stop");
     expect(lateHooks[0].durationMs).toBe(42);
+  });
+
+  it("discards a late hook when the turn produced no recordable activity (no row to attach)", async () => {
+    const { providerEmitter, hookBulk } = build();
+
+    // A fully empty turn: no body, tool call, narration, or hook before finalize.
+    // The TurnSubstance predicate is false, so no assistant row is materialized
+    // (#578) and the finalizer records no last-persisted message id.
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: THREAD_ID,
+      tokensIn: 0,
+      tokensOut: 0,
+      contextWindow: 0,
+    });
+
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    // A late Stop hook now arrives but has nothing to attach to, so it is dropped.
+    providerEmitter.emit("event", {
+      type: AgentEventType.HookStarted,
+      threadId: THREAD_ID,
+      hookName: "Stop",
+      hookType: "stop",
+    });
+    providerEmitter.emit("event", {
+      type: AgentEventType.HookCompleted,
+      threadId: THREAD_ID,
+      hookName: "Stop",
+      exitCode: 0,
+      durationMs: 42,
+      didBlock: false,
+    });
+
+    expect(hookBulk).not.toHaveBeenCalled();
   });
 
   it("marks a non-final thought as isFinalResponse when its text equals the assistant message body", async () => {

--- a/apps/server/src/services/__tests__/turn-finalizer.test.ts
+++ b/apps/server/src/services/__tests__/turn-finalizer.test.ts
@@ -142,9 +142,11 @@ describe("TurnFinalizer.finalize — turn outcome → tool-call status", () => {
     expect(toolRepo.listByMessage("m2")[0].status).toBe("cancelled");
   });
 
-  it("discards the buffered turn when no assistant row exists (precondition)", async () => {
-    // Only a user message — a pre-turn failure. Persisting would target the
-    // wrong (user) row, so the turn is discarded instead.
+  it("materializes an assistant row for a buffered tool call when no Message event fired", async () => {
+    // A turn that buffered a tool call but never emitted a provider Message
+    // (interrupted before the final body). hasRecordableActivity holds on the
+    // tool call, so finalize synthesizes the assistant row the tool attaches to
+    // rather than discarding the turn.
     insertMessage(db, "u1", "user", "do the thing", 1);
     narrativeStore.beginTurn(THREAD);
     narrativeStore.resetTurnCounters(THREAD);
@@ -152,8 +154,65 @@ describe("TurnFinalizer.finalize — turn outcome → tool-call status", () => {
 
     await finalizer.finalize(THREAD, "errored");
 
-    expect(toolRepo.listByMessage("u1")).toHaveLength(0);
+    const { messages } = new MessageRepo(db).listByThread(THREAD, 10);
+    const assistant = messages.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    const tools = toolRepo.listByMessage(assistant!.id);
+    expect(tools).toHaveLength(1);
+    expect(tools[0].status).toBe("failed");
+  });
+
+  it("leaves no assistant row and broadcasts nothing for a fully empty turn", async () => {
+    // The genuine pre-turn / no-output case: no tool, body, narration, or hook.
+    // hasRecordableActivity is false, so finalize writes nothing.
+    insertMessage(db, "u1", "user", "do the thing", 1);
+    narrativeStore.beginTurn(THREAD);
+    narrativeStore.resetTurnCounters(THREAD);
+
+    await finalizer.finalize(THREAD, "errored");
+
+    const { messages } = new MessageRepo(db).listByThread(THREAD, 10);
+    expect(messages.some((m) => m.role === "assistant")).toBe(false);
     expect(broadcast).not.toHaveBeenCalledWith("turn.persisted", expect.anything());
+  });
+
+  it("clears the last-persisted message id on an empty turn so a late hook can't attach to the prior turn", async () => {
+    // Turn 1 produces a body and records a persisted id late hooks attach to.
+    insertMessage(db, "u1", "user", "go", 1);
+    narrativeStore.beginTurn(THREAD);
+    narrativeStore.resetTurnCounters(THREAD);
+    finalizer.bufferAssistantBody(THREAD, "the answer", "claude-sonnet-4-6");
+    await finalizer.finalize(THREAD, "completed");
+    expect(finalizer.getLastPersistedMessageId(THREAD)).toBeDefined();
+
+    // Turn 2 is fully empty. Its finalize must drop turn 1's id so a late hook
+    // for turn 2 is discarded rather than mis-attached to turn 1's message.
+    narrativeStore.beginTurn(THREAD);
+    narrativeStore.resetTurnCounters(THREAD);
+    await finalizer.finalize(THREAD, "completed");
+
+    expect(finalizer.getLastPersistedMessageId(THREAD)).toBeUndefined();
+  });
+
+  it("materializes the buffered provider body into exactly one assistant row", async () => {
+    // The normal completed path: the provider body is buffered (not written on
+    // the Message event), then materialized once at finalize.
+    insertMessage(db, "u1", "user", "go", 1);
+    narrativeStore.beginTurn(THREAD);
+    narrativeStore.resetTurnCounters(THREAD);
+    const expectedId = finalizer.bufferAssistantBody(THREAD, "the final answer", "claude-sonnet-4-6");
+
+    await finalizer.finalize(THREAD, "completed");
+
+    const { messages } = new MessageRepo(db).listByThread(THREAD, 10);
+    const assistantRows = messages.filter((m) => m.role === "assistant");
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0].id).toBe(expectedId);
+    expect(assistantRows[0].content).toBe("the final answer");
+    expect(broadcast).toHaveBeenCalledWith("turn.persisted", expect.objectContaining({
+      threadId: THREAD,
+      messageId: expectedId,
+    }));
   });
 
   it("flushes interrupted streaming text into a new assistant row that tool calls attach to", async () => {
@@ -230,6 +289,89 @@ describe("TurnFinalizer.finalize — turn outcome → tool-call status", () => {
 });
 
 /**
+ * TurnSubstance predicate: hasRecordableActivity decides whether a turn is
+ * worth a persisted assistant row. Each contributor is exercised in isolation
+ * over the real-DB harness so the buffers are seeded the same way a live turn
+ * seeds them.
+ */
+describe("TurnFinalizer.hasRecordableActivity — TurnSubstance predicate", () => {
+  let db: Database.Database;
+  let narrativeStore: NarrativeStore;
+  let finalizer: TurnFinalizer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = openMemoryDatabase();
+    seedThread(db);
+    const messageRepo = new MessageRepo(db);
+    narrativeStore = new NarrativeStore(
+      messageRepo,
+      new ToolCallRecordRepo(db),
+      new ThoughtSegmentRepo(db),
+      new HookExecutionRepo(db),
+    );
+    const threadRepo = {
+      findById: vi.fn(() => ({ id: THREAD, model: "claude-sonnet-4-6" })),
+    } as unknown as ThreadRepo;
+    const snapshotService = {
+      captureRef: vi.fn(),
+      getFilesChanged: vi.fn(),
+    } as unknown as SnapshotService;
+    const turnSnapshotRepo = { create: vi.fn() } as unknown as TurnSnapshotRepo;
+    finalizer = new TurnFinalizer(
+      messageRepo,
+      threadRepo,
+      narrativeStore,
+      snapshotService,
+      turnSnapshotRepo,
+      db,
+    );
+    narrativeStore.beginTurn(THREAD);
+    narrativeStore.resetTurnCounters(THREAD);
+  });
+
+  it("is true when only a tool call is buffered", () => {
+    narrativeStore.bufferToolCall(THREAD, { toolCallId: "tc-1", toolName: "Read", toolInput: {} });
+
+    expect(finalizer.hasRecordableActivity(THREAD)).toBe(true);
+  });
+
+  it("is true when only a non-empty assistant body is buffered", () => {
+    finalizer.bufferAssistantBody(THREAD, "here is the answer", "claude-sonnet-4-6");
+
+    expect(finalizer.hasRecordableActivity(THREAD)).toBe(true);
+  });
+
+  it("is true when only a narration segment is buffered", () => {
+    narrativeStore.openOrExtendThought(THREAD, "let me think about this");
+
+    expect(finalizer.hasRecordableActivity(THREAD)).toBe(true);
+  });
+
+  it("is true when only a hook is buffered", () => {
+    narrativeStore.openHook(THREAD, {
+      hookName: "PreToolUse",
+      toolName: "Bash",
+      phase: "pre",
+      payload: "{}",
+      sortOrder: 0,
+    });
+
+    expect(finalizer.hasRecordableActivity(THREAD)).toBe(true);
+  });
+
+  it("is false for a fully empty turn (no tool, body, narration, or hook)", () => {
+    expect(finalizer.hasRecordableActivity(THREAD)).toBe(false);
+  });
+
+  it("treats a whitespace-only assistant body as no body", () => {
+    finalizer.bufferAssistantBody(THREAD, "   \n  ", null);
+
+    expect(finalizer.hasRecordableActivity(THREAD)).toBe(false);
+  });
+});
+
+/**
  * Snapshot-write seam, retargeted from the former AgentService.persistTurn
  * tests onto the public finalize interface. Uses spies on db / snapshotService
  * / turnSnapshotRepo to assert the git turn_snapshot write and the
@@ -247,6 +389,7 @@ describe("TurnFinalizer.finalize — git snapshot write", () => {
     const threadRepo = { findById: vi.fn(() => ({ model: null })) } as unknown as ThreadRepo;
     const narrativeStore = {
       getBufferedToolCalls: vi.fn(() => []),
+      hasBufferedNarrative: vi.fn(() => true),
       persistNarrative: vi.fn(() => ({ toolCallCount: 0 })),
       clearTurn: vi.fn(),
     } as unknown as NarrativeStore;

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1191,30 +1191,24 @@ export class AgentService {
 
         if (event.type === AgentEventType.Message) {
           try {
-            const { messages: existing } = this.messageRepo.listByThread(event.threadId, 1);
-            const nextSeq =
-              existing.length > 0
-                ? existing[existing.length - 1].sequence + 1
-                : 1;
             // Record the thread's active model on the message so the UI can
             // display which provider/model produced the response, even if the
             // user later switches model mid-conversation.
             const thread = this.threadRepo.findById(event.threadId);
             const modelForMessage = thread?.model ?? null;
-            const msg = this.messageRepo.create(
+            // Buffer the body behind the finalize seam instead of writing it
+            // eagerly. TurnFinalizer.finalize materializes the row only when the
+            // TurnSubstance predicate holds, so a turn that produced no tool call,
+            // body, narration, or hook leaves no assistant row (#578).
+            const messageId = this.turnFinalizer.bufferAssistantBody(
               event.threadId,
-              "assistant",
               event.content,
-              nextSeq,
-              undefined,
-              undefined,
-              undefined,
               modelForMessage,
             );
-            // Carry the persisted message ID so the broadcast schema passes it
+            // Carry the deterministic message ID so the broadcast schema passes it
             // through to the client. The client uses it for stable message identity
             // (branching, dedup across Electron's dual MessagePort+WebSocket channels).
-            event.messageId = msg.id;
+            event.messageId = messageId;
             // Carry the model too so the client's locally-built Message can
             // show the model name in the footer immediately — without it the
             // footer renders without the model until a thread refresh re-fetches
@@ -1234,10 +1228,17 @@ export class AgentService {
 
           // Persist any pending plan-output extracted from streamed text deltas.
           // Guarded on event.messageId so it only runs when the assistant message
-          // was successfully persisted above.
+          // was successfully buffered above.
           const pendingPlan = this.pendingPlanOutputs.get(event.threadId);
           const pendingExitPlan = this.pendingExitPlanMarkdown.get(event.threadId);
           const hadOutputParser = this.planOutputParsers.has(event.threadId);
+          // plans.message_id is a NOT NULL FK to messages.id, so the assistant
+          // row must exist before persistPlanRecord runs. The body is otherwise
+          // buffered until TurnFinalizer.finalize; materialize it eagerly here so
+          // the FK target is present (materializeAssistantRow is idempotent).
+          if ((pendingPlan || pendingExitPlan || hadOutputParser) && event.messageId) {
+            this.turnFinalizer.materializeAssistantRow(event.threadId);
+          }
           if (pendingPlan && event.messageId) {
             this.pendingPlanOutputs.delete(event.threadId);
             this.planOutputParsers.delete(event.threadId);

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -402,6 +402,21 @@ export class NarrativeStore {
   }
 
   /**
+   * True when the current turn has buffered at least one narrative contributor —
+   * a tool call, a narration segment (open or closed), or a hook (open or
+   * closed). Feeds the {@link TurnFinalizer.hasRecordableActivity} predicate so
+   * a turn with narrative but no assistant body still earns a persisted row.
+   */
+  hasBufferedNarrative(threadId: string): boolean {
+    if ((this.turnToolCalls.get(threadId)?.length ?? 0) > 0) return true;
+    if (this.turnOpenThought.get(threadId)) return true;
+    if ((this.turnThoughts.get(threadId)?.length ?? 0) > 0) return true;
+    if ((this.turnOpenHooks.get(threadId)?.size ?? 0) > 0) return true;
+    if ((this.turnHooks.get(threadId)?.length ?? 0) > 0) return true;
+    return false;
+  }
+
+  /**
    * Record an in-flight hook execution (HookStarted). The caller supplies the
    * already-allocated sort order (the late-hook path in AgentService allocates
    * it before deciding routing). Returns the generated row id.

--- a/apps/server/src/services/turn-finalizer.ts
+++ b/apps/server/src/services/turn-finalizer.ts
@@ -36,6 +36,12 @@ interface TurnRef {
   cwd: string;
 }
 
+/** Provider assistant body buffered during a turn, materialized at finalize. */
+interface BufferedBody {
+  content: string;
+  model: string | null;
+}
+
 /**
  * Derive the deterministic id for a turn's synthesized assistant message from
  * the turn's anchor — the id of the message immediately preceding the assistant
@@ -62,6 +68,10 @@ export class TurnFinalizer {
   private readonly lastPersistedMessageIdByThread = new Map<string, string>();
   /** Streaming assistant text accumulated from textDelta events, per thread. */
   private readonly streamingAssistantTextByThread = new Map<string, string>();
+  /** Buffered provider assistant body awaiting materialization at finalize, per thread. */
+  private readonly bufferedBodyByThread = new Map<string, BufferedBody>();
+  /** Threads whose assistant row was already materialized this turn (e.g. eagerly for a plan FK). */
+  private readonly materializedThreads = new Set<string>();
 
   constructor(
     private readonly messageRepo: MessageRepo,
@@ -83,6 +93,20 @@ export class TurnFinalizer {
     this.streamingAssistantTextByThread.delete(threadId);
   }
 
+  /**
+   * Buffer the provider's assistant body for the current turn instead of
+   * writing the row immediately. The row is materialized at {@link finalize}
+   * (or eagerly via {@link materializeAssistantRow} when a plan record needs
+   * the foreign-key target) only when {@link hasRecordableActivity} holds, so an
+   * empty turn leaves no hollow row. Returns the deterministic id the row will
+   * take, so callers can carry it on the broadcast and plan-output paths before
+   * the row exists.
+   */
+  bufferAssistantBody(threadId: string, content: string, model: string | null): string {
+    this.bufferedBodyByThread.set(threadId, { content, model });
+    return deriveTurnAssistantMessageId(threadId, this.turnAnchorId(threadId));
+  }
+
   /** Record the pre-turn git ref so the turn's file changes can be diffed at finalize. */
   recordTurnRef(threadId: string, ref: string, cwd: string): void {
     this.turnRefBefore.set(threadId, { ref, cwd });
@@ -94,39 +118,76 @@ export class TurnFinalizer {
   }
 
   /**
+   * TurnSubstance predicate: is this turn worth a persisted assistant row?
+   * True when any single contributor is present — a buffered tool call, a
+   * non-empty assistant body, a narration segment, or a hook. A fully empty
+   * turn returns false so {@link finalize} leaves no hollow assistant row.
+   */
+  hasRecordableActivity(threadId: string): boolean {
+    // An already-materialized row (e.g. eagerly written for a plan FK target)
+    // is itself recordable activity even after its buffered body was consumed.
+    if (this.materializedThreads.has(threadId)) return true;
+    if (this.hasBufferedBody(threadId)) return true;
+    return this.narrativeStore.hasBufferedNarrative(threadId);
+  }
+
+  /** True when a non-empty assistant body is buffered (provider body or streaming text). */
+  private hasBufferedBody(threadId: string): boolean {
+    const body = this.bufferedBodyByThread.get(threadId)?.content.trim();
+    if (body) return true;
+    const streamed = this.streamingAssistantTextByThread.get(threadId)?.trim();
+    return Boolean(streamed);
+  }
+
+  /**
+   * Resolve the anchor id the turn's synthesized assistant row keys on — the id
+   * of the message immediately preceding the assistant turn (normally the user
+   * message), or a positional `seq:N` fallback for an empty thread. Stable
+   * across buffer time and finalize because no message is inserted between them
+   * until the row itself materializes.
+   */
+  private turnAnchorId(threadId: string): string {
+    const { messages } = this.messageRepo.listByThread(threadId, 1);
+    const last = messages.length > 0 ? messages[messages.length - 1] : null;
+    return last ? last.id : `seq:1`;
+  }
+
+  /**
    * End the turn for `threadId` with the given {@link TurnOutcome}. Runs the
    * fixed finalize order and is a no-op if a finalize is already in flight for
-   * the thread (so retry/reconnect replay is safe to lean on). When no assistant
-   * row exists for the turn the buffered narrative is discarded rather than
-   * persisted against the wrong (user) message id.
+   * the thread (so retry/reconnect replay is safe to lean on).
+   *
+   * The assistant row is materialized here, not on the provider `Message` event:
+   * a turn with no recordable activity ({@link hasRecordableActivity} false)
+   * writes no row and broadcasts nothing, so an empty turn leaves the thread
+   * uncluttered. Otherwise the buffered body (or interrupted streaming text) is
+   * written behind {@link materializeAssistantRow} and the narrative persists
+   * against it.
    */
   async finalize(threadId: string, outcome: TurnOutcome): Promise<void> {
     if (this.persistingThreads.has(threadId)) return;
     this.persistingThreads.add(threadId);
     try {
-      // Flush partial assistant text first so any tool rows attach to the
-      // assistant message rather than the preceding user row.
-      this.flushInterruptedAssistantMessage(threadId);
-
-      const bufferedCount = this.narrativeStore.getBufferedToolCalls(threadId).length;
-      const { messages } = this.messageRepo.listByThread(threadId, 1);
-      const lastMessage = messages[messages.length - 1];
-
-      // Persist only against an assistant row. A turn that never produced one
-      // (e.g. a pre-turn CLI-not-found error, or a stop before any output)
-      // would otherwise broadcast turn.persisted with the wrong message id.
-      if (!lastMessage || lastMessage.role !== "assistant") {
-        if (bufferedCount > 0) {
-          logger.warn("Discarded buffered tool calls: no assistant message for turn", {
-            threadId,
-            toolCallCount: bufferedCount,
-          });
-        }
+      // TurnSubstance guard: nothing worth keeping → leave no assistant row.
+      if (!this.hasRecordableActivity(threadId)) {
+        // This turn persisted no row, so a late hook for it must be discarded
+        // rather than mis-attached to the previous turn's still-cached id.
+        this.lastPersistedMessageIdByThread.delete(threadId);
         this.clearTurn(threadId);
         return;
       }
 
-      const messageId = lastMessage.id;
+      const materialized = this.materializeAssistantRow(threadId);
+      if (!materialized) {
+        // The row write failed; discard rather than persist narrative against
+        // the wrong (preceding) message id. Drop the prior id for the same
+        // reason as the empty-turn branch: a late hook has no row to attach to.
+        this.lastPersistedMessageIdByThread.delete(threadId);
+        this.clearTurn(threadId);
+        return;
+      }
+
+      const messageId = materialized.id;
       // Record the message id so late hooks (Stop/SessionEnd) arriving after
       // this point can attach to the correct persisted row.
       this.lastPersistedMessageIdByThread.set(threadId, messageId);
@@ -134,7 +195,7 @@ export class TurnFinalizer {
       const { toolCallCount } = this.narrativeStore.persistNarrative(
         threadId,
         messageId,
-        lastMessage.content ?? "",
+        materialized.content,
         outcome,
       );
 
@@ -197,54 +258,68 @@ export class TurnFinalizer {
   }
 
   /**
-   * Write accumulated streaming assistant text to SQLite when a turn ends
-   * without a provider-issued `message` row (for example a user stop before
-   * the provider's result). Broadcasts `agent.event` so clients align their
-   * in-memory transcripts with the DB. A no-op when text is empty or an
-   * assistant row already exists.
+   * Materialize the turn's assistant row and return its id and stored body.
+   *
+   * The single writer for the turn's assistant message. Reuses an existing
+   * assistant row when one is already last (e.g. a plan turn that eagerly
+   * materialized for its foreign-key target). Otherwise writes the buffered
+   * provider body, or — when the turn was interrupted before the provider
+   * emitted a `Message` — the accumulated streaming text. The deterministic
+   * per-turn id makes a replayed write an `INSERT OR IGNORE` no-op.
+   *
+   * For the interrupted streaming-text path it also broadcasts `agent.event` so
+   * clients align their in-memory transcript with the new DB row; the provider
+   * body path needs no broadcast because the `Message` event already carried
+   * this id to the client. Returns null only when the write throws.
    */
-  private flushInterruptedAssistantMessage(threadId: string): void {
-    const raw = this.streamingAssistantTextByThread.get(threadId);
-    const text = raw?.trim();
-    if (!text) {
-      this.streamingAssistantTextByThread.delete(threadId);
-      return;
-    }
-
+  materializeAssistantRow(threadId: string): { id: string; content: string } | null {
     const { messages } = this.messageRepo.listByThread(threadId, 1);
     const last = messages.length > 0 ? messages[messages.length - 1] : null;
     if (last?.role === "assistant") {
       this.streamingAssistantTextByThread.delete(threadId);
-      return;
+      this.bufferedBodyByThread.delete(threadId);
+      this.materializedThreads.add(threadId);
+      return { id: last.id, content: last.content ?? "" };
     }
 
+    const buffered = this.bufferedBodyByThread.get(threadId);
+    const streamed = this.streamingAssistantTextByThread.get(threadId)?.trim();
+    // Provider body wins (may be empty for a tools-only turn); fall back to the
+    // interrupted streaming text. The streaming-text path is the only one that
+    // broadcasts, since no provider Message event reached the client.
+    const fromProvider = buffered != null;
+    const content = fromProvider ? buffered.content : (streamed ?? "");
+    const model = fromProvider ? buffered.model : (this.threadRepo.findById(threadId)?.model ?? null);
+
     const nextSeq = last ? last.sequence + 1 : 1;
+    const anchorId = last ? last.id : `seq:${nextSeq}`;
     try {
-      const thread = this.threadRepo.findById(threadId);
-      const modelForMessage = thread?.model ?? null;
-      // Anchor the deterministic id on the preceding user message so a replayed
-      // flush for the same turn lands on the same row (insert-or-ignore no-op).
-      const anchorId = last ? last.id : `seq:${nextSeq}`;
       const msg = this.messageRepo.createAssistantIdempotent({
         id: deriveTurnAssistantMessageId(threadId, anchorId),
         threadId,
-        content: text,
+        content,
         sequence: nextSeq,
-        model: modelForMessage,
+        model,
       });
       this.streamingAssistantTextByThread.delete(threadId);
-      broadcast("agent.event", {
-        type: AgentEventType.Message,
-        threadId,
-        content: text,
-        tokens: null,
-        messageId: msg.id,
-      } satisfies AgentEvent);
+      this.bufferedBodyByThread.delete(threadId);
+      this.materializedThreads.add(threadId);
+      if (!fromProvider && content) {
+        broadcast("agent.event", {
+          type: AgentEventType.Message,
+          threadId,
+          content,
+          tokens: null,
+          messageId: msg.id,
+        } satisfies AgentEvent);
+      }
+      return { id: msg.id, content };
     } catch (err) {
-      logger.error("Failed to persist interrupted assistant message", {
+      logger.error("Failed to materialize assistant message", {
         threadId,
         error: err instanceof Error ? err.message : String(err),
       });
+      return null;
     }
   }
 
@@ -255,6 +330,9 @@ export class TurnFinalizer {
    */
   private clearTurn(threadId: string): void {
     this.turnRefBefore.delete(threadId);
+    this.streamingAssistantTextByThread.delete(threadId);
+    this.bufferedBodyByThread.delete(threadId);
+    this.materializedThreads.delete(threadId);
     this.narrativeStore.clearTurn(threadId);
     this.persistingThreads.delete(threadId);
   }


### PR DESCRIPTION
## What

Gate assistant-row persistence on a **TurnSubstance** predicate so empty turns leave no DB row.

## Why

A turn that produces no tool call, body, narration, or hook previously still wrote a hollow assistant row and broadcast `turn.persisted`. #578 makes "no recordable activity" a first-class contract: such turns persist nothing and broadcast nothing, keeping threads uncluttered.

## Key changes

- **`turn-finalizer.ts`** — `bufferAssistantBody` buffers the provider body (returning the deterministic row id synchronously) instead of writing eagerly. `hasRecordableActivity` decides whether the turn earns a row. `finalize` materializes exactly one row via `materializeAssistantRow` only when the predicate holds; otherwise it clears the turn with no row and no broadcast.
- **`agent-service.ts`** — the provider `Message` handler now buffers the body. The plan-output path eagerly materializes the row first because `plans.message_id` is a NOT NULL FK; `materializeAssistantRow` is idempotent and the `materializedThreads` flag keeps the predicate true after the buffered body is consumed.
- **`narrative-store.ts`** — new `hasBufferedNarrative` feeding the predicate (tool call / narration / hook).
- **Late-hook fix (bundled)** — `lastPersistedMessageIdByThread` is now cleared on the empty-turn and materialize-failure paths, so a late Stop/SessionEnd hook for a turn that persisted no row is discarded rather than mis-attached to the previous turn's message.

### Behavioral contract changes

1. A turn that buffered a tool call but never emitted a `Message` now **materializes** an assistant row (any buffered tool call is recordable), rather than being discarded.
2. A fully empty turn leaves **no row**, so a late hook for it is dropped.

Both are covered by updated/added tests.

## Test plan

- [x] `bun run verify` — typecheck + lint + tests, 5/5 packages, 1221 server tests green
- [x] New `TurnFinalizer.hasRecordableActivity` predicate tests (per-contributor + empty + whitespace body)
- [x] New regression test: empty turn N+1 resets `getLastPersistedMessageId` so a late hook can't attach to turn N
- [x] No user-facing UI changes (epic confirmed) — no Playwright run

Closes #578

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783523146&installation_id=129163861&pr_number=592&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F592&signature=f3cc716d63937f1a6019a78b7f87d22ac5f7f69b230458df5325ae216ec0cf9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for turn finalization and narrative persistence workflows to ensure proper handling of edge cases and improve reliability.

* **Refactor**
  * Internal improvements to assistant message buffering and turn materialization logic to streamline state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->