### PR TITLE
fix(chat): stabilize streaming recovery

### DIFF
--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -286,4 +286,96 @@ describe("AgentService.sendMessage — /goal command", () => {
     expect(nonGoalStub.sendTurn).toHaveBeenCalledTimes(1);
     expect(nonGoalStub.sendTurn.mock.calls[0][0].message).toBe("/goal something");
   });
+
+  it("rejects a normal send while the thread already has an active turn", async () => {
+    const { svc, providerStub, messageRepo } = buildService(db);
+
+    await svc.sendMessage(
+      thread.id,
+      "first turn",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+    const beforeMessages = messageRepo.listByThread(thread.id, 100).messages;
+    providerStub.sendTurn.mockClear();
+
+    await expect(
+      svc.sendMessage(
+        thread.id,
+        "duplicate turn",
+        "default",
+        "claude-sonnet-4-6",
+        [],
+        undefined,
+        "claude",
+      ),
+    ).rejects.toThrow("already has an active agent session");
+
+    expect(providerStub.sendTurn).not.toHaveBeenCalled();
+    expect(messageRepo.listByThread(thread.id, 100).messages).toEqual(beforeMessages);
+  });
+
+  it("rejects concurrent normal sends before either can persist a duplicate row", async () => {
+    const { svc, providerStub, messageRepo } = buildService(db);
+
+    const first = svc.sendMessage(
+      thread.id,
+      "first turn",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+    const second = svc.sendMessage(
+      thread.id,
+      "duplicate turn",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+
+    await expect(second).rejects.toThrow("already has an active agent session");
+    await first;
+
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
+    const contents = messageRepo.listByThread(thread.id, 100).messages.map((m) => m.content);
+    expect(contents).toEqual(["first turn"]);
+  });
+
+  it("still handles /goal clear while the thread already has an active turn", async () => {
+    const { svc, providerStub, messageRepo } = buildService(db);
+
+    await svc.sendMessage(
+      thread.id,
+      "first turn",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+    providerStub.sendTurn.mockClear();
+
+    await svc.sendMessage(
+      thread.id,
+      "/goal clear",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+
+    expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
+    expect(providerStub.sendTurn).not.toHaveBeenCalled();
+    const contents = messageRepo.listByThread(thread.id, 100).messages.map((m) => m.content);
+    expect(contents).toContain("/goal clear");
+    expect(contents.some((content) => content.includes("Goal cleared"))).toBe(true);
+  });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -360,36 +360,54 @@ export class AgentService {
       content = commandOutcome.content;
     }
 
-    const cwd = this.gitService.resolveWorkingDir(
-      workspace.path,
-      thread.mode,
-      thread.worktree_path,
-    );
-
-    // Validate cwd before persisting anything
-    if (
-      !isAbsolute(cwd) ||
-      !existsSync(cwd) ||
-      !statSync(cwd).isDirectory()
-    ) {
-      throw new Error(`cwd is not a valid absolute directory: ${cwd}`);
+    if (this.activeSessionIds.has(threadId)) {
+      throw new Error(`Thread ${threadId} already has an active agent session`);
     }
 
-    this.memoryPressureService.assertCanStartTurn();
+    let activeSlotReserved = false;
+    let commandDispatched = false;
+    const releaseReservedSlot = () => {
+      if (!activeSlotReserved) return;
+      activeSlotReserved = false;
+      if (this.activeSessionIds.delete(threadId)) {
+        this.memoryPressureService.markIdle(threadId);
+      }
+    };
 
-    // Compute next sequence number and persist user message
-    const { messages: existingMessages } = this.messageRepo.listByThread(threadId, 1);
-    const nextSeq =
-      existingMessages.length > 0
-        ? existingMessages[existingMessages.length - 1].sequence + 1
-        : 1;
+    try {
+      const cwd = this.gitService.resolveWorkingDir(
+        workspace.path,
+        thread.mode,
+        thread.worktree_path,
+      );
 
-    const persistedUserText = messageDisplayContent ?? content;
+      // Validate cwd before persisting anything
+      if (
+        !isAbsolute(cwd) ||
+        !existsSync(cwd) ||
+        !statSync(cwd).isDirectory()
+      ) {
+        throw new Error(`cwd is not a valid absolute directory: ${cwd}`);
+      }
 
-    const { stored, persisted } = await this.attachmentService.persist(
-      threadId,
-      attachments,
-    );
+      this.memoryPressureService.assertCanStartTurn();
+      this.activeSessionIds.add(threadId);
+      activeSlotReserved = true;
+      this.memoryPressureService.markActive(threadId);
+
+      // Compute next sequence number and persist user message
+      const { messages: existingMessages } = this.messageRepo.listByThread(threadId, 1);
+      const nextSeq =
+        existingMessages.length > 0
+          ? existingMessages[existingMessages.length - 1].sequence + 1
+          : 1;
+
+      const persistedUserText = messageDisplayContent ?? content;
+
+      const { stored, persisted } = await this.attachmentService.persist(
+        threadId,
+        attachments,
+      );
     // Persist the user message and (when answering plan questions) the
     // answered marker in a single transaction. If the marker insert fails
     // (e.g. FK rejects an unknown messageId) the user message is rolled
@@ -556,9 +574,6 @@ export class AgentService {
 
     const resolvedProvider = this.providerRegistry.resolve(effectiveProvider);
 
-    this.activeSessionIds.add(threadId);
-    this.memoryPressureService.markActive(threadId);
-
     // Emit the live-session "turn started" signal before any other events so
     // clients can populate runningThreadIds (drives sidebar + composer indicators).
     // Cast to EventEmitter since IAgentProvider only exposes on(); all providers
@@ -576,6 +591,7 @@ export class AgentService {
     // block below runs the rollback so failures don't leave a hidden side
     // effect active. Only set for a rewrite outcome that supplied onDispatch.
     if (pendingDispatch !== null) {
+      commandDispatched = true;
       pendingDispatch();
       logger.info("Command side effect installed; dispatching to provider", {
         threadId,
@@ -659,6 +675,20 @@ export class AgentService {
         await this.giveUpTransientTurnRetry(threadId, err);
         return;
       }
+    }
+    } catch (err) {
+      releaseReservedSlot();
+      if (commandDispatched && pendingRollback !== null) {
+        try {
+          pendingRollback();
+        } catch (rollbackErr) {
+          logger.warn("Failed to roll back command side effect after send setup failure", {
+            threadId,
+            error: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
+          });
+        }
+      }
+      throw err;
     }
   }
 

--- a/apps/web/e2e/crash-reconnect-guards.spec.ts
+++ b/apps/web/e2e/crash-reconnect-guards.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test, type Page } from "@playwright/test";
+import { getDefaultSettings } from "@mcode/contracts";
+import {
+  interceptZustandStores,
+  mockWebSocketServer,
+} from "./helpers/e2e-helpers";
+
+if (process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH) {
+  test.use({
+    launchOptions: {
+      executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+    },
+  });
+}
+
+const now = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+const workspace = {
+  id: "ws-crash-reconnect",
+  name: "Crash Reconnect",
+  path: "/tmp/crash-reconnect",
+  provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+  created_at: now,
+  updated_at: now,
+};
+
+const thread = {
+  id: "thread-crash-reconnect",
+  workspace_id: workspace.id,
+  title: "Crash recovery thread",
+  status: "active" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-sonnet-4-6",
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const firstUserMessage = {
+  id: "user-first-turn",
+  thread_id: thread.id,
+  role: "user" as const,
+  content: "first turn",
+  tool_calls: null,
+  files_changed: null,
+  cost_usd: null,
+  tokens_used: null,
+  timestamp: now,
+  sequence: 1,
+  attachments: null,
+  tool_call_count: 0,
+};
+
+async function openThread(page: Page, sentMessages: string[] = []) {
+  const ws = await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [thread],
+    "conversation.page": {
+      messages: [firstUserMessage],
+      hasMore: false,
+      answeredPlanMessageIds: [],
+      narrativeByMessage: {},
+    },
+    "narrative.list": { tools: [], thoughts: [], hooks: [] },
+    "settings.get": getDefaultSettings(),
+    "provider.listModels": () => [
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", group: "Claude" },
+    ],
+    "agent.send": (params?: unknown) => {
+      const payload = params as { content?: string } | undefined;
+      if (typeof payload?.content === "string") sentMessages.push(payload.content);
+      return { ok: true };
+    },
+  });
+  await interceptZustandStores(page);
+
+  await page.goto("/");
+  await page.getByRole("option", { name: /Crash Reconnect/ }).click();
+  await page.getByRole("button", { name: /Crash Reconnect 1/ }).click();
+  await page.waitForSelector("[data-testid='thread-item']", { timeout: 30_000 });
+  await page.locator("[data-testid='thread-item']").first().click();
+  await page.waitForSelector("[data-testid='message-list']", { timeout: 30_000 });
+  await page.waitForSelector('[contenteditable="true"]', { timeout: 30_000 });
+  return ws;
+}
+
+async function hydrateRunningThreads(page: Page, ids: string[]) {
+  await page.evaluate((runningIds) => {
+    const stores: Array<{ getState: () => Record<string, unknown> }> =
+      (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown> }> })
+        .__mcodeStores ?? [];
+    const threadStore = stores.find((store) => {
+      const state = store.getState();
+      return "hydrateRunningThreads" in state && "records" in state;
+    });
+    const state = threadStore?.getState() as
+      | { hydrateRunningThreads: (threadIds: string[]) => void }
+      | undefined;
+    if (!state) throw new Error("thread store not found");
+    state.hydrateRunningThreads(runningIds);
+  }, ids);
+}
+
+async function readQueueLength(page: Page) {
+  return page.evaluate((threadId) => {
+    const stores: Array<{ getState: () => Record<string, unknown> }> =
+      (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown> }> })
+        .__mcodeStores ?? [];
+    const queueStore = stores.find((store) => {
+      const state = store.getState();
+      return "queues" in state && "enqueue" in state;
+    });
+    const queues = queueStore?.getState().queues as Record<string, unknown[]> | undefined;
+    return queues?.[threadId]?.length ?? 0;
+  }, thread.id);
+}
+
+test("rendered app clears stale text, queues follow-up, and avoids duplicate user bubbles", async ({
+  page,
+}) => {
+  const sentMessages: string[] = [];
+  const ws = await openThread(page, sentMessages);
+
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "turnStarted",
+  });
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "textDelta",
+    delta: "old crash narrative",
+    isFinalResponse: false,
+  });
+
+  await expect(page.getByText("old crash narrative")).toBeVisible();
+  await hydrateRunningThreads(page, []);
+  await page.waitForTimeout(100);
+  await expect(page.getByText("old crash narrative")).toHaveCount(0);
+
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "turnStarted",
+  });
+  const editor = page.locator('[contenteditable="true"]').first();
+  await editor.click();
+  await page.keyboard.type("what happened?");
+  await page.keyboard.press("Enter");
+
+  const queue = page.getByRole("region", { name: "Queued messages" });
+  await expect(queue).toBeVisible();
+  await expect(queue.getByText("what happened?")).toBeVisible();
+  await expect(page.locator("[data-message-role='user']").filter({ hasText: "what happened?" }))
+    .toHaveCount(0);
+  expect(sentMessages).not.toContain("what happened?");
+
+  await page.screenshot({
+    path: "e2e/screenshots/crash-reconnect-ui-queue.png",
+    fullPage: false,
+  });
+});
+
+test("rendered composer sends goal control commands while active without queueing", async ({
+  page,
+}) => {
+  const sentMessages: string[] = [];
+  const ws = await openThread(page, sentMessages);
+
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "turnStarted",
+  });
+
+  const editor = page.locator('[contenteditable="true"]').first();
+  await editor.click();
+  await editor.fill("/goal clear");
+  await page.keyboard.press("Enter");
+
+  await expect.poll(() => sentMessages, { timeout: 5_000 }).toContain("/goal clear");
+  expect(await readQueueLength(page)).toBe(0);
+});

--- a/apps/web/e2e/streaming-text-rendering.spec.ts
+++ b/apps/web/e2e/streaming-text-rendering.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "@playwright/test";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+
+const now = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+const workspace = {
+  id: "ws-streaming-text",
+  name: "Streaming Text Workspace",
+  path: "/tmp/streaming-text",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+const thread = {
+  id: "thread-streaming-text",
+  workspace_id: workspace.id,
+  title: "Streaming Text",
+  status: "paused" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  worktree_managed: false,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const userMessage = {
+  id: "user-streaming-text",
+  thread_id: thread.id,
+  role: "user" as const,
+  content: "Show markdown while streaming",
+  tool_calls: null,
+  files_changed: null,
+  cost_usd: null,
+  tokens_used: null,
+  timestamp: now,
+  sequence: 1,
+  attachments: null,
+  tool_call_count: 0,
+};
+
+test("streaming assistant text uses plain text, then settled text uses markdown", async ({ page }) => {
+  const ws = await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [thread],
+    "conversation.page": {
+      messages: [userMessage],
+      hasMore: false,
+      answeredPlanMessageIds: [],
+      narrativeByMessage: {},
+    },
+    "narrative.list": { tools: [], thoughts: [], hooks: [] },
+  });
+
+  await page.goto("/");
+  await page.getByRole("option", { name: /Streaming Text Workspace/ }).click();
+  await page.getByRole("button", { name: /Streaming Text Workspace 1/ }).click();
+  await page.waitForSelector("[data-testid='thread-item']");
+  await page.locator("[data-testid='thread-item']").first().click();
+  await page.waitForSelector("[data-testid=message-list]");
+
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "turnStarted",
+  });
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "textDelta",
+    delta: "Hello **stream**",
+    isFinalResponse: true,
+  });
+
+  const assistantText = page.locator("[data-testid='assistant-response-text']");
+  await expect(assistantText).toHaveCount(1);
+  await expect(assistantText).toContainText("Hello **stream**");
+
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "message",
+    content: "Hello **stream**",
+    messageId: "assistant-streaming-text",
+  });
+
+  await expect(assistantText).toHaveCount(1);
+  await expect(assistantText).toContainText("Hello stream");
+  await expect(assistantText).not.toContainText("Hello **stream**");
+});

--- a/apps/web/src/__tests__/running-session-hydrate.test.ts
+++ b/apps/web/src/__tests__/running-session-hydrate.test.ts
@@ -3,6 +3,7 @@ import {
   getTestAgentStartTimes,
 } from "@/stores/thread-store-test-utils";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
+import type { HookExecution, ToolCall } from "@/transport";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useThreadStore } from "@/stores/threadStore";
 import { hydrateRunningThreadsFromServer } from "@/transport/ws-transport";
@@ -30,9 +31,31 @@ describe("hydrateRunningThreadsFromServer", () => {
   });
 
   it("clears runningThreadIds when the server returns an empty array", async () => {
+    resetThreadStoreForTests({
+      runningThreadIds: new Set(["stale"]),
+      records: new Map<string, ThreadRecord>([
+        [
+          "stale",
+          {
+            ...createEmptyThreadRecord(),
+            streaming: "old response",
+            streamingPreview: "old response",
+            currentTurnMessageId: "old-assistant",
+            currentTurnResponseKey: "old-key",
+            thoughtSegments: [{ text: "old narration", startedAt: 1 }],
+          },
+        ],
+      ]),
+    });
     const rpc = vi.fn().mockResolvedValue([]);
     await hydrateRunningThreadsFromServer(rpc);
     expect(useThreadStore.getState().runningThreadIds.size).toBe(0);
+    const rec = useThreadStore.getState().records.get("stale")!;
+    expect(rec.streaming).toBe("");
+    expect(rec.streamingPreview).toBe("");
+    expect(rec.currentTurnMessageId).toBe("");
+    expect(rec.currentTurnResponseKey).toBe("");
+    expect(rec.thoughtSegments).toEqual([]);
   });
 
   it("preserves threadIds added while the RPC is in flight", async () => {
@@ -99,7 +122,19 @@ describe("hydrateRunningThreads (store action)", () => {
   });
 
   it("creates a new Set reference when hydration membership differs", () => {
-    useThreadStore.setState({ runningThreadIds: new Set(["t-1", "t-2"]) });
+    resetThreadStoreForTests({
+      runningThreadIds: new Set(["t-1", "t-2"]),
+      records: new Map<string, ThreadRecord>([
+        [
+          "t-2",
+          {
+            ...createEmptyThreadRecord(),
+            streaming: "old response",
+            thoughtSegments: [{ text: "old narration", startedAt: 1 }],
+          },
+        ],
+      ]),
+    });
     const before = useThreadStore.getState().runningThreadIds;
 
     useThreadStore.getState().hydrateRunningThreads(["t-1", "t-3"]);
@@ -109,6 +144,9 @@ describe("hydrateRunningThreads (store action)", () => {
     expect(after.has("t-1")).toBe(true);
     expect(after.has("t-2")).toBe(false);
     expect(after.has("t-3")).toBe(true);
+    const dropped = useThreadStore.getState().records.get("t-2")!;
+    expect(dropped.streaming).toBe("");
+    expect(dropped.thoughtSegments).toEqual([]);
   });
 
   it("seeds agentStartTimes for newly hydrated ids and preserves existing entries", () => {
@@ -130,5 +168,89 @@ describe("hydrateRunningThreads (store action)", () => {
     expect(times["t-2"]).toBe(200);
 
     vi.restoreAllMocks();
+  });
+
+  it("clears stale volatile turn state for ids newly reported running", () => {
+    const tid = "t-reconnected";
+    const staleTool: ToolCall = {
+      id: "tool-1",
+      toolName: "Read",
+      toolInput: {},
+      output: null,
+      isError: false,
+      isComplete: false,
+    };
+    const staleHook: HookExecution = {
+      hookName: "Stop",
+      hookType: "stop",
+      status: "running",
+      outputLines: ["old"],
+      fullOutput: ["old"],
+      startedAt: 1,
+    };
+    resetThreadStoreForTests({
+      runningThreadIds: new Set(),
+      records: new Map<string, ThreadRecord>([
+        [
+          tid,
+          {
+            ...createEmptyThreadRecord(),
+            streaming: "Implemented logo wiring is in...",
+            streamingPreview: "Implemented logo wiring is in...",
+            currentTurnMessageId: "old-assistant",
+            currentTurnResponseKey: "old-key",
+            toolCalls: [staleTool],
+            thoughtSegments: [{ text: "stale narration", startedAt: 1 }],
+            hooks: [staleHook],
+          },
+        ],
+      ]),
+    });
+    vi.spyOn(Date, "now").mockReturnValue(300);
+
+    useThreadStore.getState().hydrateRunningThreads([tid]);
+
+    const rec = useThreadStore.getState().records.get(tid)!;
+    expect(rec.streaming).toBe("");
+    expect(rec.streamingPreview).toBe("");
+    expect(rec.currentTurnMessageId).toBe("");
+    expect(rec.currentTurnResponseKey).toMatch(/^turn-response:t-reconnected:/);
+    expect(rec.toolCalls).toEqual([]);
+    expect(rec.thoughtSegments).toEqual([]);
+    expect(rec.hooks).toEqual([]);
+    expect(rec.agentStartTime).toBe(300);
+
+    vi.restoreAllMocks();
+  });
+
+  it("preserves live volatile turn state for ids that were already running", () => {
+    const tid = "t-live";
+    resetThreadStoreForTests({
+      runningThreadIds: new Set([tid]),
+      records: new Map<string, ThreadRecord>([
+        [
+          tid,
+          {
+            ...createEmptyThreadRecord(),
+            streaming: "live response",
+            streamingPreview: "live response",
+            currentTurnMessageId: "live-assistant",
+            currentTurnResponseKey: "live-key",
+            thoughtSegments: [{ text: "live narration", startedAt: 1 }],
+            agentStartTime: 100,
+          },
+        ],
+      ]),
+    });
+
+    useThreadStore.getState().hydrateRunningThreads([tid, "t-new"]);
+
+    const rec = useThreadStore.getState().records.get(tid)!;
+    expect(rec.streaming).toBe("live response");
+    expect(rec.streamingPreview).toBe("live response");
+    expect(rec.currentTurnMessageId).toBe("live-assistant");
+    expect(rec.currentTurnResponseKey).toBe("live-key");
+    expect(rec.thoughtSegments).toEqual([{ text: "live narration", startedAt: 1 }]);
+    expect(rec.agentStartTime).toBe(100);
   });
 });

--- a/apps/web/src/__tests__/thread-lifecycle.test.ts
+++ b/apps/web/src/__tests__/thread-lifecycle.test.ts
@@ -1,7 +1,10 @@
 import {
   resetThreadStoreForTests,
   getTestActiveMessages,
+  getTestThreadMessages,
   getTestThreadStreaming,
+  getTestThreadStreamingPreview,
+  getTestThreadThoughtSegments,
   getTestThreadError,
   readActiveThreadField,
 } from "@/stores/thread-store-test-utils";
@@ -28,6 +31,87 @@ describe("Thread Lifecycle Behavior", () => {
     await useThreadStore.getState().sendMessage(threadId, "Hello");
 
     expect(useThreadStore.getState().runningThreadIds.has(threadId)).toBe(true);
+  });
+
+  it("when the user sends a follow-up, stale live turn text is cleared immediately", async () => {
+    const threadId = "thread-1";
+    resetThreadStoreForTests({
+      currentThreadId: threadId,
+      records: new Map<string, ThreadRecord>([
+        [
+          threadId,
+          {
+            ...createEmptyThreadRecord(),
+            streaming: "Implemented logo wiring is in...",
+            streamingPreview: "Implemented logo wiring is in...",
+            currentTurnMessageId: "old-assistant",
+            currentTurnResponseKey: "old-key",
+            thoughtSegments: [{ text: "stale narration", startedAt: 1 }],
+          },
+        ],
+      ]),
+    });
+
+    await useThreadStore.getState().sendMessage(threadId, "what happened?");
+
+    expect(getTestThreadStreaming(threadId)).toBeUndefined();
+    expect(getTestThreadStreamingPreview(threadId)).toBeUndefined();
+    expect(readActiveThreadField((rec) => rec.currentTurnMessageId)).toBe("");
+    expect(readActiveThreadField((rec) => rec.currentTurnResponseKey)).toMatch(
+      /^turn-response:thread-1:/,
+    );
+    expect(getTestThreadThoughtSegments(threadId)).toEqual([]);
+  });
+
+  it("when a direct caller sends while running, no optimistic duplicate is appended", async () => {
+    const threadId = "thread-1";
+    const existing = createMockMessage({
+      id: "user-1",
+      thread_id: threadId,
+      content: "first turn",
+      sequence: 1,
+    });
+    resetThreadStoreForTests({
+      currentThreadId: threadId,
+      runningThreadIds: new Set([threadId]),
+      records: new Map<string, ThreadRecord>([
+        [threadId, { ...createEmptyThreadRecord(), messages: [existing] }],
+      ]),
+    });
+
+    await expect(
+      useThreadStore.getState().sendMessage(threadId, "duplicate turn"),
+    ).rejects.toThrow("already has an active agent session");
+
+    expect(mockTransport.sendMessage).not.toHaveBeenCalled();
+    expect(useThreadStore.getState().runningThreadIds.has(threadId)).toBe(true);
+    expect(getTestThreadMessages(threadId)).toEqual([existing]);
+  });
+
+  it("when the server rejects an unknown active turn, the optimistic duplicate is removed", async () => {
+    const threadId = "thread-1";
+    const existing = createMockMessage({
+      id: "user-1",
+      thread_id: threadId,
+      content: "first turn",
+      sequence: 1,
+    });
+    resetThreadStoreForTests({
+      currentThreadId: threadId,
+      runningThreadIds: new Set(),
+      records: new Map<string, ThreadRecord>([
+        [threadId, { ...createEmptyThreadRecord(), messages: [existing] }],
+      ]),
+    });
+    (
+      mockTransport.sendMessage as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("Thread thread-1 already has an active agent session"));
+
+    await useThreadStore.getState().sendMessage(threadId, "duplicate turn");
+
+    expect(useThreadStore.getState().runningThreadIds.has(threadId)).toBe(true);
+    expect(getTestThreadMessages(threadId)).toEqual([existing]);
+    expect(getTestThreadError(threadId)).toContain("already has an active agent session");
   });
 
   it("when the user stops an agent, the thread is no longer running", async () => {

--- a/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
+++ b/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
@@ -2,6 +2,7 @@ import {
   resetThreadStoreForTests,
   getTestThreadStreaming,
   getTestThreadThoughtSegments,
+  readThreadField,
 } from "@/stores/thread-store-test-utils";
 import { createEmptyThreadRecord } from "@/stores/thread-record";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -51,6 +52,51 @@ describe("threadStore textDelta batching", () => {
     expect(getTestThreadStreaming(tid)).toBe("01234567");
   });
 
+  it("drops pending deltas for threads reset by running-session hydration", () => {
+    const queue: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      queue.push(cb);
+      return queue.length;
+    });
+    const cancel = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => undefined);
+    const tid = "thread-stale-reconnect";
+    resetThreadStoreForTests({
+      runningThreadIds: new Set([tid]),
+      records: new Map([
+        [
+          tid,
+          {
+            ...createEmptyThreadRecord(),
+            streaming: "old response",
+            streamingPreview: "old response",
+            thoughtSegments: [{ text: "old narration", startedAt: 1 }],
+          },
+        ],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent(tid, {
+      method: "session.textDelta",
+      params: { delta: " stale delta", isFinalResponse: false },
+    });
+    expect(queue).toHaveLength(1);
+
+    useThreadStore.getState().hydrateRunningThreads([]);
+
+    expect(cancel).toHaveBeenCalledWith(1);
+    expect(readThreadField(tid, (record) => record.streaming)).toBe("");
+    expect(readThreadField(tid, (record) => record.streamingPreview)).toBe("");
+    expect(readThreadField(tid, (record) => record.thoughtSegments)).toEqual([]);
+
+    queue[0]!(0);
+
+    expect(readThreadField(tid, (record) => record.streaming)).toBe("");
+    expect(readThreadField(tid, (record) => record.streamingPreview)).toBe("");
+    expect(readThreadField(tid, (record) => record.thoughtSegments)).toEqual([]);
+  });
+
   it("updates streaming only for isFinalResponse deltas (skips thought segments)", () => {
     const queue: FrameRequestCallback[] = [];
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
@@ -75,6 +121,73 @@ describe("threadStore textDelta batching", () => {
     expect(getTestThreadThoughtSegments(tid)?.length).toBe(1);
     expect(getTestThreadThoughtSegments(tid)?.[0]?.text).toBe("think ");
     expect(getTestThreadThoughtSegments(tid)?.[0]?.isExplicitNonFinal).toBe(true);
+  });
+
+  it("preserves thought segment array reference for final-response-only flushes", () => {
+    const queue: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      queue.push(cb);
+      return queue.length;
+    });
+
+    const tid = "thread-final-reference";
+    const thoughtSegments = [{ text: "closed narration", startedAt: 1, endedAt: 2 }];
+    resetThreadStoreForTests({
+      records: new Map([
+        [
+          tid,
+          {
+            ...createEmptyThreadRecord(),
+            thoughtSegments,
+          },
+        ],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent(tid, {
+      method: "session.textDelta",
+      params: { delta: "final response", isFinalResponse: true },
+    });
+    queue[0]!(0);
+
+    expect(getTestThreadStreaming(tid)).toBe("final response");
+    expect(readThreadField(tid, (record) => record.thoughtSegments)).toBe(thoughtSegments);
+  });
+
+  it("replaces thought segment array reference when narration flushes", () => {
+    const queue: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      queue.push(cb);
+      return queue.length;
+    });
+
+    const tid = "thread-narration-reference";
+    const closedText = "This closed narration is long enough to stay closed. ";
+    const thoughtSegments = [{ text: closedText, startedAt: 1, endedAt: 2 }];
+    resetThreadStoreForTests({
+      records: new Map([
+        [
+          tid,
+          {
+            ...createEmptyThreadRecord(),
+            thoughtSegments,
+          },
+        ],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent(tid, {
+      method: "session.textDelta",
+      params: { delta: "New narration", isFinalResponse: false },
+    });
+    queue[0]!(0);
+
+    const nextSegments = readThreadField(tid, (record) => record.thoughtSegments);
+    expect(nextSegments).not.toBe(thoughtSegments);
+    expect(nextSegments.map((segment) => segment.text)).toEqual([
+      closedText,
+      "New narration",
+    ]);
   });
 
   it("does not mark omitted isFinalResponse deltas as explicit non-final", () => {

--- a/apps/web/src/__tests__/virtual-items-render.test.tsx
+++ b/apps/web/src/__tests__/virtual-items-render.test.tsx
@@ -1,0 +1,106 @@
+import { memo } from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  buildStableItems,
+  createVolatileItemsBuilder,
+  createVirtualItemsBuilder,
+  type ChatVirtualItem,
+} from "@/components/chat/virtual-items";
+import type { Message, ToolCall } from "@/transport/types";
+
+const renderCounts = new Map<string, number>();
+
+const Row = memo(function Row({ item }: { item: ChatVirtualItem }) {
+  renderCounts.set(item.key, (renderCounts.get(item.key) ?? 0) + 1);
+  return <div data-testid={item.key}>{item.type}</div>;
+});
+
+function ItemList({ items }: { items: readonly ChatVirtualItem[] }) {
+  return (
+    <>
+      {items.map((item) => (
+        <Row key={item.key} item={item} />
+      ))}
+    </>
+  );
+}
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    thread_id: "thread-1",
+    role: "assistant",
+    content: "Settled response",
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: "2026-01-01T00:00:00Z",
+    sequence: 1,
+    attachments: null,
+    ...overrides,
+  };
+}
+
+function makeToolCall(overrides: Partial<ToolCall> = {}): ToolCall {
+  return {
+    id: "tc-1",
+    toolName: "Read",
+    toolInput: {},
+    output: "done",
+    isError: false,
+    isComplete: true,
+    startedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("virtual item render isolation", () => {
+  it("re-renders only the typing row when final-response text changes", () => {
+    renderCounts.clear();
+    const buildVolatile = createVolatileItemsBuilder();
+    const buildVirtual = createVirtualItemsBuilder();
+    const toolCalls = [makeToolCall()];
+    const hooks = [] as const;
+    const thoughts = [] as const;
+    const currentTurn = {
+      threadId: "thread-1",
+      responseKey: "turn-response:thread-1:typing",
+    };
+    const stable = buildStableItems([
+      makeMessage({ id: "user-1", role: "user", content: "Prompt", sequence: 1 }),
+      makeMessage({ id: "assistant-1", role: "assistant", sequence: 2 }),
+    ]);
+
+    const firstVolatile = buildVolatile(
+      toolCalls,
+      true,
+      1000,
+      "first streamed answer",
+      undefined,
+      hooks,
+      thoughts,
+      currentTurn,
+    );
+    const firstItems = buildVirtual(stable, firstVolatile, true);
+    const { rerender } = render(<ItemList items={firstItems} />);
+
+    const secondVolatile = buildVolatile(
+      toolCalls,
+      true,
+      1000,
+      "second streamed answer",
+      undefined,
+      hooks,
+      thoughts,
+      currentTurn,
+    );
+    const secondItems = buildVirtual(stable, secondVolatile, true);
+    rerender(<ItemList items={secondItems} />);
+
+    expect(renderCounts.get("narrative-flow")).toBe(1);
+    expect(renderCounts.get("narrative-indicator")).toBe(1);
+    expect(renderCounts.get("turn-response:thread-1:typing")).toBe(2);
+  });
+});

--- a/apps/web/src/__tests__/virtual-items.test.ts
+++ b/apps/web/src/__tests__/virtual-items.test.ts
@@ -3,6 +3,8 @@ import {
   buildStableItems,
   buildVolatileItems,
   buildVirtualItems,
+  createVolatileItemsBuilder,
+  createVirtualItemsBuilder,
   estimateItemHeight,
   STREAMING_CARD_COLLAPSED_HEIGHT,
   assistantMessageItemKey,
@@ -139,12 +141,14 @@ describe("buildVolatileItems", () => {
     expect(items).toHaveLength(0);
   });
 
-  it("returns narrative-flow with streamingText when agent is running and streaming", () => {
+  it("keeps final-response text in the live assistant item when agent is running", () => {
     const items = buildVolatileItems([], true, 1000, "streaming...");
     const narrativeItem = items.find((i) => i.type === "narrative-flow") as Extract<(typeof items)[number], { type: "narrative-flow" }> | undefined;
     expect(narrativeItem).toBeDefined();
-    expect(narrativeItem?.streamingText).toBe("streaming...");
+    expect(narrativeItem?.streamingText).toBe("");
     expect(narrativeItem?.isAgentRunning).toBe(true);
+    const liveMessage = items.find((i) => i.type === "message" && i.assistantState?.isStreaming) as Extract<(typeof items)[number], { type: "message" }> | undefined;
+    expect(liveMessage?.message.content).toBe("streaming...");
   });
 
   it("passes thoughtSegments through on narrative-flow items", () => {
@@ -185,9 +189,143 @@ describe("buildVolatileItems", () => {
     >;
     expect(narrativeItem?.thoughtSegments).toEqual(thoughtSegments);
   });
+
+  it("memoized builder returns the same volatile item references for unchanged inputs", () => {
+    const build = createVolatileItemsBuilder();
+    const toolCalls = [makeToolCall({ id: "t1", isComplete: true })];
+    const hooks: HookExecution[] = [];
+    const thoughtSegments: ThoughtSegment[] = [];
+    const currentTurn = {
+      threadId: "thread-1",
+      responseKey: "turn-response:thread-1:stable",
+    };
+
+    const first = build(
+      toolCalls,
+      true,
+      1000,
+      "answer",
+      undefined,
+      hooks,
+      thoughtSegments,
+      currentTurn,
+    );
+    const second = build(
+      toolCalls,
+      true,
+      1000,
+      "answer",
+      undefined,
+      hooks,
+      thoughtSegments,
+      currentTurn,
+    );
+
+    expect(second).toBe(first);
+    expect(second[0]).toBe(first[0]);
+    expect(second[1]).toBe(first[1]);
+    expect(second[2]).toBe(first[2]);
+  });
+
+  it("memoized builder changes only the live typing item on final-response text deltas", () => {
+    const build = createVolatileItemsBuilder();
+    const toolCalls = [makeToolCall({ id: "t1", isComplete: true })];
+    const hooks: HookExecution[] = [];
+    const thoughtSegments: ThoughtSegment[] = [];
+    const currentTurn = {
+      threadId: "thread-1",
+      responseKey: "turn-response:thread-1:typing",
+    };
+
+    const first = build(
+      toolCalls,
+      true,
+      1000,
+      "answer one",
+      undefined,
+      hooks,
+      thoughtSegments,
+      currentTurn,
+    );
+    const second = build(
+      toolCalls,
+      true,
+      1000,
+      "answer two",
+      undefined,
+      hooks,
+      thoughtSegments,
+      currentTurn,
+    );
+
+    expect(second).not.toBe(first);
+    expect(second.find((item) => item.type === "narrative-flow")).toBe(
+      first.find((item) => item.type === "narrative-flow"),
+    );
+    expect(second.find((item) => item.type === "narrative-indicator")).toBe(
+      first.find((item) => item.type === "narrative-indicator"),
+    );
+    expect(
+      second.find((item) => item.type === "message" && item.assistantState?.isStreaming),
+    ).not.toBe(
+      first.find((item) => item.type === "message" && item.assistantState?.isStreaming),
+    );
+  });
 });
 
 describe("buildVirtualItems (combined)", () => {
+  it("memoized splicer returns the same array for unchanged stable and volatile inputs", () => {
+    const build = createVirtualItemsBuilder();
+    const stable = buildStableItems([makeMessage({ id: "msg-1" })]);
+    const volatile = buildVolatileItems([], true, 1000, "typing");
+
+    const first = build(stable, volatile, false);
+    const second = build(stable, volatile, false);
+
+    expect(second).toBe(first);
+  });
+
+  it("memoized splicer keeps new order when same-key items reorder", () => {
+    const build = createVirtualItemsBuilder();
+    const firstStable = buildStableItems([
+      makeMessage({ id: "msg-1", role: "user", content: "First", sequence: 1 }),
+      makeMessage({ id: "msg-2", role: "user", content: "Second", sequence: 2 }),
+    ]);
+    const secondStable = buildStableItems([
+      makeMessage({ id: "msg-2", role: "user", content: "Second", sequence: 2 }),
+      makeMessage({ id: "msg-1", role: "user", content: "First", sequence: 1 }),
+    ]);
+
+    build(firstStable, [], false);
+    const second = build(secondStable, [], false);
+
+    expect(second.map((item) => item.key)).toEqual(["msg-2", "msg-1"]);
+  });
+
+  it("memoized splicer does not swallow message metadata-only updates", () => {
+    const build = createVirtualItemsBuilder();
+    const firstStable = buildStableItems([
+      makeMessage({ id: "msg-1", model: "claude-old", tokens_used: 1 }),
+    ]);
+    const secondStable = buildStableItems([
+      makeMessage({ id: "msg-1", model: "claude-new", tokens_used: 2 }),
+    ]);
+
+    const first = build(firstStable, [], false);
+    const second = build(secondStable, [], false);
+    const firstMessage = first.find((item) => item.type === "message") as
+      | Extract<ChatVirtualItem, { type: "message" }>
+      | undefined;
+    const secondMessage = second.find((item) => item.type === "message") as
+      | Extract<ChatVirtualItem, { type: "message" }>
+      | undefined;
+
+    expect(second).not.toBe(first);
+    expect(secondMessage).not.toBe(firstMessage);
+    expect(secondMessage?.message.model).toBe("claude-new");
+    expect(secondMessage?.message.tokens_used).toBe(2);
+  });
+
   it("empty messages returns empty array", () => {
     const result = buildAll([], [], undefined, false, undefined);
     expect(result).toEqual([]);
@@ -250,7 +388,7 @@ describe("buildVirtualItems (combined)", () => {
       | (ChatVirtualItem & { type: "narrative-flow" })
       | undefined;
     expect(narrative).toBeDefined();
-    expect(narrative?.streamingText).toBe("partial response...");
+    expect(narrative?.streamingText).toBe("");
 
     // The streaming text also surfaces as a provisional assistant message so
     // the persisted MessageBubble keeps the same component and key.
@@ -465,7 +603,7 @@ describe("buildVirtualItems (combined)", () => {
     const types = result.map((item) => item.type);
     expect(types).toContain("narrative-flow");
     const narrative = result.find((i) => i.type === "narrative-flow") as (ChatVirtualItem & { type: "narrative-flow" }) | undefined;
-    expect(narrative?.streamingText).toBe("streaming...");
+    expect(narrative?.streamingText).toBe("");
     expect(narrative?.isAgentRunning).toBe(true);
   });
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -117,6 +117,35 @@ function resolveOutboundDisplayContent(
   return (displayInjected ?? rawInput).trim();
 }
 
+/**
+ * Resolve the running-state used by submit handlers from the latest store
+ * snapshot, covering the render gap after reconnect or server push.
+ */
+export function isThreadRunningForSubmit(
+  threadId: string | undefined,
+  renderedIsAgentRunning: boolean,
+): boolean {
+  if (renderedIsAgentRunning) return true;
+  return threadId ? useThreadStore.getState().runningThreadIds.has(threadId) : false;
+}
+
+/** Decide whether an existing-thread submit should queue behind the active turn. */
+export function shouldQueueActiveThreadSubmit(
+  threadId: string | undefined,
+  renderedIsAgentRunning: boolean,
+  branchFromMessageId: string | null | undefined,
+  isNewThread: boolean | undefined,
+  trimmedContent: string,
+): boolean {
+  return Boolean(
+    isThreadRunningForSubmit(threadId, renderedIsAgentRunning) &&
+    threadId &&
+    !branchFromMessageId &&
+    !isNewThread &&
+    !isGoalControlCommand(trimmedContent),
+  );
+}
+
 /** `accept` list for the composer's hidden file input (mirrors {@link isFileSupported}). */
 const ATTACHMENT_INPUT_ACCEPT = attachmentAcceptAttribute();
 
@@ -1752,39 +1781,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       }
     }
 
-    // ---- Queue path: agent is running on THIS thread ----
-    // Skip when composing a branch (`branchFromMessageId`) or a brand-new thread
-    // (`isNewThread`) - both target a *different* thread and must not enqueue
-    // on the parent thread that happens to be currently running.
-    //
-    // Also skip for `/goal` control-form commands (`clear`, `reset`, `show`,
-    // bare `/goal`). When a goal is active the agent's Stop hook blocks the
-    // turn from ending until the goal is met - which means `session.turnComplete`
-    // never fires and the queue never drains. Queueing `/goal clear` here would
-    // deadlock: the only way to clear the goal is to send `/goal clear`, but
-    // that message would sit in the queue waiting for a turn that cannot
-    // complete. The server intercept handles these control forms synchronously
-    // without invoking the provider, so they are safe to send mid-turn.
-    if (
-      isAgentRunning &&
-      threadId &&
-      !branchFromMessageId &&
-      !isNewThread &&
-      !isGoalControlCommand(trimmed)
-    ) {
-      const captureRows = buildAttachedBrowserCaptures(attachments);
-      const { content: injectedContent, display: displayInjected } = await injectFileContent(rawInput);
-      let content: string;
-      try {
-        content =
-          captureRows.length === 0 ? injectedContent : appendBrowserCaptureFence(injectedContent, captureRows);
-        content = content.trim();
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : "Invalid page preview payload";
-        useToastStore.getState().show("error", "Could not send message", msg);
-        return;
-      }
-      const displayContentResolved = resolveOutboundDisplayContent(rawInput, displayInjected);
+    const enqueueCurrentComposerMessage = (
+      content: string,
+      displayContentResolved: string,
+      captureRows: AttachedBrowserCapture[],
+    ) => {
+      if (!threadId) return;
       const currentAttachments = collectAndClearAttachments();
       const browserCaptureSpillPaths = collectBrowserCaptureSpillPaths(captureRows);
 
@@ -1806,10 +1808,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         browserCaptureSpillPaths:
           browserCaptureSpillPaths.length > 0 ? browserCaptureSpillPaths : undefined,
       };
-      // When saving an edit of a previously queued message, put it back at
-      // the same slot instead of appending to the tail. Show a toast so the
-      // user sees that the save took effect - without it the composer just
-      // clears silently and the queue list looks like nothing changed.
       const enqueued = editingFromQueue
         ? useQueueStore.getState().insertAt(threadId, editingFromQueue.originalIndex, payload)
         : useQueueStore.getState().enqueue(threadId, payload);
@@ -1840,6 +1838,44 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         });
       }
       editorRef.current?.focus();
+    };
+
+    // ---- Queue path: agent is running on THIS thread ----
+    // Skip when composing a branch (`branchFromMessageId`) or a brand-new thread
+    // (`isNewThread`) - both target a *different* thread and must not enqueue
+    // on the parent thread that happens to be currently running.
+    //
+    // Also skip for `/goal` control-form commands (`clear`, `reset`, `show`,
+    // bare `/goal`). When a goal is active the agent's Stop hook blocks the
+    // turn from ending until the goal is met - which means `session.turnComplete`
+    // never fires and the queue never drains. Queueing `/goal clear` here would
+    // deadlock: the only way to clear the goal is to send `/goal clear`, but
+    // that message would sit in the queue waiting for a turn that cannot
+    // complete. The server intercept handles these control forms synchronously
+    // without invoking the provider, so they are safe to send mid-turn.
+    if (
+      shouldQueueActiveThreadSubmit(
+        threadId,
+        isAgentRunning,
+        branchFromMessageId,
+        isNewThread,
+        trimmed,
+      )
+    ) {
+      const captureRows = buildAttachedBrowserCaptures(attachments);
+      const { content: injectedContent, display: displayInjected } = await injectFileContent(rawInput);
+      let content: string;
+      try {
+        content =
+          captureRows.length === 0 ? injectedContent : appendBrowserCaptureFence(injectedContent, captureRows);
+        content = content.trim();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Invalid page preview payload";
+        useToastStore.getState().show("error", "Could not send message", msg);
+        return;
+      }
+      const displayContentResolved = resolveOutboundDisplayContent(rawInput, displayInjected);
+      enqueueCurrentComposerMessage(content, displayContentResolved, captureRows);
       return;
     }
 
@@ -1880,6 +1916,19 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     const outboundDisplay = resolveOutboundDisplayContent(rawInput, displayInjected);
 
     // ---- Normal send path ----
+
+    if (
+      shouldQueueActiveThreadSubmit(
+        threadId,
+        isAgentRunning,
+        branchFromMessageId,
+        isNewThread,
+        trimmed,
+      )
+    ) {
+      enqueueCurrentComposerMessage(messageContent, outboundDisplay, captureRows);
+      return;
+    }
 
     setInput("");
     if (editorRef.current) {
@@ -2178,6 +2227,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             }
           }}
           onSendNow={async (msg) => {
+            if (useThreadStore.getState().runningThreadIds.has(threadId)) {
+              useQueueStore.getState().moveMessage(threadId, msg.id, 0);
+              return;
+            }
             const popped = useQueueStore.getState().popMessage(threadId, msg.id);
             if (!popped) return;
             try {

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -18,8 +18,8 @@ import { PermissionRequestCard } from "./PermissionRequestCard";
 import { HookActivitySection } from "./HookActivitySection";
 import {
   buildStableItems,
-  buildVolatileItems,
-  buildVirtualItems,
+  createVolatileItemsBuilder,
+  createVirtualItemsBuilder,
   estimateItemHeight,
 } from "./virtual-items";
 import type { ChatVirtualItem } from "./virtual-items";
@@ -474,8 +474,22 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     ],
   );
 
+  const volatileItemsBuilderRef = useRef<ReturnType<typeof createVolatileItemsBuilder> | null>(null);
+  if (volatileItemsBuilderRef.current == null) {
+    volatileItemsBuilderRef.current = createVolatileItemsBuilder();
+  }
+  const virtualItemsBuilderRef = useRef<ReturnType<typeof createVirtualItemsBuilder> | null>(null);
+  if (virtualItemsBuilderRef.current == null) {
+    virtualItemsBuilderRef.current = createVirtualItemsBuilder();
+  }
+
   const volatileItems = useMemo(() => {
-    const base = buildVolatileItems(
+    const lastMsg = messages[messages.length - 1];
+    const committedAssistantBody =
+      currentThreadId && !isAgentRunning && lastMsg?.role === "assistant"
+        ? lastMsg.content
+        : undefined;
+    return volatileItemsBuilderRef.current!(
       toolCalls,
       isAgentRunning,
       agentStartTime,
@@ -491,19 +505,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
             responseKeysByMessageId: assistantResponseKeys,
           }
         : undefined,
-    );
-    const lastMsg = messages[messages.length - 1];
-    const committedAssistantBody =
-      currentThreadId && !isAgentRunning && lastMsg?.role === "assistant"
-        ? lastMsg.content
-        : undefined;
-    if (!committedAssistantBody) {
-      return base;
-    }
-    return base.map((item) =>
-      item.type === "narrative-flow"
-        ? { ...item, committedAssistantBody }
-        : item,
+      committedAssistantBody,
     );
   }, [
     toolCalls,
@@ -522,7 +524,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
   const hasToolCalls = toolCalls.length > 0;
   const items = useMemo(
-    () => buildVirtualItems(stableItems, volatileItems, hasToolCalls),
+    () => virtualItemsBuilderRef.current!(stableItems, volatileItems, hasToolCalls),
     [stableItems, volatileItems, hasToolCalls],
   );
 

--- a/apps/web/src/components/chat/__tests__/Composer.running-submit.test.ts
+++ b/apps/web/src/components/chat/__tests__/Composer.running-submit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  isThreadRunningForSubmit,
+  shouldQueueActiveThreadSubmit,
+} from "../Composer";
+import { resetThreadStoreForTests } from "@/stores/thread-store-test-utils";
+import { useThreadStore } from "@/stores/threadStore";
+
+describe("Composer submit running-state", () => {
+  beforeEach(() => {
+    resetThreadStoreForTests({ runningThreadIds: new Set() });
+  });
+
+  it("treats a thread as running when the store has advanced before render props", () => {
+    useThreadStore.setState({ runningThreadIds: new Set(["t-1"]) });
+
+    expect(isThreadRunningForSubmit("t-1", false)).toBe(true);
+  });
+
+  it("keeps rendered running state authoritative while the store catches up", () => {
+    expect(isThreadRunningForSubmit("t-1", true)).toBe(true);
+  });
+
+  it("does not mark a missing thread as running", () => {
+    useThreadStore.setState({ runningThreadIds: new Set(["t-1"]) });
+
+    expect(isThreadRunningForSubmit(undefined, false)).toBe(false);
+  });
+
+  it("queues if the thread becomes running after the first submit check", () => {
+    expect(
+      shouldQueueActiveThreadSubmit("t-1", false, null, false, "follow-up"),
+    ).toBe(false);
+
+    useThreadStore.setState({ runningThreadIds: new Set(["t-1"]) });
+
+    expect(
+      shouldQueueActiveThreadSubmit("t-1", false, null, false, "follow-up"),
+    ).toBe(true);
+  });
+
+  it("does not queue goal control commands while a thread is running", () => {
+    useThreadStore.setState({ runningThreadIds: new Set(["t-1"]) });
+
+    expect(
+      shouldQueueActiveThreadSubmit("t-1", false, null, false, "/goal clear"),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/narrative/DeltaBlock.tsx
+++ b/apps/web/src/components/chat/narrative/DeltaBlock.tsx
@@ -105,8 +105,8 @@ const LONG_RESPONSE_LENGTH = 2_000;
  *   behind, the rAF loop keeps catching up instead of snapping to full height.
  *
  * Idle rate: ~6 chars every 32ms. Catch-up closes roughly 1/8 of the gap per
- * paint, with a higher cap for long responses so markdown re-render work stays
- * bounded during large flushes.
+ * paint, with a higher cap for long responses so visible text still catches up
+ * during large flushes.
  *
  * When `target` shrinks (e.g., the parent reset for a new turn), the
  * displayed value resets immediately and the animation cancels.
@@ -188,8 +188,8 @@ function useTypewriter(target: string, isStreaming: boolean): string {
  *
  * Incoming `text` deltas are buffered by `useTypewriter`, which advances the
  * displayed text at a steady rate (≈180 chars/sec when idle, scaling up to
- * close any backlog). The markdown renderer always receives the typewriter
- * output, so users see characters form rather than whole chunks pop in.
+ * close any backlog). Active streams render as plain pre-wrapped text; settled
+ * blocks hand the final text to the markdown renderer.
  *
  * The cursor is anchored at the end of whatever is currently rendered via
  * a layout effect that measures `Range.getClientRects()` and positions the
@@ -212,7 +212,7 @@ export function DeltaBlock({ text, isStreaming = true, showCursor = true }: Delt
   useLayoutEffect(() => {
     const root = rootRef.current;
     const cursor = cursorRef.current;
-    if (!root || !cursor) return;
+    if (!root || !cursor || !renderCursor) return;
 
     // If the markdown DOM is momentarily empty (Suspense in flight, or a
     // re-render between fallback and resolved children), keep the cursor at
@@ -255,19 +255,25 @@ export function DeltaBlock({ text, isStreaming = true, showCursor = true }: Delt
     cursor.style.opacity = "1";
     cursor.style.height = `${h}px`;
     cursor.style.transform = `translate3d(${x}px, ${y}px, 0)`;
-  });
+  }, [displayed, renderCursor]);
 
   return (
     <div ref={rootRef} className="relative">
-      <Suspense
-        fallback={
-          <p className="whitespace-pre-wrap text-[0.9375rem] leading-relaxed">
-            {displayed}
-          </p>
-        }
-      >
-        <LazyMarkdownContent content={displayed} isStreaming={isStreaming} />
-      </Suspense>
+      {isStreaming ? (
+        <p className="whitespace-pre-wrap text-[0.9375rem] leading-relaxed">
+          {displayed}
+        </p>
+      ) : (
+        <Suspense
+          fallback={
+            <p className="whitespace-pre-wrap text-[0.9375rem] leading-relaxed">
+              {displayed}
+            </p>
+          }
+        >
+          <LazyMarkdownContent content={displayed} isStreaming={false} />
+        </Suspense>
+      )}
       {/* Cursor is mounted ONLY when actively streaming AND `showCursor` is
           true. The `.typing-cursor` class runs a CSS blink animation that
           overrides any inline opacity, so an unmounted-but-not-rendered cursor

--- a/apps/web/src/components/chat/narrative/__tests__/DeltaBlock.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/DeltaBlock.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DeltaBlock } from "../DeltaBlock";
+
+vi.mock("@/components/chat/MarkdownContent", () => ({
+  __esModule: true,
+  default: ({ content, isStreaming }: { content: string; isStreaming?: boolean }) => (
+    <div data-testid="markdown-content" data-streaming={String(isStreaming)}>
+      {content}
+    </div>
+  ),
+}));
+
+function makeRectList(rect: Partial<DOMRect>): DOMRectList {
+  const item = {
+    right: rect.right ?? 12,
+    top: rect.top ?? 4,
+    height: rect.height ?? 16,
+  } as DOMRect;
+  return {
+    0: item,
+    length: 1,
+    item: (index: number) => (index === 0 ? item : null),
+    [Symbol.iterator]: function* () {
+      yield item;
+    },
+  } as DOMRectList;
+}
+
+describe("DeltaBlock", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses plain pre-wrapped text while streaming", () => {
+    const { container } = render(
+      <DeltaBlock text={"streaming text ".repeat(10)} isStreaming showCursor={false} />,
+    );
+
+    expect(screen.queryByTestId("markdown-content")).toBeNull();
+    expect(container.querySelector("p.whitespace-pre-wrap")?.textContent).toContain(
+      "streaming text",
+    );
+  });
+
+  it("uses the markdown adapter after settling", async () => {
+    render(<DeltaBlock text="**settled**" isStreaming={false} showCursor={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-content").textContent).toBe("**settled**");
+      expect(screen.getByTestId("markdown-content").getAttribute("data-streaming")).toBe("false");
+    });
+  });
+
+  it("does not re-measure the cursor when displayed text is unchanged", () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 40,
+      width: 100,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    const range = {
+      setStart: vi.fn(),
+      setEnd: vi.fn(),
+      getClientRects: vi.fn(() => makeRectList({ right: 12, top: 4, height: 16 })),
+    } as unknown as Range;
+    const createRange = vi.spyOn(document, "createRange").mockReturnValue(range);
+
+    const text = "x".repeat(140);
+    const { rerender } = render(<DeltaBlock text={text} isStreaming showCursor />);
+    const firstMeasureCount = createRange.mock.calls.length;
+
+    rerender(<DeltaBlock text={text} isStreaming showCursor />);
+
+    expect(firstMeasureCount).toBeGreaterThan(0);
+    expect(createRange).toHaveBeenCalledTimes(firstMeasureCount);
+  });
+});

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -25,6 +25,9 @@ function isPlanQuestionsMessage(content: string): boolean {
 /** Estimated collapsed height (px) for a streaming card virtual item. */
 export const STREAMING_CARD_COLLAPSED_HEIGHT = 56;
 
+const EMPTY_HOOKS: readonly HookExecution[] = [];
+const EMPTY_THOUGHT_SEGMENTS: readonly ThoughtSegment[] = [];
+
 /** State that lets the current turn's live and persisted assistant rows share one React key. */
 export interface CurrentTurnResponseIdentity {
   threadId: string;
@@ -261,8 +264,18 @@ export function buildVolatileItems(
   hooks?: readonly HookExecution[],
   thoughtSegments?: readonly ThoughtSegment[],
   currentTurn?: CurrentTurnResponseIdentity,
+  committedAssistantBody?: string,
 ): ChatVirtualItem[] {
   const items: ChatVirtualItem[] = [];
+  const resolvedHooks = hooks ?? EMPTY_HOOKS;
+  const resolvedThoughtSegments = thoughtSegments ?? EMPTY_THOUGHT_SEGMENTS;
+  const resolvedStreamingText = streamingText ?? "";
+  const liveText = computeLiveStreamingText({
+    thoughtSegments: resolvedThoughtSegments,
+    streamingText: resolvedStreamingText,
+    isAgentRunning,
+    toolCalls,
+  });
 
   // Emit the narrative flow item when agent is running or has tool calls.
   // This replaces the separate "active-tools", "hook-activity", "indicator",
@@ -272,23 +285,18 @@ export function buildVolatileItems(
       key: "narrative-flow",
       type: "narrative-flow",
       toolCalls,
-      hooks: hooks ?? [],
-      thoughtSegments: thoughtSegments ?? [],
-      streamingText: streamingText ?? "",
+      hooks: resolvedHooks,
+      thoughtSegments: resolvedThoughtSegments,
+      streamingText: liveText.length > 0 ? "" : resolvedStreamingText,
       isAgentRunning,
       startTime: agentStartTime,
+      committedAssistantBody,
     });
   }
 
   // Provisional assistant message — fills the slot where the persisted
   // MessageBubble will remain on `session.message`. Keeping the item type and
   // key stable lets React update the same subtree instead of remounting it.
-  const liveText = computeLiveStreamingText({
-    thoughtSegments: thoughtSegments ?? [],
-    streamingText: streamingText ?? "",
-    isAgentRunning,
-    toolCalls,
-  });
   if (liveText.length > 0) {
     const threadId = currentTurn?.threadId ?? "__active_thread__";
     const responseKey = liveFinalResponseItemKey(threadId, currentTurn?.responseKey);
@@ -360,6 +368,183 @@ export function buildVolatileItems(
   }
 
   return items;
+}
+
+function sameArrayItems<T>(
+  left: readonly T[] | undefined,
+  right: readonly T[] | undefined,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right || left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) return false;
+  }
+  return true;
+}
+
+function sameAssistantState(
+  left: Extract<ChatVirtualItem, { type: "message" }>["assistantState"],
+  right: Extract<ChatVirtualItem, { type: "message" }>["assistantState"],
+): boolean {
+  if (left === right) return true;
+  return (
+    left?.isStreaming === right?.isStreaming &&
+    left?.actionsVisible === right?.actionsVisible
+  );
+}
+
+function sameMessage(left: Message, right: Message): boolean {
+  return (
+    left.id === right.id &&
+    left.thread_id === right.thread_id &&
+    left.role === right.role &&
+    left.content === right.content &&
+    left.tool_calls === right.tool_calls &&
+    left.files_changed === right.files_changed &&
+    left.cost_usd === right.cost_usd &&
+    left.tokens_used === right.tokens_used &&
+    left.timestamp === right.timestamp &&
+    left.sequence === right.sequence &&
+    left.attachments === right.attachments &&
+    left.tool_call_count === right.tool_call_count &&
+    left.reply_to_message_id === right.reply_to_message_id &&
+    left.quoted_text === right.quoted_text &&
+    left.model === right.model &&
+    left.is_internal === right.is_internal
+  );
+}
+
+function sameVirtualItem(
+  left: ChatVirtualItem | undefined,
+  right: ChatVirtualItem,
+): boolean {
+  if (!left || left.key !== right.key || left.type !== right.type) return false;
+  switch (right.type) {
+    case "message":
+      return (
+        left.type === "message" &&
+        sameMessage(left.message, right.message) &&
+        sameAssistantState(left.assistantState, right.assistantState)
+      );
+    case "active-tools":
+      return left.type === "active-tools" && left.toolCalls === right.toolCalls;
+    case "indicator":
+      return (
+        left.type === "indicator" &&
+        left.startTime === right.startTime &&
+        sameArrayItems(left.activeToolCalls, right.activeToolCalls)
+      );
+    case "streaming":
+      return left.type === "streaming" && left.text === right.text;
+    case "turn-changes":
+      return (
+        left.type === "turn-changes" &&
+        left.messageId === right.messageId &&
+        left.filesChanged === right.filesChanged &&
+        left.isLatestTurn === right.isLatestTurn
+      );
+    case "permission-request":
+      return (
+        left.type === "permission-request" &&
+        left.requestId === right.requestId &&
+        left.toolName === right.toolName &&
+        left.input === right.input &&
+        left.title === right.title &&
+        left.settled === right.settled &&
+        left.decision === right.decision
+      );
+    case "hook-activity":
+      return left.type === "hook-activity" && left.hooks === right.hooks;
+    case "narrative-flow":
+      return (
+        left.type === "narrative-flow" &&
+        left.toolCalls === right.toolCalls &&
+        left.hooks === right.hooks &&
+        left.thoughtSegments === right.thoughtSegments &&
+        left.streamingText === right.streamingText &&
+        left.isAgentRunning === right.isAgentRunning &&
+        left.startTime === right.startTime &&
+        left.committedAssistantBody === right.committedAssistantBody
+      );
+    case "persisted-narrative":
+      return (
+        left.type === "persisted-narrative" &&
+        left.messageId === right.messageId &&
+        left.messageContent === right.messageContent
+      );
+    case "persisted-late-hooks":
+      return left.type === "persisted-late-hooks" && left.messageId === right.messageId;
+    case "persisted-turn-footer":
+      return left.type === "persisted-turn-footer" && left.messageId === right.messageId;
+    case "narrative-indicator":
+      return (
+        left.type === "narrative-indicator" &&
+        left.stepCount === right.stepCount &&
+        left.subagentCount === right.subagentCount &&
+        sameArrayItems(left.activeToolCalls, right.activeToolCalls) &&
+        left.startTime === right.startTime &&
+        left.isAgentRunning === right.isAgentRunning
+      );
+    default:
+      return assertNever(right);
+  }
+}
+
+function reuseVirtualItems(
+  previous: readonly ChatVirtualItem[],
+  next: ChatVirtualItem[],
+): ChatVirtualItem[] {
+  if (previous.length === 0) return next;
+  const previousByKey = new Map(previous.map((item) => [item.key, item]));
+  let changed = previous.length !== next.length;
+  const reused = next.map((item, index) => {
+    const prior = previousByKey.get(item.key);
+    if (sameVirtualItem(prior, item)) {
+      if (previous[index]?.key !== item.key) {
+        changed = true;
+      }
+      return prior!;
+    }
+    changed = true;
+    return item;
+  });
+  if (!changed) return previous as ChatVirtualItem[];
+  return reused;
+}
+
+/** Creates a volatile item builder that preserves slot object identity across unchanged inputs. */
+export function createVolatileItemsBuilder(): typeof buildVolatileItems {
+  let previous: readonly ChatVirtualItem[] = [];
+  return (...args) => {
+    const next = buildVolatileItems(...args);
+    previous = reuseVirtualItems(previous, next);
+    return previous as ChatVirtualItem[];
+  };
+}
+
+/** Creates a virtual item splicer that returns the same array when the splice inputs are unchanged. */
+export function createVirtualItemsBuilder(): typeof buildVirtualItems {
+  let previousStable: readonly ChatVirtualItem[] | undefined;
+  let previousVolatile: readonly ChatVirtualItem[] | undefined;
+  let previousHasToolCalls: boolean | undefined;
+  let previousResult: readonly ChatVirtualItem[] = [];
+  return (stableItems, volatileItems, hasToolCalls) => {
+    if (
+      previousStable === stableItems &&
+      previousVolatile === volatileItems &&
+      previousHasToolCalls === hasToolCalls
+    ) {
+      return previousResult as ChatVirtualItem[];
+    }
+    previousStable = stableItems;
+    previousVolatile = volatileItems;
+    previousHasToolCalls = hasToolCalls;
+    previousResult = reuseVirtualItems(
+      previousResult,
+      buildVirtualItems(stableItems, volatileItems, hasToolCalls),
+    );
+    return previousResult as ChatVirtualItem[];
+  };
 }
 
 /**

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -214,9 +214,12 @@ export function scheduleDrainAfterEdit(threadId: string): void {
  */
 function resetTurnEphemeral(_rec: ThreadRecord): Partial<ThreadRecord> {
   return {
+    streaming: "",
+    streamingPreview: "",
     toolCalls: [],
     thoughtSegments: [],
     hooks: [],
+    currentTurnMessageId: "",
     currentTurnResponseKey: "",
   };
 }
@@ -550,7 +553,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         const rec = getThreadRecord(records, tid);
         let streaming = rec.streaming;
         let streamingPreview = rec.streamingPreview;
-        let segments = [...rec.thoughtSegments];
+        let segments = rec.thoughtSegments;
+        let segmentsChanged = false;
         for (const chunk of chunks) {
           const acc = chunk.delta;
           if (!acc) continue;
@@ -588,6 +592,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
                 ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
               },
             ];
+            segmentsChanged = true;
           } else if (last.endedAt !== undefined && shouldReopen) {
             const reopened: typeof last = {
               ...last,
@@ -596,6 +601,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             };
             delete (reopened as { endedAt?: number }).endedAt;
             segments = [...segments.slice(0, -1), reopened];
+            segmentsChanged = true;
           } else {
             segments = [
               ...segments.slice(0, -1),
@@ -605,16 +611,31 @@ export const useThreadStore = create<ThreadState>((set, get) => {
                 ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
               },
             ];
+            segmentsChanged = true;
           }
         }
-        records = patchThreadRecord(records, tid, {
+        const patch: Partial<ThreadRecord> = {
           streaming,
           streamingPreview,
-          thoughtSegments: segments,
-        });
+        };
+        if (segmentsChanged) {
+          patch.thoughtSegments = segments;
+        }
+        records = patchThreadRecord(records, tid, patch);
       }
       return { records };
     });
+  };
+
+  const dropPendingTextDeltas = (threadIds: Iterable<string>) => {
+    let dropped = false;
+    for (const threadId of threadIds) {
+      dropped = pendingTextDeltaByThread.delete(threadId) || dropped;
+    }
+    if (dropped && pendingTextDeltaByThread.size === 0 && textDeltaFlushRaf != null) {
+      cancelAnimationFrame(textDeltaFlushRaf);
+      textDeltaFlushRaf = null;
+    }
   };
 
   const messageSequenceFor = (threadId: string) => getRec(threadId).messages.length + 1;
@@ -787,6 +808,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     // failure the rollback below must not clear the running-state of a real
     // turn the control command was issued against mid-flight (#583).
     const isControlCommand = isGoalControlCommand(content);
+    if (!isControlCommand && get().runningThreadIds.has(threadId)) {
+      throw new Error(`Thread ${threadId} already has an active agent session`);
+    }
+    if (!isControlCommand) {
+      dropPendingTextDeltas([threadId]);
+    }
 
     // Add user message to local state immediately (optimistic)
     // Use displayContent for the UI (without injected file blocks) if provided
@@ -883,16 +910,26 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       if (planAction === "revise") {
         usePlanStore.getState().setGenerating(threadId, false);
       }
+      const error = String(e);
+      const activeSessionConflict =
+        !isControlCommand && error.includes("already has an active agent session");
       set((state) => {
         // Control commands never added the thread to running-state, so leave it
         // untouched on rollback - a real turn in flight may own it (#583).
         const next = new Set(state.runningThreadIds);
-        if (!isControlCommand) next.delete(threadId);
+        if (activeSessionConflict) {
+          next.add(threadId);
+        } else if (!isControlCommand) {
+          next.delete(threadId);
+        }
         return {
-          records: patchThreadRecord(state.records, threadId, {
-            error: String(e),
-            agentStartTime: undefined,
-          }),
+          records: patchThreadRecord(state.records, threadId, (rec) => ({
+            error,
+            ...(activeSessionConflict && state.currentThreadId === threadId
+              ? { messages: rec.messages.filter((m) => m.id !== userMessage.id) }
+              : {}),
+            ...(!activeSessionConflict ? { agentStartTime: undefined } : {}),
+          })),
           runningThreadIds: next,
         };
       });
@@ -943,21 +980,38 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   },
 
   hydrateRunningThreads: (ids) => {
+    const resetPendingIds = new Set<string>();
     set((state) => {
       const current = state.runningThreadIds;
       if (current.size === ids.length && ids.every((id) => current.has(id))) {
         return {};
       }
       const now = Date.now();
+      const nextIds = new Set(ids);
       let records = state.records;
+      for (const id of current) {
+        if (!nextIds.has(id)) {
+          resetPendingIds.add(id);
+          records = patchThreadRecord(records, id, resetTurnEphemeral(getThreadRecord(records, id)));
+        }
+      }
       for (const id of ids) {
         const rec = getThreadRecord(records, id);
-        if (rec.agentStartTime === undefined) {
+        const isNewlyRunning = !current.has(id);
+        if (isNewlyRunning) {
+          resetPendingIds.add(id);
+          records = patchThreadRecord(records, id, {
+            ...resetTurnEphemeral(rec),
+            currentTurnResponseKey: createTurnResponseKey(id),
+            agentStartTime: rec.agentStartTime ?? now,
+          });
+        } else if (rec.agentStartTime === undefined) {
           records = patchThreadRecord(records, id, { agentStartTime: now });
         }
       }
       return { runningThreadIds: new Set(ids), records };
     });
+    dropPendingTextDeltas(resetPendingIds);
   },
 
   /** Append a single message to the current thread's message list. */


### PR DESCRIPTION
## What
Stabilizes streaming chat recovery when a turn stops abruptly or reconnect state changes.

## Why
Issue #649 track two covers cases where old live narrative can stay visible after a crash or reconnect, and where near-duplicate user messages can be persisted when two sends race on the same thread.

## Key Changes
- Reserve the server active-session slot before persisting a user turn, so concurrent sends cannot both write user rows.
- Clear stale volatile streaming, narrative, tool, and hook state when running-thread hydration drops or newly adds a thread.
- Drop pending batched text deltas when a reset happens, so stale chunks cannot repaint old narrative after reconnect.
- Guard composer submits with fresh running state and queue late follow-ups instead of losing the draft or sending into an active turn.
- Add UI, store, and server regression coverage for crash/reconnect behavior, queue routing, and duplicate-send protection.

Related to #649, #652, #653, #658

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784006640&installation_id=129163861&pr_number=734&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F734&signature=97d264aefdc55a005b0cbf17abfe060ed37f383aa7f4625e39825b60e92c3e9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Message queuing now activates when the agent is running, allowing follow-up questions to queue automatically instead of blocking.
  * Goal control commands (e.g., `/goal clear`) bypass queuing and execute immediately.
  * Improved crash reconnect handling with automatic UI cleanup for stale streaming state.

* **Bug Fixes**
  * Fixed concurrent message rejections when an agent session is already active.
  * Corrected streaming text display to render plain text while streaming, then switch to formatted markdown after settling.
  * Enhanced volatile state cleanup during session recovery and reconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->