### PR TITLE
feat(panel): commit picker with searchable commit list

### DIFF
--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -311,3 +311,62 @@ describe("GitService.removeWorktree", () => {
     expect(mockRmdir.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });
+
+describe("GitService.log", () => {
+  let gitService: GitService;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    gitService = new GitService({
+      findById: vi.fn().mockReturnValue({ id: "ws-1", path: "/repo", is_git_repo: true }),
+    } as unknown as WorkspaceRepo);
+  });
+
+  it("compares against origin HEAD instead of requiring a local default branch", async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: "origin/main\n", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: [
+          "MCODE_SEPabc123456789|||abc1234|||feat: add picker|||Dev|||2026-06-11T12:00:00.000Z",
+          "1\t0\tapps/web/src/components/diff/CommitPicker.tsx",
+        ].join("\n"),
+        stderr: "",
+      });
+
+    const commits = await gitService.log("ws-1", "feat/-commit-picker", 100);
+
+    expect(commits).toHaveLength(1);
+    expect(commits[0]?.shortSha).toBe("abc1234");
+    expect(mockExecFile).toHaveBeenNthCalledWith(
+      2,
+      "git",
+      expect.arrayContaining(["origin/main..feat/-commit-picker"]),
+      expect.objectContaining({ timeout: 10_000 }),
+    );
+  });
+
+  it("supports paged lightweight logs without numstat", async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: "origin/main\n", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: "MCODE_SEPdef123456789|||def1234|||fix: older commit|||Dev|||2026-06-10T12:00:00.000Z",
+        stderr: "",
+      });
+
+    const commits = await gitService.log(
+      "ws-1",
+      "feat/-commit-picker",
+      100,
+      undefined,
+      undefined,
+      100,
+      false,
+    );
+
+    expect(commits).toHaveLength(1);
+    expect(commits[0]?.filesChanged).toBe(0);
+    const args = mockExecFile.mock.calls[1]?.[1] as string[];
+    expect(args).toContain("--skip=100");
+    expect(args).not.toContain("--numstat");
+  });
+});

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -419,7 +419,15 @@ export class GitService {
   }
 
   /** Get commit log for a workspace. When baseBranch is provided, only returns commits on branch that are not on baseBranch. Pass repoPath to run from a worktree directory instead of the workspace root. */
-  async log(workspaceId: string, branch?: string, limit = 50, baseBranch?: string, repoPath?: string): Promise<GitCommit[]> {
+  async log(
+    workspaceId: string,
+    branch?: string,
+    limit = 50,
+    baseBranch?: string,
+    repoPath?: string,
+    skip = 0,
+    includeStats = true,
+  ): Promise<GitCommit[]> {
     const workspace = this.requireWorkspace(workspaceId);
     const effectivePath = repoPath ?? workspace.path;
 
@@ -434,9 +442,10 @@ export class GitService {
       "-C", effectivePath,
       "log",
       "--pretty=format:MCODE_SEP%H|||%h|||%s|||%an|||%aI",
-      "--numstat",
       `-${limit}`,
     ];
+    if (skip > 0) args.push(`--skip=${skip}`);
+    if (includeStats) args.push("--numstat");
     // When running from a worktree path, HEAD is the checked-out branch — no need to name it.
     const headRef = repoPath ? "HEAD" : branch;
     if (resolvedBase && headRef) {
@@ -468,7 +477,9 @@ export class GitService {
       if (!sha) continue;
 
       // numstat lines have format: additions\tdeletions\tfilename
-      const filesChanged = lines.slice(1).filter((l) => l.includes("\t")).length;
+      const filesChanged = includeStats
+        ? lines.slice(1).filter((l) => l.includes("\t")).length
+        : 0;
 
       commits.push({
         sha: sha ?? "",
@@ -655,7 +666,7 @@ export class GitService {
   /** Per-repo cache: avoids re-running mutating git commands on every log call. */
   private readonly defaultBranchCache = new Map<string, string>();
 
-  /** Detect the default upstream branch (e.g. main, master) for a repository. */
+  /** Detect the default upstream ref (e.g. origin/main, main) for a repository. */
   private async detectDefaultBranch(repoPath: string): Promise<string> {
     const cached = this.defaultBranchCache.get(repoPath);
     if (cached !== undefined) return cached;
@@ -665,7 +676,7 @@ export class GitService {
     return result;
   }
 
-  /** Resolve the default branch by probing git refs in order of cheapness. */
+  /** Resolve the default comparison ref by probing git refs in order of cheapness. */
   private async resolveDefaultBranch(repoPath: string): Promise<string> {
     // 1. Ask the remote tracking ref (fast, no network, works if origin/HEAD is set)
     try {
@@ -674,7 +685,7 @@ export class GitService {
         ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
         { timeout: 5_000, windowsHide: true },
       );
-      return stdout.trim().replace(/^[^/]+\//, "");
+      return stdout.trim();
     } catch (err) {
       logger.debug("[detectDefaultBranch] origin/HEAD not set, trying set-head", { repoPath, err });
     }
@@ -692,7 +703,7 @@ export class GitService {
         ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
         { timeout: 5_000, windowsHide: true },
       );
-      return stdout.trim().replace(/^[^/]+\//, "");
+      return stdout.trim();
     } catch (err) {
       logger.debug("[detectDefaultBranch] set-head failed, falling back to HEAD", { repoPath, err });
     }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -416,7 +416,15 @@ async function dispatch(
           repoPath = deps.gitService.resolveWorkingDir(wsForThread.path, t.mode, t.worktree_path);
         }
       }
-      return deps.gitService.log(params.workspaceId, params.branch, params.limit, params.baseBranch, repoPath);
+      return deps.gitService.log(
+        params.workspaceId,
+        params.branch,
+        params.limit,
+        params.baseBranch,
+        repoPath,
+        params.skip,
+        params.includeStats,
+      );
     }
     case "git.commitDiff": {
       const ws = deps.workspaceService.findById(params.workspaceId);

--- a/apps/web/e2e/right-panel-commit-picker.spec.ts
+++ b/apps/web/e2e/right-panel-commit-picker.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { GitCommit } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+/**
+ * Covers the Review tab's Commit picker (issue #642): the Commit view's operand
+ * slot holds a searchable list of the branch's commits since base. The default
+ * selection is the latest commit; searching filters by message and short SHA;
+ * selecting a commit renders exactly that one commit's diff.
+ */
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-commit-picker",
+  name: "Commit Picker",
+  path: "/tmp/commit-picker",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+/** Three commits since base, newest first (the order `git log` returns). */
+const COMMITS: GitCommit[] = [
+  { sha: "aaaaaaaa1", shortSha: "aaaaaaa", message: "feat: add the widget", author: "Dev", date: now, filesChanged: 1 },
+  { sha: "bbbbbbbb2", shortSha: "bbbbbbb", message: "fix: the broken seam", author: "Dev", date: now, filesChanged: 1 },
+  { sha: "cccccccc3", shortSha: "ccccccc", message: "chore: tidy imports", author: "Dev", date: now, filesChanged: 1 },
+];
+
+/** Each commit resolves to its own single file, so the rendered diff is identifiable. */
+const FILES_BY_SHA: Record<string, string[]> = {
+  aaaaaaaa1: ["src/widget.ts"],
+  bbbbbbbb2: ["src/seam.ts"],
+  cccccccc3: ["src/imports.ts"],
+};
+
+/** Opens the Review tab threadless and selects the Commit view. */
+async function openCommitView(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ workspace, wid }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+      const wsStore = stores.find(
+        (s) => "activeThreadId" in getState(s) && "pendingNewThread" in getState(s),
+      );
+      (wsStore as { setState: (p: unknown) => void } | undefined)?.setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: [],
+        activeThreadId: null,
+        pendingNewThread: true,
+      });
+      const diffStore = stores.find((s) => "showRightPanel" in getState(s));
+      const api = (
+        diffStore as {
+          getState: () => {
+            showRightPanel: (id: string, threadId?: string) => void;
+            setRightPanelTab: (id: string, t: string) => void;
+            setViewMode: (m: string) => void;
+          };
+        }
+      ).getState();
+      api.showRightPanel(wid);
+      api.setRightPanelTab(wid, "changes");
+      api.setViewMode("commit");
+    },
+    { workspace: WORKSPACE, wid: WORKSPACE.id },
+  );
+}
+
+test.describe("Review tab — Commit picker", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [],
+      "settings.get": getDefaultSettings(),
+      "git.currentBranch": "feature/widget",
+      "git.log": COMMITS,
+      "git.commitFiles": (params) => FILES_BY_SHA[(params as { sha: string }).sha] ?? [],
+      "git.commitDiff": "",
+      "git.inlineDiff": "",
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1920, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+  });
+
+  test("defaults to the latest commit and renders its diff", async ({ page }) => {
+    await openCommitView(page);
+
+    const slot = page.getByTestId("review-operand-slot");
+    await expect(slot).toHaveAttribute("data-operand", "commit", { timeout: 5_000 });
+
+    // The picker trigger labels itself with the latest commit (catalog order [0]).
+    const trigger = page.getByTestId("commit-picker-trigger");
+    await expect(trigger).toContainText("aaaaaaa");
+    await expect(trigger).toContainText("add the widget");
+
+    // The default selection's diff renders — the latest commit's single file.
+    await expect(page.getByText("widget.ts")).toBeVisible();
+  });
+
+  test("searches by message, selects, and renders exactly that commit's diff", async ({ page }) => {
+    await openCommitView(page);
+
+    const trigger = page.getByTestId("commit-picker-trigger");
+    await expect(trigger).toBeVisible({ timeout: 5_000 });
+    await trigger.click();
+
+    // Search narrows the list to the matching commit; the others drop out.
+    await page.getByPlaceholder("Search commits…").fill("broken seam");
+    await expect(page.getByTestId("commit-picker-item-bbbbbbb")).toBeVisible();
+    await expect(page.getByTestId("commit-picker-item-aaaaaaa")).toHaveCount(0);
+
+    // Selecting swaps the rendered diff to exactly that commit's file.
+    await page.getByTestId("commit-picker-item-bbbbbbb").click();
+    await expect(trigger).toContainText("bbbbbbb");
+    await expect(page.getByText("seam.ts")).toBeVisible();
+    await expect(page.getByText("widget.ts")).toHaveCount(0);
+  });
+
+  test("searches by short SHA", async ({ page }) => {
+    await openCommitView(page);
+
+    const trigger = page.getByTestId("commit-picker-trigger");
+    await trigger.click();
+    await page.getByPlaceholder("Search commits…").fill("ccccccc");
+    await expect(page.getByTestId("commit-picker-item-ccccccc")).toBeVisible();
+    await expect(page.getByTestId("commit-picker-item-aaaaaaa")).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/right-panel-commit-picker.spec.ts
+++ b/apps/web/e2e/right-panel-commit-picker.spec.ts
@@ -59,6 +59,22 @@ const COMMITS: GitCommit[] = [
   { sha: "cccccccc3", shortSha: "ccccccc", message: "chore: tidy imports", author: "Dev", date: now, filesChanged: 1 },
 ];
 
+const FIRST_PAGE_COMMITS: GitCommit[] = [
+  ...COMMITS,
+  ...Array.from({ length: 97 }, (_, i) => ({
+    sha: `f${String(i).padStart(7, "0")}`,
+    shortSha: `f${String(i).padStart(6, "0")}`,
+    message: `test: filler commit ${i}`,
+    author: "Dev",
+    date: now,
+    filesChanged: 0,
+  })),
+];
+
+const OLDER_COMMITS: GitCommit[] = [
+  { sha: "999999999", shortSha: "9999999", message: "fix: older regression", author: "Dev", date: now, filesChanged: 1 },
+];
+
 /** Thread-scoped commits come from the thread worktree HEAD, not the workspace root. */
 const THREAD_COMMITS: GitCommit[] = [
   { sha: "dddddddd4", shortSha: "ddddddd", message: "feat: thread worktree head", author: "Dev", date: now, filesChanged: 1 },
@@ -70,6 +86,7 @@ const FILES_BY_SHA: Record<string, string[]> = {
   aaaaaaaa1: ["src/widget.ts"],
   bbbbbbbb2: ["src/seam.ts"],
   cccccccc3: ["src/imports.ts"],
+  "999999999": ["src/older.ts"],
   dddddddd4: ["src/thread.ts"],
   eeeeeeee5: ["src/thread-fallback.ts"],
 };
@@ -98,6 +115,14 @@ const DIFF_BY_SHA_AND_FILE: Record<string, string> = {
     "@@ -1 +1 @@",
     "-old thread",
     "+thread worktree head diff body",
+  ].join("\n"),
+  "999999999:src/older.ts": [
+    "diff --git a/src/older.ts b/src/older.ts",
+    "--- a/src/older.ts",
+    "+++ b/src/older.ts",
+    "@@ -1 +1 @@",
+    "-old path",
+    "+older searched diff body",
   ].join("\n"),
 };
 
@@ -182,9 +207,9 @@ test.describe("Review tab — Commit picker", () => {
       "git.currentBranch": "feature/widget",
       "git.log": (params) => {
         gitLogCalls.push(params);
-        return (params as { threadId?: string } | undefined)?.threadId === THREAD.id
-          ? THREAD_COMMITS
-          : COMMITS;
+        const p = params as { threadId?: string; skip?: number } | undefined;
+        if (p?.threadId === THREAD.id) return THREAD_COMMITS;
+        return p?.skip ? OLDER_COMMITS : FIRST_PAGE_COMMITS;
       },
       "git.commitFiles": (params) => FILES_BY_SHA[(params as { sha: string }).sha] ?? [],
       "git.commitDiff": (params) => {
@@ -218,7 +243,6 @@ test.describe("Review tab — Commit picker", () => {
 
     // The default selection's diff renders — the latest commit's single file.
     await expect(page.getByText("widget.ts")).toBeVisible();
-    await page.getByText("widget.ts").click();
     await expect(page.getByText("latest widget diff body")).toBeVisible();
   });
 
@@ -239,7 +263,6 @@ test.describe("Review tab — Commit picker", () => {
     await expect(trigger).toContainText("bbbbbbb");
     await expect(page.getByText("seam.ts")).toBeVisible();
     await expect(page.getByText("widget.ts")).toHaveCount(0);
-    await page.getByText("seam.ts").click();
     await expect(page.getByText("selected commit diff body")).toBeVisible();
   });
 
@@ -251,6 +274,30 @@ test.describe("Review tab — Commit picker", () => {
     await page.getByPlaceholder("Search commits…").fill("ccccccc");
     await expect(page.getByTestId("commit-picker-item-ccccccc")).toBeVisible();
     await expect(page.getByTestId("commit-picker-item-aaaaaaa")).toHaveCount(0);
+  });
+
+  test("searches older commits on demand", async ({ page }) => {
+    await openCommitView(page);
+
+    const trigger = page.getByTestId("commit-picker-trigger");
+    await trigger.click();
+    await page.getByPlaceholder("Search commits…").fill("older regression");
+    await page.getByRole("button", { name: "Search older commits" }).click();
+
+    await expect(page.getByTestId("commit-picker-item-9999999")).toBeVisible();
+    await page.getByTestId("commit-picker-item-9999999").click();
+    await expect(trigger).toContainText("9999999");
+    await expect(page.getByText("older.ts")).toBeVisible();
+
+    expect(gitLogCalls).toContainEqual(
+      expect.objectContaining({
+        workspaceId: WORKSPACE.id,
+        branch: "feature/widget",
+        limit: 100,
+        skip: 100,
+        includeStats: false,
+      }),
+    );
   });
 
   test("thread: uses the thread worktree commit list and renders its HEAD diff", async ({ page }) => {
@@ -270,7 +317,6 @@ test.describe("Review tab — Commit picker", () => {
     );
 
     await expect(page.getByText("thread.ts")).toBeVisible();
-    await page.getByText("thread.ts").click();
     await expect(page.getByText("thread worktree head diff body")).toBeVisible();
   });
 });

--- a/apps/web/e2e/right-panel-commit-picker.spec.ts
+++ b/apps/web/e2e/right-panel-commit-picker.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import type { GitCommit } from "@mcode/contracts";
+import type { GitCommit, Thread } from "@mcode/contracts";
 import { getDefaultSettings } from "@mcode/contracts";
 import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
 
@@ -25,6 +25,33 @@ const WORKSPACE = {
   sort_order: 0,
 };
 
+const THREAD: Thread = {
+  id: "thread-commit-picker",
+  workspace_id: WORKSPACE.id,
+  title: "Commit Picker Thread",
+  status: "paused",
+  mode: "worktree",
+  worktree_path: "/tmp/commit-picker-worktree",
+  branch: "feature/thread-head",
+  worktree_managed: true,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
 /** Three commits since base, newest first (the order `git log` returns). */
 const COMMITS: GitCommit[] = [
   { sha: "aaaaaaaa1", shortSha: "aaaaaaa", message: "feat: add the widget", author: "Dev", date: now, filesChanged: 1 },
@@ -32,11 +59,46 @@ const COMMITS: GitCommit[] = [
   { sha: "cccccccc3", shortSha: "ccccccc", message: "chore: tidy imports", author: "Dev", date: now, filesChanged: 1 },
 ];
 
+/** Thread-scoped commits come from the thread worktree HEAD, not the workspace root. */
+const THREAD_COMMITS: GitCommit[] = [
+  { sha: "dddddddd4", shortSha: "ddddddd", message: "feat: thread worktree head", author: "Dev", date: now, filesChanged: 1 },
+  { sha: "eeeeeeee5", shortSha: "eeeeeee", message: "fix: thread fallback path", author: "Dev", date: now, filesChanged: 1 },
+];
+
 /** Each commit resolves to its own single file, so the rendered diff is identifiable. */
 const FILES_BY_SHA: Record<string, string[]> = {
   aaaaaaaa1: ["src/widget.ts"],
   bbbbbbbb2: ["src/seam.ts"],
   cccccccc3: ["src/imports.ts"],
+  dddddddd4: ["src/thread.ts"],
+  eeeeeeee5: ["src/thread-fallback.ts"],
+};
+
+const DIFF_BY_SHA_AND_FILE: Record<string, string> = {
+  "aaaaaaaa1:src/widget.ts": [
+    "diff --git a/src/widget.ts b/src/widget.ts",
+    "--- a/src/widget.ts",
+    "+++ b/src/widget.ts",
+    "@@ -1 +1 @@",
+    "-old widget",
+    "+latest widget diff body",
+  ].join("\n"),
+  "bbbbbbbb2:src/seam.ts": [
+    "diff --git a/src/seam.ts b/src/seam.ts",
+    "--- a/src/seam.ts",
+    "+++ b/src/seam.ts",
+    "@@ -1 +1 @@",
+    "-old seam",
+    "+selected commit diff body",
+  ].join("\n"),
+  "dddddddd4:src/thread.ts": [
+    "diff --git a/src/thread.ts b/src/thread.ts",
+    "--- a/src/thread.ts",
+    "+++ b/src/thread.ts",
+    "@@ -1 +1 @@",
+    "-old thread",
+    "+thread worktree head diff body",
+  ].join("\n"),
 };
 
 /** Opens the Review tab threadless and selects the Commit view. */
@@ -74,16 +136,61 @@ async function openCommitView(page: Page): Promise<void> {
   );
 }
 
+/** Opens the Review tab on an active thread and selects the Commit view. */
+async function openThreadCommitView(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread, wid, tid }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+      const wsStore = stores.find(
+        (s) => "activeThreadId" in getState(s) && "threads" in getState(s),
+      );
+      (wsStore as { setState: (p: unknown) => void } | undefined)?.setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: [thread],
+        activeThreadId: tid,
+      });
+      const diffStore = stores.find((s) => "showRightPanel" in getState(s));
+      const api = (
+        diffStore as {
+          getState: () => {
+            showRightPanel: (id: string, threadId?: string) => void;
+            setRightPanelTab: (id: string, t: string) => void;
+            setViewMode: (m: string) => void;
+          };
+        }
+      ).getState();
+      api.showRightPanel(wid, tid);
+      api.setRightPanelTab(wid, "changes");
+      api.setViewMode("commit");
+    },
+    { workspace: WORKSPACE, thread: THREAD, wid: WORKSPACE.id, tid: THREAD.id },
+  );
+}
+
 test.describe("Review tab — Commit picker", () => {
+  let gitLogCalls: unknown[];
+
   test.beforeEach(async ({ page }) => {
+    gitLogCalls = [];
     await mockWebSocketServer(page, {
       "workspace.list": [WORKSPACE],
-      "thread.list": [],
+      "thread.list": [THREAD],
       "settings.get": getDefaultSettings(),
       "git.currentBranch": "feature/widget",
-      "git.log": COMMITS,
+      "git.log": (params) => {
+        gitLogCalls.push(params);
+        return (params as { threadId?: string } | undefined)?.threadId === THREAD.id
+          ? THREAD_COMMITS
+          : COMMITS;
+      },
       "git.commitFiles": (params) => FILES_BY_SHA[(params as { sha: string }).sha] ?? [],
-      "git.commitDiff": "",
+      "git.commitDiff": (params) => {
+        const { sha, filePath } = params as { sha: string; filePath: string };
+        return DIFF_BY_SHA_AND_FILE[`${sha}:${filePath}`] ?? "";
+      },
       "git.inlineDiff": "",
     });
     await interceptZustandStores(page);
@@ -111,6 +218,8 @@ test.describe("Review tab — Commit picker", () => {
 
     // The default selection's diff renders — the latest commit's single file.
     await expect(page.getByText("widget.ts")).toBeVisible();
+    await page.getByText("widget.ts").click();
+    await expect(page.getByText("latest widget diff body")).toBeVisible();
   });
 
   test("searches by message, selects, and renders exactly that commit's diff", async ({ page }) => {
@@ -130,6 +239,8 @@ test.describe("Review tab — Commit picker", () => {
     await expect(trigger).toContainText("bbbbbbb");
     await expect(page.getByText("seam.ts")).toBeVisible();
     await expect(page.getByText("widget.ts")).toHaveCount(0);
+    await page.getByText("seam.ts").click();
+    await expect(page.getByText("selected commit diff body")).toBeVisible();
   });
 
   test("searches by short SHA", async ({ page }) => {
@@ -140,5 +251,26 @@ test.describe("Review tab — Commit picker", () => {
     await page.getByPlaceholder("Search commits…").fill("ccccccc");
     await expect(page.getByTestId("commit-picker-item-ccccccc")).toBeVisible();
     await expect(page.getByTestId("commit-picker-item-aaaaaaa")).toHaveCount(0);
+  });
+
+  test("thread: uses the thread worktree commit list and renders its HEAD diff", async ({ page }) => {
+    await openThreadCommitView(page);
+
+    const trigger = page.getByTestId("commit-picker-trigger");
+    await expect(trigger).toContainText("ddddddd", { timeout: 5_000 });
+    await expect(trigger).toContainText("thread worktree head");
+
+    expect(gitLogCalls).toContainEqual(
+      expect.objectContaining({
+        workspaceId: WORKSPACE.id,
+        branch: THREAD.branch,
+        limit: 100,
+        threadId: THREAD.id,
+      }),
+    );
+
+    await expect(page.getByText("thread.ts")).toBeVisible();
+    await page.getByText("thread.ts").click();
+    await expect(page.getByText("thread worktree head diff body")).toBeVisible();
   });
 });

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -29,7 +29,7 @@ describe("diffStore", () => {
   });
 
   describe("commit picker operand", () => {
-    it("defaults the picked commit to null (latest)", () => {
+    it("starts with no resolved picked commit", () => {
       expect(useDiffStore.getState().selectedCommitSha).toBeNull();
     });
 

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -22,8 +22,27 @@ describe("diffStore", () => {
       diffContent: null,
       diffLoading: false,
       viewMode: "last-turn",
+      selectedCommitSha: null,
       renderMode: "unified",
       lineWrapByThread: {},
+    });
+  });
+
+  describe("commit picker operand", () => {
+    it("defaults the picked commit to null (latest)", () => {
+      expect(useDiffStore.getState().selectedCommitSha).toBeNull();
+    });
+
+    it("stores the picked commit SHA", () => {
+      useDiffStore.getState().setSelectedCommitSha("abc1234");
+      expect(useDiffStore.getState().selectedCommitSha).toBe("abc1234");
+    });
+
+    it("resets the picked commit when the active view changes", () => {
+      const { setSelectedCommitSha, setViewMode } = useDiffStore.getState();
+      setSelectedCommitSha("abc1234");
+      setViewMode("commit");
+      expect(useDiffStore.getState().selectedCommitSha).toBeNull();
     });
   });
 

--- a/apps/web/src/components/diff/CommitPicker.tsx
+++ b/apps/web/src/components/diff/CommitPicker.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import type { GitCommit } from "@mcode/contracts";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { getTransport } from "@/transport";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useDiffStore } from "@/stores/diffStore";
+
+/** How many commits to load into the picker. Matches the Commits tab's window. */
+const COMMIT_LIMIT = 100;
+
+/** Format an ISO date to a compact relative string (mirrors CommitEntry's scale). */
+function relativeTime(isoDate: string): string {
+  const then = new Date(isoDate).getTime();
+  if (!isFinite(then)) return "";
+  const diffSec = Math.floor((Date.now() - then) / 1000);
+  if (diffSec < 60) return "now";
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h`;
+  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d`;
+  return new Date(isoDate).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+/**
+ * The Commit view's operand picker: a searchable dropdown over the branch's own
+ * commits since its base, resolving to exactly one commit's diff. Default
+ * selection is the latest commit (the thread's worktree HEAD in a thread). The
+ * picked SHA lives in {@link useDiffStore} so the Commit diff renders against it.
+ * Search filters by commit message and short SHA. See CONTEXT.md → "Commit".
+ */
+export function CommitPicker() {
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  // In a thread, scope the list to that thread's branch; threadless, the
+  // workspace's current branch is resolved below. Both yield commits since base.
+  const threadBranch = useWorkspaceStore((s) => {
+    const thread = s.threads.find((t) => t.id === activeThreadId);
+    return thread?.branch ?? undefined;
+  });
+  const selectedSha = useDiffStore((s) => s.selectedCommitSha);
+  const setSelectedSha = useDiffStore((s) => s.setSelectedCommitSha);
+
+  const [open, setOpen] = useState(false);
+  const [commits, setCommits] = useState<GitCommit[] | null>(null);
+
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    let cancelled = false;
+    setCommits(null);
+
+    const load = async (): Promise<GitCommit[]> => {
+      const transport = getTransport();
+      const branch = activeThreadId
+        ? threadBranch
+        : ((await transport.getCurrentBranch(activeWorkspaceId)) ?? undefined);
+      return transport.getGitLog(activeWorkspaceId, branch, COMMIT_LIMIT);
+    };
+
+    void load()
+      .then((list) => {
+        if (!cancelled) setCommits(list);
+      })
+      .catch(() => {
+        if (!cancelled) setCommits([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeWorkspaceId, activeThreadId, threadBranch]);
+
+  // Default to the latest commit, and recover when the active pick falls out of
+  // the current scope's list (thread or branch switch on the same Commit view).
+  useEffect(() => {
+    if (commits === null) return;
+    const present = selectedSha !== null && commits.some((c) => c.sha === selectedSha);
+    if (!present) setSelectedSha(commits[0]?.sha ?? null);
+  }, [commits, selectedSha, setSelectedSha]);
+
+  const selected = useMemo(
+    () => commits?.find((c) => c.sha === selectedSha) ?? null,
+    [commits, selectedSha],
+  );
+
+  const loading = commits === null;
+  const empty = commits !== null && commits.length === 0;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        data-testid="commit-picker-trigger"
+        disabled={loading || empty}
+        aria-label="Pick a commit"
+        className="flex h-6 min-w-0 max-w-[220px] items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+      >
+        <span className="shrink-0 font-mono text-[11px] tabular-nums text-foreground/55">
+          {selected?.shortSha ?? (loading ? "…" : "—")}
+        </span>
+        {selected && (
+          <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+            {selected.message}
+          </span>
+        )}
+        <ChevronDown size={11} className="shrink-0 text-muted-foreground/60" />
+      </PopoverTrigger>
+
+      <PopoverContent align="start" sideOffset={4} className="w-80 p-0">
+        <Command>
+          <CommandInput placeholder="Search commits…" className="h-8 text-[11.5px]" />
+          <CommandList>
+            <CommandEmpty className="py-4 text-[11px]">No commits found</CommandEmpty>
+            {commits?.map((commit) => {
+              const active = commit.sha === selectedSha;
+              return (
+                <CommandItem
+                  key={commit.sha}
+                  // cmdk filters on this value, so search matches short SHA + message.
+                  value={`${commit.shortSha} ${commit.message}`}
+                  data-testid={`commit-picker-item-${commit.shortSha}`}
+                  aria-current={active ? "true" : undefined}
+                  onSelect={() => {
+                    setSelectedSha(commit.sha);
+                    setOpen(false);
+                  }}
+                  className="gap-2 px-2 py-1.5"
+                >
+                  <span className="shrink-0 font-mono text-[11px] tabular-nums text-foreground/60">
+                    {commit.shortSha}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[11.5px] text-foreground/80">
+                    {commit.message}
+                  </span>
+                  <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/45">
+                    {relativeTime(commit.date)}
+                  </span>
+                  {active && <Check size={11} className="shrink-0 text-muted-foreground" />}
+                </CommandItem>
+              );
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/diff/CommitPicker.tsx
+++ b/apps/web/src/components/diff/CommitPicker.tsx
@@ -54,13 +54,20 @@ export function CommitPicker() {
     if (!activeWorkspaceId) return;
     let cancelled = false;
     setCommits(null);
+    setSelectedSha(null);
 
     const load = async (): Promise<GitCommit[]> => {
       const transport = getTransport();
       const branch = activeThreadId
         ? threadBranch
         : ((await transport.getCurrentBranch(activeWorkspaceId)) ?? undefined);
-      return transport.getGitLog(activeWorkspaceId, branch, COMMIT_LIMIT);
+      return transport.getGitLog(
+        activeWorkspaceId,
+        branch,
+        COMMIT_LIMIT,
+        undefined,
+        activeThreadId ?? undefined,
+      );
     };
 
     void load()
@@ -74,7 +81,7 @@ export function CommitPicker() {
     return () => {
       cancelled = true;
     };
-  }, [activeWorkspaceId, activeThreadId, threadBranch]);
+  }, [activeWorkspaceId, activeThreadId, threadBranch, setSelectedSha]);
 
   // Default to the latest commit, and recover when the active pick falls out of
   // the current scope's list (thread or branch switch on the same Commit view).

--- a/apps/web/src/components/diff/CommitPicker.tsx
+++ b/apps/web/src/components/diff/CommitPicker.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Check, ChevronDown } from "lucide-react";
 import type { GitCommit } from "@mcode/contracts";
+import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Command,
@@ -48,67 +49,100 @@ export function CommitPicker() {
   const setSelectedSha = useDiffStore((s) => s.setSelectedCommitSha);
 
   const [open, setOpen] = useState(false);
-  const [commits, setCommits] = useState<GitCommit[] | null>(null);
+  const [commits, setCommits] = useState<GitCommit[]>([]);
+  const [loadingInitial, setLoadingInitial] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [search, setSearch] = useState("");
 
-  useEffect(() => {
-    if (!activeWorkspaceId) return;
-    let cancelled = false;
-    setCommits(null);
-    setSelectedSha(null);
-
-    const load = async (): Promise<GitCommit[]> => {
+  const loadCommits = useCallback(
+    async (skip: number): Promise<GitCommit[]> => {
       const transport = getTransport();
       const branch = activeThreadId
         ? threadBranch
-        : ((await transport.getCurrentBranch(activeWorkspaceId)) ?? undefined);
+        : ((await transport.getCurrentBranch(activeWorkspaceId!)) ?? undefined);
       return transport.getGitLog(
-        activeWorkspaceId,
+        activeWorkspaceId!,
         branch,
         COMMIT_LIMIT,
         undefined,
         activeThreadId ?? undefined,
+        { skip, includeStats: false },
       );
-    };
+    },
+    [activeWorkspaceId, activeThreadId, threadBranch],
+  );
 
-    void load()
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    let cancelled = false;
+    setCommits([]);
+    setHasMore(false);
+    setLoadingInitial(true);
+    setLoadingMore(false);
+    setSearch("");
+    setSelectedSha(null);
+
+    void loadCommits(0)
       .then((list) => {
-        if (!cancelled) setCommits(list);
+        if (!cancelled) {
+          setCommits(list);
+          setHasMore(list.length === COMMIT_LIMIT);
+          setLoadingInitial(false);
+        }
       })
       .catch(() => {
-        if (!cancelled) setCommits([]);
+        if (!cancelled) {
+          setCommits([]);
+          setHasMore(false);
+          setLoadingInitial(false);
+        }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [activeWorkspaceId, activeThreadId, threadBranch, setSelectedSha]);
+  }, [activeWorkspaceId, loadCommits, setSelectedSha]);
+
+  const loadOlder = useCallback(async () => {
+    if (loadingInitial || loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    try {
+      const list = await loadCommits(commits.length);
+      setCommits((current) => [...current, ...list]);
+      setHasMore(list.length === COMMIT_LIMIT);
+    } catch {
+      setHasMore(false);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [commits.length, hasMore, loadCommits, loadingInitial, loadingMore]);
 
   // Default to the latest commit, and recover when the active pick falls out of
   // the current scope's list (thread or branch switch on the same Commit view).
   useEffect(() => {
-    if (commits === null) return;
+    if (loadingInitial) return;
     const present = selectedSha !== null && commits.some((c) => c.sha === selectedSha);
     if (!present) setSelectedSha(commits[0]?.sha ?? null);
-  }, [commits, selectedSha, setSelectedSha]);
+  }, [commits, loadingInitial, selectedSha, setSelectedSha]);
 
   const selected = useMemo(
-    () => commits?.find((c) => c.sha === selectedSha) ?? null,
+    () => commits.find((c) => c.sha === selectedSha) ?? null,
     [commits, selectedSha],
   );
 
-  const loading = commits === null;
-  const empty = commits !== null && commits.length === 0;
+  const empty = !loadingInitial && commits.length === 0;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
         data-testid="commit-picker-trigger"
-        disabled={loading || empty}
+        disabled={loadingInitial || empty}
         aria-label="Pick a commit"
         className="flex h-6 min-w-0 max-w-[220px] items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
       >
         <span className="shrink-0 font-mono text-[11px] tabular-nums text-foreground/55">
-          {selected?.shortSha ?? (loading ? "…" : "—")}
+          {selected?.shortSha ?? (loadingInitial ? "…" : "—")}
         </span>
         {selected && (
           <span className="min-w-0 truncate text-[11px] text-muted-foreground">
@@ -120,10 +154,15 @@ export function CommitPicker() {
 
       <PopoverContent align="start" sideOffset={4} className="w-80 p-0">
         <Command>
-          <CommandInput placeholder="Search commits…" className="h-8 text-[11.5px]" />
+          <CommandInput
+            placeholder="Search commits…"
+            value={search}
+            onValueChange={setSearch}
+            className="h-8 text-[11.5px]"
+          />
           <CommandList>
             <CommandEmpty className="py-4 text-[11px]">No commits found</CommandEmpty>
-            {commits?.map((commit) => {
+            {commits.map((commit) => {
               const active = commit.sha === selectedSha;
               return (
                 <CommandItem
@@ -151,6 +190,24 @@ export function CommitPicker() {
                 </CommandItem>
               );
             })}
+            {hasMore && (
+              <div className="border-t border-border/40 p-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={loadingMore}
+                  onClick={loadOlder}
+                  className="h-7 w-full justify-center text-[11px] text-muted-foreground"
+                >
+                  {loadingMore
+                    ? "Loading older commits..."
+                    : search.trim()
+                      ? "Search older commits"
+                      : "Load older commits"}
+                </Button>
+              </div>
+            )}
           </CommandList>
         </Command>
       </PopoverContent>

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -14,6 +14,7 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import type { PanelScope } from "@/lib/panel-tabs";
 import { visibleReviewViews, defaultReviewView } from "@/lib/review-views";
+import { CommitPicker } from "./CommitPicker";
 
 /** Toolbar for the Review tab: dual-scope view switcher + unified/side-by-side toggle. */
 export function DiffToolbar() {
@@ -99,14 +100,17 @@ export function DiffToolbar() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {/* Operand slot — reserved for the active view's picked operand. Empty
-            for fixed-operand views; the per-operand picker lands in #641/#642. */}
+        {/* Operand slot — reserved for the active view's picked operand. Commit
+            fills it with the commit picker; Branch's picker lands in #641, so
+            its slot stays empty for now. Fixed-operand views render no slot. */}
         {activeView?.operand && (
           <div
             className="flex min-w-0 items-center"
             data-testid="review-operand-slot"
             data-operand={activeView.operand}
-          />
+          >
+            {activeView.operand === "commit" && <CommitPicker />}
+          </div>
         )}
       </div>
 

--- a/apps/web/src/components/diff/GitDiffView.tsx
+++ b/apps/web/src/components/diff/GitDiffView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { getTransport } from "@/transport";
-import type { SelectedFile } from "@/stores/diffStore";
+import { useDiffStore, type SelectedFile } from "@/stores/diffStore";
 import { FileList } from "./FileList";
 
 /** The threadless git working-tree views the Review tab renders against the workspace root. */
@@ -67,6 +67,9 @@ function LoadingPulse() {
 export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
   const [resolved, setResolved] = useState<Resolved | null>(null);
   const [loading, setLoading] = useState(true);
+  // The Commit view's picked operand (see CommitPicker). Null until the picker
+  // resolves, in which case Commit falls back to the latest HEAD commit.
+  const selectedCommitSha = useDiffStore((s) => s.selectedCommitSha);
 
   useEffect(() => {
     let cancelled = false;
@@ -83,11 +86,15 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
         const files = await transport.getBranchFiles(workspaceId, threadId);
         return { files, source: "branch", id: workspaceId };
       }
-      // Commit view: the latest HEAD commit (the thread's worktree HEAD when in a
-      // thread). Worktrees share the object store, so the per-file diff fetched by
+      // Commit view: the picker's chosen commit, defaulting to the latest HEAD
+      // commit (the thread's worktree HEAD when in a thread) before it resolves.
+      // Worktrees share the object store, so the per-file diff fetched by
       // FileList against the workspace root still resolves the worktree's commit.
-      const log = await transport.getGitLog(workspaceId, undefined, 1, undefined, threadId);
-      const sha = log[0]?.sha;
+      let sha = selectedCommitSha ?? undefined;
+      if (!sha) {
+        const log = await transport.getGitLog(workspaceId, undefined, 1, undefined, threadId);
+        sha = log[0]?.sha;
+      }
       if (!sha) return { files: [], source: "commit", id: workspaceId };
       const files = await transport.getCommitFiles(workspaceId, sha);
       return { files, source: "commit", id: sha };
@@ -112,8 +119,9 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
     };
     // threadId is a fetch input: switching threads (or thread↔threadless) on the
     // same view+workspace must refetch the worktree's file list, not keep the
-    // previous scope's stale diff.
-  }, [view, workspaceId, threadId]);
+    // previous scope's stale diff. selectedCommitSha is one too: picking a commit
+    // refetches that commit's files (no-op for the non-commit views).
+  }, [view, workspaceId, threadId, selectedCommitSha]);
 
   if (loading) return <LoadingPulse />;
   if (!resolved || resolved.files.length === 0) {

--- a/apps/web/src/components/diff/GitDiffView.tsx
+++ b/apps/web/src/components/diff/GitDiffView.tsx
@@ -67,8 +67,8 @@ function LoadingPulse() {
 export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
   const [resolved, setResolved] = useState<Resolved | null>(null);
   const [loading, setLoading] = useState(true);
-  // The Commit view's picked operand (see CommitPicker). Null until the picker
-  // resolves, in which case Commit falls back to the latest HEAD commit.
+  // The Commit view's picked operand (see CommitPicker). Null means the picker
+  // has not resolved a commit yet, or the current scope has no commits.
   const selectedCommitSha = useDiffStore((s) => s.selectedCommitSha);
 
   useEffect(() => {
@@ -86,15 +86,10 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
         const files = await transport.getBranchFiles(workspaceId, threadId);
         return { files, source: "branch", id: workspaceId };
       }
-      // Commit view: the picker's chosen commit, defaulting to the latest HEAD
-      // commit (the thread's worktree HEAD when in a thread) before it resolves.
-      // Worktrees share the object store, so the per-file diff fetched by
-      // FileList against the workspace root still resolves the worktree's commit.
-      let sha = selectedCommitSha ?? undefined;
-      if (!sha) {
-        const log = await transport.getGitLog(workspaceId, undefined, 1, undefined, threadId);
-        sha = log[0]?.sha;
-      }
+      // Commit view: the picker's chosen commit. The picker owns defaulting to
+      // the latest HEAD commit, which avoids a duplicate git-log + commit-files
+      // fetch on first render.
+      const sha = selectedCommitSha ?? undefined;
       if (!sha) return { files: [], source: "commit", id: workspaceId };
       const files = await transport.getCommitFiles(workspaceId, sha);
       return { files, source: "commit", id: sha };

--- a/apps/web/src/components/diff/__tests__/GitDiffView.test.tsx
+++ b/apps/web/src/components/diff/__tests__/GitDiffView.test.tsx
@@ -35,9 +35,11 @@ describe("GitDiffView commit selection", () => {
   it("renders the picked commit's files without resolving the latest commit again", async () => {
     render(<GitDiffView view="commit" workspaceId="ws-1" threadId="thread-1" />);
 
-    await screen.findByText("selected.ts");
+    await waitFor(() =>
+      expect(transport.getCommitFiles).toHaveBeenCalledWith("ws-1", "bbbbbbbb2"),
+    );
 
-    expect(transport.getCommitFiles).toHaveBeenCalledWith("ws-1", "bbbbbbbb2");
+    expect(screen.getAllByText("selected.ts").length).toBeGreaterThan(0);
     expect(transport.getGitLog).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/diff/__tests__/GitDiffView.test.tsx
+++ b/apps/web/src/components/diff/__tests__/GitDiffView.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDiffStore } from "@/stores/diffStore";
+import { GitDiffView } from "../GitDiffView";
+
+vi.mock("@/hooks/useOpenInApps", () => ({
+  useOpenInApps: () => [],
+}));
+
+const transport = vi.hoisted(() => ({
+  getGitLog: vi.fn(),
+  getCommitFiles: vi.fn(),
+  getWorkingTreeFiles: vi.fn(),
+  getBranchFiles: vi.fn(),
+}));
+
+vi.mock("@/transport", () => ({
+  getTransport: () => transport,
+}));
+
+describe("GitDiffView commit selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDiffStore.setState({
+      selectedCommitSha: "bbbbbbbb2",
+      selectedFile: null,
+      diffContent: null,
+      diffLoading: false,
+      inlineDiffCache: {},
+      renderMode: "unified",
+    });
+    transport.getCommitFiles.mockResolvedValue(["selected.ts"]);
+  });
+
+  it("renders the picked commit's files without resolving the latest commit again", async () => {
+    render(<GitDiffView view="commit" workspaceId="ws-1" threadId="thread-1" />);
+
+    await screen.findByText("selected.ts");
+
+    expect(transport.getCommitFiles).toHaveBeenCalledWith("ws-1", "bbbbbbbb2");
+    expect(transport.getGitLog).not.toHaveBeenCalled();
+  });
+
+  it("waits for the picker when no commit has been resolved", async () => {
+    useDiffStore.setState({ selectedCommitSha: null });
+
+    render(<GitDiffView view="commit" workspaceId="ws-1" threadId="thread-1" />);
+
+    await waitFor(() => expect(screen.getByText("No commit yet")).toBeInTheDocument());
+
+    expect(transport.getCommitFiles).not.toHaveBeenCalled();
+    expect(transport.getGitLog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -153,6 +153,14 @@ interface DiffState {
   readonly rightPanelVisibleByThread: Record<string, boolean>;
   /** View mode within the Changes tab. */
   viewMode: DiffViewMode;
+  /**
+   * The commit the Commit view's picker has resolved to, by SHA, or `null` for
+   * its default (the latest commit). This is the Commit comparison's picked
+   * operand: the Review toolbar's commit picker writes it, and the Commit diff
+   * reads it to render exactly that one commit. Reset when the active view
+   * changes so a stale pick never bleeds into the next Commit view.
+   */
+  selectedCommitSha: string | null;
   /** Diff rendering mode. */
   renderMode: DiffRenderMode;
   /** Per-thread line-wrap preference keyed by thread ID. */
@@ -219,6 +227,8 @@ interface DiffState {
    */
   closeRightPanelTab: (workspaceId: string, tab: RightPanelTab) => void;
   setViewMode: (mode: DiffViewMode) => void;
+  /** Set the Commit view's picked operand by SHA, or `null` to fall back to the latest commit. */
+  setSelectedCommitSha: (sha: string | null) => void;
   setRenderMode: (mode: DiffRenderMode) => void;
   getLineWrap: (threadId: string) => boolean;
   toggleLineWrap: (threadId: string) => void;
@@ -252,6 +262,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   rightPanelByWorkspace: {},
   rightPanelVisibleByThread: {},
   viewMode: "last-turn",
+  selectedCommitSha: null,
   renderMode: "unified",
   lineWrapByThread: {},
   snapshotsByThread: {},
@@ -333,7 +344,9 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       };
     }),
 
-  setViewMode: (mode) => set({ viewMode: mode, selectedFile: null, diffContent: null }),
+  setViewMode: (mode) =>
+    set({ viewMode: mode, selectedFile: null, diffContent: null, selectedCommitSha: null }),
+  setSelectedCommitSha: (sha) => set({ selectedCommitSha: sha }),
   setRenderMode: (mode) => set({ renderMode: mode }),
   getLineWrap: (threadId) => get().lineWrapByThread[threadId] ?? DEFAULT_LINE_WRAP,
   toggleLineWrap: (threadId) =>

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -154,11 +154,12 @@ interface DiffState {
   /** View mode within the Changes tab. */
   viewMode: DiffViewMode;
   /**
-   * The commit the Commit view's picker has resolved to, by SHA, or `null` for
-   * its default (the latest commit). This is the Commit comparison's picked
-   * operand: the Review toolbar's commit picker writes it, and the Commit diff
-   * reads it to render exactly that one commit. Reset when the active view
-   * changes so a stale pick never bleeds into the next Commit view.
+   * The commit the Commit view's picker has resolved to, by SHA. `null` means
+   * the picker has not resolved the current scope yet, or the scope has no
+   * commits. This is the Commit comparison's picked operand: the Review toolbar's
+   * commit picker writes it, and the Commit diff reads it to render exactly that
+   * one commit. Reset when the active view changes so a stale pick never bleeds
+   * into the next Commit view.
    */
   selectedCommitSha: string | null;
   /** Diff rendering mode. */

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -380,7 +380,14 @@ export interface McodeTransport {
   /** Get cumulative diff across all turns for a thread. Implemented in Phase 3. */
   getCumulativeDiff(threadId: string, filePath?: string, maxLines?: number): Promise<string>;
   /** Get commit log for a workspace branch. Pass threadId so the server runs git from the thread's worktree path. */
-  getGitLog(workspaceId: string, branch?: string, limit?: number, baseBranch?: string, threadId?: string): Promise<GitCommit[]>;
+  getGitLog(
+    workspaceId: string,
+    branch?: string,
+    limit?: number,
+    baseBranch?: string,
+    threadId?: string,
+    options?: { skip?: number; includeStats?: boolean },
+  ): Promise<GitCommit[]>;
   /** Get unified diff for a specific git commit. Implemented in Phase 4. */
   getCommitDiff(workspaceId: string, sha: string, filePath?: string, maxLines?: number): Promise<string>;
   /** Get the list of files changed in a specific git commit. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -692,8 +692,16 @@ export function createWsTransport(
       rpc<TurnSnapshot[]>("snapshot.listByThread", { threadId }),
     getCumulativeDiff: (threadId, filePath?, maxLines?) =>
       rpc<string>("snapshot.getCumulativeDiff", { threadId, filePath, maxLines }),
-    getGitLog: (workspaceId, branch?, limit?, baseBranch?, threadId?) =>
-      rpc<GitCommit[]>("git.log", { workspaceId, branch, limit, baseBranch, threadId }),
+    getGitLog: (workspaceId, branch?, limit?, baseBranch?, threadId?, options?) =>
+      rpc<GitCommit[]>("git.log", {
+        workspaceId,
+        branch,
+        limit,
+        baseBranch,
+        threadId,
+        skip: options?.skip,
+        includeStats: options?.includeStats,
+      }),
     getCommitDiff: (workspaceId, sha, filePath?, maxLines?) =>
       rpc<string>("git.commitDiff", { workspaceId, sha, filePath, maxLines }),
     getCommitFiles: (workspaceId, sha) =>

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -320,6 +320,8 @@ export const WS_METHODS = lazySchema(() => ({
       branch: z.string().optional(),
       baseBranch: z.string().optional(),
       limit: z.number().int().min(1).max(500).optional(),
+      skip: z.number().int().min(0).optional(),
+      includeStats: z.boolean().optional(),
       threadId: z.string().optional(),
     }),
     result: z.array(GitCommitSchema),


### PR DESCRIPTION
## What
Adds a searchable Commit picker in the Review operand slot and wires selected commits to the single-commit diff view.

## Why
Closes #642. Commit view needed a branch-scoped commit list, latest-commit default, search by message and short SHA, and thread worktree scope.

## Key Changes
- Adds the Commit picker with existing Popover and Command primitives.
- Stores the picked commit SHA and renders only that commit's file list and diff.
- Scopes commit log requests to the active thread worktree when a thread is selected.
- Removes duplicate latest-commit resolution from GitDiffView.
- Adds unit and E2E coverage for search, select, rendered diff content, and thread worktree scope.

## Config Changes
None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783701283&installation_id=129163861&pr_number=679&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F679&signature=f76bb974fdce9be6fdc43931926e0ca4df9aeb3c1fb1465a92b0523e977b2a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Commit Picker interface for selecting commits in the diff view with search by message or short SHA.
  * Implemented "load older commits" pagination to browse historical commits on demand.
  * Users can now select individual commits to view their changes instead of always viewing the latest.

* **Tests**
  * Added end-to-end and unit tests for commit selection and picker functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->