### PR TITLE
fix(desktop): install cross-arch Claude SDK platform package for nightly builds

### DIFF
--- a/apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
+++ b/apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
@@ -1,9 +1,13 @@
 /**
  * Ensure the Claude Agent SDK platform package for the packaging target is installed.
  *
- * bun only installs optional platform packages for the build host. Cross-arch desktop
- * builds (e.g. macOS x64 on an arm64 runner) need the target package present before
- * afterPack copies the CLI into the installer.
+ * bun only installs platform packages whose `os`/`cpu` fields match the build host,
+ * and `bun add` silently skips linking a mismatched package even though it updates
+ * the lockfile. Cross-arch desktop builds (e.g. macOS x64 on an arm64 runner) need
+ * the target package present before afterPack copies the CLI into the installer, so
+ * this script downloads the tarball from the npm registry directly and extracts it
+ * next to the SDK inside bun's isolated store, where require resolution from the
+ * SDK entry point finds it. It never touches package.json or bun.lock.
  *
  * Usage:
  *   node apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
@@ -13,10 +17,9 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
 import {
   claudeSdkPlatformPackageCandidates,
   electronArchToNpm,
@@ -51,11 +54,53 @@ const sdkVersion = JSON.parse(
 ).version;
 const platformPkg = claudeSdkPlatformPackageCandidates(npmPlatform, targetArch)[0];
 
-console.log(`[ensure-claude-sdk] Installing ${platformPkg}@${sdkVersion} for ${npmPlatform}-${targetArch}...`);
-execFileSync("bun", ["add", `${platformPkg}@${sdkVersion}`], {
-  cwd: repoRoot,
+console.log(
+  `[ensure-claude-sdk] Downloading ${platformPkg}@${sdkVersion} for ${npmPlatform}-${targetArch}...`,
+);
+
+const registry = (
+  process.env.npm_config_registry ?? "https://registry.npmjs.org"
+).replace(/\/+$/, "");
+const metaRes = await fetch(`${registry}/${platformPkg}/${sdkVersion}`);
+if (!metaRes.ok) {
+  throw new Error(
+    `[ensure-claude-sdk] Registry lookup failed for ${platformPkg}@${sdkVersion}: HTTP ${metaRes.status}`,
+  );
+}
+const tarballUrl = (await metaRes.json()).dist?.tarball;
+if (!tarballUrl) {
+  throw new Error(
+    `[ensure-claude-sdk] Registry metadata for ${platformPkg}@${sdkVersion} has no dist.tarball`,
+  );
+}
+
+const tarRes = await fetch(tarballUrl);
+if (!tarRes.ok) {
+  throw new Error(
+    `[ensure-claude-sdk] Tarball download failed (${tarballUrl}): HTTP ${tarRes.status}`,
+  );
+}
+// dirname(sdkEntry) is the real SDK package dir inside bun's store
+// (node_modules/.bun/<sdk>@<ver>/node_modules/@anthropic-ai/claude-agent-sdk),
+// so "../<pkg basename>" lands in the scope dir of the nearest node_modules
+// that require() walks from the SDK entry.
+const destDir = resolve(dirname(sdkEntry), "..", platformPkg.split("/").pop());
+rmSync(destDir, { recursive: true, force: true });
+mkdirSync(destDir, { recursive: true });
+
+// Extract with cwd-relative paths: GNU tar on Windows misreads "C:\..." as a
+// remote host spec.
+const tarballName = "package.tgz";
+writeFileSync(join(destDir, tarballName), Buffer.from(await tarRes.arrayBuffer()));
+execFileSync("tar", ["-xzf", tarballName, "--strip-components=1"], {
+  cwd: destDir,
   stdio: "inherit",
 });
+rmSync(join(destDir, tarballName), { force: true });
+
+if (npmPlatform !== "win32") {
+  chmodSync(join(destDir, "claude"), 0o755);
+}
 
 resolveClaudeSdkCliSources(serverRoot, npmPlatform, targetArch);
-console.log(`[ensure-claude-sdk] Installed ${platformPkg}`);
+console.log(`[ensure-claude-sdk] Installed ${platformPkg} at ${destDir}`);


### PR DESCRIPTION
## Description

**What** - Fixes the macOS x64 nightly build failing at the "Ensure Claude SDK platform package" confirm step ([failing run](https://github.com/Mzeey-Empire/mcode/actions/runs/27268294937/job/80531032524)).

**Why** - The macOS x64 job runs on an arm64 runner. `bun add @anthropic-ai/claude-agent-sdk-darwin-x64` resolves the package and saves the lockfile, but bun silently skips linking any package whose `cpu` field does not match the build host. The confirm step then fails with `Cannot find module '@anthropic-ai/claude-agent-sdk-darwin-x64/claude'`. The arm64 job passes only because host and target match.

**Key changes**
- `ensure-claude-sdk-platform-package.mjs` now downloads the platform package tarball straight from the npm registry and extracts it next to the SDK inside bun's isolated store (`node_modules/.bun/.../node_modules/@anthropic-ai/`), which is exactly where the SDK's `createRequire` resolution walks.
- No longer mutates `package.json` or `bun.lock` during CI builds (the old `bun add` did).
- Tar extraction uses cwd-relative paths because GNU tar on Windows misreads `C:\...` as a remote host spec.
- Also carries the prior commit normalizing the electron-builder arch enum before mapping to the npm arch string.

Verified locally on win32-x64 by installing the win32-arm64 package (same cross-arch mismatch): download, extract, confirm-resolve, and idempotent early-exit all pass. `bun run verify` passes typecheck and lint; 3 frontend test timeouts in `PlanDocument`/`PlanPanel` are load-induced flakes that pass in isolation and are untouched by this change.

Relates to #636

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783678210&installation_id=129163861&pr_number=638&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F638&signature=26dfaee6979a7c409b39168b8a54a14d4471c3447981ec889267f0caecc2c260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved desktop application build process to ensure more reliable platform-specific package handling and cross-architecture support, reducing potential compatibility issues during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->