### PR TITLE
fix(desktop): handle version flag before app startup

### DIFF
--- a/apps/desktop/src/main/__tests__/cli-args.test.ts
+++ b/apps/desktop/src/main/__tests__/cli-args.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { shouldPrintVersion } from "../cli-args";
+
+describe("shouldPrintVersion", () => {
+  it("detects the long version flag used by Linux artifact smoke tests", () => {
+    expect(shouldPrintVersion(["/opt/Mcode/mcode-desktop", "--no-sandbox", "--version"])).toBe(true);
+  });
+
+  it("detects the short version flag", () => {
+    expect(shouldPrintVersion(["mcode-desktop", "-v"])).toBe(true);
+  });
+
+  it("ignores normal app launches", () => {
+    expect(shouldPrintVersion(["mcode-desktop", "--disable-gpu"])).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/cli-args.ts
+++ b/apps/desktop/src/main/cli-args.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns true when the desktop process should print the app version and exit.
+ */
+export function shouldPrintVersion(argv: readonly string[]): boolean {
+  return argv.includes("--version") || argv.includes("-v");
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -46,6 +46,7 @@ import { registerPreviewBrowserHandlers, disposePreviewForWindow } from "./previ
 import { startBrowserUseBridge, disposeBrowserUseBridge } from "./browser-use/index.js";
 import { resolveMcodeWorkspacePreviewUrl } from "./preview/preview-local-file.js";
 import { isDesktopDev } from "./is-desktop-dev.js";
+import { shouldPrintVersion } from "./cli-args.js";
 
 // Isolate dev's Electron userData (cache, cookies, localStorage, IndexedDB)
 // from the installed prod build. Without this, both share %APPDATA%/Mcode/
@@ -56,6 +57,11 @@ import { isDesktopDev } from "./is-desktop-dev.js";
 // before app.whenReady() and any other path-dependent call.
 if (!app.isPackaged) {
   app.setPath("userData", join(app.getPath("appData"), "Mcode-Dev"));
+}
+
+if (shouldPrintVersion(process.argv)) {
+  console.log(app.getVersion());
+  app.exit(0);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Fix the desktop Linux artifact smoke path by handling `--version` before Electron starts the full app.

## Why
The latest Nightly Desktop run failed in `Verify Linux artifacts on Ubuntu 22.04`. The installed `.deb` launched, then the full app stayed alive long enough for the updater to request `latest-linux.yml` from the per-build nightly release and the smoke command timed out with exit code 124.

## Key Changes
- Add a small CLI argument helper for `--version` and `-v`.
- Exit early from the Electron main process after printing `app.getVersion()`.
- Add a focused regression test for the Linux smoke-test argument shape.

Related to the failed Nightly Desktop run 27317694034.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783735307&installation_id=129163861&pr_number=687&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F687&signature=82ae6dce839664c38c619727ae9c9c41e6d13b85ba98f6d48a041b48c7298590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Desktop app now supports `--version` and `-v` command-line flags to display the application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->