### PR TITLE
feat(models): add Claude Fable 5 with subscription end-date gating

### DIFF
--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -12,10 +12,10 @@
 
 import { build } from "esbuild";
 import { execSync, execFileSync } from "child_process";
-import { cpSync, copyFileSync, existsSync, rmSync } from "fs";
-import { createRequire } from "module";
+import { cpSync, existsSync, rmSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import { copyClaudeSdkCliNextTo } from "../../../scripts/build-server-dev-bundle.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
@@ -83,7 +83,7 @@ try {
 // bindings that cannot be inlined and must be asarUnpack'd by electron-builder.
 //
 // import.meta.url must resolve to a real file:// URL at runtime because the
-// Claude Agent SDK calls fileURLToPath(import.meta.url) to locate cli.js.
+// Claude Agent SDK calls fileURLToPath(import.meta.url) to locate its native CLI binary.
 // A plain __filename substitution breaks fileURLToPath with ERR_INVALID_URL_SCHEME.
 await build({
   ...shared,
@@ -111,15 +111,11 @@ if (existsSync(drizzleSrc)) {
   console.log(`Copied Drizzle migrations -> ${drizzleDst}`);
 }
 
-// Copy the Claude Agent SDK's cli.js next to server.cjs so the SDK can locate
-// it via dirname(fileURLToPath(import.meta.url)) + "/cli.js".
-// dist/server/** is already in asarUnpack, so both files exist on real disk.
-const localRequire = createRequire(resolve(serverRoot, "package.json"));
-const sdkPkgPath = localRequire.resolve("@anthropic-ai/claude-agent-sdk/package.json");
-const sdkCliSrc = resolve(dirname(sdkPkgPath), "cli.js");
-const sdkCliDst = resolve(desktopRoot, "dist/server/cli.js");
-copyFileSync(sdkCliSrc, sdkCliDst);
-console.log(`Copied SDK cli.js -> ${sdkCliDst}`);
+// Stage the Claude Agent SDK's native CLI binary under dist/server/node_modules
+// so the bundled SDK's createRequire(import.meta.url) resolution finds it.
+// dist/server/** is already in asarUnpack, so the binary exists on real disk.
+copyClaudeSdkCliNextTo(resolve(desktopRoot, "dist/server/server.cjs"), serverRoot);
+console.log("Staged SDK native CLI binary -> dist/server/node_modules");
 
 // Step 3: Build web renderer for Electron (cross-platform env var)
 const rendererOutDir = resolve(desktopRoot, "dist", "renderer");

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -49,10 +49,13 @@ describe("ModelRegistry", () => {
     expect(model?.availableUntil).toBe("2026-06-22");
   });
 
-  it("isModelAvailable honors availableUntil inclusively", () => {
+  it("isModelAvailable honors availableUntil inclusively in local time", () => {
     const m = { id: "x", label: "X", providerId: "claude", availableUntil: "2026-06-22" };
-    expect(isModelAvailable(m, new Date("2026-06-22T12:00:00Z"))).toBe(true);
-    expect(isModelAvailable(m, new Date("2026-06-23T00:00:00Z"))).toBe(false);
+    // Local-time Date constructions keep this timezone-independent and match the
+    // local-formatted "Until <date>" badge users see in the picker.
+    expect(isModelAvailable(m, new Date(2026, 5, 22, 12, 0, 0))).toBe(true);
+    expect(isModelAvailable(m, new Date(2026, 5, 22, 23, 59, 59))).toBe(true);
+    expect(isModelAvailable(m, new Date(2026, 5, 23, 0, 0, 0))).toBe(false);
     expect(isModelAvailable({ id: "y", label: "Y", providerId: "claude" })).toBe(true);
   });
 

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -9,6 +9,7 @@ import {
   getDefaultModelId,
   getDefaultReasoningLevel,
   isMaxEffortModel,
+  isModelAvailable,
   isXhighEffortModel,
   normalizeReasoningLevelForModel,
   resolveThreadModelId,
@@ -34,11 +35,25 @@ describe("pickProviderModelsForSettings", () => {
 });
 
 describe("ModelRegistry", () => {
-  it("MODEL_PROVIDERS contains Claude with 5 models", () => {
+  it("MODEL_PROVIDERS contains Claude with 6 models", () => {
     const claude = MODEL_PROVIDERS.find((p) => p.id === "claude");
     expect(claude).toBeTruthy();
-    expect(claude?.models).toHaveLength(5);
+    expect(claude?.models).toHaveLength(6);
     expect(claude?.comingSoon).toBe(false);
+  });
+
+  it("findModelById returns Fable 5 with an availability end date", () => {
+    const model = findModelById("claude-fable-5");
+    expect(model?.label).toBe("Claude Fable 5");
+    expect(model?.providerId).toBe("claude");
+    expect(model?.availableUntil).toBe("2026-06-22");
+  });
+
+  it("isModelAvailable honors availableUntil inclusively", () => {
+    const m = { id: "x", label: "X", providerId: "claude", availableUntil: "2026-06-22" };
+    expect(isModelAvailable(m, new Date("2026-06-22T12:00:00Z"))).toBe(true);
+    expect(isModelAvailable(m, new Date("2026-06-23T00:00:00Z"))).toBe(false);
+    expect(isModelAvailable({ id: "y", label: "Y", providerId: "claude" })).toBe(true);
   });
 
   it("findModelById returns Opus 4.8", () => {
@@ -72,9 +87,10 @@ describe("ModelRegistry", () => {
     expect(findProviderForModel("nonexistent")).toBeUndefined();
   });
 
-  it("getDefaultModel returns Claude Opus 4.8", () => {
+  it("getDefaultModel returns the first available Claude model", () => {
     const model = getDefaultModel();
-    expect(model.id).toBe("claude-opus-4-8");
+    expect(model.providerId).toBe("claude");
+    expect(isModelAvailable(model)).toBe(true);
   });
 });
 

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -12,6 +12,7 @@ import {
 import {
   MODEL_PROVIDERS,
   findModelById,
+  isModelAvailable,
   type ModelProvider,
 } from "@/lib/model-registry";
 import { getTransport } from "@/transport";
@@ -347,6 +348,38 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
     const ctxLabel = formatContextWindow(m.contextWindow);
     const starred = isFavorite(providerId, m.id);
     const selected = isSelected(m.id);
+    const available = isModelAvailable(m);
+    if (!available) {
+      const endDate = new Date(`${m.availableUntil}T00:00:00`).toLocaleDateString(undefined, {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      });
+      return (
+        <div key={m.id} className="flex w-full items-center gap-0.5 rounded px-1">
+          <span className="h-7 w-7 shrink-0" aria-hidden />
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  disabled
+                  data-testid={`model-row-gated-${m.id}`}
+                  aria-label={`${m.label}, no longer available`}
+                  className="flex min-w-0 flex-1 cursor-not-allowed items-center gap-2 rounded px-2 py-1.5 text-xs text-muted-foreground/60"
+                >
+                  <span className="flex-1 truncate text-left">{m.label}</span>
+                  <span className="text-[10px] tabular-nums shrink-0">Ended {endDate}</span>
+                </button>
+              }
+            />
+            <TooltipContent side="right">
+              Subscription access to {m.label} ended on {endDate}.
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      );
+    }
     return (
       <div key={m.id} className="flex w-full items-center gap-0.5 rounded px-1">
         <Button
@@ -387,6 +420,11 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
           {m.multiplier != null && (
             <span className="text-[10px] text-muted-foreground/60 tabular-nums shrink-0">
               {m.multiplier}x
+            </span>
+          )}
+          {m.availableUntil && (
+            <span className="text-[10px] text-muted-foreground/60 tabular-nums shrink-0">
+              Until {new Date(`${m.availableUntil}T00:00:00`).toLocaleDateString(undefined, { day: "numeric", month: "short" })}
             </span>
           )}
           {selected && (

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -69,7 +69,12 @@ export interface ModelDefinition {
  */
 export function isModelAvailable(m: ModelDefinition, now: Date = new Date()): boolean {
   if (!m.availableUntil) return true;
-  return now.toISOString().slice(0, 10) <= m.availableUntil;
+  // Compare against the local calendar date, not UTC: `availableUntil` is a
+  // zoneless wall date and the picker renders its "Until <date>" badge with
+  // local formatting, so a UTC basis would grey the model out a day early or
+  // late for users far from UTC.
+  const localYmd = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  return localYmd <= m.availableUntil;
 }
 
 export const MODEL_PROVIDERS: readonly ModelProvider[] = [

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -54,6 +54,22 @@ export interface ModelDefinition {
   defaultReasoningLevel?: CodexReasoningLevel;
   /** Billing rate multiplier relative to the base rate (e.g. 1, 0.33, 3). */
   multiplier?: number;
+  /**
+   * ISO date (YYYY-MM-DD) after which the model can no longer be selected.
+   * Mcode authenticates via subscription credentials (never API keys), so a
+   * model whose subscription access window the vendor has end-dated stays
+   * selectable through this day, then renders greyed-out in pickers.
+   */
+  availableUntil?: string;
+}
+
+/**
+ * Returns true when the model is selectable today. Models whose
+ * `availableUntil` date has passed render greyed-out in pickers.
+ */
+export function isModelAvailable(m: ModelDefinition, now: Date = new Date()): boolean {
+  if (!m.availableUntil) return true;
+  return now.toISOString().slice(0, 10) <= m.availableUntil;
 }
 
 export const MODEL_PROVIDERS: readonly ModelProvider[] = [
@@ -63,6 +79,11 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     comingSoon: false,
     supportsCompletion: true,
     models: [
+      // Anthropic ends Fable 5 subscription access on 2026-06-22; Mcode
+      // auths via subscription, so the entry gates itself after that date.
+      { id: "claude-fable-5", label: "Claude Fable 5", providerId: "claude",
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-fable-5"],
+        availableUntil: "2026-06-22" },
       { id: "claude-opus-4-8", label: "Claude Opus 4.8", providerId: "claude",
         contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-8"] },
       { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude",
@@ -238,7 +259,9 @@ export function findProviderForModel(modelId: string): ModelProvider | undefined
 
 /** @deprecated Use `getDefaultModelId()` for settings-aware defaults. */
 export function getDefaultModel(): ModelDefinition {
-  return MODEL_PROVIDERS[0].models[0]; // Claude Opus 4.8
+  const claude = MODEL_PROVIDERS[0];
+  // Skip date-gated entries so a not-yet-selectable model never becomes the default.
+  return claude.models.find((m) => isModelAvailable(m)) ?? claude.models[0];
 }
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "mcode",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.170",
+      },
       "devDependencies": {
         "@types/node": "^22.19.17",
         "esbuild": "^0.27.7",
@@ -12,7 +15,7 @@
     },
     "apps/desktop": {
       "name": "mcode-desktop",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@electron/rebuild": "^3.7.1",
         "@mcode/contracts": "workspace:*",
@@ -40,7 +43,7 @@
     },
     "apps/server": {
       "name": "@mcode/server",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.21.0",
         "@anthropic-ai/claude-agent-sdk": "*",
@@ -72,7 +75,7 @@
     },
     "apps/web": {
       "name": "mcode-frontend",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@dnd-kit/core": "^6.3.1",
@@ -175,7 +178,23 @@
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.104", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.170", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.170", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.170" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-pAvhfk+iTodXZ6RF18Kz7BEUWFjL7EcR3tKuhUNdPpE1NAYCR3mSHGbafi72JsrNwKEDIs7FU31z3fqhwy8QzA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.170", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rwfgArIa5WI0QPNqFsRBgvtSI0mrtpynUm0oK6+l6/KX4hcgnYGEzciZR1bOeD9/7sSZlTdIgt+T9alKeZmXcg=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.170", "", { "os": "darwin", "cpu": "x64" }, "sha512-0e58h8UQMtsQxLGIv9r4foxfBFWKZ7NeDtoplLhuD7EwQonehomw1sBXCch77t/IfUS+q5vQ5zv+fOGmap5nLQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-gLbaFqcGppFJQd4DLNV4IXoeahejT/p2/M8bSSvRDbla9GOsBr1AxV5XLRyBn1e7xFGozZIAIQr3+1chp7NJgQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-SRYfQcsXlOq+CD/FqkQBTSHbaD++w73GnnO+NUV9adLYrca3kfetRwWT1iguY1cNS0l34dCR3rlzCPq78vg1Jg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.170", "", { "os": "linux", "cpu": "x64" }, "sha512-Xl/m7TaSC3T5IDBdHrZQ9fCQYyDmPELN34CL+MoyPIf7uSmuZnjE9fUOqDh2Rv26JxWssi1M6X+BBvVuKd6Cpg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.170", "", { "os": "linux", "cpu": "x64" }, "sha512-m4+I0qBEk7cxRKS+pL+eoWXbXTFOAo83fQ0tQvap4z/mDMm06IWJtEPoYTaMBwsp32GJWLkHWKbZSBCHZnp2DQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.170", "", { "os": "win32", "cpu": "arm64" }, "sha512-IG+8isJNNJKbnnhO7m+PGhfVCg+XoQ/MDxGde5eigFI0WsEfitjuWSWwx82bT9ghxI1aa6qNvI+UPgPcZuo5Fg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.170", "", { "os": "win32", "cpu": "x64" }, "sha512-7cuqSKbHVItPGVwRbd3A0BEJwcNtc7Fhoh6qHN4C6yrmjSrvdYYx3MLvq/VI768/RoG7mAMDxb+j7WfEfoP9BA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
@@ -438,38 +457,6 @@
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
     "@iconify/utils": ["@iconify/utils@3.1.0", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.0" } }, "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw=="],
-
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
-
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -44,5 +44,7 @@
     "node-pty",
     "@electron/rebuild"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.170"
+  }
 }

--- a/packages/shared/src/model-context/index.ts
+++ b/packages/shared/src/model-context/index.ts
@@ -10,6 +10,7 @@ import type { ContextWindowMode } from "@mcode/contracts";
  * (verified 2026-04-22).
  */
 export const MODEL_CONTEXT_WINDOWS_DEFAULT: Readonly<Record<string, number>> = {
+  "claude-fable-5": 200_000,
   "claude-opus-4-8": 200_000,
   "claude-opus-4-7": 200_000,
   "claude-opus-4-6": 200_000,
@@ -24,6 +25,7 @@ export const MODEL_CONTEXT_WINDOWS_DEFAULT: Readonly<Record<string, number>> = {
  * their default window.
  */
 export const MODEL_CONTEXT_WINDOWS_EXTENDED: Readonly<Record<string, number>> = {
+  "claude-fable-5": 1_000_000,
   "claude-opus-4-8": 1_000_000,
   "claude-opus-4-7": 1_000_000,
   "claude-opus-4-6": 1_000_000,

--- a/packages/shared/src/model-effort/index.ts
+++ b/packages/shared/src/model-effort/index.ts
@@ -35,6 +35,7 @@ const XHIGH_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-8", "claude-op
 
 /** Claude model IDs that support the "max" effort tier. */
 const MAX_EFFORT_MODEL_IDS: readonly string[] = [
+  "claude-fable-5",
   "claude-opus-4-8",
   "claude-opus-4-7",
   "claude-opus-4-6",
@@ -52,6 +53,7 @@ const ULTRATHINK_MODEL_IDS: readonly string[] = MAX_EFFORT_MODEL_IDS;
  * The same Opus 4.8/4.7/4.6 + Sonnet 4.6 cohort that supports the max effort tier.
  */
 const ONE_M_CONTEXT_MODEL_IDS: readonly string[] = [
+  "claude-fable-5",
   "claude-opus-4-8",
   "claude-opus-4-7",
   "claude-opus-4-6",
@@ -143,7 +145,7 @@ export function isXhighEffortModel(modelId: string): boolean {
 /**
  * Returns true when the model supports the "max" effort tier.
  *
- * Applies to the opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
+ * Applies to the fable-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
  */
 export function isMaxEffortModel(modelId: string): boolean {
   return MAX_EFFORT_MODEL_IDS.includes(normalizeModelId(modelId));
@@ -152,7 +154,7 @@ export function isMaxEffortModel(modelId: string): boolean {
 /**
  * Returns true when the model supports the "ultrathink" virtual tier.
  *
- * Applies to the opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
+ * Applies to the fable-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
  * Ultrathink resolves to "max" effort at the SDK boundary and additionally
  * prepends "Ultrathink:\n" to the user prompt.
  */
@@ -162,7 +164,7 @@ export function supportsUltrathink(modelId: string): boolean {
 
 /**
  * Returns true when the model supports the extended 1,000,000-token context
- * window. Applies to opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6.
+ * window. Applies to fable-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6.
  *
  * The window is opted into by appending `[1m]` to the model slug at send
  * time; the Claude Agent SDK handles the beta header internally.

--- a/scripts/build-server-dev-bundle.mjs
+++ b/scripts/build-server-dev-bundle.mjs
@@ -1,13 +1,13 @@
 /**
  * One-shot dev server bundle: `apps/server` tsc emit (`emitDecoratorMetadata`)
  * followed by esbuild CJS bundle to `apps/desktop/dist/server/server.cjs`, plus
- * Claude SDK cli.js beside it. Shared by desktop dev orchestration and
+ * Claude SDK native CLI binary beside it. Shared by desktop dev orchestration and
  * `scripts/dev-web.mjs` (no `--import tsx` at runtime).
  */
 
 import { build } from "esbuild";
 import { execFileSync } from "node:child_process";
-import { copyFileSync, cpSync, existsSync, rmSync } from "node:fs";
+import { copyFileSync, cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -44,20 +44,38 @@ export function compileServerWithTsc(serverRoot = resolve(repoRootFromScript(), 
 }
 
 /**
- * Copy Claude Agent SDK `cli.js` adjacent to the bundled server entry (the SDK
- * resolves it relative to dirname(import.meta.url) at runtime).
+ * Stage the Claude Agent SDK's native CLI binary next to the bundled server entry.
+ *
+ * SDK >= 0.3 ships the CLI as a platform-specific package
+ * (`@anthropic-ai/claude-agent-sdk-<platform>-<arch>/claude[.exe]`) and resolves
+ * it at runtime via `createRequire(import.meta.url)`. The esbuild bundle rewrites
+ * `import.meta.url` to point at `server.cjs`, so the binary must be reachable by
+ * walking up from `dist/server/` — i.e. under `dist/server/node_modules/`.
+ *
+ * The binary is ~230MB; the copy is skipped when the destination already matches
+ * the source size so dev rebuilds stay fast.
  *
  * @param {string} serverCjsOut Absolute path to `server.cjs`.
  * @param {string} serverPackageRoot Root of `apps/server` (directory with `package.json`).
  */
 export function copyClaudeSdkCliNextTo(serverCjsOut, serverPackageRoot) {
   const serverRequire = createRequire(resolve(serverPackageRoot, "package.json"));
-  // The SDK no longer exposes "./package.json" in its package exports, so
-  // resolve the main entry instead and walk up to the package root. cli.js
-  // sits alongside sdk.mjs at the package root.
+  const platformPkg = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`;
+  const binName = process.platform === "win32" ? "claude.exe" : "claude";
+
+  // Resolve from the SDK package itself: bun keeps platform packages as store
+  // siblings of the SDK, not hoisted to the workspace root.
   const sdkEntry = serverRequire.resolve("@anthropic-ai/claude-agent-sdk");
-  const sdkCliSrc = resolve(dirname(sdkEntry), "cli.js");
-  copyFileSync(sdkCliSrc, resolve(dirname(serverCjsOut), "cli.js"));
+  const sdkRequire = createRequire(sdkEntry);
+  const binSrc = sdkRequire.resolve(`${platformPkg}/${binName}`);
+
+  const dstPkgDir = resolve(dirname(serverCjsOut), "node_modules", platformPkg);
+  const binDst = resolve(dstPkgDir, binName);
+  mkdirSync(dstPkgDir, { recursive: true });
+  copyFileSync(resolve(dirname(binSrc), "package.json"), resolve(dstPkgDir, "package.json"));
+  if (!existsSync(binDst) || statSync(binDst).size !== statSync(binSrc).size) {
+    copyFileSync(binSrc, binDst);
+  }
 }
 
 /**


### PR DESCRIPTION
## What

Adds the **Claude Fable 5** model, gated by a subscription end date (`availableUntil`), bumps `@anthropic-ai/claude-agent-sdk` from 0.2.104 to 0.3.170, and reworks how the SDK's native CLI binary is staged into the build.

## Why

Mcode authenticates through the user's subscription, never API keys. Anthropic ends subscription access to Fable 5 on 2026-06-22, so the model needs to be selectable until then and self-disable afterward rather than silently failing. SDK 0.3 also changed packaging: the CLI now ships as a platform-specific native binary instead of a bundled `cli.js`, so the build had to stage it differently.

## Key Changes

- **Model registry**: new `availableUntil` field and `isModelAvailable` helper; Fable 5 registered across the context-window, effort-tier, and 1M-context tables; `getDefaultModel` skips date-gated entries so a not-yet-selectable model never becomes the default.
- **Model picker**: gated models render greyed-out and disabled with an "Ended <date>" label and tooltip; available dated models show an "Until <date>" badge.
- **SDK 0.3 bump**: `package.json` / `bun.lock` updated; build scripts stage the platform-specific native CLI binary under `dist/server/node_modules/` so the bundled SDK's `createRequire` resolution finds it, with a size-based skip to keep dev rebuilds fast.
- **Review fix (this PR's own commit)**: `isModelAvailable` now compares the **local** calendar date instead of UTC. The gate used `toISOString()` (UTC) while the badge formats in local time, so users far from UTC could see a model grey out a day before or after the displayed end date. Tests construct local-time dates so the day-boundary assertions are timezone-independent.

## Review notes

Reviewed across correctness, quality, security, and performance. The timezone bug above was the one confirmed defect and is fixed here. Items deliberately left as follow-ups, not bugs:

- **The gate is picker-only.** `resolveThreadModelId` and the send path do not re-check `isModelAvailable`, so a thread already locked to Fable 5 keeps using it after the end date (the vendor then rejects the request). Enforcing at resolution would mean silently swapping a locked thread's model, which is a product decision rather than a clear fix. Flagging for a maintainer call.
- **musl Linux is not staged.** The build resolves only `<platform>-<arch>` (e.g. `linux-x64`), not the `-musl` variant, so an Alpine build would fail closed. Out of scope for the current win32/darwin/glibc desktop targets.

## Verification

- `model-registry` unit tests pass: 77/77, including the new local-time day-boundary cases.
- Full `bun run verify` typecheck and lint pass. The only unit-test failures were 5000ms timeouts in `MermaidBlock.test.tsx` and `PlanDocument.test.tsx` under a resource-starved full-suite run; both pass in isolation (11/11 and 2/2) and neither file is touched by this branch nor imports the model registry. Pre-existing environment flakes, not regressions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783627647&installation_id=129163861&pr_number=629&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F629&signature=8ac6523ae52ef9ca13fb7fd14e8c4635c48d1c28ba9630cce7e07ad20a5c3f1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Claude Fable 5 model now available for selection
  * Models display availability expiry dates with "Until..." badges in the selector

* **Improvements**
  * Unavailable models are now clearly marked as "Ended" in the model selector with subscription end dates displayed
  * Enhanced model availability tracking ensures inactive models cannot be selected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->