### PR TITLE
fix: render Codex update plans in scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,22 @@ server startup before spawning children.
 ## Agent Development Workflow
 
 @docs/guides/agent-workflow.md
+
+## Verifying Behavior Changes
+
+When a change affects what the app does, verify it in this order. This includes
+UI behavior, IPC handlers, server endpoints, stores, and agent-service behavior.
+
+1. Run it live first. Start the affected app from
+   [docs/agents/runtime.md](docs/agents/runtime.md) with `bun run dev:web`,
+   `bun run dev:server`, or `bun run dev:desktop`. Exercise the changed path as a
+   user or client would. Observe the rendered UI, response body, IPC result, or
+   persisted data. This live run is the main verification step.
+2. Lock it in. Add or update a Playwright spec, desktop e2e spec, or focused test
+   that asserts the observed outcome.
+3. Run the regression floor. Run `bun run verify` and the relevant e2e suite,
+   such as `bun run e2e`, `bun run verify:e2e`, or desktop e2e as needed.
+
+Report all three: the live action and observed outcome, the assertion that
+protects it, and the suite result. If the environment blocks live verification,
+state that explicitly and list the manual check instead.

--- a/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
@@ -662,6 +662,84 @@ describe("CodexEventMapper", () => {
     });
   });
 
+  it("emits update_plan toolUse with parsed plan arguments", () => {
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        item: {
+          type: "function_call",
+          id: "call-update-plan",
+          name: "update_plan",
+          arguments: JSON.stringify({
+            plan: [
+              { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
+              { status: "in_progress", step: "Test todo item two with CODE-A2 and CODE-B2" },
+              { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
+            ],
+          }),
+          output: "",
+        },
+      },
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({
+      type: "toolUse",
+      threadId: "test-thread",
+      toolCallId: "call-update-plan",
+      toolName: "update_plan",
+      toolInput: {
+        plan: [
+          { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
+          { status: "in_progress", step: "Test todo item two with CODE-A2 and CODE-B2" },
+          { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
+        ],
+      },
+    });
+  });
+
+  it("emits update_plan toolUse from turn plan updates", () => {
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "turn/plan/updated",
+      params: {
+        threadId: "codex-thread",
+        turnId: "turn-live",
+        explanation: "Tracking scope work",
+        plan: [
+          { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
+          { status: "inProgress", step: "Test todo item two with CODE-A2 and CODE-B2" },
+          { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
+        ],
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        type: "toolUse",
+        threadId: "test-thread",
+        toolCallId: "codex-plan-turn-live-1",
+        toolName: "update_plan",
+        toolInput: {
+          explanation: "Tracking scope work",
+          plan: [
+            { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
+            { status: "inProgress", step: "Test todo item two with CODE-A2 and CODE-B2" },
+            { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
+          ],
+        },
+      },
+      {
+        type: "toolResult",
+        threadId: "test-thread",
+        toolCallId: "codex-plan-turn-live-1",
+        output: "Plan updated",
+        isError: false,
+      },
+    ]);
+  });
+
   it("handles function_call with invalid JSON arguments gracefully", () => {
     const events = mapper.mapNotification({
       jsonrpc: "2.0",

--- a/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
@@ -30,7 +30,7 @@ const KNOWN_METHODS = new Set([
   "item/reasoning/summaryPartAdded",
   "item/plan/delta",
   "error",
-  // Silenced lifecycle (see SILENCED_METHODS in mapper)
+  // Silenced lifecycle plus structured plan snapshots.
   "thread/started",
   "thread/status/changed",
   "mcpServer/startupStatus/updated",

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -6,7 +6,7 @@ import type { CodexNotification, CompletedItem } from "./codex-types.js";
 
 /** Notification methods that produce no agent events (module-level to avoid per-call allocation). */
 const SILENCED_METHODS = new Set([
-  "turn/diff/updated", "turn/plan/updated",
+  "turn/diff/updated",
   "skills/changed", "model/rerouted",
   "deprecationNotice", "configWarning",
   "item/fileChange/outputDelta",
@@ -76,6 +76,8 @@ export class CodexEventMapper {
   private pendingAssistantBoundaryItemId: string | undefined;
   /** Dedupes `item/completed` reasoning payloads against streamed reasoning deltas. */
   private lastReasoningText = "";
+  /** Per-turn sequence for synthetic update_plan tool calls from turn/plan/updated. */
+  private planUpdateSeq = 0;
   private readonly threadId: string;
   /** Codex app-server's own main thread id. Distinct from Mcode's persisted thread UUID. */
   private mainCodexThreadId: string | undefined;
@@ -782,6 +784,35 @@ export class CodexEventMapper {
       }];
     }
 
+    if (method === "turn/plan/updated") {
+      const p = notification.params as {
+        turnId?: string;
+        explanation?: string;
+        plan?: unknown;
+      };
+      if (!Array.isArray(p.plan) || p.plan.length === 0) return [];
+      const boundaryEvents = this.drainPendingAssistantBoundary(false);
+      const toolCallId = `codex-plan-${p.turnId ?? "unknown"}-${++this.planUpdateSeq}`;
+      return [...boundaryEvents, {
+        type: AgentEventType.ToolUse,
+        threadId: this.threadId,
+        toolCallId,
+        toolName: "update_plan",
+        toolInput: {
+          ...(typeof p.explanation === "string" && p.explanation.length > 0
+            ? { explanation: p.explanation }
+            : {}),
+          plan: p.plan,
+        },
+      }, {
+        type: AgentEventType.ToolResult,
+        threadId: this.threadId,
+        toolCallId,
+        output: "Plan updated",
+        isError: false,
+      }];
+    }
+
     // Streaming assistant text token. Codex has no stop reason, so every
     // assistant delta streams as narration until a later boundary promotes the
     // last assistant item to the final response at turn completion.
@@ -913,6 +944,7 @@ export class CodexEventMapper {
     this.lastCompletedAssistantText = "";
     this.pendingAssistantBoundaryItemId = undefined;
     this.lastReasoningText = "";
+    this.planUpdateSeq = 0;
     this.commandOutputBuffers.clear();
     this.startedToolUseSignatures.clear();
     this.collabScopeStack = [];

--- a/apps/server/src/providers/codex/codex-types.ts
+++ b/apps/server/src/providers/codex/codex-types.ts
@@ -148,6 +148,15 @@ export interface PlanDeltaPayload {
   delta: string;
 }
 
+/** Payload for `turn/plan/updated`, Codex's structured per-turn plan snapshot. */
+export interface TurnPlanUpdatedPayload {
+  threadId?: string;
+  turnId?: string;
+  explanation?: string;
+  plan?: unknown[];
+  [key: string]: unknown;
+}
+
 // item/completed payload
 
 /**
@@ -251,6 +260,7 @@ export type CodexNotification =
   | (JsonRpcNotification<ReasoningStreamDeltaPayload> & { method: "item/reasoning/summaryTextDelta" })
   | (JsonRpcNotification<LifecyclePayload> & { method: "item/reasoning/summaryPartAdded" })
   | (JsonRpcNotification<PlanDeltaPayload> & { method: "item/plan/delta" })
+  | (JsonRpcNotification<TurnPlanUpdatedPayload> & { method: "turn/plan/updated" })
   | (JsonRpcNotification<ItemCompletedPayload> & { method: "item/completed" })
   | (JsonRpcNotification<TurnCompletedPayload> & { method: "turn/completed" })
   | (JsonRpcNotification<ErrorNotificationPayload> & { method: "error" });

--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-event-mapper.test.ts
@@ -218,7 +218,7 @@ describe("mapCursorAcpSessionNotification", () => {
           sessionUpdate: "plan",
           entries: [
             { content: "Read the file", status: "completed", priority: "high" },
-            { content: "Edit the function", status: "in_progress", priority: "medium" },
+            { content: "Edit the function", status: "in-progress", priority: "medium" },
             { content: "Run tests", status: "pending", priority: "low" },
           ],
         },

--- a/apps/server/src/providers/cursor/__tests__/cursor-todo-snapshot.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-todo-snapshot.test.ts
@@ -24,6 +24,8 @@ describe("coercePlanStatus", () => {
   it("returns the canonical status for known values", () => {
     expect(coercePlanStatus("pending")).toBe("pending");
     expect(coercePlanStatus("in_progress")).toBe("in_progress");
+    expect(coercePlanStatus("inProgress")).toBe("in_progress");
+    expect(coercePlanStatus("in-progress")).toBe("in_progress");
     expect(coercePlanStatus("completed")).toBe("completed");
     expect(coercePlanStatus("cancelled")).toBe("cancelled");
   });
@@ -124,10 +126,12 @@ describe("normalizeCursorTodoEntry", () => {
     expect(normalizeCursorTodoEntry({ id: "abc", content: "x", status: "pending" }, 0).id).toBe("abc");
   });
 
-  it("prefers content, then title, then text for the body field", () => {
+  it("prefers content, then title, then text, then step, then description for the body field", () => {
     expect(normalizeCursorTodoEntry({ id: "1", content: "c" }, 0).content).toBe("c");
     expect(normalizeCursorTodoEntry({ id: "1", title: "t" }, 0).content).toBe("t");
     expect(normalizeCursorTodoEntry({ id: "1", text: "x" }, 0).content).toBe("x");
+    expect(normalizeCursorTodoEntry({ id: "1", step: "s" }, 0).content).toBe("s");
+    expect(normalizeCursorTodoEntry({ id: "1", description: "d" }, 0).content).toBe("d");
     expect(normalizeCursorTodoEntry({ id: "1" }, 0).content).toBe("");
   });
 

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -506,6 +506,7 @@ function normalizePlanStatus(
       return "cancelled";
     case "in_progress":
     case "inProgress":
+    case "in-progress":
       return "in_progress";
     default:
       return "pending";

--- a/apps/server/src/providers/cursor/cursor-todo-snapshot.ts
+++ b/apps/server/src/providers/cursor/cursor-todo-snapshot.ts
@@ -43,7 +43,7 @@ export function createCursorTodoSnapshot(): CursorTodoSnapshot {
 export function coercePlanStatus(
   s: unknown,
 ): "pending" | "in_progress" | "completed" | "cancelled" {
-  if (s === "in_progress") return "in_progress";
+  if (s === "in_progress" || s === "inProgress" || s === "in-progress") return "in_progress";
   if (s === "completed") return "completed";
   if (s === "cancelled" || s === "canceled") return "cancelled";
   return "pending";
@@ -116,6 +116,8 @@ export function normalizeCursorTodoEntry(
       stringField(entry, "content") ??
       stringField(entry, "title") ??
       stringField(entry, "text") ??
+      stringField(entry, "step") ??
+      stringField(entry, "description") ??
       "",
     status: coercePlanStatus(entry.status),
   };

--- a/apps/server/src/repositories/__tests__/task-repo.test.ts
+++ b/apps/server/src/repositories/__tests__/task-repo.test.ts
@@ -59,6 +59,33 @@ describe("TaskRepo", () => {
     ]);
   });
 
+  it("appendTask preserves existing tasks", () => {
+    const threadId = makeThread("append");
+    repo.upsert(threadId, [{ content: "existing", status: "pending", group: "Tasks" }]);
+    repo.appendTask(threadId, {
+      content: "created later",
+      status: "pending",
+      group: "Sub-agent",
+    });
+    expect(repo.get(threadId)).toEqual([
+      { content: "existing", status: "pending", group: "Tasks" },
+      { content: "created later", status: "pending", group: "Sub-agent" },
+    ]);
+  });
+
+  it("appendTask replaces an existing task with the same content and group", () => {
+    const threadId = makeThread("append-replace");
+    repo.upsert(threadId, [{ content: "same", status: "pending", group: "Tasks" }]);
+    repo.appendTask(threadId, {
+      content: "same",
+      status: "completed",
+      group: "Tasks",
+    });
+    expect(repo.get(threadId)).toEqual([
+      { content: "same", status: "completed", group: "Tasks" },
+    ]);
+  });
+
   it("delete removes the row", () => {
     const threadId = makeThread("3");
     repo.upsert(threadId, [{ content: "x", status: "pending" }]);

--- a/apps/server/src/repositories/task-repo.ts
+++ b/apps/server/src/repositories/task-repo.ts
@@ -57,6 +57,18 @@ export class TaskRepo {
     this.stmtUpsert.run(threadId, JSON.stringify(merged));
   }
 
+  /** Append or replace a single task in the persisted task list. */
+  appendTask(threadId: string, task: StoredTask): void {
+    const existing = this.get(threadId) ?? [];
+    const group = task.group ?? "Tasks";
+    const otherTasks = existing.filter(
+      (existingTask) =>
+        existingTask.content !== task.content ||
+        (existingTask.group ?? "Tasks") !== group,
+    );
+    this.stmtUpsert.run(threadId, JSON.stringify([...otherTasks, task]));
+  }
+
   /** Retrieve the persisted task list for a thread, or null if none exists. */
   get(threadId: string): StoredTask[] | null {
     const row = this.stmtGet.get(threadId) as { tasks_json: string } | undefined;

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -70,6 +70,8 @@ interface Built {
   thoughtBulk: ReturnType<typeof vi.fn>;
   hookBulk: ReturnType<typeof vi.fn>;
   toolBulk: ReturnType<typeof vi.fn>;
+  taskAppend: ReturnType<typeof vi.fn>;
+  taskUpsertGroup: ReturnType<typeof vi.fn>;
 }
 
 function build(): Built {
@@ -127,7 +129,14 @@ function build(): Built {
     markActive: vi.fn(),
     markIdle: vi.fn(),
   } as unknown as MemoryPressureService;
-  const taskRepo = { get: vi.fn(() => []), upsert: vi.fn() } as unknown as TaskRepo;
+  const taskAppend = vi.fn();
+  const taskUpsertGroup = vi.fn();
+  const taskRepo = {
+    get: vi.fn(() => []),
+    upsert: vi.fn(),
+    upsertGroup: taskUpsertGroup,
+    appendTask: taskAppend,
+  } as unknown as TaskRepo;
   const settingsService = {
     get: vi.fn(() => ({
       model: { defaults: { fallbackId: undefined } },
@@ -185,12 +194,69 @@ function build(): Built {
   // sendMessage uses (beginTurn + resetTurnCounters).
   narrativeStore.beginTurn(THREAD_ID);
   narrativeStore.resetTurnCounters(THREAD_ID);
-  return { service, providerEmitter, thoughtBulk, hookBulk, toolBulk };
+  return { service, providerEmitter, thoughtBulk, hookBulk, toolBulk, taskAppend, taskUpsertGroup };
 }
 
 describe("AgentService narrative persistence", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("persists TaskCreate tool calls for Scope hydration", () => {
+    const { providerEmitter, taskAppend } = build();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolUse,
+      threadId: THREAD_ID,
+      toolCallId: "task-create-1",
+      toolName: "TaskCreate",
+      toolInput: {
+        subject: "Buy groceries",
+        description: "Pick up milk, eggs, bread",
+      },
+    });
+
+    expect(taskAppend).toHaveBeenCalledWith(THREAD_ID, {
+      content: "Buy groceries - Pick up milk, eggs, bread",
+      status: "pending",
+      group: "Tasks",
+    });
+  });
+
+  it("persists Codex update_plan tool calls for Scope hydration", () => {
+    const { providerEmitter, taskUpsertGroup } = build();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolUse,
+      threadId: THREAD_ID,
+      toolCallId: "update-plan-1",
+      toolName: "update_plan",
+      toolInput: {
+        plan: [
+          { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
+          { status: "inProgress", step: "Test todo item two with CODE-A2 and CODE-B2" },
+          { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
+        ],
+      },
+    });
+
+    expect(taskUpsertGroup).toHaveBeenCalledWith(THREAD_ID, "Tasks", [
+      {
+        content: "Test todo item one with CODE-A1 and CODE-B1",
+        status: "pending",
+        group: "Tasks",
+      },
+      {
+        content: "Test todo item two with CODE-A2 and CODE-B2",
+        status: "in_progress",
+        group: "Tasks",
+      },
+      {
+        content: "Test todo item three with CODE-A3 and CODE-B3",
+        status: "completed",
+        group: "Tasks",
+      },
+    ]);
   });
 
   it("segments thoughts split by tool calls with strictly-ordered sortOrder", async () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -34,7 +34,7 @@ import { TurnFinalizer } from "./turn-finalizer.js";
 import { PlanQuestionService } from "./plan-question-service.js";
 import { TurnSnapshotRepo } from "../repositories/turn-snapshot-repo";
 import type Database from "better-sqlite3";
-import { TaskRepo } from "../repositories/task-repo";
+import { TaskRepo, type StoredTask } from "../repositories/task-repo";
 import { PlanQuestionAnswersRepo } from "../repositories/plan-question-answers-repo";
 import { GitService } from "./git-service";
 import { AttachmentService } from "./attachment-service";
@@ -1144,6 +1144,74 @@ export class AgentService {
     return "Sub-agent";
   }
 
+  private coerceStoredTaskStatus(raw: unknown): StoredTask["status"] {
+    const status = String(raw ?? "pending");
+    if (
+      status === "pending" ||
+      status === "in_progress" ||
+      status === "completed" ||
+      status === "cancelled"
+    ) {
+      return status;
+    }
+    if (status === "inProgress" || status === "in-progress") return "in_progress";
+    if (status === "canceled") return "cancelled";
+    return "pending";
+  }
+
+  private taskCreateContent(toolInput: Record<string, unknown>): string | null {
+    const subject =
+      typeof toolInput.subject === "string" && toolInput.subject.trim().length > 0
+        ? toolInput.subject.trim()
+        : typeof toolInput.title === "string" && toolInput.title.trim().length > 0
+          ? toolInput.title.trim()
+          : typeof toolInput.content === "string" && toolInput.content.trim().length > 0
+            ? toolInput.content.trim()
+            : "";
+    const description =
+      typeof toolInput.description === "string" && toolInput.description.trim().length > 0
+        ? toolInput.description.trim()
+        : "";
+
+    if (!subject && !description) return null;
+    if (!subject) return description;
+    if (!description) return subject;
+    return `${subject} - ${description}`;
+  }
+
+  private updatePlanTasks(toolInput: Record<string, unknown>, group: string): StoredTask[] {
+    const entries =
+      Array.isArray(toolInput.plan)
+        ? toolInput.plan
+        : Array.isArray(toolInput.tasks)
+          ? toolInput.tasks
+          : Array.isArray(toolInput.todos)
+            ? toolInput.todos
+            : [];
+
+    return entries.flatMap((entry): StoredTask[] => {
+      const item: Record<string, unknown> = typeof entry === "object" && entry !== null
+        ? entry as Record<string, unknown>
+        : { step: entry };
+      const content =
+        typeof item.step === "string" && item.step.trim().length > 0
+          ? item.step.trim()
+          : typeof item.content === "string" && item.content.trim().length > 0
+            ? item.content.trim()
+            : typeof item.title === "string" && item.title.trim().length > 0
+              ? item.title.trim()
+              : typeof item.description === "string" && item.description.trim().length > 0
+                ? item.description.trim()
+                : "";
+      if (!content) return [];
+      return [{
+        content,
+        status: this.coerceStoredTaskStatus(item.status),
+        group,
+      }];
+    });
+  }
+
   /** Number of currently active sessions. */
   activeCount(): number {
     return this.activeSessionIds.size;
@@ -2031,8 +2099,8 @@ ${userMessage}`;
 
   /**
    * Buffer a tool call event into the narrative write seam, then perform the
-   * non-narrative side effect AgentService still owns: persisting TodoWrite
-   * task state for reconnect hydration. The narrative buffer + agentCallStack
+   * non-narrative side effect AgentService still owns: persisting task state
+   * for reconnect hydration. The narrative buffer + agentCallStack
    * push + parent attribution (narrative-pipeline.md Trap 1) live in
    * {@link NarrativeStore.bufferToolCall}, which returns the attributed parent.
    */
@@ -2091,6 +2159,42 @@ ${userMessage}`;
             });
           }
         }
+      }
+    }
+
+    if (event.toolName === "TaskCreate") {
+      const content = this.taskCreateContent(event.toolInput);
+      if (!content) return;
+      const group = parentToolCallId
+        ? this.resolveAgentGroupLabel(threadId, parentToolCallId)
+        : "Tasks";
+      try {
+        this.taskRepo.appendTask(threadId, {
+          content,
+          status: this.coerceStoredTaskStatus(event.toolInput.status),
+          group,
+        });
+      } catch (err) {
+        logger.warn("TaskCreate task not persisted", {
+          threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    if (event.toolName === "update_plan") {
+      const group = parentToolCallId
+        ? this.resolveAgentGroupLabel(threadId, parentToolCallId)
+        : "Tasks";
+      const tasks = this.updatePlanTasks(event.toolInput, group);
+      if (tasks.length === 0) return;
+      try {
+        this.taskRepo.upsertGroup(threadId, group, tasks);
+      } catch (err) {
+        logger.warn("update_plan tasks not persisted", {
+          threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     }
   }

--- a/apps/web/e2e/right-panel-tab-status.spec.ts
+++ b/apps/web/e2e/right-panel-tab-status.spec.ts
@@ -157,6 +157,63 @@ async function addSnapshotWithNewFile(page: Page): Promise<void> {
   }, THREAD.id);
 }
 
+async function emitTaskCreate(page: Page): Promise<void> {
+  await page.evaluate((tid) => {
+    const stores: unknown[] =
+      (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+    const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+    const threadStore = stores.find((s) => "handleAgentEvent" in getState(s));
+    if (!threadStore) throw new Error("thread store not found");
+    (
+      threadStore as {
+        getState: () => {
+          handleAgentEvent: (threadId: string, event: unknown) => void;
+        };
+      }
+    ).getState().handleAgentEvent(tid, {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-create-live",
+        toolName: "TaskCreate",
+        toolInput: {
+          subject: "Buy groceries",
+          description: "Pick up milk, eggs, bread",
+        },
+      },
+    });
+  }, THREAD.id);
+}
+
+async function emitUpdatePlan(page: Page): Promise<void> {
+  await page.evaluate((tid) => {
+    const stores: unknown[] =
+      (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+    const getState = (s: unknown) => (s as { getState: () => Record<string, unknown> }).getState();
+    const threadStore = stores.find((s) => "handleAgentEvent" in getState(s));
+    if (!threadStore) throw new Error("thread store not found");
+    (
+      threadStore as {
+        getState: () => {
+          handleAgentEvent: (threadId: string, event: unknown) => void;
+        };
+      }
+    ).getState().handleAgentEvent(tid, {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "update-plan-live",
+        toolName: "update_plan",
+        toolInput: {
+          plan: [
+            { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
+            { status: "in_progress", step: "Test todo item two with CODE-A2 and CODE-B2" },
+            { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
+          ],
+        },
+      },
+    });
+  }, THREAD.id);
+}
+
 test.describe("Right panel tab status", () => {
   test.beforeEach(async ({ page }) => {
     await mockWebSocketServer(page, {
@@ -207,6 +264,30 @@ test.describe("Right panel tab status", () => {
     await expect(scopeTab).not.toHaveClass(/text-primary/);
 
     await page.screenshot({ path: testInfo.outputPath("changes-active.png") });
+  });
+
+  test("scope renders live TaskCreate tool calls", async ({ page }) => {
+    await seedPanel(page, "tasks");
+    await expect(page.locator('[data-rail-tab="tasks"]')).toContainText("2/5");
+
+    await emitTaskCreate(page);
+
+    await expect(page.getByText("Buy groceries - Pick up milk, eggs, bread")).toBeVisible();
+    await expect(page.locator('[data-rail-tab="tasks"]')).toContainText("2/6");
+    await expect(page.getByText(/nothing on the docket/i)).toHaveCount(0);
+  });
+
+  test("scope renders live Codex update_plan tool calls", async ({ page }) => {
+    await seedPanel(page, "tasks");
+    await expect(page.locator('[data-rail-tab="tasks"]')).toContainText("2/5");
+
+    await emitUpdatePlan(page);
+
+    await expect(page.getByText("Test todo item one with CODE-A1 and CODE-B1")).toBeVisible();
+    await expect(page.getByText("Test todo item two with CODE-A2 and CODE-B2")).toBeVisible();
+    await expect(page.getByText("Test todo item three with CODE-A3 and CODE-B3")).toBeVisible();
+    await expect(page.locator('[data-rail-tab="tasks"]')).toContainText("1/3");
+    await expect(page.getByText(/nothing on the docket/i)).toHaveCount(0);
   });
 
   test("review tab pulses fresh when new files land while viewing another tab", async ({ page }) => {

--- a/apps/web/e2e/scope-task-hydration.spec.ts
+++ b/apps/web/e2e/scope-task-hydration.spec.ts
@@ -1,0 +1,236 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { Thread } from "@mcode/contracts";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-scope-task-hydration",
+  name: "Scope Task Hydration",
+  path: "/tmp/scope-task-hydration",
+  provider_config: {},
+  is_git_repo: false,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+const THREAD: Thread = {
+  id: "thread-scope-task-hydration",
+  workspace_id: WORKSPACE.id,
+  title: "Scope Task Hydration Thread",
+  status: "paused",
+  mode: "direct",
+  worktree_path: null,
+  branch: "main",
+  worktree_managed: false,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+type StoredTask = {
+  content: string;
+  status: "pending" | "in_progress" | "completed" | "cancelled";
+  group?: string;
+};
+
+async function seedScopeThread(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) =>
+        (s as { getState: () => Record<string, unknown> }).getState();
+
+      const workspaceStore = stores.find(
+        (s) => "activeThreadId" in getState(s) && "threads" in getState(s),
+      );
+      if (workspaceStore) {
+        (workspaceStore as { setState: (patch: unknown) => void }).setState({
+          workspaces: [workspace],
+          activeWorkspaceId: workspace.id,
+          threads: [thread],
+          activeThreadId: thread.id,
+        });
+      }
+
+      const diffStore = stores.find(
+        (s) => "showRightPanel" in getState(s) && "setRightPanelTab" in getState(s),
+      );
+      if (diffStore) {
+        const api = (
+          diffStore as {
+            getState: () => {
+              showRightPanel: (workspaceId: string, threadId?: string) => void;
+              setRightPanelTab: (workspaceId: string, tab: string) => void;
+            };
+          }
+        ).getState();
+        api.showRightPanel(workspace.id, thread.id);
+        api.setRightPanelTab(workspace.id, "tasks");
+      }
+    },
+    { workspace: WORKSPACE, thread: THREAD },
+  );
+}
+
+async function setRunningAndResetHydration(page: Page, running: boolean): Promise<void> {
+  await page.evaluate(
+    ({ threadId, running }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const threadStore = stores.find((s) => {
+        const state = (s as { getState: () => Record<string, unknown> }).getState();
+        return "loadMessages" in state && "runningThreadIds" in state;
+      });
+      if (!threadStore) throw new Error("thread store missing");
+
+      (
+        threadStore as {
+          setState: (
+            patch: (state: {
+              records: Map<string, Record<string, unknown>>;
+            }) => {
+              records: Map<string, Record<string, unknown>>;
+              runningThreadIds: Set<string>;
+            },
+          ) => void;
+        }
+      ).setState((state) => {
+        const records = new Map(state.records);
+        const current = records.get(threadId);
+        if (current) records.set(threadId, { ...current, lastHydratedAt: 0 });
+        return {
+          records,
+          runningThreadIds: running ? new Set([threadId]) : new Set(),
+        };
+      });
+    },
+    { threadId: THREAD.id, running },
+  );
+}
+
+async function loadMessages(page: Page): Promise<void> {
+  await page.evaluate(async (threadId) => {
+    const stores: unknown[] =
+      (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+    const threadStore = stores.find((s) => {
+      const state = (s as { getState: () => Record<string, unknown> }).getState();
+      return "loadMessages" in state && "runningThreadIds" in state;
+    });
+    if (!threadStore) throw new Error("thread store missing");
+    await (
+      threadStore as {
+        getState: () => { loadMessages: (threadId: string) => Promise<void> };
+      }
+    ).getState().loadMessages(threadId);
+  }, THREAD.id);
+}
+
+async function emitUpdatePlan(page: Page, task: string): Promise<void> {
+  await page.evaluate(
+    ({ threadId, task }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const threadStore = stores.find((s) => {
+        const state = (s as { getState: () => Record<string, unknown> }).getState();
+        return "handleAgentEvent" in state;
+      });
+      if (!threadStore) throw new Error("thread store missing");
+      (
+        threadStore as {
+          getState: () => {
+            handleAgentEvent: (threadId: string, event: unknown) => void;
+          };
+        }
+      ).getState().handleAgentEvent(threadId, {
+        method: "session.toolUse",
+        params: {
+          toolCallId: `live-plan-${Date.now()}`,
+          toolName: "update_plan",
+          toolInput: {
+            plan: [{ status: "pending", step: task }],
+          },
+        },
+      });
+    },
+    { threadId: THREAD.id, task },
+  );
+}
+
+test.describe("Scope task hydration", () => {
+  test("replaces idle tasks from persistence but preserves running live task groups", async ({
+    page,
+  }, testInfo) => {
+    let persistedTasks: StoredTask[] = [
+      {
+        content: "Old stale task",
+        status: "pending",
+        group: "Tasks",
+      },
+    ];
+
+    await interceptZustandStores(page);
+    await mockWebSocketServer(page, {
+      "thread.getTasks": () => persistedTasks,
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean })
+          .__mcodeHydrationComplete === true,
+      { timeout: 30_000 },
+    );
+    await seedScopeThread(page);
+    await loadMessages(page);
+    await expect(page.getByText("Old stale task")).toBeVisible();
+
+    persistedTasks = [
+      {
+        content: "New persisted task from hydration",
+        status: "completed",
+        group: "Tasks",
+      },
+    ];
+    await setRunningAndResetHydration(page, false);
+    await loadMessages(page);
+
+    await expect(page.getByText("New persisted task from hydration")).toBeVisible();
+    await expect(page.getByText("Old stale task")).toHaveCount(0);
+
+    await emitUpdatePlan(page, "Live running task stays visible");
+    await expect(page.getByText("Live running task stays visible")).toBeVisible();
+
+    persistedTasks = [
+      {
+        content: "Persisted stale while running",
+        status: "completed",
+        group: "Tasks",
+      },
+    ];
+    await setRunningAndResetHydration(page, true);
+    await loadMessages(page);
+
+    await expect(page.getByText("Live running task stays visible")).toBeVisible();
+    await expect(page.getByText("Persisted stale while running")).toHaveCount(0);
+    await page.screenshot({ path: testInfo.outputPath("scope-task-hydration.png") });
+  });
+});

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -196,6 +196,217 @@ describe("handleAgentEvent branches", () => {
     ]);
   });
 
+  it("session.toolUse keeps sub-agent task grouping when duplicate TodoWrite omits parent", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "agent-1",
+        toolName: "Agent",
+        toolInput: { description: "Audit child scope" },
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "todo-child",
+        toolName: "TodoWrite",
+        toolInput: {},
+        parentToolCallId: "agent-1",
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "todo-child",
+        toolName: "TodoWrite",
+        toolInput: {
+          todos: [
+            { id: "child-a", content: "Trace child scope", status: "in_progress" },
+          ],
+        },
+      },
+    });
+
+    const calls = getTestThreadToolCalls("thread-1");
+    expect(calls.find((call) => call.id === "todo-child")?.parentToolCallId).toBe("agent-1");
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "child-a",
+        content: "Trace child scope",
+        status: "in_progress",
+        group: "Audit child scope",
+      },
+    ]);
+  });
+
+  it("session.toolUse updates tasks from TaskCreate tool calls", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-create-1",
+        toolName: "TaskCreate",
+        toolInput: {
+          subject: "Buy groceries",
+          description: "Pick up milk, eggs, bread",
+        },
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-create-2",
+        toolName: "TaskCreate",
+        toolInput: {
+          subject: "Clean the kitchen",
+          description: "Dishes, counters, floor",
+        },
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "task-create-1",
+        content: "Buy groceries - Pick up milk, eggs, bread",
+        status: "pending",
+        group: "Tasks",
+      },
+      {
+        id: "task-create-2",
+        content: "Clean the kitchen - Dishes, counters, floor",
+        status: "pending",
+        group: "Tasks",
+      },
+    ]);
+  });
+
+  it("session.toolUse groups sub-agent TaskCreate calls by parent Agent", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "agent-1",
+        toolName: "Agent",
+        toolInput: { description: "Prepare child tasks" },
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-create-child",
+        toolName: "TaskCreate",
+        toolInput: { subject: "Check child output" },
+        parentToolCallId: "agent-1",
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "task-create-child",
+        content: "Check child output",
+        status: "pending",
+        group: "Prepare child tasks",
+      },
+    ]);
+  });
+
+  it("session.toolUse updates parent scope tasks from Codex update_plan calls", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "update-plan-1",
+        toolName: "update_plan",
+        toolInput: {
+          plan: [
+            { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
+            { status: "inProgress", step: "Test todo item two with CODE-A2 and CODE-B2" },
+            { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
+          ],
+        },
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "0",
+        content: "Test todo item one with CODE-A1 and CODE-B1",
+        status: "pending",
+        group: "Tasks",
+      },
+      {
+        id: "1",
+        content: "Test todo item two with CODE-A2 and CODE-B2",
+        status: "in_progress",
+        group: "Tasks",
+      },
+      {
+        id: "2",
+        content: "Test todo item three with CODE-A3 and CODE-B3",
+        status: "completed",
+        group: "Tasks",
+      },
+    ]);
+  });
+
+  it("session.toolUse updates Codex update_plan tasks when duplicate enriches sparse input", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "update-plan-1",
+        toolName: "update_plan",
+        toolInput: {},
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "update-plan-1",
+        toolName: "update_plan",
+        toolInput: {
+          plan: [{ status: "in_progress", step: "Fill plan after completion" }],
+        },
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "0",
+        content: "Fill plan after completion",
+        status: "in_progress",
+        group: "Tasks",
+      },
+    ]);
+  });
+
+  it("session.toolUse keeps child Codex update_plan tasks out of the parent group", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "agent-1",
+        toolName: "Agent",
+        toolInput: { description: "Child work" },
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "update-plan-child",
+        toolName: "update_plan",
+        toolInput: {
+          plan: [{ status: "pending", step: "Child-only plan item" }],
+        },
+        parentToolCallId: "agent-1",
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "0",
+        content: "Child-only plan item",
+        status: "pending",
+        group: "Child work",
+      },
+    ]);
+  });
+
   it("toolResult fallback does not mark an Agent call complete when it has active children", () => {
     resetThreadStoreForTests({
       records: new Map<string, ThreadRecord>([

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -114,7 +114,7 @@ export function RightPanel() {
     (s) => (activeThreadId ? s.tasksByThread[activeThreadId] : undefined),
   );
 
-  // Only parent-agent tasks for the header count and task list display
+  // Scope to-do progress and visible list use only parent-agent tasks.
   const parentTasks = useMemo(
     () => (tasks ?? []).filter((t) => t.group === "Tasks"),
     [tasks],

--- a/apps/web/src/components/panels/ScopeSplitPane.test.tsx
+++ b/apps/web/src/components/panels/ScopeSplitPane.test.tsx
@@ -49,7 +49,8 @@ describe("ScopeSplitPane adaptive dock", () => {
   it("shows the resizable split when a plan and tasks both exist", () => {
     usePlanStore.setState({ plansByThread: { [THREAD]: [makePlan(1)] } });
     useTaskStore.setState({ tasksByThread: { [THREAD]: [makeTask("a")] } });
-    render(<ScopeSplitPane threadId={THREAD} parentTasks={[makeTask("a")]} />);
+    const tasks = [makeTask("a")];
+    render(<ScopeSplitPane threadId={THREAD} parentTasks={tasks} />);
     expect(screen.getByTestId("plan-panel-viewport")).toBeInTheDocument();
     expect(
       screen.getByRole("separator", { name: /resize plan and tasks/i }),
@@ -58,7 +59,8 @@ describe("ScopeSplitPane adaptive dock", () => {
 
   it("fills the pane with tasks (no plan region, no divider) when there is no plan", () => {
     useTaskStore.setState({ tasksByThread: { [THREAD]: [makeTask("a")] } });
-    render(<ScopeSplitPane threadId={THREAD} parentTasks={[makeTask("a")]} />);
+    const tasks = [makeTask("a")];
+    render(<ScopeSplitPane threadId={THREAD} parentTasks={tasks} />);
     expect(screen.queryByTestId("plan-panel-viewport")).not.toBeInTheDocument();
     expect(screen.queryByRole("separator")).not.toBeInTheDocument();
   });
@@ -82,5 +84,21 @@ describe("ScopeSplitPane adaptive dock", () => {
     render(<ScopeSplitPane threadId={THREAD} parentTasks={[]} />);
     expect(screen.getByTestId("plan-skeleton")).toBeInTheDocument();
     expect(screen.queryByRole("separator")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty docket when only child task groups exist", () => {
+    const groupedTask: TaskItem = {
+      id: "subagent",
+      content: "Task subagent",
+      status: "pending",
+      group: "Investigate UI",
+    };
+    useTaskStore.setState({ tasksByThread: { [THREAD]: [groupedTask] } });
+
+    render(<ScopeSplitPane threadId={THREAD} parentTasks={[]} />);
+
+    expect(screen.getByText(/nothing on the docket/i)).toBeInTheDocument();
+    expect(screen.queryByText("Investigate UI")).not.toBeInTheDocument();
+    expect(screen.queryByText("Task subagent")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/tasks/TaskPanel.tsx
+++ b/apps/web/src/components/tasks/TaskPanel.tsx
@@ -13,7 +13,6 @@ export function TaskPanel() {
 
   const groups = useMemo(() => {
     if (!tasks) return [];
-    // Only show top-level agent tasks; sub-agent groups are noise in the panel
     const parentTasks = tasks.filter((t) => t.group === "Tasks");
     if (parentTasks.length === 0) return [];
     return [["Tasks", parentTasks] as const];

--- a/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
@@ -72,6 +72,7 @@ describe("AuxiliaryHydrator", () => {
     overrides?: Partial<{
       getWorkspaceThread: () => { id: string; has_file_changes?: boolean } | undefined;
       getTasksForThread: (threadId: string) => readonly TaskItem[];
+      runningThreadIds: Set<string>;
     }>,
   ): AuxiliaryHydrator {
     return new AuxiliaryHydrator({
@@ -79,7 +80,7 @@ describe("AuxiliaryHydrator", () => {
       getState: () => ({
         records,
         currentThreadId,
-        runningThreadIds: new Set(),
+        runningThreadIds: overrides?.runningThreadIds ?? new Set(),
         toolCallRecordCache: { clear: vi.fn() },
       }),
       setState: applySetState,
@@ -157,7 +158,7 @@ describe("AuxiliaryHydrator", () => {
     });
   });
 
-  it("kept live tasks when task hydration returned no persisted tasks", async () => {
+  it("kept live tasks for a running thread when task hydration returned no persisted tasks", async () => {
     const liveTask: TaskItem = {
       id: "task-live",
       content: "Buy groceries - Pick up milk, eggs, bread",
@@ -168,6 +169,7 @@ describe("AuxiliaryHydrator", () => {
 
     const aux = createAux({
       getTasksForThread: () => [liveTask],
+      runningThreadIds: new Set([THREAD_ID]),
     });
     aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
 
@@ -179,7 +181,7 @@ describe("AuxiliaryHydrator", () => {
     expect(setTasksForThread).not.toHaveBeenCalled();
   });
 
-  it("kept live tasks for a group when hydration returned stale persisted tasks", async () => {
+  it("kept live tasks for a running thread group when hydration returned stale persisted tasks", async () => {
     const liveTask: TaskItem = {
       id: "task-live",
       content: "Clean the kitchen - Dishes, counters, floor",
@@ -196,6 +198,7 @@ describe("AuxiliaryHydrator", () => {
 
     const aux = createAux({
       getTasksForThread: () => [liveTask],
+      runningThreadIds: new Set([THREAD_ID]),
     });
     aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
 
@@ -207,7 +210,7 @@ describe("AuxiliaryHydrator", () => {
     expect(setTasksForThread).not.toHaveBeenCalled();
   });
 
-  it("merged persisted groups that were missing from live tasks", async () => {
+  it("merged persisted groups that were missing from live tasks on a running thread", async () => {
     const liveTask: TaskItem = {
       id: "task-live",
       content: "Clean the kitchen - Dishes, counters, floor",
@@ -224,6 +227,7 @@ describe("AuxiliaryHydrator", () => {
 
     const aux = createAux({
       getTasksForThread: () => [liveTask],
+      runningThreadIds: new Set([THREAD_ID]),
     });
     aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
 
@@ -236,6 +240,38 @@ describe("AuxiliaryHydrator", () => {
           group: "Sub-agent",
         },
         liveTask,
+      ]);
+    });
+  });
+
+  it("replaced stale in-memory tasks with persisted tasks when the thread was idle", async () => {
+    const staleTask: TaskItem = {
+      id: "task-stale",
+      content: "Old task",
+      status: "pending",
+      group: "Tasks",
+    };
+    (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        content: "New task",
+        status: "completed",
+        group: "Tasks",
+      },
+    ]);
+
+    const aux = createAux({
+      getTasksForThread: () => [staleTask],
+    });
+    aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
+
+    await vi.waitFor(() => {
+      expect(setTasksForThread).toHaveBeenCalledWith(THREAD_ID, [
+        {
+          id: "0",
+          content: "New task",
+          status: "completed",
+          group: "Tasks",
+        },
       ]);
     });
   });

--- a/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
@@ -15,7 +15,7 @@ import {
 import type { ThreadHydratorWriteState } from "@/lib/thread-hydrator/types";
 import { mockTransport, createMockMessage, createMockThread } from "@/__tests__/mocks/transport";
 import { shallowEqualBy } from "@/lib/shallowEqualBy";
-import { coerceTaskStatus } from "@/stores/taskStore";
+import { coerceTaskStatus, type TaskItem } from "@/stores/taskStore";
 
 const THREAD_ID = "aux-thread";
 
@@ -71,6 +71,7 @@ describe("AuxiliaryHydrator", () => {
   function createAux(
     overrides?: Partial<{
       getWorkspaceThread: () => { id: string; has_file_changes?: boolean } | undefined;
+      getTasksForThread: (threadId: string) => readonly TaskItem[];
     }>,
   ): AuxiliaryHydrator {
     return new AuxiliaryHydrator({
@@ -85,7 +86,7 @@ describe("AuxiliaryHydrator", () => {
       getWorkspaceThread:
         overrides?.getWorkspaceThread ??
         (() => createMockThread({ id: THREAD_ID, has_file_changes: false })),
-      getTasksForThread: () => [],
+      getTasksForThread: overrides?.getTasksForThread ?? (() => []),
       setTasksForThread,
       addPlanForThread: vi.fn(),
       shallowEqualBy,
@@ -153,6 +154,89 @@ describe("AuxiliaryHydrator", () => {
     await vi.waitFor(() => {
       expect(mockTransport.getThreadTasks).toHaveBeenCalledWith(THREAD_ID);
       expect(mockTransport.getThreadPlans).toHaveBeenCalledWith(THREAD_ID);
+    });
+  });
+
+  it("kept live tasks when task hydration returned no persisted tasks", async () => {
+    const liveTask: TaskItem = {
+      id: "task-live",
+      content: "Buy groceries - Pick up milk, eggs, bread",
+      status: "pending",
+      group: "Tasks",
+    };
+    (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const aux = createAux({
+      getTasksForThread: () => [liveTask],
+    });
+    aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
+
+    await vi.waitFor(() => {
+      expect(mockTransport.getThreadTasks).toHaveBeenCalledWith(THREAD_ID);
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setTasksForThread).not.toHaveBeenCalled();
+  });
+
+  it("kept live tasks for a group when hydration returned stale persisted tasks", async () => {
+    const liveTask: TaskItem = {
+      id: "task-live",
+      content: "Clean the kitchen - Dishes, counters, floor",
+      status: "pending",
+      group: "Tasks",
+    };
+    (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        content: "Buy groceries - Pick up milk, eggs, bread",
+        status: "pending",
+        group: "Tasks",
+      },
+    ]);
+
+    const aux = createAux({
+      getTasksForThread: () => [liveTask],
+    });
+    aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
+
+    await vi.waitFor(() => {
+      expect(mockTransport.getThreadTasks).toHaveBeenCalledWith(THREAD_ID);
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setTasksForThread).not.toHaveBeenCalled();
+  });
+
+  it("merged persisted groups that were missing from live tasks", async () => {
+    const liveTask: TaskItem = {
+      id: "task-live",
+      content: "Clean the kitchen - Dishes, counters, floor",
+      status: "pending",
+      group: "Tasks",
+    };
+    (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        content: "Check child diagnostics",
+        status: "pending",
+        group: "Sub-agent",
+      },
+    ]);
+
+    const aux = createAux({
+      getTasksForThread: () => [liveTask],
+    });
+    aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
+
+    await vi.waitFor(() => {
+      expect(setTasksForThread).toHaveBeenCalledWith(THREAD_ID, [
+        {
+          id: "0",
+          content: "Check child diagnostics",
+          status: "pending",
+          group: "Sub-agent",
+        },
+        liveTask,
+      ]);
     });
   });
 

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -108,11 +108,16 @@ export class AuxiliaryHydrator {
           group: t.group ?? "Tasks",
         }));
         const currentTasks = this.deps.getTasksForThread(threadId);
-        const currentGroups = new Set(currentTasks.map((task) => task.group));
-        const merged = [
-          ...items.filter((item) => !currentGroups.has(item.group)),
-          ...currentTasks,
-        ];
+        const isThreadRunning = this.deps.getState().runningThreadIds.has(threadId);
+        const merged = isThreadRunning
+          ? (() => {
+              const currentGroups = new Set(currentTasks.map((task) => task.group));
+              return [
+                ...items.filter((item) => !currentGroups.has(item.group)),
+                ...currentTasks,
+              ];
+            })()
+          : items;
         if (!shallowEqualBy(merged, currentTasks, ["content", "status", "group"])) {
           this.deps.setTasksForThread(threadId, merged);
         }

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -108,8 +108,13 @@ export class AuxiliaryHydrator {
           group: t.group ?? "Tasks",
         }));
         const currentTasks = this.deps.getTasksForThread(threadId);
-        if (!shallowEqualBy(items, currentTasks, ["content", "status", "group"])) {
-          this.deps.setTasksForThread(threadId, items);
+        const currentGroups = new Set(currentTasks.map((task) => task.group));
+        const merged = [
+          ...items.filter((item) => !currentGroups.has(item.group)),
+          ...currentTasks,
+        ];
+        if (!shallowEqualBy(merged, currentTasks, ["content", "status", "group"])) {
+          this.deps.setTasksForThread(threadId, merged);
         }
       })
       .catch((err) => {

--- a/apps/web/src/stores/taskStore.ts
+++ b/apps/web/src/stores/taskStore.ts
@@ -17,6 +17,7 @@ const VALID_TASK_STATUSES = new Set<string>([
  */
 export function coerceTaskStatus(raw: unknown): TaskStatus {
   const s = String(raw ?? "");
+  if (s === "inProgress" || s === "in-progress") return "in_progress";
   if (s === "canceled") return "cancelled";
   return VALID_TASK_STATUSES.has(s) ? (s as TaskStatus) : "pending";
 }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -315,6 +315,60 @@ function resolveAgentGroupLabel(
   return "Sub-agent";
 }
 
+function taskTextFromToolInput(toolInput: Record<string, unknown>): string | null {
+  const subject =
+    typeof toolInput.subject === "string" && toolInput.subject.trim().length > 0
+      ? toolInput.subject.trim()
+      : typeof toolInput.title === "string" && toolInput.title.trim().length > 0
+        ? toolInput.title.trim()
+        : typeof toolInput.content === "string" && toolInput.content.trim().length > 0
+          ? toolInput.content.trim()
+          : "";
+  const description =
+    typeof toolInput.description === "string" && toolInput.description.trim().length > 0
+      ? toolInput.description.trim()
+      : "";
+
+  if (!subject && !description) return null;
+  if (!subject) return description;
+  if (!description) return subject;
+  return `${subject} - ${description}`;
+}
+
+function updatePlanTasksFromToolInput(toolInput: Record<string, unknown>): TaskItem[] {
+  const entries =
+    Array.isArray(toolInput.plan)
+      ? toolInput.plan
+      : Array.isArray(toolInput.tasks)
+        ? toolInput.tasks
+        : Array.isArray(toolInput.todos)
+          ? toolInput.todos
+          : [];
+
+  return entries.flatMap((entry, i): TaskItem[] => {
+    const item: Record<string, unknown> = typeof entry === "object" && entry !== null
+      ? entry as Record<string, unknown>
+      : { step: entry };
+    const content =
+      typeof item.step === "string" && item.step.trim().length > 0
+        ? item.step.trim()
+        : typeof item.content === "string" && item.content.trim().length > 0
+          ? item.content.trim()
+          : typeof item.title === "string" && item.title.trim().length > 0
+            ? item.title.trim()
+            : typeof item.description === "string" && item.description.trim().length > 0
+              ? item.description.trim()
+              : "";
+    if (!content) return [];
+    return [{
+      id: item.id != null ? String(item.id) : String(i),
+      content,
+      status: coerceTaskStatus(item.status),
+      group: "Tasks",
+    }];
+  });
+}
+
 /**
  * Returns how many Agent (subagent) tool calls are still in flight for status UI.
  */
@@ -1605,13 +1659,16 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const toolName = (params.toolName as string) || "unknown";
       const incomingInput = (params.toolInput as Record<string, unknown>) || {};
       const parentToolCallId = params.parentToolCallId as string | undefined;
-      const applyTodoWriteTasks = (toolInput: Record<string, unknown>) => {
+      const applyTodoWriteTasks = (
+        toolInput: Record<string, unknown>,
+        resolvedParentToolCallId: string | undefined,
+      ) => {
         if (toolName !== "TodoWrite") return;
         const todos = toolInput.todos as Array<Record<string, unknown>> | undefined;
         if (!todos || !Array.isArray(todos)) return;
 
-        const group = parentToolCallId
-          ? resolveAgentGroupLabel(existingCalls, parentToolCallId)
+        const group = resolvedParentToolCallId
+          ? resolveAgentGroupLabel(existingCalls, resolvedParentToolCallId)
           : "Tasks";
 
         const taskItems: TaskItem[] = todos.map((t, i) => ({
@@ -1620,6 +1677,44 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           status: coerceTaskStatus(t.status),
           group,
         }));
+
+        useTaskStore.getState().setTaskGroup(threadId, group, taskItems);
+      };
+      const applyTaskCreate = (
+        toolInput: Record<string, unknown>,
+        resolvedParentToolCallId: string | undefined,
+      ) => {
+        if (toolName !== "TaskCreate") return;
+        const content = taskTextFromToolInput(toolInput);
+        if (!content) return;
+
+        const group = resolvedParentToolCallId
+          ? resolveAgentGroupLabel(existingCalls, resolvedParentToolCallId)
+          : "Tasks";
+        const taskItem: TaskItem = {
+          id: toolCallId || String(toolInput.id ?? content),
+          content,
+          status: coerceTaskStatus(toolInput.status ?? "pending"),
+          group,
+        };
+        const existingTasks = useTaskStore.getState().tasksByThread[threadId] ?? [];
+        const groupTasks = existingTasks.filter((task) => task.group === group);
+        useTaskStore.getState().setTaskGroup(
+          threadId,
+          group,
+          [...groupTasks.filter((task) => task.id !== taskItem.id), taskItem],
+        );
+      };
+      const applyUpdatePlanTasks = (
+        toolInput: Record<string, unknown>,
+        resolvedParentToolCallId: string | undefined,
+      ) => {
+        if (toolName !== "update_plan") return;
+        const group = resolvedParentToolCallId
+          ? resolveAgentGroupLabel(existingCalls, resolvedParentToolCallId)
+          : "Tasks";
+        const taskItems = updatePlanTasksFromToolInput(toolInput).map((task) => ({ ...task, group }));
+        if (taskItems.length === 0) return;
 
         useTaskStore.getState().setTaskGroup(threadId, group, taskItems);
       };
@@ -1637,6 +1732,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             );
           if (shouldMergeDuplicate) {
             const mergedInput = { ...existing.toolInput, ...incomingInput };
+            const resolvedParentToolCallId = existing.parentToolCallId ?? parentToolCallId;
             set((state) => {
               const calls = getThreadRecord(state.records, threadId).toolCalls;
               const updated = calls.map((tc) =>
@@ -1645,13 +1741,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
                       ...tc,
                       toolName,
                       toolInput: mergedInput,
-                      parentToolCallId: tc.parentToolCallId ?? parentToolCallId,
+                      parentToolCallId: tc.parentToolCallId ?? resolvedParentToolCallId,
                     }
                   : tc,
               );
               return { records: patchThreadRecord(state.records, threadId, { toolCalls: updated }) };
             });
-            applyTodoWriteTasks(mergedInput);
+            applyTodoWriteTasks(mergedInput, resolvedParentToolCallId);
+            applyTaskCreate(mergedInput, resolvedParentToolCallId);
+            applyUpdatePlanTasks(mergedInput, resolvedParentToolCallId);
           }
           return;
         }
@@ -1662,10 +1760,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       if (!parentToolCallId) {
         markPriorToolCallsComplete();
       }
-      // Intercept TodoWrite calls to populate the task panel.
+      // Intercept task tool calls to populate the task panel.
       // Sub-agent calls are grouped by their parent Agent's description so
       // multiple sub-agents each get their own collapsible section.
-      applyTodoWriteTasks(incomingInput);
+      applyTodoWriteTasks(incomingInput, parentToolCallId);
+      applyTaskCreate(incomingInput, parentToolCallId);
+      applyUpdatePlanTasks(incomingInput, parentToolCallId);
 
       const toolCall: ToolCall = {
         id: toolCallId || crypto.randomUUID(),


### PR DESCRIPTION
## What
Render Codex and Claude task tool output in Scope.

## Why
Codex sends plan snapshots as `turn/plan/updated`, not a standard `update_plan` call. Scope missed those snapshots after the right-panel move, so Codex parent tasks stayed invisible.

## Key Changes
- Map Codex `turn/plan/updated` to `update_plan` tool events.
- Persist `update_plan` and `TaskCreate` tasks, normalize `inProgress`, and hydrate persisted tasks without replacing live groups.
- Keep Scope parent-only by showing only the `Tasks` group.
- Normalize Cursor plan/todo status spellings and step/description task bodies.
- Add provider, persistence, hydration, and focused Playwright coverage.

Related to user-reported Scope task rendering bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783907530&installation_id=129163861&pr_number=724&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F724&signature=48027e23aba6a5cefa987eb3b9afad1d7b155beecbb1869253986158024ac1f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
