### PR TITLE
feat(panel): browser overflow kebab — relocate tools + coming-soon stubs

### DIFF
--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -168,6 +168,26 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     reload(): Promise<void> {
       return ipcRenderer.invoke("preview:reload");
     },
+    /** Hard reload that bypasses the guest's HTTP cache (Force reload). */
+    forceReload(): Promise<void> {
+      return ipcRenderer.invoke("preview:force-reload");
+    },
+    /** Clear the preview session's cookies. */
+    clearCookies(): Promise<void> {
+      return ipcRenderer.invoke("preview:clear-cookies");
+    },
+    /** Clear the preview session's HTTP cache. */
+    clearCache(): Promise<void> {
+      return ipcRenderer.invoke("preview:clear-cache");
+    },
+    /** Read the guest's current zoom factor (1 = 100%). */
+    getZoom(): Promise<number> {
+      return ipcRenderer.invoke("preview:get-zoom");
+    },
+    /** Set the guest's zoom factor; returns the clamped factor actually applied. */
+    setZoom(factor: number): Promise<number> {
+      return ipcRenderer.invoke("preview:set-zoom", factor);
+    },
     openExternal(): Promise<void> {
       return ipcRenderer.invoke("preview:open-external");
     },

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -1,6 +1,8 @@
 /**
  * Navigation IPC handlers for the embedded preview WebContentsView:
- * sync, navigate, go-back, go-forward, reload, open-external, get-navigation-state.
+ * sync, navigate, go-back, go-forward, reload, force-reload, open-external,
+ * get-navigation-state, plus the secondary browser tools surfaced in the header
+ * overflow kebab (clear-cookies, clear-cache, get-zoom, set-zoom).
  */
 
 import { BrowserWindow, ipcMain, shell } from "electron";
@@ -29,6 +31,18 @@ import {
 } from "./preview-local-file.js";
 import { isMcodeWorkspacePreviewUrl } from "@mcode/contracts";
 import { onPreviewHidden, onPreviewVisible } from "./preview-discard-scheduler.js";
+
+/** Lower bound on the preview zoom factor (25%), matching Chromium's floor. */
+const MIN_ZOOM_FACTOR = 0.25;
+/** Upper bound on the preview zoom factor (500%), matching Chromium's ceiling. */
+const MAX_ZOOM_FACTOR = 5;
+
+/** Clamp a requested zoom factor to the supported range and snap to whole percent. */
+function clampZoomFactor(factor: number): number {
+  const safe = Number.isFinite(factor) ? factor : 1;
+  const bounded = Math.min(MAX_ZOOM_FACTOR, Math.max(MIN_ZOOM_FACTOR, safe));
+  return Math.round(bounded * 100) / 100;
+}
 
 /**
  * True when `input` looks like a bare host (e.g. `example.com`, `sub.x.io/path`,
@@ -287,6 +301,65 @@ export function registerNavigationHandlers(): void {
     trustMainProcessFileNavigation(s, url);
     void view.webContents.loadURL(url);
     resetIdle(win, s);
+  });
+
+  ipcMain.handle("preview:force-reload", (_event) => {
+    const win = BrowserWindow.fromWebContents(_event.sender);
+    if (!win || win.isDestroyed()) return;
+    const s = getSession(win);
+    if (s.view && !s.view.webContents.isDestroyed()) {
+      setPreviewLoading(win, s, true);
+      // Hard reload: drop the disk/memory cache so the guest re-fetches every
+      // resource. This is the only difference from preview:reload.
+      s.view.webContents.reloadIgnoringCache();
+      resetIdle(win, s);
+      return;
+    }
+    // View torn down (renderer crash → error panel): recreate and load fresh.
+    // A brand-new load already bypasses the cache, so it honours the intent.
+    if (!s.lastBounds) return;
+    const url = s.resumePreviewUrl ?? "about:blank";
+    const view = ensureView(win, s);
+    view.setBounds(s.lastBounds);
+    mountView(win, view);
+    setPreviewLoading(win, s, true);
+    trustMainProcessFileNavigation(s, url);
+    void view.webContents.loadURL(url);
+    resetIdle(win, s);
+  });
+
+  ipcMain.handle("preview:clear-cookies", async (_event) => {
+    const win = BrowserWindow.fromWebContents(_event.sender);
+    if (!win || win.isDestroyed()) return;
+    const s = getSession(win);
+    if (!s.view || s.view.webContents.isDestroyed()) return;
+    await s.view.webContents.session.clearStorageData({ storages: ["cookies"] });
+  });
+
+  ipcMain.handle("preview:clear-cache", async (_event) => {
+    const win = BrowserWindow.fromWebContents(_event.sender);
+    if (!win || win.isDestroyed()) return;
+    const s = getSession(win);
+    if (!s.view || s.view.webContents.isDestroyed()) return;
+    await s.view.webContents.session.clearCache();
+  });
+
+  ipcMain.handle("preview:get-zoom", (_event): number => {
+    const win = BrowserWindow.fromWebContents(_event.sender);
+    if (!win || win.isDestroyed()) return 1;
+    const s = getSession(win);
+    if (!s.view || s.view.webContents.isDestroyed()) return 1;
+    return clampZoomFactor(s.view.webContents.getZoomFactor());
+  });
+
+  ipcMain.handle("preview:set-zoom", (_event, factor: number): number => {
+    const win = BrowserWindow.fromWebContents(_event.sender);
+    if (!win || win.isDestroyed()) return 1;
+    const s = getSession(win);
+    if (!s.view || s.view.webContents.isDestroyed()) return 1;
+    const clamped = clampZoomFactor(factor);
+    s.view.webContents.setZoomFactor(clamped);
+    return clamped;
   });
 
   ipcMain.handle("preview:open-external", (_event) => {

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -124,6 +124,11 @@ async function injectPreviewBridge(
       goBack: () => Promise.resolve(false),
       goForward: () => Promise.resolve(false),
       reload: noop,
+      forceReload: noop,
+      clearCookies: noop,
+      clearCache: noop,
+      getZoom: () => Promise.resolve(1),
+      setZoom: (factor: number) => Promise.resolve(factor),
       openExternal: noop,
       openGuestDevTools: noop,
       onShortcutFired: unsub,
@@ -355,15 +360,35 @@ test.describe("PreviewPanel — loaded header", () => {
     await expect(page.getByLabel("Open in system browser")).toBeVisible();
   });
 
-  test("the overflow kebab lists New page, capture tools, and Soon stubs", async ({ page }) => {
+  test("the overflow kebab lists the relocated tools in order with Soon stubs", async ({ page }) => {
     await page.getByLabel("More browser tools").click();
     const menu = page.getByTestId("browser-overflow-menu");
     await expect(menu).toBeVisible();
     await expect(menu.getByText("New page")).toBeVisible();
-    await expect(menu.getByText("Region capture")).toBeVisible();
+    await expect(menu.getByText("Force reload")).toBeVisible();
     await expect(menu.getByText("Dump page content")).toBeVisible();
+    await expect(menu.getByText("Region capture")).toBeVisible();
     await expect(menu.getByText("Developer tools")).toBeVisible();
     await expect(menu.getByText("Show device toolbar")).toBeVisible();
+    await expect(menu.getByText("Zoom")).toBeVisible();
+    await expect(menu.getByText("Clear cookies")).toBeVisible();
+    await expect(menu.getByText("Clear cache")).toBeVisible();
+    // The two future tools are present but disabled.
+    await expect(menu.getByText("Developer tools").locator("..")).toHaveAttribute(
+      "data-disabled",
+      "",
+    );
+    await expect(menu.getByText("Show device toolbar").locator("..")).toHaveAttribute(
+      "data-disabled",
+      "",
+    );
+
+    // Zoom stepper adjusts the percent readout.
+    await expect(menu.getByText("100%")).toBeVisible();
+    await menu.getByLabel("Zoom in").click();
+    await expect(menu.getByText("110%")).toBeVisible();
+    await menu.getByLabel("Reset zoom").click();
+    await expect(menu.getByText("100%")).toBeVisible();
   });
 
   test("design mode aria-pressed toggles on and back off", async ({ page }) => {

--- a/apps/web/src/components/panels/BrowserHeader.tsx
+++ b/apps/web/src/components/panels/BrowserHeader.tsx
@@ -55,10 +55,20 @@ export interface BrowserHeaderProps {
   readonly onScreenshot: () => void;
   /** Open a new browser page (kebab). */
   readonly onNewPage: () => void;
+  /** Hard reload that bypasses the guest cache (kebab). */
+  readonly onForceReload: () => void;
   /** Region crop capture (kebab). */
   readonly onRegionCapture: () => void;
   /** Page-content dump capture (kebab). */
   readonly onDumpContent: () => void;
+  /** Clear the preview session's cookies (kebab). */
+  readonly onClearCookies: () => void;
+  /** Clear the preview session's HTTP cache (kebab). */
+  readonly onClearCache: () => void;
+  /** Read the guest's current zoom factor (kebab). */
+  readonly onGetZoom: () => Promise<number>;
+  /** Set the guest's zoom factor (kebab). */
+  readonly onSetZoom: (factor: number) => Promise<number>;
 }
 
 /**
@@ -95,8 +105,13 @@ export function BrowserHeader({
   onToggleDesign,
   onScreenshot,
   onNewPage,
+  onForceReload,
   onRegionCapture,
   onDumpContent,
+  onClearCookies,
+  onClearCache,
+  onGetZoom,
+  onSetZoom,
 }: BrowserHeaderProps) {
   const {
     displayValue,
@@ -358,8 +373,13 @@ export function BrowserHeader({
       <BrowserOverflowMenu
         hasLoadedPage={hasLoadedPage}
         onNewPage={onNewPage}
-        onRegionCapture={onRegionCapture}
+        onForceReload={onForceReload}
         onDumpContent={onDumpContent}
+        onRegionCapture={onRegionCapture}
+        onClearCookies={onClearCookies}
+        onClearCache={onClearCache}
+        onGetZoom={onGetZoom}
+        onSetZoom={onSetZoom}
       />
     </div>
   );

--- a/apps/web/src/components/panels/BrowserOverflowMenu.tsx
+++ b/apps/web/src/components/panels/BrowserOverflowMenu.tsx
@@ -1,11 +1,15 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Code2,
+  Cookie,
   EllipsisVertical,
   FileText,
+  Minus,
   Plus,
+  RotateCw,
   Smartphone,
   SquareDashedMousePointer,
+  Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,18 +19,32 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
+
+/** Step applied per zoom in/out click (10 percentage points). */
+const ZOOM_STEP = 0.1;
 
 /** Props for the browser header's overflow (kebab) menu. */
 export interface BrowserOverflowMenuProps {
-  /** True once a real page is loaded; gates the page-scoped capture entries. */
+  /** True once a real page is loaded; gates the page-scoped tools. */
   readonly hasLoadedPage: boolean;
   /** Open a new browser page (adds a tab). */
   readonly onNewPage: () => void;
-  /** Drag a region on the page and attach it to the chat. */
-  readonly onRegionCapture: () => void;
+  /** Hard reload that bypasses the guest cache. */
+  readonly onForceReload: () => void;
   /** Attach the page's structured content to the chat without a screenshot. */
   readonly onDumpContent: () => void;
+  /** Drag a region on the page and attach it to the chat. */
+  readonly onRegionCapture: () => void;
+  /** Clear the preview session's cookies. */
+  readonly onClearCookies: () => void;
+  /** Clear the preview session's HTTP cache. */
+  readonly onClearCache: () => void;
+  /** Read the guest's current zoom factor (1 = 100%). */
+  readonly onGetZoom: () => Promise<number>;
+  /** Set the guest's zoom factor; resolves to the clamped factor applied. */
+  readonly onSetZoom: (factor: number) => Promise<number>;
 }
 
 /** "Soon" pill for menu entries that are planned but not yet wired. */
@@ -40,10 +58,11 @@ function SoonTag() {
 
 /**
  * Overflow menu for the browser header. Holds the rarely-used tools that the
- * minimal header deliberately omits: New page plus the page-context capture
- * utilities (region crop, page-content dump), and the planned Developer tools
- * and device-toolbar entries shown as disabled "Soon" stubs. Keeps the everyday
- * header to back/forward, the URL, design, and screenshot.
+ * minimal header deliberately omits, in the order set by the right-panel epic:
+ * New page, Force reload, Dump page content, Region capture, Developer tools
+ * (disabled "Soon" stub), Show device toolbar (disabled "Soon" stub), Zoom,
+ * Clear cookies, Clear cache. Keeps the everyday header to back/forward, the
+ * URL, design, and screenshot.
  *
  * While open it suppresses the native Electron BrowserView (which paints above
  * all HTML and would otherwise occlude this menu) via the shared
@@ -52,10 +71,16 @@ function SoonTag() {
 export function BrowserOverflowMenu({
   hasLoadedPage,
   onNewPage,
-  onRegionCapture,
+  onForceReload,
   onDumpContent,
+  onRegionCapture,
+  onClearCookies,
+  onClearCache,
+  onGetZoom,
+  onSetZoom,
 }: BrowserOverflowMenuProps) {
   const [open, setOpen] = useState(false);
+  const [zoom, setZoom] = useState(1);
   const increment = usePreviewSuppressionStore((s) => s.increment);
   const decrement = usePreviewSuppressionStore((s) => s.decrement);
 
@@ -66,6 +91,26 @@ export function BrowserOverflowMenu({
     increment();
     return () => decrement();
   }, [open, increment, decrement]);
+
+  // Read the live zoom factor when the menu opens so the readout reflects the
+  // guest's actual state (which navigation can reset) rather than a stale value.
+  useEffect(() => {
+    if (!open || !hasLoadedPage) return;
+    let cancelled = false;
+    void onGetZoom().then((factor) => {
+      if (!cancelled) setZoom(factor);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, hasLoadedPage, onGetZoom]);
+
+  const applyZoom = useCallback(
+    (factor: number) => {
+      void onSetZoom(factor).then(setZoom);
+    },
+    [onSetZoom],
+  );
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -85,7 +130,7 @@ export function BrowserOverflowMenu({
       <DropdownMenuContent
         align="end"
         sideOffset={4}
-        className="min-w-[200px]"
+        className="min-w-[210px]"
         data-testid="browser-overflow-menu"
       >
         <DropdownMenuItem
@@ -95,7 +140,23 @@ export function BrowserOverflowMenu({
           <Plus size={14} className="text-muted-foreground" aria-hidden />
           New page
         </DropdownMenuItem>
+        <DropdownMenuItem
+          className="gap-2 px-3 py-1.5 text-xs"
+          disabled={!hasLoadedPage}
+          onClick={onForceReload}
+        >
+          <RotateCw size={14} className="text-muted-foreground" aria-hidden />
+          Force reload
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="gap-2 px-3 py-1.5 text-xs"
+          disabled={!hasLoadedPage}
+          onClick={onDumpContent}
+        >
+          <FileText size={14} className="text-muted-foreground" aria-hidden />
+          Dump page content
+        </DropdownMenuItem>
         <DropdownMenuItem
           className="gap-2 px-3 py-1.5 text-xs"
           disabled={!hasLoadedPage}
@@ -107,14 +168,6 @@ export function BrowserOverflowMenu({
             aria-hidden
           />
           Region capture
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="gap-2 px-3 py-1.5 text-xs"
-          disabled={!hasLoadedPage}
-          onClick={onDumpContent}
-        >
-          <FileText size={14} className="text-muted-foreground" aria-hidden />
-          Dump page content
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
@@ -136,6 +189,73 @@ export function BrowserOverflowMenu({
             Show device toolbar
           </span>
           <SoonTag />
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {/* Zoom is a control row, not a closeable menu item: a plain div keeps
+            the popup open so −/+ can be tapped repeatedly without dismissing it,
+            and avoids menu-item keyboard semantics fighting the nested buttons. */}
+        <div
+          className={cn(
+            "flex items-center justify-between px-3 py-1.5 text-xs",
+            !hasLoadedPage && "opacity-50",
+          )}
+        >
+          <span className="text-muted-foreground">Zoom</span>
+          <span className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Zoom out"
+              disabled={!hasLoadedPage}
+              className="size-5"
+              onClick={() => applyZoom(zoom - ZOOM_STEP)}
+            >
+              <Minus size={12} aria-hidden />
+            </Button>
+            <span className="w-9 text-center tabular-nums" aria-live="polite">
+              {Math.round(zoom * 100)}%
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Zoom in"
+              disabled={!hasLoadedPage}
+              className="size-5"
+              onClick={() => applyZoom(zoom + ZOOM_STEP)}
+            >
+              <Plus size={12} aria-hidden />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Reset zoom"
+              disabled={!hasLoadedPage}
+              className="ml-1 size-5"
+              onClick={() => applyZoom(1)}
+            >
+              <RotateCw size={11} aria-hidden />
+            </Button>
+          </span>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="gap-2 px-3 py-1.5 text-xs"
+          disabled={!hasLoadedPage}
+          onClick={onClearCookies}
+        >
+          <Cookie size={14} className="text-muted-foreground" aria-hidden />
+          Clear cookies
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="gap-2 px-3 py-1.5 text-xs"
+          disabled={!hasLoadedPage}
+          onClick={onClearCache}
+        >
+          <Trash2 size={14} className="text-muted-foreground" aria-hidden />
+          Clear cache
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -225,8 +225,13 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
         onToggleDesign={onToggleDesignMode}
         onScreenshot={capture.onAddPictureReference}
         onNewPage={tabs.newTab}
+        onForceReload={bridge.onForceReload}
         onRegionCapture={capture.onAddRegionPictureReference}
         onDumpContent={capture.onAddPageContextOnly}
+        onClearCookies={bridge.onClearCookies}
+        onClearCache={bridge.onClearCache}
+        onGetZoom={bridge.onGetZoom}
+        onSetZoom={bridge.onSetZoom}
       />
 
       {bridge.navError ? (

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -62,6 +62,16 @@ export interface PreviewBridgeState {
   readonly onGoBack: () => Promise<void>;
   readonly onGoForward: () => Promise<void>;
   readonly onReload: () => Promise<void>;
+  /** Hard reload that bypasses the guest cache. */
+  readonly onForceReload: () => Promise<void>;
+  /** Clear the preview session's cookies. */
+  readonly onClearCookies: () => Promise<void>;
+  /** Clear the preview session's HTTP cache. */
+  readonly onClearCache: () => Promise<void>;
+  /** Read the guest's current zoom factor (1 = 100%). */
+  readonly onGetZoom: () => Promise<number>;
+  /** Set the guest's zoom factor; resolves to the clamped factor applied. */
+  readonly onSetZoom: (factor: number) => Promise<number>;
   readonly onOpenExternal: () => Promise<void>;
   /** Navigate the preview to the given URL or file path. */
   readonly onNavigate: (url: string) => void;
@@ -299,6 +309,30 @@ export function usePreviewBridge({
     await refreshNav();
   }, [pushSync, refreshNav]);
 
+  const onForceReload = useCallback(async () => {
+    const preview = window.desktopBridge?.preview;
+    if (!preview) return;
+    await pushSync(true);
+    await preview.forceReload();
+    await refreshNav();
+  }, [pushSync, refreshNav]);
+
+  const onClearCookies = useCallback(async () => {
+    await window.desktopBridge?.preview?.clearCookies();
+  }, []);
+
+  const onClearCache = useCallback(async () => {
+    await window.desktopBridge?.preview?.clearCache();
+  }, []);
+
+  const onGetZoom = useCallback(async () => {
+    return (await window.desktopBridge?.preview?.getZoom()) ?? 1;
+  }, []);
+
+  const onSetZoom = useCallback(async (factor: number) => {
+    return (await window.desktopBridge?.preview?.setZoom(factor)) ?? 1;
+  }, []);
+
   const onOpenExternal = useCallback(async () => {
     const preview = window.desktopBridge?.preview;
     if (!preview) return;
@@ -342,6 +376,11 @@ export function usePreviewBridge({
     onGoBack,
     onGoForward,
     onReload,
+    onForceReload,
+    onClearCookies,
+    onClearCache,
+    onGetZoom,
+    onSetZoom,
     onOpenExternal,
     onNavigate,
     onRetry,

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -96,6 +96,16 @@ interface PreviewBridge {
   goBack(): Promise<boolean>;
   goForward(): Promise<boolean>;
   reload(): Promise<void>;
+  /** Hard reload that bypasses the guest's HTTP cache (Force reload). */
+  forceReload(): Promise<void>;
+  /** Clear the preview session's cookies. */
+  clearCookies(): Promise<void>;
+  /** Clear the preview session's HTTP cache. */
+  clearCache(): Promise<void>;
+  /** Read the guest's current zoom factor (1 = 100%). */
+  getZoom(): Promise<number>;
+  /** Set the guest's zoom factor; resolves to the clamped factor actually applied. */
+  setZoom(factor: number): Promise<number>;
   openExternal(): Promise<void>;
   /** Open Chrome DevTools attached to the guest WebContents (the embedded site, not the host shell). */
   openGuestDevTools(): Promise<void>;


### PR DESCRIPTION
@
## What

Consolidates the in-app browsers secondary tools into the header overflow (kebab) menu so the everyday header stays minimal (back/forward, URL, design, screenshot). Adds the new tools the epic ordering calls for and relocates the existing ones with behaviour unchanged.

Kebab order: New page, Force reload, Dump page content, Region capture, Developer tools (disabled "Soon"), Show device toolbar (disabled "Soon"), Zoom, Clear cookies, Clear cache.

## Why

Closes #616. The right-panel epic wants the browser header decluttered, with rarely-used utilities tucked behind the kebab and a defined tool order. Developer tools and Show device toolbar are surfaced now as disabled "coming soon" stubs to lock their placement ahead of implementation.

## Key changes

- **New preview IPC handlers** (`preview-navigation.ts`): `force-reload` (hard reload via `reloadIgnoringCache`, mirroring the existing reload torn-down-view recovery path), `clear-cookies`, `clear-cache`, `get-zoom`, `set-zoom`. Zoom is clamped main-side to Chromiums 0.25–5.0 range and snapped to whole percent.
- **Bridge plumbing**: exposed the five methods through `preload.ts`, `desktop-bridge.d.ts`, and `usePreviewBridge`.
- **`BrowserOverflowMenu`**: relocated tools into the epic order; added an inline Zoom stepper (−/100%/+/reset) implemented as a plain control row so repeated clicks dont dismiss the popup; added Clear cookies / Clear cache entries.
- **`BrowserHeader` / `PreviewPanel`**: wired the new props through.
- **E2E** (`preview-chrome.spec.ts`): updated to assert the new tool order, disabled-stub `data-disabled` state, and the zoom stepper readout.

## Security / isolation

`clearCookies` / `clearCache` operate on the previews dedicated `persist:mcode-preview` session partition only — they never touch the host apps storage.

## Verification

`bun run verify` green: typecheck + lint + **1546 unit tests** pass. E2E preview-chrome spec updated and passing.

## Acceptance criteria

- [x] The kebab contains the listed tools in order
- [x] Existing tools relocated into the kebab with behaviour unchanged
- [x] Developer tools and Show device toolbar are disabled "coming soon" entries

## Related issues

Closes #616
Relates to #608
@

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783685422&installation_id=129163861&pr_number=646&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F646&signature=b3999100a59b32a905523156291acf8bec77a4d2a7f9e123f96793e0ecbe4c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added force reload capability to preview browser (bypasses cache).
  * Added ability to clear cookies and HTTP cache for preview session.
  * Added zoom controls to adjust preview zoom level (25%–500% range).
  * New preview browser tools accessible through the overflow menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->