### PR TITLE
feat(panel): Review switcher as dropdown with contextual operand slot

### DIFF
--- a/apps/web/e2e/right-panel-review-dual-scope.spec.ts
+++ b/apps/web/e2e/right-panel-review-dual-scope.spec.ts
@@ -178,6 +178,8 @@ test.describe("Review tab — dual-scope view selection", () => {
     // Open the dropdown — the items render in a portal, not inside the trigger.
     await switcher.click();
     await expect(page.getByTestId("review-view-unstaged")).toBeVisible();
+    // The active view exposes its selected state to assistive tech.
+    await expect(page.getByTestId("review-view-unstaged")).toHaveAttribute("aria-current", "true");
     await expect(page.getByTestId("review-view-staged")).toBeVisible();
     await expect(page.getByTestId("review-view-commit")).toBeVisible();
     await expect(page.getByTestId("review-view-branch")).toBeVisible();

--- a/apps/web/e2e/right-panel-review-dual-scope.spec.ts
+++ b/apps/web/e2e/right-panel-review-dual-scope.spec.ts
@@ -4,10 +4,13 @@ import { getDefaultSettings } from "@mcode/contracts";
 import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
 
 /**
- * Covers the Review tab's dual-scope view selection (issue #614): with no thread
- * the toolbar offers the git working-tree views (Unstaged/Staged/Commit/Branch);
- * with a thread it offers the turn views (Last turn / Cumulative). The two view
- * sets never overlap, and each view renders a single diff.
+ * Covers the Review tab's dual-scope view selection (issues #614, #640): the
+ * toolbar's view selection is a dropdown labelled with the active view. With no
+ * thread it offers the git working-tree views (Unstaged/Staged/Commit/Branch);
+ * with a thread it adds the turn views (Last turn / Cumulative) on top. Opening
+ * the dropdown and selecting a view swaps the single rendered diff. A contextual
+ * operand slot sits beside the dropdown for the comparison views (Branch,
+ * Commit) and stays absent for fixed-operand views.
  */
 
 const now = new Date().toISOString();
@@ -162,50 +165,58 @@ test.describe("Review tab — dual-scope view selection", () => {
     );
   });
 
-  test("threadless: offers the git working-tree views, not the turn views", async ({ page }) => {
+  test("threadless: dropdown offers the git working-tree views, not the turn views", async ({
+    page,
+  }) => {
     await openThreadlessReview(page);
 
     const switcher = page.getByTestId("review-view-switcher");
-    await expect(switcher.getByTestId("review-view-unstaged")).toBeVisible({ timeout: 5_000 });
-    await expect(switcher.getByTestId("review-view-staged")).toBeVisible();
-    await expect(switcher.getByTestId("review-view-commit")).toBeVisible();
-    await expect(switcher.getByTestId("review-view-branch")).toBeVisible();
+    // The dropdown is labelled with the default threadless view (Unstaged).
+    await expect(switcher).toBeVisible({ timeout: 5_000 });
+    await expect(switcher).toContainText("Unstaged");
+
+    // Open the dropdown — the items render in a portal, not inside the trigger.
+    await switcher.click();
+    await expect(page.getByTestId("review-view-unstaged")).toBeVisible();
+    await expect(page.getByTestId("review-view-staged")).toBeVisible();
+    await expect(page.getByTestId("review-view-commit")).toBeVisible();
+    await expect(page.getByTestId("review-view-branch")).toBeVisible();
 
     // The thread-scoped turn views must not appear with no thread.
-    await expect(switcher.getByTestId("review-view-last-turn")).toHaveCount(0);
-    await expect(switcher.getByTestId("review-view-cumulative")).toHaveCount(0);
+    await expect(page.getByTestId("review-view-last-turn")).toHaveCount(0);
+    await expect(page.getByTestId("review-view-cumulative")).toHaveCount(0);
 
-    // Switching to Staged activates it (the segmented control marks it pressed).
-    await switcher.getByTestId("review-view-staged").click();
-    await expect(switcher.getByTestId("review-view-staged")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    // Selecting Staged swaps the view: the dropdown relabels and the menu closes.
+    await page.getByTestId("review-view-staged").click();
+    await expect(switcher).toContainText("Staged");
+    await expect(page.getByTestId("review-view-staged")).toHaveCount(0);
+    // Staged is a fixed-operand view — no operand slot.
+    await expect(page.getByTestId("review-operand-slot")).toHaveCount(0);
   });
 
-  test("thread: adds the turn views on top of the git working-tree views", async ({ page }) => {
+  test("thread: dropdown adds the turn views on top of the git working-tree views", async ({
+    page,
+  }) => {
     await openThreadReview(page);
 
     const switcher = page.getByTestId("review-view-switcher");
-    // Last turn is the default glance; Cumulative is the thread's net diff.
-    await expect(switcher.getByTestId("review-view-last-turn")).toBeVisible({ timeout: 5_000 });
-    await expect(switcher.getByTestId("review-view-last-turn")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    await expect(switcher.getByTestId("review-view-cumulative")).toBeVisible();
+    // Last turn is the default glance in a thread.
+    await expect(switcher).toBeVisible({ timeout: 5_000 });
+    await expect(switcher).toContainText("Last turn");
 
-    // The git working-tree views stay available in a thread (additive, dual-scope).
-    await expect(switcher.getByTestId("review-view-unstaged")).toBeVisible();
-    await expect(switcher.getByTestId("review-view-staged")).toBeVisible();
-    await expect(switcher.getByTestId("review-view-commit")).toBeVisible();
-    await expect(switcher.getByTestId("review-view-branch")).toBeVisible();
+    await switcher.click();
+    // All seven entries are reachable in a thread (additive, dual-scope).
+    await expect(page.getByTestId("review-view-last-turn")).toBeVisible();
+    await expect(page.getByTestId("review-view-cumulative")).toBeVisible();
+    await expect(page.getByTestId("review-view-unstaged")).toBeVisible();
+    await expect(page.getByTestId("review-view-staged")).toBeVisible();
+    await expect(page.getByTestId("review-view-commit")).toBeVisible();
+    await expect(page.getByTestId("review-view-branch")).toBeVisible();
 
-    // Switching to a git view activates it without leaving the thread.
-    await switcher.getByTestId("review-view-branch").click();
-    await expect(switcher.getByTestId("review-view-branch")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    // Selecting Branch swaps the diff without leaving the thread, and reveals the
+    // contextual operand slot (Branch carries a picked operand).
+    await page.getByTestId("review-view-branch").click();
+    await expect(switcher).toContainText("Branch");
+    await expect(page.getByTestId("review-operand-slot")).toHaveAttribute("data-operand", "branch");
   });
 });

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useMemo } from "react";
-import { Columns2, AlignJustify, WrapText } from "lucide-react";
+import { Columns2, AlignJustify, WrapText, Check, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -44,36 +51,60 @@ export function DiffToolbar() {
     }
   }, [viewMode, viewModes, scope, setViewMode]);
 
+  const activeView = useMemo(
+    () => viewModes.find((m) => m.id === viewMode),
+    [viewModes, viewMode],
+  );
+
   return (
     <div className="flex items-center justify-between px-3 py-2 border-b border-border/30">
-      {/* View mode segmented control — underline-on-active rather than the generic shadow-pill */}
-      <div className="flex items-center gap-4" data-testid="review-view-switcher">
-        {viewModes.map((mode) => {
-          const active = viewMode === mode.id;
-          return (
-            <Button
-              key={mode.id}
-              variant="ghost"
-              size="xs"
-              onClick={() => setViewMode(mode.id)}
-              data-testid={`review-view-${mode.id}`}
-              aria-pressed={active}
-              className={`relative h-auto rounded-none border-0 bg-transparent px-0 pb-1 text-[11px] font-medium tracking-tight hover:bg-transparent ${
-                active
-                  ? "text-foreground"
-                  : "text-muted-foreground/60 hover:text-foreground/80"
-              }`}
-            >
-              {mode.label}
-              {active && (
-                <span
-                  aria-hidden="true"
-                  className="absolute -bottom-[1px] left-0 right-0 h-[1.5px] bg-foreground/85"
-                />
-              )}
-            </Button>
-          );
-        })}
+      {/* View selection is a dropdown labelled with the active view, with a
+          contextual operand slot beside it for views that carry a picked
+          operand (Branch, Commit). The slot stays empty until the picker
+          slices land. */}
+      <div className="flex min-w-0 items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            data-testid="review-view-switcher"
+            disabled={viewModes.length === 0}
+            aria-label="Select review view"
+            className="flex h-6 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium tracking-tight text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+          >
+            {activeView?.label ?? "—"}
+            <ChevronDown size={11} className="text-muted-foreground/60" />
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent align="start" sideOffset={4} className="min-w-[150px]">
+            {viewModes.map((mode) => {
+              const active = viewMode === mode.id;
+              return (
+                <DropdownMenuItem
+                  key={mode.id}
+                  onClick={() => setViewMode(mode.id)}
+                  data-testid={`review-view-${mode.id}`}
+                  data-active={active ? "true" : undefined}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 px-2 py-1.5 text-xs",
+                    active ? "text-foreground" : "text-popover-foreground",
+                  )}
+                >
+                  <span className="flex-1 text-left">{mode.label}</span>
+                  {active && <Check size={11} className="text-muted-foreground" />}
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Operand slot — reserved for the active view's picked operand. Empty
+            for fixed-operand views; the per-operand picker lands in #641/#642. */}
+        {activeView?.operand && (
+          <div
+            className="flex min-w-0 items-center"
+            data-testid="review-operand-slot"
+            data-operand={activeView.operand}
+          />
+        )}
       </div>
 
       <div className="flex items-center gap-0.5">

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -83,6 +83,9 @@ export function DiffToolbar() {
                   onClick={() => setViewMode(mode.id)}
                   data-testid={`review-view-${mode.id}`}
                   data-active={active ? "true" : undefined}
+                  // base-ui menuitems have no checked state; aria-current exposes
+                  // the active view to assistive tech (the Check is visual-only).
+                  aria-current={active ? "true" : undefined}
                   className={cn(
                     "flex cursor-pointer items-center gap-2 px-2 py-1.5 text-xs",
                     active ? "text-foreground" : "text-popover-foreground",

--- a/apps/web/src/lib/__tests__/review-views.test.ts
+++ b/apps/web/src/lib/__tests__/review-views.test.ts
@@ -43,6 +43,16 @@ describe("REVIEW_VIEWS catalog", () => {
       "summary",
     ]);
   });
+
+  it("carries a picked operand only on the comparison views (Branch, Commit)", () => {
+    expect(REVIEW_VIEWS.filter((v) => v.operand).map((v) => [v.id, v.operand])).toEqual([
+      ["commit", "commit"],
+      ["branch", "branch"],
+    ]);
+    // The fixed-operand views surface no operand control.
+    const fixed = REVIEW_VIEWS.filter((v) => !v.operand).map((v) => v.id);
+    expect(fixed).toEqual(["unstaged", "staged", "last-turn", "cumulative", "summary"]);
+  });
 });
 
 describe("availableReviewViews — dual-scope selection", () => {

--- a/apps/web/src/lib/review-views.ts
+++ b/apps/web/src/lib/review-views.ts
@@ -10,6 +10,15 @@ import type { DiffViewMode } from "@/stores/diffStore";
 export type ReviewViewRequirement = "git" | "diffSummary";
 
 /**
+ * The kind of picked operand a comparison view surfaces in the toolbar's
+ * contextual operand slot. `"branch"` picks a base→target ref pair; `"commit"`
+ * picks a single commit. Views with no operand are *fixed* comparisons
+ * (Unstaged, Staged, Last turn, Cumulative) and render no operand control. See
+ * CONTEXT.md → "Comparison".
+ */
+export type ReviewViewOperand = "branch" | "commit";
+
+/**
  * Static metadata describing one Review-tab view for the dual-scope selection
  * model. Pure data — no store or React state. See CONTEXT.md → "Review tab".
  */
@@ -29,6 +38,12 @@ export interface ReviewView {
   readonly threadOnly: boolean;
   /** Optional extra gate beyond scope; see {@link ReviewViewRequirement}. */
   readonly requires?: ReviewViewRequirement;
+  /**
+   * The picked operand this view surfaces beside the switcher, if any. Absent
+   * for fixed comparisons. The toolbar reserves its operand slot for views that
+   * carry one; the picker that fills it lands per-operand in later slices.
+   */
+  readonly operand?: ReviewViewOperand;
 }
 
 /**
@@ -41,8 +56,8 @@ export interface ReviewView {
 export const REVIEW_VIEWS: readonly ReviewView[] = [
   { id: "unstaged", label: "Unstaged", threadOnly: false, requires: "git" },
   { id: "staged", label: "Staged", threadOnly: false, requires: "git" },
-  { id: "commit", label: "Commit", threadOnly: false, requires: "git" },
-  { id: "branch", label: "Branch", threadOnly: false, requires: "git" },
+  { id: "commit", label: "Commit", threadOnly: false, requires: "git", operand: "commit" },
+  { id: "branch", label: "Branch", threadOnly: false, requires: "git", operand: "branch" },
   { id: "last-turn", label: "Last turn", threadOnly: true },
   { id: "cumulative", label: "Cumulative", threadOnly: true },
   { id: "summary", label: "Summary", threadOnly: true, requires: "diffSummary" },


### PR DESCRIPTION
@
## What

Replace the Review tab flat underline tab-row with a view dropdown labelled by the active view, plus a contextual operand slot beside it for the comparison views that carry a picked operand (Branch, Commit). Selecting a view swaps the single rendered diff.

## Why

The flat tab-row did not scale to the growing set of review views and left no room for the comparison operand (which branch / which commit). A dropdown labelled by the active view plus a contextual operand slot is the foundation the comparison pickers, the Summary lens, and the future menu hang off.

## Key changes

- Add `ReviewViewOperand` model on Branch/Commit as the picker seam
- Convert `DiffToolbar` switcher to a `DropdownMenu`, keeping `review-view-*` ids
- Operand slot stays empty until the Branch/Commit picker slices (#641, #642) land; absent for fixed-operand views (Unstaged, Staged, Last turn, Cumulative)
- Dual-scope behavior unchanged: git views in both scopes, turn views in a thread only, runtime gates still applied
- Update review-views unit test and dual-scope E2E spec for the dropdown

## Related issues/PRs

Closes #640
Relates to #641, #642
@

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783685900&installation_id=129163861&pr_number=647&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F647&signature=5dda2df14b09b668007a65695526d69fced28115d01ebf1e399491b8196ff139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dropdown for selecting review views that relabels to the active view and indicates selection.
  * Conditional operand slot appears when a comparison view (Branch/Commit) is selected.

* **Refactor**
  * Replaced button-based view switcher with a dropdown menu for a cleaner toolbar.

* **Tests**
  * Updated end-to-end and unit tests to verify dropdown behavior, operand visibility, and active-state indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->