### PR TITLE
fix: scope codex notifications by thread

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
@@ -824,6 +824,213 @@ describe("CodexEventMapper", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Thread-scoped routing
+  // ---------------------------------------------------------------------------
+
+  it("treats notifications with no thread id as main-thread notifications", () => {
+    mapper = new CodexEventMapper("test-thread", "main-codex-thread");
+
+    const delta = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { delta: "main text" },
+    });
+    const completed = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { turn: { status: "completed" } },
+    });
+
+    expect(delta).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "main text" }]);
+    expect(completed.some((event) => event.type === "turnComplete")).toBe(true);
+  });
+
+  it("drops unknown-thread notifications before they mutate main turn state", async () => {
+    const { logger } = await import("@mcode/shared");
+    mapper = new CodexEventMapper("test-thread", "main-codex-thread");
+
+    const unknown = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "stray-thread",
+        item: { type: "commandExecution", id: "cmd-stray", command: "pwd", aggregatedOutput: "x", exitCode: 0 },
+      },
+    });
+    const main = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "main-codex-thread", turn: { status: "completed" } },
+    });
+
+    expect(unknown).toEqual([]);
+    expect(main).toHaveLength(1);
+    expect(main[0]).toMatchObject({ type: "turnComplete" });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "CodexEventMapper: dropping unknown-thread notification",
+      expect.objectContaining({ method: "item/completed", notificationThreadId: "stray-thread" }),
+    );
+  });
+
+  it("consumes child-thread text and reasoning without adding it to the main final reply", () => {
+    mapper = new CodexEventMapper("test-thread", "main-codex-thread");
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId: "main-codex-thread",
+        item: { type: "collabAgentToolCall", id: "collab-a", tool: "spawnAgent" },
+      },
+    });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "main-codex-thread",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-a",
+          tool: "spawnAgent",
+          receiverThreadIds: ["child-thread"],
+          result: "done",
+        },
+      },
+    });
+
+    const childText = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { threadId: "child-thread", delta: "child private text" },
+    });
+    const childReasoning = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/reasoning/textDelta",
+      params: { threadId: "child-thread", delta: "child private reasoning" },
+    });
+    const mainText = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { threadId: "main-codex-thread", delta: "main final" },
+    });
+    const completed = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "main-codex-thread", turn: { status: "completed" } },
+    });
+
+    expect(childText).toEqual([]);
+    expect(childReasoning).toEqual([]);
+    expect(mainText).toEqual([
+      { type: "textDelta", threadId: "test-thread", delta: "main final", isFinalResponse: true },
+    ]);
+    expect(completed.find((event) => event.type === "message")).toMatchObject({
+      type: "message",
+      content: "main final",
+    });
+  });
+
+  it("does not let child turn/completed reset or latch the main turn", () => {
+    mapper = new CodexEventMapper("test-thread", "main-codex-thread");
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId: "main-codex-thread",
+        item: { type: "collabAgentToolCall", id: "collab-a", tool: "spawnAgent" },
+      },
+    });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "main-codex-thread",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-a",
+          tool: "spawnAgent",
+          receiverThreadIds: ["child-thread"],
+          result: "done",
+        },
+      },
+    });
+
+    const childCompleted = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "child-thread", turn: { status: "completed" } },
+    });
+    const mainText = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { threadId: "main-codex-thread", delta: "still streaming" },
+    });
+    const mainCompleted = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "main-codex-thread", turn: { status: "completed" } },
+    });
+
+    expect(childCompleted).toEqual([]);
+    expect(mainText).toEqual([
+      { type: "textDelta", threadId: "test-thread", delta: "still streaming", isFinalResponse: true },
+    ]);
+    expect(mainCompleted.filter((event) => event.type === "turnComplete")).toHaveLength(1);
+  });
+
+  it("still maps child-thread tools under the registered sub-agent row", () => {
+    mapper = new CodexEventMapper("test-thread", "main-codex-thread");
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId: "main-codex-thread",
+        item: { type: "collabAgentToolCall", id: "collab-a", tool: "spawnAgent" },
+      },
+    });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "main-codex-thread",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-a",
+          tool: "spawnAgent",
+          receiverThreadIds: ["child-thread"],
+          result: "done",
+        },
+      },
+    });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/commandExecution/outputDelta",
+      params: { threadId: "child-thread", itemId: "cmd-child", delta: "ok" },
+    });
+
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "child-thread",
+        item: { type: "commandExecution", id: "cmd-child", command: "git status", exitCode: 0 },
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "toolUse",
+        toolCallId: "cmd-child",
+        parentToolCallId: "collab-a",
+      }),
+      expect.objectContaining({
+        type: "toolResult",
+        toolCallId: "cmd-child",
+        output: "ok",
+      }),
+    ]);
+  });
+
+  // ---------------------------------------------------------------------------
   // Unrecognized notification method
   // ---------------------------------------------------------------------------
 

--- a/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
@@ -112,7 +112,12 @@ function loadNotifications(): { label: string; notifications: CodexNotification[
 }
 
 function replay(notifications: CodexNotification[]) {
-  const mapper = new CodexEventMapper("coverage-thread");
+  const mainThreadId = notifications
+    .filter((n) => n.method === "turn/started")
+    .map((n) => n.params as { threadId?: unknown })
+    .find((params) => typeof params.threadId === "string" && params.threadId.length > 0)
+    ?.threadId as string | undefined;
+  const mapper = new CodexEventMapper("coverage-thread", mainThreadId);
   const methodsSeen = new Set<string>();
   const events: ReturnType<CodexEventMapper["mapNotification"]> = [];
   for (const n of notifications) {
@@ -120,6 +125,19 @@ function replay(notifications: CodexNotification[]) {
     events.push(...mapper.mapNotification(n));
   }
   return { methodsSeen, events };
+}
+
+function loadGoldenScenario(id: string): CodexNotification[] {
+  if (!existsSync(FIXTURE_PATH)) return [];
+  const lines = readFileSync(FIXTURE_PATH, "utf8").split("\n").filter(Boolean);
+  const notifications: CodexNotification[] = [];
+  for (const line of lines) {
+    const row = JSON.parse(line) as NdjsonRow & { scenario?: string };
+    if (row.type === "notification" && row.scenario === id && row.raw?.method) {
+      notifications.push(row.raw);
+    }
+  }
+  return notifications;
 }
 
 describe("Codex protocol coverage", () => {
@@ -212,5 +230,21 @@ describe("Codex protocol coverage", () => {
         "D_subagents scenario did not emit collabAgentToolCall; sub-agent nesting remains unit-test only",
       );
     }
+  });
+
+  it("golden D_subagents emits one TurnComplete after main turn completion", () => {
+    if (label !== "golden") return;
+    const subagentNotifications = loadGoldenScenario("D_subagents");
+    if (subagentNotifications.length === 0) return;
+    const mainThreadId = (subagentNotifications.find((n) => n.method === "turn/started")?.params as { threadId?: string } | undefined)?.threadId;
+    const hasMainCompletion = subagentNotifications.some((n) => {
+      const params = n.params as { threadId?: string };
+      return n.method === "turn/completed" && params.threadId === mainThreadId;
+    });
+    if (!hasMainCompletion) return;
+
+    const { events } = replay(subagentNotifications);
+    const turnCompletes = events.filter((event) => event.type === AgentEventType.TurnComplete);
+    expect(turnCompletes).toHaveLength(1);
   });
 });

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -55,6 +55,8 @@ export class CodexEventMapper {
   /** Dedupes `item/completed` reasoning payloads against streamed reasoning deltas. */
   private lastReasoningText = "";
   private readonly threadId: string;
+  /** Codex app-server's own main thread id. Distinct from Mcode's persisted thread UUID. */
+  private mainCodexThreadId: string | undefined;
   /** Per-item streaming command output buffers, keyed by itemId. */
   private readonly commandOutputBuffers = new Map<string, string>();
   /** Open tool-like items keyed by id. Mirrors Claude/Cursor `pendingToolUses` for thought-vs-final classification. */
@@ -90,14 +92,78 @@ export class CodexEventMapper {
    */
   private turnEnded = false;
 
-  constructor(threadId: string) {
+  constructor(threadId: string, mainCodexThreadId?: string) {
     this.threadId = threadId;
+    this.mainCodexThreadId = mainCodexThreadId;
+  }
+
+  /** Updates the app-server thread id used to classify incoming notifications. */
+  setMainCodexThreadId(threadId: string): void {
+    this.mainCodexThreadId = threadId;
   }
 
   /** Reads `params.threadId` from a Codex notification when present. */
   private notificationThreadId(notification: CodexNotification): string | undefined {
     const tid = (notification.params as { threadId?: unknown }).threadId;
     return typeof tid === "string" && tid.length > 0 ? tid : undefined;
+  }
+
+  /** Classifies the notification against the app-server's main and known receiver threads. */
+  private classifyNotificationThread(notification: CodexNotification): "main" | "child" | "unknown" {
+    const notifThread = this.notificationThreadId(notification);
+    if (!notifThread) return "main";
+    if (this.collabReceiverThreadToCollabId.has(notifThread)) return "child";
+    if (this.mainCodexThreadId) {
+      return notifThread === this.mainCodexThreadId ? "main" : "unknown";
+    }
+    return "main";
+  }
+
+  /** Child receiver threads contribute tool rows only; text and lifecycle stay private to Codex. */
+  private mapChildThreadNotification(notification: CodexNotification): AgentEvent[] {
+    const { method } = notification;
+
+    if (method === "item/commandExecution/outputDelta") {
+      const { itemId, delta } = notification.params;
+      if (itemId && delta) {
+        const prev = this.commandOutputBuffers.get(itemId) ?? "";
+        this.commandOutputBuffers.set(itemId, prev + delta);
+      }
+      return [];
+    }
+
+    if (method === "item/started") {
+      const item = notification.params.item as CompletedItem | undefined;
+      const itemType = item?.type;
+      const itemId = typeof item?.id === "string" ? item.id : undefined;
+      if (itemType === "collabAgentToolCall" && itemId && item) {
+        this.collabToolUseFromStartIds.add(itemId);
+        this.registerCollabReceiverThreads(itemId, item);
+        return [this.buildCollabToolUseEvent(item, itemId, notification)];
+      }
+      logger.debug("Codex child thread notification consumed", { method, itemType });
+      return [];
+    }
+
+    if (method === "item/completed") {
+      const item = notification.params.item;
+      const itemType = item?.type;
+      if (
+        itemType === "commandExecution"
+        || itemType === "fileChange"
+        || itemType === "mcpToolCall"
+        || itemType === "dynamicToolCall"
+        || itemType === "function_call"
+        || itemType === "collabAgentToolCall"
+      ) {
+        return this.mapItemCompleted(item, notification, "child");
+      }
+      logger.debug("Codex child thread notification consumed", { method, itemType });
+      return [];
+    }
+
+    logger.debug("Codex child thread notification consumed", { method });
+    return [];
   }
 
   /**
@@ -156,7 +222,11 @@ export class CodexEventMapper {
   /**
    * Builds the Agent `ToolUse` for a collab item (shared by `item/started` and legacy `item/completed`).
    */
-  private buildCollabToolUseEvent(item: CompletedItem, toolCallId: string): AgentEvent {
+  private buildCollabToolUseEvent(
+    item: CompletedItem,
+    toolCallId: string,
+    notification?: CodexNotification,
+  ): AgentEvent {
     const raw = item as unknown as Record<string, unknown>;
     const fromSchema = typeof item.tool === "string" ? item.tool : undefined;
     const kind =
@@ -167,6 +237,7 @@ export class CodexEventMapper {
             ? raw.tool_kind
             : "collab");
     const prompt = typeof raw.prompt === "string" ? raw.prompt : undefined;
+    const nestParent = this.nestingParentToolCallId(notification);
     return {
       type: AgentEventType.ToolUse,
       threadId: this.threadId,
@@ -176,6 +247,7 @@ export class CodexEventMapper {
         codexCollabKind: kind,
         ...(prompt != null && prompt.length > 0 ? { prompt: prompt.slice(0, 2000) } : {}),
       },
+      ...(nestParent ? { parentToolCallId: nestParent } : {}),
     };
   }
 
@@ -185,6 +257,20 @@ export class CodexEventMapper {
    */
   mapNotification(notification: CodexNotification): AgentEvent[] {
     const { method } = notification;
+    const route = this.classifyNotificationThread(notification);
+
+    if (route === "unknown") {
+      logger.warn("CodexEventMapper: dropping unknown-thread notification", {
+        method,
+        notificationThreadId: this.notificationThreadId(notification),
+        mainCodexThreadId: this.mainCodexThreadId,
+      });
+      return [];
+    }
+
+    if (route === "child") {
+      return this.mapChildThreadNotification(notification);
+    }
 
     // turn/started: starts a new turn. Clear the suppress flag so we resume
     // emitting events. (Per-turn buffer reset happens in turn/completed.)
@@ -224,7 +310,7 @@ export class CodexEventMapper {
         this.collabScopeStack.push(itemId);
         this.collabToolUseFromStartIds.add(itemId);
         this.registerCollabReceiverThreads(itemId, item as CompletedItem);
-        return [this.buildCollabToolUseEvent(item as CompletedItem, itemId)];
+        return [this.buildCollabToolUseEvent(item as CompletedItem, itemId, notification)];
       }
       logger.debug("Codex lifecycle notification", { method, itemType });
       return [];
@@ -413,6 +499,7 @@ export class CodexEventMapper {
   private mapItemCompleted(
     item: CompletedItem | undefined,
     notification: CodexNotification,
+    route: "main" | "child" = "main",
   ): AgentEvent[] {
     if (!item) return [];
 
@@ -594,8 +681,12 @@ export class CodexEventMapper {
       this.registerCollabReceiverThreads(toolCallId, item);
       if (this.collabToolUseFromStartIds.has(toolCallId)) {
         this.collabToolUseFromStartIds.delete(toolCallId);
-        this.popCollabFromScopeStack(toolCallId);
+        if (route === "main") this.popCollabFromScopeStack(toolCallId);
         return [toolResultEvent];
+      }
+      if (route === "child") {
+        const toolUseEvent = this.buildCollabToolUseEvent(item, toolCallId, notification);
+        return [toolUseEvent, toolResultEvent];
       }
       // Legacy path: collab completes in one notification without a prior `item/started`.
       // Push onto the nesting stack so subsequent child `item/completed` rows
@@ -605,7 +696,7 @@ export class CodexEventMapper {
       // sub-agent's children does not incorrectly attach beneath it.
       this.collabScopeStack.push(toolCallId);
       this.pendingLegacyCollabPops.add(toolCallId);
-      const toolUseEvent = this.buildCollabToolUseEvent(item, toolCallId);
+      const toolUseEvent = this.buildCollabToolUseEvent(item, toolCallId, notification);
       return [toolUseEvent, toolResultEvent];
     }
 

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -406,6 +406,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
     // Register after a successful handshake so a mid-handshake thread/started
     // notification cannot persist a stale SDK thread id when init later fails.
     server.on("threadIdChanged", (newThreadId: string) => {
+      mapper.setMainCodexThreadId(newThreadId);
       this.sdkSessionIds.set(sessionId, newThreadId);
       this.emit("event", {
         type: AgentEventType.System,
@@ -424,6 +425,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
     }
 
     if (server.threadId) {
+      mapper.setMainCodexThreadId(server.threadId);
       this.sdkSessionIds.set(sessionId, server.threadId);
       this.emit("event", {
         type: AgentEventType.System,


### PR DESCRIPTION
## What
Routes Codex app-server notifications by thread before mapper state changes.

## Why
Child sub-agent notifications could mutate parent turn state. A child turn completion could emit parent Message and TurnComplete events, reset mapper state, and prevent later main-thread output from persisting. Child text and reasoning could leak into parent streamed text and final reply.

## Key Changes
- Track the app-server main thread id in CodexEventMapper and refresh it when the provider id changes.
- Drop unknown-thread notifications before state changes.
- Consume child-thread text, reasoning, and lifecycle notifications server-side.
- Keep child-thread tools nested under their Agent row.
- Add mapper and golden replay coverage for main, child, unknown, and missing thread ids.

Closes #690

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783768996&installation_id=129163861&pr_number=704&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F704&signature=73932daa40aa5a067160197e0ddf6bab4511b44131a7aeeb9aa316eee8347a14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-threaded conversations by correctly routing and processing notifications from sub-agents.
  * Fixed tool call nesting to properly associate tools created on child threads with their parent agent calls.

* **Tests**
  * Extended test coverage for thread-scoped notification routing and sub-agent scenarios.
  * Added scenario-specific test helpers for golden fixture validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->