### PR TITLE
fix(desktop): package Claude Agent SDK CLI binary in installer

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -63,6 +63,11 @@ jobs:
         shell: bash
         run: python3 -m pip install setuptools --break-system-packages 2>/dev/null || python3 -m pip install setuptools 2>/dev/null || pip install setuptools 2>/dev/null || true
 
+      - name: Ensure Claude SDK platform package for packaging target
+        run: node apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
+        env:
+          MCODE_TARGET_ARCH: ${{ matrix.target-arch }}
+
       - name: Package with electron-builder
         run: node apps/desktop/scripts/ci-package.mjs ${{ matrix.build-args }}
         env:

--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -187,6 +187,11 @@ jobs:
         shell: bash
         run: python3 -m pip install setuptools --break-system-packages 2>/dev/null || python3 -m pip install setuptools 2>/dev/null || pip install setuptools 2>/dev/null || true
 
+      - name: Ensure Claude SDK platform package for packaging target
+        run: node apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
+        env:
+          MCODE_TARGET_ARCH: ${{ matrix.target-arch }}
+
       - name: Package with electron-builder (nightly channel)
         run: node apps/desktop/scripts/ci-package.mjs --config.publish.channel=nightly ${{ matrix.build-args }}
         env:

--- a/apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs
+++ b/apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, stat, access } from "node:fs/promises";
+import { constants } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  claudeSdkPlatformPackageCandidates,
+  claudeSdkPlatformParts,
+  copyClaudeSdkCliNextTo,
+  copyClaudeSdkCliToDir,
+  electronPlatformToNpm,
+  expectedClaudeSdkCliPath,
+  findClaudeSdkCliPath,
+  resolveClaudeSdkCliSources,
+  resolvePackagedServerDir,
+} from "../../../../scripts/build-server-dev-bundle.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+const serverRoot = path.join(repoRoot, "apps/server");
+
+describe("electronPlatformToNpm", () => {
+  it("maps electron-builder platform names to npm values", () => {
+    expect(electronPlatformToNpm("win32")).toBe("win32");
+    expect(electronPlatformToNpm("darwin")).toBe("darwin");
+    expect(electronPlatformToNpm("mas")).toBe("darwin");
+    expect(electronPlatformToNpm("linux")).toBe("linux");
+  });
+});
+
+describe("resolvePackagedServerDir", () => {
+  it("resolves Windows and Linux paths under resources/", () => {
+    expect(
+      resolvePackagedServerDir({
+        appOutDir: "C:/dist/win-unpacked",
+        electronPlatformName: "win32",
+        productFilename: "Mcode",
+      }),
+    ).toBe(
+      path.join("C:/dist/win-unpacked", "resources", "app.asar.unpacked", "dist", "server"),
+    );
+  });
+
+  it("resolves macOS paths under Contents/Resources/", () => {
+    const result = resolvePackagedServerDir({
+      appOutDir: "/dist/mac",
+      electronPlatformName: "darwin",
+      productFilename: "Mcode",
+    });
+    expect(result.replace(/\\/g, "/")).toMatch(
+      /\/Mcode\.app\/Contents\/Resources\/app\.asar\.unpacked\/dist\/server$/,
+    );
+  });
+});
+
+describe("claudeSdkPlatformParts", () => {
+  it("uses claude.exe on win32 and claude elsewhere", () => {
+    expect(claudeSdkPlatformParts("win32", "x64")).toEqual({
+      platformPkg: "@anthropic-ai/claude-agent-sdk-win32-x64",
+      binName: "claude.exe",
+    });
+    expect(claudeSdkPlatformParts("darwin", "arm64")).toEqual({
+      platformPkg: "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+      binName: "claude",
+    });
+  });
+});
+
+describe("claudeSdkPlatformPackageCandidates", () => {
+  it("tries linux musl before glibc package names", () => {
+    expect(claudeSdkPlatformPackageCandidates("linux", "x64")).toEqual([
+      "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+      "@anthropic-ai/claude-agent-sdk-linux-x64",
+    ]);
+  });
+});
+
+describe("resolveClaudeSdkCliSources", () => {
+  it("resolves the installed platform package on the build host", () => {
+    const platform = process.platform;
+    const arch = process.arch;
+    const sources = resolveClaudeSdkCliSources(serverRoot, platform, arch);
+    expect(sources.binSrc).toMatch(/claude(\.exe)?$/);
+    expect(sources.platformPkg).toMatch(/@anthropic-ai\/claude-agent-sdk-/);
+  });
+
+  it("throws a bun install hint when the platform package is missing", () => {
+    expect(() =>
+      resolveClaudeSdkCliSources(serverRoot, "linux", "s390x"),
+    ).toThrow(
+      "not installed - run 'bun install' or node apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs",
+    );
+  });
+});
+
+describe("copyClaudeSdkCliToDir", () => {
+  /** @type {string | undefined} */
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "claude-sdk-copy-"));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("copies the CLI binary and package.json into dist/server/node_modules", async () => {
+    const serverDir = path.join(tmpDir, "resources", "app.asar.unpacked", "dist", "server");
+    const platform = process.platform;
+    const arch = process.arch;
+    const { binDst } = copyClaudeSdkCliToDir({
+      destServerDir: serverDir,
+      serverPackageRoot: serverRoot,
+      platform,
+      arch,
+    });
+    const expected = expectedClaudeSdkCliPath(path.join(serverDir, "server.cjs"), platform, arch);
+    const found = findClaudeSdkCliPath(path.join(serverDir, "server.cjs"), platform, arch);
+    expect(found).toBe(binDst);
+    if (platform === "linux") {
+      expect(found).toBeTruthy();
+    } else {
+      expect(binDst).toBe(expected);
+    }
+    const binStat = await stat(binDst);
+    expect(binStat.size).toBeGreaterThan(1_000_000);
+    await access(path.join(path.dirname(binDst), "package.json"), constants.R_OK);
+  });
+});
+
+describe("copyClaudeSdkCliNextTo", () => {
+  /** @type {string | undefined} */
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "claude-sdk-nextto-"));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skipped re-copying when the destination already matches the source size", async () => {
+    const serverCjs = path.join(tmpDir, "server.cjs");
+    copyClaudeSdkCliNextTo(serverCjs, serverRoot);
+    const platform = process.platform;
+    const arch = process.arch;
+    const binDst = findClaudeSdkCliPath(serverCjs, platform, arch);
+    expect(binDst).toBeTruthy();
+    const firstMtime = (await stat(binDst)).mtimeMs;
+    copyClaudeSdkCliNextTo(serverCjs, serverRoot);
+    const secondMtime = (await stat(binDst)).mtimeMs;
+    expect(secondMtime).toBe(firstMtime);
+  });
+});

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -1,8 +1,9 @@
 /**
  * electron-builder afterPack hook.
  *
- * 1. Copies browser_v8_context_snapshot.bin into the packaged app resources
- * 2. Flips the LoadBrowserProcessSpecificV8Snapshot fuse on the Electron binary
+ * 1. Built renamed `mcode-server` Electron binary (before fuse flip)
+ * 2. Copied Claude Agent SDK native CLI into the asar-unpacked server tree
+ * 3. Copied browser V8 snapshot (when generated) and flipped security fuses
  *
  * This script is invoked automatically by electron-builder via the
  * "afterPack" config in package.json.
@@ -13,6 +14,11 @@ import { copyFileSync, existsSync } from "fs";
 import { resolve, join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { buildServerBinary } from "./build-server-binary.mjs";
+import {
+  copyClaudeSdkCliToDir,
+  electronPlatformToNpm,
+  resolvePackagedServerDir,
+} from "../../../scripts/build-server-dev-bundle.mjs";
 
 /**
  * @param {import("electron-builder").AfterPackContext} context
@@ -68,6 +74,27 @@ export default async function afterPack(context) {
   });
 
   console.log("[after-pack] Built renamed server binary");
+
+  // -------------------------------------------------------------------------
+  // Step 1b: Copy Claude Agent SDK native CLI into asar-unpacked server tree.
+  // electron-builder excludes nested node_modules from the default files filter,
+  // so build-time staging under dist/server/node_modules does not survive packaging.
+  // -------------------------------------------------------------------------
+
+  const serverPackageRoot = resolve(desktopRoot, "..", "server");
+  const npmPlatform = electronPlatformToNpm(electronPlatformName);
+  const packagedServerDir = resolvePackagedServerDir({
+    appOutDir,
+    electronPlatformName,
+    productFilename,
+  });
+  const { platformPkg, binDst } = copyClaudeSdkCliToDir({
+    destServerDir: packagedServerDir,
+    serverPackageRoot,
+    platform: npmPlatform,
+    arch: context.arch,
+  });
+  console.log(`[after-pack] Copied Claude SDK CLI (${platformPkg}) to ${binDst}`);
 
   // -------------------------------------------------------------------------
   // Step 2: V8 snapshot copy + fuse flip.

--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -112,8 +112,8 @@ if (existsSync(drizzleSrc)) {
 }
 
 // Stage the Claude Agent SDK's native CLI binary under dist/server/node_modules
-// so the bundled SDK's createRequire(import.meta.url) resolution finds it.
-// dist/server/** is already in asarUnpack, so the binary exists on real disk.
+// for local dev and pre-packaging verification. Packaged installs receive the
+// binary via after-pack.mjs because electron-builder excludes nested node_modules.
 copyClaudeSdkCliNextTo(resolve(desktopRoot, "dist/server/server.cjs"), serverRoot);
 console.log("Staged SDK native CLI binary -> dist/server/node_modules");
 

--- a/apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
+++ b/apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
@@ -1,0 +1,54 @@
+/**
+ * Ensure the Claude Agent SDK platform package for the packaging target is installed.
+ *
+ * bun only installs optional platform packages for the build host. Cross-arch desktop
+ * builds (e.g. macOS x64 on an arm64 runner) need the target package present before
+ * afterPack copies the CLI into the installer.
+ *
+ * Usage:
+ *   node apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
+ *
+ * Environment:
+ *   MCODE_TARGET_ARCH - electron-builder target arch (e.g. x64, arm64). Defaults to process.arch.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  claudeSdkPlatformPackageCandidates,
+  electronPlatformToNpm,
+  repoRootFromScript,
+  resolveClaudeSdkCliSources,
+} from "../../../scripts/build-server-dev-bundle.mjs";
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = repoRootFromScript();
+const serverRoot = resolve(repoRoot, "apps/server");
+
+const targetArch = process.env.MCODE_TARGET_ARCH?.trim() || process.arch;
+const npmPlatform = electronPlatformToNpm(process.platform);
+
+try {
+  resolveClaudeSdkCliSources(serverRoot, npmPlatform, targetArch);
+  console.log(
+    `[ensure-claude-sdk] Target platform package already installed (${npmPlatform}-${targetArch})`,
+  );
+  process.exit(0);
+} catch {
+  // fall through to install
+}
+
+const serverRequire = createRequire(resolve(serverRoot, "package.json"));
+const sdkVersion = serverRequire("@anthropic-ai/claude-agent-sdk/package.json").version;
+const platformPkg = claudeSdkPlatformPackageCandidates(npmPlatform, targetArch)[0];
+
+console.log(`[ensure-claude-sdk] Installing ${platformPkg}@${sdkVersion} for ${npmPlatform}-${targetArch}...`);
+execFileSync("bun", ["add", `${platformPkg}@${sdkVersion}`], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+
+resolveClaudeSdkCliSources(serverRoot, npmPlatform, targetArch);
+console.log(`[ensure-claude-sdk] Installed ${platformPkg}`);

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -11,6 +11,7 @@
  * - Broken asarUnpack configuration
  * - Server startup crashes invisible in the packaged app
  * - Import/require resolution failures in the CJS bundle
+ * - Missing Claude Agent SDK native CLI (after-pack regression)
  *
  * Usage:
  *   node apps/desktop/scripts/smoke-test.mjs             # auto-detect unpacked dir
@@ -23,6 +24,10 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { tmpdir } from "os";
 import { randomUUID } from "crypto";
+import {
+  findClaudeSdkCliPath,
+  expectedClaudeSdkCliPath,
+} from "../../../scripts/build-server-dev-bundle.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
@@ -91,6 +96,29 @@ function findUnpackedServer() {
 }
 
 /**
+ * Infer the packaged app's npm platform/arch from the release output path.
+ *
+ * @param {string} serverPath Absolute path to packaged `server.cjs`.
+ * @returns {{ platform: NodeJS.Platform, arch: NodeJS.Architecture }}
+ */
+function inferPackagedSdkTarget(serverPath) {
+  const normalized = serverPath.replace(/\\/g, "/");
+  if (normalized.includes("/win-unpacked/")) {
+    return { platform: "win32", arch: "x64" };
+  }
+  if (normalized.includes("/linux-unpacked/")) {
+    return { platform: "linux", arch: "x64" };
+  }
+  if (normalized.includes("/mac-arm64/")) {
+    return { platform: "darwin", arch: "arm64" };
+  }
+  if (normalized.includes("/mac/")) {
+    return { platform: "darwin", arch: "x64" };
+  }
+  return { platform: process.platform, arch: process.arch };
+}
+
+/**
  * --bundle mode: test the pre-packaging bundle with the system node/bun.
  * Skips native module verification but catches JS bundle errors.
  */
@@ -118,6 +146,18 @@ console.log(`[smoke-test] Server: ${found.server}`);
 console.log(`[smoke-test] Runtime: ${found.electron}`);
 if (found.binding) {
   console.log(`[smoke-test] SQLite binding: ${found.binding}`);
+}
+
+if (!bundleOnly) {
+  const sdkTarget = inferPackagedSdkTarget(found.server);
+  const claudeCli = findClaudeSdkCliPath(found.server, sdkTarget.platform, sdkTarget.arch);
+  if (!claudeCli) {
+    const expected = expectedClaudeSdkCliPath(found.server, sdkTarget.platform, sdkTarget.arch);
+    console.error(`[smoke-test] ERROR: Claude SDK CLI binary missing at ${expected}`);
+    console.error("  after-pack.mjs should copy it into app.asar.unpacked/dist/server/node_modules/");
+    process.exit(1);
+  }
+  console.log(`[smoke-test] Claude SDK CLI: ${claudeCli}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/build-server-dev-bundle.mjs
+++ b/scripts/build-server-dev-bundle.mjs
@@ -7,7 +7,7 @@
 
 import { build } from "esbuild";
 import { execFileSync } from "node:child_process";
-import { copyFileSync, cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -44,6 +44,168 @@ export function compileServerWithTsc(serverRoot = resolve(repoRootFromScript(), 
 }
 
 /**
+ * Map electron-builder platform names to npm `process.platform` values.
+ *
+ * @param {string} electronPlatformName
+ * @returns {NodeJS.Platform}
+ */
+export function electronPlatformToNpm(electronPlatformName) {
+  if (electronPlatformName === "win32") return "win32";
+  if (electronPlatformName === "darwin" || electronPlatformName === "mas") return "darwin";
+  if (electronPlatformName === "linux") return "linux";
+  throw new Error(`Unsupported electron platform: ${electronPlatformName}`);
+}
+
+/**
+ * Resolve the on-disk `dist/server` directory inside a packaged app.
+ *
+ * @param {object} args
+ * @param {string} args.appOutDir electron-builder output directory (e.g. `win-unpacked`).
+ * @param {string} args.electronPlatformName
+ * @param {string} args.productFilename App binary filename without extension.
+ */
+export function resolvePackagedServerDir({ appOutDir, electronPlatformName, productFilename }) {
+  const tail = ["app.asar.unpacked", "dist", "server"];
+  if (electronPlatformName === "darwin" || electronPlatformName === "mas") {
+    return resolve(appOutDir, `${productFilename}.app`, "Contents", "Resources", ...tail);
+  }
+  return resolve(appOutDir, "resources", ...tail);
+}
+
+/**
+ * Ordered Claude SDK platform package names to try for a target OS/arch.
+ * Linux musl hosts only install the `-musl` optional dependency.
+ *
+ * @param {NodeJS.Platform} platform
+ * @param {NodeJS.Architecture} arch
+ * @returns {string[]}
+ */
+export function claudeSdkPlatformPackageCandidates(platform, arch) {
+  if (platform === "linux") {
+    return [
+      `@anthropic-ai/claude-agent-sdk-linux-${arch}-musl`,
+      `@anthropic-ai/claude-agent-sdk-linux-${arch}`,
+    ];
+  }
+  return [`@anthropic-ai/claude-agent-sdk-${platform}-${arch}`];
+}
+
+/**
+ * Platform package name and CLI binary filename for the Claude Agent SDK.
+ *
+ * @param {NodeJS.Platform} platform
+ * @param {NodeJS.Architecture} arch
+ */
+export function claudeSdkPlatformParts(platform, arch) {
+  const platformPkg = `@anthropic-ai/claude-agent-sdk-${platform}-${arch}`;
+  const binName = platform === "win32" ? "claude.exe" : "claude";
+  return { platformPkg, binName };
+}
+
+/**
+ * Expected on-disk path to the staged Claude SDK CLI beside a bundled `server.cjs`.
+ *
+ * @param {string} serverCjsOut Absolute path to `server.cjs`.
+ * @param {NodeJS.Platform} [platform]
+ * @param {NodeJS.Architecture} [arch]
+ */
+export function expectedClaudeSdkCliPath(
+  serverCjsOut,
+  platform = process.platform,
+  arch = process.arch,
+) {
+  const { platformPkg, binName } = claudeSdkPlatformParts(platform, arch);
+  return resolve(dirname(serverCjsOut), "node_modules", platformPkg, binName);
+}
+
+/**
+ * Locate the staged Claude SDK CLI beside `server.cjs`, trying linux musl and glibc names.
+ *
+ * @param {string} serverCjsOut
+ * @param {NodeJS.Platform} platform
+ * @param {NodeJS.Architecture} arch
+ * @returns {string | undefined}
+ */
+export function findClaudeSdkCliPath(serverCjsOut, platform, arch) {
+  const binName = platform === "win32" ? "claude.exe" : "claude";
+  const serverDir = dirname(serverCjsOut);
+  for (const platformPkg of claudeSdkPlatformPackageCandidates(platform, arch)) {
+    const candidate = resolve(serverDir, "node_modules", platformPkg, binName);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the installed Claude SDK platform package and CLI binary on the build host.
+ *
+ * @param {string} serverPackageRoot Root of `apps/server` (directory with `package.json`).
+ * @param {NodeJS.Platform} platform
+ * @param {NodeJS.Architecture} arch
+ */
+export function resolveClaudeSdkCliSources(serverPackageRoot, platform, arch) {
+  const binName = platform === "win32" ? "claude.exe" : "claude";
+  const candidates = claudeSdkPlatformPackageCandidates(platform, arch);
+  const failures = [];
+
+  try {
+    const serverRequire = createRequire(resolve(serverPackageRoot, "package.json"));
+    // Resolve from the SDK package itself: bun keeps platform packages as store
+    // siblings of the SDK, not hoisted to the workspace root.
+    const sdkEntry = serverRequire.resolve("@anthropic-ai/claude-agent-sdk");
+    const sdkRequire = createRequire(sdkEntry);
+
+    for (const platformPkg of candidates) {
+      try {
+        const binSrc = sdkRequire.resolve(`${platformPkg}/${binName}`);
+        const packageJsonSrc = resolve(dirname(binSrc), "package.json");
+        return { platformPkg, binName, binSrc, packageJsonSrc };
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        failures.push(`${platformPkg}: ${detail}`);
+      }
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    failures.push(detail);
+  }
+
+  const label = candidates.join(" or ");
+  throw new Error(
+    `${label} not installed - run 'bun install' or node apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs (node_modules out of sync with bun.lock): ${failures.join("; ")}`,
+  );
+}
+
+/**
+ * Copy the Claude Agent SDK native CLI into a directory tree (used by afterPack).
+ *
+ * @param {object} args
+ * @param {string} args.destServerDir Absolute path to packaged `dist/server` (or dev equivalent).
+ * @param {string} args.serverPackageRoot Root of `apps/server`.
+ * @param {NodeJS.Platform} args.platform Target npm `process.platform` value.
+ * @param {NodeJS.Architecture} args.arch Target npm `process.arch` value.
+ * @returns {{ platformPkg: string, binDst: string }}
+ */
+export function copyClaudeSdkCliToDir({ destServerDir, serverPackageRoot, platform, arch }) {
+  const { platformPkg, binName, binSrc, packageJsonSrc } = resolveClaudeSdkCliSources(
+    serverPackageRoot,
+    platform,
+    arch,
+  );
+  const dstPkgDir = resolve(destServerDir, "node_modules", platformPkg);
+  const binDst = resolve(dstPkgDir, binName);
+  mkdirSync(dstPkgDir, { recursive: true });
+  copyFileSync(packageJsonSrc, resolve(dstPkgDir, "package.json"));
+  copyFileSync(binSrc, binDst);
+  if (platform !== "win32") {
+    chmodSync(binDst, 0o755);
+  }
+  return { platformPkg, binDst };
+}
+
+/**
  * Stage the Claude Agent SDK's native CLI binary next to the bundled server entry.
  *
  * SDK >= 0.3 ships the CLI as a platform-specific package
@@ -57,22 +219,24 @@ export function compileServerWithTsc(serverRoot = resolve(repoRootFromScript(), 
  *
  * @param {string} serverCjsOut Absolute path to `server.cjs`.
  * @param {string} serverPackageRoot Root of `apps/server` (directory with `package.json`).
+ * @param {NodeJS.Platform} [platform]
+ * @param {NodeJS.Architecture} [arch]
  */
-export function copyClaudeSdkCliNextTo(serverCjsOut, serverPackageRoot) {
-  const serverRequire = createRequire(resolve(serverPackageRoot, "package.json"));
-  const platformPkg = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`;
-  const binName = process.platform === "win32" ? "claude.exe" : "claude";
-
-  // Resolve from the SDK package itself: bun keeps platform packages as store
-  // siblings of the SDK, not hoisted to the workspace root.
-  const sdkEntry = serverRequire.resolve("@anthropic-ai/claude-agent-sdk");
-  const sdkRequire = createRequire(sdkEntry);
-  const binSrc = sdkRequire.resolve(`${platformPkg}/${binName}`);
-
+export function copyClaudeSdkCliNextTo(
+  serverCjsOut,
+  serverPackageRoot,
+  platform = process.platform,
+  arch = process.arch,
+) {
+  const { platformPkg, binName, binSrc, packageJsonSrc } = resolveClaudeSdkCliSources(
+    serverPackageRoot,
+    platform,
+    arch,
+  );
   const dstPkgDir = resolve(dirname(serverCjsOut), "node_modules", platformPkg);
   const binDst = resolve(dstPkgDir, binName);
   mkdirSync(dstPkgDir, { recursive: true });
-  copyFileSync(resolve(dirname(binSrc), "package.json"), resolve(dstPkgDir, "package.json"));
+  copyFileSync(packageJsonSrc, resolve(dstPkgDir, "package.json"));
   if (!existsSync(binDst) || statSync(binDst).size !== statSync(binSrc).size) {
     copyFileSync(binSrc, binDst);
   }


### PR DESCRIPTION
## Summary
- Copy the Claude Agent SDK native CLI into `app.asar.unpacked/dist/server/node_modules/` during electron-builder `afterPack`
- Add smoke-test and CI guardrails so a missing packaged CLI fails the build
- Install the target platform optional package before packaging on cross-arch macOS builds

## What
Packaged Mcode desktop builds no longer ship the Claude Agent SDK CLI binary, causing the Claude provider to fail at runtime with `Native CLI binary for win32-x64 not found`.

## Why
electron-builder special-cases nested `node_modules` directories and drops the CLI staged under `dist/server/node_modules` at build time. The bundled `server.cjs` resolves the CLI relative to its on-disk path inside `app.asar.unpacked`.

## Key changes
- `after-pack.mjs` copies the platform CLI binary after packaging (Option A from the packaging handoff)
- Shared helpers in `build-server-dev-bundle.mjs` for resolution, copy, and path layout
- `ensure-claude-sdk-platform-package.mjs` plus CI step for cross-arch macOS x64 builds
- `smoke-test.mjs` asserts the CLI exists in packaged output
- Unit tests for resolution, copy, and path helpers

## Configuration changes
None.

## Related issues/PRs
Relates to #629

## Test plan
- [x] `bunx vitest run apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs` (9 tests)
- [x] `bun run verify` typecheck and lint pass; desktop tests pass
- [x] Local afterPack copy simulation and packaged app smoke on Windows
- [ ] CI nightly desktop workflow (smoke test + afterPack copy on all matrix targets)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783676267&installation_id=129163861&pr_number=636&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F636&signature=43d0644327af2a42a6376075be7887e4d401008779281bcbe26b8c96a46e0c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflows with architecture-specific platform detection to ensure correct dependency packages for each build target.
  * Enhanced desktop packaging process with verification steps for native SDK components.
  * Added post-packaging validation to confirm expected binaries are present in packaged builds.

* **Tests**
  * Added comprehensive test coverage for build script helpers and packaging verification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->