### PR TITLE
ci: move linux desktop builds to blacksmith

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,7 +29,7 @@ jobs:
           - os: blacksmith-4vcpu-windows-2025
             build-args: ""
             target-arch: ""
-          - os: ubuntu-22.04
+          - os: blacksmith-4vcpu-ubuntu-2404
             build-args: ""
             target-arch: ""
           - os: blacksmith-12vcpu-macos-26
@@ -76,6 +76,10 @@ jobs:
       - name: Smoke test packaged server
         if: matrix.target-arch == '' || matrix.target-arch == 'arm64'
         run: node apps/desktop/scripts/smoke-test.mjs
+
+      - name: Verify Linux artifacts on Ubuntu 22.04
+        if: runner.os == 'Linux'
+        run: bash apps/desktop/scripts/verify-linux-artifacts-ubuntu22.sh
 
       # macOS: upload latest-mac.yml as a workflow artifact (merged later)
       - name: Upload macOS update metadata

--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -134,7 +134,7 @@ jobs:
           - os: blacksmith-4vcpu-windows-2025
             build-args: ""
             target-arch: ""
-          - os: ubuntu-22.04
+          - os: blacksmith-4vcpu-ubuntu-2404
             build-args: ""
             target-arch: ""
           - os: blacksmith-12vcpu-macos-26
@@ -200,6 +200,10 @@ jobs:
       - name: Smoke test packaged server
         if: matrix.target-arch == '' || matrix.target-arch == 'arm64'
         run: node apps/desktop/scripts/smoke-test.mjs
+
+      - name: Verify Linux artifacts on Ubuntu 22.04
+        if: runner.os == 'Linux'
+        run: bash apps/desktop/scripts/verify-linux-artifacts-ubuntu22.sh
 
       - name: Upload macOS update metadata (nightly channel)
         if: matrix.target-arch == 'arm64' || matrix.target-arch == 'x64'

--- a/apps/desktop/scripts/verify-linux-artifacts-ubuntu22.sh
+++ b/apps/desktop/scripts/verify-linux-artifacts-ubuntu22.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_DIR="${1:-apps/desktop/release}"
+
+if [ ! -d "$RELEASE_DIR" ]; then
+  echo "[linux-artifact-smoke] ERROR: release directory not found: $RELEASE_DIR" >&2
+  exit 1
+fi
+
+appimage="$(find "$RELEASE_DIR" -maxdepth 1 -type f -name "*.AppImage" | head -n 1)"
+deb="$(find "$RELEASE_DIR" -maxdepth 1 -type f -name "*.deb" | head -n 1)"
+
+if [ -z "$appimage" ] || [ -z "$deb" ]; then
+  echo "[linux-artifact-smoke] ERROR: expected both AppImage and deb artifacts in $RELEASE_DIR" >&2
+  find "$RELEASE_DIR" -maxdepth 1 -type f -print >&2
+  exit 1
+fi
+
+abs_release_dir="$(cd "$RELEASE_DIR" && pwd)"
+
+docker run --rm \
+  --volume "$abs_release_dir:/release:ro" \
+  ubuntu:22.04 \
+  bash -lc '
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      file \
+      fuse \
+      libasound2 \
+      libatk-bridge2.0-0 \
+      libatk1.0-0 \
+      libcups2 \
+      libdrm2 \
+      libgbm1 \
+      libgtk-3-0 \
+      libnss3 \
+      libx11-xcb1 \
+      libxcb-dri3-0 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxfixes3 \
+      libxkbcommon0 \
+      libxrandr2 \
+      libxshmfence1 \
+      xvfb
+
+    appimage="$(find /release -maxdepth 1 -type f -name "*.AppImage" | head -n 1)"
+    deb="$(find /release -maxdepth 1 -type f -name "*.deb" | head -n 1)"
+
+    echo "[linux-artifact-smoke] Ubuntu: $(. /etc/os-release && echo "$PRETTY_NAME")"
+    echo "[linux-artifact-smoke] AppImage: $appimage"
+    echo "[linux-artifact-smoke] deb: $deb"
+
+    tmpdir="$(mktemp -d)"
+    dpkg-deb -x "$deb" "$tmpdir/deb-root"
+    echo "[linux-artifact-smoke] deb GLIBC requirements:"
+    find "$tmpdir/deb-root" -type f -perm /111 -print0 \
+      | xargs -0 -r strings \
+      | grep -o "GLIBC_[0-9.]*" \
+      | sort -Vu \
+      | tail -n 10 || true
+
+    tmp_appimage="$tmpdir/$(basename "$appimage")"
+    cp "$appimage" "$tmp_appimage"
+    chmod +x "$tmp_appimage"
+    "$tmp_appimage" --appimage-extract >/dev/null
+    echo "[linux-artifact-smoke] AppImage GLIBC requirements:"
+    find squashfs-root -type f -perm /111 -print0 \
+      | xargs -0 -r strings \
+      | grep -o "GLIBC_[0-9.]*" \
+      | sort -Vu \
+      | tail -n 10 || true
+
+    apt-get install -y --no-install-recommends "$deb"
+    installed_bin="$(command -v mcode-desktop || command -v mcode || true)"
+    if [ -z "$installed_bin" ]; then
+      echo "[linux-artifact-smoke] ERROR: installed desktop binary not found on PATH" >&2
+      exit 1
+    fi
+
+    echo "[linux-artifact-smoke] Launching installed deb binary: $installed_bin"
+    timeout 20s xvfb-run -a "$installed_bin" --no-sandbox --disable-gpu --version
+
+    echo "[linux-artifact-smoke] Launching AppImage"
+    timeout 20s env APPIMAGE_EXTRACT_AND_RUN=1 xvfb-run -a "$tmp_appimage" --no-sandbox --disable-gpu --version
+
+    echo "[linux-artifact-smoke] PASS: AppImage and deb launch on Ubuntu 22.04."
+  '


### PR DESCRIPTION
## What
Move Linux desktop release builds to the Blacksmith Ubuntu runner and add an Ubuntu 22.04 artifact smoke check.

## Why
Issue #670 asks for the Linux matrix entry in the Nightly Desktop and Build Release workflows to use Blacksmith, while preserving evidence that AppImage and deb outputs still launch on an Ubuntu 22.04-era distro.

## Key Changes
- Switch Linux build matrix entries in `.github/workflows/build-release.yml` and `.github/workflows/nightly-desktop.yml` from `ubuntu-22.04` to `blacksmith-4vcpu-ubuntu-2404`.
- Add `apps/desktop/scripts/verify-linux-artifacts-ubuntu22.sh` to install and launch the generated deb and AppImage inside an Ubuntu 22.04 container.
- Run the Ubuntu 22.04 artifact check after Linux packaging in both workflows.

Closes #670

Verification:
- `bash -n apps/desktop/scripts/verify-linux-artifacts-ubuntu22.sh`
- workflow static check: `workflow static checks passed`
- `bun run verify` exited 0 with repo output: `=== No code changes detected, skipping verification ===` then `$ node scripts/agent/verify-tests.mjs --full`

Local limitation: Docker is installed but not reachable in this Windows session, so the containerized artifact smoke and Docker-based actionlint could not run locally. CI will run the new artifact check on the Linux build job.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783726187&installation_id=129163861&pr_number=681&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F681&signature=bc6b695439cd45cd5fedc28eab39d7ea385532c3e265b6954c9cef824fff3af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded Linux build infrastructure configuration
  * Implemented additional verification checks for Linux desktop release artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->