### PR TITLE
fix: tear down thread resources on delete

### DIFF
--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -878,6 +878,31 @@ describe("preview-browser", () => {
       expect(closed.data.activeTabId).toBe(closed.data.tabs[0]!.id);
     });
 
+    it("tabs.closeScope disposes every page owned by a deleted thread", async () => {
+      const win = createWindow();
+      await showPreview(win, { threadId: "thread-A", url: "https://one.test" });
+      const firstView = createdViews[0]!;
+
+      const created = callTabs<{ tabId: string }>(win, "preview:tabs.create", {
+        threadId: "thread-A",
+      });
+      expect(created.ok).toBe(true);
+      const secondView = createdViews[createdViews.length - 1]!;
+
+      const closed = callTabs<{ tabs: unknown[]; activeTabId: string | null }>(
+        win,
+        "preview:tabs.closeScope",
+        { threadId: "thread-A" },
+      );
+
+      expect(closed.ok).toBe(true);
+      if (!closed.ok) return;
+      expect(closed.data.tabs).toHaveLength(0);
+      expect(closed.data.activeTabId).toBeNull();
+      expect(firstView.webContents.close).toHaveBeenCalled();
+      expect(secondView.webContents.close).toHaveBeenCalled();
+    });
+
     it("tab sets are isolated per thread (thread restore)", async () => {
       const win = createWindow();
       await showPreview(win, { threadId: "thread-A" });

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -319,6 +319,9 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       close(threadId: string, tabId: string): Promise<unknown> {
         return ipcRenderer.invoke("preview:tabs.close", { threadId, tabId });
       },
+      closeScope(threadId: string): Promise<unknown> {
+        return ipcRenderer.invoke("preview:tabs.closeScope", { threadId });
+      },
       onUpdated(callback: (payload: unknown) => void): () => void {
         const listener = (_event: unknown, payload: unknown) => callback(payload);
         ipcRenderer.on("preview:tabs-updated", listener);

--- a/apps/desktop/src/main/preview/preview-tabs.ts
+++ b/apps/desktop/src/main/preview/preview-tabs.ts
@@ -285,4 +285,32 @@ export function registerTabHandlers(): void {
       return { ok: true, data: tabs };
     },
   );
+
+  ipcMain.handle(
+    "preview:tabs.closeScope",
+    (_event, payload: { threadId?: unknown }): TabIpcResult<BrowserTabSet> => {
+      const win = BrowserWindow.fromWebContents(_event.sender);
+      if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
+      const tid = normaliseThreadId(payload?.threadId);
+      if (!tid) return { ok: false, error: "invalid-thread-id" };
+
+      const s = getSession(win);
+      const set = s.tabsByThread.get(tid);
+      if (set) {
+        for (const tab of set.tabs) {
+          disposeTabView(win, s, tab);
+        }
+        s.tabsByThread.delete(tid);
+      }
+      if (s.lastPreviewThreadId === tid) {
+        s.lastPreviewThreadId = null;
+        s.resumePreviewUrl = null;
+      }
+
+      const empty: BrowserTabSet = { threadId: tid, activeTabId: null, tabs: [] };
+      sendTabsUpdated(win, empty);
+      logger.info("Preview: tab scope closed", { threadId: tid });
+      return { ok: true, data: empty };
+    },
+  );
 }

--- a/apps/server/src/__tests__/cleanup-integration.test.ts
+++ b/apps/server/src/__tests__/cleanup-integration.test.ts
@@ -48,6 +48,7 @@ describe("Cleanup integration", () => {
   let mockTerminalService: TerminalService;
   let mockGitService: GitService;
   let mockAttachmentService: AttachmentService;
+  let mockHandoffStorage: HandoffStorage;
   let mockAgentService: AgentService;
   let workspaceService: WorkspaceService;
 
@@ -72,7 +73,18 @@ describe("Cleanup integration", () => {
       isRegisteredWorktreePath: vi.fn().mockReturnValue(true),
     } as unknown as GitService;
 
-    threadService = new ThreadService(threadRepo, workspaceRepo, mockGitService, cleanupJobRepo);
+    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+    mockHandoffStorage = {
+      deleteThreadFiles: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HandoffStorage;
+    threadService = new ThreadService(
+      threadRepo,
+      workspaceRepo,
+      mockGitService,
+      cleanupJobRepo,
+      mockAttachmentService,
+      mockHandoffStorage,
+    );
 
     worker = new CleanupWorker(
       db,
@@ -86,7 +98,6 @@ describe("Cleanup integration", () => {
       { deleteThreadFiles: vi.fn().mockResolvedValue(undefined) } as unknown as HandoffStorage,
     );
 
-    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
     mockAgentService = { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService;
     workspaceService = new WorkspaceService(
       workspaceRepo,
@@ -118,7 +129,7 @@ describe("Cleanup integration", () => {
     expect(threadBefore!.status).toBe("active");
 
     // Step 1: ThreadService.delete enqueues a cleanup job
-    const deleted = threadService.delete("thread-int-1", true);
+    const deleted = await threadService.delete("thread-int-1", true);
     expect(deleted).toBe(true);
 
     // Thread is soft-deleted (findById still returns it for cleanup, but listByWorkspace filters it)
@@ -160,7 +171,7 @@ describe("Cleanup integration", () => {
     expect(cleanupJobRepo.count()).toBe(0);
   });
 
-  it("delete is synchronous and fast (non-blocking)", () => {
+  it("delete queues cleanup without blocking on filesystem work", async () => {
     const ws = workspaceRepo.create("perf-test", "/test-repo-2");
     const now = new Date().toISOString();
     db.prepare(
@@ -170,7 +181,7 @@ describe("Cleanup integration", () => {
     ).run("thread-perf", ws.id, "Perf Thread", "mcode/perf", join(WT_BASE, "perf-wt"), now, now);
 
     const start = performance.now();
-    const result = threadService.delete("thread-perf", true);
+    const result = await threadService.delete("thread-perf", true);
     const elapsed = performance.now() - start;
 
     expect(result).toBe(true);
@@ -223,7 +234,7 @@ describe("Cleanup integration", () => {
     expect(cleanupJobRepo.count()).toBe(0);
   });
 
-  it("duplicate delete is idempotent (INSERT OR IGNORE)", () => {
+  it("duplicate delete is idempotent (INSERT OR IGNORE)", async () => {
     const ws = workspaceRepo.create("dup-test", "/test-repo-4");
     const now = new Date().toISOString();
     db.prepare(
@@ -233,9 +244,9 @@ describe("Cleanup integration", () => {
     ).run("thread-dup", ws.id, "Dup Thread", "mcode/dup", join(WT_BASE, "dup-wt"), now, now);
 
     // Delete twice - should not throw or create duplicate jobs
-    threadService.delete("thread-dup", true);
+    await threadService.delete("thread-dup", true);
     // Second delete: thread is already soft-deleted, but if called again it's safe
-    threadService.delete("thread-dup", true);
+    await threadService.delete("thread-dup", true);
 
     // Only one cleanup job exists (UNIQUE constraint + INSERT OR IGNORE)
     expect(cleanupJobRepo.count()).toBe(1);

--- a/apps/server/src/__tests__/providers-availability-rpc.test.ts
+++ b/apps/server/src/__tests__/providers-availability-rpc.test.ts
@@ -49,6 +49,7 @@ function makeMinimalDeps(
     workspaceRepo: undefined as unknown as RouterDeps["workspaceRepo"],
     ciWatcherService: undefined as unknown as RouterDeps["ciWatcherService"],
     providerAvailability: undefined as unknown as RouterDeps["providerAvailability"],
+    threadTeardownService: undefined as unknown as RouterDeps["threadTeardownService"],
     ...overrides,
   } as unknown as RouterDeps & { authToken: string; shutdown: () => void };
 }

--- a/apps/server/src/__tests__/thread-delete-teardown-rpc.test.ts
+++ b/apps/server/src/__tests__/thread-delete-teardown-rpc.test.ts
@@ -1,0 +1,130 @@
+import "reflect-metadata";
+import { describe, expect, it, vi } from "vitest";
+import { routeMessage, type RouterDeps } from "../transport/ws-router";
+
+function threadDeleteRequest(threadId: string, cleanupWorktree = false): string {
+  return JSON.stringify({
+    id: "delete-1",
+    method: "thread.delete",
+    params: { threadId, cleanupWorktree },
+  });
+}
+
+function workspaceRequest(method: "workspace.delete" | "workspace.forceDelete"): string {
+  return JSON.stringify({
+    id: "workspace-delete-1",
+    method,
+    params: { id: "workspace-1" },
+  });
+}
+
+function threadDeps(): RouterDeps {
+  return {
+    ciWatcherService: { unwatch: vi.fn() },
+    threadTeardownService: { teardownThread: vi.fn().mockResolvedValue(undefined) },
+    threadService: { delete: vi.fn().mockReturnValue(true) },
+  } as unknown as RouterDeps;
+}
+
+function workspaceDeps(): RouterDeps {
+  return {
+    gitWatcherService: { unwatchWorkspace: vi.fn() },
+    threadRepo: {
+      listAllByWorkspace: vi.fn().mockReturnValue([{ id: "t-1" }, { id: "t-2" }]),
+    },
+    threadTeardownService: { teardownThread: vi.fn().mockResolvedValue(undefined) },
+    workspaceService: {
+      delete: vi.fn().mockReturnValue(true),
+      forceDelete: vi.fn().mockReturnValue(true),
+    },
+  } as unknown as RouterDeps;
+}
+
+describe("thread.delete teardown", () => {
+  it("tears down runtime resources before deleting the thread row", async () => {
+    const d = threadDeps();
+    const calls: string[] = [];
+    vi.mocked(d.ciWatcherService.unwatch).mockImplementation(() => {
+      calls.push("ci");
+    });
+    vi.mocked(d.threadTeardownService.teardownThread).mockImplementation(async () => {
+      calls.push("teardown");
+    });
+    vi.mocked(d.threadService.delete).mockImplementation(() => {
+      calls.push("delete");
+      return true;
+    });
+
+    const response = await routeMessage(threadDeleteRequest("t-delete"), d);
+
+    expect(response).toEqual({ id: "delete-1", result: true });
+    expect(d.threadTeardownService.teardownThread).toHaveBeenCalledWith("t-delete");
+    expect(d.threadService.delete).toHaveBeenCalledWith("t-delete", false);
+    expect(calls).toEqual(["ci", "teardown", "delete"]);
+  });
+
+  it("does not hide the thread when resource teardown fails", async () => {
+    const d = threadDeps();
+    vi.mocked(d.threadTeardownService.teardownThread).mockRejectedValue(
+      new Error("PTY refused to exit"),
+    );
+
+    const response = await routeMessage(threadDeleteRequest("t-delete"), d);
+
+    expect(response).toMatchObject({
+      id: "delete-1",
+      error: { code: "INTERNAL_ERROR", message: "PTY refused to exit" },
+    });
+    expect(d.threadService.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe("workspace delete teardown", () => {
+  it("tears down child threads before soft-deleting the workspace", async () => {
+    const d = workspaceDeps();
+    const calls: string[] = [];
+    vi.mocked(d.threadTeardownService.teardownThread).mockImplementation(async (threadId) => {
+      calls.push(`teardown:${threadId}`);
+    });
+    vi.mocked(d.workspaceService.delete).mockImplementation(() => {
+      calls.push("delete");
+      return true;
+    });
+
+    const response = await routeMessage(workspaceRequest("workspace.delete"), d);
+
+    expect(response).toEqual({ id: "workspace-delete-1", result: true });
+    expect(d.threadRepo.listAllByWorkspace).toHaveBeenCalledWith("workspace-1");
+    expect(d.threadTeardownService.teardownThread).toHaveBeenCalledWith("t-1");
+    expect(d.threadTeardownService.teardownThread).toHaveBeenCalledWith("t-2");
+    expect(calls).toEqual(["teardown:t-1", "teardown:t-2", "delete"]);
+  });
+
+  it("does not hide the workspace when child thread teardown fails", async () => {
+    const d = workspaceDeps();
+    vi.mocked(d.threadTeardownService.teardownThread).mockRejectedValueOnce(
+      new Error("agent still running"),
+    );
+
+    const response = await routeMessage(workspaceRequest("workspace.delete"), d);
+
+    expect(response).toMatchObject({
+      id: "workspace-delete-1",
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Workspace teardown failed for workspace-1: agent still running",
+      },
+    });
+    expect(d.workspaceService.delete).not.toHaveBeenCalled();
+  });
+
+  it("tears down child threads before force-deleting the workspace", async () => {
+    const d = workspaceDeps();
+
+    const response = await routeMessage(workspaceRequest("workspace.forceDelete"), d);
+
+    expect(response).toEqual({ id: "workspace-delete-1", result: true });
+    expect(d.threadTeardownService.teardownThread).toHaveBeenCalledTimes(2);
+    expect(d.workspaceService.forceDelete).toHaveBeenCalledWith("workspace-1");
+  });
+});

--- a/apps/server/src/__tests__/thread-service.test.ts
+++ b/apps/server/src/__tests__/thread-service.test.ts
@@ -7,6 +7,8 @@ import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { ThreadService } from "../services/thread-service";
 import type { GitService } from "../services/git-service";
+import type { AttachmentService } from "../services/attachment-service";
+import type { HandoffStorage } from "../services/handoff/handoff-storage";
 
 describe("ThreadService.delete", () => {
   let db: Database.Database;
@@ -14,6 +16,8 @@ describe("ThreadService.delete", () => {
   let workspaceRepo: WorkspaceRepo;
   let cleanupJobRepo: CleanupJobRepo;
   let mockGitService: GitService;
+  let mockAttachmentService: AttachmentService;
+  let mockHandoffStorage: HandoffStorage;
   let threadService: ThreadService;
 
   beforeEach(() => {
@@ -31,11 +35,17 @@ describe("ThreadService.delete", () => {
       listWorktrees: vi.fn(),
       fetchBranch: vi.fn(),
     } as unknown as GitService;
+    mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
+    mockHandoffStorage = {
+      deleteThreadFiles: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HandoffStorage;
     threadService = new ThreadService(
       threadRepo,
       workspaceRepo,
       mockGitService,
       cleanupJobRepo,
+      mockAttachmentService,
+      mockHandoffStorage,
     );
   });
 
@@ -54,21 +64,21 @@ describe("ThreadService.delete", () => {
     ).run(id, workspaceId, "Test Thread", branch, wtPath, now, now);
   }
 
-  it("soft-deletes the thread immediately", () => {
+  it("soft-deletes the thread while worktree cleanup is queued", async () => {
     const ws = workspaceRepo.create("test", "/tmp/test");
     insertWorktreeThread("t-1", ws.id, "feat/test", "/tmp/wt/my-worktree");
 
-    const result = threadService.delete("t-1", true);
+    const result = await threadService.delete("t-1", true);
 
     expect(result).toBe(true);
     expect(threadRepo.findById("t-1")?.status).toBe("deleted");
   });
 
-  it("enqueues a cleanup job when cleanupWorktree is true and thread has a managed worktree", () => {
+  it("enqueues a cleanup job when cleanupWorktree is true and thread has a managed worktree", async () => {
     const ws = workspaceRepo.create("test", "/tmp/test");
     insertWorktreeThread("t-2", ws.id, "feat/test", "/tmp/wt/my-worktree");
 
-    threadService.delete("t-2", true);
+    await threadService.delete("t-2", true);
 
     expect(cleanupJobRepo.count()).toBe(1);
     const jobs = cleanupJobRepo.findDue(Date.now());
@@ -78,16 +88,19 @@ describe("ThreadService.delete", () => {
     expect(jobs[0].branch).toBe("feat/test");
   });
 
-  it("does not enqueue a cleanup job when cleanupWorktree is false", () => {
+  it("hard-deletes without a cleanup job when cleanupWorktree is false", async () => {
     const ws = workspaceRepo.create("test", "/tmp/test");
     insertWorktreeThread("t-3", ws.id, "feat/test", "/tmp/wt/my-worktree");
 
-    threadService.delete("t-3", false);
+    await threadService.delete("t-3", false);
 
     expect(cleanupJobRepo.count()).toBe(0);
+    expect(threadRepo.findById("t-3")).toBeNull();
+    expect(mockAttachmentService.removeForThread).toHaveBeenCalledWith("t-3");
+    expect(mockHandoffStorage.deleteThreadFiles).toHaveBeenCalledWith("t-3");
   });
 
-  it("does not enqueue a cleanup job for threads without a worktree path", () => {
+  it("hard-deletes threads without a worktree path", async () => {
     const ws = workspaceRepo.create("test", "/tmp/test");
     const now = new Date().toISOString();
     db.prepare(
@@ -96,21 +109,24 @@ describe("ThreadService.delete", () => {
        VALUES (?, ?, ?, ?, 'direct', 'active', 1, ?, ?)`,
     ).run("t-4", ws.id, "Direct thread", "main", now, now);
 
-    threadService.delete("t-4", true);
+    await threadService.delete("t-4", true);
 
     expect(cleanupJobRepo.count()).toBe(0);
+    expect(threadRepo.findById("t-4")).toBeNull();
+    expect(mockAttachmentService.removeForThread).toHaveBeenCalledWith("t-4");
+    expect(mockHandoffStorage.deleteThreadFiles).toHaveBeenCalledWith("t-4");
   });
 
-  it("does not call removeWorktree synchronously", () => {
+  it("does not call removeWorktree synchronously", async () => {
     const ws = workspaceRepo.create("test", "/tmp/test");
     insertWorktreeThread("t-5", ws.id, "feat/sync", "/tmp/wt/sync");
 
-    threadService.delete("t-5", true);
+    await threadService.delete("t-5", true);
 
     expect(mockGitService.removeWorktree).not.toHaveBeenCalled();
   });
 
-  it("does not enqueue a cleanup job when the workspace has been deleted", () => {
+  it("hard-deletes the thread when the workspace has been deleted", async () => {
     // Insert thread with a valid workspace, then delete the workspace row so the
     // lookup inside delete() returns null.
     const ws = workspaceRepo.create("orphan", "/tmp/orphan");
@@ -119,13 +135,14 @@ describe("ThreadService.delete", () => {
     db.prepare("DELETE FROM workspaces WHERE id = ?").run(ws.id);
     db.pragma("foreign_keys = ON");
 
-    const result = threadService.delete("t-6", true);
+    const result = await threadService.delete("t-6", true);
 
     expect(result).toBe(true);
     expect(cleanupJobRepo.count()).toBe(0);
+    expect(threadRepo.findById("t-6")).toBeNull();
   });
 
-  it("enqueues a cleanup job for an attached existing worktree when cleanup is requested", () => {
+  it("enqueues a cleanup job for an attached existing worktree when cleanup is requested", async () => {
     const ws = workspaceRepo.create("test", "/tmp/test");
     const now = new Date().toISOString();
     db.prepare(
@@ -134,7 +151,7 @@ describe("ThreadService.delete", () => {
        VALUES (?, ?, ?, ?, 'worktree', 'active', ?, 0, ?, ?)`,
     ).run("t-existing", ws.id, "Existing Worktree", "feat/existing", "/tmp/existing-wt", now, now);
 
-    const result = threadService.delete("t-existing", true);
+    const result = await threadService.delete("t-existing", true);
 
     expect(result).toBe(true);
     expect(cleanupJobRepo.count()).toBe(1);

--- a/apps/server/src/__tests__/thread-teardown-service.test.ts
+++ b/apps/server/src/__tests__/thread-teardown-service.test.ts
@@ -1,0 +1,42 @@
+import "reflect-metadata";
+import { describe, expect, it, vi } from "vitest";
+import type { ThreadRepo } from "../repositories/thread-repo";
+import { ThreadTeardownService } from "../services/thread-teardown-service";
+import type { AgentService } from "../services/agent-service";
+import type { TerminalService } from "../services/terminal-service";
+
+function build(existingThreadId: string | null = "thread-1") {
+  const threadRepo = {
+    findById: vi.fn((threadId: string) =>
+      existingThreadId === threadId ? { id: threadId } : null,
+    ),
+  } as unknown as ThreadRepo;
+  const agentService = {
+    teardownSession: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AgentService;
+  const terminalService = {
+    killByThread: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TerminalService;
+  const service = new ThreadTeardownService(threadRepo, agentService, terminalService);
+  return { threadRepo, agentService, terminalService, service };
+}
+
+describe("ThreadTeardownService", () => {
+  it("stops provider sessions and kills PTYs for an existing thread", async () => {
+    const { agentService, terminalService, service } = build("thread-1");
+
+    await service.teardownThread("thread-1");
+
+    expect(agentService.teardownSession).toHaveBeenCalledWith("thread-1");
+    expect(terminalService.killByThread).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("leaves resource owners untouched when the thread row is gone", async () => {
+    const { agentService, terminalService, service } = build();
+
+    await service.teardownThread("missing-thread");
+
+    expect(agentService.teardownSession).not.toHaveBeenCalled();
+    expect(terminalService.killByThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/__tests__/ws-server-health.test.ts
+++ b/apps/server/src/__tests__/ws-server-health.test.ts
@@ -38,6 +38,7 @@ function makeMinimalDeps(
     prDraftService: undefined as unknown as RouterDeps["prDraftService"],
     threadRepo: undefined as unknown as RouterDeps["threadRepo"],
     workspaceRepo: undefined as unknown as RouterDeps["workspaceRepo"],
+    threadTeardownService: undefined as unknown as RouterDeps["threadTeardownService"],
     ...overrides,
   } as unknown as RouterDeps & { authToken: string; shutdown: () => void };
 }

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -67,6 +67,7 @@ import { ShellEnvResolver } from "./services/shell-env-resolver";
 import { EnvService } from "./services/env-service";
 import { UtilityCompletionService } from "./services/utility-completion-service";
 import { DiffSummaryService } from "./services/diff-summary-service";
+import { ThreadTeardownService } from "./services/thread-teardown-service";
 
 /** Initialize the DI container with all server dependencies. */
 export function setupContainer(mcodeDir: string): typeof container {
@@ -289,6 +290,11 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(
     AgentService,
     { useClass: AgentService },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    ThreadTeardownService,
+    { useClass: ThreadTeardownService },
     { lifecycle: Lifecycle.Singleton },
   );
   container.register(

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -54,6 +54,7 @@ import { WorkspaceEnricher } from "./services/workspace-enricher";
 import { FilesystemBrowser } from "./services/filesystem-browser";
 import { ModelCacheService } from "./services/model-cache-service";
 import { DiffSummaryService } from "./services/diff-summary-service";
+import { ThreadTeardownService } from "./services/thread-teardown-service";
 import { HandoffStorage } from "./services/handoff/handoff-storage";
 import { WebSocket } from "ws";
 import { resolveGracePeriodMs } from "./grace-period-ms";
@@ -235,6 +236,7 @@ function warmCodexVersionGate(s = settingsService.get()): void {
 }
 
 const cleanupWorker = container.resolve(CleanupWorker);
+const threadTeardownService = container.resolve(ThreadTeardownService);
 const prDraftService = container.resolve(PrDraftService);
 const diffSummaryService = container.resolve(DiffSummaryService);
 const handoffStorage = container.resolve(HandoffStorage);
@@ -539,6 +541,7 @@ const { httpServer, wss } = createWsServer({
   filesystemBrowser,
   diffSummaryService,
   handoffStorage,
+  threadTeardownService,
   authToken: AUTH_TOKEN,
   shutdown: requestShutdown,
 });

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -2275,7 +2275,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
   }
 
   /** Abort a running session, or record a pending stop if the session hasn't been created yet. */
-  stopSession(sessionId: string): void {
+  async stopSession(sessionId: string): Promise<void> {
     // Normalize to the raw UUID that canUseTool stores as threadId.
     const tid = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
     // Reject all pending permission requests for this session and notify frontend.
@@ -2290,11 +2290,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     const entry = this.runtime.get(sessionId);
     if (entry) {
       // The runtime's stop runs interrupt (closeQueue) → close (query.close) →
-      // hard taskkill of the spawned PID. Fire-and-forget; callers that need to
-      // await the subprocess exit use waitForSessionExit.
-      void this.runtime.stop(sessionId).catch((err: unknown) => {
-        logger.warn("Claude stopSession failed", { sessionId, error: String(err) });
-      });
+      // hard taskkill of the spawned PID.
+      await this.runtime.stop(sessionId);
     } else {
       // Session not yet created (sendMessage still in flight). Record the
       // stop so doSendMessage tears the session down immediately after
@@ -2312,11 +2309,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
    * deliberately leaves goals and pending permissions intact, since the caller
    * retries the same turn on a new session.
    */
-  discardSession(sessionId: string): void {
+  async discardSession(sessionId: string): Promise<void> {
     if (this.runtime.get(sessionId) === undefined) return;
-    void this.runtime.stop(sessionId).catch((err: unknown) => {
-      logger.warn("Claude discardSession failed", { sessionId, error: String(err) });
-    });
+    await this.runtime.stop(sessionId);
   }
 
   /**

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -987,12 +987,10 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
    * the session has not spawned yet, record the intent so `sendTurn`/`spawn`
    * tear it down on arrival.
    */
-  stopSession(sessionId: string): void {
+  async stopSession(sessionId: string): Promise<void> {
     const exists = this.runtime.get(sessionId) !== undefined;
     if (exists) {
-      void this.runtime.stop(sessionId).catch((err: unknown) => {
-        logger.warn("Codex stopSession failed", { sessionId, error: String(err) });
-      });
+      await this.runtime.stop(sessionId);
     } else {
       // Drain any pending permissions for a session still mid-spawn so cards
       // clear immediately; close() will not run until/unless the session lands.
@@ -1008,11 +1006,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
    * pool eviction via the runtime's `stop` (interrupt → close → hard kill),
    * leaving goals and pending permissions intact for the retry turn.
    */
-  discardSession(sessionId: string): void {
+  async discardSession(sessionId: string): Promise<void> {
     if (this.runtime.get(sessionId) === undefined) return;
-    void this.runtime.stop(sessionId).catch((err: unknown) => {
-      logger.warn("Codex discardSession failed", { sessionId, error: String(err) });
-    });
+    await this.runtime.stop(sessionId);
   }
 
   /** Tears down all sessions, drains pending permissions, and stops the eviction timer. */

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -1132,12 +1132,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
    * `close` (both disconnect the SDK session, guarded) → hard kill (a no-op for
    * Copilot, whose PID the SDK hides).
    */
-  stopSession(sessionId: string): void {
+  async stopSession(sessionId: string): Promise<void> {
     this.contextWindowBySession.delete(sessionId);
     if (this.runtime.get(sessionId) !== undefined) {
-      void this.runtime.stop(sessionId).catch((err: unknown) =>
-        logger.warn("CopilotProvider: stopSession failed", { sessionId, error: String(err) }),
-      );
+      await this.runtime.stop(sessionId);
     } else {
       this.pendingStops.add(sessionId);
       this.pendingSpawnTurns.delete(sessionId);
@@ -1150,11 +1148,9 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
    * pool eviction via the runtime's `stop` (interrupt → close → hard kill),
    * leaving goals and pending permissions intact for the retry turn.
    */
-  discardSession(sessionId: string): void {
+  async discardSession(sessionId: string): Promise<void> {
     if (this.runtime.get(sessionId) === undefined) return;
-    void this.runtime.stop(sessionId).catch((err: unknown) =>
-      logger.warn("CopilotProvider: discardSession failed", { sessionId, error: String(err) }),
-    );
+    await this.runtime.stop(sessionId);
   }
 
   /** Tear down all sessions, stop the client, and release resources. */

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -323,18 +323,18 @@ export class CursorProvider
    * yet, hand it to `runtime.stop` (interrupt → close → hard kill). Records a
    * pending stop if the session has not spawned at all.
    */
-  stopSession(sessionId: string): void {
+  async stopSession(sessionId: string): Promise<void> {
     const entry = this.runtime.get(sessionId);
     this.cancelPendingForThread(sessionId);
     if (entry?.acpSessionId && entry.activeTurnState) {
       entry.pendingUserStopAbort = true;
     }
     if (entry?.acpSessionId) {
-      void entry.connection.cancel({ sessionId: entry.acpSessionId }).catch(() => {});
+      await entry.connection.cancel({ sessionId: entry.acpSessionId }).catch(() => {});
     } else if (entry) {
       // Entry exists but ACP session hasn't opened yet; tear down immediately.
       const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
-      void this.runtime.stop(sessionId);
+      await this.runtime.stop(sessionId);
       this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
     } else {
       this.pendingStops.add(sessionId);
@@ -348,11 +348,9 @@ export class CursorProvider
    * a graceful cancel — this tears the runtime down (interrupt → close → hard
    * kill), so a stale ACP connection is replaced rather than reused on retry.
    */
-  discardSession(sessionId: string): void {
+  async discardSession(sessionId: string): Promise<void> {
     if (this.runtime.get(sessionId) === undefined) return;
-    void this.runtime.stop(sessionId).catch((err: unknown) => {
-      logger.warn("Cursor discardSession failed", { sessionId, error: String(err) });
-    });
+    await this.runtime.stop(sessionId);
   }
 
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1086,11 +1086,22 @@ export class AgentService {
     const sessionId = `mcode-${threadId}`;
     const thread = this.threadRepo.findById(threadId);
     const providerId = (thread?.provider ?? "claude") as ProviderId;
+    let provider: import("@mcode/contracts").IAgentProvider | null = null;
     try {
-      const provider = this.providerRegistry.resolve(providerId);
-      provider.stopSession(sessionId);
+      provider = this.providerRegistry.resolve(providerId);
     } catch {
       // Provider may not be available
+    }
+    if (provider) {
+      try {
+        await provider.stopSession(sessionId);
+      } catch (err) {
+        logger.warn("Provider stopSession failed", {
+          threadId,
+          providerId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
     // Tear down any armed transient-retry window so a scheduled stream retry
     // can't re-dispatch after the user stopped, and the suppression flags don't
@@ -1106,6 +1117,35 @@ export class AgentService {
     if (this.activeSessionIds.has(threadId)) {
       this.activeSessionIds.delete(threadId);
       this.memoryPressureService.markIdle(threadId);
+    }
+  }
+
+  /** Stop the active turn and discard any pooled provider session for a deleted thread. */
+  async teardownSession(threadId: string): Promise<void> {
+    const sessionId = `mcode-${threadId}`;
+    const thread = this.threadRepo.findById(threadId);
+    const providerId = (thread?.provider ?? "claude") as ProviderId;
+    const wasActive = this.activeSessionIds.has(threadId);
+
+    if (wasActive) {
+      await this.stopSession(threadId);
+    }
+
+    let provider: import("@mcode/contracts").IAgentProvider;
+    try {
+      provider = this.providerRegistry.resolve(providerId);
+    } catch (err) {
+      logger.warn("Provider unavailable during thread teardown", {
+        threadId,
+        providerId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    if (isSessionEvictable(provider)) {
+      await this.evictPooledSession(provider, sessionId);
+    } else if (!wasActive) {
+      await provider.stopSession(sessionId);
     }
   }
 
@@ -1314,12 +1354,12 @@ export class AgentService {
    * Evicts a pooled provider session and waits for its subprocess to unwind so
    * any trailing `Ended` from teardown is emitted while suppression is still armed.
    */
-  private async evictPooledSessionForRetry(
+  private async evictPooledSession(
     provider: import("@mcode/contracts").IAgentProvider,
     sessionName: string,
   ): Promise<void> {
     if (!isSessionEvictable(provider)) return;
-    provider.discardSession(sessionName);
+    await provider.discardSession(sessionName);
     const withWait = provider as import("@mcode/contracts").IAgentProvider & {
       waitForSessionExit?: (sessionId: string, timeoutMs?: number) => Promise<void>;
     };
@@ -1341,7 +1381,7 @@ export class AgentService {
     this.endedSuppressionThreads.add(threadId);
     try {
       try {
-        await this.evictPooledSessionForRetry(dispatch.resolvedProvider, dispatch.sessionName);
+        await this.evictPooledSession(dispatch.resolvedProvider, dispatch.sessionName);
       } catch (evictErr) {
         logger.warn("Failed to discard pooled session before retry", {
           threadId,
@@ -2289,7 +2329,7 @@ ${userMessage}`;
       const providerId = (thread?.provider ?? "claude") as ProviderId;
       try {
         const provider = this.providerRegistry.resolve(providerId);
-        provider.stopSession(sessionId);
+        void Promise.resolve(provider.stopSession(sessionId)).catch(() => {});
       } catch {
         // best-effort
       }

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -11,6 +11,8 @@ import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { GitService } from "./git-service";
 import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
+import { AttachmentService } from "./attachment-service";
+import { HandoffStorage } from "./handoff/handoff-storage.js";
 
 /** Handles thread creation, deletion, worktree provisioning, and lifecycle. */
 @injectable()
@@ -20,6 +22,8 @@ export class ThreadService {
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
     @inject(GitService) private readonly gitService: GitService,
     @inject(CleanupJobRepo) private readonly cleanupJobRepo: CleanupJobRepo,
+    @inject(AttachmentService) private readonly attachmentService: AttachmentService,
+    @inject(HandoffStorage) private readonly handoffStorage: HandoffStorage,
   ) {}
 
   /**
@@ -146,10 +150,12 @@ export class ThreadService {
    * exponential backoff retries. The job stores the thread's exact branch so
    * explicit user cleanup deletes the worktree and its associated thread branch.
    */
-  delete(threadId: string, cleanupWorktree: boolean): boolean {
+  async delete(threadId: string, cleanupWorktree: boolean): Promise<boolean> {
+    const thread = this.threadRepo.findById(threadId);
+    if (!thread) return false;
+
     if (cleanupWorktree) {
-      const thread = this.threadRepo.findById(threadId);
-      if (thread?.worktree_path) {
+      if (thread.worktree_path) {
         const workspace = this.workspaceRepo.findById(thread.workspace_id);
         if (workspace) {
           this.cleanupJobRepo.insert({
@@ -162,17 +168,19 @@ export class ThreadService {
             threadId,
             worktreePath: thread.worktree_path,
           });
-        } else {
-          logger.warn("Worktree cleanup skipped - workspace not found, directory will not be removed", {
-            threadId,
-            workspaceId: thread.workspace_id,
-            worktreePath: thread.worktree_path,
-          });
+          return this.threadRepo.softDelete(threadId);
         }
+        logger.warn("Worktree cleanup skipped - workspace not found, directory will not be removed", {
+          threadId,
+          workspaceId: thread.workspace_id,
+          worktreePath: thread.worktree_path,
+        });
       }
     }
 
-    return this.threadRepo.softDelete(threadId);
+    this.attachmentService.removeForThread(threadId);
+    await this.handoffStorage.deleteThreadFiles(threadId);
+    return this.threadRepo.hardDelete(threadId);
   }
 
   /** Update a thread's display title. */

--- a/apps/server/src/services/thread-teardown-service.ts
+++ b/apps/server/src/services/thread-teardown-service.ts
@@ -1,0 +1,37 @@
+/**
+ * Central teardown boundary for resources owned by a single thread.
+ */
+import { injectable, inject } from "tsyringe";
+import { AgentService } from "./agent-service";
+import { TerminalService } from "./terminal-service";
+import { ThreadRepo } from "../repositories/thread-repo";
+
+function failureMessage(result: PromiseRejectedResult): string {
+  return result.reason instanceof Error ? result.reason.message : String(result.reason);
+}
+
+/** Tears down active and pooled runtime resources before a thread is deleted. */
+@injectable()
+export class ThreadTeardownService {
+  constructor(
+    @inject(ThreadRepo) private readonly threadRepo: ThreadRepo,
+    @inject(AgentService) private readonly agentService: AgentService,
+    @inject(TerminalService) private readonly terminalService: TerminalService,
+  ) {}
+
+  /** Stop provider sessions and kill PTYs for a thread before its row is deleted. */
+  async teardownThread(threadId: string): Promise<void> {
+    if (!this.threadRepo.findById(threadId)) return;
+
+    const results = await Promise.allSettled([
+      this.agentService.teardownSession(threadId),
+      this.terminalService.killByThread(threadId),
+    ]);
+    const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+    if (failures.length > 0) {
+      throw new Error(
+        `Thread teardown failed for ${threadId}: ${failures.map(failureMessage).join("; ")}`,
+      );
+    }
+  }
+}

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -62,6 +62,11 @@ import type { ModelCacheService } from "../services/model-cache-service.js";
 import type { DiffSummaryService } from "../services/diff-summary-service.js";
 import type { HandoffStorage } from "../services/handoff/handoff-storage.js";
 import { loadConversationPage } from "../services/conversation-page.js";
+import type { ThreadTeardownService } from "../services/thread-teardown-service.js";
+
+function teardownFailureMessage(result: PromiseRejectedResult): string {
+  return result.reason instanceof Error ? result.reason.message : String(result.reason);
+}
 
 /** Service dependencies for the router. */
 export interface RouterDeps {
@@ -114,6 +119,8 @@ export interface RouterDeps {
   filesystemBrowser: FilesystemBrowser;
   /** Generates and persists AI-powered diff summaries for threads. */
   diffSummaryService: DiffSummaryService;
+  /** Tears down provider and terminal resources owned by a thread before deletion. */
+  threadTeardownService: ThreadTeardownService;
 }
 
 /**
@@ -219,6 +226,19 @@ function resolveThreadRepoPath(deps: RouterDeps, threadId?: string): string | un
   return deps.gitService.resolveWorkingDir(ws.path, thread.mode, thread.worktree_path);
 }
 
+async function teardownWorkspaceThreads(deps: RouterDeps, workspaceId: string): Promise<void> {
+  const threads = deps.threadRepo.listAllByWorkspace(workspaceId);
+  const results = await Promise.allSettled(
+    threads.map((thread) => deps.threadTeardownService.teardownThread(thread.id)),
+  );
+  const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+  if (failures.length > 0) {
+    throw new Error(
+      `Workspace teardown failed for ${workspaceId}: ${failures.map(teardownFailureMessage).join("; ")}`,
+    );
+  }
+}
+
 /** Dispatch a validated method call to the appropriate service. */
 async function dispatch(
   method: WsMethodName,
@@ -255,6 +275,7 @@ async function dispatch(
       return workspace;
     }
     case "workspace.delete": {
+      await teardownWorkspaceThreads(deps, params.id);
       const result = deps.workspaceService.delete(params.id);
       if (result) {
         deps.gitWatcherService.unwatchWorkspace(params.id);
@@ -263,6 +284,7 @@ async function dispatch(
       return result;
     }
     case "workspace.forceDelete": {
+      await teardownWorkspaceThreads(deps, params.id);
       const result = deps.workspaceService.forceDelete(params.id);
       if (result) {
         deps.gitWatcherService.unwatchWorkspace(params.id);
@@ -316,7 +338,8 @@ async function dispatch(
       );
     case "thread.delete": {
       deps.ciWatcherService.unwatch(params.threadId);
-      return deps.threadService.delete(
+      await deps.threadTeardownService.teardownThread(params.threadId);
+      return await deps.threadService.delete(
         params.threadId,
         params.cleanupWorktree,
       );

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -7,6 +7,8 @@ import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-reco
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useWorkspaceStore, __resetThreadListMutationEpochForTests, __clearPendingThreadCreationsForTests } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
+import { usePreviewReferenceQueueStore } from "@/stores/previewReferenceQueueStore";
+import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 import {
   mockTransport,
   createMockWorkspace,
@@ -30,6 +32,8 @@ describe("Workspace Behavior", () => {
       loading: false,
       error: null,
     });
+    usePreviewTabsStore.setState({ tabSetByScope: {}, liveChromeByScope: {} });
+    usePreviewReferenceQueueStore.setState({ signal: 0, queueByThread: {} });
     vi.clearAllMocks();
   });
 
@@ -394,6 +398,52 @@ describe("Workspace Behavior", () => {
       // Other thread is preserved.
       expect(getTestThreadError("t-keep")).toBe("keep error");
       expect(ts.runningThreadIds.has("t-keep")).toBe(true);
+    });
+
+    it("clears preview browser state and queued preview references for the deleted thread", async () => {
+      const ws = createMockWorkspace();
+      const thread = createMockThread({ workspace_id: ws.id, id: "t-preview" });
+
+      useWorkspaceStore.setState({
+        workspaces: [ws],
+        activeWorkspaceId: ws.id,
+        threads: [thread],
+        activeThreadId: null,
+      });
+      usePreviewTabsStore.setState({
+        tabSetByScope: {
+          "t-preview": {
+            threadId: "t-preview",
+            activeTabId: "tab-1",
+            tabs: [{
+              id: "tab-1",
+              threadId: "t-preview",
+              title: null,
+              url: "https://example.test",
+              faviconUrl: null,
+              warm: true,
+              active: true,
+            }],
+          },
+        },
+        liveChromeByScope: {
+          "t-preview": { title: "Example", url: "https://example.test", favicon: null },
+        },
+      });
+      usePreviewReferenceQueueStore.getState().enqueuePreviewReference("t-preview", {
+        id: "att-1",
+        name: "capture.png",
+        mimeType: "image/png",
+        sizeBytes: 10,
+        previewUrl: "data:image/png;base64,AA==",
+        filePath: null,
+      });
+
+      await useWorkspaceStore.getState().deleteThread("t-preview", false);
+
+      expect(usePreviewTabsStore.getState().tabSetByScope["t-preview"]).toBeUndefined();
+      expect(usePreviewTabsStore.getState().liveChromeByScope["t-preview"]).toBeUndefined();
+      expect(usePreviewReferenceQueueStore.getState().queueByThread["t-preview"]).toBeUndefined();
     });
 
     it("clears all per-thread maps for all threads when deleting a workspace", async () => {

--- a/apps/web/src/stores/previewReferenceQueueStore.ts
+++ b/apps/web/src/stores/previewReferenceQueueStore.ts
@@ -17,6 +17,12 @@ interface PreviewReferenceQueueState {
    * Intended for a single consumer (Composer) per drain call.
    */
   drainPreviewReferences(threadId: string): PendingAttachment[];
+  /** Drop queued preview references for a deleted thread. */
+  clearThread(threadId: string): void;
+}
+
+function releasePreviewUrl(url: string): void {
+  if (url.startsWith("blob:")) URL.revokeObjectURL(url);
 }
 
 /** Zustand store: enqueue preview PNG captures; Composer drains by active thread ID. */
@@ -43,5 +49,18 @@ export const usePreviewReferenceQueueStore = create<PreviewReferenceQueueState>(
       return { queueByThread: next, signal: s.signal + 1 };
     });
     return queued;
+  },
+
+  clearThread(threadId) {
+    const queued = get().queueByThread[threadId] ?? [];
+    for (const attachment of queued) {
+      releasePreviewUrl(attachment.previewUrl);
+    }
+    if (queued.length === 0) return;
+    set((s) => {
+      const next = { ...s.queueByThread };
+      delete next[threadId];
+      return { queueByThread: next, signal: s.signal + 1 };
+    });
   },
 }));

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -38,6 +38,9 @@ interface PreviewTabsBridgeLike {
     threadId: string,
     tabId: string,
   ): Promise<{ ok: true; data: BrowserTabSet } | { ok: false; error: string }>;
+  closeScope?(
+    threadId: string,
+  ): Promise<{ ok: true; data: BrowserTabSet } | { ok: false; error: string }>;
 }
 
 function bridgeTabs(): PreviewTabsBridgeLike | undefined {
@@ -93,6 +96,8 @@ interface PreviewTabsState {
    * always-recreated empty fallback.
    */
   closePage: (scopeId: string, tabId: string, opts?: ClosePageOptions) => Promise<void>;
+  /** Close every host-owned browser page for a scope and clear renderer mirrors. */
+  clearScope: (scopeId: string) => Promise<void>;
 }
 
 /** Hooks the store offers callers when a page close empties the browser. */
@@ -164,6 +169,19 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     // rail, so drop the scope's set rather than leave that fallback as a phantom
     // page; reopening Browser re-seeds it via `list`.
     get().setTabSet(scopeId, isLast ? null : r.data);
+  },
+
+  clearScope: async (scopeId) => {
+    const tabs = bridgeTabs();
+    const r = await tabs?.closeScope?.(scopeId);
+    if (r && !r.ok) throw new Error(r.error);
+    set((s) => {
+      const tabSetByScope = { ...s.tabSetByScope };
+      const liveChromeByScope = { ...s.liveChromeByScope };
+      delete tabSetByScope[scopeId];
+      delete liveChromeByScope[scopeId];
+      return { tabSetByScope, liveChromeByScope };
+    });
   },
 }));
 

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -14,6 +14,8 @@ import { useQueueStore } from "./queueStore";
 import { useTaskStore } from "./taskStore";
 import { useComposerDraftStore } from "./composerDraftStore";
 import { useDiffStore } from "./diffStore";
+import { usePreviewReferenceQueueStore } from "./previewReferenceQueueStore";
+import { usePreviewTabsStore } from "./previewTabsStore";
 import type { ContextWindowMode, NamingMode, ReasoningLevel, InteractionMode } from "@mcode/contracts";
 import { useSettingsStore } from "./settingsStore";
 import { sanitizeCustomBranchInput, resolveBranchName } from "@/lib/branch-name";
@@ -27,6 +29,11 @@ function generateBranchId(): string {
 const SYNC_THROTTLE_MS = 30_000;
 /** Tracks the last syncThreadPrs request time per workspace. */
 const lastSyncTime = new Map<string, number>();
+
+async function clearPreviewResources(threadId: string): Promise<void> {
+  await usePreviewTabsStore.getState().clearScope(threadId);
+  usePreviewReferenceQueueStore.getState().clearThread(threadId);
+}
 
 /**
  * Trailing-edge debounce window for `markThreadViewed` RPCs. Rapid sidebar
@@ -439,11 +446,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
   deleteWorkspace: async (id) => {
     set({ error: null });
     try {
-      await getTransport().deleteWorkspace(id);
-      bumpThreadListMutationEpoch(id);
       const deletedThreadIds = get()
         .threads.filter((t) => t.workspace_id === id)
         .map((t) => t.id);
+      await Promise.all(deletedThreadIds.map((tid) => clearPreviewResources(tid)));
+      await getTransport().deleteWorkspace(id);
+      bumpThreadListMutationEpoch(id);
       const draftStore = useComposerDraftStore.getState();
       const taskStore = useTaskStore.getState();
       const terminalStore = useTerminalStore.getState();
@@ -952,6 +960,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       const isClientOnly = !!(row?.clientPreparing || row?.clientError);
 
       if (isClientOnly) {
+        await clearPreviewResources(threadId);
         if (workspaceIdForEpoch) {
           bumpThreadListMutationEpoch(workspaceIdForEpoch);
         }
@@ -978,6 +987,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         return;
       }
 
+      await clearPreviewResources(threadId);
       await getTransport().deleteThread(threadId, cleanupWorktree);
       if (workspaceIdForEpoch) {
         bumpThreadListMutationEpoch(workspaceIdForEpoch);

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -197,6 +197,7 @@ interface PreviewTabsBridge {
   create(threadId: string, activate?: boolean): Promise<PreviewTabIpcResult<PreviewTabCreateData>>;
   activate(threadId: string, tabId: string): Promise<PreviewTabIpcResult<BrowserTabSet>>;
   close(threadId: string, tabId: string): Promise<PreviewTabIpcResult<BrowserTabSet>>;
+  closeScope(threadId: string): Promise<PreviewTabIpcResult<BrowserTabSet>>;
   /** Subscribe to push-style tab set updates emitted on navigation/favicon/close. */
   onUpdated(callback: (payload: BrowserTabSet) => void): () => void;
 }

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -120,8 +120,8 @@ export interface IAgentProvider {
    */
   sendTurn(req: TurnRequest): Promise<void>;
 
-  /** Abort a running session. */
-  stopSession(sessionId: string): void;
+  /** Abort a running session. Returned promise resolves after provider-owned teardown where supported. */
+  stopSession(sessionId: string): void | Promise<void>;
 
   /** Tear down all sessions and release resources. */
   shutdown(): void;
@@ -204,9 +204,9 @@ export function isGoalCapable(provider: IAgentProvider): provider is IGoalCapabl
  * Narrowed view of an agent provider that can force-discard a pooled session.
  * Providers pool a warm CLI session keyed by `sessionId`; `stopSession` is a
  * graceful cancel that may intentionally keep that session warm. `discardSession`
- * is the harder guarantee: it evicts the pooled session so the next `sendTurn`
- * spawns a genuinely fresh subprocess. Use `isSessionEvictable()` to narrow an
- * `IAgentProvider` before calling it.
+ * is the harder guarantee: it evicts the pooled session and may return a
+ * promise that resolves after provider-owned teardown. Use
+ * `isSessionEvictable()` to narrow an `IAgentProvider` before calling it.
  */
 export interface ISessionEvictable extends IAgentProvider {
   /**
@@ -215,7 +215,7 @@ export interface ISessionEvictable extends IAgentProvider {
    * cancel pending permissions, drop goals, or emit an `ended` event — the turn
    * is expected to continue on a new session (e.g. a transient-failure retry).
    */
-  discardSession(sessionId: string): void;
+  discardSession(sessionId: string): void | Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## What
Fix thread and workspace deletion so runtime resources are torn down before rows disappear from the app.

## Why
Deleting a thread could remove it from the UI while provider sessions, PTYs, preview tabs, or queued preview references stayed alive. Direct threads could also remain as soft-deleted rows when no worktree cleanup job existed.

## Key Changes
- Add `ThreadTeardownService` for provider session eviction and terminal cleanup before thread deletion.
- Route `thread.delete`, `workspace.delete`, and `workspace.forceDelete` through teardown before deleting rows.
- Make provider `stopSession` and `discardSession` awaitable, and use eviction so pooled CLI sessions are not reused after delete.
- Close Electron preview tab scopes and clear renderer preview state on thread and workspace delete.
- Hard-delete threads immediately when no worktree cleanup job is needed, after attachment and handoff file cleanup.

## Testing
- `git diff --check`
- `bun run typecheck`
- `bun run lint`
- `cd apps/server && bunx vitest run src/__tests__/thread-service.test.ts src/__tests__/thread-delete-teardown-rpc.test.ts src/__tests__/thread-teardown-service.test.ts src/__tests__/cleanup-integration.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783950835&installation_id=129163861&pr_number=728&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F728&signature=5954155db3863dc8df89521814dc64e1e1aea65ce86eecd581bb4aac5d91cc43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to close all preview browser tabs for a thread (thread-scoped tab closing).

* **Improvements**
  * Deleting threads or workspaces now reliably clears preview tabs and queued preview references.
  * Provider session teardown is now awaitable, improving reliability of session stops.
  * Thread/workspace deletion now ensures teardown runs before final removal for safer cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->