### PR TITLE
feat(panel): rebind Browser to thread worktree

### DIFF
--- a/apps/server/src/services/__tests__/git-service-working-dir.test.ts
+++ b/apps/server/src/services/__tests__/git-service-working-dir.test.ts
@@ -1,0 +1,55 @@
+import "reflect-metadata";
+import { describe, it, expect } from "vitest";
+import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import { GitService } from "../git-service.js";
+
+/**
+ * resolveWorkingDir decides the cwd a threadless or thread-scoped terminal
+ * spawns in. It needs no repo access, so a bare GitService is enough to
+ * exercise the worktree-vs-root branch the terminal rebind relies on.
+ */
+function makeGitService(): GitService {
+  return new GitService(undefined as unknown as WorkspaceRepo);
+}
+
+describe("GitService.resolveWorkingDir", () => {
+  const WORKSPACE_ROOT = "/repo/main";
+  const WORKTREE = "/repo/worktrees/feature";
+
+  it("uses the workspace root for the threadless shell (no thread mode)", () => {
+    const git = makeGitService();
+    expect(git.resolveWorkingDir(WORKSPACE_ROOT, null, null)).toBe(WORKSPACE_ROOT);
+  });
+
+  it("uses the workspace root for a direct-mode thread", () => {
+    const git = makeGitService();
+    expect(git.resolveWorkingDir(WORKSPACE_ROOT, "direct", null)).toBe(
+      WORKSPACE_ROOT,
+    );
+  });
+
+  it("uses the thread worktree for a worktree-mode thread", () => {
+    const git = makeGitService();
+    expect(git.resolveWorkingDir(WORKSPACE_ROOT, "worktree", WORKTREE)).toBe(
+      WORKTREE,
+    );
+  });
+
+  it("rebinds from workspace root to worktree as a thread becomes active", () => {
+    const git = makeGitService();
+    // Threadless: no thread mode -> workspace root.
+    expect(git.resolveWorkingDir(WORKSPACE_ROOT, null, null)).toBe(WORKSPACE_ROOT);
+    // A worktree thread becomes active -> its worktree. This is the
+    // threadless -> worktree rebind the Terminal tab relies on.
+    expect(git.resolveWorkingDir(WORKSPACE_ROOT, "worktree", WORKTREE)).toBe(
+      WORKTREE,
+    );
+  });
+
+  it("falls back to the workspace root when a worktree thread has no path yet", () => {
+    const git = makeGitService();
+    expect(git.resolveWorkingDir(WORKSPACE_ROOT, "worktree", null)).toBe(
+      WORKSPACE_ROOT,
+    );
+  });
+});

--- a/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
+++ b/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
@@ -24,8 +24,12 @@ vi.mock("@/stores/diffStore", () => ({
 
 vi.mock("@/stores/workspaceStore", () => ({
   useWorkspaceStore: vi.fn(
-    (selector: (s: { workspaces: Array<{ id: string; path: string }> }) => unknown) =>
-      selector({ workspaces: [] }),
+    (
+      selector: (s: {
+        workspaces: Array<{ id: string; path: string }>;
+        threads: Array<{ id: string; mode: string; worktree_path: string | null }>;
+      }) => unknown,
+    ) => selector({ workspaces: [], threads: [] }),
   ),
 }));
 

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -9,6 +9,7 @@ import type { PreviewPageStatus } from "@mcode/contracts";
 import { useDiffStore } from "@/stores/diffStore";
 import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { resolveScopeBasePath } from "@/lib/resolve-scope-path";
 
 const NAV_ERROR_LABEL: Record<string, string> = {
   "no-bounds": "Wait for the panel to finish layout, then try again.",
@@ -98,8 +99,13 @@ export function usePreviewBridge({
   const phaseRef = useRef(pageStatus.phase);
   phaseRef.current = pageStatus.phase;
 
-  const workspacePath = useWorkspaceStore(
-    (s) => s.workspaces.find((w) => w.id === workspaceId)?.path ?? null,
+  // Relative file paths typed in the omnibox resolve against the scope's local
+  // checkout: the workspace root when threadless or a direct thread, the
+  // thread's worktree once a worktree thread is active. `threadId` is the
+  // opaque panel scope (a workspace id threadless, a thread id otherwise), so
+  // the active thread is whichever thread row matches it.
+  const basePath = useWorkspaceStore((s) =>
+    resolveScopeBasePath(threadId, workspaceId, s.threads, s.workspaces),
   );
 
   const storedUrl = useDiffStore(
@@ -310,13 +316,13 @@ export function usePreviewBridge({
       if (!preview) return;
       setInputUrl(url);
       setNavError(null);
-      void preview.navigate(url, workspacePath).then((r) => {
+      void preview.navigate(url, basePath).then((r) => {
         if (!r.ok) setNavError(formatNavError(r.error));
       }).catch(() => {
         setNavError("Navigation failed.");
       });
     },
-    [workspacePath],
+    [basePath],
   );
 
   return {

--- a/apps/web/src/lib/__tests__/resolve-scope-path.test.ts
+++ b/apps/web/src/lib/__tests__/resolve-scope-path.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { resolveScopeBasePath } from "../resolve-scope-path";
+
+const WORKSPACE = { id: "ws-1", path: "/repo/main" };
+const OTHER_WORKSPACE = { id: "ws-2", path: "/repo/other" };
+
+const WORKTREE_THREAD = {
+  id: "thread-wt",
+  mode: "worktree" as const,
+  worktree_path: "/repo/worktrees/feature",
+};
+const DIRECT_THREAD = {
+  id: "thread-direct",
+  mode: "direct" as const,
+  worktree_path: null,
+};
+// A worktree-mode thread whose path has not been populated yet (creation in
+// flight). It must not resolve to a bogus base path.
+const PENDING_WORKTREE_THREAD = {
+  id: "thread-wt-pending",
+  mode: "worktree" as const,
+  worktree_path: null,
+};
+
+describe("resolveScopeBasePath", () => {
+  it("returns the workspace root when the scope is the workspace (threadless)", () => {
+    expect(
+      resolveScopeBasePath("ws-1", "ws-1", [], [WORKSPACE]),
+    ).toBe("/repo/main");
+  });
+
+  it("returns the workspace root for a direct-mode thread", () => {
+    expect(
+      resolveScopeBasePath(
+        "thread-direct",
+        "ws-1",
+        [DIRECT_THREAD],
+        [WORKSPACE],
+      ),
+    ).toBe("/repo/main");
+  });
+
+  it("returns the thread worktree for a worktree-mode thread", () => {
+    expect(
+      resolveScopeBasePath(
+        "thread-wt",
+        "ws-1",
+        [WORKTREE_THREAD],
+        [WORKSPACE],
+      ),
+    ).toBe("/repo/worktrees/feature");
+  });
+
+  it("rebinds from workspace root to worktree when a worktree thread becomes the scope", () => {
+    const threads = [WORKTREE_THREAD];
+    // Threadless: scope is the workspace id -> workspace root.
+    expect(
+      resolveScopeBasePath("ws-1", "ws-1", threads, [WORKSPACE]),
+    ).toBe("/repo/main");
+    // A worktree thread becomes active: same workspace, scope is now the thread
+    // id -> the thread's worktree. This is the threadless -> worktree rebind.
+    expect(
+      resolveScopeBasePath("thread-wt", "ws-1", threads, [WORKSPACE]),
+    ).toBe("/repo/worktrees/feature");
+  });
+
+  it("falls back to the workspace root for a worktree thread with no worktree path yet", () => {
+    expect(
+      resolveScopeBasePath(
+        "thread-wt-pending",
+        "ws-1",
+        [PENDING_WORKTREE_THREAD],
+        [WORKSPACE],
+      ),
+    ).toBe("/repo/main");
+  });
+
+  it("resolves the workspace root from the active workspace id, not the scope id", () => {
+    // A direct thread in ws-2 should resolve against ws-2's root even though
+    // ws-1 is also known.
+    expect(
+      resolveScopeBasePath(
+        "thread-direct-2",
+        "ws-2",
+        [{ id: "thread-direct-2", mode: "direct", worktree_path: null }],
+        [WORKSPACE, OTHER_WORKSPACE],
+      ),
+    ).toBe("/repo/other");
+  });
+
+  it("returns null when the owning workspace is unknown", () => {
+    expect(resolveScopeBasePath("ws-x", "ws-x", [], [WORKSPACE])).toBeNull();
+    expect(resolveScopeBasePath(null, null, [], [WORKSPACE])).toBeNull();
+  });
+});

--- a/apps/web/src/lib/resolve-scope-path.ts
+++ b/apps/web/src/lib/resolve-scope-path.ts
@@ -1,0 +1,45 @@
+/** Minimal shape of a thread row needed to resolve its base path. */
+interface ScopeThread {
+  readonly id: string;
+  readonly mode: "direct" | "worktree";
+  readonly worktree_path: string | null;
+}
+
+/** Minimal shape of a workspace row needed to resolve its base path. */
+interface ScopeWorkspace {
+  readonly id: string;
+  readonly path: string;
+}
+
+/**
+ * Resolve the local filesystem base path a panel tab (Browser/Terminal) runs
+ * against for a given scope.
+ *
+ * Mirrors the server's `GitService.resolveWorkingDir`: a thread in worktree
+ * mode binds to its worktree, while direct threads and the threadless
+ * new-thread view (where the scope is a workspace, not a thread) bind to the
+ * workspace root. This is what lets the Browser and Terminal run against the
+ * workspace root with no thread and rebind to the thread's worktree once one
+ * becomes active.
+ *
+ * @param scopeId - The panel scope id: a thread id when a thread is active, or
+ *   a workspace id for the threadless shell. Null when no scope is resolved.
+ * @param workspaceId - Active workspace id that owns the scope.
+ * @param threads - All known threads in the workspace store.
+ * @param workspaces - All known workspaces in the workspace store.
+ * @returns The absolute base path, or null when the owning workspace is unknown.
+ */
+export function resolveScopeBasePath(
+  scopeId: string | null,
+  workspaceId: string | null | undefined,
+  threads: readonly ScopeThread[],
+  workspaces: readonly ScopeWorkspace[],
+): string | null {
+  const workspacePath =
+    workspaces.find((w) => w.id === workspaceId)?.path ?? null;
+  const thread = threads.find((t) => t.id === scopeId);
+  if (thread?.mode === "worktree" && thread.worktree_path) {
+    return thread.worktree_path;
+  }
+  return workspacePath;
+}


### PR DESCRIPTION
## What

Bind the Browser tab's relative-file navigation to the active thread's worktree, matching the Terminal. The Browser now runs against the workspace root when threadless or in a direct thread, and rebinds to the thread's worktree once a worktree thread becomes active.

## Why

The Browser tab resolved relative file paths against the workspace root even inside a worktree thread, so it never rebound to the thread's worktree the way the Terminal already does. Issue #613 requires both tabs to open against the workspace root with no thread and rebind to the worktree when a thread becomes active.

The Terminal already rebinds correctly through the server's `GitService.resolveWorkingDir` (added in #625). This change brings the Browser to parity.

## Key Changes

- Add `resolveScopeBasePath` in `apps/web/src/lib/resolve-scope-path.ts`, a pure helper that mirrors the server's `GitService.resolveWorkingDir`: a worktree-mode thread binds to its worktree, while direct threads and the threadless workspace scope bind to the workspace root.
- Use it in `usePreviewBridge` so omnibox navigation resolves against the active scope's checkout.
- Add tests covering the threadless to worktree rebind for both tabs: `resolveScopeBasePath` (Browser) and `resolveWorkingDir` (Terminal), including edge cases (direct mode, pending worktree path, unknown workspace).

## Verification

- `bun run verify`: typecheck + lint pass (6/6 workspaces); server tests pass.
- New tests pass: `resolve-scope-path.test.ts`, `usePreviewBridge.test.ts`, `git-service-working-dir.test.ts`.
- Pre-existing PlanDocument and sidebar-usage-token test flakes (timeouts under parallel load) are unrelated to this change; no files they cover were touched.

Closes #613

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783644028&installation_id=129163861&pr_number=633&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F633&signature=acdc0f039a624dd883f04ce62b7b36de1c3370ea59842c2d3664b0ee229f4749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved preview navigation to properly resolve paths across different workspace modes (direct and worktree contexts).

* **Tests**
  * Added comprehensive test coverage for working directory resolution and scope-based path resolution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->