### PR TITLE
fix: navigate to new-thread composer after adding project

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,11 @@ Workspace-level settings do not exist yet. All user-facing settings (default
 provider, utility provider, etc.) are global (user-level) today. Providers
 are installed on the user's machine, not on the workspace.
 
+**Project** is the user-facing name for a Workspace. Every UI string ("Add
+project", "Recent Projects", "No projects yet") says _project_; the code and
+this glossary say _Workspace_. They are the same thing.
+_Avoid_: using "project" in code or schema; reserve it for user-facing copy.
+
 ### Worktree
 A git worktree provisioned under a workspace so a thread can run against
 an isolated checkout of the repo on its own branch. Standard git semantics

--- a/apps/web/e2e/command-palette.spec.ts
+++ b/apps/web/e2e/command-palette.spec.ts
@@ -60,6 +60,7 @@ async function setupPage(page: import("@playwright/test").Page) {
       sort_order: 0,
     },
     "settings.get": MOCK_SETTINGS,
+    "thread.list": [],
   });
   await page.goto("/");
   // Wait for React to mount — "my-app" appears in the sidebar once the WS connects
@@ -149,5 +150,24 @@ test.describe("Command palette", () => {
     await page.keyboard.press("Control+Enter");
     // Successful add closes the palette.
     await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test("adding a project lands in the new-thread composer on that project", async ({ page }) => {
+    await setupPage(page);
+    await page.keyboard.press("Control+k");
+    const input = page.locator('[data-slot="palette-input"]');
+    await input.fill("~/");
+    const dialog = page.getByRole("dialog");
+    await expect(page.getByTestId("palette-add-folder")).toBeVisible();
+    await expect(dialog.locator('[data-slot="command-item"]').first()).toBeVisible();
+    await page.keyboard.press("Control+Enter");
+    // The palette closes and we drop straight into the new-thread composer for
+    // the just-added project — not back to the cold-start landing.
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByText("New thread", { exact: true })).toBeVisible({ timeout: 3000 });
+    // The composer badge names the just-added project (from the workspace.create mock).
+    await expect(page.getByText("new-project").first()).toBeVisible();
+    // The landing wordmark is gone — exact match avoids matching "Mcode" in the sidebar.
+    await expect(page.getByText("mcode", { exact: true })).not.toBeVisible();
   });
 });

--- a/apps/web/src/components/palette/views/BrowseView.tsx
+++ b/apps/web/src/components/palette/views/BrowseView.tsx
@@ -38,6 +38,8 @@ export function BrowseView() {
   const close = useCommandPaletteStore((s) => s.close);
   const createWorkspace = useWorkspaceStore((s) => s.createWorkspace);
   const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
+  const setActiveThread = useWorkspaceStore((s) => s.setActiveThread);
+  const setPendingNewThread = useWorkspaceStore((s) => s.setPendingNewThread);
 
   const mode = getPaletteMode(query);
   const isDrivesMode = mode === "drives";
@@ -97,11 +99,25 @@ export function BrowseView() {
     try {
       const ws = await createWorkspace(name, target);
       setActiveWorkspace(ws.id);
+      // Drop straight into the new-thread composer on the just-added project.
+      // setActiveWorkspace clears `pendingNewThread`, so re-set it AFTER
+      // activation; clear the active thread so ChatView shows the composer
+      // rather than a stale thread. Mirrors ProjectsView's "newThread" chain.
+      setActiveThread(null);
+      setPendingNewThread(true);
       close();
     } catch (err) {
       console.error("Failed to create workspace:", err);
     }
-  }, [result, isDrivesMode, createWorkspace, setActiveWorkspace, close]);
+  }, [
+    result,
+    isDrivesMode,
+    createWorkspace,
+    setActiveWorkspace,
+    setActiveThread,
+    setPendingNewThread,
+    close,
+  ]);
 
   // Register the confirm handler so Cmd/Ctrl+Enter in the shell adds the folder.
   // Pass `handleAdd` directly — Zustand's setter does a shallow merge, not a


### PR DESCRIPTION
## What
After adding a brand-new folder via the command palette's `Ctrl/Cmd+Enter` "add project" action, the user now lands in the chat view's new-thread composer on that project instead of being dropped back on the cold-start landing screen.

## Why
Two of the three "pick a project" paths already chained into the new-thread composer (`ProjectSelectorLanding` row click and `ProjectsView` with `nextAction: "newThread"`). The third path - adding a brand-new folder via `BrowseView.handleAdd` - just closed the palette, leaving the user stranded on the landing. This makes the third path consistent with the other two.

## Key Changes
- `BrowseView.handleAdd`: after a successful `createWorkspace` + `setActiveWorkspace`, call `setActiveThread(null)` and `setPendingNewThread(true)` before `close()`, mirroring the `ProjectsView` chain. The chaining sits inside the existing `try` after the `await`, so a failed create stays in the palette and never half-navigates.
- `command-palette.spec.ts`: new e2e test asserting the palette closes, the landing wordmark disappears, and the "New thread" composer renders with the just-added project badge. Added a shared `thread.list: []` mock that fires once the workspace activates.
- `CONTEXT.md`: glossary entry clarifying that "Project" (user-facing) == "Workspace" (code).

## Config Changes
None

## Related issues/PRs
- The duplicate-path bug (re-adding an existing project navigates into a duplicate workspace) is out of scope here and tracked separately in #597.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783587654&installation_id=129163861&pr_number=598&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F598&signature=7a1de045bfc7161a633e38b2c29eed3aef37c8be157c4f009a6a26d21a04c15c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When adding a new project through the browse interface, the application now automatically transitions to the thread composer, enabling immediate thread creation within the newly added project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->