### PR TITLE
feat: stream Codex tool lifecycle starts

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
@@ -51,13 +51,210 @@ describe("CodexEventMapper", () => {
     });
   });
 
-  it("returns empty array for item/started non-collab", () => {
+  it("emits running toolUse for item/started commandExecution", () => {
     const events = mapper.mapNotification({
       jsonrpc: "2.0",
       method: "item/started",
       params: { item: { type: "commandExecution", id: "x" } },
     });
-    expect(events).toEqual([]);
+    expect(events).toEqual([
+      {
+        type: "toolUse",
+        threadId: "test-thread",
+        toolCallId: "x",
+        toolName: "command_execution",
+        toolInput: {},
+      },
+    ]);
+  });
+
+  it("emits live command start, enriched command use, then command result", () => {
+    const started = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: { item: { type: "commandExecution", id: "cmd-live" } },
+    });
+    const completed = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          type: "commandExecution",
+          id: "cmd-live",
+          command: "echo hi",
+          aggregatedOutput: "hi\n",
+          exitCode: 0,
+        },
+      },
+    });
+
+    expect(started).toEqual([
+      {
+        type: "toolUse",
+        threadId: "test-thread",
+        toolCallId: "cmd-live",
+        toolName: "command_execution",
+        toolInput: {},
+      },
+    ]);
+    expect(completed).toEqual([
+      {
+        type: "toolUse",
+        threadId: "test-thread",
+        toolCallId: "cmd-live",
+        toolName: "command_execution",
+        toolInput: { command: "echo hi" },
+      },
+      {
+        type: "toolResult",
+        threadId: "test-thread",
+        toolCallId: "cmd-live",
+        output: "hi\n",
+        isError: false,
+      },
+    ]);
+  });
+
+  it("emits only toolResult at completion when command start already had full details", () => {
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: { item: { type: "commandExecution", id: "cmd-known", command: "echo hi" } },
+    });
+
+    const completed = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          type: "commandExecution",
+          id: "cmd-known",
+          command: "echo hi",
+          aggregatedOutput: "hi\n",
+          exitCode: 0,
+        },
+      },
+    });
+
+    expect(completed).toEqual([
+      {
+        type: "toolResult",
+        threadId: "test-thread",
+        toolCallId: "cmd-known",
+        output: "hi\n",
+        isError: false,
+      },
+    ]);
+  });
+
+  it("enriches sparse mcpToolCall start from completion details", () => {
+    const started = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: { item: { type: "mcpToolCall", id: "mcp-live" } },
+    });
+    const completed = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          type: "mcpToolCall",
+          id: "mcp-live",
+          server: "filesystem",
+          tool: "read_file",
+          arguments: JSON.stringify({ path: "README.md" }),
+          result: "contents",
+        },
+      },
+    });
+
+    expect(started).toEqual([
+      {
+        type: "toolUse",
+        threadId: "test-thread",
+        toolCallId: "mcp-live",
+        toolName: "mcp:/unknown",
+        toolInput: {},
+      },
+    ]);
+    expect(completed[0]).toEqual({
+      type: "toolUse",
+      threadId: "test-thread",
+      toolCallId: "mcp-live",
+      toolName: "mcp:filesystem/read_file",
+      toolInput: { path: "README.md" },
+    });
+    expect(completed[1]).toEqual({
+      type: "toolResult",
+      threadId: "test-thread",
+      toolCallId: "mcp-live",
+      output: "contents",
+      isError: false,
+    });
+  });
+
+  it("keeps completed-only commandExecution fallback when no item/started arrived", () => {
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          type: "commandExecution",
+          id: "cmd-fallback",
+          command: "pwd",
+          aggregatedOutput: "/repo\n",
+          exitCode: 0,
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        type: "toolUse",
+        threadId: "test-thread",
+        toolCallId: "cmd-fallback",
+        toolName: "command_execution",
+        toolInput: { command: "pwd" },
+      },
+      {
+        type: "toolResult",
+        threadId: "test-thread",
+        toolCallId: "cmd-fallback",
+        output: "/repo\n",
+        isError: false,
+      },
+    ]);
+  });
+
+  it("classifies text after completed-only commandExecution as final response", () => {
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          type: "commandExecution",
+          id: "cmd-fallback",
+          command: "pwd",
+          aggregatedOutput: "/repo\n",
+          exitCode: 0,
+        },
+      },
+    });
+
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { delta: "Done" },
+    });
+
+    expect(events).toEqual([
+      {
+        type: "textDelta",
+        threadId: "test-thread",
+        delta: "Done",
+        isFinalResponse: true,
+      },
+    ]);
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -32,6 +32,10 @@ const SILENT_ITEM_TYPES = new Set([
  * Handles the actual notification protocol from codex app-server >= 0.104.0.
  * Source: codex-rs/app-server-protocol/schema/typescript/ServerNotification.ts
  *
+ * Tool lifecycle: `item/started` emits a running tool row when Codex gives us
+ * a stable item id, even if the payload is sparse. `item/completed` enriches
+ * that row with full input details and emits the matching result.
+ *
  * Subagent nesting: `item/started` for `collabAgentToolCall` emits the `Agent` tool row early.
  * Child tools on the parent thread use `collabScopeStack` (single open collab only; parallel
  * collabs omit stack peek to avoid mis-attribution). Child tools on Codex receiver threads
@@ -57,6 +61,8 @@ export class CodexEventMapper {
   private readonly threadId: string;
   /** Per-item streaming command output buffers, keyed by itemId. */
   private readonly commandOutputBuffers = new Map<string, string>();
+  /** Start-time ToolUse signatures, so completion enrichment only emits when details changed. */
+  private readonly startedToolUseSignatures = new Map<string, string>();
   /** Open tool-like items keyed by id. Mirrors Claude/Cursor `pendingToolUses` for thought-vs-final classification. */
   private readonly pendingToolItems = new Set<string>();
   /** True once any tool-like item has fired this turn. Distinguishes pre-tool preamble from post-tool final reply. */
@@ -179,6 +185,97 @@ export class CodexEventMapper {
     };
   }
 
+  /** Parses Codex tool arguments without dropping malformed input. */
+  private parseToolArguments(args: CompletedItem["arguments"]): Record<string, unknown> {
+    if (typeof args === "string") {
+      try { return JSON.parse(args) as Record<string, unknown>; }
+      catch { return { arguments: args }; }
+    }
+    if (args && typeof args === "object") return args as Record<string, unknown>;
+    return {};
+  }
+
+  /** Builds the running `ToolUse` row for non-Agent Codex tool-like items. */
+  private buildToolUseEvent(
+    item: CompletedItem,
+    toolCallId: string,
+    notification?: CodexNotification,
+  ): AgentEvent | undefined {
+    const itemType = item.type;
+    const nestParent = this.nestingParentToolCallId(notification);
+
+    if (itemType === "function_call") {
+      return {
+        type: AgentEventType.ToolUse,
+        threadId: this.threadId,
+        toolCallId,
+        toolName: typeof item.name === "string" ? item.name : "function",
+        toolInput: this.parseToolArguments(item.arguments),
+        ...(nestParent ? { parentToolCallId: nestParent } : {}),
+      };
+    }
+
+    if (itemType === "commandExecution") {
+      return {
+        type: AgentEventType.ToolUse,
+        threadId: this.threadId,
+        toolCallId,
+        toolName: "command_execution",
+        toolInput: typeof item.command === "string" && item.command.length > 0
+          ? { command: item.command }
+          : {},
+        ...(nestParent ? { parentToolCallId: nestParent } : {}),
+      };
+    }
+
+    if (itemType === "fileChange") {
+      const changes = Array.isArray(item.changes) ? item.changes : [];
+      const paths = changes.map((c) => c.path).filter(Boolean).join(", ");
+      return {
+        type: AgentEventType.ToolUse,
+        threadId: this.threadId,
+        toolCallId,
+        toolName: "file_change",
+        toolInput: paths.length > 0 ? { files: paths } : {},
+        ...(nestParent ? { parentToolCallId: nestParent } : {}),
+      };
+    }
+
+    if (itemType === "mcpToolCall" || itemType === "dynamicToolCall") {
+      const toolName = itemType === "mcpToolCall"
+        ? `mcp:${item.server ?? ""}/${item.tool ?? item.name ?? "unknown"}`
+        : (item.name ?? "dynamic_tool");
+      return {
+        type: AgentEventType.ToolUse,
+        threadId: this.threadId,
+        toolCallId,
+        toolName,
+        toolInput: this.parseToolArguments(item.arguments),
+        ...(nestParent ? { parentToolCallId: nestParent } : {}),
+      };
+    }
+
+    return undefined;
+  }
+
+  /** Stable enough for same-turn start/completion enrichment checks. */
+  private toolUseSignature(event: AgentEvent): string {
+    if (event.type !== AgentEventType.ToolUse) return "";
+    return JSON.stringify({
+      toolName: event.toolName,
+      toolInput: event.toolInput,
+      parentToolCallId: event.parentToolCallId ?? null,
+    });
+  }
+
+  /** Returns true when completion has new ToolUse details worth broadcasting. */
+  private shouldEmitCompletionToolUse(toolCallId: string, event: AgentEvent | undefined): event is AgentEvent {
+    if (!event) return false;
+    const started = this.startedToolUseSignatures.get(toolCallId);
+    this.startedToolUseSignatures.delete(toolCallId);
+    return started == null || started !== this.toolUseSignature(event);
+  }
+
   /**
    * Translates a single `CodexNotification` into zero or more `AgentEvent` objects.
    * Returns an empty array for silently consumed notification types.
@@ -225,6 +322,13 @@ export class CodexEventMapper {
         this.collabToolUseFromStartIds.add(itemId);
         this.registerCollabReceiverThreads(itemId, item as CompletedItem);
         return [this.buildCollabToolUseEvent(item as CompletedItem, itemId)];
+      }
+      if (itemType && itemId && TOOL_LIKE_ITEM_TYPES.has(itemType) && itemType !== "webSearch") {
+        const toolUse = this.buildToolUseEvent(item as CompletedItem, itemId, notification);
+        if (toolUse) {
+          this.startedToolUseSignatures.set(itemId, this.toolUseSignature(toolUse));
+          return [toolUse];
+        }
       }
       logger.debug("Codex lifecycle notification", { method, itemType });
       return [];
@@ -303,8 +407,11 @@ export class CodexEventMapper {
       const completedItem = notification.params.item;
       const completedType = completedItem?.type;
       const completedId = typeof completedItem?.id === "string" ? completedItem.id : undefined;
-      if (completedType && completedId && TOOL_LIKE_ITEM_TYPES.has(completedType)) {
-        this.pendingToolItems.delete(completedId);
+      if (completedType && TOOL_LIKE_ITEM_TYPES.has(completedType)) {
+        this.hasFiredToolThisTurn = true;
+        if (completedId) {
+          this.pendingToolItems.delete(completedId);
+        }
       }
       logger.debug("Codex item/completed", { type: completedType });
       return this.mapItemCompleted(completedItem, notification);
@@ -386,6 +493,7 @@ export class CodexEventMapper {
     this.assistantFinalText = "";
     this.lastReasoningText = "";
     this.commandOutputBuffers.clear();
+    this.startedToolUseSignatures.clear();
     this.collabScopeStack = [];
     this.collabToolUseFromStartIds.clear();
     this.pendingLegacyCollabPops.clear();
@@ -477,23 +585,7 @@ export class CodexEventMapper {
     // OpenAI Responses API shape - function_call items carry tool invocations
     if (itemType === "function_call") {
       const toolCallId = item.id ?? `fc-${randomUUID()}`;
-      let toolInput: Record<string, unknown> = {};
-      if (typeof item.arguments === "string") {
-        try { toolInput = JSON.parse(item.arguments) as Record<string, unknown>; }
-        catch { toolInput = { arguments: item.arguments }; }
-      } else if (item.arguments && typeof item.arguments === "object") {
-        toolInput = item.arguments as Record<string, unknown>;
-      }
-      const toolName = typeof item.name === "string" ? item.name : "function";
-      const nestParent = this.nestingParentToolCallId(notification);
-      const toolUseEvent: AgentEvent = {
-        type: AgentEventType.ToolUse,
-        threadId,
-        toolCallId,
-        toolName,
-        toolInput,
-        ...(nestParent ? { parentToolCallId: nestParent } : {}),
-      };
+      const toolUseEvent = this.buildToolUseEvent(item, toolCallId, notification);
       const toolResultEvent: AgentEvent = {
         type: AgentEventType.ToolResult,
         threadId,
@@ -501,7 +593,9 @@ export class CodexEventMapper {
         output: typeof item.output === "string" ? item.output : "",
         isError: false,
       };
-      return [toolUseEvent, toolResultEvent];
+      return this.shouldEmitCompletionToolUse(toolCallId, toolUseEvent)
+        ? [toolUseEvent, toolResultEvent]
+        : [toolResultEvent];
     }
 
     if (itemType === "commandExecution") {
@@ -525,15 +619,7 @@ export class CodexEventMapper {
       const output = bufferedOutput || textOut;
       this.commandOutputBuffers.delete(toolCallId);
 
-      const nestParent = this.nestingParentToolCallId(notification);
-      const toolUseEvent: AgentEvent = {
-        type: AgentEventType.ToolUse,
-        threadId,
-        toolCallId,
-        toolName: "command_execution",
-        toolInput: { command: item.command ?? "" },
-        ...(nestParent ? { parentToolCallId: nestParent } : {}),
-      };
+      const toolUseEvent = this.buildToolUseEvent(item, toolCallId, notification);
       const toolResultEvent: AgentEvent = {
         type: AgentEventType.ToolResult,
         threadId,
@@ -541,22 +627,16 @@ export class CodexEventMapper {
         output,
         isError: item.exitCode != null && item.exitCode !== 0,
       };
-      return [toolUseEvent, toolResultEvent];
+      return this.shouldEmitCompletionToolUse(toolCallId, toolUseEvent)
+        ? [toolUseEvent, toolResultEvent]
+        : [toolResultEvent];
     }
 
     if (itemType === "fileChange") {
       const toolCallId = item.id ?? `fchg-${randomUUID()}`;
       const changes = item.changes ?? [];
       const paths = changes.map((c) => c.path).join(", ");
-      const nestParent = this.nestingParentToolCallId(notification);
-      const toolUseEvent: AgentEvent = {
-        type: AgentEventType.ToolUse,
-        threadId,
-        toolCallId,
-        toolName: "file_change",
-        toolInput: { files: paths },
-        ...(nestParent ? { parentToolCallId: nestParent } : {}),
-      };
+      const toolUseEvent = this.buildToolUseEvent(item, toolCallId, notification);
       const toolResultEvent: AgentEvent = {
         type: AgentEventType.ToolResult,
         threadId,
@@ -564,7 +644,9 @@ export class CodexEventMapper {
         output: paths,
         isError: false,
       };
-      return [toolUseEvent, toolResultEvent];
+      return this.shouldEmitCompletionToolUse(toolCallId, toolUseEvent)
+        ? [toolUseEvent, toolResultEvent]
+        : [toolResultEvent];
     }
 
     if (itemType === "collabAgentToolCall") {
@@ -611,25 +693,7 @@ export class CodexEventMapper {
 
     if (itemType === "mcpToolCall" || itemType === "dynamicToolCall") {
       const toolCallId = item.id ?? `mcp-${randomUUID()}`;
-      let toolInput: Record<string, unknown> = {};
-      if (typeof item.arguments === "string") {
-        try { toolInput = JSON.parse(item.arguments) as Record<string, unknown>; }
-        catch { toolInput = { arguments: item.arguments }; }
-      } else if (item.arguments && typeof item.arguments === "object") {
-        toolInput = item.arguments as Record<string, unknown>;
-      }
-      const toolName = itemType === "mcpToolCall"
-        ? `mcp:${item.server ?? ""}/${item.tool ?? item.name ?? "unknown"}`
-        : (item.name ?? "dynamic_tool");
-      const nestParent = this.nestingParentToolCallId(notification);
-      const toolUseEvent: AgentEvent = {
-        type: AgentEventType.ToolUse,
-        threadId,
-        toolCallId,
-        toolName,
-        toolInput,
-        ...(nestParent ? { parentToolCallId: nestParent } : {}),
-      };
+      const toolUseEvent = this.buildToolUseEvent(item, toolCallId, notification);
       const toolResultEvent: AgentEvent = {
         type: AgentEventType.ToolResult,
         threadId,
@@ -637,7 +701,9 @@ export class CodexEventMapper {
         output: String(item.error ?? item.result ?? ""),
         isError: !!item.error,
       };
-      return [toolUseEvent, toolResultEvent];
+      return this.shouldEmitCompletionToolUse(toolCallId, toolUseEvent)
+        ? [toolUseEvent, toolResultEvent]
+        : [toolResultEvent];
     }
 
     if (SILENT_ITEM_TYPES.has(itemType)) {

--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -258,6 +258,25 @@ describe("NarrativeStore write seam (server-side traps)", () => {
       store.clearTurn(THREAD);
       expect(store.getBufferedToolCalls(THREAD)).toHaveLength(0);
     });
+
+    it("merges sparse duplicate ToolUse details without adding a second row", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, {
+        toolCallId: "cmd-1",
+        toolName: "command_execution",
+        toolInput: {},
+      });
+      store.bufferToolCall(THREAD, {
+        toolCallId: "cmd-1",
+        toolName: "command_execution",
+        toolInput: { command: "echo hi" },
+      });
+
+      const calls = store.getBufferedToolCalls(THREAD);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]._rawToolInput).toEqual({ command: "echo hi" });
+    });
   });
 
   describe("Classification precedence + is_final_response safety net", () => {

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -309,7 +309,6 @@ export class NarrativeStore {
    */
   bufferToolCall(threadId: string, event: BufferToolCallEvent): string | undefined {
     const buffer = this.turnToolCalls.get(threadId) ?? [];
-    const sortOrder = this.nextSortOrder(threadId);
 
     const stack = this.agentCallStack.get(threadId) ?? [];
     // Prefer the SDK-provided parent_tool_use_id on the event (set by the
@@ -331,6 +330,30 @@ export class NarrativeStore {
         source: event.parentToolCallId ? "sdk" : "stack-fallback",
       });
     }
+
+    const existing = buffer.find((tc) => tc.toolCallId === event.toolCallId);
+    if (existing) {
+      const shouldMergeDuplicate =
+        existing.status === "running"
+        && (
+          Object.keys(existing._rawToolInput ?? {}).length === 0
+          || existing.toolName !== event.toolName
+          || (existing.toolName === "Agent" && event.toolName === "Agent")
+        );
+      if (shouldMergeDuplicate) {
+        existing.toolName = event.toolName;
+        existing._rawToolInput = {
+          ...(existing._rawToolInput ?? {}),
+          ...event.toolInput,
+        };
+        if (parentToolCallId && !existing.parentToolCallId) {
+          existing.parentToolCallId = parentToolCallId;
+        }
+      }
+      return existing.parentToolCallId;
+    }
+
+    const sortOrder = this.nextSortOrder(threadId);
     if (event.toolName === "Agent") {
       stack.push(event.toolCallId);
       this.agentCallStack.set(threadId, stack);

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -11,6 +11,7 @@ import { countActiveSubagentCalls, useThreadStore } from "@/stores/threadStore";
 import { mockTransport, createMockThread } from "./mocks/transport";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useToastStore } from "@/stores/toastStore";
+import { useTaskStore } from "@/stores/taskStore";
 
 vi.mock("@/transport", async () => ({
   ...(await vi.importActual("@/transport")),
@@ -24,6 +25,7 @@ describe("handleAgentEvent branches", () => {
       activeThreadId: "thread-1",
       threads: [createMockThread({ id: "thread-1" })],
     });
+    useTaskStore.setState({ tasksByThread: {} });
     resetThreadStoreForTests({
       currentThreadId: "thread-1",
       runningThreadIds: new Set(["thread-1"]),
@@ -153,6 +155,45 @@ describe("handleAgentEvent branches", () => {
       model: "composer-2.5-fast",
     });
     expect(calls[0].isComplete).toBe(false);
+  });
+
+  it("session.toolUse updates tasks when duplicate TodoWrite enriches sparse input", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "todo-1",
+        toolName: "TodoWrite",
+        toolInput: {},
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "todo-1",
+        toolName: "TodoWrite",
+        toolInput: {
+          todos: [
+            { id: "a", content: "Run mapper tests", status: "in_progress" },
+          ],
+        },
+      },
+    });
+
+    const calls = getTestThreadToolCalls("thread-1");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].toolInput).toEqual({
+      todos: [
+        { id: "a", content: "Run mapper tests", status: "in_progress" },
+      ],
+    });
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "a",
+        content: "Run mapper tests",
+        status: "in_progress",
+        group: "Tasks",
+      },
+    ]);
   });
 
   it("toolResult fallback does not mark an Agent call complete when it has active children", () => {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1470,30 +1470,58 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const existingCalls = getRec(threadId).toolCalls;
       const toolName = (params.toolName as string) || "unknown";
       const incomingInput = (params.toolInput as Record<string, unknown>) || {};
+      const parentToolCallId = params.parentToolCallId as string | undefined;
+      const applyTodoWriteTasks = (toolInput: Record<string, unknown>) => {
+        if (toolName !== "TodoWrite") return;
+        const todos = toolInput.todos as Array<Record<string, unknown>> | undefined;
+        if (!todos || !Array.isArray(todos)) return;
+
+        const group = parentToolCallId
+          ? resolveAgentGroupLabel(existingCalls, parentToolCallId)
+          : "Tasks";
+
+        const taskItems: TaskItem[] = todos.map((t, i) => ({
+          id: t.id != null ? String(t.id) : String(i),
+          content: String(t.content ?? ""),
+          status: coerceTaskStatus(t.status),
+          group,
+        }));
+
+        useTaskStore.getState().setTaskGroup(threadId, group, taskItems);
+      };
       if (toolCallId) {
         const existing = existingCalls.find((tc) => tc.id === toolCallId);
         if (existing) {
-          // Cursor Task: provisional ToolUse on tool_call, enriched ToolUse on cursor/task.
-          if (
-            !existing.isComplete &&
-            existing.toolName === "Agent" &&
-            toolName === "Agent"
-          ) {
+          // Providers may emit a sparse running ToolUse first, then a richer
+          // ToolUse with the same id when the completion payload arrives.
+          const shouldMergeDuplicate =
+            !existing.isComplete
+            && (
+              Object.keys(existing.toolInput ?? {}).length === 0
+              || existing.toolName !== toolName
+              || (existing.toolName === "Agent" && toolName === "Agent")
+            );
+          if (shouldMergeDuplicate) {
+            const mergedInput = { ...existing.toolInput, ...incomingInput };
             set((state) => {
               const calls = getThreadRecord(state.records, threadId).toolCalls;
               const updated = calls.map((tc) =>
                 tc.id === toolCallId
-                  ? { ...tc, toolInput: { ...tc.toolInput, ...incomingInput } }
+                  ? {
+                      ...tc,
+                      toolName,
+                      toolInput: mergedInput,
+                      parentToolCallId: tc.parentToolCallId ?? parentToolCallId,
+                    }
                   : tc,
               );
               return { records: patchThreadRecord(state.records, threadId, { toolCalls: updated }) };
             });
+            applyTodoWriteTasks(mergedInput);
           }
           return;
         }
       }
-
-      const parentToolCallId = params.parentToolCallId as string | undefined;
 
       // Only mark prior tool calls complete if this isn't a subagent's tool call
       // (subagent calls should not mark the parent Agent call as complete)
@@ -1503,26 +1531,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Intercept TodoWrite calls to populate the task panel.
       // Sub-agent calls are grouped by their parent Agent's description so
       // multiple sub-agents each get their own collapsible section.
-      if (toolName === "TodoWrite") {
-        const toolInput = (params.toolInput as Record<string, unknown>) || {};
-        const todos = toolInput.todos as Array<Record<string, unknown>> | undefined;
-        if (todos && Array.isArray(todos)) {
-          const group = parentToolCallId
-            ? resolveAgentGroupLabel(existingCalls, parentToolCallId)
-            : "Tasks";
-
-          const taskItems: TaskItem[] = todos.map((t, i) => ({
-            id: t.id != null ? String(t.id) : String(i),
-            content: String(t.content ?? ""),
-            status: coerceTaskStatus(t.status),
-            group,
-          }));
-
-          // Always merge by group so sub-agent groups are never wiped out
-          // by a top-level TodoWrite call (or vice versa).
-          useTaskStore.getState().setTaskGroup(threadId, group, taskItems);
-        }
-      }
+      applyTodoWriteTasks(incomingInput);
 
       const toolCall: ToolCall = {
         id: toolCallId || crypto.randomUUID(),


### PR DESCRIPTION
## What
Adds live Codex tool lifecycle events for command execution, file changes, MCP tools, dynamic tools, and function calls.

## Why
Codex can send `item/started` before full item details are available. Showing that start event gives long-running work a visible running row, then fills in command text, file paths, tool names, and output when completion arrives.

## Key Changes
- Map non-Agent Codex `item/started` payloads to running `ToolUse` rows.
- Enrich sparse started rows from `item/completed`, then complete them with `ToolResult`.
- Keep completed-only mapping for Codex items that never send `item/started`.
- Merge sparse duplicate `ToolUse` rows in server and client state, including TodoWrite task updates.
- Add mapper, narrative buffer, and client store tests for start/complete pairing, sparse enrichment, fallback mapping, and duplicate merging.

Closes #691

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783768884&installation_id=129163861&pr_number=703&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F703&signature=999d2591f0e1135980390b28a83071539bea17a503abd20e36fca390805f88e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tool call events now deduplicate automatically when the same tool ID appears multiple times, eliminating redundant tool rows from display
  * Command execution and advanced tool integrations receive improved event enrichment with better argument parsing and handling
  * TodoWrite task operations consolidate duplicate entries and intelligently merge task information for cleaner task management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->