### PR TITLE
fix(desktop): normalize electron-builder arch enum for Claude SDK copy

### DIFF
--- a/apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs
+++ b/apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs
@@ -8,6 +8,7 @@ import {
   claudeSdkPlatformParts,
   copyClaudeSdkCliNextTo,
   copyClaudeSdkCliToDir,
+  electronArchToNpm,
   electronPlatformToNpm,
   expectedClaudeSdkCliPath,
   findClaudeSdkCliPath,
@@ -24,6 +25,15 @@ describe("electronPlatformToNpm", () => {
     expect(electronPlatformToNpm("darwin")).toBe("darwin");
     expect(electronPlatformToNpm("mas")).toBe("darwin");
     expect(electronPlatformToNpm("linux")).toBe("linux");
+  });
+});
+
+describe("electronArchToNpm", () => {
+  it("maps electron-builder Arch enum values to npm arch strings", () => {
+    expect(electronArchToNpm(1)).toBe("x64");
+    expect(electronArchToNpm(3)).toBe("arm64");
+    expect(electronArchToNpm("x64")).toBe("x64");
+    expect(electronArchToNpm("arm64")).toBe("arm64");
   });
 });
 

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from "url";
 import { buildServerBinary } from "./build-server-binary.mjs";
 import {
   copyClaudeSdkCliToDir,
+  electronArchToNpm,
   electronPlatformToNpm,
   resolvePackagedServerDir,
 } from "../../../scripts/build-server-dev-bundle.mjs";
@@ -92,7 +93,7 @@ export default async function afterPack(context) {
     destServerDir: packagedServerDir,
     serverPackageRoot,
     platform: npmPlatform,
-    arch: context.arch,
+    arch: electronArchToNpm(context.arch),
   });
   console.log(`[after-pack] Copied Claude SDK CLI (${platformPkg}) to ${binDst}`);
 

--- a/apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
+++ b/apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
@@ -13,21 +13,25 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { resolve, dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   claudeSdkPlatformPackageCandidates,
+  electronArchToNpm,
   electronPlatformToNpm,
   repoRootFromScript,
   resolveClaudeSdkCliSources,
 } from "../../../scripts/build-server-dev-bundle.mjs";
 
-const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = repoRootFromScript();
 const serverRoot = resolve(repoRoot, "apps/server");
 
-const targetArch = process.env.MCODE_TARGET_ARCH?.trim() || process.arch;
+const rawTargetArch = process.env.MCODE_TARGET_ARCH?.trim();
+const targetArch = rawTargetArch
+  ? electronArchToNpm(rawTargetArch)
+  : process.arch;
 const npmPlatform = electronPlatformToNpm(process.platform);
 
 try {
@@ -41,7 +45,10 @@ try {
 }
 
 const serverRequire = createRequire(resolve(serverRoot, "package.json"));
-const sdkVersion = serverRequire("@anthropic-ai/claude-agent-sdk/package.json").version;
+const sdkEntry = serverRequire.resolve("@anthropic-ai/claude-agent-sdk");
+const sdkVersion = JSON.parse(
+  readFileSync(resolve(dirname(sdkEntry), "package.json"), "utf8"),
+).version;
 const platformPkg = claudeSdkPlatformPackageCandidates(npmPlatform, targetArch)[0];
 
 console.log(`[ensure-claude-sdk] Installing ${platformPkg}@${sdkVersion} for ${npmPlatform}-${targetArch}...`);

--- a/scripts/build-server-dev-bundle.mjs
+++ b/scripts/build-server-dev-bundle.mjs
@@ -57,6 +57,33 @@ export function electronPlatformToNpm(electronPlatformName) {
 }
 
 /**
+ * Map electron-builder `Arch` values (string or numeric enum) to npm `process.arch`.
+ *
+ * @param {string | number} electronArch
+ * @returns {NodeJS.Architecture}
+ */
+export function electronArchToNpm(electronArch) {
+  if (typeof electronArch === "string") {
+    if (electronArch === "armv7l") return "arm";
+    return /** @type {NodeJS.Architecture} */ (electronArch);
+  }
+  switch (electronArch) {
+    case 0:
+      return "ia32";
+    case 1:
+      return "x64";
+    case 2:
+      return "arm";
+    case 3:
+      return "arm64";
+    case 4:
+      throw new Error("electron-builder Arch.universal is not supported for Claude SDK platform packages");
+    default:
+      throw new Error(`Unsupported electron-builder arch: ${electronArch}`);
+  }
+}
+
+/**
  * Resolve the on-disk `dist/server` directory inside a packaged app.
  *
  * @param {object} args


### PR DESCRIPTION
## What
Map electron-builder `context.arch` numeric enum values to npm arch strings before resolving Claude SDK platform packages, and read SDK version from disk in the ensure script.

## Why
Nightly desktop packaging failed with `@anthropic-ai/claude-agent-sdk-win32-1` because `afterPack` passed `context.arch` as `1` (Arch.x64) instead of "x64"`. The ensure script also failed on macOS x64 cross-builds when reading `@anthropic-ai/claude-agent-sdk/package.json` via require (not exported).

## Key changes
- Add `electronArchToNpm()` and use it in `after-pack.mjs`
- Fix SDK version lookup in `ensure-claude-sdk-platform-package.mjs`
- Unit tests for arch enum mapping

## Configuration changes
None.

## Related issues/PRs
Relates to #636

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783676958&installation_id=129163861&pr_number=637&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F637&signature=34ef025c549bf45ba3f12fc4d9a736d35303cda69087eceb6b119a9c449fc166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system architecture handling for better cross-platform support
  * Enhanced SDK version detection reliability during builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->