### PR TITLE
feat(review): finalize review tab workflows

### DIFF
--- a/apps/server/src/__tests__/git-service-branch-comparison.test.ts
+++ b/apps/server/src/__tests__/git-service-branch-comparison.test.ts
@@ -108,13 +108,14 @@ describe("GitService.resolveBranchComparison", () => {
       branches: [
         { full: "refs/heads/main", short: "main" },
         { full: "refs/heads/feat/x", short: "feat/x", head: true },
+        { full: "refs/remotes/origin/main", short: "origin/main" },
       ],
     });
 
     const result = await gitService.resolveBranchComparison("ws", REPO);
 
-    expect(result).toMatchObject({ base: "main", target: "feat/x", isUnborn: false });
-    expect(result.refs.length).toBe(2);
+    expect(result).toMatchObject({ base: "origin/main", target: "feat/x", isUnborn: false });
+    expect(result.refs.length).toBe(3);
   });
 
   it("compares current → origin/current on the base branch when an upstream exists", async () => {
@@ -145,12 +146,15 @@ describe("GitService.resolveBranchComparison", () => {
   it("compares base → HEAD on a detached HEAD", async () => {
     setup({
       current: "HEAD",
-      branches: [{ full: "refs/heads/main", short: "main" }],
+      branches: [
+        { full: "refs/heads/main", short: "main" },
+        { full: "refs/remotes/origin/main", short: "origin/main" },
+      ],
     });
 
     const result = await gitService.resolveBranchComparison("ws", REPO);
 
-    expect(result).toMatchObject({ base: "main", target: "HEAD", isUnborn: false });
+    expect(result).toMatchObject({ base: "origin/main", target: "HEAD", isUnborn: false });
   });
 
   it("reports an explicit empty state on an unborn branch", async () => {
@@ -172,12 +176,13 @@ describe("GitService.resolveBranchComparison", () => {
       branches: [
         { full: "refs/heads/develop", short: "develop" },
         { full: "refs/heads/feat/y", short: "feat/y", head: true },
+        { full: "refs/remotes/origin/develop", short: "origin/develop" },
       ],
     });
 
     const result = await gitService.resolveBranchComparison("ws", REPO);
 
-    expect(result).toMatchObject({ base: "develop", target: "feat/y" });
+    expect(result).toMatchObject({ base: "origin/develop", target: "feat/y" });
   });
 
   it("falls back to a local main branch when origin is unavailable", async () => {

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -670,7 +670,8 @@ export class GitService {
    * populate the base/target pickers. Implements the context-dependent default
    * from `docs/adr/0007-branch-comparison-default-and-range.md`:
    *
-   * - **current ≠ detected base** → `base → current` (review the branch's work).
+   * - **current ≠ detected base** → `origin/base → current` when available,
+   *   else `base → current` (review the branch's work).
    * - **current == detected base** (on the base branch) → `current →
    *   origin/current` when an upstream exists, else `base → current` (empty but
    *   valid when the branch has no upstream).
@@ -690,7 +691,8 @@ export class GitService {
       return { base: null, target: null, refs, isUnborn: true };
     }
 
-    const base = await this.detectDefaultBranch(cwd);
+    const defaultBranch = await this.detectDefaultBranch(cwd);
+    const base = (await this.detectDefaultComparisonRef(cwd)) ?? defaultBranch;
     const current = getCurrentBranchForPath(cwd);
 
     if (!base) {
@@ -704,9 +706,9 @@ export class GitService {
       return { base, target: "HEAD", refs, isUnborn: false };
     }
 
-    // On the base branch, `base...current` is empty — fall back to divergence from
-    // the remote when an upstream exists, else the (empty but valid) base→current.
-    if (current === base) {
+    // On the base branch, `base...current` is empty. Use the remote if it exists,
+    // else keep the empty but valid base→current range.
+    if (current === defaultBranch || current === base) {
       const remoteRef = `origin/${current}`;
       const hasUpstream = refs.some((r) => r.type === "remote" && r.name === remoteRef);
       return { base: current, target: hasUpstream ? remoteRef : current, refs, isUnborn: false };

--- a/apps/web/e2e/right-panel-commit-picker.spec.ts
+++ b/apps/web/e2e/right-panel-commit-picker.spec.ts
@@ -75,6 +75,8 @@ const OLDER_COMMITS: GitCommit[] = [
   { sha: "999999999", shortSha: "9999999", message: "fix: older regression", author: "Dev", date: now, filesChanged: 1 },
 ];
 
+let firstPageCommits: GitCommit[] = FIRST_PAGE_COMMITS;
+
 /** Thread-scoped commits come from the thread worktree HEAD, not the workspace root. */
 const THREAD_COMMITS: GitCommit[] = [
   { sha: "dddddddd4", shortSha: "ddddddd", message: "feat: thread worktree head", author: "Dev", date: now, filesChanged: 1 },
@@ -200,6 +202,7 @@ test.describe("Review tab — Commit picker", () => {
 
   test.beforeEach(async ({ page }) => {
     gitLogCalls = [];
+    firstPageCommits = FIRST_PAGE_COMMITS;
     await mockWebSocketServer(page, {
       "workspace.list": [WORKSPACE],
       "thread.list": [THREAD],
@@ -209,7 +212,7 @@ test.describe("Review tab — Commit picker", () => {
         gitLogCalls.push(params);
         const p = params as { threadId?: string; skip?: number } | undefined;
         if (p?.threadId === THREAD.id) return THREAD_COMMITS;
-        return p?.skip ? OLDER_COMMITS : FIRST_PAGE_COMMITS;
+        return p?.skip ? OLDER_COMMITS : firstPageCommits;
       },
       "git.commitFiles": (params) => FILES_BY_SHA[(params as { sha: string }).sha] ?? [],
       "git.commitDiff": (params) => {
@@ -274,6 +277,37 @@ test.describe("Review tab — Commit picker", () => {
     await page.getByPlaceholder("Search commits…").fill("ccccccc");
     await expect(page.getByTestId("commit-picker-item-ccccccc")).toBeVisible();
     await expect(page.getByTestId("commit-picker-item-aaaaaaa")).toHaveCount(0);
+  });
+
+  test("refreshes the commit list when the picker opens", async ({ page }) => {
+    await openCommitView(page);
+
+    const trigger = page.getByTestId("commit-picker-trigger");
+    await expect(trigger).toContainText("aaaaaaa", { timeout: 5_000 });
+    await trigger.click();
+    const search = page.getByPlaceholder("Search commits…");
+    await search.fill("broken seam");
+    await expect(page.getByTestId("commit-picker-item-bbbbbbb")).toBeVisible();
+
+    firstPageCommits = [
+      {
+        sha: "dddddddd4",
+        shortSha: "ddddddd",
+        message: "feat: terminal commit",
+        author: "Dev",
+        date: now,
+        filesChanged: 1,
+      },
+      ...FIRST_PAGE_COMMITS,
+    ];
+
+    await page.keyboard.press("Escape");
+    await trigger.click();
+    await expect(page.getByTestId("commit-picker-item-ddddddd")).toHaveCount(0);
+    await expect(page.getByTestId("commit-picker-item-bbbbbbb")).toBeVisible();
+
+    await search.fill("");
+    await expect(page.getByTestId("commit-picker-item-ddddddd")).toBeVisible();
   });
 
   test("searches older commits on demand", async ({ page }) => {

--- a/apps/web/e2e/right-panel-review-dual-scope.spec.ts
+++ b/apps/web/e2e/right-panel-review-dual-scope.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect, type Page } from "@playwright/test";
-import type { Thread, TurnSnapshot } from "@mcode/contracts";
+import type { GitCommit, Thread, TurnSnapshot } from "@mcode/contracts";
 import { getDefaultSettings } from "@mcode/contracts";
-import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+  type WsController,
+} from "./helpers/e2e-helpers";
 
 /**
  * Covers the Review tab's dual-scope view selection (issues #614, #640): the
@@ -61,12 +65,23 @@ const SNAPSHOT: TurnSnapshot = {
   thread_id: THREAD.id,
   ref_before: "aaaaaaa",
   ref_after: "bbbbbbb",
-  files_changed: ["src/a.ts"],
+  files_changed: ["src/a.ts", "src/beta.ts"],
   worktree_path: null,
   created_at: now,
 };
 
+const SETTINGS = {
+  ...getDefaultSettings(),
+  diffSummary: { enabled: true },
+};
+
+let branchFilesCalls: unknown[] = [];
 let branchDiffCalls: unknown[] = [];
+let branchDiffVersion = 0;
+let snapshotListCalls = 0;
+let snapshotsForList: TurnSnapshot[] = [];
+let commitsForLog: GitCommit[] = [];
+let wsController: WsController;
 
 /** Opens the Review tab with no active thread (threadless workspace scope). */
 async function openThreadlessReview(page: Page): Promise<void> {
@@ -139,27 +154,47 @@ async function openThreadReview(page: Page): Promise<void> {
   );
 }
 
-test.describe("Review tab — dual-scope view selection", () => {
+test.describe("Review tab: dual-scope view selection", () => {
   test.beforeEach(async ({ page }) => {
+    branchFilesCalls = [];
     branchDiffCalls = [];
-    await mockWebSocketServer(page, {
+    branchDiffVersion = 0;
+    snapshotListCalls = 0;
+    snapshotsForList = [SNAPSHOT];
+    commitsForLog = [];
+    wsController = await mockWebSocketServer(page, {
       "workspace.list": [WORKSPACE],
       "thread.list": [THREAD],
-      "settings.get": getDefaultSettings(),
-      "snapshot.listByThread": [SNAPSHOT],
-      "snapshot.getDiff": "",
+      "settings.get": SETTINGS,
+      "snapshot.listByThread": () => {
+        snapshotListCalls += 1;
+        return snapshotsForList;
+      },
+      "snapshot.getDiff": (params) => {
+        const filePath = (params as { filePath?: string }).filePath ?? "src/a.ts";
+        return `@@ -1 +1 @@\n-old ${filePath}\n+new ${filePath}\n`;
+      },
+      "snapshot.getCumulativeDiff": (params) => {
+        const filePath = (params as { filePath?: string }).filePath ?? "src/a.ts";
+        return `@@ -1 +1 @@\n-old ${filePath}\n+new ${filePath}\n`;
+      },
+      "diffSummary.get": null,
       "git.workingTreeFiles": (params) =>
         (params as { staged?: boolean })?.staged ? ["src/staged.ts"] : ["src/unstaged.ts"],
       "git.workingTreeDiff": "",
-      "git.branchFiles": ["src/branch.ts"],
+      "git.branchFiles": (params) => {
+        branchFilesCalls.push(params);
+        return ["src/branch.ts"];
+      },
       "git.branchDiff": (params) => {
         branchDiffCalls.push(params);
         const base = (params as { base?: string }).base ?? "unknown";
         const target = (params as { target?: string }).target ?? "unknown";
-        return `@@ -1 +1 @@\n-old ${base} to ${target} line\n+new ${base} to ${target} line\n`;
+        const suffix = branchDiffVersion === 0 ? "line" : `reload ${branchDiffVersion}`;
+        return `@@ -1 +1 @@\n-old ${base} to ${target} ${suffix}\n+new ${base} to ${target} ${suffix}\n`;
       },
       "git.branchComparison": {
-        base: "main",
+        base: "origin/main",
         target: "feat/x",
         refs: [
           { name: "main", shortSha: "aaaaaaa", type: "local", isCurrent: false },
@@ -168,13 +203,12 @@ test.describe("Review tab — dual-scope view selection", () => {
         ],
         isUnborn: false,
       },
-      "git.log": [],
+      "git.log": () => commitsForLog,
       "git.commitFiles": [],
     });
     await interceptZustandStores(page);
     await page.setViewportSize({ width: 1920, height: 900 });
-    await page.goto("/");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForFunction(
       () =>
         (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
@@ -193,13 +227,16 @@ test.describe("Review tab — dual-scope view selection", () => {
     await expect(switcher).toBeVisible({ timeout: 5_000 });
     await expect(switcher).toContainText("Unstaged");
 
-    // Open the dropdown — the items render in a portal, not inside the trigger.
+    // Open the dropdown. The items render in a portal, not inside the trigger.
     await switcher.click();
     await expect(page.getByTestId("review-view-unstaged")).toBeVisible();
     // The active view exposes its selected state to assistive tech.
     await expect(page.getByTestId("review-view-unstaged")).toHaveAttribute("aria-current", "true");
     await expect(page.getByTestId("review-view-staged")).toBeVisible();
-    await expect(page.getByTestId("review-view-commit")).toBeVisible();
+    await expect(page.getByTestId("review-view-commit")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
     await expect(page.getByTestId("review-view-branch")).toBeVisible();
 
     // The thread-scoped turn views must not appear with no thread.
@@ -210,8 +247,42 @@ test.describe("Review tab — dual-scope view selection", () => {
     await page.getByTestId("review-view-staged").click();
     await expect(switcher).toContainText("Staged");
     await expect(page.getByTestId("review-view-staged")).toHaveCount(0);
-    // Staged is a fixed-operand view — no operand slot.
+    // Staged is a fixed-operand view, so there is no operand slot.
     await expect(page.getByTestId("review-operand-slot")).toHaveCount(0);
+  });
+
+  test("threadless: Commit enables after the menu refreshes commit availability", async ({
+    page,
+  }) => {
+    await openThreadlessReview(page);
+
+    const switcher = page.getByTestId("review-view-switcher");
+    await expect(switcher).toContainText("Unstaged");
+
+    await switcher.click();
+    await expect(page.getByTestId("review-view-commit")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("review-view-commit")).toHaveCount(0);
+
+    commitsForLog = [
+      {
+        sha: "dddddddd4",
+        shortSha: "ddddddd",
+        message: "feat: terminal commit",
+        author: "Dev",
+        date: now,
+        filesChanged: 1,
+      },
+    ];
+
+    await switcher.click();
+    await expect(page.getByTestId("review-view-commit")).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
   });
 
   test("thread: dropdown adds the turn views on top of the git working-tree views", async ({
@@ -225,19 +296,92 @@ test.describe("Review tab — dual-scope view selection", () => {
     await expect(switcher).toContainText("Last turn");
 
     await switcher.click();
-    // All seven entries are reachable in a thread (additive, dual-scope).
+    // All thread and git entries are listed in a thread.
     await expect(page.getByTestId("review-view-last-turn")).toBeVisible();
     await expect(page.getByTestId("review-view-cumulative")).toBeVisible();
     await expect(page.getByTestId("review-view-unstaged")).toBeVisible();
     await expect(page.getByTestId("review-view-staged")).toBeVisible();
-    await expect(page.getByTestId("review-view-commit")).toBeVisible();
+    await expect(page.getByTestId("review-view-commit")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
     await expect(page.getByTestId("review-view-branch")).toBeVisible();
+    await expect(page.getByTestId("review-view-summary")).toHaveCount(0);
 
     // Selecting Branch swaps the diff without leaving the thread, and reveals the
     // contextual operand slot (Branch carries a picked operand).
     await page.getByTestId("review-view-branch").click();
     await expect(switcher).toContainText("Branch");
     await expect(page.getByTestId("review-operand-slot")).toHaveAttribute("data-operand", "branch");
+  });
+
+  test("thread: Cumulative owns Summary and jump-to-file autocomplete", async ({ page }) => {
+    await openThreadReview(page);
+
+    const switcher = page.getByTestId("review-view-switcher");
+    await expect(switcher).toBeVisible({ timeout: 5_000 });
+    await switcher.click();
+    await page.getByTestId("review-view-cumulative").click();
+    await expect(switcher).toContainText("Cumulative");
+    await expect(page.getByTestId("cumulative-summary-toggle")).toBeVisible();
+
+    await expect(page.getByTestId("review-file-filter")).toHaveCount(0);
+    await page.getByTestId("review-file-jump-trigger").click();
+    const filter = page.getByTestId("review-file-filter");
+    await filter.fill("beta");
+    await expect(page.locator('[data-review-file="src/beta.ts"]')).toBeVisible();
+    await expect(page.locator('[data-review-file="src/a.ts"]')).toBeVisible();
+    await page.getByTestId("review-file-jump-item-src/beta.ts").click();
+    await expect(page.getByTestId("review-file-filter")).toHaveCount(0);
+    await expect(page.locator('[data-review-file="src/beta.ts"]')).toHaveAttribute(
+      "data-jump-highlight",
+      "true",
+    );
+    await expect(page.getByText("new src/beta.ts")).toBeVisible();
+
+    await page.getByTestId("cumulative-summary-toggle").click();
+    await expect(page.getByText("no summary")).toBeVisible();
+    await expect(page.getByTestId("review-file-filter")).toHaveCount(0);
+  });
+
+  test("thread: Cumulative offers refresh from turn.persisted while open", async ({ page }) => {
+    await openThreadReview(page);
+
+    const switcher = page.getByTestId("review-view-switcher");
+    await switcher.click();
+    await page.getByTestId("review-view-cumulative").click();
+    await expect(switcher).toContainText("Cumulative");
+    await expect(page.locator('[data-review-file="src/new.ts"]')).toHaveCount(0);
+
+    snapshotsForList = [
+      SNAPSHOT,
+      {
+        id: "s2",
+        message_id: "m-s2",
+        thread_id: THREAD.id,
+        ref_before: "bbbbbbb",
+        ref_after: "ccccccc",
+        files_changed: ["src/new.ts"],
+        worktree_path: null,
+        created_at: now,
+      },
+    ];
+
+    const listCallsBeforePush = snapshotListCalls;
+    await wsController.sendPush("turn.persisted", {
+      threadId: THREAD.id,
+      messageId: "m-s2",
+      toolCallCount: 1,
+      filesChanged: ["src/new.ts"],
+    });
+
+    await expect(page.getByTestId("cumulative-view-refresh")).toBeVisible();
+    await expect(page.locator('[data-review-file="src/new.ts"]')).toHaveCount(0);
+    expect(snapshotListCalls).toBe(listCallsBeforePush);
+    await page.getByTestId("cumulative-view-refresh").click();
+    await expect(page.locator('[data-review-file="src/new.ts"]')).toBeVisible();
+    await expect(page.getByTestId("cumulative-view-refresh")).toHaveCount(0);
+    expect(snapshotListCalls).toBeGreaterThan(listCallsBeforePush);
   });
 
   test("branch: the operand slot fixes the current branch and picks only the comparison ref", async ({
@@ -251,26 +395,35 @@ test.describe("Review tab — dual-scope view selection", () => {
     await page.getByTestId("review-view-branch").click();
 
     // The operand slot fixes the current branch on the left and only the right
-    // comparison ref is selectable. The server default `main...feat/x` is adapted
-    // to the user-facing `feat/x -> main` shape.
+    // comparison ref is selectable. The server default `origin/main...feat/x` is
+    // adapted to the user-facing `feat/x -> origin/main` shape.
     const picker = page.getByTestId("branch-ref-picker");
     await expect(picker).toBeVisible();
     await expect(page.getByTestId("branch-base-picker")).toHaveCount(0);
     await expect(page.getByTestId("branch-current-ref")).toContainText("feat/x");
     const targetPicker = page.getByTestId("branch-target-picker");
     await expect(page.getByTestId("branch-range-arrow")).toBeVisible();
-    await expect(targetPicker).toContainText("main");
+    await expect(targetPicker).toContainText("origin/main");
     // Branch diffs open automatically after the comparison resolves; no file row
     // click is needed to see the inline diff.
-    await expect(page.getByText("new feat/x to main line")).toBeVisible();
+    await expect(page.getByText("new origin/main to feat/x line")).toBeVisible();
+    await expect
+      .poll(() =>
+        branchFilesCalls.some(
+          (params) =>
+            (params as { base?: string; target?: string }).base === "origin/main" &&
+            (params as { base?: string; target?: string }).target === "feat/x",
+        ),
+      )
+      .toBe(true);
     await expect
       .poll(() =>
         branchDiffCalls.some(
           (params) =>
             (params as { base?: string; target?: string; filePath?: string }).base ===
-              "feat/x" &&
+              "origin/main" &&
             (params as { base?: string; target?: string; filePath?: string }).target ===
-              "main" &&
+              "feat/x" &&
             (params as { base?: string; target?: string; filePath?: string }).filePath ===
               "src/branch.ts",
         ),
@@ -279,22 +432,54 @@ test.describe("Review tab — dual-scope view selection", () => {
 
     // Picking a new comparison ref updates only the right side.
     await targetPicker.click();
-    await page.getByTestId("branch-ref-target-origin/main").click();
+    await page.getByTestId("branch-ref-target-main").click();
     await expect(page.getByTestId("branch-current-ref")).toContainText("feat/x");
-    await expect(targetPicker).toContainText("origin/main");
+    await expect(targetPicker).toContainText("main");
     await expect
       .poll(() =>
         branchDiffCalls.some(
           (params) =>
             (params as { base?: string; target?: string; filePath?: string }).base ===
-              "feat/x" &&
+              "main" &&
             (params as { base?: string; target?: string; filePath?: string }).target ===
-              "origin/main" &&
+              "feat/x" &&
             (params as { base?: string; target?: string; filePath?: string }).filePath ===
               "src/branch.ts",
         ),
       )
       .toBe(true);
-    await expect(page.getByText("new feat/x to origin/main line")).toBeVisible();
+    await expect(page.getByText("new main to feat/x line")).toBeVisible();
+  });
+
+  test("branch: file-change pushes refetch the visible comparison", async ({ page }) => {
+    await openThreadReview(page);
+
+    const switcher = page.getByTestId("review-view-switcher");
+    await expect(switcher).toBeVisible({ timeout: 5_000 });
+    await switcher.click();
+    await page.getByTestId("review-view-branch").click();
+
+    await expect(page.getByText("new origin/main to feat/x line")).toBeVisible();
+    branchDiffVersion = 1;
+
+    await wsController.sendPush("files.changed", {
+      workspaceId: WORKSPACE.id,
+      threadId: THREAD.id,
+    });
+
+    await expect(page.getByText("new origin/main to feat/x reload 1")).toBeVisible();
+    await expect
+      .poll(() =>
+        branchDiffCalls.filter(
+          (params) =>
+            (params as { base?: string; target?: string; filePath?: string }).base ===
+              "origin/main" &&
+            (params as { base?: string; target?: string; filePath?: string }).target ===
+              "feat/x" &&
+            (params as { base?: string; target?: string; filePath?: string }).filePath ===
+              "src/branch.ts",
+        ).length,
+      )
+      .toBeGreaterThan(1);
   });
 });

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -28,6 +28,8 @@ describe("diffStore", () => {
       selectedCommitSha: null,
       renderMode: "unified",
       lineWrapByThread: {},
+      inlineDiffCache: {},
+      diffRevisionByScope: {},
     });
   });
 
@@ -73,6 +75,42 @@ describe("diffStore", () => {
       clearThread("thread-1");
       expect(getLineWrap("thread-1")).toBe(true);
       expect(useDiffStore.getState().lineWrapByThread["thread-1"]).toBeUndefined();
+    });
+  });
+
+  describe("diff revisions", () => {
+    it("increments per mutable diff scope", () => {
+      const { bumpDiffRevision } = useDiffStore.getState();
+      bumpDiffRevision("thread-1");
+      bumpDiffRevision("thread-1");
+      bumpDiffRevision("workspace-1");
+
+      expect(useDiffStore.getState().diffRevisionByScope["thread-1"]).toBe(2);
+      expect(useDiffStore.getState().diffRevisionByScope["workspace-1"]).toBe(1);
+    });
+
+    it("evicts inline diff cache entries for the refreshed mutable scope", () => {
+      const { cacheInlineDiff, bumpDiffRevision } = useDiffStore.getState();
+      cacheInlineDiff("thread-1", "branch", "origin/main...feat/x", "src/a.ts", "diff-a");
+      cacheInlineDiff("thread-2", "branch", "origin/main...feat/y", "src/b.ts", "diff-b");
+
+      bumpDiffRevision("thread-1");
+
+      const state = useDiffStore.getState();
+      expect(state.inlineDiffCache["thread-1:branch:origin/main...feat/x:src/a.ts"]).toBeUndefined();
+      expect(state.inlineDiffCache["thread-2:branch:origin/main...feat/y:src/b.ts"]).toBe("diff-b");
+    });
+
+    it("evicts cumulative inline diff cache when snapshots refresh", () => {
+      const { cacheInlineDiff, setSnapshots } = useDiffStore.getState();
+      cacheInlineDiff("thread-1", "cumulative", "thread-1", "src/a.ts", "old");
+      cacheInlineDiff("thread-1", "snapshot", "s1", "src/a.ts", "snapshot");
+
+      setSnapshots("thread-1", []);
+
+      const state = useDiffStore.getState();
+      expect(state.inlineDiffCache["thread-1:cumulative:thread-1:src/a.ts"]).toBeUndefined();
+      expect(state.inlineDiffCache["thread-1:snapshot:s1:src/a.ts"]).toBe("snapshot");
     });
   });
 

--- a/apps/web/src/components/diff/CommitPicker.tsx
+++ b/apps/web/src/components/diff/CommitPicker.tsx
@@ -17,6 +17,14 @@ import { useDiffStore } from "@/stores/diffStore";
 /** How many commits to load into the picker. Matches the Commits tab's window. */
 const COMMIT_LIMIT = 100;
 
+function mergeFirstPageCommits(current: GitCommit[], firstPage: GitCommit[]): GitCommit[] {
+  const firstPageShas = new Set(firstPage.map((commit) => commit.sha));
+  return [
+    ...firstPage,
+    ...current.slice(COMMIT_LIMIT).filter((commit) => !firstPageShas.has(commit.sha)),
+  ];
+}
+
 /** Format an ISO date to a compact relative string (mirrors CommitEntry's scale). */
 function relativeTime(isoDate: string): string {
   const then = new Date(isoDate).getTime();
@@ -47,6 +55,9 @@ export function CommitPicker() {
   });
   const selectedSha = useDiffStore((s) => s.selectedCommitSha);
   const setSelectedSha = useDiffStore((s) => s.setSelectedCommitSha);
+  const diffScopeRevision = useDiffStore((s) =>
+    activeWorkspaceId ? (s.diffRevisionByScope[activeThreadId ?? activeWorkspaceId] ?? 0) : 0,
+  );
 
   const [open, setOpen] = useState(false);
   const [commits, setCommits] = useState<GitCommit[]>([]);
@@ -104,6 +115,49 @@ export function CommitPicker() {
     };
   }, [activeWorkspaceId, loadCommits, setSelectedSha]);
 
+  useEffect(() => {
+    if (!activeWorkspaceId || loadingInitial) return;
+    let cancelled = false;
+
+    void loadCommits(0)
+      .then((list) => {
+        if (!cancelled) {
+          setCommits((current) => mergeFirstPageCommits(current, list));
+          setHasMore(list.length === COMMIT_LIMIT);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setHasMore(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeWorkspaceId, diffScopeRevision, loadCommits, loadingInitial]);
+
+  useEffect(() => {
+    if (!open || !activeWorkspaceId || loadingInitial) return;
+    let cancelled = false;
+
+    void loadCommits(0)
+      .then((list) => {
+        if (!cancelled) {
+          setCommits((current) => mergeFirstPageCommits(current, list));
+          setHasMore(list.length === COMMIT_LIMIT);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCommits([]);
+          setHasMore(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeWorkspaceId, loadCommits, loadingInitial, open]);
+
   const loadOlder = useCallback(async () => {
     if (loadingInitial || loadingMore || !hasMore) return;
     setLoadingMore(true);
@@ -142,7 +196,7 @@ export function CommitPicker() {
         className="flex h-6 min-w-0 max-w-[220px] items-center gap-1.5 rounded px-1.5 py-0.5 hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
       >
         <span className="shrink-0 font-mono text-[11px] tabular-nums text-foreground/55">
-          {selected?.shortSha ?? (loadingInitial ? "…" : "—")}
+          {selected?.shortSha ?? (loadingInitial ? "..." : "-")}
         </span>
         {selected && (
           <span className="min-w-0 truncate text-[11px] text-muted-foreground">

--- a/apps/web/src/components/diff/CumulativeView.tsx
+++ b/apps/web/src/components/diff/CumulativeView.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from "react";
-import { RefreshCw } from "lucide-react";
+import { FileText, RefreshCw } from "lucide-react";
 import type { TurnSnapshot } from "@mcode/contracts";
 import { Button } from "@/components/ui/button";
 import { useDiffStore } from "@/stores/diffStore";
+import { useSettingsStore } from "@/stores/settingsStore";
 import { getTransport } from "@/transport";
 import { FileList } from "./FileList";
+import { SummaryView } from "./SummaryView";
 
 /** Props for CumulativeView. */
 interface CumulativeViewProps {
@@ -17,7 +19,9 @@ export function CumulativeView({ snapshots, threadId }: CumulativeViewProps) {
   const pending = useDiffStore((s) => s.snapshotsPendingByThread[threadId] ?? false);
   const setSnapshots = useDiffStore((s) => s.setSnapshots);
   const markSnapshotsPending = useDiffStore((s) => s.markSnapshotsPending);
+  const diffSummaryEnabled = useSettingsStore((s) => s.settings.diffSummary.enabled);
   const [refreshing, setRefreshing] = useState(false);
+  const [summaryLens, setSummaryLens] = useState(false);
 
   const files = useMemo(() => {
     const seen = new Set<string>();
@@ -28,6 +32,11 @@ export function CumulativeView({ snapshots, threadId }: CumulativeViewProps) {
     }
     return [...seen].sort();
   }, [snapshots]);
+
+  const cacheVersion = useMemo(
+    () => snapshots.map((snapshot) => snapshot.id).join("|"),
+    [snapshots],
+  );
 
   const handleRefresh = async () => {
     if (refreshing) return;
@@ -65,23 +74,63 @@ export function CumulativeView({ snapshots, threadId }: CumulativeViewProps) {
         <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-muted-foreground/55">
           file{files.length !== 1 ? "s" : ""} · {snapshots.length} turn{snapshots.length !== 1 ? "s" : ""}
         </span>
-        {pending && (
+        {diffSummaryEnabled && (
           <Button
             type="button"
-            variant="outline"
+            variant={summaryLens ? "secondary" : "ghost"}
             size="xs"
-            onClick={handleRefresh}
-            disabled={refreshing}
-            aria-label="New changes available — click to refresh"
-            data-testid="cumulative-view-refresh"
-            className="ml-auto gap-1.5 rounded border-primary/40 bg-primary/15 px-2.5 py-1 font-mono text-[10.5px] font-medium uppercase tracking-[0.14em] text-primary hover:border-primary/60 hover:bg-primary/25"
+            aria-pressed={summaryLens}
+            onClick={() => setSummaryLens((value) => !value)}
+            data-testid="cumulative-summary-toggle"
+            className="ml-auto gap-1.5 px-2 font-mono text-[10.5px] uppercase tracking-[0.12em]"
           >
-            <RefreshCw size={11} className={refreshing ? "animate-spin" : ""} />
-            New changes
+            <FileText size={11} />
+            {summaryLens ? "Diff" : "Summarize"}
           </Button>
         )}
       </div>
-      <FileList files={files} source="cumulative" id={threadId} threadId={threadId} />
+      {pending && (
+        <div className="border-b border-primary/20 bg-primary/[0.045] px-3 py-2">
+          <div className="flex items-center gap-2 rounded border border-primary/25 bg-background/80 px-2.5 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+            <span
+              aria-hidden="true"
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary shadow-[0_0_0_3px_hsl(var(--primary)/0.14)]"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="font-mono text-[10.5px] font-medium uppercase tracking-[0.14em] text-foreground/85">
+                New changes available
+              </p>
+              <p className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground/55">
+                Refresh to review the new files.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={handleRefresh}
+              disabled={refreshing}
+              aria-label="Refresh Cumulative diff"
+              data-testid="cumulative-view-refresh"
+              className="h-7 shrink-0 gap-1.5 rounded border-primary/35 bg-primary/10 px-2.5 font-mono text-[10.5px] font-medium uppercase tracking-[0.12em] text-primary hover:border-primary/55 hover:bg-primary/18"
+            >
+              <RefreshCw size={11} className={refreshing ? "animate-spin" : ""} />
+              {refreshing ? "Refreshing" : "Refresh"}
+            </Button>
+          </div>
+        </div>
+      )}
+      {summaryLens && diffSummaryEnabled ? (
+        <SummaryView />
+      ) : (
+        <FileList
+          files={files}
+          source="cumulative"
+          id={threadId}
+          threadId={threadId}
+          cacheVersion={cacheVersion}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/diff/DiffPanel.tsx
+++ b/apps/web/src/components/diff/DiffPanel.tsx
@@ -6,7 +6,6 @@ import { DiffToolbar } from "./DiffToolbar";
 import { LastTurnView } from "./LastTurnView";
 import { CumulativeView } from "./CumulativeView";
 import { GitDiffView, type GitView } from "./GitDiffView";
-import { SummaryView } from "./SummaryView";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 /** The threadless git working-tree view ids. */
@@ -21,7 +20,7 @@ function isGitView(mode: string): mode is GitView {
  * The Review (Changes) tab body: toolbar + a single scrollable diff. Dual-scope —
  * with no thread it renders the git working-tree views (Unstaged/Staged/Commit/
  * Branch) against the workspace root; with a thread it renders the turn views
- * (Last turn, Cumulative, Summary). Each view renders exactly one diff.
+ * (Last turn, Cumulative). Each view renders exactly one diff.
  */
 export function DiffPanel() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
@@ -102,8 +101,6 @@ export function DiffPanel() {
           // thread's checkout (passed via threadId), alongside the turn views.
           isGitView(viewMode) && activeWorkspaceId ? (
             <GitDiffView view={viewMode} workspaceId={activeWorkspaceId} threadId={activeThreadId} />
-          ) : viewMode === "summary" ? (
-            <SummaryView />
           ) : snapshotsLoading ? (
             <LoadingPulse />
           ) : viewMode === "cumulative" ? (

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Columns2, AlignJustify, WrapText, Check, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -11,11 +11,13 @@ import {
 import { cn } from "@/lib/utils";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useSettingsStore } from "@/stores/settingsStore";
+import { getTransport } from "@/transport";
 import type { PanelScope } from "@/lib/panel-tabs";
 import { visibleReviewViews, defaultReviewView } from "@/lib/review-views";
 import { BranchRefPicker } from "./BranchRefPicker";
 import { CommitPicker } from "./CommitPicker";
+
+type CommitAvailability = "loading" | "available" | "empty";
 
 /** Toolbar for the Review tab: dual-scope view switcher + unified/side-by-side toggle. */
 export function DiffToolbar() {
@@ -23,8 +25,17 @@ export function DiffToolbar() {
   const renderMode = useDiffStore((s) => s.renderMode);
   const setViewMode = useDiffStore((s) => s.setViewMode);
   const setRenderMode = useDiffStore((s) => s.setRenderMode);
+  const [viewMenuOpen, setViewMenuOpen] = useState(false);
+  const [commitProbeNonce, setCommitProbeNonce] = useState(0);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const threadBranch = useWorkspaceStore((s) => {
+    const thread = s.threads.find((t) => t.id === s.activeThreadId);
+    return thread?.branch ?? undefined;
+  });
+  const diffScopeRevision = useDiffStore((s) =>
+    activeWorkspaceId ? (s.diffRevisionByScope[activeThreadId ?? activeWorkspaceId] ?? 0) : 0,
+  );
   const lineWrap = useDiffStore((s) =>
     activeThreadId ? s.getLineWrap(activeThreadId) : true,
   );
@@ -33,26 +44,35 @@ export function DiffToolbar() {
   const isGitRepo = useWorkspaceStore((s) =>
     s.workspaces.find((w) => w.id === s.activeWorkspaceId)?.is_git_repo ?? false,
   );
-  const diffSummaryEnabled = useSettingsStore((s) => s.settings.diffSummary.enabled);
 
   // The Review tab is dual-scope: threadless yields the git working-tree views,
   // a thread yields the turn views. Runtime gates drop the git views in a
-  // non-git workspace and Summary when its setting is off.
+  // non-git workspace.
   const scope: PanelScope = activeThreadId ? "thread" : "threadless";
   const viewModes = useMemo(
-    () => visibleReviewViews(scope, { isGitRepo, diffSummaryEnabled }),
-    [scope, isGitRepo, diffSummaryEnabled],
+    () => visibleReviewViews(scope, { isGitRepo }),
+    [scope, isGitRepo],
   );
+  const commitAvailability = useCommitAvailability({
+    activeWorkspaceId,
+    activeThreadId,
+    threadBranch,
+    isGitRepo,
+    diffScopeRevision,
+    commitProbeNonce,
+  });
 
-  // Recover when the active view falls out of the current scope or gating (e.g.
-  // switching to a threadless workspace, or disabling the summary setting).
+  // Recover when the active view falls out of the current scope or gating.
   useEffect(() => {
     if (viewModes.length === 0) return;
-    if (!viewModes.some((m) => m.id === viewMode)) {
+    if (
+      !viewModes.some((m) => m.id === viewMode) ||
+      (viewMode === "commit" && commitAvailability === "empty")
+    ) {
       const fallback = defaultReviewView(scope);
       setViewMode(viewModes.some((m) => m.id === fallback) ? fallback : viewModes[0].id);
     }
-  }, [viewMode, viewModes, scope, setViewMode]);
+  }, [commitAvailability, viewMode, viewModes, scope, setViewMode]);
 
   const activeView = useMemo(
     () => viewModes.find((m) => m.id === viewMode),
@@ -66,32 +86,47 @@ export function DiffToolbar() {
           operand (Branch, Commit). The slot stays empty until the picker
           slices land. */}
       <div className="flex min-w-0 items-center gap-2">
-        <DropdownMenu>
+        <DropdownMenu
+          open={viewMenuOpen}
+          onOpenChange={(open) => {
+            setViewMenuOpen(open);
+            if (open) setCommitProbeNonce((nonce) => nonce + 1);
+          }}
+        >
           <DropdownMenuTrigger
             data-testid="review-view-switcher"
             disabled={viewModes.length === 0}
             aria-label="Select review view"
             className="flex h-6 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium tracking-tight text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
           >
-            {activeView?.label ?? "—"}
+            {activeView?.label ?? "-"}
             <ChevronDown size={11} className="text-muted-foreground/60" />
           </DropdownMenuTrigger>
 
           <DropdownMenuContent align="start" sideOffset={4} className="min-w-[150px]">
             {viewModes.map((mode) => {
               const active = viewMode === mode.id;
+              const disabled = mode.id === "commit" && commitAvailability !== "available";
               return (
                 <DropdownMenuItem
                   key={mode.id}
-                  onClick={() => setViewMode(mode.id)}
+                  disabled={disabled}
+                  onClick={() => {
+                    if (!disabled) setViewMode(mode.id);
+                  }}
                   data-testid={`review-view-${mode.id}`}
                   data-active={active ? "true" : undefined}
+                  aria-disabled={disabled ? "true" : undefined}
                   // base-ui menuitems have no checked state; aria-current exposes
                   // the active view to assistive tech (the Check is visual-only).
                   aria-current={active ? "true" : undefined}
                   className={cn(
                     "flex cursor-pointer items-center gap-2 px-2 py-1.5 text-xs",
-                    active ? "text-foreground" : "text-popover-foreground",
+                    disabled
+                      ? "cursor-not-allowed text-muted-foreground/45"
+                      : active
+                        ? "text-foreground"
+                        : "text-popover-foreground",
                   )}
                 >
                   <span className="flex-1 text-left">{mode.label}</span>
@@ -102,7 +137,7 @@ export function DiffToolbar() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {/* Operand slot — the active view's picked operand. */}
+        {/* Operand slot: the active view's picked operand. */}
         {activeView?.operand && (
           <div
             className="ml-1 flex min-w-0 items-center border-l border-border/25 pl-2"
@@ -164,4 +199,65 @@ export function DiffToolbar() {
       </div>
     </div>
   );
+}
+
+function useCommitAvailability({
+  activeWorkspaceId,
+  activeThreadId,
+  threadBranch,
+  isGitRepo,
+  diffScopeRevision,
+  commitProbeNonce,
+}: {
+  activeWorkspaceId: string | null;
+  activeThreadId: string | null;
+  threadBranch?: string;
+  isGitRepo: boolean;
+  diffScopeRevision: number;
+  commitProbeNonce: number;
+}): CommitAvailability {
+  const [availability, setAvailability] = useState<CommitAvailability>("loading");
+
+  useEffect(() => {
+    if (!activeWorkspaceId || !isGitRepo) {
+      setAvailability("empty");
+      return;
+    }
+
+    let cancelled = false;
+    setAvailability("loading");
+
+    void (async () => {
+      try {
+        const transport = getTransport();
+        const branch = activeThreadId
+          ? threadBranch
+          : ((await transport.getCurrentBranch(activeWorkspaceId)) ?? undefined);
+        const commits = await transport.getGitLog(
+          activeWorkspaceId,
+          branch,
+          1,
+          undefined,
+          activeThreadId ?? undefined,
+          { skip: 0, includeStats: false },
+        );
+        if (!cancelled) setAvailability(commits.length > 0 ? "available" : "empty");
+      } catch {
+        if (!cancelled) setAvailability("empty");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeWorkspaceId,
+    activeThreadId,
+    threadBranch,
+    isGitRepo,
+    diffScopeRevision,
+    commitProbeNonce,
+  ]);
+
+  return availability;
 }

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -27,6 +27,14 @@ interface FileEntryProps {
   depth?: number;
   /** When true the diff starts expanded on mount and after its diff identity changes. */
   defaultExpanded?: boolean;
+  /** Extra identity for mutable comparisons whose visible id can stay stable. */
+  cacheVersion?: string | number;
+  /** Changes when search/jump asks this row to open and scroll into view. */
+  jumpToken?: number;
+  /** Clears the active jump once this row has scrolled into view. */
+  onJumpSettled?: (token: number) => void;
+  /** Changes when this row should show the jump confirmation highlight. */
+  highlightToken?: number;
 }
 
 /** Extract the basename from a file path. */
@@ -66,11 +74,23 @@ type DiffState = null | { loading: true } | { loading: false; data: string };
  * Diff is loaded lazily on the first expand, or immediately for auto-opened views.
  * Large diffs (>200 lines) are truncated with a "Show all N lines" button.
  */
-export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultExpanded: defaultExpandedProp = false }: FileEntryProps) {
+export function FileEntry({
+  filePath,
+  source,
+  id,
+  threadId,
+  depth = 0,
+  defaultExpanded: defaultExpandedProp = false,
+  cacheVersion = 0,
+  jumpToken,
+  onJumpSettled,
+  highlightToken,
+}: FileEntryProps) {
   const nested = depth > 0;
   const [expanded, setExpanded] = useState(defaultExpandedProp);
   const [showAllLines, setShowAllLines] = useState(false);
   const [previewMode, setPreviewMode] = useState(false);
+  const [jumpHighlight, setJumpHighlight] = useState(false);
   const cacheKey = `${threadId}:${source}:${id}:${filePath}`;
   // Initialise from the Zustand cache so diffs survive panel close/reopen.
   const cachedDiff = useDiffStore((s) => s.inlineDiffCache[cacheKey]);
@@ -82,6 +102,7 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
   // Reset in cleanup so React StrictMode's second invocation can start a
   // fresh, non-cancelled fetch (the first is cancelled by cleanup).
   const loadStartedRef = useRef(false);
+  const rowRef = useRef<HTMLDivElement>(null);
 
   // Reset local state when the cache identity changes so a reused component
   // instance doesn't show stale content from a previous identity.
@@ -91,11 +112,32 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
     setShowAllLines(false);
     setPreviewMode(false);
     loadStartedRef.current = false;
-  }, [cacheKey]);
+  }, [cacheKey, cacheVersion]);
 
   useEffect(() => {
     if (defaultExpandedProp) setExpanded(true);
-  }, [cacheKey, defaultExpandedProp]);
+  }, [cacheKey, cacheVersion, defaultExpandedProp]);
+
+  useEffect(() => {
+    if (jumpToken === undefined) return;
+    setExpanded(true);
+    const frame = requestAnimationFrame(() => {
+      const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      rowRef.current?.scrollIntoView({
+        block: "start",
+        behavior: reducedMotion ? "auto" : "smooth",
+      });
+      onJumpSettled?.(jumpToken);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [jumpToken, onJumpSettled]);
+
+  useEffect(() => {
+    if (highlightToken === undefined) return;
+    setJumpHighlight(true);
+    const timeout = setTimeout(() => setJumpHighlight(false), 1500);
+    return () => clearTimeout(timeout);
+  }, [highlightToken]);
 
   const { basename, parent, ext, language, isMarkdown } = useMemo(() => {
     const bn = getFileBasename(filePath);
@@ -136,7 +178,7 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
       cancelled = true;
       loadStartedRef.current = false;
     };
-  }, [expanded, source, id, filePath, threadId, cacheKey]);
+  }, [expanded, source, id, filePath, threadId, cacheKey, cacheVersion]);
 
   const lines = useMemo(
     () =>
@@ -200,20 +242,30 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
   }, [lines, isLargeDiff, showAllLines]);
 
   return (
-    <div className={`border-b border-border/30 ${expanded ? "bg-muted/5" : ""}`}>
+    <div
+      ref={rowRef}
+      data-review-file={filePath}
+      data-jump-highlight={jumpHighlight ? "true" : undefined}
+      className={`border-b border-border/20 transition-colors ${
+        expanded ? "bg-muted/[0.035]" : ""
+      } ${jumpHighlight ? "animate-flash-highlight bg-primary/10" : ""}`}
+    >
       {/* File header row — sticky when expanded so filename stays visible while scrolling the diff */}
       <button
         type="button"
-        onClick={() => setExpanded((prev) => {
-          if (prev) {
-            setShowAllLines(false);
-            setPreviewMode(false);
-          }
-          return !prev;
-        })}
-        className={`group flex w-full items-center gap-2 py-[5px] pr-3 text-left transition-colors hover:bg-muted/20 ${
+        onClick={() => {
+          setExpanded((prev) => {
+            if (prev) {
+              setShowAllLines(false);
+              setPreviewMode(false);
+            }
+            return !prev;
+          });
+        }}
+        data-jump-highlight={jumpHighlight ? "true" : undefined}
+        className={`group flex w-full items-center gap-2 py-[6px] pr-3 text-left transition-colors hover:bg-muted/20 data-[jump-highlight=true]:bg-primary/10 ${
           expanded
-            ? "sticky top-0 z-10 bg-background/95 backdrop-blur-sm border-b border-border/20"
+            ? "sticky top-[57px] z-10 bg-background/95 backdrop-blur-sm border-b border-border/20"
             : ""
         }`}
         style={{ paddingLeft: nested ? `${12 + depth * 14}px` : "28px" }}
@@ -285,7 +337,7 @@ export function FileEntry({ filePath, source, id, threadId, depth = 0, defaultEx
           ~ 171px) is always fully visible even for tiny diffs. pr-8 reserves
           the collapsed rail's gutter so code never sits behind the icons. */}
       {expanded && (
-        <div className="relative border-t border-border/30 min-h-[180px]">
+        <div className="relative border-t border-border/20 min-h-[180px] bg-background/45">
           <div className="pr-8">
             {!isLoaded ? (
               <div className="flex items-center justify-center gap-1.5 py-3">

--- a/apps/web/src/components/diff/FileList.tsx
+++ b/apps/web/src/components/diff/FileList.tsx
@@ -1,8 +1,19 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FileSearch } from "lucide-react";
 import { FileEntry } from "./FileEntry";
 import { FolderEntry } from "./FolderEntry";
 import { buildFileTree, type TreeNode } from "@/lib/file-tree";
 import type { SelectedFile } from "@/stores/diffStore";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
 /** Props for FileList. */
 interface FileListProps {
@@ -13,6 +24,8 @@ interface FileListProps {
   threadId: string;
   /** When true every file entry starts expanded (used for the latest turn). */
   defaultFilesExpanded?: boolean;
+  /** Extra identity for mutable comparisons whose ref names can stay stable while content changes. */
+  cacheVersion?: string | number;
 }
 
 /**
@@ -20,8 +33,43 @@ interface FileListProps {
  * Single-child folder chains are compressed (e.g., `src/stores/__tests__/`).
  * Folders sort before files; both alphabetical within their group.
  */
-export function FileList({ files, source, id, threadId, defaultFilesExpanded = false }: FileListProps) {
+export function FileList({
+  files,
+  source,
+  id,
+  threadId,
+  defaultFilesExpanded = false,
+  cacheVersion = 0,
+}: FileListProps) {
+  const [jumpOpen, setJumpOpen] = useState(false);
+  const [jumpTarget, setJumpTarget] = useState<{ path: string; token: number } | null>(null);
+  const [highlightTarget, setHighlightTarget] = useState<{ path: string; token: number } | null>(null);
+  const jumpTokenRef = useRef(0);
+  const highlightClearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const tree = useMemo(() => buildFileTree(files), [files]);
+
+  useEffect(() => {
+    return () => {
+      if (highlightClearRef.current) clearTimeout(highlightClearRef.current);
+    };
+  }, []);
+
+  const jumpToFile = useCallback((path: string) => {
+    const token = ++jumpTokenRef.current;
+    setJumpOpen(false);
+    setJumpTarget({ path, token });
+    setHighlightTarget({ path, token });
+
+    if (highlightClearRef.current) clearTimeout(highlightClearRef.current);
+    highlightClearRef.current = setTimeout(() => {
+      setHighlightTarget((current) => (current?.token === token ? null : current));
+      highlightClearRef.current = null;
+    }, 1500);
+  }, []);
+
+  const clearJumpTarget = useCallback((token: number) => {
+    setJumpTarget((current) => (current?.token === token ? null : current));
+  }, []);
 
   if (files.length === 0) {
     return (
@@ -31,14 +79,93 @@ export function FileList({ files, source, id, threadId, defaultFilesExpanded = f
 
   return (
     <div className="flex flex-col">
+      <div className="sticky top-0 z-20 flex items-center justify-between gap-2 border-b border-border/20 bg-background/95 px-3 py-2 backdrop-blur-sm">
+        <span className="font-mono text-[10px] tabular-nums text-muted-foreground/50">
+          {files.length} {files.length === 1 ? "file" : "files"}
+        </span>
+        <Popover open={jumpOpen} onOpenChange={setJumpOpen}>
+          <PopoverTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                aria-label="Jump to file"
+                data-testid="review-file-jump-trigger"
+                className="h-6 gap-1.5 border border-border/20 bg-muted/10 px-2 font-mono text-[10.5px] text-muted-foreground/75 hover:border-border/35 hover:bg-muted/25 hover:text-foreground"
+              >
+                <FileSearch size={12} aria-hidden="true" />
+                Jump
+              </Button>
+            }
+          />
+          <PopoverContent align="end" sideOffset={6} className="w-[min(360px,calc(100vw-2rem))] p-0">
+            <Command className="rounded-lg">
+              <CommandInput
+                autoFocus
+                placeholder="Jump to file"
+                aria-label="Jump to file"
+                data-testid="review-file-filter"
+                className="h-9 font-mono text-[11px]"
+              />
+              <CommandList className="max-h-72">
+                <CommandEmpty>No files found</CommandEmpty>
+                <CommandGroup heading="Changed files">
+                  {files.map((file) => {
+                    const basename = getFileBasename(file);
+                    const parent = getParentPath(file);
+                    return (
+                      <CommandItem
+                        key={file}
+                        value={file}
+                        data-testid={`review-file-jump-item-${file}`}
+                        onSelect={() => jumpToFile(file)}
+                        className="items-start gap-2 px-2 py-2"
+                      >
+                        <FileSearch
+                          size={12}
+                          aria-hidden="true"
+                          className="mt-0.5 text-muted-foreground/45"
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-mono text-[11.5px] text-foreground/85">
+                            {basename}
+                          </span>
+                          {parent && (
+                            <span className="block truncate font-mono text-[10px] text-muted-foreground/55">
+                              {parent}/
+                            </span>
+                          )}
+                        </span>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
       {tree.map((node) => (
-        <TreeNodeRenderer key={nodeKey(node)} node={node} depth={0} source={source} id={id} threadId={threadId} defaultExpanded={defaultFilesExpanded} />
+        <TreeNodeRenderer
+          key={nodeKey(node)}
+          node={node}
+          depth={0}
+          source={source}
+          id={id}
+          threadId={threadId}
+          defaultExpanded={defaultFilesExpanded}
+          cacheVersion={cacheVersion}
+          jumpTarget={jumpTarget}
+          highlightTarget={highlightTarget}
+          onJumpSettled={clearJumpTarget}
+        />
       ))}
     </div>
   );
 }
 
-/** Stable key for a tree node — folders use their full path, files use the file path. */
+/** Stable key for a tree node. Folders use their full path, files use the file path. */
 function nodeKey(node: TreeNode): string {
   return node.type === "folder" ? `dir:${node.path}` : `file:${node.path}`;
 }
@@ -51,6 +178,10 @@ function TreeNodeRenderer({
   id,
   threadId,
   defaultExpanded,
+  cacheVersion,
+  jumpTarget,
+  highlightTarget,
+  onJumpSettled,
 }: {
   node: TreeNode;
   depth: number;
@@ -58,13 +189,35 @@ function TreeNodeRenderer({
   id: string;
   threadId: string;
   defaultExpanded?: boolean;
+  cacheVersion: string | number;
+  jumpTarget: { path: string; token: number } | null;
+  highlightTarget: { path: string; token: number } | null;
+  onJumpSettled: (token: number) => void;
 }) {
   if (node.type === "file") {
-    return <FileEntry filePath={node.path} source={source} id={id} threadId={threadId} depth={depth} defaultExpanded={defaultExpanded} />;
+    return (
+      <FileEntry
+        filePath={node.path}
+        source={source}
+        id={id}
+        threadId={threadId}
+        depth={depth}
+        defaultExpanded={defaultExpanded}
+        cacheVersion={cacheVersion}
+        jumpToken={jumpTarget?.path === node.path ? jumpTarget.token : undefined}
+        onJumpSettled={onJumpSettled}
+        highlightToken={highlightTarget?.path === node.path ? highlightTarget.token : undefined}
+      />
+    );
   }
 
   return (
-    <FolderEntry name={node.name} fileCount={node.fileCount} depth={depth}>
+    <FolderEntry
+      name={node.name}
+      fileCount={node.fileCount}
+      depth={depth}
+      forceExpanded={jumpTarget ? treeContainsPath(node, jumpTarget.path) : false}
+    >
       {node.children.map((child) => (
         <TreeNodeRenderer
           key={nodeKey(child)}
@@ -74,8 +227,29 @@ function TreeNodeRenderer({
           id={id}
           threadId={threadId}
           defaultExpanded={defaultExpanded}
+          cacheVersion={cacheVersion}
+          jumpTarget={jumpTarget}
+          highlightTarget={highlightTarget}
+          onJumpSettled={onJumpSettled}
         />
       ))}
     </FolderEntry>
   );
+}
+
+/** Whether a tree node contains a given file path. */
+function treeContainsPath(node: TreeNode, path: string): boolean {
+  if (node.type === "file") return node.path === path;
+  return node.children.some((child) => treeContainsPath(child, path));
+}
+
+/** Extract the basename from a file path for jump result labels. */
+function getFileBasename(filePath: string): string {
+  return filePath.split("/").pop() ?? filePath;
+}
+
+/** Extract the parent path from a file path for jump result labels. */
+function getParentPath(filePath: string): string {
+  const parts = filePath.split("/");
+  return parts.length > 1 ? parts.slice(0, -1).join("/") : "";
 }

--- a/apps/web/src/components/diff/FolderEntry.tsx
+++ b/apps/web/src/components/diff/FolderEntry.tsx
@@ -1,4 +1,4 @@
-import { useId, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 
 /** Props for FolderEntry. */
 interface FolderEntryProps {
@@ -10,6 +10,8 @@ interface FolderEntryProps {
   depth: number;
   /** Whether the folder starts expanded. */
   defaultExpanded?: boolean;
+  /** Force the folder open when a descendant is the active jump target. */
+  forceExpanded?: boolean;
   /** Rendered child rows (file entries or nested folders). */
   children: ReactNode;
 }
@@ -23,25 +25,31 @@ export function FolderEntry({
   fileCount,
   depth,
   defaultExpanded = true,
+  forceExpanded = false,
   children,
 }: FolderEntryProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const contentId = useId();
+  const open = forceExpanded || expanded;
+
+  useEffect(() => {
+    if (forceExpanded) setExpanded(true);
+  }, [forceExpanded]);
 
   return (
     <div>
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        aria-expanded={expanded}
+        aria-expanded={open}
         aria-controls={contentId}
-        className="group flex w-full items-baseline gap-2 py-[5px] pr-3 text-left transition-colors hover:bg-muted/[0.06]"
+        className="group flex w-full items-baseline gap-2 py-[6px] pr-3 text-left transition-colors hover:bg-muted/[0.06]"
         style={{ paddingLeft: `${12 + depth * 14}px` }}
       >
         <span
           aria-hidden="true"
           className={`shrink-0 font-mono text-[11px] leading-none transition-transform duration-150 text-muted-foreground/50 ${
-            expanded ? "rotate-90" : ""
+            open ? "rotate-90" : ""
           }`}
         >
           ›
@@ -56,7 +64,7 @@ export function FolderEntry({
         </span>
       </button>
 
-      {expanded && <div id={contentId}>{children}</div>}
+      {open && <div id={contentId}>{children}</div>}
     </div>
   );
 }

--- a/apps/web/src/components/diff/GitDiffView.tsx
+++ b/apps/web/src/components/diff/GitDiffView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getTransport } from "@/transport";
 import { useDiffStore, type SelectedFile } from "@/stores/diffStore";
 import { FileList } from "./FileList";
@@ -26,6 +26,19 @@ interface Resolved {
   source: SelectedFile["source"];
   /** FileList row id: the workspace id for working-tree/branch views, the SHA for commit. */
   id: string;
+}
+
+/** Convert the Branch toolbar's visible current→comparison pair into git's base...target range. */
+function branchRangeForReview(
+  currentBranch: string | null,
+  comparisonRef: string | null,
+): { base: string; target: string; id: string } | null {
+  if (!currentBranch || !comparisonRef) return null;
+  return {
+    base: comparisonRef,
+    target: currentBranch,
+    id: `${comparisonRef}...${currentBranch}`,
+  };
 }
 
 /** The empty-state glyph + label shown for a view with no changes. */
@@ -61,21 +74,28 @@ function LoadingPulse() {
  * Renders one threadless git working-tree view (Unstaged, Staged, Commit, or
  * Branch) as a single navigable diff: a file tree whose rows lazy-load their
  * per-file diff. Reads the workspace root via the git transport. The Commit view
- * resolves to the latest HEAD commit; Branch compares the current branch to its
- * default base. See CONTEXT.md → "Review tab".
+ * resolves to the latest HEAD commit; Branch compares the visible current branch
+ * against the selected comparison ref. See CONTEXT.md → "Review tab".
  */
 export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
   const [resolved, setResolved] = useState<Resolved | null>(null);
   const [loading, setLoading] = useState(true);
+  const diffScopeId = threadId ?? workspaceId;
+  const diffRevision = useDiffStore((s) => s.diffRevisionByScope[diffScopeId] ?? 0);
+  const mutableDiffRevision = view === "commit" ? 0 : diffRevision;
   // The Commit view's picked operand (see CommitPicker). Null means the picker
   // has not resolved a commit yet, or the current scope has no commits.
   const selectedCommitSha = useDiffStore((s) => s.selectedCommitSha);
 
-  // The Branch view's diff is driven by the current branch plus the selected
-  // comparison ref. Subscribe so picking a new target refetches the file list.
+  // The Branch toolbar stores the pair as current→comparison because that is how
+  // it is shown. Git three-dot review semantics fetch comparison...current.
   const branchBase = useDiffStore((s) => s.branchComparison?.base ?? null);
   const branchTarget = useDiffStore((s) => s.branchComparison?.target ?? null);
   const branchUnborn = useDiffStore((s) => s.branchComparison?.isUnborn ?? false);
+  const branchRange = useMemo(
+    () => branchRangeForReview(branchBase, branchTarget),
+    [branchBase, branchTarget],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -85,7 +105,7 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
     // Branch view waits for the picker to resolve a pair before fetching, unless
     // HEAD is unborn (explicit empty). Holding `loading` avoids a flash of the
     // empty state with a stale/default range during resolution.
-    if (view === "branch" && !branchUnborn && (!branchBase || !branchTarget)) {
+    if (view === "branch" && !branchUnborn && !branchRange) {
       return () => {
         cancelled = true;
       };
@@ -98,13 +118,18 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
         return { files, source: view, id: workspaceId };
       }
       if (view === "branch") {
-        if (branchUnborn || !branchBase || !branchTarget) {
+        if (branchUnborn || !branchRange) {
           return { files: [], source: "branch", id: "branch-empty" };
         }
-        const files = await transport.getBranchFiles(workspaceId, branchBase, branchTarget, threadId);
+        const files = await transport.getBranchFiles(
+          workspaceId,
+          branchRange.base,
+          branchRange.target,
+          threadId,
+        );
         // The comparison range is folded into the FileList id so the inline diff
         // cache and per-file fetch vary by pair (git refnames can't contain "..").
-        return { files, source: "branch", id: `${branchBase}...${branchTarget}` };
+        return { files, source: "branch", id: branchRange.id };
       }
       // Commit view: the picker's chosen commit. The picker owns defaulting to
       // the latest HEAD commit, which avoids a duplicate git-log + commit-files
@@ -138,7 +163,7 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
     // inputs for the Branch view: picking a new ref pair refetches its file list.
     // previous scope's stale diff. selectedCommitSha is one too: picking a commit
     // refetches that commit's files (no-op for the non-commit views).
-  }, [view, workspaceId, threadId, branchBase, branchTarget, branchUnborn, selectedCommitSha]);
+  }, [view, workspaceId, threadId, branchRange, branchUnborn, selectedCommitSha, mutableDiffRevision]);
 
   if (loading) return <LoadingPulse />;
   if (!resolved || resolved.files.length === 0) {
@@ -154,6 +179,7 @@ export function GitDiffView({ view, workspaceId, threadId }: GitDiffViewProps) {
         // Cache + per-file fetch scope: the real thread (→ its worktree) when in a
         // thread, else the workspace id (the server reads the workspace root).
         threadId={threadId ?? workspaceId}
+        cacheVersion={mutableDiffRevision}
         // Open each file's diff on arrival so switching between the git views
         // lands on the changes directly, without a click per file (each diff is
         // still fetched lazily on mount and large diffs stay truncated).

--- a/apps/web/src/components/diff/__tests__/CumulativeView.test.tsx
+++ b/apps/web/src/components/diff/__tests__/CumulativeView.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getDefaultSettings } from "@mcode/contracts";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { CumulativeView } from "../CumulativeView";
+
+vi.mock("../SummaryView", () => ({
+  SummaryView: () => <div data-testid="summary-lens">Summary lens</div>,
+}));
+
+vi.mock("@/hooks/useOpenInApps", () => ({
+  useOpenInApps: () => [],
+}));
+
+describe("CumulativeView summary lens", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      settings: {
+        ...getDefaultSettings(),
+        diffSummary: { enabled: true },
+      },
+    });
+  });
+
+  it("toggles the Cumulative diff into its summary lens in place", async () => {
+    render(
+      <CumulativeView
+        threadId="thread-1"
+        snapshots={[
+          {
+            id: "snap-1",
+            thread_id: "thread-1",
+            message_id: "turn-1",
+            ref_before: "a",
+            ref_after: "b",
+            files_changed: ["apps/web/src/a.ts"],
+            worktree_path: null,
+            created_at: "2026-06-12T10:00:00.000Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("a.ts")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("cumulative-summary-toggle"));
+
+    expect(screen.getByTestId("summary-lens")).toBeInTheDocument();
+    expect(screen.queryByText("a.ts")).not.toBeInTheDocument();
+  });
+
+  it("hides the summary lens toggle when the setting is disabled", () => {
+    useSettingsStore.setState({
+      settings: {
+        ...getDefaultSettings(),
+        diffSummary: { enabled: false },
+      },
+    });
+
+    render(
+      <CumulativeView
+        threadId="thread-1"
+        snapshots={[
+          {
+            id: "snap-1",
+            thread_id: "thread-1",
+            message_id: "turn-1",
+            ref_before: "a",
+            ref_after: "b",
+            files_changed: ["apps/web/src/a.ts"],
+            worktree_path: null,
+            created_at: "2026-06-12T10:00:00.000Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId("cumulative-summary-toggle")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/diff/__tests__/FileList.test.tsx
+++ b/apps/web/src/components/diff/__tests__/FileList.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDiffStore } from "@/stores/diffStore";
+import { FileList } from "../FileList";
+
+vi.mock("@/hooks/useOpenInApps", () => ({
+  useOpenInApps: () => [],
+}));
+
+vi.mock("@/hooks/useDiffHighlighter", () => ({
+  useDiffHighlighter: () => ({ getLineTokens: () => null }),
+}));
+
+const transport = vi.hoisted(() => ({
+  getSnapshotDiff: vi.fn(),
+}));
+
+vi.mock("@/transport", () => ({
+  getTransport: () => transport,
+}));
+
+describe("FileList jump to file", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDiffStore.setState({
+      inlineDiffCache: {},
+      renderMode: "unified",
+      lineWrapByThread: {},
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+    class ResizeObserverMock {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+    window.ResizeObserver = ResizeObserverMock;
+    transport.getSnapshotDiff.mockResolvedValue(
+      "diff --git a/apps/web/src/beta.ts b/apps/web/src/beta.ts\n@@ -1 +1 @@\n-old\n+new",
+    );
+  });
+
+  it("opens autocomplete on demand and jumps without filtering the tree", async () => {
+    render(
+      <FileList
+        files={["apps/web/src/alpha.ts", "apps/web/src/beta.ts"]}
+        source="snapshot"
+        id="snap-1"
+        threadId="thread-1"
+      />,
+    );
+
+    expect(screen.queryByTestId("review-file-filter")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("review-file-jump-trigger"));
+    await userEvent.type(screen.getByTestId("review-file-filter"), "beta");
+    await userEvent.click(screen.getByTestId("review-file-jump-item-apps/web/src/beta.ts"));
+
+    expect(screen.getByText("alpha.ts")).toBeInTheDocument();
+    expect(screen.getByText("beta.ts")).toBeInTheDocument();
+    expect(screen.queryByTestId("review-file-filter")).not.toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText("beta.ts").closest("[data-review-file]")).toHaveAttribute(
+        "data-jump-highlight",
+        "true",
+      ),
+    );
+
+    await waitFor(() =>
+      expect(transport.getSnapshotDiff).toHaveBeenCalledWith(
+        "snap-1",
+        "apps/web/src/beta.ts",
+      ),
+    );
+  });
+});

--- a/apps/web/src/components/diff/__tests__/GitDiffView.test.tsx
+++ b/apps/web/src/components/diff/__tests__/GitDiffView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDiffStore } from "@/stores/diffStore";
 import { GitDiffView } from "../GitDiffView";
@@ -27,6 +27,9 @@ describe("GitDiffView commit selection", () => {
       diffContent: null,
       diffLoading: false,
       inlineDiffCache: {},
+      diffRevisionByScope: {},
+      branchComparison: null,
+      branchComparisonKey: null,
       renderMode: "unified",
     });
     transport.getCommitFiles.mockResolvedValue(["selected.ts"]);
@@ -43,6 +46,18 @@ describe("GitDiffView commit selection", () => {
     expect(transport.getGitLog).not.toHaveBeenCalled();
   });
 
+  it("does not refetch an immutable commit when the mutable diff revision changes", async () => {
+    render(<GitDiffView view="commit" workspaceId="ws-1" threadId="thread-1" />);
+
+    await waitFor(() => expect(transport.getCommitFiles).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useDiffStore.getState().bumpDiffRevision("thread-1");
+    });
+
+    expect(transport.getCommitFiles).toHaveBeenCalledTimes(1);
+  });
+
   it("waits for the picker when no commit has been resolved", async () => {
     useDiffStore.setState({ selectedCommitSha: null });
 
@@ -52,5 +67,43 @@ describe("GitDiffView commit selection", () => {
 
     expect(transport.getCommitFiles).not.toHaveBeenCalled();
     expect(transport.getGitLog).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitDiffView mutable branch reloads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDiffStore.setState({
+      branchComparison: {
+        base: "feat/current",
+        target: "origin/main",
+        refs: [],
+        isUnborn: false,
+      },
+      branchComparisonKey: "ws-1:thread-1",
+      diffRevisionByScope: {},
+      inlineDiffCache: {},
+      renderMode: "unified",
+    });
+    transport.getBranchFiles.mockResolvedValue(["changed.ts"]);
+  });
+
+  it("refetches the branch file list when the diff scope revision changes", async () => {
+    render(<GitDiffView view="branch" workspaceId="ws-1" threadId="thread-1" />);
+
+    await waitFor(() =>
+      expect(transport.getBranchFiles).toHaveBeenCalledWith(
+        "ws-1",
+        "origin/main",
+        "feat/current",
+        "thread-1",
+      ),
+    );
+
+    act(() => {
+      useDiffStore.getState().bumpDiffRevision("thread-1");
+    });
+
+    await waitFor(() => expect(transport.getBranchFiles).toHaveBeenCalledTimes(2));
   });
 });

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -271,7 +271,13 @@ export function RightPanel() {
     <div
       ref={panelRootRef}
       style={
-        maximized
+        !panelVisible
+          ? {
+              width: 0,
+              minWidth: 0,
+              maxWidth: 0,
+            }
+          : maximized
           ? undefined
           : {
               width: panelWidth,
@@ -281,10 +287,12 @@ export function RightPanel() {
       }
       className={cn(
         "relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-lg bg-background shadow-sm focus:outline-none",
-        !panelVisible && "hidden",
+        "transition-[width,min-width,max-width,opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+        !panelVisible && "pointer-events-none translate-x-2 opacity-0",
+        panelVisible && "translate-x-0 opacity-100",
         // Maximized fills the content area (App hides the chat pane); inline
         // mode is sized by the stored width above.
-        maximized && "flex-1",
+        panelVisible && maximized && "flex-1",
       )}
       // Pair aria-hidden with inert: inert auto-blurs any focused descendant on
       // apply, which avoids Chrome's "Blocked aria-hidden on an element because

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -489,7 +489,7 @@ export function ModelSection() {
         <SettingRow
           label="Context window"
           configKey="model.defaults.contextWindow"
-          hint="200k is the standard window. 1M unlocks the extended beta window on Opus 4.7/4.6 and Sonnet 4.6."
+          hint="200k is the standard window. 1M uses the extended beta window on Opus 4.7/4.6 and Sonnet 4.6."
         >
           <SegControl
             options={[
@@ -578,7 +578,7 @@ export function ModelSection() {
           <SettingRow
             label="Diff summary"
             configKey="diffSummary.enabled"
-            hint="Show an AI-generated Summary tab in the diff panel."
+            hint="Show the Summarize toggle in the Cumulative diff."
           >
             <Switch
               checked={diffSummaryEnabled}

--- a/apps/web/src/lib/__tests__/review-views.test.ts
+++ b/apps/web/src/lib/__tests__/review-views.test.ts
@@ -21,7 +21,6 @@ describe("REVIEW_VIEWS catalog", () => {
       "branch",
       "last-turn",
       "cumulative",
-      "summary",
     ]);
   });
 
@@ -29,18 +28,15 @@ describe("REVIEW_VIEWS catalog", () => {
     const anyScope = REVIEW_VIEWS.filter((v) => !v.threadOnly).map((v) => v.id);
     const threadOnly = REVIEW_VIEWS.filter((v) => v.threadOnly).map((v) => v.id);
     expect(anyScope).toEqual(["unstaged", "staged", "commit", "branch"]);
-    expect(threadOnly).toEqual(["last-turn", "cumulative", "summary"]);
+    expect(threadOnly).toEqual(["last-turn", "cumulative"]);
   });
 
-  it("marks every git view as git-requiring and Summary as summary-gated", () => {
+  it("marks every git view as git-requiring", () => {
     expect(REVIEW_VIEWS.filter((v) => v.requires === "git").map((v) => v.id)).toEqual([
       "unstaged",
       "staged",
       "commit",
       "branch",
-    ]);
-    expect(REVIEW_VIEWS.filter((v) => v.requires === "diffSummary").map((v) => v.id)).toEqual([
-      "summary",
     ]);
   });
 
@@ -51,7 +47,7 @@ describe("REVIEW_VIEWS catalog", () => {
     ]);
     // The fixed-operand views surface no operand control.
     const fixed = REVIEW_VIEWS.filter((v) => !v.operand).map((v) => v.id);
-    expect(fixed).toEqual(["unstaged", "staged", "last-turn", "cumulative", "summary"]);
+    expect(fixed).toEqual(["unstaged", "staged", "last-turn", "cumulative"]);
   });
 });
 
@@ -73,7 +69,6 @@ describe("availableReviewViews — dual-scope selection", () => {
       "branch",
       "last-turn",
       "cumulative",
-      "summary",
     ]);
   });
 
@@ -87,25 +82,25 @@ describe("availableReviewViews — dual-scope selection", () => {
 describe("visibleReviewViews — runtime gates", () => {
   it("drops all threadless views in a non-git workspace", () => {
     expect(
-      ids(visibleReviewViews("threadless", { isGitRepo: false, diffSummaryEnabled: false })),
+      ids(visibleReviewViews("threadless", { isGitRepo: false })),
     ).toEqual([]);
   });
 
   it("keeps the git views in a git workspace", () => {
     expect(
-      ids(visibleReviewViews("threadless", { isGitRepo: true, diffSummaryEnabled: false })),
+      ids(visibleReviewViews("threadless", { isGitRepo: true })),
     ).toEqual(["unstaged", "staged", "commit", "branch"]);
   });
 
-  it("drops Summary in a thread when the diff-summary setting is off", () => {
+  it("does not expose Summary as a switcher view", () => {
     expect(
-      ids(visibleReviewViews("thread", { isGitRepo: true, diffSummaryEnabled: false })),
+      ids(visibleReviewViews("thread", { isGitRepo: true })),
     ).toEqual(["unstaged", "staged", "commit", "branch", "last-turn", "cumulative"]);
   });
 
-  it("keeps Summary in a thread when the diff-summary setting is on", () => {
+  it("keeps Cumulative visible because Summary lives inside it as a lens", () => {
     expect(
-      ids(visibleReviewViews("thread", { isGitRepo: true, diffSummaryEnabled: true })),
+      ids(visibleReviewViews("thread", { isGitRepo: true })),
     ).toEqual([
       "unstaged",
       "staged",
@@ -113,14 +108,13 @@ describe("visibleReviewViews — runtime gates", () => {
       "branch",
       "last-turn",
       "cumulative",
-      "summary",
     ]);
   });
 
   it("leaves the turn views unaffected by git presence (only git views drop)", () => {
     expect(
-      ids(visibleReviewViews("thread", { isGitRepo: false, diffSummaryEnabled: true })),
-    ).toEqual(["last-turn", "cumulative", "summary"]);
+      ids(visibleReviewViews("thread", { isGitRepo: false })),
+    ).toEqual(["last-turn", "cumulative"]);
   });
 });
 
@@ -143,7 +137,7 @@ describe("availableReviewViews / visibleReviewViews — purity and order", () =>
 
   it("does not mutate the catalog", () => {
     const before = ids(REVIEW_VIEWS);
-    visibleReviewViews("thread", { isGitRepo: true, diffSummaryEnabled: true });
+    visibleReviewViews("thread", { isGitRepo: true });
     availableReviewViews("threadless");
     expect(ids(REVIEW_VIEWS)).toEqual(before);
   });

--- a/apps/web/src/lib/review-views.ts
+++ b/apps/web/src/lib/review-views.ts
@@ -3,11 +3,10 @@ import type { DiffViewMode } from "@/stores/diffStore";
 
 /**
  * A requirement a Review view depends on beyond its scope. `"git"` views need a
- * git repository (the four working-tree views); `"diffSummary"` is gated behind
- * the diff-summary setting. Views with no requirement are always offered in their
- * scope.
+ * git repository (the four working-tree views). Views with no requirement are
+ * always offered in their scope.
  */
-export type ReviewViewRequirement = "git" | "diffSummary";
+export type ReviewViewRequirement = "git";
 
 /**
  * The kind of picked operand a comparison view surfaces in the toolbar's
@@ -29,7 +28,7 @@ export interface ReviewView {
   readonly label: string;
   /**
    * Whether the view requires an active thread. The turn views (Last turn,
-   * Cumulative, Summary) describe a thread's turns and are thread-only; the git
+   * Cumulative) describe a thread's turns and are thread-only; the git
    * working-tree views (Unstaged/Staged/Commit/Branch) work in *both* scopes —
    * threadless they read the workspace root, in a thread they read the thread's
    * checkout. So the Review tab is dual-scope and additive: a thread keeps the
@@ -60,7 +59,6 @@ export const REVIEW_VIEWS: readonly ReviewView[] = [
   { id: "branch", label: "Branch", threadOnly: false, requires: "git", operand: "branch" },
   { id: "last-turn", label: "Last turn", threadOnly: true },
   { id: "cumulative", label: "Cumulative", threadOnly: true },
-  { id: "summary", label: "Summary", threadOnly: true, requires: "diffSummary" },
 ];
 
 /**
@@ -78,14 +76,12 @@ export function availableReviewViews(scope: PanelScope): readonly ReviewView[] {
 export interface ReviewViewGates {
   /** Whether the active workspace is a git repository (gates the git views). */
   readonly isGitRepo: boolean;
-  /** Whether the diff-summary feature is enabled (gates the Summary view). */
-  readonly diffSummaryEnabled: boolean;
 }
 
 /**
  * The Review views the user can actually pick right now: {@link availableReviewViews}
- * filtered by the runtime gates (git presence for the working-tree views, the
- * diff-summary setting for Summary). Pure. Returns catalog order.
+ * filtered by the runtime gates (git presence for the working-tree views).
+ * Pure. Returns catalog order.
  */
 export function visibleReviewViews(
   scope: PanelScope,
@@ -93,7 +89,6 @@ export function visibleReviewViews(
 ): readonly ReviewView[] {
   return availableReviewViews(scope).filter((view) => {
     if (view.requires === "git" && !gates.isGitRepo) return false;
-    if (view.requires === "diffSummary" && !gates.diffSummaryEnabled) return false;
     return true;
   });
 }

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -18,8 +18,7 @@ export type DiffViewMode =
   | "commit"
   | "branch"
   | "last-turn"
-  | "cumulative"
-  | "summary";
+  | "cumulative";
 
 /** Diff rendering mode. */
 export type DiffRenderMode = "unified" | "side-by-side";
@@ -110,6 +109,28 @@ export function createDefaultRightPanelState(): RightPanelState {
     openTabs: [],
     activeTab: "tasks",
   };
+}
+
+/** Stable cache key for one inline diff payload. */
+function inlineDiffCacheKey(
+  threadId: string,
+  source: string,
+  id: string,
+  filePath: string,
+): string {
+  return `${threadId}:${source}:${id}:${filePath}`;
+}
+
+/** Drop inline diff cache entries matching a stable key prefix. */
+function omitInlineDiffCacheByPrefix(
+  cache: Record<string, string>,
+  prefix: string,
+): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const [key, value] of Object.entries(cache)) {
+    if (!key.startsWith(prefix)) next[key] = value;
+  }
+  return next;
 }
 
 /**
@@ -217,11 +238,17 @@ interface DiffState {
   /** Whether commits are currently loading, keyed by thread ID. */
   commitsLoadingByThread: Record<string, boolean>;
   /**
-   * Inline diff cache keyed by `"threadId:source:id:filePath"`. Survives
+   * Inline diff cache keyed by `"threadId:source:id:version:filePath"`. Survives
    * component unmounts (panel close/reopen, tab switches) so diffs aren't
    * re-fetched. Scoped by thread to prevent cross-thread collisions.
    */
   inlineDiffCache: Record<string, string>;
+  /**
+   * Monotonic revision by diff scope (thread id or workspace id). Mutable git
+   * views use this to refetch when a turn or filesystem event changes the
+   * checkout without changing the visible ref names.
+   */
+  diffRevisionByScope: Record<string, number>;
   /** Currently selected file for diff viewing. */
   selectedFile: SelectedFile | null;
   /** Raw unified diff text for the selected file. */
@@ -291,6 +318,8 @@ interface DiffState {
   cacheInlineDiff: (threadId: string, source: string, id: string, filePath: string, data: string) => void;
   /** Retrieve a cached inline diff, or undefined if not cached. */
   getCachedInlineDiff: (threadId: string, source: string, id: string, filePath: string) => string | undefined;
+  /** Bump a mutable diff scope so mounted file rows refetch against the latest checkout. */
+  bumpDiffRevision: (scopeId: string) => void;
   /** Persist the omnibox URL for a thread's embedded preview. */
   setPreviewUrlForThread: (threadId: string, url: string) => void;
   clearThread: (threadId: string) => void;
@@ -315,6 +344,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   commitsByThread: {},
   commitsLoadingByThread: {},
   inlineDiffCache: {},
+  diffRevisionByScope: {},
   selectedFile: null,
   diffContent: null,
   diffLoading: false,
@@ -433,6 +463,10 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       return {
         snapshotsByThread: { ...s.snapshotsByThread, [threadId]: snapshots },
         snapshotsPendingByThread: nextPending,
+        inlineDiffCache: omitInlineDiffCacheByPrefix(
+          s.inlineDiffCache,
+          `${threadId}:cumulative:${threadId}:`,
+        ),
       };
     }),
   setSnapshotsLoading: (threadId, loading) =>
@@ -455,10 +489,18 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   setSummaryLoading: (loading) => set({ summaryLoading: loading }),
   cacheInlineDiff: (threadId, source, id, filePath, data) =>
     set((s) => ({
-      inlineDiffCache: { ...s.inlineDiffCache, [`${threadId}:${source}:${id}:${filePath}`]: data },
+      inlineDiffCache: { ...s.inlineDiffCache, [inlineDiffCacheKey(threadId, source, id, filePath)]: data },
     })),
   getCachedInlineDiff: (threadId, source, id, filePath) =>
-    get().inlineDiffCache[`${threadId}:${source}:${id}:${filePath}`],
+    get().inlineDiffCache[inlineDiffCacheKey(threadId, source, id, filePath)],
+  bumpDiffRevision: (scopeId) =>
+    set((s) => ({
+      diffRevisionByScope: {
+        ...s.diffRevisionByScope,
+        [scopeId]: (s.diffRevisionByScope[scopeId] ?? 0) + 1,
+      },
+      inlineDiffCache: omitInlineDiffCacheByPrefix(s.inlineDiffCache, `${scopeId}:`),
+    })),
   setPreviewUrlForThread: (threadId, url) =>
     set((s) => ({
       previewUrlByThread: { ...s.previewUrlByThread, [threadId]: url },
@@ -481,13 +523,10 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       delete lineWrapByThread[threadId];
       const rightPanelVisibleByThread = { ...state.rightPanelVisibleByThread };
       delete rightPanelVisibleByThread[threadId];
+      const diffRevisionByScope = { ...state.diffRevisionByScope };
+      delete diffRevisionByScope[threadId];
 
-      // Evict inline diff cache entries scoped to this thread.
-      const prefix = `${threadId}:`;
-      const inlineDiffCache: Record<string, string> = {};
-      for (const [key, value] of Object.entries(state.inlineDiffCache)) {
-        if (!key.startsWith(prefix)) inlineDiffCache[key] = value;
-      }
+      const inlineDiffCache = omitInlineDiffCacheByPrefix(state.inlineDiffCache, `${threadId}:`);
 
       // Only clear the global selection when it belongs to the deleted thread.
       const selectionBelongsToThread = state.selectedFile?.threadId === threadId;
@@ -502,6 +541,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         previewUrlByThread: previewUrls,
         lineWrapByThread,
         rightPanelVisibleByThread,
+        diffRevisionByScope,
         inlineDiffCache,
         ...(selectionBelongsToThread
           ? { selectedFile: null, diffContent: null, diffLoading: false }
@@ -513,9 +553,25 @@ export const useDiffStore = create<DiffState>((set, get) => ({
     }),
   clearWorkspace: (workspaceId) =>
     set((state) => {
-      if (!(workspaceId in state.rightPanelByWorkspace)) return {};
+      const cachePrefix = `${workspaceId}:`;
+      const hasInlineDiffCache = Object.keys(state.inlineDiffCache).some((key) =>
+        key.startsWith(cachePrefix),
+      );
+      if (
+        !(workspaceId in state.rightPanelByWorkspace) &&
+        !(workspaceId in state.diffRevisionByScope) &&
+        !hasInlineDiffCache
+      ) {
+        return {};
+      }
       const rightPanelByWorkspace = { ...state.rightPanelByWorkspace };
       delete rightPanelByWorkspace[workspaceId];
-      return { rightPanelByWorkspace };
+      const diffRevisionByScope = { ...state.diffRevisionByScope };
+      delete diffRevisionByScope[workspaceId];
+      return {
+        rightPanelByWorkspace,
+        diffRevisionByScope,
+        inlineDiffCache: omitInlineDiffCacheByPrefix(state.inlineDiffCache, cachePrefix),
+      };
     }),
 }));

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -272,6 +272,7 @@ export function startPushListeners(): void {
         threadId?: string;
       };
       clearFileListCache(workspaceId, threadId);
+      useDiffStore.getState().bumpDiffRevision(threadId ?? workspaceId);
     }),
   );
 
@@ -303,14 +304,13 @@ export function startPushListeners(): void {
       // writes) would otherwise surface a "New changes" affordance with
       // nothing new to show.
       const hasFileChanges = payload.filesChanged.length > 0;
+      if (hasFileChanges) {
+        useDiffStore.getState().bumpDiffRevision(payload.threadId);
+      }
 
       try {
         const transport = getTransport();
         if (hasSnapshots && hasFileChanges) {
-          // If the user is actively viewing the All-changes panel, defer the
-          // refresh and let CumulativeView surface a refresh affordance so
-          // their scroll position isn't yanked. Otherwise refetch silently
-          // so re-entry shows the latest data.
           const wsState = useWorkspaceStore.getState();
           const workspaceId = wsState.threads.find(
             (t) => t.id === payload.threadId,


### PR DESCRIPTION
## What
Finalizes the Review tab workflows for issue #639.

## Why
The Review tab needed reliable diff scopes, a quieter jump-to-file flow, and better handling for content that changes while the user is reading.

## Key Changes
- Moves Summary into the Cumulative view and adds a user-controlled refresh affordance for new turn snapshots.
- Adds on-demand jump-to-file autocomplete with scroll and row highlight, without filtering the file tree.
- Fixes Branch and Commit comparisons: Branch compares the current checkout against the selected ref, Commit disables when no commits exist and refreshes from `git log` when opened.
- Expands file diffs by default and smooths right-panel open and close motion.
- Adds focused unit and Playwright coverage for cumulative refresh, jump, branch, and commit behavior.

Closes #639

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783965347&installation_id=129163861&pr_number=731&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F731&signature=1e4f3e3df6e96d95497eb0c2eeef96bfdfffd6cd08a3755c3d3582872afe3989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Jump to file" search with highlighting and auto-scroll in diff view
  * Added Summary toggle in Cumulative view (when diff summary enabled)
  * Commit picker now refreshes on reopen
  * Smooth panel collapse/expand animations

* **Improvements**
  * Sticky file list header shows total changed file count
  * Enhanced commit view availability detection
  * Automatic diff refresh when files change
  * Optimized caching with scope-specific revisions

* **Bug Fixes**
  * Branch comparisons now correctly use remote-tracking references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->