### PR TITLE
fix: keep Codex main turn alive past sub-agent completion; smooth turn-end transition

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-provider-subagent-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-subagent-turn.test.ts
@@ -1,0 +1,151 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@mcode/shared", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../codex-version.js", () => ({
+  checkCodexVersion: () => ({ ok: true, version: "0.40.0" }),
+  meetsMinVersion: () => true,
+}));
+
+const { sendTurnMock } = vi.hoisted(() => ({
+  sendTurnMock: vi.fn().mockResolvedValue("turn-main"),
+}));
+
+vi.mock("../codex-app-server.js", async () => {
+  const { EventEmitter } = await import("events");
+  class MockCodexAppServer extends EventEmitter {
+    isAlive = true;
+    threadId = "sdk-thread-1";
+    resumeFailed = false;
+    async start(): Promise<void> {}
+    async sendTurn(): Promise<string> {
+      return sendTurnMock();
+    }
+    async interruptTurn(): Promise<void> {}
+    async kill(): Promise<void> {}
+  }
+  return { CodexAppServer: MockCodexAppServer };
+});
+
+import { CodexProvider } from "../codex-provider.js";
+import { AgentEventType } from "@mcode/contracts";
+import type { AgentEvent } from "@mcode/contracts";
+import { stubEnvService } from "../../../__tests__/stub-env-service.js";
+
+interface PoolEntry {
+  pendingTurnId: string | null;
+  server: { emit: (event: string, payload: unknown) => void };
+}
+
+/** Spawns a provider session and returns its pool entry once the first turn was sent. */
+async function startSession(
+  provider: CodexProvider,
+  sessionId: string,
+  threadId: string,
+): Promise<PoolEntry> {
+  await provider.sendTurn({
+    sessionId,
+    threadId,
+    message: "hey",
+    cwd: process.cwd(),
+    model: "gpt-5.4",
+    interactionMode: "build",
+    providerOptions: {},
+    permissionMode: "auto",
+  });
+
+  for (let i = 0; i < 20 && sendTurnMock.mock.calls.length === 0; i++) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  expect(sendTurnMock).toHaveBeenCalled();
+
+  const pool = (
+    provider as unknown as {
+      runtime: { get: (id: string) => PoolEntry | undefined };
+    }
+  ).runtime;
+  const entry = pool.get(sessionId);
+  expect(entry).toBeDefined();
+  return entry!;
+}
+
+function makeProvider(): CodexProvider {
+  return new CodexProvider(
+    { get: async () => ({ provider: { cli: { codex: "codex" } } }) } as never,
+    { assign: vi.fn(), isWindowsJob: false } as never,
+    stubEnvService() as never,
+  );
+}
+
+/**
+ * Regression: Codex sub-agent (collab receiver) threads stream their own
+ * turn/started + turn/completed over the same app-server connection. The
+ * provider's turn bookkeeping must only react to main-thread lifecycle
+ * notifications — otherwise a finishing sub-agent resolves the main runTurn
+ * wait, emits Ended mid-turn, and the UI drops the running indicator while
+ * narration keeps streaming (and the still-busy session becomes evictable).
+ */
+describe("CodexProvider sub-agent turn lifecycle isolation", () => {
+  beforeEach(() => {
+    sendTurnMock.mockClear();
+  });
+
+  it("does not let a child-thread turn/started overwrite pendingTurnId", async () => {
+    const provider = makeProvider();
+    const entry = await startSession(provider, "mcode-subagent-a", "subagent-a");
+
+    entry.server.emit("notification", {
+      method: "turn/started",
+      params: { threadId: "sdk-thread-1", turn: { id: "turn-main" } },
+    });
+    expect(entry.pendingTurnId).toBe("turn-main");
+
+    entry.server.emit("notification", {
+      method: "turn/started",
+      params: { threadId: "child-thread-9", turn: { id: "turn-child" } },
+    });
+    expect(entry.pendingTurnId).toBe("turn-main");
+  });
+
+  it("does not emit Ended when a child-thread turn completes mid main turn", async () => {
+    const provider = makeProvider();
+    const events: AgentEvent[] = [];
+    provider.on("event", (e: AgentEvent) => events.push(e));
+
+    const entry = await startSession(provider, "mcode-subagent-b", "subagent-b");
+
+    entry.server.emit("notification", {
+      method: "turn/started",
+      params: { threadId: "sdk-thread-1", turn: { id: "turn-main" } },
+    });
+
+    // Child completion with its own turn id.
+    entry.server.emit("notification", {
+      method: "turn/completed",
+      params: { threadId: "child-thread-9", turn: { id: "turn-child", status: "completed" } },
+    });
+    // Child completion without a turn id (shape observed from wait-less collabs).
+    entry.server.emit("notification", {
+      method: "turn/completed",
+      params: { threadId: "child-thread-10", turn: { status: "completed" } },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(events.filter((e) => e.type === AgentEventType.Ended)).toHaveLength(0);
+    expect(entry.pendingTurnId).toBe("turn-main");
+
+    const ended = new Promise<void>((resolve) => {
+      provider.on("event", (e: AgentEvent) => {
+        if (e.type === AgentEventType.Ended && e.threadId === "subagent-b") resolve();
+      });
+    });
+    entry.server.emit("notification", {
+      method: "turn/completed",
+      params: { threadId: "sdk-thread-1", turn: { id: "turn-main", status: "completed" } },
+    });
+    await ended;
+  });
+});

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -146,6 +146,25 @@ function toCodexEffort(level?: ReasoningLevel): ReasoningEffort | undefined {
   return level as ReasoningEffort;
 }
 
+/**
+ * True when a turn lifecycle notification belongs to the app-server's main
+ * thread. Sub-agent (collab receiver) threads stream their own `turn/started`
+ * and `turn/completed` over the same connection, tagged with their own
+ * `threadId`; letting those drive the provider's turn bookkeeping ends the
+ * main turn early (UI drops the running indicator while streaming continues,
+ * and the still-busy session becomes evictable). Notifications without a
+ * `threadId`, or before the main thread id is known, are treated as main.
+ */
+function isMainThreadNotification(
+  server: { threadId: string | null },
+  params: Record<string, unknown> | undefined,
+): boolean {
+  const notifThreadId = typeof params?.threadId === "string" && params.threadId.length > 0
+    ? params.threadId
+    : undefined;
+  return !notifThreadId || !server.threadId || notifThreadId === server.threadId;
+}
+
 /** Codex provider adapter implementing IAgentProvider with a persistent app-server process per session. */
 @injectable()
 export class CodexProvider extends EventEmitter implements IAgentProvider, ISessionEvictable, ProtocolAdapter<CodexSessionState> {
@@ -369,7 +388,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
 
     server.on("notification", (notification) => {
       const n = notification as { method?: string; params?: Record<string, unknown> };
-      if (n.method === "turn/started") {
+      if (n.method === "turn/started" && isMainThreadNotification(server, n.params)) {
         const turn = n.params?.turn as { id?: string } | undefined;
         const flatTurnId =
           typeof n.params?.turnId === "string" ? n.params.turnId : undefined;
@@ -598,6 +617,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
           armTimer();
           const n = notification as { method?: string; params?: Record<string, unknown> };
           if (n.method === "turn/completed") {
+            // Sub-agent receiver threads complete their own turns mid-run;
+            // only the main thread's completion settles this wait.
+            if (!isMainThreadNotification(server, n.params)) return;
             const turn = n.params?.turn as { id?: string } | undefined;
             const tid = turn?.id;
             if (tid && entry.pendingTurnId && tid !== entry.pendingTurnId) {

--- a/apps/web/src/__tests__/virtual-items.test.ts
+++ b/apps/web/src/__tests__/virtual-items.test.ts
@@ -220,21 +220,26 @@ describe("buildVirtualItems (combined)", () => {
     const result = buildAll(messages, toolCalls, undefined, false, undefined);
 
     const types = result.map((item) => item.type);
-    // msg-1, narrative-flow, msg-2, persisted-late-hooks(msg-2),
-    // persisted-turn-footer(msg-2). The persisted-narrative for msg-2 is
-    // filtered out (live narrative-flow above the bubble owns the timeline),
-    // but the persisted-turn-footer is NOT filtered — it sits AFTER the
-    // bubble and owns the post-response summary that closes the turn.
+    // msg-1, narrative-flow, msg-2, narrative-indicator,
+    // persisted-late-hooks(msg-2), persisted-turn-footer(msg-2). The
+    // persisted-narrative for msg-2 is filtered out (live narrative-flow
+    // above the bubble owns the timeline), but the persisted-turn-footer is
+    // NOT filtered — it sits AFTER the bubble and owns the post-response
+    // summary that closes the turn. The narrative-indicator lingers after the
+    // turn (isAgentRunning=false, tool calls still volatile) so it can play
+    // its exit transition, and sits right after the bubble.
     expect(types).toEqual([
       "message",
       "narrative-flow",
       "message",
+      "narrative-indicator",
       "persisted-late-hooks",
       "persisted-turn-footer",
     ]);
     expect(result[0]).toMatchObject({ type: "message", key: "msg-1" });
     expect(result[1]).toMatchObject({ type: "narrative-flow" });
     expect(result[2]).toMatchObject({ type: "message", key: "msg-2" });
+    expect(result[3]).toMatchObject({ type: "narrative-indicator", isAgentRunning: false });
   });
 
   it("streaming text with agent running emits narrative-flow and live assistant message items", () => {
@@ -393,10 +398,24 @@ describe("buildVirtualItems (combined)", () => {
     expect(indicator?.subagentCount).toBe(2);
   });
 
-  it("does not emit a narrative-indicator when the agent is not running", () => {
+  it("does not emit a narrative-indicator when not running and no tool calls remain", () => {
     const messages = [makeMessage({ id: "msg-1" })];
     const result = buildAll(messages, [], undefined, false, undefined);
     expect(result.some((i) => i.type === "narrative-indicator")).toBe(false);
+  });
+
+  it("keeps the narrative-indicator (isAgentRunning=false) while tool calls are still volatile", () => {
+    // Regression for issue #695: removing the indicator item at turnComplete
+    // made it vanish in a single frame. It now stays emitted through the
+    // turn's volatile tail so NarrativeIndicator can animate out; the
+    // component renders null once the exit completes.
+    const toolCalls = [makeToolCall({ id: "tc-1", isComplete: true })];
+    const items = buildVolatileItems(toolCalls, false, 1000, undefined);
+    const indicator = items.find((i) => i.type === "narrative-indicator") as
+      | (ChatVirtualItem & { type: "narrative-indicator" })
+      | undefined;
+    expect(indicator).toBeDefined();
+    expect(indicator?.isAgentRunning).toBe(false);
   });
 
   it("indicator (running, no streaming) appends narrative-flow followed by narrative-indicator", () => {
@@ -460,7 +479,8 @@ describe("buildVirtualItems (combined)", () => {
 
     // Persisted-narrative(msg-1) precedes the assistant message, then
     // persisted-late-hooks(msg-1) and persisted-turn-footer(msg-1) follow it,
-    // then user, then narrative-flow (no split because the tail isn't an
+    // then user, then narrative-flow and the lingering narrative-indicator
+    // appended at the tail (no split because the trailing message isn't an
     // assistant).
     const types = result.map((item) => item.type);
     expect(types).toEqual([
@@ -470,6 +490,7 @@ describe("buildVirtualItems (combined)", () => {
       "persisted-turn-footer",
       "message",
       "narrative-flow",
+      "narrative-indicator",
     ]);
   });
 
@@ -485,9 +506,10 @@ describe("buildVirtualItems (combined)", () => {
     const result = buildAll(messages, toolCalls, "Here is my answer...", true, 99999);
 
     const types = result.map((item) => item.type);
-    // user msg, narrative-flow (before split assistant msg), narrative-indicator
-    // (status footer below where the live response would render), split
-    // assistant msg, persisted-late-hooks(msg-2), persisted-turn-footer(msg-2).
+    // user msg, narrative-flow (before split assistant msg), split assistant
+    // msg, narrative-indicator (status footer below the response — it stays
+    // under the bubble through the persist swap so its exit transition plays
+    // in place), persisted-late-hooks(msg-2), persisted-turn-footer(msg-2).
     // live assistant response is suppressed because a tool is still running —
     // `computeLiveStreamingText` returns "" while any top-level tool is in
     // flight, since the model isn't streaming user-facing text during tool
@@ -497,13 +519,13 @@ describe("buildVirtualItems (combined)", () => {
     expect(types).toEqual([
       "message",
       "narrative-flow",
-      "narrative-indicator",
       "message",
+      "narrative-indicator",
       "persisted-late-hooks",
       "persisted-turn-footer",
     ]);
     expect(result[0]).toMatchObject({ key: "msg-1" });
-    expect(result[3]).toMatchObject({ key: "msg-2" });
+    expect(result[2]).toMatchObject({ key: "msg-2" });
     const narrativeItem = result[1] as ChatVirtualItem & { type: "narrative-flow" };
     expect(narrativeItem.toolCalls).toHaveLength(2);
     expect(narrativeItem.streamingText).toBe("Here is my answer...");
@@ -685,4 +707,24 @@ describe("estimateItemHeight", () => {
     expect(estimateItemHeight(item)).toBe(STREAMING_CARD_COLLAPSED_HEIGHT);
   });
 
+  it("estimates the streaming slot and the persisted assistant bubble identically", () => {
+    // Regression for issue #695: the streaming provisional bubble and the
+    // persisted assistant message share a virtual-item key and render the
+    // same chrome, so their estimates must match — a difference reflows the
+    // virtualizer and nudges the scroll position at persist time.
+    const content = "A response body.\n\nWith a second paragraph and a list:\n- one\n- two\n";
+    const streaming: ChatVirtualItem = {
+      key: "turn-response:thread-1:abc",
+      type: "message",
+      message: makeMessage({ content }),
+      assistantState: { isStreaming: true, actionsVisible: false },
+    };
+    const persisted: ChatVirtualItem = {
+      key: "turn-response:thread-1:abc",
+      type: "message",
+      message: makeMessage({ content }),
+      assistantState: { isStreaming: false, actionsVisible: true },
+    };
+    expect(estimateItemHeight(streaming)).toBe(estimateItemHeight(persisted));
+  });
 });

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -161,6 +161,7 @@ const VirtualItemRenderer = memo(function VirtualItemRenderer({
           subagentCount={item.subagentCount}
           activeToolCalls={item.activeToolCalls}
           startTime={item.startTime}
+          isAgentRunning={item.isAgentRunning}
         />
       );
   }

--- a/apps/web/src/components/chat/narrative/NarrativeIndicator.tsx
+++ b/apps/web/src/components/chat/narrative/NarrativeIndicator.tsx
@@ -1,8 +1,18 @@
 import { useState, useEffect, useMemo } from "react";
+import { cn } from "@/lib/utils";
 import { formatDuration } from "@/lib/time";
 import type { ToolCall } from "@/transport/types";
 import { TOOL_PHASE_LABELS } from "../tool-renderers/constants";
 import { StackedLayersIcon, stackedLayersIconClassName } from "./StackedLayersIcon";
+
+/**
+ * How long the exit animation plays before the component stops rendering.
+ * Matches the `narrative-indicator-out` keyframes duration in index.css.
+ */
+const EXIT_DURATION_MS = 240;
+
+/** Lifecycle of the indicator: live → animating out → unrendered. */
+type IndicatorPhase = "running" | "exiting" | "done";
 
 /** Derive the current phase label from active tool calls. */
 function derivePhaseLabel(toolCalls: readonly ToolCall[]): string {
@@ -27,6 +37,8 @@ interface NarrativeIndicatorProps {
   activeToolCalls: readonly ToolCall[];
   /** Epoch ms when the agent turn started, used to compute elapsed time. */
   startTime?: number;
+  /** Whether the agent is still running; flipping to false plays the exit transition. */
+  isAgentRunning: boolean;
 }
 
 /**
@@ -37,17 +49,44 @@ interface NarrativeIndicatorProps {
  *   ● 6 steps · Thinking... (0:22)
  *   ● 4 steps · 2 subagents · Thinking deeper... (0:15)
  *   ● 5 steps · Running a command... (0:38)
+ *
+ * When the turn ends the bar collapses and fades out over
+ * {@link EXIT_DURATION_MS} instead of vanishing in a single frame, then
+ * renders nothing. Mounting with the agent already stopped (e.g. revisiting
+ * a thread whose turn finished) skips straight to rendering nothing.
  */
 export function NarrativeIndicator({
   stepCount,
   subagentCount,
   activeToolCalls,
   startTime,
+  isAgentRunning,
 }: NarrativeIndicatorProps) {
   const [elapsed, setElapsed] = useState(0);
+  // Initializing from isAgentRunning means a fresh mount after the turn ended
+  // never replays the exit animation — only a live running→stopped transition does.
+  const [phase, setPhase] = useState<IndicatorPhase>(
+    isAgentRunning ? "running" : "done",
+  );
 
   useEffect(() => {
-    if (!startTime) return;
+    if (isAgentRunning) {
+      setPhase("running");
+      return;
+    }
+    setPhase((prev) => (prev === "running" ? "exiting" : prev));
+  }, [isAgentRunning]);
+
+  useEffect(() => {
+    if (phase !== "exiting") return;
+    const timer = setTimeout(() => setPhase("done"), EXIT_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [phase]);
+
+  useEffect(() => {
+    // Freeze the elapsed readout once the turn ends so the exit animation
+    // fades out a stable value instead of ticking mid-fade.
+    if (!startTime || !isAgentRunning) return;
 
     setElapsed(Math.floor((Date.now() - startTime) / 1000));
 
@@ -56,15 +95,23 @@ export function NarrativeIndicator({
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [startTime]);
+  }, [startTime, isAgentRunning]);
 
   const phaseLabel = useMemo(() => derivePhaseLabel(activeToolCalls), [activeToolCalls]);
+
+  if (phase === "done") return null;
 
   const subagentLabel =
     subagentCount === 1 ? "1 subagent" : `${subagentCount} subagents`;
 
   return (
-    <div className="flex items-center gap-2 px-4 py-2 mt-1.5">
+    <div
+      className={cn(
+        "flex items-center gap-2 px-4 py-2 mt-1.5",
+        phase === "exiting" && "narrative-indicator-exit",
+      )}
+      data-state={phase}
+    >
       <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
         {/* When sub-agents are dispatched, the stacked-layers icon (with its
             float + per-layer ripple) becomes the "agent working" mark — more
@@ -83,7 +130,7 @@ export function NarrativeIndicator({
           </>
         )}
         <span className="text-muted-foreground/45">·</span>
-        {phaseLabel}
+        {phase === "exiting" ? "Done" : phaseLabel}
       </span>
       {startTime !== undefined && (
         <span className="text-xs text-muted-foreground/50">

--- a/apps/web/src/components/chat/narrative/__tests__/NarrativeIndicator.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/NarrativeIndicator.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { NarrativeIndicator } from "../NarrativeIndicator";
+
+/**
+ * Exit-lifecycle coverage for issue #695: the indicator must animate out when
+ * the turn ends instead of vanishing in a single frame, must stop rendering
+ * after the exit completes, and must not replay the exit on a fresh mount for
+ * an already-finished turn.
+ */
+describe("NarrativeIndicator exit lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function renderRunning() {
+    return render(
+      <NarrativeIndicator
+        stepCount={3}
+        subagentCount={0}
+        activeToolCalls={[]}
+        startTime={Date.now()}
+        isAgentRunning
+      />,
+    );
+  }
+
+  it("renders the status line while the agent is running", () => {
+    renderRunning();
+    const bar = screen.getByText(/3 steps/).closest("[data-state]");
+    expect(bar?.getAttribute("data-state")).toBe("running");
+  });
+
+  it("plays the exit transition when the agent stops, then renders nothing", () => {
+    const { rerender, container } = renderRunning();
+
+    rerender(
+      <NarrativeIndicator
+        stepCount={3}
+        subagentCount={0}
+        activeToolCalls={[]}
+        startTime={Date.now()}
+        isAgentRunning={false}
+      />,
+    );
+
+    const exiting = container.querySelector('[data-state="exiting"]');
+    expect(exiting).not.toBeNull();
+    expect(exiting?.classList.contains("narrative-indicator-exit")).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(container.querySelector("[data-state]")).toBeNull();
+  });
+
+  it("renders nothing when mounted with the agent already stopped", () => {
+    const { container } = render(
+      <NarrativeIndicator
+        stepCount={3}
+        subagentCount={0}
+        activeToolCalls={[]}
+        startTime={Date.now()}
+        isAgentRunning={false}
+      />,
+    );
+    expect(container.querySelector("[data-state]")).toBeNull();
+  });
+
+  it("returns to the running state when a new turn starts mid-exit", () => {
+    const { rerender, container } = renderRunning();
+
+    rerender(
+      <NarrativeIndicator
+        stepCount={3}
+        subagentCount={0}
+        activeToolCalls={[]}
+        startTime={Date.now()}
+        isAgentRunning={false}
+      />,
+    );
+    expect(container.querySelector('[data-state="exiting"]')).not.toBeNull();
+
+    rerender(
+      <NarrativeIndicator
+        stepCount={0}
+        subagentCount={0}
+        activeToolCalls={[]}
+        startTime={Date.now()}
+        isAgentRunning
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(container.querySelector('[data-state="running"]')).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -148,13 +148,17 @@ export type ChatVirtualItem =
       /**
        * "X steps · N subagents · phase…" status footer rendered BELOW the
        * live assistant response so the writing animation reads as the primary
-       * surface and the progress meta sits underneath. Only emitted while the
-       * agent is running.
+       * surface and the progress meta sits underneath. Emitted while the agent
+       * is running and kept through the turn's volatile tail (tool calls still
+       * in memory) so the component can animate out instead of vanishing in a
+       * single frame; it renders nothing once its exit completes.
        */
       stepCount: number;
       subagentCount: number;
       activeToolCalls: readonly ToolCall[];
       startTime: number | undefined;
+      /** False once the turn ended — tells the component to play its exit. */
+      isAgentRunning: boolean;
     };
 
 /**
@@ -312,8 +316,10 @@ export function buildVolatileItems(
   // as its own virtual-item slot BELOW the live assistant response so the writing
   // animation reads as the primary surface and the meta status sits underneath
   // it (rather than above, between the actions molecule and the response).
-  // Only emitted while the agent is running.
-  if (isAgentRunning) {
+  // Kept emitted after the turn ends (while the turn's tool calls are still in
+  // volatile memory) so NarrativeIndicator can animate out; it renders null
+  // once the exit transition completes.
+  if (isAgentRunning || toolCalls.length > 0) {
     const topLevelTools = toolCalls.filter((tc) => tc.parentToolCallId == null);
     // Match `buildNarrativeItems` / `NarrativeCounts.steps`: top-level tool
     // calls only. Thought segments are tracked separately in the footer.
@@ -329,6 +335,7 @@ export function buildVolatileItems(
       subagentCount,
       activeToolCalls,
       startTime: agentStartTime,
+      isAgentRunning,
     });
   }
 
@@ -412,17 +419,20 @@ export function buildVirtualItems(
     lastItem.message.role === "assistant" &&
     !isPlanQuestionsMessage(lastItem.message.content)
   ) {
-    // narrative-flow, the live assistant message, and narrative-indicator all go
-    // BEFORE the last assistant message bubble so the user reads
-    // top-to-bottom: actions → response → progress meta. The live assistant
-    // sits under narrative-flow (mirroring where the MessageBubble lands on
-    // persist), and the indicator sits under that response so the
-    // writing animation reads as the primary surface.
+    // narrative-flow and the live assistant message go BEFORE the last
+    // assistant message bubble so the user reads top-to-bottom: actions →
+    // response. The live assistant sits under narrative-flow (mirroring where
+    // the MessageBubble lands on persist). The narrative-indicator goes
+    // immediately AFTER the bubble so the progress meta stays underneath the
+    // response — including through the persist swap, where it now lingers to
+    // play its exit transition instead of jumping above the bubble.
     const headItems = dedupedVolatileItems.filter(
       (v) =>
         v.type === "narrative-flow" ||
-        (v.type === "message" && v.message.role === "assistant" && v.assistantState?.isStreaming) ||
-        v.type === "narrative-indicator",
+        (v.type === "message" && v.message.role === "assistant" && v.assistantState?.isStreaming),
+    );
+    const indicatorItems = dedupedVolatileItems.filter(
+      (v) => v.type === "narrative-indicator",
     );
     const tailItems = dedupedVolatileItems.filter(
       (v) =>
@@ -460,13 +470,23 @@ export function buildVirtualItems(
     return [
       ...filteredStable.slice(0, newLastAssistantIdx),
       ...headItems,
-      ...filteredStable.slice(newLastAssistantIdx),
+      filteredStable[newLastAssistantIdx],
+      ...indicatorItems,
+      ...filteredStable.slice(newLastAssistantIdx + 1),
       ...tailItems,
     ];
   }
 
   return [...stableItems, ...dedupedVolatileItems];
 }
+
+/**
+ * Estimated chrome (px) around an assistant bubble's markdown body: the
+ * reserved actions row, provenance foot line, and inter-block spacing.
+ * Used for BOTH the streaming provisional bubble and the persisted message —
+ * they must stay equal so persisting a turn never changes the estimate.
+ */
+const ASSISTANT_BUBBLE_CHROME_PX = 80;
 
 const LIST_ITEM_RE = /^[-*]\s|^\d+\.\s/;
 const LINE_HEIGHT = 22;
@@ -551,8 +571,12 @@ export function estimateItemHeight(item: ChatVirtualItem): number {
       if (message.role === "system") return 40;
       const contentHeight = estimateMarkdownHeight(message.content);
       if (message.role === "user") return 52 + contentHeight;
-      if (item.assistantState?.isStreaming) return Math.max(contentHeight, 48);
-      return 80 + contentHeight;
+      // Streaming and persisted assistant bubbles share one estimate: they
+      // render the same chrome (the DeltaBlock stays mounted on persist and
+      // the actions row reserves its height while hidden), and they share a
+      // virtual-item key. A differing estimate made the persist swap reflow
+      // the virtualizer by the chrome offset and nudge the scroll position.
+      return ASSISTANT_BUBBLE_CHROME_PX + contentHeight;
     }
     case "active-tools":
       return Math.min(item.toolCalls.length * 48, 400);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -659,6 +659,20 @@ input[type="range"].settings-range::-moz-range-thumb {
   animation: assistant-just-persisted-in 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* Turn-end exit for the live narrative step indicator: fade while collapsing
+   the row (max-height covers the bar's content + padding; margin-top folds
+   away with it) so the rows below glide up instead of snapping. Duration must
+   match EXIT_DURATION_MS in NarrativeIndicator.tsx. */
+@keyframes narrative-indicator-out {
+  from { opacity: 1; max-height: 48px; margin-top: 6px; }
+  to   { opacity: 0; max-height: 0;    margin-top: 0; }
+}
+
+.narrative-indicator-exit {
+  overflow: hidden;
+  animation: narrative-indicator-out 240ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .narrative-row-enter,
   .thought-row.narrative-row-enter,
@@ -667,7 +681,8 @@ input[type="range"].settings-range::-moz-range-thumb {
   }
 
   .thought-settling,
-  .assistant-just-persisted {
+  .assistant-just-persisted,
+  .narrative-indicator-exit {
     animation: none;
   }
 


### PR DESCRIPTION
## What

Two fixes. The Codex provider no longer ends the main turn when a sub-agent thread completes, and the chat timeline no longer reflows or snaps at turn end.

## Why

**Headless runs.** With Codex sub-agents (#708), collab receiver threads stream their own `turn/started` and `turn/completed` notifications over the same app-server connection. The provider's turn bookkeeping ignored the notification's `threadId`, so a child's `turn/started` overwrote `pendingTurnId` and the child's `turn/completed` resolved the main `runTurn` wait. That emitted `Ended` mid-turn: the UI dropped the thread from `runningThreadIds` while narration kept streaming, and clearing `pendingTurnId` removed the `isBusy` guard, leaving the still-running session open to idle eviction.

**Turn-end paper cuts (#695).** The streaming slot and the persisted assistant message used different height estimates even though they render the same chrome and share a virtual-item key, so persisting a turn reflowed the virtualizer and nudged the scroll position. The narrative step indicator was emitted only while the agent ran, so it vanished in a single frame at `turnComplete` and snapped the rows below it.

## Key Changes

- `codex-provider.ts`: `turn/started` and `turn/completed` handlers ignore notifications whose `threadId` is not the app-server's main thread. Notifications without a `threadId` still count as main for older Codex builds.
- New regression test `codex-provider-subagent-turn.test.ts`: child-thread lifecycle notifications must not overwrite `pendingTurnId` or emit `Ended` mid-turn.
- `virtual-items.ts`: one shared height-estimate formula for the streaming slot and the persisted assistant bubble.
- `virtual-items.ts` + `NarrativeIndicator.tsx`: the indicator stays emitted through the turn's volatile tail, sits below the bubble through the persist swap, plays a 240ms fade-and-collapse exit, then renders nothing. Fresh mounts after the turn ended skip the exit, so revisiting a thread does not replay it. Reduced motion is respected.
- Tests: estimate-parity and indicator-placement regressions in `virtual-items.test.ts`; exit-lifecycle coverage in `NarrativeIndicator.test.tsx`.

## Verification

- All 169 Codex provider tests pass; the new regression test failed before the provider fix and passes after.
- `bun run verify`: typecheck and lint pass. The only unit-test failures are the documented Windows flakes (snapshot-service git hooks, sidebar/PlanDocument under load), which pass in isolation and are untouched by this change.
- Playwright e2e: 199 passed. The failures on this machine are pre-existing: the same specs fail identically with these changes stashed.

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783889836&installation_id=129163861&pr_number=719&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F719&signature=f7401d4e187eb8d7c9c35899b5bbcee84bb7222baa61120070e0f6b81db01ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Narrative indicator now smoothly animates out when the agent completes a turn.

* **Bug Fixes**
  * Fixed turn bookkeeping to prevent sub-agent threads from interfering with main thread state tracking.
  * Improved narrative indicator display and ordering during agent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->