### PR TITLE
feat(panel): tab-availability model and empty-state card grid

### DIFF
--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -132,6 +132,27 @@ describe("diffStore", () => {
       setRightPanelTab("ws-1", "preview");
       expect(getRightPanel("ws-1").activeTab).toBe("preview");
     });
+
+    it("defaults to no open tabs (empty-state card grid)", () => {
+      const { getRightPanel } = useDiffStore.getState();
+      expect(getRightPanel("ws-fresh").openTabs).toEqual([]);
+    });
+
+    it("opens a tab (adds it to openTabs) when first activated", () => {
+      const { setRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "preview");
+      expect(getRightPanel("ws-1").openTabs).toEqual(["preview"]);
+      expect(getRightPanel("ws-1").activeTab).toBe("preview");
+    });
+
+    it("accumulates open tabs in open order without duplicating", () => {
+      const { setRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "preview");
+      setRightPanelTab("ws-1", "terminal");
+      setRightPanelTab("ws-1", "preview"); // refocus, not reopen
+      expect(getRightPanel("ws-1").openTabs).toEqual(["preview", "terminal"]);
+      expect(getRightPanel("ws-1").activeTab).toBe("preview");
+    });
   });
 
   // The panel is workspace-global: its open state must survive having no thread

--- a/apps/web/src/__tests__/right-panel-resize.test.ts
+++ b/apps/web/src/__tests__/right-panel-resize.test.ts
@@ -10,6 +10,6 @@ const RIGHT_PANEL_SRC = readFileSync(
 describe("RightPanel resize handle stacking", () => {
   it("keeps the col-resize handle above the terminal tab layer", () => {
     expect(RIGHT_PANEL_SRC).toMatch(/z-20[^"]*cursor-col-resize/);
-    expect(RIGHT_PANEL_SRC).toMatch(/activeTab === "terminal" && "z-10"/);
+    expect(RIGHT_PANEL_SRC).toMatch(/terminalActive && "z-10"/);
   });
 });

--- a/apps/web/src/components/panels/PanelEmptyState.tsx
+++ b/apps/web/src/components/panels/PanelEmptyState.tsx
@@ -1,0 +1,84 @@
+import { getKeybindingForCommand, formatKeybinding } from "@/lib/keybinding-manager";
+import { isMac } from "@/lib/platform";
+import { Kbd } from "@/components/palette/Kbd";
+import {
+  shownTabTypes,
+  type PanelScope,
+  type PanelTabType,
+  type PanelTabTypeId,
+} from "@/lib/panel-tabs";
+import type { RightPanelTab } from "@/stores/diffStore";
+import { cn } from "@/lib/utils";
+
+/** The mcode keycap for a tab type, or null when it has no binding. */
+function tabKeycap(type: PanelTabType): string | null {
+  if (!type.commandId) return null;
+  const binding = getKeybindingForCommand(type.commandId);
+  return binding ? formatKeybinding(binding.key, isMac) : null;
+}
+
+/** "Soon" tag for tab types that are not openable yet (deferred features). */
+function SoonBadge() {
+  return (
+    <span className="rounded bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+      Soon
+    </span>
+  );
+}
+
+/**
+ * The empty-state create surface for the right panel: a card grid of the tab
+ * types creatable in the current scope. Each card carries an icon, label, blurb,
+ * and the type's mcode keycap; clicking one opens that tab. Coming-soon types
+ * (Files) render as a disabled "Soon" teaser and are excluded from the creatable
+ * set. There is intentionally no add control here — the grid is the create
+ * surface (ADR-0004, issue #610).
+ */
+export function PanelEmptyState({
+  scope,
+  openTabs,
+  onOpen,
+}: {
+  scope: PanelScope;
+  /** Tab types already open, dropped from the grid by the cardinality filter. */
+  readonly openTabs: readonly PanelTabTypeId[];
+  /** Open (create-or-focus) a tab type. Never called for coming-soon teasers. */
+  onOpen: (id: RightPanelTab) => void;
+}) {
+  const cards = shownTabTypes(scope, openTabs);
+
+  return (
+    <div
+      data-testid="panel-empty-state"
+      className="flex h-full flex-col overflow-y-auto p-6"
+    >
+      <div className="m-auto grid w-full max-w-md grid-cols-2 gap-3">
+        {cards.map((type) => {
+          const Icon = type.icon;
+          const keycap = tabKeycap(type);
+          return (
+            <button
+              key={type.id}
+              type="button"
+              data-testid={`panel-card-${type.id}`}
+              disabled={type.comingSoon}
+              aria-label={type.comingSoon ? `${type.label} (coming soon)` : `Open ${type.label}`}
+              onClick={type.comingSoon ? undefined : () => onOpen(type.id as RightPanelTab)}
+              className={cn(
+                "flex flex-col items-center gap-2 rounded-lg border border-border bg-card px-4 py-6 text-center transition-colors",
+                type.comingSoon
+                  ? "cursor-default opacity-50"
+                  : "hover:border-primary/50 hover:bg-card/80",
+              )}
+            >
+              <Icon size={22} className="text-muted-foreground" />
+              <div className="text-sm font-medium text-foreground">{type.label}</div>
+              <div className="text-xs text-muted-foreground">{type.blurb}</div>
+              {type.comingSoon ? <SoonBadge /> : keycap && <Kbd>{keycap}</Kbd>}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -14,6 +14,8 @@ import {
   type RightPanelTab,
 } from "@/stores/diffStore";
 import { ScopeSplitPane } from "./ScopeSplitPane";
+import { PanelEmptyState } from "./PanelEmptyState";
+import type { PanelScope } from "@/lib/panel-tabs";
 import { DiffPanel } from "@/components/diff";
 import { PreviewPanel } from "@/components/panels/PreviewPanel";
 import { TerminalTabContent } from "@/components/terminal/TerminalTabContent";
@@ -219,6 +221,13 @@ export function RightPanel() {
     [storedPanel],
   );
   const { width: panelWidth, activeTab } = panelState;
+  // Tabs are singletons opened on demand; an empty set means no tab is open and
+  // the panel shows the card-grid empty state. Defensive default for any stored
+  // row that predates the openTabs field. See ADR-0004 / issue #610.
+  const openTabs = panelState.openTabs ?? [];
+  // Review and Scope are creatable only in a thread; threadless the panel runs
+  // against the workspace root and offers just Browser/Terminal/Files.
+  const panelScope: PanelScope = activeThreadId ? "thread" : "threadless";
   // Open/closed is per-thread (falling back to the workspace threadless shell);
   // width and active tab stay workspace-global. See ADR-0004.
   const panelVisible = useDiffStore((s) =>
@@ -277,7 +286,14 @@ export function RightPanel() {
     return files.size;
   }, [snapshots]);
 
-  const isChangesActive = panelVisible && activeTab === "changes";
+  // A tab's content renders only when it is both the active tab and actually
+  // open. Guards against a persisted/default activeTab leaking content behind
+  // the card-grid empty state when its type is not in the open set.
+  const changesActive = activeTab === "changes" && openTabs.includes("changes");
+  const previewActive = activeTab === "preview" && openTabs.includes("preview");
+  const terminalActive = activeTab === "terminal" && openTabs.includes("terminal");
+
+  const isChangesActive = panelVisible && changesActive;
   const changesFresh = useChangesFreshness(activeThreadId, changesCount, isChangesActive);
 
   // Drop inactive tab labels when the rendered panel is narrow. Overlay mode
@@ -330,10 +346,10 @@ export function RightPanel() {
   // in the background, and intentionally not gated on the terminal count so
   // killing the last terminal does not immediately respawn one.
   useEffect(() => {
-    if (panelVisible && activeTab === "terminal" && panelScopeId) {
+    if (panelVisible && terminalActive && panelScopeId) {
       ensureTerminalForScope(panelScopeId);
     }
-  }, [panelVisible, activeTab, panelScopeId]);
+  }, [panelVisible, terminalActive, panelScopeId]);
 
   // Close on Escape when overlaid.
   useEffect(() => {
@@ -541,7 +557,7 @@ export function RightPanel() {
       <div ref={headerRef} className="relative flex-none border-b border-border/40">
         <div className="flex h-11 items-center justify-between px-3">
           <div ref={tablistRef} className="flex items-center gap-0.5">
-            {TABS.map((tab) => {
+            {TABS.filter((tab) => openTabs.includes(tab.id)).map((tab) => {
               const isActive = activeTab === tab.id;
               const Icon = tab.icon;
               const showLabel = isActive || !compactTabs;
@@ -597,27 +613,39 @@ export function RightPanel() {
 
       {/* Tab content — DiffPanel and terminal pool stay mounted (stacked) so
           turn expand state, loaded diffs, and xterm scroll anchors survive tab
-          and workspace thread switches. */}
+          and workspace thread switches. With no tab open the panel shows the
+          card-grid empty state, which is itself the create surface. */}
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-        {activeTab === "tasks" && activeThreadId && (
+        {openTabs.length === 0 && (
+          <PanelEmptyState
+            scope={panelScope}
+            openTabs={openTabs}
+            onOpen={(id) => setRightPanelTab(activeWorkspaceId!, id)}
+          />
+        )}
+        {activeTab === "tasks" && openTabs.includes("tasks") && activeThreadId && (
           <ScopeSplitPane threadId={activeThreadId} parentTasks={parentTasks} />
         )}
-        <div className={activeTab === "changes" ? "flex flex-1 flex-col min-h-0" : "hidden"}>
+        <div
+          className={
+            changesActive ? "flex flex-1 flex-col min-h-0" : "hidden"
+          }
+        >
           <DiffPanel />
         </div>
-        {activeTab === "preview" && panelScopeId && (
+        {previewActive && panelScopeId && (
           <PreviewPanel threadId={panelScopeId} workspaceId={activeWorkspaceId} />
         )}
         <div
           className={cn(
             "absolute inset-0 flex min-h-0 flex-row overflow-hidden",
-            activeTab !== "terminal" && "pointer-events-none z-0 opacity-0",
-            activeTab === "terminal" && "z-10",
+            !terminalActive && "pointer-events-none z-0 opacity-0",
+            terminalActive && "z-10",
           )}
-          aria-hidden={activeTab !== "terminal"}
-          inert={activeTab !== "terminal" ? true : undefined}
+          aria-hidden={!terminalActive}
+          inert={!terminalActive ? true : undefined}
         >
-          {activeTab === "terminal" && panelScopeId && (
+          {terminalActive && panelScopeId && (
             <TerminalTabContent threadId={panelScopeId} />
           )}
           <TerminalPoolSlot className="relative min-h-0 min-w-0 flex-1 overflow-hidden p-2" />

--- a/apps/web/src/components/panels/__tests__/PanelEmptyState.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PanelEmptyState.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Behaviour tests for the right-panel empty-state card grid (issue #610):
+ * scope-filtered cards, the Files coming-soon teaser, the absence of an add
+ * control, and opening a tab by clicking its card.
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PanelEmptyState } from "../PanelEmptyState";
+import { loadKeybindings, clearKeybindings } from "@/lib/keybinding-manager";
+import defaultKeybindings from "@/config/default-keybindings.json";
+
+beforeEach(() => {
+  clearKeybindings();
+  loadKeybindings(defaultKeybindings);
+});
+
+describe("PanelEmptyState — scope filter", () => {
+  it("threadless: shows Browser, Terminal, and Files only", () => {
+    render(<PanelEmptyState scope="threadless" openTabs={[]} onOpen={vi.fn()} />);
+    expect(screen.getByTestId("panel-card-preview")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-card-terminal")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-card-files")).toBeInTheDocument();
+    expect(screen.queryByTestId("panel-card-changes")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("panel-card-tasks")).not.toBeInTheDocument();
+  });
+
+  it("thread: also shows Review and Scope", () => {
+    render(<PanelEmptyState scope="thread" openTabs={[]} onOpen={vi.fn()} />);
+    expect(screen.getByTestId("panel-card-changes")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-card-tasks")).toBeInTheDocument();
+  });
+});
+
+describe("PanelEmptyState — cardinality filter", () => {
+  it("drops a type once it is open", () => {
+    render(
+      <PanelEmptyState scope="threadless" openTabs={["preview"]} onOpen={vi.fn()} />,
+    );
+    expect(screen.queryByTestId("panel-card-preview")).not.toBeInTheDocument();
+    expect(screen.getByTestId("panel-card-terminal")).toBeInTheDocument();
+  });
+});
+
+describe("PanelEmptyState — Files coming-soon teaser", () => {
+  it("renders Files disabled with a Soon badge", () => {
+    render(<PanelEmptyState scope="threadless" openTabs={[]} onOpen={vi.fn()} />);
+    const files = screen.getByTestId("panel-card-files");
+    expect(files).toBeDisabled();
+    expect(screen.getByText(/soon/i)).toBeInTheDocument();
+  });
+
+  it("does not open Files when its card is clicked", () => {
+    const onOpen = vi.fn();
+    render(<PanelEmptyState scope="threadless" openTabs={[]} onOpen={onOpen} />);
+    fireEvent.click(screen.getByTestId("panel-card-files"));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("PanelEmptyState — create surface", () => {
+  it("opens a tab when its card is clicked", () => {
+    const onOpen = vi.fn();
+    render(<PanelEmptyState scope="threadless" openTabs={[]} onOpen={onOpen} />);
+    fireEvent.click(screen.getByTestId("panel-card-preview"));
+    expect(onOpen).toHaveBeenCalledWith("preview");
+  });
+
+  it("renders no add control (the grid is the create surface)", () => {
+    render(<PanelEmptyState scope="thread" openTabs={[]} onOpen={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /add|new tab|\+/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the mcode keycap for an openable type", () => {
+    render(<PanelEmptyState scope="threadless" openTabs={[]} onOpen={vi.fn()} />);
+    // Terminal binds to mod+j → "Ctrl+J" on non-mac.
+    const terminal = screen.getByTestId("panel-card-terminal");
+    expect(terminal.querySelector("kbd")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/__tests__/panel-tabs.test.ts
+++ b/apps/web/src/lib/__tests__/panel-tabs.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  PANEL_TAB_TYPES,
+  creatableTypes,
+  shownTabTypes,
+  type PanelTabTypeId,
+} from "../panel-tabs";
+
+/** Pull just the ids out of a result for terse assertions. */
+function ids(types: readonly { id: PanelTabTypeId }[]): PanelTabTypeId[] {
+  return types.map((t) => t.id);
+}
+
+describe("PANEL_TAB_TYPES catalog", () => {
+  it("declares the five revamp tab types in prototype order", () => {
+    expect(ids(PANEL_TAB_TYPES)).toEqual([
+      "preview",
+      "terminal",
+      "files",
+      "changes",
+      "tasks",
+    ]);
+  });
+
+  it("marks only Files as coming-soon", () => {
+    const comingSoon = PANEL_TAB_TYPES.filter((t) => t.comingSoon).map((t) => t.id);
+    expect(comingSoon).toEqual(["files"]);
+  });
+
+  it("marks Review and Scope as thread-only", () => {
+    const threadOnly = PANEL_TAB_TYPES.filter((t) => t.needsThread).map((t) => t.id);
+    expect(threadOnly).toEqual(["changes", "tasks"]);
+  });
+
+  it("gives every openable type a commandId for keycap resolution", () => {
+    for (const type of PANEL_TAB_TYPES) {
+      if (type.comingSoon) {
+        expect(type.commandId).toBeUndefined();
+      } else {
+        expect(type.commandId).toBeTruthy();
+      }
+    }
+  });
+
+  it("gives every type a label and a blurb", () => {
+    for (const type of PANEL_TAB_TYPES) {
+      expect(type.label.length).toBeGreaterThan(0);
+      expect(type.blurb.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("shownTabTypes — scope filter", () => {
+  it("drops thread-only types when threadless", () => {
+    expect(ids(shownTabTypes("threadless", []))).toEqual([
+      "preview",
+      "terminal",
+      "files",
+    ]);
+  });
+
+  it("keeps every type in a thread", () => {
+    expect(ids(shownTabTypes("thread", []))).toEqual([
+      "preview",
+      "terminal",
+      "files",
+      "changes",
+      "tasks",
+    ]);
+  });
+});
+
+describe("shownTabTypes — cardinality filter", () => {
+  it("drops singletons already open", () => {
+    expect(ids(shownTabTypes("threadless", ["preview"]))).toEqual([
+      "terminal",
+      "files",
+    ]);
+  });
+
+  it("keeps the coming-soon teaser even when every openable type is open", () => {
+    expect(
+      ids(shownTabTypes("thread", ["preview", "terminal", "changes", "tasks"])),
+    ).toEqual(["files"]);
+  });
+
+  it("ignores open ids that the scope filter already removed", () => {
+    // "tasks" is thread-only, so it is dropped by the scope filter regardless of
+    // whether it appears in openTabs; the result is unchanged.
+    expect(ids(shownTabTypes("threadless", ["tasks"]))).toEqual([
+      "preview",
+      "terminal",
+      "files",
+    ]);
+  });
+});
+
+describe("creatableTypes — coming-soon exclusion", () => {
+  it("excludes Files from the creatable set when threadless", () => {
+    expect(ids(creatableTypes("threadless", []))).toEqual(["preview", "terminal"]);
+  });
+
+  it("excludes Files from the creatable set in a thread", () => {
+    expect(ids(creatableTypes("thread", []))).toEqual([
+      "preview",
+      "terminal",
+      "changes",
+      "tasks",
+    ]);
+  });
+
+  it("never returns Files regardless of scope or open tabs", () => {
+    const scopes = ["threadless", "thread"] as const;
+    for (const scope of scopes) {
+      expect(ids(creatableTypes(scope, [])).includes("files")).toBe(false);
+      expect(ids(creatableTypes(scope, ["preview"])).includes("files")).toBe(false);
+    }
+  });
+});
+
+describe("creatableTypes — combined scope + cardinality", () => {
+  it("drops both scope-filtered and already-open types", () => {
+    expect(ids(creatableTypes("threadless", ["preview"]))).toEqual(["terminal"]);
+  });
+
+  it("returns an empty set when every openable type is open", () => {
+    expect(
+      ids(creatableTypes("thread", ["preview", "terminal", "changes", "tasks"])),
+    ).toEqual([]);
+  });
+
+  it("is a strict subset of shownTabTypes (only the coming-soon teaser differs)", () => {
+    const shown = ids(shownTabTypes("thread", []));
+    const creatable = ids(creatableTypes("thread", []));
+    const removed = shown.filter((id) => !creatable.includes(id));
+    expect(removed).toEqual(["files"]);
+  });
+});
+
+describe("creatableTypes / shownTabTypes — purity", () => {
+  it("does not mutate the openTabs argument", () => {
+    const open: PanelTabTypeId[] = ["preview"];
+    creatableTypes("thread", open);
+    shownTabTypes("thread", open);
+    expect(open).toEqual(["preview"]);
+  });
+
+  it("returns results in catalog order", () => {
+    // Open tabs given out of order must not reorder the result.
+    expect(ids(creatableTypes("thread", ["tasks", "preview"]))).toEqual([
+      "terminal",
+      "changes",
+    ]);
+  });
+});

--- a/apps/web/src/lib/panel-tabs.ts
+++ b/apps/web/src/lib/panel-tabs.ts
@@ -1,0 +1,120 @@
+import type { LucideIcon } from "lucide-react";
+import { Globe, Terminal, Files, Diff, ListChecks } from "lucide-react";
+import type { RightPanelTab } from "@/stores/diffStore";
+
+/**
+ * Whether a thread is active. Tab availability is filtered by scope first: some
+ * tab types (Review, Scope) only make sense once a thread exists, so they are
+ * dropped when the panel runs threadless against the workspace root. See ADR-0004.
+ */
+export type PanelScope = "threadless" | "thread";
+
+/**
+ * Identifier for a creatable panel tab type. Openable types map 1:1 onto the
+ * store's {@link RightPanelTab}; `"files"` is a coming-soon teaser that is shown
+ * but never actually opened, so it has no backing {@link RightPanelTab}.
+ */
+export type PanelTabTypeId = RightPanelTab | "files";
+
+/**
+ * Static metadata describing one panel tab type for the availability model and
+ * the empty-state card grid. Pure data — no store or React state.
+ */
+export interface PanelTabType {
+  /** Stable id; openable ids are {@link RightPanelTab}, `"files"` is coming-soon only. */
+  readonly id: PanelTabTypeId;
+  /** Product-facing name shown on the card (e.g. "Browser", "Review"). */
+  readonly label: string;
+  /** Card glyph. */
+  readonly icon: LucideIcon;
+  /** One-line description shown under the label on the empty-state card. */
+  readonly blurb: string;
+  /** Only creatable once a thread exists; dropped by the scope filter when threadless. */
+  readonly needsThread: boolean;
+  /** Shown as a disabled teaser and excluded from the creatable set (Files). */
+  readonly comingSoon?: boolean;
+  /**
+   * Command id whose keybinding renders as the card's keycap. Absent for
+   * coming-soon types, which have no binding yet.
+   */
+  readonly commandId?: string;
+}
+
+/**
+ * The revamp's tab-type catalog, in display order (ADR-0004). Order is the
+ * single source of truth for how cards and rail entries are laid out, so the
+ * availability helpers preserve it. Labels are the product language (Browser,
+ * Review, Scope) even though the openable ids reuse the legacy
+ * {@link RightPanelTab} values (preview, changes, tasks).
+ */
+export const PANEL_TAB_TYPES: readonly PanelTabType[] = [
+  {
+    id: "preview",
+    label: "Browser",
+    icon: Globe,
+    blurb: "Open a website",
+    needsThread: false,
+    commandId: "preview.toggle",
+  },
+  {
+    id: "terminal",
+    label: "Terminal",
+    icon: Terminal,
+    blurb: "Start a shell",
+    needsThread: false,
+    commandId: "terminal.toggle",
+  },
+  {
+    id: "files",
+    label: "Files",
+    icon: Files,
+    blurb: "Browse project files",
+    needsThread: false,
+    comingSoon: true,
+  },
+  {
+    id: "changes",
+    label: "Review",
+    icon: Diff,
+    blurb: "View code changes",
+    needsThread: true,
+    commandId: "changes.toggle",
+  },
+  {
+    id: "tasks",
+    label: "Scope",
+    icon: ListChecks,
+    blurb: "Plan and tasks",
+    needsThread: true,
+    commandId: "tasks.toggle",
+  },
+];
+
+/**
+ * Tab types displayed in the current scope, in catalog order: scope-filtered
+ * (thread-only types dropped when threadless) then cardinality-filtered
+ * (singletons already open dropped). Coming-soon teasers (Files) are kept so the
+ * empty-state grid can render them disabled. Pure — does not read or mutate any
+ * external state.
+ */
+export function shownTabTypes(
+  scope: PanelScope,
+  openTabs: readonly PanelTabTypeId[],
+): readonly PanelTabType[] {
+  return PANEL_TAB_TYPES.filter((type) => {
+    const allowedInScope = scope === "thread" || !type.needsThread;
+    return allowedInScope && !openTabs.includes(type.id);
+  });
+}
+
+/**
+ * The creatable tab types in the current scope: {@link shownTabTypes} minus the
+ * coming-soon teasers. This is the set the user can actually open, used for the
+ * creatable count and (in the rail) the add control. Pure.
+ */
+export function creatableTypes(
+  scope: PanelScope,
+  openTabs: readonly PanelTabTypeId[],
+): readonly PanelTabType[] {
+  return shownTabTypes(scope, openTabs).filter((type) => !type.comingSoon);
+}

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -45,10 +45,16 @@ export interface SelectedFile {
   threadId: string;
 }
 
-/** Workspace-global right panel state (visibility, width, active tab). */
+/** Workspace-global right panel state (visibility, width, open tabs, active tab). */
 export type RightPanelState = {
   readonly visible: boolean;
   readonly width: number;
+  /**
+   * The singleton tab types the user has opened, in open order. Empty means no
+   * tab is open and the panel shows the card-grid empty state (ADR-0004). Tab
+   * types are opened on demand rather than always present.
+   */
+  readonly openTabs: readonly RightPanelTab[];
   readonly activeTab: RightPanelTab;
 };
 
@@ -62,6 +68,7 @@ export function createDefaultRightPanelState(): RightPanelState {
   return {
     visible: false,
     width: getDefaultPanelWidthPx(),
+    openTabs: [],
     activeTab: "tasks",
   };
 }
@@ -103,6 +110,7 @@ function setPanelVisible(
 export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
   visible: false,
   width: PANEL_DEFAULT_WIDTH,
+  openTabs: [],
   activeTab: "tasks",
 } as const;
 
@@ -266,10 +274,16 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   setRightPanelTab: (workspaceId, tab) =>
     set((state) => {
       const current = state.rightPanelByWorkspace[workspaceId] ?? createDefaultRightPanelState();
+      // Activating a tab opens it: tabs are singletons created on demand, so
+      // focusing one that is not yet open adds it to the open set (the card grid
+      // is the create surface). Already-open tabs are just refocused.
+      const openTabs = current.openTabs.includes(tab)
+        ? current.openTabs
+        : [...current.openTabs, tab];
       return {
         rightPanelByWorkspace: {
           ...state.rightPanelByWorkspace,
-          [workspaceId]: { ...current, activeTab: tab },
+          [workspaceId]: { ...current, openTabs, activeTab: tab },
         },
       };
     }),


### PR DESCRIPTION
## What

Introduce the pure tab-availability model and the right-panel empty-state card grid (issue #610).

## Why

The right panel previously rendered a fixed strip of four tabs that were always present. The revamp (ADR-0004) makes panel tabs singletons opened on demand: with no tab open, the panel shows a card grid that is itself the create surface. This slice lands the model and the empty state; the rail and close-tab affordance arrive in sibling issues under #608.

## Key Changes

- `lib/panel-tabs.ts`: pure `shownTabTypes` / `creatableTypes` helpers over a `PANEL_TAB_TYPES` catalog. Scope filter drops thread-only types (Review, Scope) when threadless; cardinality filter drops singletons already open; `creatableTypes` excludes the Files coming-soon teaser. Exhaustively unit-tested.
- `diffStore`: `RightPanelState` gains an `openTabs` set. `setRightPanelTab` opens a tab on activation (adds it to the set, refocuses if already open). Empty set means the empty state.
- `PanelEmptyState`: card grid of creatable types with icon, label, blurb, and mcode keycap. Clicking a card opens that tab. Files renders as a disabled "Soon" teaser. No add control.
- `RightPanel`: renders the empty state when `openTabs` is empty; gates each tab's content on both active and open so the default `activeTab` never leaks content behind the grid.

## Testing

- `node scripts/agent/verify-fast.mjs`: typecheck + lint pass (full turbo cache).
- 65 tests across the changed files pass (`panel-tabs`, `PanelEmptyState`, `diffStore`, `right-panel-resize`).
- Full `bun run verify`: 1543 passing; the only 3 failures are pre-existing load-induced timeout flakes in `PlanDocument.test.tsx` / `PlanPanel.test.tsx` (Plan panel, untouched here), which pass in isolation.
- Visual verification with Playwright not run: no dev server available in this environment. Interactive behavior is covered by the `@testing-library` component tests (click-to-open, scope filter, disabled teaser, no add control, keycap).

Closes #610

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783630605&installation_id=129163861&pr_number=630&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F630&signature=881f938ffbc1f73f5820eb2ce5888d4338dfa3a45f05741e2435b63617c31ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Empty-state grid now appears in the right panel when all tabs are closed, presenting available tab options as cards with icons, labels, keyboard shortcuts, and indicators for upcoming features

* **Tests**
  * Added comprehensive test suites for right-panel tab management, empty-state interface rendering, and tab type catalog filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->