### PR TITLE
fix(claude): restore auto-compaction in 200k window after SDK 0.3.x bump

### DIFF
--- a/apps/server/src/providers/claude/__tests__/context-window.test.ts
+++ b/apps/server/src/providers/claude/__tests__/context-window.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the SDK 0.3.x context-window overrides.
+ *
+ * The 0.3.x CLI treats 1M-capable models as natively 1M-context, so without
+ * an autoCompactWindow override a standard-mode session never compacts before
+ * the 200k tier rejects the request, and the reported contextWindow inflates
+ * the UI ring to the 1M ceiling.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  STANDARD_CONTEXT_WINDOW_TOKENS,
+  resolveAutoCompactWindow,
+  clampContextWindowToMode,
+} from "../context-window.js";
+
+describe("resolveAutoCompactWindow", () => {
+  it("pins the auto-compact window to 200k in standard mode", () => {
+    expect(resolveAutoCompactWindow("200k", "claude-sonnet-4-6")).toBe(
+      STANDARD_CONTEXT_WINDOW_TOKENS,
+    );
+  });
+
+  it("pins the auto-compact window to 200k when the mode is unspecified", () => {
+    expect(resolveAutoCompactWindow(undefined, "claude-sonnet-4-6")).toBe(
+      STANDARD_CONTEXT_WINDOW_TOKENS,
+    );
+  });
+
+  it("sends no override in 1M mode for a 1M-capable model", () => {
+    expect(resolveAutoCompactWindow("1m", "claude-sonnet-4-6")).toBeUndefined();
+  });
+
+  it("still pins to 200k in 1M mode when the model does not support extended context", () => {
+    expect(resolveAutoCompactWindow("1m", "claude-haiku-4-5")).toBe(
+      STANDARD_CONTEXT_WINDOW_TOKENS,
+    );
+  });
+});
+
+describe("clampContextWindowToMode", () => {
+  it("clamps the SDK's 1M capability ceiling to 200k in standard mode", () => {
+    expect(clampContextWindowToMode(1_000_000, "200k", "claude-sonnet-4-6")).toBe(
+      STANDARD_CONTEXT_WINDOW_TOKENS,
+    );
+    expect(clampContextWindowToMode(1_000_000, undefined, "claude-sonnet-4-6")).toBe(
+      STANDARD_CONTEXT_WINDOW_TOKENS,
+    );
+  });
+
+  it("passes 200k-and-below values through unchanged", () => {
+    expect(clampContextWindowToMode(200_000, "200k", "claude-sonnet-4-6")).toBe(200_000);
+    expect(clampContextWindowToMode(180_000, undefined, "claude-sonnet-4-6")).toBe(180_000);
+  });
+
+  it("passes the reported window through unchanged in 1M mode for a 1M-capable model", () => {
+    expect(clampContextWindowToMode(1_000_000, "1m", "claude-sonnet-4-6")).toBe(1_000_000);
+  });
+
+  it("clamps in 1M mode when the model does not support extended context", () => {
+    expect(clampContextWindowToMode(1_000_000, "1m", "claude-haiku-4-5")).toBe(
+      STANDARD_CONTEXT_WINDOW_TOKENS,
+    );
+  });
+
+  it("returns undefined when the SDK reported no window", () => {
+    expect(clampContextWindowToMode(undefined, "200k", "claude-sonnet-4-6")).toBeUndefined();
+    expect(clampContextWindowToMode(undefined, "1m", "claude-sonnet-4-6")).toBeUndefined();
+  });
+});

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -30,6 +30,7 @@ import type {
 import { buildReasoningOptions } from "./build-reasoning-options.js";
 import { listClaudeModels } from "./list-models.js";
 import { applyUltrathinkPrefix, resolveSdkModelSlug } from "./resolve-slug.js";
+import { clampContextWindowToMode, resolveAutoCompactWindow } from "./context-window.js";
 import { readAnthropicOauthToken } from "@mcode/shared/usage";
 import { AnthropicOAuthUsageSource } from "./usage/oauth-usage-source.js";
 import { AnthropicHeaderUsageSource } from "./usage/header-usage-source.js";
@@ -979,6 +980,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
 
     const resumeId = this.sdkSessionIds.get(sessionId) ?? uuid;
 
+    const autoCompactWindow = resolveAutoCompactWindow(contextWindowMode, resolvedModel);
+
     const baseOptions = {
       cwd: resolvedCwd,
       // sdkModelSlug appends "[1m]" when the user opted into the 1M context window
@@ -1133,6 +1136,16 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       }) satisfies CanUseTool,
       ...buildReasoningOptions(reasoningLevel, resolvedModel, thinking),
       ...(fallbackModel && { fallbackModel }),
+      // SDK 0.3.x derives its auto-compaction trigger from the model's 1M
+      // capability ceiling; in standard mode that means compaction never fires
+      // before the 200k tier rejects the request. resolveAutoCompactWindow
+      // pins the window to 200k unless the session actually runs on the 1M
+      // wire tier (mode plus model support). Inline `settings` is the SDK's
+      // `--settings` layer, so this takes precedence over any autoCompactWindow
+      // in the user's own settings.json.
+      ...(autoCompactWindow !== undefined && {
+        settings: { autoCompactWindow },
+      }),
       includePartialMessages: true,
       // Guardrails are fixed at session creation. If the user changes the
       // setting between turns while the session is still live in memory, the
@@ -1723,13 +1736,22 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
 
               // Extract the authoritative context window from SDK modelUsage.
               // modelUsage is Record<modelId, { contextWindow?: number, ... }>.
+              // SDK 0.3.x reports the model's 1M capability ceiling here even
+              // when the session runs on the standard 200k tier, so clamp to
+              // the window mode the subprocess was actually spawned with.
               const sdkModelUsage = (anyMsg.modelUsage ?? {}) as Record<
                 string,
                 { contextWindow?: number }
               >;
-              const sdkContextWindow = Object.values(sdkModelUsage).find(
-                (u) => typeof u.contextWindow === "number",
-              )?.contextWindow;
+              const sdkContextWindow = clampContextWindowToMode(
+                Object.values(sdkModelUsage).find(
+                  (u) =>
+                    typeof u.contextWindow === "number" &&
+                    Number.isFinite(u.contextWindow),
+                )?.contextWindow,
+                entry?.contextWindowMode,
+                entry?.model,
+              );
 
               const usage = (anyMsg.usage ?? {}) as {
                 input_tokens?: number;

--- a/apps/server/src/providers/claude/context-window.ts
+++ b/apps/server/src/providers/claude/context-window.ts
@@ -1,0 +1,55 @@
+import type { ContextWindowMode } from "@mcode/contracts";
+import { supports1MContextWindow } from "@mcode/shared";
+
+/**
+ * The standard (non-1M) Claude context window in tokens. Every model mcode
+ * offers runs on this tier unless the user explicitly opts into 1M mode.
+ */
+export const STANDARD_CONTEXT_WINDOW_TOKENS = 200_000;
+
+/**
+ * Auto-compact window override passed to the SDK via the `settings` option.
+ *
+ * Claude Agent SDK 0.3.x treats 1M-capable models (Fable 5, Opus 4.x,
+ * Sonnet 4.6) as natively 1M-context, so its auto-compaction trigger only
+ * fires near 1M tokens. Subscription accounts without usage credits are
+ * rejected the moment a request crosses the 200k tier ("API Error: Usage
+ * credits required for 1M context"), which means a standard-mode session
+ * errors at the 200k limit instead of compacting. Pinning
+ * `autoCompactWindow` restores the 0.2.x behavior of compacting within the
+ * 200k window.
+ *
+ * Returns `undefined` only when the session actually runs on the 1M wire tier
+ * (`mode === "1m"` and the model supports `[1m]`). Models that ignore the mode
+ * flag (e.g. Haiku) still need the 200k pin.
+ */
+export function resolveAutoCompactWindow(
+  mode: ContextWindowMode | undefined,
+  modelId: string,
+): number | undefined {
+  if (mode === "1m" && supports1MContextWindow(modelId)) {
+    return undefined;
+  }
+  return STANDARD_CONTEXT_WINDOW_TOKENS;
+}
+
+/**
+ * Clamps the context window the SDK reports in `modelUsage` to the window the
+ * session actually runs in.
+ *
+ * In standard mode the 0.3.x SDK reports the model's 1M capability ceiling,
+ * not the 200k tier the requests are billed against, so the context ring and
+ * the token estimator would show ~20% fill at the real limit. In 1M mode the
+ * reported value is passed through unchanged.
+ */
+export function clampContextWindowToMode(
+  reported: number | undefined,
+  mode: ContextWindowMode | undefined,
+  modelId: string | undefined,
+): number | undefined {
+  if (reported === undefined) return reported;
+  if (mode === "1m" && modelId !== undefined && supports1MContextWindow(modelId)) {
+    return reported;
+  }
+  return Math.min(reported, STANDARD_CONTEXT_WINDOW_TOKENS);
+}


### PR DESCRIPTION
## What
Restore auto-compaction and accurate context-window reporting for standard (200k) Claude sessions after the Agent SDK bump to 0.3.x.

## Why
SDK 0.3.x treats 1M-capable models as natively 1M-context and sets its auto-compaction trigger near 1M tokens. On subscription accounts without 1M usage credits, sessions exceed the 200k tier and hit API rejection before compaction fires.

## Key changes
- Added `context-window.ts` with `resolveAutoCompactWindow` and `clampContextWindowToMode`
- Override SDK `autoCompactWindow` to 200k for sessions that do not actually run on the 1M wire tier (standard mode, or 1M mode on models like Haiku that ignore `[1m]`)
- Clamp `modelUsage.contextWindow` before emitting `turnComplete` so the context ring reflects the real 200k limit
- Guard against non-finite `contextWindow` values from the SDK
- 9 unit tests covering standard, 1M, and Haiku-in-1M-mode edge cases

## Configuration changes
None.

## Related issues/PRs
- SDK bump: commit 7559aa6d (Fable 5 migration)
- Upstream: https://code.claude.com/docs/en/agent-sdk/agent-loop
- Related upstream issues: anthropics/claude-code#18264, #24976

## Test plan
- [x] `bun run verify` (1252 tests)
- [x] `context-window.test.ts` (9 tests)
