### PR TITLE
fix: preserve Codex narration through tool turns

### DIFF
--- a/apps/server/src/providers/codex/CODEX-NARRATIVE-NOTES.md
+++ b/apps/server/src/providers/codex/CODEX-NARRATIVE-NOTES.md
@@ -4,7 +4,7 @@ Internal notes so we do not redo the same experiments. For the product contract 
 
 ## What the user sees
 
-Thought rows come from `AgentEventType.TextDelta` with `isFinalResponse: false`. The web client merges those into `thoughtSegmentsByThread`. Final reply text uses `isFinalResponse: true` and stays out of thought segments.
+Thought rows come from non-final `AgentEventType.TextDelta` events. The web client merges those into `thoughtSegmentsByThread`. Codex assistant text now streams this way until the mapper emits `AssistantMessageBoundary`; the last assistant item of a completed main turn is promoted to the final reply.
 
 Sub-agent rows are `ToolUse` with `toolName: "Agent"`. Children nest when their `ToolUse` carries `parentToolCallId` pointing at the collab item id.
 

--- a/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
@@ -226,7 +226,7 @@ describe("CodexEventMapper", () => {
     ]);
   });
 
-  it("classifies text after completed-only commandExecution as final response", () => {
+  it("streams text after completed-only commandExecution as narration until turn completion", () => {
     mapper.mapNotification({
       jsonrpc: "2.0",
       method: "item/completed",
@@ -252,7 +252,7 @@ describe("CodexEventMapper", () => {
         type: "textDelta",
         threadId: "test-thread",
         delta: "Done",
-        isFinalResponse: true,
+        isFinalResponse: false,
       },
     ]);
   });
@@ -261,9 +261,8 @@ describe("CodexEventMapper", () => {
   // item/agentMessage/delta – streaming text tokens
   // ---------------------------------------------------------------------------
 
-  it("emits textDelta WITHOUT isFinalResponse for pre-tool item/agentMessage/delta (thought)", () => {
-    // No tool has fired this turn yet — every delta is a thought, matching
-    // Claude/Cursor's tool-state-based classification.
+  it("emits non-final textDelta for pre-tool item/agentMessage/delta", () => {
+    // Codex assistant text is classified later by assistantMessageBoundary.
     const e1 = mapper.mapNotification({
       jsonrpc: "2.0",
       method: "item/agentMessage/delta",
@@ -275,12 +274,12 @@ describe("CodexEventMapper", () => {
       params: { threadId: "t", turnId: "u", itemId: "i", delta: "!" },
     });
 
-    expect(e1).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "Hello" }]);
-    expect(e2).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "!" }]);
+    expect(e1).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "Hello", isFinalResponse: false }]);
+    expect(e2).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "!", isFinalResponse: false }]);
   });
 
-  it("emits textDelta WITH isFinalResponse:true for item/agentMessage/delta after tool completes", () => {
-    // Tool fires and completes -> subsequent agentMessage deltas are the final reply.
+  it("emits non-final textDelta for item/agentMessage/delta after tool completes", () => {
+    // Even post-tool text can be followed by another tool, so only lookahead promotes it.
     mapper.mapNotification({
       jsonrpc: "2.0",
       method: "item/started",
@@ -296,12 +295,11 @@ describe("CodexEventMapper", () => {
       method: "item/agentMessage/delta",
       params: { delta: "Done" },
     });
-    expect(evt).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "Done", isFinalResponse: true }]);
+    expect(evt).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "Done", isFinalResponse: false }]);
   });
 
   it("keeps pre-tool agentMessage delta as thought even while tools run", () => {
     // Some Codex turns interleave: preamble -> tool start -> more text -> tool complete -> final.
-    // While a tool is in-flight, deltas are still thoughts (pendingToolItems > 0).
     mapper.mapNotification({
       jsonrpc: "2.0",
       method: "item/started",
@@ -312,7 +310,7 @@ describe("CodexEventMapper", () => {
       method: "item/agentMessage/delta",
       params: { delta: "thinking..." },
     });
-    expect(mid).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "thinking..." }]);
+    expect(mid).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "thinking...", isFinalResponse: false }]);
   });
 
   it("emits Message with full accumulated text on turn/completed after deltas", () => {
@@ -326,7 +324,172 @@ describe("CodexEventMapper", () => {
     });
 
     const msg = events.find((e) => e.type === "message");
+    expect(events[0]).toMatchObject({ type: "assistantMessageBoundary", isFinalResponse: true });
     expect(msg).toMatchObject({ type: "message", content: "Hello world" });
+  });
+
+  it("keeps streamed text when item deltas omit ids but completion includes one", () => {
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { delta: "Legacy streamed answer" },
+    });
+    expect(mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { item: { type: "agentMessage", id: "msg-with-id" } },
+    })).toEqual([]);
+
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { turn: { status: "completed" } },
+    });
+
+    expect(events[0]).toMatchObject({ type: "assistantMessageBoundary", isFinalResponse: true });
+    expect(events.find((event) => event.type === "message")).toMatchObject({
+      type: "message",
+      content: "Legacy streamed answer",
+    });
+  });
+
+  it("classifies inter-tool assistant messages as narration and promotes only the last assistant item", () => {
+    expect(mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { itemId: "msg-1", delta: "First narration." },
+    })).toEqual([
+      { type: "textDelta", threadId: "test-thread", delta: "First narration.", isFinalResponse: false },
+    ]);
+    expect(mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { item: { type: "agentMessage", id: "msg-1" } },
+    })).toEqual([]);
+
+    const firstTool = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: { item: { type: "commandExecution", id: "cmd-1" } },
+    });
+    expect(firstTool[0]).toEqual({
+      type: "assistantMessageBoundary",
+      threadId: "test-thread",
+      isFinalResponse: false,
+    });
+    expect(firstTool[1]).toMatchObject({ type: "toolUse", toolCallId: "cmd-1" });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { item: { type: "commandExecution", id: "cmd-1", command: "pwd", output: "/repo", exitCode: 0 } },
+    });
+
+    expect(mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { itemId: "msg-2", delta: "Middle narration." },
+    })).toEqual([
+      { type: "textDelta", threadId: "test-thread", delta: "Middle narration.", isFinalResponse: false },
+    ]);
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { item: { type: "agentMessage", id: "msg-2" } },
+    });
+
+    const secondTool = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: { item: { type: "commandExecution", id: "cmd-2" } },
+    });
+    expect(secondTool[0]).toEqual({
+      type: "assistantMessageBoundary",
+      threadId: "test-thread",
+      isFinalResponse: false,
+    });
+    expect(secondTool[1]).toMatchObject({ type: "toolUse", toolCallId: "cmd-2" });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { item: { type: "commandExecution", id: "cmd-2", command: "ls", output: "ok", exitCode: 0 } },
+    });
+
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { itemId: "msg-final", delta: "Final answer only." },
+    });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { item: { type: "agentMessage", id: "msg-final" } },
+    });
+
+    const completed = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { turn: { status: "completed" } },
+    });
+    expect(completed[0]).toEqual({
+      type: "assistantMessageBoundary",
+      threadId: "test-thread",
+      isFinalResponse: true,
+    });
+    expect(completed.find((event) => event.type === "message")).toEqual({
+      type: "message",
+      threadId: "test-thread",
+      content: "Final answer only.",
+      tokens: null,
+    });
+  });
+
+  it("promotes a tool-free assistant item to final response on turn completion", () => {
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { itemId: "msg-only", delta: "Tool-free final." },
+    });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { item: { type: "agentMessage", id: "msg-only" } },
+    });
+
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { turn: { status: "completed" } },
+    });
+
+    expect(events[0]).toMatchObject({ type: "assistantMessageBoundary", isFinalResponse: true });
+    expect(events.find((event) => event.type === "message")).toMatchObject({
+      type: "message",
+      content: "Tool-free final.",
+    });
+  });
+
+  it("flushes held assistant text as non-final on failed turn", () => {
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { itemId: "msg-fail", delta: "Partial narration." },
+    });
+    mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { item: { type: "agentMessage", id: "msg-fail" } },
+    });
+
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { turn: { status: "failed", error: { message: "boom" } } },
+    });
+
+    expect(events).toEqual([
+      { type: "assistantMessageBoundary", threadId: "test-thread", isFinalResponse: false },
+      { type: "error", threadId: "test-thread", error: "boom" },
+    ]);
   });
 
   it("returns empty array for item/agentMessage/delta with empty delta", () => {
@@ -356,7 +519,7 @@ describe("CodexEventMapper", () => {
     });
 
     expect(events).toEqual([
-      { type: "textDelta", threadId: "test-thread", delta: "Hello", isFinalResponse: true },
+      { type: "textDelta", threadId: "test-thread", delta: "Hello", isFinalResponse: false },
     ]);
   });
 
@@ -373,7 +536,7 @@ describe("CodexEventMapper", () => {
       },
     });
     expect(events).toEqual([
-      { type: "textDelta", threadId: "test-thread", delta: "Hello from codex", isFinalResponse: true },
+      { type: "textDelta", threadId: "test-thread", delta: "Hello from codex", isFinalResponse: false },
     ]);
   });
 
@@ -395,7 +558,7 @@ describe("CodexEventMapper", () => {
     });
 
     expect(events).toEqual([
-      { type: "textDelta", threadId: "test-thread", delta: " world", isFinalResponse: true },
+      { type: "textDelta", threadId: "test-thread", delta: " world", isFinalResponse: false },
     ]);
   });
 
@@ -805,14 +968,19 @@ describe("CodexEventMapper", () => {
       },
     });
 
-    expect(events).toHaveLength(2);
+    expect(events).toHaveLength(3);
     expect(events[0]).toEqual({
+      type: "assistantMessageBoundary",
+      threadId: "test-thread",
+      isFinalResponse: true,
+    });
+    expect(events[1]).toEqual({
       type: "message",
       threadId: "test-thread",
       content: "Hello world",
       tokens: null,
     });
-    expect(events[1]).toEqual({
+    expect(events[2]).toEqual({
       type: "turnComplete",
       threadId: "test-thread",
       reason: "end_turn",
@@ -940,7 +1108,7 @@ describe("CodexEventMapper", () => {
 
     // After reset the accumulator is empty, so "Hello" is emitted as a full delta
     expect(events).toEqual([
-      { type: "textDelta", threadId: "test-thread", delta: "Hello", isFinalResponse: true },
+      { type: "textDelta", threadId: "test-thread", delta: "Hello", isFinalResponse: false },
     ]);
   });
 
@@ -1038,7 +1206,8 @@ describe("CodexEventMapper", () => {
       params: { turn: { status: "completed" } },
     });
 
-    expect(delta).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "main text" }]);
+    expect(delta).toEqual([{ type: "textDelta", threadId: "test-thread", delta: "main text", isFinalResponse: false }]);
+    expect(completed[0]).toMatchObject({ type: "assistantMessageBoundary", isFinalResponse: true });
     expect(completed.some((event) => event.type === "turnComplete")).toBe(true);
   });
 
@@ -1118,8 +1287,9 @@ describe("CodexEventMapper", () => {
     expect(childText).toEqual([]);
     expect(childReasoning).toEqual([]);
     expect(mainText).toEqual([
-      { type: "textDelta", threadId: "test-thread", delta: "main final", isFinalResponse: true },
+      { type: "textDelta", threadId: "test-thread", delta: "main final", isFinalResponse: false },
     ]);
+    expect(completed[0]).toMatchObject({ type: "assistantMessageBoundary", isFinalResponse: true });
     expect(completed.find((event) => event.type === "message")).toMatchObject({
       type: "message",
       content: "main final",
@@ -1169,8 +1339,9 @@ describe("CodexEventMapper", () => {
 
     expect(childCompleted).toEqual([]);
     expect(mainText).toEqual([
-      { type: "textDelta", threadId: "test-thread", delta: "still streaming", isFinalResponse: true },
+      { type: "textDelta", threadId: "test-thread", delta: "still streaming", isFinalResponse: false },
     ]);
+    expect(mainCompleted[0]).toMatchObject({ type: "assistantMessageBoundary", isFinalResponse: true });
     expect(mainCompleted.filter((event) => event.type === "turnComplete")).toHaveLength(1);
   });
 

--- a/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
@@ -203,6 +203,34 @@ describe("Codex protocol coverage", () => {
     }
   });
 
+  it("classifies Codex assistant text with assistantMessageBoundary, not final text deltas", () => {
+    const { events } = replay(notifications);
+    const assistantDeltas = events.filter(
+      (e) => e.type === AgentEventType.TextDelta && e.isFinalResponse === true,
+    );
+    const boundaries = events.filter(
+      (e): e is Extract<AgentEvent, { type: "assistantMessageBoundary" }> =>
+        e.type === AgentEventType.AssistantMessageBoundary,
+    );
+    const messages = events.filter((e) => e.type === AgentEventType.Message);
+    const hasAssistantText = notifications.some(
+      (n) => n.method === "item/agentMessage/delta"
+        || (
+          n.method === "item/completed"
+          && ["agentMessage", "message"].includes(
+            ((n.params as { item?: { type?: string } }).item?.type) ?? "",
+          )
+        ),
+    );
+
+    expect(assistantDeltas).toHaveLength(0);
+    if (hasAssistantText) {
+      expect(boundaries.length).toBeGreaterThan(0);
+      expect(messages.length).toBeGreaterThan(0);
+      expect(boundaries.some((e) => e.isFinalResponse)).toBe(true);
+    }
+  });
+
   it("golden fixture documents sub-agent scenario when captured", () => {
     if (label !== "golden") return;
     const lines = readFileSync(FIXTURE_PATH, "utf8").split("\n").filter(Boolean);

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -60,7 +60,7 @@ describe("CodexProvider permission flow", () => {
     // Pre-register a session entry so drain logic has something to iterate.
     seedSession(provider, sessionId, threadId, {
       server: { kill: vi.fn().mockResolvedValue(undefined), interruptTurn: vi.fn().mockResolvedValue(undefined), isAlive: true },
-      mapper: { reset: vi.fn() },
+      mapper: { reset: vi.fn(), drainPendingAssistantBoundary: vi.fn(() => []) },
       lastUsedAt: Date.now() - 1000,
       sandboxMode: "workspace-write",
     });
@@ -173,7 +173,7 @@ describe("CodexProvider permission flow", () => {
     fakeServer.isAlive = true;
     seedSession(provider, sessionId, threadId, {
       server: fakeServer,
-      mapper: { reset: vi.fn() },
+      mapper: { reset: vi.fn(), drainPendingAssistantBoundary: vi.fn(() => []) },
       lastUsedAt: Date.now(),
       sandboxMode: "workspace-write",
     });

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -45,17 +45,30 @@ const SILENT_ITEM_TYPES = new Set([
  *
  * Thinking stream: `item/reasoning/*` plus experimental `item/plan/delta` map to non-final
  * text deltas (`AgentEventType.TextDelta` with `isFinalResponse: false`) so the UI can show thought segments.
+ *
+ * Assistant text classification: Codex does not expose a stop reason. The mapper
+ * streams every assistant message as narration and retroactively promotes only
+ * the last assistant item to the final reply when the main turn completes.
  */
-/** Item types whose `item/started` marks "a tool fired this turn" for thought-vs-final classification. */
+/** Item types that appear as user-visible tools in the narrative. */
 const TOOL_LIKE_ITEM_TYPES = new Set([
   "commandExecution", "mcpToolCall", "dynamicToolCall",
   "fileChange", "collabAgentToolCall", "function_call", "webSearch",
 ]);
 
+const FALLBACK_ASSISTANT_ITEM_ID = "__codex_assistant_message__";
+
 export class CodexEventMapper {
-  private lastAssistantText = "";
-  /** Post-tool slice of assistant text — only deltas tagged `isFinalResponse: true`. Persisted as the assistant message body. */
-  private assistantFinalText = "";
+  /** Main-thread assistant text buffers keyed by Codex item id. */
+  private readonly assistantTextByItemId = new Map<string, string>();
+  /** The assistant item currently receiving streamed text. */
+  private currentAssistantItemId: string | undefined;
+  /** Text for the current assistant item, used when old Codex builds omit item ids. */
+  private currentAssistantItemText = "";
+  /** Last completed assistant item on the main Codex thread. Promoted on turn completion. */
+  private lastCompletedAssistantText = "";
+  /** Held assistant-message boundary waiting for one-event lookahead. */
+  private pendingAssistantBoundaryItemId: string | undefined;
   /** Dedupes `item/completed` reasoning payloads against streamed reasoning deltas. */
   private lastReasoningText = "";
   private readonly threadId: string;
@@ -65,10 +78,6 @@ export class CodexEventMapper {
   private readonly commandOutputBuffers = new Map<string, string>();
   /** Start-time ToolUse signatures, so completion enrichment only emits when details changed. */
   private readonly startedToolUseSignatures = new Map<string, string>();
-  /** Open tool-like items keyed by id. Mirrors Claude/Cursor `pendingToolUses` for thought-vs-final classification. */
-  private readonly pendingToolItems = new Set<string>();
-  /** True once any tool-like item has fired this turn. Distinguishes pre-tool preamble from post-tool final reply. */
-  private hasFiredToolThisTurn = false;
   /**
    * Open `collabAgentToolCall` item ids (LIFO). `item/started` pushes;
    * `item/completed` for the same collab pops. Nested collabs are supported.
@@ -348,6 +357,132 @@ export class CodexEventMapper {
     return started == null || started !== this.toolUseSignature(event);
   }
 
+  /** Returns a stable id for assistant-text notifications, including older shapes without item ids. */
+  private assistantItemId(
+    notification: CodexNotification,
+    item?: CompletedItem,
+  ): string {
+    const rawItemId = item?.id;
+    if (typeof rawItemId === "string" && rawItemId.length > 0) return rawItemId;
+    const paramsItemId = (notification.params as { itemId?: unknown }).itemId;
+    if (typeof paramsItemId === "string" && paramsItemId.length > 0) return paramsItemId;
+    return this.currentAssistantItemId ?? FALLBACK_ASSISTANT_ITEM_ID;
+  }
+
+  /** Extracts assistant text from completed assistant message item shapes. */
+  private assistantTextFromCompletedItem(item: CompletedItem): string {
+    const content = item.content ?? [];
+    if (Array.isArray(content)) {
+      return content
+        .filter((c) => c.type === "output_text" || c.type === "text")
+        .map((c) => c.text ?? "")
+        .join("");
+    }
+    const raw = item as { text?: unknown; output?: unknown };
+    if (typeof raw.text === "string") return raw.text;
+    if (typeof raw.output === "string") return raw.output;
+    return "";
+  }
+
+  /** True when there is assistant text whose boundary has not yet been classified. */
+  private hasOpenAssistantText(): boolean {
+    return (
+      this.pendingAssistantBoundaryItemId !== undefined
+      || this.currentAssistantItemText.length > 0
+    );
+  }
+
+  /**
+   * Flushes the held assistant-message boundary using Codex lookahead.
+   * Non-final boundaries clear assistant text so later turn failure/cancel
+   * cannot persist narration as the assistant reply.
+   */
+  drainPendingAssistantBoundary(isFinalResponse = false): AgentEvent[] {
+    if (!this.hasOpenAssistantText()) return [];
+    if (isFinalResponse && this.lastCompletedAssistantText.length === 0) {
+      this.lastCompletedAssistantText = this.currentAssistantItemText;
+    }
+    const event: AgentEvent = {
+      type: AgentEventType.AssistantMessageBoundary,
+      threadId: this.threadId,
+      isFinalResponse,
+    };
+    this.pendingAssistantBoundaryItemId = undefined;
+    if (!isFinalResponse) {
+      this.assistantTextByItemId.clear();
+      this.currentAssistantItemId = undefined;
+      this.currentAssistantItemText = "";
+      this.lastCompletedAssistantText = "";
+    }
+    return [event];
+  }
+
+  /** Flushes a pending boundary when a different item starts producing work. */
+  private drainAssistantBoundaryBeforeItem(nextItemId?: string): AgentEvent[] {
+    if (!this.hasOpenAssistantText()) return [];
+    if (nextItemId && this.currentAssistantItemId === nextItemId) return [];
+    return this.drainPendingAssistantBoundary(false);
+  }
+
+  /** Records streamed assistant text and emits it as narration until a boundary promotes it. */
+  private recordAssistantDelta(itemId: string, delta: string): void {
+    const prev = this.assistantTextByItemId.get(itemId) ?? "";
+    const next = prev + delta;
+    this.assistantTextByItemId.set(itemId, next);
+    this.currentAssistantItemId = itemId;
+    this.currentAssistantItemText = next;
+  }
+
+  /**
+   * Handles completed assistant items. It may emit a missing non-final delta for
+   * completed-only message shapes, but it holds the boundary until lookahead.
+   */
+  private recordAssistantCompletion(
+    item: CompletedItem,
+    notification: CodexNotification,
+  ): AgentEvent[] {
+    const itemId = this.assistantItemId(notification, item);
+    const completedText = this.assistantTextFromCompletedItem(item);
+    const hasSpecificItemId = itemId !== FALLBACK_ASSISTANT_ITEM_ID;
+    if (
+      hasSpecificItemId
+      && this.currentAssistantItemId === FALLBACK_ASSISTANT_ITEM_ID
+      && this.currentAssistantItemText.length > 0
+      && !this.assistantTextByItemId.has(itemId)
+    ) {
+      this.assistantTextByItemId.delete(FALLBACK_ASSISTANT_ITEM_ID);
+      this.assistantTextByItemId.set(itemId, this.currentAssistantItemText);
+      this.currentAssistantItemId = itemId;
+    }
+    const boundaryEvents = this.drainAssistantBoundaryBeforeItem(itemId);
+    const previousText = this.assistantTextByItemId.get(itemId) ?? "";
+    const events: AgentEvent[] = [...boundaryEvents];
+
+    if (completedText.length > 0) {
+      const delta = completedText.length > previousText.length
+        ? completedText.slice(previousText.length)
+        : "";
+      if (delta.length > 0) {
+        events.push({
+          type: AgentEventType.TextDelta,
+          threadId: this.threadId,
+          delta,
+          isFinalResponse: false,
+        });
+      }
+      this.assistantTextByItemId.set(itemId, completedText);
+      this.currentAssistantItemId = itemId;
+      this.currentAssistantItemText = completedText;
+    }
+
+    const text = this.assistantTextByItemId.get(itemId) ?? "";
+    if (text.length > 0) {
+      this.lastCompletedAssistantText = text;
+      this.pendingAssistantBoundaryItemId = itemId;
+    }
+    return events;
+  }
+
   /**
    * Translates a single `CodexNotification` into zero or more `AgentEvent` objects.
    * Returns an empty array for silently consumed notification types.
@@ -390,10 +525,7 @@ export class CodexEventMapper {
       const item = notification.params.item as CompletedItem | undefined;
       const itemType = item?.type;
       const itemId = typeof item?.id === "string" ? item.id : undefined;
-      if (itemType && itemId && TOOL_LIKE_ITEM_TYPES.has(itemType)) {
-        this.pendingToolItems.add(itemId);
-        this.hasFiredToolThisTurn = true;
-      }
+      const boundaryEvents = this.drainAssistantBoundaryBeforeItem(itemId);
       // The coordinator started a new tool-like item: any legacy collab whose
       // children have finished should be popped now so this new tool doesn't
       // accidentally inherit it as a parent.
@@ -407,17 +539,17 @@ export class CodexEventMapper {
         this.collabScopeStack.push(itemId);
         this.collabToolUseFromStartIds.add(itemId);
         this.registerCollabReceiverThreads(itemId, item as CompletedItem);
-        return [this.buildCollabToolUseEvent(item as CompletedItem, itemId, notification)];
+        return [...boundaryEvents, this.buildCollabToolUseEvent(item as CompletedItem, itemId, notification)];
       }
       if (itemType && itemId && TOOL_LIKE_ITEM_TYPES.has(itemType) && itemType !== "webSearch") {
         const toolUse = this.buildToolUseEvent(item as CompletedItem, itemId, notification);
         if (toolUse) {
           this.startedToolUseSignatures.set(itemId, this.toolUseSignature(toolUse));
-          return [toolUse];
+          return [...boundaryEvents, toolUse];
         }
       }
       logger.debug("Codex lifecycle notification", { method, itemType });
-      return [];
+      return boundaryEvents;
     }
 
     // Streaming reasoning summaries from the Codex app-server (Responses API reasoning item).
@@ -434,8 +566,9 @@ export class CodexEventMapper {
             ? p.text
             : "";
       if (!delta) return [];
+      const boundaryEvents = this.drainPendingAssistantBoundary(false);
       this.lastReasoningText += delta;
-      return [{
+      return [...boundaryEvents, {
         type: AgentEventType.TextDelta,
         threadId: this.threadId,
         delta,
@@ -452,7 +585,8 @@ export class CodexEventMapper {
       const p = notification.params as { delta?: string };
       const delta = typeof p.delta === "string" ? p.delta : "";
       if (!delta) return [];
-      return [{
+      const boundaryEvents = this.drainPendingAssistantBoundary(false);
+      return [...boundaryEvents, {
         type: AgentEventType.TextDelta,
         threadId: this.threadId,
         delta,
@@ -460,47 +594,42 @@ export class CodexEventMapper {
       }];
     }
 
-    // Streaming assistant text token. Codex sends pre-tool preamble AND post-tool final
-    // reply on the same wire channel. Mirror Claude/Cursor: tag `isFinalResponse: true`
-    // only when every tool started this turn has completed; otherwise emit as a
-    // thought delta so pre-tool / inter-tool narration shows in the thought timeline.
+    // Streaming assistant text token. Codex has no stop reason, so every
+    // assistant delta streams as narration until a later boundary promotes the
+    // last assistant item to the final response at turn completion.
     if (method === "item/agentMessage/delta") {
       const delta = notification.params.delta;
       if (!delta) return [];
-      const isFinalResponse =
-        this.pendingToolItems.size === 0 && this.hasFiredToolThisTurn;
-      this.lastAssistantText += delta;
-      if (isFinalResponse) this.assistantFinalText += delta;
-      return [{
+      const itemId = this.assistantItemId(notification);
+      const boundaryEvents = this.drainAssistantBoundaryBeforeItem(itemId);
+      this.recordAssistantDelta(itemId, delta);
+      return [...boundaryEvents, {
         type: AgentEventType.TextDelta,
         threadId: this.threadId,
         delta,
-        ...(isFinalResponse ? { isFinalResponse: true } : {}),
+        isFinalResponse: false,
       }];
     }
 
     // Streaming shell command output - accumulate per item for inclusion in ToolResult
     if (method === "item/commandExecution/outputDelta") {
+      const boundaryEvents = this.drainPendingAssistantBoundary(false);
       const { itemId, delta } = notification.params;
       if (itemId && delta) {
         const prev = this.commandOutputBuffers.get(itemId) ?? "";
         this.commandOutputBuffers.set(itemId, prev + delta);
       }
-      return [];
+      return boundaryEvents;
     }
 
     if (method === "item/completed") {
       const completedItem = notification.params.item;
       const completedType = completedItem?.type;
       const completedId = typeof completedItem?.id === "string" ? completedItem.id : undefined;
-      if (completedType && TOOL_LIKE_ITEM_TYPES.has(completedType)) {
-        this.hasFiredToolThisTurn = true;
-        if (completedId) {
-          this.pendingToolItems.delete(completedId);
-        }
-      }
+      const isAssistantItem = completedType === "agentMessage" || completedType === "message";
+      const boundaryEvents = isAssistantItem ? [] : this.drainAssistantBoundaryBeforeItem(completedId);
       logger.debug("Codex item/completed", { type: completedType });
-      return this.mapItemCompleted(completedItem, notification);
+      return [...boundaryEvents, ...this.mapItemCompleted(completedItem, notification)];
     }
 
     if (method === "turn/completed") {
@@ -511,17 +640,21 @@ export class CodexEventMapper {
       if (turn?.status === "failed") {
         const errorMsg = turn.error?.message ?? "Codex turn failed";
         logger.error("Codex turn failed", { error: errorMsg, codexErrorInfo: turn.error?.codexErrorInfo });
+        const boundaryEvents = this.drainPendingAssistantBoundary(false);
         this.reset();
         this.turnEnded = true;
-        return [{ type: AgentEventType.Error, threadId: this.threadId, error: errorMsg }];
+        return [...boundaryEvents, { type: AgentEventType.Error, threadId: this.threadId, error: errorMsg }];
       }
 
-      // Persist only the post-tool final slice when tools fired (mirrors Cursor's
-      // resolveCursorAssistantMessageContent). Tool-free turns fall back to the
-      // full streamed text since nothing was tagged final.
-      const finalSlice = this.assistantFinalText.trim();
-      const text =
-        finalSlice.length > 0 ? this.assistantFinalText : this.lastAssistantText;
+      if (turn?.status === "interrupted") {
+        const boundaryEvents = this.drainPendingAssistantBoundary(false);
+        this.reset();
+        this.turnEnded = true;
+        return boundaryEvents;
+      }
+
+      const boundaryEvents = this.drainPendingAssistantBoundary(true);
+      const text = this.lastCompletedAssistantText;
       const usage = turn?.usage ?? {};
       const inputTokens = usage.input_tokens ?? 0;
       const cachedInputTokens = usage.cached_input_tokens ?? 0;
@@ -529,7 +662,7 @@ export class CodexEventMapper {
       const tokensOut = usage.output_tokens ?? 0;
       const totalProcessedTokens = inputTokens + cachedInputTokens + tokensOut;
 
-      const events: AgentEvent[] = [];
+      const events: AgentEvent[] = [...boundaryEvents];
       if (text) {
         events.push({ type: AgentEventType.Message, threadId: this.threadId, content: text, tokens: null });
       }
@@ -558,10 +691,11 @@ export class CodexEventMapper {
       const errorMsg = notification.params.error?.message ?? "Unknown error from codex app-server";
       const willRetry = notification.params.willRetry ?? false;
       logger.debug("Codex error notification", { error: errorMsg, willRetry });
+      const boundaryEvents = this.drainPendingAssistantBoundary(false);
       if (willRetry) {
-        return [{ type: AgentEventType.ApiRetry, threadId: this.threadId, reason: errorMsg }];
+        return [...boundaryEvents, { type: AgentEventType.ApiRetry, threadId: this.threadId, reason: errorMsg }];
       }
-      return [{ type: AgentEventType.Error, threadId: this.threadId, error: errorMsg }];
+      return [...boundaryEvents, { type: AgentEventType.Error, threadId: this.threadId, error: errorMsg }];
     }
 
     if (SILENCED_METHODS.has(method)) {
@@ -575,8 +709,11 @@ export class CodexEventMapper {
 
   /** Resets per-turn accumulated state between turns. */
   reset(): void {
-    this.lastAssistantText = "";
-    this.assistantFinalText = "";
+    this.assistantTextByItemId.clear();
+    this.currentAssistantItemId = undefined;
+    this.currentAssistantItemText = "";
+    this.lastCompletedAssistantText = "";
+    this.pendingAssistantBoundaryItemId = undefined;
     this.lastReasoningText = "";
     this.commandOutputBuffers.clear();
     this.startedToolUseSignatures.clear();
@@ -584,8 +721,6 @@ export class CodexEventMapper {
     this.collabToolUseFromStartIds.clear();
     this.pendingLegacyCollabPops.clear();
     this.collabReceiverThreadToCollabId.clear();
-    this.pendingToolItems.clear();
-    this.hasFiredToolThisTurn = false;
     // Note: turnEnded is intentionally NOT cleared here. reset() is called
     // from inside turn/completed, and we want the latch to stay armed until
     // the next turn opens. Use prepareForTurn() before a new outbound turn.
@@ -620,8 +755,7 @@ export class CodexEventMapper {
     }
 
     if (itemType === "agentMessage") {
-      // Text was already streamed via item/agentMessage/delta; completion just confirms it
-      return [];
+      return this.recordAssistantCompletion(item, notification);
     }
 
     if (itemType === "reasoning") {
@@ -649,24 +783,9 @@ export class CodexEventMapper {
     }
 
     // OpenAI Responses API shape - some codex versions emit "message" items with a content array
-    // instead of (or in addition to) streaming deltas. Compute delta vs accumulated text.
+    // instead of (or in addition to) streaming deltas.
     if (itemType === "message") {
-      const content = (item.content ?? []) as Array<{ type: string; text?: string }>;
-      const fullText = content
-        .filter((c) => c.type === "output_text" || c.type === "text")
-        .map((c) => c.text ?? "")
-        .join("");
-      const delta = fullText.length > this.lastAssistantText.length
-        ? fullText.slice(this.lastAssistantText.length)
-        : "";
-      if (!delta) return [];
-      this.lastAssistantText = fullText;
-      return [{
-        type: AgentEventType.TextDelta,
-        threadId,
-        delta,
-        isFinalResponse: true,
-      }];
+      return this.recordAssistantCompletion(item, notification);
     }
 
     // OpenAI Responses API shape - function_call items carry tool invocations

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -386,6 +386,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
 
     server.on("fatal", (error: string) => {
       logger.error("CodexAppServer fatal", { sessionId, error });
+      for (const event of mapper.drainPendingAssistantBoundary(false)) {
+        this.emit("event", event);
+      }
       this.emit("event", { type: AgentEventType.Error, threadId, error } satisfies AgentEvent);
       this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
       void this.runtime.stop(sessionId);
@@ -472,6 +475,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
 
   /** Graceful protocol interrupt of the in-flight turn (does not kill the process). */
   async interrupt(state: CodexSessionState): Promise<void> {
+    for (const event of state.mapper.drainPendingAssistantBoundary(false)) {
+      this.emit("event", event);
+    }
     await state.server.interruptTurn();
   }
 
@@ -481,6 +487,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
    * Drives every teardown path (stop, shutdown, eviction, stale-discard).
    */
   async close(state: CodexSessionState): Promise<void> {
+    for (const event of state.mapper.drainPendingAssistantBoundary(false)) {
+      this.emit("event", event);
+    }
     this.drainPending((e) => e.sessionId === state.sessionId);
     await state.server.kill();
   }
@@ -507,6 +516,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
     const entry = this.runtime.get(sessionId);
     if (!entry) return;
 
+    for (const event of entry.mapper.drainPendingAssistantBoundary(false)) {
+      this.emit("event", event);
+    }
     entry.mapper.prepareForTurn();
 
     // Only pay the turn/interrupt round-trip when a previous turn is actually
@@ -631,6 +643,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
           sessionId,
           timeoutMs: TURN_TIMEOUT_MS,
         });
+        for (const event of entry.mapper.drainPendingAssistantBoundary(false)) {
+          this.emit("event", event);
+        }
         // Interrupt the upstream turn so the app-server state matches the UI
         // ("ended") instead of silently chewing in the background.
         void server.interruptTurn();
@@ -639,6 +654,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
       if (!serverDied && seq === entry.runTurnSeq) {
         const errorMessage = e instanceof Error ? e.message : String(e);
         logger.error("Codex turn failed", { sessionId, error: errorMessage });
+        for (const event of entry.mapper.drainPendingAssistantBoundary(false)) {
+          this.emit("event", event);
+        }
         this.emit("event", { type: AgentEventType.Error, threadId, error: errorMessage } satisfies AgentEvent);
       }
     } finally {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1568,6 +1568,7 @@ export class AgentService {
             this.narrativeStore.dropOpenThought(event.threadId);
           } else {
             this.narrativeStore.closeOpenThought(event.threadId);
+            this.turnFinalizer.resetStreamingText(event.threadId);
           }
         }
 

--- a/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
+++ b/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
@@ -3,12 +3,25 @@ import {
   getTestThreadStreaming,
   getTestThreadThoughtSegments,
 } from "@/stores/thread-store-test-utils";
+import { createEmptyThreadRecord } from "@/stores/thread-record";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useThreadStore } from "@/stores/threadStore";
+import { mockTransport } from "./mocks/transport";
+
+vi.mock("@/transport", async () => ({
+  ...(await vi.importActual("@/transport")),
+  getTransport: () => mockTransport,
+}));
 
 describe("threadStore textDelta batching", () => {
   beforeEach(() => {
     resetThreadStoreForTests();
+    vi.mocked(mockTransport.listNarrative).mockReset();
+    vi.mocked(mockTransport.listNarrative).mockResolvedValue({
+      tools: [],
+      thoughts: [],
+      hooks: [],
+    });
   });
 
   afterEach(() => {
@@ -61,6 +74,27 @@ describe("threadStore textDelta batching", () => {
     expect(getTestThreadStreaming(tid)).toBe("think final");
     expect(getTestThreadThoughtSegments(tid)?.length).toBe(1);
     expect(getTestThreadThoughtSegments(tid)?.[0]?.text).toBe("think ");
+    expect(getTestThreadThoughtSegments(tid)?.[0]?.isExplicitNonFinal).toBe(true);
+  });
+
+  it("does not mark omitted isFinalResponse deltas as explicit non-final", () => {
+    const queue: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      queue.push(cb);
+      return queue.length;
+    });
+
+    const tid = "thread-legacy-unclassified";
+    useThreadStore.getState().handleAgentEvent(tid, {
+      method: "session.textDelta",
+      params: { delta: "legacy " },
+    });
+    expect(queue).toHaveLength(1);
+
+    queue[0]!(0);
+
+    expect(getTestThreadThoughtSegments(tid)?.[0]?.text).toBe("legacy ");
+    expect(getTestThreadThoughtSegments(tid)?.[0]?.isExplicitNonFinal).toBeUndefined();
   });
 
   it("flushes pending deltas before session.turnComplete reads streaming", () => {
@@ -83,5 +117,73 @@ describe("threadStore textDelta batching", () => {
     });
 
     expect(getTestThreadStreaming(tid)).toBeUndefined();
+  });
+
+  it("backfills volatile thoughts from persisted narrative after turn.persisted", async () => {
+    const tid = "thread-persisted-backfill";
+    const localMessageId = "local-msg";
+    const serverMessageId = "server-msg";
+    vi.mocked(mockTransport.listNarrative).mockResolvedValueOnce({
+      tools: [],
+      thoughts: [
+        {
+          id: "th-1",
+          message_id: serverMessageId,
+          text: "I saw `C:\\src\\automaker`.",
+          started_at: "2026-06-11T16:11:01.000Z",
+          ended_at: "2026-06-11T16:11:02.000Z",
+          sort_order: 1,
+          is_final_response: 0,
+        },
+        {
+          id: "th-2",
+          message_id: serverMessageId,
+          text: "Tree is dirty.",
+          started_at: "2026-06-11T16:11:03.000Z",
+          ended_at: "2026-06-11T16:11:04.000Z",
+          sort_order: 3,
+          is_final_response: 0,
+        },
+      ],
+      hooks: [],
+    });
+    resetThreadStoreForTests({
+      currentThreadId: tid,
+      records: new Map([
+        [
+          tid,
+          {
+            ...createEmptyThreadRecord(),
+            currentTurnMessageId: localMessageId,
+            toolCalls: [
+              {
+                id: "cmd-1",
+                toolName: "Bash",
+                toolInput: { command: "pwd" },
+                output: "C:\\src\\automaker",
+                isError: false,
+                isComplete: true,
+                parentToolCallId: undefined,
+                startedAt: 1,
+              },
+            ],
+          },
+        ],
+      ]),
+    });
+
+    useThreadStore.getState().handleTurnPersisted({
+      threadId: tid,
+      messageId: serverMessageId,
+      toolCallCount: 1,
+      filesChanged: [],
+    });
+
+    await vi.waitFor(() => {
+      expect(getTestThreadThoughtSegments(tid)?.map((segment) => segment.text)).toEqual([
+        "I saw `C:\\src\\automaker`.",
+        "Tree is dirty.",
+      ]);
+    });
   });
 });

--- a/apps/web/src/__tests__/virtual-items.test.ts
+++ b/apps/web/src/__tests__/virtual-items.test.ts
@@ -156,6 +156,35 @@ describe("buildVolatileItems", () => {
     >;
     expect(narrativeItem?.thoughtSegments).toEqual(thoughtSegments);
   });
+
+  it("does not emit a live assistant message for explicit non-final narration", () => {
+    const thoughtSegments: ThoughtSegment[] = [
+      { text: "codex narration", startedAt: 42, isExplicitNonFinal: true },
+    ];
+    const items = buildVolatileItems(
+      [],
+      true,
+      1000,
+      "codex narration",
+      undefined,
+      [],
+      thoughtSegments,
+    );
+
+    expect(
+      items.some(
+        (i) =>
+          i.type === "message" &&
+          i.message.role === "assistant" &&
+          i.assistantState?.isStreaming,
+      ),
+    ).toBe(false);
+    const narrativeItem = items.find((i) => i.type === "narrative-flow") as Extract<
+      (typeof items)[number],
+      { type: "narrative-flow" }
+    >;
+    expect(narrativeItem?.thoughtSegments).toEqual(thoughtSegments);
+  });
 });
 
 describe("buildVirtualItems (combined)", () => {

--- a/apps/web/src/components/chat/narrative/__tests__/build-narrative-counts.test.ts
+++ b/apps/web/src/components/chat/narrative/__tests__/build-narrative-counts.test.ts
@@ -85,6 +85,24 @@ describe("buildNarrativeItems counts", () => {
     expect(counts.thoughts).toBe(0);
   });
 
+  it("keeps an explicit non-final open segment as a thought when no tool is running", () => {
+    const thoughts: ThoughtSegment[] = [
+      { ...mkThought("codex narration", 1000), isExplicitNonFinal: true },
+    ];
+    const { items, counts } = buildNarrativeItems({
+      toolCalls: [],
+      hooks: [],
+      thoughtSegments: thoughts,
+      streamingText: "codex narration",
+      isAgentRunning: true,
+    });
+
+    expect(items.some((it) => it.type === "delta")).toBe(false);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ type: "thought", isActive: true });
+    expect(counts.thoughts).toBe(1);
+  });
+
   it("appends isFinal surplus as delta after thoughts when streaming extends past segment tape", () => {
     const thoughts: ThoughtSegment[] = [
       mkThought("pre-tool reasoning", 100, 700),

--- a/apps/web/src/components/chat/narrative/build-narrative.ts
+++ b/apps/web/src/components/chat/narrative/build-narrative.ts
@@ -15,7 +15,8 @@ const AGENT_TOOL_NAME = "Agent";
  *
  *  - When the latest thought segment is open and no tool is running, that
  *    segment IS the live response (tool-free turn, or pre-tool preamble that
- *    will be classified by the next `AssistantMessageBoundary`).
+ *    will be classified by the next `AssistantMessageBoundary`). An explicit
+ *    non-final segment stays in the timeline instead.
  *  - Otherwise, the suffix of `streamingText` past the closed-thought tape is
  *    the final-response text emitted after the last tool completed.
  */
@@ -35,6 +36,7 @@ export function computeLiveStreamingText(params: {
 
   const lastSeg = thoughtSegments[thoughtSegments.length - 1];
   if (lastSeg && lastSeg.endedAt == null) {
+    if (lastSeg.isExplicitNonFinal) return "";
     return lastSeg.text;
   }
 
@@ -103,6 +105,7 @@ type TimelineEvent =
  * in `streamingText` but not in `thoughtSegments`; the surplus over the joined
  * segment texts is appended as a `delta` row. When `isFinalResponse` is omitted
  * (legacy tool-free turns), the last open segment is still elevated to `delta`.
+ * Explicit non-final segments remain thought rows even when no tool is running.
  *
  * When `committedAssistantBody` is set (typically the last assistant bubble after
  * `session.turnComplete`), thought rows that only repeat that body are omitted so
@@ -215,7 +218,11 @@ export function buildNarrativeItems(params: {
       // Fallback when `isFinalResponse` never arrived: streamed text lives in the
       // latest open segment (`streamingSuffix` is empty).
       const useLegacyTapeFinalDelta =
-        streamingSuffix === "" && isLatest && isStreaming && !anyToolRunning;
+        streamingSuffix === "" &&
+        isLatest &&
+        isStreaming &&
+        !anyToolRunning &&
+        !evt.segment.isExplicitNonFinal;
       if (useLegacyTapeFinalDelta) {
         items.push({ type: "delta", text: evt.segment.text });
         emittedFinalDeltaFromTape = true;

--- a/apps/web/src/components/chat/narrative/types.ts
+++ b/apps/web/src/components/chat/narrative/types.ts
@@ -10,6 +10,8 @@ export interface ThoughtSegment {
   startedAt: number;
   /** Epoch ms when the segment ended (next toolUse or turnComplete). Undefined if still streaming. */
   endedAt?: number;
+  /** True when the provider explicitly classified this segment as non-final narration. */
+  isExplicitNonFinal?: boolean;
 }
 
 /**

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
-import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, ToolCallRecord } from "@/transport";
+import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, ToolCallRecord, ThoughtSegmentRecord } from "@/transport";
 import type { ContextWindowMode, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
+import type { ThoughtSegment } from "@/components/chat/narrative/types";
 import { PlanQuestionSchema, PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
 import { getTransport } from "@/transport";
 import { useWorkspaceStore } from "./workspaceStore";
@@ -225,6 +226,26 @@ function createTurnResponseKey(threadId: string): string {
   return `turn-response:${threadId}:${crypto.randomUUID()}`;
 }
 
+/** Maps a persisted thought row into the live narrative segment shape. */
+function persistedThoughtToSegment(record: ThoughtSegmentRecord): ThoughtSegment {
+  const startedAt = Date.parse(record.started_at);
+  const endedAt = record.ended_at ? Date.parse(record.ended_at) : NaN;
+  return {
+    text: record.text,
+    startedAt: Number.isFinite(startedAt) ? startedAt : Date.now(),
+    endedAt: Number.isFinite(endedAt) ? endedAt : undefined,
+  };
+}
+
+/** Returns persisted thought rows that should remain visible above the final reply. */
+function visiblePersistedThoughtSegments(
+  thoughts: readonly ThoughtSegmentRecord[],
+): ThoughtSegment[] {
+  return thoughts
+    .filter((thought) => !thought.is_final_response)
+    .map(persistedThoughtToSegment);
+}
+
 /**
  * Walk up the parentToolCallId chain to find the nearest Agent tool call
  * and return its description as a group label for TodoWrite tasks.
@@ -393,8 +414,8 @@ export function extractPendingPlanQuestions(
 }
 
 /** Zustand store for thread-scoped messages, streaming session state, and agent event handling. */
-/** One coalesced `session.textDelta` span for rAF flushing; merges adjacent chunks with same `isFinalResponse`. */
-type PendingTextChunk = { delta: string; isFinalResponse: boolean };
+/** One coalesced `session.textDelta` span for rAF flushing; preserves missing `isFinalResponse` for legacy fallback behavior. */
+type PendingTextChunk = { delta: string; isFinalResponse?: boolean };
 
 export const useThreadStore = create<ThreadState>((set, get) => {
   let textDeltaFlushRaf: number | null = null;
@@ -442,6 +463,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             continue;
           }
 
+          const isExplicitNonFinal = chunk.isFinalResponse === false;
           const last = segments[segments.length - 1];
           const looksLikeContinuation = (prevText: string, nextText: string): boolean => {
             const trimmedPrev = prevText.trimEnd();
@@ -459,15 +481,30 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             (last.text.length < TINY_SEGMENT_THRESHOLD ||
               looksLikeContinuation(last.text, acc));
           if (!last || (last.endedAt !== undefined && !shouldReopen)) {
-            segments = [...segments, { text: acc, startedAt: Date.now() }];
+            segments = [
+              ...segments,
+              {
+                text: acc,
+                startedAt: Date.now(),
+                ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
+              },
+            ];
           } else if (last.endedAt !== undefined && shouldReopen) {
-            const reopened: typeof last = { ...last, text: last.text + acc };
+            const reopened: typeof last = {
+              ...last,
+              text: last.text + acc,
+              ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
+            };
             delete (reopened as { endedAt?: number }).endedAt;
             segments = [...segments.slice(0, -1), reopened];
           } else {
             segments = [
               ...segments.slice(0, -1),
-              { ...last, text: last.text + acc },
+              {
+                ...last,
+                text: last.text + acc,
+                ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
+              },
             ];
           }
         }
@@ -1657,7 +1694,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (method === "session.textDelta") {
       const delta = (params.delta as string) || "";
       if (!delta) return;
-      const isFinalResponse = params.isFinalResponse === true;
+      const rawIsFinalResponse = params.isFinalResponse;
+      const isFinalResponse =
+        typeof rawIsFinalResponse === "boolean" ? rawIsFinalResponse : undefined;
       const hadPending = pendingTextDeltaByThread.has(threadId);
       const existing = pendingTextDeltaByThread.get(threadId) ?? [];
       const next = [...existing];
@@ -2430,9 +2469,19 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       .then(() => {
         const currentId = get().currentThreadId;
         if (!currentId) return;
+        if (currentId !== payload.threadId) return;
         const rec = getRec(currentId);
         const serverRes = rec.narrativeByMessage[payload.messageId];
-        if (!serverRes || !localIdForBackfill) return;
+        if (!serverRes) return;
+        const persistedThoughtSegments = visiblePersistedThoughtSegments(serverRes.thoughts);
+        if (persistedThoughtSegments.length > rec.thoughtSegments.length) {
+          patchRec(currentId, (r) => {
+            if (r.toolCalls.length === 0) return {};
+            if (r.thoughtSegments.length >= persistedThoughtSegments.length) return {};
+            return { thoughtSegments: persistedThoughtSegments };
+          });
+        }
+        if (!localIdForBackfill) return;
         if (localIdForBackfill === payload.messageId) return;
         patchRec(currentId, (r) => ({
           narrativeByMessage: {

--- a/docs/guides/codex-app-server-trace.md
+++ b/docs/guides/codex-app-server-trace.md
@@ -26,9 +26,9 @@ Across both runs, Codex split "thinking" from "answer" cleanly at the wire: anyt
 | `item/started` (commandExecution) | Shell command starting | between reasoning and final message | B:12 |
 | `item/commandExecution/outputDelta` | Streaming stdout/stderr token | repeated | B:13,14 |
 | `item/completed` (commandExecution) | Command finished, includes `command`, `aggregatedOutput`, `exitCode` | after command stream | B:15 |
-| `item/started` (agentMessage) | Final assistant turn began | after tools | A:12 / B:16 |
-| `item/agentMessage/delta` | Streaming final answer token | many | A:13 / B:17–31 |
-| `item/completed` (agentMessage) | Final answer text closed | end of answer stream | A:14 / B:32 |
+| `item/started` (agentMessage) | Assistant text item began | after tools in these traces | A:12 / B:16 |
+| `item/agentMessage/delta` | Streaming assistant text token | many | A:13 / B:17-31 |
+| `item/completed` (agentMessage) | Assistant text item closed | end of answer stream in these traces | A:14 / B:32 |
 | `turn/completed` | Turn ended with `status: "completed"`, `turn.items` length 0 | terminal | A:18 / B:36 |
 
 `turn.items` was **empty** (`itemsLen: 0`) in both completed turns. Streaming items are the only place children appear; the post-hoc `turn.items` array was not populated in this CLI version. Code that depends on `turn.items` to reconstruct child order is unsafe — trust live ordering.
@@ -37,15 +37,15 @@ Across both runs, Codex split "thinking" from "answer" cleanly at the wire: anyt
 
 | Method | Route in Mcode | Evidence |
 |---|---|---|
-| `item/agentMessage/delta` | `TextDelta` with `isFinalResponse: true` | A:13, B:17–31 stream the user-facing answer |
+| `item/agentMessage/delta` | non-final `TextDelta`; later `AssistantMessageBoundary` promotes the last assistant item on main turn completion | A:13, B:17-31 stream the user-facing answer |
 | `item/reasoning/textDelta` | `TextDelta` with `isFinalResponse: false` (thought) | **unverified in this run** — low effort produced no deltas |
 | `item/reasoning/summaryTextDelta` | `TextDelta` with `isFinalResponse: false` (thought) | unverified — no deltas in either run |
 | `item/reasoning/summaryPartAdded` | ignore (lifecycle) | unverified |
 | `item/plan/delta` | `TextDelta` with `isFinalResponse: false` (thought, experimental) | unverified |
 | `item/completed` type `reasoning` | If `summary` or `reasoningContent` non-empty, emit `TextDelta isFinalResponse:false` as delta vs accumulator | summary was empty on A:11; mapper's diff-vs-accumulator stays correct |
-| `item/completed` type `agentMessage` | no event (text already streamed) | A:14, B:32 confirm — final text was complete by the time completed fired |
+| `item/completed` type `agentMessage` | holds the assistant boundary for one-event lookahead | A:14, B:32 confirm final text was complete by the time completed fired |
 
-The current mapper at `apps/server/src/providers/codex/codex-event-mapper.ts:128-164` already implements these rules. The traces give no contradiction; they just don't exercise the reasoning/plan paths under default settings.
+The current mapper implements these routes. The traces give no contradiction; they just do not exercise the reasoning and plan paths under default settings.
 
 ## Sub-agent nesting (collabAgentToolCall)
 

--- a/docs/guides/codex-narrative-spec.md
+++ b/docs/guides/codex-narrative-spec.md
@@ -29,8 +29,8 @@ For pipeline traps and shared behavior with Claude, see [narrative-pipeline.md](
 
 | Element | Expected behavior |
 |--------|-------------------|
-| Thought rows | Dimmed / “thinking” style blocks built from `TextDelta` with `isFinalResponse: false`. |
-| Final reply | Full-weight prose from `TextDelta` with `isFinalResponse: true`, then committed message on turn end. |
+| Thought rows | Dimmed / “thinking” style blocks built from non-final `TextDelta` events. |
+| Final reply | Full-weight prose from the assistant item promoted by `AssistantMessageBoundary`, then committed message on turn end. |
 | Agent / sub-agent row | `ToolUse` with `toolName: "Agent"`; label may reflect Codex collab kind (e.g. spawn). |
 | Child tools | Nested under the correct Agent row; expandable like today’s narrative. |
 | Turn footer | Step / sub-agent counts and duration reflect nested tools and Agent rows (existing narrative rules). |
@@ -44,7 +44,7 @@ For pipeline traps and shared behavior with Claude, see [narrative-pipeline.md](
 - **Thought stream**: Any Codex notification that represents non-final model text must map to `AgentEventType.TextDelta` with `isFinalResponse: false`.  
   Known sources today: `item/reasoning/*`, `item/completed` with `type: "reasoning"`, and experimental `item/plan/delta` when the app-server uses it for live planning text.
 
-- **Final answer stream**: `item/agentMessage/delta` and equivalent completed shapes map to `TextDelta` with `isFinalResponse: true`.
+- **Assistant stream**: `item/agentMessage/delta` and equivalent completed shapes map to non-final `TextDelta` events while the turn is running. At main turn completion, the mapper emits `AssistantMessageBoundary` with `isFinalResponse: true` for the last assistant item and persists that item as the final reply.
 
 - **Sub-agent scope**: Child `ToolUse` events must include `parentToolCallId` set to the Codex collab item id when the work is under that sub-agent.
 

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -139,12 +139,12 @@ export const AgentEventSchema = lazySchema(() =>
       delta: z.string(),
       /**
        * Set to `true` when this delta belongs to the final user-facing response
-       * (i.e. all tool calls have been resolved for this turn). The client uses
+       * for providers that can classify it while streaming. The client uses
        * this to suppress creating a ThoughtSegment row for these deltas.
        *
-       * Not set for tool-free turns (no lookahead is possible at the provider
-       * layer); the client fallback in `build-narrative.ts` and the
-       * `persistTurn` suffix-match safeguard handle that case instead.
+       * `AssistantMessageBoundary` is the authoritative classifier. Providers
+       * without stop reasons, such as Codex, may stream assistant text as
+       * non-final and promote the last assistant item at turn completion.
        */
       isFinalResponse: z.boolean().optional(),
     }),
@@ -291,9 +291,8 @@ export const AgentEventSchema = lazySchema(() =>
        *   other non-finalizing value) — the deltas were preamble. The consumer
        *   should close the open thought segment so it persists as a thought.
        *
-       * This is the authoritative classification signal, replacing the legacy
-       * `hasFiredToolThisTurn && pendingToolUses==0` heuristic for tool-free
-       * turns and other cases the heuristic could not lookahead for.
+       * This is the authoritative classification signal. Providers without a
+       * stop reason use it for retroactive promotion of the last assistant item.
        */
       type: z.literal(AgentEventType.AssistantMessageBoundary),
       threadId: z.string(),


### PR DESCRIPTION
## What
Preserve Codex assistant narration across tool boundaries and final response promotion.

## Why
Issue #693: Codex text between tool calls could render as the final response, get replaced by the next active tool row, or disappear after `turn.persisted`.

## Key Changes
- Classify Codex assistant deltas as non-final until a boundary promotes only the final assistant item.
- Teach the web client that explicit `isFinalResponse: false` means narration, not legacy fallback.
- Backfill volatile thought rows from persisted narrative after `turn.persisted` so DB-backed thoughts stay visible while volatile tool rows remain.
- Add mapper, protocol coverage, store, and narrative builder regressions.

Closes #693

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787519&installation_id=129163861&pr_number=707&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F707&signature=a8e768f2a1710e70da561b9fb70c5bee47ebeed42b38c91ad9dbb9fd75bcefca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced assistant message streaming with improved distinction between thinking-in-progress and final responses.

* **Improvements**
  * More accurate classification and display of assistant reasoning versus final answers in conversations.

* **Documentation**
  * Updated protocol and narrative guides to reflect updated event handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->