### PR TITLE
chore: retire MutatingForker and the mutating fork capability

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,7 @@ The provider used for short, one-shot, non-conversational completions that
 the app issues on the user's behalf (currently: drafting PR titles/bodies
 and summarising a diff). Set globally in user settings; may differ from the
 default provider. Handoff generation is **not** a utility-provider use case;
-handoffs route through the originating thread's own provider via the B/A/D
+handoffs route through the originating thread's own provider via the B/D
 pipeline.
 
 ### Session runtime
@@ -335,31 +335,20 @@ user-configurable Hook.
 
 ### Handoff pipeline
 The orchestration layer that produces a handoff for a given fork. Routes
-through one of three paths (B / A / D) based on the parent provider's
-capability and live availability.
+through one of two paths (B / D) based on the parent provider's capability
+and live availability.
 
 ### Side-channel
 A provider call made out-of-band from the user-visible conversation, used to
-generate a handoff. Does not appear in the parent thread's UI. Distinct from
-a "hidden turn". Side-channels typically use a separate SDK process.
+generate a handoff. Does not appear in the parent thread's UI. Side-channels
+typically use a separate SDK process.
 
-### Hidden turn
-A message persisted with `is_internal: 1` so it doesn't render in the UI but
-is still present in the provider's session state. Used in path A to inject
-the handoff request into the parent's session without polluting the user's
-view of the conversation.
-
-### Disregard turn
-A second hidden turn following a hidden handoff request, instructing the
-model to ignore the previous request and continue normally. Specific to
-path A's session-mutation cleanup.
-
-## The B/A/D ladder
+## The B/D ladder
 
 ### Path B (clean side-channel)
 Resumes the parent provider's session in a forked SDK process to generate
 the handoff. The original session is untouched. Used when the provider
-declares `sessionForkOnResume: "clean"` (Claude).
+declares `sessionForkOnResume: "clean"` (Claude, Cursor).
 
 ### Path B-prime (sessionless side-channel)
 Variant of path B that runs without `resume:` when the parent's session
@@ -367,28 +356,15 @@ isn't available (e.g. after a server restart). Provides the conversation
 history as text in the prompt instead. Same artifact ladder step ("B") from
 the caller's perspective.
 
-### Path A (mutating resume)
-Injects hidden turns directly into the parent thread's session. Used when
-the provider declares `sessionForkOnResume: "mutating"` (Cursor today).
-Cleaned up with a disregard turn.
-
-> **Retirement pending.** Path A (the `MutatingForker`) is queued for removal
-> once Cursor's `loadSession` is verified to carry parent context across
-> stop/resume without the hidden-turn-then-disregard dance. The verification
-> (launch Cursor, send a Turn, stop, resume, send a follow-up, confirm context
-> carried) has not been run, so `MutatingForker` and the `"mutating"` value are
-> retained as the safe default. If it passes, Cursor moves to `CleanForker` (or
-> `DeterministicForker`) and the ladder reduces to B and D.
-
 ### Path D (deterministic)
 Local builder that produces the handoff from message rows without invoking
 any provider. Used as the universal fallback. Lowest fidelity but always
 available.
 
 ### Ladder step
-A label on a produced handoff artifact (`"B" | "A" | "D"`) identifying which
-path generated it. Stored in `handoff.json` for diagnostics and the
-fallback banner copy.
+A label on a produced handoff artifact (`"B" | "D"`) identifying which path
+generated it. Stored in `handoff.json` for diagnostics and the fallback
+banner copy.
 
 ## Handoff delivery
 
@@ -413,14 +389,14 @@ for Handoff purposes after this change.
 ## Provider capabilities
 
 ### Session fork behavior
-Declared per provider as `"clean" | "mutating" | "unsupported"`. **Metadata
-only** since each Provider now carries a `forker: SessionForker` that the
-pipeline dispatches through (`provider.forker.fork(req)`); this label is used
-for `handoff.json` provenance and the fallback banner copy, and historically
+Declared per provider as `"clean" | "unsupported"`. **Metadata only** since
+each Provider now carries a `forker: SessionForker` that the pipeline
+dispatches through (`provider.forker.fork(req)`); this label is used for
+`handoff.json` provenance and the fallback banner copy, and historically
 mapped to ladder paths as:
 
-- **clean**: `resume:` spawns a fork without mutating the original (Claude)
-- **mutating**: `resume:` mutates the session forward (Cursor today)
+- **clean**: `resume:` spawns a fork without mutating the original (Claude,
+  Cursor)
 - **unsupported**: provider can't fork sessions; pipeline goes directly to
   path D (Codex, Copilot today)
 
@@ -443,9 +419,8 @@ under `Slash command`).
 
 ### Internal message
 A message persisted with `is_internal: 1`. Excluded from the user-visible
-timeline and from queries by default. Used for hidden turns and for the
-synthetic system message anchoring a handoff at sequence 1 in a child
-thread.
+timeline and from queries by default. Used for the synthetic system message
+anchoring a handoff at sequence 1 in a child thread.
 
 ### Provenance metadata
 The `handoff.json` sidecar accompanying every `handoff.md`. Records which

--- a/apps/server/src/providers/cursor/__tests__/cursor-side-channel.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-side-channel.test.ts
@@ -44,7 +44,7 @@ describe("Cursor clean side-channel fork", () => {
     const envStub = { getEnv: () => ({}) } as unknown as EnvService;
     const jobStub = {} as unknown as JobObject;
 
-    provider = new CursorProvider(settingsStub, skillStub, envStub, jobStub, messageRepo);
+    provider = new CursorProvider(settingsStub, skillStub, envStub, jobStub);
 
     // Replace the real `cursor-agent acp` spawn with a fake transport that
     // streams a summary chunk back through the client (no subprocess, no

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -28,7 +28,6 @@ import {
 import { SettingsService } from "../../services/settings-service.js";
 import { SkillService } from "../../services/skill-service.js";
 import { EnvService } from "../../services/env-service.js";
-import { MessageRepo } from "../../repositories/message-repo.js";
 import { JobObject } from "../../services/job-object.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
@@ -220,7 +219,6 @@ export class CursorProvider
     @inject(SkillService) private readonly skillService: SkillService,
     @inject(EnvService) private readonly envService: EnvService,
     @inject("JobObject") private readonly jobObject: JobObject,
-    @inject(MessageRepo) private readonly messageRepo: MessageRepo,
   ) {
     super();
     this.runtime = new SessionRuntime<CursorSessionState>(this, {
@@ -1150,108 +1148,6 @@ export class CursorProvider
   }
 
   /**
-   * Runs two hidden prompt/reply pairs on the parent thread's active Cursor session
-   * to extract a handoff summary without surfacing them in the UI.
-   *
-   * The four persisted messages (isInternal=true) form a bracket:
-   *   user: handoff prompt -> assistant: handoff reply
-   *   user: disregard instruction -> assistant: ack
-   *
-   * Returns the handoff reply text (the assistant response to the handoff prompt).
-   */
-  async runHiddenTurn(args: {
-    parentThreadId: string;
-    prompt: string;
-    abortSignal?: AbortSignal;
-  }): Promise<string> {
-    const { parentThreadId, prompt, abortSignal } = args;
-    const sessionKey = `mcode-${parentThreadId}`;
-    const entry = this.runtime.get(sessionKey);
-    if (!entry) {
-      throw new Error(`No active Cursor session for parent thread: ${parentThreadId}`);
-    }
-
-    // Wait for any in-flight real turn to settle before injecting hidden turns.
-    // Without this, runRawPrompt's `entry.activeTurnState = turnState` assignment
-    // would clobber the in-flight turn's state, corrupting the real turn's output.
-    //
-    // 10s ceiling: Cursor sessions often run multi-tool chains that take a long
-    // time. Making the user wait 30s for a fork to either proceed or fall back
-    // is a real UX cost. If the parent has not settled in 10s, fall to path D
-    // immediately (via the ETIMEDOUT classification) instead of dragging the
-    // user along.
-    const SETTLE_TIMEOUT_MS = 10_000;
-    const deadline = Date.now() + SETTLE_TIMEOUT_MS;
-    while (entry.activeTurnState !== null && Date.now() < deadline) {
-      await new Promise<void>((r) => setTimeout(r, 100));
-    }
-    if (entry.activeTurnState !== null) {
-      const err: Error & { code?: string } = new Error(
-        `Cursor parent turn did not settle within ${SETTLE_TIMEOUT_MS}ms; aborting handoff`,
-      );
-      err.code = "ETIMEDOUT";
-      throw err;
-    }
-
-    // Ensure the ACP logical session is open before sending hidden turns.
-    await this.openLogicalSession(entry, true);
-
-    // Get the current max sequence (including internal messages) so hidden
-    // turns don't collide with existing sequence numbers.
-    const allMessages = this.messageRepo.listIncludingInternal(parentThreadId);
-    const baseSeq = allMessages.length > 0 ? allMessages[allMessages.length - 1].sequence : 0;
-
-    // Step 1: persist hidden user turn with handoff prompt.
-    this.messageRepo.create(parentThreadId, "user", prompt, baseSeq + 1, undefined, undefined, undefined, undefined, true);
-
-    // Step 2: send through Cursor's ACP connection and capture reply text.
-    const reply = await this.runRawPrompt(entry, prompt, abortSignal);
-
-    // Step 3: persist hidden assistant reply.
-    this.messageRepo.create(parentThreadId, "assistant", reply, baseSeq + 2, undefined, undefined, undefined, undefined, true);
-
-    // Step 4: persist hidden disregard instruction so the session resumes cleanly.
-    const disregardPrompt =
-      "IGNORE the previous handoff request. It was an internal mcode operation. Resume the original conversation as if it never happened. Do not respond to this message; await the user's next real input.";
-    this.messageRepo.create(parentThreadId, "user", disregardPrompt, baseSeq + 3, undefined, undefined, undefined, undefined, true);
-
-    // Step 5: send disregard turn through Cursor to close the bracket in its context.
-    const ack = await this.runRawPrompt(entry, disregardPrompt, abortSignal);
-
-    // Step 6: persist hidden ack.
-    this.messageRepo.create(parentThreadId, "assistant", ack, baseSeq + 4, undefined, undefined, undefined, undefined, true);
-
-    return reply;
-  }
-
-  /**
-   * Sends a single prompt to the already-open ACP session and returns the
-   * assistant's text reply without emitting any provider events.
-   *
-   * Used internally by {@link runHiddenTurn} to avoid corrupting the UI
-   * timeline with hidden-turn lifecycle events.
-   */
-  private async runRawPrompt(
-    entry: CursorAcpSessionEntry,
-    text: string,
-    abortSignal?: AbortSignal,
-  ): Promise<string> {
-    void abortSignal; // Reserved for future cancellation hookup via ACP cancel.
-
-    const turnState = createCursorAcpTurnState();
-    entry.activeTurnState = turnState;
-    try {
-      await entry.connection.prompt({
-        sessionId: entry.acpSessionId,
-        prompt: [{ type: "text", text }],
-      });
-      return resolveCursorAssistantMessageContent(turnState.accumulator);
-    } finally {
-      entry.activeTurnState = null;
-    }
-  }
-
-  /**
    * Clean side-channel handoff query (path B). Reconstructs the parent thread's
    * persisted Cursor session into a throwaway ACP connection, runs the summary
    * prompt against that fork, and returns the assistant text. It writes nothing
@@ -1261,8 +1157,7 @@ export class CursorProvider
    *
    * Because loading the same session id into a second connection branches the
    * conversation rather than advancing the canonical server-side session, the
-   * parent is never mutated — this is the primitive that retires the path-A
-   * hidden-turn dance ({@link runHiddenTurn}).
+   * parent is never mutated.
    *
    * Falls back to a transient (path-D) error when there is no persisted session
    * to reconstruct, the load fails, or the fork produces no text — the pipeline

--- a/apps/server/src/services/handoff/__tests__/handoff-coordinator.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-coordinator.test.ts
@@ -124,17 +124,6 @@ describe("HandoffCoordinator.deliverHandoff", () => {
     expect(providerWireOverride).toContain("continue the work please");
   });
 
-  it("path A: a mutating-provider artifact still broadcasts ready and delivers off-band", async () => {
-    const deps = mkDeps();
-    deps.handoffPipeline.orchestrate = vi.fn(async () => mkArtifact("A"));
-    const coordinator = HandoffCoordinator.forTesting(deps);
-
-    const { providerWireOverride } = await coordinator.deliverHandoff(mkInput());
-
-    expect(lastHandoffStatus()).toMatchObject({ status: "ready", ladderStep: "A" });
-    expect(providerWireOverride).toContain("mcode-handoff-t_child-");
-  });
-
   it("path D (pipeline-produced): broadcasts fallback with ladderStep D but still uses off-band delivery", async () => {
     const deps = mkDeps();
     deps.handoffPipeline.orchestrate = vi.fn(async () => mkArtifact("D", "quota"));

--- a/apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { describe, expect, it, vi } from "vitest";
 import type { IProviderRegistry } from "@mcode/contracts";
 import { HandoffPipelineService } from "../handoff-pipeline.js";
-import { CleanForker, MutatingForker, DeterministicForker } from "../session-forker.js";
+import { CleanForker, DeterministicForker } from "../session-forker.js";
 
 /**
  * Wrap a partial Claude-like mock (with runSideChannelQuery) in a real
@@ -10,11 +10,6 @@ import { CleanForker, MutatingForker, DeterministicForker } from "../session-for
  */
 function withCleanForker<T extends { runSideChannelQuery: (...a: any[]) => any }>(p: T) {
   return { ...p, forker: new CleanForker(p as any) };
-}
-
-/** Wrap a Cursor-like mock (with runHiddenTurn) in a real MutatingForker. */
-function withMutatingForker<T extends { runHiddenTurn: (...a: any[]) => any }>(p: T) {
-  return { ...p, forker: new MutatingForker(p as any) };
 }
 
 /** Attach a DeterministicForker to a provider with no fork capability. */
@@ -88,22 +83,19 @@ describe("HandoffPipelineService.orchestrate", () => {
     expect(r.meta.providerErrorOnGenerate).toBe("quota");
   });
 
-  it("mutating-resume provider uses path A; mode is always full after off-band delivery", async () => {
+  it("clean-resume provider keeps mode full after off-band delivery", async () => {
     const deps = mkDeps();
-    deps.providerRegistry.resolve = vi.fn(() => withMutatingForker({
-      sessionForkOnResume: "mutating",
+    deps.providerRegistry.resolve = vi.fn(() => withCleanForker({
+      sessionForkOnResume: "clean",
       // A small child cap no longer downgrades the doc: off-band delivery
       // (PRD #538) retired the minimal mode and the per-turn char budget.
       maxInputCharactersPerTurn: 4_000,
-      id: "cursor",
-      runHiddenTurn: vi.fn(async () => "# Handoff\n\n## Goal\nX"),
+      id: "claude",
+      runSideChannelQuery: vi.fn(async () => "# Handoff\n\n## Goal\nX"),
     }));
     const svc = HandoffPipelineService.forTesting(deps);
-    const r = await svc.orchestrate({
-      ...BASE_REQ,
-      childProviderId: "cursor",
-    });
-    expect(r.meta.ladderStep).toBe("A");
+    const r = await svc.orchestrate(BASE_REQ);
+    expect(r.meta.ladderStep).toBe("B");
     expect(r.meta.mode).toBe("full");
   });
 
@@ -124,7 +116,7 @@ describe("HandoffPipelineService.orchestrate", () => {
   });
 
   // 17.1: missing sdk_session_id falls through to D for path B (session needed
-  // for resume), path A is unaffected (no session required for hidden turns).
+  // for resume).
   it("falls to D when parent has no sdkSessionId and provider is clean-resume", async () => {
     const deps = mkDeps();
     // Override parent to have no session id
@@ -183,41 +175,5 @@ describe("HandoffPipelineService.orchestrate", () => {
     } finally {
       globalThis.AbortController = OriginalAbortController;
     }
-  });
-
-  // 17.3: concurrent path A forks on the same parent thread are serialized
-  it("serializes concurrent path-A forks on the same parent thread", { timeout: 10_000 }, async () => {
-    const order: number[] = [];
-    let resolveFirst!: () => void;
-    const firstStarted = new Promise<void>((res) => { resolveFirst = res; });
-
-    const deps = mkDeps();
-    let callCount = 0;
-    deps.providerRegistry.resolve = vi.fn(() => withMutatingForker({
-      sessionForkOnResume: "mutating",
-      maxInputCharactersPerTurn: 180_000,
-      id: "cursor",
-      runHiddenTurn: vi.fn(async () => {
-        const idx = ++callCount;
-        order.push(idx);
-        if (idx === 1) {
-          resolveFirst();
-          // First call holds the lock briefly so the second must queue.
-          await new Promise<void>((res) => setTimeout(res, 50));
-        }
-        return "# Handoff\n\n## Goal\nX";
-      }),
-    }));
-
-    const svc = HandoffPipelineService.forTesting(deps);
-    const p1 = svc.orchestrate(BASE_REQ);
-    await firstStarted;
-    const p2 = svc.orchestrate(BASE_REQ);
-
-    const [r1, r2] = await Promise.all([p1, p2]);
-    expect(r1.meta.ladderStep).toBe("A");
-    expect(r2.meta.ladderStep).toBe("A");
-    // The second hidden turn must start only after the first completes.
-    expect(order).toEqual([1, 2]);
   });
 });

--- a/apps/server/src/services/handoff/__tests__/session-forker.test.ts
+++ b/apps/server/src/services/handoff/__tests__/session-forker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ForkRequest } from "@mcode/contracts";
 import type { Thread, Message } from "@mcode/contracts";
-import { CleanForker, DeterministicForker, MutatingForker } from "../session-forker.js";
+import { CleanForker, DeterministicForker } from "../session-forker.js";
 
 const parent = {
   id: "t_parent",
@@ -83,17 +83,5 @@ describe("CleanForker", () => {
     await forker.fork(baseReq({ parentSdkSessionId: null }));
     const args = runSideChannelQuery.mock.calls[0][0];
     expect(args.parentSdkSessionId).toBe("");
-  });
-});
-
-describe("MutatingForker", () => {
-  it("delegates to runHiddenTurn and wraps a path-A artifact", async () => {
-    const runHiddenTurn = vi.fn(async () => "# Handoff\n\n## Goal\nX");
-    const forker = new MutatingForker({ id: "cursor", runHiddenTurn });
-    const artifact = await forker.fork(baseReq());
-
-    expect(runHiddenTurn).toHaveBeenCalledOnce();
-    expect(artifact.meta.ladderStep).toBe("A");
-    expect(artifact.meta.generatedBy).toBe("provider");
   });
 });

--- a/apps/server/src/services/handoff/handoff-pipeline.ts
+++ b/apps/server/src/services/handoff/handoff-pipeline.ts
@@ -3,10 +3,9 @@
  * {@link SessionForker}.
  *
  * The pipeline builds a {@link ForkRequest} and calls `provider.forker.fork(req)`.
- * Each provider owns the strategy: CleanForker (Claude, path B), MutatingForker
- * (Cursor, path A), or DeterministicForker (Codex/Copilot, path D). The
- * `sessionForkOnResume` field is now metadata only (provenance + the path-A
- * mutex decision), not the dispatch key.
+ * Each provider owns the strategy: CleanForker (Claude/Cursor, path B) or
+ * DeterministicForker (Codex/Copilot, path D). The `sessionForkOnResume` field
+ * is now metadata only (provenance), not the dispatch key.
  *
  * On a classified non-retryable provider error (quota/auth/context-overflow/
  * fatal) or a timeout, the pipeline falls back to a shared DeterministicForker
@@ -95,7 +94,7 @@ interface IThoughtSegmentRepo {
 const RECENT_ASSISTANT_MESSAGES_FOR_D = 5;
 
 /**
- * Timeout for side-channel and hidden-turn provider calls, in milliseconds.
+ * Timeout for side-channel provider calls, in milliseconds.
  * Handoff generation includes a cold SDK subprocess start plus model inference;
  * 60s was too tight after server restarts on Windows.
  */
@@ -111,12 +110,6 @@ const REPLAY_BUDGET_CHARS = 100_000;
 
 @injectable()
 export class HandoffPipelineService {
-  /**
-   * Per-thread mutex for path A. Hidden turns must not interleave on the same
-   * parent thread because each turn mutates the provider session state.
-   */
-  private readonly pathALocks = new Map<string, Promise<void>>();
-
   /**
    * Cross-forker fallback. The pipeline delegates to a provider's own forker
    * first; on a classified non-retryable error or timeout it falls back to this
@@ -160,13 +153,12 @@ export class HandoffPipelineService {
     };
     // Initialize instance fields that aren't set via the constructor (Object.create
     // bypasses field initializers).
-    (svc as any).pathALocks = new Map<string, Promise<void>>();
     (svc as any).deterministicForker = new DeterministicForker();
     return svc;
   }
 
   /**
-   * Orchestrates B->A->D. Returns a HandoffArtifact. The caller is responsible
+   * Orchestrates B->D. Returns a HandoffArtifact. The caller is responsible
    * for persisting it via HandoffStorage.write() so the orchestrator stays
    * free of disk I/O and is fully testable in isolation.
    */
@@ -233,15 +225,11 @@ export class HandoffPipelineService {
     // clean-resume provider with no session id to resume go straight to the
     // deterministic forker. The DeterministicForker is also the cross-forker
     // fallback below.
-    const canProviderFork =
-      !!parentProvider &&
-      ((capability === "clean" && !!parentSdkSession) || capability === "mutating");
+    const canProviderFork = !!parentProvider && capability === "clean" && !!parentSdkSession;
     if (!canProviderFork) {
       return this.deterministicForker.fork({ ...forkReq, forkReason: null });
     }
 
-    // Path A (mutating) must be serialized per parent thread because each
-    // hidden turn mutates provider session state. Path B (clean) does not.
     const runFork = async (): Promise<HandoffArtifact> => {
       const abort = new AbortController();
       const timer = setTimeout(() => abort.abort(), PROVIDER_CALL_TIMEOUT_MS);
@@ -267,9 +255,6 @@ export class HandoffPipelineService {
       }
     };
 
-    if (capability === "mutating") {
-      return this.withPathALock(req.parentThreadId, runFork);
-    }
     return runFork();
   }
 
@@ -338,26 +323,6 @@ export class HandoffPipelineService {
       return this.providerRegistry.resolve(providerId as ProviderId);
     } catch {
       return null;
-    }
-  }
-
-  /**
-   * Serializes path A calls on the same parent thread. Concurrent fork
-   * requests mutate the provider session state, so each hidden turn must
-   * complete before the next begins.
-   */
-  private async withPathALock<T>(threadId: string, fn: () => Promise<T>): Promise<T> {
-    while (this.pathALocks.has(threadId)) {
-      await this.pathALocks.get(threadId);
-    }
-    let release!: () => void;
-    const p = new Promise<void>((res) => { release = res; });
-    this.pathALocks.set(threadId, p);
-    try {
-      return await fn();
-    } finally {
-      this.pathALocks.delete(threadId);
-      release();
     }
   }
 }

--- a/apps/server/src/services/handoff/session-forker.ts
+++ b/apps/server/src/services/handoff/session-forker.ts
@@ -1,21 +1,19 @@
 /**
  * Per-Provider session forkers for the chat fork handoff pipeline.
  *
- * Replaces the B/A/D dispatch that lived inline in
+ * Replaces the B/D dispatch that lived inline in
  * {@link HandoffPipelineService.orchestrate}. Each provider owns a `forker`
  * (see {@link IAgentProvider.forker}) that knows how to produce a handoff
  * artifact for that provider's session-fork semantics:
  *
- * - {@link CleanForker} (Claude, path B + B-prime): runs a side-channel query
- *   against a forked copy of the parent session.
- * - {@link MutatingForker} (Cursor, path A): runs a hidden turn on the parent's
- *   mutable session.
+ * - {@link CleanForker} (Claude + Cursor, path B + B-prime): runs a
+ *   side-channel query against a forked copy of the parent session.
  * - {@link DeterministicForker} (path D): stateless replay-based builder, also
  *   the pipeline's cross-forker fallback when a provider fork fails.
  *
- * The forkers call the providers' concrete `runSideChannelQuery` /
- * `runHiddenTurn` methods directly. Those methods are intentionally off the
- * {@link IAgentProvider} interface now — only the forkers reach them.
+ * The forkers call the providers' concrete `runSideChannelQuery` method
+ * directly. That method is intentionally off the {@link IAgentProvider}
+ * interface now — only the forkers reach it.
  */
 
 import type { ForkRequest, HandoffArtifact, HandoffMeta, SessionForker } from "@mcode/contracts";
@@ -40,26 +38,14 @@ interface CleanForkCapable {
 }
 
 /**
- * Structural shape of the Cursor provider's concrete `runHiddenTurn`.
- */
-interface MutatingForkCapable {
-  runHiddenTurn(args: {
-    parentThreadId: string;
-    prompt: string;
-    abortSignal?: AbortSignal;
-  }): Promise<string>;
-  readonly id: string;
-}
-
-/**
- * Build a provider-generated artifact (path B or A) with the given ladder step.
+ * Build a provider-generated artifact (path B) with the given ladder step.
  * Mode is decided by the pipeline (budget-driven) and stamped here; the
  * forkers do not own mode selection.
  */
 function buildProviderArtifact(
   req: ForkRequest,
   markdownBody: string,
-  step: "B" | "A",
+  step: "B",
 ): HandoffArtifact {
   const parent = req.parentThread;
   const meta: HandoffMeta = {
@@ -83,7 +69,7 @@ function buildProviderArtifact(
 }
 
 /**
- * Path B (+ B-prime) forker for clean-resume providers (Claude). Runs a
+ * Path B (+ B-prime) forker for clean-resume providers (Claude, Cursor). Runs a
  * one-shot side-channel query against a forked copy of the parent session. If
  * `parentSdkSessionId` is missing the provider's own sessionless B-prime
  * fallback (driven by `conversationHistory`) still produces a path-B result.
@@ -102,25 +88,6 @@ export class CleanForker implements SessionForker {
       cwd: req.cwd,
     });
     return buildProviderArtifact(req, text, "B");
-  }
-}
-
-/**
- * Path A forker for mutating-resume providers (Cursor). Runs a hidden turn on
- * the parent thread's mutable session. The pipeline serializes concurrent
- * calls per parent thread because each hidden turn mutates session state.
- */
-export class MutatingForker implements SessionForker {
-  constructor(private readonly provider: MutatingForkCapable) {}
-
-  /** Produce a path-A handoff via the provider's hidden turn. */
-  async fork(req: ForkRequest): Promise<HandoffArtifact> {
-    const text = await this.provider.runHiddenTurn({
-      parentThreadId: req.parentThreadId,
-      prompt: req.prompt,
-      abortSignal: req.abortSignal,
-    });
-    return buildProviderArtifact(req, text, "A");
   }
 }
 

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -16,7 +16,7 @@ import type { ThoughtSegment } from "@/components/chat/narrative/types";
  */
 export interface HandoffMeta {
   status: "generating" | "ready" | "fallback" | "error";
-  ladderStep?: "B" | "A" | "D";
+  ladderStep?: "B" | "D";
   providerErrorOnGenerate?: "quota" | "auth" | "context-overflow" | "transient" | "fatal" | null;
 }
 

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -429,7 +429,7 @@ export interface McodeTransport {
       childThreadId: string;
       generatedBy: "provider" | "deterministic";
       provider: string | null;
-      ladderStep: "B" | "A" | "D";
+      ladderStep: "B" | "D";
       mode: "full" | "minimal";
       generatedAt: string;
       characterCount: number;
@@ -437,7 +437,7 @@ export interface McodeTransport {
       providerErrorOnGenerate: "quota" | "auth" | "context-overflow" | "transient" | "fatal" | "clean" | null;
       regenerationHistory: Array<{
         at: string;
-        ladderStep: "B" | "A" | "D";
+        ladderStep: "B" | "D";
         reason: "quota" | "auth" | "context-overflow" | "transient" | "fatal" | "clean" | "user-requested";
       }>;
       attachments: Array<{

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -506,7 +506,7 @@ export function startPushListeners(): void {
       const payload = data as {
         threadId: string;
         status: "generating" | "ready" | "fallback" | "error";
-        ladderStep?: "B" | "A" | "D";
+        ladderStep?: "B" | "D";
         providerErrorOnGenerate?: "quota" | "auth" | "context-overflow" | "transient" | "fatal" | null;
       };
       if (!payload.threadId || !payload.status) return;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -768,7 +768,7 @@ export function createWsTransport(
           childThreadId: string;
           generatedBy: "provider" | "deterministic";
           provider: string | null;
-          ladderStep: "B" | "A" | "D";
+          ladderStep: "B" | "D";
           mode: "full" | "minimal";
           generatedAt: string;
           characterCount: number;
@@ -776,7 +776,7 @@ export function createWsTransport(
           providerErrorOnGenerate: "quota" | "auth" | "context-overflow" | "transient" | "fatal" | "clean" | null;
           regenerationHistory: Array<{
             at: string;
-            ladderStep: "B" | "A" | "D";
+            ladderStep: "B" | "D";
             reason: "quota" | "auth" | "context-overflow" | "transient" | "fatal" | "clean" | "user-requested";
           }>;
           attachments: Array<{

--- a/docs/guides/chat-fork-handoff.md
+++ b/docs/guides/chat-fork-handoff.md
@@ -6,19 +6,17 @@ How chat forking works in mcode and how to extend it.
 
 Clicking the fork icon on a message in a parent thread creates a child thread. The child receives a "handoff document" that summarises the parent conversation up to the fork point, giving the child's first turn full context without replaying every message token-by-token.
 
-The document is produced either by the parent's provider (when the provider supports a side-channel or hidden-turn query) or by a deterministic builder (when it does not). Either way the artifact is the same shape: a Markdown file with YAML frontmatter plus a JSON sidecar.
+The document is produced either by the parent's provider (when the provider supports a side-channel query) or by a deterministic builder (when it does not). Either way the artifact is the same shape: a Markdown file with YAML frontmatter plus a JSON sidecar.
 
 The pipeline lives in `apps/server/src/services/handoff/`.
 
-## The B/A/D ladder
+## The B/D ladder
 
-Three paths are tried in order. The result of the first path that succeeds becomes the handoff artifact.
+Two paths are tried in order. The result of the first path that succeeds becomes the handoff artifact.
 
-**Path B -- clean-fork providers (e.g. Claude).** The pipeline calls `runSideChannelQuery` on the parent provider. This issues a new query against the provider's existing session without mutating it, so the parent thread's conversation state is unchanged. Path B requires a live `sdk_session_id` on the parent thread because the side-channel must resume the correct provider conversation.
+**Path B -- clean-fork providers (e.g. Claude, Cursor).** The pipeline calls `runSideChannelQuery` on the parent provider. This issues a new query against a forked copy of the provider's existing session without mutating it, so the parent thread's conversation state is unchanged. Path B requires a live `sdk_session_id` on the parent thread because the side-channel must resume the correct provider conversation.
 
-**Path A -- mutating-resume providers (e.g. Cursor).** The pipeline calls `runHiddenTurn` on the parent provider. This injects an ephemeral turn into the parent's mutable session. Because the hidden turn modifies session state, concurrent path A forks on the same parent thread are serialized via a per-thread mutex. Path A does not require `sdk_session_id`; providers that defer session creation until the first real turn still produce useful output (they have no prior context but generate a valid handoff structure).
-
-**Path D -- deterministic fallback.** Always available. Builds the handoff by walking the message list up to the fork point and rendering a structured Markdown summary. No provider call is made. Path D fires when the parent provider does not support forking at all (`sessionForkOnResume === "unsupported"`), when the parent has no `sdk_session_id` and the provider is clean-resume, or when path B or A throws an error that error-classification routes as quota, auth, context-overflow, or fatal (errors for which retrying the next ladder step would hit the same wall).
+**Path D -- deterministic fallback.** Always available. Builds the handoff by walking the message list up to the fork point and rendering a structured Markdown summary. No provider call is made. Path D fires when the parent provider does not support forking at all (`sessionForkOnResume === "unsupported"`), when the parent has no `sdk_session_id` and the provider is clean-resume, or when path B throws an error that error-classification routes as quota, auth, context-overflow, or fatal (errors for which retrying would hit the same wall).
 
 Transient errors (network blips, 5xx, AbortController timeout at 60s) also route to path D so forks always succeed.
 
@@ -26,11 +24,11 @@ Transient errors (network blips, 5xx, AbortController timeout at 60s) also route
 
 Two fields on the provider interface control which path fires. Both are declared in `packages/contracts/src/providers/interfaces.ts`.
 
-`sessionForkOnResume: "clean" | "mutating" | "unsupported"` -- declares whether the provider supports side-channel queries (`"clean"`), hidden turns (`"mutating"`), or neither (`"unsupported"`). Omitting this field or returning `null` is treated as `"unsupported"`.
+`sessionForkOnResume: "clean" | "unsupported"` -- declares whether the provider supports side-channel queries (`"clean"`) or not (`"unsupported"`). Omitting this field or returning `null` is treated as `"unsupported"`.
 
-`maxInputCharactersPerTurn: number` -- the provider's per-turn input character cap. The pipeline uses this to pick the handoff mode (see below) and to guard against oversized provider output.
+`maxInputCharactersPerTurn: number` -- the provider's per-turn input character cap. The pipeline uses this to guard against oversized provider output.
 
-Implement `runSideChannelQuery` on path-B providers and `runHiddenTurn` on path-A providers. Both receive an `AbortSignal` that fires after 60 seconds.
+Implement `runSideChannelQuery` on path-B providers. It receives an `AbortSignal` that fires after 60 seconds.
 
 ## Storage layout
 
@@ -62,7 +60,6 @@ The mode is recorded in `HandoffMeta.mode` (`"full"` or `"minimal"`) and in the 
 The pipeline includes several guards to avoid blocking or corrupting the fork flow:
 
 - **60-second timeout.** An `AbortController` wraps every provider call. If the controller fires, the pipeline catches the abort and falls to path D with `reason: "transient"`.
-- **Per-thread mutex on path A.** Concurrent hidden turns on the same parent thread are serialized via `pathALocks` in `HandoffPipelineService` to prevent interleaved session mutation.
 - **25 MB attachment size cap.** `HandoffStorage.copyAttachments` skips any attachment larger than 25 MB and records a sentinel `sha256: "<skipped>"` in the manifest.
 - **Budget truncation at section boundaries.** When a provider returns more than 115% of the computed character budget, `applyBudgetGuard` truncates at the nearest H2 heading boundary and appends a notice so the child agent knows the doc was cut.
 - **Abandoned-child cleanup.** Before writing the artifact, `AgentService` re-fetches the child thread. If it has been hard-deleted between orchestration start and the write, the artifact is dropped and the fork fails cleanly rather than writing orphaned files.
@@ -73,14 +70,12 @@ The pipeline includes several guards to avoid blocking or corrupting the fork fl
 
 ## Adding a new provider
 
-1. Decide which path the provider supports based on its session model. Providers with stateless or read-only session replay use `"clean"`. Providers that resume by appending to a mutable history use `"mutating"`. Providers with no session concept use `"unsupported"`.
+1. Decide which path the provider supports based on its session model. Providers that can fork a session (resuming a session id into a throwaway connection branches the conversation rather than mutating it) use `"clean"`. Providers with no forkable session concept use `"unsupported"`.
 
 2. Set `sessionForkOnResume` to the chosen value and `maxInputCharactersPerTurn` to the provider's documented limit (or a conservative estimate like `16_000` if unknown).
 
 3. If `"clean"`: implement `runSideChannelQuery({ parentThreadId, parentSdkSessionId, prompt, abortSignal })`. The method must return a Markdown string. It must respect `abortSignal` and throw (or let the signal reject the underlying fetch) when it fires.
 
-4. If `"mutating"`: implement `runHiddenTurn({ parentThreadId, prompt, abortSignal })`. Same contract as above.
+4. Run `(cd apps/server && npx vitest run src/services/handoff)` to verify the existing tests still pass with the new provider registered.
 
-5. Run `(cd apps/server && npx vitest run src/services/handoff)` to verify the existing tests still pass with the new provider registered.
-
-6. Add a test case in `apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts` covering the happy path and at least one failure mode for the new provider.
+5. Add a test case in `apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts` covering the happy path and at least one failure mode for the new provider.

--- a/docs/guides/cursor-sdk-migration.md
+++ b/docs/guides/cursor-sdk-migration.md
@@ -1,11 +1,26 @@
 # Cursor SDK Migration Handoff
 
-> **Status: DEFERRED (2026-05-23)**
+> **Status: DEFERRED (2026-05-23). Scope reduced 2026-06-08.**
 >
-> Investigation completed 2026-05-23. The migration is on hold until one of the
-> two un-defer triggers below fires. The existing `cursor-agent acp` subprocess
-> plus path A handoff implementation keep working as-is; nothing in the
-> running system needs to change.
+> Investigation completed 2026-05-23. The migration is on hold until the
+> un-defer trigger below fires.
+>
+> **Update (2026-06-08): path A is gone.** Cursor's handoff no longer uses the
+> hidden-turn workaround. `sessionForkOnResume` is now `"clean"` and the
+> provider runs `runSideChannelQuery` by reconstructing the parent's persisted
+> session into a throwaway ACP connection (loading a session id into a second
+> connection branches the conversation rather than advancing the canonical
+> session, so the parent is never mutated). The `MutatingForker`, `runHiddenTurn`,
+> `runRawPrompt`, the settle-wait poll, the disregard turn, and the `"mutating"`
+> capability have all been retired. The `LadderStep` union is now `"B" | "D"`.
+> Everything below that frames this migration as a way to *remove path A* is
+> therefore already done; treat that framing as historical.
+>
+> **What still remains** is the original swap itself: the provider still spawns
+> the long-lived `cursor-agent acp` subprocess. Migrating that to `@cursor/sdk`
+> remains deferred and is now a self-contained cleanup (remove subprocess
+> plumbing) with no handoff-pipeline impact, since the pipeline already treats
+> Cursor as a clean-fork provider.
 >
 > **Why deferred:** `@cursor/sdk` v1.0.13 requires an API key, either passed as
 > `apiKey` per call or read from `process.env.CURSOR_API_KEY` (see
@@ -15,17 +30,9 @@
 > to set API keys directly, and reverse-engineering the CLI's token store is
 > too fragile to commit to.
 >
-> **Un-defer triggers (either resolves the blocker):**
+> **Un-defer trigger:**
 >
-> 1. **Cursor fixes the ACP `session/load` bug.** If this lands first, the
->    migration is no longer needed. Flip `sessionForkOnResume` in
->    `apps/server/src/providers/cursor/cursor-provider.ts:131` from
->    `"mutating"` to `"clean"`, delete `runHiddenTurn` plus the path A
->    branch in `handoff-pipeline.ts`, ship. No SDK swap required. Track:
->    https://forum.cursor.com/t/acp-no-conversation-history-is-restored-when-loading-an-existing-session/158388
->    (still open as of 2026-05-17; cursor-cli `2026.05.16-0338208` still
->    affected).
-> 2. **`@cursor/sdk` gains CLI-auth support.** If a future SDK release can
+> 1. **`@cursor/sdk` gains CLI-auth support.** If a future SDK release can
 >    read the local `cursor login` token (no `CURSOR_API_KEY` env, no
 >    settings entry), the migration described below becomes viable. Track
 >    the SDK changelog and: https://forum.cursor.com/t/cursor-sdk-cloud-agents-api-updates/159284
@@ -33,18 +40,12 @@
 > **Recheck on or after 2026-08-23.** To recheck:
 >
 > ```sh
-> # 1. ACP session/load bug fixed?
-> #    Read the forum thread above for new replies, then compare the
-> #    installed cursor-cli version against the version mentioned in the
-> #    latest reply.
-> cursor-agent --version
->
-> # 2. @cursor/sdk gained CLI-auth support?
+> # @cursor/sdk gained CLI-auth support?
 > npm view @cursor/sdk version   # anything newer than 1.0.13?
 > npm view @cursor/sdk readme    # look for CLI-auth / cursor-login mentions
 > ```
 >
-> If neither trigger has fired, bump this recheck date by another 3 months
+> If the trigger has not fired, bump this recheck date by another 3 months
 > and leave the rest of the doc alone.
 
 A persistent handoff doc for whoever picks up the Cursor provider migration

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -14,7 +14,7 @@ import type { SessionForker } from "./session-forker.js";
 export type ProviderId = "claude" | "codex" | "gemini" | "copilot" | "cursor" | "opencode";
 
 /** How a provider's `resume` mechanism behaves when used to fork a session. */
-export type SessionForkBehavior = "clean" | "mutating" | "unsupported";
+export type SessionForkBehavior = "clean" | "unsupported";
 
 /**
  * Per-Provider knobs that ride on a {@link TurnRequest}, keyed by {@link ProviderId}.
@@ -86,7 +86,6 @@ export interface IAgentProvider {
    * Now metadata only (provenance + UI banner) — it no longer drives handoff
    * dispatch. The handoff pipeline delegates to {@link forker} instead:
    * - "clean": resuming creates a forked session; the original session is unaffected.
-   * - "mutating": resuming mutates the original session's forward history.
    * - "unsupported": resuming is not supported or not yet verified.
    */
   readonly sessionForkOnResume: SessionForkBehavior;
@@ -95,10 +94,9 @@ export interface IAgentProvider {
    * The session-fork strategy for this provider's handoff generation. The
    * handoff pipeline calls `provider.forker.fork(req)` instead of branching on
    * {@link sessionForkOnResume}. Clean-resume providers use CleanForker (path
-   * B), mutating providers use MutatingForker (path A), and providers that
-   * cannot fork a session use DeterministicForker (path D). The forkers reach
-   * the providers' concrete side-channel / hidden-turn methods directly; those
-   * methods are intentionally not on this interface.
+   * B) and providers that cannot fork a session use DeterministicForker (path
+   * D). The forkers reach the providers' concrete side-channel methods
+   * directly; those methods are intentionally not on this interface.
    */
   readonly forker: SessionForker;
 

--- a/packages/contracts/src/providers/session-forker.ts
+++ b/packages/contracts/src/providers/session-forker.ts
@@ -1,7 +1,7 @@
 /**
  * Session-fork contract for the chat fork handoff pipeline.
  *
- * The B/A/D ladder is no longer dispatched inline in the handoff pipeline.
+ * The B/D ladder is no longer dispatched inline in the handoff pipeline.
  * Instead every {@link IAgentProvider} exposes a `forker` whose `fork(req)`
  * produces a {@link HandoffArtifact}. This module is the canonical home for
  * the artifact shape and the forker contract so the provider interface (which
@@ -13,8 +13,8 @@
 
 import type { Message, Thread, ToolCallRecord, ThoughtSegmentRecord } from "../index.js";
 
-/** Which step of the B->A->D ladder produced the handoff. */
-export type LadderStep = "B" | "A" | "D";
+/** Which step of the B->D ladder produced the handoff. */
+export type LadderStep = "B" | "D";
 
 /**
  * Handoff doc mode. Retained as a constant `"full"` for provenance/frontmatter
@@ -27,7 +27,7 @@ export type HandoffMode = "full";
 /** Whether the parent message at the fork point was authored by the user or assistant. */
 export type ForkAnchorRole = "user" | "assistant";
 
-/** Classified provider error returned during path-B/A attempts. */
+/** Classified provider error returned during path-B attempts. */
 export type ProviderErrorClass =
   | "quota"             // 429, rate-limit, billing-exhausted
   | "auth"              // 401, expired credentials
@@ -133,8 +133,8 @@ export interface ForkRequest {
 
 /**
  * A provider-specific strategy that turns a {@link ForkRequest} into a
- * {@link HandoffArtifact}. Implemented server-side by CleanForker (path B),
- * MutatingForker (path A), and DeterministicForker (path D).
+ * {@link HandoffArtifact}. Implemented server-side by CleanForker (path B)
+ * and DeterministicForker (path D).
  */
 export interface SessionForker {
   fork(req: ForkRequest): Promise<HandoffArtifact>;

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -122,7 +122,7 @@ export const WS_CHANNELS = {
   "thread.handoff": z.object({
     threadId: z.string(),
     status: z.enum(["generating", "ready", "fallback", "error"]),
-    ladderStep: z.enum(["B", "A", "D"]).optional(),
+    ladderStep: z.enum(["B", "D"]).optional(),
     providerErrorOnGenerate: z
       .enum(["quota", "auth", "context-overflow", "transient", "fatal"])
       .nullable()

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -717,7 +717,7 @@ export const WS_METHODS = lazySchema(() => ({
         childThreadId: z.string(),
         generatedBy: z.enum(["provider", "deterministic"]),
         provider: z.string().nullable(),
-        ladderStep: z.enum(["B", "A", "D"]),
+        ladderStep: z.enum(["B", "D"]),
         mode: z.enum(["full", "minimal"]),
         generatedAt: z.string(),
         characterCount: z.number(),
@@ -727,7 +727,7 @@ export const WS_METHODS = lazySchema(() => ({
           .nullable(),
         regenerationHistory: z.array(z.object({
           at: z.string(),
-          ladderStep: z.enum(["B", "A", "D"]),
+          ladderStep: z.enum(["B", "D"]),
           reason: z.enum(["quota", "auth", "context-overflow", "transient", "fatal", "clean", "user-requested"]),
         })),
         attachments: z.array(z.object({


### PR DESCRIPTION
## What

Retire the `MutatingForker` adapter and the entire mutating fork capability. The handoff ladder collapses from B/A/D to B/D, and `SessionForkBehavior` narrows from `"clean" | "mutating" | "unsupported"` to `"clean" | "unsupported"`.

## Why

Slice 2 of the F-A handoff cleanup (parent #538). Path A (mutating hidden-turn resume) was superseded by the clean side-channel (path B) delivered in Slice 1 (#558). No provider wires the mutating forker anymore, so the adapter, Cursor's `runHiddenTurn` machinery, and the path-A mutex are dead weight. Removing them simplifies the pipeline and the provider contract.

## Key changes

- **Delete `MutatingForker`** class and its `MutatingForkCapable` interface (`session-forker.ts`).
- **Delete Cursor's `runHiddenTurn`** method and the `runRawPrompt` helper; drop the now-unused `MessageRepo` constructor dependency from `CursorProvider`.
- **Collapse the ladder to B/D**: `LadderStep` becomes `"B" | "D"` across contracts, WS channels/methods, and the web transport/store types.
- **Narrow `SessionForkBehavior`** to `"clean" | "unsupported"`; Cursor declares `"clean"`.
- **Remove the path-A mutex** (`pathALocks`, `withPathALock`) from `HandoffPipelineService`; simplify `canProviderFork`.
- **Tests**: drop the `MutatingForker` describe block, the `withMutatingForker` helper, the path-A pipeline/coordinator tests, and replace the mutating-resume case with a clean-resume equivalent.
- **Docs**: update `CONTEXT.md` and `docs/guides/chat-fork-handoff.md` to describe the B/D ladder; remove "Hidden turn", "Disregard turn", and "Path A" definitions. Correct the deferred `docs/guides/cursor-sdk-migration.md` handoff, which still framed path A as live and told a future reader to delete code this PR already removed; its status block now records the retirement and scopes the remaining deferred work to the subprocess-to-SDK swap.

End-to-end behavior is unchanged: Cursor forks still produce a non-empty handoff via the clean side-channel.

## Verification

- `bun run verify` (full gate: typecheck + lint + unit tests): typecheck, lint, and the server suite pass. Two frontend Plan-panel tests (`PlanDocument`, `PlanPanel`) timed out under the full parallel run but pass in isolation (`3 passed`); they touch no code in this PR.
- No source reference to the removed symbols remains: `grep -rn "MutatingForker\|runHiddenTurn\|pathALock"` over `apps/` and `packages/` returns nothing.
- `LadderStep` is `"B" | "D"` across contracts, WS channels/methods, and the web transport/store; the `"A"` enum member is gone everywhere it was declared.

## Acceptance criteria

- [x] `MutatingForker` and `MutatingForkCapable` removed.
- [x] Cursor `runHiddenTurn` / `runRawPrompt` removed and the `MessageRepo` dependency dropped.
- [x] `SessionForkBehavior` narrowed to `"clean" | "unsupported"`; Cursor declares `"clean"`.
- [x] Path-A mutex (`pathALocks`, `withPathALock`) removed from `HandoffPipelineService`.
- [x] `LadderStep` collapsed to `"B" | "D"` across all packages.
- [x] Path-A tests removed; mutating-resume case replaced with a clean-resume equivalent.
- [x] Docs reflect the B/D ladder (`CONTEXT.md`, `chat-fork-handoff.md`, `cursor-sdk-migration.md`).

## Configuration changes

None.

## Related issues/PRs

- Closes #559
- Relates to Mzeey-Empire/mcode#538
- Relates to Mzeey-Empire/mcode#558

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783528738&installation_id=129163861&pr_number=596&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F596&signature=aa662d77ef9a9033a0bf380eed988fd788efb17e3f339242029689ece8ee6f65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
