### PR TITLE
feat(panel): activity rail for the right panel

### DIFF
--- a/apps/web/e2e/right-panel-activity-rail.spec.ts
+++ b/apps/web/e2e/right-panel-activity-rail.spec.ts
@@ -1,0 +1,201 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { Thread } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-activity-rail",
+  name: "Activity Rail",
+  path: "/tmp/activity-rail",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+function makeThread(id: string, title: string): Thread {
+  return {
+    id,
+    workspace_id: WORKSPACE.id,
+    title,
+    status: "paused",
+    mode: "direct",
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+  };
+}
+
+const THREAD = makeThread("thread-activity-rail", "Rail Thread");
+
+/**
+ * Seeds the stores and opens the right panel, optionally with an active thread
+ * and a list of tabs pre-opened (in order; the last becomes active). With no
+ * tabs the panel renders its empty-state card grid.
+ */
+async function seed(
+  page: Page,
+  opts: { thread?: boolean; tabs?: readonly string[] } = {},
+): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread, wid, tid, withThread, tabs }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) =>
+        (s as { getState: () => Record<string, unknown> }).getState();
+
+      const wsStore = stores.find(
+        (s) => "activeThreadId" in getState(s) && "threads" in getState(s),
+      );
+      (wsStore as { setState: (p: unknown) => void } | undefined)?.setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: withThread ? [thread] : [],
+        activeThreadId: withThread ? tid : null,
+        pendingNewThread: !withThread,
+      });
+
+      const diffStore = stores.find((s) => "showRightPanel" in getState(s));
+      if (diffStore) {
+        const api = (
+          diffStore as {
+            getState: () => {
+              showRightPanel: (id: string, threadId?: string) => void;
+              setRightPanelTab: (id: string, t: string) => void;
+            };
+          }
+        ).getState();
+        api.showRightPanel(wid, withThread ? tid : undefined);
+        for (const t of tabs) api.setRightPanelTab(wid, t);
+      }
+    },
+    {
+      workspace: WORKSPACE,
+      thread: THREAD,
+      wid: WORKSPACE.id,
+      tid: THREAD.id,
+      withThread: opts.thread ?? false,
+      tabs: opts.tabs ?? [],
+    },
+  );
+}
+
+test.describe("Right panel activity rail", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [THREAD],
+      "thread.getTasks": [],
+      "snapshot.listByThread": [],
+      "terminal.create": { ptyId: "pty-rail", shell: "bash" },
+      "terminal.resize": true,
+      "terminal.kill": true,
+      "terminal.killByThread": true,
+      "settings.get": getDefaultSettings(),
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1920, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+  });
+
+  test("switches the active tab when a rail icon is clicked", async ({ page }) => {
+    // Browser then Terminal open; Terminal is active (opened last).
+    await seed(page, { tabs: ["preview", "terminal"] });
+
+    const browserIcon = page.locator('[data-rail-tab="preview"]');
+    const terminalIcon = page.locator('[data-rail-tab="terminal"]');
+    await expect(browserIcon).toBeVisible();
+    await expect(terminalIcon).toHaveClass(/text-primary/);
+
+    // Clicking the Browser icon moves the active lamp to it.
+    await browserIcon.click();
+    await expect(browserIcon).toHaveClass(/text-primary/);
+    await expect(terminalIcon).not.toHaveClass(/text-primary/);
+  });
+
+  test("closes a tab via its hover-× and refocuses a survivor", async ({ page }) => {
+    await seed(page, { tabs: ["preview", "terminal"] });
+
+    const terminalIcon = page.locator('[data-rail-tab="terminal"]');
+    await terminalIcon.hover();
+    // The × is a sibling control revealed on hover; its name carries the tab label.
+    await page.getByRole("button", { name: "Close Terminal" }).click();
+
+    // Terminal is gone and Browser takes the active lamp.
+    await expect(page.locator('[data-rail-tab="terminal"]')).toHaveCount(0);
+    await expect(page.locator('[data-rail-tab="preview"]')).toHaveClass(/text-primary/);
+
+    // Closing the last tab returns to the empty-state card grid.
+    await page.locator('[data-rail-tab="preview"]').hover();
+    await page.getByRole("button", { name: "Close Browser" }).click();
+    await expect(page.getByTestId("panel-empty-state")).toBeVisible();
+  });
+
+  test("add control: hidden when nothing is creatable", async ({ page }) => {
+    // Threadless, both creatable types open → nothing left to create.
+    await seed(page, { tabs: ["preview", "terminal"] });
+
+    const rail = page.getByTestId("activity-rail");
+    await expect(rail).toBeVisible();
+    await expect(rail.getByRole("button", { name: /^New / })).toHaveCount(0);
+  });
+
+  test("add control: one creatable type opens directly", async ({ page }) => {
+    // Threadless with only Terminal open → Browser is the sole creatable type.
+    await seed(page, { tabs: ["terminal"] });
+
+    const addDirect = page.getByRole("button", { name: "New Browser" });
+    await expect(addDirect).toBeVisible();
+    // No menu trigger when a single type opens directly.
+    await expect(page.getByRole("button", { name: "New tab" })).toHaveCount(0);
+
+    await addDirect.click();
+    await expect(page.locator('[data-rail-tab="preview"]')).toHaveClass(/text-primary/);
+  });
+
+  test("add control: several creatable types show a menu", async ({ page }) => {
+    // Thread scope with only Scope open → Browser, Terminal, Review remain.
+    await seed(page, { thread: true, tabs: ["tasks"] });
+
+    const addMenu = page.getByRole("button", { name: "New tab" });
+    await expect(addMenu).toBeVisible();
+    await addMenu.click();
+
+    // The menu presents the creatable set plus the Files coming-soon teaser.
+    await expect(page.getByRole("menuitem", { name: /Browser/ })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: /Review/ })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: /Files/ })).toBeDisabled();
+
+    // Choosing Terminal opens and activates it.
+    await page.getByRole("menuitem", { name: /Terminal/ }).click();
+    await expect(page.locator('[data-rail-tab="terminal"]')).toHaveClass(/text-primary/);
+  });
+});

--- a/apps/web/e2e/right-panel-tab-status.spec.ts
+++ b/apps/web/e2e/right-panel-tab-status.spec.ts
@@ -115,6 +115,10 @@ async function seedPanel(page: Page, tab: "tasks" | "changes"): Promise<void> {
         ).getState();
         api.setSnapshots(tid, snapshots);
         api.showRightPanel(wid, tid);
+        // Open both rail tabs so switching can be exercised; the requested tab
+        // is activated last.
+        api.setRightPanelTab(wid, "tasks");
+        api.setRightPanelTab(wid, "changes");
         api.setRightPanelTab(wid, tab);
       }
     },
@@ -177,24 +181,27 @@ test.describe("Right panel tab status", () => {
     );
   });
 
-  test("tabs show scope progress, change count, and the active-tab lamp", async ({ page }, testInfo) => {
+  test("rail icons show scope progress, change count, and the active-tab lamp", async ({ page }, testInfo) => {
     await seedPanel(page, "tasks");
 
-    const scopeTab = page.getByRole("button", { name: /Scope/ });
-    const changesTab = page.getByRole("button", { name: /Changes/ });
+    // Rail icons are addressed by their stable data attribute: the hover-× close
+    // control shares the tab's product label in its accessible name, so a name
+    // match would be ambiguous.
+    const scopeTab = page.locator('[data-rail-tab="tasks"]');
+    const changesTab = page.locator('[data-rail-tab="changes"]');
     await expect(scopeTab).toBeVisible();
 
-    // Scope progress (2 completed of 5) and Changes file count (4 distinct).
+    // Scope progress (2 completed of 5) and Review file count (4 distinct).
     await expect(scopeTab).toContainText("2/5");
     await expect(changesTab).toContainText("4");
 
-    // The active tab carries the amber lamp; the sliding indicator is present.
+    // The active icon carries the amber lamp + its indicator bar.
     await expect(scopeTab).toHaveClass(/text-primary/);
-    await expect(page.getByTestId("tab-indicator")).toBeAttached();
+    await expect(page.getByTestId("rail-active-indicator")).toBeAttached();
 
     await page.screenshot({ path: testInfo.outputPath("scope-active.png") });
 
-    // Switching tabs moves the lamp to Changes.
+    // Switching tabs moves the lamp to Review.
     await changesTab.click();
     await expect(changesTab).toHaveClass(/text-primary/);
     await expect(scopeTab).not.toHaveClass(/text-primary/);
@@ -202,26 +209,26 @@ test.describe("Right panel tab status", () => {
     await page.screenshot({ path: testInfo.outputPath("changes-active.png") });
   });
 
-  test("changes tab pulses fresh when new files land while viewing another tab", async ({ page }) => {
-    // Open on Scope so the Changes tab is inactive; this also baselines the
+  test("review tab pulses fresh when new files land while viewing another tab", async ({ page }) => {
+    // Open on Scope so the Review tab is inactive; this also baselines the
     // current file count so pre-existing changes do not pulse.
     await seedPanel(page, "tasks");
 
-    const changesTab = page.getByRole("button", { name: /Changes/ });
+    const changesTab = page.locator('[data-rail-tab="changes"]');
     await expect(changesTab).toContainText("4");
     await expect(changesTab.locator(".changes-fresh-ring")).toHaveCount(0);
 
-    // A new turn lands while the user is on Scope → Changes goes fresh.
+    // A new turn lands while the user is on Scope → Review goes fresh.
     await addSnapshotWithNewFile(page);
     await expect(changesTab).toContainText("5");
     await expect(changesTab.locator(".changes-fresh-ring")).toBeVisible();
 
-    // Viewing Changes clears the freshness signal.
+    // Viewing Review clears the freshness signal.
     await changesTab.click();
     await expect(changesTab.locator(".changes-fresh-ring")).toHaveCount(0);
   });
 
-  test("changes badge caps the count for very large diffs", async ({ page }) => {
+  test("review badge caps the count for very large diffs", async ({ page }) => {
     // Seed on Scope (Changes inactive) so the DiffPanel does not refetch and
     // overwrite the large snapshot we poke in below.
     await seedPanel(page, "tasks");
@@ -252,7 +259,7 @@ test.describe("Right panel tab status", () => {
     }, THREAD.id);
 
     // 200 distinct files renders as the capped label, not "200".
-    const changesTab = page.getByRole("button", { name: /Changes/ });
+    const changesTab = page.locator('[data-rail-tab="changes"]');
     await expect(changesTab).toContainText("99+");
   });
 });

--- a/apps/web/e2e/right-panel-terminal-autostart.spec.ts
+++ b/apps/web/e2e/right-panel-terminal-autostart.spec.ts
@@ -89,7 +89,8 @@ async function openPanelOnScope(page: Page): Promise<void> {
           }
         ).getState();
         api.showRightPanel(wid, tid);
-        api.setRightPanelTab(wid, "tasks");
+        // Leave the panel on its empty-state card grid so the Terminal can be
+        // opened through the real create surface.
       }
     },
     { workspace: WORKSPACE, thread: THREAD, tid: THREAD.id, wid: WORKSPACE.id },
@@ -125,7 +126,7 @@ test.describe("Right panel terminal auto-start", () => {
     // No terminals before the tab is opened.
     expect(await terminalCount(page, THREAD.id)).toBe(0);
 
-    await page.getByRole("button", { name: "Terminal", exact: true }).click();
+    await page.getByTestId("panel-card-terminal").click();
 
     // Opening the tab spawns one without the user clicking "New terminal".
     await expect.poll(() => terminalCount(page, THREAD.id), { timeout: 5_000 }).toBe(1);

--- a/apps/web/e2e/right-panel-terminal-threadless.spec.ts
+++ b/apps/web/e2e/right-panel-terminal-threadless.spec.ts
@@ -67,9 +67,9 @@ async function openThreadlessPanel(page: Page): Promise<void> {
             };
           }
         ).getState();
-        // No thread id → threadless workspace visibility.
+        // No thread id → threadless workspace visibility. Leave the panel on
+        // its empty-state card grid so the Terminal opens via the create surface.
         api.showRightPanel(wid);
-        api.setRightPanelTab(wid, "tasks");
       }
     },
     { workspace: WORKSPACE, wid: WORKSPACE.id },
@@ -107,7 +107,7 @@ test.describe("Right panel threadless terminal", () => {
     // No terminals exist for the workspace scope before the tab is opened.
     expect(await terminalCount(page, WORKSPACE.id)).toBe(0);
 
-    await page.getByRole("button", { name: "Terminal", exact: true }).click();
+    await page.getByTestId("panel-card-terminal").click();
 
     // The shell is keyed by the workspace id (the threadless scope), not a thread.
     await expect.poll(() => terminalCount(page, WORKSPACE.id), { timeout: 5_000 }).toBe(1);

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -155,6 +155,57 @@ describe("diffStore", () => {
     });
   });
 
+  describe("closeRightPanelTab", () => {
+    it("removes a tab from the open set", () => {
+      const { setRightPanelTab, closeRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "preview");
+      setRightPanelTab("ws-1", "terminal");
+      closeRightPanelTab("ws-1", "preview");
+      expect(getRightPanel("ws-1").openTabs).toEqual(["terminal"]);
+    });
+
+    it("moves focus to the most-recently-opened survivor when the active tab closes", () => {
+      const { setRightPanelTab, closeRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "preview");
+      setRightPanelTab("ws-1", "terminal"); // terminal is active
+      closeRightPanelTab("ws-1", "terminal");
+      expect(getRightPanel("ws-1").openTabs).toEqual(["preview"]);
+      expect(getRightPanel("ws-1").activeTab).toBe("preview");
+    });
+
+    it("leaves the active tab unchanged when closing an inactive tab", () => {
+      const { setRightPanelTab, closeRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "preview");
+      setRightPanelTab("ws-1", "terminal"); // terminal is active
+      closeRightPanelTab("ws-1", "preview");
+      expect(getRightPanel("ws-1").activeTab).toBe("terminal");
+    });
+
+    it("empties the open set when the last tab closes (returns to card grid)", () => {
+      const { setRightPanelTab, closeRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "preview");
+      closeRightPanelTab("ws-1", "preview");
+      expect(getRightPanel("ws-1").openTabs).toEqual([]);
+    });
+
+    it("is a no-op when the tab is not open", () => {
+      const { setRightPanelTab, closeRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "preview");
+      closeRightPanelTab("ws-1", "terminal");
+      expect(getRightPanel("ws-1").openTabs).toEqual(["preview"]);
+      expect(getRightPanel("ws-1").activeTab).toBe("preview");
+    });
+
+    it("affects only the target workspace", () => {
+      const { setRightPanelTab, closeRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "preview");
+      setRightPanelTab("ws-2", "preview");
+      closeRightPanelTab("ws-1", "preview");
+      expect(getRightPanel("ws-1").openTabs).toEqual([]);
+      expect(getRightPanel("ws-2").openTabs).toEqual(["preview"]);
+    });
+  });
+
   // The panel is workspace-global: its open state must survive having no thread
   // active (e.g. the threadless workspace shell) and persist across navigation.
   describe("workspace-global persistence", () => {

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -1,0 +1,344 @@
+import { Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Kbd } from "@/components/palette/Kbd";
+import { getKeybindingForCommand, formatKeybinding } from "@/lib/keybinding-manager";
+import { isMac } from "@/lib/platform";
+import {
+  PANEL_TAB_TYPES,
+  shownTabTypes,
+  creatableTypes,
+  type PanelScope,
+  type PanelTabType,
+} from "@/lib/panel-tabs";
+import type { RightPanelTab } from "@/stores/diffStore";
+import { cn } from "@/lib/utils";
+
+/** Aggregate task completion across a thread's parent tasks (Scope glance). */
+export interface ScopeProgress {
+  readonly done: number;
+  readonly total: number;
+}
+
+/** Past this many changed files the Review badge renders "{cap}+" instead of the exact count. */
+const CHANGES_COUNT_CAP = 99;
+
+/** Catalog metadata (product label + icon) for an openable tab, by store id. */
+function metaForTab(id: RightPanelTab): PanelTabType | undefined {
+  return PANEL_TAB_TYPES.find((t) => t.id === id);
+}
+
+/** The mcode keycap for a tab type, or null when it has no binding. */
+function tabKeycap(type: PanelTabType): string | null {
+  if (!type.commandId) return null;
+  const binding = getKeybindingForCommand(type.commandId);
+  return binding ? formatKeybinding(binding.key, isMac) : null;
+}
+
+/**
+ * Accessible name for a rail icon, carrying its glance status as text so screen
+ * readers get the signal sighted users read from the count and the freshness
+ * color. The visible rail glyph is icon-only, so this is the tab's only name.
+ */
+function railAccessibleLabel(
+  id: RightPanelTab,
+  label: string,
+  scope: ScopeProgress,
+  changesCount: number,
+  changesFresh: boolean,
+): string {
+  if (id === "tasks") {
+    return scope.total > 0 ? `${label}, ${scope.done} of ${scope.total} tasks done` : label;
+  }
+  if (id === "changes") {
+    if (changesCount === 0) return label;
+    const files = `${changesCount} ${changesCount === 1 ? "file" : "files"} changed`;
+    return `${label}, ${files}${changesFresh ? ", new since last viewed" : ""}`;
+  }
+  return label;
+}
+
+/**
+ * Compact glance status under a rail icon: Scope task progress and the Review
+ * file count. Returns null for tabs with nothing to report so a calm icon stays
+ * a bare glyph. Mirrors the One Lamp Rule — the active icon tints amber while
+ * its status text stays legible.
+ */
+function RailStatus({
+  id,
+  active,
+  scope,
+  changesCount,
+  changesFresh,
+}: {
+  id: RightPanelTab;
+  active: boolean;
+  scope: ScopeProgress;
+  changesCount: number;
+  changesFresh: boolean;
+}) {
+  if (id === "tasks") {
+    if (scope.total === 0) return null;
+    const complete = scope.done === scope.total;
+    return (
+      <span
+        className={cn(
+          "font-mono text-[9px] font-medium leading-none tabular-nums",
+          complete
+            ? "text-[var(--diff-add-strong)]"
+            : active
+              ? "text-current"
+              : "text-muted-foreground",
+        )}
+      >
+        {scope.done}/{scope.total}
+      </span>
+    );
+  }
+  if (id === "changes") {
+    if (changesCount === 0) return null;
+    const label = changesCount > CHANGES_COUNT_CAP ? `${CHANGES_COUNT_CAP}+` : String(changesCount);
+    return (
+      <span
+        className={cn(
+          "font-mono text-[9px] font-medium leading-none tabular-nums",
+          changesFresh
+            ? "changes-fresh-ring text-primary"
+            : active
+              ? "text-current"
+              : "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+    );
+  }
+  return null;
+}
+
+/** One rail entry: a select glyph with an active lamp, plus a hover-revealed × to close. */
+function RailTab({
+  id,
+  active,
+  scope,
+  changesCount,
+  changesFresh,
+  onSelect,
+  onClose,
+}: {
+  id: RightPanelTab;
+  active: boolean;
+  scope: ScopeProgress;
+  changesCount: number;
+  changesFresh: boolean;
+  onSelect: (id: RightPanelTab) => void;
+  onClose: (id: RightPanelTab) => void;
+}) {
+  const meta = metaForTab(id);
+  if (!meta) return null;
+  const Icon = meta.icon;
+  const label = meta.label;
+  return (
+    <div className="group relative">
+      <button
+        type="button"
+        data-rail-tab={id}
+        data-active={active ? "true" : undefined}
+        aria-pressed={active}
+        aria-label={railAccessibleLabel(id, label, scope, changesCount, changesFresh)}
+        title={label}
+        onClick={() => onSelect(id)}
+        className={cn(
+          "flex min-h-9 w-9 flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors",
+          active
+            ? "bg-card text-primary"
+            : "text-foreground/70 hover:bg-card/60 hover:text-foreground",
+        )}
+      >
+        <Icon size={17} />
+        <RailStatus
+          id={id}
+          active={active}
+          scope={scope}
+          changesCount={changesCount}
+          changesFresh={changesFresh}
+        />
+      </button>
+      {/* Active lamp: a short amber bar on the rail's inner edge. */}
+      {active && (
+        <span
+          data-testid="rail-active-indicator"
+          aria-hidden
+          className="pointer-events-none absolute -left-1.5 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-r-full bg-primary"
+        />
+      )}
+      {/* Hover/focus-revealed close. A sibling button (not nested) so the markup
+          stays valid and the × is its own focusable, announced control. */}
+      <button
+        type="button"
+        aria-label={`Close ${label}`}
+        title={`Close ${label}`}
+        onClick={() => onClose(id)}
+        className={cn(
+          "absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-background text-muted-foreground opacity-0 ring-1 ring-border transition",
+          "hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100",
+        )}
+      >
+        <X size={10} />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The dynamic add control: hidden when nothing is creatable, opens the one
+ * creatable type directly when exactly one remains, otherwise a menu of the
+ * shown set (the same set the empty-state grid presents — coming-soon teasers
+ * disabled). Only rendered when at least one tab is already open; the empty
+ * state's card grid is its own create surface (ADR-0004, issue #611).
+ */
+function RailAddControl({
+  scope,
+  openTabs,
+  onCreate,
+}: {
+  scope: PanelScope;
+  openTabs: readonly RightPanelTab[];
+  onCreate: (id: RightPanelTab) => void;
+}) {
+  const shown = shownTabTypes(scope, openTabs);
+  const creatable = creatableTypes(scope, openTabs);
+
+  // Nothing openable hides the control entirely, even if a coming-soon teaser remains.
+  if (creatable.length === 0) return null;
+
+  // Exactly one creatable type opens directly — no pointless menu.
+  if (creatable.length === 1) {
+    const only = creatable[0];
+    return (
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        className="h-9 w-9 text-muted-foreground hover:text-foreground"
+        title={`New ${only.label}`}
+        aria-label={`New ${only.label}`}
+        onClick={() => onCreate(only.id as RightPanelTab)}
+      >
+        <Plus size={16} />
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="h-9 w-9 text-muted-foreground hover:text-foreground"
+            title="New tab"
+            aria-label="New tab"
+          >
+            <Plus size={16} />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="start" sideOffset={6} className="min-w-[184px]">
+        {shown.map((type) => {
+          const keycap = tabKeycap(type);
+          return (
+            <DropdownMenuItem
+              key={type.id}
+              disabled={type.comingSoon}
+              onClick={type.comingSoon ? undefined : () => onCreate(type.id as RightPanelTab)}
+              className="flex items-center justify-between gap-3 px-2.5 py-1.5 text-xs"
+            >
+              <span className="flex items-center gap-2">
+                <type.icon size={14} className="text-muted-foreground" />
+                {type.label}
+              </span>
+              {type.comingSoon ? (
+                <span className="rounded bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Soon
+                </span>
+              ) : (
+                keycap && <Kbd>{keycap}</Kbd>
+              )}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/**
+ * Vertical activity rail that navigates the right panel's open singleton tabs.
+ * Each open tab is an icon with an active-tab lamp; hovering an icon reveals an
+ * × that closes it. An add control offers the creatable set (one opens directly,
+ * several show a menu, none hides it). The panel's close-chrome lives at the
+ * foot of the rail so it stays reachable in every state. See ADR-0004 / issue #611.
+ */
+export function ActivityRail({
+  openTabs,
+  activeTab,
+  scope,
+  scopeProgress,
+  changesCount,
+  changesFresh,
+  onSelect,
+  onClose,
+  onCreate,
+  onClosePanel,
+}: {
+  readonly openTabs: readonly RightPanelTab[];
+  readonly activeTab: RightPanelTab;
+  readonly scope: PanelScope;
+  readonly scopeProgress: ScopeProgress;
+  readonly changesCount: number;
+  readonly changesFresh: boolean;
+  onSelect: (id: RightPanelTab) => void;
+  onClose: (id: RightPanelTab) => void;
+  onCreate: (id: RightPanelTab) => void;
+  onClosePanel: () => void;
+}) {
+  return (
+    <div
+      data-testid="activity-rail"
+      className="flex w-12 flex-none flex-col items-center gap-1 border-r border-border/40 py-2"
+    >
+      {openTabs.map((id) => (
+        <RailTab
+          key={id}
+          id={id}
+          active={id === activeTab}
+          scope={scopeProgress}
+          changesCount={changesCount}
+          changesFresh={changesFresh}
+          onSelect={onSelect}
+          onClose={onClose}
+        />
+      ))}
+      {/* The add control only appears once a tab is open; with none open the
+          empty-state card grid is the create surface. */}
+      {openTabs.length > 0 && (
+        <RailAddControl scope={scope} openTabs={openTabs} onCreate={onCreate} />
+      )}
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        onClick={onClosePanel}
+        className="mt-auto h-7 w-7 text-muted-foreground/70 transition-colors hover:bg-transparent hover:text-foreground"
+        aria-label="Close panel"
+      >
+        <X size={13} />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -1,8 +1,5 @@
-import type { LucideIcon } from "lucide-react";
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { ListChecks, Diff, Globe, Terminal, X } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTaskStore } from "@/stores/taskStore";
 import {
@@ -15,6 +12,7 @@ import {
 } from "@/stores/diffStore";
 import { ScopeSplitPane } from "./ScopeSplitPane";
 import { PanelEmptyState } from "./PanelEmptyState";
+import { ActivityRail, type ScopeProgress } from "./ActivityRail";
 import type { PanelScope } from "@/lib/panel-tabs";
 import { DiffPanel } from "@/components/diff";
 import { PreviewPanel } from "@/components/panels/PreviewPanel";
@@ -23,37 +21,6 @@ import { TerminalPoolSlot } from "@/components/terminal/TerminalPoolSlotContext"
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { ensureTerminalForScope } from "@/lib/ensure-terminal";
 import { cn } from "@/lib/utils";
-
-/** Static definition of a right-panel tab: id, label, and icon. */
-interface TabDef {
-  readonly id: RightPanelTab;
-  readonly label: string;
-  readonly icon: LucideIcon;
-}
-
-/** The four right-panel tabs, in display order. */
-const TABS: readonly TabDef[] = [
-  { id: "tasks", label: "Scope", icon: ListChecks },
-  { id: "changes", label: "Changes", icon: Diff },
-  { id: "preview", label: "Preview", icon: Globe },
-  { id: "terminal", label: "Terminal", icon: Terminal },
-];
-
-/**
- * Below this rendered panel width (px) the tab strip drops inactive labels to
- * icon-only so four tabs plus their status never crowd at the 384px floor. The
- * active tab keeps its label; every tab keeps its status glyph.
- */
-const COMPACT_TAB_WIDTH = 440;
-
-/**
- * Past this many changed files the Changes badge renders "{cap}+" instead of
- * the exact number. The glance only needs "a lot"; an exact 3-4 digit count
- * adds width without information and would grow the tab on large diffs. Only
- * the rendered label is capped — the underlying count stays exact so freshness
- * detection still registers further growth above the cap.
- */
-const CHANGES_COUNT_CAP = 99;
 
 /**
  * Tracks whether the Changes tab has unreviewed new files for the active
@@ -89,94 +56,7 @@ function useChangesFreshness(
   return fresh;
 }
 
-/** Aggregate task completion across a thread's parent tasks. */
-interface ScopeProgress {
-  readonly done: number;
-  readonly total: number;
-}
-
-/**
- * Per-tab glance status rendered beside the label: Scope task progress and the
- * Changes file count. Returns null for tabs with nothing to report so a calm
- * tab stays a bare label. Terminal and Preview carry no status yet (their
- * running/errored state is not surfaced per-thread).
- */
-function TabStatus({
-  tab,
-  active,
-  scope,
-  changesCount,
-  changesFresh,
-}: {
-  tab: RightPanelTab;
-  active: boolean;
-  scope: ScopeProgress;
-  changesCount: number;
-  changesFresh: boolean;
-}) {
-  if (tab === "tasks") {
-    if (scope.total === 0) return null;
-    const complete = scope.done === scope.total;
-    return (
-      <span
-        className={cn(
-          "font-mono text-[10px] font-medium tabular-nums tracking-normal",
-          complete
-            ? "text-[var(--diff-add-strong)]"
-            : active
-              ? "text-current"
-              : "text-muted-foreground",
-        )}
-      >
-        {scope.done}/{scope.total}
-      </span>
-    );
-  }
-  if (tab === "changes") {
-    if (changesCount === 0) return null;
-    const label = changesCount > CHANGES_COUNT_CAP ? `${CHANGES_COUNT_CAP}+` : String(changesCount);
-    return (
-      <span
-        className={cn(
-          "font-mono text-[10px] font-medium tabular-nums tracking-normal",
-          changesFresh
-            ? "changes-fresh-ring text-primary"
-            : active
-              ? "text-current"
-              : "text-muted-foreground",
-        )}
-      >
-        {label}
-      </span>
-    );
-  }
-  return null;
-}
-
-/**
- * Accessible name for a tab, carrying its glance status as text so screen
- * readers get the same signal sighted users read from the count and the amber
- * freshness color. Also keeps the name complete when narrow mode hides the
- * visible label.
- */
-function tabAccessibleLabel(
-  tab: RightPanelTab,
-  scope: ScopeProgress,
-  changesCount: number,
-  changesFresh: boolean,
-): string {
-  if (tab === "tasks") {
-    return scope.total > 0 ? `Scope, ${scope.done} of ${scope.total} tasks done` : "Scope";
-  }
-  if (tab === "changes") {
-    if (changesCount === 0) return "Changes";
-    const files = `${changesCount} ${changesCount === 1 ? "file" : "files"} changed`;
-    return `Changes, ${files}${changesFresh ? ", new since last viewed" : ""}`;
-  }
-  return tab === "preview" ? "Preview" : "Terminal";
-}
-
-/** Right-side panel with tabs for Tasks, Changes, and Preview. */
+/** Right-side panel: a vertical activity rail navigating open singleton tabs. */
 export function RightPanel() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
@@ -242,7 +122,8 @@ export function RightPanel() {
   // Zustand action refs are stable (same identity for the store's lifetime),
   // so destructuring from getState() at render time is safe and avoids
   // adding actions to useCallback/useEffect dependency arrays.
-  const { setRightPanelWidth, setRightPanelTab, hideRightPanel } = useDiffStore.getState();
+  const { setRightPanelWidth, setRightPanelTab, closeRightPanelTab, hideRightPanel } =
+    useDiffStore.getState();
 
   const tasks = useTaskStore(
     (s) => (activeThreadId ? s.tasksByThread[activeThreadId] : undefined),
@@ -295,50 +176,6 @@ export function RightPanel() {
 
   const isChangesActive = panelVisible && changesActive;
   const changesFresh = useChangesFreshness(activeThreadId, changesCount, isChangesActive);
-
-  // Drop inactive tab labels when the rendered panel is narrow. Overlay mode
-  // renders at min(panelWidth, 90vw), so measure against that.
-  const renderedTabWidth = isOverlay
-    ? Math.min(panelWidth, viewportWidth * 0.9)
-    : panelWidth;
-  const compactTabs = renderedTabWidth < COMPACT_TAB_WIDTH;
-
-  // Active-tab underline indicator. Measured imperatively (rather than derived
-  // from layout) so it slides between tabs whose widths vary with their status.
-  const headerRef = useRef<HTMLDivElement>(null);
-  const tablistRef = useRef<HTMLDivElement>(null);
-  const indicatorRef = useRef<HTMLSpanElement>(null);
-  const measureIndicator = useCallback(() => {
-    const header = headerRef.current;
-    const indicator = indicatorRef.current;
-    const active = tablistRef.current?.querySelector<HTMLElement>('[data-tab-active="true"]');
-    if (!header || !indicator) return;
-    // Drive the slide with a GPU-composited transform (translate + scaleX off a
-    // 1px base) rather than animating left/width, so the underline never
-    // triggers layout. scaleX(0) parks it invisibly when there is no target.
-    if (!active) {
-      indicator.style.transform = "scaleX(0)";
-      return;
-    }
-    const headerRect = header.getBoundingClientRect();
-    const activeRect = active.getBoundingClientRect();
-    if (activeRect.width === 0) {
-      indicator.style.transform = "scaleX(0)";
-      return;
-    }
-    const offset = activeRect.left - headerRect.left;
-    indicator.style.transform = `translateX(${offset}px) scaleX(${activeRect.width})`;
-  }, []);
-  useLayoutEffect(() => {
-    measureIndicator();
-  }, [measureIndicator, activeTab, panelVisible, compactTabs, scope, changesCount]);
-  useEffect(() => {
-    const list = tablistRef.current;
-    if (!list || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(() => measureIndicator());
-    ro.observe(list);
-    return () => ro.disconnect();
-  }, [measureIndicator]);
 
   // Anticipate the next step: opening the Terminal tab spawns a shell when the
   // thread has none, so the user lands in a ready terminal instead of an empty
@@ -551,104 +388,68 @@ export function RightPanel() {
         />
       </div>
 
-      {/* Tab header. The active tab is marked by Filament Amber text and a 2px
-          amber underline that slides between tabs (the One Lamp Rule applied to
-          tab selection); each tab carries a glance status beside its label. */}
-      <div ref={headerRef} className="relative flex-none border-b border-border/40">
-        <div className="flex h-11 items-center justify-between px-3">
-          <div ref={tablistRef} className="flex items-center gap-0.5">
-            {TABS.filter((tab) => openTabs.includes(tab.id)).map((tab) => {
-              const isActive = activeTab === tab.id;
-              const Icon = tab.icon;
-              const showLabel = isActive || !compactTabs;
-              return (
-                <button
-                  key={tab.id}
-                  type="button"
-                  data-tab-active={isActive ? "true" : undefined}
-                  aria-pressed={isActive}
-                  aria-label={tabAccessibleLabel(tab.id, scope, changesCount, changesFresh)}
-                  title={tab.label}
-                  onClick={() => setRightPanelTab(activeWorkspaceId!, tab.id)}
-                  className={cn(
-                    "flex items-center gap-1.5 rounded-md px-2 py-1 font-mono text-[10px] font-semibold tracking-[0.16em] uppercase transition-colors",
-                    isActive ? "text-primary" : "text-foreground/70 hover:text-foreground",
-                  )}
-                >
-                  <Icon size={12} />
-                  {showLabel && <span>{tab.label}</span>}
-                  <TabStatus
-                    tab={tab.id}
-                    active={isActive}
-                    scope={scope}
-                    changesCount={changesCount}
-                    changesFresh={changesFresh}
-                  />
-                </button>
-              );
-            })}
-          </div>
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            onClick={() => {
-              // Blur the close button before triggering the hide so focus is
-              // not inside the panel when aria-hidden applies on re-render.
-              (document.activeElement as HTMLElement | null)?.blur?.();
-              hideRightPanel(activeWorkspaceId!, activeThreadId);
-            }}
-            className="h-5 w-5 text-muted-foreground/70 hover:text-foreground hover:bg-transparent transition-colors duration-150"
-            aria-label="Close panel"
-          >
-            <X size={11} />
-          </Button>
-        </div>
-        <span
-          ref={indicatorRef}
-          data-testid="tab-indicator"
-          aria-hidden
-          className="pointer-events-none absolute bottom-0 left-0 h-0.5 w-px origin-left rounded-full bg-primary transition-transform duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
+      {/* Rail + content. The vertical activity rail navigates open singleton
+          tabs (active lamp + hover-× close + add control) and holds the panel's
+          close-chrome at its foot; the content area renders the active tab, or
+          the card-grid empty state when nothing is open. */}
+      <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
+        <ActivityRail
+          openTabs={openTabs}
+          activeTab={activeTab}
+          scope={panelScope}
+          scopeProgress={scope}
+          changesCount={changesCount}
+          changesFresh={changesFresh}
+          onSelect={(id) => setRightPanelTab(activeWorkspaceId!, id)}
+          onClose={(id) => closeRightPanelTab(activeWorkspaceId!, id)}
+          onCreate={(id) => setRightPanelTab(activeWorkspaceId!, id)}
+          onClosePanel={() => {
+            // Blur the close button before triggering the hide so focus is not
+            // inside the panel when aria-hidden applies on re-render.
+            (document.activeElement as HTMLElement | null)?.blur?.();
+            hideRightPanel(activeWorkspaceId!, activeThreadId);
+          }}
         />
-      </div>
 
-      {/* Tab content — DiffPanel and terminal pool stay mounted (stacked) so
-          turn expand state, loaded diffs, and xterm scroll anchors survive tab
-          and workspace thread switches. With no tab open the panel shows the
-          card-grid empty state, which is itself the create surface. */}
-      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-        {openTabs.length === 0 && (
-          <PanelEmptyState
-            scope={panelScope}
-            openTabs={openTabs}
-            onOpen={(id) => setRightPanelTab(activeWorkspaceId!, id)}
-          />
-        )}
-        {activeTab === "tasks" && openTabs.includes("tasks") && activeThreadId && (
-          <ScopeSplitPane threadId={activeThreadId} parentTasks={parentTasks} />
-        )}
-        <div
-          className={
-            changesActive ? "flex flex-1 flex-col min-h-0" : "hidden"
-          }
-        >
-          <DiffPanel />
-        </div>
-        {previewActive && panelScopeId && (
-          <PreviewPanel threadId={panelScopeId} workspaceId={activeWorkspaceId} />
-        )}
-        <div
-          className={cn(
-            "absolute inset-0 flex min-h-0 flex-row overflow-hidden",
-            !terminalActive && "pointer-events-none z-0 opacity-0",
-            terminalActive && "z-10",
+        {/* Tab content — DiffPanel and terminal pool stay mounted (stacked) so
+            turn expand state, loaded diffs, and xterm scroll anchors survive tab
+            and workspace thread switches. With no tab open the panel shows the
+            card-grid empty state, which is itself the create surface. */}
+        <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          {openTabs.length === 0 && (
+            <PanelEmptyState
+              scope={panelScope}
+              openTabs={openTabs}
+              onOpen={(id) => setRightPanelTab(activeWorkspaceId!, id)}
+            />
           )}
-          aria-hidden={!terminalActive}
-          inert={!terminalActive ? true : undefined}
-        >
-          {terminalActive && panelScopeId && (
-            <TerminalTabContent threadId={panelScopeId} />
+          {activeTab === "tasks" && openTabs.includes("tasks") && activeThreadId && (
+            <ScopeSplitPane threadId={activeThreadId} parentTasks={parentTasks} />
           )}
-          <TerminalPoolSlot className="relative min-h-0 min-w-0 flex-1 overflow-hidden p-2" />
+          <div
+            className={
+              changesActive ? "flex flex-1 flex-col min-h-0" : "hidden"
+            }
+          >
+            <DiffPanel />
+          </div>
+          {previewActive && panelScopeId && (
+            <PreviewPanel threadId={panelScopeId} workspaceId={activeWorkspaceId} />
+          )}
+          <div
+            className={cn(
+              "absolute inset-0 flex min-h-0 flex-row overflow-hidden",
+              !terminalActive && "pointer-events-none z-0 opacity-0",
+              terminalActive && "z-10",
+            )}
+            aria-hidden={!terminalActive}
+            inert={!terminalActive ? true : undefined}
+          >
+            {terminalActive && panelScopeId && (
+              <TerminalTabContent threadId={panelScopeId} />
+            )}
+            <TerminalPoolSlot className="relative min-h-0 min-w-0 flex-1 overflow-hidden p-2" />
+          </div>
         </div>
       </div>
       </div>

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -8,7 +8,6 @@ import {
   PANEL_WIDE_WIDTH,
   createDefaultRightPanelState,
   getDefaultPanelWidthPx,
-  type RightPanelTab,
 } from "@/stores/diffStore";
 import { ScopeSplitPane } from "./ScopeSplitPane";
 import { PanelEmptyState } from "./PanelEmptyState";

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -194,6 +194,13 @@ interface DiffState {
   hideRightPanel: (workspaceId: string, threadId?: string | null) => void;
   setRightPanelWidth: (workspaceId: string, width: number) => void;
   setRightPanelTab: (workspaceId: string, tab: RightPanelTab) => void;
+  /**
+   * Close (remove) a singleton tab from the open set. When the closed tab was
+   * active, focus falls back to the most-recently-opened remaining tab; with
+   * none left the panel returns to the card-grid empty state. No-op when the tab
+   * is not open. See ADR-0004.
+   */
+  closeRightPanelTab: (workspaceId: string, tab: RightPanelTab) => void;
   setViewMode: (mode: DiffViewMode) => void;
   setRenderMode: (mode: DiffRenderMode) => void;
   getLineWrap: (threadId: string) => boolean;
@@ -284,6 +291,27 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         rightPanelByWorkspace: {
           ...state.rightPanelByWorkspace,
           [workspaceId]: { ...current, openTabs, activeTab: tab },
+        },
+      };
+    }),
+
+  closeRightPanelTab: (workspaceId, tab) =>
+    set((state) => {
+      const current = state.rightPanelByWorkspace[workspaceId] ?? createDefaultRightPanelState();
+      if (!current.openTabs.includes(tab)) return {};
+      const openTabs = current.openTabs.filter((t) => t !== tab);
+      // Closing the active tab hands focus to the most-recently-opened survivor
+      // (the rail's right-most/last entry); with none left, activeTab is left
+      // untouched and inert — the empty-state grid renders and the panel's
+      // content guards on openTabs.includes(activeTab).
+      const activeTab =
+        current.activeTab === tab
+          ? (openTabs[openTabs.length - 1] ?? current.activeTab)
+          : current.activeTab;
+      return {
+        rightPanelByWorkspace: {
+          ...state.rightPanelByWorkspace,
+          [workspaceId]: { ...current, openTabs, activeTab },
         },
       };
     }),


### PR DESCRIPTION
## What

Replace the right panel's horizontal tab strip with a vertical activity rail. Open singleton tabs render as icons with an active-tab lamp, a hover-revealed close control, and a dynamic add control.

## Why

The horizontal strip did not scale with the per-scope tab model introduced in #610/#630. A vertical rail gives each open tab a stable glanceable slot (Scope progress, Review file count, freshness pulse) and a consistent create surface, satisfying the acceptance criteria in #611.

## Key Changes

- `ActivityRail` component: icon-per-tab with amber active lamp, accessible glance status, and a sibling hover/focus close button (valid, announced markup).
- Dynamic add control: opens the lone creatable type directly, shows a menu when several remain, hides when none are creatable. Mirrors the empty-state card grid's creatable set.
- New `closeRightPanelTab` store action: refocuses the most-recently-opened survivor when the active tab closes, returns to the card-grid empty state when the last tab closes. Covered by 6 unit tests.
- New `right-panel-activity-rail` e2e spec covering tab switch, hover-close, and all three add-control states.

## Spec migration caveat

The `right-panel-tab-status`, `right-panel-terminal-autostart`, and `right-panel-terminal-threadless` specs were already stale after #610 removed the old top-strip tabs. They are migrated here onto the rail (`data-rail-tab`) and card-grid (`panel-card-*`) create surfaces. Reviewer may want to confirm this migration aligns with conventions.

## Verification

- Typecheck + lint: pass.
- Unit tests: 1556 pass. The 2 `PlanDocument` failures under the full parallel gate are a known load flake; they pass 2/2 in isolation (confirmed).
- E2E: 11/11 affected specs pass.

Closes #611

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783635240&installation_id=129163861&pr_number=631&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F631&signature=86acb1951d578976a28311a18cae875d88d8b16a25057cb466f3decc46f394f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vertical activity rail for the right panel with icon buttons, active indicators, hover-close controls, scope progress and change counts, and a footer "Close panel" action
  * Dynamic "New" control: hidden when nothing creatable, single-action when one type, or a menu when multiple types (with disabled coming-soon items)
  * Terminal can be opened from the creation surface

* **Bug Fixes**
  * Closing a tab moves focus to the most-recently-opened remaining tab or returns to empty state

* **Tests**
  * Added/updated end-to-end and unit tests covering rail interactions, tab lifecycle, status indicators, and creation flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->