### PR TITLE
fix: dedupe workspace list when re-adding existing project (#597)

### DIFF
--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -47,6 +47,26 @@ describe("Workspace Behavior", () => {
     expect(useWorkspaceStore.getState().workspaces).toContainEqual(ws);
   });
 
+  it("when the user re-adds an existing project, it is deduped and moved to the front", async () => {
+    const existing = createMockWorkspace({ id: "ws-existing", name: "existing" });
+    const other = createMockWorkspace({ id: "ws-other", name: "other" });
+    useWorkspaceStore.setState({ workspaces: [other, existing] });
+
+    // Server is idempotent on path: re-adding returns the live workspace.
+    (
+      mockTransport.createWorkspace as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(existing);
+
+    await useWorkspaceStore
+      .getState()
+      .createWorkspace("existing", "/tmp/existing");
+
+    const { workspaces } = useWorkspaceStore.getState();
+    expect(workspaces).toHaveLength(2);
+    expect(workspaces.filter((w) => w.id === "ws-existing")).toHaveLength(1);
+    expect(workspaces[0].id).toBe("ws-existing");
+  });
+
   it("when the user deletes the active workspace, threads and selection clear", async () => {
     const ws = createMockWorkspace();
     const thread = createMockThread({ workspace_id: ws.id });

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -419,7 +419,16 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     set({ error: null });
     try {
       const workspace = await getTransport().createWorkspace(name, path);
-      set((state) => ({ workspaces: [workspace, ...state.workspaces] }));
+      // The server is idempotent on path: re-adding an existing folder returns
+      // the live workspace (bumped to the top server-side). Dedupe by id before
+      // prepending so a re-add moves the existing entry to the front instead of
+      // rendering it twice.
+      set((state) => ({
+        workspaces: [
+          workspace,
+          ...state.workspaces.filter((w) => w.id !== workspace.id),
+        ],
+      }));
       return workspace;
     } catch (e) {
       set({ error: String(e) });


### PR DESCRIPTION
## What

Dedupe the client workspace store list when re-adding a folder that is already open as a project, so the picker no longer renders the same workspace twice.

## Why

`WorkspaceService.create` has been idempotent on path since #358: when a live workspace exists for the requested folder, the server returns that existing workspace (original id, original threads) and bumps it to the top of the sidebar order. The client store's `createWorkspace` action, however, blindly prepended the returned workspace to its in-memory list. When the server returned an already-present workspace, its id landed in the list twice and the picker rendered the project twice.

Navigation was never affected (the add flow calls `setActiveWorkspace` with the real returned id), and the database/server layer was already correct. The bug only ever manifested as duplicate UI rows.

## Key changes

- `apps/web/src/stores/workspaceStore.ts` — `createWorkspace` now filters any entry with the returned `workspace.id` out of the list before prepending. For a re-add this moves the existing entry to the front (mirroring the server's `prependToSortOrder`); for a genuinely new path it behaves exactly as before.
- `apps/web/src/__tests__/workspace-behavior.test.ts` — added a test seeding an existing workspace, resolving the same workspace from the transport, and asserting a single entry remains at index 0.

## Verification

`bun run verify` passes: typecheck + lint + 1474 unit tests (167 files) green.

Closes #597

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783587957&installation_id=129163861&pr_number=599&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F599&signature=af8645258248ea39e3c5a46afd41d011a7401ef0311a742091ce21a6efd256e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace deduplication when re-adding an existing workspace. The workspace now appears once at the top of the list instead of creating duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->