### PR TITLE
fix: stabilize turn-end chat rendering

### DIFF
--- a/apps/web/src/__tests__/threadStore-assistant-message-boundary.test.ts
+++ b/apps/web/src/__tests__/threadStore-assistant-message-boundary.test.ts
@@ -1,6 +1,7 @@
 import {
   resetThreadStoreForTests,
   getTestThreadStreaming,
+  getTestThreadStreamingPreview,
   getTestThreadThoughtSegments,
 } from "@/stores/thread-store-test-utils";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
@@ -114,5 +115,37 @@ describe("threadStore assistantMessageBoundary", () => {
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
     expect(segs).toEqual([{ text: "old thought", startedAt: 1, endedAt: 2 }]);
+  });
+
+  it("clears stale streamed text when a new turn starts after stop or resume", () => {
+    const tid = "thread-resume";
+    resetThreadStoreForTests({
+      records: new Map<string, ThreadRecord>([
+        [
+          tid,
+          {
+            ...createEmptyThreadRecord(),
+            streaming: "Using gpt-writing for the README note.",
+            streamingPreview: "Using gpt-writing for the README note.",
+            currentTurnMessageId: "assistant-old",
+            currentTurnResponseKey: "turn-response:old",
+            thoughtSegments: [
+              {
+                text: "Using gpt-writing for the README note.",
+                startedAt: 1,
+              },
+            ],
+          },
+        ],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent(tid, {
+      method: "session.turnStarted",
+    });
+
+    expect(getTestThreadStreaming(tid)).toBeUndefined();
+    expect(getTestThreadStreamingPreview(tid)).toBeUndefined();
+    expect(getTestThreadThoughtSegments(tid) ?? []).toEqual([]);
   });
 });

--- a/apps/web/src/__tests__/virtual-items.test.ts
+++ b/apps/web/src/__tests__/virtual-items.test.ts
@@ -156,6 +156,31 @@ describe("buildVolatileItems", () => {
     >;
     expect(narrativeItem?.thoughtSegments).toEqual(thoughtSegments);
   });
+
+  it("does not mirror open unclassified narration into a provisional assistant message", () => {
+    const thoughtSegments: ThoughtSegment[] = [
+      { text: "I will check the README before running Prettier.", startedAt: 42 },
+    ];
+    const items = buildVolatileItems(
+      [],
+      true,
+      1000,
+      "I will check the README before running Prettier.",
+      undefined,
+      [],
+      thoughtSegments,
+    );
+
+    expect(items.some((i) => i.type === "narrative-flow")).toBe(true);
+    expect(
+      items.some(
+        (i) =>
+          i.type === "message" &&
+          i.message.role === "assistant" &&
+          i.assistantState?.isStreaming,
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("buildVirtualItems (combined)", () => {

--- a/apps/web/src/__tests__/virtual-items.test.ts
+++ b/apps/web/src/__tests__/virtual-items.test.ts
@@ -115,6 +115,38 @@ describe("final response item keys", () => {
 
     expect(persistedKey).toBe("turn-response:thread-1:abc");
   });
+
+  it("does not duplicate the response key after the assistant message has persisted", () => {
+    const currentTurn = {
+      threadId: "thread-1",
+      messageId: "persisted-msg",
+      responseKey: "turn-response:thread-1:abc",
+      responseKeysByMessageId: {
+        "persisted-msg": "turn-response:thread-1:abc",
+      },
+    };
+    const stable = buildStableItems(
+      [makeMessage({ id: "persisted-msg", thread_id: "thread-1" })],
+      undefined,
+      undefined,
+      currentTurn,
+    );
+    const volatile = buildVolatileItems(
+      [],
+      true,
+      1000,
+      "confirmed final suffix",
+      undefined,
+      [],
+      [],
+      currentTurn,
+    );
+    const items = buildVirtualItems(stable, volatile, false);
+
+    expect(
+      items.filter((item) => item.key === "turn-response:thread-1:abc"),
+    ).toHaveLength(1);
+  });
 });
 
 describe("buildVolatileItems", () => {

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -51,6 +51,7 @@ const WHEEL_UP_FOLLOW_PAUSE_MS = 750;
 const OVERSCAN = 8;
 const DEFAULT_ITEM_HEIGHT = 80;
 const PAGINATION_THRESHOLD = 200;
+const NARRATIVE_INDICATOR_EXIT_MS = 220;
 /** Top inset on the scroll container when the sticky user bar is hidden (`pt-4`). */
 const MESSAGE_LIST_TOP_PADDING_PX = 16;
 /**
@@ -161,6 +162,7 @@ const VirtualItemRenderer = memo(function VirtualItemRenderer({
           subagentCount={item.subagentCount}
           activeToolCalls={item.activeToolCalls}
           startTime={item.startTime}
+          isExiting={item.isExiting}
         />
       );
   }
@@ -279,6 +281,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const stickyUserMessageTargetRef = useRef<{ id: string; itemIndex: number } | null>(null);
   /** Latest virtualizer instance for scroll-time sticky visibility checks. */
   const virtualizerRef = useRef<StickyVisibilityVirtualizer | null>(null);
+  const lastNarrativeIndicatorRef =
+    useRef<Extract<ChatVirtualItem, { type: "narrative-indicator" }> | null>(null);
+  const narrativeIndicatorExitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [exitingNarrativeIndicator, setExitingNarrativeIndicator] =
+    useState<Extract<ChatVirtualItem, { type: "narrative-indicator" }> | null>(null);
 
   const messages = useActiveThreadRecord((r) => r.messages);
   const loading = useActiveThreadRecord((r) => r.loading);
@@ -519,10 +526,62 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     assistantResponseKeys,
   ]);
 
+  const liveNarrativeIndicator = useMemo(
+    () =>
+      volatileItems.find(
+        (item): item is Extract<ChatVirtualItem, { type: "narrative-indicator" }> =>
+          item.type === "narrative-indicator",
+      ) ?? null,
+    [volatileItems],
+  );
+
+  useLayoutEffect(() => {
+    if (narrativeIndicatorExitTimerRef.current) {
+      clearTimeout(narrativeIndicatorExitTimerRef.current);
+      narrativeIndicatorExitTimerRef.current = null;
+    }
+
+    if (liveNarrativeIndicator) {
+      lastNarrativeIndicatorRef.current = liveNarrativeIndicator;
+      setExitingNarrativeIndicator(null);
+      return;
+    }
+
+    const lastIndicator = lastNarrativeIndicatorRef.current;
+    if (!lastIndicator) return;
+
+    lastNarrativeIndicatorRef.current = null;
+    setExitingNarrativeIndicator({
+      ...lastIndicator,
+      key: `${lastIndicator.key}-exit`,
+      isExiting: true,
+    });
+    narrativeIndicatorExitTimerRef.current = setTimeout(() => {
+      setExitingNarrativeIndicator(null);
+      narrativeIndicatorExitTimerRef.current = null;
+    }, NARRATIVE_INDICATOR_EXIT_MS);
+  }, [liveNarrativeIndicator]);
+
+  useEffect(() => {
+    return () => {
+      if (narrativeIndicatorExitTimerRef.current) {
+        clearTimeout(narrativeIndicatorExitTimerRef.current);
+      }
+    };
+  }, []);
+
+  const visibleVolatileItems = useMemo(
+    () =>
+      exitingNarrativeIndicator
+        ? [...volatileItems, exitingNarrativeIndicator]
+        : volatileItems,
+    [volatileItems, exitingNarrativeIndicator],
+  );
+
   const hasToolCalls = toolCalls.length > 0;
   const items = useMemo(
-    () => buildVirtualItems(stableItems, volatileItems, hasToolCalls),
-    [stableItems, volatileItems, hasToolCalls],
+    () => buildVirtualItems(stableItems, visibleVolatileItems, hasToolCalls),
+    [stableItems, visibleVolatileItems, hasToolCalls],
   );
 
   const lastUserMessage = useMemo(() => {

--- a/apps/web/src/components/chat/__tests__/virtual-items.test.ts
+++ b/apps/web/src/components/chat/__tests__/virtual-items.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVirtualItems,
+  estimateItemHeight,
+  type ChatVirtualItem,
+} from "../virtual-items";
+import type { Message } from "@/transport/types";
+
+function mkAssistantMessage(id: string, content: string): Message {
+  return {
+    id,
+    thread_id: "thread-1",
+    role: "assistant",
+    content,
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    sequence: 1,
+    attachments: null,
+  } as Message;
+}
+
+describe("chat virtual items", () => {
+  it("keeps current-turn assistant height estimates stable across persist", () => {
+    const message = mkAssistantMessage("assistant-1", "Final response text.");
+    const streaming: ChatVirtualItem = {
+      key: "turn-response:thread-1:response-1",
+      type: "message",
+      message,
+      assistantState: { isStreaming: true, actionsVisible: false },
+    };
+    const justPersisted: ChatVirtualItem = {
+      ...streaming,
+      message: { ...message, id: "assistant-1" },
+      assistantState: { isStreaming: false, actionsVisible: false },
+    };
+
+    expect(estimateItemHeight(justPersisted)).toBe(estimateItemHeight(streaming));
+  });
+
+  it("places an exiting narrative indicator after the persisted assistant response", () => {
+    const assistant = mkAssistantMessage("assistant-1", "Final response text.");
+    const stableItems: ChatVirtualItem[] = [
+      {
+        key: "persisted-narrative-assistant-1",
+        type: "persisted-narrative",
+        messageId: assistant.id,
+        messageContent: assistant.content,
+      },
+      {
+        key: assistant.id,
+        type: "message",
+        message: assistant,
+        assistantState: { isStreaming: false, actionsVisible: false },
+      },
+    ];
+    const volatileItems: ChatVirtualItem[] = [
+      {
+        key: "narrative-flow",
+        type: "narrative-flow",
+        toolCalls: [],
+        hooks: [],
+        thoughtSegments: [],
+        streamingText: "",
+        isAgentRunning: false,
+        startTime: 1000,
+      },
+      {
+        key: "narrative-indicator-exit",
+        type: "narrative-indicator",
+        stepCount: 1,
+        subagentCount: 0,
+        activeToolCalls: [],
+        startTime: 1000,
+        isExiting: true,
+      },
+    ];
+
+    const items = buildVirtualItems(stableItems, volatileItems, true);
+    const assistantIndex = items.findIndex(
+      (item) => item.type === "message" && item.message.id === assistant.id,
+    );
+    const indicatorIndex = items.findIndex((item) => item.key === "narrative-indicator-exit");
+
+    expect(indicatorIndex).toBeGreaterThan(assistantIndex);
+  });
+});

--- a/apps/web/src/components/chat/narrative/NarrativeIndicator.tsx
+++ b/apps/web/src/components/chat/narrative/NarrativeIndicator.tsx
@@ -3,6 +3,7 @@ import { formatDuration } from "@/lib/time";
 import type { ToolCall } from "@/transport/types";
 import { TOOL_PHASE_LABELS } from "../tool-renderers/constants";
 import { StackedLayersIcon, stackedLayersIconClassName } from "./StackedLayersIcon";
+import { cn } from "@/lib/utils";
 
 /** Derive the current phase label from active tool calls. */
 function derivePhaseLabel(toolCalls: readonly ToolCall[]): string {
@@ -27,6 +28,8 @@ interface NarrativeIndicatorProps {
   activeToolCalls: readonly ToolCall[];
   /** Epoch ms when the agent turn started, used to compute elapsed time. */
   startTime?: number;
+  /** True while the row is leaving after turn completion. */
+  isExiting?: boolean;
 }
 
 /**
@@ -43,6 +46,7 @@ export function NarrativeIndicator({
   subagentCount,
   activeToolCalls,
   startTime,
+  isExiting = false,
 }: NarrativeIndicatorProps) {
   const [elapsed, setElapsed] = useState(0);
 
@@ -64,7 +68,14 @@ export function NarrativeIndicator({
     subagentCount === 1 ? "1 subagent" : `${subagentCount} subagents`;
 
   return (
-    <div className="flex items-center gap-2 px-4 py-2 mt-1.5">
+    <div
+      className={cn(
+        "mt-1.5 flex items-center gap-2 overflow-hidden px-4 py-2 transition-all duration-200 ease-out",
+        isExiting && "mt-0 max-h-0 translate-y-1 py-0 opacity-0",
+        !isExiting && "max-h-10 translate-y-0 opacity-100",
+      )}
+      aria-hidden={isExiting ? true : undefined}
+    >
       <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
         {/* When sub-agents are dispatched, the stacked-layers icon (with its
             float + per-layer ripple) becomes the "agent working" mark — more

--- a/apps/web/src/components/chat/narrative/__tests__/build-narrative-counts.test.ts
+++ b/apps/web/src/components/chat/narrative/__tests__/build-narrative-counts.test.ts
@@ -69,9 +69,9 @@ describe("buildNarrativeItems counts", () => {
     expect(counts.steps).toBe(1);
   });
 
-  it("does not count the streaming final response as a thought", () => {
+  it("keeps an open unclassified segment as a thought until final-response certainty", () => {
     const thoughts: ThoughtSegment[] = [
-      mkThought("streaming-final", 1000), // no endedAt → still streaming
+      mkThought("I will check the file.", 1000), // no endedAt -> still unclassified
     ];
     const { items, counts } = buildNarrativeItems({
       toolCalls: [],
@@ -80,9 +80,9 @@ describe("buildNarrativeItems counts", () => {
       streamingText: "",
       isAgentRunning: true,
     });
-    // Final streaming response renders as `delta`, not `thought` (no anyToolRunning)
-    expect(items.find((it) => it.type === "delta")).toBeDefined();
-    expect(counts.thoughts).toBe(0);
+    expect(items.find((it) => it.type === "delta")).toBeUndefined();
+    expect(items.find((it) => it.type === "thought")).toBeDefined();
+    expect(counts.thoughts).toBe(1);
   });
 
   it("appends isFinal surplus as delta after thoughts when streaming extends past segment tape", () => {

--- a/apps/web/src/components/chat/narrative/build-narrative.ts
+++ b/apps/web/src/components/chat/narrative/build-narrative.ts
@@ -13,11 +13,11 @@ const AGENT_TOOL_NAME = "Agent";
  * slot stay in sync. Returns "" when there is nothing to render — caller
  * suppresses the virtual item in that case.
  *
- *  - When the latest thought segment is open and no tool is running, that
- *    segment IS the live response (tool-free turn, or pre-tool preamble that
- *    will be classified by the next `AssistantMessageBoundary`).
- *  - Otherwise, the suffix of `streamingText` past the closed-thought tape is
- *    the final-response text emitted after the last tool completed.
+ *  - The suffix of `streamingText` past the closed-thought tape is the
+ *    final-response text emitted after the last tool completed.
+ *  - An open thought segment is still unclassified. Keeping it in the
+ *    narrative flow avoids moving pre-tool narration into the response slot
+ *    and then snapping it back when the first tool call arrives.
  */
 export function computeLiveStreamingText(params: {
   thoughtSegments: readonly ThoughtSegment[];
@@ -32,11 +32,6 @@ export function computeLiveStreamingText(params: {
     (tc) => tc.parentToolCallId == null && !tc.isComplete,
   );
   if (anyToolRunning) return "";
-
-  const lastSeg = thoughtSegments[thoughtSegments.length - 1];
-  if (lastSeg && lastSeg.endedAt == null) {
-    return lastSeg.text;
-  }
 
   const tape = thoughtSegments.map((s) => s.text).join("");
   if (streamingText.startsWith(tape) && streamingText.length > tape.length) {
@@ -127,15 +122,6 @@ export function buildNarrativeItems(params: {
       : params.thoughtSegments;
 
   if (thoughtSegments.length === 0 && toolCalls.length === 0 && hooks.length === 0) {
-    if (isAgentRunning && streamingText.length > 0) {
-      // The agent is streaming its final (and only) response — no tools were
-      // called, so this text IS the assistant reply, not a reasoning step.
-      // Render as delta (full-weight prose) instead of a thought (italic/dimmed).
-      return {
-        items: [{ type: "delta", text: streamingText }],
-        counts: { steps: 0, thoughts: 0, subagents: 0 },
-      };
-    }
     return { items: [], counts: { steps: 0, thoughts: 0, subagents: 0 } };
   }
 
@@ -193,35 +179,15 @@ export function buildNarrativeItems(params: {
     pendingGroup.length = 0;
   };
 
-  // Find the index of the last thought segment for active-state detection.
-  const lastSegmentStartedAt = thoughtSegments.length > 0
-    ? thoughtSegments[thoughtSegments.length - 1].startedAt
-    : -1;
-
   const thoughtTape = thoughtSegments.map((s) => s.text).join("");
   const streamingSuffix =
     isAgentRunning && !anyToolRunning && streamingText.startsWith(thoughtTape)
       ? streamingText.slice(thoughtTape.length)
       : "";
 
-  let emittedFinalDeltaFromTape = false;
-
   for (const evt of timeline) {
     if (evt.kind === "thought") {
       flushGroup();
-      const isLatest = evt.segment.startedAt === lastSegmentStartedAt;
-      const isStreaming = evt.segment.endedAt == null;
-
-      // Fallback when `isFinalResponse` never arrived: streamed text lives in the
-      // latest open segment (`streamingSuffix` is empty).
-      const useLegacyTapeFinalDelta =
-        streamingSuffix === "" && isLatest && isStreaming && !anyToolRunning;
-      if (useLegacyTapeFinalDelta) {
-        items.push({ type: "delta", text: evt.segment.text });
-        emittedFinalDeltaFromTape = true;
-        continue;
-      }
-
       // `isActive` drives `DeltaBlock.isStreaming` inside `ThoughtBlock`.
       // While the agent turn is live, every thought segment (including ones
       // that have just closed because a tool_use boundary fired) animates
@@ -270,7 +236,6 @@ export function buildNarrativeItems(params: {
   }
 
   if (
-    !emittedFinalDeltaFromTape &&
     streamingSuffix.length > 0 &&
     isAgentRunning
   ) {

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -287,7 +287,7 @@ export function buildVolatileItems(
     isAgentRunning,
     toolCalls,
   });
-  if (liveText.length > 0) {
+  if (liveText.length > 0 && !currentTurn?.messageId) {
     const threadId = currentTurn?.threadId ?? "__active_thread__";
     const responseKey = liveFinalResponseItemKey(threadId, currentTurn?.responseKey);
     items.push({

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -155,6 +155,8 @@ export type ChatVirtualItem =
       subagentCount: number;
       activeToolCalls: readonly ToolCall[];
       startTime: number | undefined;
+      /** True while the status row is animating out after the turn completes. */
+      isExiting?: boolean;
     };
 
 /**
@@ -405,13 +407,13 @@ export function buildVirtualItems(
       (v) =>
         v.type === "narrative-flow" ||
         (v.type === "message" && v.message.role === "assistant" && v.assistantState?.isStreaming) ||
-        v.type === "narrative-indicator",
+        (v.type === "narrative-indicator" && !v.isExiting),
     );
     const tailItems = volatileItems.filter(
       (v) =>
         v.type !== "narrative-flow" &&
         !(v.type === "message" && v.message.role === "assistant" && v.assistantState?.isStreaming) &&
-        v.type !== "narrative-indicator",
+        !(v.type === "narrative-indicator" && !v.isExiting),
     );
     // Drop the persisted-narrative placeholder for the message that has live
     // narrative-flow above it, to avoid double-rendering the same timeline
@@ -534,7 +536,7 @@ export function estimateItemHeight(item: ChatVirtualItem): number {
       if (message.role === "system") return 40;
       const contentHeight = estimateMarkdownHeight(message.content);
       if (message.role === "user") return 52 + contentHeight;
-      if (item.assistantState?.isStreaming) return Math.max(contentHeight, 48);
+      if (item.assistantState) return Math.max(contentHeight, 48);
       return 80 + contentHeight;
     }
     case "active-tools":

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -213,9 +213,12 @@ export function scheduleDrainAfterEdit(threadId: string): void {
  */
 function resetTurnEphemeral(_rec: ThreadRecord): Partial<ThreadRecord> {
   return {
+    streaming: "",
+    streamingPreview: "",
     toolCalls: [],
     thoughtSegments: [],
     hooks: [],
+    currentTurnMessageId: "",
     currentTurnResponseKey: "",
   };
 }


### PR DESCRIPTION
## What
Draft PR for current turn-end rendering work. Latest feedback says it needs another pass before merge.

## Why
Issue #695 reports virtualizer reflow when the streaming response persists and the narrative step indicator disappearing in one frame. Follow-up testing exposed stale streamed text after stop or continue, narration moving between rows when tool calls start, and duplicate React keys after final response persists.

## Key Changes
- Aligns the streaming slot and saved assistant message around one response key.
- Adds an exit state for the live narrative step indicator.
- Clears stale streaming state when a new turn starts.
- Keeps unclassified provider text in the narrative flow until final-response certainty.
- Stops rendering the live provisional response once the persisted assistant message is known.

Related to #695

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783781837&installation_id=129163861&pr_number=706&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F706&signature=cdd52eca93ee939767215983b218e731d6c55aea82cc003af06f55ef0d9e92d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->