### PR TITLE
fix(queue): prevent /goal control commands from corrupting running-state mid-turn

### DIFF
--- a/apps/server/src/commands/__tests__/goal-command.test.ts
+++ b/apps/server/src/commands/__tests__/goal-command.test.ts
@@ -156,10 +156,12 @@ describe("GoalCommand", () => {
         "ship the feature",
       );
 
-      // The composer clears its optimistic running state on Ended.
+      // The reply renders via the Message event. No synthetic Ended: control
+      // commands never start a turn, so emitting Ended would clear the running
+      // state of a real turn in flight (issue #583).
       const events = broadcastEvents();
       expect(events.some((e) => e.type === AgentEventType.Message)).toBe(true);
-      expect(events.some((e) => e.type === AgentEventType.Ended)).toBe(true);
+      expect(events.some((e) => e.type === AgentEventType.Ended)).toBe(false);
     });
 
     it("reports no active goal when none is set", () => {
@@ -178,7 +180,7 @@ describe("GoalCommand", () => {
   });
 
   describe("CLEAR form", () => {
-    it("clears the goal, persists a confirmation pill, and emits Ended", () => {
+    it("clears the goal and persists a confirmation pill without emitting Ended", () => {
       const provider = fakeGoalCapableProvider();
       const cmd = build();
 
@@ -192,8 +194,11 @@ describe("GoalCommand", () => {
         /Goal cleared/,
       );
 
+      // The reply renders via Message; no Ended (issue #583) so a real turn in
+      // flight keeps its running-state.
       const events = broadcastEvents();
-      expect(events.some((e) => e.type === AgentEventType.Ended)).toBe(true);
+      expect(events.some((e) => e.type === AgentEventType.Message)).toBe(true);
+      expect(events.some((e) => e.type === AgentEventType.Ended)).toBe(false);
     });
   });
 });

--- a/apps/server/src/commands/goal-command.ts
+++ b/apps/server/src/commands/goal-command.ts
@@ -102,8 +102,14 @@ export class GoalCommand implements McodeCommand {
 
   /**
    * Persist the user message and a synthetic confirmation pill in one
-   * transaction, then broadcast the pill and an Ended event. Ended clears the
-   * composer's optimistic running state since no provider call ran.
+   * transaction, then broadcast the pill as a Message event.
+   *
+   * No Ended event is emitted: a control command never starts a provider turn,
+   * so it must not touch turn running-state. Emitting Ended here would clear the
+   * client's running-state for a real turn already in flight (the composer keys
+   * `isAgentRunning` on it), which breaks message-queue coordination (#583). The
+   * client mirror skips the optimistic running-state for control commands, so
+   * there is nothing for an Ended to clear in the idle case either.
    */
   private persistControlReply(threadId: string, userText: string, replyText: string): void {
     const { messages: existing } = this.deps.messageRepo.listByThread(threadId, 1);
@@ -121,10 +127,6 @@ export class GoalCommand implements McodeCommand {
       content: replyText,
       tokens: null,
       messageId: assistantMsgId,
-    } satisfies AgentEvent);
-    this.broadcast("agent.event", {
-      type: AgentEventType.Ended,
-      threadId,
     } satisfies AgentEvent);
   }
 }

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -204,7 +204,7 @@ describe("AgentService.sendMessage — /goal command", () => {
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
   });
 
-  it("/goal clear short-circuits — clears the goal, does NOT invoke the provider, emits Ended", async () => {
+  it("/goal clear short-circuits — clears the goal, does NOT invoke the provider, broadcasts a Message pill without Ended", async () => {
     const { svc, providerStub, messageRepo } = buildService(db);
 
     await svc.sendMessage(
@@ -225,13 +225,21 @@ describe("AgentService.sendMessage — /goal command", () => {
     const assistantMsg = messages.find((m) => m.role === "assistant");
     expect(assistantMsg?.content).toMatch(/Goal cleared/);
 
-    // The composer relies on Ended to clear its optimistic running state —
-    // without this broadcast the UI hangs on "thinking" forever.
-    const endedEvents = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+    // The confirmation renders via a Message event. No Ended (#583): a control
+    // command never starts a turn, so emitting Ended would clear the running
+    // state of a real turn in flight and break queue coordination. The client
+    // mirrors this by never marking the thread running for control commands.
+    const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const messageEvents = calls.filter(
+      ([channel, payload]) =>
+        channel === "agent.event" && (payload as { type?: string }).type === AgentEventType.Message,
+    );
+    const endedEvents = calls.filter(
       ([channel, payload]) =>
         channel === "agent.event" && (payload as { type?: string }).type === AgentEventType.Ended,
     );
-    expect(endedEvents.length).toBeGreaterThanOrEqual(1);
+    expect(messageEvents.length).toBeGreaterThanOrEqual(1);
+    expect(endedEvents.length).toBe(0);
   });
 
   it("/goal (no args) reports active goal without invoking the provider", async () => {

--- a/apps/web/e2e/goal-clear-bypass-queue.spec.ts
+++ b/apps/web/e2e/goal-clear-bypass-queue.spec.ts
@@ -159,6 +159,55 @@ test.describe("/goal control commands bypass the composer queue", () => {
     expect(await readQueueLength(page, THREAD.id)).toBe(0);
   });
 
+  test("a normal message still enqueues after a `/goal clear` is sent mid-turn", async ({
+    page,
+  }) => {
+    // AC2 (#583): issuing a control command mid-turn must not disturb queue
+    // coordination. After `/goal clear` bypasses the queue, the thread is still
+    // running, so the next normal message must enqueue (not slip out directly
+    // and collide with the live turn).
+    const sentMessages: string[] = [];
+    await mockWebSocketServer(page, {
+      "workspace.enrich": { items: [] },
+      "settings.get": MOCK_SETTINGS,
+      "provider.listModels": () => [
+        { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", group: "Claude" },
+      ],
+      "agent.send": (params?: unknown) => {
+        const p = params as { content?: string } | undefined;
+        if (typeof p?.content === "string") sentMessages.push(p.content);
+        return { ok: true };
+      },
+    });
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean })
+          .__mcodeHydrationComplete === true,
+    );
+    await setupChat(page, true);
+    await page.waitForSelector('[contenteditable="true"]', { timeout: 30_000 });
+
+    const editor = page.locator('[contenteditable="true"]').first();
+    await editor.click();
+    await editor.fill("/goal clear");
+    await page.keyboard.press("Enter");
+
+    await expect.poll(() => sentMessages, { timeout: 5_000 }).toContain(
+      "/goal clear",
+    );
+
+    await editor.click();
+    await page.keyboard.type("now ship the feature");
+    await page.keyboard.press("Enter");
+
+    await expect.poll(() => readQueueLength(page, THREAD.id), { timeout: 5_000 })
+      .toBe(1);
+    expect(sentMessages).not.toContain("now ship the feature");
+  });
+
   test("non-control messages still enqueue while the agent is running", async ({
     page,
   }) => {

--- a/apps/web/src/__tests__/goal-control-running-state.test.ts
+++ b/apps/web/src/__tests__/goal-control-running-state.test.ts
@@ -1,0 +1,58 @@
+import {
+  resetThreadStoreForTests,
+} from "@/stores/thread-store-test-utils";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useThreadStore } from "@/stores/threadStore";
+import { mockTransport } from "./mocks/transport";
+import { clearRecordCache } from "@/lib/thread-hydrator/record-cache";
+
+vi.mock("@/transport", async () => ({
+  ...(await vi.importActual("@/transport")),
+  getTransport: () => mockTransport,
+}));
+
+/**
+ * Regression coverage for issue #583: `/goal` control commands must not
+ * participate in turn running-state. A control command never starts a
+ * provider turn, so sending one must neither mark an idle thread running
+ * nor (on send failure) clear the running-state of a real turn already in
+ * flight. Pairing: the server drops the synthetic `Ended` for control forms
+ * (see goal-command.test.ts) so the in-flight turn's running-state survives.
+ */
+describe("issue #583 — /goal control commands and running-state", () => {
+  beforeEach(() => {
+    clearRecordCache();
+    resetThreadStoreForTests({ runningThreadIds: new Set(), currentThreadId: null });
+    vi.clearAllMocks();
+  });
+
+  it("does not mark an idle thread running when a /goal control command is sent", async () => {
+    const threadId = "thread-1";
+
+    await useThreadStore.getState().sendMessage(threadId, "/goal show");
+
+    expect(useThreadStore.getState().runningThreadIds.has(threadId)).toBe(false);
+  });
+
+  it("still marks the thread running for the /goal SET form (it starts a turn)", async () => {
+    const threadId = "thread-1";
+
+    await useThreadStore.getState().sendMessage(threadId, "/goal ship the feature");
+
+    expect(useThreadStore.getState().runningThreadIds.has(threadId)).toBe(true);
+  });
+
+  it("leaves a real in-flight turn running when a control-command send fails", async () => {
+    const threadId = "thread-1";
+    useThreadStore.setState({ runningThreadIds: new Set([threadId]) });
+    (
+      mockTransport.sendMessage as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("spawn failed"));
+
+    await useThreadStore.getState().sendMessage(threadId, "/goal clear");
+
+    // The rollback must not clobber the running turn the control command
+    // was issued against.
+    expect(useThreadStore.getState().runningThreadIds.has(threadId)).toBe(true);
+  });
+});

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -22,6 +22,7 @@ import {
 import { shallowEqualBy } from "@/lib/shallowEqualBy";
 import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
 import { releaseBrowserCaptureSpills } from "@/lib/browser-capture-spill";
+import { isGoalControlCommand } from "@/lib/goal-command";
 import {
   createThreadHydrator,
   registerThreadHydrator,
@@ -618,6 +619,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   sendMessage: async (threadId, content, model, permissionMode, attachments, displayContent, reasoningLevel, provider, copilotAgent, contextWindow, thinking, codexFastMode, replyToMessageId, quotedText, planAction) => {
     evictCachedRecord(threadId);
 
+    // A `/goal` control form (show/clear/reset/bare) never starts a provider
+    // turn - the server services it synchronously and returns. It must not
+    // touch turn running-state: marking an idle thread running would strand it
+    // (no Ended clears it, by design - see goal-command.ts), and on send
+    // failure the rollback below must not clear the running-state of a real
+    // turn the control command was issued against mid-flight (#583).
+    const isControlCommand = isGoalControlCommand(content);
+
     // Add user message to local state immediately (optimistic)
     // Use displayContent for the UI (without injected file blocks) if provided
     const userMessage: Message = {
@@ -682,7 +691,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           apiRetry: undefined,
           error: null,
         }),
-        runningThreadIds: new Set([...state.runningThreadIds, threadId]),
+        runningThreadIds: isControlCommand
+          ? state.runningThreadIds
+          : new Set([...state.runningThreadIds, threadId]),
       };
     });
 
@@ -711,8 +722,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         usePlanStore.getState().setGenerating(threadId, false);
       }
       set((state) => {
+        // Control commands never added the thread to running-state, so leave it
+        // untouched on rollback - a real turn in flight may own it (#583).
         const next = new Set(state.runningThreadIds);
-        next.delete(threadId);
+        if (!isControlCommand) next.delete(threadId);
         return {
           records: patchThreadRecord(state.records, threadId, {
             error: String(e),


### PR DESCRIPTION
## What

`/goal` control forms (`show` / `clear` / `reset` / bare `/goal`) no longer participate in turn running-state lifecycle on either the server or the client.

## Why

A control command never starts a provider turn, yet both sides treated it as if it did:
- The server broadcast a synthetic `Ended` event alongside the confirmation pill.
- The client optimistically added the thread to `runningThreadIds`.

Issued **mid-turn**, the synthetic `Ended` deleted the thread from `runningThreadIds` while the real turn was still running (the client's `session.ended` handler clears running-state). That flipped `isAgentRunning` to `false` prematurely, so the next normal message bypassed the queue guard and collided with the live turn (#583).

## Key changes

- **Server** (`goal-command.ts`): `persistControlReply` drops the `Ended` broadcast. The pill still renders via the `Message` event - `Ended` only ever existed to clear the client's optimistic running-state, and never drained the queue.
- **Client** (`threadStore.ts`): `sendMessage` detects control forms via `isGoalControlCommand` and skips both the optimistic `runningThreadIds` add and the rollback delete, so a real turn in flight keeps its running-state.
- **Predicate parity**: the client `isGoalControlCommand` matches the server `isControl` rule exactly (case-insensitive `"" | show | clear | reset`, whitespace-tolerant).

Control commands still **bypass** the queue (queueing them reintroduces the #475 deadlock where a queued `/goal clear` waits forever for a turn the goal-gate blocks). The SET form (`/goal <condition>`) still queues normally because it starts a real turn.

## Test coverage

- **Server unit** (`goal-command.test.ts`, `agent-service-goal-command.test.ts`): assert the control reply broadcasts a `Message` and **no** `Ended`. These distinguish fixed vs. unfixed code.
- **Client unit** (new `goal-control-running-state.test.ts`): idle control command does not mark running; SET form still marks running; a failed control-command send leaves a real in-flight turn running. The idle + rollback cases distinguish fixed vs. unfixed code.
- **E2E** (`goal-clear-bypass-queue.spec.ts`): extended with AC2/AC3 - a normal message still enqueues after a mid-turn `/goal clear`. Note: the WS server is mocked so this is an acceptance-level check (it does not by itself fail against unfixed client code); the unit tests provide the tight regression guard.
- `bun run verify` passes (typecheck + lint + 1211 server tests + client tests).

## Notes

- A mid-turn control command still runs `resetTurnEphemeral` (`threadStore.ts:685`), wiping the live turn's tool-calls/thought-segments from the UI. This is **pre-existing and unchanged** by this fix; it is owned by follow-up spike #593.

## Related issues/PRs

- Closes #583
- Relates to #593 (spike: control-plane vs chat data-plane for `/goal`)
- Relates to #475 (the original `/goal clear` deadlock this fix preserves the bypass for)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783524541&installation_id=129163861&pr_number=594&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F594&signature=4ede34296ffaf2d1dfbf8d709b5709522cc1ceddc2c23ba854554888aaf1ac30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue `#583`: Goal control commands (`/goal show`, `/goal clear`, `/goal reset`) no longer incorrectly affect thread running state or interfere with in-flight conversations.
  * Control commands now emit only message events without clearing composer state.

* **Tests**
  * Added regression tests for goal control command behavior and queue handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->