### PR TITLE
feat: bound fork handoff history reads

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -392,7 +392,7 @@ typically use a separate SDK process.
 ### Path B (clean side-channel)
 Resumes the parent provider's session in a forked SDK process to generate
 the handoff. The original session is untouched. Used when the provider
-declares `sessionForkOnResume: "clean"` (Claude, Cursor).
+declares `sessionForkOnResume: "clean"` (Claude, Cursor, Codex, Copilot).
 
 ### Path B-prime (sessionless side-channel)
 Variant of path B that runs without `resume:` when the parent's session
@@ -440,9 +440,9 @@ dispatches through (`provider.forker.fork(req)`); this label is used for
 mapped to ladder paths as:
 
 - **clean**: `resume:` spawns a fork without mutating the original (Claude,
-  Cursor)
+  Cursor, Codex, Copilot)
 - **unsupported**: provider can't fork sessions; pipeline goes directly to
-  path D (Codex, Copilot today)
+  path D
 
 ### Per-turn input cap
 The maximum input characters a provider accepts per turn. Declared as

--- a/apps/server/src/__tests__/message-repo.test.ts
+++ b/apps/server/src/__tests__/message-repo.test.ts
@@ -159,6 +159,37 @@ ORDER BY m.sequence ASC`,
         { id: anchor.id, originalBytes: 6, retainedBytes: 3 },
       ]);
     });
+
+    it("caps retained history by row count as well as bytes", () => {
+      for (let i = 1; i <= 10; i++) {
+        repo.create("thread-1", "user", "x", i);
+      }
+
+      const result = repo.listByThreadUpToSequenceBudgeted("thread-1", 10, {
+        maxBytes: 100,
+        maxRows: 3,
+      });
+
+      expect(result.messages.map((m) => m.sequence)).toEqual([8, 9, 10]);
+      expect(result.budget.omittedBeforeCount).toBe(7);
+      expect(result.budget.retainedBytes).toBe(3);
+      expect(result.budget.truncatedMessages).toEqual([]);
+    });
+
+    it("reports retained bytes after trimming to valid utf8 boundaries", () => {
+      const anchor = repo.create("thread-1", "assistant", "ééé", 1);
+
+      const result = repo.listByThreadUpToSequenceBudgeted("thread-1", 1, {
+        maxBytes: 5,
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].content).toBe("éé");
+      expect(result.budget.retainedBytes).toBe(4);
+      expect(result.budget.truncatedMessages).toEqual([
+        { id: anchor.id, originalBytes: 6, retainedBytes: 4 },
+      ]);
+    });
   });
 
   describe("create with reply fields", () => {

--- a/apps/server/src/__tests__/message-repo.test.ts
+++ b/apps/server/src/__tests__/message-repo.test.ts
@@ -126,6 +126,41 @@ ORDER BY m.sequence ASC`,
     });
   });
 
+  describe("listByThreadUpToSequenceBudgeted", () => {
+    it("keeps newest messages within the byte budget and reports older elision", () => {
+      for (let i = 1; i <= 4; i++) {
+        repo.create("thread-1", "user", `msg-${i}`, i);
+      }
+
+      const result = repo.listByThreadUpToSequenceBudgeted("thread-1", 4, {
+        maxBytes: 10,
+        pageSize: 2,
+      });
+
+      expect(result.messages.map((m) => m.sequence)).toEqual([3, 4]);
+      expect(result.budget.omittedBeforeCount).toBe(2);
+      expect(result.budget.retainedBytes).toBe(10);
+      expect(result.budget.truncatedMessages).toEqual([]);
+    });
+
+    it("truncates the fork anchor when one message exceeds the byte budget", () => {
+      repo.create("thread-1", "user", "older", 1);
+      const anchor = repo.create("thread-1", "assistant", "abcdef", 2);
+
+      const result = repo.listByThreadUpToSequenceBudgeted("thread-1", 2, {
+        maxBytes: 3,
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].id).toBe(anchor.id);
+      expect(result.messages[0].content).toBe("abc");
+      expect(result.budget.omittedBeforeCount).toBe(1);
+      expect(result.budget.truncatedMessages).toEqual([
+        { id: anchor.id, originalBytes: 6, retainedBytes: 3 },
+      ]);
+    });
+  });
+
   describe("create with reply fields", () => {
     it("persists replyToMessageId and quotedText", () => {
       const original = repo.create("thread-1", "assistant", "hello", 1);

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -16,7 +16,7 @@ vi.mock("../codex-version.js", () => ({
 const { sendTurnMock, listSkillsMock, appServers } = vi.hoisted(() => ({
   sendTurnMock: vi.fn().mockResolvedValue("turn-test-id"),
   listSkillsMock: vi.fn().mockResolvedValue({ data: [] }),
-  appServers: [] as Array<import("events").EventEmitter & { isAlive: boolean }>,
+  appServers: [] as Array<import("events").EventEmitter & { isAlive: boolean; options: unknown }>,
 }));
 
 vi.mock("../codex-app-server.js", async () => {
@@ -25,8 +25,10 @@ vi.mock("../codex-app-server.js", async () => {
     isAlive = true;
     threadId = "sdk-thread-1";
     resumeFailed = false;
-    constructor() {
+    options: unknown;
+    constructor(options: unknown) {
       super();
+      this.options = options;
       appServers.push(this);
     }
     async start(): Promise<void> {}
@@ -301,6 +303,10 @@ describe("CodexProvider first turn on new session", () => {
 
     expect(appServers[0]).toBeDefined();
     const sideChannelServer = appServers[0]!;
+    expect(sideChannelServer.options).toMatchObject({
+      sandbox: "read-only",
+      approvalPolicy: "on-request",
+    });
     sideChannelServer.emit("notification", {
       method: "item/agentMessage/delta",
       params: { delta: "# Handoff" },

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -13,9 +13,10 @@ vi.mock("../codex-version.js", () => ({
   meetsMinVersion: () => true,
 }));
 
-const { sendTurnMock, listSkillsMock } = vi.hoisted(() => ({
+const { sendTurnMock, listSkillsMock, appServers } = vi.hoisted(() => ({
   sendTurnMock: vi.fn().mockResolvedValue("turn-test-id"),
   listSkillsMock: vi.fn().mockResolvedValue({ data: [] }),
+  appServers: [] as Array<import("events").EventEmitter & { isAlive: boolean }>,
 }));
 
 vi.mock("../codex-app-server.js", async () => {
@@ -24,6 +25,10 @@ vi.mock("../codex-app-server.js", async () => {
     isAlive = true;
     threadId = "sdk-thread-1";
     resumeFailed = false;
+    constructor() {
+      super();
+      appServers.push(this);
+    }
     async start(): Promise<void> {}
     async sendTurn(input: unknown, turnOptions: unknown): Promise<string> {
       return sendTurnMock(input, turnOptions);
@@ -32,7 +37,9 @@ vi.mock("../codex-app-server.js", async () => {
       return listSkillsMock(cwds);
     }
     async interruptTurn(): Promise<void> {}
-    async kill(): Promise<void> {}
+    async kill(): Promise<void> {
+      this.isAlive = false;
+    }
   }
   return { CodexAppServer: MockCodexAppServer };
 });
@@ -65,6 +72,7 @@ describe("CodexProvider first turn on new session", () => {
     sendTurnMock.mockClear();
     listSkillsMock.mockReset();
     listSkillsMock.mockResolvedValue({ data: [] });
+    appServers.length = 0;
   });
 
   it("sent turn/start after spawn when the runtime pool registers on the next tick", async () => {
@@ -270,5 +278,38 @@ describe("CodexProvider first turn on new session", () => {
       nativeName: "control-in-app-browser",
       path: skillPath,
     }]);
+  });
+
+  it("runs side-channel handoff turns at low effort", async () => {
+    const provider = makeProvider();
+
+    const result = provider.runSideChannelQuery({
+      parentThreadId: "parent-thread",
+      parentSdkSessionId: "sdk-thread-1",
+      prompt: "Generate the handoff.",
+      cwd: process.cwd(),
+    });
+
+    for (let i = 0; i < 20 && sendTurnMock.mock.calls.length === 0; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(sendTurnMock).toHaveBeenCalledWith(
+      [{ type: "text", text: "Generate the handoff." }],
+      { effort: "low" },
+    );
+
+    expect(appServers[0]).toBeDefined();
+    const sideChannelServer = appServers[0]!;
+    sideChannelServer.emit("notification", {
+      method: "item/agentMessage/delta",
+      params: { delta: "# Handoff" },
+    });
+    sideChannelServer.emit("notification", {
+      method: "turn/completed",
+      params: { turn: { status: "completed" } },
+    });
+
+    await expect(result).resolves.toBe("# Handoff");
   });
 });

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -681,7 +681,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
       cliPath,
       workingDirectory: cwd,
       sandbox: "read-only",
-      approvalPolicy: "never",
+      // No approvalHandler is registered here, so side-channel tool requests
+      // are denied while the handoff prompt still runs in the parent session.
+      approvalPolicy: "on-request",
       resumeThreadId: parentSdkSessionId || undefined,
       jobObject: this.jobObject,
       getSpawnEnv: () => this.envService.getEnv(),

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -20,7 +20,7 @@ import { SessionRuntime } from "../../services/session-runtime.js";
 import { AttachmentService } from "../../services/attachment-service.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import type { MemoryPressureLevel } from "../../services/memory-pressure-service.js";
-import { DeterministicForker } from "../../services/handoff/session-forker.js";
+import { CleanForker } from "../../services/handoff/session-forker.js";
 import { SkillService, codexPluginNameFromSkillPath } from "../../services/skill-service.js";
 import type {
   IAgentProvider,
@@ -67,6 +67,7 @@ import {
  * permission approval awaits the user, the watchdog re-arms without probing.
  */
 const TURN_TIMEOUT_MS = 5 * 60 * 1000;
+const SIDE_CHANNEL_TIMEOUT_MS = 120_000;
 
 /** Internal: a newer `sendMessage` aborted this turn wait (not user-facing). */
 class CodexTurnSupersededError extends Error {
@@ -84,6 +85,12 @@ class CodexTurnIdleTimeoutError extends Error {
     );
     this.name = "CodexTurnIdleTimeoutError";
   }
+}
+
+function transientHandoffError(message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = "ETIMEDOUT";
+  return err;
 }
 
 /**
@@ -245,16 +252,25 @@ function isMainThreadNotification(
   return !notifThreadId || !server.threadId || notifThreadId === server.threadId;
 }
 
+function completedAssistantText(item: CompletedItem | undefined): string {
+  if (!item || (item.type !== "agentMessage" && item.type !== "message")) return "";
+  const parts = Array.isArray(item.content) ? item.content : [];
+  return parts
+    .map((part) => (typeof part.text === "string" ? part.text : ""))
+    .join("")
+    .trim();
+}
+
 /** Codex provider adapter implementing IAgentProvider with a persistent app-server process per session. */
 @injectable()
 export class CodexProvider extends EventEmitter implements IAgentProvider, ISessionEvictable, ISkillCatalogCapable, ProtocolAdapter<CodexSessionState> {
   readonly id: ProviderId = "codex";
   /** Codex CLI is an agentic tool with no one-shot text completion mode. */
   readonly supportsCompletion = false;
-  readonly sessionForkOnResume = "unsupported" as const;
+  readonly sessionForkOnResume = "clean" as const;
   readonly maxInputCharactersPerTurn = 16_000;
-  /** Path D forker; Codex cannot fork a session, so handoffs are deterministic. */
-  readonly forker: SessionForker = new DeterministicForker();
+  /** Path B forker; calls this provider's throwaway app-server side channel. */
+  readonly forker: SessionForker = new CleanForker(this);
 
   /** Returns the static Codex model catalog. Codex does not support dynamic model discovery. */
   async listModels(): Promise<ProviderModelInfo[]> {
@@ -636,6 +652,138 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, ISess
     if (!state.server.isAlive) return true;
     const sandbox = args.permissionMode === "full" ? "danger-full-access" : "workspace-write";
     return state.sandboxMode !== sandbox || state.cwd !== args.cwd;
+  }
+
+  /**
+   * Run a handoff prompt against a throwaway Codex app-server session.
+   * The pooled parent session is left untouched; the throwaway process is killed.
+   */
+  async runSideChannelQuery(args: {
+    parentThreadId: string;
+    parentSdkSessionId: string;
+    prompt: string;
+    abortSignal?: AbortSignal;
+    conversationHistory?: string;
+    cwd: string;
+  }): Promise<string> {
+    const { parentThreadId, parentSdkSessionId, prompt, abortSignal, conversationHistory, cwd } = args;
+    if (abortSignal?.aborted) throw transientHandoffError("Codex side-channel query aborted before start");
+
+    const settings = await this.settingsService.get();
+    const cliPath = settings.provider.cli.codex || "codex";
+    const versionResult = checkCodexVersion(cliPath);
+    if (!versionResult.ok) throw transientHandoffError(versionResult.error);
+    if (!meetsMinVersion(versionResult.version, "0.37.0")) {
+      throw transientHandoffError(`Codex CLI version ${versionResult.version} is too old for side-channel handoff`);
+    }
+
+    const server = new CodexAppServer({
+      cliPath,
+      workingDirectory: cwd,
+      sandbox: "read-only",
+      approvalPolicy: "never",
+      resumeThreadId: parentSdkSessionId || undefined,
+      jobObject: this.jobObject,
+      getSpawnEnv: () => this.envService.getEnv(),
+    });
+
+    let settled = false;
+    let deltaText = "";
+    let completedText = "";
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = async (): Promise<void> => {
+      clearTimeout(timeout);
+      abortSignal?.removeEventListener("abort", onAbort);
+      await server.kill().catch((err: unknown) =>
+        logger.debug("Codex side-channel kill failed", { parentThreadId, error: String(err) }),
+      );
+    };
+
+    const onAbort = (): void => {
+      if (settled) return;
+      settled = true;
+      void cleanup();
+    };
+
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+
+    try {
+      await server.start();
+      if (server.resumeFailed && !conversationHistory) {
+        throw transientHandoffError(`Codex side-channel could not resume parent thread ${parentThreadId}`);
+      }
+
+      const sideChannelPrompt = server.resumeFailed && conversationHistory
+        ? `Conversation history up to the fork point:\n\n${conversationHistory}\n\n---\n\n${prompt}`
+        : prompt;
+
+      const result = await new Promise<string>((resolve, reject) => {
+        const finish = (value: string): void => {
+          abortSignal?.removeEventListener("abort", abortDuringTurn);
+          server.removeListener("notification", onNotification);
+          server.removeListener("fatal", onFatal);
+          resolve(value);
+        };
+        const rejectTransient = (message: string): void => {
+          abortSignal?.removeEventListener("abort", abortDuringTurn);
+          server.removeListener("notification", onNotification);
+          server.removeListener("fatal", onFatal);
+          reject(transientHandoffError(message));
+        };
+        const abortDuringTurn = (): void => rejectTransient("Codex side-channel query aborted");
+
+        timeout = setTimeout(
+          () => rejectTransient("Codex side-channel query timed out"),
+          SIDE_CHANNEL_TIMEOUT_MS,
+        );
+
+        const onNotification = (notification: unknown): void => {
+          const n = notification as CodexNotification;
+          if (n.method === "item/agentMessage/delta") {
+            deltaText += n.params.delta ?? "";
+            return;
+          }
+          if (n.method === "item/completed") {
+            const text = completedAssistantText(n.params.item);
+            if (text) completedText = text;
+            return;
+          }
+          if (n.method === "turn/completed") {
+            const turn = n.params.turn;
+            if (turn?.status === "failed") {
+              rejectTransient(turn.error?.message ?? "Codex side-channel query failed");
+              return;
+            }
+            const text = (completedText || deltaText).trim();
+            if (!text) {
+              rejectTransient("Codex side-channel query returned empty output");
+              return;
+            }
+            finish(text);
+          }
+        };
+
+        const onFatal = (error: string): void => rejectTransient(error);
+        server.on("notification", onNotification);
+        server.once("fatal", onFatal);
+        abortSignal?.addEventListener("abort", abortDuringTurn, { once: true });
+
+        void server.sendTurn(
+          [{ type: "text", text: sideChannelPrompt }],
+          {
+            effort: "low",
+            ...(settings.provider.codex?.fastMode === true && { serviceTier: "priority" }),
+          },
+        )
+          .catch((err: unknown) => rejectTransient(err instanceof Error ? err.message : String(err)));
+      });
+
+      settled = true;
+      return result;
+    } finally {
+      await cleanup();
+    }
   }
 
   /** Lists native Codex skills from an already-running app-server session. */

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -33,7 +33,7 @@ import { EnvService } from "../../services/env-service.js";
 import { JobObject } from "../../services/job-object.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
-import { DeterministicForker } from "../../services/handoff/session-forker.js";
+import { CleanForker } from "../../services/handoff/session-forker.js";
 import type {
   IAgentProvider,
   ISessionEvictable,
@@ -51,6 +51,13 @@ import { AgentEventType } from "@mcode/contracts";
 
 /** Promisified execFile used to retrieve the gh auth token. */
 const execFileAsync = promisify(execFile);
+const SIDE_CHANNEL_TIMEOUT_MS = 120_000;
+
+function transientHandoffError(message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = "ETIMEDOUT";
+  return err;
+}
 
 /**
  * Reads user-level Copilot instructions from `~/.copilot/copilot-instructions.md`.
@@ -161,10 +168,10 @@ interface CopilotSessionState {
 export class CopilotProvider extends EventEmitter implements IAgentProvider, ISessionEvictable, ProtocolAdapter<CopilotSessionState> {
   readonly id: ProviderId = "copilot";
   readonly supportsCompletion = true;
-  readonly sessionForkOnResume = "unsupported" as const;
+  readonly sessionForkOnResume = "clean" as const;
   readonly maxInputCharactersPerTurn = 16_000;
-  /** Path D forker; Copilot cannot fork a session, so handoffs are deterministic. */
-  readonly forker: SessionForker = new DeterministicForker();
+  /** Path B forker; calls this provider's throwaway SDK side channel. */
+  readonly forker: SessionForker = new CleanForker(this);
 
   private client: CopilotClient | null = null;
   private lastCliPath: string | undefined;
@@ -291,6 +298,126 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
         logger.debug("CopilotProvider: error disconnecting ephemeral session", {
           error: err instanceof Error ? err.message : String(err),
         }),
+      );
+    }
+  }
+
+  /**
+   * Run a handoff prompt in a throwaway Copilot session.
+   * The pooled parent session is left untouched; the SDK session is disconnected.
+   */
+  async runSideChannelQuery(args: {
+    parentThreadId: string;
+    parentSdkSessionId: string;
+    prompt: string;
+    abortSignal?: AbortSignal;
+    conversationHistory?: string;
+    cwd: string;
+  }): Promise<string> {
+    const { parentThreadId, parentSdkSessionId, prompt, abortSignal, conversationHistory, cwd } = args;
+    if (abortSignal?.aborted) throw transientHandoffError("Copilot side-channel query aborted before start");
+
+    await this.refreshClient();
+    const notFoundMessage = this.cliNotFoundMessage();
+    if (notFoundMessage) throw transientHandoffError(notFoundMessage);
+    const client = this.client;
+    if (!client) throw transientHandoffError("Copilot client not available");
+
+    const userInstructions = readUserInstructions();
+    const skillDirs = userSkillDirectories();
+    const sessionBase = {
+      onPermissionRequest: approveAll,
+      workingDirectory: cwd,
+      enableConfigDiscovery: true,
+      ...(skillDirs.length > 0 && { skillDirectories: skillDirs }),
+      ...(userInstructions && { systemMessage: { content: userInstructions } }),
+    };
+
+    let session: CopilotSession;
+    let usingSessionlessHistory = false;
+    try {
+      session = parentSdkSessionId
+        ? await client.resumeSession(parentSdkSessionId, sessionBase)
+        : await client.createSession(sessionBase);
+    } catch (err) {
+      if (!conversationHistory) {
+        throw transientHandoffError(
+          `Copilot side-channel could not resume parent thread ${parentThreadId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      usingSessionlessHistory = true;
+      session = await client.createSession(sessionBase);
+    }
+
+    const sideChannelPrompt = usingSessionlessHistory && conversationHistory
+      ? `Conversation history up to the fork point:\n\n${conversationHistory}\n\n---\n\n${prompt}`
+      : prompt;
+
+    const unsubscribers: Array<() => void> = [];
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let messageText = "";
+    let deltaText = "";
+
+    try {
+      const result = await new Promise<string>((resolve, reject) => {
+        const finish = (value: string): void => {
+          abortSignal?.removeEventListener("abort", abortDuringTurn);
+          clearTimeout(timeout);
+          resolve(value);
+        };
+        const rejectTransient = (message: string): void => {
+          abortSignal?.removeEventListener("abort", abortDuringTurn);
+          clearTimeout(timeout);
+          reject(transientHandoffError(message));
+        };
+        const abortDuringTurn = (): void => {
+          void session.disconnect().catch(() => {});
+          rejectTransient("Copilot side-channel query aborted");
+        };
+
+        timeout = setTimeout(
+          () => rejectTransient("Copilot side-channel query timed out"),
+          SIDE_CHANNEL_TIMEOUT_MS,
+        );
+        abortSignal?.addEventListener("abort", abortDuringTurn, { once: true });
+
+        unsubscribers.push(
+          session.on("assistant.message_delta", (event: { data: { deltaContent: string } }) => {
+            deltaText += event.data.deltaContent;
+          }),
+        );
+        unsubscribers.push(
+          session.on("assistant.message", (event: { data: { content: string; phase?: string } }) => {
+            if (event.data.phase === "thinking") return;
+            if (event.data.content) messageText = event.data.content;
+          }),
+        );
+        unsubscribers.push(
+          session.on("session.error", (event: { data: { message: string } }) => {
+            rejectTransient(event.data.message);
+          }),
+        );
+        unsubscribers.push(
+          session.on("session.idle", () => {
+            const text = (messageText || deltaText).trim();
+            if (!text) {
+              rejectTransient("Copilot side-channel query returned empty output");
+              return;
+            }
+            finish(text);
+          }),
+        );
+
+        void session.send({ prompt: sideChannelPrompt })
+          .catch((err: unknown) => rejectTransient(err instanceof Error ? err.message : String(err)));
+      });
+
+      return result;
+    } finally {
+      clearTimeout(timeout);
+      for (const unsub of unsubscribers) unsub();
+      await session.disconnect().catch((err: unknown) =>
+        logger.debug("Copilot side-channel disconnect failed", { parentThreadId, error: String(err) }),
       );
     }
   }

--- a/apps/server/src/repositories/message-repo.ts
+++ b/apps/server/src/repositories/message-repo.ts
@@ -492,12 +492,14 @@ LIMIT ?`,
     }>,
     truncatedMessages: ThreadHistoryBudget["truncatedMessages"],
   ): { messages: Message[]; retainedBytesDelta: number } {
+    const toolCallCountSql =
+      "(SELECT COUNT(*) FROM tool_call_records WHERE message_id = m.id) AS tool_call_count";
     const fullStmt = this.db.prepare(
       `SELECT
   m.id, m.thread_id, m.role, m.content, NULL AS tool_calls,
   m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence,
   m.attachments, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal,
-  ${TOOL_CALL_COUNT_SQL}
+  ${toolCallCountSql}
 FROM messages m
 WHERE m.id = ?`,
     );
@@ -506,7 +508,7 @@ WHERE m.id = ?`,
   m.id, m.thread_id, m.role, substr(m.content, 1, ?) AS content, NULL AS tool_calls,
   m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence,
   m.attachments, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal,
-  ${TOOL_CALL_COUNT_SQL}
+  ${toolCallCountSql}
 FROM messages m
 WHERE m.id = ?`,
     );

--- a/apps/server/src/repositories/message-repo.ts
+++ b/apps/server/src/repositories/message-repo.ts
@@ -57,6 +57,7 @@ export interface BudgetedThreadMessages {
 export interface BudgetedThreadMessageOptions {
   maxBytes: number;
   pageSize?: number;
+  maxRows?: number;
   includeInternal?: boolean;
 }
 
@@ -114,6 +115,8 @@ const TOOL_CALL_COUNT_SQL =
 
 const DEFAULT_HISTORY_PAGE_SIZE = 100;
 const MAX_HISTORY_PAGE_SIZE = 500;
+const DEFAULT_HISTORY_MAX_ROWS = 500;
+const MAX_HISTORY_MAX_ROWS = 2_000;
 
 function clampPositiveInt(value: number, fallback: number, max: number): number {
   if (!Number.isFinite(value)) return fallback;
@@ -364,6 +367,7 @@ ORDER BY m.sequence ASC`,
   ): BudgetedThreadMessages {
     const budgetBytes = clampPositiveInt(options.maxBytes, 1, Number.MAX_SAFE_INTEGER);
     const pageSize = clampPositiveInt(options.pageSize ?? DEFAULT_HISTORY_PAGE_SIZE, DEFAULT_HISTORY_PAGE_SIZE, MAX_HISTORY_PAGE_SIZE);
+    const maxRows = clampPositiveInt(options.maxRows ?? DEFAULT_HISTORY_MAX_ROWS, DEFAULT_HISTORY_MAX_ROWS, MAX_HISTORY_MAX_ROWS);
     const includeInternal = options.includeInternal === true;
     const internalClause = includeInternal ? "" : "AND m.is_internal = 0";
     const countInternalClause = includeInternal ? "" : "AND is_internal = 0";
@@ -413,6 +417,20 @@ LIMIT ?`,
         const rowCost = Math.max(1, rowBytes);
 
         if (retainedBytes + rowCost <= budgetBytes) {
+          if (selected.length >= maxRows) {
+            const countRow = countAtOrBeforeStmt.get(threadId, row.sequence) as { count: number };
+            omittedBeforeCount = countRow.count;
+            const fetched = this.fetchBudgetedMessages(selected, truncatedMessages);
+            return {
+              messages: fetched.messages,
+              budget: {
+                budgetBytes,
+                retainedBytes: retainedBytes + fetched.retainedBytesDelta,
+                omittedBeforeCount,
+                truncatedMessages,
+              },
+            };
+          }
           selected.push({ id: row.id, sequence: row.sequence, originalBytes: contentBytes });
           retainedBytes += rowCost;
           continue;
@@ -439,12 +457,12 @@ LIMIT ?`,
           omittedBeforeCount = countRow.count;
         }
 
-        const messages = this.fetchBudgetedMessages(selected);
+        const fetched = this.fetchBudgetedMessages(selected, truncatedMessages);
         return {
-          messages,
+          messages: fetched.messages,
           budget: {
             budgetBytes,
-            retainedBytes,
+            retainedBytes: retainedBytes + fetched.retainedBytesDelta,
             omittedBeforeCount,
             truncatedMessages,
           },
@@ -455,7 +473,7 @@ LIMIT ?`,
     }
 
     return {
-      messages: this.fetchBudgetedMessages(selected),
+      messages: this.fetchBudgetedMessages(selected, truncatedMessages).messages,
       budget: {
         budgetBytes,
         retainedBytes,
@@ -472,7 +490,8 @@ LIMIT ?`,
       originalBytes: number;
       truncateContentToBytes?: number;
     }>,
-  ): Message[] {
+    truncatedMessages: ThreadHistoryBudget["truncatedMessages"],
+  ): { messages: Message[]; retainedBytesDelta: number } {
     const fullStmt = this.db.prepare(
       `SELECT
   m.id, m.thread_id, m.role, m.content, NULL AS tool_calls,
@@ -492,7 +511,8 @@ FROM messages m
 WHERE m.id = ?`,
     );
 
-    return selected
+    let retainedBytesDelta = 0;
+    const messages = selected
       .sort((a, b) => a.sequence - b.sequence)
       .map((item) => {
         if (item.truncateContentToBytes === undefined) {
@@ -505,10 +525,14 @@ WHERE m.id = ?`,
         const truncated = rowToMessage(row);
         const tracked = item.truncateContentToBytes;
         if (tracked !== prefix.bytes) {
+          retainedBytesDelta += prefix.bytes - tracked;
+          const budgetEntry = truncatedMessages.find((entry) => entry.id === item.id);
+          if (budgetEntry) budgetEntry.retainedBytes = prefix.bytes;
           truncated.content = prefix.text;
         }
         return truncated;
       });
+    return { messages, retainedBytesDelta };
   }
 
   /** Find a single message by ID within a specific thread. Returns null if not found. */

--- a/apps/server/src/repositories/message-repo.ts
+++ b/apps/server/src/repositories/message-repo.ts
@@ -31,6 +31,35 @@ interface MessageRow {
   tool_call_count?: number;
 }
 
+interface MessageBudgetRow {
+  id: string;
+  sequence: number;
+  content_bytes: number;
+  metadata_bytes: number;
+}
+
+export interface ThreadHistoryBudget {
+  budgetBytes: number;
+  retainedBytes: number;
+  omittedBeforeCount: number;
+  truncatedMessages: Array<{
+    id: string;
+    originalBytes: number;
+    retainedBytes: number;
+  }>;
+}
+
+export interface BudgetedThreadMessages {
+  messages: Message[];
+  budget: ThreadHistoryBudget;
+}
+
+export interface BudgetedThreadMessageOptions {
+  maxBytes: number;
+  pageSize?: number;
+  includeInternal?: boolean;
+}
+
 function parseJsonField(value: string | null): unknown | null {
   if (value === null) {
     return null;
@@ -82,6 +111,31 @@ const MESSAGE_COLUMNS_PREFIXED =
  */
 const TOOL_CALL_COUNT_SQL =
   "(SELECT COUNT(*) FROM tool_call_records WHERE message_id = m.id) AS tool_call_count";
+
+const DEFAULT_HISTORY_PAGE_SIZE = 100;
+const MAX_HISTORY_PAGE_SIZE = 500;
+
+function clampPositiveInt(value: number, fallback: number, max: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(max, Math.floor(value)));
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function takeUtf8Prefix(text: string, maxBytes: number): { text: string; bytes: number } {
+  if (maxBytes <= 0) return { text: "", bytes: 0 };
+  let bytes = 0;
+  let out = "";
+  for (const char of text) {
+    const next = byteLength(char);
+    if (bytes + next > maxBytes) break;
+    out += char;
+    bytes += next;
+  }
+  return { text: out, bytes };
+}
 
 /** Repository for message creation and retrieval against SQLite. */
 @injectable()
@@ -297,6 +351,164 @@ ORDER BY m.sequence ASC`,
       .all(threadId, maxSequence) as MessageRow[];
 
     return rows.map(rowToMessage);
+  }
+
+  /**
+   * Return the newest messages at or before `maxSequence` under a byte budget.
+   * Reads lightweight metadata in reverse pages, then fetches only retained rows.
+   */
+  listByThreadUpToSequenceBudgeted(
+    threadId: string,
+    maxSequence: number,
+    options: BudgetedThreadMessageOptions,
+  ): BudgetedThreadMessages {
+    const budgetBytes = clampPositiveInt(options.maxBytes, 1, Number.MAX_SAFE_INTEGER);
+    const pageSize = clampPositiveInt(options.pageSize ?? DEFAULT_HISTORY_PAGE_SIZE, DEFAULT_HISTORY_PAGE_SIZE, MAX_HISTORY_PAGE_SIZE);
+    const includeInternal = options.includeInternal === true;
+    const internalClause = includeInternal ? "" : "AND m.is_internal = 0";
+    const countInternalClause = includeInternal ? "" : "AND is_internal = 0";
+
+    const pageStmt = this.db.prepare(
+      `SELECT
+  m.id,
+  m.sequence,
+  length(CAST(m.content AS BLOB)) AS content_bytes,
+  (
+    length(CAST(COALESCE(m.files_changed, '') AS BLOB)) +
+    length(CAST(COALESCE(m.attachments, '') AS BLOB)) +
+    length(CAST(COALESCE(m.quoted_text, '') AS BLOB))
+  ) AS metadata_bytes
+FROM messages m
+WHERE m.thread_id = ? AND m.sequence <= ? AND m.sequence < ? ${internalClause}
+ORDER BY m.sequence DESC
+LIMIT ?`,
+    );
+
+    const countBeforeStmt = this.db.prepare(
+      `SELECT COUNT(*) AS count FROM messages WHERE thread_id = ? AND sequence < ? ${countInternalClause}`,
+    );
+    const countAtOrBeforeStmt = this.db.prepare(
+      `SELECT COUNT(*) AS count FROM messages WHERE thread_id = ? AND sequence <= ? ${countInternalClause}`,
+    );
+
+    const selected: Array<{
+      id: string;
+      sequence: number;
+      originalBytes: number;
+      truncateContentToBytes?: number;
+    }> = [];
+    const truncatedMessages: ThreadHistoryBudget["truncatedMessages"] = [];
+    let retainedBytes = 0;
+    let cursor = maxSequence + 1;
+    let omittedBeforeCount = 0;
+
+    while (true) {
+      const rows = pageStmt.all(threadId, maxSequence, cursor, pageSize) as MessageBudgetRow[];
+      if (rows.length === 0) break;
+
+      for (const row of rows) {
+        const contentBytes = Math.max(0, row.content_bytes ?? 0);
+        const metadataBytes = Math.max(0, row.metadata_bytes ?? 0);
+        const rowBytes = contentBytes + metadataBytes;
+        const rowCost = Math.max(1, rowBytes);
+
+        if (retainedBytes + rowCost <= budgetBytes) {
+          selected.push({ id: row.id, sequence: row.sequence, originalBytes: contentBytes });
+          retainedBytes += rowCost;
+          continue;
+        }
+
+        if (selected.length === 0) {
+          const contentBudget = Math.max(0, budgetBytes - metadataBytes);
+          selected.push({
+            id: row.id,
+            sequence: row.sequence,
+            originalBytes: contentBytes,
+            truncateContentToBytes: contentBudget,
+          });
+          retainedBytes = Math.min(budgetBytes, metadataBytes + contentBudget);
+          truncatedMessages.push({
+            id: row.id,
+            originalBytes: contentBytes,
+            retainedBytes: contentBudget,
+          });
+          const countRow = countBeforeStmt.get(threadId, row.sequence) as { count: number };
+          omittedBeforeCount = countRow.count;
+        } else {
+          const countRow = countAtOrBeforeStmt.get(threadId, row.sequence) as { count: number };
+          omittedBeforeCount = countRow.count;
+        }
+
+        const messages = this.fetchBudgetedMessages(selected);
+        return {
+          messages,
+          budget: {
+            budgetBytes,
+            retainedBytes,
+            omittedBeforeCount,
+            truncatedMessages,
+          },
+        };
+      }
+
+      cursor = rows[rows.length - 1]!.sequence;
+    }
+
+    return {
+      messages: this.fetchBudgetedMessages(selected),
+      budget: {
+        budgetBytes,
+        retainedBytes,
+        omittedBeforeCount,
+        truncatedMessages,
+      },
+    };
+  }
+
+  private fetchBudgetedMessages(
+    selected: Array<{
+      id: string;
+      sequence: number;
+      originalBytes: number;
+      truncateContentToBytes?: number;
+    }>,
+  ): Message[] {
+    const fullStmt = this.db.prepare(
+      `SELECT
+  m.id, m.thread_id, m.role, m.content, NULL AS tool_calls,
+  m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence,
+  m.attachments, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal,
+  ${TOOL_CALL_COUNT_SQL}
+FROM messages m
+WHERE m.id = ?`,
+    );
+    const truncatedStmt = this.db.prepare(
+      `SELECT
+  m.id, m.thread_id, m.role, substr(m.content, 1, ?) AS content, NULL AS tool_calls,
+  m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence,
+  m.attachments, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal,
+  ${TOOL_CALL_COUNT_SQL}
+FROM messages m
+WHERE m.id = ?`,
+    );
+
+    return selected
+      .sort((a, b) => a.sequence - b.sequence)
+      .map((item) => {
+        if (item.truncateContentToBytes === undefined) {
+          return rowToMessage(fullStmt.get(item.id) as MessageRow);
+        }
+
+        const row = truncatedStmt.get(item.truncateContentToBytes, item.id) as MessageRow;
+        const prefix = takeUtf8Prefix(row.content, item.truncateContentToBytes);
+        row.content = prefix.text;
+        const truncated = rowToMessage(row);
+        const tracked = item.truncateContentToBytes;
+        if (tracked !== prefix.bytes) {
+          truncated.content = prefix.text;
+        }
+        return truncated;
+      });
   }
 
   /** Find a single message by ID within a specific thread. Returns null if not found. */

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -88,6 +88,7 @@ function truncateTitle(content: string): string {
 
 const FORK_HISTORY_BUDGET_BYTES = 1_000_000;
 const FORK_HISTORY_PAGE_SIZE = 100;
+const FORK_HISTORY_MAX_MESSAGES = 500;
 
 /** Orchestrates agent sessions, message sending, and event forwarding. */
 @injectable()
@@ -955,6 +956,7 @@ export class AgentService {
       {
         maxBytes: FORK_HISTORY_BUDGET_BYTES,
         pageSize: FORK_HISTORY_PAGE_SIZE,
+        maxRows: FORK_HISTORY_MAX_MESSAGES,
       },
     );
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -86,6 +86,9 @@ function truncateTitle(content: string): string {
   return truncated.slice(0, cutPoint) + "...";
 }
 
+const FORK_HISTORY_BUDGET_BYTES = 1_000_000;
+const FORK_HISTORY_PAGE_SIZE = 100;
+
 /** Orchestrates agent sessions, message sending, and event forwarding. */
 @injectable()
 export class AgentService {
@@ -946,18 +949,13 @@ export class AgentService {
       throw new Error(`Fork message not found in parent thread: ${resolvedForkMessageId}`);
     }
 
-    /** Guards fork handoff against loading unbounded history into memory. */
-    const FORK_HISTORY_MAX_SEQUENCE = 10_000;
-    if (forkMessage.sequence > FORK_HISTORY_MAX_SEQUENCE) {
-      throw new Error(
-        `Fork point includes too much prior history (sequence ${forkMessage.sequence}; max ${FORK_HISTORY_MAX_SEQUENCE}). Choose an earlier message (lower sequence) to branch from.`,
-      );
-    }
-
-    // Load all messages up to and including the fork point — no row cap.
-    const forkedMessages = this.messageRepo.listByThreadUpToSequence(
+    const { messages: forkedMessages, budget: forkHistoryBudget } = this.messageRepo.listByThreadUpToSequenceBudgeted(
       parentThreadId,
       forkMessage.sequence,
+      {
+        maxBytes: FORK_HISTORY_BUDGET_BYTES,
+        pageSize: FORK_HISTORY_PAGE_SIZE,
+      },
     );
 
     // Create child thread with lineage
@@ -1036,6 +1034,7 @@ export class AgentService {
       childProvider: provider,
       forkMessage,
       forkedMessages,
+      historyBudget: forkHistoryBudget,
       userMessage: content,
       model,
     });

--- a/apps/server/src/services/handoff/__tests__/fork-flow.e2e.test.ts
+++ b/apps/server/src/services/handoff/__tests__/fork-flow.e2e.test.ts
@@ -85,6 +85,16 @@ const BASE_REQ = {
   forkAnchorRole: "user" as const,
   childThreadId: "t_child",
   childProviderId: "claude",
+  messagesUpToFork: [
+    {
+      id: "m_1",
+      thread_id: "t_parent",
+      role: "user",
+      content: "What is the refactor plan?",
+      sequence: 1,
+      is_internal: false,
+    },
+  ] as any,
   userFollowUpMessage: "Can you elaborate on the refactor plan?",
 };
 

--- a/apps/server/src/services/handoff/__tests__/handoff-coordinator.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-coordinator.test.ts
@@ -74,7 +74,7 @@ const FORKED_MESSAGES = [
   FORK_MESSAGE,
 ] as any;
 
-function mkInput() {
+function mkInput(overrides: Record<string, unknown> = {}) {
   return {
     parentThread: PARENT_THREAD,
     childThreadId: "t_child",
@@ -83,6 +83,7 @@ function mkInput() {
     forkedMessages: FORKED_MESSAGES,
     userMessage: "continue the work please",
     model: "claude-sonnet-4-6",
+    ...overrides,
   };
 }
 
@@ -135,6 +136,19 @@ describe("HandoffCoordinator.deliverHandoff", () => {
     expect(lastHandoffStatus()).toMatchObject({ status: "fallback", ladderStep: "D", providerErrorOnGenerate: "quota" });
     // A pipeline-produced D is NOT the legacy replay: it ships the doc off-band.
     expect(providerWireOverride).toContain("mcode-handoff-t_child-");
+  });
+
+  it("codex child receives the bounded artifact inline instead of a temp-file Read prompt", async () => {
+    const deps = mkDeps();
+    deps.handoffPipeline.orchestrate = vi.fn(async () => mkArtifact("B"));
+    const coordinator = HandoffCoordinator.forTesting(deps);
+
+    const { providerWireOverride } = await coordinator.deliverHandoff(mkInput({ childProvider: "codex" as const }));
+
+    expect(deps.scopedPreGrant.issue).not.toHaveBeenCalled();
+    expect(providerWireOverride).toContain("# Handoff");
+    expect(providerWireOverride).not.toContain("mcode-handoff-t_child-");
+    expect(providerWireOverride).toContain("continue the work please");
   });
 
   it("legacy-replay fallback: when the pipeline throws, builds a deterministic replay and persists a D artifact", async () => {

--- a/apps/server/src/services/handoff/__tests__/handoff-coordinator.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-coordinator.test.ts
@@ -14,8 +14,8 @@ const broadcastMock = vi.mocked(broadcast);
 function mkArtifact(
   ladderStep: LadderStep,
   providerErrorOnGenerate: ProviderErrorClass | null = null,
+  markdown = "# Handoff\n\nThis paragraph orients the child on the parent thread's goal.",
 ): HandoffArtifact {
-  const markdown = "# Handoff\n\nThis paragraph orients the child on the parent thread's goal.";
   return {
     markdown,
     meta: {
@@ -148,6 +148,19 @@ describe("HandoffCoordinator.deliverHandoff", () => {
     expect(deps.scopedPreGrant.issue).not.toHaveBeenCalled();
     expect(providerWireOverride).toContain("# Handoff");
     expect(providerWireOverride).not.toContain("mcode-handoff-t_child-");
+    expect(providerWireOverride).toContain("continue the work please");
+  });
+
+  it("codex inline handoff is capped to the first-turn input limit", async () => {
+    const deps = mkDeps();
+    deps.handoffPipeline.orchestrate = vi.fn(async () => mkArtifact("B", null, `# Handoff\n\n${"x".repeat(20_000)}`));
+    const coordinator = HandoffCoordinator.forTesting(deps);
+
+    const { providerWireOverride } = await coordinator.deliverHandoff(mkInput({ childProvider: "codex" as const }));
+
+    expect(deps.scopedPreGrant.issue).not.toHaveBeenCalled();
+    expect(providerWireOverride.length).toBeLessThanOrEqual(14_000);
+    expect(providerWireOverride).toContain("Inline Codex handoff shortened");
     expect(providerWireOverride).toContain("continue the work please");
   });
 

--- a/apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-pipeline.test.ts
@@ -44,6 +44,9 @@ const BASE_REQ = {
   forkAnchorRole: "user" as const,
   childThreadId: "t_child",
   childProviderId: "claude",
+  messagesUpToFork: [
+    { id: "m_1", thread_id: "t_parent", role: "user", content: "hi", sequence: 1, is_internal: false },
+  ] as any,
   userFollowUpMessage: "What should I do next?",
 };
 

--- a/apps/server/src/services/handoff/__tests__/handoff-prompt.test.ts
+++ b/apps/server/src/services/handoff/__tests__/handoff-prompt.test.ts
@@ -35,6 +35,13 @@ describe("buildHandoffPrompt", () => {
     expect(p.toLowerCase()).not.toContain("output mode:");
   });
 
+  it("caps the requested handoff size for Codex inline delivery", () => {
+    const p = buildHandoffPrompt({ ...baseInput, childProviderId: "codex" });
+    expect(p.toLowerCase()).toContain("under 12,000 characters");
+    expect(p.toLowerCase()).toContain("codex receives this handoff inline");
+    expect(p.toLowerCase()).not.toContain("no character cap");
+  });
+
   it("frames user-msg fork as retry, assistant-msg fork as follow-up about assistant reply", () => {
     const userFork = buildHandoffPrompt({ ...baseInput, forkAnchorRole: "user" });
     expect(userFork).toMatch(/retry this question/i);

--- a/apps/server/src/services/handoff/__tests__/path-d-deterministic.test.ts
+++ b/apps/server/src/services/handoff/__tests__/path-d-deterministic.test.ts
@@ -82,6 +82,23 @@ describe("runPathDDeterministic", () => {
     expect(a.markdown.length).toBeGreaterThan(0);
   });
 
+  it("surfaces history budget elision in the handoff body and metadata", async () => {
+    const a = await runPathDDeterministic({
+      ...BASE,
+      historyBudget: {
+        budgetBytes: 10,
+        retainedBytes: 10,
+        omittedBeforeCount: 2,
+        truncatedMessages: [{ id: "m_2", originalBytes: 20, retainedBytes: 10 }],
+      },
+    });
+
+    expect(a.markdown).toContain("## History limit");
+    expect(a.markdown).toContain("2 earlier messages were elided");
+    expect(a.markdown).toContain("1 retained message was truncated");
+    expect(a.meta.historyBudget?.omittedBeforeCount).toBe(2);
+  });
+
   it("is deterministic for fixed input (modulo generatedAt)", async () => {
     const input: PathDInput = {
       ...BASE,

--- a/apps/server/src/services/handoff/handoff-coordinator.ts
+++ b/apps/server/src/services/handoff/handoff-coordinator.ts
@@ -82,6 +82,40 @@ function buildOffBandHandoffPrompt(tempPath: string, markdown: string, userMessa
   ].join("\n");
 }
 
+const CODEX_INLINE_HANDOFF_MAX_CHARS = 14_000;
+const CODEX_INLINE_MAX_USER_CHARS = 4_000;
+const CODEX_HANDOFF_TRUNCATION_NOTICE =
+  "\n\n[Inline Codex handoff shortened to fit the first-turn input limit. Full handoff remains stored in mcode.]\n\n";
+const CODEX_USER_TRUNCATION_NOTICE =
+  "\n\n[User message shortened to fit the first-turn input limit.]";
+
+function takeCharsWithNotice(text: string, maxChars: number, notice: string): string {
+  if (maxChars <= 0) return "";
+  if (text.length <= maxChars) return text;
+  if (maxChars <= notice.length) return notice.slice(0, maxChars);
+  return `${text.slice(0, maxChars - notice.length).trimEnd()}${notice}`;
+}
+
+function buildInlineHandoffPrompt(markdown: string, userMessage: string): string {
+  const separator = "\n\n---\n\n";
+  const fullPrompt = `${markdown}${separator}${userMessage}`;
+  if (fullPrompt.length <= CODEX_INLINE_HANDOFF_MAX_CHARS) return fullPrompt;
+
+  const boundedUserMessage = takeCharsWithNotice(
+    userMessage,
+    Math.min(userMessage.length, CODEX_INLINE_MAX_USER_CHARS),
+    CODEX_USER_TRUNCATION_NOTICE,
+  );
+  const markdownBudget =
+    CODEX_INLINE_HANDOFF_MAX_CHARS - separator.length - boundedUserMessage.length;
+  const boundedMarkdown = takeCharsWithNotice(
+    markdown,
+    markdownBudget,
+    CODEX_HANDOFF_TRUNCATION_NOTICE,
+  );
+  return `${boundedMarkdown}${separator}${boundedUserMessage}`;
+}
+
 function formatHistoryBudgetNotice(historyBudget?: ForkHistoryBudget): string | null {
   if (!historyBudget) return null;
   const lines: string[] = [];
@@ -271,7 +305,7 @@ export class HandoffCoordinator {
       if (shouldInlineHandoffArtifact(childProvider)) {
         // Codex does not consume Mcode's Read pre-grant, so a temp-file prompt
         // can stall on tool access. Inline the bounded artifact instead.
-        providerWireOverride = `${artifact.markdown}\n\n---\n\n${userMessage}`;
+        providerWireOverride = buildInlineHandoffPrompt(artifact.markdown, userMessage);
       } else {
         // Off-band delivery (PRD #538): write the FULL handoff doc to a stable OS
         // temp path and shrink the child's inline first-Turn prompt to a small

--- a/apps/server/src/services/handoff/handoff-coordinator.ts
+++ b/apps/server/src/services/handoff/handoff-coordinator.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { logger, getMcodeDir } from "@mcode/shared";
 import { storedAttachmentSuffix } from "@mcode/contracts";
-import type { Thread, Message, ProviderId } from "@mcode/contracts";
+import type { Thread, Message, ProviderId, ForkHistoryBudget } from "@mcode/contracts";
 import { ThreadRepo } from "../../repositories/thread-repo";
 import { MessageRepo } from "../../repositories/message-repo";
 import { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo";
@@ -82,6 +82,32 @@ function buildOffBandHandoffPrompt(tempPath: string, markdown: string, userMessa
   ].join("\n");
 }
 
+function formatHistoryBudgetNotice(historyBudget?: ForkHistoryBudget): string | null {
+  if (!historyBudget) return null;
+  const lines: string[] = [];
+  if (historyBudget.omittedBeforeCount > 0) {
+    const suffix = historyBudget.omittedBeforeCount === 1 ? "" : "s";
+    lines.push(
+      `[${historyBudget.omittedBeforeCount} earlier message${suffix} elided because the fork history budget was reached]`,
+    );
+  }
+  if (historyBudget.truncatedMessages.length > 0) {
+    const suffix = historyBudget.truncatedMessages.length === 1 ? "" : "s";
+    lines.push(`[${historyBudget.truncatedMessages.length} retained message${suffix} truncated by the fork history budget]`);
+  }
+  return lines.length > 0 ? lines.join("\n") : null;
+}
+
+function prefixHistoryBudgetNotice(text: string, historyBudget?: ForkHistoryBudget): string {
+  const notice = formatHistoryBudgetNotice(historyBudget);
+  if (!notice) return text;
+  return text ? `${notice}\n\n${text}` : notice;
+}
+
+function shouldInlineHandoffArtifact(childProvider: ProviderId): boolean {
+  return childProvider === "codex";
+}
+
 /** Inputs needed to run a branch-thread handoff for one child thread. */
 export interface HandoffDeliveryInput {
   /** The parent thread being forked from. */
@@ -94,6 +120,8 @@ export interface HandoffDeliveryInput {
   forkMessage: Message;
   /** Parent messages up to and including the fork anchor, ascending. */
   forkedMessages: Message[];
+  /** Byte-budget metadata for the retained parent history window. */
+  historyBudget?: ForkHistoryBudget;
   /** The child's first user message. */
   userMessage: string;
   /** The child's model id (sizes the legacy replay budget). */
@@ -155,7 +183,7 @@ export class HandoffCoordinator {
    * thread vanishes mid-handoff, so the caller aborts the branch.
    */
   async deliverHandoff(input: HandoffDeliveryInput): Promise<HandoffDeliveryResult> {
-    const { parentThread, childThreadId, childProvider, forkMessage, forkedMessages, userMessage, model } = input;
+    const { parentThread, childThreadId, childProvider, forkMessage, forkedMessages, historyBudget, userMessage, model } = input;
     const parentThreadId = parentThread.id;
     const resolvedForkMessageId = forkMessage.id;
 
@@ -177,6 +205,8 @@ export class HandoffCoordinator {
         forkAnchorRole,
         childThreadId,
         childProviderId: childProvider,
+        messagesUpToFork: forkedMessages,
+        historyBudget,
         userFollowUpMessage: userMessage,
       });
 
@@ -238,32 +268,38 @@ export class HandoffCoordinator {
         undefined, undefined, undefined, undefined, /* isInternal */ true,
       );
 
-      // Off-band delivery (PRD #538): write the FULL handoff doc to a stable OS
-      // temp path and shrink the child's inline first-Turn prompt to a small
-      // pointer + graceful-degradation summary + the user's message. Issue a
-      // ScopedPreGrant so the child can Read that one file on its first Turn
-      // without prompting, regardless of permissionMode.
-      const handoffTempPath = join(
-        tmpdir(),
-        `mcode-handoff-${childThreadId}-${Date.now()}.md`,
-      );
-      try {
-        await writeFile(handoffTempPath, artifact.markdown, "utf8");
-        this.scopedPreGrant.issue({
-          threadId: childThreadId,
-          toolName: "Read",
-          path: handoffTempPath,
-        });
-        providerWireOverride = buildOffBandHandoffPrompt(handoffTempPath, artifact.markdown, userMessage);
-      } catch (writeErr) {
-        // If the temp write fails we cannot pre-grant a Read, so fall back to
-        // inlining the full doc (legacy behaviour) — the fork still succeeds.
-        logger.warn("Off-band handoff write failed; inlining full doc", {
-          threadId: childThreadId,
-          handoffTempPath,
-          error: writeErr instanceof Error ? writeErr.message : String(writeErr),
-        });
+      if (shouldInlineHandoffArtifact(childProvider)) {
+        // Codex does not consume Mcode's Read pre-grant, so a temp-file prompt
+        // can stall on tool access. Inline the bounded artifact instead.
         providerWireOverride = `${artifact.markdown}\n\n---\n\n${userMessage}`;
+      } else {
+        // Off-band delivery (PRD #538): write the FULL handoff doc to a stable OS
+        // temp path and shrink the child's inline first-Turn prompt to a small
+        // pointer + graceful-degradation summary + the user's message. Issue a
+        // ScopedPreGrant so the child can Read that one file on its first Turn
+        // without prompting, regardless of permissionMode.
+        const handoffTempPath = join(
+          tmpdir(),
+          `mcode-handoff-${childThreadId}-${Date.now()}.md`,
+        );
+        try {
+          await writeFile(handoffTempPath, artifact.markdown, "utf8");
+          this.scopedPreGrant.issue({
+            threadId: childThreadId,
+            toolName: "Read",
+            path: handoffTempPath,
+          });
+          providerWireOverride = buildOffBandHandoffPrompt(handoffTempPath, artifact.markdown, userMessage);
+        } catch (writeErr) {
+          // If the temp write fails we cannot pre-grant a Read, so fall back to
+          // inlining the full doc. The fork still succeeds.
+          logger.warn("Off-band handoff write failed; inlining full doc", {
+            threadId: childThreadId,
+            handoffTempPath,
+            error: writeErr instanceof Error ? writeErr.message : String(writeErr),
+          });
+          providerWireOverride = `${artifact.markdown}\n\n---\n\n${userMessage}`;
+        }
       }
     } catch (pipelineErr) {
       // Re-check child thread existence before writing any fallback artifacts.
@@ -345,7 +381,10 @@ export class HandoffCoordinator {
           }
         }
       }
-      const replay = buildConversationReplay(forkedMessages, budget, compactSummary);
+      const replay = prefixHistoryBudgetNotice(
+        buildConversationReplay(forkedMessages, budget, compactSummary),
+        historyBudget,
+      );
       const replayHeader = `You are continuing work from a previous thread titled "${parentThread.title}". Here is the conversation history up to the fork point:\n\n`;
       providerWireOverride = replay ? `${replayHeader}${replay}\n\n---\n\n${userMessage}` : userMessage;
 
@@ -370,6 +409,7 @@ export class HandoffCoordinator {
           providerErrorOnGenerate: errClass === "clean" ? "fatal" : errClass,
           regenerationHistory: [],
           attachments: [],
+          ...(historyBudget && { historyBudget }),
         },
       };
       try {

--- a/apps/server/src/services/handoff/handoff-pipeline.ts
+++ b/apps/server/src/services/handoff/handoff-pipeline.ts
@@ -3,8 +3,9 @@
  * {@link SessionForker}.
  *
  * The pipeline builds a {@link ForkRequest} and calls `provider.forker.fork(req)`.
- * Each provider owns the strategy: CleanForker (Claude/Cursor, path B) or
- * DeterministicForker (Codex/Copilot, path D). The `sessionForkOnResume` field
+ * Each provider owns the strategy: clean-resume providers use CleanForker
+ * (path B); unsupported providers use DeterministicForker (path D). The
+ * `sessionForkOnResume` field
  * is now metadata only (provenance), not the dispatch key.
  *
  * On a classified non-retryable provider error (quota/auth/context-overflow/
@@ -15,7 +16,6 @@
 import { inject, injectable } from "tsyringe";
 import { logger } from "@mcode/shared";
 import { ThreadRepo } from "../../repositories/thread-repo.js";
-import { MessageRepo } from "../../repositories/message-repo.js";
 import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
 import { ThoughtSegmentRepo } from "../../repositories/thought-segment-repo.js";
@@ -31,6 +31,7 @@ import type {
   ToolCallRecord,
   ThoughtSegmentRecord,
   Message,
+  ForkHistoryBudget,
 } from "@mcode/contracts";
 /**
  * Render an Error-shaped value for structured logging. Winston cannot
@@ -73,9 +74,6 @@ import type {
 interface IThreadRepo {
   findById(id: string): Promise<any> | any;
 }
-interface IMessageRepo {
-  listIncludingInternal(threadId: string): Promise<any[]> | any[];
-}
 interface IWorkspaceRepo {
   findById(id: string): Promise<any> | any;
 }
@@ -108,6 +106,28 @@ const PROVIDER_CALL_TIMEOUT_MS = 120_000;
  */
 const REPLAY_BUDGET_CHARS = 100_000;
 
+function formatHistoryBudgetNotice(historyBudget?: ForkHistoryBudget): string | null {
+  if (!historyBudget) return null;
+  const lines: string[] = [];
+  if (historyBudget.omittedBeforeCount > 0) {
+    const suffix = historyBudget.omittedBeforeCount === 1 ? "" : "s";
+    lines.push(
+      `[${historyBudget.omittedBeforeCount} earlier message${suffix} elided because the fork history budget was reached]`,
+    );
+  }
+  if (historyBudget.truncatedMessages.length > 0) {
+    const suffix = historyBudget.truncatedMessages.length === 1 ? "" : "s";
+    lines.push(`[${historyBudget.truncatedMessages.length} retained message${suffix} truncated by the fork history budget]`);
+  }
+  return lines.length > 0 ? lines.join("\n") : null;
+}
+
+function prefixHistoryBudgetNotice(text: string, historyBudget?: ForkHistoryBudget): string {
+  const notice = formatHistoryBudgetNotice(historyBudget);
+  if (!notice) return text;
+  return text ? `${notice}\n\n${text}` : notice;
+}
+
 @injectable()
 export class HandoffPipelineService {
   /**
@@ -119,7 +139,6 @@ export class HandoffPipelineService {
 
   constructor(
     @inject(ThreadRepo) private readonly threadRepo: IThreadRepo,
-    @inject(MessageRepo) private readonly messageRepo: IMessageRepo,
     @inject("IProviderRegistry") private readonly providerRegistry: Pick<IProviderRegistry, "resolve">,
     @inject(WorkspaceRepo) private readonly workspaceRepo: IWorkspaceRepo,
     @inject(ToolCallRecordRepo) private readonly toolCallRecordRepo: IToolCallRecordRepo,
@@ -132,7 +151,6 @@ export class HandoffPipelineService {
    */
   static forTesting(deps: {
     threadRepo: IThreadRepo;
-    messageRepo: IMessageRepo;
     providerRegistry: Pick<IProviderRegistry, "resolve">;
     workspaceRepo?: IWorkspaceRepo;
     toolCallRecordRepo?: IToolCallRecordRepo;
@@ -140,7 +158,6 @@ export class HandoffPipelineService {
   }): HandoffPipelineService {
     const svc = Object.create(HandoffPipelineService.prototype) as HandoffPipelineService;
     (svc as any).threadRepo = deps.threadRepo;
-    (svc as any).messageRepo = deps.messageRepo;
     (svc as any).providerRegistry = deps.providerRegistry;
     (svc as any).workspaceRepo = deps.workspaceRepo ?? {
       findById: async () => ({ path: process.cwd() }),
@@ -175,12 +192,9 @@ export class HandoffPipelineService {
     const parentCwd: string = parent.worktree_path ?? workspace.path;
 
     const parentProvider = this.tryResolveProvider(parent.provider);
-    const messages = await this.messageRepo.listIncludingInternal(req.parentThreadId);
-    const forkIndex = messages.findIndex((m: any) => m.id === req.forkedFromMessageId);
+    const messagesUpToFork = req.messagesUpToFork;
+    const forkIndex = messagesUpToFork.findIndex((m: any) => m.id === req.forkedFromMessageId);
     if (forkIndex === -1) throw new Error(`Fork message ${req.forkedFromMessageId} not in parent`);
-    // Slice to only include messages up to and including the fork anchor so that
-    // later parent messages cannot leak into the child handoff context.
-    const messagesUpToFork = messages.slice(0, forkIndex + 1);
     const forkMsg = messagesUpToFork[forkIndex];
 
     const prompt = buildHandoffPrompt({
@@ -200,11 +214,14 @@ export class HandoffPipelineService {
     // PARENT provider's side-channel resume body (not the child's delivery,
     // which is off-band), so it is a fixed generous cap rather than a function
     // of the child provider's per-turn input window.
-    const conversationHistory = buildConversationReplay(messagesUpToFork, REPLAY_BUDGET_CHARS, null);
+    const conversationHistory = prefixHistoryBudgetNotice(
+      buildConversationReplay(messagesUpToFork, REPLAY_BUDGET_CHARS, null),
+      req.historyBudget,
+    );
 
     // Pre-gather the deterministic (path-D) signals from the parent thread so
     // DeterministicForker stays stateless. These are no-ops for provider paths
-    // (B/A) — the forkers simply ignore the extra fields.
+    // (path B) since the clean forker ignores the extra fields.
     const deterministicInputs = await this.gatherDeterministicInputs(parent, messagesUpToFork, forkMsg);
 
     const forkReq: ForkRequest = {
@@ -216,6 +233,7 @@ export class HandoffPipelineService {
       parentSdkSessionId: parentSdkSession,
       conversationHistory,
       messagesUpToFork,
+      historyBudget: req.historyBudget,
       parentThread: parent,
       childThreadId: req.childThreadId,
       ...deterministicInputs,

--- a/apps/server/src/services/handoff/handoff-prompt.ts
+++ b/apps/server/src/services/handoff/handoff-prompt.ts
@@ -3,12 +3,12 @@
  * to produce a handoff document. Vendors the /handoff skill instructions and
  * tailors them with fork context.
  *
- * Off-band delivery (PRD #538) retired the full-vs-minimal mode selection, the
- * child-input character budget, and the >115% truncation/overflow guard: the
- * full doc is now written to an OS temp file and the child reads it on demand
- * via a one-shot ScopedPreGrant, so doc-body sizing no longer needs to fit a
- * provider's per-turn input window. The prompt therefore asks for a complete,
- * self-contained document with no character cap.
+ * PRD #538 retired the full-vs-minimal mode selection, the child-input
+ * character budget, and the >115% truncation/overflow guard. Most providers
+ * read the full doc from an OS temp file via a one-shot ScopedPreGrant.
+ * Providers without that read path may receive the bounded artifact inline.
+ * The prompt therefore asks for a complete, self-contained document with no
+ * character cap.
  */
 
 import type { ForkAnchorRole } from "./handoff-types.js";

--- a/apps/server/src/services/handoff/handoff-prompt.ts
+++ b/apps/server/src/services/handoff/handoff-prompt.ts
@@ -8,7 +8,7 @@
  * read the full doc from an OS temp file via a one-shot ScopedPreGrant.
  * Providers without that read path may receive the bounded artifact inline.
  * The prompt therefore asks for a complete, self-contained document with no
- * character cap.
+ * character cap unless the child provider cannot read the off-band artifact.
  */
 
 import type { ForkAnchorRole } from "./handoff-types.js";
@@ -48,6 +48,9 @@ export function buildHandoffPrompt(input: HandoffPromptInput): string {
   const argumentBlock = userFollowUpMessage.trim().length > 0
     ? `The user's follow-up message in the new branched thread (treat this as the skill's "arguments", the description of what the next session will focus on): "${userFollowUpMessage.slice(0, 800)}"`
     : "The user has not provided a follow-up message yet (no skill arguments). Hand off the full context up to the fork point so the next agent is prepared for any direction the user takes.";
+  const deliveryConstraint = childProviderId === "codex"
+    ? "- Write a complete, self-contained document under 12,000 characters because Codex receives this handoff inline. Prefer the details needed for the follow-up over exhaustive history."
+    : "- Write a complete, self-contained document. There is no character cap: mcode delivers the full doc to the next agent off-band (written to a file the agent reads on demand), so prefer completeness over brevity while staying focused on what matters for the follow-up.";
 
   return [
     "You are executing the /handoff skill on the conversation up to the fork point. Below are the skill's instructions verbatim, followed by mcode-specific context.",
@@ -74,7 +77,7 @@ export function buildHandoffPrompt(input: HandoffPromptInput): string {
     argumentBlock,
     "",
     "## Output constraints (mcode-specific)",
-    "- Write a complete, self-contained document. There is no character cap: mcode delivers the full doc to the next agent off-band (written to a file the agent reads on demand), so prefer completeness over brevity while staying focused on what matters for the follow-up.",
+    deliveryConstraint,
     "- Return the complete handoff document as your assistant text response.",
     "- Do NOT call any tools. Do NOT write to disk. mcode handles persistence.",
     "- Do NOT include YAML frontmatter (the pipeline injects that).",

--- a/apps/server/src/services/handoff/handoff-types.ts
+++ b/apps/server/src/services/handoff/handoff-types.ts
@@ -14,9 +14,10 @@ export type {
   ProviderErrorClass,
   HandoffMeta,
   HandoffArtifact,
+  ForkHistoryBudget,
 } from "@mcode/contracts";
 
-import type { ForkAnchorRole } from "@mcode/contracts";
+import type { ForkAnchorRole, ForkHistoryBudget, Message } from "@mcode/contracts";
 
 /** Input to the pipeline's orchestrate() method. */
 export interface HandoffRequest {
@@ -25,6 +26,10 @@ export interface HandoffRequest {
   forkAnchorRole: ForkAnchorRole;
   childThreadId: string;
   childProviderId: string;
+  /** Parent messages retained under the fork history budget, ascending. */
+  messagesUpToFork: Message[];
+  /** Byte-budget metadata for the retained parent history window. */
+  historyBudget?: ForkHistoryBudget;
   /** The user's new message in the fork composer that the child agent will receive as its first turn. */
   userFollowUpMessage: string;
 }

--- a/apps/server/src/services/handoff/path-d-deterministic.ts
+++ b/apps/server/src/services/handoff/path-d-deterministic.ts
@@ -15,7 +15,7 @@
  * `ladderStep: "D"` and `generatedBy: "deterministic"`.
  */
 
-import type { Thread, Message, ToolCallRecord, ThoughtSegmentRecord } from "@mcode/contracts";
+import type { Thread, Message, ToolCallRecord, ThoughtSegmentRecord, ForkHistoryBudget } from "@mcode/contracts";
 import { HANDOFF_MARKER } from "@mcode/contracts";
 import type { HandoffArtifact, HandoffMeta, ForkAnchorRole, ProviderErrorClass } from "./handoff-types.js";
 
@@ -38,10 +38,33 @@ export interface PathDInput {
   thoughtSegments?: ThoughtSegmentRecord[];
   /** De-duplicated files changed across recent parent messages. */
   filesChanged?: string[];
+  /** Byte-budget metadata for the retained parent history window. */
+  historyBudget?: ForkHistoryBudget;
 }
 
 /** Max narration highlights surfaced so reasoning context stays focused. */
 const MAX_NARRATION_HIGHLIGHTS = 8;
+
+function renderHistoryBudget(lines: string[], historyBudget?: ForkHistoryBudget): void {
+  if (!historyBudget) return;
+  const hasOmittedHistory = historyBudget.omittedBeforeCount > 0;
+  const hasTruncation = historyBudget.truncatedMessages.length > 0;
+  if (!hasOmittedHistory && !hasTruncation) return;
+
+  lines.push("");
+  lines.push("## History limit");
+  lines.push("");
+  if (hasOmittedHistory) {
+    const suffix = historyBudget.omittedBeforeCount === 1 ? "" : "s";
+    const verb = historyBudget.omittedBeforeCount === 1 ? "was" : "were";
+    lines.push(`${historyBudget.omittedBeforeCount} earlier message${suffix} ${verb} elided because the fork history budget was reached.`);
+  }
+  if (hasTruncation) {
+    const suffix = historyBudget.truncatedMessages.length === 1 ? "" : "s";
+    const verb = historyBudget.truncatedMessages.length === 1 ? "was" : "were";
+    lines.push(`${historyBudget.truncatedMessages.length} retained message${suffix} ${verb} truncated to keep the handoff within budget.`);
+  }
+}
 
 /**
  * Render the structured Markdown body (everything above the metadata comment).
@@ -58,6 +81,7 @@ function renderBody(input: PathDInput): string {
     toolCallRecords,
     thoughtSegments,
     filesChanged,
+    historyBudget,
   } = input;
 
   const lines: string[] = [];
@@ -66,6 +90,7 @@ function renderBody(input: PathDInput): string {
   lines.push(`You are continuing work from a previous thread titled "${parentThread.title}".`);
   const modelInfo = parentThread.model ? ` ${parentThread.model}` : "";
   lines.push(`The previous thread used${modelInfo} on branch ${parentThread.branch}.`);
+  renderHistoryBudget(lines, historyBudget);
 
   // Goal / summary: prefer the model-generated compact summary, then the
   // fork-anchor body, then the last assistant message. No truncation.
@@ -179,6 +204,7 @@ export async function runPathDDeterministic(input: PathDInput): Promise<HandoffA
     providerErrorOnGenerate: reason,
     regenerationHistory: [],
     attachments: [],
+    ...(input.historyBudget && { historyBudget: input.historyBudget }),
   };
   return { markdown, meta };
 }

--- a/apps/server/src/services/handoff/session-forker.ts
+++ b/apps/server/src/services/handoff/session-forker.ts
@@ -6,14 +6,14 @@
  * (see {@link IAgentProvider.forker}) that knows how to produce a handoff
  * artifact for that provider's session-fork semantics:
  *
- * - {@link CleanForker} (Claude + Cursor, path B + B-prime): runs a
+ * - {@link CleanForker} (clean-resume providers, path B + B-prime): runs a
  *   side-channel query against a forked copy of the parent session.
  * - {@link DeterministicForker} (path D): stateless replay-based builder, also
  *   the pipeline's cross-forker fallback when a provider fork fails.
  *
  * The forkers call the providers' concrete `runSideChannelQuery` method
  * directly. That method is intentionally off the {@link IAgentProvider}
- * interface now — only the forkers reach it.
+ * interface now, so only the forkers reach it.
  */
 
 import type { ForkRequest, HandoffArtifact, HandoffMeta, SessionForker } from "@mcode/contracts";
@@ -64,12 +64,13 @@ function buildProviderArtifact(
     providerErrorOnGenerate: null,
     regenerationHistory: [],
     attachments: [],
+    ...(req.historyBudget && { historyBudget: req.historyBudget }),
   };
   return { markdown: markdownBody, meta };
 }
 
 /**
- * Path B (+ B-prime) forker for clean-resume providers (Claude, Cursor). Runs a
+ * Path B (+ B-prime) forker for clean-resume providers. Runs a
  * one-shot side-channel query against a forked copy of the parent session. If
  * `parentSdkSessionId` is missing the provider's own sessionless B-prime
  * fallback (driven by `conversationHistory`) still produces a path-B result.
@@ -93,8 +94,8 @@ export class CleanForker implements SessionForker {
 
 /**
  * Path D forker: stateless, replay-based deterministic builder. Used directly
- * by providers that cannot fork a session (Codex, Copilot) and as the
- * pipeline's cross-forker fallback when a provider fork fails or times out.
+ * by providers that cannot fork a session and as the pipeline's cross-forker
+ * fallback when a provider fork fails or times out.
  */
 export class DeterministicForker implements SessionForker {
   /** Produce a path-D handoff from the parent message replay. */
@@ -111,6 +112,7 @@ export class DeterministicForker implements SessionForker {
       toolCallRecords: req.toolCallRecords,
       thoughtSegments: req.thoughtSegments,
       filesChanged: req.filesChanged,
+      historyBudget: req.historyBudget,
     });
   }
 }

--- a/docs/guides/chat-fork-handoff.md
+++ b/docs/guides/chat-fork-handoff.md
@@ -14,21 +14,21 @@ The pipeline lives in `apps/server/src/services/handoff/`.
 
 Two paths are tried in order. The result of the first path that succeeds becomes the handoff artifact.
 
-**Path B -- clean-fork providers (e.g. Claude, Cursor).** The pipeline calls `runSideChannelQuery` on the parent provider. This issues a new query against a forked copy of the provider's existing session without mutating it, so the parent thread's conversation state is unchanged. Path B requires a live `sdk_session_id` on the parent thread because the side-channel must resume the correct provider conversation.
+**Path B -- clean-fork providers (Claude, Cursor, Codex, Copilot).** The pipeline calls `runSideChannelQuery` on the parent provider. This issues a new query against a forked copy of the provider's existing session without mutating it, so the parent thread's conversation state is unchanged. Path B requires a live `sdk_session_id` on the parent thread because the side-channel must resume the correct provider conversation.
 
 **Path D -- deterministic fallback.** Always available. Builds the handoff by walking the message list up to the fork point and rendering a structured Markdown summary. No provider call is made. Path D fires when the parent provider does not support forking at all (`sessionForkOnResume === "unsupported"`), when the parent has no `sdk_session_id` and the provider is clean-resume, or when path B throws an error that error-classification routes as quota, auth, context-overflow, or fatal (errors for which retrying would hit the same wall).
 
-Transient errors (network blips, 5xx, AbortController timeout at 60s) also route to path D so forks always succeed.
+Transient errors (network blips, 5xx, AbortController timeout at 120 seconds) also route to path D so forks always succeed.
 
 ## Provider capabilities
 
-Two fields on the provider interface control which path fires. Both are declared in `packages/contracts/src/providers/interfaces.ts`.
+Provider fork capability is declared in `packages/contracts/src/providers/interfaces.ts`.
 
-`sessionForkOnResume: "clean" | "unsupported"` -- declares whether the provider supports side-channel queries (`"clean"`) or not (`"unsupported"`). Omitting this field or returning `null` is treated as `"unsupported"`.
+`sessionForkOnResume: "clean" | "unsupported"` -- declares whether the provider supports side-channel queries (`"clean"`) or not (`"unsupported"`).
 
-`maxInputCharactersPerTurn: number` -- the provider's per-turn input character cap. The pipeline uses this to guard against oversized provider output.
+`forker: SessionForker` -- produces the handoff artifact. Clean providers use `CleanForker`; unsupported providers use `DeterministicForker`.
 
-Implement `runSideChannelQuery` on path-B providers. It receives an `AbortSignal` that fires after 60 seconds.
+Implement `runSideChannelQuery` on path-B providers. It receives an `AbortSignal` that fires after 120 seconds.
 
 ## Storage layout
 
@@ -59,7 +59,8 @@ The mode is recorded in `HandoffMeta.mode` (`"full"` or `"minimal"`) and in the 
 
 The pipeline includes several guards to avoid blocking or corrupting the fork flow:
 
-- **60-second timeout.** An `AbortController` wraps every provider call. If the controller fires, the pipeline catches the abort and falls to path D with `reason: "transient"`.
+- **120-second timeout.** An `AbortController` wraps every provider call. If the controller fires, the pipeline catches the abort and falls to path D with `reason: "transient"`.
+- **Fork history budget.** Parent history is read in newest-first pages under a byte budget. The handoff records when older history was elided.
 - **25 MB attachment size cap.** `HandoffStorage.copyAttachments` skips any attachment larger than 25 MB and records a sentinel `sha256: "<skipped>"` in the manifest.
 - **Budget truncation at section boundaries.** When a provider returns more than 115% of the computed character budget, `applyBudgetGuard` truncates at the nearest H2 heading boundary and appends a notice so the child agent knows the doc was cut.
 - **Abandoned-child cleanup.** Before writing the artifact, `AgentService` re-fetches the child thread. If it has been hard-deleted between orchestration start and the write, the artifact is dropped and the fork fails cleanly rather than writing orphaned files.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -322,6 +322,7 @@ export type {
   HandoffMode,
   LadderStep,
   ForkAnchorRole,
+  ForkHistoryBudget,
   ProviderErrorClass,
 } from "./providers/session-forker.js";
 

--- a/packages/contracts/src/providers/session-forker.ts
+++ b/packages/contracts/src/providers/session-forker.ts
@@ -18,9 +18,10 @@ export type LadderStep = "B" | "D";
 
 /**
  * Handoff doc mode. Retained as a constant `"full"` for provenance/frontmatter
- * stability after off-band delivery (PRD #538) retired the full-vs-minimal
- * sizing selection. The child receives a small pointer + summary inline and
- * reads the full doc off-band, so doc-body sizing no longer drives a mode.
+ * stability after PRD #538 retired the full-vs-minimal sizing selection.
+ * Most providers receive a small pointer + summary inline and read the full
+ * doc off-band. Providers without that read path may receive the bounded
+ * artifact inline, so doc-body sizing no longer drives a mode.
  */
 export type HandoffMode = "full";
 
@@ -63,6 +64,19 @@ export interface HandoffMeta {
     mime: string;
     parentMessageId: string;
   }>;
+  historyBudget?: ForkHistoryBudget;
+}
+
+/** Describes parent history omitted while building a fork handoff. */
+export interface ForkHistoryBudget {
+  budgetBytes: number;
+  retainedBytes: number;
+  omittedBeforeCount: number;
+  truncatedMessages: Array<{
+    id: string;
+    originalBytes: number;
+    retainedBytes: number;
+  }>;
 }
 
 /** Returned by every forker. The pipeline writes both fields to disk. */
@@ -90,6 +104,8 @@ export interface ForkRequest {
   conversationHistory?: string;
   /** Parent messages up to the fork point, for the deterministic builder. */
   messagesUpToFork: Message[];
+  /** Budget metadata for the retained parent history window. */
+  historyBudget?: ForkHistoryBudget;
   /** Full parent thread row; the deterministic builder needs its metadata. */
   parentThread: Thread;
   /** The forked child thread id, threaded through to the artifact metadata. */


### PR DESCRIPTION
## What
Bounds fork and handoff history reads by byte budget, then records retained, omitted, and truncated history in handoff metadata.

## Why
Long parent threads could load too much history while creating a fork. The fork path needs enough recent context for a useful handoff without reading the full thread.

## Key Changes
- Added budgeted newest-first history reads for fork handoffs, with omission and truncation metadata.
- Reused the budgeted message window through the handoff pipeline instead of rereading the parent thread.
- Enabled clean side-channel forks for Codex and Copilot with deterministic fallback.
- Delivered Codex child handoffs inline because Codex does not consume Mcode's one-shot Read pre-grant.
- Updated fork handoff tests and docs.

## Verification
- `cd apps/server && bun x vitest run src/__tests__/message-repo.test.ts src/services/handoff/__tests__/path-d-deterministic.test.ts src/services/handoff/__tests__/handoff-pipeline.test.ts src/services/handoff/__tests__/fork-flow.e2e.test.ts src/services/handoff/__tests__/handoff-coordinator.test.ts src/providers/codex/__tests__/codex-provider-first-turn.test.ts`
- `cd apps/server && bun x vitest run --testTimeout=30000 --hookTimeout=60000`
- `bun run typecheck`
- `bun run lint`
- Live app check: Codex parent `parent-ok`, clean handoff `ladderStep=B`, child `fork-ok`.
- Live app check: Copilot parent `parent-ok`, clean handoff `ladderStep=B`, child `fork-ok`.

Closes #714

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783953197&installation_id=129163861&pr_number=730&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F730&signature=e9cc9497aac1ac29b9f0c23b917002b7800f05c6010011b1fe502bd032070da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->