### PR TITLE
feat(panel): summon shortcuts for right-panel tabs

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -18,6 +18,7 @@ import { usePreviewDockStore } from "@/stores/previewDockStore";
 import { usePreviewFocusStore } from "@/stores/previewFocusStore";
 import { useUiStore } from "@/stores/uiStore";
 import { initShortcuts } from "@/lib/shortcuts";
+import { summonTab } from "@/lib/summon-tab";
 import { registerCommand } from "@/lib/command-registry";
 import { setContext } from "@/lib/context-tracker";
 import { startPushListeners, stopPushListeners } from "@/transport/ws-events";
@@ -209,29 +210,9 @@ export function App() {
         id: "terminal.toggle",
         title: "Toggle Terminal",
         category: "View",
-        handler: () => {
-          const { activeWorkspaceId: wid, activeThreadId: tid } =
-            useWorkspaceStore.getState();
-          if (!wid) return;
-          const {
-            getRightPanel,
-            getRightPanelVisible,
-            showRightPanel,
-            setRightPanelTab,
-            hideRightPanel,
-          } = useDiffStore.getState();
-          const panel = getRightPanel(wid);
-          if (!getRightPanelVisible(wid, tid)) {
-            showRightPanel(wid, tid);
-            setRightPanelTab(wid, "terminal");
-          } else if (panel.activeTab !== "terminal") {
-            setRightPanelTab(wid, "terminal");
-          } else {
-            hideRightPanel(wid, tid);
-          }
-          // Terminal creation on open is handled by RightPanel's
-          // ensureTerminalForScope effect (fires for every open path).
-        },
+        // Terminal creation on open is handled by RightPanel's
+        // ensureTerminalForScope effect (fires for every open path).
+        handler: () => summonTab("terminal"),
       }),
       registerCommand({
         id: "settings.open",
@@ -258,83 +239,25 @@ export function App() {
         id: "tasks.toggle",
         title: "Toggle Scope Panel",
         category: "View",
-        handler: () => {
-          const { activeWorkspaceId: wid, activeThreadId: tid } =
-            useWorkspaceStore.getState();
-          if (!wid) return;
-          const {
-            getRightPanel,
-            getRightPanelVisible,
-            showRightPanel,
-            setRightPanelTab,
-            hideRightPanel,
-          } = useDiffStore.getState();
-          const panel = getRightPanel(wid);
-          if (!getRightPanelVisible(wid, tid)) {
-            showRightPanel(wid, tid);
-            setRightPanelTab(wid, "tasks");
-          } else if (panel.activeTab !== "tasks") {
-            setRightPanelTab(wid, "tasks");
-          } else {
-            hideRightPanel(wid, tid);
-          }
-        },
+        // Scope is thread-only; summonTab no-ops when there is no thread.
+        handler: () => summonTab("tasks"),
       }),
       registerCommand({
         id: "changes.toggle",
         title: "Toggle Changes Panel",
         category: "View",
-        handler: () => {
-          const { activeWorkspaceId: wid, activeThreadId: tid } =
-            useWorkspaceStore.getState();
-          if (!wid) return;
-          const {
-            getRightPanel,
-            getRightPanelVisible,
-            showRightPanel,
-            setRightPanelTab,
-            hideRightPanel,
-          } = useDiffStore.getState();
-          const panel = getRightPanel(wid);
-          if (!getRightPanelVisible(wid, tid)) {
-            showRightPanel(wid, tid);
-            setRightPanelTab(wid, "changes");
-          } else if (panel.activeTab !== "changes") {
-            setRightPanelTab(wid, "changes");
-          } else {
-            hideRightPanel(wid, tid);
-          }
-        },
+        handler: () => summonTab("changes"),
       }),
       registerCommand({
         id: "preview.toggle",
         title: "Toggle Preview Panel",
         category: "View",
-        handler: () => {
-          const { activeWorkspaceId: wid, activeThreadId: tid } =
-            useWorkspaceStore.getState();
-          if (!wid) return;
-          const {
-            getRightPanel,
-            getRightPanelVisible,
-            showRightPanel,
-            setRightPanelTab,
-            hideRightPanel,
-          } = useDiffStore.getState();
-          const panel = getRightPanel(wid);
-          if (!getRightPanelVisible(wid, tid)) {
-            showRightPanel(wid, tid);
-            setRightPanelTab(wid, "preview");
-            // Pull focus into the URL field so the user can type a URL
-            // immediately after opening the preview by shortcut.
-            usePreviewFocusStore.getState().requestOmniboxFocus();
-          } else if (panel.activeTab !== "preview") {
-            setRightPanelTab(wid, "preview");
-            usePreviewFocusStore.getState().requestOmniboxFocus();
-          } else {
-            hideRightPanel(wid, tid);
-          }
-        },
+        // Pull focus into the URL field on open/refocus so the user can type a
+        // URL immediately after summoning the Browser by shortcut.
+        handler: () =>
+          summonTab("preview", () =>
+            usePreviewFocusStore.getState().requestOmniboxFocus(),
+          ),
       }),
       registerCommand({
         id: "preview.devDock.toggle",

--- a/apps/web/src/lib/__tests__/summon-tab.test.ts
+++ b/apps/web/src/lib/__tests__/summon-tab.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { summonTab } from "@/lib/summon-tab";
+import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+const WID = "ws-1";
+const TID = "thread-1";
+
+/** Read the effective panel state for the test workspace. */
+function panel() {
+  const s = useDiffStore.getState();
+  return {
+    visible: s.getRightPanelVisible(WID, useWorkspaceStore.getState().activeThreadId),
+    activeTab: s.getRightPanel(WID).activeTab,
+    openTabs: s.getRightPanel(WID).openTabs,
+  };
+}
+
+describe("summonTab", () => {
+  beforeEach(() => {
+    useDiffStore.setState({
+      rightPanelByWorkspace: {},
+      rightPanelVisibleByThread: {},
+    });
+    useWorkspaceStore.setState({ activeWorkspaceId: WID, activeThreadId: TID });
+  });
+
+  describe("create-or-focus", () => {
+    it("opens the panel and focuses the tab when the panel is closed", () => {
+      expect(panel().visible).toBe(false);
+
+      summonTab("preview");
+
+      expect(panel().visible).toBe(true);
+      expect(panel().activeTab).toBe("preview");
+      expect(panel().openTabs).toContain("preview");
+    });
+
+    it("creates the tab if absent (adds it to the open set)", () => {
+      summonTab("preview");
+      expect(panel().openTabs).toEqual(["preview"]);
+
+      summonTab("terminal");
+      // preview stays open; terminal is created and focused.
+      expect(panel().openTabs).toEqual(["preview", "terminal"]);
+      expect(panel().activeTab).toBe("terminal");
+    });
+
+    it("focuses an open-but-inactive tab without hiding the panel", () => {
+      summonTab("preview");
+      summonTab("terminal");
+      expect(panel().activeTab).toBe("terminal");
+
+      summonTab("preview");
+
+      expect(panel().visible).toBe(true);
+      expect(panel().activeTab).toBe("preview");
+      // No tab was closed — both remain open.
+      expect(panel().openTabs).toEqual(["preview", "terminal"]);
+    });
+  });
+
+  describe("hide-when-active", () => {
+    it("hides the panel when its shortcut targets the already-active tab", () => {
+      summonTab("preview");
+      expect(panel().visible).toBe(true);
+      expect(panel().activeTab).toBe("preview");
+
+      summonTab("preview");
+
+      expect(panel().visible).toBe(false);
+      // The tab stays open so re-summoning restores it; only visibility toggled.
+      expect(panel().openTabs).toContain("preview");
+    });
+
+    it("re-summoning after hide re-opens to the same tab", () => {
+      summonTab("preview");
+      summonTab("preview"); // hide
+      expect(panel().visible).toBe(false);
+
+      summonTab("preview"); // re-open
+
+      expect(panel().visible).toBe(true);
+      expect(panel().activeTab).toBe("preview");
+    });
+  });
+
+  describe("Scope no-op when threadless", () => {
+    beforeEach(() => {
+      useWorkspaceStore.setState({ activeWorkspaceId: WID, activeThreadId: null });
+    });
+
+    it("does nothing when summoning Scope with no thread", () => {
+      summonTab("tasks");
+
+      expect(panel().visible).toBe(false);
+      expect(panel().openTabs).toEqual([]);
+    });
+
+    it("still summons a workspace-global tab (Browser) with no thread", () => {
+      summonTab("preview");
+
+      expect(panel().visible).toBe(true);
+      expect(panel().activeTab).toBe("preview");
+    });
+
+    it("summons Scope once a thread exists", () => {
+      useWorkspaceStore.setState({ activeThreadId: TID });
+
+      summonTab("tasks");
+
+      expect(panel().visible).toBe(true);
+      expect(panel().activeTab).toBe("tasks");
+    });
+  });
+
+  describe("guards and side effects", () => {
+    it("no-ops when there is no active workspace", () => {
+      useWorkspaceStore.setState({ activeWorkspaceId: null, activeThreadId: null });
+
+      summonTab("preview");
+
+      expect(useDiffStore.getState().rightPanelByWorkspace).toEqual({});
+    });
+
+    it("runs onFocus on open and refocus, but not on hide", () => {
+      const onFocus = vi.fn();
+
+      summonTab("preview", onFocus); // open
+      expect(onFocus).toHaveBeenCalledTimes(1);
+
+      summonTab("terminal");
+      summonTab("preview", onFocus); // refocus
+      expect(onFocus).toHaveBeenCalledTimes(2);
+
+      summonTab("preview", onFocus); // hide
+      expect(onFocus).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/src/lib/summon-tab.ts
+++ b/apps/web/src/lib/summon-tab.ts
@@ -1,0 +1,50 @@
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useDiffStore, type RightPanelTab } from "@/stores/diffStore";
+import { PANEL_TAB_TYPES } from "@/lib/panel-tabs";
+
+/** Whether a tab type only makes sense once a thread exists (Scope, and Review until it goes dual-scope). */
+function tabNeedsThread(tab: RightPanelTab): boolean {
+  return PANEL_TAB_TYPES.find((type) => type.id === tab)?.needsThread ?? false;
+}
+
+/**
+ * Summon a right-panel tab from a keyboard shortcut: create-or-focus the tab
+ * (opening the panel if it is closed), refocus it if it is open but inactive,
+ * and hide the panel if it is already the active tab. One key thus toggles its
+ * surface. See ADR-0004 and issue #612.
+ *
+ * Thread-only tabs (Scope, and Review until it goes dual-scope) have nothing to
+ * show against the workspace root, so their shortcut is inert when no thread is
+ * active — this mirrors the availability model, which drops `needsThread` tab
+ * types from the threadless creatable set.
+ *
+ * @param tab The panel tab type to summon.
+ * @param onFocus Optional side effect run whenever the tab gains focus (open or
+ *   refocus paths, not the hide path). The Browser tab uses this to pull focus
+ *   into its URL field.
+ */
+export function summonTab(tab: RightPanelTab, onFocus?: () => void): void {
+  const { activeWorkspaceId: wid, activeThreadId: tid } = useWorkspaceStore.getState();
+  if (!wid) return;
+  if (tabNeedsThread(tab) && !tid) return;
+
+  const {
+    getRightPanel,
+    getRightPanelVisible,
+    showRightPanel,
+    setRightPanelTab,
+    hideRightPanel,
+  } = useDiffStore.getState();
+  const panel = getRightPanel(wid);
+
+  if (!getRightPanelVisible(wid, tid)) {
+    showRightPanel(wid, tid);
+    setRightPanelTab(wid, tab);
+    onFocus?.();
+  } else if (panel.activeTab !== tab) {
+    setRightPanelTab(wid, tab);
+    onFocus?.();
+  } else {
+    hideRightPanel(wid, tid);
+  }
+}


### PR DESCRIPTION
## What

Each right-panel tab's keyboard shortcut now "summons" its tab: it creates-or-focuses the tab (opening the panel if closed), refocuses it if open but inactive, and hides the panel if the tab is already active. The Scope shortcut no-ops when no thread is active.

## Why

The four tab-toggle command handlers in `App.tsx` each inlined the same create-or-focus / hide-when-active logic, with no shared coverage. Issue #612 asks for consistent summon semantics across all tab shortcuts and a thread guard for Scope. Extracting the logic into one helper removes the duplication and makes the behavior unit-testable.

## Key Changes

- Add `apps/web/src/lib/summon-tab.ts` exporting `summonTab(tab, onFocus?)`, which encapsulates the create-or-focus / hide-when-active flow and gates thread-only tabs (Scope, Review) on an active thread via the panel-tab catalog's `needsThread` flag.
- Refactor the `terminal`, `tasks`, `changes`, and `preview` toggle handlers in `App.tsx` to delegate to `summonTab`, removing ~90 lines of duplicated logic. The Browser handler passes an `onFocus` callback to keep its omnibox-focus behavior.
- Add `apps/web/src/lib/__tests__/summon-tab.test.ts` with 10 tests covering create-or-focus, hide-when-active, the threadless Scope no-op, and the no-workspace guard.

## Acceptance criteria

- [x] A tab shortcut creates-or-focuses its tab, opening the panel if closed
- [x] Pressing the shortcut for the already-active tab hides the panel
- [x] The Scope shortcut does nothing when there is no thread
- [x] The command/shortcut layer is unit-tested for these semantics

## Verification

- Typecheck and lint pass.
- `summon-tab.test.ts`: 10/10 pass.
- Two failures in `PlanDocument.test.tsx` are a pre-existing flake unrelated to this change. Confirmed identical failures on the parent commit (3369d505), and PlanDocument has no import linkage to any changed file.

Closes #612

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783641337&installation_id=129163861&pr_number=632&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F632&signature=6b9b620d48d3d5324fed4567f52ddd36de10cbd8f4ff8d0d390f49b2c9879d75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Right-panel tabs (terminal, tasks, changes, preview) now use a unified mechanism for opening, switching, and toggling visibility.
  * Preview tab toggle now supports optional focus requests.

* **Refactor**
  * Centralized right-panel management logic, reducing duplication in command handlers.

* **Tests**
  * Added comprehensive test coverage for right-panel tab behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->