### PR TITLE
feat: add branch comparison UI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -538,9 +538,8 @@ resolve to exactly one diff. Some comparisons have **fixed** operands the
 user cannot change (Unstaged = index→worktree; Staged = HEAD→index); others
 have **picked** operands the user chooses through a picker that still
 resolves to a single diff — never N diffs at once. The picked comparisons
-are **Branch** (a base ref → a target ref, both selectable; by default it
-compares the current branch against its detected base, or — when you are
-*on* the base branch — against that branch's remote), **Commit** (one commit
+are **Branch** (the current branch fixed on the left → one selected comparison
+ref on the right; the right side is the only picker), **Commit** (one commit
 chosen from a searchable list; default is the latest commit), and the turn
 **picker** (one turn's diff).
 

--- a/apps/server/src/__tests__/git-service-branch-comparison.test.ts
+++ b/apps/server/src/__tests__/git-service-branch-comparison.test.ts
@@ -201,6 +201,16 @@ describe("GitService.branchFiles / branchDiff ranges", () => {
     );
   });
 
+  it("rejects a ref that could smuggle a git flag (argument injection)", async () => {
+    await expect(
+      gitService.branchFiles("ws", "--output=/tmp/pwned", "HEAD", REPO),
+    ).rejects.toThrow(/unsafe git ref/i);
+    await expect(
+      gitService.branchDiff("ws", "main", "-rf", undefined, undefined, REPO),
+    ).rejects.toThrow(/unsafe git ref/i);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
   it("falls back to the detected default base ...HEAD when no pair is given", async () => {
     // symbolic-ref resolves the default branch; the diff call returns the files.
     mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {

--- a/apps/server/src/__tests__/git-service-branch-comparison.test.ts
+++ b/apps/server/src/__tests__/git-service-branch-comparison.test.ts
@@ -69,10 +69,12 @@ describe("GitService.resolveBranchComparison", () => {
     current: string;
     branches: Array<{ full: string; short: string; head?: boolean }>;
     hasCommits?: boolean;
-    defaultBranch?: string;
+    defaultBranch?: string | null;
+    localDefaultBranches?: string[];
   }) {
     const hasCommits = opts.hasCommits ?? true;
-    const defaultBranch = opts.defaultBranch ?? "main";
+    const defaultBranch = opts.defaultBranch === undefined ? "main" : opts.defaultBranch;
+    const localDefaultBranches = opts.localDefaultBranches ?? [];
 
     mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
       if (args.includes("branch")) return branchListOutput(opts.branches);
@@ -81,12 +83,20 @@ describe("GitService.resolveBranchComparison", () => {
     });
 
     mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
-      if (args.includes("--verify")) {
+      if (args.includes("rev-parse") && args.includes("--verify")) {
         if (!hasCommits) throw new Error("unborn");
         return { stdout: "deadbeef\n", stderr: "" };
       }
       if (args.includes("symbolic-ref")) {
+        if (defaultBranch === null) throw new Error("no origin head");
         return { stdout: `origin/${defaultBranch}\n`, stderr: "" };
+      }
+      if (args.includes("remote")) throw new Error("no origin");
+      if (args.includes("show-ref")) {
+        const ref = args.at(-1) ?? "";
+        const branch = ref.replace("refs/heads/", "");
+        if (localDefaultBranches.includes(branch)) return { stdout: "", stderr: "" };
+        throw new Error("missing local default");
       }
       return { stdout: "", stderr: "" };
     });
@@ -116,7 +126,7 @@ describe("GitService.resolveBranchComparison", () => {
       ],
     });
 
-    const result = await gitService.resolveBranchComparison("ws", REPO);
+    const result = await gitService.resolveBranchComparison("ws", "/repo-no-base");
 
     expect(result).toMatchObject({ base: "main", target: "origin/main", isUnborn: false });
   });
@@ -168,6 +178,44 @@ describe("GitService.resolveBranchComparison", () => {
     const result = await gitService.resolveBranchComparison("ws", REPO);
 
     expect(result).toMatchObject({ base: "develop", target: "feat/y" });
+  });
+
+  it("falls back to a local main branch when origin is unavailable", async () => {
+    setup({
+      current: "feat/local-only",
+      defaultBranch: null,
+      localDefaultBranches: ["main"],
+      branches: [
+        { full: "refs/heads/main", short: "main" },
+        { full: "refs/heads/feat/local-only", short: "feat/local-only", head: true },
+      ],
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", REPO);
+
+    expect(result).toMatchObject({
+      base: "main",
+      target: "feat/local-only",
+      isUnborn: false,
+    });
+  });
+
+  it("opens with no base when no default branch can be detected", async () => {
+    setup({
+      current: "feat/unknown-base",
+      defaultBranch: null,
+      branches: [
+        { full: "refs/heads/feat/unknown-base", short: "feat/unknown-base", head: true },
+      ],
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", "/repo-no-base");
+
+    expect(result).toMatchObject({
+      base: null,
+      target: "feat/unknown-base",
+      isUnborn: false,
+    });
   });
 });
 
@@ -224,6 +272,24 @@ describe("GitService.branchFiles / branchDiff ranges", () => {
       "git",
       ["-C", REPO, "diff", "--name-only", "main...HEAD"],
       expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it("returns an explicit empty list when no default base is detected", async () => {
+    mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("symbolic-ref")) throw new Error("no origin head");
+      if (args.includes("remote")) throw new Error("no origin");
+      if (args.includes("show-ref")) throw new Error("missing local default");
+      return { stdout: "a.ts", stderr: "" };
+    });
+
+    const files = await gitService.branchFiles("ws", undefined, undefined, REPO);
+
+    expect(files).toEqual([]);
+    expect(mockExecFile).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["diff"]),
+      expect.anything(),
     );
   });
 });

--- a/apps/server/src/__tests__/git-service-branch-comparison.test.ts
+++ b/apps/server/src/__tests__/git-service-branch-comparison.test.ts
@@ -1,0 +1,219 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { WorkspaceRepo } from "../repositories/workspace-repo";
+
+const { mockExecFile, mockExecFileSync, mockLogger } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  mockExecFileSync: vi.fn(),
+  mockLogger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("child_process", () => ({
+  execFileSync: mockExecFileSync,
+  execFile: vi.fn(),
+}));
+
+vi.mock("util", () => ({
+  promisify: () => mockExecFile,
+}));
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  rm: vi.fn(),
+  rename: vi.fn(),
+  rmdir: vi.fn(),
+}));
+
+vi.mock("@mcode/shared", () => ({
+  getMcodeDir: () => "/mock/mcode",
+  validateBranchName: vi.fn(),
+  validateWorktreeName: vi.fn(),
+  logger: mockLogger,
+}));
+
+import { GitService } from "../services/git-service";
+
+/**
+ * Builds the `git branch -a --format=...` output the standalone ref lister
+ * parses: one line per ref, fields joined by `|||`
+ * (refname, refname:short, objectname:short, HEAD marker, worktreepath).
+ */
+function branchListOutput(
+  rows: Array<{ full: string; short: string; head?: boolean }>,
+): string {
+  return rows
+    .map((r) => `${r.full}|||${r.short}|||abc1234|||${r.head ? "*" : ""}|||`)
+    .join("\n");
+}
+
+const REPO = "/repo";
+
+describe("GitService.resolveBranchComparison", () => {
+  let gitService: GitService;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    gitService = new GitService({} as WorkspaceRepo);
+  });
+
+  /**
+   * Wire the git mocks for one scenario. `current` is the abbreviated HEAD ref
+   * (a branch name, or "HEAD" when detached); `hasCommits` toggles the unborn
+   * path; `defaultBranch` is what `symbolic-ref origin/HEAD` resolves to.
+   */
+  function setup(opts: {
+    current: string;
+    branches: Array<{ full: string; short: string; head?: boolean }>;
+    hasCommits?: boolean;
+    defaultBranch?: string;
+  }) {
+    const hasCommits = opts.hasCommits ?? true;
+    const defaultBranch = opts.defaultBranch ?? "main";
+
+    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes("branch")) return branchListOutput(opts.branches);
+      if (args.includes("rev-parse")) return `${opts.current}\n`;
+      return "";
+    });
+
+    mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("--verify")) {
+        if (!hasCommits) throw new Error("unborn");
+        return { stdout: "deadbeef\n", stderr: "" };
+      }
+      if (args.includes("symbolic-ref")) {
+        return { stdout: `origin/${defaultBranch}\n`, stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    });
+  }
+
+  it("compares base → current when current differs from the detected base", async () => {
+    setup({
+      current: "feat/x",
+      branches: [
+        { full: "refs/heads/main", short: "main" },
+        { full: "refs/heads/feat/x", short: "feat/x", head: true },
+      ],
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", REPO);
+
+    expect(result).toMatchObject({ base: "main", target: "feat/x", isUnborn: false });
+    expect(result.refs.length).toBe(2);
+  });
+
+  it("compares current → origin/current on the base branch when an upstream exists", async () => {
+    setup({
+      current: "main",
+      branches: [
+        { full: "refs/heads/main", short: "main", head: true },
+        { full: "refs/remotes/origin/main", short: "origin/main" },
+      ],
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", REPO);
+
+    expect(result).toMatchObject({ base: "main", target: "origin/main", isUnborn: false });
+  });
+
+  it("falls back to base → current on the base branch with no upstream", async () => {
+    setup({
+      current: "main",
+      branches: [{ full: "refs/heads/main", short: "main", head: true }],
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", REPO);
+
+    expect(result).toMatchObject({ base: "main", target: "main", isUnborn: false });
+  });
+
+  it("compares base → HEAD on a detached HEAD", async () => {
+    setup({
+      current: "HEAD",
+      branches: [{ full: "refs/heads/main", short: "main" }],
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", REPO);
+
+    expect(result).toMatchObject({ base: "main", target: "HEAD", isUnborn: false });
+  });
+
+  it("reports an explicit empty state on an unborn branch", async () => {
+    setup({
+      current: "main",
+      branches: [],
+      hasCommits: false,
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", REPO);
+
+    expect(result).toEqual({ base: null, target: null, refs: [], isUnborn: true });
+  });
+
+  it("uses a non-main detected default branch", async () => {
+    setup({
+      current: "feat/y",
+      defaultBranch: "develop",
+      branches: [
+        { full: "refs/heads/develop", short: "develop" },
+        { full: "refs/heads/feat/y", short: "feat/y", head: true },
+      ],
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", REPO);
+
+    expect(result).toMatchObject({ base: "develop", target: "feat/y" });
+  });
+});
+
+describe("GitService.branchFiles / branchDiff ranges", () => {
+  let gitService: GitService;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    gitService = new GitService({} as WorkspaceRepo);
+    mockExecFile.mockResolvedValue({ stdout: "a.ts\nb.ts", stderr: "" });
+  });
+
+  it("diffs an explicit pair three-dot for branchFiles", async () => {
+    const files = await gitService.branchFiles("ws", "main", "feat/x", REPO);
+
+    expect(files).toEqual(["a.ts", "b.ts"]);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "git",
+      ["-C", REPO, "diff", "--name-only", "main...feat/x"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it("diffs an explicit pair three-dot for branchDiff with renames", async () => {
+    await gitService.branchDiff("ws", "main", "origin/main", "a.ts", undefined, REPO);
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "git",
+      ["-C", REPO, "diff", "--find-renames", "main...origin/main", "--", "a.ts"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it("falls back to the detected default base ...HEAD when no pair is given", async () => {
+    // symbolic-ref resolves the default branch; the diff call returns the files.
+    mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes("symbolic-ref")) return { stdout: "origin/main\n", stderr: "" };
+      return { stdout: "a.ts", stderr: "" };
+    });
+
+    await gitService.branchFiles("ws", undefined, undefined, REPO);
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "git",
+      ["-C", REPO, "diff", "--name-only", "main...HEAD"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+});

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -606,6 +606,7 @@ export class GitService {
   ): Promise<string[]> {
     const cwd = repoPath ?? this.requireWorkspace(workspaceId).path;
     const resolvedBase = base ?? (await this.detectDefaultBranch(cwd));
+    if (!resolvedBase) return [];
     const resolvedTarget = target ?? "HEAD";
     assertSafeRef(resolvedBase);
     assertSafeRef(resolvedTarget);
@@ -638,6 +639,7 @@ export class GitService {
   ): Promise<string> {
     const cwd = repoPath ?? this.requireWorkspace(workspaceId).path;
     const resolvedBase = base ?? (await this.detectDefaultBranch(cwd));
+    if (!resolvedBase) return "";
     const resolvedTarget = target ?? "HEAD";
     assertSafeRef(resolvedBase);
     assertSafeRef(resolvedTarget);
@@ -660,9 +662,11 @@ export class GitService {
    * - **current ≠ detected base** → `base → current` (review the branch's work).
    * - **current == detected base** (on the base branch) → `current →
    *   origin/current` when an upstream exists, else `base → current` (empty but
-   *   valid — no origin / never pushed).
+   *   valid when the branch has no upstream).
    * - **detached HEAD** → `base → HEAD` (three-dot already takes the merge-base).
    * - **unborn branch** (no commits) → explicit empty state (`isUnborn`).
+   * - **no detectable base** → no base is selected; the picker waits for the
+   *   user to choose one.
    *
    * Reads the workspace root by default; pass `repoPath` to resolve against a
    * thread's worktree so "current branch" is the thread's branch.
@@ -677,6 +681,11 @@ export class GitService {
 
     const base = await this.detectDefaultBranch(cwd);
     const current = getCurrentBranchForPath(cwd);
+
+    if (!base) {
+      const target = current && current !== "HEAD" ? current : "HEAD";
+      return { base: null, target, refs, isUnborn: false };
+    }
 
     // Detached HEAD (no branch name): compare the detected base to HEAD. Three-dot
     // semantics resolve the merge-base internally, so an explicit base is enough.
@@ -729,10 +738,10 @@ export class GitService {
   }
 
   /** Per-repo cache: avoids re-running mutating git commands on every log call. */
-  private readonly defaultBranchCache = new Map<string, string>();
+  private readonly defaultBranchCache = new Map<string, string | null>();
 
   /** Detect the default upstream branch (e.g. main, master) for a repository. */
-  private async detectDefaultBranch(repoPath: string): Promise<string> {
+  private async detectDefaultBranch(repoPath: string): Promise<string | null> {
     const cached = this.defaultBranchCache.get(repoPath);
     if (cached !== undefined) return cached;
 
@@ -742,7 +751,7 @@ export class GitService {
   }
 
   /** Resolve the default branch by probing git refs in order of cheapness. */
-  private async resolveDefaultBranch(repoPath: string): Promise<string> {
+  private async resolveDefaultBranch(repoPath: string): Promise<string | null> {
     // 1. Ask the remote tracking ref (fast, no network, works if origin/HEAD is set)
     try {
       const { stdout } = await execFile(
@@ -773,18 +782,23 @@ export class GitService {
       logger.debug("[detectDefaultBranch] set-head failed, falling back to HEAD", { repoPath, err });
     }
 
-    // 3. Last resort: use whatever HEAD currently points at (works for local-only repos)
-    try {
-      const { stdout } = await execFile(
-        "git",
-        ["-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD"],
-        { timeout: 5_000, windowsHide: true },
-      );
-      return stdout.trim();
-    } catch (err) {
-      logger.debug("[detectDefaultBranch] rev-parse failed, defaulting to main", { repoPath, err });
-      return "main";
+    // 3. Local-only repos have no origin/HEAD; prefer established default branch
+    // names when they exist instead of treating the current feature branch as base.
+    for (const branch of ["main", "master", "develop", "trunk"]) {
+      try {
+        await execFile(
+          "git",
+          ["-C", repoPath, "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+          { timeout: 5_000, windowsHide: true },
+        );
+        return branch;
+      } catch {
+        // Keep probing the next conventional default name.
+      }
     }
+
+    logger.debug("[detectDefaultBranch] no default branch detected", { repoPath });
+    return null;
   }
 
   /**

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -11,7 +11,7 @@ import { rm, rename, rmdir } from "fs/promises";
 import { existsSync, mkdirSync } from "fs";
 import { join, basename, dirname, resolve, relative, isAbsolute } from "path";
 import { getMcodeDir, validateBranchName, validateWorktreeName, logger } from "@mcode/shared";
-import type { GitBranch, WorktreeInfo, GitCommit } from "@mcode/contracts";
+import type { GitBranch, WorktreeInfo, GitCommit, BranchComparison } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 
 const execFile = promisify(execFileCb);
@@ -589,18 +589,28 @@ export class GitService {
   }
 
   /**
-   * List files that differ between a checkout's current branch and its default
-   * base branch (the `base...HEAD` symmetric-difference range). Reads the
-   * workspace root by default; pass `repoPath` to read a thread's worktree (so
-   * HEAD is the thread branch). Returns an empty list when HEAD already matches base.
+   * List files that differ between two refs as a three-dot comparison
+   * (`base...target`, the symmetric-difference range — only what changed on the
+   * target side since the two diverged). `base`/`target` default to the detected
+   * default branch and HEAD respectively, preserving the legacy `base...HEAD`
+   * behavior for callers that pass neither. The default pair the Branch view
+   * uses is resolved by {@link resolveBranchComparison} per ADR 0007 and passed
+   * explicitly. Reads the workspace root by default; pass `repoPath` to read a
+   * thread's worktree. Returns an empty list when the refs match.
    */
-  async branchFiles(workspaceId: string, repoPath?: string): Promise<string[]> {
+  async branchFiles(
+    workspaceId: string,
+    base?: string,
+    target?: string,
+    repoPath?: string,
+  ): Promise<string[]> {
     const cwd = repoPath ?? this.requireWorkspace(workspaceId).path;
-    const base = await this.detectDefaultBranch(cwd);
+    const resolvedBase = base ?? (await this.detectDefaultBranch(cwd));
+    const resolvedTarget = target ?? "HEAD";
     try {
       const { stdout } = await execFile(
         "git",
-        ["-C", cwd, "diff", "--name-only", `${base}...HEAD`],
+        ["-C", cwd, "diff", "--name-only", `${resolvedBase}...${resolvedTarget}`],
         { timeout: 10_000, windowsHide: true },
       );
       return stdout.trim().split("\n").filter(Boolean);
@@ -610,19 +620,24 @@ export class GitService {
   }
 
   /**
-   * Get the unified diff between a checkout's current branch and its default base
-   * branch (`base...HEAD`). Reads the workspace root by default; pass `repoPath`
-   * to read a thread's worktree. Optionally scoped to a single file and truncated.
+   * Get the unified diff between two refs as a three-dot comparison
+   * (`base...target`). `base`/`target` default to the detected default branch and
+   * HEAD; see {@link branchFiles} for the range semantics. Reads the workspace
+   * root by default; pass `repoPath` to read a thread's worktree. Optionally
+   * scoped to a single file and truncated.
    */
   async branchDiff(
     workspaceId: string,
+    base?: string,
+    target?: string,
     filePath?: string,
     maxLines?: number,
     repoPath?: string,
   ): Promise<string> {
     const cwd = repoPath ?? this.requireWorkspace(workspaceId).path;
-    const base = await this.detectDefaultBranch(cwd);
-    const args = ["-C", cwd, "diff", "--find-renames", `${base}...HEAD`];
+    const resolvedBase = base ?? (await this.detectDefaultBranch(cwd));
+    const resolvedTarget = target ?? "HEAD";
+    const args = ["-C", cwd, "diff", "--find-renames", `${resolvedBase}...${resolvedTarget}`];
     if (filePath) args.push("--", filePath);
     try {
       const { stdout } = await execFile("git", args, { timeout: 10_000, windowsHide: true });
@@ -630,6 +645,63 @@ export class GitService {
       return maxLines ? result.split("\n").slice(0, maxLines).join("\n") : result;
     } catch {
       return "";
+    }
+  }
+
+  /**
+   * Resolve the default Branch comparison for a checkout, plus the refs that
+   * populate the base/target pickers. Implements the context-dependent default
+   * from `docs/adr/0007-branch-comparison-default-and-range.md`:
+   *
+   * - **current ≠ detected base** → `base → current` (review the branch's work).
+   * - **current == detected base** (on the base branch) → `current →
+   *   origin/current` when an upstream exists, else `base → current` (empty but
+   *   valid — no origin / never pushed).
+   * - **detached HEAD** → `base → HEAD` (three-dot already takes the merge-base).
+   * - **unborn branch** (no commits) → explicit empty state (`isUnborn`).
+   *
+   * Reads the workspace root by default; pass `repoPath` to resolve against a
+   * thread's worktree so "current branch" is the thread's branch.
+   */
+  async resolveBranchComparison(workspaceId: string, repoPath?: string): Promise<BranchComparison> {
+    const cwd = repoPath ?? this.requireWorkspace(workspaceId).path;
+    const refs = listBranchesForPath(cwd);
+
+    if (!(await this.hasCommits(cwd))) {
+      return { base: null, target: null, refs, isUnborn: true };
+    }
+
+    const base = await this.detectDefaultBranch(cwd);
+    const current = getCurrentBranchForPath(cwd);
+
+    // Detached HEAD (no branch name): compare the detected base to HEAD. Three-dot
+    // semantics resolve the merge-base internally, so an explicit base is enough.
+    if (!current || current === "HEAD") {
+      return { base, target: "HEAD", refs, isUnborn: false };
+    }
+
+    // On the base branch, `base...current` is empty — fall back to divergence from
+    // the remote when an upstream exists, else the (empty but valid) base→current.
+    if (current === base) {
+      const remoteRef = `origin/${current}`;
+      const hasUpstream = refs.some((r) => r.type === "remote" && r.name === remoteRef);
+      return { base: current, target: hasUpstream ? remoteRef : current, refs, isUnborn: false };
+    }
+
+    return { base, target: current, refs, isUnborn: false };
+  }
+
+  /** Whether HEAD resolves to a commit (false on an unborn branch / empty repo). */
+  private async hasCommits(repoPath: string): Promise<boolean> {
+    try {
+      await execFile(
+        "git",
+        ["-C", repoPath, "rev-parse", "--verify", "--quiet", "HEAD"],
+        { timeout: 5_000, windowsHide: true },
+      );
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -607,6 +607,8 @@ export class GitService {
     const cwd = repoPath ?? this.requireWorkspace(workspaceId).path;
     const resolvedBase = base ?? (await this.detectDefaultBranch(cwd));
     const resolvedTarget = target ?? "HEAD";
+    assertSafeRef(resolvedBase);
+    assertSafeRef(resolvedTarget);
     try {
       const { stdout } = await execFile(
         "git",
@@ -637,6 +639,8 @@ export class GitService {
     const cwd = repoPath ?? this.requireWorkspace(workspaceId).path;
     const resolvedBase = base ?? (await this.detectDefaultBranch(cwd));
     const resolvedTarget = target ?? "HEAD";
+    assertSafeRef(resolvedBase);
+    assertSafeRef(resolvedTarget);
     const args = ["-C", cwd, "diff", "--find-renames", `${resolvedBase}...${resolvedTarget}`];
     if (filePath) args.push("--", filePath);
     try {
@@ -822,6 +826,19 @@ export class GitService {
 // ---------------------------------------------------------------------------
 // Standalone helper functions (not on the class, to keep them testable)
 // ---------------------------------------------------------------------------
+
+/**
+ * Reject a git ref that could smuggle a flag into a git argv (a leading `-`) or
+ * contains characters outside what refnames and short SHAs use. Guards the
+ * base/target of a Branch comparison before they are interpolated into a rev
+ * range; the WS layer also validates via `GitRefSchema`, this is defense in
+ * depth for any direct caller.
+ */
+function assertSafeRef(ref: string): void {
+  if (!/^(?!-)[A-Za-z0-9._/-]+$/.test(ref)) {
+    throw new Error(`Unsafe git ref: ${ref}`);
+  }
+}
 
 /** List all branches (local, remote, worktree-attached) for a repository path. */
 function listBranchesForPath(repoPath: string): GitBranch[] {

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -441,12 +441,17 @@ async function dispatch(
     case "git.branchFiles": {
       const ws = deps.workspaceService.findById(params.workspaceId);
       if (!ws?.is_git_repo) return [];
-      return deps.gitService.branchFiles(params.workspaceId, resolveThreadRepoPath(deps, params.threadId));
+      return deps.gitService.branchFiles(params.workspaceId, params.base, params.target, resolveThreadRepoPath(deps, params.threadId));
     }
     case "git.branchDiff": {
       const ws = deps.workspaceService.findById(params.workspaceId);
       if (!ws?.is_git_repo) return "";
-      return deps.gitService.branchDiff(params.workspaceId, params.filePath, params.maxLines, resolveThreadRepoPath(deps, params.threadId));
+      return deps.gitService.branchDiff(params.workspaceId, params.base, params.target, params.filePath, params.maxLines, resolveThreadRepoPath(deps, params.threadId));
+    }
+    case "git.branchComparison": {
+      const ws = deps.workspaceService.findById(params.workspaceId);
+      if (!ws?.is_git_repo) return { base: null, target: null, refs: [], isUnborn: false };
+      return deps.gitService.resolveBranchComparison(params.workspaceId, resolveThreadRepoPath(deps, params.threadId));
     }
 
     // Agent

--- a/apps/web/e2e/right-panel-review-dual-scope.spec.ts
+++ b/apps/web/e2e/right-panel-review-dual-scope.spec.ts
@@ -155,7 +155,8 @@ test.describe("Review tab — dual-scope view selection", () => {
       "git.branchDiff": (params) => {
         branchDiffCalls.push(params);
         const base = (params as { base?: string }).base ?? "unknown";
-        return `@@ -1 +1 @@\n-old ${base} line\n+new ${base} line\n`;
+        const target = (params as { target?: string }).target ?? "unknown";
+        return `@@ -1 +1 @@\n-old ${base} to ${target} line\n+new ${base} to ${target} line\n`;
       },
       "git.branchComparison": {
         base: "main",
@@ -239,7 +240,7 @@ test.describe("Review tab — dual-scope view selection", () => {
     await expect(page.getByTestId("review-operand-slot")).toHaveAttribute("data-operand", "branch");
   });
 
-  test("branch: the operand slot hosts the base→target ref picker and switches the comparison", async ({
+  test("branch: the operand slot fixes the current branch and picks only the comparison ref", async ({
     page,
   }) => {
     await openThreadReview(page);
@@ -249,51 +250,51 @@ test.describe("Review tab — dual-scope view selection", () => {
     await switcher.click();
     await page.getByTestId("review-view-branch").click();
 
-    // The ref picker renders in the operand slot, seeded with the resolved default
-    // pair (base "main" → target "feat/x", per ADR 0007 for current ≠ base).
+    // The operand slot fixes the current branch on the left and only the right
+    // comparison ref is selectable. The server default `main...feat/x` is adapted
+    // to the user-facing `feat/x -> main` shape.
     const picker = page.getByTestId("branch-ref-picker");
     await expect(picker).toBeVisible();
-    const basePicker = page.getByTestId("branch-base-picker");
+    await expect(page.getByTestId("branch-base-picker")).toHaveCount(0);
+    await expect(page.getByTestId("branch-current-ref")).toContainText("feat/x");
     const targetPicker = page.getByTestId("branch-target-picker");
-    await expect(basePicker).toContainText("main");
     await expect(page.getByTestId("branch-range-arrow")).toBeVisible();
-    await expect(targetPicker).toContainText("feat/x");
+    await expect(targetPicker).toContainText("main");
     // Branch diffs open automatically after the comparison resolves; no file row
     // click is needed to see the inline diff.
-    await expect(page.getByText("new main line")).toBeVisible();
+    await expect(page.getByText("new feat/x to main line")).toBeVisible();
     await expect
       .poll(() =>
         branchDiffCalls.some(
           (params) =>
             (params as { base?: string; target?: string; filePath?: string }).base ===
-              "main" &&
-            (params as { base?: string; target?: string; filePath?: string }).target ===
               "feat/x" &&
+            (params as { base?: string; target?: string; filePath?: string }).target ===
+              "main" &&
             (params as { base?: string; target?: string; filePath?: string }).filePath ===
               "src/branch.ts",
         ),
       )
       .toBe(true);
 
-    // Picking a new base ref updates the comparison; the base relabels.
-    await basePicker.click();
-    await page.getByTestId("branch-ref-base-origin/main").click();
-    await expect(basePicker).toContainText("origin/main");
-    // The target side is independent and keeps its selection.
-    await expect(targetPicker).toContainText("feat/x");
+    // Picking a new comparison ref updates only the right side.
+    await targetPicker.click();
+    await page.getByTestId("branch-ref-target-origin/main").click();
+    await expect(page.getByTestId("branch-current-ref")).toContainText("feat/x");
+    await expect(targetPicker).toContainText("origin/main");
     await expect
       .poll(() =>
         branchDiffCalls.some(
           (params) =>
             (params as { base?: string; target?: string; filePath?: string }).base ===
-              "origin/main" &&
-            (params as { base?: string; target?: string; filePath?: string }).target ===
               "feat/x" &&
+            (params as { base?: string; target?: string; filePath?: string }).target ===
+              "origin/main" &&
             (params as { base?: string; target?: string; filePath?: string }).filePath ===
               "src/branch.ts",
         ),
       )
       .toBe(true);
-    await expect(page.getByText("new origin/main line")).toBeVisible();
+    await expect(page.getByText("new feat/x to origin/main line")).toBeVisible();
   });
 });

--- a/apps/web/e2e/right-panel-review-dual-scope.spec.ts
+++ b/apps/web/e2e/right-panel-review-dual-scope.spec.ts
@@ -66,6 +66,8 @@ const SNAPSHOT: TurnSnapshot = {
   created_at: now,
 };
 
+let branchDiffCalls: unknown[] = [];
+
 /** Opens the Review tab with no active thread (threadless workspace scope). */
 async function openThreadlessReview(page: Page): Promise<void> {
   await page.evaluate(
@@ -139,6 +141,7 @@ async function openThreadReview(page: Page): Promise<void> {
 
 test.describe("Review tab — dual-scope view selection", () => {
   test.beforeEach(async ({ page }) => {
+    branchDiffCalls = [];
     await mockWebSocketServer(page, {
       "workspace.list": [WORKSPACE],
       "thread.list": [THREAD],
@@ -149,7 +152,11 @@ test.describe("Review tab — dual-scope view selection", () => {
         (params as { staged?: boolean })?.staged ? ["src/staged.ts"] : ["src/unstaged.ts"],
       "git.workingTreeDiff": "",
       "git.branchFiles": ["src/branch.ts"],
-      "git.branchDiff": "",
+      "git.branchDiff": (params) => {
+        branchDiffCalls.push(params);
+        const base = (params as { base?: string }).base ?? "unknown";
+        return `@@ -1 +1 @@\n-old ${base} line\n+new ${base} line\n`;
+      },
       "git.branchComparison": {
         base: "main",
         target: "feat/x",
@@ -249,7 +256,24 @@ test.describe("Review tab — dual-scope view selection", () => {
     const basePicker = page.getByTestId("branch-base-picker");
     const targetPicker = page.getByTestId("branch-target-picker");
     await expect(basePicker).toContainText("main");
+    await expect(page.getByTestId("branch-range-arrow")).toBeVisible();
     await expect(targetPicker).toContainText("feat/x");
+    // Branch diffs open automatically after the comparison resolves; no file row
+    // click is needed to see the inline diff.
+    await expect(page.getByText("new main line")).toBeVisible();
+    await expect
+      .poll(() =>
+        branchDiffCalls.some(
+          (params) =>
+            (params as { base?: string; target?: string; filePath?: string }).base ===
+              "main" &&
+            (params as { base?: string; target?: string; filePath?: string }).target ===
+              "feat/x" &&
+            (params as { base?: string; target?: string; filePath?: string }).filePath ===
+              "src/branch.ts",
+        ),
+      )
+      .toBe(true);
 
     // Picking a new base ref updates the comparison; the base relabels.
     await basePicker.click();
@@ -257,5 +281,19 @@ test.describe("Review tab — dual-scope view selection", () => {
     await expect(basePicker).toContainText("origin/main");
     // The target side is independent and keeps its selection.
     await expect(targetPicker).toContainText("feat/x");
+    await expect
+      .poll(() =>
+        branchDiffCalls.some(
+          (params) =>
+            (params as { base?: string; target?: string; filePath?: string }).base ===
+              "origin/main" &&
+            (params as { base?: string; target?: string; filePath?: string }).target ===
+              "feat/x" &&
+            (params as { base?: string; target?: string; filePath?: string }).filePath ===
+              "src/branch.ts",
+        ),
+      )
+      .toBe(true);
+    await expect(page.getByText("new origin/main line")).toBeVisible();
   });
 });

--- a/apps/web/e2e/right-panel-review-dual-scope.spec.ts
+++ b/apps/web/e2e/right-panel-review-dual-scope.spec.ts
@@ -150,6 +150,16 @@ test.describe("Review tab — dual-scope view selection", () => {
       "git.workingTreeDiff": "",
       "git.branchFiles": ["src/branch.ts"],
       "git.branchDiff": "",
+      "git.branchComparison": {
+        base: "main",
+        target: "feat/x",
+        refs: [
+          { name: "main", shortSha: "aaaaaaa", type: "local", isCurrent: false },
+          { name: "feat/x", shortSha: "bbbbbbb", type: "local", isCurrent: true },
+          { name: "origin/main", shortSha: "aaaaaaa", type: "remote", isCurrent: false },
+        ],
+        isUnborn: false,
+      },
       "git.log": [],
       "git.commitFiles": [],
     });
@@ -220,5 +230,32 @@ test.describe("Review tab — dual-scope view selection", () => {
     await page.getByTestId("review-view-branch").click();
     await expect(switcher).toContainText("Branch");
     await expect(page.getByTestId("review-operand-slot")).toHaveAttribute("data-operand", "branch");
+  });
+
+  test("branch: the operand slot hosts the base→target ref picker and switches the comparison", async ({
+    page,
+  }) => {
+    await openThreadReview(page);
+
+    const switcher = page.getByTestId("review-view-switcher");
+    await expect(switcher).toBeVisible({ timeout: 5_000 });
+    await switcher.click();
+    await page.getByTestId("review-view-branch").click();
+
+    // The ref picker renders in the operand slot, seeded with the resolved default
+    // pair (base "main" → target "feat/x", per ADR 0007 for current ≠ base).
+    const picker = page.getByTestId("branch-ref-picker");
+    await expect(picker).toBeVisible();
+    const basePicker = page.getByTestId("branch-base-picker");
+    const targetPicker = page.getByTestId("branch-target-picker");
+    await expect(basePicker).toContainText("main");
+    await expect(targetPicker).toContainText("feat/x");
+
+    // Picking a new base ref updates the comparison; the base relabels.
+    await basePicker.click();
+    await page.getByTestId("branch-ref-base-origin/main").click();
+    await expect(basePicker).toContainText("origin/main");
+    // The target side is independent and keeps its selection.
+    await expect(targetPicker).toContainText("feat/x");
   });
 });

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -166,6 +166,9 @@ export const mockTransport: McodeTransport = {
   getWorkingTreeDiff: vi.fn().mockResolvedValue(""),
   getBranchFiles: vi.fn().mockResolvedValue([]),
   getBranchDiff: vi.fn().mockResolvedValue(""),
+  getBranchComparison: vi
+    .fn()
+    .mockResolvedValue({ base: null, target: null, refs: [], isUnborn: false }),
   push: vi.fn().mockResolvedValue({ success: true }),
   generatePrDraft: vi.fn().mockResolvedValue({ title: "", body: "" }),
   createPr: vi.fn().mockResolvedValue({ number: 1, url: "" }),

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -1,12 +1,15 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Check, ChevronDown } from "lucide-react";
 import type { BranchComparison, GitBranch } from "@mcode/contracts";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from "@/components/ui/dropdown-menu";
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { cn } from "@/lib/utils";
 import { getTransport } from "@/transport";
 import { useDiffStore } from "@/stores/diffStore";
@@ -63,15 +66,75 @@ function useResolveBranchComparison(
   return { comparison, loading };
 }
 
-/** Human-readable group label for a ref type in the picker menu. */
-const REF_GROUP_LABEL: Record<GitBranch["type"], string> = {
-  local: "Local",
-  worktree: "Worktrees",
-  remote: "Remotes",
-};
+/** Refs bucketed for the picker's group sections, in render order. */
+interface RefGroups {
+  worktree: GitBranch[];
+  local: GitBranch[];
+  remote: GitBranch[];
+}
 
-/** One side (base or target) of the comparison: a dropdown labelled with the chosen ref. */
-function RefDropdown({
+/** Bucket the flat ref list into the picker's three sections. */
+function groupRefs(refs: readonly GitBranch[]): RefGroups {
+  const groups: RefGroups = { worktree: [], local: [], remote: [] };
+  for (const ref of refs) groups[ref.type].push(ref);
+  return groups;
+}
+
+/** Section order + headings for the grouped ref menu. */
+const REF_SECTIONS: ReadonlyArray<{ type: GitBranch["type"]; heading: string }> = [
+  { type: "worktree", heading: "Worktrees" },
+  { type: "local", heading: "Local" },
+  { type: "remote", heading: "Remotes" },
+];
+
+/**
+ * Truncate a long ref name in the middle rather than at the tail. Branch names
+ * put the distinctive part last (`…/docstrings/2bbc811`), so tail-ellipsis makes
+ * long siblings identical; keeping both ends tells them apart at a glance.
+ */
+function middleTruncate(name: string, max: number): string {
+  if (name.length <= max) return name;
+  const tail = 12;
+  return `${name.slice(0, max - tail - 1)}…${name.slice(-tail)}`;
+}
+
+/**
+ * A ref name with its remote prefix de-emphasized. Every row in the Remotes
+ * section starts with the same `origin/`; muting it makes the distinctive rest
+ * carry the row. Long names middle-truncate so sibling refs stay tellable apart.
+ */
+function RefName({
+  name,
+  type,
+  active,
+}: {
+  name: string;
+  type: GitBranch["type"];
+  active: boolean;
+}) {
+  const slash = type === "remote" ? name.indexOf("/") : -1;
+  const prefix = slash >= 0 ? name.slice(0, slash + 1) : null;
+  const rest = slash >= 0 ? name.slice(slash + 1) : name;
+  return (
+    <span
+      className={cn(
+        "flex-1 truncate whitespace-nowrap",
+        active ? "text-foreground" : "text-popover-foreground",
+      )}
+      title={name}
+    >
+      {prefix && <span className="text-muted-foreground/50">{prefix}</span>}
+      {middleTruncate(rest, prefix ? 22 : 29)}
+    </span>
+  );
+}
+
+/**
+ * One side (base or target) of the comparison: a quiet toolbar chip that opens a
+ * searchable, grouped ref combobox. Machine facts (ref names, SHAs) are mono;
+ * the current branch carries the amber dot; selection is a row-fill + check.
+ */
+function RefCombobox({
   side,
   value,
   refs,
@@ -82,55 +145,95 @@ function RefDropdown({
   refs: readonly GitBranch[];
   onSelect: (ref: string) => void;
 }) {
-  // Catalog order already groups by type (local → worktree → remote); render
-  // group headers as the type changes so the menu reads as sections.
+  const [open, setOpen] = useState(false);
+  const groups = useMemo(() => groupRefs(refs), [refs]);
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
         data-testid={`branch-${side}-picker`}
         aria-label={`Select ${side} ref`}
-        className="flex h-6 min-w-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium tracking-tight text-foreground hover:bg-accent"
-      >
-        <span className="max-w-[140px] truncate font-mono">{value ?? "Select…"}</span>
-        <ChevronDown size={11} className="shrink-0 text-muted-foreground/60" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={4} className="max-h-[320px] min-w-[180px] overflow-y-auto">
-        {refs.length === 0 ? (
-          <div className="px-2 py-1.5 text-xs text-muted-foreground">No refs</div>
-        ) : (
-          refs.map((ref, i) => {
-            const active = ref.name === value;
-            const showHeader = i === 0 || refs[i - 1].type !== ref.type;
-            return (
-              <div key={`${ref.type}:${ref.name}`}>
-                {showHeader && (
-                  <div className="px-2 pb-0.5 pt-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
-                    {REF_GROUP_LABEL[ref.type]}
-                  </div>
-                )}
-                <DropdownMenuItem
-                  onClick={() => onSelect(ref.name)}
-                  data-testid={`branch-ref-${side}-${ref.name}`}
-                  aria-current={active ? "true" : undefined}
-                  className={cn(
-                    "flex cursor-pointer items-center gap-2 px-2 py-1 text-xs",
-                    active ? "text-foreground" : "text-popover-foreground",
-                  )}
-                >
-                  <span className="flex-1 truncate text-left font-mono">{ref.name}</span>
-                  {ref.isCurrent && (
-                    <span className="text-[9px] uppercase tracking-wider text-muted-foreground/50">
-                      current
-                    </span>
-                  )}
-                  {active && <Check size={11} className="shrink-0 text-muted-foreground" />}
-                </DropdownMenuItem>
-              </div>
-            );
-          })
+        className={cn(
+          "flex h-6 min-w-0 items-center gap-1 rounded-md px-1.5 font-mono text-[11px] font-medium",
+          "bg-muted/60 text-foreground transition-colors hover:bg-accent",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      >
+        <span className={cn("max-w-[132px] truncate", !value && "text-muted-foreground")}>
+          {value ?? "select ref"}
+        </span>
+        <ChevronDown size={11} className="shrink-0 text-muted-foreground/60" />
+      </PopoverTrigger>
+
+      <PopoverContent align="start" sideOffset={6} className="w-[320px] p-0">
+        <Command>
+          <CommandInput
+            placeholder="Filter refs"
+            className="h-8 py-2 font-mono text-xs"
+            data-testid={`branch-${side}-filter`}
+          />
+          <CommandList className="max-h-[296px]">
+            <CommandEmpty>
+              <div className="flex flex-col items-center gap-2 py-4">
+                <span aria-hidden="true" className="font-mono text-xl leading-none text-muted-foreground/15">
+                  ⊘
+                </span>
+                <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground/40">
+                  No matching refs
+                </span>
+              </div>
+            </CommandEmpty>
+
+            {REF_SECTIONS.map(({ type, heading }) => {
+              const sectionRefs = groups[type];
+              if (sectionRefs.length === 0) return null;
+              return (
+                <CommandGroup
+                  key={type}
+                  heading={heading}
+                  className="[&_[cmdk-group-heading]]:font-mono [&_[cmdk-group-heading]]:text-[9.5px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.18em] [&_[cmdk-group-heading]]:text-muted-foreground/50"
+                >
+                  {sectionRefs.map((ref) => {
+                    const active = ref.name === value;
+                    return (
+                      <CommandItem
+                        key={ref.name}
+                        value={ref.name}
+                        onSelect={() => {
+                          onSelect(ref.name);
+                          setOpen(false);
+                        }}
+                        data-testid={`branch-ref-${side}-${ref.name}`}
+                        aria-current={active ? "true" : undefined}
+                        className="gap-2 py-1 font-mono text-xs"
+                      >
+                        {/* The amber dot marks the checked-out branch — the same
+                            glance vocabulary as the sidebar's status dots. */}
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            "size-1.5 shrink-0 rounded-full",
+                            ref.isCurrent ? "bg-primary" : "bg-transparent",
+                          )}
+                        />
+                        <RefName name={ref.name} type={ref.type} active={active} />
+                        {active ? (
+                          <Check size={11} className="shrink-0 text-muted-foreground" />
+                        ) : (
+                          <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/40">
+                            {ref.shortSha}
+                          </span>
+                        )}
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              );
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -143,10 +246,10 @@ interface BranchRefPickerProps {
 }
 
 /**
- * The Branch view's operand control: two ref dropdowns (`base … target`) the user
- * picks independently, always diffed three-dot. Renders into the Review toolbar's
- * contextual operand slot. Resolves its default pair per ADR 0007 and writes the
- * chosen pair to the diff store, which drives the rendered Branch diff.
+ * The Branch view's operand control: two ref comboboxes (`base … target`) the
+ * user picks independently, always diffed three-dot. Renders into the Review
+ * toolbar's contextual operand slot. Resolves its default pair per ADR 0007 and
+ * writes the chosen pair to the diff store, which drives the rendered Branch diff.
  */
 export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps) {
   const { comparison, loading } = useResolveBranchComparison(workspaceId, threadId);
@@ -154,21 +257,29 @@ export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps)
   const setBranchTarget = useDiffStore((s) => s.setBranchTarget);
 
   if (loading && !comparison) {
-    return <span className="text-[11px] text-muted-foreground/50">Loading refs…</span>;
+    return (
+      <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground/40">
+        Resolving
+      </span>
+    );
   }
   if (comparison?.isUnborn) {
-    return <span className="text-[11px] text-muted-foreground/50">No commits yet</span>;
+    return (
+      <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground/40">
+        No commits yet
+      </span>
+    );
   }
 
   const refs = comparison?.refs ?? [];
   return (
-    <div className="flex min-w-0 items-center gap-0.5" data-testid="branch-ref-picker">
-      <RefDropdown side="base" value={comparison?.base ?? null} refs={refs} onSelect={setBranchBase} />
+    <div className="flex min-w-0 items-center gap-1" data-testid="branch-ref-picker">
+      <RefCombobox side="base" value={comparison?.base ?? null} refs={refs} onSelect={setBranchBase} />
       {/* Three-dot range indicator (always `base...target`, never two-dot). */}
-      <span aria-hidden="true" className="px-0.5 font-mono text-[11px] text-muted-foreground/40">
+      <span aria-hidden="true" className="font-mono text-[11px] leading-none text-muted-foreground/40">
         …
       </span>
-      <RefDropdown side="target" value={comparison?.target ?? null} refs={refs} onSelect={setBranchTarget} />
+      <RefCombobox side="target" value={comparison?.target ?? null} refs={refs} onSelect={setBranchTarget} />
     </div>
   );
 }

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import type { BranchComparison, GitBranch } from "@mcode/contracts";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { getTransport } from "@/transport";
+import { useDiffStore } from "@/stores/diffStore";
+
+/** The scope key a comparison is resolved against (`workspaceId:threadId`). */
+function scopeKey(workspaceId: string, threadId?: string): string {
+  return `${workspaceId}:${threadId ?? ""}`;
+}
+
+/**
+ * Resolves the default Branch comparison for a scope (per ADR 0007) and seeds it
+ * into the diff store. Re-resolves when the scope changes; preserves a user's
+ * picked pair when the active comparison was already resolved for this scope (so
+ * toggling views within a scope keeps the chosen base/target). Returns the
+ * current comparison plus whether the initial resolve is in flight.
+ */
+function useResolveBranchComparison(
+  workspaceId: string,
+  threadId?: string,
+): { comparison: BranchComparison | null; loading: boolean } {
+  const comparison = useDiffStore((s) => s.branchComparison);
+  const setBranchComparison = useDiffStore((s) => s.setBranchComparison);
+  const [loading, setLoading] = useState(false);
+  const key = scopeKey(workspaceId, threadId);
+
+  useEffect(() => {
+    // Keep the pair the user already resolved/picked for this exact scope.
+    const state = useDiffStore.getState();
+    if (state.branchComparisonKey === key && state.branchComparison) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    void getTransport()
+      .getBranchComparison(workspaceId, threadId)
+      .then((result) => {
+        if (cancelled) return;
+        setBranchComparison(result, key);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setBranchComparison({ base: null, target: null, refs: [], isUnborn: false }, key);
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key, workspaceId, threadId, setBranchComparison]);
+
+  return { comparison, loading };
+}
+
+/** Human-readable group label for a ref type in the picker menu. */
+const REF_GROUP_LABEL: Record<GitBranch["type"], string> = {
+  local: "Local",
+  worktree: "Worktrees",
+  remote: "Remotes",
+};
+
+/** One side (base or target) of the comparison: a dropdown labelled with the chosen ref. */
+function RefDropdown({
+  side,
+  value,
+  refs,
+  onSelect,
+}: {
+  side: "base" | "target";
+  value: string | null;
+  refs: readonly GitBranch[];
+  onSelect: (ref: string) => void;
+}) {
+  // Catalog order already groups by type (local → worktree → remote); render
+  // group headers as the type changes so the menu reads as sections.
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        data-testid={`branch-${side}-picker`}
+        aria-label={`Select ${side} ref`}
+        className="flex h-6 min-w-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium tracking-tight text-foreground hover:bg-accent"
+      >
+        <span className="max-w-[140px] truncate font-mono">{value ?? "Select…"}</span>
+        <ChevronDown size={11} className="shrink-0 text-muted-foreground/60" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" sideOffset={4} className="max-h-[320px] min-w-[180px] overflow-y-auto">
+        {refs.length === 0 ? (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">No refs</div>
+        ) : (
+          refs.map((ref, i) => {
+            const active = ref.name === value;
+            const showHeader = i === 0 || refs[i - 1].type !== ref.type;
+            return (
+              <div key={`${ref.type}:${ref.name}`}>
+                {showHeader && (
+                  <div className="px-2 pb-0.5 pt-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                    {REF_GROUP_LABEL[ref.type]}
+                  </div>
+                )}
+                <DropdownMenuItem
+                  onClick={() => onSelect(ref.name)}
+                  data-testid={`branch-ref-${side}-${ref.name}`}
+                  aria-current={active ? "true" : undefined}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 px-2 py-1 text-xs",
+                    active ? "text-foreground" : "text-popover-foreground",
+                  )}
+                >
+                  <span className="flex-1 truncate text-left font-mono">{ref.name}</span>
+                  {ref.isCurrent && (
+                    <span className="text-[9px] uppercase tracking-wider text-muted-foreground/50">
+                      current
+                    </span>
+                  )}
+                  {active && <Check size={11} className="shrink-0 text-muted-foreground" />}
+                </DropdownMenuItem>
+              </div>
+            );
+          })
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Props for {@link BranchRefPicker}. */
+interface BranchRefPickerProps {
+  /** Active workspace id (the repo whose refs populate the pickers). */
+  workspaceId: string;
+  /** Active thread id; makes "current branch" the thread's worktree branch. */
+  threadId?: string;
+}
+
+/**
+ * The Branch view's operand control: two ref dropdowns (`base … target`) the user
+ * picks independently, always diffed three-dot. Renders into the Review toolbar's
+ * contextual operand slot. Resolves its default pair per ADR 0007 and writes the
+ * chosen pair to the diff store, which drives the rendered Branch diff.
+ */
+export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps) {
+  const { comparison, loading } = useResolveBranchComparison(workspaceId, threadId);
+  const setBranchBase = useDiffStore((s) => s.setBranchBase);
+  const setBranchTarget = useDiffStore((s) => s.setBranchTarget);
+
+  if (loading && !comparison) {
+    return <span className="text-[11px] text-muted-foreground/50">Loading refs…</span>;
+  }
+  if (comparison?.isUnborn) {
+    return <span className="text-[11px] text-muted-foreground/50">No commits yet</span>;
+  }
+
+  const refs = comparison?.refs ?? [];
+  return (
+    <div className="flex min-w-0 items-center gap-0.5" data-testid="branch-ref-picker">
+      <RefDropdown side="base" value={comparison?.base ?? null} refs={refs} onSelect={setBranchBase} />
+      {/* Three-dot range indicator (always `base...target`, never two-dot). */}
+      <span aria-hidden="true" className="px-0.5 font-mono text-[11px] text-muted-foreground/40">
+        …
+      </span>
+      <RefDropdown side="target" value={comparison?.target ?? null} refs={refs} onSelect={setBranchTarget} />
+    </div>
+  );
+}

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -278,17 +278,10 @@ function CurrentRefChip({ value }: { value: string | null }) {
       aria-label={`Current branch: ${value ?? "unknown"}`}
       title={value ?? "Current branch"}
       className={cn(
-        "flex h-6 min-w-0 shrink items-center gap-1.5 rounded-md px-2 font-mono text-xs font-medium",
+        "flex h-6 min-w-0 shrink items-center rounded-md px-2 font-mono text-xs font-medium",
         "text-muted-foreground",
       )}
     >
-      <span
-        aria-hidden="true"
-        className={cn(
-          "size-1.5 shrink-0 rounded-full",
-          value ? "bg-primary/80" : "bg-muted-foreground/30",
-        )}
-      />
       <span className={cn("max-w-[142px] truncate", !value && "text-muted-foreground")}>
         {value ?? "current"}
       </span>

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -185,8 +185,7 @@ function RefCombobox({
             aria-haspopup="dialog"
             className={cn(
               "h-6 min-w-0 max-w-[164px] flex-1 shrink justify-between gap-1.5 rounded-md px-2 font-mono text-xs font-medium",
-              "bg-background/75 text-foreground shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--border),transparent_40%)]",
-              "hover:bg-accent/80 aria-expanded:bg-accent/80",
+              "text-foreground shadow-none hover:bg-foreground/[0.06] aria-expanded:bg-foreground/[0.06]",
             )}
           >
             <span className={cn("min-w-0 truncate", !value && "text-muted-foreground")}>
@@ -330,15 +329,17 @@ export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps)
       aria-label="Branch comparison range"
     >
       <CurrentRefChip value={comparison?.base ?? null} />
-      {/* Directional cue for the fixed current-to-selected comparison. */}
-      <span
-        aria-hidden="true"
-        data-testid="branch-range-arrow"
-        className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/50"
-      >
-        <ArrowRight size={12} strokeWidth={1.8} />
-      </span>
-      <RefCombobox value={comparison?.target ?? null} refs={refs} onSelect={setBranchTarget} />
+      {/* Target side: divider + arrow + picker share one hover surface (no nested chip). */}
+      <div className="flex min-w-0 flex-1 items-center gap-0.5 border-l border-border/25 pl-1">
+        <span
+          aria-hidden="true"
+          data-testid="branch-range-arrow"
+          className="inline-flex size-5 shrink-0 items-center justify-center text-muted-foreground/50"
+        >
+          <ArrowRight size={12} strokeWidth={1.8} />
+        </span>
+        <RefCombobox value={comparison?.target ?? null} refs={refs} onSelect={setBranchTarget} />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { ArrowRight, Check, ChevronDown } from "lucide-react";
 import type { BranchComparison, GitBranch } from "@mcode/contracts";
+import { Button } from "@/components/ui/button";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import {
   Command,
@@ -173,18 +174,28 @@ function RefCombobox({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
-        data-testid="branch-target-picker"
-        aria-label="Select comparison ref"
-        className={cn(
-          "flex h-6 min-w-0 items-center gap-1 rounded-md px-1.5 font-mono text-[11px] font-medium",
-          "bg-muted/60 text-foreground transition-colors hover:bg-accent",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-        )}
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            data-testid="branch-target-picker"
+            aria-label="Select comparison ref"
+            aria-expanded={open}
+            aria-haspopup="dialog"
+            className={cn(
+              "h-6 min-w-0 max-w-[164px] flex-1 shrink justify-between gap-1.5 rounded-md px-2 font-mono text-xs font-medium",
+              "bg-background/75 text-foreground shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--border),transparent_40%)]",
+              "hover:bg-accent/80 aria-expanded:bg-accent/80",
+            )}
+          >
+            <span className={cn("min-w-0 truncate", !value && "text-muted-foreground")}>
+              {value ?? "select ref"}
+            </span>
+            <ChevronDown size={11} className="shrink-0 text-muted-foreground/65" />
+          </Button>
+        }
       >
-        <span className={cn("max-w-[132px] truncate", !value && "text-muted-foreground")}>
-          {value ?? "select ref"}
-        </span>
-        <ChevronDown size={11} className="shrink-0 text-muted-foreground/60" />
       </PopoverTrigger>
 
       <PopoverContent align="start" sideOffset={6} className="w-[320px] p-0">
@@ -264,14 +275,21 @@ function CurrentRefChip({ value }: { value: string | null }) {
   return (
     <span
       data-testid="branch-current-ref"
-      aria-label="Current branch"
+      aria-label={`Current branch: ${value ?? "unknown"}`}
       title={value ?? "Current branch"}
       className={cn(
-        "flex h-6 min-w-0 items-center rounded-md px-1.5 font-mono text-[11px] font-medium",
-        "bg-muted/35 text-foreground/80",
+        "flex h-6 min-w-0 shrink items-center gap-1.5 rounded-md px-2 font-mono text-xs font-medium",
+        "text-muted-foreground",
       )}
     >
-      <span className={cn("max-w-[132px] truncate", !value && "text-muted-foreground")}>
+      <span
+        aria-hidden="true"
+        className={cn(
+          "size-1.5 shrink-0 rounded-full",
+          value ? "bg-primary/80" : "bg-muted-foreground/30",
+        )}
+      />
+      <span className={cn("max-w-[142px] truncate", !value && "text-muted-foreground")}>
         {value ?? "current"}
       </span>
     </span>
@@ -312,13 +330,18 @@ export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps)
 
   const refs = comparison?.refs ?? [];
   return (
-    <div className="flex min-w-0 items-center gap-1" data-testid="branch-ref-picker">
+    <div
+      className="flex h-7 min-w-0 max-w-[min(46vw,390px)] items-center gap-1 overflow-hidden rounded-lg border border-border/30 bg-muted/25 px-1 shadow-[inset_0_1px_0_color-mix(in_oklch,var(--foreground),transparent_94%)]"
+      data-testid="branch-ref-picker"
+      role="group"
+      aria-label="Branch comparison range"
+    >
       <CurrentRefChip value={comparison?.base ?? null} />
       {/* Directional cue for the fixed current-to-selected comparison. */}
       <span
         aria-hidden="true"
         data-testid="branch-range-arrow"
-        className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/45"
+        className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/50"
       >
         <ArrowRight size={12} strokeWidth={1.8} />
       </span>

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { ArrowRight, Check, ChevronDown } from "lucide-react";
 import type { BranchComparison, GitBranch } from "@mcode/contracts";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import {
@@ -246,7 +246,7 @@ interface BranchRefPickerProps {
 }
 
 /**
- * The Branch view's operand control: two ref comboboxes (`base … target`) the
+ * The Branch view's operand control: two ref comboboxes (`base -> target`) the
  * user picks independently, always diffed three-dot. Renders into the Review
  * toolbar's contextual operand slot. Resolves its default pair per ADR 0007 and
  * writes the chosen pair to the diff store, which drives the rendered Branch diff.
@@ -275,9 +275,13 @@ export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps)
   return (
     <div className="flex min-w-0 items-center gap-1" data-testid="branch-ref-picker">
       <RefCombobox side="base" value={comparison?.base ?? null} refs={refs} onSelect={setBranchBase} />
-      {/* Three-dot range indicator (always `base...target`, never two-dot). */}
-      <span aria-hidden="true" className="font-mono text-[11px] leading-none text-muted-foreground/40">
-        …
+      {/* Directional cue for the fixed `base...target` comparison. */}
+      <span
+        aria-hidden="true"
+        data-testid="branch-range-arrow"
+        className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/45"
+      >
+        <ArrowRight size={12} strokeWidth={1.8} />
       </span>
       <RefCombobox side="target" value={comparison?.target ?? null} refs={refs} onSelect={setBranchTarget} />
     </div>

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -143,8 +143,8 @@ function RefName({
   return (
     <span
       className={cn(
-        "flex-1 truncate whitespace-nowrap",
-        active ? "text-foreground" : "text-popover-foreground",
+        "min-w-0 flex-1 truncate whitespace-nowrap font-mono text-[11px]",
+        active ? "text-foreground" : "text-foreground/80",
       )}
       title={name}
     >
@@ -156,8 +156,8 @@ function RefName({
 
 /**
  * The selected comparison ref: a quiet toolbar chip that opens a searchable,
- * grouped ref combobox. Machine facts (ref names, SHAs) are mono;
- * the current branch carries the amber dot; selection is a row-fill + check.
+ * grouped ref combobox. Ref rows follow the Commit picker rhythm: primary ref
+ * name, quiet metadata, and a check for the active selection.
  */
 function RefCombobox({
   value,
@@ -197,34 +197,21 @@ function RefCombobox({
       >
       </PopoverTrigger>
 
-      <PopoverContent align="start" sideOffset={6} className="w-[320px] p-0">
+      <PopoverContent align="start" sideOffset={4} className="w-80 p-0">
         <Command>
           <CommandInput
-            placeholder="Filter refs"
-            className="h-8 py-2 font-mono text-xs"
+            placeholder="Search refs..."
+            className="h-8 text-[11.5px]"
             data-testid="branch-target-filter"
           />
-          <CommandList className="max-h-[296px]">
-            <CommandEmpty>
-              <div className="flex flex-col items-center gap-2 py-4">
-                <span aria-hidden="true" className="font-mono text-xl leading-none text-muted-foreground/15">
-                  ⊘
-                </span>
-                <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground/40">
-                  No matching refs
-                </span>
-              </div>
-            </CommandEmpty>
+          <CommandList>
+            <CommandEmpty className="py-4 text-[11px]">No refs found</CommandEmpty>
 
             {REF_SECTIONS.map(({ type, heading }) => {
               const sectionRefs = groups[type];
               if (sectionRefs.length === 0) return null;
               return (
-                <CommandGroup
-                  key={type}
-                  heading={heading}
-                  className="[&_[cmdk-group-heading]]:font-mono [&_[cmdk-group-heading]]:text-[9.5px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.18em] [&_[cmdk-group-heading]]:text-muted-foreground/50"
-                >
+                <CommandGroup key={type} heading={heading}>
                   {sectionRefs.map((ref) => {
                     const active = ref.name === value;
                     return (
@@ -237,22 +224,13 @@ function RefCombobox({
                         }}
                         data-testid={`branch-ref-target-${ref.name}`}
                         aria-current={active ? "true" : undefined}
-                        className="gap-2 py-1 font-mono text-xs"
+                        className="gap-2 px-2 py-1.5"
                       >
-                        {/* The amber dot marks the checked-out branch — the same
-                            glance vocabulary as the sidebar's status dots. */}
-                        <span
-                          aria-hidden="true"
-                          className={cn(
-                            "size-1.5 shrink-0 rounded-full",
-                            ref.isCurrent ? "bg-primary" : "bg-transparent",
-                          )}
-                        />
                         <RefName name={ref.name} type={ref.type} active={active} />
                         {active ? (
                           <Check size={11} className="shrink-0 text-muted-foreground" />
                         ) : (
-                          <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/40">
+                          <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/45">
                             {ref.shortSha}
                           </span>
                         )}

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -21,9 +21,10 @@ function scopeKey(workspaceId: string, threadId?: string): string {
 
 /**
  * Resolves the default Branch comparison for a scope (per ADR 0007) and seeds it
- * into the diff store. Re-resolves when the scope changes; preserves a user's
- * picked pair when the active comparison was already resolved for this scope (so
- * toggling views within a scope keeps the chosen base/target). Returns the
+ * into the diff store as `current -> selected ref`. Re-resolves when the scope
+ * changes; preserves a user's picked target when the active comparison was
+ * already resolved for this scope (so toggling views within a scope keeps the
+ * chosen target). Returns the
  * current comparison plus whether the initial resolve is in flight.
  */
 function useResolveBranchComparison(
@@ -49,7 +50,7 @@ function useResolveBranchComparison(
       .getBranchComparison(workspaceId, threadId)
       .then((result) => {
         if (cancelled) return;
-        setBranchComparison(result, key);
+        setBranchComparison(normalizeToCurrentComparison(result), key);
         setLoading(false);
       })
       .catch(() => {
@@ -64,6 +65,29 @@ function useResolveBranchComparison(
   }, [key, workspaceId, threadId, setBranchComparison]);
 
   return { comparison, loading };
+}
+
+/**
+ * Adapt the server's semantic default (`base...current` for feature branches)
+ * into the toolbar model the user sees: current branch fixed on the left, one
+ * selectable comparison ref on the right.
+ */
+function normalizeToCurrentComparison(comparison: BranchComparison): BranchComparison {
+  if (comparison.isUnborn) return comparison;
+
+  const current = comparison.refs.find((ref) => ref.isCurrent)?.name ?? (
+    comparison.target === "HEAD" ? "HEAD" : null
+  );
+  if (!current) return comparison;
+
+  const selected =
+    comparison.base === null
+      ? null
+      : comparison.base === current
+        ? comparison.target
+        : comparison.base;
+
+  return { ...comparison, base: current, target: selected };
 }
 
 /** Refs bucketed for the picker's group sections, in render order. */
@@ -130,17 +154,15 @@ function RefName({
 }
 
 /**
- * One side (base or target) of the comparison: a quiet toolbar chip that opens a
- * searchable, grouped ref combobox. Machine facts (ref names, SHAs) are mono;
+ * The selected comparison ref: a quiet toolbar chip that opens a searchable,
+ * grouped ref combobox. Machine facts (ref names, SHAs) are mono;
  * the current branch carries the amber dot; selection is a row-fill + check.
  */
 function RefCombobox({
-  side,
   value,
   refs,
   onSelect,
 }: {
-  side: "base" | "target";
   value: string | null;
   refs: readonly GitBranch[];
   onSelect: (ref: string) => void;
@@ -151,8 +173,8 @@ function RefCombobox({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
-        data-testid={`branch-${side}-picker`}
-        aria-label={`Select ${side} ref`}
+        data-testid="branch-target-picker"
+        aria-label="Select comparison ref"
         className={cn(
           "flex h-6 min-w-0 items-center gap-1 rounded-md px-1.5 font-mono text-[11px] font-medium",
           "bg-muted/60 text-foreground transition-colors hover:bg-accent",
@@ -170,7 +192,7 @@ function RefCombobox({
           <CommandInput
             placeholder="Filter refs"
             className="h-8 py-2 font-mono text-xs"
-            data-testid={`branch-${side}-filter`}
+            data-testid="branch-target-filter"
           />
           <CommandList className="max-h-[296px]">
             <CommandEmpty>
@@ -203,7 +225,7 @@ function RefCombobox({
                           onSelect(ref.name);
                           setOpen(false);
                         }}
-                        data-testid={`branch-ref-${side}-${ref.name}`}
+                        data-testid={`branch-ref-target-${ref.name}`}
                         aria-current={active ? "true" : undefined}
                         className="gap-2 py-1 font-mono text-xs"
                       >
@@ -237,6 +259,25 @@ function RefCombobox({
   );
 }
 
+/** Read-only chip for the current branch on the left side of the comparison. */
+function CurrentRefChip({ value }: { value: string | null }) {
+  return (
+    <span
+      data-testid="branch-current-ref"
+      aria-label="Current branch"
+      title={value ?? "Current branch"}
+      className={cn(
+        "flex h-6 min-w-0 items-center rounded-md px-1.5 font-mono text-[11px] font-medium",
+        "bg-muted/35 text-foreground/80",
+      )}
+    >
+      <span className={cn("max-w-[132px] truncate", !value && "text-muted-foreground")}>
+        {value ?? "current"}
+      </span>
+    </span>
+  );
+}
+
 /** Props for {@link BranchRefPicker}. */
 interface BranchRefPickerProps {
   /** Active workspace id (the repo whose refs populate the pickers). */
@@ -246,14 +287,12 @@ interface BranchRefPickerProps {
 }
 
 /**
- * The Branch view's operand control: two ref comboboxes (`base -> target`) the
- * user picks independently, always diffed three-dot. Renders into the Review
- * toolbar's contextual operand slot. Resolves its default pair per ADR 0007 and
- * writes the chosen pair to the diff store, which drives the rendered Branch diff.
+ * The Branch view's operand control: a read-only current-branch chip on the left
+ * and one selected comparison ref on the right. The stored pair is always
+ * `current...selected`, and the right side is the only picker.
  */
 export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps) {
   const { comparison, loading } = useResolveBranchComparison(workspaceId, threadId);
-  const setBranchBase = useDiffStore((s) => s.setBranchBase);
   const setBranchTarget = useDiffStore((s) => s.setBranchTarget);
 
   if (loading && !comparison) {
@@ -274,8 +313,8 @@ export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps)
   const refs = comparison?.refs ?? [];
   return (
     <div className="flex min-w-0 items-center gap-1" data-testid="branch-ref-picker">
-      <RefCombobox side="base" value={comparison?.base ?? null} refs={refs} onSelect={setBranchBase} />
-      {/* Directional cue for the fixed `base...target` comparison. */}
+      <CurrentRefChip value={comparison?.base ?? null} />
+      {/* Directional cue for the fixed current-to-selected comparison. */}
       <span
         aria-hidden="true"
         data-testid="branch-range-arrow"
@@ -283,7 +322,7 @@ export function BranchRefPicker({ workspaceId, threadId }: BranchRefPickerProps)
       >
         <ArrowRight size={12} strokeWidth={1.8} />
       </span>
-      <RefCombobox side="target" value={comparison?.target ?? null} refs={refs} onSelect={setBranchTarget} />
+      <RefCombobox value={comparison?.target ?? null} refs={refs} onSelect={setBranchTarget} />
     </div>
   );
 }

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -14,6 +14,7 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import type { PanelScope } from "@/lib/panel-tabs";
 import { visibleReviewViews, defaultReviewView } from "@/lib/review-views";
+import { BranchRefPicker } from "./BranchRefPicker";
 
 /** Toolbar for the Review tab: dual-scope view switcher + unified/side-by-side toggle. */
 export function DiffToolbar() {
@@ -22,6 +23,7 @@ export function DiffToolbar() {
   const setViewMode = useDiffStore((s) => s.setViewMode);
   const setRenderMode = useDiffStore((s) => s.setRenderMode);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const lineWrap = useDiffStore((s) =>
     activeThreadId ? s.getLineWrap(activeThreadId) : true,
   );
@@ -99,14 +101,21 @@ export function DiffToolbar() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {/* Operand slot — reserved for the active view's picked operand. Empty
-            for fixed-operand views; the per-operand picker lands in #641/#642. */}
+        {/* Operand slot — the active view's picked operand. Branch carries a
+            base→target ref picker; Commit's picker lands in #642. */}
         {activeView?.operand && (
           <div
             className="flex min-w-0 items-center"
             data-testid="review-operand-slot"
             data-operand={activeView.operand}
-          />
+          >
+            {activeView.operand === "branch" && activeWorkspaceId && (
+              <BranchRefPicker
+                workspaceId={activeWorkspaceId}
+                threadId={activeThreadId ?? undefined}
+              />
+            )}
+          </div>
         )}
       </div>
 

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -105,7 +105,7 @@ export function DiffToolbar() {
             base→target ref picker; Commit's picker lands in #642. */}
         {activeView?.operand && (
           <div
-            className="flex min-w-0 items-center"
+            className="ml-1 flex min-w-0 items-center border-l border-border/25 pl-2"
             data-testid="review-operand-slot"
             data-operand={activeView.operand}
           >

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -25,7 +25,7 @@ interface FileEntryProps {
    * parent-path suffix is suppressed (the folder header above carries it).
    */
   depth?: number;
-  /** When true the diff starts expanded on mount (used for the latest turn). */
+  /** When true the diff starts expanded on mount and after its diff identity changes. */
   defaultExpanded?: boolean;
 }
 
@@ -63,7 +63,7 @@ type DiffState = null | { loading: true } | { loading: false; data: string };
 /**
  * Single file row with an inline expandable diff.
  * Clicking toggles the diff open/closed directly below the filename.
- * Diff is loaded lazily on the first expand.
+ * Diff is loaded lazily on the first expand, or immediately for auto-opened views.
  * Large diffs (>200 lines) are truncated with a "Show all N lines" button.
  */
 export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultExpanded: defaultExpandedProp = false }: FileEntryProps) {
@@ -71,8 +71,9 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
   const [expanded, setExpanded] = useState(defaultExpandedProp);
   const [showAllLines, setShowAllLines] = useState(false);
   const [previewMode, setPreviewMode] = useState(false);
+  const cacheKey = `${threadId}:${source}:${id}:${filePath}`;
   // Initialise from the Zustand cache so diffs survive panel close/reopen.
-  const cachedDiff = useDiffStore((s) => s.inlineDiffCache[`${threadId}:${source}:${id}:${filePath}`]);
+  const cachedDiff = useDiffStore((s) => s.inlineDiffCache[cacheKey]);
   const [diffState, setDiffState] = useState<DiffState>(
     () => (cachedDiff !== undefined ? { loading: false, data: cachedDiff } : null),
   );
@@ -84,7 +85,6 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
 
   // Reset local state when the cache identity changes so a reused component
   // instance doesn't show stale content from a previous identity.
-  const cacheKey = `${threadId}:${source}:${id}:${filePath}`;
   useEffect(() => {
     const cached = useDiffStore.getState().inlineDiffCache[cacheKey];
     setDiffState(cached !== undefined ? { loading: false, data: cached } : null);
@@ -93,6 +93,10 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
     loadStartedRef.current = false;
   }, [cacheKey]);
 
+  useEffect(() => {
+    if (defaultExpandedProp) setExpanded(true);
+  }, [cacheKey, defaultExpandedProp]);
+
   const { basename, parent, ext, language, isMarkdown } = useMemo(() => {
     const bn = getFileBasename(filePath);
     const pr = getParentDir(filePath);
@@ -100,9 +104,15 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
     return { basename: bn, parent: pr, ext: ex, language: langFromPath(filePath), isMarkdown: isMarkdownFile(filePath) };
   }, [filePath]);
 
-  // Load diff lazily on first expand. Skips if the diff is already cached.
+  // Load diff lazily on first expand. Reads the cache at effect time so a reused
+  // row with a new comparison id does not miss its fresh load.
   useEffect(() => {
-    if (!expanded || loadStartedRef.current || (diffState !== null && !diffState.loading)) return;
+    if (!expanded || loadStartedRef.current) return;
+    const cached = useDiffStore.getState().inlineDiffCache[cacheKey];
+    if (cached !== undefined) {
+      setDiffState({ loading: false, data: cached });
+      return;
+    }
     loadStartedRef.current = true;
 
     let cancelled = false;
@@ -126,7 +136,7 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
       cancelled = true;
       loadStartedRef.current = false;
     };
-  }, [expanded, source, id, filePath, threadId]);
+  }, [expanded, source, id, filePath, threadId, cacheKey]);
 
   const lines = useMemo(
     () =>

--- a/apps/web/src/components/diff/GitDiffView.tsx
+++ b/apps/web/src/components/diff/GitDiffView.tsx
@@ -150,6 +150,7 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
         // Cache + per-file fetch scope: the real thread (→ its worktree) when in a
         // thread, else the workspace id (the server reads the workspace root).
         threadId={threadId ?? workspaceId}
+        defaultFilesExpanded={view === "branch"}
       />
     </div>
   );

--- a/apps/web/src/components/diff/GitDiffView.tsx
+++ b/apps/web/src/components/diff/GitDiffView.tsx
@@ -68,8 +68,8 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
   const [resolved, setResolved] = useState<Resolved | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // The Branch view's diff is driven by the comparison the ref picker resolves
-  // (ADR 0007). Subscribe so picking a new base/target refetches the file list.
+  // The Branch view's diff is driven by the current branch plus the selected
+  // comparison ref. Subscribe so picking a new target refetches the file list.
   const branchBase = useDiffStore((s) => s.branchComparison?.base ?? null);
   const branchTarget = useDiffStore((s) => s.branchComparison?.target ?? null);
   const branchUnborn = useDiffStore((s) => s.branchComparison?.isUnborn ?? false);

--- a/apps/web/src/components/diff/GitDiffView.tsx
+++ b/apps/web/src/components/diff/GitDiffView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { getTransport } from "@/transport";
-import type { SelectedFile } from "@/stores/diffStore";
+import { useDiffStore, type SelectedFile } from "@/stores/diffStore";
 import { FileList } from "./FileList";
 
 /** The threadless git working-tree views the Review tab renders against the workspace root. */
@@ -68,10 +68,25 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
   const [resolved, setResolved] = useState<Resolved | null>(null);
   const [loading, setLoading] = useState(true);
 
+  // The Branch view's diff is driven by the comparison the ref picker resolves
+  // (ADR 0007). Subscribe so picking a new base/target refetches the file list.
+  const branchBase = useDiffStore((s) => s.branchComparison?.base ?? null);
+  const branchTarget = useDiffStore((s) => s.branchComparison?.target ?? null);
+  const branchUnborn = useDiffStore((s) => s.branchComparison?.isUnborn ?? false);
+
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setResolved(null);
+
+    // Branch view waits for the picker to resolve a pair before fetching, unless
+    // HEAD is unborn (explicit empty). Holding `loading` avoids a flash of the
+    // empty state with a stale/default range during resolution.
+    if (view === "branch" && !branchUnborn && (!branchBase || !branchTarget)) {
+      return () => {
+        cancelled = true;
+      };
+    }
 
     const load = async (): Promise<Resolved> => {
       const transport = getTransport();
@@ -80,8 +95,13 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
         return { files, source: view, id: workspaceId };
       }
       if (view === "branch") {
-        const files = await transport.getBranchFiles(workspaceId, threadId);
-        return { files, source: "branch", id: workspaceId };
+        if (branchUnborn || !branchBase || !branchTarget) {
+          return { files: [], source: "branch", id: "branch-empty" };
+        }
+        const files = await transport.getBranchFiles(workspaceId, branchBase, branchTarget, threadId);
+        // The comparison range is folded into the FileList id so the inline diff
+        // cache and per-file fetch vary by pair (git refnames can't contain "..").
+        return { files, source: "branch", id: `${branchBase}...${branchTarget}` };
       }
       // Commit view: the latest HEAD commit (the thread's worktree HEAD when in a
       // thread). Worktrees share the object store, so the per-file diff fetched by
@@ -112,8 +132,9 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
     };
     // threadId is a fetch input: switching threads (or thread↔threadless) on the
     // same view+workspace must refetch the worktree's file list, not keep the
-    // previous scope's stale diff.
-  }, [view, workspaceId, threadId]);
+    // previous scope's stale diff. branchBase/branchTarget/branchUnborn are fetch
+    // inputs for the Branch view: picking a new ref pair refetches its file list.
+  }, [view, workspaceId, threadId, branchBase, branchTarget, branchUnborn]);
 
   if (loading) return <LoadingPulse />;
   if (!resolved || resolved.files.length === 0) {

--- a/apps/web/src/lib/load-file-diff.ts
+++ b/apps/web/src/lib/load-file-diff.ts
@@ -6,11 +6,11 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
  * Fetch the unified diff for a single file in a Review view. Centralizes the
  * per-source routing shared by the inline file rows and the selected-file pane,
  * so the two stay in lockstep as sources are added. The `id` resolves the diff
- * per {@link SelectedFile.id}: snapshot ID, thread ID, commit SHA, or — for the
- * git working-tree views — the workspace ID. For those git views `threadId`
- * (when a real thread) makes the diff read the thread's worktree rather than the
- * workspace root; the server treats a non-thread id as the workspace root.
- * Returns `""` on any failure.
+ * per {@link SelectedFile.id}: snapshot ID, thread ID, commit SHA, the
+ * `base...target` comparison range for `"branch"`, or the workspace ID for the
+ * working-tree views. For the git views `threadId` (when a real thread) makes
+ * the diff read the thread's worktree rather than the workspace root; the server
+ * treats a non-thread id as the workspace root. Returns `""` on any failure.
  */
 export async function loadFileDiff(
   transport: McodeTransport,
@@ -28,8 +28,16 @@ export async function loadFileDiff(
       return transport.getWorkingTreeDiff(id, false, filePath, undefined, threadId);
     case "staged":
       return transport.getWorkingTreeDiff(id, true, filePath, undefined, threadId);
-    case "branch":
-      return transport.getBranchDiff(id, filePath, undefined, threadId);
+    case "branch": {
+      // For branch, `id` is the comparison range `base...target` (git refnames
+      // can't contain ".."), so the cache key and per-file fetch vary by pair.
+      const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
+      if (!workspaceId) return "";
+      const sep = id.indexOf("...");
+      const base = sep >= 0 ? id.slice(0, sep) : undefined;
+      const target = sep >= 0 ? id.slice(sep + 3) : undefined;
+      return transport.getBranchDiff(workspaceId, base, target, filePath, undefined, threadId);
+    }
     case "commit": {
       const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
       return workspaceId ? transport.getCommitDiff(workspaceId, id, filePath) : "";

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
-import type { TurnSnapshot, GitCommit } from "@mcode/contracts";
+import type { TurnSnapshot, GitCommit, BranchComparison } from "@mcode/contracts";
 
-export type { GitCommit };
+export type { GitCommit, BranchComparison };
 
 /** Active tab in the right panel. */
 export type RightPanelTab = "tasks" | "changes" | "preview" | "terminal";
@@ -153,6 +153,19 @@ interface DiffState {
   readonly rightPanelVisibleByThread: Record<string, boolean>;
   /** View mode within the Changes tab. */
   viewMode: DiffViewMode;
+  /**
+   * The Branch view's resolved (and possibly user-overridden) base→target
+   * comparison for the current scope, or null until the picker resolves it.
+   * Drives both the ref picker and the rendered Branch diff. See
+   * `docs/adr/0007-branch-comparison-default-and-range.md`.
+   */
+  branchComparison: BranchComparison | null;
+  /**
+   * The scope key (`workspaceId:threadId`) {@link branchComparison} was resolved
+   * for. Lets the picker re-resolve on a scope change while preserving a user's
+   * picked pair when toggling views within the same scope.
+   */
+  branchComparisonKey: string | null;
   /** Diff rendering mode. */
   renderMode: DiffRenderMode;
   /** Per-thread line-wrap preference keyed by thread ID. */
@@ -219,6 +232,12 @@ interface DiffState {
    */
   closeRightPanelTab: (workspaceId: string, tab: RightPanelTab) => void;
   setViewMode: (mode: DiffViewMode) => void;
+  /** Store a resolved Branch comparison for a scope, keyed for staleness tracking. */
+  setBranchComparison: (comparison: BranchComparison | null, key: string | null) => void;
+  /** Override the base ref of the active Branch comparison (no-op if none resolved). */
+  setBranchBase: (ref: string) => void;
+  /** Override the target ref of the active Branch comparison (no-op if none resolved). */
+  setBranchTarget: (ref: string) => void;
   setRenderMode: (mode: DiffRenderMode) => void;
   getLineWrap: (threadId: string) => boolean;
   toggleLineWrap: (threadId: string) => void;
@@ -252,6 +271,8 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   rightPanelByWorkspace: {},
   rightPanelVisibleByThread: {},
   viewMode: "last-turn",
+  branchComparison: null,
+  branchComparisonKey: null,
   renderMode: "unified",
   lineWrapByThread: {},
   snapshotsByThread: {},
@@ -334,6 +355,29 @@ export const useDiffStore = create<DiffState>((set, get) => ({
     }),
 
   setViewMode: (mode) => set({ viewMode: mode, selectedFile: null, diffContent: null }),
+  setBranchComparison: (comparison, key) =>
+    set({ branchComparison: comparison, branchComparisonKey: key }),
+  setBranchBase: (ref) =>
+    set((s) =>
+      s.branchComparison
+        ? {
+            branchComparison: { ...s.branchComparison, base: ref },
+            // Changing an operand invalidates the selected file's diff.
+            selectedFile: null,
+            diffContent: null,
+          }
+        : {},
+    ),
+  setBranchTarget: (ref) =>
+    set((s) =>
+      s.branchComparison
+        ? {
+            branchComparison: { ...s.branchComparison, target: ref },
+            selectedFile: null,
+            diffContent: null,
+          }
+        : {},
+    ),
   setRenderMode: (mode) => set({ renderMode: mode }),
   getLineWrap: (threadId) => get().lineWrapByThread[threadId] ?? DEFAULT_LINE_WRAP,
   toggleLineWrap: (threadId) =>

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -154,16 +154,16 @@ interface DiffState {
   /** View mode within the Changes tab. */
   viewMode: DiffViewMode;
   /**
-   * The Branch view's resolved (and possibly user-overridden) base→target
-   * comparison for the current scope, or null until the picker resolves it.
-   * Drives both the ref picker and the rendered Branch diff. See
+   * The Branch view's current→selected comparison for the current scope, or null
+   * until the picker resolves it. Drives both the ref picker and the rendered
+   * Branch diff. See
    * `docs/adr/0007-branch-comparison-default-and-range.md`.
    */
   branchComparison: BranchComparison | null;
   /**
    * The scope key (`workspaceId:threadId`) {@link branchComparison} was resolved
    * for. Lets the picker re-resolve on a scope change while preserving a user's
-   * picked pair when toggling views within the same scope.
+   * picked comparison ref when toggling views within the same scope.
    */
   branchComparisonKey: string | null;
   /** Diff rendering mode. */

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -7,6 +7,7 @@ import type {
   PaginatedMessages,
   AttachmentMeta,
   GitBranch,
+  BranchComparison,
   WorktreeInfo,
   PrInfo,
   PrDetail,
@@ -47,6 +48,7 @@ export type {
   AttachmentMeta,
   StoredAttachment,
   GitBranch,
+  BranchComparison,
   WorktreeInfo,
   PrInfo,
   PrDetail,
@@ -389,10 +391,12 @@ export interface McodeTransport {
   getWorkingTreeFiles(workspaceId: string, staged: boolean, threadId?: string): Promise<string[]>;
   /** Get the unified diff for the working tree (staged or unstaged), optionally per file. Pass threadId to read the thread's worktree. */
   getWorkingTreeDiff(workspaceId: string, staged: boolean, filePath?: string, maxLines?: number, threadId?: string): Promise<string>;
-  /** List files differing between the current branch and its default base branch. Pass threadId to read the thread's worktree. */
-  getBranchFiles(workspaceId: string, threadId?: string): Promise<string[]>;
-  /** Get the unified diff between the current branch and its default base branch, optionally per file. Pass threadId to read the thread's worktree. */
-  getBranchDiff(workspaceId: string, filePath?: string, maxLines?: number, threadId?: string): Promise<string>;
+  /** List files differing between two refs (`base...target`, three-dot). Omit base/target to use the detected default branch → HEAD. Pass threadId to read the thread's worktree. */
+  getBranchFiles(workspaceId: string, base?: string, target?: string, threadId?: string): Promise<string[]>;
+  /** Get the unified diff between two refs (`base...target`, three-dot), optionally per file. Omit base/target to use the detected default branch → HEAD. Pass threadId to read the thread's worktree. */
+  getBranchDiff(workspaceId: string, base?: string, target?: string, filePath?: string, maxLines?: number, threadId?: string): Promise<string>;
+  /** Resolve the default Branch comparison (base→target per ADR 0007) plus the refs that populate the pickers. Pass threadId so "current branch" is the thread's worktree branch. */
+  getBranchComparison(workspaceId: string, threadId?: string): Promise<BranchComparison>;
 
   // GitHub PR (advanced)
   /** Push a branch to the remote. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -4,6 +4,7 @@ import type {
   WorkspaceEnrichment,
   Thread,
   GitBranch,
+  BranchComparison,
   WorktreeInfo,
   AttachmentMeta,
   SkillInfo,
@@ -702,10 +703,12 @@ export function createWsTransport(
       rpc<string[]>("git.workingTreeFiles", { workspaceId, staged, threadId }),
     getWorkingTreeDiff: (workspaceId, staged, filePath?, maxLines?, threadId?) =>
       rpc<string>("git.workingTreeDiff", { workspaceId, staged, filePath, maxLines, threadId }),
-    getBranchFiles: (workspaceId, threadId?) =>
-      rpc<string[]>("git.branchFiles", { workspaceId, threadId }),
-    getBranchDiff: (workspaceId, filePath?, maxLines?, threadId?) =>
-      rpc<string>("git.branchDiff", { workspaceId, filePath, maxLines, threadId }),
+    getBranchFiles: (workspaceId, base?, target?, threadId?) =>
+      rpc<string[]>("git.branchFiles", { workspaceId, base, target, threadId }),
+    getBranchDiff: (workspaceId, base?, target?, filePath?, maxLines?, threadId?) =>
+      rpc<string>("git.branchDiff", { workspaceId, base, target, filePath, maxLines, threadId }),
+    getBranchComparison: (workspaceId, threadId?) =>
+      rpc<BranchComparison>("git.branchComparison", { workspaceId, threadId }),
 
     // GitHub PR (advanced)
     push: (workspaceId, branch) =>

--- a/docs/adr/0007-branch-comparison-default-and-range.md
+++ b/docs/adr/0007-branch-comparison-default-and-range.md
@@ -7,9 +7,10 @@ status: accepted
 ## Context
 
 The Review tab's git views are moving from fixed diffs to **comparisons** — a
-base ref and a target ref that the user can pick (see `CONTEXT.md` → Comparison).
-The Branch comparison is the first with two user-selectable sides, which forces
-two decisions a casual reader would otherwise assume the opposite of:
+resolved ref pair that produces one diff (see `CONTEXT.md` → Comparison).
+The Branch comparison fixes the current branch on the left and lets the user
+pick the comparison ref on the right. Its default pair still needs two decisions
+a casual reader would otherwise assume the opposite of:
 
 1. **What does Branch compare by default?** The obvious answer — "the current
    branch against its remote" (`current → origin/current`) — answers *"what

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -10,6 +10,27 @@ export const GitBranchSchema = z.object({
 /** Git branch metadata record. */
 export type GitBranch = z.infer<typeof GitBranchSchema>;
 
+/**
+ * A resolved Branch comparison: the base→target ref pair the Review tab's Branch
+ * view diffs (always three-dot, `base...target`), plus the refs available to
+ * populate the pickers. The default pair is resolved per
+ * `docs/adr/0007-branch-comparison-default-and-range.md` before the diff call.
+ * `base`/`target` are null only when no comparison can be formed (unborn branch,
+ * or no base could be detected and the user must pick one).
+ */
+export const BranchComparisonSchema = z.object({
+  /** Base ref (the "from" side); null when unresolved (unborn / no base). */
+  base: z.string().nullable(),
+  /** Target ref (the "to" side); null when unresolved (unborn / no base). */
+  target: z.string().nullable(),
+  /** Refs available to populate the base/target pickers (local, remote, worktree). */
+  refs: z.array(GitBranchSchema),
+  /** True when HEAD has no commits yet — the diff is an explicit empty state. */
+  isUnborn: z.boolean(),
+});
+/** Resolved Branch comparison record. */
+export type BranchComparison = z.infer<typeof BranchComparisonSchema>;
+
 /** A git worktree registered in the repository. */
 export const WorktreeSchema = z.object({
   name: z.string(),

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -11,6 +11,16 @@ export const GitBranchSchema = z.object({
 export type GitBranch = z.infer<typeof GitBranchSchema>;
 
 /**
+ * A git ref string safe to interpolate into a git argv. Rejects a leading `-`
+ * (which git would parse as a flag — argument injection) and restricts to the
+ * characters git refnames and short SHAs actually use. Used to validate the
+ * user-picked base/target of a Branch comparison before they reach `git diff`.
+ */
+export const GitRefSchema = z
+  .string()
+  .regex(/^(?!-)[A-Za-z0-9._/-]+$/, "invalid git ref");
+
+/**
  * A resolved Branch comparison: the base→target ref pair the Review tab's Branch
  * view diffs (always three-dot, `base...target`), plus the refs available to
  * populate the pickers. The default pair is resolved per

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -227,8 +227,8 @@ export type {
 } from "./models/permission.js";
 
 // Git / GitHub
-export { GitBranchSchema, WorktreeSchema, GitCommitSchema } from "./git.js";
-export type { GitBranch, WorktreeInfo, GitCommit } from "./git.js";
+export { GitBranchSchema, WorktreeSchema, GitCommitSchema, BranchComparisonSchema } from "./git.js";
+export type { GitBranch, WorktreeInfo, GitCommit, BranchComparison } from "./git.js";
 
 export { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrParamsSchema, CreatePrResultSchema, CheckRunSchema, ChecksStatusSchema } from "./github.js";
 export type { PrInfo, PrDetail, PrDraft, CreatePrParams, CreatePrResult, CheckRun, ChecksStatus } from "./github.js";

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -9,7 +9,7 @@ import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { ThoughtSegmentRecordSchema } from "../models/thought-segment.js";
 import { HookExecutionRecordSchema } from "../models/hook-execution.js";
 import { NarrativeEntrySchema, TurnRangeSchema } from "../models/narrative-entry.js";
-import { GitBranchSchema, WorktreeSchema } from "../git.js";
+import { GitBranchSchema, WorktreeSchema, BranchComparisonSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
 import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema, ChecksStatusSchema } from "../github.js";
 import { SkillInfoSchema, SkillDiagnosticsSchema } from "../skills.js";
@@ -361,6 +361,10 @@ export const WS_METHODS = lazySchema(() => ({
   "git.branchFiles": {
     params: z.object({
       workspaceId: z.string(),
+      /** Base ref of the comparison; omit to use the detected default branch. */
+      base: z.string().optional(),
+      /** Target ref of the comparison; omit to use HEAD. */
+      target: z.string().optional(),
       threadId: z.string().optional(),
     }),
     result: z.array(z.string()),
@@ -368,11 +372,22 @@ export const WS_METHODS = lazySchema(() => ({
   "git.branchDiff": {
     params: z.object({
       workspaceId: z.string(),
+      /** Base ref of the comparison; omit to use the detected default branch. */
+      base: z.string().optional(),
+      /** Target ref of the comparison; omit to use HEAD. */
+      target: z.string().optional(),
       filePath: z.string().optional(),
       maxLines: z.number().int().positive().optional(),
       threadId: z.string().optional(),
     }),
     result: z.string(),
+  },
+  "git.branchComparison": {
+    params: z.object({
+      workspaceId: z.string(),
+      threadId: z.string().optional(),
+    }),
+    result: BranchComparisonSchema,
   },
   "agent.send": {
     params: SendMessageSchema(),

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -9,7 +9,7 @@ import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { ThoughtSegmentRecordSchema } from "../models/thought-segment.js";
 import { HookExecutionRecordSchema } from "../models/hook-execution.js";
 import { NarrativeEntrySchema, TurnRangeSchema } from "../models/narrative-entry.js";
-import { GitBranchSchema, WorktreeSchema, BranchComparisonSchema } from "../git.js";
+import { GitBranchSchema, WorktreeSchema, BranchComparisonSchema, GitRefSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
 import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema, ChecksStatusSchema } from "../github.js";
 import { SkillInfoSchema, SkillDiagnosticsSchema } from "../skills.js";
@@ -362,9 +362,9 @@ export const WS_METHODS = lazySchema(() => ({
     params: z.object({
       workspaceId: z.string(),
       /** Base ref of the comparison; omit to use the detected default branch. */
-      base: z.string().optional(),
+      base: GitRefSchema.optional(),
       /** Target ref of the comparison; omit to use HEAD. */
-      target: z.string().optional(),
+      target: GitRefSchema.optional(),
       threadId: z.string().optional(),
     }),
     result: z.array(z.string()),
@@ -373,9 +373,9 @@ export const WS_METHODS = lazySchema(() => ({
     params: z.object({
       workspaceId: z.string(),
       /** Base ref of the comparison; omit to use the detected default branch. */
-      base: z.string().optional(),
+      base: GitRefSchema.optional(),
       /** Target ref of the comparison; omit to use HEAD. */
-      target: z.string().optional(),
+      target: GitRefSchema.optional(),
       filePath: z.string().optional(),
       maxLines: z.number().int().positive().optional(),
       threadId: z.string().optional(),


### PR DESCRIPTION
## What
Adds a branch comparison UI to the Narrative panel so users can choose base and target refs and inspect commits ahead, commits behind, and file changes.

## Why
Users need to compare branches without leaving Mcode. Issue #641 asked for UI controls, server support for explicit refs, documented default ref behavior, and edge-case handling.

## Key Changes
- Added `base` and `target` query support to the branch comparison route.
- Added `git.branchComparison(repo, base, target)` server behavior with ref validation.
- Added ADR-0007 for default branch resolution.
- Added a searchable grouped `BranchRefPicker` for branches, tags, and commits.
- Integrated the picker into the Narrative operand slot from slice #640.
- Added loading, empty, current-branch, short SHA, and long-ref truncation states.

## Config Changes
None

## Verification
- `bun run verify`
- 10 new server unit tests for branch comparison and ref validation
- 3 E2E tests for the branch comparison flow
- Manual UI checks for search, grouping, and edge cases

## Related issues/PRs
Closes #641

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783700394&installation_id=129163861&pr_number=678&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F678&signature=db36ea69d184bcb2919ddca9f32bb2ff4228a3d17a2dde6db4d85fe72abaa9f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch comparison UI: left shows current branch; right is a searchable, categorized ref picker (Local/Remote/Worktrees).
  * Branch diffs/files accept explicit base/target refs and use three‑dot range semantics; thread-scoped repo support and explicit “no commits” (unborn) state.

* **Tests**
  * Added unit and e2e tests covering branch comparison resolution, diff/file fetching, picker behavior, and safety checks.

* **Bug Fixes**
  * Hardened ref validation to prevent unsafe ref injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->