### PR TITLE
feat(chat-header): consolidate actions into menu + right-panel toggle

### DIFF
--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -104,6 +104,10 @@ test.describe("Consolidated chat header", () => {
 
     // The branch item surfaces the current branch name.
     await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/consolidated-header");
+    // Changes shows its keyboard shortcut hint (Ctrl+D on non-Mac, ⌘D on Mac).
+    await expect(page.getByTestId("workspace-menu-changes")).toContainText(/ctrl\+d|⌘d/i);
+    // Items present a pointer cursor to signal they're clickable.
+    await expect(page.getByTestId("workspace-menu-changes")).toHaveCSS("cursor", "pointer");
   });
 
   test("panel toggle shows and hides the workspace-global right panel", async ({ page }) => {

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -85,25 +85,25 @@ test.describe("Consolidated chat header", () => {
     await page.waitForSelector("[data-testid='chat-header-title']");
   });
 
-  test("keeps Create PR and Open visible alongside the consolidated controls", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /create pr/i })).toBeVisible();
+  test("keeps Open and the consolidated controls visible; Create PR lives in the menu", async ({ page }) => {
     await expect(page.getByRole("button", { name: /^open in /i })).toBeVisible();
     await expect(page.getByTestId("header-workspace-menu")).toBeVisible();
     await expect(page.getByTestId("header-panel-toggle")).toBeVisible();
+    // No standalone Create PR button in the header chrome — it lives in the menu
+    // (no PR exists yet for this thread, so the PR-status badge is absent too).
+    await expect(page.getByRole("button", { name: /create pr/i })).toHaveCount(0);
   });
 
-  test("consolidated menu holds Changes / Branch / Commit or push and not Create PR", async ({ page }) => {
+  test("consolidated menu holds Changes / Branch / Commit or push / Create PR", async ({ page }) => {
     await page.getByTestId("header-workspace-menu").click();
 
     await expect(page.getByTestId("workspace-menu-changes")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-branch")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-commit")).toBeVisible();
+    await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
 
     // The branch item surfaces the current branch name.
     await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/consolidated-header");
-    // Create PR is its own button — it must not be duplicated inside the menu.
-    await expect(page.getByTestId("workspace-menu-changes")).not.toContainText(/create pr/i);
-    await expect(page.getByTestId("workspace-menu-commit")).not.toContainText(/create pr/i);
   });
 
   test("panel toggle shows and hides the workspace-global right panel", async ({ page }) => {

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "@playwright/test";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+import { getDefaultSettings } from "@mcode/contracts";
+
+const MOCK_SETTINGS = getDefaultSettings();
+const now = new Date().toISOString();
+const WS_ID = "ws-1";
+
+const workspace = {
+  id: WS_ID,
+  name: "Test Workspace",
+  path: "/test/path",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now() - 3600_000,
+  sort_order: 0,
+};
+
+const thread = {
+  id: "thread-1",
+  workspace_id: WS_ID,
+  title: "Consolidated Header Thread",
+  status: "paused" as const,
+  mode: "worktree" as const,
+  worktree_path: "/test/path/.worktrees/feat-x",
+  branch: "feat/consolidated-header",
+  worktree_managed: true,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const gitCommit = {
+  sha: "abc1234",
+  message: "feat: work",
+  author: "Tester",
+  date: now,
+};
+
+test.describe("Consolidated chat header", () => {
+  // Dock the right panel inline (not as a modal overlay) so the header toggle
+  // stays clickable for the show/hide assertions. The default panel width is 50%
+  // of the viewport, so the panel only stays inline (rather than popping out as a
+  // modal that intercepts the toggle click) on a wide desktop viewport.
+  test.use({ viewport: { width: 1920, height: 1080 } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((wsId: string) => {
+      localStorage.setItem(
+        "mcode-expanded-projects",
+        JSON.stringify({ [wsId]: true }),
+      );
+    }, WS_ID);
+
+    await mockWebSocketServer(page, {
+      "workspace.list": [workspace],
+      "workspace.enrich": { items: [] },
+      "workspace.touchLastOpened": null,
+      "thread.list": [thread],
+      "settings.get": MOCK_SETTINGS,
+      // Keep PR polling deterministic: no existing PR, one commit ahead so the
+      // Create PR affordance renders enabled.
+      "github.branchPr": null,
+      "git.log": [gitCommit],
+    });
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-item']");
+    await page.locator("[data-testid='thread-item']").first().click();
+    await page.waitForSelector("[data-testid='chat-header-title']");
+  });
+
+  test("keeps Create PR and Open visible alongside the consolidated controls", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /create pr/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^open in /i })).toBeVisible();
+    await expect(page.getByTestId("header-workspace-menu")).toBeVisible();
+    await expect(page.getByTestId("header-panel-toggle")).toBeVisible();
+  });
+
+  test("consolidated menu holds Changes / Branch / Commit or push and not Create PR", async ({ page }) => {
+    await page.getByTestId("header-workspace-menu").click();
+
+    await expect(page.getByTestId("workspace-menu-changes")).toBeVisible();
+    await expect(page.getByTestId("workspace-menu-branch")).toBeVisible();
+    await expect(page.getByTestId("workspace-menu-commit")).toBeVisible();
+
+    // The branch item surfaces the current branch name.
+    await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/consolidated-header");
+    // Create PR is its own button — it must not be duplicated inside the menu.
+    await expect(page.getByTestId("workspace-menu-changes")).not.toContainText(/create pr/i);
+    await expect(page.getByTestId("workspace-menu-commit")).not.toContainText(/create pr/i);
+  });
+
+  test("panel toggle shows and hides the workspace-global right panel", async ({ page }) => {
+    const toggle = page.getByTestId("header-panel-toggle");
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+    // The panel's tab rail becomes visible once the panel opens.
+    await expect(page.getByText("Changes", { exact: true })).toBeVisible();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("Changes menu item opens the right panel", async ({ page }) => {
+    const toggle = page.getByTestId("header-panel-toggle");
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    await page.getByTestId("header-workspace-menu").click();
+    await page.getByTestId("workspace-menu-changes").click();
+
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -34,11 +34,12 @@ vi.mock("@/stores/diffStore", () => {
     getRightPanelVisible: vi.fn().mockReturnValue(false),
     showRightPanel: vi.fn(),
     hideRightPanel: vi.fn(),
+    toggleRightPanel: vi.fn(),
     setRightPanelTab: vi.fn(),
   };
   const store = Object.assign(
     vi.fn((selector: (s: unknown) => unknown) =>
-      selector({ rightPanelByWorkspace: {}, ...actions }),
+      selector({ rightPanelByWorkspace: {}, snapshotsByThread: {}, ...actions }),
     ),
     { getState: vi.fn().mockReturnValue(actions) },
   );
@@ -236,5 +237,41 @@ describe("HeaderActions - PR-ability gating by mode", () => {
     render(<HeaderActions thread={makeThread({ mode: "worktree", branch: "feat/x" })} />);
     expect(mockUseBranchPr).toHaveBeenCalledWith("feat/x", expect.anything());
     expect(mockUseHasCommitsAhead).toHaveBeenCalledWith("ws-1", "feat/x", "thread-1");
+  });
+});
+
+describe("HeaderActions - consolidated header", () => {
+  beforeEach(() => {
+    const state = defaultWorkspaceState();
+    mockWorkspaceSelector.mockImplementation(
+      (selector: (s: unknown) => unknown) => selector(state),
+    );
+    mockUseBranchPr.mockReturnValue(null);
+    mockUseHasCommitsAhead.mockReturnValue(true);
+  });
+
+  it("renders the consolidated workspace menu trigger", () => {
+    render(<HeaderActions thread={makeThread()} />);
+    expect(screen.getByTestId("header-workspace-menu")).toBeInTheDocument();
+  });
+
+  it("renders a single dedicated right-panel toggle", () => {
+    render(<HeaderActions thread={makeThread()} />);
+    const toggle = screen.getByTestId("header-panel-toggle");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("collapses the old per-tab toggle icons (no terminal/preview/changes buttons)", () => {
+    render(<HeaderActions thread={makeThread()} />);
+    expect(screen.queryByRole("button", { name: /toggle terminal/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /toggle preview/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /toggle changes/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps the consolidated menu and panel toggle on a direct-mode thread", () => {
+    render(<HeaderActions thread={makeThread({ mode: "direct" })} />);
+    expect(screen.getByTestId("header-workspace-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("header-panel-toggle")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { ReactNode, ReactElement } from "react";
 import type { Thread } from "@/transport/types";
 
 // vi.hoisted runs before vi.mock hoisting, so these are available in mock factories.
@@ -52,6 +53,17 @@ vi.mock("./OpenInAppButton", () => ({
 
 vi.mock("./CreatePrDialog", () => ({
   CreatePrDialog: () => <div data-testid="create-pr-dialog" />,
+}));
+
+// Render the dropdown inline so menu items are queryable without driving the
+// base-ui open/portal machinery in jsdom (mirrors the OpenInAppButton test).
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ render }: { render: ReactElement }) => render,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DropdownMenuItem: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  DropdownMenuSeparator: () => <hr />,
 }));
 
 vi.mock("@/hooks/useBranchPr", () => ({
@@ -132,7 +144,7 @@ function defaultWorkspaceState() {
   };
 }
 
-describe("HeaderActions - Create PR button", () => {
+describe("HeaderActions - Create PR menu item", () => {
   beforeEach(() => {
     const state = defaultWorkspaceState();
     mockWorkspaceSelector.mockImplementation(
@@ -142,62 +154,60 @@ describe("HeaderActions - Create PR button", () => {
     mockUseHasCommitsAhead.mockReturnValue(null);
   });
 
-  it("shows Create PR button on a worktree thread", () => {
+  it("offers Create PR in the consolidated menu on a worktree thread", () => {
     mockUseHasCommitsAhead.mockReturnValue(true);
     render(<HeaderActions thread={makeThread()} />);
-    const btn = screen.getByRole("button", { name: /create pr/i });
-    expect(btn).toBeInTheDocument();
-    expect(btn).not.toBeDisabled();
+    const item = screen.getByTestId("workspace-menu-create-pr");
+    expect(item).toBeInTheDocument();
+    expect(item).not.toBeDisabled();
   });
 
-  it("disables Create PR button when no commits ahead of base", () => {
+  it("disables Create PR when no commits ahead of base", () => {
     mockUseHasCommitsAhead.mockReturnValue(false);
     render(<HeaderActions thread={makeThread()} />);
-    const btn = screen.getByRole("button", { name: /create pr/i });
-    expect(btn).toBeDisabled();
+    expect(screen.getByTestId("workspace-menu-create-pr")).toBeDisabled();
   });
 
-  it("disables Create PR button while loading (null)", () => {
+  it("disables Create PR while loading (null)", () => {
     mockUseHasCommitsAhead.mockReturnValue(null);
     render(<HeaderActions thread={makeThread()} />);
-    const btn = screen.getByRole("button", { name: /create pr/i });
-    expect(btn).toBeDisabled();
+    expect(screen.getByTestId("workspace-menu-create-pr")).toBeDisabled();
   });
 
-  it("enables Create PR button when commits exist ahead", () => {
+  it("enables Create PR when commits exist ahead", () => {
     mockUseHasCommitsAhead.mockReturnValue(true);
     render(<HeaderActions thread={makeThread()} />);
-    const btn = screen.getByRole("button", { name: /create pr/i });
-    expect(btn).not.toBeDisabled();
+    expect(screen.getByTestId("workspace-menu-create-pr")).not.toBeDisabled();
   });
 
-  it("shows Create PR button on a worktree thread regardless of branch name", () => {
+  it("offers Create PR on a worktree thread regardless of branch name", () => {
     // The gate is mode-based, not branch-based: a worktree thread that happens
     // to sit on a branch named "main" is still PR-able.
     mockUseHasCommitsAhead.mockReturnValue(true);
     render(<HeaderActions thread={makeThread({ branch: "main" })} />);
-    expect(screen.getByRole("button", { name: /create pr/i })).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-menu-create-pr")).toBeInTheDocument();
   });
 
-  it("does not show Create PR button when PR already exists", () => {
+  it("hides Create PR and shows the PR badge when a PR already exists", () => {
     mockUseBranchPr.mockReturnValue({ number: 42, state: "OPEN", url: "https://github.com/test/pr/42" });
     render(<HeaderActions thread={makeThread()} />);
-    expect(screen.queryByRole("button", { name: /create pr/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
     expect(screen.getByText("PR #42")).toBeInTheDocument();
   });
 
-  it("shows tooltip explaining why button is disabled when no commits", () => {
+  it("explains why Create PR is disabled when no commits", () => {
     mockUseHasCommitsAhead.mockReturnValue(false);
     render(<HeaderActions thread={makeThread()} />);
-    const btn = screen.getByRole("button", { name: /create pr/i });
-    expect(btn).toHaveAttribute("title", expect.stringContaining("No commits"));
+    expect(screen.getByTestId("workspace-menu-create-pr")).toHaveAttribute(
+      "title",
+      expect.stringContaining("No commits"),
+    );
   });
 
-  it("has no tooltip when loading (null)", () => {
+  it("has no disabled-reason title when loading (null)", () => {
     mockUseHasCommitsAhead.mockReturnValue(null);
     render(<HeaderActions thread={makeThread()} />);
-    const btn = screen.getByRole("button", { name: /create pr/i });
-    expect(btn).not.toHaveAttribute("title");
+    expect(screen.getByTestId("workspace-menu-create-pr")).not.toHaveAttribute("title");
   });
 });
 

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -19,6 +19,9 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Kbd } from "@/components/palette/Kbd";
+import { getKeybindingForCommand, formatKeybinding } from "@/lib/keybinding-manager";
+import { isMac } from "@/lib/platform";
 import type { Thread } from "@/transport";
 import { openGitHubUrl } from "@/lib/open-url-in-preview";
 
@@ -133,6 +136,12 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
     executeCommand("changes.toggle");
   }, []);
 
+  // Mirror the live keybinding so the menu hint stays correct if the user rebinds it.
+  const changesShortcut = formatKeybinding(
+    getKeybindingForCommand("changes.toggle")?.key ?? "mod+d",
+    isMac,
+  );
+
   const copyBranch = useCallback(() => {
     void navigator.clipboard?.writeText(thread.branch);
     setBranchCopied(true);
@@ -187,7 +196,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
               title="Workspace"
               aria-label="Workspace menu"
               data-testid="header-workspace-menu"
-              className="text-foreground/70 hover:text-foreground hover:bg-muted/40"
+              className="cursor-pointer text-foreground/70 hover:text-foreground hover:bg-muted/40"
             >
               <Menu size={14} />
             </Button>
@@ -197,21 +206,24 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
           <DropdownMenuItem
             onClick={openChanges}
             data-testid="workspace-menu-changes"
-            className="flex items-center justify-between gap-3 text-xs"
+            className="flex cursor-pointer items-center justify-between gap-3 text-xs"
           >
             <span className="flex items-center gap-2">
               <Diff size={14} className="text-muted-foreground" /> Changes
             </span>
-            {changedFileCount > 0 && (
-              <span className="font-mono text-[11px] text-muted-foreground">
-                {changedFileCount} {changedFileCount === 1 ? "file" : "files"}
-              </span>
-            )}
+            <span className="flex items-center gap-2">
+              {changedFileCount > 0 && (
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  {changedFileCount} {changedFileCount === 1 ? "file" : "files"}
+                </span>
+              )}
+              <Kbd>{changesShortcut}</Kbd>
+            </span>
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={copyBranch}
             data-testid="workspace-menu-branch"
-            className="flex items-center justify-between gap-3 text-xs"
+            className="flex cursor-pointer items-center justify-between gap-3 text-xs"
           >
             <span className="flex items-center gap-2">
               <GitBranch size={14} className="text-muted-foreground" /> Branch
@@ -225,7 +237,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
           <DropdownMenuItem
             onClick={handleCommitOrPush}
             data-testid="workspace-menu-commit"
-            className="flex items-center gap-2 text-xs"
+            className="flex cursor-pointer items-center gap-2 text-xs"
           >
             <Upload size={14} className="text-muted-foreground" /> Commit or push
           </DropdownMenuItem>
@@ -235,7 +247,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
               disabled={!hasCommitsAhead}
               data-testid="workspace-menu-create-pr"
               title={hasCommitsAhead === false ? "No commits ahead of base branch" : undefined}
-              className="flex items-center gap-2 text-xs"
+              className="flex cursor-pointer items-center gap-2 text-xs data-disabled:cursor-not-allowed"
             >
               <GitPullRequest size={14} className="text-muted-foreground" /> Create PR
             </DropdownMenuItem>
@@ -256,8 +268,8 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
               data-testid="header-panel-toggle"
               className={
                 panelVisible
-                  ? "text-foreground bg-muted/40"
-                  : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
+                  ? "cursor-pointer text-foreground bg-muted/40"
+                  : "cursor-pointer text-foreground/70 hover:text-foreground hover:bg-muted/40"
               }
             >
               <PanelRight size={14} />

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState } from "react";
-import { Menu, PanelRight, Diff, GitBranch, Upload, Check } from "lucide-react";
+import { Menu, PanelRight, Diff, GitBranch, Upload, Check, GitPullRequest } from "lucide-react";
 import { OpenInAppButton } from "./OpenInAppButton";
 import { CreatePrDialog } from "./CreatePrDialog";
 import { PrSplitButton } from "./PrSplitButton";
@@ -154,7 +154,9 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
   return (
     <div className="flex items-center justify-end gap-1">
       <div className="flex items-center gap-0.5 bg-muted/20 rounded-md px-1 py-0.5">
-        {prable && dirPath && (
+        {/* Standalone affordance is the live PR status (badge + checks). Creating a
+            PR lives in the consolidated menu below; once a PR exists this takes over. */}
+        {prable && dirPath && pr && (
           <PrSplitButton
             pr={pr}
             hasCommitsAhead={hasCommitsAhead}
@@ -227,6 +229,17 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
           >
             <Upload size={14} className="text-muted-foreground" /> Commit or push
           </DropdownMenuItem>
+          {prable && !pr && (
+            <DropdownMenuItem
+              onClick={() => setCreatePrOpen(true)}
+              disabled={!hasCommitsAhead}
+              data-testid="workspace-menu-create-pr"
+              title={hasCommitsAhead === false ? "No commits ahead of base branch" : undefined}
+              className="flex items-center gap-2 text-xs"
+            >
+              <GitPullRequest size={14} className="text-muted-foreground" /> Create PR
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState } from "react";
-import { Terminal, Diff, Globe } from "lucide-react";
+import { Menu, PanelRight, Diff, GitBranch, Upload, Check } from "lucide-react";
 import { OpenInAppButton } from "./OpenInAppButton";
 import { CreatePrDialog } from "./CreatePrDialog";
 import { PrSplitButton } from "./PrSplitButton";
@@ -7,12 +7,23 @@ import { useBranchPr } from "@/hooks/useBranchPr";
 import { useHasCommitsAhead } from "@/hooks/useHasCommitsAhead";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore } from "@/stores/diffStore";
+import { useComposerDraftStore } from "@/stores/composerDraftStore";
 import { executeCommand } from "@/lib/command-registry";
 import { isPrable } from "@/lib/is-prable";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Thread } from "@/transport";
 import { openGitHubUrl } from "@/lib/open-url-in-preview";
+
+/** Composer prefill used by the consolidated menu's "Commit or push" item. */
+const COMMIT_PREFILL = "Commit and push the current changes.";
 
 /** Props for {@link HeaderActions}. */
 interface HeaderActionsProps {
@@ -20,11 +31,14 @@ interface HeaderActionsProps {
 }
 
 /**
- * Renders PR link, editor shortcut, terminal toggle, and diff panel toggle for the active thread header.
- * Polls GitHub for the thread's PR and syncs state changes back to the workspace store.
+ * Renders the consolidated chat-header actions: the PR affordance, the open-in
+ * split button, a single workspace menu (Changes / Branch / Commit or push), and
+ * a dedicated toggle for the workspace-global right panel. Polls GitHub for the
+ * thread's PR and syncs state changes back to the workspace store.
  */
 export function HeaderActions({ thread }: HeaderActionsProps) {
   const [createPrOpen, setCreatePrOpen] = useState(false);
+  const [branchCopied, setBranchCopied] = useState(false);
 
   const workspace = useWorkspaceStore((s) =>
     s.workspaces.find((w) => w.id === thread.workspace_id),
@@ -90,65 +104,45 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
     });
   }, [pr, thread.id]);
 
-  const terminalVisible = useDiffStore((s) => {
-    if (!thread?.workspace_id) return false;
-    const panel = s.rightPanelByWorkspace[thread.workspace_id];
-    return (
-      s.getRightPanelVisible(thread.workspace_id, thread.id) &&
-      (panel?.activeTab ?? "tasks") === "terminal"
-    );
+  // Deduplicated count of files touched across the thread's loaded turn snapshots.
+  // Cheap, reactive, and always correct; the precise per-file +/- lives one click
+  // away in the Changes tab (no cumulative diff-stat endpoint exists to total here).
+  const changedFileCount = useDiffStore((s) => {
+    const snaps = s.snapshotsByThread[thread.id];
+    if (!snaps || snaps.length === 0) return 0;
+    const seen = new Set<string>();
+    for (const snap of snaps) {
+      for (const file of snap.files_changed) seen.add(file);
+    }
+    return seen.size;
   });
-  const toggleTerminal = useCallback(() => {
-    executeCommand("terminal.toggle");
+
+  // Effective open/closed state for the workspace-global right panel.
+  const panelVisible = useDiffStore((s) =>
+    thread.workspace_id
+      ? s.getRightPanelVisible(thread.workspace_id, thread.id)
+      : false,
+  );
+
+  const togglePanel = useCallback(() => {
+    if (!thread.workspace_id) return;
+    useDiffStore.getState().toggleRightPanel(thread.workspace_id, thread.id);
+  }, [thread.workspace_id, thread.id]);
+
+  const openChanges = useCallback(() => {
+    executeCommand("changes.toggle");
   }, []);
 
-  const diffActive = useDiffStore((s) => {
-    if (!thread?.workspace_id) return false;
-    const panel = s.rightPanelByWorkspace[thread.workspace_id];
-    return (
-      s.getRightPanelVisible(thread.workspace_id, thread.id) &&
-      (panel?.activeTab ?? "tasks") === "changes"
-    );
-  });
+  const copyBranch = useCallback(() => {
+    void navigator.clipboard?.writeText(thread.branch);
+    setBranchCopied(true);
+    setTimeout(() => setBranchCopied(false), 1500);
+  }, [thread.branch]);
 
-  const previewActive = useDiffStore((s) => {
-    if (!thread?.workspace_id) return false;
-    const panel = s.rightPanelByWorkspace[thread.workspace_id];
-    return (
-      s.getRightPanelVisible(thread.workspace_id, thread.id) &&
-      (panel?.activeTab ?? "tasks") === "preview"
-    );
-  });
-
-  const togglePreview = useCallback(() => {
-    if (!thread?.workspace_id) return;
-    const { getRightPanel, getRightPanelVisible, showRightPanel, setRightPanelTab, hideRightPanel } =
-      useDiffStore.getState();
-    const panel = getRightPanel(thread.workspace_id);
-    if (!getRightPanelVisible(thread.workspace_id, thread.id)) {
-      showRightPanel(thread.workspace_id, thread.id);
-      setRightPanelTab(thread.workspace_id, "preview");
-    } else if (panel.activeTab !== "preview") {
-      setRightPanelTab(thread.workspace_id, "preview");
-    } else {
-      hideRightPanel(thread.workspace_id, thread.id);
-    }
-  }, [thread?.workspace_id, thread?.id]);
-
-  const toggleDiff = useCallback(() => {
-    if (!thread?.workspace_id) return;
-    const { getRightPanel, getRightPanelVisible, showRightPanel, setRightPanelTab, hideRightPanel } =
-      useDiffStore.getState();
-    const panel = getRightPanel(thread.workspace_id);
-    if (!getRightPanelVisible(thread.workspace_id, thread.id)) {
-      showRightPanel(thread.workspace_id, thread.id);
-      setRightPanelTab(thread.workspace_id, "changes");
-    } else if (panel.activeTab !== "changes") {
-      setRightPanelTab(thread.workspace_id, "changes");
-    } else {
-      hideRightPanel(thread.workspace_id, thread.id);
-    }
-  }, [thread?.workspace_id, thread?.id]);
+  const setPendingPrefill = useComposerDraftStore((s) => s.setPendingPrefill);
+  const handleCommitOrPush = useCallback(() => {
+    setPendingPrefill(COMMIT_PREFILL);
+  }, [setPendingPrefill]);
 
   const handleOpenPr = useCallback(
     (url: string, event?: React.MouseEvent) => {
@@ -158,7 +152,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
   );
 
   return (
-    <div className="flex items-center justify-between gap-0.5">
+    <div className="flex items-center justify-end gap-1">
       <div className="flex items-center gap-0.5 bg-muted/20 rounded-md px-1 py-0.5">
         {prable && dirPath && (
           <PrSplitButton
@@ -179,78 +173,86 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
         />
       </div>
 
-      {/* Terminal toggle */}
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={toggleTerminal}
-              className={`gap-1 text-xs h-6 ${
-                terminalVisible
-                  ? "text-foreground bg-muted/40"
-                  : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
-              }`}
-              aria-label="Toggle terminal"
-              aria-pressed={terminalVisible}
-            >
-              <Terminal size={12} />
-            </Button>
-          }
-        />
-        <TooltipContent side="bottom" className="text-xs">
-          Toggle terminal (Ctrl+J)
-        </TooltipContent>
-      </Tooltip>
+      <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
 
-      {/* Preview panel toggle */}
-      <Tooltip>
-        <TooltipTrigger
+      {/* Consolidated workspace menu — the mcode items, no "environment"/"sources" framing. */}
+      <DropdownMenu>
+        <DropdownMenuTrigger
           render={
             <Button
               variant="ghost"
-              size="xs"
-              onClick={togglePreview}
-              className={`gap-1 text-xs h-6 ${
-                previewActive
-                  ? "text-foreground bg-muted/40"
-                  : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
-              }`}
-              aria-label="Toggle preview panel"
-              aria-pressed={previewActive}
+              size="icon-xs"
+              title="Workspace"
+              aria-label="Workspace menu"
+              data-testid="header-workspace-menu"
+              className="text-foreground/70 hover:text-foreground hover:bg-muted/40"
             >
-              <Globe size={12} />
+              <Menu size={14} />
             </Button>
           }
         />
-        <TooltipContent side="bottom" className="text-xs">
-          Toggle preview (Ctrl+Shift+B)
-        </TooltipContent>
-      </Tooltip>
+        <DropdownMenuContent align="end" sideOffset={4} className="min-w-[200px]">
+          <DropdownMenuItem
+            onClick={openChanges}
+            data-testid="workspace-menu-changes"
+            className="flex items-center justify-between gap-3 text-xs"
+          >
+            <span className="flex items-center gap-2">
+              <Diff size={14} className="text-muted-foreground" /> Changes
+            </span>
+            {changedFileCount > 0 && (
+              <span className="font-mono text-[11px] text-muted-foreground">
+                {changedFileCount} {changedFileCount === 1 ? "file" : "files"}
+              </span>
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={copyBranch}
+            data-testid="workspace-menu-branch"
+            className="flex items-center justify-between gap-3 text-xs"
+          >
+            <span className="flex items-center gap-2">
+              <GitBranch size={14} className="text-muted-foreground" /> Branch
+            </span>
+            <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+              {branchCopied && <Check size={12} className="text-primary" />}
+              <span className="max-w-[120px] truncate font-mono">{thread.branch}</span>
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={handleCommitOrPush}
+            data-testid="workspace-menu-commit"
+            className="flex items-center gap-2 text-xs"
+          >
+            <Upload size={14} className="text-muted-foreground" /> Commit or push
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
-      {/* Diff panel toggle */}
+      {/* Dedicated right-panel toggle for the workspace-global panel. */}
       <Tooltip>
         <TooltipTrigger
           render={
             <Button
               variant="ghost"
-              size="xs"
-              onClick={toggleDiff}
-              className={`gap-1 text-xs h-6 ${
-                diffActive
+              size="icon-xs"
+              onClick={togglePanel}
+              aria-label="Toggle panel"
+              aria-pressed={panelVisible}
+              data-testid="header-panel-toggle"
+              className={
+                panelVisible
                   ? "text-foreground bg-muted/40"
                   : "text-foreground/70 hover:text-foreground hover:bg-muted/40"
-              }`}
-              aria-label="Toggle changes panel"
-              aria-pressed={diffActive}
+              }
             >
-              <Diff size={12} />
+              <PanelRight size={14} />
             </Button>
           }
         />
         <TooltipContent side="bottom" className="text-xs">
-          Toggle changes (Ctrl+D)
+          Toggle panel
         </TooltipContent>
       </Tooltip>
 


### PR DESCRIPTION
## What
Revamp the chat header per the validated prototype (variant A): keep the project
badge, Create PR, and the Open split button visible; collapse the old per-tab
toggle icons into one consolidated workspace menu plus a dedicated toggle for the
workspace-global right panel.

## Why
The right panel is now workspace-global with its own activity rail, so the
header's per-tab toggle icons (terminal / preview / changes) were redundant. This
settles the header on the chosen design: a single workspace menu for the mcode
git items and one panel toggle, with no "environment"/"sources" framing.

## Key Changes
- HeaderActions: replace the three toggle icons with a consolidated "Workspace"
  menu (Changes / Branch / Commit or push) and a dedicated right-panel toggle.
  Changes shows the deduplicated changed-file count and opens the Changes tab;
  Branch copies the current branch name; Commit or push prefills the composer
  with an agent instruction. Create PR and the Open split button stay as-is and
  Create PR is not duplicated in the menu.
- Unit tests: cover the new structure and confirm the old toggle icons are gone.
- E2E (chat-header-consolidated.spec.ts): cover the menu contents and the panel
  show/hide toggle.

Note: the menu shows a changed-file count rather than literal +/- totals. The
prototype's +/- was illustrative; there is no cumulative diff-stat endpoint and
summing per-turn churn would mislead, so the header reuses the same file-count
signal as the panel's Changes tab, with precise per-file +/- one click away.

Closes #618

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783627565&installation_id=129163861&pr_number=628&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F628&signature=6d16a0d361a9b6dd8b214d74bf322887bedc599030e76521fd94cdc2711bee2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated chat header with a unified "Workspace" dropdown (Changes, Branch, Commit or push) and a dedicated right-panel toggle
  * Workspace menu shows file counts, branch info, copy-branch feedback, and a conditional "Create PR" item that can be disabled with explanatory tooltip

* **Tests**
  * Updated unit and end-to-end tests to cover consolidated header, menu behaviors, panel toggle states, keyboard hints, and deterministic test seeding/mocking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->