### PR TITLE
feat: terminal app-kind (Windows Terminal / Git Bash / WSL) (#606)

### DIFF
--- a/apps/desktop/src/main/__tests__/terminal-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/terminal-adapter.test.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from "events";
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildTerminalArgs,
+  createTerminalAdapter,
+  type TerminalAdapterConfig,
+  type TerminalAdapterDeps,
+  type TerminalId,
+} from "../open-in/terminal-adapter";
+
+const WT_CONFIG: TerminalAdapterConfig = {
+  id: "windows-terminal",
+  label: "Windows Terminal",
+  iconKey: "windows-terminal",
+  command: "wt",
+  windowsPaths: ["C:\\fallback\\wt.exe"],
+};
+
+/** Fake deps: a fake spawn that emits "spawn" so launch resolves, plus probes. */
+function fakeDeps(overrides: Partial<TerminalAdapterDeps> = {}): {
+  deps: TerminalAdapterDeps;
+  spawns: { cmd: string; args: readonly string[] }[];
+} {
+  const spawns: { cmd: string; args: readonly string[] }[] = [];
+  const spawn = vi.fn((cmd: string, args: readonly string[]) => {
+    spawns.push({ cmd, args });
+    const child = new EventEmitter() as EventEmitter & { unref(): void };
+    child.unref = () => {};
+    queueMicrotask(() => child.emit("spawn"));
+    return child;
+  });
+  return {
+    spawns,
+    deps: {
+      commandOnPath: () => false,
+      fileExists: () => false,
+      spawn: spawn as unknown as TerminalAdapterDeps["spawn"],
+      platform: "win32",
+      ...overrides,
+    },
+  };
+}
+
+describe("buildTerminalArgs", () => {
+  it.each<[TerminalId, string[]]>([
+    ["windows-terminal", ["-d", "C:\\repo"]],
+    ["wsl", ["--cd", "C:\\repo"]],
+    ["git-bash", ["--cd=C:\\repo"]],
+  ])("shapes %s launch args per ADR-0006", (id, expected) => {
+    expect(buildTerminalArgs(id, "C:\\repo")).toEqual(expected);
+  });
+});
+
+describe("createTerminalAdapter detection", () => {
+  it("detects when the command is on PATH", () => {
+    const { deps } = fakeDeps({ commandOnPath: (c) => c === "wt" });
+    expect(createTerminalAdapter(WT_CONFIG, deps).detect()).toBe(true);
+  });
+
+  it("falls back to a Windows install path when not on PATH", () => {
+    const { deps } = fakeDeps({
+      commandOnPath: () => false,
+      fileExists: (p) => p === "C:\\fallback\\wt.exe",
+    });
+    expect(createTerminalAdapter(WT_CONFIG, deps).detect()).toBe(true);
+  });
+
+  it("is not detected when neither PATH nor fallback paths resolve", () => {
+    const { deps } = fakeDeps();
+    expect(createTerminalAdapter(WT_CONFIG, deps).detect()).toBe(false);
+  });
+
+  it("is never detected off Windows, without probing PATH", () => {
+    const commandOnPath = vi.fn().mockReturnValue(true);
+    const { deps } = fakeDeps({ platform: "darwin", commandOnPath });
+    expect(createTerminalAdapter(WT_CONFIG, deps).detect()).toBe(false);
+    expect(commandOnPath).not.toHaveBeenCalled();
+  });
+
+  it("memoizes resolution so PATH is probed once across detect + launch", async () => {
+    const commandOnPath = vi.fn().mockReturnValue(true);
+    const { deps } = fakeDeps({ commandOnPath });
+    const adapter = createTerminalAdapter(WT_CONFIG, deps);
+
+    adapter.detect();
+    adapter.detect();
+    await adapter.launch({ path: "C:\\repo" });
+
+    expect(commandOnPath).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createTerminalAdapter launch", () => {
+  it("spawns the resolved command with directory args", async () => {
+    const { deps, spawns } = fakeDeps({ commandOnPath: (c) => c === "wt" });
+    await createTerminalAdapter(WT_CONFIG, deps).launch({ path: "C:\\repo" });
+
+    expect(spawns).toEqual([{ cmd: "wt", args: ["-d", "C:\\repo"] }]);
+  });
+
+  it("spawns the fallback executable path when PATH lookup misses", async () => {
+    const { deps, spawns } = fakeDeps({
+      commandOnPath: () => false,
+      fileExists: (p) => p === "C:\\fallback\\wt.exe",
+    });
+    await createTerminalAdapter(WT_CONFIG, deps).launch({ path: "C:\\repo" });
+
+    expect(spawns[0]?.cmd).toBe("C:\\fallback\\wt.exe");
+  });
+
+  it("rejects when the terminal is not detected", async () => {
+    const { deps, spawns } = fakeDeps();
+    await expect(
+      createTerminalAdapter(WT_CONFIG, deps).launch({ path: "C:\\repo" }),
+    ).rejects.toThrow(/Terminal not detected: windows-terminal/);
+    expect(spawns).toEqual([]);
+  });
+
+  it("exposes terminal-kind metadata to the registry", () => {
+    const { deps } = fakeDeps();
+    const adapter = createTerminalAdapter(WT_CONFIG, deps);
+    expect(adapter.kind).toBe("terminal");
+    expect(adapter.id).toBe("windows-terminal");
+    expect(adapter.iconKey).toBe("windows-terminal");
+  });
+});

--- a/apps/desktop/src/main/__tests__/terminal-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/terminal-adapter.test.ts
@@ -108,6 +108,36 @@ describe("createTerminalAdapter launch", () => {
     expect(spawns[0]?.cmd).toBe("C:\\fallback\\wt.exe");
   });
 
+  it("quotes a launcher path containing spaces so cmd.exe does not split it (Git Bash)", async () => {
+    const gitBashPath = "C:\\Program Files\\Git\\git-bash.exe";
+    const { deps, spawns } = fakeDeps({
+      commandOnPath: () => false,
+      fileExists: (p) => p === gitBashPath,
+    });
+    await createTerminalAdapter(
+      {
+        id: "git-bash",
+        label: "Git Bash",
+        iconKey: "git-bash",
+        command: "git-bash",
+        windowsPaths: [gitBashPath],
+      },
+      deps,
+    ).launch({ path: "C:\\repo" });
+
+    expect(spawns[0]).toEqual({
+      cmd: `"${gitBashPath}"`,
+      args: ["--cd=C:\\repo"],
+    });
+  });
+
+  it("does not quote a bare PATH command without spaces", async () => {
+    const { deps, spawns } = fakeDeps({ commandOnPath: (c) => c === "wt" });
+    await createTerminalAdapter(WT_CONFIG, deps).launch({ path: "C:\\repo" });
+
+    expect(spawns[0]?.cmd).toBe("wt");
+  });
+
   it("rejects when the terminal is not detected", async () => {
     const { deps, spawns } = fakeDeps();
     await expect(

--- a/apps/desktop/src/main/__tests__/terminal-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/terminal-adapter.test.ts
@@ -138,6 +138,25 @@ describe("createTerminalAdapter launch", () => {
     expect(spawns[0]?.cmd).toBe("wt");
   });
 
+  it("quotes a target directory containing spaces so cmd.exe does not split it", async () => {
+    const { deps, spawns } = fakeDeps({ commandOnPath: (c) => c === "wt" });
+    await createTerminalAdapter(WT_CONFIG, deps).launch({
+      path: "C:\\Users\\John Doe\\repo",
+    });
+
+    expect(spawns[0]).toEqual({
+      cmd: "wt",
+      args: ["-d", '"C:\\Users\\John Doe\\repo"'],
+    });
+  });
+
+  it("quotes a target directory with a shell metacharacter so cmd.exe cannot inject", async () => {
+    const { deps, spawns } = fakeDeps({ commandOnPath: (c) => c === "wt" });
+    await createTerminalAdapter(WT_CONFIG, deps).launch({ path: "C:\\repo&calc" });
+
+    expect(spawns[0]?.args).toEqual(["-d", '"C:\\repo&calc"']);
+  });
+
   it("rejects when the terminal is not detected", async () => {
     const { deps, spawns } = fakeDeps();
     await expect(

--- a/apps/desktop/src/main/open-in/index.ts
+++ b/apps/desktop/src/main/open-in/index.ts
@@ -7,6 +7,10 @@
 import { join } from "path";
 import { createEditorAdapter, type EditorAdapterConfig } from "./editor-adapter.js";
 import { createFileExplorerAdapter } from "./file-explorer-adapter.js";
+import {
+  createTerminalAdapter,
+  type TerminalAdapterConfig,
+} from "./terminal-adapter.js";
 import { OpenInRegistry } from "./registry.js";
 
 /** Known editors, with Windows fallback install paths for PATH-less setups. */
@@ -61,9 +65,56 @@ const EDITOR_CONFIGS: readonly EditorAdapterConfig[] = [
   },
 ];
 
-/** Singleton registry: editors first (menu order), then File Explorer. */
+/**
+ * Known external terminals, with Windows fallback install paths for setups where
+ * the launcher is not on PATH (Git Bash in particular ships no PATH entry).
+ */
+const TERMINAL_CONFIGS: readonly TerminalAdapterConfig[] = [
+  {
+    id: "windows-terminal",
+    label: "Windows Terminal",
+    iconKey: "windows-terminal",
+    command: "wt",
+    windowsPaths: [
+      join(
+        process.env.LOCALAPPDATA ?? "",
+        "Microsoft",
+        "WindowsApps",
+        "wt.exe",
+      ),
+    ],
+  },
+  {
+    id: "git-bash",
+    label: "Git Bash",
+    iconKey: "git-bash",
+    command: "git-bash",
+    windowsPaths: [
+      join(process.env.ProgramFiles ?? "", "Git", "git-bash.exe"),
+      join(process.env["ProgramFiles(x86)"] ?? "", "Git", "git-bash.exe"),
+      join(
+        process.env.LOCALAPPDATA ?? "",
+        "Programs",
+        "Git",
+        "git-bash.exe",
+      ),
+    ],
+  },
+  {
+    id: "wsl",
+    label: "WSL",
+    iconKey: "wsl",
+    command: "wsl",
+    windowsPaths: [
+      join(process.env.SystemRoot ?? "", "System32", "wsl.exe"),
+    ],
+  },
+];
+
+/** Singleton registry: editors, then terminals, then File Explorer (menu order). */
 export const openInRegistry = new OpenInRegistry([
   ...EDITOR_CONFIGS.map(createEditorAdapter),
+  ...TERMINAL_CONFIGS.map((c) => createTerminalAdapter(c)),
   createFileExplorerAdapter(),
 ]);
 

--- a/apps/desktop/src/main/open-in/terminal-adapter.ts
+++ b/apps/desktop/src/main/open-in/terminal-adapter.ts
@@ -1,0 +1,150 @@
+/**
+ * Terminal adapters for the Open-in app registry. Each terminal (Windows
+ * Terminal, Git Bash, WSL) launches an external terminal emulator at the target
+ * working directory. Per ADR-0006 these are ordinary registry adapters that
+ * resolve their own environment — they do NOT share the server's
+ * `ShellEnvResolver`, which stays a PTY-only concern.
+ *
+ * Detection and launch-argument shaping live here (the testable surface); the
+ * leaf spawn is a thin fire-and-forget shim matching the editor adapters.
+ */
+
+import { execFileSync, spawn, type ChildProcess } from "child_process";
+import { existsSync } from "fs";
+import type { LaunchTarget, OpenInAdapter } from "./types.js";
+
+/** IDs of the external terminals we detect and can launch. */
+export type TerminalId = "windows-terminal" | "git-bash" | "wsl";
+
+/** Static declaration for a terminal adapter. */
+export interface TerminalAdapterConfig {
+  readonly id: TerminalId;
+  readonly label: string;
+  /** Renderer-side icon key (resolved to a component in the renderer). */
+  readonly iconKey: string;
+  /** Executable/command name checked on PATH and spawned when found. */
+  readonly command: string;
+  /** Absolute fallback executable paths checked on Windows when not on PATH. */
+  readonly windowsPaths?: readonly string[];
+}
+
+/**
+ * Injectable system probes. Defaults hit the real OS; tests pass fakes so
+ * detection and launch can be exercised without spawning anything or depending
+ * on which terminals happen to be installed on the test machine.
+ */
+export interface TerminalAdapterDeps {
+  /** Whether a command resolves on the system PATH. */
+  commandOnPath(cmd: string): boolean;
+  /** Whether an absolute path exists on disk. */
+  fileExists(path: string): boolean;
+  /** Spawn a detached child process. */
+  spawn: typeof spawn;
+  /** Host platform (terminals here are Windows-only). */
+  platform: NodeJS.Platform;
+}
+
+/** Check whether a command exists on the system PATH. */
+function commandOnPathReal(cmd: string): boolean {
+  const checkCmd = process.platform === "win32" ? "where" : "which";
+  try {
+    execFileSync(checkCmd, [cmd], { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const REAL_DEPS: TerminalAdapterDeps = {
+  commandOnPath: commandOnPathReal,
+  fileExists: existsSync,
+  spawn,
+  platform: process.platform,
+};
+
+/**
+ * Build the CLI arguments to launch a terminal at a working directory. Pure
+ * function — the highest-value test target. The arg shapes follow ADR-0006:
+ * Windows Terminal `-d <dir>`, WSL `--cd <dir>`, Git Bash `--cd=<dir>`.
+ */
+export function buildTerminalArgs(terminal: TerminalId, dir: string): string[] {
+  switch (terminal) {
+    case "windows-terminal":
+      return ["-d", dir];
+    case "wsl":
+      return ["--cd", dir];
+    case "git-bash":
+      return [`--cd=${dir}`];
+  }
+}
+
+/**
+ * Build a terminal adapter from a static config. The resolved executable is
+ * memoized on first detection so {@link OpenInAdapter.launch} reuses it without a
+ * second PATH lookup. External terminals are a Windows concern here, so
+ * detection is always false off Windows.
+ */
+export function createTerminalAdapter(
+  config: TerminalAdapterConfig,
+  deps: TerminalAdapterDeps = REAL_DEPS,
+): OpenInAdapter {
+  // `undefined` = not yet resolved; `null` = resolved as not installed.
+  let resolvedCommand: string | null | undefined;
+
+  function resolveCommand(): string | null {
+    if (resolvedCommand !== undefined) return resolvedCommand;
+    if (deps.platform !== "win32") {
+      resolvedCommand = null;
+      return resolvedCommand;
+    }
+    if (deps.commandOnPath(config.command)) {
+      resolvedCommand = config.command;
+      return resolvedCommand;
+    }
+    for (const p of config.windowsPaths ?? []) {
+      if (deps.fileExists(p)) {
+        resolvedCommand = p;
+        return resolvedCommand;
+      }
+    }
+    resolvedCommand = null;
+    return resolvedCommand;
+  }
+
+  return {
+    id: config.id,
+    label: config.label,
+    kind: "terminal",
+    iconKey: config.iconKey,
+
+    detect() {
+      return resolveCommand() !== null;
+    },
+
+    launch(target: LaunchTarget): Promise<void> {
+      const cmd = resolveCommand();
+      if (!cmd) {
+        return Promise.reject(new Error(`Terminal not detected: ${config.id}`));
+      }
+
+      const args = buildTerminalArgs(config.id, target.path);
+
+      return new Promise<void>((resolve, reject) => {
+        // Terminal executables on Windows (wt.exe, wsl.exe, git-bash.exe) launch
+        // their own window and resolve their own environment; we fire and forget.
+        const child: ChildProcess = deps.spawn(cmd, args, {
+          detached: true,
+          stdio: "ignore",
+          shell: true,
+        });
+
+        child.on("error", (err: Error) => reject(new Error(err.message)));
+        // The "spawn" event fires once the child process has been created.
+        child.on("spawn", () => {
+          child.unref();
+          resolve();
+        });
+      });
+    },
+  };
+}

--- a/apps/desktop/src/main/open-in/terminal-adapter.ts
+++ b/apps/desktop/src/main/open-in/terminal-adapter.ts
@@ -129,10 +129,16 @@ export function createTerminalAdapter(
 
       const args = buildTerminalArgs(config.id, target.path);
 
+      // shell:true lets PATH aliases like `wt` resolve, but cmd.exe concatenates
+      // the command and args without quoting. A launcher resolved to an absolute
+      // path with spaces (Git Bash under "Program Files") would be split at the
+      // first space, so quote it; bare PATH names have no spaces and are untouched.
+      const spawnCmd = /\s/.test(cmd) ? `"${cmd}"` : cmd;
+
       return new Promise<void>((resolve, reject) => {
         // Terminal executables on Windows (wt.exe, wsl.exe, git-bash.exe) launch
         // their own window and resolve their own environment; we fire and forget.
-        const child: ChildProcess = deps.spawn(cmd, args, {
+        const child: ChildProcess = deps.spawn(spawnCmd, args, {
           detached: true,
           stdio: "ignore",
           shell: true,

--- a/apps/desktop/src/main/open-in/terminal-adapter.ts
+++ b/apps/desktop/src/main/open-in/terminal-adapter.ts
@@ -63,6 +63,18 @@ const REAL_DEPS: TerminalAdapterDeps = {
 };
 
 /**
+ * Quote a token for a `shell: true` spawn on Windows. cmd.exe joins the command
+ * and args into a single line and applies no quoting of its own, so a token
+ * containing whitespace or a shell metacharacter (`& | < > ^ ( )`) would be
+ * split — or, for metacharacters, interpreted by cmd.exe (command injection).
+ * Wrapping such a token in double quotes neutralizes both; Windows paths cannot
+ * contain `"`, so quoting is lossless. Tokens needing no quoting are unchanged.
+ */
+function quoteForShell(token: string): string {
+  return /[\s&|<>^()]/.test(token) ? `"${token}"` : token;
+}
+
+/**
  * Build the CLI arguments to launch a terminal at a working directory. Pure
  * function — the highest-value test target. The arg shapes follow ADR-0006:
  * Windows Terminal `-d <dir>`, WSL `--cd <dir>`, Git Bash `--cd=<dir>`.
@@ -129,16 +141,18 @@ export function createTerminalAdapter(
 
       const args = buildTerminalArgs(config.id, target.path);
 
-      // shell:true lets PATH aliases like `wt` resolve, but cmd.exe concatenates
-      // the command and args without quoting. A launcher resolved to an absolute
-      // path with spaces (Git Bash under "Program Files") would be split at the
-      // first space, so quote it; bare PATH names have no spaces and are untouched.
-      const spawnCmd = /\s/.test(cmd) ? `"${cmd}"` : cmd;
+      // shell:true lets PATH aliases like `wt` and the git-bash launcher resolve,
+      // but cmd.exe concatenates the command and args into one unquoted line. The
+      // launcher path ("Program Files") and the target directory can both carry
+      // spaces or shell metacharacters, so quote every token that needs it; bare
+      // tokens (`wt`, `-d`, a space-free path) pass through untouched.
+      const spawnCmd = quoteForShell(cmd);
+      const spawnArgs = args.map(quoteForShell);
 
       return new Promise<void>((resolve, reject) => {
         // Terminal executables on Windows (wt.exe, wsl.exe, git-bash.exe) launch
         // their own window and resolve their own environment; we fire and forget.
-        const child: ChildProcess = deps.spawn(spawnCmd, args, {
+        const child: ChildProcess = deps.spawn(spawnCmd, spawnArgs, {
           detached: true,
           stdio: "ignore",
           shell: true,

--- a/apps/desktop/src/main/open-in/types.ts
+++ b/apps/desktop/src/main/open-in/types.ts
@@ -8,10 +8,10 @@
 
 /**
  * The category of an openable app. Drives launch semantics and how the renderer
- * groups apps in the menu. `editor` opens a file/folder, `fileManager` reveals a
- * path in the OS file browser.
+ * groups apps in the menu. `editor` opens a file/folder, `terminal` opens a shell
+ * at the working directory, `fileManager` reveals a path in the OS file browser.
  */
-export type OpenInAppKind = "editor" | "fileManager";
+export type OpenInAppKind = "editor" | "terminal" | "fileManager";
 
 /**
  * Serializable metadata for an openable app. This is the shape the renderer

--- a/apps/web/src/components/chat/__tests__/OpenInAppButton.test.tsx
+++ b/apps/web/src/components/chat/__tests__/OpenInAppButton.test.tsx
@@ -93,6 +93,12 @@ function app(over: Partial<OpenInApp> & Pick<OpenInApp, "id">): OpenInApp {
 
 const VSCODE = app({ id: "vscode", label: "VS Code", iconKey: "vscode" });
 const CURSOR = app({ id: "cursor", label: "Cursor", iconKey: "cursor" });
+const WINDOWS_TERMINAL = app({
+  id: "windows-terminal",
+  label: "Windows Terminal",
+  kind: "terminal",
+  iconKey: "windows-terminal",
+});
 const EXPLORER = app({ id: "explorer", label: "File Explorer", kind: "fileManager", iconKey: "explorer" });
 
 describe("OpenInAppButton", () => {
@@ -135,6 +141,16 @@ describe("OpenInAppButton", () => {
     await userEvent.click(screen.getByRole("button", { name: "Cursor" }));
     expect(openInSpy).toHaveBeenCalledWith("cursor", "/dir");
     expect(setThreadSettingsSpy).toHaveBeenCalledWith("t1", { defaultOpenInApp: "cursor" });
+  });
+
+  it("lists a detected terminal and sets it as the thread default when picked", async () => {
+    appsRef.current = [VSCODE, WINDOWS_TERMINAL, EXPLORER];
+    render(<OpenInAppButton dirPath="/dir" threadId="t1" threadOverride={null} />);
+    await userEvent.click(screen.getByRole("button", { name: "Windows Terminal" }));
+    expect(openInSpy).toHaveBeenCalledWith("windows-terminal", "/dir");
+    expect(setThreadSettingsSpy).toHaveBeenCalledWith("t1", {
+      defaultOpenInApp: "windows-terminal",
+    });
   });
 
   it("is disabled with no workspace and registers no shortcut", () => {

--- a/apps/web/src/components/chat/openInAppIcons.tsx
+++ b/apps/web/src/components/chat/openInAppIcons.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { FolderOpen } from "lucide-react";
+import { FolderOpen, Terminal, TerminalSquare, SquareChevronRight } from "lucide-react";
 import { VsCodeIcon, ZedIcon } from "./EditorIcons";
 import { CursorProviderIcon } from "./ProviderIcons";
 
@@ -17,6 +17,12 @@ export function openInAppIcon(iconKey: string, size: number): React.ReactNode {
       return <CursorProviderIcon size={size} />;
     case "zed":
       return <ZedIcon size={size} />;
+    case "windows-terminal":
+      return <TerminalSquare size={size} />;
+    case "git-bash":
+      return <Terminal size={size} />;
+    case "wsl":
+      return <SquareChevronRight size={size} />;
     case "explorer":
       return <FolderOpen size={size} />;
     default:

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -103,7 +103,7 @@ export interface HookExecution {
 }
 
 /** Category of an openable app, mirroring the desktop registry's adapter kinds. */
-export type OpenInAppKind = "editor" | "fileManager";
+export type OpenInAppKind = "editor" | "terminal" | "fileManager";
 
 /**
  * Openable-app metadata as exposed by the desktop main-process registry. Icons


### PR DESCRIPTION
## What
Adds a `terminal` app-kind to the Open-in-App registry so Windows Terminal, Git Bash, and WSL can be launched at a thread's working directory from the "Open in..." split-button menu.

## Why
Closes #606 (phase D of epic #576, the Open-in-App registry). Builds on the merged #603 (split-button UI + thread default) and #604 (collapsed IPC seam), which already make the renderer and IPC handle any app kind generically. Terminals therefore needed only a new adapter plus surface registration.

## Key Changes
- New `terminal-adapter.ts`: `buildTerminalArgs` (pure, ADR-0006 arg shaping: `wt -d`, `wsl --cd`, `git-bash --cd=`) and `createTerminalAdapter` with PATH-then-Windows-fallback detection, memoized resolution, and a detached fire-and-forget spawn. Detection is Windows-only.
- Registry: registered Windows Terminal, Git Bash (with `Program Files`/`LOCALAPPDATA` fallbacks; ships no PATH entry), and WSL.
- Added `"terminal"` to `OpenInAppKind` in both the desktop registry and the renderer transport types.
- Mapped `windows-terminal` / `git-bash` / `wsl` icon keys to lucide icons.
- Tests: 16 desktop unit tests (arg shaping, detection tiers, off-Windows, memoization, launch dispatch, quoting) plus an integration case asserting a terminal appears in the menu and becomes the thread default.

### Quoting hardening (code-review fix)
- `shell: true` is required for PATH aliases (`wt`) and `.exe`/launcher resolution, but cmd.exe joins command + args into one unquoted line. The initial fix quoted only the executable. This PR adds a shared `quoteForShell` helper applied to the executable **and** every argument, so a target directory with spaces (`C:\Users\John Doe\repo`) is no longer split and shell metacharacters (`& | < > ^ ( )`) in the path can't be interpreted by cmd.exe. Regression tests cover both cases.

## Config Changes
None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783614550&installation_id=129163861&pr_number=626&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F626&signature=5f34339aed8c2bbb02fd7416fe6db9845d7baf1460e8f240a2a830dcdbd91484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Open in" now includes terminals (Windows Terminal, Git Bash, WSL): users can launch a terminal at a chosen directory from the menu.
  * Terminal apps appear in the UI with new terminal icons and are selectable; selection persists via thread default override.

* **Tests**
  * Added tests covering terminal detection, launch behavior, argument quoting, and UI selection wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->