### PR TITLE
feat(panel): per-thread panel visibility with workspace-global width/tab

### DIFF
--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -113,24 +113,39 @@ export class TerminalService {
   }
 
   /**
-   * Spawn a new PTY session tied to the given thread.
-   * Resolves the working directory from the thread's workspace and worktree path.
+   * Spawn a new PTY session tied to the given scope.
+   *
+   * The scope id is normally a thread id, in which case the working directory
+   * follows the thread's worktree (worktree mode) or the workspace root. When no
+   * thread is active yet — the new-thread composer view — the scope id is a
+   * workspace id and the shell opens at the workspace root (the local checkout),
+   * never a worktree, because no worktree exists until the thread is created.
+   *
+   * @param scopeId - A thread id, or a workspace id for the threadless shell.
    * @returns The unique PTY session ID.
    */
-  create(threadId: string): { ptyId: string; shell: string } {
-    const thread = this.threadRepo.findById(threadId);
-    if (!thread) throw new Error(`Thread not found: ${threadId}`);
+  create(scopeId: string): { ptyId: string; shell: string } {
+    const thread = this.threadRepo.findById(scopeId);
 
-    const workspace = this.workspaceRepo.findById(thread.workspace_id);
-    if (!workspace) {
-      throw new Error(`Workspace not found: ${thread.workspace_id}`);
+    let cwd: string;
+    if (thread) {
+      const workspace = this.workspaceRepo.findById(thread.workspace_id);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${thread.workspace_id}`);
+      }
+      cwd = this.gitService.resolveWorkingDir(
+        workspace.path,
+        thread.mode,
+        thread.worktree_path,
+      );
+    } else {
+      // Threadless shell: the scope is a workspace, so anchor at its local root.
+      const workspace = this.workspaceRepo.findById(scopeId);
+      if (!workspace) {
+        throw new Error(`Thread or workspace not found: ${scopeId}`);
+      }
+      cwd = workspace.path;
     }
-
-    const cwd = this.gitService.resolveWorkingDir(
-      workspace.path,
-      thread.mode,
-      thread.worktree_path,
-    );
 
     if (
       !isAbsolute(cwd) ||
@@ -140,19 +155,19 @@ export class TerminalService {
       throw new Error(`Invalid working directory: ${cwd}`);
     }
 
-    const threadPtys = this.threadIndex.get(threadId);
+    const threadPtys = this.threadIndex.get(scopeId);
     const count = threadPtys?.size ?? 0;
 
     if (count >= MAX_PTYS_PER_THREAD) {
       throw new Error(
-        `Maximum PTY limit (${MAX_PTYS_PER_THREAD}) reached for thread ${threadId}`,
+        `Maximum PTY limit (${MAX_PTYS_PER_THREAD}) reached for scope ${scopeId}`,
       );
     }
 
     const id = uuid();
     const shell = defaultShell();
 
-    logger.info("Spawning PTY", { id, threadId, shell, cwd });
+    logger.info("Spawning PTY", { id, scopeId, shell, cwd });
 
     const pty = getSpawn()(shell, [], {
       name: TERM_NAME,
@@ -208,7 +223,7 @@ export class TerminalService {
 
     const session: PtySession = {
       id,
-      threadId,
+      threadId: scopeId,
       pty,
       dataDisposable,
       exitDisposable,
@@ -219,7 +234,7 @@ export class TerminalService {
     updatedSet.add(id);
     this.threadIndex = new Map([
       ...this.threadIndex,
-      [threadId, updatedSet],
+      [scopeId, updatedSet],
     ]);
 
     return { ptyId: id, shell: shellBasename(shell) };

--- a/apps/web/e2e/composer-codex-fast-mode.spec.ts
+++ b/apps/web/e2e/composer-codex-fast-mode.spec.ts
@@ -72,7 +72,7 @@ async function setupCodexChat(page: Page): Promise<void> {
         return "showRightPanel" in st && "hideRightPanel" in st;
       });
       if (diffStore) {
-        diffStore.getState().hideRightPanel(th.id);
+        diffStore.getState().hideRightPanel(ws.id);
       }
     },
     { ws: WORKSPACE, th: CODEX_THREAD },

--- a/apps/web/e2e/plan-tab.spec.ts
+++ b/apps/web/e2e/plan-tab.spec.ts
@@ -64,20 +64,21 @@ async function setupWorkspace(page: Page): Promise<void> {
   );
 }
 
-async function showRightPanel(page: Page, threadId: string): Promise<void> {
+async function showRightPanel(page: Page, workspaceId: string, threadId: string): Promise<void> {
   await page.evaluate(
-    ({ tid }) => {
+    ({ wid, tid }) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const stores: any[] = (window as any).__mcodeStores ?? [];
       const diffStore = stores.find((s) => {
         const st = s.getState();
-        return "rightPanelByThread" in st && "showRightPanel" in st;
+        return "rightPanelByWorkspace" in st && "showRightPanel" in st;
       });
       if (!diffStore) throw new Error("[E2E] diff store not found");
-      diffStore.getState().showRightPanel(tid);
-      diffStore.getState().setRightPanelTab(tid, "tasks");
+      // Open/closed is per-thread; width/tab stay workspace-global.
+      diffStore.getState().showRightPanel(wid, tid);
+      diffStore.getState().setRightPanelTab(wid, "tasks");
     },
-    { tid: threadId },
+    { wid: workspaceId, tid: threadId },
   );
 }
 
@@ -111,7 +112,7 @@ test.describe("Plan view in Scope tab", () => {
   });
 
   test("scope tab button exists in the right panel header", async ({ page }) => {
-    await showRightPanel(page, THREAD.id);
+    await showRightPanel(page, WORKSPACE.id, THREAD.id);
 
     const scopeTab = page.getByRole("button", { name: "Scope" });
     await expect(scopeTab).toBeVisible({ timeout: 3000 });
@@ -119,7 +120,7 @@ test.describe("Plan view in Scope tab", () => {
 
   test("scope tab shows empty state when no plan and no tasks exist", async ({ page }) => {
     await seedPlanStore(page, THREAD.id);
-    await showRightPanel(page, THREAD.id);
+    await showRightPanel(page, WORKSPACE.id, THREAD.id);
 
     // The empty state shows the existing "Nothing on the docket" message
     await expect(page.getByText("Nothing on the docket")).toBeVisible({ timeout: 3000 });

--- a/apps/web/e2e/plan-version-scroll.spec.ts
+++ b/apps/web/e2e/plan-version-scroll.spec.ts
@@ -66,21 +66,22 @@ async function setupWorkspace(page: Page): Promise<void> {
   );
 }
 
-async function showRightPanel(page: Page, threadId: string): Promise<void> {
+async function showRightPanel(page: Page, workspaceId: string, threadId: string): Promise<void> {
   await page.evaluate(
-    ({ tid }) => {
+    ({ wid, tid }) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const stores: any[] = (window as any).__mcodeStores ?? [];
       const diffStore = stores.find((s) => {
         const st = s.getState();
-        return "rightPanelByThread" in st && "showRightPanel" in st;
+        return "rightPanelByWorkspace" in st && "showRightPanel" in st;
       });
       if (!diffStore) throw new Error("[E2E] diff store not found");
-      diffStore.getState().showRightPanel(tid);
-      diffStore.getState().setRightPanelTab(tid, "tasks");
-      diffStore.getState().setRightPanelWidth(tid, 520);
+      // Open/closed is per-thread; width/tab stay workspace-global.
+      diffStore.getState().showRightPanel(wid, tid);
+      diffStore.getState().setRightPanelTab(wid, "tasks");
+      diffStore.getState().setRightPanelWidth(wid, 520);
     },
-    { tid: threadId },
+    { wid: workspaceId, tid: threadId },
   );
 }
 
@@ -200,7 +201,7 @@ test.describe("Plan version navigation layout stability", () => {
     await page.waitForLoadState("networkidle");
     await setupWorkspace(page);
     await seedPlanVersions(page, THREAD.id);
-    await showRightPanel(page, THREAD.id);
+    await showRightPanel(page, WORKSPACE.id, THREAD.id);
     await expect(page.getByRole("button", { name: "Next version" })).toBeVisible({
       timeout: 5000,
     });
@@ -255,7 +256,7 @@ test.describe("Plan version navigation layout stability", () => {
 
   test("overlay panel mode keeps stable width on version switch", async ({ page }) => {
     await page.setViewportSize({ width: 900, height: 700 });
-    await showRightPanel(page, THREAD.id);
+    await showRightPanel(page, WORKSPACE.id, THREAD.id);
     await expect(page.getByRole("button", { name: "Next version" })).toBeVisible({
       timeout: 5000,
     });

--- a/apps/web/e2e/right-panel-preview-threadless.spec.ts
+++ b/apps/web/e2e/right-panel-preview-threadless.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect, type Page } from "@playwright/test";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-preview-threadless",
+  name: "Threadless Preview WS",
+  path: "/tmp/preview-threadless",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+/**
+ * Inject a no-op `window.desktopBridge.preview` before the page loads so the
+ * PreviewPanel renders its chrome instead of the desktop-only empty state.
+ * Mirrors the bridge stub in preview-chrome.spec.ts, trimmed to the methods the
+ * panel touches on first paint.
+ */
+async function injectPreviewBridge(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const noop = (): Promise<void> => Promise.resolve();
+    const captureFail = (): Promise<{ ok: false; error: string }> =>
+      Promise.resolve({ ok: false, error: "no-preview" });
+    const unsub = (): (() => void) => () => undefined;
+    const emptyTabSet = (threadId: string): unknown => ({
+      threadId,
+      activeTabId: null,
+      tabs: [],
+    });
+    const tabOk = (threadId: string): Promise<unknown> =>
+      Promise.resolve({ ok: true, data: emptyTabSet(threadId) });
+    const tabCreateOk = (threadId: string): Promise<unknown> =>
+      Promise.resolve({
+        ok: true,
+        data: { tabSet: emptyTabSet(threadId), createdTabId: "mock-tab" },
+      });
+    const preview = {
+      sync: noop,
+      navigate: () => Promise.resolve({ ok: true } as const),
+      goBack: () => Promise.resolve(false),
+      goForward: () => Promise.resolve(false),
+      reload: noop,
+      openExternal: noop,
+      openGuestDevTools: noop,
+      onShortcutFired: unsub,
+      getNavigationState: () =>
+        Promise.resolve({ canGoBack: false, canGoForward: false }),
+      capturePictureReference: captureFail,
+      capturePictureReferenceRegion: captureFail,
+      capturePictureReferenceElementPick: captureFail,
+      capturePageContext: () =>
+        Promise.resolve({ ok: false, error: "no-preview" } as const),
+      releaseBrowserCaptureSpills: noop,
+      onPageStatus: (
+        cb: (s: {
+          url: string | null;
+          title: string | null;
+          favicon: string | null;
+          phase: "loading" | "loaded" | "error" | "discarded";
+        }) => void,
+      ) => {
+        cb({ url: null, title: null, favicon: null, phase: "loaded" });
+        return () => undefined;
+      },
+      cancelCapture: noop,
+      tabs: {
+        list: (threadId: string) => tabOk(threadId),
+        create: (threadId: string) => tabCreateOk(threadId),
+        activate: (threadId: string) => tabOk(threadId),
+        close: (threadId: string) => tabOk(threadId),
+        onUpdated: unsub,
+      },
+      getPerfCounters: () =>
+        Promise.resolve({
+          ramKb: 0,
+          frameRateHz: 60,
+          gpuProcessActive: false,
+          allocationsPerSec: 0,
+        }),
+      adoptWebview: () => Promise.resolve({ ok: true } as const),
+      releaseWebview: () => Promise.resolve({ ok: true } as const),
+      design: {
+        setViewport: () =>
+          Promise.resolve({ ok: true, data: { width: 0, height: 0 } } as const),
+        resetViewport: noop,
+        setInspect: () => Promise.resolve({ ok: true } as const),
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).desktopBridge = { preview };
+  });
+}
+
+/**
+ * Enters the new-thread composer view (a workspace is active but no thread is)
+ * and opens the right panel threadless on the Preview tab. This is the state the
+ * user sees before sending the first message, where the Browser tab must still
+ * render against the workspace's local checkout.
+ */
+async function openThreadlessPreview(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ workspace, wid }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) =>
+        (s as { getState: () => Record<string, unknown> }).getState();
+      const wsStore = stores.find(
+        (s) => "activeThreadId" in getState(s) && "pendingNewThread" in getState(s),
+      );
+      (wsStore as { setState: (p: unknown) => void } | undefined)?.setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: [],
+        activeThreadId: null,
+        // New-thread composer view: panel renders without a thread.
+        pendingNewThread: true,
+      });
+      const diffStore = stores.find((s) => "showRightPanel" in getState(s));
+      if (diffStore) {
+        const api = (
+          diffStore as {
+            getState: () => {
+              showRightPanel: (id: string, threadId?: string) => void;
+              setRightPanelTab: (id: string, t: string) => void;
+            };
+          }
+        ).getState();
+        // No thread id → threadless workspace visibility.
+        api.showRightPanel(wid);
+        api.setRightPanelTab(wid, "preview");
+      }
+    },
+    { workspace: WORKSPACE, wid: WORKSPACE.id },
+  );
+}
+
+test.describe("Right panel threadless preview", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectPreviewBridge(page);
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [],
+      "settings.get": getDefaultSettings(),
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1920, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+  });
+
+  test("the Preview tab renders chrome with no active thread", async ({ page }) => {
+    await openThreadlessPreview(page);
+
+    // The Browser tab must paint against the workspace scope, not stay blank
+    // because no thread is active. The chrome path (not the desktop-only empty
+    // state) proves the panel mounted threadless.
+    await expect(page.getByTestId("preview-panel")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByLabel("Reload")).toBeVisible();
+  });
+});

--- a/apps/web/e2e/right-panel-tab-status.spec.ts
+++ b/apps/web/e2e/right-panel-tab-status.spec.ts
@@ -84,7 +84,7 @@ const SNAPSHOTS = [
  */
 async function seedPanel(page: Page, tab: "tasks" | "changes"): Promise<void> {
   await page.evaluate(
-    ({ workspace, thread, tid, snapshots, tab }) => {
+    ({ workspace, thread, tid, wid, snapshots, tab }) => {
       const stores: unknown[] =
         (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
       const getState = (s: unknown) =>
@@ -108,17 +108,17 @@ async function seedPanel(page: Page, tab: "tasks" | "changes"): Promise<void> {
           diffStore as {
             getState: () => {
               setSnapshots: (id: string, snaps: unknown) => void;
-              showRightPanel: (id: string) => void;
+              showRightPanel: (id: string, threadId?: string) => void;
               setRightPanelTab: (id: string, t: string) => void;
             };
           }
         ).getState();
         api.setSnapshots(tid, snapshots);
-        api.showRightPanel(tid);
-        api.setRightPanelTab(tid, tab);
+        api.showRightPanel(wid, tid);
+        api.setRightPanelTab(wid, tab);
       }
     },
-    { workspace: WORKSPACE, thread: THREAD, tid: THREAD.id, snapshots: SNAPSHOTS, tab },
+    { workspace: WORKSPACE, thread: THREAD, tid: THREAD.id, wid: WORKSPACE.id, snapshots: SNAPSHOTS, tab },
   );
 }
 

--- a/apps/web/e2e/right-panel-terminal-resize.spec.ts
+++ b/apps/web/e2e/right-panel-terminal-resize.spec.ts
@@ -49,9 +49,9 @@ function makeThread(id: string, title: string): Thread {
 
 const THREAD = makeThread("thread-resize", "Resize Thread");
 
-/** Reads the stored right-panel width for a thread from diffStore. */
-async function getRightPanelWidth(page: Page, threadId: string): Promise<number> {
-  return page.evaluate((tid) => {
+/** Reads the stored right-panel width for a workspace from diffStore. */
+async function getRightPanelWidth(page: Page, workspaceId: string): Promise<number> {
+  return page.evaluate((wid) => {
     const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
     const diffStore = stores.find((s: unknown) => {
       const st = (s as { getState: () => Record<string, unknown> }).getState();
@@ -62,15 +62,15 @@ async function getRightPanelWidth(page: Page, threadId: string): Promise<number>
       diffStore as { getState: () => { getRightPanel: (id: string) => { width: number } } }
     )
       .getState()
-      .getRightPanel(tid);
+      .getRightPanel(wid);
     return panel.width;
-  }, threadId);
+  }, workspaceId);
 }
 
 /** Opens the right-panel terminal tab and mounts a PTY for the thread. */
 async function openTerminalWithPty(page: Page, threadId: string): Promise<void> {
   await page.evaluate(
-    ({ workspace, thread, tid }) => {
+    ({ workspace, thread, tid, wid }) => {
       const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
       const wsStore = stores.find((s: unknown) => {
         const st = (s as { getState: () => Record<string, unknown> }).getState();
@@ -93,13 +93,13 @@ async function openTerminalWithPty(page: Page, threadId: string): Promise<void> 
         const api = (
           diffStore as {
             getState: () => {
-              showRightPanel: (id: string) => void;
+              showRightPanel: (id: string, threadId?: string) => void;
               setRightPanelTab: (id: string, tab: string) => void;
             };
           }
         ).getState();
-        api.showRightPanel(tid);
-        api.setRightPanelTab(tid, "terminal");
+        api.showRightPanel(wid, tid);
+        api.setRightPanelTab(wid, "terminal");
       }
 
       const termStore = stores.find((s: unknown) => {
@@ -116,7 +116,7 @@ async function openTerminalWithPty(page: Page, threadId: string): Promise<void> 
           .addTerminal(tid, `pty-${tid}`, "bash");
       }
     },
-    { workspace: WORKSPACE, thread: THREAD, tid: threadId },
+    { workspace: WORKSPACE, thread: THREAD, tid: threadId, wid: WORKSPACE.id },
   );
 }
 
@@ -153,7 +153,7 @@ test.describe("Right panel resize with terminal tab", () => {
     const box = await handle.boundingBox();
     expect(box, "vertical resize handle must be visible").not.toBeNull();
 
-    const widthBefore = await getRightPanelWidth(page, THREAD.id);
+    const widthBefore = await getRightPanelWidth(page, WORKSPACE.id);
     expect(widthBefore).toBeGreaterThan(0);
 
     await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
@@ -162,7 +162,7 @@ test.describe("Right panel resize with terminal tab", () => {
     await page.mouse.up();
 
     await expect
-      .poll(() => getRightPanelWidth(page, THREAD.id), { timeout: 3_000 })
+      .poll(() => getRightPanelWidth(page, WORKSPACE.id), { timeout: 3_000 })
       .not.toBe(widthBefore);
   });
 });

--- a/apps/web/e2e/right-panel-terminal-threadless.spec.ts
+++ b/apps/web/e2e/right-panel-terminal-threadless.spec.ts
@@ -1,14 +1,13 @@
 import { test, expect, type Page } from "@playwright/test";
-import type { Thread } from "@mcode/contracts";
 import { getDefaultSettings } from "@mcode/contracts";
 import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
 
 const now = new Date().toISOString();
 
 const WORKSPACE = {
-  id: "ws-term-autostart",
-  name: "Autostart WS",
-  path: "/tmp/term-autostart",
+  id: "ws-term-threadless",
+  name: "Threadless WS",
+  path: "/tmp/term-threadless",
   provider_config: {},
   is_git_repo: true,
   created_at: now,
@@ -18,40 +17,9 @@ const WORKSPACE = {
   sort_order: 0,
 };
 
-function makeThread(id: string, title: string): Thread {
-  return {
-    id,
-    workspace_id: WORKSPACE.id,
-    title,
-    status: "paused",
-    mode: "direct",
-    worktree_path: null,
-    branch: "main",
-    worktree_managed: false,
-    issue_number: null,
-    pr_number: null,
-    pr_status: null,
-    sdk_session_id: null,
-    created_at: now,
-    updated_at: now,
-    model: "claude-3-5-sonnet",
-    provider: "claude",
-    deleted_at: null,
-    last_context_tokens: null,
-    context_window: null,
-    reasoning_level: null,
-    interaction_mode: null,
-    permission_mode: null,
-    parent_thread_id: null,
-    forked_from_message_id: null,
-  };
-}
-
-const THREAD = makeThread("thread-term-autostart", "Autostart Thread");
-
-/** Reads the number of terminals the store holds for a thread. */
-async function terminalCount(page: Page, threadId: string): Promise<number> {
-  return page.evaluate((tid) => {
+/** Reads how many terminals the store holds for a scope (thread or workspace). */
+async function terminalCount(page: Page, scopeId: string): Promise<number> {
+  return page.evaluate((sid) => {
     const stores: unknown[] =
       (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
     const termStore = stores.find(
@@ -60,23 +28,34 @@ async function terminalCount(page: Page, threadId: string): Promise<number> {
     if (!termStore) return -1;
     const terminals = (
       termStore as { getState: () => { terminals: Record<string, unknown[]> } }
-    ).getState().terminals[tid];
+    ).getState().terminals[sid];
     return terminals ? terminals.length : 0;
-  }, threadId);
+  }, scopeId);
 }
 
-async function openPanelOnScope(page: Page): Promise<void> {
+/**
+ * Enters the new-thread composer view (a workspace is active but no thread is)
+ * and opens the right panel threadless on the Scope tab. This is the state the
+ * user sees before sending the first message, where the Terminal must still run
+ * against the workspace's local checkout.
+ */
+async function openThreadlessPanel(page: Page): Promise<void> {
   await page.evaluate(
-    ({ workspace, thread, tid, wid }) => {
+    ({ workspace, wid }) => {
       const stores: unknown[] =
         (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
-      const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
-      const wsStore = stores.find((s) => "activeThreadId" in getState(s) && "threads" in getState(s));
+      const getState = (s: unknown) =>
+        (s as { getState: () => Record<string, unknown> }).getState();
+      const wsStore = stores.find(
+        (s) => "activeThreadId" in getState(s) && "pendingNewThread" in getState(s),
+      );
       (wsStore as { setState: (p: unknown) => void } | undefined)?.setState({
         workspaces: [workspace],
         activeWorkspaceId: workspace.id,
-        threads: [thread],
-        activeThreadId: tid,
+        threads: [],
+        activeThreadId: null,
+        // New-thread composer view: panel renders without a thread.
+        pendingNewThread: true,
       });
       const diffStore = stores.find((s) => "showRightPanel" in getState(s));
       if (diffStore) {
@@ -88,20 +67,21 @@ async function openPanelOnScope(page: Page): Promise<void> {
             };
           }
         ).getState();
-        api.showRightPanel(wid, tid);
+        // No thread id → threadless workspace visibility.
+        api.showRightPanel(wid);
         api.setRightPanelTab(wid, "tasks");
       }
     },
-    { workspace: WORKSPACE, thread: THREAD, tid: THREAD.id, wid: WORKSPACE.id },
+    { workspace: WORKSPACE, wid: WORKSPACE.id },
   );
 }
 
-test.describe("Right panel terminal auto-start", () => {
+test.describe("Right panel threadless terminal", () => {
   test.beforeEach(async ({ page }) => {
     await mockWebSocketServer(page, {
       "workspace.list": [WORKSPACE],
-      "thread.list": [THREAD],
-      "terminal.create": { ptyId: "pty-term-autostart", shell: "bash" },
+      "thread.list": [],
+      "terminal.create": { ptyId: "pty-term-threadless", shell: "bash" },
       "terminal.resize": true,
       "terminal.kill": true,
       "terminal.killByThread": true,
@@ -119,16 +99,18 @@ test.describe("Right panel terminal auto-start", () => {
     );
   });
 
-  test("clicking the Terminal tab auto-starts a shell", async ({ page }) => {
-    await openPanelOnScope(page);
+  test("opening the Terminal tab with no active thread spawns a workspace-scoped shell", async ({
+    page,
+  }) => {
+    await openThreadlessPanel(page);
 
-    // No terminals before the tab is opened.
-    expect(await terminalCount(page, THREAD.id)).toBe(0);
+    // No terminals exist for the workspace scope before the tab is opened.
+    expect(await terminalCount(page, WORKSPACE.id)).toBe(0);
 
     await page.getByRole("button", { name: "Terminal", exact: true }).click();
 
-    // Opening the tab spawns one without the user clicking "New terminal".
-    await expect.poll(() => terminalCount(page, THREAD.id), { timeout: 5_000 }).toBe(1);
+    // The shell is keyed by the workspace id (the threadless scope), not a thread.
+    await expect.poll(() => terminalCount(page, WORKSPACE.id), { timeout: 5_000 }).toBe(1);
     await expect(page.getByText("No terminals")).toHaveCount(0);
   });
 });

--- a/apps/web/e2e/terminal-scroll-thread-switch.spec.ts
+++ b/apps/web/e2e/terminal-scroll-thread-switch.spec.ts
@@ -79,9 +79,10 @@ async function setActiveThread(
 /** Opens the right-panel terminal tab via store (avoids duplicate Toggle terminal buttons). */
 async function openTerminalTab(
   page: import("@playwright/test").Page,
+  workspaceId: string,
   threadId: string,
 ): Promise<void> {
-  await page.evaluate((tid) => {
+  await page.evaluate(({ wid, tid }) => {
     const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
     const diffStore = stores.find((s: unknown) => {
       const st = (s as { getState: () => Record<string, unknown> }).getState();
@@ -89,12 +90,13 @@ async function openTerminalTab(
     });
     if (!diffStore) return;
     const api = (diffStore as { getState: () => {
-      showRightPanel: (id: string) => void;
+      showRightPanel: (id: string, threadId?: string) => void;
       setRightPanelTab: (id: string, tab: string) => void;
     } }).getState();
-    api.showRightPanel(tid);
-    api.setRightPanelTab(tid, "terminal");
-  }, threadId);
+    // Open/closed is per-thread; the active tab stays workspace-global.
+    api.showRightPanel(wid, tid);
+    api.setRightPanelTab(wid, "terminal");
+  }, { wid: workspaceId, tid: threadId });
 }
 
 /** Ensures a thread has a terminal instance in the store (mounts pooled xterm). */
@@ -183,7 +185,7 @@ async function seedThreadsAndOpenTerminal(
     },
     { workspace: WORKSPACE, threads: [THREAD_A, THREAD_B], activeId: activeThreadId },
   );
-  await openTerminalTab(page, activeThreadId);
+  await openTerminalTab(page, WS_ID, activeThreadId);
   await ensureThreadTerminal(page, activeThreadId, ptyId);
 }
 
@@ -276,7 +278,7 @@ test.describe("Terminal scroll on workspace thread switch", () => {
     await setActiveThread(page, "thread-b");
     await page.waitForTimeout(600);
     await setActiveThread(page, "thread-a");
-    await openTerminalTab(page, "thread-a");
+    await openTerminalTab(page, WS_ID, "thread-a");
 
     await page.waitForFunction(
       ({ id, expected }) => {
@@ -324,7 +326,7 @@ test.describe("Terminal scroll on workspace thread switch", () => {
 
     await ensureThreadTerminal(page, "thread-b", "pty-thread-b", "powershell");
     await setActiveThread(page, "thread-b");
-    await openTerminalTab(page, "thread-b");
+    await openTerminalTab(page, WS_ID, "thread-b");
     await page.waitForTimeout(400);
 
     const ptyB = await getActivePtyId(page, "thread-b");
@@ -347,7 +349,7 @@ test.describe("Terminal scroll on workspace thread switch", () => {
     );
 
     await setActiveThread(page, "thread-a");
-    await openTerminalTab(page, "thread-a");
+    await openTerminalTab(page, WS_ID, "thread-a");
     await page.waitForTimeout(400);
 
     await expect(page.locator(".xterm").first()).toBeVisible({ timeout: 15_000 });
@@ -403,7 +405,7 @@ test.describe("Terminal scroll on workspace thread switch", () => {
       { workspace: WORKSPACE, threads: [THREAD_A, THREAD_B] },
     );
 
-    await openTerminalTab(page, "thread-a");
+    await openTerminalTab(page, WS_ID, "thread-a");
 
     await page.waitForFunction(
       () =>

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -4,7 +4,7 @@ import { MarkdownContent } from "../components/chat/MarkdownContent";
 import { CodeBlock } from "../components/chat/CodeBlock";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { useDiffStore } from "../stores/diffStore";
-import { createMockWorkspace } from "./mocks/transport";
+import { createMockWorkspace, createMockThread } from "./mocks/transport";
 
 // Mock CodeBlock to avoid shiki/worker dependencies
 vi.mock("../components/chat/MermaidBlock", () => ({
@@ -113,6 +113,7 @@ describe("MarkdownContent workspace preview navigation", () => {
       workspaces: [ws],
       activeWorkspaceId: ws.id,
       activeThreadId: "thread-prev",
+      threads: [createMockThread({ id: "thread-prev", workspace_id: ws.id })],
     });
     useDiffStore.setState({
       showRightPanel,
@@ -165,8 +166,8 @@ describe("MarkdownContent workspace preview navigation", () => {
       fireEvent.click(link!, { ctrlKey: true });
       await vi.runAllTimersAsync();
     });
-    expect(showRightPanel).toHaveBeenCalledWith("thread-prev");
-    expect(setRightPanelTab).toHaveBeenCalledWith("thread-prev", "preview");
+    expect(showRightPanel).toHaveBeenCalledWith("ws-prev", "thread-prev");
+    expect(setRightPanelTab).toHaveBeenCalledWith("ws-prev", "preview");
     expect(mockCreate).toHaveBeenCalledWith("thread-prev", true);
     expect(mockNavigate).toHaveBeenCalledWith(
       "mcode-workspace:///sub/page.html",

--- a/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
+++ b/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
@@ -179,7 +179,7 @@ describe("Agent event thread isolation", () => {
       await Promise.resolve();
 
       const { useDiffStore } = await import("@/stores/diffStore");
-      expect(useDiffStore.getState().rightPanelByThread[THREAD_A]?.visible).toBeFalsy();
+      expect(useDiffStore.getState().getRightPanelVisible("ws-1", THREAD_A)).toBeFalsy();
     });
 
     it("does not auto-open task panel on TodoWrite", async () => {
@@ -197,7 +197,7 @@ describe("Agent event thread isolation", () => {
       await Promise.resolve();
 
       const { useDiffStore } = await import("@/stores/diffStore");
-      expect(useDiffStore.getState().rightPanelByThread[THREAD_A]?.visible).toBeFalsy();
+      expect(useDiffStore.getState().getRightPanelVisible("ws-1", THREAD_A)).toBeFalsy();
     });
   });
 

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -11,7 +11,8 @@ describe("diffStore", () => {
   beforeEach(() => {
     useDiffStore.setState({
       previewUrlByThread: {},
-      rightPanelByThread: {},
+      rightPanelByWorkspace: {},
+      rightPanelVisibleByThread: {},
       snapshotsByThread: {},
       snapshotsLoadingByThread: {},
       snapshotsPendingByThread: {},
@@ -54,82 +55,211 @@ describe("diffStore", () => {
   });
 
   describe("getRightPanel", () => {
-    it("should return defaults for unknown thread", () => {
+    it("should return defaults for unknown workspace", () => {
       const { getRightPanel } = useDiffStore.getState();
       expect(getRightPanel("unknown")).toEqual(createDefaultRightPanelState());
     });
 
-    it("should return stored state for known thread", () => {
+    it("should return stored state for known workspace", () => {
       const { showRightPanel, getRightPanel } = useDiffStore.getState();
-      showRightPanel("thread-1");
-      expect(getRightPanel("thread-1").visible).toBe(true);
+      showRightPanel("ws-1");
+      expect(getRightPanel("ws-1").visible).toBe(true);
     });
   });
 
   describe("toggleRightPanel", () => {
-    it("should flip visibility for one thread", () => {
+    it("should flip visibility for one workspace", () => {
       const { toggleRightPanel, getRightPanel } = useDiffStore.getState();
-      toggleRightPanel("thread-1");
-      expect(getRightPanel("thread-1").visible).toBe(true);
-      toggleRightPanel("thread-1");
-      expect(getRightPanel("thread-1").visible).toBe(false);
+      toggleRightPanel("ws-1");
+      expect(getRightPanel("ws-1").visible).toBe(true);
+      toggleRightPanel("ws-1");
+      expect(getRightPanel("ws-1").visible).toBe(false);
     });
 
-    it("should not affect other threads", () => {
+    it("should not affect other workspaces", () => {
       const { toggleRightPanel, getRightPanel } = useDiffStore.getState();
-      toggleRightPanel("thread-1");
-      expect(getRightPanel("thread-2").visible).toBe(false);
+      toggleRightPanel("ws-1");
+      expect(getRightPanel("ws-2").visible).toBe(false);
     });
   });
 
   describe("showRightPanel / hideRightPanel", () => {
     it("showRightPanel sets visible true without affecting width", () => {
       const { showRightPanel, setRightPanelWidth, getRightPanel } = useDiffStore.getState();
-      setRightPanelWidth("thread-1", 500);
-      showRightPanel("thread-1");
-      const panel = getRightPanel("thread-1");
+      setRightPanelWidth("ws-1", 500);
+      showRightPanel("ws-1");
+      const panel = getRightPanel("ws-1");
       expect(panel.visible).toBe(true);
       expect(panel.width).toBe(500);
     });
 
     it("hideRightPanel sets visible false without affecting tab", () => {
       const { showRightPanel, hideRightPanel, setRightPanelTab, getRightPanel } = useDiffStore.getState();
-      showRightPanel("thread-1");
-      setRightPanelTab("thread-1", "changes");
-      hideRightPanel("thread-1");
-      const panel = getRightPanel("thread-1");
+      showRightPanel("ws-1");
+      setRightPanelTab("ws-1", "changes");
+      hideRightPanel("ws-1");
+      const panel = getRightPanel("ws-1");
       expect(panel.visible).toBe(false);
       expect(panel.activeTab).toBe("changes");
     });
   });
 
   describe("setRightPanelWidth", () => {
-    it("should update width for one thread", () => {
+    it("should update width for one workspace", () => {
       const { setRightPanelWidth, getRightPanel } = useDiffStore.getState();
-      setRightPanelWidth("thread-1", 500);
-      expect(getRightPanel("thread-1").width).toBe(500);
-      expect(getRightPanel("thread-2").width).toBe(getDefaultPanelWidthPx());
+      setRightPanelWidth("ws-1", 500);
+      expect(getRightPanel("ws-1").width).toBe(500);
+      expect(getRightPanel("ws-2").width).toBe(getDefaultPanelWidthPx());
     });
 
     it("should clamp width to PANEL_MIN_WIDTH", () => {
       const { setRightPanelWidth, getRightPanel } = useDiffStore.getState();
-      setRightPanelWidth("thread-1", 100);
-      expect(getRightPanel("thread-1").width).toBe(PANEL_MIN_WIDTH);
+      setRightPanelWidth("ws-1", 100);
+      expect(getRightPanel("ws-1").width).toBe(PANEL_MIN_WIDTH);
     });
   });
 
   describe("setRightPanelTab", () => {
-    it("should update active tab for one thread only", () => {
+    it("should update active tab for one workspace only", () => {
       const { setRightPanelTab, getRightPanel } = useDiffStore.getState();
-      setRightPanelTab("thread-1", "changes");
-      expect(getRightPanel("thread-1").activeTab).toBe("changes");
-      expect(getRightPanel("thread-2").activeTab).toBe("tasks");
+      setRightPanelTab("ws-1", "changes");
+      expect(getRightPanel("ws-1").activeTab).toBe("changes");
+      expect(getRightPanel("ws-2").activeTab).toBe("tasks");
     });
 
     it("should support preview tab", () => {
       const { setRightPanelTab, getRightPanel } = useDiffStore.getState();
-      setRightPanelTab("thread-1", "preview");
-      expect(getRightPanel("thread-1").activeTab).toBe("preview");
+      setRightPanelTab("ws-1", "preview");
+      expect(getRightPanel("ws-1").activeTab).toBe("preview");
+    });
+  });
+
+  // The panel is workspace-global: its open state must survive having no thread
+  // active (e.g. the threadless workspace shell) and persist across navigation.
+  describe("workspace-global persistence", () => {
+    it("retains visibility, width, and tab with no active thread", () => {
+      const { showRightPanel, setRightPanelWidth, setRightPanelTab, getRightPanel } =
+        useDiffStore.getState();
+      showRightPanel("ws-1");
+      setRightPanelWidth("ws-1", 460);
+      setRightPanelTab("ws-1", "preview");
+
+      // No thread keying is involved, so re-reading the workspace slice returns
+      // the same state regardless of which (or no) thread is active.
+      const panel = getRightPanel("ws-1");
+      expect(panel.visible).toBe(true);
+      expect(panel.width).toBe(460);
+      expect(panel.activeTab).toBe("preview");
+    });
+
+    it("keeps panel state when threads are cleared", () => {
+      const { showRightPanel, setRightPanelTab, clearThread, getRightPanel } =
+        useDiffStore.getState();
+      showRightPanel("ws-1");
+      setRightPanelTab("ws-1", "changes");
+
+      // Clearing a thread must not touch the workspace-global panel slice.
+      clearThread("thread-1");
+
+      const panel = getRightPanel("ws-1");
+      expect(panel.visible).toBe(true);
+      expect(panel.activeTab).toBe("changes");
+    });
+  });
+
+  // Open/closed is per-thread within a workspace: opening the panel on one
+  // thread must not open it on a sibling thread, while width and active tab
+  // remain shared workspace-global state. See ADR-0004.
+  describe("per-thread visibility", () => {
+    it("getRightPanelVisible defaults to closed for an unknown thread", () => {
+      const { getRightPanelVisible } = useDiffStore.getState();
+      expect(getRightPanelVisible("ws-1", "thread-1")).toBe(false);
+    });
+
+    it("showRightPanel with a thread opens only that thread", () => {
+      const { showRightPanel, getRightPanelVisible } = useDiffStore.getState();
+      showRightPanel("ws-1", "thread-1");
+      expect(getRightPanelVisible("ws-1", "thread-1")).toBe(true);
+      expect(getRightPanelVisible("ws-1", "thread-2")).toBe(false);
+    });
+
+    it("hideRightPanel with a thread closes only that thread", () => {
+      const { showRightPanel, hideRightPanel, getRightPanelVisible } = useDiffStore.getState();
+      showRightPanel("ws-1", "thread-1");
+      showRightPanel("ws-1", "thread-2");
+      hideRightPanel("ws-1", "thread-1");
+      expect(getRightPanelVisible("ws-1", "thread-1")).toBe(false);
+      expect(getRightPanelVisible("ws-1", "thread-2")).toBe(true);
+    });
+
+    it("toggleRightPanel with a thread flips only that thread", () => {
+      const { toggleRightPanel, getRightPanelVisible } = useDiffStore.getState();
+      toggleRightPanel("ws-1", "thread-1");
+      expect(getRightPanelVisible("ws-1", "thread-1")).toBe(true);
+      toggleRightPanel("ws-1", "thread-1");
+      expect(getRightPanelVisible("ws-1", "thread-1")).toBe(false);
+    });
+
+    it("shares width and active tab across threads in the same workspace", () => {
+      const { showRightPanel, setRightPanelWidth, setRightPanelTab, getRightPanel } =
+        useDiffStore.getState();
+      showRightPanel("ws-1", "thread-1");
+      setRightPanelWidth("ws-1", 540);
+      setRightPanelTab("ws-1", "preview");
+
+      // Width and tab live on the workspace slice, so a sibling thread sees them.
+      const panel = getRightPanel("ws-1");
+      expect(panel.width).toBe(540);
+      expect(panel.activeTab).toBe("preview");
+    });
+
+    it("threadless visibility is independent of per-thread visibility", () => {
+      const { showRightPanel, getRightPanelVisible } = useDiffStore.getState();
+      showRightPanel("ws-1", "thread-1");
+      // No thread → reads the workspace threadless slice, still closed.
+      expect(getRightPanelVisible("ws-1")).toBe(false);
+      showRightPanel("ws-1");
+      expect(getRightPanelVisible("ws-1")).toBe(true);
+      // Opening threadless must not retroactively open a different thread.
+      expect(getRightPanelVisible("ws-1", "thread-2")).toBe(false);
+    });
+
+    it("clearThread drops the thread's visibility entry", () => {
+      const { showRightPanel, clearThread, getRightPanelVisible } = useDiffStore.getState();
+      showRightPanel("ws-1", "thread-1");
+      clearThread("thread-1");
+      expect(getRightPanelVisible("ws-1", "thread-1")).toBe(false);
+      expect(useDiffStore.getState().rightPanelVisibleByThread["thread-1"]).toBeUndefined();
+    });
+  });
+
+  describe("clearWorkspace", () => {
+    it("removes the panel slice for the given workspace", () => {
+      const { showRightPanel, setRightPanelTab, clearWorkspace, getRightPanel } =
+        useDiffStore.getState();
+      showRightPanel("ws-1");
+      setRightPanelTab("ws-1", "preview");
+
+      clearWorkspace("ws-1");
+
+      expect(useDiffStore.getState().rightPanelByWorkspace["ws-1"]).toBeUndefined();
+      expect(getRightPanel("ws-1")).toEqual(createDefaultRightPanelState());
+    });
+
+    it("does not affect other workspaces", () => {
+      const { showRightPanel, clearWorkspace, getRightPanel } = useDiffStore.getState();
+      showRightPanel("ws-1");
+      showRightPanel("ws-2");
+
+      clearWorkspace("ws-1");
+
+      expect(getRightPanel("ws-2").visible).toBe(true);
+    });
+
+    it("is a no-op for an unknown workspace", () => {
+      const { clearWorkspace } = useDiffStore.getState();
+      expect(() => clearWorkspace("nope")).not.toThrow();
+      expect(useDiffStore.getState().rightPanelByWorkspace["nope"]).toBeUndefined();
     });
   });
 
@@ -147,17 +277,14 @@ describe("diffStore", () => {
   describe("clearThread", () => {
     it("should remove all per-thread entries", () => {
       const {
-        showRightPanel,
         setSnapshots,
         setSnapshotsLoading,
         setCommits,
         setCommitsLoading,
         setPreviewUrlForThread,
         clearThread,
-        getRightPanel,
       } =
         useDiffStore.getState();
-      showRightPanel("thread-1");
       setSnapshots("thread-1", [{ id: "s1" } as never]);
       setSnapshotsLoading("thread-1", true);
       setCommits("thread-1", [{ sha: "c1" } as never]);
@@ -168,8 +295,6 @@ describe("diffStore", () => {
 
       const state = useDiffStore.getState();
       expect(state.previewUrlByThread["thread-1"]).toBeUndefined();
-      expect(state.rightPanelByThread["thread-1"]).toBeUndefined();
-      expect(getRightPanel("thread-1")).toEqual(createDefaultRightPanelState());
       expect(state.snapshotsByThread["thread-1"]).toBeUndefined();
       expect(state.snapshotsLoadingByThread["thread-1"]).toBeUndefined();
       expect(state.commitsByThread["thread-1"]).toBeUndefined();
@@ -177,10 +302,8 @@ describe("diffStore", () => {
     });
 
     it("should not affect other threads", () => {
-      const { showRightPanel, setSnapshots, setSnapshotsLoading, setCommits, setCommitsLoading, clearThread, getRightPanel } =
+      const { setSnapshots, setSnapshotsLoading, setCommits, setCommitsLoading, clearThread } =
         useDiffStore.getState();
-      showRightPanel("thread-1");
-      showRightPanel("thread-2");
       setSnapshots("thread-1", [{ id: "s1" } as never]);
       setSnapshots("thread-2", [{ id: "s2" } as never]);
       setSnapshotsLoading("thread-2", true);
@@ -190,7 +313,6 @@ describe("diffStore", () => {
       clearThread("thread-1");
 
       const state = useDiffStore.getState();
-      expect(getRightPanel("thread-2").visible).toBe(true);
       expect(state.snapshotsByThread["thread-2"]).toHaveLength(1);
       expect(state.snapshotsLoadingByThread["thread-2"]).toBe(true);
       expect(state.commitsByThread["thread-2"]).toHaveLength(1);

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -210,21 +210,27 @@ export function App() {
         title: "Toggle Terminal",
         category: "View",
         handler: () => {
-          const tid = useWorkspaceStore.getState().activeThreadId;
-          if (!tid) return;
-          const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
-            useDiffStore.getState();
-          const panel = getRightPanel(tid);
-          if (!panel.visible) {
-            showRightPanel(tid);
-            setRightPanelTab(tid, "terminal");
+          const { activeWorkspaceId: wid, activeThreadId: tid } =
+            useWorkspaceStore.getState();
+          if (!wid) return;
+          const {
+            getRightPanel,
+            getRightPanelVisible,
+            showRightPanel,
+            setRightPanelTab,
+            hideRightPanel,
+          } = useDiffStore.getState();
+          const panel = getRightPanel(wid);
+          if (!getRightPanelVisible(wid, tid)) {
+            showRightPanel(wid, tid);
+            setRightPanelTab(wid, "terminal");
           } else if (panel.activeTab !== "terminal") {
-            setRightPanelTab(tid, "terminal");
+            setRightPanelTab(wid, "terminal");
           } else {
-            hideRightPanel(tid);
+            hideRightPanel(wid, tid);
           }
           // Terminal creation on open is handled by RightPanel's
-          // ensureTerminalForThread effect (fires for every open path).
+          // ensureTerminalForScope effect (fires for every open path).
         },
       }),
       registerCommand({
@@ -253,18 +259,24 @@ export function App() {
         title: "Toggle Scope Panel",
         category: "View",
         handler: () => {
-          const tid = useWorkspaceStore.getState().activeThreadId;
-          if (!tid) return;
-          const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
-            useDiffStore.getState();
-          const panel = getRightPanel(tid);
-          if (!panel.visible) {
-            showRightPanel(tid);
-            setRightPanelTab(tid, "tasks");
+          const { activeWorkspaceId: wid, activeThreadId: tid } =
+            useWorkspaceStore.getState();
+          if (!wid) return;
+          const {
+            getRightPanel,
+            getRightPanelVisible,
+            showRightPanel,
+            setRightPanelTab,
+            hideRightPanel,
+          } = useDiffStore.getState();
+          const panel = getRightPanel(wid);
+          if (!getRightPanelVisible(wid, tid)) {
+            showRightPanel(wid, tid);
+            setRightPanelTab(wid, "tasks");
           } else if (panel.activeTab !== "tasks") {
-            setRightPanelTab(tid, "tasks");
+            setRightPanelTab(wid, "tasks");
           } else {
-            hideRightPanel(tid);
+            hideRightPanel(wid, tid);
           }
         },
       }),
@@ -273,18 +285,24 @@ export function App() {
         title: "Toggle Changes Panel",
         category: "View",
         handler: () => {
-          const tid = useWorkspaceStore.getState().activeThreadId;
-          if (!tid) return;
-          const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
-            useDiffStore.getState();
-          const panel = getRightPanel(tid);
-          if (!panel.visible) {
-            showRightPanel(tid);
-            setRightPanelTab(tid, "changes");
+          const { activeWorkspaceId: wid, activeThreadId: tid } =
+            useWorkspaceStore.getState();
+          if (!wid) return;
+          const {
+            getRightPanel,
+            getRightPanelVisible,
+            showRightPanel,
+            setRightPanelTab,
+            hideRightPanel,
+          } = useDiffStore.getState();
+          const panel = getRightPanel(wid);
+          if (!getRightPanelVisible(wid, tid)) {
+            showRightPanel(wid, tid);
+            setRightPanelTab(wid, "changes");
           } else if (panel.activeTab !== "changes") {
-            setRightPanelTab(tid, "changes");
+            setRightPanelTab(wid, "changes");
           } else {
-            hideRightPanel(tid);
+            hideRightPanel(wid, tid);
           }
         },
       }),
@@ -293,22 +311,28 @@ export function App() {
         title: "Toggle Preview Panel",
         category: "View",
         handler: () => {
-          const tid = useWorkspaceStore.getState().activeThreadId;
-          if (!tid) return;
-          const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
-            useDiffStore.getState();
-          const panel = getRightPanel(tid);
-          if (!panel.visible) {
-            showRightPanel(tid);
-            setRightPanelTab(tid, "preview");
+          const { activeWorkspaceId: wid, activeThreadId: tid } =
+            useWorkspaceStore.getState();
+          if (!wid) return;
+          const {
+            getRightPanel,
+            getRightPanelVisible,
+            showRightPanel,
+            setRightPanelTab,
+            hideRightPanel,
+          } = useDiffStore.getState();
+          const panel = getRightPanel(wid);
+          if (!getRightPanelVisible(wid, tid)) {
+            showRightPanel(wid, tid);
+            setRightPanelTab(wid, "preview");
             // Pull focus into the URL field so the user can type a URL
             // immediately after opening the preview by shortcut.
             usePreviewFocusStore.getState().requestOmniboxFocus();
           } else if (panel.activeTab !== "preview") {
-            setRightPanelTab(tid, "preview");
+            setRightPanelTab(wid, "preview");
             usePreviewFocusStore.getState().requestOmniboxFocus();
           } else {
-            hideRightPanel(tid);
+            hideRightPanel(wid, tid);
           }
         },
       }),
@@ -317,20 +341,24 @@ export function App() {
         title: "Toggle Preview Capture Tools",
         category: "View",
         handler: () => {
-          const tid = useWorkspaceStore.getState().activeThreadId;
-          if (!tid) return;
+          const { activeThreadId: tid, activeWorkspaceId: wid } =
+            useWorkspaceStore.getState();
+          // The capture dock is thread-scoped (it attaches to a thread's
+          // preview), so this shortcut is a no-op with no thread even though
+          // the panel itself is workspace-global.
+          if (!tid || !wid) return;
           // The dock only renders inside PreviewPanel, which mounts only
           // when the right panel is visible AND on the preview tab. If
           // either is closed, ensure them first so a freshly-toggled
           // dock has somewhere to render. Mirrors preview.toggle (mod+
           // shift+b) so the two shortcuts feel like part of the same
           // surface.
-          const { getRightPanel, showRightPanel, setRightPanelTab } =
+          const { getRightPanel, getRightPanelVisible, showRightPanel, setRightPanelTab } =
             useDiffStore.getState();
-          const panel = getRightPanel(tid);
-          if (!panel.visible || panel.activeTab !== "preview") {
-            showRightPanel(tid);
-            setRightPanelTab(tid, "preview");
+          const panel = getRightPanel(wid);
+          if (!getRightPanelVisible(wid, tid) || panel.activeTab !== "preview") {
+            showRightPanel(wid, tid);
+            setRightPanelTab(wid, "preview");
           }
           usePreviewDockStore.getState().toggle(tid);
         },

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -176,17 +176,19 @@ function ComposerOptionsMenu({
   const hasTasks = useTaskStore(
     (s) => !!(threadId && s.tasksByThread[threadId]?.length),
   );
-  const panelVisible = useDiffStore(
-    (s) => !!(threadId && s.rightPanelByThread[threadId]?.visible),
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const panelVisible = useDiffStore((s) =>
+    activeWorkspaceId ? s.getRightPanelVisible(activeWorkspaceId, threadId) : false,
   );
 
   const toggleTasksPanel = () => {
-    if (!threadId) return;
+    // Scope is thread-only; open/closed is per-thread, width/tab workspace-keyed.
+    if (!threadId || !activeWorkspaceId) return;
     if (panelVisible) {
-      useDiffStore.getState().hideRightPanel(threadId);
+      useDiffStore.getState().hideRightPanel(activeWorkspaceId, threadId);
     } else {
-      useDiffStore.getState().showRightPanel(threadId);
-      useDiffStore.getState().setRightPanelTab(threadId, "tasks");
+      useDiffStore.getState().showRightPanel(activeWorkspaceId, threadId);
+      useDiffStore.getState().setRightPanelTab(activeWorkspaceId, "tasks");
     }
   };
 
@@ -335,17 +337,19 @@ function InlineComposerOptions({
   const hasTasks = useTaskStore(
     (s) => !!(threadId && s.tasksByThread[threadId]?.length),
   );
-  const panelVisible = useDiffStore(
-    (s) => !!(threadId && s.rightPanelByThread[threadId]?.visible),
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const panelVisible = useDiffStore((s) =>
+    activeWorkspaceId ? s.getRightPanelVisible(activeWorkspaceId, threadId) : false,
   );
 
   const toggleTasksPanel = () => {
-    if (!threadId) return;
+    // Scope is thread-only; open/closed is per-thread, width/tab workspace-keyed.
+    if (!threadId || !activeWorkspaceId) return;
     if (panelVisible) {
-      useDiffStore.getState().hideRightPanel(threadId);
+      useDiffStore.getState().hideRightPanel(activeWorkspaceId, threadId);
     } else {
-      useDiffStore.getState().showRightPanel(threadId);
-      useDiffStore.getState().setRightPanelTab(threadId, "tasks");
+      useDiffStore.getState().showRightPanel(activeWorkspaceId, threadId);
+      useDiffStore.getState().setRightPanelTab(activeWorkspaceId, "tasks");
     }
   };
 

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -31,13 +31,14 @@ vi.mock("@/stores/diffStore", () => {
   const getRightPanel = vi.fn().mockReturnValue({ visible: false, width: 380, activeTab: "tasks" });
   const actions = {
     getRightPanel,
+    getRightPanelVisible: vi.fn().mockReturnValue(false),
     showRightPanel: vi.fn(),
     hideRightPanel: vi.fn(),
     setRightPanelTab: vi.fn(),
   };
   const store = Object.assign(
     vi.fn((selector: (s: unknown) => unknown) =>
-      selector({ rightPanelByThread: {}, ...actions }),
+      selector({ rightPanelByWorkspace: {}, ...actions }),
     ),
     { getState: vi.fn().mockReturnValue(actions) },
   );

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -91,55 +91,64 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
   }, [pr, thread.id]);
 
   const terminalVisible = useDiffStore((s) => {
-    if (!thread?.id) return false;
-    const panel = s.rightPanelByThread[thread.id];
-    return (panel?.visible ?? false) && (panel?.activeTab ?? "tasks") === "terminal";
+    if (!thread?.workspace_id) return false;
+    const panel = s.rightPanelByWorkspace[thread.workspace_id];
+    return (
+      s.getRightPanelVisible(thread.workspace_id, thread.id) &&
+      (panel?.activeTab ?? "tasks") === "terminal"
+    );
   });
   const toggleTerminal = useCallback(() => {
     executeCommand("terminal.toggle");
   }, []);
 
   const diffActive = useDiffStore((s) => {
-    if (!thread?.id) return false;
-    const panel = s.rightPanelByThread[thread.id];
-    return (panel?.visible ?? false) && (panel?.activeTab ?? "tasks") === "changes";
+    if (!thread?.workspace_id) return false;
+    const panel = s.rightPanelByWorkspace[thread.workspace_id];
+    return (
+      s.getRightPanelVisible(thread.workspace_id, thread.id) &&
+      (panel?.activeTab ?? "tasks") === "changes"
+    );
   });
 
   const previewActive = useDiffStore((s) => {
-    if (!thread?.id) return false;
-    const panel = s.rightPanelByThread[thread.id];
-    return (panel?.visible ?? false) && (panel?.activeTab ?? "tasks") === "preview";
+    if (!thread?.workspace_id) return false;
+    const panel = s.rightPanelByWorkspace[thread.workspace_id];
+    return (
+      s.getRightPanelVisible(thread.workspace_id, thread.id) &&
+      (panel?.activeTab ?? "tasks") === "preview"
+    );
   });
 
   const togglePreview = useCallback(() => {
-    if (!thread?.id) return;
-    const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
+    if (!thread?.workspace_id) return;
+    const { getRightPanel, getRightPanelVisible, showRightPanel, setRightPanelTab, hideRightPanel } =
       useDiffStore.getState();
-    const panel = getRightPanel(thread.id);
-    if (!panel.visible) {
-      showRightPanel(thread.id);
-      setRightPanelTab(thread.id, "preview");
+    const panel = getRightPanel(thread.workspace_id);
+    if (!getRightPanelVisible(thread.workspace_id, thread.id)) {
+      showRightPanel(thread.workspace_id, thread.id);
+      setRightPanelTab(thread.workspace_id, "preview");
     } else if (panel.activeTab !== "preview") {
-      setRightPanelTab(thread.id, "preview");
+      setRightPanelTab(thread.workspace_id, "preview");
     } else {
-      hideRightPanel(thread.id);
+      hideRightPanel(thread.workspace_id, thread.id);
     }
-  }, [thread?.id]);
+  }, [thread?.workspace_id, thread?.id]);
 
   const toggleDiff = useCallback(() => {
-    if (!thread?.id) return;
-    const { getRightPanel, showRightPanel, setRightPanelTab, hideRightPanel } =
+    if (!thread?.workspace_id) return;
+    const { getRightPanel, getRightPanelVisible, showRightPanel, setRightPanelTab, hideRightPanel } =
       useDiffStore.getState();
-    const panel = getRightPanel(thread.id);
-    if (!panel.visible) {
-      showRightPanel(thread.id);
-      setRightPanelTab(thread.id, "changes");
+    const panel = getRightPanel(thread.workspace_id);
+    if (!getRightPanelVisible(thread.workspace_id, thread.id)) {
+      showRightPanel(thread.workspace_id, thread.id);
+      setRightPanelTab(thread.workspace_id, "changes");
     } else if (panel.activeTab !== "changes") {
-      setRightPanelTab(thread.id, "changes");
+      setRightPanelTab(thread.workspace_id, "changes");
     } else {
-      hideRightPanel(thread.id);
+      hideRightPanel(thread.workspace_id, thread.id);
     }
-  }, [thread?.id]);
+  }, [thread?.workspace_id, thread?.id]);
 
   const handleOpenPr = useCallback(
     (url: string, event?: React.MouseEvent) => {

--- a/apps/web/src/components/chat/PlanCard.tsx
+++ b/apps/web/src/components/chat/PlanCard.tsx
@@ -15,6 +15,7 @@ interface PlanCardProps {
  */
 export function PlanCard({ messageId }: PlanCardProps) {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const allPlans = usePlanStore((s) =>
     activeThreadId ? s.plansByThread[activeThreadId] : undefined,
   );
@@ -24,13 +25,13 @@ export function PlanCard({ messageId }: PlanCardProps) {
     [allPlans, messageId],
   );
 
-  if (!plan || !activeThreadId) return null;
+  if (!plan || !activeThreadId || !activeWorkspaceId) return null;
 
   const sectionCount = plan.sectionsJson?.length ?? 0;
 
   const handleClick = () => {
-    useDiffStore.getState().showRightPanel(activeThreadId);
-    useDiffStore.getState().setRightPanelTab(activeThreadId, "tasks");
+    useDiffStore.getState().showRightPanel(activeWorkspaceId, activeThreadId);
+    useDiffStore.getState().setRightPanelTab(activeWorkspaceId, "tasks");
     usePlanStore.getState().setActiveVersion(activeThreadId, plan.version);
   };
 

--- a/apps/web/src/components/chat/TurnChangeSummary.tsx
+++ b/apps/web/src/components/chat/TurnChangeSummary.tsx
@@ -94,12 +94,13 @@ export function TurnChangeSummary({ messageId, filesChanged, isLatestTurn, manua
 
   /** Open the diff panel focused on the Changes tab, scrolled to this turn's snapshot. */
   const handleViewAllDiffs = useCallback(async () => {
-    const threadId = useWorkspaceStore.getState().activeThreadId;
-    if (!threadId) return;
+    const { activeThreadId: threadId, activeWorkspaceId: workspaceId } =
+      useWorkspaceStore.getState();
+    if (!threadId || !workspaceId) return;
 
     const store = useDiffStore.getState();
-    store.showRightPanel(threadId);
-    store.setRightPanelTab(threadId, "changes");
+    store.showRightPanel(workspaceId, threadId);
+    store.setRightPanelTab(workspaceId, "changes");
     store.setViewMode("by-turn");
 
     // Ensure snapshots are loaded so the panel can display this turn

--- a/apps/web/src/components/diff/DiffPanel.tsx
+++ b/apps/web/src/components/diff/DiffPanel.tsx
@@ -15,6 +15,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
  */
 export function DiffPanel() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const viewMode = useDiffStore((s) => s.viewMode);
   const snapshots = useDiffStore((s) =>
     activeThreadId ? s.snapshotsByThread[activeThreadId] : undefined,
@@ -26,7 +27,11 @@ export function DiffPanel() {
     activeThreadId ? (s.snapshotsPendingByThread[activeThreadId] ?? false) : false,
   );
   const panelState = useDiffStore((s) =>
-    activeThreadId ? s.rightPanelByThread[activeThreadId] : undefined,
+    activeWorkspaceId ? s.rightPanelByWorkspace[activeWorkspaceId] : undefined,
+  );
+  // Open/closed is per-thread; the active tab is workspace-global.
+  const panelVisible = useDiffStore((s) =>
+    activeWorkspaceId ? s.getRightPanelVisible(activeWorkspaceId, activeThreadId) : false,
   );
   const setSnapshots = useDiffStore((s) => s.setSnapshots);
   const setSnapshotsLoading = useDiffStore((s) => s.setSnapshotsLoading);
@@ -60,8 +65,8 @@ export function DiffPanel() {
   useEffect(() => {
     if (!activeThreadId || !snapshotsPending) return;
     const isViewingAllChanges =
-      panelState?.visible === true &&
-      panelState.activeTab === "changes" &&
+      panelVisible &&
+      panelState?.activeTab === "changes" &&
       viewMode === "all";
     if (isViewingAllChanges) return;
 
@@ -75,7 +80,7 @@ export function DiffPanel() {
     return () => {
       cancelled = true;
     };
-  }, [activeThreadId, snapshotsPending, panelState, viewMode, setSnapshots]);
+  }, [activeThreadId, snapshotsPending, panelVisible, panelState, viewMode, setSnapshots]);
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden min-h-0">

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -19,7 +19,7 @@ import { PreviewPanel } from "@/components/panels/PreviewPanel";
 import { TerminalTabContent } from "@/components/terminal/TerminalTabContent";
 import { TerminalPoolSlot } from "@/components/terminal/TerminalPoolSlotContext";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
-import { ensureTerminalForThread } from "@/lib/ensure-terminal";
+import { ensureTerminalForScope } from "@/lib/ensure-terminal";
 import { cn } from "@/lib/utils";
 
 /** Static definition of a right-panel tab: id, label, and icon. */
@@ -211,14 +211,24 @@ export function RightPanel() {
   }, []);
 
   const storedPanel = useDiffStore((s) =>
-    activeThreadId ? s.rightPanelByThread[activeThreadId] : undefined,
+    activeWorkspaceId ? s.rightPanelByWorkspace[activeWorkspaceId] : undefined,
   );
   /** Avoid a Zustand selector that allocates a fresh default object every evaluation. */
   const panelState = useMemo(
     () => storedPanel ?? createDefaultRightPanelState(),
-    [storedPanel, viewportWidth],
+    [storedPanel],
   );
-  const { visible: panelVisible, width: panelWidth, activeTab } = panelState;
+  const { width: panelWidth, activeTab } = panelState;
+  // Open/closed is per-thread (falling back to the workspace threadless shell);
+  // width and active tab stay workspace-global. See ADR-0004.
+  const panelVisible = useDiffStore((s) =>
+    activeWorkspaceId ? s.getRightPanelVisible(activeWorkspaceId, activeThreadId) : false,
+  );
+
+  // The Terminal and Preview tabs bind to the active thread, or to the
+  // workspace itself in the threadless new-thread view (where they run against
+  // the local workspace root). Their stores treat this as an opaque scope key.
+  const panelScopeId = activeThreadId ?? activeWorkspaceId;
 
   // Zustand action refs are stable (same identity for the store's lifetime),
   // so destructuring from getState() at render time is safe and avoids
@@ -320,20 +330,20 @@ export function RightPanel() {
   // in the background, and intentionally not gated on the terminal count so
   // killing the last terminal does not immediately respawn one.
   useEffect(() => {
-    if (panelVisible && activeTab === "terminal" && activeThreadId) {
-      ensureTerminalForThread(activeThreadId);
+    if (panelVisible && activeTab === "terminal" && panelScopeId) {
+      ensureTerminalForScope(panelScopeId);
     }
-  }, [panelVisible, activeTab, activeThreadId]);
+  }, [panelVisible, activeTab, panelScopeId]);
 
   // Close on Escape when overlaid.
   useEffect(() => {
-    if (!isOverlay || !panelVisible || !activeThreadId) return;
+    if (!isOverlay || !panelVisible || !activeWorkspaceId) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") hideRightPanel(activeThreadId);
+      if (e.key === "Escape") hideRightPanel(activeWorkspaceId, activeThreadId);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [isOverlay, panelVisible, activeThreadId, hideRightPanel]);
+  }, [isOverlay, panelVisible, activeWorkspaceId, activeThreadId, hideRightPanel]);
 
   // Focus handoff for overlay mode. When the panel pops out as a modal we
   // must move focus into it so keyboard users aren't stranded behind the
@@ -362,13 +372,13 @@ export function RightPanel() {
   // so the panel never exceeds the available space after the user shrinks the browser.
   // Runs in both inline and overlay modes: overlay renders at min(panelWidth, 90vw)
   // visually, but the stored width still drives the cramp-detection threshold.
-  // Re-registers when activeThreadId changes (each thread has its own stored width).
+  // Re-registers when activeWorkspaceId changes (each workspace has its own stored width).
   // Throttled with rAF so rapid resize events only trigger one recalculation per frame.
   useEffect(() => {
-    if (!activeThreadId || !panelVisible) return;
+    if (!activeWorkspaceId || !panelVisible) return;
     // Clamp immediately in case the stored width already exceeds the viewport.
     const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
-    if (panelWidthRef.current > maxAllowed) setRightPanelWidth(activeThreadId, maxAllowed);
+    if (panelWidthRef.current > maxAllowed) setRightPanelWidth(activeWorkspaceId, maxAllowed);
 
     let rafId: number | null = null;
     const onResize = () => {
@@ -376,7 +386,7 @@ export function RightPanel() {
       rafId = requestAnimationFrame(() => {
         rafId = null;
         const max = window.innerWidth - PANEL_MIN_WIDTH;
-        if (panelWidthRef.current > max) setRightPanelWidth(activeThreadId, max);
+        if (panelWidthRef.current > max) setRightPanelWidth(activeWorkspaceId, max);
       });
     };
     window.addEventListener("resize", onResize);
@@ -384,7 +394,7 @@ export function RightPanel() {
       window.removeEventListener("resize", onResize);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [activeThreadId, panelVisible]);
+  }, [activeWorkspaceId, panelVisible]);
 
   const onDragStart = useCallback(
     (e: ReactMouseEvent) => {
@@ -398,7 +408,7 @@ export function RightPanel() {
         const delta = startX - moveEvent.clientX;
         // Always leave at least PANEL_MIN_WIDTH px for the chat area
         const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
-        setRightPanelWidth(activeThreadId!, Math.min(startWidth + delta, viewportCap));
+        setRightPanelWidth(activeWorkspaceId!, Math.min(startWidth + delta, viewportCap));
       };
 
       const onMouseUp = () => {
@@ -412,7 +422,7 @@ export function RightPanel() {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     },
-    [panelWidth, activeThreadId],
+    [panelWidth, activeWorkspaceId],
   );
 
   useEffect(() => {
@@ -427,9 +437,11 @@ export function RightPanel() {
   }, []);
 
   // Keep the panel (and terminal pool) mounted when hidden so xterm instances
-  // and scroll anchors survive workspace thread switches. Per-thread visibility
-  // uses Tailwind `hidden` so layout width stays zero.
-  if (!activeThreadId) return null;
+  // and scroll anchors survive workspace thread switches. Workspace-global
+  // visibility uses Tailwind `hidden` so layout width stays zero. The panel is
+  // workspace-scoped, not thread-scoped: it renders with no thread (an empty
+  // shell) and only bails when there is no workspace to anchor it to.
+  if (!activeWorkspaceId) return null;
 
   // Overlay-mode width: cap to 90vw so the chat is still partially visible
   // behind the backdrop and the panel doesn't dominate small screens.
@@ -447,7 +459,7 @@ export function RightPanel() {
             // Blur first so focus inside the panel does not collide with the
             // incoming aria-hidden on the panel container.
             (document.activeElement as HTMLElement | null)?.blur?.();
-            hideRightPanel(activeThreadId);
+            hideRightPanel(activeWorkspaceId, activeThreadId);
           }}
           className="fixed inset-0 z-40 bg-foreground/30 backdrop-blur-[2px] animate-fade-up-in"
         />
@@ -456,7 +468,7 @@ export function RightPanel() {
         ref={panelRef}
         role={isOverlay ? "dialog" : undefined}
         aria-modal={isOverlay ? true : undefined}
-        aria-label={isOverlay ? "Thread side panel" : undefined}
+        aria-label={isOverlay ? "Workspace side panel" : undefined}
         tabIndex={isOverlay ? -1 : undefined}
         style={
           isOverlay
@@ -497,7 +509,7 @@ export function RightPanel() {
             panelWidth >= PANEL_WIDE_WIDTH
               ? narrow
               : Math.min(PANEL_WIDE_WIDTH, viewportCap);
-          setRightPanelWidth(activeThreadId!, Math.max(PANEL_MIN_WIDTH, target));
+          setRightPanelWidth(activeWorkspaceId!, Math.max(PANEL_MIN_WIDTH, target));
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
@@ -508,7 +520,7 @@ export function RightPanel() {
               panelWidth >= PANEL_WIDE_WIDTH
                 ? narrow
                 : Math.min(PANEL_WIDE_WIDTH, viewportCap);
-            setRightPanelWidth(activeThreadId!, Math.max(PANEL_MIN_WIDTH, target));
+            setRightPanelWidth(activeWorkspaceId!, Math.max(PANEL_MIN_WIDTH, target));
           }
         }}
       >
@@ -541,7 +553,7 @@ export function RightPanel() {
                   aria-pressed={isActive}
                   aria-label={tabAccessibleLabel(tab.id, scope, changesCount, changesFresh)}
                   title={tab.label}
-                  onClick={() => setRightPanelTab(activeThreadId!, tab.id)}
+                  onClick={() => setRightPanelTab(activeWorkspaceId!, tab.id)}
                   className={cn(
                     "flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-[10px] font-semibold tracking-[0.16em] uppercase transition-colors",
                     isActive ? "text-primary" : "text-foreground/70 hover:text-foreground",
@@ -567,7 +579,7 @@ export function RightPanel() {
               // Blur the close button before triggering the hide so focus is
               // not inside the panel when aria-hidden applies on re-render.
               (document.activeElement as HTMLElement | null)?.blur?.();
-              hideRightPanel(activeThreadId!);
+              hideRightPanel(activeWorkspaceId!, activeThreadId);
             }}
             className="h-5 w-5 text-muted-foreground/70 hover:text-foreground hover:bg-transparent transition-colors duration-150"
             aria-label="Close panel"
@@ -593,8 +605,8 @@ export function RightPanel() {
         <div className={activeTab === "changes" ? "flex flex-1 flex-col min-h-0" : "hidden"}>
           <DiffPanel />
         </div>
-        {activeTab === "preview" && (
-          <PreviewPanel threadId={activeThreadId} workspaceId={activeWorkspaceId} />
+        {activeTab === "preview" && panelScopeId && (
+          <PreviewPanel threadId={panelScopeId} workspaceId={activeWorkspaceId} />
         )}
         <div
           className={cn(
@@ -605,8 +617,8 @@ export function RightPanel() {
           aria-hidden={activeTab !== "terminal"}
           inert={activeTab !== "terminal" ? true : undefined}
         >
-          {activeTab === "terminal" && (
-            <TerminalTabContent threadId={activeThreadId} />
+          {activeTab === "terminal" && panelScopeId && (
+            <TerminalTabContent threadId={panelScopeId} />
           )}
           <TerminalPoolSlot className="relative min-h-0 min-w-0 flex-1 overflow-hidden p-2" />
         </div>

--- a/apps/web/src/components/terminal/TerminalPoolHost.tsx
+++ b/apps/web/src/components/terminal/TerminalPoolHost.tsx
@@ -23,18 +23,31 @@ import { resolveActiveTerminalId } from "./resolveActiveTerminalId";
 export function TerminalPoolHost() {
   const { slotEl, offScreenEl } = useTerminalPoolSlot();
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  // The terminal binds to the active thread, or to the workspace itself in the
+  // threadless new-thread view. The store keys this as an opaque scope id.
+  const terminalScopeId = activeThreadId ?? activeWorkspaceId;
   const storedPanel = useDiffStore((s) =>
-    activeThreadId ? s.rightPanelByThread[activeThreadId] : undefined,
+    activeWorkspaceId ? s.rightPanelByWorkspace[activeWorkspaceId] : undefined,
   );
-  const panelState = storedPanel ?? createDefaultRightPanelState();
-  const panelVisible = !!activeThreadId && panelState.visible;
+  const panelState = useMemo(
+    () => storedPanel ?? createDefaultRightPanelState(),
+    [storedPanel],
+  );
+  // Open/closed is per-thread, falling back to the workspace threadless shell.
+  // The active tab stays workspace-global.
+  const panelVisible = useDiffStore((s) =>
+    activeWorkspaceId
+      ? s.getRightPanelVisible(activeWorkspaceId, activeThreadId)
+      : false,
+  );
   const terminalTabVisible =
     panelVisible && panelState.activeTab === "terminal";
 
   const terminals = useTerminalStore((s) => s.terminals);
   const storedActiveTerminalId = useTerminalStore((s) =>
-    activeThreadId
-      ? (s.terminalPanelByThread[activeThreadId] ?? TERMINAL_PANEL_DEFAULTS)
+    terminalScopeId
+      ? (s.terminalPanelByThread[terminalScopeId] ?? TERMINAL_PANEL_DEFAULTS)
           .activeTerminalId
       : null,
   );
@@ -42,16 +55,16 @@ export function TerminalPoolHost() {
   const activeTerminalId = useMemo(
     () =>
       resolveActiveTerminalId(
-        activeThreadId,
+        terminalScopeId,
         storedActiveTerminalId,
         terminals,
       ),
-    [activeThreadId, storedActiveTerminalId, terminals],
+    [terminalScopeId, storedActiveTerminalId, terminals],
   );
 
   const pool = useTerminalStore(selectTerminalPool);
 
-  useTerminalPtyLifecycle(activeThreadId, terminalTabVisible);
+  useTerminalPtyLifecycle(terminalScopeId, terminalTabVisible);
 
   // Prefer the in-panel slot whenever it exists so pool DOM never hops to off-screen
   // on thread switch (that hop blanks xterm until a full re-open).
@@ -60,16 +73,16 @@ export function TerminalPoolHost() {
   const slotSized = !!slotEl && isContainerReadyForFit(slotEl);
 
   useLayoutEffect(() => {
-    if (!activeThreadId || !activeTerminalId) return;
+    if (!terminalScopeId || !activeTerminalId) return;
     if (storedActiveTerminalId !== activeTerminalId) {
-      useTerminalStore.getState().setActiveTerminal(activeThreadId, activeTerminalId);
+      useTerminalStore.getState().setActiveTerminal(terminalScopeId, activeTerminalId);
     }
-  }, [activeThreadId, activeTerminalId, storedActiveTerminalId]);
+  }, [terminalScopeId, activeTerminalId, storedActiveTerminalId]);
 
   useLayoutEffect(() => {
     if (!portalTarget) return;
     dispatchTerminalPoolRefit();
-  }, [activeThreadId, activeTerminalId, terminalTabVisible, portalTarget, slotSized]);
+  }, [terminalScopeId, activeTerminalId, terminalTabVisible, portalTarget, slotSized]);
 
   useEffect(() => {
     if (!slotEl) return;
@@ -85,7 +98,7 @@ export function TerminalPoolHost() {
   const poolContent = (
     <>
       {pool.map(({ term, ownerThreadId }) => {
-        const isActiveThread = ownerThreadId === activeThreadId;
+        const isActiveThread = ownerThreadId === terminalScopeId;
         const isShown =
           terminalTabVisible &&
           isActiveThread &&

--- a/apps/web/src/lib/__tests__/open-url-in-preview.test.ts
+++ b/apps/web/src/lib/__tests__/open-url-in-preview.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../open-url-in-preview";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { createMockWorkspace } from "@/__tests__/mocks/transport";
+import { createMockWorkspace, createMockThread } from "@/__tests__/mocks/transport";
 
 describe("isModifierClick", () => {
   it("returns true for ctrl+click", () => {
@@ -97,6 +97,7 @@ describe("openUrlInPreview", () => {
       workspaces: [ws],
       activeWorkspaceId: ws.id,
       activeThreadId: "thread-1",
+      threads: [createMockThread({ id: "thread-1", workspace_id: ws.id })],
     });
 
     window.desktopBridge = {
@@ -121,8 +122,8 @@ describe("openUrlInPreview", () => {
     openUrlInPreview({ url: "https://example.com/pr/1", threadId: "thread-1" });
     await vi.runAllTimersAsync();
 
-    expect(showRightPanel).toHaveBeenCalledWith("thread-1");
-    expect(setRightPanelTab).toHaveBeenCalledWith("thread-1", "preview");
+    expect(showRightPanel).toHaveBeenCalledWith("ws-1", "thread-1");
+    expect(setRightPanelTab).toHaveBeenCalledWith("ws-1", "preview");
     expect(mockCreate).toHaveBeenCalledWith("thread-1", true);
     expect(mockNavigate).toHaveBeenCalledWith("https://example.com/pr/1", "/tmp/workspace");
     expect(setPreviewUrlForThread).not.toHaveBeenCalled();

--- a/apps/web/src/lib/ensure-terminal.ts
+++ b/apps/web/src/lib/ensure-terminal.ts
@@ -1,16 +1,35 @@
 import { useDiffStore } from "@/stores/diffStore";
 import { useTerminalStore } from "@/stores/terminalStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { getTransport } from "@/transport";
 
 /**
- * Threads with an in-flight terminal creation. Shared module-level guard so
+ * Scopes with an in-flight terminal creation. Shared module-level guard so
  * concurrent triggers (tab click, the mod+j keybinding, React strict-mode
- * double-invoked effects) spawn at most one terminal per thread.
+ * double-invoked effects) spawn at most one terminal per scope.
  */
 const creationInFlight = new Set<string>();
 
 /**
- * Spawns a terminal for the thread when it has none, so opening the Terminal
+ * Resolve the workspace that owns a terminal scope. The scope is a thread id
+ * when a thread is active, or a workspace id for the threadless new-thread
+ * shell, so look the scope up as a thread first and fall back to a workspace.
+ */
+function resolveScopeWorkspace(scopeId: string): {
+  workspaceId: string | undefined;
+  isThread: boolean;
+} {
+  const ws = useWorkspaceStore.getState();
+  const thread = ws.threads.find((t) => t.id === scopeId);
+  if (thread) return { workspaceId: thread.workspace_id, isThread: true };
+  if (ws.workspaces.some((w) => w.id === scopeId)) {
+    return { workspaceId: scopeId, isThread: false };
+  }
+  return { workspaceId: undefined, isThread: false };
+}
+
+/**
+ * Spawns a terminal for the scope when it has none, so opening the Terminal
  * tab lands the user in a ready shell instead of an empty pane (the "anticipate
  * the next step" product principle).
  *
@@ -19,38 +38,46 @@ const creationInFlight = new Set<string>();
  * (the user closed the panel or switched tabs mid-creation), the orphaned PTY
  * is killed rather than added to the store.
  *
- * @param threadId - The thread to ensure a terminal for.
+ * @param scopeId - A thread id, or a workspace id for the threadless shell.
  */
-export function ensureTerminalForThread(threadId: string): void {
-  if (creationInFlight.has(threadId)) return;
-  const existing = useTerminalStore.getState().terminals[threadId];
+export function ensureTerminalForScope(scopeId: string): void {
+  if (creationInFlight.has(scopeId)) return;
+  const existing = useTerminalStore.getState().terminals[scopeId];
   if (existing && existing.length > 0) return;
 
-  creationInFlight.add(threadId);
+  creationInFlight.add(scopeId);
   try {
     const transport = getTransport();
     transport
-      .terminalCreate(threadId)
+      .terminalCreate(scopeId)
       .then(({ ptyId, shell }) => {
-        creationInFlight.delete(threadId);
-        const panel = useDiffStore.getState().getRightPanel(threadId);
+        creationInFlight.delete(scopeId);
+        // Width/tab are workspace-global; open/closed is per-thread (or the
+        // workspace threadless shell). Resolve the owning workspace to read
+        // panel state, passing the thread id only when the scope is a thread.
+        const { workspaceId, isThread } = resolveScopeWorkspace(scopeId);
+        const diff = useDiffStore.getState();
+        const panel = workspaceId ? diff.getRightPanel(workspaceId) : undefined;
+        const panelVisible = workspaceId
+          ? diff.getRightPanelVisible(workspaceId, isThread ? scopeId : undefined)
+          : false;
         // Panel closed or tab switched while creation was in flight — dispose
         // the orphaned PTY instead of adding a terminal nobody asked to see.
-        if (!panel.visible || panel.activeTab !== "terminal") {
+        if (!panel || !panelVisible || panel.activeTab !== "terminal") {
           transport.terminalKill(ptyId).catch(() => {});
           return;
         }
-        const current = useTerminalStore.getState().terminals[threadId];
+        const current = useTerminalStore.getState().terminals[scopeId];
         if (!current || current.length === 0) {
-          useTerminalStore.getState().addTerminal(threadId, ptyId, shell);
+          useTerminalStore.getState().addTerminal(scopeId, ptyId, shell);
         } else {
           transport.terminalKill(ptyId).catch(() => {});
         }
       })
       .catch(() => {
-        creationInFlight.delete(threadId);
+        creationInFlight.delete(scopeId);
       });
   } catch {
-    creationInFlight.delete(threadId);
+    creationInFlight.delete(scopeId);
   }
 }

--- a/apps/web/src/lib/open-url-in-preview.ts
+++ b/apps/web/src/lib/open-url-in-preview.ts
@@ -108,8 +108,18 @@ export function openUrlInPreview({
 
   const wsPath = resolveWorkspacePath(workspacePath);
   const { showRightPanel, setRightPanelTab, setPreviewUrlForThread } = useDiffStore.getState();
-  showRightPanel(threadId);
-  setRightPanelTab(threadId, "preview");
+  // Width and tab are workspace-global; open/closed is per-thread. The scope is
+  // a thread id, or a workspace id for the threadless new-thread preview, so
+  // resolve the owning workspace from either and open the panel for that scope.
+  const ws = useWorkspaceStore.getState();
+  const thread = ws.threads.find((t) => t.id === threadId);
+  const workspaceId = thread
+    ? thread.workspace_id
+    : ws.workspaces.find((w) => w.id === threadId)?.id;
+  if (workspaceId) {
+    showRightPanel(workspaceId, thread ? threadId : undefined);
+    setRightPanelTab(workspaceId, "preview");
+  }
 
   const run = async (): Promise<void> => {
     const openInNewTab = newTab && (await shouldOpenInNewTab(threadId, preview.tabs));

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -45,7 +45,7 @@ export interface SelectedFile {
   threadId: string;
 }
 
-/** Per-thread right panel state (visibility, width, active tab). */
+/** Workspace-global right panel state (visibility, width, active tab). */
 export type RightPanelState = {
   readonly visible: boolean;
   readonly width: number;
@@ -56,7 +56,7 @@ export type RightPanelState = {
 export const DEFAULT_LINE_WRAP = true;
 
 /**
- * Baseline right-panel state for a thread that has no persisted row (50% viewport width).
+ * Baseline right-panel state for a workspace that has no persisted row (50% viewport width).
  */
 export function createDefaultRightPanelState(): RightPanelState {
   return {
@@ -67,7 +67,37 @@ export function createDefaultRightPanelState(): RightPanelState {
 }
 
 /**
- * Static defaults for threads with no panel store row; live width uses
+ * Computes the next state slice for a panel visibility change. With a thread,
+ * writes the per-thread visibility map; without a thread, writes the workspace
+ * threadless `visible` field. Pass `next` to set an explicit value, or
+ * `undefined` to toggle the current effective value.
+ */
+function setPanelVisible(
+  state: DiffState,
+  workspaceId: string,
+  threadId: string | null | undefined,
+  next: boolean | undefined,
+): Partial<DiffState> {
+  if (threadId) {
+    const current = state.rightPanelVisibleByThread[threadId] ?? false;
+    return {
+      rightPanelVisibleByThread: {
+        ...state.rightPanelVisibleByThread,
+        [threadId]: next ?? !current,
+      },
+    };
+  }
+  const current = state.rightPanelByWorkspace[workspaceId] ?? createDefaultRightPanelState();
+  return {
+    rightPanelByWorkspace: {
+      ...state.rightPanelByWorkspace,
+      [workspaceId]: { ...current, visible: next ?? !current.visible },
+    },
+  };
+}
+
+/**
+ * Static defaults for workspaces with no panel store row; live width uses
  * {@link getDefaultPanelWidthPx} through {@link createDefaultRightPanelState}.
  */
 export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
@@ -80,8 +110,22 @@ export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
 interface DiffState {
   /** Last preview URL typed or loaded per thread (in-memory only). */
   readonly previewUrlByThread: Record<string, string>;
-  /** Per-thread right panel state keyed by thread ID. */
-  readonly rightPanelByThread: Record<string, RightPanelState>;
+  /**
+   * Workspace-scoped right panel shell keyed by workspace ID. Width and active
+   * tab belong to the workspace and persist across thread navigation and with no
+   * thread open. The `visible` field here is the *threadless* open/closed state
+   * (used when no thread is selected); per-thread open/closed lives in
+   * {@link rightPanelVisibleByThread}. Tab *contents* keep their own (thread or
+   * workspace-root) scope; see ADR-0004.
+   */
+  readonly rightPanelByWorkspace: Record<string, RightPanelState>;
+  /**
+   * Per-thread right panel open/closed state keyed by thread ID. Opening the
+   * panel on one thread does not open it on a sibling thread in the same
+   * workspace; width and active tab remain shared via {@link rightPanelByWorkspace}.
+   * Absent entry means closed. See ADR-0004.
+   */
+  readonly rightPanelVisibleByThread: Record<string, boolean>;
   /** View mode within the Changes tab. */
   viewMode: DiffViewMode;
   /** Diff rendering mode. */
@@ -127,12 +171,21 @@ interface DiffState {
   } | null;
   /** Whether a summary is currently being generated. */
   summaryLoading: boolean;
-  getRightPanel: (threadId: string) => RightPanelState;
-  toggleRightPanel: (threadId: string) => void;
-  showRightPanel: (threadId: string) => void;
-  hideRightPanel: (threadId: string) => void;
-  setRightPanelWidth: (threadId: string, width: number) => void;
-  setRightPanelTab: (threadId: string, tab: RightPanelTab) => void;
+  getRightPanel: (workspaceId: string) => RightPanelState;
+  /**
+   * Effective open/closed state for the panel. With a thread, reads the
+   * per-thread map (default closed); without a thread, reads the workspace
+   * threadless `visible` field.
+   */
+  getRightPanelVisible: (workspaceId: string, threadId?: string | null) => boolean;
+  /** Toggle the panel for a thread (per-thread) or the threadless shell (workspace). */
+  toggleRightPanel: (workspaceId: string, threadId?: string | null) => void;
+  /** Open the panel for a thread (per-thread) or the threadless shell (workspace). */
+  showRightPanel: (workspaceId: string, threadId?: string | null) => void;
+  /** Close the panel for a thread (per-thread) or the threadless shell (workspace). */
+  hideRightPanel: (workspaceId: string, threadId?: string | null) => void;
+  setRightPanelWidth: (workspaceId: string, width: number) => void;
+  setRightPanelTab: (workspaceId: string, tab: RightPanelTab) => void;
   setViewMode: (mode: DiffViewMode) => void;
   setRenderMode: (mode: DiffRenderMode) => void;
   getLineWrap: (threadId: string) => boolean;
@@ -157,12 +210,15 @@ interface DiffState {
   /** Persist the omnibox URL for a thread's embedded preview. */
   setPreviewUrlForThread: (threadId: string, url: string) => void;
   clearThread: (threadId: string) => void;
+  /** Drop a workspace's persisted panel state (called on workspace deletion). */
+  clearWorkspace: (workspaceId: string) => void;
 }
 
 /** Zustand store for diff panel and right panel tab state. */
 export const useDiffStore = create<DiffState>((set, get) => ({
   previewUrlByThread: {},
-  rightPanelByThread: {},
+  rightPanelByWorkspace: {},
+  rightPanelVisibleByThread: {},
   viewMode: "by-turn",
   renderMode: "unified",
   lineWrapByThread: {},
@@ -178,60 +234,42 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   summaryRecord: null,
   summaryLoading: false,
 
-  getRightPanel: (threadId) =>
-    get().rightPanelByThread[threadId] ?? createDefaultRightPanelState(),
+  getRightPanel: (workspaceId) =>
+    get().rightPanelByWorkspace[workspaceId] ?? createDefaultRightPanelState(),
 
-  toggleRightPanel: (threadId) =>
+  getRightPanelVisible: (workspaceId, threadId) => {
+    const state = get();
+    if (threadId) return state.rightPanelVisibleByThread[threadId] ?? false;
+    return state.rightPanelByWorkspace[workspaceId]?.visible ?? false;
+  },
+
+  toggleRightPanel: (workspaceId, threadId) =>
+    set((state) => setPanelVisible(state, workspaceId, threadId, undefined)),
+
+  showRightPanel: (workspaceId, threadId) =>
+    set((state) => setPanelVisible(state, workspaceId, threadId, true)),
+
+  hideRightPanel: (workspaceId, threadId) =>
+    set((state) => setPanelVisible(state, workspaceId, threadId, false)),
+
+  setRightPanelWidth: (workspaceId, width) =>
     set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
+      const current = state.rightPanelByWorkspace[workspaceId] ?? createDefaultRightPanelState();
       return {
-        rightPanelByThread: {
-          ...state.rightPanelByThread,
-          [threadId]: { ...current, visible: !current.visible },
+        rightPanelByWorkspace: {
+          ...state.rightPanelByWorkspace,
+          [workspaceId]: { ...current, width: clampWidth(width) },
         },
       };
     }),
 
-  showRightPanel: (threadId) =>
+  setRightPanelTab: (workspaceId, tab) =>
     set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
+      const current = state.rightPanelByWorkspace[workspaceId] ?? createDefaultRightPanelState();
       return {
-        rightPanelByThread: {
-          ...state.rightPanelByThread,
-          [threadId]: { ...current, visible: true },
-        },
-      };
-    }),
-
-  hideRightPanel: (threadId) =>
-    set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
-      return {
-        rightPanelByThread: {
-          ...state.rightPanelByThread,
-          [threadId]: { ...current, visible: false },
-        },
-      };
-    }),
-
-  setRightPanelWidth: (threadId, width) =>
-    set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
-      return {
-        rightPanelByThread: {
-          ...state.rightPanelByThread,
-          [threadId]: { ...current, width: clampWidth(width) },
-        },
-      };
-    }),
-
-  setRightPanelTab: (threadId, tab) =>
-    set((state) => {
-      const current = state.rightPanelByThread[threadId] ?? createDefaultRightPanelState();
-      return {
-        rightPanelByThread: {
-          ...state.rightPanelByThread,
-          [threadId]: { ...current, activeTab: tab },
+        rightPanelByWorkspace: {
+          ...state.rightPanelByWorkspace,
+          [workspaceId]: { ...current, activeTab: tab },
         },
       };
     }),
@@ -298,12 +336,12 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       delete commits[threadId];
       const commitsLoading = { ...state.commitsLoadingByThread };
       delete commitsLoading[threadId];
-      const rightPanels = { ...state.rightPanelByThread };
-      delete rightPanels[threadId];
       const previewUrls = { ...state.previewUrlByThread };
       delete previewUrls[threadId];
       const lineWrapByThread = { ...state.lineWrapByThread };
       delete lineWrapByThread[threadId];
+      const rightPanelVisibleByThread = { ...state.rightPanelVisibleByThread };
+      delete rightPanelVisibleByThread[threadId];
 
       // Evict inline diff cache entries scoped to this thread.
       const prefix = `${threadId}:`;
@@ -322,9 +360,9 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         snapshotsPendingByThread: snapshotsPending,
         commitsByThread: commits,
         commitsLoadingByThread: commitsLoading,
-        rightPanelByThread: rightPanels,
         previewUrlByThread: previewUrls,
         lineWrapByThread,
+        rightPanelVisibleByThread,
         inlineDiffCache,
         ...(selectionBelongsToThread
           ? { selectedFile: null, diffContent: null, diffLoading: false }
@@ -333,5 +371,12 @@ export const useDiffStore = create<DiffState>((set, get) => ({
           ? { summaryRecord: null, summaryLoading: false }
           : {}),
       };
+    }),
+  clearWorkspace: (workspaceId) =>
+    set((state) => {
+      if (!(workspaceId in state.rightPanelByWorkspace)) return {};
+      const rightPanelByWorkspace = { ...state.rightPanelByWorkspace };
+      delete rightPanelByWorkspace[workspaceId];
+      return { rightPanelByWorkspace };
     }),
 }));

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -454,6 +454,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         terminalStore.clearThread(tid);
         diffStore.clearThread(tid);
       }
+      // The right panel is workspace-global, so its state is dropped once per
+      // workspace rather than per thread.
+      diffStore.clearWorkspace(id);
       // Remove threads from store FIRST (same ordering as deleteThread) so
       // any in-flight timer callbacks see threads as gone before timers are cancelled.
       const deletedIdSet = new Set(deletedThreadIds);

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -311,10 +311,19 @@ export function startPushListeners(): void {
           // refresh and let CumulativeView surface a refresh affordance so
           // their scroll position isn't yanked. Otherwise refetch silently
           // so re-entry shows the latest data.
-          const panel = snap.rightPanelByThread[payload.threadId];
+          const wsState = useWorkspaceStore.getState();
+          const workspaceId = wsState.threads.find(
+            (t) => t.id === payload.threadId,
+          )?.workspace_id;
+          const panel = workspaceId
+            ? snap.rightPanelByWorkspace[workspaceId]
+            : undefined;
+          // Open/closed is per-thread; width and tab are workspace-global. Only
+          // defer when this thread is on screen with its panel open on Changes.
           const isViewingAllChanges =
-            panel?.visible === true &&
-            panel.activeTab === "changes" &&
+            wsState.activeThreadId === payload.threadId &&
+            snap.rightPanelVisibleByThread[payload.threadId] === true &&
+            panel?.activeTab === "changes" &&
             snap.viewMode === "all";
 
           if (isViewingAllChanges) {

--- a/docs/adr/0004-workspace-global-right-panel-singleton-tabs.md
+++ b/docs/adr/0004-workspace-global-right-panel-singleton-tabs.md
@@ -2,7 +2,7 @@
 status: accepted
 ---
 
-# The right panel is workspace-global with singleton tabs; tab contents keep their own scope
+# The right panel splits its state: open/closed is per-thread, width and tab are workspace-global; singleton tabs keep their own scope
 
 ## Context
 
@@ -18,11 +18,27 @@ That breaks the "no thread → no panel" invariant the whole module was built on
 and forces a decision about where panel state lives and what scope each tab runs
 against.
 
+An initial revision of this ADR made *all* panel state workspace-global,
+including open/closed. Product feedback rejected that: opening the panel on one
+thread must not open it on a sibling thread in the same workspace. Whether the
+panel is showing is a per-thread reading decision; only its **size and which tab
+is selected** are workspace-level preferences worth sharing. The decision below
+reflects that hybrid split.
+
 ## Decision
 
-The **panel container** becomes **workspace-global**: visibility, width, and
-active tab persist with no thread open. The panel no longer returns `null` when
-there is no thread.
+The **panel container** state is **split by concern**:
+
+- **Open/closed (visibility) is per-thread.** Showing the panel on one thread
+  leaves it closed on its siblings. This lives in `diffStore`'s
+  `rightPanelVisibleByThread: Record<threadId, boolean>` (absent = closed).
+- **Width and active tab are workspace-global.** They persist across threads and
+  with no thread open, in the `rightPanelByWorkspace` slice.
+
+When **no thread is active**, visibility falls back to the workspace slice's
+`visible` field, so the threadless Browser/Terminal shell can be opened against
+the workspace itself. The panel no longer returns `null` when there is no
+thread.
 
 Individual **tabs keep their own scope**, declared per tab type rather than
 inherited from the panel:
@@ -43,10 +59,19 @@ opens it directly, when none are it is hidden.
 
 - **Keep the panel fully thread-scoped (rejected).** Status quo; makes the
   threadless Browser/Terminal requirement impossible.
+- **Make the whole panel container workspace-global, including open/closed
+  (rejected).** Simpler state, but opening the panel on one thread would open it
+  on every sibling thread in the same workspace. Product feedback called this
+  wrong: visibility is a per-thread reading choice, not a shared workspace
+  preference.
 - **Make everything fully workspace-scoped (rejected).** Detaches tabs from
   threads entirely, discarding the per-thread Preview/Terminal model the rest of
   the app and the existing stores depend on, and breaking "each thread keeps its
   own tabs."
+- **Split the state: per-thread visibility, workspace-global width and tab
+  (chosen).** Keeps the per-thread open/closed feel users expect while sharing
+  the size and tab selection — the two settings users do not want to re-set on
+  every thread — and still supports a threadless shell via the workspace slice.
 - **Allow multiple top-level tabs of the same type (rejected).** Duplicate
   Browser/Terminal tabs at the panel level would make the "add" menu never empty
   and contradict the existing internal page/shell pooling. Singleton tabs with
@@ -55,11 +80,18 @@ opens it directly, when none are it is hidden.
 
 ## Consequences
 
-- `rightPanelByThread` migrates to a workspace-global slice plus per-tab content
-  scope. This is the costly-to-reverse part of the decision.
-- Panel state is global but tab *contents* are scoped — a deliberate split that
-  a future reader should not "simplify" into one or the other.
+- `rightPanelByThread` is replaced by two slices: `rightPanelByWorkspace`
+  (width, active tab, and the threadless `visible` fallback) and
+  `rightPanelVisibleByThread` (per-thread open/closed). This is the
+  costly-to-reverse part of the decision.
+- Panel **visibility is per-thread**, but **width and tab are workspace-global**,
+  and tab *contents* keep their own scope — a deliberate three-way split that a
+  future reader should not "simplify" into a single scope. Read effective
+  visibility through `getRightPanelVisible(workspaceId, threadId?)`, never by
+  reaching into either slice directly.
+- `clearThread` must drop the thread's `rightPanelVisibleByThread` entry so a
+  deleted thread does not leave a dangling open/closed bit.
 - Threadless tabs need a cwd; they resolve to the active workspace root, and are
   unavailable when there is no workspace at all.
 - The `CONTEXT.md` "Preview is thread-scoped" language is superseded; Preview is
-  now the Browser tab type within the workspace-global panel.
+  now the Browser tab type within this panel.


### PR DESCRIPTION
## What

Implements the right-panel shell from #609: a hybrid state model where the panel's **open/closed** state is per-thread, its **width and active tab** are workspace-global, and the panel renders a **threadless shell** (no active thread) so Terminal and Preview work in the new-thread composer view.

## Why

The right-panel revamp requires the panel to be usable before any thread exists (open a Terminal or Browser against the workspace from the empty app). That breaks the old "no thread -> no panel" invariant. An initial design made all panel state workspace-global, but product feedback rejected that: opening the panel on one thread must not open it on a sibling thread. The chosen split keeps the per-thread open/closed feel while sharing the two preferences users do not want to re-set per thread (size and selected tab). See ADR-0004.

## Key changes

- **State model (`diffStore.ts`):** new `rightPanelVisibleByThread` (per-thread open/closed) and `rightPanelByWorkspace` (workspace-global width, tab, threadless `visible` fallback) slices. Effective visibility is read through `getRightPanelVisible(workspaceId, threadId?)` rather than reaching into either slice. Replaces the old `rightPanelByThread` slice.
- **RightPanel:** renders the workspace shell when `activeThreadId` is null; bails only when there is no workspace. Tab content scopes by `panelScopeId = activeThreadId ?? activeWorkspaceId`.
- **Terminal & Preview threadless support:** terminal `create()` and `openUrlInPreview` resolve thread-or-workspace scope; the workspace-scoped shell anchors cwd at the **local `workspace.path`, never a worktree** (no worktree exists until the thread is created).
- **Callers re-keyed** to `(workspaceId, threadId?)` across App, Composer, HeaderActions, PlanCard, TurnChangeSummary, DiffPanel, ws-events.
- **Cleanup:** `clearThread` drops the thread's visibility entry; new `clearWorkspace` drops workspace panel state on deletion.
- **Tests:** unit tests for the hybrid persistence model + e2e specs for threadless terminal and preview.

## Review fixes applied in this branch

- Removed a spurious `viewportWidth` dependency from the `panelState` `useMemo` in `RightPanel.tsx` (was recomputing the default object on every resize).
- Fixed two false-green assertions in `agent-event-thread-isolation.test.ts` that keyed `rightPanelByWorkspace` by a thread id (always `undefined`); they now route through `getRightPanelVisible` and exercise per-thread visibility.
- Memoized `panelState` in `TerminalPoolHost.tsx` to match RightPanel and avoid a `window.innerWidth` read each render.

## Notes / follow-ups (not addressed here)

- **Terminal rebind:** when the threadless workspace shell transitions to a newly created thread, the panel rebinds to the (empty) thread scope; the workspace PTY stays alive but is not shown. Flagged in handoff, no objection - confirm this is the intended behavior.
- **Security (low, deferred):** `terminal.create` accepts either a thread or workspace id under the same `threadId` schema param; consider renaming to `scopeId` / discriminated union. The workspace-scoped cwd uses `workspace.path` (the user's own local checkout, no privilege boundary) without `path.resolve` canonicalization - cheap defense-in-depth if desired.

## Test plan

- [x] `bun run verify` (typecheck + lint + 1486 unit tests) - green
- [ ] e2e: `right-panel-terminal-threadless.spec.ts`, `right-panel-preview-threadless.spec.ts`
- [ ] Manual: open Terminal/Preview from the new-thread view; verify per-thread open/closed and shared width/tab across threads

Closes #609

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783612170&installation_id=129163861&pr_number=625&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F625&signature=bd6fd79c19a19e9c47d5665684134847393887e6aeca86f6f788cad6502f801c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Right panel (terminal, preview, and tasks tabs) now works in threadless workspace mode without requiring an active thread.
  * Terminals can now be spawned and managed at the workspace scope level.

* **Bug Fixes**
  * Improved right panel state persistence across workspace and thread contexts.

* **Refactor**
  * Internal right panel state model refactored for better workspace-level organization and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->