### PR TITLE
feat(server): auto-retry transient turn failures and hide session handoffs

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -373,7 +373,25 @@ for (const provider of providerRegistry.resolveAll()) {
       }
     }
 
+    // Hide failed-attempt teardown (`Ended`, `TurnComplete`) so the UI's running
+    // state survives the retry window instead of flashing blank before the fresh
+    // attempt streams (see AgentService.endedSuppressionThreads).
+    if (
+      (event.type === AgentEventType.Ended &&
+        agentService.shouldSuppressTurnEnded(event.threadId)) ||
+      (event.type === AgentEventType.TurnComplete &&
+        agentService.shouldSuppressTurnComplete(event.threadId))
+    ) {
+      return;
+    }
+
     if (event.type === AgentEventType.Error) {
+      // Hide a transient failure that AgentService is about to retry, so the user
+      // never sees the swallowed flake. The gate only suppresses transient
+      // signatures inside an active retry window; fatal errors still broadcast.
+      if (agentService.shouldSuppressTransientTurnError(event.threadId, event.error ?? "")) {
+        return;
+      }
       const threadMeta = threadRepo.findById(event.threadId);
       const providerForThread =
         typeof threadMeta?.provider === "string" && threadMeta.provider.length > 0

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -14,6 +14,7 @@ import { AgentEventType, isVirtualBrowserContextAttachment } from "@mcode/contra
 import type {
   IAgentProvider,
   IGoalCapable,
+  ISessionEvictable,
   TurnRequest,
   ProviderId,
   ReasoningLevel,
@@ -294,7 +295,7 @@ interface PendingSpawnTurn {
 
 /** Claude Agent SDK adapter implementing IAgentProvider with prompt queue pattern. */
 @injectable()
-export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoalCapable, ProtocolAdapter<ClaudeSessionState> {
+export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoalCapable, ISessionEvictable, ProtocolAdapter<ClaudeSessionState> {
   readonly id: ProviderId = "claude";
   /** Claude supports one-shot text completion via sdkQuery with maxTurns: 1. */
   readonly supportsCompletion = true;
@@ -331,6 +332,19 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
    * torn down immediately so the agent never starts.
    */
   private pendingStops = new Set<string>();
+  /**
+   * SDK query handles whose stream teardown must not emit `Ended`. Populated
+   * when a live session is intentionally superseded (spawn-param mismatch,
+   * setModel failure) before `runtime.stop` deletes the pool entry — the
+   * stream loop's finally block can then outlive the session map lookup.
+   */
+  private readonly suppressEndedQueries = new Set<Query>();
+  /**
+   * Threads whose next `SessionStart` hook should be hidden. Set when a
+   * context-window or permission-mode change forces an internal session
+   * recreation so the handoff stays invisible in the narrative timeline.
+   */
+  private readonly suppressSessionStartHooks = new Set<string>();
   /** Threads currently in plan-answer mode. ExitPlanMode is only captured for these. */
   private planAnswerThreads = new Set<string>();
   /** Pending permission requests awaiting user decision, keyed by requestId. */
@@ -880,6 +894,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       });
       // Suppress the teardown's Ended emit; the fresh session takes over the id.
       existing.suppressEnded = true;
+      this.suppressEndedQueries.add(existing.query);
+      this.suppressSessionStartHooks.add(tid);
       await this.runtime.stop(sessionId);
     }
 
@@ -911,6 +927,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
           // teardown Ended and fall through to the fresh-spawn path with a
           // resume:false stage so the new subprocess starts a clean session.
           existing.suppressEnded = true;
+          this.suppressEndedQueries.add(existing.query);
+          this.suppressSessionStartHooks.add(tid);
           await this.runtime.stop(sessionId);
           return this.doSendMessage({ ...params, resume: false });
         }
@@ -1838,10 +1856,17 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
                   errorStatus: (anyMsg.error_status as number | undefined) ?? undefined,
                 } satisfies AgentEvent);
               } else if ((anyMsg.subtype as string) === "hook_started") {
+                const hookName = (anyMsg.hook_name as string) || "unknown";
+                if (
+                  hookName.startsWith("SessionStart") &&
+                  this.suppressSessionStartHooks.has(threadId)
+                ) {
+                  break;
+                }
                 this.emit("event", {
                   type: AgentEventType.HookStarted,
                   threadId,
-                  hookName: (anyMsg.hook_name as string) || "unknown",
+                  hookName,
                   hookType: anyMsg.tool_name ? "permission" : "stop",
                   ...(anyMsg.tool_name ? { toolName: anyMsg.tool_name as string } : {}),
                 } satisfies AgentEvent);
@@ -1853,10 +1878,18 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
                   output: (anyMsg.output as string) || "",
                 } satisfies AgentEvent);
               } else if ((anyMsg.subtype as string) === "hook_response") {
+                const hookName = (anyMsg.hook_name as string) || "unknown";
+                if (
+                  hookName.startsWith("SessionStart") &&
+                  this.suppressSessionStartHooks.has(threadId)
+                ) {
+                  this.suppressSessionStartHooks.delete(threadId);
+                  break;
+                }
                 this.emit("event", {
                   type: AgentEventType.HookCompleted,
                   threadId,
-                  hookName: (anyMsg.hook_name as string) || "unknown",
+                  hookName,
                   exitCode: (anyMsg.exit_code as number) ?? 1,
                   durationMs: (anyMsg.duration_ms as number) ?? 0,
                   didBlock: (anyMsg.did_block as boolean) ?? false,
@@ -2094,16 +2127,30 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
         }
       } finally {
         this.recentStderr.delete(sessionId);
+        const wasSuppressedQuery = this.suppressEndedQueries.has(q);
+        this.suppressEndedQueries.delete(q);
         const current = this.runtime.get(sessionId);
+        const superseded = current !== undefined && current.query !== q;
         if (current?.query === q) {
           // The SDK subprocess has exited; drop the dead session from the pool.
           // `runtime.stop` also best-effort taskkills the (already-gone) PIDs,
           // which is harmless. Fire-and-forget: the stream loop is unwinding.
           void this.runtime.stop(sessionId);
+          // Clear any stale SessionStart suppression: if the recreated session
+          // had a SessionStart hook it already self-cleared on hook_response; if
+          // it had none, the flag would otherwise outlive this pooled session and
+          // suppress a legitimately-configured SessionStart on the next resume.
+          this.suppressSessionStartHooks.delete(threadId);
         }
         logger.info("Session stream ended", { sessionId });
         this.emit(`_streamDone:${sessionId}`);
-        if (!suppressEnded && !current?.suppressEnded && (!current || current.query === q)) {
+        if (
+          !suppressEnded &&
+          !wasSuppressedQuery &&
+          !superseded &&
+          !current?.suppressEnded &&
+          (!current || current.query === q)
+        ) {
           this.emit("event", {
             type: AgentEventType.Ended,
             threadId,
@@ -2235,6 +2282,19 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       // error, client disconnect, etc.) so the set doesn't leak.
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
     }
+  }
+
+  /**
+   * Force-discard the pooled session so the next sendTurn spawns fresh. Pure
+   * pool eviction via the runtime's `stop` (interrupt → close → hard kill); it
+   * deliberately leaves goals and pending permissions intact, since the caller
+   * retries the same turn on a new session.
+   */
+  discardSession(sessionId: string): void {
+    if (this.runtime.get(sessionId) === undefined) return;
+    void this.runtime.stop(sessionId).catch((err: unknown) => {
+      logger.warn("Claude discardSession failed", { sessionId, error: String(err) });
+    });
   }
 
   /**

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -21,6 +21,7 @@ import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/ses
 import { DeterministicForker } from "../../services/handoff/session-forker.js";
 import type {
   IAgentProvider,
+  ISessionEvictable,
   SessionForker,
   TurnRequest,
   ProviderId,
@@ -149,7 +150,7 @@ function toCodexEffort(level?: ReasoningLevel): ReasoningEffort | undefined {
 
 /** Codex provider adapter implementing IAgentProvider with a persistent app-server process per session. */
 @injectable()
-export class CodexProvider extends EventEmitter implements IAgentProvider, ProtocolAdapter<CodexSessionState> {
+export class CodexProvider extends EventEmitter implements IAgentProvider, ISessionEvictable, ProtocolAdapter<CodexSessionState> {
   readonly id: ProviderId = "codex";
   /** Codex CLI is an agentic tool with no one-shot text completion mode. */
   readonly supportsCompletion = false;
@@ -731,6 +732,18 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, Proto
       this.pendingSpawnTurns.delete(sessionId);
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
     }
+  }
+
+  /**
+   * Force-discard the pooled session so the next sendTurn spawns fresh. Pure
+   * pool eviction via the runtime's `stop` (interrupt → close → hard kill),
+   * leaving goals and pending permissions intact for the retry turn.
+   */
+  discardSession(sessionId: string): void {
+    if (this.runtime.get(sessionId) === undefined) return;
+    void this.runtime.stop(sessionId).catch((err: unknown) => {
+      logger.warn("Codex discardSession failed", { sessionId, error: String(err) });
+    });
   }
 
   /** Tears down all sessions, drains pending permissions, and stops the eviction timer. */

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -36,6 +36,7 @@ import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/ses
 import { DeterministicForker } from "../../services/handoff/session-forker.js";
 import type {
   IAgentProvider,
+  ISessionEvictable,
   SessionForker,
   TurnRequest,
   ProviderId,
@@ -157,7 +158,7 @@ interface CopilotSessionState {
 
 /** GitHub Copilot SDK adapter implementing IAgentProvider with callback-based event mapping. */
 @injectable()
-export class CopilotProvider extends EventEmitter implements IAgentProvider, ProtocolAdapter<CopilotSessionState> {
+export class CopilotProvider extends EventEmitter implements IAgentProvider, ISessionEvictable, ProtocolAdapter<CopilotSessionState> {
   readonly id: ProviderId = "copilot";
   readonly supportsCompletion = true;
   readonly sessionForkOnResume = "unsupported" as const;
@@ -1142,6 +1143,18 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, Pro
       this.pendingSpawnTurns.delete(sessionId);
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
     }
+  }
+
+  /**
+   * Force-discard the pooled session so the next sendTurn spawns fresh. Pure
+   * pool eviction via the runtime's `stop` (interrupt → close → hard kill),
+   * leaving goals and pending permissions intact for the retry turn.
+   */
+  discardSession(sessionId: string): void {
+    if (this.runtime.get(sessionId) === undefined) return;
+    void this.runtime.stop(sessionId).catch((err: unknown) =>
+      logger.warn("CopilotProvider: discardSession failed", { sessionId, error: String(err) }),
+    );
   }
 
   /** Tear down all sessions, stop the client, and release resources. */

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -44,6 +44,7 @@ import type {
   AttachmentMeta,
   AgentEvent,
   IAgentProvider,
+  ISessionEvictable,
   TurnRequest,
   PermissionDecision,
   PermissionRequest,
@@ -178,7 +179,7 @@ type CursorSessionState = CursorAcpSessionEntry;
 @injectable()
 export class CursorProvider
   extends EventEmitter
-  implements IAgentProvider, ProtocolAdapter<CursorSessionState>
+  implements IAgentProvider, ISessionEvictable, ProtocolAdapter<CursorSessionState>
 {
   readonly id: ProviderId = "cursor";
   readonly supportsCompletion = false;
@@ -341,6 +342,19 @@ export class CursorProvider
       this.pendingStops.add(sessionId);
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
     }
+  }
+
+  /**
+   * Force-discard the pooled session so the next sendTurn spawns fresh. Unlike
+   * {@link stopSession} — which keeps a warm ACP session pooled and only issues
+   * a graceful cancel — this tears the runtime down (interrupt → close → hard
+   * kill), so a stale ACP connection is replaced rather than reused on retry.
+   */
+  discardSession(sessionId: string): void {
+    if (this.runtime.get(sessionId) === undefined) return;
+    void this.runtime.stop(sessionId).catch((err: unknown) => {
+      logger.warn("Cursor discardSession failed", { sessionId, error: String(err) });
+    });
   }
 
 

--- a/apps/server/src/services/__tests__/agent-service-transient-retry.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-transient-retry.test.ts
@@ -1,0 +1,464 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+import type { Thread, IProviderRegistry, TurnRequest } from "@mcode/contracts";
+import { AgentService } from "../agent-service.js";
+import { NarrativeStore } from "../narrative-store.js";
+import { PlanQuestionService } from "../plan-question-service.js";
+import type { ThreadRepo } from "../../repositories/thread-repo.js";
+import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import type { MessageRepo } from "../../repositories/message-repo.js";
+import type { GitService } from "../git-service.js";
+import type { AttachmentService } from "../attachment-service.js";
+import type { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
+import type { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo.js";
+import type { SnapshotService } from "../snapshot-service.js";
+import type { MemoryPressureService } from "../memory-pressure-service.js";
+import type { TaskRepo } from "../../repositories/task-repo.js";
+import type { SettingsService } from "../settings-service.js";
+import type { ThreadService } from "../thread-service.js";
+import type { ProviderAvailabilityService } from "../provider-availability-service.js";
+import type { PlanQuestionAnswersRepo } from "../../repositories/plan-question-answers-repo.js";
+
+vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    statSync: vi.fn(() => ({ isDirectory: () => true })),
+  };
+});
+
+const THREAD_ID = "thread-retry-test";
+
+/** Thread fixture that resumes a live SDK session, so the first attempt sends `resumeFrom`. */
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: THREAD_ID,
+    workspace_id: "ws-1",
+    title: "Test thread",
+    status: "idle",
+    mode: "direct",
+    branch: "main",
+    worktree_path: null,
+    model: "claude-sonnet-4-6",
+    provider: "claude",
+    sdk_session_id: "sess-abc",
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    copilot_agent: null,
+    last_compact_summary: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    deleted_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as Thread;
+}
+
+/** Build an AgentService over a fake provider whose `sendTurn` the test scripts per attempt. */
+function buildService(): {
+  service: AgentService;
+  sendTurn: ReturnType<typeof vi.fn>;
+  discardSession: ReturnType<typeof vi.fn>;
+  waitForSessionExit: ReturnType<typeof vi.fn>;
+  providerEmitter: EventEmitter;
+  threadRepo: ThreadRepo & { clearSdkSessionId: ReturnType<typeof vi.fn>; updateStatus: ReturnType<typeof vi.fn> };
+} {
+  const thread = makeThread();
+  const providerEmitter = new EventEmitter();
+  const sendTurn = vi.fn(() => Promise.resolve());
+  (providerEmitter as unknown as { sendTurn: typeof sendTurn }).sendTurn = sendTurn;
+  // Implementing discardSession makes the fake provider ISessionEvictable, so
+  // the retry path force-evicts the pooled session before re-dispatch.
+  const discardSession = vi.fn();
+  const waitForSessionExit = vi.fn().mockResolvedValue(undefined);
+  (providerEmitter as unknown as { discardSession: typeof discardSession }).discardSession = discardSession;
+  (providerEmitter as unknown as { waitForSessionExit: typeof waitForSessionExit }).waitForSessionExit =
+    waitForSessionExit;
+
+  const threadRepo = {
+    findById: vi.fn(() => thread),
+    updateStatus: vi.fn(),
+    updateModel: vi.fn(),
+    updateProvider: vi.fn(),
+    updateSettings: vi.fn(),
+    create: vi.fn(),
+    softDelete: vi.fn(),
+    updateWorktreePath: vi.fn(),
+    updateContextUsage: vi.fn(),
+    updateSdkSessionId: vi.fn(),
+    clearSdkSessionId: vi.fn(),
+    updateCompactSummary: vi.fn(),
+    updateLineage: vi.fn(),
+  } as unknown as ThreadRepo & { clearSdkSessionId: ReturnType<typeof vi.fn>; updateStatus: ReturnType<typeof vi.fn> };
+
+  const workspaceRepo = {
+    findById: vi.fn(() => ({ id: "ws-1", path: "/workspace" })),
+  } as unknown as WorkspaceRepo;
+
+  // A prior message means nextSeq > 1, so the first attempt is a resume.
+  const messageRepo = {
+    listByThread: vi.fn(() => ({ messages: [{ id: "m0", sequence: 1, role: "user", content: "prev" }] })),
+    create: vi.fn(() => ({ id: "msg-1", sequence: 2 })),
+    findByIdInThread: vi.fn(),
+    listByThreadUpToSequence: vi.fn(() => []),
+  } as unknown as MessageRepo;
+
+  const gitService = {
+    resolveWorkingDir: vi.fn(() => "/workspace"),
+    listWorktrees: vi.fn(() => []),
+  } as unknown as GitService;
+
+  const attachmentService = {
+    persist: vi.fn(() => Promise.resolve({ stored: [], persisted: [] })),
+  } as unknown as AttachmentService;
+
+  const providerRegistry = {
+    resolve: vi.fn(() => providerEmitter),
+    resolveAll: vi.fn(() => [providerEmitter]),
+    shutdown: vi.fn(),
+  } as unknown as IProviderRegistry;
+
+  const threadService = { create: vi.fn() } as unknown as ThreadService;
+  const toolCallRecordRepo = { bulkCreate: vi.fn() } as unknown as ToolCallRecordRepo;
+  const turnSnapshotRepo = {
+    listByThread: vi.fn(() => []),
+    create: vi.fn(),
+  } as unknown as TurnSnapshotRepo;
+  const snapshotService = {
+    captureRef: vi.fn(() => Promise.resolve("abc123")),
+    getFilesChanged: vi.fn(() => Promise.resolve([])),
+  } as unknown as SnapshotService;
+  const memoryPressureService = {
+    markActive: vi.fn(),
+    markIdle: vi.fn(),
+  } as unknown as MemoryPressureService;
+  const taskRepo = { get: vi.fn(() => []), upsert: vi.fn() } as unknown as TaskRepo;
+  const settingsService = {
+    get: vi.fn(() => ({
+      model: { defaults: { fallbackId: undefined } },
+      agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
+      provider: { enabled: {}, cli: {} },
+    })),
+    on: vi.fn(),
+  } as unknown as SettingsService;
+  const availability = { assertUsable: vi.fn() } as unknown as ProviderAvailabilityService;
+  const planQuestionAnswersRepo = {
+    markAnswered: vi.fn(),
+    isAnswered: vi.fn(() => false),
+    listAnsweredForThread: vi.fn(() => []),
+  } as unknown as PlanQuestionAnswersRepo;
+  const db = {
+    transaction: vi.fn((fn: (...args: unknown[]) => unknown) => fn),
+    prepare: vi.fn(() => ({ run: vi.fn() })),
+  } as unknown as import("better-sqlite3").Database;
+
+  const service = new AgentService(
+    threadRepo,
+    workspaceRepo,
+    messageRepo,
+    gitService,
+    attachmentService,
+    providerRegistry,
+    threadService,
+    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    turnSnapshotRepo,
+    snapshotService,
+    db,
+    memoryPressureService,
+    taskRepo,
+    settingsService,
+    availability,
+    planQuestionAnswersRepo,
+    { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+    { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as never,
+    { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as never,
+    new NarrativeStore(
+      messageRepo,
+      toolCallRecordRepo,
+      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    ),
+    new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
+  );
+
+  return { service, sendTurn, discardSession, waitForSessionExit, providerEmitter, threadRepo };
+}
+
+describe("AgentService transient-failure auto-retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retries a transient send failure once against a fresh session", async () => {
+    const { service, sendTurn, discardSession, threadRepo } = buildService();
+    service.init();
+    sendTurn
+      .mockRejectedValueOnce(new Error("read ECONNRESET"))
+      .mockResolvedValueOnce(undefined);
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    expect(sendTurn).toHaveBeenCalledTimes(2);
+    // First attempt resumes the live session; the retry must drop it for a fresh spawn.
+    expect((sendTurn.mock.calls[0][0] as TurnRequest).resumeFrom).toBe("sess-abc");
+    expect((sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom).toBeUndefined();
+    // Dropping resumeFrom is not enough: the provider pools a warm session by
+    // sessionName, so the retry must also force-evict it to truly spawn fresh.
+    expect(discardSession).toHaveBeenCalledWith(`mcode-${THREAD_ID}`);
+    expect(threadRepo.clearSdkSessionId).toHaveBeenCalledWith(THREAD_ID);
+    expect(threadRepo.updateStatus).not.toHaveBeenCalledWith(THREAD_ID, "errored");
+  });
+
+  it("does not retry a fatal send failure", async () => {
+    const { service, sendTurn, discardSession, threadRepo } = buildService();
+    service.init();
+    sendTurn.mockRejectedValue(new Error("permission denied"));
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+    expect(discardSession).not.toHaveBeenCalled();
+    expect(threadRepo.clearSdkSessionId).not.toHaveBeenCalled();
+    expect(threadRepo.updateStatus).toHaveBeenCalledWith(THREAD_ID, "errored");
+  });
+
+  it("hides the failed attempt's transient error from the UI but keeps a fatal error visible", async () => {
+    const { service, sendTurn, providerEmitter } = buildService();
+    service.init();
+
+    // Probe the suppression gate from inside the failing attempt — this is the
+    // window during which the provider emits its mid-attempt Error event.
+    let transientSuppressedDuringAttempt: boolean | undefined;
+    let fatalSuppressedDuringAttempt: boolean | undefined;
+    sendTurn
+      .mockImplementationOnce(() => {
+        transientSuppressedDuringAttempt = service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET");
+        fatalSuppressedDuringAttempt = service.shouldSuppressTransientTurnError(THREAD_ID, "permission denied");
+        return Promise.reject(new Error("read ECONNRESET"));
+      })
+      .mockResolvedValueOnce(undefined);
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    // During the retried attempt: a transient error is swallowed, a fatal one is not.
+    expect(transientSuppressedDuringAttempt).toBe(true);
+    expect(fatalSuppressedDuringAttempt).toBe(false);
+    // Fire-and-forget providers keep the window armed until TurnComplete.
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(true);
+    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
+  });
+
+  it("swallows the failed attempt's trailing Ended so the UI's running state survives the retry", async () => {
+    const { service, sendTurn, providerEmitter } = buildService();
+    service.init();
+
+    // Model the await-full-turn provider flow: stream, hit a mid-attempt
+    // transient error (emitted through the provider), then reject so the loop
+    // retries. The trailing `Ended` from that failed attempt must be armed for
+    // suppression so it never tears down the spinner before the retry streams.
+    let endedSuppressedDuringAttempt: boolean | undefined;
+    sendTurn
+      .mockImplementationOnce(() => {
+        providerEmitter.emit("event", {
+          type: "error",
+          threadId: THREAD_ID,
+          error: "read ECONNRESET",
+        });
+        endedSuppressedDuringAttempt = service.shouldSuppressTurnEnded(THREAD_ID);
+        return Promise.reject(new Error("read ECONNRESET"));
+      })
+      .mockResolvedValueOnce(undefined);
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    // The trailing Ended was armed for suppression during the failed attempt...
+    expect(endedSuppressedDuringAttempt).toBe(true);
+    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
+    expect(service.shouldSuppressTurnEnded(THREAD_ID)).toBe(false);
+  });
+
+  it("does not arm Ended suppression for a fatal error (the spinner tears down)", async () => {
+    const { service, sendTurn, providerEmitter } = buildService();
+    service.init();
+
+    let endedSuppressedDuringAttempt: boolean | undefined;
+    sendTurn.mockImplementationOnce(() => {
+      providerEmitter.emit("event", {
+        type: "error",
+        threadId: THREAD_ID,
+        error: "permission denied",
+      });
+      endedSuppressedDuringAttempt = service.shouldSuppressTurnEnded(THREAD_ID);
+      return Promise.reject(new Error("permission denied"));
+    });
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    // A fatal error is not part of a retry window, so its Ended must reach the UI.
+    expect(endedSuppressedDuringAttempt).toBe(false);
+    expect(service.shouldSuppressTurnEnded(THREAD_ID)).toBe(false);
+  });
+
+  it("disarms suppression before the final give-up so the error still reaches the UI", async () => {
+    const { service, sendTurn } = buildService();
+    service.init();
+    sendTurn.mockRejectedValue(new Error("read ECONNRESET"));
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    // Give-up disarms the retry window so the terminal error is visible.
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
+  });
+
+  it("swallows discardSession's trailing Ended when sendTurn rejects without emitting Error", async () => {
+    const { service, sendTurn, discardSession, waitForSessionExit, providerEmitter } = buildService();
+    service.init();
+
+    let endedSuppressedWhenDiscardUnwinds: boolean | undefined;
+    // Spawn-style failure: no provider Error, but discardSession unwinds a pooled
+    // subprocess and emits Ended on the next tick while the retry catch runs.
+    discardSession.mockImplementation(() => {
+      queueMicrotask(() => {
+        endedSuppressedWhenDiscardUnwinds = service.shouldSuppressTurnEnded(THREAD_ID);
+        providerEmitter.emit("event", { type: "ended", threadId: THREAD_ID });
+      });
+    });
+    waitForSessionExit.mockImplementation(async () => {
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+    });
+    sendTurn
+      .mockRejectedValueOnce(new Error("spawn claude EAGAIN"))
+      .mockResolvedValueOnce(undefined);
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    expect(discardSession).toHaveBeenCalledWith(`mcode-${THREAD_ID}`);
+    expect(waitForSessionExit).toHaveBeenCalledWith(`mcode-${THREAD_ID}`, 5000);
+    expect(endedSuppressedWhenDiscardUnwinds).toBe(true);
+    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
+    expect(service.shouldSuppressTurnEnded(THREAD_ID)).toBe(false);
+  });
+
+  it("does not suppress a bare Ended for a normal in-flight turn (no transient retry armed)", async () => {
+    const { service, sendTurn } = buildService();
+    service.init();
+
+    sendTurn.mockResolvedValueOnce(undefined);
+
+    await service.sendMessage(
+      THREAD_ID,
+      "hello",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "1m",
+    );
+
+    // A bare `Ended` with no in-flight transient retry means the stream
+    // genuinely ended; it must reach the cleanup path even though the
+    // fire-and-forget retry window is still armed. The superseded session's
+    // `Ended` during an internal recreation is suppressed at the provider
+    // layer, not here, so this gate stays narrow.
+    expect(service.shouldSuppressTurnEnded(THREAD_ID)).toBe(false);
+  });
+
+  it("disarms the retry window on a user stop so it can't re-dispatch or suppress later events", async () => {
+    const { service, sendTurn } = buildService();
+    service.init();
+    sendTurn.mockResolvedValueOnce(undefined);
+
+    // Fire-and-forget send leaves the retry window armed until TurnComplete.
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(true);
+
+    // A user stop ends the turn via finalize; it must tear down the armed
+    // window so a scheduled stream retry can't re-dispatch after the stop and
+    // the suppression flags don't outlive into the next turn.
+    await service.stopSession(THREAD_ID);
+
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
+  });
+
+  it("retries when sendTurn resolves early then a transient stream Error arrives", async () => {
+    const { service, sendTurn, providerEmitter } = buildService();
+    service.init();
+
+    sendTurn
+      .mockImplementationOnce(async () => {
+        // Fire-and-forget: resolve before the stream error.
+      })
+      .mockResolvedValueOnce(undefined);
+
+    const sendPromise = service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await sendPromise;
+
+    providerEmitter.emit("event", {
+      type: "error",
+      threadId: THREAD_ID,
+      error: "read ECONNRESET",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(sendTurn).toHaveBeenCalledTimes(2);
+    expect((sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom).toBeUndefined();
+  });
+
+  it("swallows a failed attempt's TurnComplete during the retry window", async () => {
+    const { service, sendTurn, providerEmitter } = buildService();
+    service.init();
+
+    let turnCompleteSuppressedDuringAttempt: boolean | undefined;
+    sendTurn
+      .mockImplementationOnce(() => {
+        providerEmitter.emit("event", {
+          type: "error",
+          threadId: THREAD_ID,
+          error: "read ECONNRESET",
+        });
+        providerEmitter.emit("event", {
+          type: "turnComplete",
+          threadId: THREAD_ID,
+          reason: "end_turn",
+          costUsd: null,
+          tokensIn: 0,
+          tokensOut: 0,
+        });
+        turnCompleteSuppressedDuringAttempt = service.shouldSuppressTurnComplete(THREAD_ID);
+        return Promise.reject(new Error("read ECONNRESET"));
+      })
+      .mockResolvedValueOnce(undefined);
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    expect(turnCompleteSuppressedDuringAttempt).toBe(true);
+    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
+    expect(service.shouldSuppressTurnComplete(THREAD_ID)).toBe(false);
+  });
+
+  it("stops retrying at the attempt cap when a transient signature keeps failing", async () => {
+    const { service, sendTurn, threadRepo } = buildService();
+    service.init();
+    sendTurn.mockRejectedValue(new Error("read ECONNRESET"));
+
+    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    // Cap is 2: one original attempt plus one retry, then it gives up.
+    expect(sendTurn).toHaveBeenCalledTimes(2);
+    expect(threadRepo.updateStatus).toHaveBeenCalledWith(THREAD_ID, "errored");
+  });
+});

--- a/apps/server/src/services/__tests__/turn-error-policy.test.ts
+++ b/apps/server/src/services/__tests__/turn-error-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { TurnErrorPolicy } from "../turn-error-policy.js";
+
+describe("TurnErrorPolicy.classify", () => {
+  const policy = new TurnErrorPolicy();
+
+  it("classifies an unrecognized error as fatal", () => {
+    expect(policy.classify(new Error("model refused: invalid request"))).toBe("fatal");
+  });
+
+  it("classifies a stale pooled session as transient", () => {
+    expect(policy.classify(new Error("ACP connection closed"))).toBe("transient");
+    expect(policy.classify(new Error("session invalidated"))).toBe("transient");
+  });
+
+  it("classifies a subprocess spawn race as transient", () => {
+    expect(policy.classify(new Error("spawn claude EAGAIN"))).toBe("transient");
+    expect(policy.classify(new Error("spawn codex ETXTBSY"))).toBe("transient");
+  });
+
+  it("keeps a missing-CLI spawn (ENOENT) fatal", () => {
+    expect(policy.classify(new Error("spawn claude ENOENT"))).toBe("fatal");
+  });
+
+  it("classifies a brief network blip as transient", () => {
+    expect(policy.classify(new Error("read ECONNRESET"))).toBe("transient");
+    expect(policy.classify(new Error("connect ETIMEDOUT 1.2.3.4:443"))).toBe("transient");
+    expect(policy.classify(new Error("socket hang up"))).toBe("transient");
+    expect(policy.classify(new Error("fetch failed"))).toBe("transient");
+  });
+
+  it("matches against a raw string error and never throws on nullish input", () => {
+    expect(policy.classify("read ECONNRESET")).toBe("transient");
+    expect(policy.classify("permission denied")).toBe("fatal");
+    expect(policy.classify(null)).toBe("fatal");
+    expect(policy.classify(undefined)).toBe("fatal");
+  });
+});
+
+describe("TurnErrorPolicy.shouldRetry", () => {
+  const policy = new TurnErrorPolicy();
+
+  it("retries a transient failure on the first attempt", () => {
+    expect(policy.shouldRetry(new Error("read ECONNRESET"), 1)).toBe(true);
+  });
+
+  it("never retries a fatal failure", () => {
+    expect(policy.shouldRetry(new Error("permission denied"), 1)).toBe(false);
+  });
+
+  it("stops retrying once the attempt cap is reached", () => {
+    const transient = new Error("read ECONNRESET");
+    expect(policy.shouldRetry(transient, 2)).toBe(false);
+    expect(policy.shouldRetry(transient, 3)).toBe(false);
+  });
+
+  it("honors a custom attempt cap", () => {
+    const noRetry = new TurnErrorPolicy(1);
+    expect(noRetry.shouldRetry(new Error("read ECONNRESET"), 1)).toBe(false);
+  });
+});

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -9,7 +9,7 @@ import { injectable, inject, delay } from "tsyringe";
 import { existsSync, statSync } from "fs";
 import { isAbsolute } from "path";
 import { logger } from "@mcode/shared";
-import { AgentEventType } from "@mcode/contracts";
+import { AgentEventType, isSessionEvictable } from "@mcode/contracts";
 import type {
   Thread,
   AttachmentMeta,
@@ -58,6 +58,7 @@ import { PlanRepo } from "../repositories/plan-repo";
 import { HandoffCoordinator } from "./handoff/handoff-coordinator.js";
 import { ScopedPreGrantService } from "./scoped-pre-grant.js";
 import { normalizeAgentProviderError } from "./provider-agent-error-normalize.js";
+import { TurnErrorPolicy } from "./turn-error-policy.js";
 
 /**
  * Escape special XML characters in a string to prevent injection into
@@ -107,6 +108,55 @@ export class AgentService {
    * {@link TurnFinalizer.finalize} from each turn-end path.
    */
   private readonly turnFinalizer: TurnFinalizer;
+  /**
+   * Classifies a failed send as transient or fatal and caps the automatic
+   * retry, so a brief flake doesn't cost the user a manual re-send while a
+   * misclassified fatal error can't loop.
+   */
+  private readonly turnErrorPolicy = new TurnErrorPolicy();
+  /**
+   * Threads with a transient-failure retry in flight. While a thread is armed,
+   * a transient `Error` event from the failed attempt is hidden from the UI (the
+   * broadcast in the composition root and the errored-finalize here both consult
+   * {@link shouldSuppressTransientTurnError}). The retry's fresh attempt then
+   * surfaces normally, so the user never sees the swallowed flake. Disarmed on
+   * success or just before the final-failure emit, so a give-up still shows.
+   */
+  private readonly retryingThreads = new Set<string>();
+  /**
+   * Threads whose failed-attempt teardown events (`Ended`, `TurnComplete`) must
+   * be swallowed during a transient retry. Without this the failed attempt would
+   * tear down the UI's running state (spinner off, partial stream committed)
+   * before the retry streams, producing a visible gap. Armed when a transient
+   * `Error` is suppressed and again at the start of each retry catch (before
+   * `discardSession`, which can emit a trailing `Ended` without a preceding
+   * `Error`). Consulted by {@link shouldSuppressTurnEnded} and
+   * {@link shouldSuppressTurnComplete}; cleared only after pooled-session
+   * eviction drains (or immediately when no session existed), on success, or on
+   * give-up so the retry's own terminal events still reach the UI.
+   */
+  private readonly endedSuppressionThreads = new Set<string>();
+  /**
+   * Per-thread dispatch state for transient retries. Fire-and-forget providers
+   * (Claude) can return from `sendTurn` before the stream ends, so the retry
+   * window must stay armed until `TurnComplete` and stream failures must be
+   * able to re-dispatch from the `Error` handler rather than only from the
+   * `sendTurn` catch.
+   */
+  private readonly turnRetryDispatchByThread = new Map<
+    string,
+    {
+      attempt: number;
+      retryInFlight: boolean;
+      /** False once the in-flight `sendTurn` promise has settled (success or throw). */
+      sendTurnInFlight: boolean;
+      sessionName: string;
+      resolvedProvider: import("@mcode/contracts").IAgentProvider;
+      effectiveProvider: ProviderId;
+      turnRequest: TurnRequest;
+      pendingGoalInstall: string | null;
+    }
+  >();
   /**
    * Threads whose `TurnComplete` event has already been processed but whose
    * finalize may still be in-flight or have already finished.
@@ -521,74 +571,70 @@ export class AgentService {
             ? { agent: effectiveCopilotAgent }
             : {};
 
-    try {
-      await resolvedProvider.sendTurn({
-        sessionId: sessionName,
-        threadId,
-        message: providerMessage,
-        cwd,
-        model: resolvedModel,
-        fallbackModel,
-        permissionMode,
-        interactionMode: effectiveInteractionMode ?? "build",
-        attachments: persisted.length > 0 ? persisted : undefined,
-        reasoningLevel,
-        ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
-        ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
-        resumeFrom,
-        providerOptions,
-      } as TurnRequest);
-      logger.info("Message sent via provider", {
-        threadId,
-        session: sessionName,
-        model: resolvedModel,
-      });
-    } catch (err) {
-      this.activeSessionIds.delete(threadId);
-      if (this.activeSessionIds.size === 0) {
-        this.memoryPressureService.markIdle();
-      }
-      // Roll the just-installed goal back so a failed send doesn't leave a
-      // hidden Stop-hook gate active on the next (possibly unrelated) turn.
-      // Only runs when we got past the deferred install above.
-      if (pendingGoalInstall !== null) {
-        try {
-          goalCommand.rollbackGoal(threadId);
-        } catch (clearErr) {
-          logger.warn("Failed to clear goal after failed send", {
-            threadId,
-            error: clearErr instanceof Error ? clearErr.message : String(clearErr),
-          });
-        }
-      }
-      const rawMessage = err instanceof Error ? err.message : String(err);
-      // Normalize spawn ENOENT into a user-friendly CLI-not-found message that
-      // the frontend CliErrorBanner can detect and display with setup instructions.
-      const errorMessage = this.normalizeProviderError(rawMessage, effectiveProvider);
-      logger.error("Provider send failed", { threadId, error: rawMessage });
-
-      // Emit an error event through the provider so the frontend receives it
-      // via the normal agent.event push pipeline and can display the CLI error banner.
-      // Cast to EventEmitter since all providers extend it, but IAgentProvider only exposes on().
+    // Auto-retry loop for transient send failures. A known-transient signature
+    // (stale pooled session, spawn race, brief network blip) retries once
+    // against a fresh session so a flake doesn't cost the user a manual re-send;
+    // the policy's attempt cap stops a misclassified fatal error from looping.
+    let attemptResumeFrom = resumeFrom;
+    // Arm the retry-suppression window for the whole loop so a transient `Error`
+    // the provider emits mid-attempt (before its rejection reaches the catch
+    // below) is hidden from the UI. The classification gate in
+    // `shouldSuppressTransientTurnError` keeps fatal errors visible; both exits
+    // (success and give-up) disarm before returning.
+    this.retryingThreads.add(threadId);
+    const baseTurnRequest = {
+      sessionId: sessionName,
+      threadId,
+      message: providerMessage,
+      cwd,
+      model: resolvedModel,
+      fallbackModel,
+      permissionMode,
+      interactionMode: effectiveInteractionMode ?? "build",
+      attachments: persisted.length > 0 ? persisted : undefined,
+      reasoningLevel,
+      ...(effectiveBudget > 0 && { maxBudgetUsd: effectiveBudget }),
+      ...(effectiveTurns > 0 && { maxTurns: effectiveTurns }),
+      resumeFrom: attemptResumeFrom,
+      providerOptions,
+    } as TurnRequest;
+    this.turnRetryDispatchByThread.set(threadId, {
+      attempt: 1,
+      retryInFlight: false,
+      sendTurnInFlight: false,
+      sessionName,
+      resolvedProvider,
+      effectiveProvider,
+      turnRequest: baseTurnRequest,
+      pendingGoalInstall,
+    });
+    for (;;) {
+      const dispatch = this.turnRetryDispatchByThread.get(threadId);
+      if (!dispatch) return;
+      dispatch.turnRequest = {
+        ...dispatch.turnRequest,
+        resumeFrom: attemptResumeFrom,
+      };
+      dispatch.sendTurnInFlight = true;
       try {
-        const resolvedProvider = this.providerRegistry.resolve(effectiveProvider) as unknown as import("events").EventEmitter;
-        resolvedProvider.emit("event", {
-          type: "error",
+        await resolvedProvider.sendTurn(dispatch.turnRequest);
+        dispatch.sendTurnInFlight = false;
+        logger.info("Message sent via provider", {
           threadId,
-          error: errorMessage,
-        } satisfies AgentEvent);
-        resolvedProvider.emit("event", {
-          type: "ended",
-          threadId,
-        } satisfies AgentEvent);
-      } catch (emitErr) {
-        logger.warn("Failed to emit error event to provider", {
-          threadId,
-          error: emitErr instanceof Error ? emitErr.message : String(emitErr),
+          session: sessionName,
+          model: resolvedModel,
         });
+        // Fire-and-forget providers return before the stream ends. Keep the retry
+        // window armed until TurnComplete so mid-stream transient errors stay
+        // suppressed and can re-dispatch via the Error handler.
+        return;
+      } catch (err) {
+        dispatch.sendTurnInFlight = false;
+        const retried = await this.runTransientTurnRetry(threadId, err);
+        if (retried) return;
+        await this.giveUpTransientTurnRetry(threadId, err);
+        return;
       }
-
-      this.threadRepo.updateStatus(threadId, "errored");
     }
   }
 
@@ -1029,6 +1075,11 @@ export class AgentService {
     } catch {
       // Provider may not be available
     }
+    // Tear down any armed transient-retry window so a scheduled stream retry
+    // can't re-dispatch after the user stopped, and the suppression flags don't
+    // outlive the turn (they would otherwise swallow the next turn's terminal
+    // events). The stop's own finalize below clears the UI running state.
+    this.disarmTurnRetryWindow(threadId);
     // A user stop ends the turn. The finalizer flushes partial assistant text,
     // persists buffered tool calls (running ones inherit "cancelled"), captures
     // the snapshot, broadcasts turn.persisted, and clears per-turn state.
@@ -1123,6 +1174,203 @@ export class AgentService {
     if (this.activeSessionIds.size === 0) {
       this.memoryPressureService.markIdle();
     }
+  }
+
+  /**
+   * Whether a provider-emitted `Error` for `threadId` should be hidden from the
+   * UI because a transient-failure retry is in flight. True only when the thread
+   * is armed (mid retry loop) AND the error itself classifies as transient, so a
+   * fatal error always reaches the user even during the retry window. Consulted
+   * by the composition root before broadcasting and by the errored-finalize path.
+   */
+  shouldSuppressTransientTurnError(threadId: string, errorMessage: string): boolean {
+    return this.retryingThreads.has(threadId) && this.turnErrorPolicy.classify(errorMessage) === "transient";
+  }
+
+  /**
+   * Whether a provider-emitted `Ended` for `threadId` should be swallowed because
+   * it trails a just-suppressed transient `Error` from a failed attempt. Keeps
+   * the failed attempt's teardown (spinner off, partial-stream commit) from
+   * flashing before the retry re-arms the running state. The flag is one retry
+   * window wide: cleared before each re-dispatch and on the loop's final exit, so
+   * the retry's own (or the give-up's) `Ended` still reaches the UI. Consulted by
+   * the composition root before broadcasting and by the `Ended` cleanup path.
+   *
+   * Only the transient-retry flags gate this. A bare `Ended` with no in-flight
+   * retry means the stream genuinely ended and must reach the cleanup path, or
+   * the thread leaks in the running state. Internal session recreation
+   * (context-window / permission-mode handoff) suppresses the superseded
+   * session's `Ended` at the provider layer (`suppressEndedQueries`), so it never
+   * needs a broad gate here.
+   */
+  shouldSuppressTurnEnded(threadId: string): boolean {
+    if (this.endedSuppressionThreads.has(threadId)) return true;
+    // Swallow `Ended` emitted while a re-dispatch is mid-flight (e.g. the pooled
+    // session's eviction `Ended` during a transient retry).
+    const dispatch = this.turnRetryDispatchByThread.get(threadId);
+    return dispatch?.retryInFlight === true;
+  }
+
+  /**
+   * Whether a provider-emitted `TurnComplete` for `threadId` should be swallowed
+   * because it belongs to a failed attempt that is being retried. Mirrors
+   * {@link shouldSuppressTurnEnded}: both gate the same retry-window teardown.
+   */
+  shouldSuppressTurnComplete(threadId: string): boolean {
+    return this.endedSuppressionThreads.has(threadId);
+  }
+
+  /**
+   * Clears the transient-retry window once the turn has finished or given up.
+   */
+  private disarmTurnRetryWindow(threadId: string): void {
+    this.retryingThreads.delete(threadId);
+    this.endedSuppressionThreads.delete(threadId);
+    this.turnRetryDispatchByThread.delete(threadId);
+  }
+
+  /**
+   * Evicts a pooled provider session and waits for its subprocess to unwind so
+   * any trailing `Ended` from teardown is emitted while suppression is still armed.
+   */
+  private async evictPooledSessionForRetry(
+    provider: import("@mcode/contracts").IAgentProvider,
+    sessionName: string,
+  ): Promise<void> {
+    if (!isSessionEvictable(provider)) return;
+    provider.discardSession(sessionName);
+    const withWait = provider as import("@mcode/contracts").IAgentProvider & {
+      waitForSessionExit?: (sessionId: string, timeoutMs?: number) => Promise<void>;
+    };
+    if (typeof withWait.waitForSessionExit === "function") {
+      await withWait.waitForSessionExit(sessionName, 5000);
+    }
+  }
+
+  /**
+   * Re-dispatches a turn against a fresh session after a transient failure.
+   * Returns true when a retry `sendTurn` was issued and the outer loop should continue.
+   */
+  private async runTransientTurnRetry(threadId: string, triggerErr: unknown): Promise<boolean> {
+    const dispatch = this.turnRetryDispatchByThread.get(threadId);
+    if (!dispatch || dispatch.retryInFlight) return false;
+    if (!this.turnErrorPolicy.shouldRetry(triggerErr, dispatch.attempt)) return false;
+
+    dispatch.retryInFlight = true;
+    this.endedSuppressionThreads.add(threadId);
+    try {
+      try {
+        await this.evictPooledSessionForRetry(dispatch.resolvedProvider, dispatch.sessionName);
+      } catch (evictErr) {
+        logger.warn("Failed to discard pooled session before retry", {
+          threadId,
+          error: evictErr instanceof Error ? evictErr.message : String(evictErr),
+        });
+      }
+      try {
+        this.threadRepo.clearSdkSessionId(threadId);
+      } catch (clearErr) {
+        logger.warn("Failed to clear sdk_session_id before retry", {
+          threadId,
+          error: clearErr instanceof Error ? clearErr.message : String(clearErr),
+        });
+      }
+      logger.warn("Transient send failed; retried against a fresh session", {
+        threadId,
+        attempt: dispatch.attempt,
+        error: triggerErr instanceof Error ? triggerErr.message : String(triggerErr),
+      });
+      dispatch.attempt += 1;
+      dispatch.turnRequest = { ...dispatch.turnRequest, resumeFrom: undefined };
+      this.endedSuppressionThreads.delete(threadId);
+      dispatch.sendTurnInFlight = true;
+      try {
+        await dispatch.resolvedProvider.sendTurn(dispatch.turnRequest);
+        dispatch.sendTurnInFlight = false;
+        return true;
+      } catch (sendErr) {
+        dispatch.sendTurnInFlight = false;
+        if (this.turnErrorPolicy.shouldRetry(sendErr, dispatch.attempt)) {
+          return this.runTransientTurnRetry(threadId, sendErr);
+        }
+        return false;
+      }
+    } finally {
+      dispatch.retryInFlight = false;
+    }
+  }
+
+  /**
+   * Schedules a stream-time transient retry from the `Error` event handler.
+   * Fire-and-forget providers can emit `Error` after `sendTurn` already resolved.
+   */
+  private scheduleTransientStreamRetry(threadId: string, errorMessage: string): void {
+    const dispatch = this.turnRetryDispatchByThread.get(threadId);
+    if (!dispatch || dispatch.retryInFlight) return;
+    void (async () => {
+      if (this.turnErrorPolicy.shouldRetry(errorMessage, dispatch.attempt)) {
+        const retried = await this.runTransientTurnRetry(threadId, errorMessage);
+        if (retried) return;
+      }
+      await this.giveUpTransientTurnRetry(threadId, errorMessage);
+    })().catch((err) => {
+      logger.error("Transient stream retry failed", {
+        threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
+  /**
+   * Surfaces a terminal failure after the retry cap is exhausted.
+   */
+  private async giveUpTransientTurnRetry(threadId: string, err: unknown): Promise<void> {
+    const dispatch = this.turnRetryDispatchByThread.get(threadId);
+    const effectiveProvider = dispatch?.effectiveProvider ?? "claude";
+    const pendingGoalInstall = dispatch?.pendingGoalInstall ?? null;
+
+    this.disarmTurnRetryWindow(threadId);
+    this.activeSessionIds.delete(threadId);
+    if (this.activeSessionIds.size === 0) {
+      this.memoryPressureService.markIdle();
+    }
+    if (pendingGoalInstall !== null) {
+      try {
+        new GoalCommand(
+          this.providerRegistry.resolve(effectiveProvider),
+          { messageRepo: this.messageRepo, db: this.db },
+          broadcast,
+        ).rollbackGoal(threadId);
+      } catch (clearErr) {
+        logger.warn("Failed to clear goal after failed send", {
+          threadId,
+          error: clearErr instanceof Error ? clearErr.message : String(clearErr),
+        });
+      }
+    }
+    const rawMessage = err instanceof Error ? err.message : String(err);
+    const errorMessage = this.normalizeProviderError(rawMessage, effectiveProvider);
+    logger.error("Provider send failed", { threadId, error: rawMessage });
+
+    try {
+      const resolvedProvider = this.providerRegistry.resolve(effectiveProvider) as unknown as import("events").EventEmitter;
+      resolvedProvider.emit("event", {
+        type: "error",
+        threadId,
+        error: errorMessage,
+      } satisfies AgentEvent);
+      resolvedProvider.emit("event", {
+        type: "ended",
+        threadId,
+      } satisfies AgentEvent);
+    } catch (emitErr) {
+      logger.warn("Failed to emit error event to provider", {
+        threadId,
+        error: emitErr instanceof Error ? emitErr.message : String(emitErr),
+      });
+    }
+
+    this.threadRepo.updateStatus(threadId, "errored");
   }
 
   /**
@@ -1404,6 +1652,11 @@ export class AgentService {
         }
 
         if (event.type === AgentEventType.TurnComplete) {
+          // Swallow a failed attempt's `TurnComplete` during a retry so the UI
+          // running state survives until the fresh attempt streams.
+          if (this.shouldSuppressTurnComplete(event.threadId)) {
+            return;
+          }
           // Mark that the turn result has been seen so any hooks that arrive
           // after this point (Stop / SessionEnd / PreCompact) are routed through
           // flushLateHook instead of the normal mid-turn buffer.
@@ -1423,6 +1676,7 @@ export class AgentService {
           // automatically.
           if (!this.compactionInProgressByThread.has(event.threadId)) {
             this.trackSessionEnded(event.threadId);
+            this.disarmTurnRetryWindow(event.threadId);
           }
 
           // Persist context usage so the tracker shows immediately on thread reload.
@@ -1452,9 +1706,27 @@ export class AgentService {
         }
 
         if (event.type === AgentEventType.Error) {
+          // Hide a transient failure that is about to be retried: skip the
+          // errored finalize so the failed attempt does not persist a partial
+          // turn or clear per-turn state mid-retry. The fresh attempt owns the
+          // turn's real outcome. Fatal errors are not suppressed (see the gate).
+          if (this.shouldSuppressTransientTurnError(event.threadId, event.error ?? "")) {
+            // Also swallow the `Ended` that trails this error so the failed
+            // attempt's teardown never reaches the UI mid-retry. The retry loop
+            // clears the flag before re-dispatch and on its final exit.
+            this.endedSuppressionThreads.add(event.threadId);
+            const streamDispatch = this.turnRetryDispatchByThread.get(event.threadId);
+            // Only re-dispatch from the stream when sendTurn already settled.
+            // Rejections are retried from the sendTurn catch to avoid double retry.
+            if (streamDispatch && !streamDispatch.sendTurnInFlight) {
+              this.scheduleTransientStreamRetry(event.threadId, event.error ?? "");
+            }
+            return;
+          }
           // The finalizer discards the buffered turn when no assistant row
           // exists (e.g. a pre-turn CLI-not-found failure) rather than
           // broadcasting turn.persisted against the wrong (user) message id.
+          this.disarmTurnRetryWindow(event.threadId);
           this.turnFinalizer.finalize(event.threadId, "errored").catch((err) => {
             logger.error("finalize failed on error event", {
               threadId: event.threadId,
@@ -1546,6 +1818,12 @@ export class AgentService {
         }
 
         if (event.type === AgentEventType.Ended) {
+          // Swallow the failed attempt's trailing `Ended` during a retry so the
+          // UI's running state survives until the fresh attempt streams. Skip the
+          // teardown/cleanup below; the retry (or give-up) owns the real `Ended`.
+          if (this.shouldSuppressTurnEnded(event.threadId)) {
+            return;
+          }
           this.trackSessionEnded(event.threadId);
           // Turn-scoped cleanup of any one-shot handoff Read grant. No-op on
           // later turns since the grant is already gone (consumed or cleared).

--- a/apps/server/src/services/turn-error-policy.ts
+++ b/apps/server/src/services/turn-error-policy.ts
@@ -1,0 +1,66 @@
+/**
+ * Classifies a failed turn as `transient` or `fatal` and gates an automatic
+ * retry on an attempt cap.
+ */
+
+/** Whether a turn failure is worth one automatic retry (`transient`) or not (`fatal`). */
+export type TurnErrorKind = "transient" | "fatal";
+
+/**
+ * Explicit allowlist of known-transient failure signatures. Deliberately small:
+ * the policy retries only failures with strong evidence of being a brief flake,
+ * so a misclassified fatal error never enters the retry path in the first place.
+ *
+ * - Stale pooled session: a resume against a session the provider already
+ *   abandoned, surfaced as an ACP disconnect or an invalidated-session message.
+ * - Subprocess spawn race: a transient spawn failure (`EAGAIN`, `ETXTBSY`).
+ *   `ENOENT` is intentionally excluded — a missing CLI is fatal, not a flake.
+ * - Brief network blip: a dropped or timed-out connection to the provider
+ *   (`ECONNRESET`, `ETIMEDOUT`, `socket hang up`, `fetch failed`).
+ */
+const TRANSIENT_SIGNATURES: readonly RegExp[] = [
+  /\bacp connection closed\b/i,
+  /\bsession invalidated\b/i,
+  /\bspawn\b[^]*\bEAGAIN\b/i,
+  /\bETXTBSY\b/i,
+  /\bECONNRESET\b/i,
+  /\bETIMEDOUT\b/i,
+  /\bsocket hang up\b/i,
+  /\bfetch failed\b/i,
+];
+
+/** One original send plus one automatic retry. */
+const DEFAULT_MAX_ATTEMPTS = 2;
+
+/** Decides retry eligibility for a failed turn from an explicit transient-signature allowlist. */
+export class TurnErrorPolicy {
+  /**
+   * @param maxAttempts - Total attempts allowed per turn, including the original
+   *   send. Defaults to {@link DEFAULT_MAX_ATTEMPTS} (one automatic retry). The
+   *   cap is what stops a misclassified fatal error from looping.
+   */
+  constructor(private readonly maxAttempts: number = DEFAULT_MAX_ATTEMPTS) {}
+
+  /**
+   * Classify a turn failure against the transient allowlist.
+   *
+   * @param err - The error thrown by the turn (an `Error`, a string, or any value).
+   */
+  classify(err: unknown): TurnErrorKind {
+    const message = err instanceof Error ? err.message : String(err);
+    return TRANSIENT_SIGNATURES.some((re) => re.test(message)) ? "transient" : "fatal";
+  }
+
+  /**
+   * Decide whether a failed turn should be retried against a fresh session.
+   * Retries only a {@link classify}-transient failure that has not yet hit the
+   * attempt cap.
+   *
+   * @param err - The error that ended the turn.
+   * @param attempt - Attempts made so far, 1-based (the original send is `1`).
+   */
+  shouldRetry(err: unknown, attempt: number): boolean {
+    if (this.classify(err) !== "transient") return false;
+    return attempt < this.maxAttempts;
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -294,6 +294,7 @@ export type {
   IAgentProvider,
   ICompletionCapable,
   IGoalCapable,
+  ISessionEvictable,
   IProviderRegistry,
   TurnRequest,
   ProviderOptionsByProvider,
@@ -310,7 +311,7 @@ export {
   ModelPolicyStateSchema,
 } from "./providers/models.js";
 export type { ProviderModelInfo } from "./providers/models.js";
-export { isCompletionCapable, isGoalCapable } from "./providers/interfaces.js";
+export { isCompletionCapable, isGoalCapable, isSessionEvictable } from "./providers/interfaces.js";
 
 export type {
   SessionForker,

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -201,6 +201,33 @@ export function isGoalCapable(provider: IAgentProvider): provider is IGoalCapabl
   );
 }
 
+/**
+ * Narrowed view of an agent provider that can force-discard a pooled session.
+ * Providers pool a warm CLI session keyed by `sessionId`; `stopSession` is a
+ * graceful cancel that may intentionally keep that session warm. `discardSession`
+ * is the harder guarantee: it evicts the pooled session so the next `sendTurn`
+ * spawns a genuinely fresh subprocess. Use `isSessionEvictable()` to narrow an
+ * `IAgentProvider` before calling it.
+ */
+export interface ISessionEvictable extends IAgentProvider {
+  /**
+   * Force-discard the pooled session for `sessionId` so the next `sendTurn`
+   * spawns fresh. Unlike {@link IAgentProvider.stopSession}, this does not
+   * cancel pending permissions, drop goals, or emit an `ended` event — the turn
+   * is expected to continue on a new session (e.g. a transient-failure retry).
+   */
+  discardSession(sessionId: string): void;
+}
+
+/**
+ * Type guard: returns true when the provider can force-discard a pooled session.
+ * Narrows `IAgentProvider` to `ISessionEvictable` so `discardSession` is
+ * callable without casting.
+ */
+export function isSessionEvictable(provider: IAgentProvider): provider is ISessionEvictable {
+  return typeof (provider as Partial<ISessionEvictable>).discardSession === "function";
+}
+
 /** Registry that resolves provider instances by ID. */
 export interface IProviderRegistry {
   /** Get a single provider by ID. Throws if not registered. */


### PR DESCRIPTION
## What

Make in-flight turn retries and internal session recreations invisible in the UI. The user sees one continuous running state: no blank gap, no premature error banner, no duplicate `SessionStart:resume` hook, no duplicate partial messages.

## Why

Two failure modes tore down the UI mid-turn:

1. **Transient send failure** (`ECONNRESET`, spawn `EAGAIN`, stale pooled session, brief network blip) surfaced an error and idle flash even though a single automatic retry would have recovered.
2. **Session recreation** - the first message after toggling context window (`200k` ↔ `1m`) or changing permission mode stops a warm pooled Claude session and respawns it. The superseded session's trailing `Ended` leaked (the pool entry was already deleted, so `suppressEnded` was lost) and a duplicate `SessionStart:resume` hook appeared as a visible timeline break.

## Key changes

- **`TurnErrorPolicy`** (new) - classifies a failure against a small transient allowlist and caps the retry so a misclassified fatal error can't loop.
- **Transient retry loop** in `AgentService` - retries once against a fresh session. The failed attempt's `Error` / `Ended` / `TurnComplete` are suppressed for one retry window; the fresh attempt owns the real outcome. Fire-and-forget providers keep the window armed until `TurnComplete` and can re-dispatch from the stream `Error` handler.
- **`ISessionEvictable.discardSession`** - force-evicts a pooled session so the retry truly spawns fresh. Implemented for claude, codex, copilot, cursor.
- **Provider-layer recreation suppression** (`ClaudeProvider`) - `suppressEndedQueries` hides the superseded query's `Ended`; `suppressSessionStartHooks` hides the duplicate `SessionStart` hook.

## Review fixes applied (this branch)

A 4-dimension review (correctness, quality, performance, security) ran on the diff. Fixes:

- **Thread-leak bug (correctness):** `shouldSuppressTurnEnded` previously suppressed *any* bare `Ended` during an in-flight turn via a broad `retryingThreads && activeSessionIds` arm. A bare `Ended` with no `TurnComplete`/`Error` (caught by the existing `agent-service-turn-cleanup` suite) left the thread stuck in the running state. The arm was also redundant: transient-retry teardown is gated precisely by `endedSuppressionThreads` / `retryInFlight`, and recreation `Ended`s are suppressed at the provider layer. Narrowed the gate to the transient-retry flags only.
- **Ghost retry after user stop (correctness):** `stopSession` now calls `disarmTurnRetryWindow`, so a scheduled stream retry can't re-dispatch after a stop and suppression flags don't outlive the turn.
- **`suppressSessionStartHooks` leak (correctness):** when no `SessionStart` hook is configured the `hook_response` delete never ran, latently suppressing a future legitimately-configured `SessionStart`. The stale flag is now cleared on the live session's stream-loop teardown.
- **Log tense (quality):** transient-retry warning now reads in past tense per repo convention.

Rejected as false positives: regex word-boundary "fix" (all signatures already anchor with `\b`), `waitForSessionExit` "dead code" (it is implemented on `ClaudeProvider`; the duck-type guard intentionally covers providers that lack it).

## Configuration changes

None.

## Test plan

- [x] `bun run verify` - typecheck + lint + 1223 server unit tests pass
- [ ] Manual UI repro: toggle context `200k` ↔ `1m`, send first message on a resumed thread - UI stays active, no `SessionStart:resume` break, response streams
- [ ] Manual UI repro: transient retry shows no error/idle flash during the retry window
- [ ] Manual UI repro: `agent.stop` mid-turn clears running state via finalize

## Related issues

Relates to #580

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783524798&installation_id=129163861&pr_number=595&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F595&signature=213829bba1fb73612df4e8f3bd7b67965de5971ae1ac0670fcfc71a1c7efbb9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry for transient failures with UI suppression of intermediate error/teardown events.
  * Session eviction capability to force fresh provider sessions when needed.

* **Chores**
  * Added a retry policy to classify transient vs fatal turn errors and orchestration to manage retries and suppression windows.
  * Extended provider contracts to support session eviction.

* **Tests**
  * Added comprehensive tests covering retry behavior, suppression semantics, and error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->