### PR TITLE
feat(panel): composer-first layout, maximize mode, and right panel polish

### DIFF
--- a/apps/web/e2e/right-panel-activity-rail.spec.ts
+++ b/apps/web/e2e/right-panel-activity-rail.spec.ts
@@ -153,15 +153,27 @@ test.describe("Right panel activity rail", () => {
     await expect(page.locator('[data-rail-tab="terminal"]')).toHaveCount(0);
     await expect(page.locator('[data-rail-tab="preview"]')).toHaveClass(/text-primary/);
 
-    // Closing the last tab returns to the empty-state card grid.
+    // Closing the last tab returns to the empty-state tool list; maximize stays on the rail.
     await page.locator('[data-rail-tab="preview"]').hover();
     await page.getByRole("button", { name: "Close Browser" }).click();
     await expect(page.getByTestId("panel-empty-state")).toBeVisible();
+    await expect(page.getByTestId("rail-maximize-toggle")).toBeVisible();
+  });
+
+  test("maximize button is visible in the empty state", async ({ page }) => {
+    await seed(page);
+
+    await expect(page.getByTestId("panel-empty-state")).toBeVisible();
+    await expect(page.getByTestId("rail-maximize-toggle")).toBeVisible();
+    await expect(page.getByTestId("rail-maximize-toggle")).toHaveAttribute(
+      "aria-label",
+      "Maximize panel",
+    );
   });
 
   test("add control: hidden when nothing is creatable", async ({ page }) => {
-    // Threadless, both creatable types open → nothing left to create.
-    await seed(page, { tabs: ["preview", "terminal"] });
+    // Threadless with every creatable tab open (Browser, Terminal, Review).
+    await seed(page, { tabs: ["preview", "terminal", "changes"] });
 
     const rail = page.getByTestId("activity-rail");
     await expect(rail).toBeVisible();
@@ -169,16 +181,16 @@ test.describe("Right panel activity rail", () => {
   });
 
   test("add control: one creatable type opens directly", async ({ page }) => {
-    // Threadless with only Terminal open → Browser is the sole creatable type.
-    await seed(page, { tabs: ["terminal"] });
+    // Threadless with Browser and Terminal open → Review is the sole creatable type.
+    await seed(page, { tabs: ["preview", "terminal"] });
 
-    const addDirect = page.getByRole("button", { name: "New Browser" });
+    const addDirect = page.getByRole("button", { name: "New Review" });
     await expect(addDirect).toBeVisible();
     // No menu trigger when a single type opens directly.
     await expect(page.getByRole("button", { name: "New tab" })).toHaveCount(0);
 
     await addDirect.click();
-    await expect(page.locator('[data-rail-tab="preview"]')).toHaveClass(/text-primary/);
+    await expect(page.locator('[data-rail-tab="changes"]')).toHaveClass(/text-primary/);
   });
 
   test("add control: several creatable types show a menu", async ({ page }) => {
@@ -197,5 +209,26 @@ test.describe("Right panel activity rail", () => {
     // Choosing Terminal opens and activates it.
     await page.getByRole("menuitem", { name: /Terminal/ }).click();
     await expect(page.locator('[data-rail-tab="terminal"]')).toHaveClass(/text-primary/);
+  });
+
+  test("maximize button fills the content area and restores on second click", async ({ page }) => {
+    await seed(page, { tabs: ["terminal"] });
+
+    const chatMain = page.locator("main").filter({ has: page.getByText("Message Mcode...") });
+    const projectTree = page.getByRole("button", { name: "Activity Rail Delete Activity Rail" });
+    const maximize = page.getByTestId("rail-maximize-toggle");
+
+    await expect(chatMain).toBeVisible();
+    await expect(projectTree).toBeVisible();
+    await expect(maximize).toBeVisible();
+
+    await maximize.click();
+    await expect(chatMain).toBeHidden();
+    await expect(projectTree).toBeVisible();
+    await expect(maximize).toHaveAttribute("aria-label", "Restore panel");
+
+    await maximize.click();
+    await expect(chatMain).toBeVisible();
+    await expect(maximize).toHaveAttribute("aria-label", "Maximize panel");
   });
 });

--- a/apps/web/e2e/right-panel-toggle-shortcut.spec.ts
+++ b/apps/web/e2e/right-panel-toggle-shortcut.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { Thread } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+/**
+ * The `rightPanel.toggle` command (bound to mod+alt+b — Ctrl+Alt+B on
+ * Windows/Linux, Cmd+Alt+B on macOS) shows and hides the whole right panel.
+ * Unlike the per-tab summon shortcuts, it has no `!inputFocused` guard, so it
+ * works while the composer is focused — the common case when a developer is
+ * typing a prompt and wants to flip the panel open.
+ */
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-panel-shortcut",
+  name: "Panel Shortcut",
+  path: "/tmp/panel-shortcut",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+const THREAD: Thread = {
+  id: "thread-panel-shortcut",
+  workspace_id: WORKSPACE.id,
+  title: "Panel Shortcut",
+  status: "paused",
+  mode: "direct",
+  worktree_path: null,
+  branch: "main",
+  worktree_managed: false,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+/** Reads the panel's effective open/closed state for the active thread. */
+async function panelVisible(page: Page): Promise<boolean> {
+  return page.evaluate(({ wid, tid }) => {
+    const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+    const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+    const diff = stores.find((s) => "getRightPanelVisible" in getState(s));
+    return (
+      diff as { getState: () => { getRightPanelVisible: (w: string, t?: string) => boolean } }
+    ).getState().getRightPanelVisible(wid, tid);
+  }, { wid: WORKSPACE.id, tid: THREAD.id });
+}
+
+test.describe("Right panel toggle shortcut", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [THREAD],
+      "settings.get": getDefaultSettings(),
+      "thread.getTasks": [],
+      "snapshot.listByThread": [],
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+    await page.evaluate(({ ws, thread }) => {
+      const stores: unknown[] = (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+      const wsStore = stores.find((s) => "activeThreadId" in getState(s) && "threads" in getState(s));
+      (wsStore as { setState: (p: unknown) => void } | undefined)?.setState({
+        workspaces: [ws],
+        activeWorkspaceId: ws.id,
+        threads: [thread],
+        activeThreadId: thread.id,
+      });
+    }, { ws: WORKSPACE, thread: THREAD });
+  });
+
+  test("mod+alt+b shows then hides the panel while the composer is focused", async ({ page }) => {
+    // Focus the composer to mimic typing a prompt — the guard-free shortcut must
+    // still fire here (the per-tab summons are gated on !inputFocused; this isn't).
+    await page.locator('[contenteditable="true"]').first().click().catch(() => {});
+
+    expect(await panelVisible(page)).toBe(false);
+
+    await page.keyboard.press("Control+Alt+b");
+    await expect.poll(() => panelVisible(page), { timeout: 4_000 }).toBe(true);
+    await expect(page.getByTestId("activity-rail")).toBeVisible();
+
+    await page.keyboard.press("Control+Alt+b");
+    await expect.poll(() => panelVisible(page), { timeout: 4_000 }).toBe(false);
+  });
+});

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   useDiffStore,
   PANEL_MIN_WIDTH,
+  COMPOSER_MIN_WIDTH,
+  PANEL_SPLIT_GAP_PX,
+  maxPanelWidthInSplit,
   getDefaultPanelWidthPx,
   createDefaultRightPanelState,
   DEFAULT_LINE_WRAP,
@@ -116,6 +119,19 @@ describe("diffStore", () => {
       const { setRightPanelWidth, getRightPanel } = useDiffStore.getState();
       setRightPanelWidth("ws-1", 100);
       expect(getRightPanel("ws-1").width).toBe(PANEL_MIN_WIDTH);
+    });
+  });
+
+  describe("maxPanelWidthInSplit", () => {
+    it("reserves composer min width and split gap from the row width", () => {
+      const split = 1200;
+      expect(maxPanelWidthInSplit(split)).toBe(
+        split - COMPOSER_MIN_WIDTH - PANEL_SPLIT_GAP_PX,
+      );
+    });
+
+    it("never returns below PANEL_MIN_WIDTH", () => {
+      expect(maxPanelWidthInSplit(500)).toBe(PANEL_MIN_WIDTH);
     });
   });
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, lazy, Suspense } from "react";
+import { useEffect, useState, useRef, lazy, Suspense } from "react";
 import { Sidebar } from "@/components/sidebar/Sidebar";
 import { ChatView } from "@/components/chat/ChatView";
 import { ConnectionBanner } from "@/components/ConnectionBanner";
@@ -13,6 +13,7 @@ import { ShortcutHelpDialog } from "@/components/ShortcutHelpDialog";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { resizeRecordCache } from "@/lib/thread-hydrator/record-cache";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { COMPOSER_MIN_WIDTH } from "@/stores/diffStore";
 import { usePreviewFocusStore } from "@/stores/previewFocusStore";
 import { useUiStore } from "@/stores/uiStore";
 import { initShortcuts } from "@/lib/shortcuts";
@@ -21,6 +22,8 @@ import { registerCommand } from "@/lib/command-registry";
 import { setContext } from "@/lib/context-tracker";
 import { startPushListeners, stopPushListeners } from "@/transport/ws-events";
 import { useIdleReclamation } from "@/hooks/useIdleReclamation";
+import { useComposerLayoutGuard } from "@/hooks/useComposerLayoutGuard";
+import { toggleRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ToastContainer } from "@/components/Toast";
 import type { SettingsSection } from "@/components/settings/settings-nav";
@@ -50,13 +53,32 @@ export function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSection, setSettingsSection] = useState<SettingsSection>("model");
   const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
+  const sidebarFloating = useUiStore((s) => s.sidebarFloating);
+  const rightPanelMaximized = useUiStore((s) => s.rightPanelMaximized);
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const outerRowRef = useRef<HTMLDivElement>(null);
+  const contentRowRef = useRef<HTMLDivElement>(null);
   const pendingNewThread = useWorkspaceStore((s) => s.pendingNewThread);
   // Landing is the default whenever no thread is active. The new-thread composer
   // takes precedence so the user can compose against an active workspace without
   // bouncing back to the project list.
   const showLanding = activeThreadId === null && !pendingNewThread;
   useIdleReclamation();
+
+  useComposerLayoutGuard(outerRowRef, contentRowRef, {
+    settingsOpen,
+    showLanding,
+    activeWorkspaceId,
+    activeThreadId,
+  });
+
+  // Settings uses a docked project tree; undock the float when entering settings.
+  useEffect(() => {
+    if (settingsOpen) {
+      useUiStore.setState({ sidebarFloating: false, sidebarCollapsed: false });
+    }
+  }, [settingsOpen]);
 
   useEffect(() => {
     startPushListeners();
@@ -187,6 +209,19 @@ export function App() {
         handler: () => useUiStore.getState().toggleSidebar(),
       }),
       registerCommand({
+        id: "rightPanel.toggle",
+        title: "Toggle Right Panel",
+        category: "View",
+        // Panel-level open/close (mirrors the chat-header toggle button); the
+        // per-tab summon commands focus a specific tab, this just shows/hides the
+        // whole panel for the active thread (or the threadless workspace shell).
+        handler: () => {
+          const { activeWorkspaceId, activeThreadId } = useWorkspaceStore.getState();
+          if (!activeWorkspaceId) return;
+          toggleRightPanelAdaptive(activeWorkspaceId, activeThreadId);
+        },
+      }),
+      registerCommand({
         id: "terminal.toggle",
         title: "Toggle Terminal",
         category: "View",
@@ -293,12 +328,14 @@ export function App() {
           appears lifted off the chrome — no inter-panel divider lines required. */}
       <div className="flex h-screen flex-col overflow-hidden bg-page text-foreground">
         <ConnectionBanner />
-        <div className="flex flex-1 gap-1.5 overflow-hidden p-1.5">
-          {/* Settings view force-expands the sidebar so the settings nav is reachable.
-              When the sidebar is hidden, the chat panel claims the full width and the
-              reveal button lives inline in the chat header (see ChatView). */}
-          {(!sidebarCollapsed || settingsOpen) && (
-            <div className="flex shrink-0 overflow-hidden rounded-lg shadow-sm">
+        <div ref={outerRowRef} className="flex flex-1 gap-1.5 overflow-hidden p-1.5">
+          {/* Docked project tree: hidden when collapsed, force-shown in settings,
+              or shown as a float (see below). Maximize hides only the chat pane. */}
+          {(!sidebarCollapsed || settingsOpen) && !sidebarFloating && (
+            <div
+              data-testid="sidebar-docked"
+              className="flex shrink-0 overflow-hidden rounded-lg shadow-sm"
+            >
               <Sidebar
                 settingsOpen={settingsOpen}
                 settingsSection={settingsSection}
@@ -308,8 +345,39 @@ export function App() {
               />
             </div>
           )}
-          <div className="flex flex-1 gap-1.5 overflow-hidden">
-            <main className="flex-1 overflow-hidden rounded-lg bg-background shadow-sm">
+          {sidebarFloating && !sidebarCollapsed && !settingsOpen && (
+            <>
+              <button
+                type="button"
+                aria-label="Close project tree"
+                className="fixed inset-0 z-40 bg-black/20"
+                onClick={() => useUiStore.getState().closeFloatingSidebar()}
+              />
+              <div
+                data-testid="sidebar-floating"
+                className="fixed bottom-1.5 left-1.5 top-1.5 z-50 flex w-72 overflow-hidden rounded-lg shadow-xl ring-1 ring-border/40"
+              >
+                <Sidebar
+                  settingsOpen={false}
+                  settingsSection={settingsSection}
+                  onSettingsSection={setSettingsSection}
+                  onOpenSettings={() => setSettingsOpen(true)}
+                  onCloseSettings={() => setSettingsOpen(false)}
+                />
+              </div>
+            </>
+          )}
+          <div
+            ref={contentRowRef}
+            data-testid="content-row"
+            className="flex min-w-0 flex-1 gap-1.5 overflow-hidden"
+          >
+            {/* Chat / settings / landing: hidden when the right panel is maximized. */}
+            {!rightPanelMaximized && (
+            <main
+              className="flex-1 overflow-hidden rounded-lg bg-background shadow-sm"
+              style={{ minWidth: COMPOSER_MIN_WIDTH }}
+            >
               {settingsOpen ? (
                 <Suspense fallback={null}>
                   <LazySettingsView section={settingsSection} />
@@ -329,6 +397,7 @@ export function App() {
                 <ChatView />
               )}
             </main>
+            )}
             {!settingsOpen && !showLanding && (
               <Suspense fallback={null}>
                 <LazyRightPanel />

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -46,6 +46,10 @@ import { AgentStatusBar } from "./AgentStatusBar";
 import { TerminalStatusIndicator } from "./TerminalStatusIndicator";
 import { useTaskStore } from "@/stores/taskStore";
 import { useDiffStore } from "@/stores/diffStore";
+import {
+  hideRightPanelAdaptive,
+  showRightPanelAdaptive,
+} from "@/lib/right-panel-layout";
 import { extractFileRefs, buildInjectedMessage } from "@/lib/file-tags";
 import { resolveBranchName } from "@/lib/branch-name";
 import { useSlashCommand } from "./useSlashCommand";
@@ -185,9 +189,9 @@ function ComposerOptionsMenu({
     // Scope is thread-only; open/closed is per-thread, width/tab workspace-keyed.
     if (!threadId || !activeWorkspaceId) return;
     if (panelVisible) {
-      useDiffStore.getState().hideRightPanel(activeWorkspaceId, threadId);
+      hideRightPanelAdaptive(activeWorkspaceId, threadId);
     } else {
-      useDiffStore.getState().showRightPanel(activeWorkspaceId, threadId);
+      showRightPanelAdaptive(activeWorkspaceId, threadId);
       useDiffStore.getState().setRightPanelTab(activeWorkspaceId, "tasks");
     }
   };
@@ -346,9 +350,9 @@ function InlineComposerOptions({
     // Scope is thread-only; open/closed is per-thread, width/tab workspace-keyed.
     if (!threadId || !activeWorkspaceId) return;
     if (panelVisible) {
-      useDiffStore.getState().hideRightPanel(activeWorkspaceId, threadId);
+      hideRightPanelAdaptive(activeWorkspaceId, threadId);
     } else {
-      useDiffStore.getState().showRightPanel(activeWorkspaceId, threadId);
+      showRightPanelAdaptive(activeWorkspaceId, threadId);
       useDiffStore.getState().setRightPanelTab(activeWorkspaceId, "tasks");
     }
   };

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -7,6 +7,7 @@ import { useBranchPr } from "@/hooks/useBranchPr";
 import { useHasCommitsAhead } from "@/hooks/useHasCommitsAhead";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore } from "@/stores/diffStore";
+import { toggleRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { useComposerDraftStore } from "@/stores/composerDraftStore";
 import { executeCommand } from "@/lib/command-registry";
 import { isPrable } from "@/lib/is-prable";
@@ -129,7 +130,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
 
   const togglePanel = useCallback(() => {
     if (!thread.workspace_id) return;
-    useDiffStore.getState().toggleRightPanel(thread.workspace_id, thread.id);
+    toggleRightPanelAdaptive(thread.workspace_id, thread.id);
   }, [thread.workspace_id, thread.id]);
 
   const openChanges = useCallback(() => {
@@ -139,6 +140,12 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
   // Mirror the live keybinding so the menu hint stays correct if the user rebinds it.
   const changesShortcut = formatKeybinding(
     getKeybindingForCommand("changes.toggle")?.key ?? "mod+d",
+    isMac,
+  );
+
+  // Live keycap for the right-panel toggle, shown in the button's tooltip.
+  const panelShortcut = formatKeybinding(
+    getKeybindingForCommand("rightPanel.toggle")?.key ?? "mod+alt+b",
     isMac,
   );
 
@@ -277,7 +284,8 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
           }
         />
         <TooltipContent side="bottom" className="text-xs">
-          Toggle panel
+          Toggle panel{" "}
+          <span className="text-foreground">{panelShortcut}</span>
         </TooltipContent>
       </Tooltip>
 

--- a/apps/web/src/components/chat/PlanCard.tsx
+++ b/apps/web/src/components/chat/PlanCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { usePlanStore } from "@/stores/planStore";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { showRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { ScrollText, ArrowUpRight } from "lucide-react";
 
 interface PlanCardProps {
@@ -30,7 +31,7 @@ export function PlanCard({ messageId }: PlanCardProps) {
   const sectionCount = plan.sectionsJson?.length ?? 0;
 
   const handleClick = () => {
-    useDiffStore.getState().showRightPanel(activeWorkspaceId, activeThreadId);
+    showRightPanelAdaptive(activeWorkspaceId, activeThreadId);
     useDiffStore.getState().setRightPanelTab(activeWorkspaceId, "tasks");
     usePlanStore.getState().setActiveVersion(activeThreadId, plan.version);
   };

--- a/apps/web/src/components/chat/TurnChangeSummary.tsx
+++ b/apps/web/src/components/chat/TurnChangeSummary.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useDiffStore } from "@/stores/diffStore";
 import { readThreadRecord } from "@/stores/thread-selectors";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { showRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { getTransport } from "@/transport";
 
 /** Props for TurnChangeSummary. */
@@ -99,7 +100,7 @@ export function TurnChangeSummary({ messageId, filesChanged, isLatestTurn, manua
     if (!threadId || !workspaceId) return;
 
     const store = useDiffStore.getState();
-    store.showRightPanel(workspaceId, threadId);
+    showRightPanelAdaptive(workspaceId, threadId);
     store.setRightPanelTab(workspaceId, "changes");
     // "View all diffs" lands on the thread's cumulative diff across every turn.
     store.setViewMode("cumulative");

--- a/apps/web/src/components/diff/GitDiffView.tsx
+++ b/apps/web/src/components/diff/GitDiffView.tsx
@@ -129,6 +129,10 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
         // Cache + per-file fetch scope: the real thread (→ its worktree) when in a
         // thread, else the workspace id (the server reads the workspace root).
         threadId={threadId ?? workspaceId}
+        // Open each file's diff on arrival so switching between the git views
+        // lands on the changes directly, without a click per file (each diff is
+        // still fetched lazily on mount and large diffs stay truncated).
+        defaultFilesExpanded
       />
     </div>
   );

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -1,4 +1,4 @@
-import { Globe, Plus, X } from "lucide-react";
+import { Globe, Maximize2, Minimize2, Plus, X } from "lucide-react";
 import type { BrowserTabInfo, BrowserTabSet } from "@mcode/contracts";
 import { Button } from "@/components/ui/button";
 import {
@@ -408,11 +408,11 @@ function RailAddControl({
 }
 
 /**
- * Vertical activity rail that navigates the right panel's open singleton tabs.
- * Each open tab is an icon with an active-tab lamp; hovering an icon reveals an
- * × that closes it. An add control offers the creatable set (one opens directly,
- * several show a menu, none hides it). The panel's close-chrome lives at the
- * foot of the rail so it stays reachable in every state. See ADR-0004 / issue #611.
+ * Vertical activity rail for the right panel: maximize/restore at the head, then
+ * open singleton tabs (active lamp, hover-× close, add control when tabs exist).
+ * With no tabs open the rail is only the maximize toggle beside the empty-state
+ * list. The panel itself is opened and closed from the chat-header toggle.
+ * See ADR-0004 / issue #611.
  */
 export function ActivityRail({
   openTabs,
@@ -422,10 +422,11 @@ export function ActivityRail({
   changesCount,
   changesFresh,
   browserTabSet,
+  maximized,
+  onToggleMaximized,
   onSelect,
   onClose,
   onCreate,
-  onClosePanel,
   onSelectBrowserPage,
   onCloseBrowserPage,
 }: {
@@ -437,10 +438,12 @@ export function ActivityRail({
   readonly changesFresh: boolean;
   /** The Browser tab's open pages, or null when none are known (web build / not yet loaded). */
   readonly browserTabSet: BrowserTabSet | null;
+  /** Whether the panel is maximized (fills content area beside the project tree). */
+  readonly maximized: boolean;
+  onToggleMaximized: () => void;
   onSelect: (id: RightPanelTab) => void;
   onClose: (id: RightPanelTab) => void;
   onCreate: (id: RightPanelTab) => void;
-  onClosePanel: () => void;
   onSelectBrowserPage: (pageId: string) => void;
   onCloseBrowserPage: (pageId: string) => void;
 }) {
@@ -449,6 +452,20 @@ export function ActivityRail({
       data-testid="activity-rail"
       className="flex w-12 flex-none flex-col items-center gap-1 border-r border-border/40 py-2"
     >
+      {/* Maximize / restore sits at the rail head (not the foot) so it stays in
+          the first tab stop and never scrolls off-screen on short viewports. */}
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        onClick={onToggleMaximized}
+        className="h-7 w-7 shrink-0 text-muted-foreground/70 transition-colors hover:bg-transparent hover:text-foreground"
+        aria-label={maximized ? "Restore panel" : "Maximize panel"}
+        title={maximized ? "Restore panel" : "Maximize panel"}
+        data-testid="rail-maximize-toggle"
+      >
+        {maximized ? <Minimize2 size={13} /> : <Maximize2 size={13} />}
+      </Button>
+
       {openTabs.map((id) => {
         // The Browser tab becomes its page switcher: when its pages are known,
         // render them as a favicon group instead of the single tab glyph. With
@@ -483,15 +500,6 @@ export function ActivityRail({
       {openTabs.length > 0 && (
         <RailAddControl scope={scope} openTabs={openTabs} onCreate={onCreate} />
       )}
-      <Button
-        variant="ghost"
-        size="icon-xs"
-        onClick={onClosePanel}
-        className="mt-auto h-7 w-7 text-muted-foreground/70 transition-colors hover:bg-transparent hover:text-foreground"
-        aria-label="Close panel"
-      >
-        <X size={13} />
-      </Button>
     </div>
   );
 }

--- a/apps/web/src/components/panels/PanelEmptyState.tsx
+++ b/apps/web/src/components/panels/PanelEmptyState.tsx
@@ -27,12 +27,16 @@ function SoonBadge() {
 }
 
 /**
- * The empty-state create surface for the right panel: a card grid of the tab
- * types creatable in the current scope. Each card carries an icon, label, blurb,
- * and the type's mcode keycap; clicking one opens that tab. Coming-soon types
- * (Files) render as a disabled "Soon" teaser and are excluded from the creatable
- * set. There is intentionally no add control here — the grid is the create
- * surface (ADR-0004, issue #610).
+ * The empty-state create surface for the right panel: a centered list of the
+ * tab types creatable in the current scope, under a short header. Each row
+ * carries an icon, label, blurb, and the type's mcode keycap; clicking one opens
+ * that tab. Coming-soon types (Files) render as a disabled "Soon" teaser and are
+ * excluded from the creatable set. There is intentionally no add control here —
+ * the list is the create surface (ADR-0004, issue #610).
+ *
+ * A single column (rather than a grid) keeps the surface legible at the panel's
+ * minimum width, gives the first-listed types (Browser, Terminal) natural
+ * primacy, and never orphans an odd card on a half-empty row.
  */
 export function PanelEmptyState({
   scope,
@@ -40,44 +44,61 @@ export function PanelEmptyState({
   onOpen,
 }: {
   scope: PanelScope;
-  /** Tab types already open, dropped from the grid by the cardinality filter. */
+  /** Tab types already open, dropped from the list by the cardinality filter. */
   readonly openTabs: readonly PanelTabTypeId[];
   /** Open (create-or-focus) a tab type. Never called for coming-soon teasers. */
   onOpen: (id: RightPanelTab) => void;
 }) {
-  const cards = shownTabTypes(scope, openTabs);
+  const rows = shownTabTypes(scope, openTabs);
 
   return (
     <div
       data-testid="panel-empty-state"
-      className="flex h-full flex-col overflow-y-auto p-6"
+      className="flex h-full flex-col overflow-y-auto px-5 py-10"
     >
-      <div className="m-auto grid w-full max-w-md grid-cols-2 gap-3">
-        {cards.map((type) => {
-          const Icon = type.icon;
-          const keycap = tabKeycap(type);
-          return (
-            <button
-              key={type.id}
-              type="button"
-              data-testid={`panel-card-${type.id}`}
-              disabled={type.comingSoon}
-              aria-label={type.comingSoon ? `${type.label} (coming soon)` : `Open ${type.label}`}
-              onClick={type.comingSoon ? undefined : () => onOpen(type.id as RightPanelTab)}
-              className={cn(
-                "flex flex-col items-center gap-2 rounded-lg border border-border bg-card px-4 py-6 text-center transition-colors",
-                type.comingSoon
-                  ? "cursor-default opacity-50"
-                  : "hover:border-primary/50 hover:bg-card/80",
-              )}
-            >
-              <Icon size={22} className="text-muted-foreground" />
-              <div className="text-sm font-medium text-foreground">{type.label}</div>
-              <div className="text-xs text-muted-foreground">{type.blurb}</div>
-              {type.comingSoon ? <SoonBadge /> : keycap && <Kbd>{keycap}</Kbd>}
-            </button>
-          );
-        })}
+      {/* m-auto centers the block when there's room and lets it scroll from the
+          top when the list is taller than the panel (auto margins collapse
+          rather than clip, unlike justify-center). */}
+      <div className="m-auto w-full max-w-sm">
+        <header className="mb-5 text-center">
+          <h2 className="text-lg font-semibold tracking-tight text-foreground">
+            Open a tool
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Pick one to open it in this panel.
+          </p>
+        </header>
+        <div className="flex flex-col gap-1.5">
+          {rows.map((type) => {
+            const Icon = type.icon;
+            const keycap = tabKeycap(type);
+            return (
+              <button
+                key={type.id}
+                type="button"
+                data-testid={`panel-card-${type.id}`}
+                disabled={type.comingSoon}
+                aria-label={type.comingSoon ? `${type.label} (coming soon)` : `Open ${type.label}`}
+                onClick={type.comingSoon ? undefined : () => onOpen(type.id as RightPanelTab)}
+                className={cn(
+                  "flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-3 text-left transition-colors",
+                  type.comingSoon
+                    ? "cursor-default opacity-50"
+                    : "hover:border-primary/50 hover:bg-card/80",
+                )}
+              >
+                <span className="grid size-9 flex-none place-items-center rounded-md bg-muted/40 text-muted-foreground">
+                  <Icon size={18} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium text-foreground">{type.label}</span>
+                  <span className="block truncate text-xs text-muted-foreground">{type.blurb}</span>
+                </span>
+                {type.comingSoon ? <SoonBadge /> : keycap && <Kbd>{keycap}</Kbd>}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -1,11 +1,15 @@
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useUiStore } from "@/stores/uiStore";
 import { useTaskStore } from "@/stores/taskStore";
 import {
   useDiffStore,
   PANEL_MIN_WIDTH,
   PANEL_WIDE_WIDTH,
+  COMPOSER_MIN_WIDTH,
+  PANEL_SPLIT_GAP_PX,
+  maxPanelWidthInSplit,
   createDefaultRightPanelState,
   getDefaultPanelWidthPx,
 } from "@/stores/diffStore";
@@ -18,7 +22,6 @@ import { PreviewPanel } from "@/components/panels/PreviewPanel";
 import { usePreviewDisplayTabSet, usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { TerminalTabContent } from "@/components/terminal/TerminalTabContent";
 import { TerminalPoolSlot } from "@/components/terminal/TerminalPoolSlotContext";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { ensureTerminalForScope } from "@/lib/ensure-terminal";
 import { cn } from "@/lib/utils";
 
@@ -61,36 +64,11 @@ export function RightPanel() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
 
-  // Render the panel as a modal overlay anchored to the right edge with a
-  // backdrop covering the chat whenever side-by-side layout would leave the
-  // chat uncomfortably narrow. Two triggers:
-  //  1. Viewport below the md breakpoint — a second pane always feels cramped.
-  //  2. Panel width would leave less than CHAT_COMFORT_MIN for the chat after
-  //     accounting for the sidebar — i.e. the user dragged the panel wide
-  //     enough that it should pop out instead of squeezing the chat.
-  const isWide = useMediaQuery("(min-width: 768px)");
-
-  // Track viewport width so the pop-out threshold recomputes when the user
-  // resizes the window (not just when they drag the panel).
-  const [viewportWidth, setViewportWidth] = useState(() =>
-    typeof window === "undefined" ? 0 : window.innerWidth,
-  );
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    let rafId: number | null = null;
-    const onResize = () => {
-      if (rafId !== null) return;
-      rafId = requestAnimationFrame(() => {
-        rafId = null;
-        setViewportWidth(window.innerWidth);
-      });
-    };
-    window.addEventListener("resize", onResize);
-    return () => {
-      window.removeEventListener("resize", onResize);
-      if (rafId !== null) cancelAnimationFrame(rafId);
-    };
-  }, []);
+  // Maximized mode fills the content area beside the project tree and hides the
+  // chat/composer (App.tsx suppresses the chat pane). A transient view toggle,
+  // not a stored width — the panel keeps its width so restoring drops back inline.
+  const maximized = useUiStore((s) => s.rightPanelMaximized);
+  const toggleMaximized = useUiStore((s) => s.toggleRightPanelMaximized);
 
   const storedPanel = useDiffStore((s) =>
     activeWorkspaceId ? s.rightPanelByWorkspace[activeWorkspaceId] : undefined,
@@ -129,7 +107,7 @@ export function RightPanel() {
   // Zustand action refs are stable (same identity for the store's lifetime),
   // so destructuring from getState() at render time is safe and avoids
   // adding actions to useCallback/useEffect dependency arrays.
-  const { setRightPanelWidth, setRightPanelTab, closeRightPanelTab, hideRightPanel } =
+  const { setRightPanelWidth, setRightPanelTab, closeRightPanelTab } =
     useDiffStore.getState();
 
   const tasks = useTaskStore(
@@ -141,14 +119,6 @@ export function RightPanel() {
     () => (tasks ?? []).filter((t) => t.group === "Tasks"),
     [tasks],
   );
-
-  // Thresholds tuned for a readable chat column next to an expanded sidebar.
-  const CHAT_COMFORT_MIN = 520;
-  const SIDEBAR_BUFFER = 290;
-  const LAYOUT_GAPS = 24;
-  const wouldCrampChat =
-    panelWidth + CHAT_COMFORT_MIN + SIDEBAR_BUFFER + LAYOUT_GAPS > viewportWidth;
-  const isOverlay = !isWide || wouldCrampChat;
 
   // Tab-strip glance status. Scope progress counts completed and cancelled
   // tasks as settled (a dropped task is no longer pending work); Changes counts
@@ -195,66 +165,58 @@ export function RightPanel() {
     }
   }, [panelVisible, terminalActive, panelScopeId]);
 
-  // Close on Escape when overlaid.
+  // Exit maximize when the panel is hidden so the user never lands on a blank
+  // full-screen shell with no panel chrome to restore from.
+  const setMaximized = useUiStore.getState().setRightPanelMaximized;
   useEffect(() => {
-    if (!isOverlay || !panelVisible || !activeWorkspaceId) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") hideRightPanel(activeWorkspaceId, activeThreadId);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [isOverlay, panelVisible, activeWorkspaceId, activeThreadId, hideRightPanel]);
-
-  // Focus handoff for overlay mode. When the panel pops out as a modal we
-  // must move focus into it so keyboard users aren't stranded behind the
-  // backdrop, and restore focus to whatever opened it when it closes.
-  const panelRef = useRef<HTMLDivElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
-  useEffect(() => {
-    if (!isOverlay || !panelVisible) return;
-    previousFocusRef.current = document.activeElement as HTMLElement | null;
-    // Defer to next frame so the panel is in the DOM before focus moves.
-    const rafId = requestAnimationFrame(() => panelRef.current?.focus());
-    return () => {
-      cancelAnimationFrame(rafId);
-      previousFocusRef.current?.focus?.();
-    };
-  }, [isOverlay, panelVisible]);
+    if (maximized && !panelVisible) setMaximized(false);
+  }, [maximized, panelVisible, setMaximized]);
 
   const draggingRef = useRef(false);
   const dragListenersRef = useRef<{ move: (e: globalThis.MouseEvent) => void; up: () => void } | null>(null);
+  const panelRootRef = useRef<HTMLDivElement>(null);
   // Ref keeps the latest panelWidth readable inside the resize handler without
   // the handler needing to be re-registered on every width change.
   const panelWidthRef = useRef(panelWidth);
   useEffect(() => { panelWidthRef.current = panelWidth; }, [panelWidth]);
 
-  // Re-clamp stored width when the panel becomes visible or the window is resized
-  // so the panel never exceeds the available space after the user shrinks the browser.
-  // Runs in both inline and overlay modes: overlay renders at min(panelWidth, 90vw)
-  // visually, but the stored width still drives the cramp-detection threshold.
-  // Re-registers when activeWorkspaceId changes (each workspace has its own stored width).
-  // Throttled with rAF so rapid resize events only trigger one recalculation per frame.
+  /** Max panel width that still leaves {@link COMPOSER_MIN_WIDTH}px for the chat. */
+  const getMaxPanelWidth = useCallback((): number => {
+    const split = panelRootRef.current?.parentElement;
+    if (!split) {
+      return Math.max(PANEL_MIN_WIDTH, window.innerWidth - COMPOSER_MIN_WIDTH);
+    }
+    return maxPanelWidthInSplit(split.clientWidth);
+  }, []);
+
+  // Re-clamp stored width when the split row shrinks (window resize, sidebar
+  // toggle, etc.) so the panel never eats the composer's minimum width.
   useEffect(() => {
-    if (!activeWorkspaceId || !panelVisible) return;
-    // Clamp immediately in case the stored width already exceeds the viewport.
-    const maxAllowed = window.innerWidth - PANEL_MIN_WIDTH;
-    if (panelWidthRef.current > maxAllowed) setRightPanelWidth(activeWorkspaceId, maxAllowed);
+    if (!activeWorkspaceId || !panelVisible || maximized) return;
+    const split = panelRootRef.current?.parentElement;
+    if (!split) return;
+
+    const clampToSplit = () => {
+      const max = maxPanelWidthInSplit(split.clientWidth);
+      if (panelWidthRef.current > max) setRightPanelWidth(activeWorkspaceId, max);
+    };
+
+    clampToSplit();
 
     let rafId: number | null = null;
-    const onResize = () => {
+    const ro = new ResizeObserver(() => {
       if (rafId !== null) return;
       rafId = requestAnimationFrame(() => {
         rafId = null;
-        const max = window.innerWidth - PANEL_MIN_WIDTH;
-        if (panelWidthRef.current > max) setRightPanelWidth(activeWorkspaceId, max);
+        clampToSplit();
       });
-    };
-    window.addEventListener("resize", onResize);
+    });
+    ro.observe(split);
     return () => {
-      window.removeEventListener("resize", onResize);
+      ro.disconnect();
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [activeWorkspaceId, panelVisible]);
+  }, [activeWorkspaceId, panelVisible, maximized]);
 
   const onDragStart = useCallback(
     (e: ReactMouseEvent) => {
@@ -266,9 +228,11 @@ export function RightPanel() {
       const onMouseMove = (moveEvent: globalThis.MouseEvent) => {
         if (!draggingRef.current) return;
         const delta = startX - moveEvent.clientX;
-        // Always leave at least PANEL_MIN_WIDTH px for the chat area
-        const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
-        setRightPanelWidth(activeWorkspaceId!, Math.min(startWidth + delta, viewportCap));
+        const maxWidth = getMaxPanelWidth();
+        setRightPanelWidth(
+          activeWorkspaceId!,
+          Math.max(PANEL_MIN_WIDTH, Math.min(startWidth + delta, maxWidth)),
+        );
       };
 
       const onMouseUp = () => {
@@ -282,7 +246,7 @@ export function RightPanel() {
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     },
-    [panelWidth, activeWorkspaceId],
+    [panelWidth, activeWorkspaceId, getMaxPanelWidth],
   );
 
   useEffect(() => {
@@ -303,58 +267,37 @@ export function RightPanel() {
   // shell) and only bails when there is no workspace to anchor it to.
   if (!activeWorkspaceId) return null;
 
-  // Overlay-mode width: cap to 90vw so the chat is still partially visible
-  // behind the backdrop and the panel doesn't dominate small screens.
-  const overlayWidth = isOverlay
-    ? `min(${panelWidth}px, 90vw)`
-    : undefined;
-
   return (
-    <>
-      {/* Backdrop — overlay mode with panel open only. Click dismisses the panel. */}
-      {isOverlay && panelVisible && (
-        <div
-          role="presentation"
-          onClick={() => {
-            // Blur first so focus inside the panel does not collide with the
-            // incoming aria-hidden on the panel container.
-            (document.activeElement as HTMLElement | null)?.blur?.();
-            hideRightPanel(activeWorkspaceId, activeThreadId);
-          }}
-          className="fixed inset-0 z-40 bg-foreground/30 backdrop-blur-[2px] animate-fade-up-in"
-        />
+    <div
+      ref={panelRootRef}
+      style={
+        maximized
+          ? undefined
+          : {
+              width: panelWidth,
+              minWidth: PANEL_MIN_WIDTH,
+              maxWidth: `calc(100% - ${COMPOSER_MIN_WIDTH}px - ${PANEL_SPLIT_GAP_PX}px)`,
+            }
+      }
+      className={cn(
+        "relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-lg bg-background shadow-sm focus:outline-none",
+        !panelVisible && "hidden",
+        // Maximized fills the content area (App hides the chat pane); inline
+        // mode is sized by the stored width above.
+        maximized && "flex-1",
       )}
-      <div
-        ref={panelRef}
-        role={isOverlay ? "dialog" : undefined}
-        aria-modal={isOverlay ? true : undefined}
-        aria-label={isOverlay ? "Workspace side panel" : undefined}
-        tabIndex={isOverlay ? -1 : undefined}
-        style={
-          isOverlay
-            // Drop minWidth entirely on overlay: on narrow viewports the
-            // 90vw cap would still exceed a large pixel minimum.
-            ? { width: overlayWidth }
-            : { width: panelWidth, minWidth: PANEL_MIN_WIDTH, maxWidth: `calc(100vw - ${PANEL_MIN_WIDTH}px)` }
-        }
-        className={cn(
-          "relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background focus:outline-none",
-          !panelVisible && "hidden",
-          isOverlay
-            ? "fixed inset-y-0 right-0 z-50 shadow-sm animate-fade-up-in"
-            : "rounded-lg shadow-sm",
-        )}
-        // Pair aria-hidden with inert: inert auto-blurs any focused
-        // descendant on apply, which avoids Chrome's "Blocked aria-hidden on
-        // an element because its descendant retained focus" warning when the
-        // user clicks the close button (focus is on the button when the
-        // panel is told to hide). Same pattern as the terminal tab below.
-        aria-hidden={!panelVisible}
-        inert={!panelVisible ? true : undefined}
-      >
+      // Pair aria-hidden with inert: inert auto-blurs any focused descendant on
+      // apply, which avoids Chrome's "Blocked aria-hidden on an element because
+      // its descendant retained focus" warning when the user clicks the close
+      // button (focus is on the button when the panel is told to hide). Same
+      // pattern as the terminal tab below.
+      aria-hidden={!panelVisible}
+      inert={!panelVisible ? true : undefined}
+    >
       {/* Drag handle (left edge) — double-click snaps between default and wide.
-          Kept visible in overlay mode too, so the user can shrink the panel
-          below the crowding threshold and snap it back into the inline layout. */}
+          Hidden while maximized: the panel owns the full content area, so there
+          is nothing to resize against. */}
+      {!maximized && (
       <div
         role="separator"
         aria-orientation="vertical"
@@ -363,23 +306,23 @@ export function RightPanel() {
         className="group absolute inset-y-0 left-0 z-20 flex w-3 cursor-col-resize items-stretch justify-center focus:outline-none"
         onMouseDown={onDragStart}
         onDoubleClick={() => {
-          const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
+          const maxWidth = getMaxPanelWidth();
           const narrow = getDefaultPanelWidthPx();
           const target =
             panelWidth >= PANEL_WIDE_WIDTH
               ? narrow
-              : Math.min(PANEL_WIDE_WIDTH, viewportCap);
+              : Math.min(PANEL_WIDE_WIDTH, maxWidth);
           setRightPanelWidth(activeWorkspaceId!, Math.max(PANEL_MIN_WIDTH, target));
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            const viewportCap = window.innerWidth - PANEL_MIN_WIDTH;
+            const maxWidth = getMaxPanelWidth();
             const narrow = getDefaultPanelWidthPx();
             const target =
               panelWidth >= PANEL_WIDE_WIDTH
                 ? narrow
-                : Math.min(PANEL_WIDE_WIDTH, viewportCap);
+                : Math.min(PANEL_WIDE_WIDTH, maxWidth);
             setRightPanelWidth(activeWorkspaceId!, Math.max(PANEL_MIN_WIDTH, target));
           }
         }}
@@ -394,11 +337,11 @@ export function RightPanel() {
           className="pointer-events-none my-2.5 w-px shrink-0 rounded-full bg-transparent transition-colors group-hover:bg-border group-focus-visible:w-0.5 group-focus-visible:bg-ring group-active:w-0.5 group-active:bg-muted-foreground/60"
         />
       </div>
+      )}
 
-      {/* Rail + content. The vertical activity rail navigates open singleton
-          tabs (active lamp + hover-× close + add control) and holds the panel's
-          close-chrome at its foot; the content area renders the active tab, or
-          the card-grid empty state when nothing is open. */}
+      {/* Rail + content. The activity rail carries the maximize toggle and, once
+          tabs are open, tab navigation and the add control. With no tabs the rail
+          is just the maximize button beside the empty-state create list. */}
       <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
         <ActivityRail
           openTabs={openTabs}
@@ -408,6 +351,8 @@ export function RightPanel() {
           changesCount={changesCount}
           changesFresh={changesFresh}
           browserTabSet={browserTabSet}
+          maximized={maximized}
+          onToggleMaximized={toggleMaximized}
           onSelect={(id) => setRightPanelTab(activeWorkspaceId!, id)}
           onClose={(id) => closeRightPanelTab(activeWorkspaceId!, id)}
           onCreate={(id) => setRightPanelTab(activeWorkspaceId!, id)}
@@ -425,12 +370,6 @@ export function RightPanel() {
             void usePreviewTabsStore.getState().closePage(panelScopeId, pageId, {
               onLastClose: () => closeRightPanelTab(activeWorkspaceId!, "preview"),
             });
-          }}
-          onClosePanel={() => {
-            // Blur the close button before triggering the hide so focus is not
-            // inside the panel when aria-hidden applies on re-render.
-            (document.activeElement as HTMLElement | null)?.blur?.();
-            hideRightPanel(activeWorkspaceId!, activeThreadId);
           }}
         />
 
@@ -475,7 +414,6 @@ export function RightPanel() {
           </div>
         </div>
       </div>
-      </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/components/panels/__tests__/PanelEmptyState.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PanelEmptyState.test.tsx
@@ -1,7 +1,7 @@
 /**
- * Behaviour tests for the right-panel empty-state card grid (issue #610):
- * scope-filtered cards, the Files coming-soon teaser, the absence of an add
- * control, and opening a tab by clicking its card.
+ * Behaviour tests for the right-panel empty-state tool list (issue #610):
+ * scope-filtered rows, the Files coming-soon teaser, the absence of an add
+ * control, and opening a tab by clicking its row.
  */
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -32,7 +32,7 @@ export function Sidebar({
   onOpenSettings,
   onCloseSettings,
 }: SidebarProps) {
-  const toggleSidebar = useUiStore((s) => s.toggleSidebar);
+  const collapseSidebar = useUiStore((s) => s.collapseSidebar);
 
   const handleEditJson = () => {
     if (window.desktopBridge) {
@@ -63,7 +63,7 @@ export function Sidebar({
             <Button
               variant="ghost"
               size="icon-sm"
-              onClick={toggleSidebar}
+              onClick={collapseSidebar}
               aria-label="Collapse sidebar"
               className="text-muted-foreground"
             >

--- a/apps/web/src/components/sidebar/SidebarRevealButton.tsx
+++ b/apps/web/src/components/sidebar/SidebarRevealButton.tsx
@@ -58,12 +58,12 @@ export function PanelCollapseIcon({ className }: { className?: string }) {
  * chevron slides outward on hover to telegraph the reveal action.
  */
 export function SidebarRevealButton() {
-  const toggle = useUiStore((s) => s.toggleSidebar);
+  const expandSidebar = useUiStore((s) => s.expandSidebar);
 
   return (
     <Tooltip>
       <TooltipTrigger
-        onClick={toggle}
+        onClick={expandSidebar}
         aria-label="Expand sidebar"
         className={cn(
           "group inline-flex size-7 shrink-0 items-center justify-center rounded-md",

--- a/apps/web/src/components/terminal/TerminalList.tsx
+++ b/apps/web/src/components/terminal/TerminalList.tsx
@@ -49,8 +49,8 @@ export const TerminalList = memo(function TerminalList({
 
   if (collapsed) {
     return (
-      <div className="flex w-[38px] flex-shrink-0 flex-col border-r border-border">
-        <div className="flex h-[34px] items-center justify-center border-b border-border">
+      <div className="flex w-[38px] flex-shrink-0 flex-col border-r border-border/40 bg-muted/20">
+        <div className="flex h-[34px] items-center justify-center border-b border-border/40">
           <Tooltip>
             <TooltipTrigger
               render={
@@ -104,9 +104,9 @@ export const TerminalList = memo(function TerminalList({
   }
 
   return (
-    <div className="flex w-[148px] flex-shrink-0 flex-col border-r border-border">
+    <div className="flex w-[148px] flex-shrink-0 flex-col border-r border-border/40 bg-muted/20">
       {/* Header: collapse toggle + actions, left-aligned */}
-      <div className="flex h-[34px] items-center gap-0.5 border-b border-border px-1.5">
+      <div className="flex h-[34px] items-center gap-0.5 border-b border-border/40 px-1.5">
         <Tooltip>
           <TooltipTrigger
             render={

--- a/apps/web/src/config/default-keybindings.json
+++ b/apps/web/src/config/default-keybindings.json
@@ -10,6 +10,7 @@
     "when": "showLanding && !commandPaletteOpen && !inputFocused"
   },
   { "key": "mod+\\", "command": "sidebar.toggle", "when": "!inputFocused" },
+  { "key": "mod+alt+b", "command": "rightPanel.toggle" },
   { "key": "mod+j", "command": "terminal.toggle" },
   { "key": "mod+,", "command": "settings.open", "when": "!inputFocused" },
   { "key": "mod+shift+?", "command": "shortcuts.help", "when": "!inputFocused" },

--- a/apps/web/src/hooks/useComposerLayoutGuard.ts
+++ b/apps/web/src/hooks/useComposerLayoutGuard.ts
@@ -1,0 +1,114 @@
+import { useEffect, type RefObject } from "react";
+import { COMPOSER_MIN_WIDTH } from "@/stores/diffStore";
+import { useDiffStore } from "@/stores/diffStore";
+import { useUiStore } from "@/stores/uiStore";
+import {
+  canFitInlineSidebar,
+  canFitSideBySidePanel,
+  minContentWidthForSideBySidePanel,
+  minOuterWidthForInlineSidebar,
+  setLayoutMeasurements,
+} from "@/lib/composer-layout";
+import { hideRightPanelAdaptive } from "@/lib/right-panel-layout";
+
+/** Inputs that affect composer-first layout enforcement. */
+export interface ComposerLayoutGuardOptions {
+  readonly settingsOpen: boolean;
+  readonly showLanding: boolean;
+  readonly activeWorkspaceId: string | null;
+  readonly activeThreadId: string | null;
+}
+
+/**
+ * Composer-first responsive guard: on shrink, closes the inline right panel and
+ * collapses the docked project tree before the chat/composer can fall below its
+ * minimum width. Publishes live row measurements for adaptive open paths.
+ */
+export function useComposerLayoutGuard(
+  outerRowRef: RefObject<HTMLElement | null>,
+  contentRowRef: RefObject<HTMLElement | null>,
+  opts: ComposerLayoutGuardOptions,
+): void {
+  const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
+  const sidebarFloating = useUiStore((s) => s.sidebarFloating);
+  const rightPanelMaximized = useUiStore((s) => s.rightPanelMaximized);
+
+  useEffect(() => {
+    if (opts.settingsOpen || opts.showLanding || !opts.activeWorkspaceId) return;
+
+    const outer = outerRowRef.current;
+    const content = contentRowRef.current;
+    if (!outer || !content) return;
+
+    const enforce = () => {
+      const outerWidth = outer.clientWidth;
+      const contentWidth = content.clientWidth;
+      setLayoutMeasurements(contentWidth, outerWidth);
+
+      const ui = useUiStore.getState();
+      const diff = useDiffStore.getState();
+      const { activeWorkspaceId, activeThreadId } = opts;
+      if (!activeWorkspaceId) return;
+
+      const panelVisible = diff.getRightPanelVisible(activeWorkspaceId, activeThreadId);
+      const panelWidth = diff.getRightPanel(activeWorkspaceId).width;
+      const panelInline = panelVisible && !ui.rightPanelMaximized;
+      const sidebarDocked = !ui.sidebarCollapsed && !ui.sidebarFloating;
+
+      if (panelInline && sidebarDocked) {
+        const needAll = minOuterWidthForInlineSidebar(
+          minContentWidthForSideBySidePanel(panelWidth),
+        );
+        if (outerWidth < needAll) {
+          hideRightPanelAdaptive(activeWorkspaceId, activeThreadId);
+          ui.collapseSidebar();
+          return;
+        }
+      }
+
+      if (panelInline && !canFitSideBySidePanel(contentWidth, panelWidth)) {
+        hideRightPanelAdaptive(activeWorkspaceId, activeThreadId);
+        return;
+      }
+
+      if (!sidebarDocked) return;
+
+      const contentNeed = panelInline
+        ? minContentWidthForSideBySidePanel(panelWidth)
+        : COMPOSER_MIN_WIDTH;
+
+      if (contentWidth < contentNeed || !canFitInlineSidebar(outerWidth, contentNeed)) {
+        ui.collapseSidebar();
+      }
+    };
+
+    enforce();
+
+    let rafId: number | null = null;
+    const schedule = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        enforce();
+      });
+    };
+
+    const ro = new ResizeObserver(schedule);
+    ro.observe(outer);
+    ro.observe(content);
+    return () => {
+      ro.disconnect();
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [
+    outerRowRef,
+    contentRowRef,
+    opts.settingsOpen,
+    opts.showLanding,
+    opts.activeWorkspaceId,
+    opts.activeThreadId,
+    sidebarCollapsed,
+    sidebarFloating,
+    rightPanelMaximized,
+  ]);
+}

--- a/apps/web/src/lib/__tests__/composer-layout.test.ts
+++ b/apps/web/src/lib/__tests__/composer-layout.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  SIDEBAR_WIDTH_PX,
+  LAYOUT_COLUMN_GAP_PX,
+  canFitInlineSidebar,
+  canFitSideBySidePanel,
+  minContentWidthForSideBySidePanel,
+  minOuterWidthForInlineSidebar,
+} from "@/lib/composer-layout";
+import { COMPOSER_MIN_WIDTH, PANEL_MIN_WIDTH, PANEL_SPLIT_GAP_PX } from "@/stores/diffStore";
+
+describe("composer-layout", () => {
+  it("computes side-by-side minimum from composer, gap, and panel width", () => {
+    expect(minContentWidthForSideBySidePanel(440)).toBe(
+      COMPOSER_MIN_WIDTH + PANEL_SPLIT_GAP_PX + 440,
+    );
+    expect(minContentWidthForSideBySidePanel(100)).toBe(
+      COMPOSER_MIN_WIDTH + PANEL_SPLIT_GAP_PX + PANEL_MIN_WIDTH,
+    );
+  });
+
+  it("computes inline sidebar minimum from content need and column gap", () => {
+    expect(minOuterWidthForInlineSidebar(COMPOSER_MIN_WIDTH)).toBe(
+      COMPOSER_MIN_WIDTH + LAYOUT_COLUMN_GAP_PX + SIDEBAR_WIDTH_PX,
+    );
+  });
+
+  it("reports side-by-side fit from content-row width", () => {
+    const need = minContentWidthForSideBySidePanel(440);
+    expect(canFitSideBySidePanel(need, 440)).toBe(true);
+    expect(canFitSideBySidePanel(need - 1, 440)).toBe(false);
+  });
+
+  it("reports inline sidebar fit from outer-row width", () => {
+    const need = minOuterWidthForInlineSidebar(COMPOSER_MIN_WIDTH);
+    expect(canFitInlineSidebar(need, COMPOSER_MIN_WIDTH)).toBe(true);
+    expect(canFitInlineSidebar(need - 1, COMPOSER_MIN_WIDTH)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/composer-layout.ts
+++ b/apps/web/src/lib/composer-layout.ts
@@ -1,0 +1,61 @@
+import {
+  COMPOSER_MIN_WIDTH,
+  PANEL_MIN_WIDTH,
+  PANEL_SPLIT_GAP_PX,
+} from "@/stores/diffStore";
+
+/** Inline project-tree width (`Sidebar` uses Tailwind `w-72`). */
+export const SIDEBAR_WIDTH_PX = 288;
+
+/** Gap between the project tree and the chat/panel row in App.tsx (`gap-1.5`). */
+export const LAYOUT_COLUMN_GAP_PX = 6;
+
+/** Live measurements from App layout refs; updated by {@link setLayoutMeasurements}. */
+let measuredContentRowWidth = 0;
+let measuredOuterRowWidth = 0;
+
+/**
+ * Publishes the current content-row and outer-row widths for layout decisions
+ * outside React render (panel open, sidebar expand).
+ */
+export function setLayoutMeasurements(contentRowWidth: number, outerRowWidth: number): void {
+  measuredContentRowWidth = contentRowWidth;
+  measuredOuterRowWidth = outerRowWidth;
+}
+
+/** Width of the chat + right-panel split row, or a conservative fallback before mount. */
+export function getContentRowWidth(): number {
+  if (measuredContentRowWidth > 0) return measuredContentRowWidth;
+  return Math.max(COMPOSER_MIN_WIDTH, window.innerWidth - SIDEBAR_WIDTH_PX - 24);
+}
+
+/** Width of the row that may include an inline project tree, or a fallback before mount. */
+export function getOuterRowWidth(): number {
+  if (measuredOuterRowWidth > 0) return measuredOuterRowWidth;
+  return window.innerWidth - 12;
+}
+
+/**
+ * Minimum content-row width for composer + inline panel at the given stored width.
+ */
+export function minContentWidthForSideBySidePanel(panelWidth: number): number {
+  return COMPOSER_MIN_WIDTH + PANEL_SPLIT_GAP_PX + Math.max(PANEL_MIN_WIDTH, panelWidth);
+}
+
+/**
+ * Minimum outer-row width to dock the project tree inline while reserving
+ * `contentNeed` pixels for the chat/panel row.
+ */
+export function minOuterWidthForInlineSidebar(contentNeed: number): number {
+  return contentNeed + LAYOUT_COLUMN_GAP_PX + SIDEBAR_WIDTH_PX;
+}
+
+/** Whether the content row can host composer and an inline panel side by side. */
+export function canFitSideBySidePanel(contentRowWidth: number, panelWidth: number): boolean {
+  return contentRowWidth >= minContentWidthForSideBySidePanel(panelWidth);
+}
+
+/** Whether the project tree can dock inline beside a content row of `contentNeed` px. */
+export function canFitInlineSidebar(outerRowWidth: number, contentNeed: number): boolean {
+  return outerRowWidth >= minOuterWidthForInlineSidebar(contentNeed);
+}

--- a/apps/web/src/lib/open-url-in-preview.ts
+++ b/apps/web/src/lib/open-url-in-preview.ts
@@ -2,6 +2,7 @@ import { isMcodeWorkspacePreviewUrl } from "@mcode/contracts";
 import type { BrowserTabInfo } from "@mcode/contracts";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { showRightPanelAdaptive } from "@/lib/right-panel-layout";
 
 /** Returns true when the event is a Ctrl+click (Windows/Linux) or Cmd+click (macOS). */
 export function isModifierClick(e: { ctrlKey: boolean; metaKey: boolean }): boolean {
@@ -107,7 +108,7 @@ export function openUrlInPreview({
   }
 
   const wsPath = resolveWorkspacePath(workspacePath);
-  const { showRightPanel, setRightPanelTab, setPreviewUrlForThread } = useDiffStore.getState();
+  const { setRightPanelTab, setPreviewUrlForThread } = useDiffStore.getState();
   // Width and tab are workspace-global; open/closed is per-thread. The scope is
   // a thread id, or a workspace id for the threadless new-thread preview, so
   // resolve the owning workspace from either and open the panel for that scope.
@@ -117,7 +118,7 @@ export function openUrlInPreview({
     ? thread.workspace_id
     : ws.workspaces.find((w) => w.id === threadId)?.id;
   if (workspaceId) {
-    showRightPanel(workspaceId, thread ? threadId : undefined);
+    showRightPanelAdaptive(workspaceId, thread ? threadId : undefined);
     setRightPanelTab(workspaceId, "preview");
   }
 

--- a/apps/web/src/lib/right-panel-layout.ts
+++ b/apps/web/src/lib/right-panel-layout.ts
@@ -1,0 +1,62 @@
+import { useDiffStore } from "@/stores/diffStore";
+import { useUiStore } from "@/stores/uiStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import {
+  canFitSideBySidePanel,
+  getContentRowWidth,
+} from "@/lib/composer-layout";
+
+/**
+ * After opening the right panel, maximize it when the content row cannot fit
+ * composer and panel side by side. Composer-first: inline mode only when there
+ * is room; otherwise the panel owns the content row.
+ */
+export function applyMaximizeIfCramped(workspaceId: string): void {
+  const panelWidth = useDiffStore.getState().getRightPanel(workspaceId).width;
+  if (canFitSideBySidePanel(getContentRowWidth(), panelWidth)) return;
+  useUiStore.getState().setRightPanelMaximized(true);
+}
+
+/**
+ * Opens the right panel for a workspace/thread and applies cramped-layout maximize.
+ */
+export function showRightPanelAdaptive(
+  workspaceId: string,
+  threadId?: string | null,
+): void {
+  useDiffStore.getState().showRightPanel(workspaceId, threadId);
+  applyMaximizeIfCramped(workspaceId);
+}
+
+/**
+ * Toggles the right panel; on open applies cramped-layout maximize, on close
+ * clears maximize so the chat pane returns cleanly.
+ */
+export function toggleRightPanelAdaptive(
+  workspaceId: string,
+  threadId?: string | null,
+): void {
+  const diff = useDiffStore.getState();
+  const wasVisible = diff.getRightPanelVisible(workspaceId, threadId);
+  diff.toggleRightPanel(workspaceId, threadId);
+  if (wasVisible) {
+    useUiStore.getState().setRightPanelMaximized(false);
+    return;
+  }
+  applyMaximizeIfCramped(workspaceId);
+}
+
+/**
+ * Hides the right panel for the active workspace/thread and clears maximize.
+ */
+export function hideRightPanelAdaptive(workspaceId: string, threadId?: string | null): void {
+  useDiffStore.getState().hideRightPanel(workspaceId, threadId);
+  useUiStore.getState().setRightPanelMaximized(false);
+}
+
+/** Active workspace/thread hide helper for layout guard and Escape paths. */
+export function hideActiveRightPanelAdaptive(): void {
+  const { activeWorkspaceId, activeThreadId } = useWorkspaceStore.getState();
+  if (!activeWorkspaceId) return;
+  hideRightPanelAdaptive(activeWorkspaceId, activeThreadId);
+}

--- a/apps/web/src/lib/summon-tab.ts
+++ b/apps/web/src/lib/summon-tab.ts
@@ -1,6 +1,7 @@
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore, type RightPanelTab } from "@/stores/diffStore";
 import { PANEL_TAB_TYPES } from "@/lib/panel-tabs";
+import { hideRightPanelAdaptive, showRightPanelAdaptive } from "@/lib/right-panel-layout";
 
 /** Whether a tab type only makes sense once a thread exists (Scope, and Review until it goes dual-scope). */
 function tabNeedsThread(tab: RightPanelTab): boolean {
@@ -28,23 +29,17 @@ export function summonTab(tab: RightPanelTab, onFocus?: () => void): void {
   if (!wid) return;
   if (tabNeedsThread(tab) && !tid) return;
 
-  const {
-    getRightPanel,
-    getRightPanelVisible,
-    showRightPanel,
-    setRightPanelTab,
-    hideRightPanel,
-  } = useDiffStore.getState();
+  const { getRightPanel, getRightPanelVisible, setRightPanelTab } = useDiffStore.getState();
   const panel = getRightPanel(wid);
 
   if (!getRightPanelVisible(wid, tid)) {
-    showRightPanel(wid, tid);
+    showRightPanelAdaptive(wid, tid);
     setRightPanelTab(wid, tab);
     onFocus?.();
   } else if (panel.activeTab !== tab) {
     setRightPanelTab(wid, tab);
     onFocus?.();
   } else {
-    hideRightPanel(wid, tid);
+    hideRightPanelAdaptive(wid, tid);
   }
 }

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -27,10 +27,21 @@ export type DiffRenderMode = "unified" | "side-by-side";
 /** Minimum right panel width in pixels. */
 export const PANEL_MIN_WIDTH = 384;
 /**
- * Fallback width when the viewport is unavailable (tests, SSR). Live UI uses half the
- * viewport via {@link getDefaultPanelWidthPx}.
+ * Minimum width reserved for the chat/composer beside an inline right panel.
+ * Drag and resize clamping use this (not {@link PANEL_MIN_WIDTH}) so the panel
+ * cannot swallow the project tree and still crush the composer to one column.
  */
-export const PANEL_DEFAULT_WIDTH = 380;
+export const COMPOSER_MIN_WIDTH = 480;
+/** Gap between chat main and right panel in App.tsx (`gap-1.5`). */
+export const PANEL_SPLIT_GAP_PX = 6;
+/**
+ * The panel's default width — a fixed value, not a fraction of the viewport, so
+ * the panel opens at the same size on every startup, on every view, regardless of
+ * monitor width. Half-the-viewport defaults made the empty/startup panel balloon
+ * (e.g. 800px on a 1600px screen) and tip into the cramped-chat overlay; a fixed
+ * default keeps it consistent and inline.
+ */
+export const PANEL_DEFAULT_WIDTH = 440;
 /** Wide snap target for the right panel (double-click drag handle). */
 export const PANEL_WIDE_WIDTH = 680;
 
@@ -39,12 +50,23 @@ function clampWidth(w: number): number {
 }
 
 /**
- * Returns the default panel width for the current window (50% of the viewport, clamped
- * to {@link PANEL_MIN_WIDTH}). Used when a thread has no stored width yet.
+ * Returns the panel's default width ({@link PANEL_DEFAULT_WIDTH}, clamped to
+ * {@link PANEL_MIN_WIDTH}). A fixed default keeps the startup size consistent
+ * across views and monitors. Used when a workspace has no stored width yet.
  */
 export function getDefaultPanelWidthPx(): number {
-  if (typeof globalThis.window === "undefined") return clampWidth(PANEL_DEFAULT_WIDTH);
-  return clampWidth(Math.round(globalThis.window.innerWidth * 0.5));
+  return clampWidth(PANEL_DEFAULT_WIDTH);
+}
+
+/**
+ * Largest panel width that still leaves {@link COMPOSER_MIN_WIDTH}px for the
+ * composer in a split row of the given inner width (chat + gap + panel).
+ */
+export function maxPanelWidthInSplit(
+  splitWidthPx: number,
+  gapPx: number = PANEL_SPLIT_GAP_PX,
+): number {
+  return Math.max(PANEL_MIN_WIDTH, splitWidthPx - COMPOSER_MIN_WIDTH - gapPx);
 }
 
 /** Currently selected file for diff viewing. */
@@ -79,7 +101,7 @@ export type RightPanelState = {
 export const DEFAULT_LINE_WRAP = true;
 
 /**
- * Baseline right-panel state for a workspace that has no persisted row (50% viewport width).
+ * Baseline right-panel state for a workspace that has no persisted row (default width).
  */
 export function createDefaultRightPanelState(): RightPanelState {
   return {

--- a/apps/web/src/stores/uiStore.ts
+++ b/apps/web/src/stores/uiStore.ts
@@ -1,25 +1,84 @@
 import { create } from "zustand";
+import {
+  canFitInlineSidebar,
+  getContentRowWidth,
+  getOuterRowWidth,
+  minContentWidthForSideBySidePanel,
+} from "@/lib/composer-layout";
+import { COMPOSER_MIN_WIDTH, useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 /** UI state for cross-component toggles that commands need to control. */
 interface UiState {
   /** Whether the sidebar is collapsed. */
   sidebarCollapsed: boolean;
+  /**
+   * When true the project tree is open as a left-anchored floating panel rather
+   * than a docked column (composer-first cramped layouts).
+   */
+  sidebarFloating: boolean;
   /** Whether the shortcut help dialog is open. */
   shortcutHelpOpen: boolean;
+  /**
+   * Whether the right panel is maximized to fill the content area beside the
+   * project tree, hiding the chat/composer. A transient view mode (not persisted):
+   * the panel keeps its stored width, so toggling back restores side-by-side.
+   */
+  rightPanelMaximized: boolean;
 
-  /** Toggle sidebar collapsed state. */
+  /** Toggle sidebar collapsed state (expands floating when inline will not fit). */
   toggleSidebar: () => void;
+  /** Expand the project tree inline when there is room, otherwise as a float. */
+  expandSidebar: () => void;
+  /** Collapse the project tree and exit floating mode. */
+  collapseSidebar: () => void;
+  /** Dismiss the floating project tree without changing docked expand state. */
+  closeFloatingSidebar: () => void;
   /** Set shortcut help dialog open state. */
   setShortcutHelpOpen: (open: boolean) => void;
+  /** Toggle the right panel between maximized (full content area) and side-by-side. */
+  toggleRightPanelMaximized: () => void;
+  /** Set the right panel maximized state explicitly. */
+  setRightPanelMaximized: (maximized: boolean) => void;
+}
+
+/** Minimum content-row width needed given the current right-panel visibility. */
+function contentNeedForSidebarDock(rightPanelMaximized: boolean): number {
+  const { activeWorkspaceId, activeThreadId } = useWorkspaceStore.getState();
+  if (!activeWorkspaceId) return COMPOSER_MIN_WIDTH;
+
+  const diff = useDiffStore.getState();
+  const panelVisible = diff.getRightPanelVisible(activeWorkspaceId, activeThreadId);
+  const panelInline = panelVisible && !rightPanelMaximized;
+  if (!panelInline) return COMPOSER_MIN_WIDTH;
+
+  return minContentWidthForSideBySidePanel(diff.getRightPanel(activeWorkspaceId).width);
 }
 
 /** Zustand store for global UI toggle state. Command palette state lives in commandPaletteStore. */
-export const useUiStore = create<UiState>((set) => ({
+export const useUiStore = create<UiState>((set, get) => ({
   sidebarCollapsed: false,
+  sidebarFloating: false,
   shortcutHelpOpen: false,
+  rightPanelMaximized: false,
 
-  toggleSidebar: () =>
-    set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
+  toggleSidebar: () => {
+    if (get().sidebarCollapsed) get().expandSidebar();
+    else get().collapseSidebar();
+  },
+  expandSidebar: () => {
+    const contentNeed = contentNeedForSidebarDock(get().rightPanelMaximized);
+    const inline =
+      canFitInlineSidebar(getOuterRowWidth(), contentNeed) &&
+      getContentRowWidth() >= contentNeed;
+    set({ sidebarCollapsed: false, sidebarFloating: !inline });
+  },
+  collapseSidebar: () => set({ sidebarCollapsed: true, sidebarFloating: false }),
+  closeFloatingSidebar: () => set({ sidebarFloating: false, sidebarCollapsed: true }),
   setShortcutHelpOpen: (open) =>
     set({ shortcutHelpOpen: open }),
+  toggleRightPanelMaximized: () =>
+    set((s) => ({ rightPanelMaximized: !s.rightPanelMaximized })),
+  setRightPanelMaximized: (maximized) =>
+    set({ rightPanelMaximized: maximized }),
 }));


### PR DESCRIPTION
## Summary

- Composer-first responsive layout: on window shrink, close the right panel and collapse the project tree before the chat falls below 480px; when both are open and neither can shrink further, close both together.
- Adaptive panel open paths auto-maximize when side-by-side layout will not fit; project tree expands inline when there is room, otherwise as a left-anchored float.
- Right panel polish: maximize/restore on the activity rail (including empty state), panel width guards, Ctrl+Alt+B toggle shortcut, empty-state layout refresh, and readable tooltip shortcut text.

## What

Polish pass for epic #608: composer-first layout enforcement, floating project tree, panel maximize mode, rail UX cleanup, and adaptive open/toggle behavior across panel entry points.

## Why

The compose chat is the primary surface. Side panels must not crush it during resize or open. Maximize gives a focused tool view without hiding the project tree.

## Key changes

- useComposerLayoutGuard and composer-layout.ts enforce composer minimum width on resize
- right-panel-layout.ts adaptive helpers for show/toggle/hide with auto-maximize when cramped
- Floating project tree (sidebarFloating) when inline dock will not fit; backdrop dismiss
- Maximize toggle at rail head; chat pane hidden while maximized, project tree stays visible
- COMPOSER_MIN_WIDTH (480px) and split-aware panel width clamping via maxPanelWidthInSplit
- Ctrl+Alt+B (rightPanel.toggle) shortcut; header panel toggle uses adaptive open
- Empty-state card list layout; removed redundant rail close button
- E2E: activity rail maximize scenarios + toggle shortcut spec (8/8 passing)

## Configuration changes

- Added keybinding: rightPanel.toggle -> mod+alt+b in default-keybindings.json

## Test plan

- [x] bun run verify (all checks passed)
- [x] bun run e2e -- right-panel-activity-rail.spec.ts right-panel-toggle-shortcut.spec.ts (8/8 passed)
- [ ] Manual: narrow window with panel + sidebar open; confirm both close before composer crushes
- [ ] Manual: open panel in narrow window; confirm maximize mode
- [ ] Manual: expand sidebar in narrow window; confirm floating tree

## Related issues/PRs

Relates to #608

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783699573&installation_id=129163861&pr_number=677&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F677&signature=c8840467fe0ee2c2dfe4dcae31095d83ea1256a03effc7419c8ff6b049a4b803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->