### PR TITLE
fix: keep the server alive through sleep and bring it back when it dies

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -458,6 +458,20 @@ resubscribes and hydration covers the gap. Payload validation at this seam
 has two adapters: validating (dev, logs schema drift) and pass-through
 (production). (Epic #649, slices #656/#657.)
 
+### Grace period
+The countdown between the last client session disconnecting and the server
+shutting itself down. It only starts when the server is not busy; a busy
+server never begins the countdown, no matter how long clients stay away.
+A new session connecting cancels it. Distinct from session-runtime idle
+eviction (which retires pooled provider CLI sessions, not the server).
+
+### Busy (server)
+The server is busy while any agent turn is in flight or any integrated
+terminal is running. Busy suppresses the grace period and is the condition
+under which the desktop app holds a power-save blocker so the machine does
+not suspend mid-work. Connected-but-idle clients do not make the server
+busy.
+
 ### Git executor
 The single module that owns running git as a child process on the server:
 asynchronous execution, queueing per repository, timeouts, and caching of

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -13,6 +13,8 @@ import {
   clipboard,
   dialog,
   ipcMain,
+  powerMonitor,
+  powerSaveBlocker,
   protocol,
   session,
   shell,
@@ -101,6 +103,93 @@ function openIfAllowed(url: string): void {
 
 let mainWindow: BrowserWindow | null = null;
 const serverManager = new ServerManager();
+
+// ---------------------------------------------------------------------------
+// Sleep-resilient server lifecycle (self-healing restart + power save blocker)
+// ---------------------------------------------------------------------------
+
+/** Sliding window for counting silent restarts before escalating to the crash dialog. */
+const SILENT_RESTART_WINDOW_MS = 60_000;
+/** Silent restarts allowed within the window; the next failure shows the crash dialog. */
+const SILENT_RESTART_LIMIT = 3;
+
+/** Timestamps of recent silent restarts (pruned to the sliding window). */
+let silentRestartTimestamps: number[] = [];
+/** Single in-flight ensure promise so concurrent triggers (resume + renderer fallback) coalesce. */
+let ensureInFlight: Promise<void> | null = null;
+
+/** Show the Restart / Quit dialog used when the server crashes or restart-loops. */
+async function showServerCrashDialog(code: number | null): Promise<void> {
+  if (!mainWindow) return;
+  const { response } = await dialog.showMessageBox(mainWindow, {
+    type: "error",
+    title: "Server crashed",
+    message: `The Mcode server exited unexpectedly (code ${code ?? "unknown"}).`,
+    buttons: ["Restart", "Quit"],
+    defaultId: 0,
+    cancelId: 1,
+  });
+  if (response === 0) {
+    await serverManager.restart();
+  } else {
+    app.quit();
+  }
+}
+
+/**
+ * Verify the server is reachable and silently restart it if not.
+ * Called on OS resume and from the renderer's reconnect fallback.
+ * Escalates to the crash dialog after {@link SILENT_RESTART_LIMIT} silent
+ * restarts within {@link SILENT_RESTART_WINDOW_MS} — a restart loop means
+ * something is genuinely broken and hiding it would strand the user.
+ */
+function ensureServerRunning(): Promise<void> {
+  if (ensureInFlight) return ensureInFlight;
+  ensureInFlight = (async () => {
+    if (await serverManager.isHealthy()) return;
+
+    const now = Date.now();
+    silentRestartTimestamps = silentRestartTimestamps.filter(
+      (t) => now - t < SILENT_RESTART_WINDOW_MS,
+    );
+    if (silentRestartTimestamps.length >= SILENT_RESTART_LIMIT) {
+      await showServerCrashDialog(null);
+      return;
+    }
+    silentRestartTimestamps.push(now);
+
+    console.log("[main] Server unhealthy, restarting silently");
+    try {
+      await serverManager.restart();
+    } catch (err) {
+      console.error("[main] Silent server restart failed:", err);
+    }
+  })().finally(() => {
+    ensureInFlight = null;
+  });
+  return ensureInFlight;
+}
+
+/** WebContents ids that currently report the server as busy. */
+const busySenders = new Set<number>();
+/** Sender ids that already have a destroyed-cleanup listener registered. */
+const busyCleanupRegistered = new Set<number>();
+/** Active powerSaveBlocker id, or null when not blocking. */
+let powerSaveBlockerId: number | null = null;
+
+/** Start/stop the app-suspension blocker to match the busy-sender set. */
+function updatePowerSaveBlocker(): void {
+  if (busySenders.size > 0) {
+    if (powerSaveBlockerId === null) {
+      powerSaveBlockerId = powerSaveBlocker.start("prevent-app-suspension");
+      console.log("[main] Power save blocker started (server busy)");
+    }
+  } else if (powerSaveBlockerId !== null) {
+    powerSaveBlocker.stop(powerSaveBlockerId);
+    powerSaveBlockerId = null;
+    console.log("[main] Power save blocker stopped (server idle)");
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Window creation
@@ -379,6 +468,30 @@ function registerIpcHandlers(): void {
     }
   });
 
+  // Renderer fallback: verify the server is up, silently restart if not.
+  ipcMain.handle("ensure-server-running", () => ensureServerRunning());
+
+  // Busy reporting: while any sender is busy, hold a power save blocker so
+  // the OS does not suspend the machine mid-turn. Refcounted per webContents
+  // and cleared on destroy so a crashed/closed renderer cannot leak the blocker.
+  ipcMain.handle("set-server-busy", (event, busy: boolean) => {
+    const id = event.sender.id;
+    if (busy) {
+      busySenders.add(id);
+      if (!busyCleanupRegistered.has(id)) {
+        busyCleanupRegistered.add(id);
+        event.sender.once("destroyed", () => {
+          busySenders.delete(id);
+          busyCleanupRegistered.delete(id);
+          updatePowerSaveBlocker();
+        });
+      }
+    } else {
+      busySenders.delete(id);
+    }
+    updatePowerSaveBlocker();
+  });
+
   // App version + auto-update controls
   ipcMain.handle("app:get-version", () => app.getVersion());
   ipcMain.handle("app:get-update-status", () => getUpdateStatus());
@@ -541,22 +654,15 @@ app.whenReady().then(async () => {
     setBeforeInstallHook(() => serverManager.forceReplace());
 
     // Show a Restart / Quit dialog if the server crashes unexpectedly
-    serverManager.onUnexpectedExit = async (code) => {
-      if (!mainWindow) return;
-      const { response } = await dialog.showMessageBox(mainWindow, {
-        type: "error",
-        title: "Server crashed",
-        message: `The Mcode server exited unexpectedly (code ${code ?? "unknown"}).`,
-        buttons: ["Restart", "Quit"],
-        defaultId: 0,
-        cancelId: 1,
-      });
-      if (response === 0) {
-        await serverManager.restart();
-      } else {
-        app.quit();
-      }
+    serverManager.onUnexpectedExit = (code) => {
+      void showServerCrashDialog(code);
     };
+
+    // Self-heal after sleep: the server's grace timer or the OS may have
+    // killed it while the machine was suspended.
+    powerMonitor.on("resume", () => {
+      void ensureServerRunning();
+    });
 
     // Register custom protocol for attachment files
     registerAttachmentProtocol();

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -11,6 +11,14 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   /** Get the WebSocket URL (with auth token) and IPC path for connecting to the server. */
   getServerUrl: (): Promise<{ url: string; ipcPath: string }> => ipcRenderer.invoke("get-server-url"),
 
+  /** Verify the server is reachable; the main process silently restarts it if not. */
+  ensureServerRunning: (): Promise<void> => ipcRenderer.invoke("ensure-server-running"),
+
+  /** Report whether this renderer considers the server busy (running turns / terminals).
+   * While any renderer is busy, the main process holds a power save blocker. */
+  setServerBusy: (busy: boolean): Promise<void> =>
+    ipcRenderer.invoke("set-server-busy", busy),
+
   /** Show a native open-directory dialog. Returns the selected path or null. */
   showOpenDialog: (opts: Record<string, unknown>): Promise<string | null> =>
     ipcRenderer.invoke("show-open-dialog", opts),

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -437,6 +437,23 @@ export class ServerManager {
   }
 
   /**
+   * Probe the server's /health endpoint once. Used by the self-healing
+   * resume path to decide whether a silent restart is needed; a short
+   * timeout keeps the post-sleep check from hanging on a dead socket.
+   */
+  async isHealthy(): Promise<boolean> {
+    if (!this._port) return false;
+    try {
+      const res = await fetch(`http://localhost:${this._port}/health`, {
+        signal: AbortSignal.timeout(3_000),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Force-replace the current server and start a fresh one.
    * Uses {@link forceReplace} to gracefully shut down the old server,
    * then waits briefly before spawning a new one.

--- a/apps/server/src/__tests__/grace-controller.test.ts
+++ b/apps/server/src/__tests__/grace-controller.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createGraceController } from "../grace-controller";
+
+const GRACE_MS = 10_000;
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn() };
+}
+
+describe("createGraceController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls shutdown after grace period when idle and no clock jump", () => {
+    let wallClock = 0;
+    const shutdown = vi.fn();
+    const sessionCount = vi.fn(() => 0);
+    const isBusy = vi.fn(() => false);
+    const now = () => wallClock;
+
+    const ctrl = createGraceController({
+      graceMs: GRACE_MS,
+      sessionCount,
+      isBusy,
+      shutdown,
+      logger: makeLogger(),
+      now,
+    });
+
+    ctrl.handleSessionChange(0); // arm
+
+    // Advance wall clock by exactly graceMs (within the 2x threshold).
+    wallClock += GRACE_MS;
+    vi.advanceTimersByTime(GRACE_MS);
+
+    expect(shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("cancels the timer when a session reconnects", () => {
+    const shutdown = vi.fn();
+    const ctrl = createGraceController({
+      graceMs: GRACE_MS,
+      sessionCount: vi.fn(() => 1),
+      isBusy: vi.fn(() => false),
+      shutdown,
+      logger: makeLogger(),
+    });
+
+    ctrl.handleSessionChange(0); // arm
+    ctrl.handleSessionChange(1); // cancel
+
+    vi.advanceTimersByTime(GRACE_MS * 2);
+
+    expect(shutdown).not.toHaveBeenCalled();
+  });
+
+  it("re-arms when busy on fire, then shuts down once idle", () => {
+    let wallClock = 0;
+    const shutdown = vi.fn();
+    const sessionCount = vi.fn(() => 0);
+    let busy = true;
+    const isBusy = vi.fn(() => busy);
+    const now = () => wallClock;
+
+    const ctrl = createGraceController({
+      graceMs: GRACE_MS,
+      sessionCount,
+      isBusy,
+      shutdown,
+      logger: makeLogger(),
+      now,
+    });
+
+    ctrl.handleSessionChange(0); // arm
+
+    // First fire — server is busy; should re-arm, not shut down.
+    wallClock += GRACE_MS;
+    vi.advanceTimersByTime(GRACE_MS);
+    expect(shutdown).not.toHaveBeenCalled();
+
+    // Second fire — server is now idle.
+    busy = false;
+    wallClock += GRACE_MS;
+    vi.advanceTimersByTime(GRACE_MS);
+    expect(shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("re-arms on clock jump (elapsed > graceMs * 2) instead of shutting down", () => {
+    let wallClock = 0;
+    const shutdown = vi.fn();
+    const sessionCount = vi.fn(() => 0);
+    const isBusy = vi.fn(() => false);
+    const now = () => wallClock;
+
+    const ctrl = createGraceController({
+      graceMs: GRACE_MS,
+      sessionCount,
+      isBusy,
+      shutdown,
+      logger: makeLogger(),
+      now,
+    });
+
+    ctrl.handleSessionChange(0); // arm
+
+    // Simulate machine sleeping: wall clock jumps far ahead while the JS
+    // timer fires only slightly past graceMs.
+    wallClock += GRACE_MS * 5; // large wall-clock jump
+    vi.advanceTimersByTime(GRACE_MS); // JS timer fires
+
+    // Should not shut down yet — re-armed for the full grace period.
+    expect(shutdown).not.toHaveBeenCalled();
+
+    // After re-arm, wall clock advances normally.
+    wallClock += GRACE_MS;
+    vi.advanceTimersByTime(GRACE_MS);
+
+    expect(shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("does not shut down when sessions reconnect between arm and fire", () => {
+    let sessions = 0;
+    const shutdown = vi.fn();
+    const ctrl = createGraceController({
+      graceMs: GRACE_MS,
+      sessionCount: () => sessions,
+      isBusy: vi.fn(() => false),
+      shutdown,
+      logger: makeLogger(),
+    });
+
+    ctrl.handleSessionChange(0); // arm
+
+    // A new session arrives before the timer fires.
+    sessions = 1;
+
+    vi.advanceTimersByTime(GRACE_MS);
+    expect(shutdown).not.toHaveBeenCalled();
+  });
+
+  it("dispose cancels a pending timer", () => {
+    const shutdown = vi.fn();
+    const ctrl = createGraceController({
+      graceMs: GRACE_MS,
+      sessionCount: vi.fn(() => 0),
+      isBusy: vi.fn(() => false),
+      shutdown,
+      logger: makeLogger(),
+    });
+
+    ctrl.handleSessionChange(0); // arm
+    ctrl.dispose();
+
+    vi.advanceTimersByTime(GRACE_MS * 2);
+    expect(shutdown).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/grace-controller.ts
+++ b/apps/server/src/grace-controller.ts
@@ -1,0 +1,144 @@
+/**
+ * Grace-period controller for server lifecycle management.
+ *
+ * Owns the shutdown-after-idle timer and guards against two failure modes:
+ * 1. Shutting down while work is still in progress (busy suppression).
+ * 2. Shutting down because the timer fired after the machine woke from sleep
+ *    (clock-jump detection via wall-clock elapsed vs. graceMs * 2).
+ */
+
+/** Logger subset used by the controller — avoids a hard dependency on a concrete logger. */
+export interface GraceLogger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/** Dependencies injected by the caller so the controller stays unit-testable. */
+export interface GraceDeps {
+  /** Grace period length in milliseconds. */
+  graceMs: number;
+  /** Returns the current number of active WebSocket sessions. */
+  sessionCount(): number;
+  /**
+   * Returns true when the server has in-flight work that must not be
+   * interrupted (active agent turns or running terminal sessions).
+   */
+  isBusy(): boolean;
+  /** Initiates a graceful server shutdown. */
+  shutdown(): void;
+  /** Logger for lifecycle events. */
+  logger: GraceLogger;
+  /**
+   * Wall-clock timestamp in milliseconds — defaults to Date.now().
+   * Injected in tests so fake timers control both setTimeout and elapsed time.
+   */
+  now?(): number;
+}
+
+/** Public interface returned by `createGraceController`. */
+export interface GraceController {
+  /**
+   * Called whenever the WebSocket session count changes.
+   * Arms the grace timer at zero, cancels it above zero.
+   */
+  handleSessionChange(count: number): void;
+  /**
+   * Cancels any pending timer. Call during shutdown so the timer does not
+   * fire after shutdown has already been initiated externally.
+   */
+  dispose(): void;
+}
+
+/**
+ * Creates a grace-period controller.
+ *
+ * The controller arms a countdown timer when all sessions disconnect. When
+ * the timer fires it checks three conditions before allowing shutdown:
+ *
+ * - Sessions have reconnected → clear and ignore.
+ * - Server is busy (agents or terminals) → re-arm and wait.
+ * - Wall-clock elapsed > graceMs * 2 → machine probably slept through the
+ *   countdown; re-arm so the full grace period runs from a clean wake.
+ *
+ * Only when none of those conditions hold does it invoke shutdown().
+ */
+export function createGraceController(deps: GraceDeps): GraceController {
+  const { graceMs, sessionCount, isBusy, shutdown, logger } = deps;
+  const now = deps.now ?? Date.now;
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  /** Wall-clock time at which the current timer was armed. */
+  let armedAt: number | null = null;
+
+  function arm(): void {
+    if (timer !== null) return; // already armed
+    armedAt = now();
+    timer = setTimeout(onFire, graceMs);
+    logger.info("Grace period armed", { graceMs });
+  }
+
+  function cancel(): void {
+    if (timer === null) return;
+    clearTimeout(timer);
+    timer = null;
+    armedAt = null;
+    logger.info("Grace period cancelled (session reconnected)");
+  }
+
+  function reArm(reason: string): void {
+    // Clear without logging the cancel message — we log the reason instead.
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    armedAt = now();
+    timer = setTimeout(onFire, graceMs);
+    logger.info("Grace period re-armed", { reason, graceMs });
+  }
+
+  function onFire(): void {
+    timer = null;
+
+    // A session reconnected between the arm and the fire.
+    if (sessionCount() > 0) {
+      armedAt = null;
+      logger.info("Grace period fired but sessions are active — ignoring");
+      return;
+    }
+
+    // Detect a clock jump: if wall-clock elapsed is more than twice graceMs
+    // the process almost certainly slept through the countdown. Re-arm so we
+    // give the full grace period starting from the wake moment.
+    const elapsed = now() - (armedAt ?? now());
+    if (elapsed > graceMs * 2) {
+      reArm("clock jump detected — machine may have slept");
+      return;
+    }
+
+    // An agent or terminal is still running. Re-arm and wait.
+    if (isBusy()) {
+      reArm("server is busy (active agents or terminals)");
+      return;
+    }
+
+    logger.info("Grace period expired — initiating shutdown");
+    shutdown();
+  }
+
+  return {
+    handleSessionChange(count: number): void {
+      if (count === 0 && timer === null) {
+        arm();
+      } else if (count > 0 && timer !== null) {
+        cancel();
+      }
+    },
+    dispose(): void {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+        armedAt = null;
+      }
+    },
+  };
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -57,6 +57,7 @@ import { DiffSummaryService } from "./services/diff-summary-service";
 import { HandoffStorage } from "./services/handoff/handoff-storage";
 import { WebSocket } from "ws";
 import { resolveGracePeriodMs } from "./grace-period-ms";
+import { createGraceController } from "./grace-controller";
 import { AgentEventType } from "@mcode/contracts";
 import type { AgentEvent } from "@mcode/contracts";
 import { normalizeAgentProviderError } from "./services/provider-agent-error-normalize.js";
@@ -564,31 +565,35 @@ function listen(port: number, attempt = 1): void {
   });
 }
 
-/** Timer handle for the active grace period, null when no grace period is running. */
-let graceTimer: ReturnType<typeof setTimeout> | null = null;
+/**
+ * Grace-period controller instance. Created in startServerAndSubscribe so it
+ * can close over the resolved services, and disposed in shutdown so a pending
+ * timer does not fire after an externally-triggered shutdown.
+ */
+let graceController: ReturnType<typeof createGraceController> | null = null;
 
 /** Start HTTP server and subscribe to session changes for grace period shutdown. */
 function startServerAndSubscribe(): void {
   listen(PREFERRED_PORT);
 
+  // isBusy guards against shutting down mid-turn or mid-terminal session.
+  // Both services are resolved from the container before this function is called.
+  const isBusy = () =>
+    agentService.activeCount() > 0 ||
+    terminalService.listActiveSessions().length > 0;
+
+  graceController = createGraceController({
+    graceMs: GRACE_PERIOD_MS,
+    sessionCount,
+    isBusy,
+    shutdown,
+    logger,
+  });
+
   // Subscribe to session changes after the server starts so the grace period
   // only activates once the server is ready to accept connections.
   onSessionChange((count) => {
-    if (count === 0 && !graceTimer) {
-      logger.info("All sessions disconnected, grace period started", {
-        graceMs: GRACE_PERIOD_MS,
-      });
-      graceTimer = setTimeout(() => {
-        if (sessionCount() === 0) {
-          logger.info("Grace period expired with zero sessions, shutdown initiated");
-          shutdown();
-        }
-      }, GRACE_PERIOD_MS);
-    } else if (count > 0 && graceTimer) {
-      logger.info("New session connected, grace period cancelled");
-      clearTimeout(graceTimer);
-      graceTimer = null;
-    }
+    graceController?.handleSessionChange(count);
   });
 }
 
@@ -619,11 +624,10 @@ ipcServer.listen(ipcPath).then(() => {
 async function shutdown(): Promise<void> {
   logger.info("Shutdown initiated");
 
-  // Clear any pending grace period timer
-  if (graceTimer) {
-    clearTimeout(graceTimer);
-    graceTimer = null;
-  }
+  // Disarm the grace-period controller so its timer does not fire after
+  // an externally-triggered shutdown (e.g. SIGTERM).
+  graceController?.dispose();
+  graceController = null;
 
   // 0. Close the MessagePort stream transport
   portPush.detach();

--- a/apps/web/src/__tests__/desktop-power.test.ts
+++ b/apps/web/src/__tests__/desktop-power.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { computeServerBusy } from "@/lib/desktop-power";
+import {
+  requestEnsureServerRunning,
+  resetEnsureServerThrottleForTest,
+} from "@/transport/ws-transport";
+
+describe("computeServerBusy", () => {
+  it("is idle with no running threads and no terminals", () => {
+    expect(computeServerBusy(new Set(), {})).toBe(false);
+  });
+
+  it("is busy when any agent turn is running", () => {
+    expect(computeServerBusy(new Set(["thread-1"]), {})).toBe(true);
+  });
+
+  it("is busy when any terminal session is open", () => {
+    expect(computeServerBusy(new Set(), { "thread-1": [{ id: "pty-1" }] })).toBe(true);
+  });
+
+  it("ignores threads whose terminal list is empty", () => {
+    expect(computeServerBusy(new Set(), { "thread-1": [] })).toBe(false);
+  });
+
+  it("is busy when both turns and terminals are active", () => {
+    expect(
+      computeServerBusy(new Set(["thread-1"]), { "thread-2": [{ id: "pty-1" }] }),
+    ).toBe(true);
+  });
+});
+
+describe("requestEnsureServerRunning throttle", () => {
+  let ensureMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resetEnsureServerThrottleForTest();
+    ensureMock = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { desktopBridge?: unknown }).desktopBridge = {
+      ensureServerRunning: ensureMock,
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { desktopBridge?: unknown }).desktopBridge;
+    resetEnsureServerThrottleForTest();
+  });
+
+  it("issues a request on the first call", () => {
+    expect(requestEnsureServerRunning(100_000)).toBe(true);
+    expect(ensureMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses calls within the 15s window", () => {
+    expect(requestEnsureServerRunning(100_000)).toBe(true);
+    expect(requestEnsureServerRunning(100_000 + 14_999)).toBe(false);
+    expect(ensureMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a new request after the window elapses", () => {
+    expect(requestEnsureServerRunning(100_000)).toBe(true);
+    expect(requestEnsureServerRunning(100_000 + 15_000)).toBe(true);
+    expect(ensureMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-ops without desktopBridge (browser builds) but still consumes the window", () => {
+    delete (window as unknown as { desktopBridge?: unknown }).desktopBridge;
+    expect(requestEnsureServerRunning(100_000)).toBe(true);
+    expect(ensureMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/desktop-power.ts
+++ b/apps/web/src/lib/desktop-power.ts
@@ -1,0 +1,79 @@
+/**
+ * Desktop power-state reporting.
+ *
+ * Derives a single "server busy" boolean from renderer state (running agent
+ * turns + open terminal sessions) and forwards changes to the Electron main
+ * process via `desktopBridge.setServerBusy`. While busy, the main process
+ * holds a power save blocker so the OS does not suspend the machine mid-turn.
+ *
+ * No-op in browser builds where `desktopBridge` is absent.
+ */
+
+import { useThreadStore } from "@/stores/threadStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+
+/** Trailing-edge debounce so rapid turn/terminal churn does not flap the blocker. */
+const BUSY_DEBOUNCE_MS = 1_000;
+
+/**
+ * Derive the busy flag from store snapshots: busy while any agent turn is
+ * running or any terminal session is open. Exported for unit testing.
+ */
+export function computeServerBusy(
+  runningThreadIds: ReadonlySet<string>,
+  terminals: Record<string, readonly unknown[]>,
+): boolean {
+  if (runningThreadIds.size > 0) return true;
+  for (const instances of Object.values(terminals)) {
+    if (instances.length > 0) return true;
+  }
+  return false;
+}
+
+let initialized = false;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let lastSent: boolean | null = null;
+
+/** Read the current busy state from the live stores. */
+function currentBusy(): boolean {
+  return computeServerBusy(
+    useThreadStore.getState().runningThreadIds,
+    useTerminalStore.getState().terminals,
+  );
+}
+
+/** Push the busy flag to the main process if it changed since the last send. */
+function sendIfChanged(): void {
+  const busy = currentBusy();
+  if (busy === lastSent) return;
+  lastSent = busy;
+  void window.desktopBridge?.setServerBusy?.(busy)?.catch(() => {
+    // Best-effort: a failed IPC call only means the blocker state lags.
+  });
+}
+
+/**
+ * Start reporting server-busy state to the desktop main process.
+ * Call once at app bootstrap; subsequent calls are no-ops. Does nothing in
+ * browser builds (no `desktopBridge`).
+ */
+export function initDesktopPowerReporting(): void {
+  if (initialized) return;
+  if (typeof window === "undefined" || !window.desktopBridge?.setServerBusy) return;
+  initialized = true;
+
+  const scheduleUpdate = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      sendIfChanged();
+    }, BUSY_DEBOUNCE_MS);
+  };
+
+  useThreadStore.subscribe(scheduleUpdate);
+  useTerminalStore.subscribe(scheduleUpdate);
+
+  // Report the initial state immediately (no debounce) so a reload during a
+  // running turn re-acquires the blocker without a one-second gap.
+  sendIfChanged();
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app/App";
 import { initTransport } from "./transport";
+import { initDesktopPowerReporting } from "./lib/desktop-power";
 import "./index.css";
 
 /** Render an error fallback when transport initialization fails. */
@@ -64,6 +65,9 @@ renderConnecting(root);
 
 initTransport()
   .then(() => {
+    // Desktop only: report running turns / open terminals to the main
+    // process so it can hold a power save blocker while the server is busy.
+    initDesktopPowerReporting();
     root.innerHTML = "";
     createRoot(root).render(
       <StrictMode>

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -243,6 +243,19 @@ interface SpellcheckBridge {
 interface DesktopBridge {
   /** Return the URL and IPC path of the local mcode server. */
   getServerUrl(): Promise<{ url: string; ipcPath: string }>;
+  /**
+   * Verify the server is reachable; the main process silently restarts it if
+   * not. Optional: older desktop builds may not expose it, so call sites use
+   * optional chaining.
+   */
+  ensureServerRunning?(): Promise<void>;
+  /**
+   * Report whether this renderer considers the server busy (running turns or
+   * terminals). While any renderer is busy the main process holds a power
+   * save blocker so the OS does not suspend mid-turn. Optional: older desktop
+   * builds may not expose it.
+   */
+  setServerBusy?(busy: boolean): Promise<void>;
   /** Open a native folder-picker dialog. Returns the selected path or null. */
   showOpenDialog(options: { title?: string }): Promise<string | null>;
   /** Open a URL in the default browser. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -44,6 +44,33 @@ const lastLoadThreadsAtByWorkspace = new Map<string, number>();
 /** Minimum interval between reconnect-triggered thread-list fetches to avoid rapid-reconnect storms. */
 const LOAD_THREADS_RECONNECT_COOLDOWN_MS = 5_000;
 
+/** Minimum interval between desktop ensure-server-running requests. */
+const ENSURE_SERVER_THROTTLE_MS = 15_000;
+/** Timestamp of the last ensure-server-running request (module-level: one server per app). */
+let lastEnsureServerAt = 0;
+
+/**
+ * Ask the Electron main process to verify (and silently restart) the server.
+ * Throttled so rapid reconnect attempts do not stack health checks. No-op in
+ * browser builds where `desktopBridge` is absent.
+ *
+ * Returns whether a request was actually issued. Exported for unit testing.
+ */
+export function requestEnsureServerRunning(now: number = Date.now()): boolean {
+  if (now - lastEnsureServerAt < ENSURE_SERVER_THROTTLE_MS) return false;
+  lastEnsureServerAt = now;
+  if (typeof window === "undefined") return false;
+  void window.desktopBridge?.ensureServerRunning?.()?.catch(() => {
+    // Best-effort: reconnect backoff continues regardless.
+  });
+  return true;
+}
+
+/** Reset the ensure-server throttle. Test-only. */
+export function resetEnsureServerThrottleForTest(): void {
+  lastEnsureServerAt = 0;
+}
+
 type Listener = (data: unknown) => void;
 
 /**
@@ -336,6 +363,13 @@ export function createWsTransport(
 
   function scheduleReconnect(immediate = false) {
     if (reconnectTimer) return;
+
+    // Non-auth disconnects may mean the server died (e.g. killed during OS
+    // sleep). Ask the desktop main process to health-check and self-heal it;
+    // throttled so backoff retries do not stack requests.
+    if (!immediate) {
+      requestEnsureServerRunning();
+    }
 
     // Auth failures use immediate reconnect (delay=0) for the first
     // MAX_IMMEDIATE_AUTH_RETRIES attempts, then fall back to normal backoff


### PR DESCRIPTION
## What
Makes the server lifecycle resilient to system sleep: the server no longer shuts down while agents or terminals are running, the machine stays awake during agent work, and a dead server is restarted silently instead of leaving the frontend reconnecting forever.

## Why
Unplugging or sleeping the machine mid-turn killed the server. The grace period only counted connected WebSocket sessions, so when sleep dropped the renderer connection the server shut itself down even with agents running. On wake, nothing respawned it: the web client polled a dead port and the crash dialog never fired because the shutdown was "clean".

## Key Changes
- **Server:** new grace controller gates the shutdown countdown on the server being idle (no active agent turns, no running terminals). When the timer fires it re-arms if the server is busy, or if wall-clock drift shows the process slept through the countdown (the resume race). Unit tested.
- **Desktop:** holds `powerSaveBlocker("prevent-app-suspension")` while any renderer reports the server busy, so the machine does not suspend mid-work. On `powerMonitor.resume` or renderer request it health-checks the server and silently restarts it if dead; three silent restarts within a minute escalate to the existing crash dialog.
- **Web:** derives busy from running threads and open terminals and reports it over a new `desktopBridge.setServerBusy` IPC. While WebSocket reconnects keep failing it calls `desktopBridge.ensureServerRunning` (throttled to once per 15s). Both are no-ops in browser builds.
- **Docs:** "Grace period" and "Busy (server)" added to the CONTEXT.md glossary.

Out of scope: recovering provider turns frozen by a sleep that happens anyway (for example battery-critical). The turn may fail; this PR guarantees the server itself comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783765994&installation_id=129163861&pr_number=697&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F697&signature=bc577bc109db575dd8b8ad055fcfd6bbc3d13bcab8b97e7d7239e3ce32abaa05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic power-save blocking prevents app suspension while work is running on the server.
  * Server health monitoring automatically attempts recovery after unexpected disconnections.

* **Bug Fixes**
  * Improved server crash recovery with clearer user feedback and restart options.
  * Enhanced graceful shutdown behavior for better server lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->