### PR TITLE
feat: improve backend memory recovery and narrative ownership

### DIFF
--- a/apps/desktop/src/main/__tests__/server-crash-recovery.test.ts
+++ b/apps/desktop/src/main/__tests__/server-crash-recovery.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SERVER_CRASH_BACKOFF_MS,
+  SERVER_CRASH_WINDOW_MS,
+  ServerCrashRecovery,
+} from "../server-crash-recovery.js";
+
+describe("ServerCrashRecovery", () => {
+  it("restarts after the first abnormal exit with the first backoff delay", async () => {
+    const restart = vi.fn().mockResolvedValue(undefined);
+    const notifyRecovered = vi.fn();
+    const showError = vi.fn();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const recovery = new ServerCrashRecovery({
+      restart,
+      notifyRecovered,
+      showError,
+      now: () => 1_000,
+      sleep,
+    });
+
+    await recovery.handleUnexpectedExit(1);
+
+    expect(sleep).toHaveBeenCalledWith(SERVER_CRASH_BACKOFF_MS[0]);
+    expect(restart).toHaveBeenCalledOnce();
+    expect(notifyRecovered).toHaveBeenCalledWith(1);
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it("uses bounded backoff and stops after the retry budget is exhausted", async () => {
+    const restart = vi.fn().mockResolvedValue(undefined);
+    const notifyRecovered = vi.fn();
+    const showError = vi.fn();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    let now = 10_000;
+
+    const recovery = new ServerCrashRecovery({
+      restart,
+      notifyRecovered,
+      showError,
+      now: () => now,
+      sleep,
+    });
+
+    for (const delay of SERVER_CRASH_BACKOFF_MS) {
+      await recovery.handleUnexpectedExit(1);
+      expect(sleep).toHaveBeenLastCalledWith(delay);
+      now += 1_000;
+    }
+
+    await recovery.handleUnexpectedExit(1);
+
+    expect(restart).toHaveBeenCalledTimes(SERVER_CRASH_BACKOFF_MS.length);
+    expect(showError).toHaveBeenCalledWith(1);
+  });
+
+  it("forgets old crashes outside the crash-loop window", async () => {
+    const restart = vi.fn().mockResolvedValue(undefined);
+    const notifyRecovered = vi.fn();
+    const showError = vi.fn();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    let now = 10_000;
+
+    const recovery = new ServerCrashRecovery({
+      restart,
+      notifyRecovered,
+      showError,
+      now: () => now,
+      sleep,
+    });
+
+    await recovery.handleUnexpectedExit(1);
+    now += SERVER_CRASH_WINDOW_MS + 1;
+    await recovery.handleUnexpectedExit(1);
+
+    expect(sleep).toHaveBeenNthCalledWith(1, SERVER_CRASH_BACKOFF_MS[0]);
+    expect(sleep).toHaveBeenNthCalledWith(2, SERVER_CRASH_BACKOFF_MS[0]);
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it("shows the terminal error state when restart fails", async () => {
+    const restart = vi.fn().mockRejectedValue(new Error("restart failed"));
+    const notifyRecovered = vi.fn();
+    const showError = vi.fn();
+
+    const recovery = new ServerCrashRecovery({
+      restart,
+      notifyRecovered,
+      showError,
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await recovery.handleUnexpectedExit(1);
+
+    expect(showError).toHaveBeenCalledWith(1);
+    expect(notifyRecovered).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/server-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/server-manager.test.ts
@@ -83,6 +83,7 @@ vi.mock("node:fs", () => ({
     err.code = "ENOENT";
     throw err;
   }),
+  renameSync: vi.fn(),
   unlinkSync: vi.fn(),
   writeFileSync: vi.fn(),
   // createWriteStream is used in non-dev mode to route stderr to a log file.
@@ -135,8 +136,10 @@ const originalFetch = globalThis.fetch;
 
 import { ServerManager } from "../server-manager.js";
 import { spawn } from "child_process";
-import { existsSync, readFileSync, writeFileSync, createWriteStream } from "fs";
+import { existsSync, readFileSync, writeFileSync, createWriteStream, renameSync } from "fs";
 import { readFile } from "fs/promises";
+import { join } from "path";
+import { SERVER_HEAP_DEFAULT_MB, SERVER_HEAP_LEGACY_DEFAULT_MB } from "@mcode/contracts";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -235,12 +238,12 @@ describe("ServerManager", () => {
   // V8 flags in args array
   // -----------------------------------------------------------------------
 
-  it("passes V8 flags in the args array with default heap (96 MB)", async () => {
+  it("passes V8 flags in the args array with default heap", async () => {
     await manager.start();
 
     const spawnCall = vi.mocked(spawn).mock.calls[0];
     const args = spawnCall[1] as string[];
-    expect(args).toContain("--max-old-space-size=96");
+    expect(args).toContain(`--max-old-space-size=${SERVER_HEAP_DEFAULT_MB}`);
     expect(args).toContain("--max-semi-space-size=2");
     expect(args).toContain("--expose-gc");
   });
@@ -328,6 +331,27 @@ describe("ServerManager", () => {
     expect(args).toContain("--max-old-space-size=1024");
   });
 
+  it("treats the old default heap setting as unset", async () => {
+    vi.mocked(readFileSync).mockReset();
+    const enoent = () => {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    };
+    vi.mocked(readFileSync)
+      .mockImplementationOnce(enoent)
+      .mockReturnValueOnce(
+        JSON.stringify({ server: { memory: { heapMb: SERVER_HEAP_LEGACY_DEFAULT_MB } } }),
+      );
+    vi.mocked(readFile).mockResolvedValueOnce(LOCK_FILE_JSON as never);
+
+    await manager.start();
+
+    const spawnCall = vi.mocked(spawn).mock.calls[0];
+    const args = spawnCall[1] as string[];
+    expect(args).toContain(`--max-old-space-size=${SERVER_HEAP_DEFAULT_MB}`);
+  });
+
   it("uses MCODE_SERVER_HEAP_MB env var over settings.json", async () => {
     process.env.MCODE_SERVER_HEAP_MB = "2048";
 
@@ -348,6 +372,27 @@ describe("ServerManager", () => {
     const spawnCall = vi.mocked(spawn).mock.calls[0];
     const args = spawnCall[1] as string[];
     expect(args).toContain("--max-old-space-size=2048");
+  });
+
+  it("falls through to settings.json when MCODE_SERVER_HEAP_MB is invalid", async () => {
+    process.env.MCODE_SERVER_HEAP_MB = "invalid";
+
+    vi.mocked(readFileSync).mockReset();
+    const enoent = () => {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    };
+    vi.mocked(readFileSync)
+      .mockImplementationOnce(enoent)
+      .mockReturnValueOnce(JSON.stringify({ server: { memory: { heapMb: 1024 } } }));
+    vi.mocked(readFile).mockResolvedValueOnce(LOCK_FILE_JSON as never);
+
+    await manager.start();
+
+    const spawnCall = vi.mocked(spawn).mock.calls[0];
+    const args = spawnCall[1] as string[];
+    expect(args).toContain("--max-old-space-size=1024");
   });
 
   // -----------------------------------------------------------------------
@@ -385,6 +430,23 @@ describe("ServerManager", () => {
     const spawnCall = vi.mocked(spawn).mock.calls[0];
     const args = spawnCall[1] as string[];
     expect(args.join(" ")).toContain("server.cjs");
+  });
+
+  it("enables fatal V8 reports in packaged builds", async () => {
+    refs.setIsPackaged(true);
+    Object.defineProperty(process, "resourcesPath", {
+      value: "/test/resources",
+      configurable: true,
+      writable: true,
+    });
+
+    await manager.start();
+
+    const spawnCall = vi.mocked(spawn).mock.calls[0];
+    const args = spawnCall[1] as string[];
+    expect(args).toContain("--report-on-fatalerror");
+    expect(args).toContain("--report-directory=/tmp/mcode");
+    expect(args).toContain("--heapsnapshot-near-heap-limit=1");
   });
 
   it("uses process.execPath when packaged but renamed binary is missing", async () => {
@@ -591,6 +653,23 @@ describe("ServerManager", () => {
 
     await expect(manager.start()).rejects.toThrow("spawn ENOENT");
     expect(mockStream.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("rotates the previous stderr log before opening a new one", async () => {
+    vi.mocked(existsSync).mockImplementation((path) =>
+      String(path).endsWith("server-stderr.log"),
+    );
+
+    await manager.start();
+
+    expect(renameSync).toHaveBeenCalledWith(
+      join("/tmp/mcode", "server-stderr.log"),
+      join("/tmp/mcode", "server-stderr.1.log"),
+    );
+    expect(createWriteStream).toHaveBeenCalledWith(
+      join("/tmp/mcode", "server-stderr.log"),
+      { flags: "w" },
+    );
   });
 
   // -----------------------------------------------------------------------

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -13,6 +13,7 @@ import {
   clipboard,
   dialog,
   ipcMain,
+  Notification,
   powerMonitor,
   powerSaveBlocker,
   protocol,
@@ -32,6 +33,7 @@ const getExtension = globalThis.__v8Snapshot?.contracts?.getExtension ?? bundled
 
 import { openInRegistry } from "./open-in/index.js";
 import { ServerManager } from "./server-manager.js";
+import { ServerCrashRecovery } from "./server-crash-recovery.js";
 import { startIpcRelay } from "./ipc-relay.js";
 import {
   applyReleaseLineSwitch,
@@ -109,6 +111,11 @@ function openIfAllowed(url: string): void {
 
 let mainWindow: BrowserWindow | null = null;
 const serverManager = new ServerManager();
+const serverCrashRecovery = new ServerCrashRecovery({
+  restart: () => serverManager.restart(),
+  notifyRecovered: (code) => showServerRecoveredNotification(code),
+  showError: (code) => showServerCrashDialog(code),
+});
 
 // ---------------------------------------------------------------------------
 // Sleep-resilient server lifecycle (self-healing restart + power save blocker)
@@ -140,6 +147,22 @@ async function showServerCrashDialog(code: number | null): Promise<void> {
   } else {
     app.quit();
   }
+}
+
+/** Notify the user after an automatic backend restart succeeds. */
+function showServerRecoveredNotification(code: number | null): void {
+  if (!Notification.isSupported()) return;
+  const notification = new Notification({
+    title: "Mcode server recovered",
+    body: `The backend crashed (code ${code ?? "unknown"}) and restarted.`,
+  });
+  notification.on("click", () => {
+    if (!mainWindow) return;
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.show();
+    mainWindow.focus();
+  });
+  notification.show();
 }
 
 /**
@@ -659,9 +682,9 @@ app.whenReady().then(async () => {
     // installer does not hit locked files under the install directory.
     setBeforeInstallHook(() => serverManager.forceReplace());
 
-    // Show a Restart / Quit dialog if the server crashes unexpectedly
+    // Recover once the server process exits unexpectedly.
     serverManager.onUnexpectedExit = (code) => {
-      void showServerCrashDialog(code);
+      void serverCrashRecovery.handleUnexpectedExit(code);
     };
 
     // Self-heal after sleep: the server's grace timer or the OS may have

--- a/apps/desktop/src/main/server-crash-recovery.ts
+++ b/apps/desktop/src/main/server-crash-recovery.ts
@@ -1,0 +1,76 @@
+/** Backoff delays for backend crash recovery attempts. */
+export const SERVER_CRASH_BACKOFF_MS = [1_000, 5_000, 15_000] as const;
+
+/** Time window used to decide whether crashes are part of one crash loop. */
+export const SERVER_CRASH_WINDOW_MS = 5 * 60_000;
+
+/** Dependencies required by {@link ServerCrashRecovery}. */
+export interface ServerCrashRecoveryDeps {
+  /** Restart the backend server. */
+  restart: () => Promise<void>;
+  /** Surface that the backend crashed and was recovered. */
+  notifyRecovered: (code: number | null) => void;
+  /** Surface the terminal crash-loop state to the user. */
+  showError: (code: number | null) => Promise<void> | void;
+  /** Clock injection for deterministic tests. */
+  now?: () => number;
+  /** Timer injection for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Handles bounded backend restart attempts after abnormal server exits. */
+export class ServerCrashRecovery {
+  private readonly restart: () => Promise<void>;
+  private readonly notifyRecovered: (code: number | null) => void;
+  private readonly showError: (code: number | null) => Promise<void> | void;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private crashTimestamps: number[] = [];
+  private inFlight: Promise<void> | null = null;
+
+  constructor(deps: ServerCrashRecoveryDeps) {
+    this.restart = deps.restart;
+    this.notifyRecovered = deps.notifyRecovered;
+    this.showError = deps.showError;
+    this.now = deps.now ?? Date.now;
+    this.sleep =
+      deps.sleep ??
+      ((ms) =>
+        new Promise((resolve) => {
+          setTimeout(resolve, ms);
+        }));
+  }
+
+  /** Restart after an unexpected backend exit, or surface a crash loop. */
+  handleUnexpectedExit(code: number | null): Promise<void> {
+    if (this.inFlight) return this.inFlight;
+
+    this.inFlight = this.recover(code).finally(() => {
+      this.inFlight = null;
+    });
+    return this.inFlight;
+  }
+
+  private async recover(code: number | null): Promise<void> {
+    const now = this.now();
+    this.crashTimestamps = this.crashTimestamps.filter(
+      (timestamp) => now - timestamp < SERVER_CRASH_WINDOW_MS,
+    );
+
+    const attemptIndex = this.crashTimestamps.length;
+    if (attemptIndex >= SERVER_CRASH_BACKOFF_MS.length) {
+      await this.showError(code);
+      return;
+    }
+
+    this.crashTimestamps.push(now);
+    await this.sleep(SERVER_CRASH_BACKOFF_MS[attemptIndex]);
+
+    try {
+      await this.restart();
+      this.notifyRecovered(code);
+    } catch {
+      await this.showError(code);
+    }
+  }
+}

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -9,12 +9,24 @@
 
 import { app } from "electron";
 import { execSync, spawn, type ChildProcess } from "child_process";
-import { createWriteStream, existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import {
+  createWriteStream,
+  existsSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
 import { readFile } from "fs/promises";
 import { createServer, type AddressInfo } from "net";
 import { resolve, join, dirname } from "path";
 import { getMcodeDir } from "@mcode/shared";
-import { SettingsSchema as BundledSettingsSchema } from "@mcode/contracts";
+import {
+  SettingsSchema as BundledSettingsSchema,
+  SERVER_HEAP_DEFAULT_MB,
+  SERVER_HEAP_MAX_MB,
+  SERVER_HEAP_MIN_MB,
+} from "@mcode/contracts";
 import { resolveServerBinary } from "./server-binary-resolver.js";
 import { isDesktopDev } from "./is-desktop-dev.js";
 
@@ -77,34 +89,43 @@ const STARTUP_TIMEOUT_MS = 30_000;
 
 /** Server stderr log file path. Rotated on each spawn to keep size bounded. */
 const SERVER_LOG_PATH = join(getMcodeDir(), "server-stderr.log");
+/** Previous server stderr log retained across one respawn for crash diagnostics. */
+const SERVER_ROTATED_LOG_PATH = join(getMcodeDir(), "server-stderr.1.log");
 
-/** Default V8 max old space size in MB. Tuned for the < 100MB idle target. */
-const DEFAULT_HEAP_MB = 96;
-
-/** Minimum allowed heap size in MB. */
-const MIN_HEAP_MB = 64;
-
-/** Maximum allowed heap size in MB. */
-const MAX_HEAP_MB = 8192;
+/** Rotate the previous packaged-server stderr log before opening a fresh one. */
+function rotateServerLog(): void {
+  if (!existsSync(SERVER_LOG_PATH)) return;
+  try {
+    if (existsSync(SERVER_ROTATED_LOG_PATH)) {
+      unlinkSync(SERVER_ROTATED_LOG_PATH);
+    }
+    renameSync(SERVER_LOG_PATH, SERVER_ROTATED_LOG_PATH);
+  } catch (err) {
+    console.warn("[server-manager] Failed to rotate previous server stderr log", err);
+  }
+}
 
 /**
  * Determine the V8 max old space size for the server process.
- * Priority: MCODE_SERVER_HEAP_MB env var > settings.json > default (96).
+ * Priority: MCODE_SERVER_HEAP_MB env var > settings.json > default.
  */
 function readServerHeapMb(): number {
   // 1. Environment variable takes highest precedence
   const envVal = process.env.MCODE_SERVER_HEAP_MB;
   if (envVal !== undefined) {
     const parsed = Number(envVal);
-    if (Number.isInteger(parsed) && parsed >= MIN_HEAP_MB && parsed <= MAX_HEAP_MB) {
+    if (
+      Number.isInteger(parsed) &&
+      parsed >= SERVER_HEAP_MIN_MB &&
+      parsed <= SERVER_HEAP_MAX_MB
+    ) {
       return parsed;
     }
     console.warn(
       `[server-manager] MCODE_SERVER_HEAP_MB="${envVal}" is invalid ` +
-        `(parsed: ${parsed}, allowed: ${MIN_HEAP_MB}-${MAX_HEAP_MB} integer). ` +
-        `Falling back to default ${DEFAULT_HEAP_MB} MB.`,
+        `(parsed: ${parsed}, allowed: ${SERVER_HEAP_MIN_MB}-${SERVER_HEAP_MAX_MB} integer). ` +
+        "Falling through to settings.json.",
     );
-    return DEFAULT_HEAP_MB;
   }
 
   // 2. Read from settings.json via the Zod schema
@@ -119,7 +140,7 @@ function readServerHeapMb(): number {
     // File missing or unreadable, fall through to default
   }
 
-  return DEFAULT_HEAP_MB;
+  return SERVER_HEAP_DEFAULT_MB;
 }
 
 /**
@@ -377,11 +398,25 @@ export class ServerManager {
       }
 
       // V8 flags go in the args array for child_process.spawn.
-      const v8Flags = [`--max-old-space-size=${heapMb}`, "--max-semi-space-size=2", "--expose-gc"];
+      const v8Flags = [
+        `--max-old-space-size=${heapMb}`,
+        "--max-semi-space-size=2",
+        "--expose-gc",
+      ];
+      if (app.isPackaged) {
+        v8Flags.push(
+          "--report-on-fatalerror",
+          `--report-directory=${getMcodeDir()}`,
+          "--heapsnapshot-near-heap-limit=1",
+        );
+      }
       const args = [...v8Flags, entry];
 
       // In production, route stderr to a log file so crashes are diagnosable.
       // Dev mode inherits stdio for immediate console visibility.
+      if (!isDesktopDev()) {
+        rotateServerLog();
+      }
       const stderrStream = isDesktopDev()
         ? undefined
         : createWriteStream(SERVER_LOG_PATH, { flags: "w" });

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -508,6 +508,70 @@ describe("AgentService narrative persistence", () => {
     expect(thoughtBulk).not.toHaveBeenCalled();
   });
 
+  it("transfers boundary-final text to the assistant body owner when Message is absent", async () => {
+    const { providerEmitter, thoughtBulk, service } = build();
+    const body = "Tool-free final answer";
+    const userMsg: Message = {
+      id: "user-anchor",
+      thread_id: THREAD_ID,
+      role: "user",
+      content: "go",
+      tool_calls: null,
+      files_changed: null,
+      cost_usd: null,
+      tokens_used: null,
+      timestamp: new Date().toISOString(),
+      sequence: 1,
+      attachments: null,
+      is_internal: false,
+    };
+    const assistantMsg: Message = {
+      id: MSG_ID,
+      thread_id: THREAD_ID,
+      role: "assistant",
+      content: body,
+      tool_calls: null,
+      files_changed: null,
+      cost_usd: null,
+      tokens_used: null,
+      timestamp: new Date().toISOString(),
+      sequence: 2,
+      attachments: null,
+      is_internal: false,
+    };
+    const messageRepo = (service as unknown as { messageRepo: MessageRepo }).messageRepo as
+      & MessageRepo
+      & { createAssistantIdempotent: ReturnType<typeof vi.fn> };
+    messageRepo.listByThread = vi.fn(() => ({ messages: [userMsg], hasMore: false }));
+    messageRepo.createAssistantIdempotent = vi.fn(() => assistantMsg);
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.TextDelta,
+      threadId: THREAD_ID,
+      delta: body,
+    });
+    providerEmitter.emit("event", {
+      type: AgentEventType.AssistantMessageBoundary,
+      threadId: THREAD_ID,
+      isFinalResponse: true,
+    });
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: THREAD_ID,
+      tokensIn: 0,
+      tokensOut: 0,
+      contextWindow: 0,
+    });
+
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(messageRepo.createAssistantIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({ content: body }),
+    );
+    expect(thoughtBulk).not.toHaveBeenCalled();
+  });
+
   it("persists preamble thought when AssistantMessageBoundary reports isFinalResponse=false", async () => {
     const { providerEmitter, thoughtBulk } = build();
 

--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -304,11 +304,22 @@ describe("NarrativeStore write seam (server-side traps)", () => {
       store.beginTurn(THREAD);
       store.resetTurnCounters(THREAD);
       store.openOrExtendThought(THREAD, "Tool-free final answer");
-      // end_turn-style boundary → final response → drop, never persisted.
+      // end_turn-style boundary means final response, so drop it.
       store.dropOpenThought(THREAD);
 
       store.persistNarrative(THREAD, "m1", "Tool-free final answer", "completed");
       expect(new ThoughtSegmentRepo(db).listByMessage("m1")).toHaveLength(0);
+    });
+
+    it("moves an open thought out of the narrative buffer for final-response ownership transfer", () => {
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.openOrExtendThought(THREAD, "Tool-free final answer");
+
+      const text = store.takeOpenThought(THREAD);
+
+      expect(text).toBe("Tool-free final answer");
+      expect(store.hasBufferedNarrative(THREAD)).toBe(false);
     });
 
     it("persists preamble as a thought when the boundary reports tool_use (non-final)", () => {
@@ -316,7 +327,7 @@ describe("NarrativeStore write seam (server-side traps)", () => {
       store.beginTurn(THREAD);
       store.resetTurnCounters(THREAD);
       store.openOrExtendThought(THREAD, "Let me check that file.");
-      // tool_use stop_reason → close as preamble.
+      // tool_use stop_reason means preamble.
       store.closeOpenThought(THREAD);
       store.bufferToolCall(THREAD, toolUse("tc-read", "Read"));
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1475,12 +1475,14 @@ export class AgentService {
         // cannot submit answers against a still-active session, which would
         // risk overlapping sends on the same thread.
         if (event.type === AgentEventType.TextDelta) {
-          this.turnFinalizer.appendStreamingText(event.threadId, event.delta);
-          // Final-response deltas are the assistant's user-facing reply — they will
-          // be stored as the message body when the Message event arrives. Do not
-          // open a ThoughtSegment for them: that would cause the text to appear
-          // twice (once as a dimmed thought block, once as the assistant message).
-          if (!event.isFinalResponse) {
+          // Final-response deltas belong to TurnFinalizer, which owns the
+          // assistant body fallback when a provider Message never arrives.
+          // Unknown/non-final deltas belong to NarrativeStore until the
+          // authoritative boundary either closes them as thoughts or transfers
+          // them into TurnFinalizer.
+          if (event.isFinalResponse) {
+            this.turnFinalizer.appendStreamingText(event.threadId, event.delta);
+          } else {
             // Open or extend the current thought segment. NarrativeStore allocates
             // the sort order lazily on the first delta so consecutive deltas keep
             // the same slot, taken BEFORE any following tool call's sort order.
@@ -1638,14 +1640,15 @@ export class AgentService {
         if (event.type === AgentEventType.AssistantMessageBoundary) {
           // Authoritative classification of the just-streamed text deltas based
           // on the Anthropic message-level `stop_reason`. When `isFinalResponse`
-          // is true the open thought segment was really the final user-facing
-          // response (the legacy heuristic could not detect this for tool-free
-          // turns) — drop it so it never gets persisted as a thought row, which
-          // would otherwise render alongside the assistant message bubble.
+          // is true, move that text to the assistant body owner so it never
+          // persists as a thought row or lives in two server-side buffers.
           // Otherwise the message ended with a non-finalizing stop_reason such
           // as `tool_use`; close the thought so it persists as preamble.
           if (event.isFinalResponse) {
-            this.narrativeStore.dropOpenThought(event.threadId);
+            const finalText = this.narrativeStore.takeOpenThought(event.threadId);
+            if (finalText) {
+              this.turnFinalizer.appendStreamingText(event.threadId, finalText);
+            }
           } else {
             this.narrativeStore.closeOpenThought(event.threadId);
             this.turnFinalizer.resetStreamingText(event.threadId);

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -268,6 +268,19 @@ export class NarrativeStore {
   }
 
   /**
+   * Move the open thought text out of NarrativeStore without persisting it.
+   *
+   * Used when an authoritative boundary retroactively classifies previously
+   * unknown deltas as the final assistant response. Ownership moves to
+   * TurnFinalizer so the same text is not buffered in both stores.
+   */
+  takeOpenThought(threadId: string): string {
+    const open = this.turnOpenThought.get(threadId);
+    this.turnOpenThought.set(threadId, null);
+    return open?.text ?? "";
+  }
+
+  /**
    * Get the current parent tool call ID for a thread's active Agent nesting.
    * This is the fallback consulted by `index.ts` enrichment and
    * {@link bufferToolCall} when the SDK omits `parent_tool_use_id` (Trap 1).

--- a/docs/guides/settings-schema.md
+++ b/docs/guides/settings-schema.md
@@ -146,7 +146,7 @@ When adding a new setting, ask these questions in order:
   },
   "server": {
     "memory": {
-      "heapMb": 512                    // 64-8192, V8 max old space (MB)
+      "heapMb": 512                    // 256-8192, V8 max old space (MB)
     }
   },
   "provider": {

--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -28,15 +28,15 @@ Per-setting reference for Mcode's `settings.json`. For schema conventions and st
 | `worktree.naming.mode` | enum | `"auto"` | `"auto"` \| `"custom"` \| `"ai"` | - | Naming strategy for new worktree branches |
 | `worktree.naming.aiConfirmation` | boolean | `true` | - | - | Prompt before using AI-generated branch names |
 | `performance.threadCacheSize` | integer | `10` | 1-25 | - | Number of threads to keep in memory for instant switching. Lower values reduce memory use; values ≤ 3 mean most thread switches reload from the server. Takes effect immediately. |
-| `server.memory.heapMb` | integer | `512` | 64-8192 | `MCODE_SERVER_HEAP_MB` | V8 max old space for the server process (MB) |
+| `server.memory.heapMb` | integer | `512` | 256-8192 | `MCODE_SERVER_HEAP_MB` | V8 max old space for the server process (MB). Invalid environment values fall through to `settings.json`. |
 | `preview.memorySaver.maxWarm` | integer | `3` | 1-20 | - | Most-recently-used background preview tabs kept warm while the panel is hidden. Others are discarded (renderer freed) and reload on reopen. |
 | `preview.memorySaver.bgIdleMs` | integer | `300000` | 30000-3600000 | - | Idle time (ms) before a background preview tab is discarded while the panel is visible. |
 | `preview.memorySaver.hiddenIdleMs` | integer | `60000` | 5000-600000 | - | Idle time (ms) after the preview panel hides before the warm set is trimmed to `maxWarm`. A reshow within the window cancels the trim. |
 | `provider.cli.codex` | string | `""` | - | - | Path to the Codex CLI binary. When empty, mcode looks for `codex` on the system PATH. |
 | `provider.cli.claude` | string | `""` | - | - | Path to the Claude Code CLI binary. When empty, mcode looks for `claude` on the system PATH. |
 | `provider.cursor.alwaysSendFullInstructions` | boolean | `false` | - | - | When true, Cursor ACP sends full stitched workspace guidance and the skill catalogue on every turn instead of sticky shortening (largest prompts). |
-| `provider.cursor.fullPreambleEveryNTurns` | integer | `12` | 0–999 | - | With sticky shortening, force a fresh full preamble every N prompts for that subprocess. `0` turns this off. |
-| `provider.cursor.idleSessionTtlMinutes` | integer | `20` | 5–240 | - | Idle minutes before tearing down an unused `cursor-agent` subprocess. |
+| `provider.cursor.fullPreambleEveryNTurns` | integer | `12` | 0-999 | - | With sticky shortening, force a fresh full preamble every N prompts for that subprocess. `0` turns this off. |
+| `provider.cursor.idleSessionTtlMinutes` | integer | `20` | 5-240 | - | Idle minutes before tearing down an unused `cursor-agent` subprocess. |
 | `provider.cursor.retryTransientFailuresOnce` | boolean | `true` | - | - | Retry `session/prompt` once when the failure looks like a transient CLI or HTTP transport flake. |
 | `provider.cursor.verboseFailureLogs` | boolean | `true` | - | - | On Cursor prompt failure, append recent stderr lines to structured logs when available. |
 | `provider.cursor.traceSessionUpdates` | boolean | `false` | - | - | When true, writes sanitized Cursor ACP `session/update` payloads and mapped agent events to daily server logs (skips noisy `agent_message_chunk` streaming). Inspect `$MCODE_DATA_DIR/logs/` for timelines. |

--- a/packages/contracts/src/__tests__/settings.test.ts
+++ b/packages/contracts/src/__tests__/settings.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { SettingsSchema, getDefaultSettings } from "../models/settings.js";
+import {
+  SettingsSchema,
+  getDefaultSettings,
+  SERVER_HEAP_DEFAULT_MB,
+  SERVER_HEAP_LEGACY_DEFAULT_MB,
+  SERVER_HEAP_MIN_MB,
+} from "../models/settings.js";
 
 describe("SettingsSchema", () => {
   describe("server.memory.heapMb", () => {
-    it("defaults to 96 when parsing an empty object", () => {
+    it("defaults to the supported server heap cap when parsing an empty object", () => {
       const result = SettingsSchema().parse({});
-      expect(result.server.memory.heapMb).toBe(96);
+      expect(result.server.memory.heapMb).toBe(SERVER_HEAP_DEFAULT_MB);
     });
 
     it("accepts a valid heapMb value", () => {
@@ -13,8 +19,17 @@ describe("SettingsSchema", () => {
       expect(result.server.memory.heapMb).toBe(1024);
     });
 
-    it("rejects heapMb below minimum (64)", () => {
-      const result = SettingsSchema().safeParse({ server: { memory: { heapMb: 32 } } });
+    it("migrates the old shipped default to the current default", () => {
+      const result = SettingsSchema().parse({
+        server: { memory: { heapMb: SERVER_HEAP_LEGACY_DEFAULT_MB } },
+      });
+      expect(result.server.memory.heapMb).toBe(SERVER_HEAP_DEFAULT_MB);
+    });
+
+    it("rejects heapMb below the supported floor", () => {
+      const result = SettingsSchema().safeParse({
+        server: { memory: { heapMb: SERVER_HEAP_MIN_MB - 1 } },
+      });
       expect(result.success).toBe(false);
     });
 
@@ -29,7 +44,7 @@ describe("SettingsSchema", () => {
     });
 
     it("includes server.memory.heapMb in getDefaultSettings", () => {
-      expect(getDefaultSettings().server.memory.heapMb).toBe(96);
+      expect(getDefaultSettings().server.memory.heapMb).toBe(SERVER_HEAP_DEFAULT_MB);
     });
   });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -80,6 +80,10 @@ export {
   UpdateCheckIntervalSchema,
   UpdateReleaseLineSchema,
   GRACE_PERIOD_DEFAULT_SECONDS,
+  SERVER_HEAP_DEFAULT_MB,
+  SERVER_HEAP_MIN_MB,
+  SERVER_HEAP_MAX_MB,
+  SERVER_HEAP_LEGACY_DEFAULT_MB,
 } from "./models/settings.js";
 export type {
   Settings,

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -93,6 +93,18 @@ export type UpdateReleaseLine = z.infer<typeof UpdateReleaseLineSchema>;
  */
 export const GRACE_PERIOD_DEFAULT_SECONDS = 30;
 
+/** Default V8 max old space size for the desktop-managed server process, in MB. */
+export const SERVER_HEAP_DEFAULT_MB = 512;
+
+/** Lowest supported V8 max old space size for the server process, in MB. */
+export const SERVER_HEAP_MIN_MB = 256;
+
+/** Highest supported V8 max old space size for the server process, in MB. */
+export const SERVER_HEAP_MAX_MB = 8192;
+
+/** Shipped default from older installs, migrated to {@link SERVER_HEAP_DEFAULT_MB}. */
+export const SERVER_HEAP_LEGACY_DEFAULT_MB = 96;
+
 // ---------------------------------------------------------------------------
 // Settings schema
 // ---------------------------------------------------------------------------
@@ -260,8 +272,18 @@ export const SettingsSchema = lazySchema(() =>
         /** Memory settings for the server process. */
         memory: z
           .object({
-            /** V8 max old space size in MB. Valid range: 64-8192. Default tuned for < 100MB idle. */
-            heapMb: z.number().int().min(64).max(8192).default(96),
+            /** V8 max old space size in MB. Valid range: 256-8192. */
+            heapMb: z
+              .preprocess(
+                (value) =>
+                  value === SERVER_HEAP_LEGACY_DEFAULT_MB ? undefined : value,
+                z
+                  .number()
+                  .int()
+                  .min(SERVER_HEAP_MIN_MB)
+                  .max(SERVER_HEAP_MAX_MB)
+                  .default(SERVER_HEAP_DEFAULT_MB),
+              ),
           })
           .default({}),
         /** Grace period before auto-shutdown after all UI sessions disconnect. */
@@ -558,7 +580,12 @@ export const PartialSettingsSchema = lazySchema(() =>
       .object({
         memory: z
           .object({
-            heapMb: z.number().int().min(64).max(8192).optional(),
+            heapMb: z
+              .number()
+              .int()
+              .min(SERVER_HEAP_MIN_MB)
+              .max(SERVER_HEAP_MAX_MB)
+              .optional(),
           })
           .optional(),
         gracePeriod: z


### PR DESCRIPTION
## What
Raise the backend heap policy to the documented 512 MB default, add crash recovery around the packaged server, and move final-response text to a single persisted owner.

## Why
Issue #710 groups the memory work. These changes handle the concrete follow-ups for heap sizing, backend crash diagnostics, and duplicate live narration buffering.

## Key Changes
- Set `server.memory.heapMb` to default 512 MB with a 256 MB floor and 8192 MB ceiling. Legacy 96 MB settings now migrate to the default, and invalid `MCODE_SERVER_HEAP_MB` values fall through to settings.
- Preserve backend crash evidence by rotating `server-stderr.1.log`, enabling packaged V8 fatal reports, and retrying abnormal exits with bounded backoff before surfacing an error.
- Transfer boundary-final Codex text from the narrative buffer into the assistant body owner, so final text is not retained in both `NarrativeStore` and `TurnFinalizer`.
- Update focused tests and settings docs for the new heap policy, crash recovery, and final-response ownership path.

## Validation
- Focused heap, crash recovery, contracts, narrative-store, agent-service, and turn-finalizer tests passed.
- `bun run verify` passed typecheck and lint. The frontend unit gate still hit existing Vitest worker startup timeouts: 168 passed, 2 failed, 11 worker timeout errors.
- Live check ran backend plus Vite, opened the app, sent three concurrent Codex threads, confirmed all assistant rows persisted, and confirmed final text was not duplicated into `thought_segments`.

Closes #712
Closes #713
Closes #715
Related to #710

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783921805&installation_id=129163861&pr_number=726&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F726&signature=dfad7c27175e857d402bc20fead58890737b1df5c94b7c5cd6f2677fc9d1b7bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->