### PR TITLE
fix(browser): freeze-frame the preview while overlays suppress it

### DIFF
--- a/apps/desktop/e2e/preview-freeze-frame.spec.ts
+++ b/apps/desktop/e2e/preview-freeze-frame.spec.ts
@@ -114,6 +114,22 @@ test.describe("preview freeze-frame", () => {
       expect(Math.abs(frameBox!.width - surfaceBox!.width)).toBeLessThan(4);
       expect(Math.abs(frameBox!.height - surfaceBox!.height)).toBeLessThan(4);
 
+      // Resize while frozen: the snapshot must stay pinned to its
+      // capture-time size (clip/reveal, never stretch) and keep standing in
+      // for the detached view — a stray bounds sync must not remount the
+      // native view above the open menu.
+      const before = await frame.boundingBox();
+      await app.evaluate(({ BrowserWindow }, delta) => {
+        const w = BrowserWindow.getAllWindows()[0];
+        const [width, height] = w.getSize();
+        w.setSize(width + delta, height - delta);
+      }, 80);
+      await win.waitForTimeout(800);
+      await expect(frame).toBeVisible();
+      const after = await frame.boundingBox();
+      expect(Math.abs(after!.width - before!.width)).toBeLessThan(2);
+      expect(Math.abs(after!.height - before!.height)).toBeLessThan(2);
+
       // Closing the menu remounts the live view and clears the snapshot.
       await win.keyboard.press("Escape");
       await expect(frame).not.toBeAttached();

--- a/apps/desktop/e2e/preview-freeze-frame.spec.ts
+++ b/apps/desktop/e2e/preview-freeze-frame.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Freeze-frame regression spec for overlay suppression over the embedded
+ * browser (WebContentsView).
+ *
+ * The native view composites above all HTML, so any renderer overlay
+ * (dropdown, dialog) forces the view to detach while it is open. The
+ * freeze-frame keeps a JPEG snapshot of the page in the view's place so the
+ * surface never blanks. This spec loads a local page, opens the browser
+ * header overflow menu (a suppressor), and asserts the snapshot stands in,
+ * matches the surface bounds, and clears once the menu closes.
+ *
+ * Requires `apps/desktop/dist/main/main.cjs`; build with
+ * `cd apps/desktop && bun run build` first (same as electron-smoke.spec.ts).
+ */
+import { test, expect, _electron as electron } from "@playwright/test";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// import.meta-based dirname: this package is ESM, so specs transpile without
+// a CommonJS __dirname.
+const DESKTOP_DIR = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const MAIN_BUNDLE = join(DESKTOP_DIR, "dist", "main", "main.cjs");
+
+/** Demo page with unmistakable content so a blank capture cannot pass. */
+const PAGE_HTML = `<!doctype html><html><head><title>Freeze Frame Demo</title></head>
+<body style="margin:0;height:100vh;display:grid;place-items:center;background:linear-gradient(135deg,#5b21b6,#0ea5e9);color:#fff;font:700 42px system-ui">
+LIVE PAGE CONTENT</body></html>`;
+
+test.describe("preview freeze-frame", () => {
+  test.beforeAll(() => {
+    if (!existsSync(MAIN_BUNDLE)) {
+      throw new Error(
+        `Missing ${MAIN_BUNDLE}. Run \`cd apps/desktop && bun run build\` first.`,
+      );
+    }
+  });
+
+  test("overflow menu floats over a frozen page instead of a blank hole", async () => {
+    const pagePath = join(mkdtempSync(join(tmpdir(), "mcode-ff-")), "demo.html");
+    writeFileSync(pagePath, PAGE_HTML);
+
+    // Agent harnesses set ELECTRON_RUN_AS_NODE=1, which would make Electron
+    // boot as plain Node and never open a window. Strip it for the launch.
+    const env = { ...process.env } as Record<string, string>;
+    delete env.ELECTRON_RUN_AS_NODE;
+
+    const app = await electron.launch({
+      args: ["."],
+      cwd: DESKTOP_DIR,
+      env,
+      timeout: 120_000,
+    });
+    try {
+      const win = await app.firstWindow({ timeout: 120_000 });
+      await win.waitForLoadState("domcontentloaded");
+      // Transport connected and sidebar shell rendered.
+      await win
+        .getByPlaceholder("Search threads...")
+        .waitFor({ state: "visible", timeout: 120_000 });
+      await win.waitForTimeout(1_000);
+
+      // Open a thread when one exists: the browser panel mounts inside a
+      // thread/workspace scope, so a bare home screen cannot host it.
+      const threadItem = win.locator('[data-testid="thread-item"]').first();
+      const recentRow = win.locator('[data-testid="recent-thread-row"]').first();
+      if (await threadItem.isVisible().catch(() => false)) {
+        await threadItem.click({ timeout: 10_000 }).catch(() => {});
+      } else if (await recentRow.isVisible().catch(() => false)) {
+        await recentRow.click({ timeout: 10_000 }).catch(() => {});
+      }
+      await win.waitForTimeout(1_000);
+
+      // preview.toggle is gated on !inputFocused; drop focus first.
+      await win.evaluate(() => {
+        const el = document.activeElement;
+        if (el instanceof HTMLElement) el.blur();
+      });
+      await win.keyboard.press("Control+Shift+B");
+
+      const panel = win.locator('[data-testid="preview-panel"]');
+      const panelOpened = await panel
+        .waitFor({ state: "visible", timeout: 15_000 })
+        .then(() => true)
+        .catch(() => false);
+      // A pristine profile with no workspace cannot host the browser panel;
+      // skip rather than fail in that environment.
+      test.skip(!panelOpened, "browser panel unavailable (no workspace configured)");
+
+      const omnibox = win.locator('input[aria-label="Preview URL"]');
+      await omnibox.click();
+      await omnibox.fill(pagePath);
+      await omnibox.press("Enter");
+      await win.waitForTimeout(2_500);
+
+      await win.locator('button[aria-label="More browser tools"]').click();
+      await expect(
+        win.locator('[data-testid="browser-overflow-menu"]'),
+      ).toBeVisible();
+
+      // The snapshot must stand in while the suppressor is open...
+      const frame = win.locator('[data-testid="preview-freeze-frame"]');
+      await expect(frame).toBeVisible();
+      await expect(frame).toHaveAttribute("src", /^data:image\/jpeg;base64,/);
+
+      // ...and cover the surface the native view vacated.
+      const frameBox = await frame.boundingBox();
+      const surfaceBox = await win
+        .locator('[role="region"][aria-label="Page preview"]')
+        .boundingBox();
+      expect(frameBox).not.toBeNull();
+      expect(surfaceBox).not.toBeNull();
+      expect(Math.abs(frameBox!.width - surfaceBox!.width)).toBeLessThan(4);
+      expect(Math.abs(frameBox!.height - surfaceBox!.height)).toBeLessThan(4);
+
+      // Closing the menu remounts the live view and clears the snapshot.
+      await win.keyboard.press("Escape");
+      await expect(frame).not.toBeAttached();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -164,6 +164,15 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     }): Promise<void> {
       return ipcRenderer.invoke("preview:sync", payload);
     },
+    /**
+     * Capture the live preview as a data-URL freeze-frame. Shown in place of
+     * the native view while a renderer overlay suppresses it, so the hide
+     * reads as a frozen page rather than a blank hole. Resolves null when no
+     * page is mounted to capture.
+     */
+    captureSnapshot(): Promise<string | null> {
+      return ipcRenderer.invoke("preview:capture-snapshot");
+    },
     navigate(url: string, workspacePath?: string | null): Promise<{ ok: true } | { ok: false; error: string }> {
       return ipcRenderer.invoke("preview:navigate", url, workspacePath ?? null);
     },

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -37,6 +37,9 @@ const MIN_ZOOM_FACTOR = 0.25;
 /** Upper bound on the preview zoom factor (500%), matching Chromium's ceiling. */
 const MAX_ZOOM_FACTOR = 5;
 
+/** JPEG quality for the overlay freeze-frame snapshot (see preview:capture-snapshot). */
+const SNAPSHOT_JPEG_QUALITY = 82;
+
 /** Clamp a requested zoom factor to the supported range and snap to whole percent. */
 function clampZoomFactor(factor: number): number {
   const safe = Number.isFinite(factor) ? factor : 1;
@@ -187,6 +190,26 @@ export function registerNavigationHandlers(): void {
       onPreviewVisible(win, s);
     },
   );
+
+  // Freeze-frame for overlay suppression: the renderer captures the live page
+  // as a data URL right before it detaches the native view (which composites
+  // above all HTML), then shows the image in the view's place so an open
+  // dialog/menu floats over a frozen page instead of a blank hole. JPEG keeps
+  // the IPC payload small; the frame is a transient stand-in, not an artifact.
+  ipcMain.handle("preview:capture-snapshot", async (_event): Promise<string | null> => {
+    const win = BrowserWindow.fromWebContents(_event.sender);
+    if (!win || win.isDestroyed()) return null;
+    const s = getSession(win);
+    const view = s.view;
+    if (!view || view.webContents.isDestroyed()) return null;
+    try {
+      const image = await view.webContents.capturePage();
+      if (image.isEmpty()) return null;
+      return `data:image/jpeg;base64,${image.toJPEG(SNAPSHOT_JPEG_QUALITY).toString("base64")}`;
+    } catch {
+      return null;
+    }
+  });
 
   ipcMain.handle(
     "preview:navigate",

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -239,20 +239,28 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
         className={cn(
           "relative mx-2 mb-2 mt-1 min-h-[min(40vh,20rem)] min-w-0 flex-1 rounded-md border border-border/40 bg-muted/10",
           showLocalPorts && "overflow-y-auto",
+          // Clip the pinned freeze-frame when the surface shrinks mid-overlay.
+          bridge.freezeFrame && "overflow-hidden",
         )}
       >
         {/* Freeze-frame stand-in: while an overlay (dialog, menu) suppresses
             the native WebContentsView, this snapshot keeps the page visibly
             present instead of leaving a blank hole. The live view composites
-            above it once remounted, so the swap back is invisible. */}
+            above it once remounted, so the swap back is invisible. Pinned to
+            its capture-time size and clipped by the surface so a resize while
+            frozen reveals/clips like a real viewport instead of stretching. */}
         {bridge.freezeFrame ? (
           <img
-            src={bridge.freezeFrame}
+            src={bridge.freezeFrame.url}
             alt=""
             aria-hidden
             draggable={false}
             data-testid="preview-freeze-frame"
-            className="pointer-events-none absolute inset-0 size-full rounded-[inherit] object-fill"
+            className="pointer-events-none absolute left-0 top-0 max-w-none"
+            style={{
+              width: bridge.freezeFrame.width,
+              height: bridge.freezeFrame.height,
+            }}
           />
         ) : null}
         {/* Loading: thin indeterminate progress bar at top of content area.

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -241,6 +241,20 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
           showLocalPorts && "overflow-y-auto",
         )}
       >
+        {/* Freeze-frame stand-in: while an overlay (dialog, menu) suppresses
+            the native WebContentsView, this snapshot keeps the page visibly
+            present instead of leaving a blank hole. The live view composites
+            above it once remounted, so the swap back is invisible. */}
+        {bridge.freezeFrame ? (
+          <img
+            src={bridge.freezeFrame}
+            alt=""
+            aria-hidden
+            draggable={false}
+            data-testid="preview-freeze-frame"
+            className="pointer-events-none absolute inset-0 size-full rounded-[inherit] object-fill"
+          />
+        ) : null}
         {/* Loading: thin indeterminate progress bar at top of content area.
             motion-safe gates the animation so users with prefers-reduced-motion
             get a static bar instead of a perpetual sweep. */}

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -28,6 +28,18 @@ export function formatNavError(code: string): string {
   return NAV_ERROR_LABEL[code] ?? code;
 }
 
+/**
+ * Snapshot shown in the native view's place while an overlay suppresses it.
+ * `width`/`height` are the surface's CSS-px size at capture time; the panel
+ * pins the <img> to them so resizing while frozen clips instead of stretching.
+ */
+export interface PreviewFreezeFrame {
+  /** JPEG data URL of the captured page. */
+  readonly url: string;
+  readonly width: number;
+  readonly height: number;
+}
+
 /** Options for the {@link usePreviewBridge} hook. */
 export interface UsePreviewBridgeOptions {
   /** Thread id that owns this preview session. */
@@ -56,10 +68,10 @@ export interface PreviewBridgeState {
   /** Persisted URL for the current thread (Zustand store). */
   readonly storedUrl: string;
   /**
-   * Freeze-frame data URL shown in the native view's place while an overlay
+   * Freeze-frame shown in the native view's place while an overlay
    * suppresses it, or null when the live view owns the surface.
    */
-  readonly freezeFrame: string | null;
+  readonly freezeFrame: PreviewFreezeFrame | null;
   /** Push current bounds and visibility to the native BrowserView. */
   readonly pushSync: (visible: boolean) => Promise<void>;
   /** Refresh navigation state (canGoBack / canGoForward) from IPC. */
@@ -248,7 +260,7 @@ export function usePreviewBridge({
   // it stand in. Order matters: capture while the view is still mounted
   // (capturePage needs a painted surface), commit the <img>, wait a frame so
   // it is on screen underneath the native view, then detach.
-  const [freezeFrame, setFreezeFrame] = useState<string | null>(null);
+  const [freezeFrame, setFreezeFrame] = useState<PreviewFreezeFrame | null>(null);
   const suppressionCount = usePreviewSuppressionStore((s) => s.count);
   const prevSuppressionRef = useRef(0);
   useEffect(() => {
@@ -276,9 +288,13 @@ export function usePreviewBridge({
     let cancelled = false;
     void (async () => {
       let frame: string | null = null;
+      // The surface rect at capture time, in CSS px. The <img> is pinned to
+      // this size so a resize while the overlay is open clips/reveals like a
+      // real frozen viewport instead of stretching the snapshot.
+      const rect = surfaceRef.current?.getBoundingClientRect() ?? null;
       // Only a loaded page has pixels worth freezing; the empty/ports surface
       // is plain HTML that overlays already stack above.
-      if (storedUrlRef.current.trim().length > 0) {
+      if (storedUrlRef.current.trim().length > 0 && rect) {
         try {
           frame = (await window.desktopBridge?.preview?.captureSnapshot?.()) ?? null;
         } catch {
@@ -286,8 +302,8 @@ export function usePreviewBridge({
         }
       }
       if (cancelled) return;
-      if (frame) {
-        setFreezeFrame(frame);
+      if (frame && rect) {
+        setFreezeFrame({ url: frame, width: rect.width, height: rect.height });
         // Two RAFs ~= one painted frame: the <img> must be on screen before
         // the native view detaches or the surface blanks for a frame.
         await new Promise<void>((resolve) =>

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -55,6 +55,11 @@ export interface PreviewBridgeState {
   readonly pageStatus: PreviewPageStatus;
   /** Persisted URL for the current thread (Zustand store). */
   readonly storedUrl: string;
+  /**
+   * Freeze-frame data URL shown in the native view's place while an overlay
+   * suppresses it, or null when the live view owns the surface.
+   */
+  readonly freezeFrame: string | null;
   /** Push current bounds and visibility to the native BrowserView. */
   readonly pushSync: (visible: boolean) => Promise<void>;
   /** Refresh navigation state (canGoBack / canGoForward) from IPC. */
@@ -155,8 +160,13 @@ export function usePreviewBridge({
       if (!preview) return;
       const el = surfaceRef.current;
       const hint = storedUrlRef.current.trim() || null;
-      // Keep the native view hidden while an error panel owns the surface.
-      const effectiveVisible = visible && phaseRef.current !== "error";
+      // Suppression (overlay open) and the error panel both force the native
+      // view hidden regardless of what the caller asked for, so stray
+      // pushSync(true) calls (ResizeObserver, thread switch) cannot pop the
+      // view back above an open overlay.
+      const suppressed = usePreviewSuppressionStore.getState().count > 0;
+      const effectiveVisible =
+        visible && !suppressed && phaseRef.current !== "error";
       if (!effectiveVisible || !el) {
         await preview.sync({
           visible: false,
@@ -231,26 +241,74 @@ export function usePreviewBridge({
     return unsub;
   }, [threadId, refreshNav]);
 
-  // Hide the native WebContentsView while any modal/dialog overlay is open
-  // in the renderer. Without this the native view paints above all HTML and
-  // covers Dialog/CommandPalette/etc. The bounds are remembered on the host
-  // (s.lastBounds), so reattach is seamless.
+  // While any modal/dialog overlay is open in the renderer the native
+  // WebContentsView must be detached: it composites above all HTML and would
+  // occlude the overlay. Naively detaching leaves a blank hole where the page
+  // was, so on the first suppressor we grab a freeze-frame of the page and let
+  // it stand in. Order matters: capture while the view is still mounted
+  // (capturePage needs a painted surface), commit the <img>, wait a frame so
+  // it is on screen underneath the native view, then detach.
+  const [freezeFrame, setFreezeFrame] = useState<string | null>(null);
   const suppressionCount = usePreviewSuppressionStore((s) => s.count);
+  const prevSuppressionRef = useRef(0);
   useEffect(() => {
-    if (suppressionCount > 0) {
-      void pushSyncRef.current(false);
-    } else {
-      void pushSyncRef.current(true);
+    const prev = prevSuppressionRef.current;
+    prevSuppressionRef.current = suppressionCount;
+    if (suppressionCount === 0) {
+      // Remount first, clear the frame after: the live view paints above the
+      // <img> once attached, so the swap is invisible, whereas clearing early
+      // would flash the empty surface. Skip the clear if another suppressor
+      // opened while the sync was in flight.
+      void pushSyncRef.current(true).finally(() => {
+        if (usePreviewSuppressionStore.getState().count === 0) {
+          setFreezeFrame(null);
+        }
+      });
+      return;
     }
+    if (prev > 0) {
+      // Nested suppressor (e.g. dialog over menu): the view is already hidden
+      // and the existing freeze-frame stays valid; capturing a detached view
+      // would yield an empty image.
+      void pushSyncRef.current(false);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      let frame: string | null = null;
+      // Only a loaded page has pixels worth freezing; the empty/ports surface
+      // is plain HTML that overlays already stack above.
+      if (storedUrlRef.current.trim().length > 0) {
+        try {
+          frame = (await window.desktopBridge?.preview?.captureSnapshot?.()) ?? null;
+        } catch {
+          frame = null;
+        }
+      }
+      if (cancelled) return;
+      if (frame) {
+        setFreezeFrame(frame);
+        // Two RAFs ~= one painted frame: the <img> must be on screen before
+        // the native view detaches or the surface blanks for a frame.
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        );
+        if (cancelled) return;
+      }
+      void pushSyncRef.current(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [suppressionCount]);
 
   // Re-sync the native view on every error<->non-error transition: hide it when
-  // an error panel takes over, re-show it when a retry clears the error. Defer to
-  // suppression: a load completing while a dialog/overlay is open must not reshow
-  // the BrowserView above it, so respect suppressionCount instead of forcing true.
+  // an error panel takes over, re-show it when a retry clears the error.
+  // pushSync itself defers to suppression, so a load completing while a
+  // dialog/overlay is open cannot reshow the BrowserView above it.
   useEffect(() => {
-    void pushSyncRef.current(suppressionCount === 0);
-  }, [pageStatus.phase, suppressionCount]);
+    void pushSyncRef.current(true);
+  }, [pageStatus.phase]);
 
   useEffect(() => {
     const preview = window.desktopBridge?.preview;
@@ -371,6 +429,7 @@ export function usePreviewBridge({
     faviconUrl,
     pageStatus,
     storedUrl,
+    freezeFrame,
     pushSync,
     refreshNav,
     onGoBack,

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -92,6 +92,12 @@ interface PreviewBridge {
     /** Active workspace id; scopes preview spill files under the Mcode app data directory. */
     workspaceId?: string | null;
   }): Promise<void>;
+  /**
+   * Capture the live preview as a data-URL freeze-frame, shown in place of the
+   * native view while overlays suppress it. Resolves null when nothing is
+   * mounted to capture.
+   */
+  captureSnapshot(): Promise<string | null>;
   navigate(url: string, workspacePath?: string | null): Promise<PreviewNavigateResult>;
   goBack(): Promise<boolean>;
   goForward(): Promise<boolean>;


### PR DESCRIPTION
## What

Shows a freeze-frame snapshot of the embedded browser while a renderer overlay (dialog, dropdown menu) is open over it, instead of leaving a blank hole where the page was.

## Why

The embedded browser is an Electron `WebContentsView`, a native surface that composites above all HTML. CSS cannot place an overlay on top of it, so any open overlay detaches the view. That detach blanked the whole browser surface, which read as the browser being torn down every time a menu or dialog opened. Transparent overlay windows are not an option on Windows (DWM cannot composite one over a `WebContentsView`; see `preview-overlay.ts`), so the standard fix is a freeze-frame: capture the page before detaching and let the overlay float over a pixel-identical still.

## Key Changes

- New `preview:capture-snapshot` IPC: main process captures the live view as a JPEG data URL, exposed through the preload bridge as `preview.captureSnapshot()`.
- `usePreviewBridge` sequences the hide: capture while the view is still mounted, commit the `<img>`, wait one painted frame, then detach. On the last suppressor closing, it remounts the live view first and clears the frame after, so both swaps are invisible.
- `pushSync` now reads the suppression store directly, so a stray bounds sync (resize, thread switch, load completion) cannot remount the native view above an open overlay. This was a pre-existing bug.
- The snapshot is pinned to its capture-time CSS size, anchored top-left and clipped by the surface. Resizing while frozen clips or reveals like a real viewport instead of stretching the image.
- New Electron E2E spec `apps/desktop/e2e/preview-freeze-frame.spec.ts`: loads a page, opens the header overflow menu, asserts the snapshot stands in, matches the surface bounds, survives a mid-overlay window resize at its pinned size, and clears once the menu closes.

Both existing suppressors (all app dialogs via `dialog.tsx` and the browser overflow menu) get this behavior automatically; any future overlay only needs the existing `previewSuppressionStore` increment/decrement.

## Verification

- `bun run verify`: typecheck PASS, lint PASS; unit failures limited to the documented load flakes (PlanDocument, sidebar, PrSplitButton, ModelSection, server timeout tests), all of which pass in isolation and also fail on the clean base commit.
- Desktop unit tests 263/263, preview-related frontend tests 133/133.
- E2E spec passes against the real built app (1 passed, 1.2m).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783892698&installation_id=129163861&pr_number=720&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F720&signature=fe3de04d76e31251c0ef6ad9f657a5f7e9ef118e4b6ba3979bc186842e3578c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added freeze-frame overlay that stabilizes the preview content when browser menu overlays are open, preventing visual disruptions during interactions.

* **Tests**
  * Added end-to-end test to verify freeze-frame overlay behavior and window resizing during overlay interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->