### PR TITLE
fix(codex): stabilise the app-server provider and cut startup latency

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -38,6 +38,7 @@ import { PlanQuestionAnswersRepo } from "./repositories/plan-question-answers-re
 import { PlanRepo } from "./repositories/plan-repo";
 import { SnapshotService } from "./services/snapshot-service";
 import { SettingsService } from "./services/settings-service";
+import { warmCodexVersionCache } from "./providers/codex/codex-version";
 import { GitWatcherService } from "./services/git-watcher-service";
 import { SkillWatcherService } from "./services/skill-watcher-service";
 import { MemoryPressureService } from "./services/memory-pressure-service";
@@ -207,7 +208,19 @@ settingsService.on("change", (next) => {
     modelCacheService.invalidate("copilot");
   }
   lastCliPathsForModelCache = next.provider.cli;
+  // Re-warm the Codex version gate when its CLI path changes so the next
+  // send is a cache hit (no blocking spawnSync on the send path).
+  warmCodexVersionGate(next);
 });
+
+/**
+ * Warms the Codex `--version` gate cache off the send path. No-op when the
+ * provider is disabled or the path is already cached.
+ */
+function warmCodexVersionGate(s = settingsService.get()): void {
+  if (!s.provider.enabled.codex) return;
+  void warmCodexVersionCache(s.provider.cli.codex || "codex");
+}
 
 const cleanupWorker = container.resolve(CleanupWorker);
 const prDraftService = container.resolve(PrDraftService);
@@ -278,6 +291,9 @@ providerAvailability
   .verifyAllEnabled()
   .then(() => {
     broadcast("providers.availability", providerAvailability.listAvailability());
+    // Warm the Codex version gate at boot so the first send never pays a
+    // blocking `codex --version` spawnSync.
+    warmCodexVersionGate();
     // Warm the model cache once after CLI verification has gated which providers
     // are usable. Triggering this per WS connect would spam refreshes; running
     // it once at startup is sufficient because ModelCacheService also refreshes

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -39,6 +39,7 @@ import { PlanRepo } from "./repositories/plan-repo";
 import { SnapshotService } from "./services/snapshot-service";
 import { SettingsService } from "./services/settings-service";
 import { warmCodexVersionCache } from "./providers/codex/codex-version";
+import { warmCodexAppServer } from "./providers/codex/codex-app-server";
 import { GitWatcherService } from "./services/git-watcher-service";
 import { SkillWatcherService } from "./services/skill-watcher-service";
 import { MemoryPressureService } from "./services/memory-pressure-service";
@@ -213,13 +214,23 @@ settingsService.on("change", (next) => {
   warmCodexVersionGate(next);
 });
 
+/** CLI paths whose app-server has already been warmed this run. */
+const warmedCodexPaths = new Set<string>();
+
 /**
- * Warms the Codex `--version` gate cache off the send path. No-op when the
- * provider is disabled or the path is already cached.
+ * Warms the Codex `--version` gate cache and cold-starts a throwaway
+ * app-server (file cache + chatgpt.com TLS/auth) off the send path. No-op
+ * when the provider is disabled; the app-server warm-up runs once per CLI
+ * path per app run.
  */
 function warmCodexVersionGate(s = settingsService.get()): void {
   if (!s.provider.enabled.codex) return;
-  void warmCodexVersionCache(s.provider.cli.codex || "codex");
+  const cliPath = s.provider.cli.codex || "codex";
+  void warmCodexVersionCache(cliPath);
+  if (!warmedCodexPaths.has(cliPath)) {
+    warmedCodexPaths.add(cliPath);
+    void warmCodexAppServer(cliPath);
+  }
 }
 
 const cleanupWorker = container.resolve(CleanupWorker);

--- a/apps/server/src/providers/codex/__tests__/codex-app-server-warmup.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-app-server-warmup.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { warmCodexAppServer } from "../codex-app-server.js";
+
+describe("warmCodexAppServer", () => {
+  it("resolves false for a missing binary without throwing", async () => {
+    await expect(
+      warmCodexAppServer("definitely-not-a-real-binary-xyz", 5000),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -320,6 +320,7 @@ export function enrichHandshakeError(err: unknown, stderr: string | null): Error
  *
  * Emits:
  * - `notification(data: unknown)` - JSON-RPC notification forwarded from the RPC client
+ * - `activity()` - a server-initiated request arrived (liveness signal for turn watchdogs)
  * - `fatal(error: string)` - unrecoverable error from stderr, unexpected exit, or handshake failure
  * - `exit(code: number | null, signal: string | null)` - child process exit
  */
@@ -474,6 +475,9 @@ export class CodexAppServer extends EventEmitter {
     // for policy="never", handler-driven supervised mode, silent-deny fallback).
     this.rpc.on("serverRequest", (msg: unknown) => {
       const request = msg as { id?: number; method?: string; params?: Record<string, unknown> };
+      // Let turn-level watchdogs treat an inbound approval request as liveness:
+      // the server is healthy, it is just waiting on a user decision.
+      this.emit("activity");
       void routeCodexServerRequest({
         msg: request,
         approvalPolicy: this.options.approvalPolicy,
@@ -623,16 +627,23 @@ export class CodexAppServer extends EventEmitter {
         return;
       }
 
-      for (const pattern of FATAL_PATTERNS) {
-        if (line.includes(pattern)) {
-          this.lastStderr = line;
-          const msg = `Codex app-server fatal stderr: ${line}`;
-          logger.error(msg, { cliPath: this.cliPath });
-          this.emit("fatal", msg);
-          this.kill().catch((err: unknown) => {
-            logger.error("CodexAppServer: kill after fatal stderr failed", { error: String(err) });
-          });
-          return;
+      // Fatal classification applies only before a thread is established.
+      // Once the session is live, stderr carries tool output and agent-generated
+      // content; a build or curl that prints "ECONNRESET" must not kill the
+      // whole app-server. Post-handshake transport failures surface via the
+      // child exit event and RPC stream-close rejection instead.
+      if (this._threadId === null) {
+        for (const pattern of FATAL_PATTERNS) {
+          if (line.includes(pattern)) {
+            this.lastStderr = line;
+            const msg = `Codex app-server fatal stderr: ${line}`;
+            logger.error(msg, { cliPath: this.cliPath });
+            this.emit("fatal", msg);
+            this.kill().catch((err: unknown) => {
+              logger.error("CodexAppServer: kill after fatal stderr failed", { error: String(err) });
+            });
+            return;
+          }
         }
       }
 

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -458,11 +458,15 @@ export class CodexAppServer extends EventEmitter {
           // Without this, app restarts would try to resume the stale thread ID.
           this.emit("threadIdChanged", newThreadId);
         }
+        this.emit("activity");
         logger.debug("Codex lifecycle notification", { method });
         return;
       }
 
       if (LIFECYCLE_NOTIFICATION_PREFIXES.some((p) => method.startsWith(p))) {
+        // Swallowed from the mapper, but still proof of life: thread/status
+        // and similar lifecycle traffic must reset turn-level watchdogs.
+        this.emit("activity");
         logger.debug("Codex lifecycle notification", { method });
         return;
       }
@@ -594,6 +598,22 @@ export class CodexAppServer extends EventEmitter {
       logger.debug("Codex turn/start acknowledged", { threadId: this.threadId, turnId });
     }
     return turnId;
+  }
+
+  /**
+   * Cheap liveness probe: true when the app-server still answers RPCs.
+   * `model/list` is the lightest request the protocol guarantees post-init.
+   * Used by turn watchdogs to distinguish "long-running but healthy" from
+   * "wedged" before giving up on a silent turn.
+   */
+  async ping(timeoutMs = 10_000): Promise<boolean> {
+    if (!this._isAlive || !this.rpc) return false;
+    try {
+      await this.rpc.sendRequest("model/list", {}, timeoutMs);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -316,6 +316,100 @@ export function enrichHandshakeError(err: unknown, stderr: string | null): Error
 }
 
 /**
+ * Boot-time cold-start warm-up: spawns a throwaway `codex app-server`, runs
+ * `initialize`, and kills it. The first `initialize` on a cold machine pays
+ * for paging the large Rust binary into the OS file cache plus a TLS/auth
+ * round trip to chatgpt.com (~1.7s+, worse on slow networks); paying it at
+ * app boot means the user's first real session starts warm.
+ *
+ * Fire-and-forget safe: never throws, resolves `true` only when `initialize`
+ * was acknowledged within the timeout.
+ */
+export async function warmCodexAppServer(cliPath: string, timeoutMs = 20_000): Promise<boolean> {
+  let resolvedCliPath = cliPath;
+  if (!isAbsolute(cliPath)) {
+    try {
+      resolvedCliPath = await which(cliPath);
+    } catch {
+      return false;
+    }
+  }
+  const needsShell =
+    process.platform === "win32" && resolvedCliPath.toLowerCase().endsWith(".cmd");
+
+  return await new Promise<boolean>((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = spawn(resolvedCliPath, ["app-server"], {
+        stdio: ["pipe", "pipe", "ignore"],
+        shell: needsShell,
+        env: flattenProcessEnv(process.env),
+        windowsHide: true,
+      });
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // taskkill reaps the whole tree on Windows; with shell:true a plain
+      // kill() would only hit cmd.exe and orphan the codex child.
+      if (process.platform === "win32" && child.pid != null) {
+        void import("child_process").then(({ execFile }) => {
+          execFile("taskkill", ["/T", "/F", "/PID", String(child.pid)], () => {});
+        });
+      } else {
+        child.kill("SIGKILL");
+      }
+      resolve(ok);
+    };
+
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    child.once("error", () => finish(false));
+    child.once("exit", () => finish(false));
+
+    let buffer = "";
+    child.stdout!.setEncoding("utf8");
+    child.stdout!.on("data", (chunk: string) => {
+      buffer += chunk;
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line) as { id?: number };
+          if (msg.id === 1) {
+            logger.info("Codex app-server warm-up completed", { cliPath });
+            finish(true);
+            return;
+          }
+        } catch {
+          // ignore non-JSON output
+        }
+      }
+    });
+
+    child.once("spawn", () => {
+      child.stdin!.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            clientInfo: { name: "mcode", version: "1.0.0" },
+            capabilities: { experimentalApi: true },
+          },
+        }) + "\n",
+      );
+    });
+  });
+}
+
+/**
  * Manages the lifecycle of a `codex app-server` child process.
  *
  * Emits:

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -227,7 +227,11 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
       codexFastMode !== undefined
         ? codexFastMode
         : settings.provider.codex?.fastMode === true;
-    const fastServiceTier = useFastTier ? "fast" : undefined;
+    // The app-server's model/list advertises the fast tier with id "priority"
+    // (display name "Fast"). Sending "fast" is silently ignored upstream, so
+    // fast mode had no effect. Only some models (e.g. gpt-5.4 / gpt-5.5)
+    // expose the tier; the server falls back to standard for the rest.
+    const fastServiceTier = useFastTier ? "priority" : undefined;
 
     const turnOptions = {
       model: model || undefined,

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -45,19 +45,14 @@ import {
 import type { TurnInputPart, CodexNotification, CodexTurnOptions, ReasoningEffort } from "./codex-types.js";
 
 /**
- * Maximum wall-clock idle between Codex app-server notifications while
- * waiting for `turn/completed`. The timer resets on every notification so
- * active streams and tool output keep the turn alive; only a fully silent
- * stretch trips it. Set to 60s (matching Copilot's `COMPLETE_TIMEOUT_MS`) so a
- * stalled upstream turn — where `turn/completed` never arrives and the session
- * stays `isBusy`, exempt from idle eviction — unblocks the UI rather than
- * leaving it stuck "thinking" indefinitely.
- *
- * Set to 5 minutes: tools that run silently (no output deltas, e.g. long
- * builds or installs) routinely exceed 60s, and tripping the watchdog mid-tool
- * silently ended healthy turns. The watchdog also re-arms while a permission
- * approval is pending (user silence, not server silence) and treats inbound
- * approval requests as liveness via the app-server `activity` event.
+ * Liveness-probe interval for a silent turn, not a turn deadline. The timer
+ * resets on every notification (including swallowed lifecycle traffic and
+ * inbound approval requests, via the app-server `activity` event). When a
+ * turn stays fully silent for this long, the watchdog pings the app-server
+ * with a cheap RPC: responsive → re-arm (a healthy turn can run forever);
+ * unresponsive → end the turn so the session does not stay `isBusy` (exempt
+ * from idle eviction) with the UI stuck "thinking" indefinitely. While a
+ * permission approval awaits the user, the watchdog re-arms without probing.
  */
 const TURN_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -69,11 +64,11 @@ class CodexTurnSupersededError extends Error {
   }
 }
 
-/** Internal: idle notification watchdog fired; ends the turn without a user error. */
+/** Internal: silent turn AND the app-server failed a liveness probe; ends the turn without a user error. */
 class CodexTurnIdleTimeoutError extends Error {
   constructor() {
     super(
-      `Codex turn timed out after ${TURN_TIMEOUT_MS / 1000}s with no app-server notifications`,
+      `Codex turn abandoned: no notifications for ${TURN_TIMEOUT_MS / 1000}s and the app-server failed a liveness probe`,
     );
     this.name = "CodexTurnIdleTimeoutError";
   }
@@ -556,8 +551,23 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
               armTimer();
               return;
             }
-            cleanup();
-            reject(new CodexTurnIdleTimeoutError());
+            // Probe before giving up: a turn is only abandoned when the
+            // app-server stops answering RPCs, never just for being slow.
+            // A healthy-but-silent turn (long tool, deep reasoning) re-arms
+            // and can run indefinitely.
+            void server.ping().then((alive) => {
+              if (settled) return;
+              if (alive) {
+                logger.debug("Codex turn silent but server responsive; watchdog re-armed", {
+                  sessionId,
+                  silenceMs: TURN_TIMEOUT_MS,
+                });
+                armTimer();
+                return;
+              }
+              cleanup();
+              reject(new CodexTurnIdleTimeoutError());
+            });
           }, TURN_TIMEOUT_MS);
         };
 

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -50,13 +50,16 @@ import type { TurnInputPart, CodexNotification, CodexTurnOptions, ReasoningEffor
  * active streams and tool output keep the turn alive; only a fully silent
  * stretch trips it. Set to 60s (matching Copilot's `COMPLETE_TIMEOUT_MS`) so a
  * stalled upstream turn — where `turn/completed` never arrives and the session
- * stays `isBusy`, exempt from idle eviction — unblocks the UI in seconds instead
- * of leaving it stuck "thinking" for half an hour. The trade-off: a tool that
- * runs silently (no output deltas) for longer than this window will also trip
- * it; that case is logged and suppressed from the chat UI (see
- * {@link CodexTurnIdleTimeoutError}).
+ * stays `isBusy`, exempt from idle eviction — unblocks the UI rather than
+ * leaving it stuck "thinking" indefinitely.
+ *
+ * Set to 5 minutes: tools that run silently (no output deltas, e.g. long
+ * builds or installs) routinely exceed 60s, and tripping the watchdog mid-tool
+ * silently ended healthy turns. The watchdog also re-arms while a permission
+ * approval is pending (user silence, not server silence) and treats inbound
+ * approval requests as liveness via the app-server `activity` event.
  */
-const TURN_TIMEOUT_MS = 60 * 1000;
+const TURN_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Internal: a newer `sendMessage` aborted this turn wait (not user-facing). */
 class CodexTurnSupersededError extends Error {
@@ -505,6 +508,12 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
 
     entry.mapper.prepareForTurn();
 
+    // Only pay the turn/interrupt round-trip when a previous turn is actually
+    // in flight. Interrupting an idle session added a needless RPC (up to its
+    // 5s timeout) of latency to every message.
+    const hadInflightTurn =
+      entry.pendingTurnId !== null || entry.abortPendingTurnWait !== undefined;
+
     entry.abortPendingTurnWait?.();
     entry.abortPendingTurnWait = undefined;
 
@@ -512,7 +521,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
     const seq = entry.runTurnSeq;
     entry.pendingTurnId = null;
 
-    await server.interruptTurn();
+    if (hadInflightTurn) {
+      await server.interruptTurn();
+    }
 
     let serverDied = false;
     let endedEmitted = false;
@@ -527,6 +538,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
           settled = true;
           clearTimeout(activityTimer);
           server.removeListener("notification", onNotification);
+          server.removeListener("activity", onActivity);
           server.removeListener("fatal", onFatal);
           if (entry.abortPendingTurnWait === abortThis) entry.abortPendingTurnWait = undefined;
         };
@@ -534,10 +546,19 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
         const armTimer = () => {
           clearTimeout(activityTimer);
           activityTimer = setTimeout(() => {
+            // Silence while an approval card waits on the user is the user's
+            // silence, not the server's: keep the turn alive until they decide.
+            if (this.hasPendingApprovalFor(sessionId)) {
+              armTimer();
+              return;
+            }
             cleanup();
             reject(new CodexTurnIdleTimeoutError());
           }, TURN_TIMEOUT_MS);
         };
+
+        // Server-initiated approval requests count as liveness too.
+        const onActivity = () => armTimer();
 
         const abortThis = () => {
           cleanup();
@@ -574,6 +595,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
 
         armTimer();
         server.on("notification", onNotification);
+        server.on("activity", onActivity);
         server.once("fatal", onFatal);
 
         void (async () => {
@@ -589,10 +611,13 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
     } catch (e: unknown) {
       if (e instanceof CodexTurnSupersededError) return;
       if (e instanceof CodexTurnIdleTimeoutError) {
-        logger.debug("Codex turn idle timeout (suppressed from UI)", {
+        logger.warn("Codex turn idle timeout (suppressed from UI)", {
           sessionId,
           timeoutMs: TURN_TIMEOUT_MS,
         });
+        // Interrupt the upstream turn so the app-server state matches the UI
+        // ("ended") instead of silently chewing in the background.
+        void server.interruptTurn();
         return;
       }
       if (!serverDied && seq === entry.runTurnSeq) {
@@ -694,6 +719,14 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
     server.on("fatal", () => {
       this.drainPending((e) => e.sessionId === sessionId);
     });
+  }
+
+  /** True when at least one permission approval is awaiting the user for this session. */
+  private hasPendingApprovalFor(sessionId: string): boolean {
+    for (const entry of this.pendingPermissions.values()) {
+      if (entry.sessionId === sessionId) return true;
+    }
+    return false;
   }
 
   /**

--- a/apps/server/src/providers/codex/codex-version.ts
+++ b/apps/server/src/providers/codex/codex-version.ts
@@ -1,12 +1,18 @@
-import { spawnSync } from "child_process";
+import { spawnSync, execFile } from "child_process";
 
 /** Shell metacharacters that must not appear in a CLI path passed to `shell: true`. */
 const SHELL_METACHAR_RE = /[;&|`$(){}!<>"'\s\n\r]/;
 
-/** TTL for cached version results (5 minutes). */
-const VERSION_CACHE_TTL_MS = 5 * 60 * 1000;
+/** Matches a semver triplet not followed by a fourth dotted segment. */
+const SEMVER_RE = /\b(\d+\.\d+\.\d+)(?!\.\d)/;
 
-/** Cached version check results keyed by cliPath. */
+/**
+ * Cached version check results keyed by cliPath. Successes are cached for the
+ * app lifetime: the check is a min-version gate, and a CLI upgrade mid-run
+ * cannot move below the minimum. Failures are never cached, so a user fixing
+ * a broken install recovers on the next send. The cache is warmed off the
+ * send path at startup via {@link warmCodexVersionCache}.
+ */
 const versionCache = new Map<string, { result: ReturnType<typeof checkCodexVersion>; checkedAt: number }>();
 
 /**
@@ -28,9 +34,10 @@ export function checkCodexVersion(
     return { ok: false, error: `Codex CLI path contains invalid characters: "${cliPath}"` };
   }
 
-  // Return cached result if fresh, avoiding a blocking spawnSync on the event loop.
+  // Cached successes are returned for the app lifetime, avoiding a blocking
+  // spawnSync on the event loop on the send path.
   const cached = versionCache.get(cliPath);
-  if (cached && Date.now() - cached.checkedAt < VERSION_CACHE_TTL_MS) {
+  if (cached) {
     return cached.result;
   }
 
@@ -62,7 +69,7 @@ export function checkCodexVersion(
   }
 
   const output = (result.stdout ?? "") + (result.stderr ?? "");
-  const match = output.match(/\b(\d+\.\d+\.\d+)(?!\.\d)/);
+  const match = output.match(SEMVER_RE);
 
   if (match == null) {
     return { ok: false, error: notFoundError };
@@ -71,6 +78,39 @@ export function checkCodexVersion(
   const success = { ok: true as const, version: match[1] };
   versionCache.set(cliPath, { result: success, checkedAt: Date.now() });
   return success;
+}
+
+/**
+ * Warms the version cache off the send path with a non-blocking `--version`
+ * probe. Call at app startup (and on CLI-path settings changes) so the
+ * synchronous {@link checkCodexVersion} gate in `sendTurn` is a pure cache
+ * hit instead of a blocking spawnSync. No-op when the path is already cached
+ * or contains shell metacharacters; failures are not cached (the send-path
+ * check surfaces the user-facing error with fresh state).
+ */
+export function warmCodexVersionCache(cliPath: string): Promise<void> {
+  if (SHELL_METACHAR_RE.test(cliPath) || versionCache.has(cliPath)) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    execFile(
+      cliPath,
+      ["--version"],
+      { shell: true, timeout: 5000, windowsHide: true, encoding: "utf8" },
+      (err, stdout, stderr) => {
+        if (err == null) {
+          const match = ((stdout ?? "") + (stderr ?? "")).match(SEMVER_RE);
+          if (match != null) {
+            versionCache.set(cliPath, {
+              result: { ok: true, version: match[1] },
+              checkedAt: Date.now(),
+            });
+          }
+        }
+        resolve();
+      },
+    );
+  });
 }
 
 /** Clears the cached version results. Exposed for testing only. */

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -67,7 +67,7 @@ export const threads = sqliteTable(
     contextWindowMode: text("context_window_mode"),
     thinking: integer("thinking"),
     /**
-     * Codex-only: 1 = request `serviceTier: fast`, 0 = standard, null = inherit global
+     * Codex-only: 1 = request `serviceTier: priority` (the "Fast" tier), 0 = standard, null = inherit global
      * `settings.provider.codex.fastMode`.
      */
     codexFastMode: integer("codex_fast_mode"),

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -305,7 +305,7 @@ export const SettingsSchema = lazySchema(() =>
         codex: z
           .object({
             /**
-             * When true, pass `serviceTier: "fast"` on Codex turns (OpenAI fast tier when available).
+             * When true, pass `serviceTier: "priority"` on Codex turns (OpenAI "Fast" tier when the model supports it).
              */
             fastMode: z.boolean().optional(),
             /** @deprecated Migrated into {@link fastMode}; still read from disk for older settings files. */


### PR DESCRIPTION
## What

Five fixes that stop the Codex provider from silently ending or killing healthy sessions, make fast mode work, and cut first-message latency.

## Why

Codex sessions would stop mid-turn with no error, die while running, and feel slower than the Codex app. Investigation found three stability bugs and two startup-path costs, plus a fast mode toggle that sent a value the backend ignores.

## Key Changes

- **Turn watchdog is now a liveness probe, not a deadline.** The old 60s idle timer silently ended any turn with a pending approval card or a quiet long-running tool. Now all server traffic (including lifecycle notifications) counts as activity, approval waits pause the timer, and after 5 minutes of true silence the server is pinged; only an unresponsive server ends the turn.
- **Fatal stderr classification is scoped to the handshake.** Tool output is muxed onto stderr, so an agent command printing ECONNRESET could kill its own session. Post-handshake crashes are detected via process exit instead.
- **No turn/interrupt round trip when nothing is in flight.** Removed up to 5s of latency per message.
- **Fast mode sends the real tier id.** The app-server advertises the fast tier as `priority` (verified against codex-cli 0.130.0 via its generated protocol schema and a live `model/list`); we sent `fast`, which was silently ignored. Only gpt-5.4/5.5 expose the tier.
- **Startup costs moved off the send path.** The `codex --version` gate (blocking spawnSync, 5 min cache) is now warmed asynchronously at boot and on CLI-path changes, with successes cached for the app lifetime. A throwaway app-server is also spawned at boot to pre-pay the cold-start cost (binary paging + chatgpt.com TLS/auth, measured 1.7s cold vs ~160ms warm).

First message now costs roughly 0.6-1s of provider overhead instead of 4s+.

All 140 codex tests pass; typecheck and lint green. The only failing suite is the known pre-existing snapshot-service Windows flake.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783732101&installation_id=129163861&pr_number=682&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F682&signature=b31f6ffcfd065ced624d0e589707124b59ce618d3003b638c6a81f5279bdb9be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Codex operations pre-warm on startup and settings changes, reducing initial operation latency.
  * Version check results now cache for the application lifetime.

* **Reliability**
  * Added server liveness detection to distinguish between slow responses and unresponsive servers.
  * Turn timeout increased from 60 seconds to 5 minutes.
  * Improved error messaging for timeout scenarios.

* **Changes**
  * Fast mode now uses priority service tier designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->