### PR TITLE
fix: persist Codex partial content when turns end

### DIFF
--- a/apps/server/src/__tests__/snapshot-service.integration.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.integration.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { SnapshotService } from "../services/snapshot-service";
 
+const GIT_REPO_SETUP_TIMEOUT_MS = 30_000;
+
 /**
  * Integration tests for SnapshotService using real git repositories.
  * These tests exercise the full git pipeline with no mocks to verify
@@ -46,7 +48,7 @@ describe("SnapshotService integration", () => {
   beforeEach(() => {
     service = new SnapshotService();
     tmpDir = createGitRepo();
-  });
+  }, GIT_REPO_SETUP_TIMEOUT_MS);
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
@@ -161,7 +163,7 @@ describe("SnapshotService integration - unborn repo", () => {
   beforeEach(() => {
     service = new SnapshotService();
     tmpDir = createUnbornRepo();
-  });
+  }, GIT_REPO_SETUP_TIMEOUT_MS);
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });

--- a/apps/server/src/__tests__/ws-server-health.test.ts
+++ b/apps/server/src/__tests__/ws-server-health.test.ts
@@ -150,6 +150,7 @@ describe("/health endpoint", () => {
     expect((body as Record<string, unknown>).status).toBe("ok");
     expect((body as Record<string, unknown>).activeAgents).toBe(2);
   });
+
 });
 
 describe("/shutdown endpoint", () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -660,7 +660,7 @@ async function shutdown(): Promise<void> {
   const activeThreadIds = agentService.activeThreadIds();
 
   // 2. Stop all agent sessions
-  agentService.stopAll();
+  await agentService.stopAll();
 
   // 3. Shutdown provider registry
   providerRegistry.shutdown();

--- a/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
@@ -16,6 +16,7 @@ import type { CodexNotification } from "../codex-types.js";
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = join(__dir, "fixtures", "codex-protocol-golden.ndjson");
+const GOLDEN_REPLAY_TIMEOUT_MS = 30_000;
 
 /** Methods the mapper must handle without logging "unrecognized". */
 const KNOWN_METHODS = new Set([
@@ -147,7 +148,7 @@ describe("Codex protocol coverage", () => {
     const { methodsSeen } = replay(notifications);
     const unknown = [...methodsSeen].filter((m) => !KNOWN_METHODS.has(m));
     expect(unknown, `Add to KNOWN_METHODS or SILENCED_METHODS: ${unknown.join(", ")}`).toEqual([]);
-  });
+  }, GOLDEN_REPLAY_TIMEOUT_MS);
 
   it("maps collab Agent rows and nests child-thread commandExecution under collab", () => {
     const { events } = replay(notifications);
@@ -185,7 +186,7 @@ describe("Codex protocol coverage", () => {
     } else if (agentUses.length === 1) {
       expect(nestedCommands.length).toBeGreaterThan(0);
     }
-  });
+  }, GOLDEN_REPLAY_TIMEOUT_MS);
 
   it("emits non-final textDelta for plan/reasoning when present", () => {
     const { events } = replay(notifications);
@@ -201,7 +202,7 @@ describe("Codex protocol coverage", () => {
     if (hasPlanOrReasoning) {
       expect(thoughtDeltas.length).toBeGreaterThan(0);
     }
-  });
+  }, GOLDEN_REPLAY_TIMEOUT_MS);
 
   it("classifies Codex assistant text with assistantMessageBoundary, not final text deltas", () => {
     const { events } = replay(notifications);
@@ -229,7 +230,7 @@ describe("Codex protocol coverage", () => {
       expect(messages.length).toBeGreaterThan(0);
       expect(boundaries.some((e) => e.isFinalResponse)).toBe(true);
     }
-  });
+  }, GOLDEN_REPLAY_TIMEOUT_MS);
 
   it("golden fixture documents sub-agent scenario when captured", () => {
     if (label !== "golden") return;
@@ -301,5 +302,5 @@ describe("Codex protocol coverage", () => {
     expect(spawnUses.length).toBeGreaterThan(0);
     expect(waitUses).toHaveLength(0);
     expect(spawnResults.length).toBeGreaterThan(0);
-  });
+  }, GOLDEN_REPLAY_TIMEOUT_MS);
 });

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -68,6 +68,8 @@ import {
  */
 const TURN_TIMEOUT_MS = 5 * 60 * 1000;
 
+type CodexEndedOutcome = "completed" | "errored" | "cancelled";
+
 /** Internal: a newer `sendMessage` aborted this turn wait (not user-facing). */
 class CodexTurnSupersededError extends Error {
   constructor() {
@@ -707,6 +709,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
 
     let serverDied = false;
     let endedEmitted = false;
+    let endedOutcome: CodexEndedOutcome | undefined;
 
     try {
       await new Promise<void>((resolve, reject) => {
@@ -768,7 +771,13 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
             // Sub-agent receiver threads complete their own turns mid-run;
             // only the main thread's completion settles this wait.
             if (!isMainThreadNotification(server, n.params)) return;
-            const turn = n.params?.turn as { id?: string } | undefined;
+            const turn = n.params?.turn as { id?: string; status?: string } | undefined;
+            endedOutcome =
+              turn?.status === "failed"
+                ? "errored"
+                : turn?.status === "interrupted"
+                  ? "cancelled"
+                  : "completed";
             const tid = turn?.id;
             if (tid && entry.pendingTurnId && tid !== entry.pendingTurnId) {
               logger.debug("Codex turn/completed ignored (stale or unmatched)", {
@@ -809,6 +818,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
     } catch (e: unknown) {
       if (e instanceof CodexTurnSupersededError) return;
       if (e instanceof CodexTurnIdleTimeoutError) {
+        endedOutcome = "errored";
         logger.warn("Codex turn idle timeout (suppressed from UI)", {
           sessionId,
           timeoutMs: TURN_TIMEOUT_MS,
@@ -822,6 +832,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
         return;
       }
       if (!serverDied && seq === entry.runTurnSeq) {
+        endedOutcome = "errored";
         const errorMessage = e instanceof Error ? e.message : String(e);
         logger.error("Codex turn failed", { sessionId, error: errorMessage });
         for (const event of entry.mapper.drainPendingAssistantBoundary(false)) {
@@ -838,7 +849,11 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
       }
       if (!serverDied && seq === entry.runTurnSeq && !endedEmitted) {
         endedEmitted = true;
-        this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+        this.emit("event", {
+          type: AgentEventType.Ended,
+          threadId,
+          ...(endedOutcome ? { outcome: endedOutcome } : {}),
+        } satisfies AgentEvent);
       }
     }
   }

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -3,9 +3,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
 import { AgentEventType } from "@mcode/contracts";
 import type { AgentEvent, Thread, IProviderRegistry } from "@mcode/contracts";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../../store/database.js";
+import { ThreadRepo as RealThreadRepo } from "../../repositories/thread-repo.js";
+import { WorkspaceRepo as RealWorkspaceRepo } from "../../repositories/workspace-repo.js";
+import { MessageRepo as RealMessageRepo } from "../../repositories/message-repo.js";
+import { ToolCallRecordRepo as RealToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
+import { ThoughtSegmentRepo as RealThoughtSegmentRepo } from "../../repositories/thought-segment-repo.js";
+import { HookExecutionRepo as RealHookExecutionRepo } from "../../repositories/hook-execution-repo.js";
 import { AgentService } from "../agent-service.js";
 import { NarrativeStore } from "../narrative-store.js";
 import { PlanQuestionService } from "../plan-question-service.js";
+import { broadcast } from "../../transport/push.js";
 import type { ThreadRepo } from "../../repositories/thread-repo.js";
 import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import type { MessageRepo } from "../../repositories/message-repo.js";
@@ -355,5 +364,143 @@ describe("AgentService turn cleanup", () => {
 
     expect(service.activeThreadIds()).not.toContain(THREAD_ID);
     expect(memoryPressureService.markIdle).toHaveBeenCalled();
+  });
+});
+
+describe("AgentService Ended finalization", () => {
+  let db: Database.Database;
+  let threadRepo: RealThreadRepo;
+  let workspaceRepo: RealWorkspaceRepo;
+  let messageRepo: RealMessageRepo;
+  let providerEmitter: EventEmitter & { sendTurn: ReturnType<typeof vi.fn>; stopSession: ReturnType<typeof vi.fn> };
+  let service: AgentService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = openMemoryDatabase();
+    threadRepo = new RealThreadRepo(db);
+    workspaceRepo = new RealWorkspaceRepo(db);
+    messageRepo = new RealMessageRepo(db);
+    const toolCallRecordRepo = new RealToolCallRecordRepo(db);
+    const thoughtSegmentRepo = new RealThoughtSegmentRepo(db);
+    const hookExecutionRepo = new RealHookExecutionRepo(db);
+    providerEmitter = Object.assign(new EventEmitter(), {
+      sendTurn: vi.fn(() => Promise.resolve()),
+      stopSession: vi.fn(),
+      shutdown: vi.fn(),
+    });
+
+    const providerRegistry = {
+      resolve: vi.fn(() => providerEmitter),
+      resolveAll: vi.fn(() => [providerEmitter]),
+      shutdown: vi.fn(),
+    } as unknown as IProviderRegistry;
+    const gitService = {
+      resolveWorkingDir: vi.fn(() => process.cwd()),
+      listWorktrees: vi.fn(() => []),
+    } as unknown as GitService;
+    const attachmentService = {
+      persist: vi.fn(() => Promise.resolve({ stored: [], persisted: [] })),
+    } as unknown as AttachmentService;
+    const snapshotService = {
+      captureRef: vi.fn(() => Promise.resolve("ref-before")),
+      getFilesChanged: vi.fn(() => Promise.resolve([])),
+    } as unknown as SnapshotService;
+    const memoryPressureService = {
+      markActive: vi.fn(),
+      markIdle: vi.fn(),
+      assertCanStartTurn: vi.fn(),
+      onPressureChange: vi.fn(),
+    } as unknown as MemoryPressureService;
+    const settingsService = {
+      get: vi.fn(() => ({
+        model: { defaults: { fallbackId: undefined } },
+        agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
+        provider: { enabled: {}, cli: {} },
+      })),
+      on: vi.fn(),
+    } as unknown as SettingsService;
+    const planQuestionAnswersRepo = {
+      markAnswered: vi.fn(),
+      isAnswered: vi.fn(() => false),
+      listAnsweredForThread: vi.fn(() => []),
+    } as unknown as PlanQuestionAnswersRepo;
+
+    service = new AgentService(
+      threadRepo,
+      workspaceRepo,
+      messageRepo,
+      gitService,
+      attachmentService,
+      providerRegistry,
+      { create: vi.fn() } as unknown as ThreadService,
+      hookExecutionRepo,
+      { listByThread: vi.fn(() => []), create: vi.fn() } as unknown as TurnSnapshotRepo,
+      snapshotService,
+      db,
+      memoryPressureService,
+      { get: vi.fn(() => []), upsert: vi.fn() } as unknown as TaskRepo,
+      settingsService,
+      { assertUsable: vi.fn() } as unknown as ProviderAvailabilityService,
+      planQuestionAnswersRepo,
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(messageRepo, toolCallRecordRepo, thoughtSegmentRepo, hookExecutionRepo),
+      new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
+    );
+    service.init();
+  });
+
+  it("persists partial assistant text when a running turn ends with only Ended", async () => {
+    const workspace = workspaceRepo.create("Test", process.cwd());
+    const thread = threadRepo.create(workspace.id, "Test thread", "direct", "main", true, "codex");
+
+    await service.sendMessage(thread.id, "please investigate", "default", "gpt-5", [], undefined, "codex");
+    providerEmitter.emit("event", {
+      type: AgentEventType.TextDelta,
+      threadId: thread.id,
+      delta: "partial answer before the provider stopped",
+      isFinalResponse: false,
+    } satisfies AgentEvent);
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.Ended,
+      threadId: thread.id,
+    } satisfies AgentEvent);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const { messages } = messageRepo.listByThread(thread.id, 10);
+    const assistant = messages.find((message) => message.role === "assistant");
+    expect(assistant?.content).toBe("partial answer before the provider stopped");
+    expect(broadcast).toHaveBeenCalledWith("turn.persisted", expect.objectContaining({
+      threadId: thread.id,
+      messageId: assistant?.id,
+    }));
+  });
+
+  it("does not infer cancellation from a bare Ended event for non-Codex providers", async () => {
+    const workspace = workspaceRepo.create("Test", process.cwd());
+    const thread = threadRepo.create(workspace.id, "Test thread", "direct", "main", true, "cursor");
+
+    await service.sendMessage(thread.id, "please investigate", "default", "gpt-5", [], undefined, "cursor");
+    providerEmitter.emit("event", {
+      type: AgentEventType.TextDelta,
+      threadId: thread.id,
+      delta: "partial cursor text",
+      isFinalResponse: false,
+    } satisfies AgentEvent);
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.Ended,
+      threadId: thread.id,
+    } satisfies AgentEvent);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const { messages } = messageRepo.listByThread(thread.id, 10);
+    expect(messages.some((message) =>
+      message.role === "assistant" && message.content === "partial cursor text",
+    )).toBe(false);
+    expect(broadcast).not.toHaveBeenCalledWith("turn.persisted", expect.anything());
   });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -61,6 +61,7 @@ import { HandoffCoordinator } from "./handoff/handoff-coordinator.js";
 import { ScopedPreGrantService } from "./scoped-pre-grant.js";
 import { normalizeAgentProviderError } from "./provider-agent-error-normalize.js";
 import { TurnErrorPolicy } from "./turn-error-policy.js";
+import type { TurnOutcome } from "./turn-outcome.js";
 
 /**
  * Escape special XML characters in a string to prevent injection into
@@ -138,6 +139,8 @@ export class AgentService {
    * give-up so the retry's own terminal events still reach the UI.
    */
   private readonly endedSuppressionThreads = new Set<string>();
+  /** Threads that have already entered the finalizer for the current turn. */
+  private readonly terminalFinalizedThreads = new Set<string>();
   /**
    * Per-thread dispatch state for transient retries. Fire-and-forget providers
    * (Claude) can return from `sendTurn` before the stream ends, so the retry
@@ -1086,23 +1089,6 @@ export class AgentService {
     const sessionId = `mcode-${threadId}`;
     const thread = this.threadRepo.findById(threadId);
     const providerId = (thread?.provider ?? "claude") as ProviderId;
-    let provider: import("@mcode/contracts").IAgentProvider | null = null;
-    try {
-      provider = this.providerRegistry.resolve(providerId);
-    } catch {
-      // Provider may not be available
-    }
-    if (provider) {
-      try {
-        await provider.stopSession(sessionId);
-      } catch (err) {
-        logger.warn("Provider stopSession failed", {
-          threadId,
-          providerId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
     // Tear down any armed transient-retry window so a scheduled stream retry
     // can't re-dispatch after the user stopped, and the suppression flags don't
     // outlive the turn (they would otherwise swallow the next turn's terminal
@@ -1111,7 +1097,18 @@ export class AgentService {
     // A user stop ends the turn. The finalizer flushes partial assistant text,
     // persists buffered tool calls (running ones inherit "cancelled"), captures
     // the snapshot, broadcasts turn.persisted, and clears per-turn state.
-    await this.turnFinalizer.finalize(threadId, "cancelled");
+    const finalize = this.finalizeTerminalTurn(threadId, "cancelled", "user stop");
+    try {
+      const provider = this.providerRegistry.resolve(providerId);
+      await provider.stopSession(sessionId);
+    } catch (err) {
+      logger.warn("Provider stopSession failed", {
+        threadId,
+        providerId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    await (finalize ?? Promise.resolve());
     this.threadRepo.updateStatus(threadId, "paused");
     broadcast("thread.status", { threadId, status: "paused" });
     if (this.activeSessionIds.has(threadId)) {
@@ -1348,6 +1345,27 @@ export class AgentService {
     this.retryingThreads.delete(threadId);
     this.endedSuppressionThreads.delete(threadId);
     this.turnRetryDispatchByThread.delete(threadId);
+  }
+
+  /**
+   * Starts finalization once for a terminal turn path. Provider streams can emit
+   * both Error/TurnComplete and a trailing Ended for the same turn.
+   */
+  private finalizeTerminalTurn(
+    threadId: string,
+    outcome: TurnOutcome,
+    source: string,
+  ): Promise<void> | null {
+    if (this.terminalFinalizedThreads.has(threadId)) return null;
+    this.terminalFinalizedThreads.add(threadId);
+    return this.turnFinalizer.finalize(threadId, outcome).catch((err) => {
+      logger.error("finalize failed on terminal event", {
+        threadId,
+        outcome,
+        source,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   }
 
   /**
@@ -1798,6 +1816,7 @@ export class AgentService {
           // while late hooks from the prior turn can still increment the old one.
           this.narrativeStore.resetTurnCounters(event.threadId);
           this.turnCompleteSeenByThread.delete(event.threadId);
+          this.terminalFinalizedThreads.delete(event.threadId);
         }
 
         if (event.type === AgentEventType.TurnComplete) {
@@ -1811,12 +1830,7 @@ export class AgentService {
           // flushLateHook instead of the normal mid-turn buffer.
           this.turnCompleteSeenByThread.add(event.threadId);
 
-          this.turnFinalizer.finalize(event.threadId, "completed").catch((err) => {
-            logger.error("finalize failed on turnComplete", {
-              threadId: event.threadId,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
+          void this.finalizeTerminalTurn(event.threadId, "completed", "turnComplete");
 
           // Clear the "running" flag so agent.listRunning no longer reports
           // this thread and shutdown won't downgrade it to "interrupted."
@@ -1876,12 +1890,7 @@ export class AgentService {
           // exists (e.g. a pre-turn CLI-not-found failure) rather than
           // broadcasting turn.persisted against the wrong (user) message id.
           this.disarmTurnRetryWindow(event.threadId);
-          this.turnFinalizer.finalize(event.threadId, "errored").catch((err) => {
-            logger.error("finalize failed on error event", {
-              threadId: event.threadId,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
+          void this.finalizeTerminalTurn(event.threadId, "errored", "error");
           // Turn-scoped cleanup of any one-shot handoff Read grant when the
           // first Turn errors out before completing normally.
           this.scopedPreGrant.clear(event.threadId);
@@ -1972,6 +1981,21 @@ export class AgentService {
           // teardown/cleanup below; the retry (or give-up) owns the real `Ended`.
           if (this.shouldSuppressTurnEnded(event.threadId)) {
             return;
+          }
+          const thread = this.threadRepo.findById(event.threadId);
+          const shouldInferCodexCancellation = event.outcome == null
+            && thread?.provider === "codex"
+            && this.activeSessionIds.has(event.threadId);
+          const outcome = event.outcome
+            ?? (shouldInferCodexCancellation ? "cancelled" : undefined);
+          if (outcome) {
+            if (shouldInferCodexCancellation) {
+              const finalText = this.narrativeStore.takeOpenThought(event.threadId);
+              if (finalText) {
+                this.turnFinalizer.appendStreamingText(event.threadId, finalText);
+              }
+            }
+            void this.finalizeTerminalTurn(event.threadId, outcome, "ended");
           }
           this.trackSessionEnded(event.threadId);
           // Turn-scoped cleanup of any one-shot handoff Read grant. No-op on
@@ -2321,8 +2345,13 @@ ${userMessage}`;
   }
 
   /** Stop all active agent sessions (for graceful shutdown). */
-  stopAll(): void {
+  async stopAll(): Promise<void> {
     const ids = [...this.activeSessionIds];
+    await Promise.all(
+      ids.map((threadId) =>
+        this.finalizeTerminalTurn(threadId, "cancelled", "shutdown") ?? Promise.resolve(),
+      ),
+    );
     for (const threadId of ids) {
       const sessionId = `mcode-${threadId}`;
       const thread = this.threadRepo.findById(threadId);

--- a/apps/server/src/transport/ws-server.ts
+++ b/apps/server/src/transport/ws-server.ts
@@ -47,8 +47,13 @@ const ATTACHMENT_EXT_MIME: Record<string, string> = {
   odp: "application/vnd.oasis.opendocument.presentation",
 };
 
+type WsServerDeps = RouterDeps & {
+  authToken: string;
+  shutdown: () => void;
+};
+
 /** Create and configure the HTTP + WebSocket server. */
-export function createWsServer(deps: RouterDeps & { authToken: string; shutdown: () => void }): {
+export function createWsServer(deps: WsServerDeps): {
   httpServer: Server;
   wss: WebSocketServer;
 } {

--- a/packages/contracts/src/events/__tests__/agent-event.test.ts
+++ b/packages/contracts/src/events/__tests__/agent-event.test.ts
@@ -54,3 +54,18 @@ describe("AgentEvent generated attachments", () => {
     expect(parsed.attachments).toEqual([attachment]);
   });
 });
+
+describe("AgentEvent ended outcome", () => {
+  it("parses a terminal Ended outcome", () => {
+    const parsed = AgentEventSchema().parse({
+      type: "ended",
+      threadId: "t-1",
+      outcome: "errored",
+      reason: "codex_idle_timeout",
+    });
+
+    expect(parsed.type).toBe(AgentEventType.Ended);
+    if (parsed.type !== AgentEventType.Ended) throw new Error("unreachable");
+    expect(parsed.outcome).toBe("errored");
+  });
+});

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -3,6 +3,8 @@ import { lazySchema } from "../utils/lazySchema.js";
 import { QuotaCategorySchema } from "../providers/usage.js";
 import { StoredAttachmentSchema } from "../models/attachment.js";
 
+const TurnOutcomeSchema = z.enum(["completed", "errored", "cancelled"]);
+
 /**
  * All valid `type` discriminants for `AgentEvent`.
  * Use these constants instead of string literals to get autocomplete and
@@ -120,6 +122,8 @@ export const AgentEventSchema = lazySchema(() =>
     z.object({
       type: z.literal(AgentEventType.Ended),
       threadId: z.string(),
+      outcome: TurnOutcomeSchema.optional(),
+      reason: z.string().optional(),
     }),
     z.object({
       type: z.literal(AgentEventType.System),


### PR DESCRIPTION
## What
Persist streamed Codex assistant text when a turn ends through a terminal `Ended` event instead of a normal `TurnComplete` event.

## Why
When Codex stopped mid-task, the UI could show streamed text that was never finalized into the thread. A refresh or reconnect could then lose that visible content.

## Key Changes
- Add an optional terminal outcome to `AgentEventType.Ended`.
- Emit Codex `Ended` outcomes for completed, failed, interrupted, idle-timeout, and run-error paths.
- Finalize each terminal turn path once in `AgentService`, including Codex bare `Ended` events while the thread is still active.
- Await active turn finalization during graceful shutdown before provider teardown clears streaming state.
- Route authenticated `/shutdown` through the server shutdown callback instead of relying on `SIGTERM` delivery on Windows.
- Add regression coverage for Codex partial text persistence, non-Codex bare `Ended` events, shutdown callback routing, and terminal event contract parsing.

Related to manual report: sudden Codex stop loses streamed assistant content.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783951721&installation_id=129163861&pr_number=729&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F729&signature=941893c5e520f89ab0769152657122d2ea08568b74fbaa69126d1ef1f29cbef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->