### PR TITLE
fix(desktop): restore VS Code open-in on Windows

### DIFF
--- a/apps/desktop/src/main/__tests__/spawn-launch.test.ts
+++ b/apps/desktop/src/main/__tests__/spawn-launch.test.ts
@@ -89,7 +89,7 @@ describe("createExecutableResolver", () => {
 });
 
 describe("spawnDetached", () => {
-  it("quotes the executable and arguments in the Windows shell branch", async () => {
+  it("quotes only tokens with spaces or shell metacharacters in the Windows shell branch", async () => {
     setPlatform("win32");
     const child = fakeChild();
     spawnMock.mockReturnValue(child);
@@ -104,6 +104,22 @@ describe("spawnDetached", () => {
       expect.objectContaining({ shell: true, detached: true }),
     );
     expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it("leaves bare PATH commands and CLI flags unquoted in the Windows shell branch", async () => {
+    setPlatform("win32");
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = spawnDetached("code", ["-g", "C:\\my repo\\file.ts:42"]);
+    child.emit("spawn");
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "code",
+      ["-g", '"C:\\my repo\\file.ts:42"'],
+      expect.objectContaining({ shell: true, detached: true }),
+    );
   });
 
   it("spawns an .exe directly on Windows without a shell", async () => {

--- a/apps/desktop/src/main/open-in/spawn-launch.ts
+++ b/apps/desktop/src/main/open-in/spawn-launch.ts
@@ -51,13 +51,16 @@ export function createExecutableResolver(
 }
 
 /**
- * Wrap a token in double quotes for `cmd.exe`. Windows paths cannot contain `"`
- * (it is an illegal filename character), so quoting is both safe and sufficient:
- * spaces stay inside one argument and shell metacharacters such as `&`, `|`, or
- * `^` in a directory name are read literally instead of chaining commands.
+ * Quote a token for a `shell: true` spawn on Windows. cmd.exe joins the command
+ * and args into a single line and applies no quoting of its own, so a token
+ * containing whitespace or a shell metacharacter (`& | < > ^ ( )`) would be
+ * split - or, for metacharacters, interpreted by cmd.exe (command injection).
+ * Wrapping such a token in double quotes neutralizes both; Windows paths cannot
+ * contain `"`, so quoting is lossless. Tokens needing no quoting (e.g. `code`,
+ * `-g`) pass through untouched so PATH shims and CLI flags stay intact.
  */
-function quoteForCmd(token: string): string {
-  return `"${token}"`;
+function quoteForShell(token: string): string {
+  return /[\s&|<>^()]/.test(token) ? `"${token}"` : token;
 }
 
 /**
@@ -69,10 +72,10 @@ function quoteForCmd(token: string): string {
  * path are handled by Node instead of breaking `cmd.exe` word-splitting. Bare
  * PATH commands ("code") and `.cmd`/`.bat` shims still need `shell: true` so
  * Windows can resolve and execute them; with `shell: true` Node forwards the raw
- * argv to `cmd.exe` without quoting, so the executable and every argument are
- * quoted here. That keeps spaced install paths (e.g. "Microsoft VS Code") and
- * spaced target directories intact, and prevents a directory name from injecting
- * a chained command.
+ * argv to `cmd.exe` without quoting, so only tokens that carry spaces or shell
+ * metacharacters are quoted here. That keeps spaced install paths (e.g.
+ * "Microsoft VS Code") and spaced target directories intact without wrapping bare
+ * command names or flags like `-g` in extra quotes.
  */
 export function spawnDetached(cmd: string, args: string[]): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -80,7 +83,7 @@ export function spawnDetached(cmd: string, args: string[]): Promise<void> {
     if (process.platform === "win32" && /\.exe$/i.test(cmd)) {
       child = spawn(cmd, args, { detached: true, stdio: "ignore" });
     } else if (process.platform === "win32") {
-      child = spawn(quoteForCmd(cmd), args.map(quoteForCmd), {
+      child = spawn(quoteForShell(cmd), args.map(quoteForShell), {
         detached: true,
         stdio: "ignore",
         shell: true,

--- a/apps/web/src/components/chat/__tests__/OpenInAppButton.test.tsx
+++ b/apps/web/src/components/chat/__tests__/OpenInAppButton.test.tsx
@@ -91,7 +91,7 @@ function app(over: Partial<OpenInApp> & Pick<OpenInApp, "id">): OpenInApp {
   return { label: over.id, kind: "editor", iconKey: over.id, detected: true, ...over };
 }
 
-const VSCODE = app({ id: "vscode", label: "VS Code", iconKey: "vscode" });
+const VSCODE = app({ id: "code", label: "VS Code", iconKey: "vscode" });
 const CURSOR = app({ id: "cursor", label: "Cursor", iconKey: "cursor" });
 const WINDOWS_TERMINAL = app({
   id: "windows-terminal",
@@ -113,14 +113,14 @@ describe("OpenInAppButton", () => {
   it("primary click opens the resolved default (auto-detected top editor)", async () => {
     render(<OpenInAppButton dirPath="/dir" threadId="t1" threadOverride={null} />);
     await userEvent.click(screen.getByRole("button", { name: /open in vs code/i }));
-    expect(openInSpy).toHaveBeenCalledWith("vscode", "/dir");
+    expect(openInSpy).toHaveBeenCalledWith("code", "/dir");
   });
 
   it("mod+o command opens the resolved default through the transport", () => {
     render(<OpenInAppButton dirPath="/dir" threadId="t1" threadOverride={null} />);
     expect(getCommand("openin.openDefault")).toBeDefined();
     executeCommand("openin.openDefault");
-    expect(openInSpy).toHaveBeenCalledWith("vscode", "/dir");
+    expect(openInSpy).toHaveBeenCalledWith("code", "/dir");
   });
 
   it("honours the thread override as tier-1 default", async () => {


### PR DESCRIPTION
## What
Fixed Open in VS Code on Windows by correcting how editor launch arguments are quoted for `cmd.exe`.

## Why
PR #623 added Visual Studio support and quoted every spawn token to handle spaced install paths. Visual Studio uses `devenv.exe` and takes the direct spawn path, so it kept working. VS Code goes through the `shell: true` branch via `code` or `code.cmd`, and over-quoting broke PATH resolution and CLI flags like `-g`.

## Key changes
- Use selective quoting in `spawn-launch.ts` (only tokens with spaces or shell metacharacters), matching the terminal adapter pattern
- Add a regression test for bare `code` + `-g` with a spaced path
- Fix `OpenInAppButton.test.tsx` to use the correct registry id `code` instead of `vscode`

## Configuration changes
None

## Related issues/PRs
- Relates to #623
- Relates to #605

## Test plan
- [x] `apps/desktop`: spawn-launch tests (7/7)
- [x] `apps/desktop`: open-in adapter tests (8/8)
- [x] `apps/web`: OpenInAppButton tests (7/7)
- [ ] Manual: Open in VS Code from thread header on Windows
- [ ] Manual: Open file at line from diff view in VS Code on Windows

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698561&installation_id=129163861&pr_number=676&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F676&signature=77786e946a97de049226917c048a7708a886d9e95aeae8771ff77fab34f04ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows command spawning now applies selective quoting, quoting only tokens with spaces or shell metacharacters while preserving bare command names and flags unquoted

* **Tests**
  * Enhanced test coverage for Windows shell command quoting behavior with additional validation scenarios
  * Updated default app selection identifier in tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->