### PR TITLE
chore: add right-panel revamp ADRs, glossary, and prototypes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -447,13 +447,66 @@ within their own provider's context window. Distinct from a fork handoff,
 though the orchestrator does consult `last_compact_summary` when building a
 deterministic path-D handoff.
 
+## Right panel
+
+### Right panel
+The workspace-level surface docked to the right of the chat, hosting a set
+of typed tabs (Browser, Terminal, Review, Scope, and later Files). The
+panel itself — its visibility, width, and active tab — is **workspace-global**
+and persists with no thread open. Each tab type sets its own availability:
+some (Browser, Terminal) run against the **workspace root** when no thread
+exists; others (Scope) require a thread. This replaces the former model
+where the entire panel was thread-scoped and could not render without a
+thread. (Per-tab *content* scope — e.g. whether a thread keeps its own
+Browser tabs — is defined on each tab type below, not here.)
+
+### Tab availability
+The rule set governing which tab types a user can create at a given moment.
+Every top-level tab is a **singleton** — at most one Browser, one Terminal,
+one Review, one Scope, one Files. Multiplicity lives *inside* a tab (the
+Browser holds many pages, the Terminal many shells), never as duplicate
+top-level tabs. The set of **creatable** types is filtered twice: by
+**scope** (types needing a thread are dropped when no thread is active) and
+by **cardinality** (singletons already open are dropped). When exactly one
+type is creatable, the add affordance opens it directly instead of showing
+a menu; when none are, the add affordance is hidden. The empty panel and
+the add menu present this same creatable-types set.
+
+### Review tab
+The right-panel tab that shows code changes. **Dual-scope**: its
+git-working-tree views (Unstaged, Staged, Commit, Branch) read the
+**workspace root** and need no thread; its turn views need a thread. The
+two turn views are **Last turn** (the most recent turn's diff — the default
+glance when a thread is active) and **Cumulative** (the thread's net diff
+versus its base). Each view renders exactly one diff; there is no eager
+render of every turn's diff. A per-turn browse, if offered, is a turn
+**picker** that resolves to a single turn's diff, never N diffs at once.
+
+## Open-in app
+
+### Open-in app
+An external application mcode can open the current working directory in: an
+**editor** (VS Code, Visual Studio, Cursor, Zed), a **terminal** (Windows
+Terminal, Git Bash, WSL), a **git GUI** (GitHub Desktop), or the system
+**File Explorer**. Distinct from the in-app right-panel tabs — an open-in
+app launches a separate program against the directory, it does not embed.
+
+### Default open-in app
+The open-in app that the dedicated shortcut and the split button's primary
+action open without the user choosing from the menu. Resolved per thread in
+three tiers: a **thread override** (the app last picked from *that thread's*
+menu, sticky to the thread) wins; otherwise the **global default** from user
+settings; otherwise an **auto-resolution** to the highest-priority installed
+editor, falling back to File Explorer. Choosing an app from a thread's menu
+sets the thread override only; it never changes the global default, which is
+configured in Settings.
+
 ## In-app browser preview
 
 ### Preview
-The embedded in-app browser panel that renders a web URL or a local file
-alongside a thread. Distinct from opening the page in the user's external
-browser. The preview is **thread-scoped**: each thread keeps its own set of
-tabs.
+The embedded in-app browser panel that renders a web URL or a local file.
+It is the **Browser** tab type within the workspace-global right panel.
+Distinct from opening the page in the user's external browser.
 
 ### Preview tab
 One navigable page within the preview, belonging to a thread. A thread can

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -56,6 +56,12 @@ const LazyBrowserViewPrototype = lazy(async () => {
   return { default: m.BrowserViewPrototype };
 });
 
+// THROWAWAY: chat-header prototype, reachable via ?prototype=header. Delete with the prototype.
+const LazyHeaderPrototype = lazy(async () => {
+  const m = await import("@/components/prototype/HeaderPrototype");
+  return { default: m.HeaderPrototype };
+});
+
 /** Root application component. Initializes WS transport and push listeners. */
 export function App() {
   const theme = useSettingsStore((s) => s.settings.appearance.theme);
@@ -378,7 +384,7 @@ export function App() {
   // THROWAWAY: short-circuit to the right-panel prototype. Placed after all hooks
   // so hook order is unaffected. Remove when the prototype is folded in or deleted.
   const protoSurface = new URLSearchParams(window.location.search).get("prototype");
-  if (import.meta.env.DEV && (protoSurface === "panel" || protoSurface === "browser")) {
+  if (import.meta.env.DEV && (protoSurface === "panel" || protoSurface === "browser" || protoSurface === "header")) {
     // Seed the variant from the URL eagerly — before transport init reloads to add
     // ?token= (which drops ?variant=). The lazy prototype then reads it from storage.
     const protoVariant = new URLSearchParams(window.location.search).get("variant");
@@ -387,7 +393,13 @@ export function App() {
     }
     return (
       <Suspense fallback={null}>
-        {protoSurface === "browser" ? <LazyBrowserViewPrototype /> : <LazyRightPanelPrototype />}
+        {protoSurface === "browser" ? (
+          <LazyBrowserViewPrototype />
+        ) : protoSurface === "header" ? (
+          <LazyHeaderPrototype />
+        ) : (
+          <LazyRightPanelPrototype />
+        )}
       </Suspense>
     );
   }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -44,6 +44,18 @@ const LazyCommandPalette = lazy(async () => {
   return { default: m.CommandPalette };
 });
 
+// THROWAWAY: right-panel revamp prototype, reachable via ?prototype=panel. Delete with the prototype.
+const LazyRightPanelPrototype = lazy(async () => {
+  const m = await import("@/components/prototype/RightPanelPrototype");
+  return { default: m.RightPanelPrototype };
+});
+
+// THROWAWAY: browser-view prototype, reachable via ?prototype=browser. Delete with the prototype.
+const LazyBrowserViewPrototype = lazy(async () => {
+  const m = await import("@/components/prototype/BrowserViewPrototype");
+  return { default: m.BrowserViewPrototype };
+});
+
 /** Root application component. Initializes WS transport and push listeners. */
 export function App() {
   const theme = useSettingsStore((s) => s.settings.appearance.theme);
@@ -362,6 +374,23 @@ export function App() {
       applyTheme(theme === "dark");
     }
   }, [theme]);
+
+  // THROWAWAY: short-circuit to the right-panel prototype. Placed after all hooks
+  // so hook order is unaffected. Remove when the prototype is folded in or deleted.
+  const protoSurface = new URLSearchParams(window.location.search).get("prototype");
+  if (import.meta.env.DEV && (protoSurface === "panel" || protoSurface === "browser")) {
+    // Seed the variant from the URL eagerly — before transport init reloads to add
+    // ?token= (which drops ?variant=). The lazy prototype then reads it from storage.
+    const protoVariant = new URLSearchParams(window.location.search).get("variant");
+    if (protoVariant === "A" || protoVariant === "B" || protoVariant === "C") {
+      sessionStorage.setItem("proto-variant", protoVariant);
+    }
+    return (
+      <Suspense fallback={null}>
+        {protoSurface === "browser" ? <LazyBrowserViewPrototype /> : <LazyRightPanelPrototype />}
+      </Suspense>
+    );
+  }
 
   return (
     <TerminalPoolSlotProvider>

--- a/apps/web/src/components/prototype/BrowserViewPrototype.tsx
+++ b/apps/web/src/components/prototype/BrowserViewPrototype.tsx
@@ -1,0 +1,407 @@
+/**
+ * THROWAWAY PROTOTYPE — browser view for the revamped right panel. NOT production.
+ *
+ * Question: what does the in-app Browser view look like now that pages are no
+ * longer top-level panel tabs — the clean URL header and its states (empty →
+ * focused → loaded), the hover affordances, the overflow menu, and the
+ * localhost-ports empty state.
+ *
+ * Run:  bun run dev:web  →  http://localhost:5173/?prototype=browser
+ * Use the state switcher (Empty / Focused / Loaded + Hover) to see each header
+ * state. Fold the winner into the real preview panel, then delete this file.
+ */
+import { useEffect, useState } from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  RotateCw,
+  EllipsisVertical,
+  ArrowUpRight,
+  PencilRuler,
+  Camera,
+  SquareDashedMousePointer,
+  Monitor,
+  Scroll,
+  Paperclip,
+  X,
+  Plus,
+  Minus,
+  Smartphone,
+  Code2,
+  FileText,
+  SlidersHorizontal,
+  Cookie,
+  Trash2,
+  Globe,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+
+type ViewState = "empty" | "focused" | "loaded";
+
+interface LocalPort {
+  readonly name: string;
+  readonly port: number;
+  readonly online: boolean;
+}
+
+const LOCAL_PORTS: readonly LocalPort[] = [
+  { name: "Mcode", port: 5173, online: true },
+  { name: "Storybook", port: 6006, online: true },
+  { name: "API", port: 19400, online: false },
+];
+
+const PAGE = { title: "google.com", url: "https://google.com" };
+
+/** Square icon button used across the browser header. */
+function IconBtn({
+  icon: Icon,
+  title,
+  disabled,
+  onClick,
+}: {
+  icon: typeof Globe;
+  title: string;
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      title={title}
+      disabled={disabled}
+      onClick={onClick}
+      className="h-7 w-7 text-muted-foreground hover:text-foreground disabled:opacity-30"
+    >
+      <Icon size={15} />
+    </Button>
+  );
+}
+
+/** "Soon" tag for menu items that aren't wired yet. */
+function SoonTag() {
+  return (
+    <span className="rounded bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+      Soon
+    </span>
+  );
+}
+
+/** The kebab overflow: the rarely-needed tools, hidden until summoned. */
+function OverflowMenu() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button variant="ghost" size="icon-xs" title="More" className="h-7 w-7 text-muted-foreground hover:text-foreground">
+            <EllipsisVertical size={15} />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end" sideOffset={4} className="min-w-[200px]">
+        <DropdownMenuItem className="gap-2 px-3 py-1.5 text-xs">
+          <Plus size={14} className="text-muted-foreground" /> New page
+        </DropdownMenuItem>
+        <DropdownMenuItem className="gap-2 px-3 py-1.5 text-xs">
+          <RotateCw size={14} className="text-muted-foreground" /> Force reload
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="gap-2 px-3 py-1.5 text-xs">
+          <FileText size={14} className="text-muted-foreground" /> Dump page content
+        </DropdownMenuItem>
+        <DropdownMenuItem className="gap-2 px-3 py-1.5 text-xs">
+          <SquareDashedMousePointer size={14} className="text-muted-foreground" /> Region capture
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem disabled className="flex items-center justify-between gap-2 px-3 py-1.5 text-xs">
+          <span className="flex items-center gap-2">
+            <Code2 size={14} className="text-muted-foreground" /> Developer tools
+          </span>
+          <SoonTag />
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled className="flex items-center justify-between gap-2 px-3 py-1.5 text-xs">
+          <span className="flex items-center gap-2">
+            <Smartphone size={14} className="text-muted-foreground" /> Show device toolbar
+          </span>
+          <SoonTag />
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <div className="flex items-center justify-between px-3 py-1.5 text-xs">
+          <span className="text-muted-foreground">Zoom</span>
+          <span className="flex items-center gap-1">
+            <Button variant="ghost" size="icon-xs" className="h-5 w-5">
+              <Minus size={12} />
+            </Button>
+            <span className="w-9 text-center tabular-nums">100%</span>
+            <Button variant="ghost" size="icon-xs" className="h-5 w-5">
+              <Plus size={12} />
+            </Button>
+            <Button variant="ghost" size="icon-xs" className="ml-1 h-5 w-5">
+              <RotateCw size={11} />
+            </Button>
+          </span>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="gap-2 px-3 py-1.5 text-xs">
+          <Cookie size={14} className="text-muted-foreground" /> Clear cookies
+        </DropdownMenuItem>
+        <DropdownMenuItem className="gap-2 px-3 py-1.5 text-xs">
+          <Trash2 size={14} className="text-muted-foreground" /> Clear cache
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** The clean URL header. Center morphs across empty / focused / loaded. */
+function BrowserHeader({
+  state,
+  hovering,
+  designMode,
+  onFocusBar,
+  onToggleDesign,
+}: {
+  state: ViewState;
+  hovering: boolean;
+  designMode: boolean;
+  onFocusBar: () => void;
+  onToggleDesign: () => void;
+}) {
+  const loadedHover = state === "loaded" && hovering;
+  return (
+    <div className="flex h-10 items-center gap-1 border-b border-border/60 px-2">
+      <IconBtn icon={ArrowLeft} title="Back" disabled={state !== "loaded"} />
+      <IconBtn icon={ArrowRight} title="Forward" disabled />
+      {(state === "focused" || state === "loaded") && <IconBtn icon={RotateCw} title="Reload" />}
+
+      <div className="flex flex-1 justify-center px-1">
+        {state === "empty" && (
+          <button
+            onClick={onFocusBar}
+            className="w-full max-w-md rounded-full px-3 py-1 text-center text-sm text-muted-foreground transition hover:bg-input/60"
+          >
+            Enter a URL
+          </button>
+        )}
+
+        {state === "focused" && (
+          <div className="flex w-full max-w-md items-center gap-2 rounded-full bg-input px-3 py-1 ring-2 ring-ring/70 transition-all">
+            <input
+              autoFocus
+              placeholder="Enter a URL"
+              className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            />
+            <ArrowUpRight size={14} className="text-muted-foreground" />
+          </div>
+        )}
+
+        {state === "loaded" && (
+          <div
+            className={`flex items-center gap-2 rounded-full px-3 py-1 text-sm transition-all ${
+              loadedHover ? "bg-input text-foreground ring-1 ring-border" : "text-foreground/80"
+            }`}
+          >
+            <span>{PAGE.title}</span>
+            {loadedHover && (
+              <button title="Open in external browser" className="text-muted-foreground hover:text-foreground">
+                <ArrowUpRight size={14} />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {state === "loaded" && !hovering && (
+        <>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={onToggleDesign}
+            title="Design mode"
+            className={`h-7 w-7 ${designMode ? "bg-primary/15 text-primary" : "text-muted-foreground hover:text-foreground"}`}
+          >
+            <PencilRuler size={15} />
+          </Button>
+          <IconBtn icon={Camera} title="Screenshot" />
+        </>
+      )}
+      <OverflowMenu />
+    </div>
+  );
+}
+
+/** Capture-mode tool in the design toolbar. */
+function ToolBtn({ icon: Icon, label, active }: { icon: typeof Globe; label: string; active?: boolean }) {
+  return (
+    <button
+      className={`flex items-center gap-1.5 rounded px-2 py-1 text-xs transition ${
+        active ? "bg-primary/15 text-primary" : "text-muted-foreground hover:bg-muted hover:text-foreground"
+      }`}
+    >
+      <Icon size={13} />
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Design mode overlay: a capture toolbar over the page, a live region selection,
+ * and a tray of captured shots to attach to the chat as design context.
+ */
+function DesignModeOverlay({ onExit }: { onExit: () => void }) {
+  return (
+    <div className="absolute inset-0">
+      <div className="absolute inset-0 bg-background/50" />
+      {/* a sample region selection */}
+      <div className="absolute left-10 top-20 h-28 w-56 rounded border-2 border-primary/70 bg-primary/5" />
+
+      {/* capture toolbar */}
+      <div className="absolute left-1/2 top-3 flex -translate-x-1/2 items-center gap-1 rounded-lg border border-border bg-popover p-1 shadow-md">
+        <ToolBtn icon={SquareDashedMousePointer} label="Region" active />
+        <ToolBtn icon={Monitor} label="Viewport" />
+        <ToolBtn icon={Scroll} label="Full page" />
+        <span className="mx-1 h-5 w-px bg-border" />
+        <IconBtn icon={Smartphone} title="Device frame" />
+        <IconBtn icon={X} title="Exit design mode" onClick={onExit} />
+      </div>
+
+      {/* captures tray */}
+      <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-2 rounded-lg border border-border bg-popover p-2 shadow-md">
+        <div className="h-12 w-16 rounded border border-border bg-card" />
+        <div className="h-12 w-16 rounded border border-border bg-card" />
+        <Button size="xs" className="ml-1 h-8 gap-1.5">
+          <Paperclip size={13} /> Attach 2 to chat
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** Empty-state body: detected localhost ports to open. */
+function LocalPortsBody() {
+  return (
+    <div className="mx-auto mt-24 w-full max-w-md px-6">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">Local</span>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          disabled
+          title="Sort & filter (coming soon)"
+          className="h-6 w-6 text-muted-foreground opacity-40"
+        >
+          <SlidersHorizontal size={13} />
+        </Button>
+      </div>
+      <div className="flex flex-col gap-2">
+        {LOCAL_PORTS.map((p) => (
+          <button
+            key={p.port}
+            className="flex items-center gap-3 rounded-lg border border-border bg-card/40 px-3 py-2.5 text-left transition hover:bg-card"
+          >
+            <span className="flex h-9 w-12 items-center justify-center overflow-hidden rounded border border-border bg-background">
+              <span className="flex flex-col gap-0.5">
+                <span className="flex gap-0.5">
+                  <span className="h-1 w-1 rounded-full bg-red-400/70" />
+                  <span className="h-1 w-1 rounded-full bg-amber-400/70" />
+                  <span className="h-1 w-1 rounded-full bg-emerald-400/70" />
+                </span>
+                <span className="h-3 w-8 rounded-[1px] bg-muted" />
+              </span>
+            </span>
+            <span className="flex-1">
+              <span className="block text-sm font-medium text-foreground">{p.name}</span>
+              <span className="block text-xs text-muted-foreground">localhost:{p.port}</span>
+            </span>
+            <span
+              className={`h-2 w-2 rounded-full ${p.online ? "bg-emerald-500" : "bg-muted-foreground/40"}`}
+              title={p.online ? "Online" : "Offline"}
+            />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Throwaway browser-view prototype. Mounted by App on ?prototype=browser.
+ * The state switcher walks the header through empty / focused / loaded.
+ */
+export function BrowserViewPrototype() {
+  const [state, setStateRaw] = useState<ViewState>("empty");
+  const [hovering, setHovering] = useState(false);
+  const [designMode, setDesignMode] = useState(false);
+
+  // Design mode only exists on a loaded page; leaving the loaded state exits it.
+  const setState = (s: ViewState) => {
+    setStateRaw(s);
+    if (s !== "loaded") setDesignMode(false);
+  };
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const had = html.classList.contains("dark");
+    html.classList.add("dark");
+    return () => {
+      if (!had) html.classList.remove("dark");
+    };
+  }, []);
+
+  return (
+    <div className="flex h-screen flex-col bg-page text-foreground">
+      {/* Prototype scaffolding — not part of the design under evaluation. */}
+      <div className="flex items-center gap-3 border-b border-border bg-background px-4 py-2 text-xs">
+        <span className="font-semibold text-foreground/80">Browser-view prototype</span>
+        <span className="text-muted-foreground">state:</span>
+        {(["empty", "focused", "loaded"] as const).map((s) => (
+          <button
+            key={s}
+            onClick={() => setState(s)}
+            className={`rounded px-2 py-0.5 capitalize ${
+              state === s ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+        <label className="ml-2 flex items-center gap-1.5 text-muted-foreground">
+          <input type="checkbox" checked={hovering} onChange={(e) => setHovering(e.target.checked)} />
+          hover URL bar
+        </label>
+      </div>
+
+      <div className="flex flex-1 justify-end overflow-hidden p-1.5">
+        <div className="flex h-full w-[440px] flex-col overflow-hidden rounded-lg bg-background shadow-sm">
+          <BrowserHeader
+            state={state}
+            hovering={hovering}
+            designMode={designMode}
+            onFocusBar={() => setState("focused")}
+            onToggleDesign={() => setDesignMode((d) => !d)}
+          />
+          <div className="flex-1 overflow-hidden">
+            {state === "loaded" ? (
+              <div className="relative h-full">
+                <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+                  <Globe size={26} className="opacity-50" />
+                  <span className="text-xs">page content for {PAGE.title}</span>
+                </div>
+                {designMode && <DesignModeOverlay onExit={() => setDesignMode(false)} />}
+              </div>
+            ) : (
+              <LocalPortsBody />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/prototype/HeaderPrototype.tsx
+++ b/apps/web/src/components/prototype/HeaderPrototype.tsx
@@ -1,0 +1,203 @@
+/**
+ * THROWAWAY PROTOTYPE — chat-header revamp (chosen design). NOT production code.
+ *
+ * Verdict (variant A): keep the project badge + Create PR + Open visible; collapse
+ * the old right-panel toggle icons into one consolidated menu (mcode items only,
+ * no "environment"/"sources"); add a dedicated right-panel toggle. The Open button
+ * is the open-in split button (default-app icon + caret to pick the app) from the
+ * open-in work (#601-#603 / ADR-0005).
+ *
+ * Run:  bun run dev:web  →  http://localhost:5173/?prototype=header
+ * Fold into the real chat header, then delete this file.
+ */
+import { useEffect, useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  GitPullRequest,
+  Menu as MenuIcon,
+  PanelRight,
+  Diff,
+  GitBranch,
+  Upload,
+  ChevronDown,
+  Check,
+  Code2,
+  Zap,
+  Github,
+  SquareTerminal,
+  FolderOpen,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+
+const TITLE = "/grill-with-docs Hey we need to revamp the right…";
+
+interface OpenInApp {
+  readonly id: string;
+  readonly label: string;
+  readonly icon: LucideIcon;
+}
+
+const OPEN_IN_APPS: readonly OpenInApp[] = [
+  { id: "code", label: "VS Code", icon: Code2 },
+  { id: "zed", label: "Zed", icon: Zap },
+  { id: "github", label: "GitHub Desktop", icon: Github },
+  { id: "gitbash", label: "Git Bash", icon: SquareTerminal },
+  { id: "explorer", label: "File Explorer", icon: FolderOpen },
+];
+
+function CreatePRButton() {
+  return (
+    <Button variant="ghost" size="xs" className="h-7 gap-1.5 text-muted-foreground hover:text-foreground">
+      <GitPullRequest size={14} />
+      <span className="text-xs">Create PR</span>
+    </Button>
+  );
+}
+
+/** Open split button: opens in the default app; caret picks the app (per ADR-0005). */
+function OpenSplitButton() {
+  const [defaultId, setDefaultId] = useState("code");
+  const current = OPEN_IN_APPS.find((a) => a.id === defaultId) ?? OPEN_IN_APPS[0];
+  const Icon = current.icon;
+  return (
+    <div className="flex items-center">
+      <Button
+        variant="ghost"
+        size="xs"
+        title={`Open in ${current.label}`}
+        className="h-7 gap-1.5 rounded-r-none text-muted-foreground hover:text-foreground"
+      >
+        <Icon size={14} />
+        <span className="text-xs">Open</span>
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              title="Choose app"
+              className="h-7 w-6 rounded-l-none border-l border-border text-muted-foreground hover:text-foreground"
+            >
+              <ChevronDown size={12} />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="end" sideOffset={4} className="min-w-[180px]">
+          {OPEN_IN_APPS.map((a) => (
+            <DropdownMenuItem
+              key={a.id}
+              onClick={() => setDefaultId(a.id)}
+              className="flex items-center justify-between gap-3 px-3 py-1.5 text-xs"
+            >
+              <span className="flex items-center gap-2">
+                <a.icon size={14} className="text-muted-foreground" />
+                {a.label}
+              </span>
+              {a.id === defaultId && <Check size={13} className="text-primary" />}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <div className="px-3 py-1 text-[10px] text-muted-foreground">Sets this thread's default</div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+/** The consolidated menu — the mcode items, no "environment" framing. */
+function ConsolidatedMenu() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button variant="ghost" size="icon-xs" title="Workspace" className="h-7 w-7 text-muted-foreground hover:text-foreground">
+            <MenuIcon size={15} />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end" sideOffset={4} className="min-w-[200px]">
+        <DropdownMenuItem className="flex items-center justify-between gap-3 px-3 py-1.5 text-xs">
+          <span className="flex items-center gap-2">
+            <Diff size={14} className="text-muted-foreground" /> Changes
+          </span>
+          <span className="font-mono text-[11px]">
+            <span className="text-emerald-500">+233</span> <span className="text-muted-foreground">-0</span>
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="flex items-center justify-between gap-3 px-3 py-1.5 text-xs">
+          <span className="flex items-center gap-2">
+            <GitBranch size={14} className="text-muted-foreground" /> Branch
+          </span>
+          <span className="text-[11px] text-muted-foreground">main</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="gap-2 px-3 py-1.5 text-xs">
+          <Upload size={14} className="text-muted-foreground" /> Commit or push
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function PanelToggle({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      onClick={onToggle}
+      title="Toggle right panel"
+      className={`h-7 w-7 ${open ? "bg-primary/15 text-primary" : "text-muted-foreground hover:text-foreground"}`}
+    >
+      <PanelRight size={15} />
+    </Button>
+  );
+}
+
+/**
+ * Throwaway chat-header prototype (chosen variant A). Mounted by App on
+ * ?prototype=header. Fold into the real header, then delete.
+ */
+export function HeaderPrototype() {
+  const [panelOpen, setPanelOpen] = useState(false);
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const had = html.classList.contains("dark");
+    html.classList.add("dark");
+    return () => {
+      if (!had) html.classList.remove("dark");
+    };
+  }, []);
+
+  return (
+    <div className="flex h-screen flex-col bg-background text-foreground">
+      <div className="flex h-12 items-center gap-3 border-b border-border px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-medium text-foreground/90">{TITLE}</span>
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">mcode</span>
+        </div>
+        <div className="ml-auto flex items-center gap-1">
+          <CreatePRButton />
+          <OpenSplitButton />
+          <span className="mx-1 h-5 w-px bg-border" />
+          <ConsolidatedMenu />
+          <PanelToggle open={panelOpen} onToggle={() => setPanelOpen((o) => !o)} />
+        </div>
+      </div>
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">thread content</div>
+        {panelOpen && (
+          <div className="w-64 border-l border-border bg-page p-3 text-xs text-muted-foreground">right panel</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/prototype/NOTES.md
+++ b/apps/web/src/components/prototype/NOTES.md
@@ -75,6 +75,32 @@ page closes the Browser tab closes. "New page" (header / kebab) adds a rail entr
 - Where **Dump page content / Region capture / Screenshot** outputs land in the
   composer (the attach-to-chat flow).
 
+## Chat header (`?prototype=header`)
+
+Question: how the chat header consolidates once the right-panel toggle icons move
+out of it. Keep Create PR + Open visible; collapse the rest into one menu (no
+"environment"/"sources" framing — those aren't mcode concepts); add a dedicated
+right-panel toggle; decide whether the project badge stays.
+
+- **A — Badge + actions:** project badge kept; right = Create PR · Open ·
+  [consolidated menu] · [panel toggle].
+- **B — No badge:** project badge removed (title only); same right cluster.
+- **C — Grouped + edge toggle:** badge removed; Create PR · Open · menu grouped
+  in a bordered pill, panel toggle pushed to the far edge.
+
+The consolidated menu holds the mcode items: Changes (+/-), Branch (main), Commit
+or push. The panel toggle opens/closes the (now workspace-global) right panel.
+
+### Verdict: variant A
+Chosen. The **project badge stays**. The old right-panel toggle icons collapse
+into the consolidated menu, and a dedicated **right-panel toggle** is added. The
+**Open** button is the open-in split button (default-app icon + caret to pick the
+app) from the open-in work (#601-#603 / ADR-0005) — not a plain button.
+
+Remaining design detail: refine the consolidated-menu contents. Create PR is
+already its own button, so avoid duplicating it in the menu; settle the final set
+(Changes / Branch / Commit or push is the starting point).
+
 ## Cleanup
 
 Throwaway. Fold the rail + card-grid empty state into the real panel

--- a/apps/web/src/components/prototype/NOTES.md
+++ b/apps/web/src/components/prototype/NOTES.md
@@ -55,10 +55,11 @@ The Browser tab's content view, now that pages are not top-level panel tabs.
 - **Empty state lists detected localhost ports** as cards (name, port, online
   dot). The sort/filter control (Recently used / Port; All / Online / Hidden) is
   a **future** addition — stubbed disabled.
-- **Design mode** (entered from the header's Design button): a capture toolbar
-  (Region / Viewport / Full page + device frame + exit), a live region selection
-  over the dimmed page, and a captures tray with **Attach N to chat** — the
-  design screenshots become context for the agent.
+- **Design mode** and **Screenshot** already exist and are **not changing** in
+  this revamp — the prototype's design overlay is illustrative only. The work is
+  to surface their existing entry points in the new clean header (a Design icon
+  and a Screenshot icon), with behavior preserved. A future revamp of design
+  mode itself is out of scope here.
 
 ### Multi-page = the right-panel rail (settled)
 Multiple Browser pages live in the **right-panel activity rail**, not a top tab

--- a/apps/web/src/components/prototype/NOTES.md
+++ b/apps/web/src/components/prototype/NOTES.md
@@ -1,0 +1,82 @@
+# Right-panel prototype — verdict
+
+**Question:** what should the revamped right panel (ADR-0004) look and feel like —
+empty-state presentation, tab navigation, the dynamic "+" menu, and the
+coming-soon treatment.
+
+## Chosen direction (a merge of two variants)
+
+- **Tab navigation: the activity rail (variant C).** A vertical icon rail on the
+  panel's edge. Singleton tabs as icons, active-tab indicator, **hover-revealed
+  × on each icon to close**, "+" at the top of the rail (only when ≥1 tab is
+  open), open-in / panel chrome at the bottom. The **Browser tab's rail glyph is
+  the active page's favicon** (globe is the blank/new-tab fallback) — binds to
+  the active preview tab's favicon in the real panel.
+- **Empty state: the card grid (variant B).** When no tab is open the content
+  area shows a 2-col grid of cards (icon + label + blurb + mcode keycap). The
+  card grid is the create surface, so **there is no "+" in the empty state**.
+
+Variant A (quiet list) was liked but the card grid won the empty state; variant
+B's top pill tab-strip was dropped in favour of C's rail.
+
+## Rules confirmed on the prototype
+
+- Panel is **workspace-global** — renders with no thread (threadless scope shows
+  Browser/Terminal/Files; a thread unlocks Review/Scope).
+- Creatable set = **scope-filter then cardinality-filter**; "+" hides when nothing
+  is openable and opens directly when exactly one type remains.
+- **Files is a coming-soon teaser** — shown disabled with a "Soon" badge, excluded
+  from the creatable count and from "+" actions (it is a deferred feature).
+- **mcode keycaps** on every card/menu (Browser mod+shift+b, Terminal mod+j,
+  Review mod+d, Scope mod+t), not Codex's bindings.
+
+## Follow-ups (not decided here)
+
+- The **open-in split button belongs in the chat header**, not the panel; it sits
+  in the prototype's panel top-right only for demo convenience. The real home is
+  the chat header (covered by the open-in issues #601-#603).
+- Rail close could add **middle-click** and a **right-click "Close / Close others"**
+  menu as complements to the hover-×.
+- The card grid should **scroll** when a thread unlocks all five types.
+
+## Browser view (`?prototype=browser`)
+
+The Browser tab's content view, now that pages are not top-level panel tabs.
+
+- **Clean URL header** — back/forward/reload + centered URL/title + an overflow
+  kebab; the rarely-needed tools (Force reload, device toolbar, Zoom, Clear
+  cookies, Clear cache) live in the kebab, out of view until summoned.
+- **Header states** — *empty* ("Enter a URL"), *focused* (ringed pill + ↗),
+  *loaded* (page title centered + a **design-mode icon** + a **screenshot icon**
+  + kebab). *Hover* on a loaded bar reveals reload + the **open-in-external ↗**.
+  Secondary tools live in the kebab — New page, Force reload, Dump page content,
+  Region capture, Developer tools (Soon), Show device toolbar (Soon), Zoom, Clear
+  cookies/cache — so the header stays minimal.
+- **Empty state lists detected localhost ports** as cards (name, port, online
+  dot). The sort/filter control (Recently used / Port; All / Online / Hidden) is
+  a **future** addition — stubbed disabled.
+- **Design mode** (entered from the header's Design button): a capture toolbar
+  (Region / Viewport / Full page + device frame + exit), a live region selection
+  over the dimmed page, and a captures tray with **Attach N to chat** — the
+  design screenshots become context for the agent.
+
+### Multi-page = the right-panel rail (settled)
+Multiple Browser pages live in the **right-panel activity rail**, not a top tab
+strip. Each page is a favicon entry in the rail (consistent with the Browser rail
+glyph = active page favicon); the rail **is** the page switcher. Concretely:
+pages render as favicon entries grouped under the Browser tab in the rail, the
+active page highlighted, each closeable via the rail's hover-×; when the last
+page closes the Browser tab closes. "New page" (header / kebab) adds a rail entry.
+
+### Browser-view open items
+- The empty → focused **animation** is only suggested (ring/pill); needs a real
+  morph transition.
+- Where **Dump page content / Region capture / Screenshot** outputs land in the
+  composer (the attach-to-chat flow).
+
+## Cleanup
+
+Throwaway. Fold the rail + card-grid empty state into the real panel
+(`apps/web/src/components/panels/RightPanel.tsx`), then delete
+`apps/web/src/components/prototype/` and the `?prototype=panel` short-circuit +
+lazy import in `apps/web/src/app/App.tsx`.

--- a/apps/web/src/components/prototype/RightPanelPrototype.tsx
+++ b/apps/web/src/components/prototype/RightPanelPrototype.tsx
@@ -1,0 +1,644 @@
+/**
+ * THROWAWAY PROTOTYPE — right-panel revamp (ADR-0004). NOT production code.
+ *
+ * Question it answers: what should the revamped right panel look and feel like —
+ * empty-state as a quiet list vs a card grid, the tab-strip treatment, the
+ * dynamic "+" menu (scope-filter then cardinality-filter), and the split
+ * "open-in" button. Three structurally-different variants switch via ?variant=.
+ *
+ * Run:  bun run dev:web   →   http://localhost:5173/?prototype=panel
+ * Toggle the threadless/thread scope with the prototype control to feel the
+ * availability rules. Fold the winner into the real panel, then delete this file.
+ *
+ * Deliberately self-contained: no real zustand stores, no Electron, in-memory state.
+ */
+import { useCallback, useEffect, useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Globe,
+  Terminal as TerminalIcon,
+  Diff,
+  Files as FilesIcon,
+  ListChecks,
+  Plus,
+  X,
+  ChevronDown,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Code2,
+  Github,
+  SquareTerminal,
+  FolderOpen,
+  Zap,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+
+type TabId = "browser" | "terminal" | "review" | "files" | "scope";
+type Scope = "threadless" | "thread";
+type VariantKey = "A" | "B" | "C";
+
+interface TabMeta {
+  readonly id: TabId;
+  readonly label: string;
+  readonly icon: LucideIcon;
+  /** Pre-formatted mcode keycap; empty for types without a binding yet (Files). */
+  readonly keycap: string;
+  /** Only creatable once a thread exists (Review + Scope per the prototype brief). */
+  readonly needsThread: boolean;
+  readonly blurb: string;
+  /** Shown as a disabled teaser, not yet openable (Files is a deferred feature). */
+  readonly comingSoon?: boolean;
+}
+
+const TABS: readonly TabMeta[] = [
+  { id: "browser", label: "Browser", icon: Globe, keycap: "Ctrl ⇧ B", needsThread: false, blurb: "Open a website" },
+  { id: "terminal", label: "Terminal", icon: TerminalIcon, keycap: "Ctrl J", needsThread: false, blurb: "Start a shell" },
+  { id: "files", label: "Files", icon: FilesIcon, keycap: "", needsThread: false, blurb: "Browse project files", comingSoon: true },
+  { id: "review", label: "Review", icon: Diff, keycap: "Ctrl D", needsThread: true, blurb: "View code changes" },
+  { id: "scope", label: "Scope", icon: ListChecks, keycap: "Ctrl T", needsThread: true, blurb: "Plan and tasks" },
+];
+
+// Stand-in for the active page's favicon. In the real panel the Browser tab's
+// rail glyph is the active preview tab's favicon, with the globe as the
+// blank/new-tab fallback.
+const MOCK_FAVICON =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='4' fill='%234f9eff'/%3E%3Ctext x='8' y='12' font-size='11' font-family='sans-serif' text-anchor='middle' fill='white'%3EM%3C/text%3E%3C/svg%3E";
+
+const VARIANT_NAMES: Record<VariantKey, string> = {
+  A: "Quiet list",
+  B: "Card grid",
+  C: "Activity rail",
+};
+
+interface OpenInApp {
+  readonly id: string;
+  readonly label: string;
+  readonly icon: LucideIcon;
+}
+
+const OPEN_IN_APPS: readonly OpenInApp[] = [
+  { id: "code", label: "VS Code", icon: Code2 },
+  { id: "zed", label: "Zed", icon: Zap },
+  { id: "github", label: "GitHub Desktop", icon: Github },
+  { id: "gitbash", label: "Git Bash", icon: SquareTerminal },
+  { id: "explorer", label: "File Explorer", icon: FolderOpen },
+];
+
+/** Small keycap chip; renders nothing when the binding is still pending. */
+function Kbd({ value }: { value: string }) {
+  if (!value) return null;
+  return (
+    <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+      {value}
+    </kbd>
+  );
+}
+
+/** "Soon" tag for tab types that aren't openable yet (deferred features). */
+function SoonBadge() {
+  return (
+    <span className="rounded bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+      Soon
+    </span>
+  );
+}
+
+/** Live availability + open-tab model shared by every variant. */
+interface PanelModel {
+  readonly scope: Scope;
+  readonly openTabs: readonly TabId[];
+  readonly activeTab: TabId | null;
+  /** Types displayed (scope-filtered, not open) — includes coming-soon teasers. */
+  readonly shown: readonly TabMeta[];
+  /** Openable subset of `shown` (excludes coming-soon) — drives the "+" behavior. */
+  readonly available: readonly TabMeta[];
+  readonly openTab: (id: TabId) => void;
+  readonly closeTab: (id: TabId) => void;
+  readonly setActive: (id: TabId) => void;
+}
+
+function usePanelModel(): PanelModel & { setScope: (s: Scope) => void; reset: () => void } {
+  const [scope, setScopeRaw] = useState<Scope>("threadless");
+  const [openTabs, setOpenTabs] = useState<readonly TabId[]>([]);
+  const [activeTab, setActiveTab] = useState<TabId | null>(null);
+
+  const creatableInScope = useCallback(
+    (id: TabId) => {
+      const meta = TABS.find((t) => t.id === id);
+      if (!meta) return false;
+      return scope === "thread" || !meta.needsThread;
+    },
+    [scope],
+  );
+
+  const openTab = useCallback(
+    (id: TabId) => {
+      setOpenTabs((prev) => (prev.includes(id) ? prev : [...prev, id]));
+      setActiveTab(id);
+    },
+    [],
+  );
+
+  const closeTab = useCallback(
+    (id: TabId) => {
+      setOpenTabs((prev) => {
+        const next = prev.filter((t) => t !== id);
+        setActiveTab((cur) => (cur === id ? next[next.length - 1] ?? null : cur));
+        return next;
+      });
+    },
+    [],
+  );
+
+  const setScope = useCallback((s: Scope) => {
+    setScopeRaw(s);
+    // Tabs that need a thread drop when we go threadless — demonstrates rebinding.
+    setOpenTabs((prev) => {
+      const next = prev.filter((id) => {
+        const meta = TABS.find((t) => t.id === id);
+        return s === "thread" || !meta?.needsThread;
+      });
+      setActiveTab((cur) => (cur && next.includes(cur) ? cur : next[next.length - 1] ?? null));
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setOpenTabs([]);
+    setActiveTab(null);
+  }, []);
+
+  const shown = TABS.filter((t) => creatableInScope(t.id) && !openTabs.includes(t.id));
+  const available = shown.filter((t) => !t.comingSoon);
+
+  return { scope, openTabs, activeTab, shown, available, openTab, closeTab, setActive: setActiveTab, setScope, reset };
+}
+
+/**
+ * The dynamic "+" affordance: hidden when nothing is creatable, opens the one
+ * remaining type directly when exactly one is, otherwise shows a menu.
+ */
+function AddAffordance({
+  available,
+  shown,
+  onCreate,
+  iconOnly,
+}: {
+  available: readonly TabMeta[];
+  shown: readonly TabMeta[];
+  onCreate: (id: TabId) => void;
+  iconOnly?: boolean;
+}) {
+  // Nothing openable hides the "+" entirely, even if a coming-soon teaser remains.
+  if (available.length === 0) return null;
+
+  // Exactly one creatable type and nothing else to show opens it directly, no menu.
+  if (available.length === 1 && shown.length === 1) {
+    const only = available[0];
+    return (
+      <Button
+        variant="ghost"
+        size="xs"
+        className="h-7 gap-1 text-muted-foreground hover:text-foreground"
+        title={`New ${only.label}`}
+        onClick={() => onCreate(only.id)}
+      >
+        <Plus size={14} />
+        {!iconOnly && <span className="text-xs">{only.label}</span>}
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="xs"
+            className="h-7 gap-1 text-muted-foreground hover:text-foreground"
+            title="New tab"
+          >
+            <Plus size={14} />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="start" sideOffset={4} className="min-w-[180px]">
+        {shown.map((t) => (
+          <DropdownMenuItem
+            key={t.id}
+            disabled={t.comingSoon}
+            onClick={t.comingSoon ? undefined : () => onCreate(t.id)}
+            className="flex items-center justify-between gap-3 px-3 py-1.5 text-xs data-[disabled]:opacity-60"
+          >
+            <span className="flex items-center gap-2">
+              <t.icon size={14} className="text-muted-foreground" />
+              {t.label}
+            </span>
+            {t.comingSoon ? <SoonBadge /> : <Kbd value={t.keycap} />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Split "open-in" button: default app icon + caret menu (icon + name). */
+function OpenInSplitButton() {
+  const [defaultId, setDefaultId] = useState<string>("code");
+  const current = OPEN_IN_APPS.find((a) => a.id === defaultId) ?? OPEN_IN_APPS[0];
+  const Icon = current.icon;
+  return (
+    <div className="flex items-center">
+      <Button
+        variant="ghost"
+        size="xs"
+        className="h-7 rounded-r-none px-2 text-muted-foreground hover:text-foreground"
+        title={`Open in ${current.label}  ·  Ctrl O`}
+      >
+        <Icon size={14} />
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="xs"
+              className="h-7 rounded-l-none border-l border-border px-1 text-muted-foreground hover:text-foreground"
+              title="Choose app"
+            >
+              <ChevronDown size={12} />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="end" sideOffset={4} className="min-w-[180px]">
+          {OPEN_IN_APPS.map((a) => (
+            <DropdownMenuItem
+              key={a.id}
+              onClick={() => setDefaultId(a.id)}
+              className="flex cursor-pointer items-center justify-between gap-3 px-3 py-1.5 text-xs"
+            >
+              <span className="flex items-center gap-2">
+                <a.icon size={14} className="text-muted-foreground" />
+                {a.label}
+              </span>
+              {a.id === defaultId && <Check size={13} className="text-primary" />}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <div className="px-3 py-1 text-[10px] text-muted-foreground">Sets this thread's default</div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+/** Placeholder body for an open tab. */
+function TabBody({ id }: { id: TabId }) {
+  const meta = TABS.find((t) => t.id === id);
+  if (!meta) return null;
+  const Icon = meta.icon;
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+      <Icon size={28} className="opacity-60" />
+      <div className="text-sm font-medium text-foreground/80">{meta.label}</div>
+      <div className="text-xs">{meta.blurb}</div>
+    </div>
+  );
+}
+
+/* ── Variant A — Quiet list ─────────────────────────────────────────────── */
+function VariantA({ model }: { model: PanelModel }) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-1 border-b border-border/60 px-2 py-1.5">
+        {model.openTabs.map((id) => {
+          const meta = TABS.find((t) => t.id === id);
+          if (!meta) return null;
+          const active = id === model.activeTab;
+          return (
+            <button
+              key={id}
+              onClick={() => model.setActive(id)}
+              className={`group relative flex items-center gap-1.5 rounded px-2 py-1 text-xs ${
+                active ? "text-foreground" : "text-muted-foreground hover:text-foreground/80"
+              }`}
+            >
+              <meta.icon size={13} />
+              {meta.label}
+              {active && <span className="absolute inset-x-1 -bottom-[7px] h-0.5 rounded bg-primary" />}
+              <X
+                size={12}
+                className="ml-0.5 opacity-0 transition group-hover:opacity-60 hover:!opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  model.closeTab(id);
+                }}
+              />
+            </button>
+          );
+        })}
+        {model.openTabs.length > 0 && (
+          <AddAffordance available={model.available} shown={model.shown} onCreate={model.openTab} />
+        )}
+        <div className="ml-auto">
+          <OpenInSplitButton />
+        </div>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {model.activeTab ? (
+          <TabBody id={model.activeTab} />
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <div className="flex w-56 flex-col gap-0.5">
+              {model.shown.map((t) => (
+                <button
+                  key={t.id}
+                  disabled={t.comingSoon}
+                  onClick={t.comingSoon ? undefined : () => model.openTab(t.id)}
+                  className={`flex items-center justify-between rounded px-3 py-2 text-left text-sm text-muted-foreground transition ${
+                    t.comingSoon ? "cursor-default opacity-50" : "hover:bg-muted/40 hover:text-foreground"
+                  }`}
+                >
+                  <span className="flex items-center gap-2.5">
+                    <t.icon size={15} className="opacity-70" />
+                    {t.label}
+                  </span>
+                  {t.comingSoon ? <SoonBadge /> : <Kbd value={t.keycap} />}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Variant B — Card grid ──────────────────────────────────────────────── */
+function VariantB({ model }: { model: PanelModel }) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-1.5 px-2 py-2">
+        {model.openTabs.map((id) => {
+          const meta = TABS.find((t) => t.id === id);
+          if (!meta) return null;
+          const active = id === model.activeTab;
+          return (
+            <button
+              key={id}
+              onClick={() => model.setActive(id)}
+              className={`group flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs ${
+                active
+                  ? "border-primary/60 bg-card text-foreground"
+                  : "border-border bg-transparent text-muted-foreground hover:bg-card/60"
+              }`}
+            >
+              <meta.icon size={13} />
+              {meta.label}
+              <X
+                size={12}
+                className="opacity-0 transition group-hover:opacity-60 hover:!opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  model.closeTab(id);
+                }}
+              />
+            </button>
+          );
+        })}
+        {model.openTabs.length > 0 && (
+          <AddAffordance available={model.available} shown={model.shown} onCreate={model.openTab} />
+        )}
+        <div className="ml-auto">
+          <OpenInSplitButton />
+        </div>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {model.activeTab ? (
+          <TabBody id={model.activeTab} />
+        ) : (
+          <div className="grid h-full grid-cols-2 content-center gap-3 p-6">
+            {model.shown.map((t) => (
+              <button
+                key={t.id}
+                disabled={t.comingSoon}
+                onClick={t.comingSoon ? undefined : () => model.openTab(t.id)}
+                className={`flex flex-col items-center gap-2 rounded-lg border border-border bg-card px-4 py-6 text-center transition ${
+                  t.comingSoon ? "cursor-default opacity-50" : "hover:border-primary/50 hover:bg-card/80"
+                }`}
+              >
+                <t.icon size={22} className="text-muted-foreground" />
+                <div className="text-sm font-medium text-foreground">{t.label}</div>
+                <div className="text-xs text-muted-foreground">{t.blurb}</div>
+                {t.comingSoon ? <SoonBadge /> : <Kbd value={t.keycap} />}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Variant C — Activity rail ──────────────────────────────────────────── */
+function VariantC({ model }: { model: PanelModel }) {
+  return (
+    <div className="flex h-full">
+      <div className="flex w-12 flex-col items-center gap-1 border-r border-border/60 py-2">
+        {model.openTabs.map((id) => {
+          const meta = TABS.find((t) => t.id === id);
+          if (!meta) return null;
+          const active = id === model.activeTab;
+          return (
+            <button
+              key={id}
+              onClick={() => model.setActive(id)}
+              title={meta.label}
+              className={`group relative flex h-9 w-9 items-center justify-center rounded-md ${
+                active ? "bg-card text-foreground" : "text-muted-foreground hover:bg-card/60"
+              }`}
+            >
+              {meta.id === "browser" ? (
+                <img src={MOCK_FAVICON} alt="" className="h-4 w-4 rounded-[3px]" />
+              ) : (
+                <meta.icon size={16} />
+              )}
+              {active && <span className="absolute -left-2 h-5 w-0.5 rounded bg-primary" />}
+              <X
+                size={11}
+                className="absolute -right-1 -top-1 rounded-full bg-background p-[1px] text-muted-foreground opacity-0 ring-1 ring-border transition group-hover:opacity-100 hover:!text-foreground"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  model.closeTab(id);
+                }}
+              />
+            </button>
+          );
+        })}
+        {model.openTabs.length > 0 && (
+          <div className="mt-1">
+            <AddAffordance available={model.available} shown={model.shown} onCreate={model.openTab} iconOnly />
+          </div>
+        )}
+        <div className="mt-auto">
+          <OpenInSplitButton />
+        </div>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {model.activeTab ? (
+          <TabBody id={model.activeTab} />
+        ) : (
+          <div className="grid h-full grid-cols-2 content-center gap-3 overflow-y-auto p-6">
+            {model.shown.map((t) => (
+              <button
+                key={t.id}
+                disabled={t.comingSoon}
+                onClick={t.comingSoon ? undefined : () => model.openTab(t.id)}
+                className={`flex flex-col items-center gap-2 rounded-lg border border-border bg-card px-4 py-6 text-center transition ${
+                  t.comingSoon ? "cursor-default opacity-50" : "hover:border-primary/50 hover:bg-card/80"
+                }`}
+              >
+                <t.icon size={22} className="text-muted-foreground" />
+                <div className="text-sm font-medium text-foreground">{t.label}</div>
+                <div className="text-xs text-muted-foreground">{t.blurb}</div>
+                {t.comingSoon ? <SoonBadge /> : <Kbd value={t.keycap} />}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Floating variant switcher. Hidden in production builds. */
+function Switcher({ current, onCycle }: { current: VariantKey; onCycle: (dir: 1 | -1) => void }) {
+  if (import.meta.env.PROD) return null;
+  return (
+    <div className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-full border border-white/15 bg-black/80 px-3 py-1.5 text-white shadow-lg backdrop-blur">
+      <button onClick={() => onCycle(-1)} className="rounded p-1 hover:bg-white/10" title="Previous (←)">
+        <ChevronLeft size={16} />
+      </button>
+      <span className="min-w-[140px] text-center text-xs font-medium">
+        {current} — {VARIANT_NAMES[current]}
+      </span>
+      <button onClick={() => onCycle(1)} className="rounded p-1 hover:bg-white/10" title="Next (→)">
+        <ChevronRight size={16} />
+      </button>
+    </div>
+  );
+}
+
+const ORDER: readonly VariantKey[] = ["A", "B", "C"];
+const STORAGE_KEY = "proto-variant";
+
+function coerce(v: string | null): VariantKey | null {
+  return v === "A" || v === "B" || v === "C" ? v : null;
+}
+
+// The app reloads once on boot to set the dev ?token=, which drops our ?variant=.
+// Seed storage from the URL at module-eval time (before that reload) so direct
+// ?variant= links win; storage then carries the choice across the reload.
+(() => {
+  const fromUrl = coerce(new URLSearchParams(window.location.search).get("variant"));
+  if (fromUrl) sessionStorage.setItem(STORAGE_KEY, fromUrl);
+})();
+
+function readVariant(): VariantKey {
+  return coerce(sessionStorage.getItem(STORAGE_KEY)) ?? "A";
+}
+
+/**
+ * Throwaway prototype surface for the right-panel revamp. Mounted by App when
+ * `?prototype=panel` is present. Compare empty-state and tab-strip treatments
+ * across three variants; toggle scope to feel the availability rules.
+ */
+export function RightPanelPrototype() {
+  const [variant, setVariant] = useState<VariantKey>(readVariant);
+  const model = usePanelModel();
+
+  // The revamp targets the dark Whisper aesthetic; force it on regardless of the
+  // user's theme so the prototype is judged in its intended palette. Throwaway.
+  useEffect(() => {
+    const html = document.documentElement;
+    const had = html.classList.contains("dark");
+    html.classList.add("dark");
+    return () => {
+      if (!had) html.classList.remove("dark");
+    };
+  }, []);
+
+  const cycle = useCallback((dir: 1 | -1) => {
+    setVariant((cur) => {
+      const next = ORDER[(ORDER.indexOf(cur) + dir + ORDER.length) % ORDER.length];
+      sessionStorage.setItem(STORAGE_KEY, next);
+      const url = new URL(window.location.href);
+      url.searchParams.set("prototype", "panel");
+      url.searchParams.set("variant", next);
+      window.history.replaceState(null, "", url);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const el = document.activeElement;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || (el as HTMLElement).isContentEditable)) {
+        return;
+      }
+      if (e.key === "ArrowLeft") cycle(-1);
+      if (e.key === "ArrowRight") cycle(1);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [cycle]);
+
+  return (
+    <div className="flex h-screen flex-col bg-page text-foreground">
+      {/* Prototype scaffolding — clearly not part of the design under evaluation. */}
+      <div className="flex items-center gap-3 border-b border-border bg-background px-4 py-2 text-xs">
+        <span className="font-semibold text-foreground/80">Right-panel prototype</span>
+        <span className="text-muted-foreground">scope:</span>
+        {(["threadless", "thread"] as const).map((s) => (
+          <button
+            key={s}
+            onClick={() => model.setScope(s)}
+            className={`rounded px-2 py-0.5 ${
+              model.scope === s ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
+            }`}
+          >
+            {s === "threadless" ? "No thread" : "Thread open"}
+          </button>
+        ))}
+        <button onClick={model.reset} className="ml-2 rounded bg-muted px-2 py-0.5 text-muted-foreground hover:text-foreground">
+          Reset tabs
+        </button>
+        <span className="ml-auto text-muted-foreground">
+          {model.openTabs.length} open · {model.available.length} creatable
+        </span>
+      </div>
+
+      {/* The panel surface, centered against page chrome like the real layout. */}
+      <div className="flex flex-1 justify-end overflow-hidden p-1.5">
+        <div className="flex h-full w-[440px] overflow-hidden rounded-lg bg-background shadow-sm">
+          <div className="flex-1">
+            {variant === "A" && <VariantA model={model} />}
+            {variant === "B" && <VariantB model={model} />}
+            {variant === "C" && <VariantC model={model} />}
+          </div>
+        </div>
+      </div>
+
+      <Switcher current={variant} onCycle={cycle} />
+    </div>
+  );
+}

--- a/docs/adr/0004-workspace-global-right-panel-singleton-tabs.md
+++ b/docs/adr/0004-workspace-global-right-panel-singleton-tabs.md
@@ -1,0 +1,65 @@
+---
+status: accepted
+---
+
+# The right panel is workspace-global with singleton tabs; tab contents keep their own scope
+
+## Context
+
+The right panel was entirely thread-scoped: `RightPanel.tsx` returns `null`
+without an `activeThreadId`, and every bit of panel state (visibility, width,
+active tab) lived in `diffStore`'s `rightPanelByThread: Record<threadId, ...>`.
+`CONTEXT.md` reinforced this — Preview was defined as "thread-scoped: each
+thread keeps its own set of tabs."
+
+The revamp requires the panel to be usable **before any thread exists** — the
+user can open a Browser or Terminal against the workspace from the empty app.
+That breaks the "no thread → no panel" invariant the whole module was built on,
+and forces a decision about where panel state lives and what scope each tab runs
+against.
+
+## Decision
+
+The **panel container** becomes **workspace-global**: visibility, width, and
+active tab persist with no thread open. The panel no longer returns `null` when
+there is no thread.
+
+Individual **tabs keep their own scope**, declared per tab type rather than
+inherited from the panel:
+
+- **Browser, Terminal, Files** run against the **workspace root** when no thread
+  is active, and rebind to the thread's worktree when one exists.
+- **Review** is dual-scope: its git-working-tree views (Unstaged/Staged/Commit/
+  Branch) need no thread; its turn views (Last turn, Cumulative) need one.
+- **Scope** is thread-only and is simply unavailable threadless.
+
+Every top-level tab is a **singleton** — at most one Browser, Terminal, Review,
+Files, Scope. Multiplicity lives *inside* a tab (Browser pages, Terminal
+shells), never as duplicate top-level tabs. The creatable-types set is filtered
+by scope then by cardinality; when one type is creatable the add affordance
+opens it directly, when none are it is hidden.
+
+## Considered Options
+
+- **Keep the panel fully thread-scoped (rejected).** Status quo; makes the
+  threadless Browser/Terminal requirement impossible.
+- **Make everything fully workspace-scoped (rejected).** Detaches tabs from
+  threads entirely, discarding the per-thread Preview/Terminal model the rest of
+  the app and the existing stores depend on, and breaking "each thread keeps its
+  own tabs."
+- **Allow multiple top-level tabs of the same type (rejected).** Duplicate
+  Browser/Terminal tabs at the panel level would make the "add" menu never empty
+  and contradict the existing internal page/shell pooling. Singleton tabs with
+  internal multiplicity match both the Codex pattern and mcode's current
+  `PreviewTabBar` / `TerminalPoolHost`.
+
+## Consequences
+
+- `rightPanelByThread` migrates to a workspace-global slice plus per-tab content
+  scope. This is the costly-to-reverse part of the decision.
+- Panel state is global but tab *contents* are scoped — a deliberate split that
+  a future reader should not "simplify" into one or the other.
+- Threadless tabs need a cwd; they resolve to the active workspace root, and are
+  unavailable when there is no workspace at all.
+- The `CONTEXT.md` "Preview is thread-scoped" language is superseded; Preview is
+  now the Browser tab type within the workspace-global panel.

--- a/docs/adr/0005-two-tier-default-open-in-app.md
+++ b/docs/adr/0005-two-tier-default-open-in-app.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+---
+
+# The default open-in app resolves in three tiers; choosing in a thread sets a thread-only override
+
+## Context
+
+"Open in editor" was a fixed dropdown: `mod+o` always opened the system File
+Explorer, and selecting an editor was a one-off action that persisted nothing
+(`OpenInEditorMenu.tsx`). The revamp turns this into a split button whose
+primary action / `mod+o` opens a **default** app, with a dropdown to choose it.
+
+The question is where that default lives. A single global setting is the obvious
+choice, but it loses per-thread intent: a user reviewing a thread in Cursor and
+another in VS Code would have to keep flipping one global preference.
+
+## Decision
+
+The effective open-in app resolves in **three tiers**:
+
+1. **Thread override** — the app last picked from *that thread's* menu, persisted
+   on the thread and surviving restarts.
+2. **Global default** — `externalApps.defaultEditor` in user settings.
+3. **Auto-resolve** — highest-priority installed editor (VS Code → Cursor → Zed),
+   falling back to File Explorer.
+
+Choosing an app from a thread's menu writes **tier 1 only**; it never changes the
+global default. The global default is configured in Settings, independent of any
+thread.
+
+## Consequences
+
+- A choice made in a thread is sticky to that thread and does not leak into the
+  user's global preference — the surprising-but-intentional behavior this ADR
+  exists to record.
+- The auto-resolve tier means the split button is fully usable on day one with no
+  configuration, so the Settings UI for the global default can ship as a
+  follow-up without blocking the feature.
+- Per-thread override persistence requires thread-scoped storage alongside the
+  existing per-thread panel state.
+- The open-in app registry expands beyond editors (terminals, git GUI, Explorer);
+  every detected app is eligible as the default. That registry/detection
+  expansion is tracked separately as an architecture-improvement effort.

--- a/docs/adr/0006-external-terminal-launch-no-shell-resolver-sharing.md
+++ b/docs/adr/0006-external-terminal-launch-no-shell-resolver-sharing.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+---
+
+# External-terminal launch does not share the server's ShellEnvResolver
+
+## Context
+
+An architecture review of the open-in app surface proposed sharing the
+server's `ShellEnvResolver` with a desktop external-terminal launch path, to
+avoid re-implementing shell selection. `ShellEnvResolver` lives in the server
+process because it resolves the **login shell and merged environment for the
+embedded PTY** — the in-app terminal.
+
+"Open in Windows Terminal / Git Bash / WSL", by contrast, launches an
+**external** terminal emulator. Those programs set up their own environment and
+are started by spawning their executable with a working-directory argument
+(`wt -d <dir>`, `wsl --cd <dir>`, `git-bash --cd=<dir>`). That is the same shape
+as the per-editor launch arguments the open-in app registry already models.
+
+## Decision
+
+External-terminal launch is an ordinary **Open-in app registry** adapter:
+detect the terminal executable, launch it with the target directory. It does
+**not** share, import, or RPC into `ShellEnvResolver`, which stays a PTY-only
+concern. There is no cross-process coupling between desktop-main and the server
+for this feature.
+
+We deliberately forgo **environment parity** between the in-app PTY and an
+externally launched terminal: an external terminal behaves like the user's
+normal terminal, resolving its own environment.
+
+## Consequences
+
+- The terminal app kind folds into the registry alongside editors, the git GUI,
+  and File Explorer — no shared package and no server round-trip.
+- The previously "speculative" candidate to share `ShellEnvResolver` is closed;
+  future architecture reviews should not re-raise it.
+- If environment parity between the in-app PTY and external terminals is ever
+  wanted, it is an additive enhancement layered on the adapter, not a reversal
+  of this decision, and should be recorded separately.


### PR DESCRIPTION
## What
Design records (ADRs + glossary) and dev-only throwaway prototypes for the right-panel revamp, the in-app browser view, and the chat-header consolidation. No production behavior changes.

## Why
This branch is the design/spike phase. The ADRs capture the decisions reached while grilling the design; the prototypes validate the look-and-feel before implementation. The validated designs are tracked as issues that fold them into the real UI — epics #601 (open-in app) and #608 (panel / browser / chat header) — and the prototypes are removed by #619 once those features land.

## Key Changes
- **ADRs + glossary:** ADR-0004 (workspace-global right panel with singleton tabs), ADR-0005 (three-tier default open-in app), ADR-0006 (external-terminal launch does not share `ShellEnvResolver`), plus matching `CONTEXT.md` terms (Right panel, Tab availability, Review tab, Open-in app, Default open-in app).
- **Prototypes (dev-only, gated on `import.meta.env.DEV` + a `?prototype=` search param):**
  - `?prototype=panel` — workspace-global activity-rail tabbed panel, card-grid empty state, dynamic add control, hover-x close, favicon rail glyph.
  - `?prototype=browser` — clean URL header states, localhost-ports empty state, decluttered overflow kebab. (Design mode / screenshot are existing and unchanged — illustrative only.)
  - `?prototype=header` — chat-header variant A: project badge + Create PR + open-in split Open button, a consolidated workspace menu, and a right-panel toggle.
- **`NOTES.md`** captures the verdicts for each surface.
- No production code paths touched beyond a dev-gated early return in `App.tsx`.

## Config Changes
None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783603319&installation_id=129163861&pr_number=620&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F620&signature=4578efe6e4605703f6b5d28e5019ff15a92eb1bf4eb5a1daa2efdf3933f133fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified right panel workspace-global scope and tab availability rules, including dual-scope behavior for Review tabs.
  * Documented default "Open in app" resolution order (thread override → global default → auto-resolution).
  * Updated terminology for Browser tab type and in-app preview availability.

* **Architecture**
  * Recorded decisions on workspace-global right panel design with per-tab singleton patterns.
  * Documented external terminal launch strategy as a standard app registry adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->