### PR TITLE
fix(server): honor update shutdown requests

### DIFF
--- a/apps/server/src/__tests__/providers-availability-rpc.test.ts
+++ b/apps/server/src/__tests__/providers-availability-rpc.test.ts
@@ -22,9 +22,10 @@ const AUTH_TOKEN = "test-token-providers";
  */
 function makeMinimalDeps(
   overrides: Partial<RouterDeps> = {},
-): RouterDeps & { authToken: string } {
+): RouterDeps & { authToken: string; shutdown: () => void } {
   return {
     authToken: AUTH_TOKEN,
+    shutdown: () => {},
     agentService: { activeCount: () => 0 } as unknown as RouterDeps["agentService"],
     workspaceService: undefined as unknown as RouterDeps["workspaceService"],
     threadService: undefined as unknown as RouterDeps["threadService"],
@@ -49,7 +50,7 @@ function makeMinimalDeps(
     ciWatcherService: undefined as unknown as RouterDeps["ciWatcherService"],
     providerAvailability: undefined as unknown as RouterDeps["providerAvailability"],
     ...overrides,
-  };
+  } as unknown as RouterDeps & { authToken: string; shutdown: () => void };
 }
 
 /** Build a WebSocket URL with the auth token as a query param. */

--- a/apps/server/src/__tests__/ws-server-health.test.ts
+++ b/apps/server/src/__tests__/ws-server-health.test.ts
@@ -5,15 +5,18 @@
  */
 
 import "reflect-metadata";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import http from "http";
 import { createWsServer } from "../transport/ws-server";
 import type { RouterDeps } from "../transport/ws-router";
 
 /** Minimal RouterDeps stub — only agentService is called by the health handler. */
-function makeMinimalDeps(): RouterDeps & { authToken: string } {
+function makeMinimalDeps(
+  overrides: Partial<RouterDeps & { authToken: string; shutdown: () => void }> = {},
+): RouterDeps & { authToken: string; shutdown: () => void } {
   return {
     authToken: "test-token-abc",
+    shutdown: vi.fn(),
     agentService: { activeCount: () => 2 } as unknown as RouterDeps["agentService"],
     workspaceService: undefined as unknown as RouterDeps["workspaceService"],
     threadService: undefined as unknown as RouterDeps["threadService"],
@@ -35,7 +38,8 @@ function makeMinimalDeps(): RouterDeps & { authToken: string } {
     prDraftService: undefined as unknown as RouterDeps["prDraftService"],
     threadRepo: undefined as unknown as RouterDeps["threadRepo"],
     workspaceRepo: undefined as unknown as RouterDeps["workspaceRepo"],
-  };
+    ...overrides,
+  } as unknown as RouterDeps & { authToken: string; shutdown: () => void };
 }
 
 /** Issue a GET /health request to the given server and return status + parsed body. */
@@ -60,6 +64,41 @@ function getHealth(server: http.Server): Promise<{ status: number; body: unknown
       },
     );
     req.on("error", reject);
+  });
+}
+
+/** Issue a POST /shutdown request to the given server. */
+function postShutdown(
+  server: http.Server,
+  token?: string,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+      return reject(new Error("Server not listening on a TCP port"));
+    }
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port: addr.port,
+        path: "/shutdown",
+        method: "POST",
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      },
+      (res) => {
+        let raw = "";
+        res.on("data", (chunk: string) => { raw += chunk; });
+        res.on("end", () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body: raw });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
   });
 }
 
@@ -109,5 +148,59 @@ describe("/health endpoint", () => {
     const { body } = await getHealth(server);
     expect((body as Record<string, unknown>).status).toBe("ok");
     expect((body as Record<string, unknown>).activeAgents).toBe(2);
+  });
+});
+
+describe("/shutdown endpoint", () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("runs the injected shutdown callback after an authorized request", async () => {
+    const shutdown = vi.fn();
+    const deps = makeMinimalDeps({ shutdown });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true as never);
+    ({ httpServer: server } = createWsServer(deps));
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const { status, body } = await postShutdown(server, "test-token-abc");
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(status).toBe(200);
+      expect(body).toEqual({ status: "shutting_down" });
+      expect(shutdown).toHaveBeenCalledOnce();
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it("rejects unauthenticated shutdown requests", async () => {
+    const shutdown = vi.fn();
+    const deps = makeMinimalDeps({ shutdown });
+    ({ httpServer: server } = createWsServer(deps));
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    const { status, body } = await postShutdown(server);
+
+    expect(status).toBe(401);
+    expect(body).toBe("Unauthorized");
+    expect(shutdown).not.toHaveBeenCalled();
+  });
+
+  it("rejects shutdown requests with the wrong token", async () => {
+    const shutdown = vi.fn();
+    const deps = makeMinimalDeps({ shutdown });
+    ({ httpServer: server } = createWsServer(deps));
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    const { status, body } = await postShutdown(server, "wrong-token");
+
+    expect(status).toBe(401);
+    expect(body).toBe("Unauthorized");
+    expect(shutdown).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -540,6 +540,7 @@ const { httpServer, wss } = createWsServer({
   diffSummaryService,
   handoffStorage,
   authToken: AUTH_TOKEN,
+  shutdown: requestShutdown,
 });
 
 /**
@@ -598,7 +599,7 @@ function startServerAndSubscribe(): void {
     graceMs: GRACE_PERIOD_MS,
     sessionCount,
     isBusy,
-    shutdown,
+    shutdown: requestShutdown,
     logger,
   });
 
@@ -749,15 +750,19 @@ async function shutdown(): Promise<void> {
   process.exit(0);
 }
 
-process.once("SIGTERM", () => {
-  shutdown().catch((err) => {
+let shutdownPromise: Promise<void> | null = null;
+
+/** Initiate server shutdown once, regardless of which trigger won the race. */
+function requestShutdown(): void {
+  shutdownPromise ??= shutdown().catch((err) => {
     logger.error("Shutdown error", { error: String(err) });
     process.exit(1);
   });
+}
+
+process.once("SIGTERM", () => {
+  requestShutdown();
 });
 process.once("SIGINT", () => {
-  shutdown().catch((err) => {
-    logger.error("Shutdown error", { error: String(err) });
-    process.exit(1);
-  });
+  requestShutdown();
 });

--- a/apps/server/src/transport/ws-server.ts
+++ b/apps/server/src/transport/ws-server.ts
@@ -48,7 +48,7 @@ const ATTACHMENT_EXT_MIME: Record<string, string> = {
 };
 
 /** Create and configure the HTTP + WebSocket server. */
-export function createWsServer(deps: RouterDeps & { authToken: string }): {
+export function createWsServer(deps: RouterDeps & { authToken: string; shutdown: () => void }): {
   httpServer: Server;
   wss: WebSocketServer;
 } {
@@ -80,8 +80,7 @@ export function createWsServer(deps: RouterDeps & { authToken: string }): {
         return;
       }
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "shutting_down" }));
-      process.kill(process.pid, "SIGTERM");
+      res.end(JSON.stringify({ status: "shutting_down" }), () => deps.shutdown());
       return;
     }
 


### PR DESCRIPTION
## What
Route authenticated `/shutdown` requests through the server's own shutdown lifecycle instead of self-signalling the process.

## Why
The desktop update flow already asks the server to shut down before installing. On Windows, the old endpoint could acknowledge the request and then terminate before the cleanup path finished, which risked leaving the installer with live server resources.

## Key Changes
- Add an injected shutdown callback to the HTTP server transport.
- Share one idempotent shutdown requester across `/shutdown`, grace-period expiry, SIGTERM, and SIGINT.
- Cover authorized, missing-token, and wrong-token shutdown requests in tests.

## Verification
- `bunx vitest run src/__tests__/ws-server-health.test.ts`
- `bunx vitest run src/__tests__/providers-availability-rpc.test.ts`
- `bun x tsc --noEmit`
- Started the bundled server under Electron's Node, posted `/shutdown`, and observed `Shutdown complete`, `.clean-shutdown` written, and `server.lock` removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783919258&installation_id=129163861&pr_number=725&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F725&signature=a7bea05f7485c4a18cbf82043a4d67606271e0997098e36098533146c47af6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown mechanism to be graceful and idempotent, preventing multiple simultaneous shutdown triggers and ensuring controlled error handling with proper exit codes.
  * Updated the `/shutdown` endpoint to return a JSON status response indicating the shutdown state.

* **Tests**
  * Added comprehensive shutdown endpoint tests verifying authorization, proper callback invocation, and response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->