### PR TITLE
perf: make thread switches pay one page-load toll

### DIFF
--- a/apps/server/drizzle/0013_thread_perf_indexes.sql
+++ b/apps/server/drizzle/0013_thread_perf_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX `idx_threads_workspace_deleted` ON `threads` (`workspace_id`, `deleted_at`);--> statement-breakpoint
+CREATE INDEX `idx_threads_workspace_recency` ON `threads` (`workspace_id`, `updated_at` DESC);

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1781296049611,
       "tag": "0012_bound_tool_output",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1781371200000,
+      "tag": "0013_thread_perf_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/scripts/bench-conversation-page.ts
+++ b/apps/server/scripts/bench-conversation-page.ts
@@ -1,0 +1,122 @@
+import "reflect-metadata";
+import { performance } from "node:perf_hooks";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../src/store/database.js";
+import { MessageRepo } from "../src/repositories/message-repo.js";
+import { ToolCallRecordRepo } from "../src/repositories/tool-call-record-repo.js";
+import { ThoughtSegmentRepo } from "../src/repositories/thought-segment-repo.js";
+import { HookExecutionRepo } from "../src/repositories/hook-execution-repo.js";
+import { PlanQuestionAnswersRepo } from "../src/repositories/plan-question-answers-repo.js";
+import { NarrativeStore } from "../src/services/narrative-store.js";
+import { loadConversationPage } from "../src/services/conversation-page.js";
+
+const assistantCount = Number(process.argv[2] ?? 100);
+const iterations = Number(process.argv[3] ?? 50);
+const threadId = "bench-thread";
+
+function seedThread(db: Database.Database): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    "INSERT INTO workspaces (id, name, path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+  ).run("bench-ws", "Bench", "/tmp/mcode-bench", now, now);
+  db.prepare(
+    "INSERT INTO threads (id, workspace_id, title, branch, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(threadId, "bench-ws", "Bench thread", "main", now, now);
+}
+
+function seedMessages(db: Database.Database): void {
+  const now = new Date().toISOString();
+  const insert = db.prepare(
+    "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence) VALUES (?, ?, ?, ?, ?, ?)",
+  );
+  const insertMany = db.transaction(() => {
+    for (let i = 1; i <= assistantCount; i++) {
+      insert.run(`u-${i}`, threadId, "user", `User message ${i}`, now, i * 2 - 1);
+      insert.run(`a-${i}`, threadId, "assistant", `Assistant answer ${i}`, now, i * 2);
+    }
+  });
+  insertMany();
+}
+
+function seedNarrative(db: Database.Database): void {
+  const tools = new ToolCallRecordRepo(db);
+  const thoughts = new ThoughtSegmentRepo(db);
+  const hooks = new HookExecutionRepo(db);
+  tools.bulkCreate(
+    Array.from({ length: assistantCount }, (_, i) => ({
+      messageId: `a-${i + 1}`,
+      toolName: "Read",
+      inputSummary: `src/file-${i + 1}.ts`,
+      outputSummary: "ok",
+      status: "completed" as const,
+      sortOrder: 1,
+    })),
+  );
+  thoughts.bulkCreate(
+    Array.from({ length: assistantCount }, (_, i) => ({
+      messageId: `a-${i + 1}`,
+      text: `Thinking ${i + 1}`,
+      startedAt: "2026-01-01T00:00:00Z",
+      endedAt: "2026-01-01T00:00:01Z",
+      sortOrder: 0,
+    })),
+  );
+  hooks.bulkCreate(
+    Array.from({ length: assistantCount }, (_, i) => ({
+      messageId: `a-${i + 1}`,
+      hookName: `PreToolUse-${i + 1}`,
+      toolName: "Read",
+      phase: "pre",
+      payload: "{}",
+      durationMs: 1,
+      didBlock: false,
+      startedAt: "2026-01-01T00:00:00Z",
+      endedAt: "2026-01-01T00:00:01Z",
+      sortOrder: 2,
+    })),
+  );
+}
+
+const db = openMemoryDatabase();
+seedThread(db);
+seedMessages(db);
+seedNarrative(db);
+
+const messageRepo = new MessageRepo(db);
+const deps = {
+  messageRepo,
+  narrativeStore: new NarrativeStore(
+    messageRepo,
+    new ToolCallRecordRepo(db),
+    new ThoughtSegmentRepo(db),
+    new HookExecutionRepo(db),
+  ),
+  planQuestionAnswersRepo: new PlanQuestionAnswersRepo(db),
+};
+
+let prepareCount = 0;
+const originalPrepare = db.prepare.bind(db);
+(db as unknown as { prepare: typeof db.prepare }).prepare = ((source: string) => {
+  prepareCount++;
+  return originalPrepare(source);
+}) as typeof db.prepare;
+
+loadConversationPage(deps, { threadId, limit: assistantCount * 2 });
+prepareCount = 0;
+
+const started = performance.now();
+let lastRows = 0;
+for (let i = 0; i < iterations; i++) {
+  const page = loadConversationPage(deps, { threadId, limit: assistantCount * 2 });
+  lastRows = Object.values(page.narrativeByMessage)
+    .reduce((sum, item) => sum + item.tools.length + item.thoughts.length + item.hooks.length, 0);
+}
+const elapsedMs = performance.now() - started;
+
+console.log(JSON.stringify({
+  assistantMessages: assistantCount,
+  iterations,
+  avgMs: Number((elapsedMs / iterations).toFixed(3)),
+  prepareCallsPerLoad: Number((prepareCount / iterations).toFixed(1)),
+  narrativeRows: lastRows,
+}));

--- a/apps/server/src/__tests__/message-repo.test.ts
+++ b/apps/server/src/__tests__/message-repo.test.ts
@@ -65,20 +65,28 @@ describe("MessageRepo", () => {
       repo.create("thread-1", "user", "x", 1);
       const stmt = db.prepare(
         `EXPLAIN QUERY PLAN
-SELECT id, thread_id, role, content, tool_calls, files_changed, cost_usd, tokens_used, timestamp, sequence, attachments, reply_to_message_id, quoted_text, model,
-(SELECT COUNT(*) FROM tool_call_records WHERE message_id = m.id) AS tool_call_count
-FROM (
+WITH page AS (
   SELECT m.id, m.thread_id, m.role, m.content, m.tool_calls, m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence, m.attachments, m.reply_to_message_id, m.quoted_text, m.model
   FROM messages m
-  WHERE m.thread_id = ?
+  WHERE m.thread_id = ? AND m.is_internal = 0
   ORDER BY m.sequence DESC
   LIMIT ?
-) m
-ORDER BY m.sequence ASC`,
+),
+tool_counts AS (
+  SELECT message_id, COUNT(*) AS tool_call_count
+  FROM tool_call_records
+  WHERE message_id IN (SELECT id FROM page)
+  GROUP BY message_id
+)
+SELECT page.*, COALESCE(tool_counts.tool_call_count, 0) AS tool_call_count
+FROM page
+LEFT JOIN tool_counts ON tool_counts.message_id = page.id
+ORDER BY page.sequence ASC`,
       );
       const plan = stmt.all("thread-1", 11) as Array<{ detail?: string }>;
       const text = plan.map((r) => r.detail ?? "").join("\n").toUpperCase();
       expect(text).not.toContain("SCAN TOOL_CALL_RECORDS");
+      expect(text).not.toContain("CORRELATED");
     });
   });
 

--- a/apps/server/src/repositories/hook-execution-repo.ts
+++ b/apps/server/src/repositories/hook-execution-repo.ts
@@ -137,6 +137,27 @@ export class HookExecutionRepo {
     return rows.map(rowToRecord);
   }
 
+  /** List hook executions for many messages in one indexed query, grouped by message id. */
+  listByMessages(messageIds: readonly string[]): Map<string, HookExecutionRecord[]> {
+    const grouped = new Map<string, HookExecutionRecord[]>();
+    if (messageIds.length === 0) return grouped;
+
+    const placeholders = messageIds.map(() => "?").join(", ");
+    const rows = this.db
+      .prepare(
+        `SELECT ${COLUMNS} FROM hook_executions WHERE message_id IN (${placeholders}) ORDER BY message_id ASC, sort_order ASC`,
+      )
+      .all(...messageIds) as HookExecutionRow[];
+
+    for (const row of rows) {
+      const record = rowToRecord(row);
+      const list = grouped.get(record.message_id) ?? [];
+      list.push(record);
+      grouped.set(record.message_id, list);
+    }
+    return grouped;
+  }
+
   /** Count the number of hook executions for a message. */
   countByMessage(messageId: string): number {
     const row = this.stmtCountByMessage.get(messageId) as { count: number };

--- a/apps/server/src/repositories/message-repo.ts
+++ b/apps/server/src/repositories/message-repo.ts
@@ -77,11 +77,28 @@ const MESSAGE_COLUMNS_PREFIXED =
   "m.id, m.thread_id, m.role, m.content, m.tool_calls, m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence, m.attachments, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal";
 
 /**
- * Per-row tool call counts via index on `message_id`.
- * Avoids a full-table `GROUP BY` over `tool_call_records` for each list query.
+ * Pre-aggregates tool call counts for the selected page only.
+ * The page CTE prevents a correlated count from running once per message row.
  */
-const TOOL_CALL_COUNT_SQL =
-  "(SELECT COUNT(*) FROM tool_call_records WHERE message_id = m.id) AS tool_call_count";
+function pagedMessageQuery(whereClause: string): string {
+  return `WITH page AS (
+  SELECT ${MESSAGE_COLUMNS_PREFIXED}
+  FROM messages m
+  WHERE ${whereClause}
+  ORDER BY m.sequence DESC
+  LIMIT ?
+),
+tool_counts AS (
+  SELECT message_id, COUNT(*) AS tool_call_count
+  FROM tool_call_records
+  WHERE message_id IN (SELECT id FROM page)
+  GROUP BY message_id
+)
+SELECT page.*, COALESCE(tool_counts.tool_call_count, 0) AS tool_call_count
+FROM page
+LEFT JOIN tool_counts ON tool_counts.message_id = page.id
+ORDER BY page.sequence ASC`;
+}
 
 /** Repository for message creation and retrieval against SQLite. */
 @injectable()
@@ -254,17 +271,7 @@ export class MessageRepo {
       : [threadId, fetchLimit];
 
     let rows = this.db
-      .prepare(
-        `SELECT ${MESSAGE_COLUMNS}, ${TOOL_CALL_COUNT_SQL}
-FROM (
-  SELECT ${MESSAGE_COLUMNS_PREFIXED}
-  FROM messages m
-  WHERE ${whereClause}
-  ORDER BY m.sequence DESC
-  LIMIT ?
-) m
-ORDER BY m.sequence ASC`,
-      )
+      .prepare(pagedMessageQuery(whereClause))
       .all(...queryParams) as MessageRow[];
 
     const hasMore = rows.length > clampedLimit;
@@ -289,12 +296,21 @@ ORDER BY m.sequence ASC`,
   ): Message[] {
     const rows = this.db
       .prepare(
-        `SELECT ${MESSAGE_COLUMNS_PREFIXED}, ${TOOL_CALL_COUNT_SQL}
+        `WITH counts AS (
+  SELECT message_id, COUNT(*) AS tool_call_count
+  FROM tool_call_records
+  WHERE message_id IN (
+    SELECT id FROM messages WHERE thread_id = ? AND sequence <= ? AND is_internal = 0
+  )
+  GROUP BY message_id
+)
+SELECT ${MESSAGE_COLUMNS_PREFIXED}, COALESCE(counts.tool_call_count, 0) AS tool_call_count
 FROM messages m
+LEFT JOIN counts ON counts.message_id = m.id
 WHERE m.thread_id = ? AND m.sequence <= ? AND m.is_internal = 0
 ORDER BY m.sequence ASC`,
       )
-      .all(threadId, maxSequence) as MessageRow[];
+      .all(threadId, maxSequence, threadId, maxSequence) as MessageRow[];
 
     return rows.map(rowToMessage);
   }
@@ -329,12 +345,19 @@ ORDER BY m.sequence ASC`,
   listIncludingInternal(threadId: string): Message[] {
     const rows = this.db
       .prepare(
-        `SELECT ${MESSAGE_COLUMNS_PREFIXED}, ${TOOL_CALL_COUNT_SQL}
+        `WITH counts AS (
+  SELECT message_id, COUNT(*) AS tool_call_count
+  FROM tool_call_records
+  WHERE message_id IN (SELECT id FROM messages WHERE thread_id = ?)
+  GROUP BY message_id
+)
+SELECT ${MESSAGE_COLUMNS_PREFIXED}, COALESCE(counts.tool_call_count, 0) AS tool_call_count
 FROM messages m
+LEFT JOIN counts ON counts.message_id = m.id
 WHERE m.thread_id = ?
 ORDER BY m.sequence ASC`,
       )
-      .all(threadId) as MessageRow[];
+      .all(threadId, threadId) as MessageRow[];
 
     return rows.map(rowToMessage);
   }

--- a/apps/server/src/repositories/thought-segment-repo.ts
+++ b/apps/server/src/repositories/thought-segment-repo.ts
@@ -114,6 +114,27 @@ export class ThoughtSegmentRepo {
     return rows.map(rowToRecord);
   }
 
+  /** List thought segments for many messages in one indexed query, grouped by message id. */
+  listByMessages(messageIds: readonly string[]): Map<string, ThoughtSegmentRecord[]> {
+    const grouped = new Map<string, ThoughtSegmentRecord[]>();
+    if (messageIds.length === 0) return grouped;
+
+    const placeholders = messageIds.map(() => "?").join(", ");
+    const rows = this.db
+      .prepare(
+        `SELECT ${COLUMNS} FROM thought_segments WHERE message_id IN (${placeholders}) ORDER BY message_id ASC, sort_order ASC`,
+      )
+      .all(...messageIds) as ThoughtSegmentRow[];
+
+    for (const row of rows) {
+      const record = rowToRecord(row);
+      const list = grouped.get(record.message_id) ?? [];
+      list.push(record);
+      grouped.set(record.message_id, list);
+    }
+    return grouped;
+  }
+
   /** Count the number of thought segments for a message. */
   countByMessage(messageId: string): number {
     const row = this.stmtCountByMessage.get(messageId) as { count: number };

--- a/apps/server/src/repositories/tool-call-record-repo.ts
+++ b/apps/server/src/repositories/tool-call-record-repo.ts
@@ -157,6 +157,27 @@ export class ToolCallRecordRepo {
     return rows.map(rowToToolCallRecord);
   }
 
+  /** List tool call records for many messages in one indexed query, grouped by message id. */
+  listByMessages(messageIds: readonly string[]): Map<string, ToolCallRecord[]> {
+    const grouped = new Map<string, ToolCallRecord[]>();
+    if (messageIds.length === 0) return grouped;
+
+    const placeholders = messageIds.map(() => "?").join(", ");
+    const rows = this.db
+      .prepare(
+        `SELECT ${TOOL_CALL_RECORD_COLUMNS} FROM tool_call_records WHERE message_id IN (${placeholders}) ORDER BY message_id ASC, sort_order ASC`,
+      )
+      .all(...messageIds) as ToolCallRecordRow[];
+
+    for (const row of rows) {
+      const record = rowToToolCallRecord(row);
+      const list = grouped.get(record.message_id) ?? [];
+      list.push(record);
+      grouped.set(record.message_id, list);
+    }
+    return grouped;
+  }
+
   /** List child tool call records for a parent, ordered by sort_order ascending. */
   listByParent(parentToolCallId: string): ToolCallRecord[] {
     const rows = this.stmtListByParent.all(parentToolCallId) as ToolCallRecordRow[];

--- a/apps/server/src/services/__tests__/conversation-page.test.ts
+++ b/apps/server/src/services/__tests__/conversation-page.test.ts
@@ -1,0 +1,144 @@
+import "reflect-metadata";
+import { describe, expect, it, vi } from "vitest";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../../store/database";
+import { MessageRepo } from "../../repositories/message-repo";
+import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo";
+import { ThoughtSegmentRepo } from "../../repositories/thought-segment-repo";
+import { HookExecutionRepo } from "../../repositories/hook-execution-repo";
+import { PlanQuestionAnswersRepo } from "../../repositories/plan-question-answers-repo";
+import { NarrativeStore } from "../narrative-store";
+import { loadConversationPage } from "../conversation-page";
+
+function seedThread(db: Database.Database): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    "INSERT INTO workspaces (id, name, path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+  ).run("ws-1", "Test", "/tmp/conversation-page", now, now);
+  db.prepare(
+    "INSERT INTO threads (id, workspace_id, title, branch, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run("thread-1", "ws-1", "Thread", "main", now, now);
+}
+
+function insertMessage(
+  db: Database.Database,
+  id: string,
+  role: string,
+  content: string,
+  sequence: number,
+  isInternal = false,
+): void {
+  db.prepare(
+    "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence, is_internal) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ).run(id, "thread-1", role, content, new Date().toISOString(), sequence, isInternal ? 1 : 0);
+}
+
+function createDeps(db: Database.Database) {
+  const messageRepo = new MessageRepo(db);
+  const narrativeStore = new NarrativeStore(
+    messageRepo,
+    new ToolCallRecordRepo(db),
+    new ThoughtSegmentRepo(db),
+    new HookExecutionRepo(db),
+  );
+  return {
+    messageRepo,
+    narrativeStore,
+    planQuestionAnswersRepo: new PlanQuestionAnswersRepo(db),
+  };
+}
+
+describe("loadConversationPage", () => {
+  it("returns a paginated message page with grouped narrative payloads", () => {
+    const db = openMemoryDatabase();
+    seedThread(db);
+    insertMessage(db, "u1", "user", "start", 1);
+    insertMessage(db, "a1", "assistant", "answer one", 2);
+    insertMessage(db, "u2", "user", "continue", 3);
+    insertMessage(db, "a2", "assistant", "answer two", 4);
+    insertMessage(db, "internal-a", "assistant", "hidden", 5, true);
+
+    new ToolCallRecordRepo(db).bulkCreate([
+      {
+        messageId: "a1",
+        toolName: "Read",
+        inputSummary: "src/a.ts",
+        outputSummary: "ok",
+        status: "completed",
+        sortOrder: 1,
+      },
+    ]);
+    new ThoughtSegmentRepo(db).bulkCreate([
+      {
+        messageId: "a1",
+        text: "checking",
+        startedAt: "2026-01-01T00:00:00Z",
+        endedAt: "2026-01-01T00:00:01Z",
+        sortOrder: 0,
+      },
+    ]);
+    new HookExecutionRepo(db).bulkCreate([
+      {
+        messageId: "a1",
+        hookName: "PreToolUse",
+        toolName: "Read",
+        phase: "pre",
+        payload: "{}",
+        durationMs: 1,
+        didBlock: false,
+        startedAt: "2026-01-01T00:00:00Z",
+        endedAt: "2026-01-01T00:00:01Z",
+        sortOrder: 2,
+      },
+    ]);
+
+    const page = loadConversationPage(createDeps(db), {
+      threadId: "thread-1",
+      limit: 10,
+    });
+
+    expect(page.messages.map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
+    expect(page.messages.find((m) => m.id === "a1")?.tool_call_count).toBe(1);
+    expect(page.narrativeByMessage.a1.tools).toHaveLength(1);
+    expect(page.narrativeByMessage.a1.thoughts).toHaveLength(1);
+    expect(page.narrativeByMessage.a1.hooks).toHaveLength(1);
+    expect(page.narrativeByMessage.a2).toEqual({ tools: [], thoughts: [], hooks: [] });
+    expect(page.narrativeByMessage["internal-a"]).toBeUndefined();
+  });
+
+  it("uses a fixed set of page and child-table statements for many assistant messages", () => {
+    const db = openMemoryDatabase();
+    seedThread(db);
+    for (let i = 1; i <= 8; i++) {
+      insertMessage(db, `a${i}`, "assistant", `answer ${i}`, i);
+    }
+    const deps = createDeps(db);
+    const prepareSpy = vi.spyOn(db, "prepare");
+
+    loadConversationPage(deps, { threadId: "thread-1", limit: 8 });
+
+    const sql = prepareSpy.mock.calls.map((call) => String(call[0]));
+    expect(sql.filter((s) => s.includes("FROM tool_call_records WHERE message_id IN"))).toHaveLength(1);
+    expect(sql.filter((s) => s.includes("FROM thought_segments WHERE message_id IN"))).toHaveLength(1);
+    expect(sql.filter((s) => s.includes("FROM hook_executions WHERE message_id IN"))).toHaveLength(1);
+    expect(sql.join("\n")).not.toContain("WHERE message_id = ?");
+  });
+
+  it("paginates through the same interface", () => {
+    const db = openMemoryDatabase();
+    seedThread(db);
+    for (let i = 1; i <= 5; i++) {
+      insertMessage(db, `m${i}`, i % 2 === 0 ? "assistant" : "user", `msg ${i}`, i);
+    }
+
+    const page = loadConversationPage(createDeps(db), {
+      threadId: "thread-1",
+      limit: 2,
+      before: 5,
+    });
+
+    expect(page.messages.map((m) => m.sequence)).toEqual([3, 4]);
+    expect(page.hasMore).toBe(true);
+    expect(page.narrativeByMessage.m4).toEqual({ tools: [], thoughts: [], hooks: [] });
+  });
+});

--- a/apps/server/src/services/conversation-page.ts
+++ b/apps/server/src/services/conversation-page.ts
@@ -1,0 +1,65 @@
+import type {
+  ConversationNarrativeBatch,
+  ConversationPage,
+  NarrativeEntry,
+} from "@mcode/contracts";
+import type { MessageRepo } from "../repositories/message-repo.js";
+import type { NarrativeStore } from "./narrative-store.js";
+import type { PlanQuestionAnswersRepo } from "../repositories/plan-question-answers-repo.js";
+
+/** Dependencies needed to load one paginated conversation page. */
+export interface ConversationPageDeps {
+  messageRepo: MessageRepo;
+  narrativeStore: NarrativeStore;
+  planQuestionAnswersRepo: PlanQuestionAnswersRepo;
+}
+
+/** Groups flat narrative entries into the legacy per-message payload shape. */
+export function groupNarrativeEntriesByMessage(
+  entries: readonly NarrativeEntry[],
+): Record<string, ConversationNarrativeBatch> {
+  const grouped: Record<string, ConversationNarrativeBatch> = {};
+  const bucket = (messageId: string): ConversationNarrativeBatch => {
+    let entry = grouped[messageId];
+    if (!entry) {
+      entry = { tools: [], thoughts: [], hooks: [] };
+      grouped[messageId] = entry;
+    }
+    return entry;
+  };
+
+  for (const entry of entries) {
+    switch (entry.kind) {
+      case "toolCall":
+        bucket(entry.record.message_id).tools.push(entry.record);
+        break;
+      case "narrationSegment":
+        bucket(entry.record.message_id).thoughts.push(entry.record);
+        break;
+      case "hook":
+        bucket(entry.record.message_id).hooks.push(entry.record);
+        break;
+      case "assistantMessage":
+        bucket(entry.messageId);
+        break;
+    }
+  }
+
+  return grouped;
+}
+
+/** Loads messages and their persisted narrative for one thread page. */
+export function loadConversationPage(
+  deps: ConversationPageDeps,
+  input: { threadId: string; limit: number; before?: number },
+): ConversationPage {
+  const page = deps.messageRepo.listByThread(input.threadId, input.limit, input.before);
+  const entries = deps.narrativeStore.loadForMessages(page.messages);
+
+  return {
+    ...page,
+    answeredPlanMessageIds:
+      deps.planQuestionAnswersRepo.listAnsweredForThread(input.threadId),
+    narrativeByMessage: groupNarrativeEntriesByMessage(entries),
+  };
+}

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -36,7 +36,7 @@
 import { injectable, inject } from "tsyringe";
 import { randomUUID } from "crypto";
 import { logger } from "@mcode/shared";
-import type { NarrativeEntry, TurnRange } from "@mcode/contracts";
+import type { Message, NarrativeEntry, TurnRange } from "@mcode/contracts";
 import { MessageRepo } from "../repositories/message-repo";
 import {
   ToolCallRecordRepo,
@@ -135,13 +135,28 @@ export class NarrativeStore {
       range?.before,
     );
 
+    return this.loadForMessages(messages);
+  }
+
+  /**
+   * Build persisted narrative entries for an already-loaded message page.
+   * Used by the conversation-page RPC so messages and narrative share one page
+   * query and the child tables are fetched once each across all assistants.
+   */
+  loadForMessages(messages: readonly Message[]): NarrativeEntry[] {
     const entries: NarrativeEntry[] = [];
-    for (const m of messages) {
+    const assistantMessages = messages.filter((m) => m.role === "assistant");
+    const assistantMessageIds = assistantMessages.map((m) => m.id);
+    const toolsByMessage = this.toolCallRecordRepo.listByMessages(assistantMessageIds);
+    const thoughtsByMessage = this.thoughtSegmentRepo.listByMessages(assistantMessageIds);
+    const hooksByMessage = this.hookExecutionRepo.listByMessages(assistantMessageIds);
+
+    for (const m of assistantMessages) {
       if (m.role !== "assistant") continue;
 
-      const tools = this.toolCallRecordRepo.listByMessage(m.id);
-      const thoughts = this.thoughtSegmentRepo.listByMessage(m.id);
-      const hooks = this.hookExecutionRepo.listByMessage(m.id);
+      const tools = toolsByMessage.get(m.id) ?? [];
+      const thoughts = thoughtsByMessage.get(m.id) ?? [];
+      const hooks = hooksByMessage.get(m.id) ?? [];
 
       const finalSeg = thoughts.find((t) => (t.is_final_response ?? 0) !== 0);
       entries.push({

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -77,6 +77,8 @@ export const threads = sqliteTable(
   },
   (table) => [
     index("idx_threads_workspace").on(table.workspaceId),
+    index("idx_threads_workspace_deleted").on(table.workspaceId, table.deletedAt),
+    index("idx_threads_workspace_recency").on(table.workspaceId, desc(table.updatedAt)),
     index("idx_threads_status").on(table.status),
     index("idx_threads_parent_thread_id").on(table.parentThreadId),
     index("idx_threads_forked_from_message_id").on(table.forkedFromMessageId),

--- a/apps/server/src/transport/payload-validation.ts
+++ b/apps/server/src/transport/payload-validation.ts
@@ -1,0 +1,72 @@
+import type { z } from "zod";
+import { logger } from "@mcode/shared";
+
+/** Result of validating a server push payload before delivery. */
+export type PushValidationResult =
+  | { ok: true; data: unknown }
+  | { ok: false };
+
+/** Adapter seam for hot-path push and RPC response validation. */
+export interface TransportPayloadValidator {
+  validatePush(channel: string, data: unknown, schema: z.ZodTypeAny): PushValidationResult;
+  validateRpcResult(method: string, result: unknown, schema: z.ZodTypeAny): void;
+}
+
+/** Builds the dev adapter that parses payloads and logs schema drift. */
+export function createValidatingTransportPayloadValidator(): TransportPayloadValidator {
+  return {
+    validatePush(channel, data, schema) {
+      const parsed = schema.safeParse(data);
+      if (!parsed.success) {
+        logger.warn("Push data validation failed", {
+          channel,
+          error: parsed.error.message,
+        });
+        return { ok: false };
+      }
+      return { ok: true, data: parsed.data };
+    },
+    validateRpcResult(method, result, schema) {
+      const parsed = schema.safeParse(result);
+      if (!parsed.success) {
+        logger.warn("Result validation failed", {
+          method,
+          error: parsed.error.message,
+        });
+      }
+    },
+  };
+}
+
+/** Builds the production adapter that leaves payloads untouched. */
+export function createPassThroughTransportPayloadValidator(): TransportPayloadValidator {
+  return {
+    validatePush(_channel, data) {
+      return { ok: true, data };
+    },
+    validateRpcResult() {},
+  };
+}
+
+let validator: TransportPayloadValidator =
+  process.env.NODE_ENV === "production"
+    ? createPassThroughTransportPayloadValidator()
+    : createValidatingTransportPayloadValidator();
+
+/** Return the process-wide transport payload validator. */
+export function getTransportPayloadValidator(): TransportPayloadValidator {
+  return validator;
+}
+
+/** Replace the process-wide transport payload validator. Intended for tests. */
+export function setTransportPayloadValidatorForTest(next: TransportPayloadValidator): void {
+  validator = next;
+}
+
+/** Restore the default dev/prod validator. Intended for tests. */
+export function resetTransportPayloadValidatorForTest(): void {
+  validator =
+    process.env.NODE_ENV === "production"
+      ? createPassThroughTransportPayloadValidator()
+      : createValidatingTransportPayloadValidator();
+}

--- a/apps/server/src/transport/push.test.ts
+++ b/apps/server/src/transport/push.test.ts
@@ -2,10 +2,19 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { WebSocket } from "ws";
 import {
   addClient,
+  broadcast,
   broadcastTerminalData,
+  subscribeClientToThread,
+  unsubscribeClientFromThread,
   _resetForTest,
 } from "./push.js";
 import { decodeTerminalDataFrame } from "@mcode/contracts";
+import {
+  createPassThroughTransportPayloadValidator,
+  createValidatingTransportPayloadValidator,
+  resetTransportPayloadValidatorForTest,
+  setTransportPayloadValidatorForTest,
+} from "./payload-validation.js";
 
 function fakeOpenSocket(received: Array<{ buf: Buffer; binary: boolean }>): WebSocket {
   const ws: Partial<WebSocket> = {
@@ -22,8 +31,14 @@ function fakeOpenSocket(received: Array<{ buf: Buffer; binary: boolean }>): WebS
 }
 
 describe("broadcastTerminalData", () => {
-  beforeEach(() => _resetForTest());
-  afterEach(() => _resetForTest());
+  beforeEach(() => {
+    _resetForTest();
+    resetTransportPayloadValidatorForTest();
+  });
+  afterEach(() => {
+    _resetForTest();
+    resetTransportPayloadValidatorForTest();
+  });
 
   it("sends a binary frame to every connected client", () => {
     const a: Array<{ buf: Buffer; binary: boolean }> = [];
@@ -49,5 +64,86 @@ describe("broadcastTerminalData", () => {
     broadcastTerminalData("pty-1", 0, payload);
     const decoded = decodeTerminalDataFrame(new Uint8Array(received[0].buf));
     expect(decoded.payload).toEqual(payload);
+  });
+});
+
+describe("broadcast", () => {
+  beforeEach(() => {
+    _resetForTest();
+    resetTransportPayloadValidatorForTest();
+  });
+  afterEach(() => {
+    _resetForTest();
+    resetTransportPayloadValidatorForTest();
+  });
+
+  it("routes thread-scoped events only to clients subscribed to that thread", () => {
+    const a: Array<{ buf: Buffer; binary: boolean }> = [];
+    const b: Array<{ buf: Buffer; binary: boolean }> = [];
+    const wsA = fakeOpenSocket(a);
+    const wsB = fakeOpenSocket(b);
+    addClient(wsA);
+    addClient(wsB);
+    subscribeClientToThread(wsA, "thread-a");
+    subscribeClientToThread(wsB, "thread-b");
+
+    broadcast("agent.event", {
+      type: "textDelta",
+      threadId: "thread-a",
+      delta: "hello",
+    });
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(0);
+    expect(JSON.parse(a[0].buf.toString("utf-8")).data.threadId).toBe("thread-a");
+  });
+
+  it("stops routing after a client unsubscribes from a thread", () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    const ws = fakeOpenSocket(received);
+    addClient(ws);
+    subscribeClientToThread(ws, "thread-a");
+    unsubscribeClientFromThread(ws, "thread-a");
+
+    broadcast("agent.event", {
+      type: "textDelta",
+      threadId: "thread-a",
+      delta: "hello",
+    });
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("broadcasts threadless events to every client", () => {
+    const a: Array<{ buf: Buffer; binary: boolean }> = [];
+    const b: Array<{ buf: Buffer; binary: boolean }> = [];
+    addClient(fakeOpenSocket(a));
+    addClient(fakeOpenSocket(b));
+
+    broadcast("skills.changed", {});
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  it("lets tests swap validating and pass-through payload adapters", () => {
+    const validating: Array<{ buf: Buffer; binary: boolean }> = [];
+    const validatingWs = fakeOpenSocket(validating);
+    addClient(validatingWs);
+    subscribeClientToThread(validatingWs, "thread-a");
+    setTransportPayloadValidatorForTest(createValidatingTransportPayloadValidator());
+
+    broadcast("thread.status", { threadId: "thread-a", status: "not-a-status" });
+    expect(validating).toHaveLength(0);
+
+    _resetForTest();
+    const passThrough: Array<{ buf: Buffer; binary: boolean }> = [];
+    const passThroughWs = fakeOpenSocket(passThrough);
+    addClient(passThroughWs);
+    subscribeClientToThread(passThroughWs, "thread-a");
+    setTransportPayloadValidatorForTest(createPassThroughTransportPayloadValidator());
+
+    broadcast("thread.status", { threadId: "thread-a", status: "not-a-status" });
+    expect(passThrough).toHaveLength(1);
   });
 });

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -6,8 +6,10 @@
 import type { WebSocket } from "ws";
 import { WS_CHANNELS, type WsChannelName, encodeTerminalDataFrame } from "@mcode/contracts";
 import { logger } from "@mcode/shared";
+import { getTransportPayloadValidator } from "./payload-validation.js";
 
 const clients = new Set<WebSocket>();
+const threadSubscriptions = new Map<WebSocket, Set<string>>();
 
 let _sessionCount = 0;
 const sessionChangeListeners: ((count: number) => void)[] = [];
@@ -39,6 +41,7 @@ export function onSessionChange(cb: (count: number) => void): () => void {
 /** Register a WebSocket client for push event delivery. */
 export function addClient(ws: WebSocket): void {
   clients.add(ws);
+  threadSubscriptions.set(ws, new Set());
   _sessionCount++;
   for (let i = 0; i < sessionChangeListeners.length; i++) sessionChangeListeners[i](_sessionCount);
 }
@@ -46,8 +49,22 @@ export function addClient(ws: WebSocket): void {
 /** Remove a disconnected WebSocket client. No-op if already removed. */
 export function removeClient(ws: WebSocket): void {
   if (!clients.delete(ws)) return;
+  threadSubscriptions.delete(ws);
   _sessionCount--;
   for (let i = 0; i < sessionChangeListeners.length; i++) sessionChangeListeners[i](_sessionCount);
+}
+
+/** Subscribe a connected client to push events for one thread. */
+export function subscribeClientToThread(ws: WebSocket, threadId: string): void {
+  if (!clients.has(ws)) return;
+  const subscriptions = threadSubscriptions.get(ws) ?? new Set<string>();
+  subscriptions.add(threadId);
+  threadSubscriptions.set(ws, subscriptions);
+}
+
+/** Remove a connected client's push subscription for one thread. */
+export function unsubscribeClientFromThread(ws: WebSocket, threadId: string): void {
+  threadSubscriptions.get(ws)?.delete(threadId);
 }
 
 /** Get the current number of connected clients. */
@@ -69,6 +86,12 @@ export function maxBufferedAmount(): number {
   return max;
 }
 
+function payloadThreadId(data: unknown): string | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const threadId = (data as { threadId?: unknown }).threadId;
+  return typeof threadId === "string" && threadId.length > 0 ? threadId : undefined;
+}
+
 /**
  * Broadcast a push event to all connected WebSocket clients.
  * Validates the data against the channel's Zod schema before sending.
@@ -83,23 +106,21 @@ export function broadcast(
     return;
   }
 
-  const parsed = schema.safeParse(data);
-  if (!parsed.success) {
-    logger.warn("Push data validation failed", {
-      channel,
-      error: parsed.error.message,
-    });
+  const validation = getTransportPayloadValidator().validatePush(channel, data, schema);
+  if (!validation.ok) {
     return;
   }
 
   const payload = JSON.stringify({
     type: "push" as const,
     channel,
-    data: parsed.data,
+    data: validation.data,
   });
+  const threadId = payloadThreadId(validation.data);
 
   for (const ws of clients) {
     if (ws.readyState === ws.OPEN) {
+      if (threadId && !threadSubscriptions.get(ws)?.has(threadId)) continue;
       ws.send(payload);
     }
   }
@@ -143,4 +164,5 @@ export function _resetForTest(): void {
   _sessionCount = 0;
   sessionChangeListeners.length = 0;
   clients.clear();
+  threadSubscriptions.clear();
 }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "crypto";
 import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
+import type { WebSocket } from "ws";
 
 import {
   WS_METHODS,
@@ -50,7 +51,8 @@ import type { ThreadRepo } from "../repositories/thread-repo";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { WorkspaceEnricher } from "../services/workspace-enricher";
 import type { FilesystemBrowser } from "../services/filesystem-browser";
-import { broadcast } from "./push";
+import { broadcast, subscribeClientToThread, unsubscribeClientFromThread } from "./push";
+import { getTransportPayloadValidator } from "./payload-validation.js";
 import {
   ProviderCliMissingError,
   isProviderAvailabilityError,
@@ -59,6 +61,7 @@ import type { ProviderAvailabilityService } from "../services/provider-availabil
 import type { ModelCacheService } from "../services/model-cache-service.js";
 import type { DiffSummaryService } from "../services/diff-summary-service.js";
 import type { HandoffStorage } from "../services/handoff/handoff-storage.js";
+import { loadConversationPage } from "../services/conversation-page.js";
 
 /** Service dependencies for the router. */
 export interface RouterDeps {
@@ -120,6 +123,7 @@ export interface RouterDeps {
 export async function routeMessage(
   raw: string,
   deps: RouterDeps,
+  context: { client?: WebSocket } = {},
 ): Promise<WebSocketResponse> {
   let request: WebSocketRequest;
   try {
@@ -170,17 +174,14 @@ export async function routeMessage(
       request.method as WsMethodName,
       paramsResult.data,
       deps,
+      context,
     );
 
-    // Validate result
-    const resultValidation = methodDef.result.safeParse(result);
-    if (!resultValidation.success) {
-      logger.warn("Result validation failed", {
-        method: request.method,
-        error: resultValidation.error.message,
-      });
-      // Still return the result - schema drift should not block responses
-    }
+    getTransportPayloadValidator().validateRpcResult(
+      request.method,
+      result,
+      methodDef.result,
+    );
 
     return { id: request.id, result };
   } catch (err) {
@@ -224,8 +225,20 @@ async function dispatch(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: any,
   deps: RouterDeps,
+  context: { client?: WebSocket },
 ): Promise<unknown> {
   switch (method) {
+    case "push.subscribeThread":
+      if (context.client) {
+        subscribeClientToThread(context.client, params.threadId);
+      }
+      return;
+    case "push.unsubscribeThread":
+      if (context.client) {
+        unsubscribeClientFromThread(context.client, params.threadId);
+      }
+      return;
+
     // Workspace
     case "workspace.list":
       return deps.workspaceService.list();
@@ -550,6 +563,12 @@ async function dispatch(
           deps.planQuestionAnswersRepo.listAnsweredForThread(params.threadId),
       };
     }
+    case "conversation.page":
+      return loadConversationPage(deps, {
+        threadId: params.threadId,
+        limit: params.limit,
+        before: params.before,
+      });
 
     // Files
     case "file.list":

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { routeMessage, type RouterDeps } from "./ws-router.js";
+import {
+  resetTransportPayloadValidatorForTest,
+  setTransportPayloadValidatorForTest,
+  type TransportPayloadValidator,
+} from "./payload-validation.js";
+
+describe("routeMessage result validation seam", () => {
+  afterEach(() => {
+    resetTransportPayloadValidatorForTest();
+  });
+
+  it("delegates RPC result validation to the configured adapter", async () => {
+    const validateRpcResult = vi.fn();
+    const validator: TransportPayloadValidator = {
+      validatePush: (_channel, data) => ({ ok: true, data }),
+      validateRpcResult,
+    };
+    setTransportPayloadValidatorForTest(validator);
+
+    const response = await routeMessage(
+      JSON.stringify({ id: "req-1", method: "app.version", params: {} }),
+      {} as RouterDeps,
+    );
+
+    expect(response.id).toBe("req-1");
+    expect(typeof response.result).toBe("string");
+    expect(validateRpcResult).toHaveBeenCalledWith(
+      "app.version",
+      response.result,
+      expect.anything(),
+    );
+  });
+});

--- a/apps/server/src/transport/ws-server.ts
+++ b/apps/server/src/transport/ws-server.ts
@@ -257,7 +257,7 @@ export function createWsServer(deps: RouterDeps & { authToken: string }): {
         // Not JSON or not a header — fall through to normal routing
       }
 
-      routeMessage(raw, deps)
+      routeMessage(raw, deps, { client: ws })
         .then((response) => {
           if (ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify(response));

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -91,12 +91,51 @@ export async function mockWebSocketServer(
         }
         return;
       }
+      if (method === "conversation.page" && "message.list" in overrides) {
+        const handler = overrides["message.list"];
+        try {
+          const messageResult =
+            typeof handler === "function"
+              ? await (handler as (params?: unknown) => unknown | Promise<unknown>)(msg.params)
+              : handler;
+          const paginated = Array.isArray(messageResult)
+            ? { messages: messageResult, hasMore: false, answeredPlanMessageIds: [] }
+            : messageResult as { messages?: unknown[]; hasMore?: boolean; answeredPlanMessageIds?: unknown[] };
+          ws.send(JSON.stringify({
+            id: msg.id,
+            result: {
+              messages: paginated.messages ?? [],
+              hasMore: paginated.hasMore ?? false,
+              answeredPlanMessageIds: paginated.answeredPlanMessageIds ?? [],
+              narrativeByMessage: {},
+            },
+          }));
+        } catch (err) {
+          ws.send(
+            JSON.stringify({
+              id: msg.id,
+              error: {
+                code: -32000,
+                message: err instanceof Error ? err.message : "Override handler failed",
+              },
+            }),
+          );
+        }
+        return;
+      }
       // Default responses
       let result: unknown;
       // `message.list` matches the generic *.list branch below but must return a
       // paginated shape; returning [] leaves loadMessages in an error state.
       if (method === "message.list") {
         result = { messages: [], hasMore: false, answeredPlanMessageIds: [] };
+      } else if (method === "conversation.page") {
+        result = {
+          messages: [],
+          hasMore: false,
+          answeredPlanMessageIds: [],
+          narrativeByMessage: {},
+        };
       } else if (method === "permission.listPending") {
         result = [];
       } else if (method === "thread.getTasks") {
@@ -109,8 +148,11 @@ export async function mockWebSocketServer(
       else if (method === "git.currentBranch") result = "main";
       else if (method === "agent.activeCount") result = 0;
       else if (method === "agent.listRunning") result = [];
+      else if (method === "push.subscribeThread" || method === "push.unsubscribeThread") result = undefined;
       else if (method === "agent.dismissPlanQuestions") result = undefined;
       else if (method === "plan.list") result = [];
+      else if (method === "thread.syncPrs") result = [];
+      else if (method === "workspace.enrich") result = { items: [] };
       else if (method === "app.version") result = "0.0.1-test";
       else if (method === "config.discover") result = {};
       // Return canonical settings defaults so App can bootstrap correctly.

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect } from "@playwright/test";
+import {
+  interceptZustandStores,
+  mockWebSocketServer,
+} from "./helpers/e2e-helpers";
+
+type RpcCall = { method: string; params: unknown };
+
+const now = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+const workspace = {
+  id: "ws-conversation-page",
+  name: "Conversation Page Workspace",
+  path: "/tmp/conversation-page",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+function thread(id: string, title: string) {
+  return {
+    id,
+    workspace_id: workspace.id,
+    title,
+    status: "paused" as const,
+    mode: "direct" as const,
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+  };
+}
+
+function message(threadId: string, id: string, role: "user" | "assistant", content: string, sequence: number) {
+  return {
+    id,
+    thread_id: threadId,
+    role,
+    content,
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: now,
+    sequence,
+    attachments: null,
+    tool_call_count: 0,
+  };
+}
+
+test("thread switch cache miss hydrates messages and narrative through conversation.page", async ({ page }) => {
+  const calls: RpcCall[] = [];
+  const threads = [
+    thread("thread-a", "Thread A"),
+    thread("thread-b", "Thread B"),
+  ];
+  const messagesByThread = {
+    "thread-a": [
+      message("thread-a", "thread-a-user", "user", "Alpha request", 1),
+      message("thread-a", "thread-a-assistant", "assistant", "Alpha response", 2),
+    ],
+    "thread-b": [
+      message("thread-b", "thread-b-user", "user", "Beta request", 1),
+      message("thread-b", "thread-b-assistant", "assistant", "Beta response", 2),
+    ],
+  };
+
+  await interceptZustandStores(page);
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": threads,
+    "conversation.page": (params) => {
+      calls.push({ method: "conversation.page", params });
+      const threadId = (params as { threadId?: keyof typeof messagesByThread } | undefined)?.threadId;
+      const messages = threadId ? messagesByThread[threadId] : [];
+      return {
+        messages,
+        hasMore: false,
+        answeredPlanMessageIds: [],
+        narrativeByMessage: threadId
+          ? {
+              [`${threadId}-assistant`]: {
+                tools: [],
+                thoughts: [],
+                hooks: [],
+              },
+            }
+          : {},
+      };
+    },
+    "message.list": (params) => {
+      calls.push({ method: "message.list", params });
+      return { messages: [], hasMore: false, answeredPlanMessageIds: [] };
+    },
+    "turn.load": (params) => {
+      calls.push({ method: "turn.load", params });
+      return [];
+    },
+    "narrative.list": (params) => {
+      calls.push({ method: "narrative.list", params });
+      return [];
+    },
+  });
+
+  await page.goto("/");
+  await page.getByRole("option", { name: /Conversation Page Workspace/ }).click();
+  await page.getByRole("button", { name: /Conversation Page Workspace 2/ }).click();
+  await page.waitForSelector("[data-testid='thread-item']");
+
+  const threadItems = page.locator("[data-testid='thread-item']");
+  await threadItems.nth(0).click();
+  await expect.poll(
+    () => calls.filter((call) => call.method === "conversation.page" && (call.params as { threadId?: string }).threadId === "thread-a").length,
+  ).toBe(1);
+  await expect(page.locator("[data-testid=message-list]")).toContainText("Alpha response");
+
+  await page.evaluate(() => {
+    const stores: Array<{ getState: () => Record<string, unknown>; subscribe: (fn: (state: Record<string, unknown>) => void) => () => void }> =
+      (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown>; subscribe: (fn: (state: Record<string, unknown>) => void) => () => void }> }).__mcodeStores ?? [];
+    const store = stores.find((candidate) => {
+      const state = candidate.getState();
+      return "handleAgentEvent" in state && "records" in state;
+    });
+    if (!store) throw new Error("Thread store not found");
+
+    (window as unknown as { __conversationPageSnapshots?: Array<{ messages: number; hasNarrative: boolean }> }).__conversationPageSnapshots = [];
+    store.subscribe((state) => {
+      if (state.currentThreadId !== "thread-b") return;
+      const record = (state.records as Map<string, { messages?: unknown[]; narrativeByMessage?: Record<string, unknown> }>).get("thread-b");
+      (window as unknown as { __conversationPageSnapshots: Array<{ messages: number; hasNarrative: boolean }> }).__conversationPageSnapshots.push({
+        messages: record?.messages?.length ?? 0,
+        hasNarrative: Boolean(record?.narrativeByMessage?.["thread-b-assistant"]),
+      });
+    });
+  });
+
+  await threadItems.nth(1).click();
+  await expect(page.locator("[data-testid=message-list]")).toContainText("Beta response");
+
+  const state = await page.evaluate(() => {
+    const stores: Array<{ getState: () => Record<string, unknown> }> =
+      (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown> }> }).__mcodeStores ?? [];
+    const store = stores.find((candidate) => {
+      const current = candidate.getState();
+      return "handleAgentEvent" in current && "records" in current;
+    });
+    const current = store?.getState();
+    const record = (current?.records as Map<string, { messages?: unknown[]; narrativeByMessage?: Record<string, unknown> }> | undefined)?.get("thread-b");
+    const snapshots = (window as unknown as { __conversationPageSnapshots?: Array<{ messages: number; hasNarrative: boolean }> }).__conversationPageSnapshots ?? [];
+    return {
+      messages: record?.messages?.length ?? 0,
+      hasNarrative: Boolean(record?.narrativeByMessage?.["thread-b-assistant"]),
+      partialPaints: snapshots.filter((snapshot) => snapshot.messages > 0 && !snapshot.hasNarrative).length,
+    };
+  });
+
+  expect(state).toEqual({ messages: 2, hasNarrative: true, partialPaints: 0 });
+  expect(calls.filter((call) => call.method === "conversation.page" && (call.params as { threadId?: string }).threadId === "thread-b")).toHaveLength(1);
+  expect(calls.filter((call) => call.method === "message.list" || call.method === "turn.load" || call.method === "narrative.list")).toHaveLength(0);
+});

--- a/apps/web/e2e/thread-switch-no-remount.spec.ts
+++ b/apps/web/e2e/thread-switch-no-remount.spec.ts
@@ -123,15 +123,16 @@ async function mockWebSocketServer(page: Page): Promise<void> {
       let result: unknown = null;
       if (method === "workspace.list") result = [workspace];
       else if (method === "thread.list") result = [threadA, threadB];
-      else if (method === "message.list") {
+      else if (method === "message.list" || method === "conversation.page") {
         // Derive the response from the request payload so reordered or
         // concurrent requests can't cross-contaminate replies.
         const params = msg.params as Record<string, unknown> | undefined;
-        const threadId = params?.thread_id;
+        const threadId = params?.threadId ?? params?.thread_id;
+        let selected: typeof messages;
         if (threadId === "thread-b") {
-          result = messageB;
+          selected = messageB;
         } else if (threadId === "thread-a") {
-          result = messages;
+          selected = messages;
         } else {
           ws.send(
             JSON.stringify({
@@ -141,9 +142,19 @@ async function mockWebSocketServer(page: Page): Promise<void> {
           );
           return;
         }
+        result = method === "conversation.page"
+          ? {
+              messages: selected,
+              hasMore: false,
+              answeredPlanMessageIds: [],
+              narrativeByMessage: {},
+            }
+          : { messages: selected, hasMore: false, answeredPlanMessageIds: [] };
       } else if (method?.endsWith(".list")) result = [];
       else if (method === "git.currentBranch") result = "main";
       else if (method === "agent.activeCount") result = 0;
+      else if (method === "agent.listRunning") result = [];
+      else if (method === "push.subscribeThread" || method === "push.unsubscribeThread") result = undefined;
       else if (method === "app.version") result = "0.0.1-test";
       else if (method === "config.discover") result = {};
       else if (method === "settings.get") result = getDefaultSettings();

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -115,7 +115,10 @@ export const mockTransport: McodeTransport = {
   dismissPlanQuestions: vi.fn().mockResolvedValue(undefined),
   getActiveAgentCount: vi.fn().mockResolvedValue(0),
   listRunning: vi.fn().mockResolvedValue([]),
+  subscribeThread: vi.fn().mockResolvedValue(undefined),
+  unsubscribeThread: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
+  loadConversationPage: vi.fn(),
   createAndSendMessage: vi.fn(),
   updateThreadTitle: vi.fn().mockResolvedValue(true),
   updateThreadSettings: vi.fn().mockResolvedValue(true),
@@ -194,3 +197,10 @@ export const mockTransport: McodeTransport = {
   }),
   readLatestHandoff: vi.fn().mockResolvedValue(null),
 };
+
+vi.mocked(mockTransport.loadConversationPage).mockImplementation(
+  async (threadId: string, limit: number, before?: number) => {
+    const result = await mockTransport.getMessages(threadId, limit, before);
+    return { ...result, narrativeByMessage: {} };
+  },
+);

--- a/apps/web/src/__tests__/prefetch.test.ts
+++ b/apps/web/src/__tests__/prefetch.test.ts
@@ -34,11 +34,13 @@ describe("prefetch", () => {
     vi.useFakeTimers();
     clearRecordCache();
     vi.mocked(mockTransport.getMessages).mockReset();
-    vi.mocked(mockTransport.getMessages).mockResolvedValue({
+    vi.mocked(mockTransport.loadConversationPage).mockReset();
+    vi.mocked(mockTransport.loadConversationPage).mockResolvedValue({
       messages: [
         createMockMessage({ id: "m1", thread_id: "t1", sequence: 1 }),
       ],
       hasMore: false,
+      narrativeByMessage: {},
     });
 
     // Ensure threadStore registers the hydrator before prefetch runs.
@@ -60,11 +62,12 @@ describe("prefetch", () => {
     schedulePrefetch("t1");
 
     // Not yet fired
-    expect(mockTransport.getMessages).not.toHaveBeenCalled();
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
 
     // Advance past debounce
     vi.advanceTimersByTime(150);
-    expect(mockTransport.getMessages).toHaveBeenCalledWith("t1", 100);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith("t1", 100);
+    expect(mockTransport.getMessages).not.toHaveBeenCalled();
 
     // Let the async prefetch settle
     await vi.runAllTimersAsync();
@@ -76,7 +79,7 @@ describe("prefetch", () => {
     cancelPrefetch();
 
     vi.advanceTimersByTime(200);
-    expect(mockTransport.getMessages).not.toHaveBeenCalled();
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
   });
 
   it("skips threads that are already cached", () => {
@@ -85,37 +88,38 @@ describe("prefetch", () => {
     schedulePrefetch("t1");
     vi.advanceTimersByTime(150);
 
-    expect(mockTransport.getMessages).not.toHaveBeenCalled();
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
   });
 
   it("prevents duplicate in-flight requests", async () => {
     // First prefetch: resolved after a tick
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let resolveFirst!: (v: any) => void;
-    vi.mocked(mockTransport.getMessages).mockImplementationOnce(
+    vi.mocked(mockTransport.loadConversationPage).mockImplementationOnce(
       () => new Promise((r) => { resolveFirst = r; }),
     );
 
     schedulePrefetch("t1");
     vi.advanceTimersByTime(150);
-    expect(mockTransport.getMessages).toHaveBeenCalledTimes(1);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
 
     // Schedule a second prefetch for the same thread while the first is in flight
     schedulePrefetch("t1");
     vi.advanceTimersByTime(150);
     // Should not fire a second RPC
-    expect(mockTransport.getMessages).toHaveBeenCalledTimes(1);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
 
     // Resolve the first to clean up
     resolveFirst({
       messages: [createMockMessage({ id: "m1", thread_id: "t1", sequence: 1 })],
       hasMore: false,
+      narrativeByMessage: {},
     });
     await vi.runAllTimersAsync();
   });
 
   it("does not throw on failed prefetch", async () => {
-    vi.mocked(mockTransport.getMessages).mockRejectedValueOnce(
+    vi.mocked(mockTransport.loadConversationPage).mockRejectedValueOnce(
       new Error("network error"),
     );
 
@@ -138,7 +142,7 @@ describe("prefetch", () => {
 
     // Only the last one should fire after full debounce
     vi.advanceTimersByTime(150);
-    expect(mockTransport.getMessages).toHaveBeenCalledTimes(1);
-    expect(mockTransport.getMessages).toHaveBeenCalledWith("t3", 100);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith("t3", 100);
   });
 });

--- a/apps/web/src/__tests__/threadStore-message-cache.test.ts
+++ b/apps/web/src/__tests__/threadStore-message-cache.test.ts
@@ -34,6 +34,11 @@ function resetThreadStoreTestState() {
   clearRecordCache();
   vi.clearAllMocks();
   (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockResolvedValue({ messages: fakeMessages, hasMore: false });
+  (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValue({
+    messages: fakeMessages,
+    hasMore: false,
+    narrativeByMessage: {},
+  });
   resetThreadStoreForTests({
     currentThreadId: null,
     runningThreadIds: new Set<string>(),
@@ -46,19 +51,20 @@ describe("loadMessages cache integration", () => {
     resetThreadStoreTestState();
   });
 
-  it("calls getMessages on first load (cache miss) and populates cache", async () => {
+  it("calls conversation.page on first load (cache miss) and populates cache", async () => {
     await useThreadStore.getState().loadMessages("t1");
 
-    expect(mockTransport.getMessages).toHaveBeenCalledWith("t1", MESSAGE_FETCH_SIZE);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith("t1", MESSAGE_FETCH_SIZE);
+    expect(mockTransport.getMessages).not.toHaveBeenCalled();
     expect(getTestActiveMessages()).toEqual(fakeMessages);
     expect(getCachedRecord("t1")).toBeDefined();
     expect(getCachedRecord("t1")?.messages).toEqual(fakeMessages);
   });
 
-  it("on cache hit, does not call getMessages and renders from cache", async () => {
+  it("on cache hit, does not call conversation.page and renders from cache", async () => {
     // First load primes the cache
     await useThreadStore.getState().loadMessages("t1");
-    expect(mockTransport.getMessages).toHaveBeenCalledTimes(1);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
 
     // Switch away
     useThreadStore.setState((s) => ({
@@ -68,7 +74,7 @@ describe("loadMessages cache integration", () => {
 
     // Switch back -- should hit cache
     await useThreadStore.getState().loadMessages("t1");
-    expect(mockTransport.getMessages).toHaveBeenCalledTimes(1); // unchanged
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1); // unchanged
     expect(getTestActiveMessages()).toEqual(fakeMessages);
     expect(useThreadStore.getState().currentThreadId).toBe("t1");
   });

--- a/apps/web/src/__tests__/threadStore-skip-rpc.test.ts
+++ b/apps/web/src/__tests__/threadStore-skip-rpc.test.ts
@@ -34,6 +34,11 @@ function resetState() {
     messages: fakeMessages,
     hasMore: false,
   });
+  (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValue({
+    messages: fakeMessages,
+    hasMore: false,
+    narrativeByMessage: {},
+  });
   (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
   resetThreadStoreForTests({
@@ -58,8 +63,9 @@ describe("loadMessages - listSnapshots RPC gating", () => {
 
     // Allow any async microtasks to flush
     await vi.waitFor(() => {
-      expect(mockTransport.getMessages).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
     });
+    expect(mockTransport.getMessages).not.toHaveBeenCalled();
 
     expect(mockTransport.listSnapshots).not.toHaveBeenCalled();
   });
@@ -104,7 +110,7 @@ describe("loadMessages (cache-hit) - hydration staleness gate", () => {
     // First load: cache-miss path populates cache AND stamps lastHydratedByThread.
     await useThreadStore.getState().loadMessages(THREAD_ID);
     await vi.waitFor(() => {
-      expect(mockTransport.getMessages).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
     });
 
     // Switch away so the next load is a cache-hit.
@@ -116,6 +122,7 @@ describe("loadMessages (cache-hit) - hydration staleness gate", () => {
     // Give any erroneously-scheduled microtasks a chance to fire.
     await new Promise((r) => setTimeout(r, 20));
 
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
     expect(mockTransport.getMessages).not.toHaveBeenCalled();
     expect(mockTransport.listPendingPermissions).not.toHaveBeenCalled();
     expect(mockTransport.getThreadTasks).not.toHaveBeenCalled();
@@ -127,7 +134,7 @@ describe("loadMessages (cache-hit) - hydration staleness gate", () => {
 
     await useThreadStore.getState().loadMessages(THREAD_ID);
     await vi.waitFor(() => {
-      expect(mockTransport.getMessages).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
     });
 
     // Simulate ">2s ago" by rewinding the hydration timestamp.

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -6,8 +6,12 @@ import type { Thread } from "@/transport/types";
 // Store mocks must be declared before importing the component under test.
 
 /** Holds the store snapshot backing both the hook selector and `getState()` (real Zustand API). */
-const { chatViewWorkspaceMockRef } = vi.hoisted(() => ({
+const { chatViewWorkspaceMockRef, chatViewTransportMock } = vi.hoisted(() => ({
   chatViewWorkspaceMockRef: { current: null as Record<string, unknown> | null },
+  chatViewTransportMock: {
+    subscribeThread: vi.fn(),
+    unsubscribeThread: vi.fn(),
+  },
 }));
 
 vi.mock("@/stores/workspaceStore", () => ({
@@ -60,6 +64,10 @@ vi.mock("@/stores/composerDraftStore", () => ({
   useComposerDraftStore: vi.fn((selector: (s: unknown) => unknown) =>
     selector({ setPendingPrefill: vi.fn() })
   ),
+}));
+
+vi.mock("@/transport", () => ({
+  getTransport: () => chatViewTransportMock,
 }));
 
 // Composer and MessageList have deep dependencies; stub them out.
@@ -177,6 +185,10 @@ function setupWorkspaceMock(state: ReturnType<typeof defaultWorkspaceState>) {
 
 describe("ChatView - Thread Title Double-Click Rename", () => {
   beforeEach(() => {
+    chatViewTransportMock.subscribeThread.mockResolvedValue(undefined);
+    chatViewTransportMock.unsubscribeThread.mockResolvedValue(undefined);
+    chatViewTransportMock.subscribeThread.mockClear();
+    chatViewTransportMock.unsubscribeThread.mockClear();
     setupWorkspaceMock(defaultWorkspaceState());
   });
 

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -21,6 +21,7 @@ import { SidebarRevealButton } from "@/components/sidebar/SidebarRevealButton";
 import { useUiStore } from "@/stores/uiStore";
 import { preparingStatusLabel, type WorkspaceThread } from "@/lib/workspace-thread";
 import { useReplyStore } from "@/stores/replyStore";
+import { getTransport } from "@/transport";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -324,6 +325,14 @@ export function ChatView() {
   }, [connectionStatus]);
 
   const prevThreadIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!activeThreadId) return;
+    void getTransport().subscribeThread(activeThreadId).catch(() => {});
+    return () => {
+      void getTransport().unsubscribeThread(activeThreadId).catch(() => {});
+    };
+  }, [activeThreadId]);
 
   useEffect(() => {
     if (!activeThreadId) {

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -89,6 +89,13 @@ function resetStores() {
       hasMore: false,
     }),
   );
+  (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+    async (threadId: string) => ({
+      messages: threadId === THREAD_B ? [msgB] : [msgA],
+      hasMore: false,
+      narrativeByMessage: {},
+    }),
+  );
   (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   (mockTransport.listPendingPermissions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -120,12 +127,13 @@ describe("ThreadHydrator", () => {
     hydrator = createStoreHydrator();
   });
 
-  it("cache hit restores synchronously with loading false and skips getMessages", async () => {
+  it("cache hit restores synchronously with loading false and skips conversation.page", async () => {
     cacheRecord(THREAD_A, makeCachedRecord());
 
     const beforeEpoch = getTestThreadLoadEpoch(THREAD_A);
     await hydrator.hydrate(THREAD_A, "active");
 
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
     expect(mockTransport.getMessages).not.toHaveBeenCalled();
     expect(readActiveThreadField((r) => r.loading)).toBe(false);
     expect(getTestActiveMessages()).toEqual([msgA]);
@@ -133,10 +141,11 @@ describe("ThreadHydrator", () => {
     expect(getTestThreadLoadEpoch(THREAD_A)).toBe(beforeEpoch + 1);
   });
 
-  it("cache miss fetches messages, commits store, and populates cache", async () => {
+  it("cache miss fetches a conversation page, commits store, and populates cache", async () => {
     await hydrator.hydrate(THREAD_A, "active");
 
-    expect(mockTransport.getMessages).toHaveBeenCalledWith(THREAD_A, MESSAGE_FETCH_SIZE);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, MESSAGE_FETCH_SIZE);
+    expect(mockTransport.getMessages).not.toHaveBeenCalled();
     expect(getTestActiveMessages()).toEqual([msgA]);
     expect(readActiveThreadField((r) => r.loading)).toBe(false);
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
@@ -222,6 +231,7 @@ describe("ThreadHydrator", () => {
 
     await hydrator.hydrate(THREAD_A, "active");
 
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
     expect(mockTransport.getMessages).not.toHaveBeenCalled();
     expect(getTestThreadStreaming(THREAD_A)).toBe("partial...");
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
@@ -229,15 +239,15 @@ describe("ThreadHydrator", () => {
   });
 
   it("does not commit stale RPC results after a cross-thread race", async () => {
-    let resolveA!: (v: { messages: typeof msgA[]; hasMore: boolean }) => void;
-    (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockImplementation(
+    let resolveA!: (v: { messages: typeof msgA[]; hasMore: boolean; narrativeByMessage: Record<string, never> }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
       (threadId: string) => {
         if (threadId === THREAD_A) {
           return new Promise((r) => {
             resolveA = r;
           });
         }
-        return Promise.resolve({ messages: [msgB], hasMore: false });
+        return Promise.resolve({ messages: [msgB], hasMore: false, narrativeByMessage: {} });
       },
     );
 
@@ -247,7 +257,7 @@ describe("ThreadHydrator", () => {
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
     expect(getTestActiveMessages()).toEqual([msgB]);
 
-    resolveA({ messages: [msgA], hasMore: false });
+    resolveA({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
     await loadA;
 
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
@@ -269,26 +279,56 @@ describe("ThreadHydrator", () => {
     expect(getTestActiveMessages()).toEqual([msgB]);
   });
 
-  it("falls back to per-message narrative fetches when turn.load fails", async () => {
+  it("commits messages and narrative from one conversation page fetch", async () => {
     const assistant = createMockMessage({
       id: "asst-1",
       thread_id: THREAD_A,
       role: "assistant",
       sequence: 2,
     });
-    (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValue({
       messages: [msgA, assistant],
       hasMore: false,
+      narrativeByMessage: {
+        "asst-1": { tools: [], thoughts: [], hooks: [] },
+      },
     });
-    (mockTransport.loadTurn as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("turn.load unsupported"),
-    );
-    const listNarrativeSpy = vi.spyOn(mockTransport, "listNarrative");
 
     await hydrator.hydrate(THREAD_A, "active");
-    await vi.waitFor(() => {
-      expect(listNarrativeSpy).toHaveBeenCalled();
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, MESSAGE_FETCH_SIZE);
+    expect(mockTransport.loadTurn).not.toHaveBeenCalled();
+    expect(mockTransport.listNarrative).not.toHaveBeenCalled();
+    expect(readActiveThreadField((r) => r.narrativeByMessage["asst-1"])).toEqual({
+      tools: [],
+      thoughts: [],
+      hooks: [],
     });
+  });
+
+  it("coalesces duplicate active cache-miss hydrates for one thread", async () => {
+    let resolvePage!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePage = resolve;
+        }),
+    );
+
+    const first = hydrator.hydrate(THREAD_A, "active");
+    const second = hydrator.hydrate(THREAD_A, "active");
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+
+    resolvePage({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([first, second]);
+
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
   });
 
   it("bumps load epoch on each hydrate so stale pagination is discarded", async () => {

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -12,13 +12,11 @@ import {
 import type { ThreadRecord } from "@/stores/thread-record";
 import type {
   HydrateMode,
-  NarrativeBatchResult,
   ThreadHydratorDeps,
   ThreadHydratorOptions,
   ThreadHydratorTransport,
   ThreadHydratorWriteState,
 } from "./types";
-import type { NarrativeEntry } from "@mcode/contracts";
 import { snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
 
@@ -27,9 +25,6 @@ export const MESSAGE_FETCH_SIZE = 100;
 
 /** Auxiliary side-effect refresh TTL (permissions, tasks, plans). */
 export const HYDRATION_TTL_MS = 2000;
-
-/** Assistant messages to eager-prefetch narrative for on cache miss. */
-const NARRATIVE_PREFETCH_BATCH = 20;
 
 /** Background hover prefetch limit (matches legacy prefetch.ts). */
 export const BACKGROUND_PREFETCH_LIMIT = 100;
@@ -40,6 +35,7 @@ export const BACKGROUND_PREFETCH_LIMIT = 100;
  */
 export class ThreadHydrator {
   private readonly auxiliaryHydrator: AuxiliaryHydrator;
+  private readonly activeHydrates = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: ThreadHydratorDeps) {
     this.auxiliaryHydrator = new AuxiliaryHydrator({
@@ -83,8 +79,8 @@ export class ThreadHydrator {
       const workspaceThread = this.deps.getWorkspaceThread(threadId);
       const shouldFetchSnapshots = workspaceThread?.has_file_changes !== false;
 
-      const [messageResult, snapshots] = await Promise.all([
-        this.transport().getMessages(threadId, BACKGROUND_PREFETCH_LIMIT),
+      const [pageResult, snapshots] = await Promise.all([
+        this.transport().loadConversationPage(threadId, BACKGROUND_PREFETCH_LIMIT),
         shouldFetchSnapshots
           ? this.transport().listSnapshots(threadId).catch(() => [] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>)
           : Promise.resolve([] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>),
@@ -93,15 +89,16 @@ export class ThreadHydrator {
       if (hasCachedRecord(threadId)) return;
 
       const patch = snapshotBuilder.build({
-        messages: messageResult.messages,
-        hasMore: messageResult.hasMore,
-        answeredPlanMessageIds: messageResult.answeredPlanMessageIds,
+        messages: pageResult.messages,
+        hasMore: pageResult.hasMore,
+        answeredPlanMessageIds: pageResult.answeredPlanMessageIds,
         snapshots,
       });
 
       const record: ThreadRecord = {
         ...createEmptyThreadRecord(),
         ...patch,
+        narrativeByMessage: pageResult.narrativeByMessage,
         settings: this.deps.getWorkspaceThreadSettings(threadId),
       };
       cacheRecord(threadId, record);
@@ -127,7 +124,19 @@ export class ThreadHydrator {
       return;
     }
 
-    await this.fetchAndCommit(threadId, opts);
+    const inFlight = this.activeHydrates.get(threadId);
+    if (inFlight) {
+      await inFlight;
+      return;
+    }
+
+    const hydrate = this.fetchAndCommit(threadId, opts).finally(() => {
+      if (this.activeHydrates.get(threadId) === hydrate) {
+        this.activeHydrates.delete(threadId);
+      }
+    });
+    this.activeHydrates.set(threadId, hydrate);
+    await hydrate;
   }
 
   /**
@@ -230,8 +239,8 @@ export class ThreadHydrator {
       const workspaceThread = this.deps.getWorkspaceThread(threadId);
       const shouldFetchSnapshots = workspaceThread?.has_file_changes !== false;
 
-      const [messageResult, snapshots] = await Promise.all([
-        this.transport().getMessages(threadId, MESSAGE_FETCH_SIZE),
+      const [pageResult, snapshots] = await Promise.all([
+        this.transport().loadConversationPage(threadId, MESSAGE_FETCH_SIZE),
         shouldFetchSnapshots
           ? this.transport().listSnapshots(threadId).catch(() => [] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>)
           : Promise.resolve([] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>),
@@ -240,22 +249,21 @@ export class ThreadHydrator {
       if (getState().currentThreadId !== threadId) return;
 
       const patch = snapshotBuilder.build({
-        messages: messageResult.messages,
-        hasMore: messageResult.hasMore,
-        answeredPlanMessageIds: messageResult.answeredPlanMessageIds,
+        messages: pageResult.messages,
+        hasMore: pageResult.hasMore,
+        answeredPlanMessageIds: pageResult.answeredPlanMessageIds,
         snapshots,
       });
 
       setState((state: ThreadHydratorWriteState) => ({
         records: patchThreadRecord(state.records, threadId, {
           ...patch,
+          narrativeByMessage: pageResult.narrativeByMessage,
           loading: false,
           isLoadingMore: false,
           settings: this.deps.getWorkspaceThreadSettings(threadId),
         }),
       }));
-
-      this.prefetchNarratives(threadId, patch.messages);
 
       this.auxiliaryHydrator.hydrate(threadId, {
         freshnessTtlMs: HYDRATION_TTL_MS,
@@ -288,92 +296,6 @@ export class ThreadHydrator {
     }
   }
 
-  /**
-   * Eager-hydrate persisted narrative for the thread via the single
-   * server-ordered `turn.load` call, then group the flat {@link NarrativeEntry}
-   * list back into the per-message {@link NarrativeBatchResult} shape that
-   * `narrativeByMessage` consumers expect (back-compat is intentional).
-   *
-   * On `turn.load` rejection we leave the lazy per-message
-   * `loadNarrativeForMessage` (`narrative.list`) path to fill in, so hydration
-   * never crashes on a transport failure.
-   */
-  private prefetchNarratives(threadId: string, messages: import("@/transport").Message[]): void {
-    const lastAssistants = messages.filter((m) => m.role === "assistant").slice(-NARRATIVE_PREFETCH_BATCH);
-    const narrativeByMessage = getThreadRecord(this.deps.getState().records, threadId).narrativeByMessage;
-    const idsToFetch = lastAssistants
-      .map((m) => m.id)
-      .filter((id) => !narrativeByMessage[id]);
-
-    if (idsToFetch.length === 0) return;
-
-    void this.transport()
-      .loadTurn(threadId)
-      .then((entries) => {
-        const grouped = groupNarrativeEntriesByMessage(entries);
-        this.deps.setState((state: ThreadHydratorWriteState) => {
-          if (!state.records.has(threadId)) return {};
-          const rec = getThreadRecord(state.records, threadId);
-          // Preserve already-loaded entries: only commit messages we still need.
-          const next = { ...rec.narrativeByMessage };
-          for (const id of idsToFetch) {
-            next[id] = grouped[id] ?? { tools: [], thoughts: [], hooks: [] };
-          }
-          return {
-            records: patchThreadRecord(state.records, threadId, {
-              narrativeByMessage: next,
-            }),
-          };
-        });
-      })
-      .catch((err) => {
-        console.warn("[narrative] turn.load failed, falling back to lazy narrative.list", err);
-        for (const m of lastAssistants) {
-          void this.deps.loadNarrativeForMessage(m.id);
-        }
-      });
-  }
-}
-
-/**
- * Group a flat, server-ordered {@link NarrativeEntry} list into the legacy
- * per-message {@link NarrativeBatchResult} shape keyed by `message_id`.
- *
- * `assistantMessage` entries are skipped: their body already lives on the
- * message row, so they do not belong in `narrativeByMessage`. The server
- * already orders entries by (sequence, sortOrder), so per-message arrays
- * preserve that order without re-sorting here.
- */
-export function groupNarrativeEntriesByMessage(
-  entries: NarrativeEntry[],
-): NarrativeBatchResult {
-  const grouped: NarrativeBatchResult = {};
-  const bucket = (messageId: string): NarrativeBatchResult[string] => {
-    let entry = grouped[messageId];
-    if (!entry) {
-      entry = { tools: [], thoughts: [], hooks: [] };
-      grouped[messageId] = entry;
-    }
-    return entry;
-  };
-
-  for (const entry of entries) {
-    switch (entry.kind) {
-      case "toolCall":
-        bucket(entry.record.message_id).tools.push(entry.record);
-        break;
-      case "narrationSegment":
-        bucket(entry.record.message_id).thoughts.push(entry.record);
-        break;
-      case "hook":
-        bucket(entry.record.message_id).hooks.push(entry.record);
-        break;
-      case "assistantMessage":
-        break;
-    }
-  }
-
-  return grouped;
 }
 
 /** Module-scoped hydrator instance registered by threadStore at init. */

--- a/apps/web/src/lib/thread-hydrator/types.ts
+++ b/apps/web/src/lib/thread-hydrator/types.ts
@@ -1,5 +1,5 @@
 import type { Message, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord } from "@/transport";
-import type { TurnSnapshot, PermissionRequest, PlanRecord, NarrativeEntry } from "@mcode/contracts";
+import type { TurnSnapshot, PermissionRequest, PlanRecord, NarrativeEntry, ConversationPage } from "@mcode/contracts";
 import type { TaskItem } from "@/stores/taskStore";
 import type { PlanQuestion } from "@mcode/contracts";
 import type { ThreadRecord } from "@/stores/thread-record";
@@ -33,6 +33,7 @@ export type NarrativeBatchResult = Record<
 /** Transport surface used by {@link ThreadHydrator}. */
 export interface ThreadHydratorTransport {
   getMessages(threadId: string, limit: number, before?: number): Promise<PaginatedMessages>;
+  loadConversationPage(threadId: string, limit: number, before?: number): Promise<ConversationPage>;
   listSnapshots(threadId: string): Promise<TurnSnapshot[]>;
   listNarrative(messageId: string): Promise<NarrativeBatchResult[string]>;
   loadTurn(threadId: string): Promise<NarrativeEntry[]>;

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -696,7 +696,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     try {
       const cursor = getRec(threadId).oldestLoadedSequence;
       const epoch = getRec(threadId).loadEpoch;
-      const { messages: olderMessages, hasMore } = await getTransport().getMessages(threadId, OLDER_PAGE_SIZE, cursor);
+      const {
+        messages: olderMessages,
+        hasMore,
+        narrativeByMessage,
+      } = await getTransport().loadConversationPage(threadId, OLDER_PAGE_SIZE, cursor);
 
       const isStale = get().currentThreadId !== threadId
         || getRec(threadId).loadEpoch !== epoch;
@@ -717,6 +721,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       patchRec(threadId, (r) => ({
         messages: [...olderMessages, ...r.messages],
         persistedToolCallCounts: { ...r.persistedToolCallCounts, ...newCounts },
+        narrativeByMessage: { ...narrativeByMessage, ...r.narrativeByMessage },
         oldestLoadedSequence: newOldest,
         hasMoreMessages: hasMore,
         isLoadingMore: false,

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -36,6 +36,7 @@ import type {
   PermissionDecision,
   PermissionRequest,
   CreateAndSendResult,
+  ConversationPage,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
@@ -65,7 +66,7 @@ export type {
   ProviderModelInfo,
 } from "@mcode/contracts";
 
-export type { PaginatedMessages, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord, TurnSnapshot, CopilotSubagent } from "@mcode/contracts";
+export type { PaginatedMessages, ConversationPage, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord, TurnSnapshot, CopilotSubagent } from "@mcode/contracts";
 
 export { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
 
@@ -248,6 +249,10 @@ export interface McodeTransport {
    * optimistic client-side set was lost (reload, new tab, reconnect).
    */
   listRunning(): Promise<string[]>;
+  /** Subscribe this client connection to push events for the active thread. */
+  subscribeThread(threadId: string): Promise<void>;
+  /** Remove this client connection's push subscription for a thread. */
+  unsubscribeThread(threadId: string): Promise<void>;
 
   // Thread mutations
   updateThreadTitle(threadId: string, title: string): Promise<boolean>;
@@ -282,6 +287,8 @@ export interface McodeTransport {
    * @returns Paginated response with messages array and hasMore flag.
    */
   getMessages(threadId: string, limit: number, before?: number): Promise<PaginatedMessages>;
+  /** Fetch persisted messages and grouped narrative for one thread page. */
+  loadConversationPage(threadId: string, limit: number, before?: number): Promise<ConversationPage>;
 
   // Config
   discoverConfig(workspacePath: string): Promise<Record<string, unknown>>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -22,7 +22,7 @@ import type {
 } from "./types";
 import type { CreateAndSendResult } from "@mcode/contracts";
 import { emitPtyReconnectGap } from "@/components/terminal/ptyDataRegistry";
-import type { PaginatedMessages, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability } from "@mcode/contracts";
+import type { PaginatedMessages, ConversationPage, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 import {
   TERMINAL_DATA_TAG,
@@ -246,7 +246,10 @@ export function createWsTransport(
       // Deferred import avoids a circular dependency at module evaluation time.
       const nowForThreads = Date.now();
       import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        const { activeWorkspaceId, loadThreads } = useWorkspaceStore.getState();
+        const { activeWorkspaceId, activeThreadId, loadThreads } = useWorkspaceStore.getState();
+        if (activeThreadId) {
+          rpc<void>("push.subscribeThread", { threadId: activeThreadId }).catch(() => {});
+        }
         if (!activeWorkspaceId) return;
         const last = lastLoadThreadsAtByWorkspace.get(activeWorkspaceId) ?? 0;
         if (nowForThreads - last <= LOAD_THREADS_RECONNECT_COOLDOWN_MS) return;
@@ -634,10 +637,14 @@ export function createWsTransport(
       rpcBinary<AttachmentMeta | null>("clipboard.saveFile", { mimeType, fileName }, data),
     getActiveAgentCount: () => rpc<number>("agent.activeCount", {}),
     listRunning: () => rpc<string[]>("agent.listRunning", {}),
+    subscribeThread: (threadId) => rpc<void>("push.subscribeThread", { threadId }),
+    unsubscribeThread: (threadId) => rpc<void>("push.unsubscribeThread", { threadId }),
 
     // Messages
     getMessages: (threadId, limit, before?) =>
       rpc<PaginatedMessages>("message.list", { threadId, limit, ...(before != null ? { before } : {}) }),
+    loadConversationPage: (threadId, limit, before?) =>
+      rpc<ConversationPage>("conversation.page", { threadId, limit, ...(before != null ? { before } : {}) }),
 
     // Config
     discoverConfig: (workspacePath) =>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -47,6 +47,15 @@ export { MessageSchema, PaginatedMessagesSchema } from "./models/message.js";
 export type { Message, PaginatedMessages } from "./models/message.js";
 
 export {
+  ConversationPageSchema,
+  ConversationNarrativeBatchSchema,
+} from "./models/conversation-page.js";
+export type {
+  ConversationPage,
+  ConversationNarrativeBatch,
+} from "./models/conversation-page.js";
+
+export {
   ToolCallRecordSchema,
   ToolCallStatusSchema,
 } from "./models/tool-call-record.js";

--- a/packages/contracts/src/models/conversation-page.ts
+++ b/packages/contracts/src/models/conversation-page.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+import { MessageSchema } from "./message.js";
+import { ToolCallRecordSchema } from "./tool-call-record.js";
+import { ThoughtSegmentRecordSchema } from "./thought-segment.js";
+import { HookExecutionRecordSchema } from "./hook-execution.js";
+
+/** Persisted narrative records grouped under one assistant message. */
+export const ConversationNarrativeBatchSchema = lazySchema(() =>
+  z.object({
+    tools: z.array(ToolCallRecordSchema),
+    thoughts: z.array(ThoughtSegmentRecordSchema),
+    hooks: z.array(HookExecutionRecordSchema),
+  }),
+);
+
+/** Thread conversation page: messages plus their grouped narrative payloads. */
+export const ConversationPageSchema = lazySchema(() =>
+  z.object({
+    messages: z.array(MessageSchema()),
+    hasMore: z.boolean(),
+    answeredPlanMessageIds: z.array(z.string()).optional(),
+    narrativeByMessage: z.record(ConversationNarrativeBatchSchema()),
+  }),
+);
+
+/** Persisted narrative records grouped under one assistant message. */
+export type ConversationNarrativeBatch = z.infer<ReturnType<typeof ConversationNarrativeBatchSchema>>;
+
+/** Thread conversation page returned by `conversation.page`. */
+export type ConversationPage = z.infer<ReturnType<typeof ConversationPageSchema>>;

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -3,6 +3,7 @@ import { WorkspaceSchema, WorkspaceEnrichmentSchema } from "../models/workspace.
 import { ThreadSchema, RecentThreadSchema } from "../models/thread.js";
 import { ThreadModeSchema, PermissionModeSchema, InteractionModeSchema } from "../models/enums.js";
 import { PaginatedMessagesSchema } from "../models/message.js";
+import { ConversationPageSchema } from "../models/conversation-page.js";
 import { AttachmentMetaSchema } from "../models/attachment.js";
 import { MAX_ATTACHMENTS } from "../models/file-types.js";
 import { ToolCallRecordSchema } from "../models/tool-call-record.js";
@@ -411,6 +412,14 @@ export const WS_METHODS = lazySchema(() => ({
     params: z.object({}),
     result: z.array(z.string()),
   },
+  "push.subscribeThread": {
+    params: z.object({ threadId: z.string() }),
+    result: z.void(),
+  },
+  "push.unsubscribeThread": {
+    params: z.object({ threadId: z.string() }),
+    result: z.void(),
+  },
   "agent.answerQuestions": {
     params: z.object({
       threadId: z.string(),
@@ -465,6 +474,14 @@ export const WS_METHODS = lazySchema(() => ({
       before: z.number().int().optional(),
     }),
     result: PaginatedMessagesSchema(),
+  },
+  "conversation.page": {
+    params: z.object({
+      threadId: z.string(),
+      limit: z.number().int().min(1).max(1000),
+      before: z.number().int().optional(),
+    }),
+    result: ConversationPageSchema(),
   },
   "file.list": {
     params: z.object({


### PR DESCRIPTION
## What
Batch thread switch loading behind a new `conversation.page` RPC so messages and their narrative metadata arrive together.

## Why
Track 1 for Epic #649 targets query fanout during thread switches. A busy thread used to issue separate message and narrative calls, then per-message repository reads for tool calls, thought segments, and hook executions. The new path keeps the UI state update atomic and bounds database prepares per page.

## Key Changes
- Added `conversation.page` across contracts, server routing, web transport, hydrator, and pagination.
- Batched narrative repository reads and aggregated tool-call counts during message page loads.
- Scoped push events to subscribed thread IDs, with active-thread subscribe and reconnect resubscribe.
- Added a transport payload validator adapter for lower-noise transport tests.
- Added thread list indexes, focused tests, a Playwright thread-switch spec, and a conversation page benchmark.

Closes #650 / Closes #651 / Closes #656 / Closes #657
Related to #649

## Verification
- `bun run typecheck`: `Tasks: 5 successful, 5 total`
- `bun run lint`: `Tasks: 1 successful, 1 total`
- Focused server tests: `5 passed`, `42 tests passed`
- Focused web tests: `4 passed`, `32 tests passed`
- Extra fixture tests: `3 passed`, `22 tests passed`
- Live Playwright thread switch: `1 passed (5.5s)` on `127.0.0.1:5190`
- Benchmark: `{"assistantMessages":100,"iterations":50,"avgMs":2.51,"prepareCallsPerLoad":4,"narrativeRows":300}`

`bun run verify` did not fully pass under default unit parallelism. Typecheck and lint passed there. Unit failures were timeout-heavy tests. Reruns with larger timeouts passed for snapshot integration (`10 passed`) and codex protocol coverage (`7 passed`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783923802&installation_id=129163861&pr_number=727&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F727&signature=f7d4f253e5c885306e4b87b709462668d89a8bf5b7ca40e018cc1472fc52d38a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->