### PR TITLE
feat: Epic #649 track 3 — git executor, snapshots, composer session

### DIFF
--- a/apps/server/src/__tests__/git-service-branch-comparison.test.ts
+++ b/apps/server/src/__tests__/git-service-branch-comparison.test.ts
@@ -1,20 +1,11 @@
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
+import { GitService } from "../services/git-service";
+import { createMockGitExecutor } from "../services/git-executor/__tests__/mock-git-executor.js";
 
-const { mockExecFile, mockExecFileSync, mockLogger } = vi.hoisted(() => ({
-  mockExecFile: vi.fn(),
-  mockExecFileSync: vi.fn(),
+const { mockLogger } = vi.hoisted(() => ({
   mockLogger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
-}));
-
-vi.mock("child_process", () => ({
-  execFileSync: mockExecFileSync,
-  execFile: vi.fn(),
-}));
-
-vi.mock("util", () => ({
-  promisify: () => mockExecFile,
 }));
 
 vi.mock("fs", () => ({
@@ -35,7 +26,8 @@ vi.mock("@mcode/shared", () => ({
   logger: mockLogger,
 }));
 
-import { GitService } from "../services/git-service";
+import type { Mock } from "vitest";
+import type { GitExecOptions, GitExecResult } from "../services/git-executor/types.js";
 
 /**
  * Builds the `git branch -a --format=...` output the standalone ref lister
@@ -54,10 +46,13 @@ const REPO = "/repo";
 
 describe("GitService.resolveBranchComparison", () => {
   let gitService: GitService;
+  let execFn: Mock<(args: string[], opts?: GitExecOptions) => Promise<GitExecResult>>;
 
   beforeEach(() => {
     vi.resetAllMocks();
-    gitService = new GitService({} as WorkspaceRepo);
+    const mock = createMockGitExecutor();
+    execFn = mock.execFn;
+    gitService = new GitService({} as WorkspaceRepo, mock.executor);
   });
 
   /**
@@ -76,13 +71,13 @@ describe("GitService.resolveBranchComparison", () => {
     const defaultBranch = opts.defaultBranch === undefined ? "main" : opts.defaultBranch;
     const localDefaultBranches = opts.localDefaultBranches ?? [];
 
-    mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
-      if (args.includes("branch")) return branchListOutput(opts.branches);
-      if (args.includes("rev-parse")) return `${opts.current}\n`;
-      return "";
-    });
-
-    mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
+    execFn.mockImplementation(async (args: string[]) => {
+      if (args.includes("branch") && args.includes("-a")) {
+        return { stdout: branchListOutput(opts.branches), stderr: "" };
+      }
+      if (args.includes("rev-parse") && args.includes("--abbrev-ref")) {
+        return { stdout: `${opts.current}\n`, stderr: "" };
+      }
       if (args.includes("rev-parse") && args.includes("--verify")) {
         if (!hasCommits) throw new Error("unborn");
         return { stdout: "deadbeef\n", stderr: "" };
@@ -221,19 +216,21 @@ describe("GitService.resolveBranchComparison", () => {
 
 describe("GitService.branchFiles / branchDiff ranges", () => {
   let gitService: GitService;
+  let execFn: Mock<(args: string[], opts?: GitExecOptions) => Promise<GitExecResult>>;
 
   beforeEach(() => {
     vi.resetAllMocks();
-    gitService = new GitService({} as WorkspaceRepo);
-    mockExecFile.mockResolvedValue({ stdout: "a.ts\nb.ts", stderr: "" });
+    const mock = createMockGitExecutor();
+    execFn = mock.execFn;
+    gitService = new GitService({} as WorkspaceRepo, mock.executor);
+    execFn.mockResolvedValue({ stdout: "a.ts\nb.ts", stderr: "" });
   });
 
   it("diffs an explicit pair three-dot for branchFiles", async () => {
     const files = await gitService.branchFiles("ws", "main", "feat/x", REPO);
 
     expect(files).toEqual(["a.ts", "b.ts"]);
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledWith(
       ["-C", REPO, "diff", "--name-only", "main...feat/x"],
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
@@ -242,8 +239,7 @@ describe("GitService.branchFiles / branchDiff ranges", () => {
   it("diffs an explicit pair three-dot for branchDiff with renames", async () => {
     await gitService.branchDiff("ws", "main", "origin/main", "a.ts", undefined, REPO);
 
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledWith(
       ["-C", REPO, "diff", "--find-renames", "main...origin/main", "--", "a.ts"],
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
@@ -256,27 +252,26 @@ describe("GitService.branchFiles / branchDiff ranges", () => {
     await expect(
       gitService.branchDiff("ws", "main", "-rf", undefined, undefined, REPO),
     ).rejects.toThrow(/unsafe git ref/i);
-    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(execFn).not.toHaveBeenCalled();
   });
 
   it("falls back to the detected default base ...HEAD when no pair is given", async () => {
     // symbolic-ref resolves the default branch; the diff call returns the files.
-    mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
+    execFn.mockImplementation(async (args: string[]) => {
       if (args.includes("symbolic-ref")) return { stdout: "origin/main\n", stderr: "" };
       return { stdout: "a.ts", stderr: "" };
     });
 
     await gitService.branchFiles("ws", undefined, undefined, REPO);
 
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledWith(
       ["-C", REPO, "diff", "--name-only", "main...HEAD"],
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
   });
 
   it("returns an explicit empty list when no default base is detected", async () => {
-    mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
+    execFn.mockImplementation(async (args: string[]) => {
       if (args.includes("symbolic-ref")) throw new Error("no origin head");
       if (args.includes("remote")) throw new Error("no origin");
       if (args.includes("show-ref")) throw new Error("missing local default");
@@ -286,8 +281,7 @@ describe("GitService.branchFiles / branchDiff ranges", () => {
     const files = await gitService.branchFiles("ws", undefined, undefined, REPO);
 
     expect(files).toEqual([]);
-    expect(mockExecFile).not.toHaveBeenCalledWith(
-      "git",
+    expect(execFn).not.toHaveBeenCalledWith(
       expect.arrayContaining(["diff"]),
       expect.anything(),
     );

--- a/apps/server/src/__tests__/git-service-push.test.ts
+++ b/apps/server/src/__tests__/git-service-push.test.ts
@@ -1,19 +1,8 @@
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
-
-const { mockExecFile } = vi.hoisted(() => ({
-  mockExecFile: vi.fn(),
-}));
-
-vi.mock("child_process", () => ({
-  execFileSync: vi.fn(),
-  execFile: vi.fn(),
-}));
-
-vi.mock("util", () => ({
-  promisify: () => mockExecFile,
-}));
+import { GitService } from "../services/git-service";
+import { createMockGitExecutor } from "../services/git-executor/__tests__/mock-git-executor.js";
 
 vi.mock("fs", () => ({
   existsSync: vi.fn(),
@@ -32,33 +21,33 @@ vi.mock("@mcode/shared", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
-import { GitService } from "../services/git-service";
-
 describe("GitService.push", () => {
   let gitService: GitService;
+  let execFn: ReturnType<typeof createMockGitExecutor>["execFn"];
 
   beforeEach(() => {
     vi.clearAllMocks();
+    const mock = createMockGitExecutor();
+    execFn = mock.execFn;
     const mockWorkspaceRepo = {
       findById: vi.fn().mockReturnValue({ path: "/repo" }),
     } as unknown as WorkspaceRepo;
-    gitService = new GitService(mockWorkspaceRepo);
+    gitService = new GitService(mockWorkspaceRepo, mock.executor);
   });
 
   it("pushes branch to origin with --set-upstream", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
 
     await gitService.push("/repo", "feat/my-branch");
 
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledWith(
       ["-C", "/repo", "push", "--set-upstream", "origin", "feat/my-branch"],
       expect.objectContaining({ timeout: 60_000 }),
     );
   });
 
   it("throws when push fails", async () => {
-    mockExecFile.mockRejectedValue(new Error("rejected"));
+    execFn.mockRejectedValue(new Error("rejected"));
 
     await expect(gitService.push("/repo", "feat/my-branch")).rejects.toThrow(
       "rejected",
@@ -68,14 +57,17 @@ describe("GitService.push", () => {
 
 describe("GitService.diffStat", () => {
   let gitService: GitService;
+  let execFn: ReturnType<typeof createMockGitExecutor>["execFn"];
 
   beforeEach(() => {
     vi.clearAllMocks();
-    gitService = new GitService({} as WorkspaceRepo);
+    const mock = createMockGitExecutor();
+    execFn = mock.execFn;
+    gitService = new GitService({} as WorkspaceRepo, mock.executor);
   });
 
   it("returns diff stat between two refs", async () => {
-    mockExecFile.mockResolvedValue({
+    execFn.mockResolvedValue({
       stdout: " 3 files changed, 42 insertions(+), 5 deletions(-)\n",
       stderr: "",
     });
@@ -83,8 +75,7 @@ describe("GitService.diffStat", () => {
     const result = await gitService.diffStat("/repo", "main", "feat/x");
 
     expect(result).toBe("3 files changed, 42 insertions(+), 5 deletions(-)");
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledWith(
       ["-C", "/repo", "diff", "--stat", "main...feat/x"],
       expect.objectContaining({ timeout: 30_000 }),
     );

--- a/apps/server/src/__tests__/git-service-push.test.ts
+++ b/apps/server/src/__tests__/git-service-push.test.ts
@@ -53,6 +53,18 @@ describe("GitService.push", () => {
       "rejected",
     );
   });
+
+  it("rejects branch names that look like git flags", async () => {
+    const { validateBranchName } = await import("@mcode/shared");
+    vi.mocked(validateBranchName).mockImplementation(() => {
+      throw new Error("Branch name cannot start with '-'");
+    });
+
+    await expect(gitService.push("/repo", "--force")).rejects.toThrow(
+      "Branch name cannot start with '-'",
+    );
+    expect(execFn).not.toHaveBeenCalled();
+  });
 });
 
 describe("GitService.diffStat", () => {

--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -2,22 +2,12 @@ import "reflect-metadata";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 
-const { mockExecFile, mockRm, mockRename, mockRmdir, mockExistsSync, mockLogger } = vi.hoisted(() => ({
-  mockExecFile: vi.fn(),
+const { mockRm, mockRename, mockRmdir, mockExistsSync, mockLogger } = vi.hoisted(() => ({
   mockRm: vi.fn(),
   mockRename: vi.fn(),
   mockRmdir: vi.fn(),
   mockExistsSync: vi.fn(),
   mockLogger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
-
-vi.mock("child_process", () => ({
-  execFileSync: vi.fn(),
-  execFile: vi.fn(),
-}));
-
-vi.mock("util", () => ({
-  promisify: () => mockExecFile,
 }));
 
 vi.mock("fs", () => ({
@@ -39,17 +29,21 @@ vi.mock("@mcode/shared", () => ({
 }));
 
 import { GitService } from "../services/git-service";
+import { createMockGitExecutor } from "../services/git-executor/__tests__/mock-git-executor.js";
 
 describe("GitService.removeWorktree", () => {
   let gitService: GitService;
+  let execFn: ReturnType<typeof createMockGitExecutor>["execFn"];
 
   beforeEach(() => {
     vi.resetAllMocks();
-    gitService = new GitService({} as WorkspaceRepo);
+    const mock = createMockGitExecutor();
+    execFn = mock.execFn;
+    gitService = new GitService({} as WorkspaceRepo, mock.executor);
   });
 
   it("removes worktree and branch when git succeeds", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
 
     const result = await gitService.removeWorktree(
@@ -59,8 +53,7 @@ describe("GitService.removeWorktree", () => {
     );
 
     expect(result).toBe(true);
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledWith(
       [
         "-C",
         "/repo",
@@ -72,8 +65,7 @@ describe("GitService.removeWorktree", () => {
       ],
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledWith(
       ["-C", "/repo", "branch", "-d", "feat/test"],
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
@@ -81,7 +73,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("falls back to fs.rm when git remove fails", async () => {
-    mockExecFile
+    execFn
       .mockRejectedValueOnce(new Error("git worktree remove failed"))
       .mockResolvedValueOnce({ stdout: "", stderr: "" }) // prune
       .mockResolvedValueOnce({ stdout: "", stderr: "" }); // branch -d
@@ -99,7 +91,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("returns false when directory cannot be removed", async () => {
-    mockExecFile.mockRejectedValue(new Error("git failed"));
+    execFn.mockRejectedValue(new Error("git failed"));
     mockExistsSync.mockReturnValue(true);
     mockRm.mockRejectedValue(new Error("permission denied"));
 
@@ -110,7 +102,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("succeeds even when branch deletion fails", async () => {
-    mockExecFile
+    execFn
       .mockResolvedValueOnce({ stdout: "", stderr: "" }) // worktree remove
       .mockResolvedValueOnce({ stdout: "", stderr: "" }) // prune
       .mockRejectedValueOnce(new Error("branch not found")); // branch -d
@@ -127,9 +119,9 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("passes maxRetries and retryDelay to fs.rm", async () => {
-    mockExecFile.mockRejectedValueOnce(new Error("git failed")); // worktree remove
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" }); // prune
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" }); // branch -d
+    execFn.mockRejectedValueOnce(new Error("git failed")); // worktree remove
+    execFn.mockResolvedValueOnce({ stdout: "", stderr: "" }); // prune
+    execFn.mockResolvedValueOnce({ stdout: "", stderr: "" }); // branch -d
     mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
     mockRm.mockResolvedValue(undefined);
 
@@ -142,20 +134,19 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("uses double --force for git worktree remove", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
 
     await gitService.removeWorktree("/repo", "my-worktree", { branchName: "feat/test" });
 
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledWith(
       ["-C", "/repo", "worktree", "remove", expect.stringContaining("my-worktree"), "--force", "--force"],
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
   });
 
   it("skips branch deletion when deleteBranch is false", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
 
     const result = await gitService.removeWorktree("/repo", "my-worktree", {
@@ -163,18 +154,17 @@ describe("GitService.removeWorktree", () => {
     });
 
     expect(result).toBe(true);
-    expect(mockExecFile).toHaveBeenCalledTimes(2);
-    expect(mockExecFile).not.toHaveBeenCalledWith(
-      "git",
+    expect(execFn).toHaveBeenCalledTimes(2);
+    expect(execFn).not.toHaveBeenCalledWith(
       expect.arrayContaining(["branch", "-d"]),
       expect.anything(),
     );
   });
 
   it("renames directory then deletes when fs.rm fails on first path", async () => {
-    mockExecFile.mockRejectedValueOnce(new Error("git failed")); // worktree remove
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" }); // prune
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" }); // branch -d
+    execFn.mockRejectedValueOnce(new Error("git failed")); // worktree remove
+    execFn.mockResolvedValueOnce({ stdout: "", stderr: "" }); // prune
+    execFn.mockResolvedValueOnce({ stdout: "", stderr: "" }); // branch -d
     // fs.rm fails on original path
     mockRm.mockRejectedValueOnce(Object.assign(new Error("EBUSY"), { code: "EBUSY" }));
     mockRename.mockResolvedValue(undefined);
@@ -194,7 +184,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("returns false when both fs.rm and rename-then-delete fail", async () => {
-    mockExecFile.mockRejectedValue(new Error("git failed"));
+    execFn.mockRejectedValue(new Error("git failed"));
     mockRm.mockRejectedValue(Object.assign(new Error("EBUSY"), { code: "EBUSY" }));
     mockRename.mockRejectedValue(new Error("rename failed"));
     mockExistsSync.mockReturnValue(true);
@@ -205,7 +195,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("prunes stale metadata after manual fallback before deleting the branch", async () => {
-    mockExecFile
+    execFn
       .mockRejectedValueOnce(new Error("git failed")) // worktree remove
       .mockResolvedValueOnce({ stdout: "", stderr: "" }) // prune
       .mockResolvedValueOnce({ stdout: "", stderr: "" }); // branch -d
@@ -218,8 +208,8 @@ describe("GitService.removeWorktree", () => {
 
     const pruneIndex = 1;
     const branchIndex = 2;
-    expect(mockExecFile.mock.calls[pruneIndex]?.[1]).toEqual(["-C", "/repo", "worktree", "prune"]);
-    expect(mockExecFile.mock.calls[branchIndex]?.[1]).toEqual([
+    expect(execFn.mock.calls[pruneIndex]?.[0]).toEqual(["-C", "/repo", "worktree", "prune"]);
+    expect(execFn.mock.calls[branchIndex]?.[0]).toEqual([
       "-C",
       "/repo",
       "branch",
@@ -227,15 +217,15 @@ describe("GitService.removeWorktree", () => {
       "mcode/my-worktree",
     ]);
     expect(mockRm.mock.invocationCallOrder[0]).toBeLessThan(
-      mockExecFile.mock.invocationCallOrder[pruneIndex],
+      execFn.mock.invocationCallOrder[pruneIndex],
     );
-    expect(mockExecFile.mock.invocationCallOrder[pruneIndex]).toBeLessThan(
-      mockExecFile.mock.invocationCallOrder[branchIndex],
+    expect(execFn.mock.invocationCallOrder[pruneIndex]).toBeLessThan(
+      execFn.mock.invocationCallOrder[branchIndex],
     );
   });
 
   it("removes an empty managed parent directory after worktree cleanup", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
     mockRmdir.mockResolvedValue(undefined);
 
@@ -246,7 +236,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("does not remove parent directories for external worktrees", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
 
     await gitService.removeWorktree("/repo", "my-worktree", {
@@ -258,7 +248,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("retries EBUSY on parent dir rmdir and succeeds on later attempt", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
 
     const ebusyErr = Object.assign(new Error("EBUSY"), { code: "EBUSY" });
@@ -278,7 +268,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("gives up parent dir cleanup after exhausting EBUSY retries", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
 
     const ebusyErr = Object.assign(new Error("EBUSY"), { code: "EBUSY" });
@@ -296,7 +286,7 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("retries EPERM on parent dir rmdir the same as EBUSY", async () => {
-    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
     mockExistsSync.mockReturnValue(false);
 
     const epermErr = Object.assign(new Error("EPERM"), { code: "EPERM" });
@@ -314,16 +304,22 @@ describe("GitService.removeWorktree", () => {
 
 describe("GitService.log", () => {
   let gitService: GitService;
+  let execFn: ReturnType<typeof createMockGitExecutor>["execFn"];
 
   beforeEach(() => {
     vi.resetAllMocks();
-    gitService = new GitService({
-      findById: vi.fn().mockReturnValue({ id: "ws-1", path: "/repo", is_git_repo: true }),
-    } as unknown as WorkspaceRepo);
+    const mock = createMockGitExecutor();
+    execFn = mock.execFn;
+    gitService = new GitService(
+      {
+        findById: vi.fn().mockReturnValue({ id: "ws-1", path: "/repo", is_git_repo: true }),
+      } as unknown as WorkspaceRepo,
+      mock.executor,
+    );
   });
 
   it("compares against origin HEAD instead of requiring a local default branch", async () => {
-    mockExecFile
+    execFn
       .mockResolvedValueOnce({ stdout: "origin/main\n", stderr: "" })
       .mockResolvedValueOnce({
         stdout: [
@@ -337,16 +333,15 @@ describe("GitService.log", () => {
 
     expect(commits).toHaveLength(1);
     expect(commits[0]?.shortSha).toBe("abc1234");
-    expect(mockExecFile).toHaveBeenNthCalledWith(
+    expect(execFn).toHaveBeenNthCalledWith(
       2,
-      "git",
       expect.arrayContaining(["origin/main..feat/-commit-picker"]),
       expect.objectContaining({ timeout: 10_000 }),
     );
   });
 
   it("supports paged lightweight logs without numstat", async () => {
-    mockExecFile
+    execFn
       .mockResolvedValueOnce({ stdout: "origin/main\n", stderr: "" })
       .mockResolvedValueOnce({
         stdout: "MCODE_SEPdef123456789|||def1234|||fix: older commit|||Dev|||2026-06-10T12:00:00.000Z",
@@ -365,7 +360,7 @@ describe("GitService.log", () => {
 
     expect(commits).toHaveLength(1);
     expect(commits[0]?.filesChanged).toBe(0);
-    const args = mockExecFile.mock.calls[1]?.[1] as string[];
+    const args = execFn.mock.calls[1]?.[0] as string[];
     expect(args).toContain("--skip=100");
     expect(args).not.toContain("--numstat");
   });

--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -236,7 +236,15 @@ describe("GitService.removeWorktree", () => {
   });
 
   it("does not remove parent directories for external worktrees", async () => {
-    execFn.mockResolvedValue({ stdout: "", stderr: "" });
+    execFn.mockImplementation(async (args: string[]) => {
+      if (args.includes("list") && args.includes("--porcelain")) {
+        return {
+          stdout: "worktree /external/worktrees/my-worktree\nbranch refs/heads/main\n\n",
+          stderr: "",
+        };
+      }
+      return { stdout: "", stderr: "" };
+    });
     mockExistsSync.mockReturnValue(false);
 
     await gitService.removeWorktree("/repo", "my-worktree", {
@@ -245,6 +253,19 @@ describe("GitService.removeWorktree", () => {
     });
 
     expect(mockRmdir).not.toHaveBeenCalled();
+  });
+
+  it("rejects unregistered external worktree paths before filesystem cleanup", async () => {
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
+    mockExistsSync.mockReturnValue(false);
+
+    await expect(
+      gitService.removeWorktree("/repo", "my-worktree", {
+        worktreePath: "/external/worktrees/my-worktree",
+        deleteBranch: false,
+      }),
+    ).rejects.toThrow("worktreePath is not a managed or registered worktree");
+    expect(mockRm).not.toHaveBeenCalled();
   });
 
   it("retries EBUSY on parent dir rmdir and succeeds on later attempt", async () => {

--- a/apps/server/src/__tests__/snapshot-service.integration.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.integration.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { SnapshotService } from "../services/snapshot-service";
+import { RealGitExecutor } from "../services/git-executor/real-git-executor.js";
 
 const GIT_REPO_SETUP_TIMEOUT_MS = 30_000;
 
@@ -46,7 +47,7 @@ describe("SnapshotService integration", () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    service = new SnapshotService();
+    service = new SnapshotService(new RealGitExecutor());
     tmpDir = createGitRepo();
   }, GIT_REPO_SETUP_TIMEOUT_MS);
 
@@ -161,7 +162,7 @@ describe("SnapshotService integration - unborn repo", () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    service = new SnapshotService();
+    service = new SnapshotService(new RealGitExecutor());
     tmpDir = createUnbornRepo();
   }, GIT_REPO_SETUP_TIMEOUT_MS);
 

--- a/apps/server/src/__tests__/snapshot-service.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.test.ts
@@ -1,176 +1,73 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeEach, vi } from "vitest";
-
-const { mockExecFile, mockUnlink } = vi.hoisted(() => ({
-  mockExecFile: vi.fn(),
-  mockUnlink: vi.fn(),
-}));
-
-vi.mock("node:child_process", () => ({
-  execFile: vi.fn(),
-}));
-
-vi.mock("node:util", () => ({
-  promisify: () => mockExecFile,
-}));
-
-vi.mock("node:fs/promises", () => ({
-  unlink: mockUnlink,
-}));
-
-import { SnapshotService } from "../services/snapshot-service";
+import { describe, it, expect, beforeEach } from "vitest";
+import { FakeGitExecutor } from "../services/git-executor/fake-git-executor.js";
+import { SnapshotService } from "../services/snapshot-service.js";
 
 describe("SnapshotService.captureRef", () => {
+  let fake: FakeGitExecutor;
   let service: SnapshotService;
   const cwd = "/repo";
   const treeSha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
   const gitDir = "/repo/.git";
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockUnlink.mockResolvedValue(undefined);
-    service = new SnapshotService();
+    fake = new FakeGitExecutor();
+    service = new SnapshotService(fake);
   });
 
-  it("returns the tree SHA from write-tree after read-tree + add -A", async () => {
-    // 1. rev-parse --git-dir
-    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
-    // 2. read-tree HEAD
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    // 3. add -A
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    // 4. write-tree
-    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
+  it("returns HEAD tree SHA on a clean working tree without staging", async () => {
+    fake.setResponse(["status", "--porcelain"], { stdout: "", stderr: "" });
+    fake.setResponse(["rev-parse", "HEAD^{tree}"], { stdout: `${treeSha}\n`, stderr: "" });
 
     const result = await service.captureRef(cwd);
 
     expect(result).toBe(treeSha);
-    expect(mockExecFile).toHaveBeenCalledTimes(4);
-
-    // Verify command sequence
-    expect(mockExecFile.mock.calls[0][1]).toEqual(["-C", cwd, "rev-parse", "--git-dir"]);
-    expect(mockExecFile.mock.calls[1][1]).toEqual(["-C", cwd, "read-tree", "HEAD"]);
-    expect(mockExecFile.mock.calls[2][1]).toEqual(["-C", cwd, "add", "-A"]);
-    expect(mockExecFile.mock.calls[3][1]).toEqual(["-C", cwd, "write-tree"]);
-
-    // Verify all index-touching commands use GIT_INDEX_FILE
-    for (const callIdx of [1, 2, 3]) {
-      expect(mockExecFile.mock.calls[callIdx][2]).toEqual(
-        expect.objectContaining({
-          env: expect.objectContaining({ GIT_INDEX_FILE: expect.stringContaining(`${gitDir}/mcode-index-`) }),
-        }),
-      );
-    }
-
-    // No commit-tree call
-    const commitTreeCall = mockExecFile.mock.calls.find(
-      (call) => Array.isArray(call[1]) && call[1].includes("commit-tree"),
-    );
-    expect(commitTreeCall).toBeUndefined();
+    expect(fake.calls.map((c) => c.args)).toEqual([
+      ["-C", cwd, "status", "--porcelain"],
+      ["-C", cwd, "rev-parse", "HEAD^{tree}"],
+    ]);
   });
 
-  it("unborn repo: skips read-tree failure and proceeds with empty index", async () => {
-    // 1. rev-parse --git-dir
-    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
-    // 2. read-tree HEAD fails (unborn repo)
-    mockExecFile.mockRejectedValueOnce(new Error("fatal: Not a valid object name HEAD"));
-    // 3. add -A (proceeds with empty index)
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    // 4. write-tree
-    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
+  it("returns the tree SHA from write-tree after read-tree + add -A when dirty", async () => {
+    fake.setResponse(["status", "--porcelain"], { stdout: " M file.txt\n", stderr: "" });
+    fake.setResponse(["rev-parse", "--git-dir"], { stdout: `${gitDir}\n`, stderr: "" });
+    fake.setResponse(["read-tree", "HEAD"], { stdout: "", stderr: "" });
+    fake.setResponse(["add", "-A"], { stdout: "", stderr: "" });
+    fake.setResponse(["write-tree"], { stdout: `${treeSha}\n`, stderr: "" });
 
     const result = await service.captureRef(cwd);
 
     expect(result).toBe(treeSha);
-    expect(mockExecFile).toHaveBeenCalledTimes(4);
-
-    // add -A was still called after read-tree failed
-    expect(mockExecFile.mock.calls[2][1]).toEqual(["-C", cwd, "add", "-A"]);
+    expect(fake.calls.some((c) => c.args.includes("add"))).toBe(true);
+    expect(fake.calls.some((c) => c.args.includes("write-tree"))).toBe(true);
   });
 
-  it("throws when rev-parse --git-dir fails (not a git repo)", async () => {
-    mockExecFile.mockRejectedValueOnce(new Error("not a git repo"));
+  it("unborn repo: falls back to staged capture when HEAD^{tree} fails", async () => {
+    fake.setResponse(["status", "--porcelain"], { stdout: "", stderr: "" });
+    fake.setResponse(["rev-parse", "HEAD^{tree}"], new Error("fatal: Not a valid object name HEAD"));
+    fake.setResponse(["rev-parse", "--git-dir"], { stdout: `${gitDir}\n`, stderr: "" });
+    fake.setResponse(["read-tree", "HEAD"], new Error("fatal: Not a valid object name HEAD"));
+    fake.setResponse(["add", "-A"], { stdout: "", stderr: "" });
+    fake.setResponse(["write-tree"], { stdout: `${treeSha}\n`, stderr: "" });
+
+    const result = await service.captureRef(cwd);
+
+    expect(result).toBe(treeSha);
+    expect(fake.calls.some((c) => c.args.includes("add"))).toBe(true);
+  });
+
+  it("throws when status fails on a non-git repo", async () => {
+    fake.setResponse(["status", "--porcelain"], new Error("not a git repo"));
 
     await expect(service.captureRef(cwd)).rejects.toThrow("not a git repo");
   });
 
-  it("throws when add -A fails (disk full, permissions)", async () => {
-    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    mockExecFile.mockRejectedValueOnce(new Error("add failed"));
+  it("throws when add -A fails on a dirty tree", async () => {
+    fake.setResponse(["status", "--porcelain"], { stdout: " M file.txt\n", stderr: "" });
+    fake.setResponse(["rev-parse", "--git-dir"], { stdout: `${gitDir}\n`, stderr: "" });
+    fake.setResponse(["read-tree", "HEAD"], { stdout: "", stderr: "" });
+    fake.setResponse(["add", "-A"], new Error("add failed"));
 
     await expect(service.captureRef(cwd)).rejects.toThrow("add failed");
-  });
-
-  it("throws when write-tree fails", async () => {
-    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    mockExecFile.mockRejectedValueOnce(new Error("write-tree failed"));
-
-    await expect(service.captureRef(cwd)).rejects.toThrow("write-tree failed");
-  });
-
-  it("resolves relative git-dir path against cwd", async () => {
-    // rev-parse --git-dir returns relative ".git"
-    mockExecFile.mockResolvedValueOnce({ stdout: ".git\n", stderr: "" });
-    // read-tree HEAD
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    // add -A
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    // write-tree
-    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
-
-    const result = await service.captureRef(cwd);
-    expect(result).toBe(treeSha);
-
-    // Verify temp index path contains both the resolved .git dir and mcode-index- prefix.
-    // join() produces backslashes on Windows, so use regex to accept either separator.
-    const indexPath = mockExecFile.mock.calls[1][2].env.GIT_INDEX_FILE as string;
-    expect(indexPath).toMatch(/\.git/);
-    expect(indexPath).toMatch(/mcode-index-/);
-  });
-
-  it("cleans up temp index on success", async () => {
-    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
-
-    await service.captureRef(cwd);
-
-    expect(mockUnlink).toHaveBeenCalledTimes(1);
-    expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining(`${gitDir}/mcode-index-`));
-  });
-
-  it("cleans up temp index even when add -A throws", async () => {
-    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    mockExecFile.mockRejectedValueOnce(new Error("add -A failed"));
-
-    await expect(service.captureRef(cwd)).rejects.toThrow();
-
-    expect(mockUnlink).toHaveBeenCalledTimes(1);
-    expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining(`${gitDir}/mcode-index-`));
-  });
-
-  it("cleans up temp index when read-tree fails (unborn repo path)", async () => {
-    mockExecFile.mockResolvedValueOnce({ stdout: `${gitDir}\n`, stderr: "" });
-    mockExecFile.mockRejectedValueOnce(new Error("not a valid object name HEAD"));
-    mockExecFile.mockResolvedValueOnce({ stdout: "", stderr: "" });
-    mockExecFile.mockResolvedValueOnce({ stdout: `${treeSha}\n`, stderr: "" });
-
-    await service.captureRef(cwd);
-
-    expect(mockUnlink).toHaveBeenCalledTimes(1);
-    expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining(`${gitDir}/mcode-index-`));
-  });
-
-  it("does not attempt unlink when rev-parse --git-dir fails (no tmpIndex created)", async () => {
-    mockExecFile.mockRejectedValueOnce(new Error("not a git repo"));
-
-    await expect(service.captureRef(cwd)).rejects.toThrow();
-
-    expect(mockUnlink).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/__tests__/snapshot-service.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.test.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { describe, it, expect, beforeEach } from "vitest";
 import { FakeGitExecutor } from "../services/git-executor/fake-git-executor.js";
+import type { GitExecutor } from "../services/git-executor/types.js";
 import { SnapshotService } from "../services/snapshot-service.js";
 
 describe("SnapshotService.captureRef", () => {
@@ -25,7 +26,37 @@ describe("SnapshotService.captureRef", () => {
     expect(fake.calls.map((c) => c.args)).toEqual([
       ["-C", cwd, "status", "--porcelain"],
       ["-C", cwd, "rev-parse", "HEAD^{tree}"],
+      ["-C", cwd, "status", "--porcelain"],
     ]);
+  });
+
+  it("falls back to staged capture when the tree becomes dirty before the second status check", async () => {
+    const stagedSha = "staged-tree-sha";
+    let statusCalls = 0;
+    const toctouFake: GitExecutor = {
+      async exec(args) {
+        const normalized = args[0] === "-C" ? args.slice(2) : args;
+        if (normalized[0] === "status") {
+          statusCalls += 1;
+          return { stdout: statusCalls <= 1 ? "" : " M file.txt\n", stderr: "" };
+        }
+        if (normalized.join(" ") === "rev-parse HEAD^{tree}") {
+          return { stdout: `${treeSha}\n`, stderr: "" };
+        }
+        if (normalized.join(" ") === "rev-parse --git-dir") {
+          return { stdout: `${gitDir}\n`, stderr: "" };
+        }
+        if (normalized[0] === "read-tree") return { stdout: "", stderr: "" };
+        if (normalized[0] === "add") return { stdout: "", stderr: "" };
+        if (normalized[0] === "write-tree") return { stdout: `${stagedSha}\n`, stderr: "" };
+        return { stdout: "", stderr: "" };
+      },
+    };
+
+    const result = await new SnapshotService(toctouFake).captureRef(cwd);
+
+    expect(result).toBe(stagedSha);
+    expect(statusCalls).toBe(2);
   });
 
   it("returns the tree SHA from write-tree after read-tree + add -A when dirty", async () => {
@@ -69,5 +100,21 @@ describe("SnapshotService.captureRef", () => {
     fake.setResponse(["add", "-A"], new Error("add failed"));
 
     await expect(service.captureRef(cwd)).rejects.toThrow("add failed");
+  });
+});
+
+describe("SnapshotService.validateRef", () => {
+  let fake: FakeGitExecutor;
+  let service: SnapshotService;
+  const cwd = "/repo";
+
+  beforeEach(() => {
+    fake = new FakeGitExecutor();
+    service = new SnapshotService(fake);
+  });
+
+  it("rejects refs that look like git flags", async () => {
+    expect(await service.validateRef(cwd, "--batch")).toBe(false);
+    expect(fake.calls).toHaveLength(0);
   });
 });

--- a/apps/server/src/__tests__/workspace-repo.test.ts
+++ b/apps/server/src/__tests__/workspace-repo.test.ts
@@ -8,6 +8,7 @@ import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { WorkspaceService } from "../services/workspace-service";
 import { AttachmentService } from "../services/attachment-service";
 import type { AgentService } from "../services/agent-service";
+import { FakeGitExecutor } from "../services/git-executor/fake-git-executor.js";
 
 describe("WorkspaceRepo", () => {
   let db: Database.Database;
@@ -90,22 +91,29 @@ describe("WorkspaceService", () => {
     const threadRepo = new ThreadRepo(db);
     const cleanupJobRepo = new CleanupJobRepo(db);
     const mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
-    service = new WorkspaceService(repo, threadRepo, cleanupJobRepo, mockAttachmentService, { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService);
+    service = new WorkspaceService(
+      repo,
+      threadRepo,
+      cleanupJobRepo,
+      mockAttachmentService,
+      { stopSession: vi.fn().mockResolvedValue(undefined) } as unknown as AgentService,
+      new FakeGitExecutor(),
+    );
   });
 
-  it("create() returns existing workspace when path already exists", () => {
-    const ws1 = service.create("project-a", "/tmp/existing");
-    service.create("other", "/tmp/other");
+  it("create() returns existing workspace when path already exists", async () => {
+    const ws1 = await service.create("project-a", "/tmp/existing");
+    await service.create("other", "/tmp/other");
 
-    const ws2 = service.create("project-a-renamed", "/tmp/existing");
+    const ws2 = await service.create("project-a-renamed", "/tmp/existing");
 
     expect(ws2.id).toBe(ws1.id);
     expect(ws2.name).toBe("project-a");
     expect(repo.listAll()[0]!.id).toBe(ws1.id);
   });
 
-  it("create() creates a new workspace when path does not exist", () => {
-    const ws = service.create("new-project", "/tmp/new");
+  it("create() creates a new workspace when path does not exist", async () => {
+    const ws = await service.create("new-project", "/tmp/new");
     expect(ws.name).toBe("new-project");
     expect(ws.path).toBe("/tmp/new");
   });

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -68,6 +68,7 @@ import { EnvService } from "./services/env-service";
 import { UtilityCompletionService } from "./services/utility-completion-service";
 import { DiffSummaryService } from "./services/diff-summary-service";
 import { ThreadTeardownService } from "./services/thread-teardown-service";
+import { RealGitExecutor } from "./services/git-executor/index.js";
 
 /** Initialize the DI container with all server dependencies. */
 export function setupContainer(mcodeDir: string): typeof container {
@@ -245,6 +246,16 @@ export function setupContainer(mcodeDir: string): typeof container {
   );
   container.register("IProviderRegistry", {
     useFactory: (c) => c.resolve(ProviderRegistry),
+  });
+
+  // GitExecutor — registered before services that depend on it
+  container.register(
+    RealGitExecutor,
+    { useClass: RealGitExecutor },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register("GitExecutor", {
+    useFactory: (c) => c.resolve(RealGitExecutor),
   });
 
   // Services (Singleton)

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,7 +12,7 @@ import { logger, getMcodeDir } from "@mcode/shared";
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
-import { execSync } from "child_process";
+import { RealGitExecutor } from "./services/git-executor/index.js";
 import { killOrphanedServer, reapOrphanedPtys } from "./services/orphan-cleanup";
 import { PtyPidRegistry } from "./services/pty-pid-registry";
 
@@ -129,37 +129,42 @@ if (existsSync(SHUTDOWN_MARKER_PATH)) {
   );
 }
 
-// Standalone dev: detect the checkout branch for branch-specific DB paths.
-// The desktop shell sets MCODE_GIT_BRANCH when it spawns the server.
-if (!process.env.MCODE_GIT_BRANCH && process.env.NODE_ENV !== "production") {
-  try {
-    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
-      encoding: "utf-8",
-      timeout: 3000,
-    }).trim();
-    if (branch && branch !== "HEAD") {
-      process.env.MCODE_GIT_BRANCH = branch;
+/** Standalone dev: populate MCODE_GIT_BRANCH / MCODE_GIT_TOPLEVEL before DB path selection. */
+async function applyDevGitCheckoutEnv(): Promise<void> {
+  if (process.env.NODE_ENV === "production") return;
+  const executor = new RealGitExecutor();
+  const cwd = process.cwd();
+  if (!process.env.MCODE_GIT_BRANCH) {
+    try {
+      const { stdout } = await executor.exec(["rev-parse", "--abbrev-ref", "HEAD"], {
+        cwd,
+        timeout: 3000,
+      });
+      const branch = stdout.trim();
+      if (branch && branch !== "HEAD") {
+        process.env.MCODE_GIT_BRANCH = branch;
+      }
+    } catch {
+      // Not a git checkout or git missing; keep shared mcode.db
     }
-  } catch {
-    // Not a git checkout or git missing; keep shared mcode.db
+  }
+  if (!process.env.MCODE_GIT_TOPLEVEL) {
+    try {
+      const { stdout } = await executor.exec(["rev-parse", "--show-toplevel"], {
+        cwd,
+        timeout: 3000,
+      });
+      const top = stdout.trim();
+      if (top) {
+        process.env.MCODE_GIT_TOPLEVEL = top;
+      }
+    } catch {
+      // Not a git checkout or git missing
+    }
   }
 }
 
-// Standalone dev: detect checkout root for `.mcode-local` DB paths in linked worktrees.
-// The desktop shell sets MCODE_GIT_TOPLEVEL when it spawns the server.
-if (!process.env.MCODE_GIT_TOPLEVEL && process.env.NODE_ENV !== "production") {
-  try {
-    const top = execSync("git rev-parse --show-toplevel", {
-      encoding: "utf-8",
-      timeout: 3000,
-    }).trim();
-    if (top) {
-      process.env.MCODE_GIT_TOPLEVEL = top;
-    }
-  } catch {
-    // Not a git checkout or git missing
-  }
-}
+await applyDevGitCheckoutEnv();
 
 // Initialize DI container (PtyPidRegistry needs the data dir path at construction time)
 const container = setupContainer(getMcodeDir());

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,7 +12,7 @@ import { logger, getMcodeDir } from "@mcode/shared";
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
-import { RealGitExecutor } from "./services/git-executor/index.js";
+import { execFileSync } from "child_process";
 import { killOrphanedServer, reapOrphanedPtys } from "./services/orphan-cleanup";
 import { PtyPidRegistry } from "./services/pty-pid-registry";
 
@@ -130,15 +130,15 @@ if (existsSync(SHUTDOWN_MARKER_PATH)) {
 }
 
 /** Standalone dev: populate MCODE_GIT_BRANCH / MCODE_GIT_TOPLEVEL before DB path selection. */
-async function applyDevGitCheckoutEnv(): Promise<void> {
+function applyDevGitCheckoutEnv(): void {
   if (process.env.NODE_ENV === "production") return;
-  const executor = new RealGitExecutor();
   const cwd = process.cwd();
   if (!process.env.MCODE_GIT_BRANCH) {
     try {
-      const { stdout } = await executor.exec(["rev-parse", "--abbrev-ref", "HEAD"], {
+      const stdout = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         timeout: 3000,
+        encoding: "utf8",
       });
       const branch = stdout.trim();
       if (branch && branch !== "HEAD") {
@@ -150,9 +150,10 @@ async function applyDevGitCheckoutEnv(): Promise<void> {
   }
   if (!process.env.MCODE_GIT_TOPLEVEL) {
     try {
-      const { stdout } = await executor.exec(["rev-parse", "--show-toplevel"], {
+      const stdout = execFileSync("git", ["rev-parse", "--show-toplevel"], {
         cwd,
         timeout: 3000,
+        encoding: "utf8",
       });
       const top = stdout.trim();
       if (top) {
@@ -164,7 +165,7 @@ async function applyDevGitCheckoutEnv(): Promise<void> {
   }
 }
 
-await applyDevGitCheckoutEnv();
+applyDevGitCheckoutEnv();
 
 // Initialize DI container (PtyPidRegistry needs the data dir path at construction time)
 const container = setupContainer(getMcodeDir());

--- a/apps/server/src/services/__tests__/git-service-working-dir.test.ts
+++ b/apps/server/src/services/__tests__/git-service-working-dir.test.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { describe, it, expect } from "vitest";
 import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import { FakeGitExecutor } from "../git-executor/fake-git-executor.js";
 import { GitService } from "../git-service.js";
 
 /**
@@ -9,7 +10,7 @@ import { GitService } from "../git-service.js";
  * exercise the worktree-vs-root branch the terminal rebind relies on.
  */
 function makeGitService(): GitService {
-  return new GitService(undefined as unknown as WorkspaceRepo);
+  return new GitService(undefined as unknown as WorkspaceRepo, new FakeGitExecutor());
 }
 
 describe("GitService.resolveWorkingDir", () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -810,7 +810,7 @@ export class AgentService {
       // Attach to existing worktree
       const workspace = this.workspaceRepo.findById(workspaceId);
       if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
-      const knownWorktrees = this.gitService.listWorktrees(workspaceId);
+      const knownWorktrees = await this.gitService.listWorktrees(workspaceId);
       const normalize = (p: string) =>
         p.replace(/\\/g, "/").replace(/\/$/, "").toLowerCase();
       const normalizedInput = normalize(existingWorktreePath);
@@ -1006,7 +1006,7 @@ export class AgentService {
     if (existingWorktreePath) {
       const workspace = this.workspaceRepo.findById(workspaceId);
       if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
-      const knownWorktrees = this.gitService.listWorktrees(workspaceId);
+      const knownWorktrees = await this.gitService.listWorktrees(workspaceId);
       const normalize = (p: string) => p.replace(/\\/g, "/").replace(/\/$/, "").toLowerCase();
       const normalizedInput = normalize(existingWorktreePath);
       const matched = knownWorktrees.find((wt) => normalize(wt.path) === normalizedInput);

--- a/apps/server/src/services/cleanup-worker.ts
+++ b/apps/server/src/services/cleanup-worker.ts
@@ -160,7 +160,7 @@ export class CleanupWorker {
 
       const rel = relative(worktreeBase, resolvedWt);
       const isManagedPath = !(rel.startsWith("..") || isAbsolute(rel));
-      if (!isManagedPath && !this.gitService.isRegisteredWorktreePath(resolvedWs, resolvedWt)) {
+      if (!isManagedPath && !(await this.gitService.isRegisteredWorktreePath(resolvedWs, resolvedWt))) {
         throw new Error(`worktree_path is not a registered worktree for repo: ${resolvedWt}`);
       }
 

--- a/apps/server/src/services/diff-summary-service.ts
+++ b/apps/server/src/services/diff-summary-service.ts
@@ -10,6 +10,7 @@ import type Database from "better-sqlite3";
 import { logger } from "@mcode/shared";
 import { UtilityCompletionService } from "./utility-completion-service.js";
 import { SnapshotService } from "./snapshot-service.js";
+import type { GitExecutor } from "./git-executor/index.js";
 import { ThreadDiffSource } from "./diff-summary-source.js";
 import type { TurnSnapshotRow } from "./diff-summary-source.js";
 import { buildDiffSummaryPrompt } from "./diff-summary-prompt.js";
@@ -62,6 +63,8 @@ export class DiffSummaryService {
     private readonly utilityCompletion: UtilityCompletionService,
     @inject(SnapshotService)
     private readonly snapshotService: SnapshotService,
+    @inject("GitExecutor")
+    private readonly gitExecutor: GitExecutor,
     @inject("Database")
     db: Database.Database,
   ) {
@@ -88,7 +91,12 @@ export class DiffSummaryService {
     snapshots: TurnSnapshotRow[],
     cwd: string,
   ): Promise<DiffSummaryRecord> {
-    const source = new ThreadDiffSource(snapshots, cwd, this.snapshotService);
+    const source = new ThreadDiffSource(
+      snapshots,
+      cwd,
+      this.snapshotService,
+      this.gitExecutor,
+    );
 
     const payload = await source.getDiff();
 

--- a/apps/server/src/services/diff-summary-source.ts
+++ b/apps/server/src/services/diff-summary-source.ts
@@ -4,11 +4,9 @@
  * allowing future sources (e.g. BranchDiffSource) without pipeline changes.
  */
 
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
+import type { GitExecutor } from "./git-executor/index.js";
+import { RealGitExecutor } from "./git-executor/real-git-executor.js";
 import type { SnapshotService } from "./snapshot-service.js";
-
-const execFile = promisify(execFileCb);
 
 /** Per-file diff statistics. */
 export interface FileDiffStat {
@@ -65,6 +63,7 @@ export class ThreadDiffSource implements DiffSummarySource {
     private readonly snapshots: TurnSnapshotRow[],
     private readonly cwd: string,
     private readonly snapshotService: SnapshotService,
+    private readonly gitExecutor: GitExecutor,
   ) {}
 
   /** Build the aggregate diff payload from the thread's turn snapshots. */
@@ -140,7 +139,7 @@ export class ThreadDiffSource implements DiffSummarySource {
   }
 
   /**
-   * Retrieve the commit log between two tree refs via git directly.
+   * Retrieve the commit log between two tree refs via git.
    * GitService.log() requires a workspaceId and only supports branch-based ranges,
    * so we invoke git here to support arbitrary tree SHA ranges.
    */
@@ -148,9 +147,12 @@ export class ThreadDiffSource implements DiffSummarySource {
     refBefore: string,
     refAfter: string,
   ): Promise<string> {
+    if (!/^[0-9a-fA-F]{4,40}$/.test(refBefore) || !/^[0-9a-fA-F]{4,40}$/.test(refAfter)) {
+      return "";
+    }
+
     try {
-      const { stdout } = await execFile(
-        "git",
+      const { stdout } = await this.gitExecutor.exec(
         [
           "-C",
           this.cwd,
@@ -158,7 +160,7 @@ export class ThreadDiffSource implements DiffSummarySource {
           "--pretty=format:%h %s",
           `${refBefore}..${refAfter}`,
         ],
-        { timeout: 10_000, windowsHide: true },
+        { timeout: RealGitExecutor.DEFAULT_TIMEOUT },
       );
       return stdout.trim();
     } catch {

--- a/apps/server/src/services/file-service.ts
+++ b/apps/server/src/services/file-service.ts
@@ -5,12 +5,12 @@
  */
 
 import { injectable, inject } from "tsyringe";
-import { execFileSync } from "child_process";
 import { readFileSync, existsSync, statSync, realpathSync } from "fs";
 import { resolve, isAbsolute, sep } from "path";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { GitService } from "./git-service";
+import type { GitExecutor } from "./git-executor/index.js";
 
 /** Handles file listing and content reading for workspaces and threads. */
 @injectable()
@@ -19,6 +19,7 @@ export class FileService {
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
     @inject(ThreadRepo) private readonly threadRepo: ThreadRepo,
     @inject(GitService) private readonly gitService: GitService,
+    @inject("GitExecutor") private readonly gitExecutor: GitExecutor,
   ) {}
 
   /**
@@ -26,23 +27,17 @@ export class FileService {
    * Uses `git ls-files --cached --others --exclude-standard` to include
    * untracked files that are not gitignored.
    */
-  list(workspaceId: string, threadId?: string): string[] {
+  async list(workspaceId: string, threadId?: string): Promise<string[]> {
     const cwd = this.resolveWorkingDir(workspaceId, threadId);
 
     try {
-      const output = execFileSync(
-        "git",
+      const { stdout } = await this.gitExecutor.exec(
         ["ls-files", "--cached", "--others", "--exclude-standard"],
-        {
-          cwd,
-          maxBuffer: 10 * 1024 * 1024,
-          windowsHide: true,
-        },
+        { cwd },
       );
-      return output
-        .toString("utf-8")
+      return stdout
         .split("\n")
-        .filter((line) => line.length > 0);
+        .filter((line: string) => line.length > 0);
     } catch (err) {
       throw new Error(
         `Failed to list files: ${err instanceof Error ? err.message : String(err)}`,

--- a/apps/server/src/services/git-executor/__tests__/fake-git-executor.test.ts
+++ b/apps/server/src/services/git-executor/__tests__/fake-git-executor.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { FakeGitExecutor } from "../fake-git-executor.js";
+
+describe("FakeGitExecutor", () => {
+  it("records calls and returns canned responses", async () => {
+    const fake = new FakeGitExecutor();
+    fake.setResponse(["rev-parse", "--git-dir"], { stdout: ".git\n", stderr: "" });
+
+    const result = await fake.exec(["-C", "/repo", "rev-parse", "--git-dir"]);
+
+    expect(result.stdout).toBe(".git\n");
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.args).toEqual(["-C", "/repo", "rev-parse", "--git-dir"]);
+  });
+
+  it("accepts concurrent calls for the same repo cwd", async () => {
+    const fake = new FakeGitExecutor();
+    fake.setResponse(["rev-parse", "--git-dir"], { stdout: ".git\n", stderr: "" });
+
+    await Promise.all([
+      fake.exec(["-C", "/repo", "rev-parse", "--git-dir"]),
+      fake.exec(["-C", "/repo", "rev-parse", "--git-dir"]),
+    ]);
+
+    expect(fake.calls).toHaveLength(2);
+    expect(fake.calls.every((c) => c.args.includes("--git-dir"))).toBe(true);
+  });
+
+  it("propagates registered errors", async () => {
+    const fake = new FakeGitExecutor();
+    fake.setResponse(["status", "--porcelain"], new Error("not a git repo"));
+
+    await expect(fake.exec(["-C", "/repo", "status", "--porcelain"])).rejects.toThrow(
+      "not a git repo",
+    );
+  });
+});

--- a/apps/server/src/services/git-executor/__tests__/mock-git-executor.ts
+++ b/apps/server/src/services/git-executor/__tests__/mock-git-executor.ts
@@ -1,0 +1,14 @@
+import { vi, type Mock } from "vitest";
+import type { GitExecutor, GitExecOptions, GitExecResult } from "../types.js";
+
+/** Vitest-backed {@link GitExecutor} for GitService unit tests. */
+export function createMockGitExecutor(): {
+  executor: GitExecutor;
+  execFn: Mock<(args: string[], opts?: GitExecOptions) => Promise<GitExecResult>>;
+} {
+  const execFn = vi.fn(async (_args: string[], _opts?: GitExecOptions): Promise<GitExecResult> => ({
+    stdout: "",
+    stderr: "",
+  }));
+  return { executor: { exec: execFn }, execFn };
+}

--- a/apps/server/src/services/git-executor/__tests__/real-git-executor.test.ts
+++ b/apps/server/src/services/git-executor/__tests__/real-git-executor.test.ts
@@ -1,0 +1,67 @@
+import "reflect-metadata";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.fn();
+
+vi.mock("child_process", () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+import { RealGitExecutor } from "../real-git-executor.js";
+
+describe("RealGitExecutor", () => {
+  let executor: RealGitExecutor;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+    executor = new RealGitExecutor();
+  });
+
+  it("serialises concurrent calls for the same cwd", async () => {
+    const order: number[] = [];
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const id = order.length + 1;
+      setTimeout(() => {
+        order.push(id);
+        cb(null, { stdout: `out-${id}`, stderr: "" });
+      }, 10);
+    });
+
+    const [first, second] = await Promise.all([
+      executor.exec(["-C", "/repo", "status", "--porcelain"]),
+      executor.exec(["-C", "/repo", "rev-parse", "HEAD"]),
+    ]);
+
+    expect(order).toEqual([1, 2]);
+    expect(first.stdout).toBe("out-1");
+    expect(second.stdout).toBe("out-2");
+  });
+
+  it("caches rev-parse --git-dir only inside the queue", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(null, { stdout: "/repo/.git\n", stderr: "" });
+    });
+
+    await executor.exec(["-C", "/repo", "rev-parse", "--git-dir"]);
+    await executor.exec(["-C", "/repo", "rev-parse", "--git-dir"]);
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates rev-parse cache after mutating commands", async () => {
+    execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+      const argv = args as string[];
+      if (argv.includes("--git-dir")) {
+        cb(null, { stdout: "/repo/.git\n", stderr: "" });
+        return;
+      }
+      cb(null, { stdout: "", stderr: "" });
+    });
+
+    await executor.exec(["-C", "/repo", "rev-parse", "--git-dir"]);
+    await executor.exec(["-C", "/repo", "add", "-A"]);
+    await executor.exec(["-C", "/repo", "rev-parse", "--git-dir"]);
+
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/server/src/services/git-executor/fake-git-executor.ts
+++ b/apps/server/src/services/git-executor/fake-git-executor.ts
@@ -1,0 +1,108 @@
+/**
+ * Test double for GitExecutor.
+ * Records every call and returns canned responses from a configurable map.
+ * Preserves per-key FIFO serialisation so queue-ordering tests remain valid.
+ */
+
+import type { GitExecutor, GitExecOptions, GitExecResult } from "./types.js";
+
+/** A single recorded invocation. */
+export interface FakeGitCall {
+  /** Arguments passed to exec (excluding the implicit "git" binary). */
+  args: string[];
+  /** Options passed to exec, if any. */
+  opts: GitExecOptions | undefined;
+}
+
+/** Noop used to drain queue chains. */
+const noop = () => {};
+
+/**
+ * In-memory {@link GitExecutor} for unit tests.
+ *
+ * Usage:
+ * ```ts
+ * const fake = new FakeGitExecutor();
+ * fake.setResponse(["rev-parse", "--git-dir"], { stdout: ".git", stderr: "" });
+ * const result = await fake.exec(["-C", "/repo", "rev-parse", "--git-dir"]);
+ * ```
+ *
+ * Response lookup strips the leading `-C <path>` pair before matching so the
+ * same canned response applies regardless of which cwd is passed.
+ *
+ * If no matching response is registered, exec resolves with `{ stdout: "", stderr: "" }`.
+ */
+export class FakeGitExecutor implements GitExecutor {
+  /** Ordered list of every exec invocation (for assertion in tests). */
+  readonly calls: FakeGitCall[] = [];
+
+  /** Canned responses keyed by JSON-serialised args (after stripping -C). */
+  private readonly responses = new Map<string, GitExecResult | Error>();
+
+  /** Per-key serialisation queues (mirrors RealGitExecutor behaviour). */
+  private readonly queues = new Map<string, Promise<void>>();
+
+  /**
+   * Register a canned response for the given argument list.
+   * The args should omit the leading `-C <path>` pair; the executor strips it
+   * automatically during lookup.
+   *
+   * Pass an `Error` instance to simulate a non-zero exit code.
+   */
+  setResponse(args: string[], result: GitExecResult | Error): void {
+    this.responses.set(this.responseKey(args), result);
+  }
+
+  /** Remove all registered canned responses and clear recorded calls. */
+  reset(): void {
+    this.calls.length = 0;
+    this.responses.clear();
+    this.queues.clear();
+  }
+
+  /**
+   * Execute a git command, honouring the registered canned response.
+   * Serialises calls per effective cwd so queue-ordering tests work correctly.
+   */
+  async exec(args: string[], opts?: GitExecOptions): Promise<GitExecResult> {
+    const queueKey = this.getQueueKey(args, opts);
+
+    return this.enqueue(queueKey, async () => {
+      this.calls.push({ args, opts });
+
+      const normalized = this.stripCArg(args);
+      const key = this.responseKey(normalized);
+      const response = this.responses.get(key);
+
+      if (response instanceof Error) throw response;
+      return response ?? { stdout: "", stderr: "" };
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private enqueue<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = (this.queues.get(key) ?? Promise.resolve()) as Promise<void>;
+    const next = prev.then(fn, fn);
+    this.queues.set(key, next.then(noop, noop));
+    return next;
+  }
+
+  private getQueueKey(args: string[], opts?: GitExecOptions): string {
+    const cIdx = args.indexOf("-C");
+    if (cIdx !== -1 && cIdx + 1 < args.length) return args[cIdx + 1]!;
+    return opts?.cwd ?? "__global__";
+  }
+
+  /** Strip a leading `-C <path>` pair from args for response-key normalisation. */
+  private stripCArg(args: string[]): string[] {
+    if (args[0] === "-C" && args.length >= 2) return args.slice(2);
+    return args;
+  }
+
+  private responseKey(args: string[]): string {
+    return JSON.stringify(args);
+  }
+}

--- a/apps/server/src/services/git-executor/index.ts
+++ b/apps/server/src/services/git-executor/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Git executor module.
+ * Provides an injectable abstraction over spawning git subprocesses with
+ * per-repo serialisation, configurable timeouts, and a transparent cache for
+ * cheap rev-parse results.
+ */
+
+export type { GitExecutor, GitExecOptions, GitExecResult } from "./types.js";
+export { RealGitExecutor } from "./real-git-executor.js";
+export { FakeGitExecutor } from "./fake-git-executor.js";

--- a/apps/server/src/services/git-executor/real-git-executor.ts
+++ b/apps/server/src/services/git-executor/real-git-executor.ts
@@ -45,9 +45,6 @@ export class RealGitExecutor implements GitExecutor {
    */
   async exec(args: string[], opts: GitExecOptions = {}): Promise<GitExecResult> {
     const cacheKey = this.getCacheKey(args);
-    const cached = cacheKey ? this.revParseCache.get(cacheKey) : undefined;
-    if (cached) return cached;
-
     const queueKey = this.getQueueKey(args, opts);
 
     return this.enqueue(queueKey, async () => {
@@ -57,7 +54,11 @@ export class RealGitExecutor implements GitExecutor {
       if (cachedNow) return cachedNow;
 
       const result = await this.runGit(args, opts);
-      if (cacheKey) this.revParseCache.set(cacheKey, result);
+      if (cacheKey) {
+        this.revParseCache.set(cacheKey, result);
+      } else {
+        this.invalidateRevParseCacheForCwd(this.getEffectiveCwd(args, opts));
+      }
       return result;
     });
   }
@@ -106,6 +107,18 @@ export class RealGitExecutor implements GitExecutor {
    * `opts.cwd`, used as the serialisation queue key.
    */
   private getQueueKey(args: string[], opts: GitExecOptions): string {
+    return this.getEffectiveCwd(args, opts);
+  }
+
+  /** Drop cached rev-parse probes for a checkout after mutating git commands. */
+  private invalidateRevParseCacheForCwd(cwd: string): void {
+    if (cwd === "__global__") return;
+    this.revParseCache.delete(`git-dir:${cwd}`);
+    this.revParseCache.delete(`show-toplevel:${cwd}`);
+  }
+
+  /** Extract the effective working directory from `-C <path>` or `opts.cwd`. */
+  private getEffectiveCwd(args: string[], opts: GitExecOptions): string {
     const cIdx = args.indexOf("-C");
     if (cIdx !== -1 && cIdx + 1 < args.length) return args[cIdx + 1]!;
     return opts.cwd ?? "__global__";

--- a/apps/server/src/services/git-executor/real-git-executor.ts
+++ b/apps/server/src/services/git-executor/real-git-executor.ts
@@ -1,0 +1,128 @@
+/**
+ * Production git executor.
+ * Wraps promisified execFile with per-repo serialisation, a configurable
+ * default timeout, and a transparent result cache for cheap rev-parse calls.
+ */
+
+import { injectable } from "tsyringe";
+import { execFile as execFileCb } from "child_process";
+import { promisify } from "util";
+import type { GitExecutor, GitExecOptions, GitExecResult } from "./types.js";
+
+const execFile = promisify(execFileCb);
+
+/** Noop used to suppress unhandled-rejection warnings on queue chains. */
+const noop = () => {};
+
+/**
+ * Production implementation of {@link GitExecutor}.
+ *
+ * Features:
+ * - Serialises concurrent git calls per effective working directory so that
+ *   index-mutating operations (worktree add/remove, checkout) do not race.
+ * - Transparent LRU-style cache for `rev-parse --git-dir` and
+ *   `rev-parse --show-toplevel` results keyed by cwd.
+ * - Default timeout of 10 s, overridable per call.
+ */
+@injectable()
+export class RealGitExecutor implements GitExecutor {
+  /** Default timeout in milliseconds for all git invocations. */
+  static readonly DEFAULT_TIMEOUT = 10_000;
+
+  /** Per-directory promise queues (key = effective cwd). */
+  private readonly queues = new Map<string, Promise<void>>();
+
+  /**
+   * Cache for `rev-parse --git-dir` and `rev-parse --show-toplevel` results.
+   * Key format: `"git-dir:<cwd>"` or `"show-toplevel:<cwd>"`.
+   */
+  private readonly revParseCache = new Map<string, GitExecResult>();
+
+  /**
+   * Run `git` with the given arguments, serialising calls per effective cwd.
+   * Results of `rev-parse --git-dir` and `rev-parse --show-toplevel` are
+   * cached transparently so repeated probe calls are free.
+   */
+  async exec(args: string[], opts: GitExecOptions = {}): Promise<GitExecResult> {
+    const cacheKey = this.getCacheKey(args);
+    const cached = cacheKey ? this.revParseCache.get(cacheKey) : undefined;
+    if (cached) return cached;
+
+    const queueKey = this.getQueueKey(args, opts);
+
+    return this.enqueue(queueKey, async () => {
+      // Re-check cache inside the queue in case a concurrent queued operation
+      // already populated it while we were waiting.
+      const cachedNow = cacheKey ? this.revParseCache.get(cacheKey) : undefined;
+      if (cachedNow) return cachedNow;
+
+      const result = await this.runGit(args, opts);
+      if (cacheKey) this.revParseCache.set(cacheKey, result);
+      return result;
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enqueue an async operation behind any previously queued operation for the
+   * same key. Each operation runs regardless of whether the previous one
+   * succeeded or failed, preventing a single error from stalling the queue.
+   */
+  private enqueue<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = (this.queues.get(key) ?? Promise.resolve()) as Promise<void>;
+    // Run fn after prev settles (success or failure).
+    const next = prev.then(fn, fn);
+    // Store a void sentinel so map values are homogeneous and results don't
+    // accumulate in memory.
+    const sentinel = next.then(noop, noop);
+    this.queues.set(key, sentinel);
+    return next;
+  }
+
+  /** Invoke git, returning stdout/stderr as UTF-8 strings. */
+  private async runGit(
+    args: string[],
+    opts: GitExecOptions,
+  ): Promise<GitExecResult> {
+    const timeout = opts.timeout ?? RealGitExecutor.DEFAULT_TIMEOUT;
+    const result = await execFile("git", args, {
+      timeout,
+      windowsHide: true,
+      encoding: "utf8",
+      ...(opts.env ? { env: opts.env } : {}),
+      ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    });
+    return {
+      stdout: typeof result.stdout === "string" ? result.stdout : String(result.stdout),
+      stderr: typeof result.stderr === "string" ? result.stderr : String(result.stderr),
+    };
+  }
+
+  /**
+   * Extract the effective working directory from a `-C <path>` arg or
+   * `opts.cwd`, used as the serialisation queue key.
+   */
+  private getQueueKey(args: string[], opts: GitExecOptions): string {
+    const cIdx = args.indexOf("-C");
+    if (cIdx !== -1 && cIdx + 1 < args.length) return args[cIdx + 1]!;
+    return opts.cwd ?? "__global__";
+  }
+
+  /**
+   * Return a deterministic cache key when the command is a cheap read-only
+   * rev-parse probe that produces stable output for a given repo checkout.
+   * Returns null for all other commands.
+   */
+  private getCacheKey(args: string[]): string | null {
+    if (!args.includes("rev-parse")) return null;
+    const cIdx = args.indexOf("-C");
+    if (cIdx === -1 || cIdx + 1 >= args.length) return null;
+    const cwd = args[cIdx + 1]!;
+    if (args.includes("--git-dir")) return `git-dir:${cwd}`;
+    if (args.includes("--show-toplevel")) return `show-toplevel:${cwd}`;
+    return null;
+  }
+}

--- a/apps/server/src/services/git-executor/types.ts
+++ b/apps/server/src/services/git-executor/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Core types for the git executor abstraction.
+ */
+
+/** Options accepted by {@link GitExecutor.exec}. */
+export interface GitExecOptions {
+  /** Working directory to pass as the CWD of the spawned process. */
+  cwd?: string;
+  /** Timeout in milliseconds. Defaults to RealGitExecutor.DEFAULT_TIMEOUT (10 s). */
+  timeout?: number;
+  /** Environment variables to merge into the subprocess environment. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/** Stdout/stderr pair returned by a successful git invocation. */
+export interface GitExecResult {
+  /** The raw stdout string (UTF-8). */
+  stdout: string;
+  /** The raw stderr string (UTF-8). */
+  stderr: string;
+}
+
+/**
+ * Abstraction over running `git <args>`.
+ * Inject this interface so tests can swap in {@link FakeGitExecutor} without
+ * spawning real processes.
+ */
+export interface GitExecutor {
+  /**
+   * Run `git` with the given argument list.
+   * Rejects with an error when git exits non-zero, mirroring the behaviour of
+   * the promisified `child_process.execFile` it wraps.
+   */
+  exec(args: string[], opts?: GitExecOptions): Promise<GitExecResult>;
+}

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -1,20 +1,19 @@
 /**
  * Git operations service.
- * Manages branches, worktrees, checkout, and fetch operations using shell git commands.
- * Extracted from apps/desktop/src/main/worktree.ts.
+ * Manages branches, worktrees, checkout, and fetch operations using the
+ * injected GitExecutor abstraction. All git invocations go through the
+ * executor so tests can swap in FakeGitExecutor and production code benefits
+ * from per-repo serialisation and rev-parse caching.
  */
 
 import { injectable, inject } from "tsyringe";
-import { execFileSync, execFile as execFileCb } from "child_process";
-import { promisify } from "util";
 import { rm, rename, rmdir } from "fs/promises";
 import { existsSync, mkdirSync } from "fs";
 import { join, basename, dirname, resolve, relative, isAbsolute } from "path";
 import { getMcodeDir, validateBranchName, validateWorktreeName, logger } from "@mcode/shared";
 import type { GitBranch, WorktreeInfo, GitCommit, BranchComparison } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
-
-const execFile = promisify(execFileCb);
+import type { GitExecutor } from "./git-executor/index.js";
 
 /**
  * Options for fs.rm when removing worktree directories.
@@ -128,16 +127,16 @@ async function removeEmptyManagedParentDirs(wtPath: string): Promise<boolean> {
   return true;
 }
 
-/** Check whether a branch ref exists in the repository. */
-function branchExists(repoPath: string, branch: string): boolean {
-  try {
-    execFileSync("git", ["-C", repoPath, "rev-parse", "--verify", branch], {
-      stdio: "pipe",
-      windowsHide: true,
-    });
-    return true;
-  } catch {
-    return false;
+/**
+ * Reject a git ref that could smuggle a flag into a git argv (a leading `-`) or
+ * contains characters outside what refnames and short SHAs use. Guards the
+ * base/target of a Branch comparison before they are interpolated into a rev
+ * range; the WS layer also validates via `GitRefSchema`, this is defense in
+ * depth for any direct caller.
+ */
+function assertSafeRef(ref: string): void {
+  if (!/^(?!-)[A-Za-z0-9._/-]+$/.test(ref)) {
+    throw new Error(`Unsafe git ref: ${ref}`);
   }
 }
 
@@ -146,18 +145,19 @@ function branchExists(repoPath: string, branch: string): boolean {
 export class GitService {
   constructor(
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
+    @inject("GitExecutor") private readonly gitExecutor: GitExecutor,
   ) {}
 
   /** List all branches (local, remote, and worktree-attached) for a workspace. */
-  listBranches(workspaceId: string): GitBranch[] {
+  async listBranches(workspaceId: string): Promise<GitBranch[]> {
     const workspace = this.requireWorkspace(workspaceId);
-    return listBranchesForPath(workspace.path);
+    return this.listBranchesForPath(workspace.path);
   }
 
   /** Get the current branch name for a workspace. Returns null for non-git workspaces. */
-  getCurrentBranch(workspaceId: string): string | null {
+  async getCurrentBranch(workspaceId: string): Promise<string | null> {
     const workspace = this.requireWorkspace(workspaceId);
-    return getCurrentBranchForPath(workspace.path);
+    return this.getCurrentBranchForPath(workspace.path);
   }
 
   /**
@@ -165,44 +165,42 @@ export class GitService {
    * Use this instead of getCurrentBranch when you already have the resolved path
    * (e.g. a worktree directory that may differ from the workspace root).
    */
-  getCurrentBranchAt(repoPath: string): string | null {
-    return getCurrentBranchForPath(repoPath);
+  async getCurrentBranchAt(repoPath: string): Promise<string | null> {
+    return this.getCurrentBranchForPath(repoPath);
   }
 
   /** Checkout an existing branch in the workspace repository. */
-  checkout(workspaceId: string, branch: string): void {
+  async checkout(workspaceId: string, branch: string): Promise<void> {
     const workspace = this.requireWorkspace(workspaceId);
-    execFileSync("git", ["-C", workspace.path, "checkout", branch], {
-      stdio: "pipe",
-      windowsHide: true,
-    });
+    await this.gitExecutor.exec(["-C", workspace.path, "checkout", branch]);
   }
 
   /** List all git worktrees registered for a workspace. */
-  listWorktrees(workspaceId: string): WorktreeInfo[] {
+  async listWorktrees(workspaceId: string): Promise<WorktreeInfo[]> {
     const workspace = this.requireWorkspace(workspaceId);
-    return listWorktreesForPath(workspace.path);
+    return this.listWorktreesForPath(workspace.path);
   }
 
   /** Check whether a filesystem path is a git-registered worktree for a repository. */
-  isRegisteredWorktreePath(repoPath: string, worktreePath: string): boolean {
+  async isRegisteredWorktreePath(repoPath: string, worktreePath: string): Promise<boolean> {
     const normalize = (value: string) =>
       resolve(value).replace(/\\/g, "/").toLowerCase().replace(/\/+$/, "");
     const target = normalize(worktreePath);
-    return listWorktreesForPath(repoPath).some((worktree) => normalize(worktree.path) === target);
+    const worktrees = await this.listWorktreesForPath(repoPath);
+    return worktrees.some((worktree) => normalize(worktree.path) === target);
   }
 
   /**
    * Fetch a remote branch from origin and create a local tracking branch.
    * When prNumber is provided, fetches via `refs/pull/<n>/head` refspec.
    */
-  fetchBranch(
+  async fetchBranch(
     workspaceId: string,
     branch: string,
     prNumber?: number,
-  ): void {
+  ): Promise<void> {
     const workspace = this.requireWorkspace(workspaceId);
-    fetchBranchForPath(workspace.path, branch, prNumber);
+    await this.fetchBranchForPath(workspace.path, branch, prNumber);
   }
 
   /**
@@ -211,11 +209,11 @@ export class GitService {
    * call created the branch or attached to an existing one, and any non-fatal
    * warnings (e.g. post-checkout hook failures).
    */
-  createWorktree(
+  async createWorktree(
     repoPath: string,
     name: string,
     branchName?: string,
-  ): WorktreeInfo & { createdBranch: boolean; warnings: string[] } {
+  ): Promise<WorktreeInfo & { createdBranch: boolean; warnings: string[] }> {
     validateWorktreeName(name);
 
     if (!existsSync(repoPath)) {
@@ -230,22 +228,14 @@ export class GitService {
       throw new Error(`Worktree directory already exists: ${wtPath}`);
     }
 
-    const createdBranch = !branchExists(repoPath, branch);
+    const createdBranch = !(await this.branchExists(repoPath, branch));
     const warnings: string[] = [];
 
     try {
       if (!createdBranch) {
-        execFileSync(
-          "git",
-          ["-C", repoPath, "worktree", "add", wtPath, branch],
-          { stdio: "pipe", windowsHide: true },
-        );
+        await this.gitExecutor.exec(["-C", repoPath, "worktree", "add", wtPath, branch]);
       } else {
-        execFileSync(
-          "git",
-          ["-C", repoPath, "worktree", "add", wtPath, "-b", branch],
-          { stdio: "pipe", windowsHide: true },
-        );
+        await this.gitExecutor.exec(["-C", repoPath, "worktree", "add", wtPath, "-b", branch]);
       }
     } catch (err) {
       // If the worktree's .git file exists, git initialized the worktree
@@ -294,12 +284,11 @@ export class GitService {
 
     // 1. Try git worktree remove
     try {
-      await execFile(
-        "git",
+      await this.gitExecutor.exec(
         // Double --force: the second flag tells git to remove even if the
         // worktree directory is locked (e.g. held by a Windows process).
         ["-C", repoPath, "worktree", "remove", wtPath, "--force", "--force"],
-        { timeout: 30_000, windowsHide: true },
+        { timeout: 30_000 },
       );
     } catch (err) {
       logger.warn("git worktree remove failed", {
@@ -363,10 +352,7 @@ export class GitService {
 
     // 5. Prune stale worktree metadata after any manual fallback removed the path.
     try {
-      await execFile("git", ["-C", repoPath, "worktree", "prune"], {
-        timeout: 10_000,
-        windowsHide: true,
-      });
+      await this.gitExecutor.exec(["-C", repoPath, "worktree", "prune"], { timeout: 10_000 });
     } catch (err) {
       logger.warn("git worktree prune failed", {
         error: err instanceof Error ? err.message : String(err),
@@ -388,10 +374,7 @@ export class GitService {
     //    dir state - always attempt this).
     if (branch) {
       try {
-        await execFile("git", ["-C", repoPath, "branch", "-d", branch], {
-          timeout: 10_000,
-          windowsHide: true,
-        });
+        await this.gitExecutor.exec(["-C", repoPath, "branch", "-d", branch], { timeout: 10_000 });
       } catch (err) {
         logger.warn("Branch deletion failed (may not exist)", {
           branch,
@@ -458,7 +441,7 @@ export class GitService {
 
     let stdout: string;
     try {
-      const result = await execFile("git", args, { timeout: 10_000, windowsHide: true });
+      const result = await this.gitExecutor.exec(args, { timeout: 10_000 });
       stdout = result.stdout;
     } catch {
       return [];
@@ -509,7 +492,7 @@ export class GitService {
     if (filePath) args.push("--", filePath);
 
     try {
-      const { stdout } = await execFile("git", args, { timeout: 10_000, windowsHide: true });
+      const { stdout } = await this.gitExecutor.exec(args, { timeout: 10_000 });
       const result = stdout.trim();
       if (maxLines) {
         return result.split("\n").slice(0, maxLines).join("\n");
@@ -521,7 +504,7 @@ export class GitService {
         const emptyTree = "4b825dc642cb6eb9a060e54bf899d69f82049264";
         const args2 = ["-C", workspace.path, "diff", "--find-renames", `${emptyTree}..${sha}`];
         if (filePath) args2.push("--", filePath);
-        const { stdout } = await execFile("git", args2, { timeout: 10_000, windowsHide: true });
+        const { stdout } = await this.gitExecutor.exec(args2, { timeout: 10_000 });
         return stdout.trim();
       } catch {
         return "";
@@ -537,16 +520,15 @@ export class GitService {
     const workspace = this.requireWorkspace(workspaceId);
     const nameOnlyArgs = ["-C", workspace.path, "diff", "--name-only", `${sha}~1..${sha}`];
     try {
-      const { stdout } = await execFile("git", nameOnlyArgs, { timeout: 5_000, windowsHide: true });
+      const { stdout } = await this.gitExecutor.exec(nameOnlyArgs, { timeout: 5_000 });
       return stdout.trim().split("\n").filter(Boolean);
     } catch {
       // Root commit — diff against empty tree
       const emptyTree = "4b825dc642cb6eb9a060e54bf899d69f82049264";
       try {
-        const { stdout } = await execFile(
-          "git",
+        const { stdout } = await this.gitExecutor.exec(
           ["-C", workspace.path, "diff", "--name-only", `${emptyTree}..${sha}`],
-          { timeout: 5_000, windowsHide: true },
+          { timeout: 5_000 },
         );
         return stdout.trim().split("\n").filter(Boolean);
       } catch {
@@ -566,7 +548,7 @@ export class GitService {
     const args = ["-C", cwd, "diff", "--name-only"];
     if (staged) args.push("--cached");
     try {
-      const { stdout } = await execFile("git", args, { timeout: 10_000, windowsHide: true });
+      const { stdout } = await this.gitExecutor.exec(args, { timeout: 10_000 });
       return stdout.trim().split("\n").filter(Boolean);
     } catch {
       return [];
@@ -591,7 +573,7 @@ export class GitService {
     if (staged) args.push("--cached");
     if (filePath) args.push("--", filePath);
     try {
-      const { stdout } = await execFile("git", args, { timeout: 10_000, windowsHide: true });
+      const { stdout } = await this.gitExecutor.exec(args, { timeout: 10_000 });
       const result = stdout.trim();
       return maxLines ? result.split("\n").slice(0, maxLines).join("\n") : result;
     } catch {
@@ -622,10 +604,9 @@ export class GitService {
     assertSafeRef(resolvedBase);
     assertSafeRef(resolvedTarget);
     try {
-      const { stdout } = await execFile(
-        "git",
+      const { stdout } = await this.gitExecutor.exec(
         ["-C", cwd, "diff", "--name-only", `${resolvedBase}...${resolvedTarget}`],
-        { timeout: 10_000, windowsHide: true },
+        { timeout: 10_000 },
       );
       return stdout.trim().split("\n").filter(Boolean);
     } catch {
@@ -657,7 +638,7 @@ export class GitService {
     const args = ["-C", cwd, "diff", "--find-renames", `${resolvedBase}...${resolvedTarget}`];
     if (filePath) args.push("--", filePath);
     try {
-      const { stdout } = await execFile("git", args, { timeout: 10_000, windowsHide: true });
+      const { stdout } = await this.gitExecutor.exec(args, { timeout: 10_000 });
       const result = stdout.trim();
       return maxLines ? result.split("\n").slice(0, maxLines).join("\n") : result;
     } catch {
@@ -684,14 +665,14 @@ export class GitService {
    */
   async resolveBranchComparison(workspaceId: string, repoPath?: string): Promise<BranchComparison> {
     const cwd = repoPath ?? this.requireWorkspace(workspaceId).path;
-    const refs = listBranchesForPath(cwd);
+    const refs = await this.listBranchesForPath(cwd);
 
     if (!(await this.hasCommits(cwd))) {
       return { base: null, target: null, refs, isUnborn: true };
     }
 
     const base = await this.detectDefaultBranch(cwd);
-    const current = getCurrentBranchForPath(cwd);
+    const current = await this.getCurrentBranchForPath(cwd);
 
     if (!base) {
       const target = current && current !== "HEAD" ? current : "HEAD";
@@ -718,10 +699,9 @@ export class GitService {
   /** Whether HEAD resolves to a commit (false on an unborn branch / empty repo). */
   private async hasCommits(repoPath: string): Promise<boolean> {
     try {
-      await execFile(
-        "git",
+      await this.gitExecutor.exec(
         ["-C", repoPath, "rev-parse", "--verify", "--quiet", "HEAD"],
-        { timeout: 5_000, windowsHide: true },
+        { timeout: 5_000 },
       );
       return true;
     } catch {
@@ -731,128 +711,19 @@ export class GitService {
 
   /** Push a branch to the origin remote, creating the upstream tracking ref if needed. */
   async push(repoPath: string, branch: string): Promise<void> {
-    await execFile(
-      "git",
+    await this.gitExecutor.exec(
       ["-C", repoPath, "push", "--set-upstream", "origin", branch],
-      { timeout: 60_000, windowsHide: true },
+      { timeout: 60_000 },
     );
   }
 
   /** Return a diff stat summary between two refs. */
   async diffStat(repoPath: string, base: string, head: string): Promise<string> {
-    const { stdout } = await execFile(
-      "git",
+    const { stdout } = await this.gitExecutor.exec(
       ["-C", repoPath, "diff", "--stat", `${base}...${head}`],
-      { timeout: 30_000, windowsHide: true },
+      { timeout: 30_000 },
     );
     return stdout.trim();
-  }
-
-  /** Per-repo cache: avoids re-running mutating git commands on every log call. */
-  private readonly defaultBranchCache = new Map<string, string | null>();
-  private readonly defaultComparisonRefCache = new Map<string, string | null>();
-
-  /** Detect the default comparison ref for commit ranges, preferring the remote-qualified ref. */
-  private async detectDefaultComparisonRef(repoPath: string): Promise<string | null> {
-    const cached = this.defaultComparisonRefCache.get(repoPath);
-    if (cached !== undefined) return cached;
-
-    const result = await this.resolveDefaultComparisonRef(repoPath);
-    this.defaultComparisonRefCache.set(repoPath, result);
-    return result;
-  }
-
-  /** Resolve the default comparison ref, preserving `origin/main` when available. */
-  private async resolveDefaultComparisonRef(repoPath: string): Promise<string | null> {
-    try {
-      const { stdout } = await execFile(
-        "git",
-        ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        { timeout: 5_000, windowsHide: true },
-      );
-      return stdout.trim();
-    } catch (err) {
-      logger.debug("[detectDefaultComparisonRef] origin/HEAD not set, trying set-head", { repoPath, err });
-    }
-
-    try {
-      await execFile(
-        "git",
-        ["-C", repoPath, "remote", "set-head", "origin", "--auto"],
-        { timeout: 1_500, windowsHide: true },
-      );
-      const { stdout } = await execFile(
-        "git",
-        ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        { timeout: 5_000, windowsHide: true },
-      );
-      return stdout.trim();
-    } catch (err) {
-      logger.debug("[detectDefaultComparisonRef] set-head failed, falling back to local default", { repoPath, err });
-    }
-
-    return this.detectDefaultBranch(repoPath);
-  }
-
-  /** Detect the default upstream branch (e.g. main, master) for a repository. */
-  private async detectDefaultBranch(repoPath: string): Promise<string | null> {
-    const cached = this.defaultBranchCache.get(repoPath);
-    if (cached !== undefined) return cached;
-
-    const result = await this.resolveDefaultBranch(repoPath);
-    this.defaultBranchCache.set(repoPath, result);
-    return result;
-  }
-
-  /** Resolve the default comparison branch by probing git refs in order of cheapness. */
-  private async resolveDefaultBranch(repoPath: string): Promise<string | null> {
-    // 1. Ask the remote tracking ref (fast, no network, works if origin/HEAD is set)
-    try {
-      const { stdout } = await execFile(
-        "git",
-        ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        { timeout: 5_000, windowsHide: true },
-      );
-      return stdout.trim().replace(/^[^/]+\//, "");
-    } catch (err) {
-      logger.debug("[detectDefaultBranch] origin/HEAD not set, trying set-head", { repoPath, err });
-    }
-
-    // 2. Ask the remote to set origin/HEAD, then re-read it.
-    // Timeout is short (1 500 ms) so an unreachable remote doesn't block the caller.
-    try {
-      await execFile(
-        "git",
-        ["-C", repoPath, "remote", "set-head", "origin", "--auto"],
-        { timeout: 1_500, windowsHide: true },
-      );
-      const { stdout } = await execFile(
-        "git",
-        ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        { timeout: 5_000, windowsHide: true },
-      );
-      return stdout.trim().replace(/^[^/]+\//, "");
-    } catch (err) {
-      logger.debug("[detectDefaultBranch] set-head failed, falling back to HEAD", { repoPath, err });
-    }
-
-    // 3. Local-only repos have no origin/HEAD; prefer established default branch
-    // names when they exist instead of treating the current feature branch as base.
-    for (const branch of ["main", "master", "develop", "trunk"]) {
-      try {
-        await execFile(
-          "git",
-          ["-C", repoPath, "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
-          { timeout: 5_000, windowsHide: true },
-        );
-        return branch;
-      } catch {
-        // Keep probing the next conventional default name.
-      }
-    }
-
-    logger.debug("[detectDefaultBranch] no default branch detected", { repoPath });
-    return null;
   }
 
   /**
@@ -864,8 +735,7 @@ export class GitService {
    */
   async isWorkingTreeClean(repoPath: string): Promise<boolean> {
     try {
-      const { stdout } = await execFile(
-        "git",
+      const { stdout } = await this.gitExecutor.exec(
         ["-C", repoPath, "status", "--porcelain"],
         { timeout: 5_000 },
       );
@@ -889,226 +759,299 @@ export class GitService {
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
     return workspace;
   }
-}
 
-// ---------------------------------------------------------------------------
-// Standalone helper functions (not on the class, to keep them testable)
-// ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Private git helpers (formerly module-level functions)
+  // ---------------------------------------------------------------------------
 
-/**
- * Reject a git ref that could smuggle a flag into a git argv (a leading `-`) or
- * contains characters outside what refnames and short SHAs use. Guards the
- * base/target of a Branch comparison before they are interpolated into a rev
- * range; the WS layer also validates via `GitRefSchema`, this is defense in
- * depth for any direct caller.
- */
-function assertSafeRef(ref: string): void {
-  if (!/^(?!-)[A-Za-z0-9._/-]+$/.test(ref)) {
-    throw new Error(`Unsafe git ref: ${ref}`);
+  /** Check whether a branch ref exists in the repository. */
+  private async branchExists(repoPath: string, branch: string): Promise<boolean> {
+    try {
+      await this.gitExecutor.exec(["-C", repoPath, "rev-parse", "--verify", branch]);
+      return true;
+    } catch {
+      return false;
+    }
   }
-}
 
-/** List all branches (local, remote, worktree-attached) for a repository path. */
-function listBranchesForPath(repoPath: string): GitBranch[] {
-  let output: string;
-  try {
-    output = execFileSync(
-      "git",
-      [
+  /** Get the current branch name for a repository path. Returns null for non-git paths. */
+  private async getCurrentBranchForPath(repoPath: string): Promise<string | null> {
+    try {
+      const { stdout } = await this.gitExecutor.exec(
+        ["-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD"],
+      );
+      return stdout.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** List all branches (local, remote, worktree-attached) for a repository path. */
+  private async listBranchesForPath(repoPath: string): Promise<GitBranch[]> {
+    let output: string;
+    try {
+      const { stdout } = await this.gitExecutor.exec([
         "-C",
         repoPath,
         "branch",
         "-a",
         "--format=%(refname)|||%(refname:short)|||%(objectname:short)|||%(HEAD)|||%(worktreepath)",
-      ],
-      { stdio: "pipe", encoding: "utf-8", windowsHide: true },
-    );
-  } catch {
-    return [];
-  }
-
-  const branches: GitBranch[] = [];
-
-  for (const line of output.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-
-    const [fullRefname, refname, shortSha, head, worktreepath] = trimmed.split("|||");
-    // Skip remote HEAD symrefs (refs/remotes/*/HEAD)
-    if (!fullRefname || !refname || /\/HEAD$/.test(fullRefname)) continue;
-
-    let type: GitBranch["type"];
-    if (worktreepath && worktreepath.length > 0) {
-      type = "worktree";
-    } else if (fullRefname.startsWith("refs/remotes/")) {
-      type = "remote";
-    } else {
-      type = "local";
+      ]);
+      output = stdout;
+    } catch {
+      return [];
     }
 
-    branches.push({
-      name: refname,
-      shortSha: shortSha ?? "",
-      type,
-      isCurrent: head === "*",
+    const branches: GitBranch[] = [];
+
+    for (const line of output.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      const [fullRefname, refname, shortSha, head, worktreepath] = trimmed.split("|||");
+      // Skip remote HEAD symrefs (refs/remotes/*/HEAD)
+      if (!fullRefname || !refname || /\/HEAD$/.test(fullRefname)) continue;
+
+      let type: GitBranch["type"];
+      if (worktreepath && worktreepath.length > 0) {
+        type = "worktree";
+      } else if (fullRefname.startsWith("refs/remotes/")) {
+        type = "remote";
+      } else {
+        type = "local";
+      }
+
+      branches.push({
+        name: refname,
+        shortSha: shortSha ?? "",
+        type,
+        isCurrent: head === "*",
+      });
+    }
+
+    const typeOrder: Record<GitBranch["type"], number> = {
+      local: 0,
+      worktree: 1,
+      remote: 2,
+    };
+
+    return branches.sort((a, b) => {
+      if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1;
+      const orderDiff = typeOrder[a.type] - typeOrder[b.type];
+      if (orderDiff !== 0) return orderDiff;
+      return a.name.localeCompare(b.name);
     });
   }
 
-  const typeOrder: Record<GitBranch["type"], number> = {
-    local: 0,
-    worktree: 1,
-    remote: 2,
-  };
+  /** List all git worktrees for a repository path. */
+  private async listWorktreesForPath(repoPath: string): Promise<WorktreeInfo[]> {
+    const worktreesDir = getWorktreeBaseDir(repoPath)
+      .replace(/\\/g, "/")
+      .toLowerCase();
+    const normalizedRepo = repoPath
+      .replace(/\\/g, "/")
+      .toLowerCase()
+      .replace(/\/+$/, "");
 
-  return branches.sort((a, b) => {
-    if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1;
-    const orderDiff = typeOrder[a.type] - typeOrder[b.type];
-    if (orderDiff !== 0) return orderDiff;
-    return a.name.localeCompare(b.name);
-  });
-}
+    let output: string;
+    try {
+      const { stdout } = await this.gitExecutor.exec(
+        ["-C", repoPath, "worktree", "list", "--porcelain"],
+      );
+      output = stdout;
+    } catch {
+      return [];
+    }
 
-/** Get the current branch name for a repository path. Returns null for non-git paths. */
-export function getCurrentBranchForPath(repoPath: string): string | null {
-  try {
-    const output = execFileSync(
-      "git",
-      ["-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD"],
-      { stdio: "pipe", encoding: "utf-8", windowsHide: true },
-    );
-    return output.trim() || null;
-  } catch {
-    return null;
-  }
-}
+    const result: WorktreeInfo[] = [];
+    let currentPath = "";
+    let currentBranch = "";
 
-/** List all git worktrees for a repository path. */
-function listWorktreesForPath(repoPath: string): WorktreeInfo[] {
-  const worktreesDir = getWorktreeBaseDir(repoPath)
-    .replace(/\\/g, "/")
-    .toLowerCase();
-  const normalizedRepo = repoPath
-    .replace(/\\/g, "/")
-    .toLowerCase()
-    .replace(/\/+$/, "");
+    for (const line of output.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        currentPath = line.slice("worktree ".length).trim();
+        currentBranch = "";
+      } else if (line.startsWith("branch ")) {
+        currentBranch = line
+          .slice("branch ".length)
+          .trim()
+          .replace("refs/heads/", "");
+      } else if (line === "detached") {
+        currentBranch = "(detached)";
+      } else if (line.trim() === "" && currentPath) {
+        const normalized = currentPath
+          .replace(/\\/g, "/")
+          .toLowerCase()
+          .replace(/\/+$/, "");
+        if (normalized !== normalizedRepo && currentBranch) {
+          const name =
+            currentPath.replace(/\\/g, "/").split("/").pop() || currentPath;
+          const managed = normalized.startsWith(worktreesDir + "/");
+          result.push({ name, path: currentPath, branch: currentBranch, managed });
+        }
+        currentPath = "";
+        currentBranch = "";
+      }
+    }
 
-  let output: string;
-  try {
-    output = execFileSync(
-      "git",
-      ["-C", repoPath, "worktree", "list", "--porcelain"],
-      { stdio: "pipe", encoding: "utf-8", windowsHide: true },
-    );
-  } catch {
-    return [];
-  }
-
-  const result: WorktreeInfo[] = [];
-  let currentPath = "";
-  let currentBranch = "";
-
-  for (const line of output.split("\n")) {
-    if (line.startsWith("worktree ")) {
-      currentPath = line.slice("worktree ".length).trim();
-      currentBranch = "";
-    } else if (line.startsWith("branch ")) {
-      currentBranch = line
-        .slice("branch ".length)
-        .trim()
-        .replace("refs/heads/", "");
-    } else if (line === "detached") {
-      currentBranch = "(detached)";
-    } else if (line.trim() === "" && currentPath) {
+    // Handle last entry (porcelain output may not end with blank line)
+    if (currentPath && currentBranch) {
       const normalized = currentPath
         .replace(/\\/g, "/")
         .toLowerCase()
         .replace(/\/+$/, "");
-      if (normalized !== normalizedRepo && currentBranch) {
+      if (normalized !== normalizedRepo) {
         const name =
           currentPath.replace(/\\/g, "/").split("/").pop() || currentPath;
         const managed = normalized.startsWith(worktreesDir + "/");
         result.push({ name, path: currentPath, branch: currentBranch, managed });
       }
-      currentPath = "";
-      currentBranch = "";
     }
+
+    return result;
   }
 
-  // Handle last entry (porcelain output may not end with blank line)
-  if (currentPath && currentBranch) {
-    const normalized = currentPath
-      .replace(/\\/g, "/")
-      .toLowerCase()
-      .replace(/\/+$/, "");
-    if (normalized !== normalizedRepo) {
-      const name =
-        currentPath.replace(/\\/g, "/").split("/").pop() || currentPath;
-      const managed = normalized.startsWith(worktreesDir + "/");
-      result.push({ name, path: currentPath, branch: currentBranch, managed });
-    }
-  }
+  /**
+   * Fetch a remote branch from origin and create a local tracking branch.
+   * When prNumber is provided, fetches via `refs/pull/<n>/head` refspec.
+   */
+  private async fetchBranchForPath(
+    repoPath: string,
+    branch: string,
+    prNumber?: number,
+  ): Promise<void> {
+    validateBranchName(branch);
 
-  return result;
-}
-
-/**
- * Fetch a remote branch from origin and create a local tracking branch.
- * When prNumber is provided, fetches via `refs/pull/<n>/head` refspec.
- */
-function fetchBranchForPath(
-  repoPath: string,
-  branch: string,
-  prNumber?: number,
-): void {
-  validateBranchName(branch);
-
-  let fetchOk = true;
-  try {
-    if (prNumber != null) {
-      execFileSync(
-        "git",
-        [
+    let fetchOk = true;
+    try {
+      if (prNumber != null) {
+        await this.gitExecutor.exec([
           "-C",
           repoPath,
           "fetch",
           "origin",
           `+pull/${prNumber}/head:${branch}`,
-        ],
-        { stdio: "pipe", windowsHide: true },
-      );
-    } else {
-      execFileSync("git", ["-C", repoPath, "fetch", "origin", branch], {
-        stdio: "pipe",
-        windowsHide: true,
-      });
+        ]);
+      } else {
+        await this.gitExecutor.exec(["-C", repoPath, "fetch", "origin", branch]);
+      }
+    } catch {
+      fetchOk = false;
     }
-  } catch {
-    fetchOk = false;
+
+    if (fetchOk && prNumber == null) {
+      const localExists = await this.branchExists(repoPath, branch);
+      if (localExists) {
+        await this.gitExecutor.exec(
+          ["-C", repoPath, "branch", "-f", branch, `origin/${branch}`],
+        );
+      } else {
+        await this.gitExecutor.exec(
+          ["-C", repoPath, "branch", "--track", branch, `origin/${branch}`],
+        );
+      }
+    } else if (!fetchOk && !(await this.branchExists(repoPath, branch))) {
+      throw new Error(`Branch "${branch}" not found locally or on origin`);
+    }
   }
 
-  if (fetchOk && prNumber == null) {
-    const localExists = branchExists(repoPath, branch);
-    if (localExists) {
-      execFileSync(
-        "git",
-        ["-C", repoPath, "branch", "-f", branch, `origin/${branch}`],
-        { stdio: "pipe", windowsHide: true },
+  /** Per-repo cache: avoids re-running mutating git commands on every log call. */
+  private readonly defaultBranchCache = new Map<string, string | null>();
+  private readonly defaultComparisonRefCache = new Map<string, string | null>();
+
+  /** Detect the default comparison ref for commit ranges, preferring the remote-qualified ref. */
+  private async detectDefaultComparisonRef(repoPath: string): Promise<string | null> {
+    const cached = this.defaultComparisonRefCache.get(repoPath);
+    if (cached !== undefined) return cached;
+
+    const result = await this.resolveDefaultComparisonRef(repoPath);
+    this.defaultComparisonRefCache.set(repoPath, result);
+    return result;
+  }
+
+  /** Resolve the default comparison ref, preserving `origin/main` when available. */
+  private async resolveDefaultComparisonRef(repoPath: string): Promise<string | null> {
+    try {
+      const { stdout } = await this.gitExecutor.exec(
+        ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        { timeout: 5_000 },
       );
-    } else {
-      execFileSync(
-        "git",
-        [
-          "-C",
-          repoPath,
-          "branch",
-          "--track",
-          branch,
-          `origin/${branch}`,
-        ],
-        { stdio: "pipe", windowsHide: true },
-      );
+      return stdout.trim();
+    } catch (err) {
+      logger.debug("[detectDefaultComparisonRef] origin/HEAD not set, trying set-head", { repoPath, err });
     }
-  } else if (!fetchOk && !branchExists(repoPath, branch)) {
-    throw new Error(`Branch "${branch}" not found locally or on origin`);
+
+    try {
+      await this.gitExecutor.exec(
+        ["-C", repoPath, "remote", "set-head", "origin", "--auto"],
+        { timeout: 1_500 },
+      );
+      const { stdout } = await this.gitExecutor.exec(
+        ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        { timeout: 5_000 },
+      );
+      return stdout.trim();
+    } catch (err) {
+      logger.debug("[detectDefaultComparisonRef] set-head failed, falling back to local default", { repoPath, err });
+    }
+
+    return this.detectDefaultBranch(repoPath);
+  }
+
+  /** Detect the default upstream branch (e.g. main, master) for a repository. */
+  private async detectDefaultBranch(repoPath: string): Promise<string | null> {
+    const cached = this.defaultBranchCache.get(repoPath);
+    if (cached !== undefined) return cached;
+
+    const result = await this.resolveDefaultBranch(repoPath);
+    this.defaultBranchCache.set(repoPath, result);
+    return result;
+  }
+
+  /** Resolve the default comparison branch by probing git refs in order of cheapness. */
+  private async resolveDefaultBranch(repoPath: string): Promise<string | null> {
+    // 1. Ask the remote tracking ref (fast, no network, works if origin/HEAD is set)
+    try {
+      const { stdout } = await this.gitExecutor.exec(
+        ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        { timeout: 5_000 },
+      );
+      return stdout.trim().replace(/^[^/]+\//, "");
+    } catch (err) {
+      logger.debug("[detectDefaultBranch] origin/HEAD not set, trying set-head", { repoPath, err });
+    }
+
+    // 2. Ask the remote to set origin/HEAD, then re-read it.
+    // Timeout is short (1 500 ms) so an unreachable remote doesn't block the caller.
+    try {
+      await this.gitExecutor.exec(
+        ["-C", repoPath, "remote", "set-head", "origin", "--auto"],
+        { timeout: 1_500 },
+      );
+      const { stdout } = await this.gitExecutor.exec(
+        ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        { timeout: 5_000 },
+      );
+      return stdout.trim().replace(/^[^/]+\//, "");
+    } catch (err) {
+      logger.debug("[detectDefaultBranch] set-head failed, falling back to HEAD", { repoPath, err });
+    }
+
+    // 3. Local-only repos have no origin/HEAD; prefer established default branch
+    // names when they exist instead of treating the current feature branch as base.
+    for (const branchName of ["main", "master", "develop", "trunk"]) {
+      try {
+        await this.gitExecutor.exec(
+          ["-C", repoPath, "show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
+          { timeout: 5_000 },
+        );
+        return branchName;
+      } catch {
+        // Keep probing the next conventional default name.
+      }
+    }
+
+    logger.debug("[detectDefaultBranch] no default branch detected", { repoPath });
+    return null;
   }
 }

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -171,6 +171,7 @@ export class GitService {
 
   /** Checkout an existing branch in the workspace repository. */
   async checkout(workspaceId: string, branch: string): Promise<void> {
+    validateBranchName(branch);
     const workspace = this.requireWorkspace(workspaceId);
     await this.gitExecutor.exec(["-C", workspace.path, "checkout", branch]);
   }
@@ -282,6 +283,8 @@ export class GitService {
       validateBranchName(branch);
     }
 
+    await this.assertRemovableWorktreePath(repoPath, wtPath);
+
     // 1. Try git worktree remove
     try {
       await this.gitExecutor.exec(
@@ -387,6 +390,27 @@ export class GitService {
   }
 
   /**
+   * Reject fallback fs.rm when a caller-supplied worktree path is outside the
+   * managed mcode worktree root and not registered with git for the repo.
+   */
+  private async assertRemovableWorktreePath(
+    repoPath: string,
+    worktreePath: string,
+  ): Promise<void> {
+    const managedRoot = resolve(getMcodeDir(), "worktrees");
+    const rel = relative(managedRoot, resolve(worktreePath));
+    const isManagedPath = !(rel.startsWith("..") || isAbsolute(rel));
+    if (isManagedPath) return;
+
+    const isRegistered = await this.isRegisteredWorktreePath(repoPath, worktreePath);
+    if (!isRegistered) {
+      throw new Error(
+        `worktreePath is not a managed or registered worktree: ${worktreePath}`,
+      );
+    }
+  }
+
+  /**
    * Resolve the working directory for a thread, accounting for worktree mode.
    * Uses the thread's worktree_path when available, otherwise the workspace root.
    */
@@ -413,6 +437,9 @@ export class GitService {
   ): Promise<GitCommit[]> {
     const workspace = this.requireWorkspace(workspaceId);
     const effectivePath = repoPath ?? workspace.path;
+
+    if (branch !== undefined) assertSafeRef(branch);
+    if (baseBranch !== undefined) assertSafeRef(baseBranch);
 
     // Auto-detect default branch when baseBranch is omitted but branch is specified
     const resolvedBase = baseBranch !== undefined
@@ -711,6 +738,7 @@ export class GitService {
 
   /** Push a branch to the origin remote, creating the upstream tracking ref if needed. */
   async push(repoPath: string, branch: string): Promise<void> {
+    validateBranchName(branch);
     await this.gitExecutor.exec(
       ["-C", repoPath, "push", "--set-upstream", "origin", branch],
       { timeout: 60_000 },

--- a/apps/server/src/services/git-watcher-service.ts
+++ b/apps/server/src/services/git-watcher-service.ts
@@ -6,12 +6,12 @@
 
 import { injectable, inject } from "tsyringe";
 import { watch, existsSync, type FSWatcher } from "fs";
-import { execFileSync } from "child_process";
 import { join, dirname, basename } from "path";
 import { logger } from "@mcode/shared";
 import { broadcast } from "../transport/push";
-import { getCurrentBranchForPath } from "./git-service";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
+import type { GitExecutor } from "./git-executor/index.js";
+import type { GitService } from "./git-service.js";
 
 /** Debounce delay in milliseconds to batch rapid HEAD file writes (e.g., during rebase). */
 const DEBOUNCE_MS = 200;
@@ -34,6 +34,8 @@ export class GitWatcherService {
 
   constructor(
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
+    @inject("GitExecutor") private readonly gitExecutor: GitExecutor,
+    @inject("GitService") private readonly gitService: GitService,
   ) {}
 
   /**
@@ -41,15 +43,13 @@ export class GitWatcherService {
    * Uses `git rev-parse --git-dir` to handle both main repos and worktrees.
    * Returns null if the path is not a git repository or the HEAD file is missing.
    */
-  private resolveHeadFile(workspacePath: string): string | null {
+  private async resolveHeadFile(workspacePath: string): Promise<string | null> {
     let gitDir: string;
     try {
-      const output = execFileSync(
-        "git",
+      const { stdout } = await this.gitExecutor.exec(
         ["-C", workspacePath, "rev-parse", "--git-dir"],
-        { stdio: "pipe", encoding: "utf-8", windowsHide: true },
       );
-      gitDir = output.trim();
+      gitDir = stdout.trim();
     } catch {
       logger.warn("GitWatcherService: not a git repo, skipping watcher", {
         workspacePath,
@@ -78,12 +78,12 @@ export class GitWatcherService {
    * Start watching the HEAD file for the given workspace.
    * A duplicate call for the same `workspaceId` is a no-op (existing watcher is kept).
    */
-  watchWorkspace(workspaceId: string, workspacePath: string): void {
+  async watchWorkspace(workspaceId: string, workspacePath: string): Promise<void> {
     if (this.watchers.has(workspaceId)) {
       return;
     }
 
-    const headFile = this.resolveHeadFile(workspacePath);
+    const headFile = await this.resolveHeadFile(workspacePath);
     if (!headFile) {
       return;
     }
@@ -109,12 +109,18 @@ export class GitWatcherService {
         }
         entry.timer = setTimeout(() => {
           entry.timer = null;
-          const branch = getCurrentBranchForPath(workspacePath);
-          logger.info("GitWatcherService: branch changed", {
-            workspaceId,
-            branch,
+          void this.gitService.getCurrentBranchAt(workspacePath).then((branch) => {
+            logger.info("GitWatcherService: branch changed", {
+              workspaceId,
+              branch,
+            });
+            broadcast("branch.changed", { workspaceId, branch });
+          }).catch((err) => {
+            logger.warn("GitWatcherService: failed to read branch after HEAD change", {
+              workspaceId,
+              error: err instanceof Error ? err.message : String(err),
+            });
           });
-          broadcast("branch.changed", { workspaceId, branch });
         }, DEBOUNCE_MS);
       });
 
@@ -144,15 +150,15 @@ export class GitWatcherService {
    * Called on thread.list to catch `git init` within a session.
    * Returns true if the workspace is now a git repo and the watcher was started.
    */
-  retryWatch(workspaceId: string, workspacePath: string): boolean {
+  async retryWatch(workspaceId: string, workspacePath: string): Promise<boolean> {
     if (this.watchers.has(workspaceId)) return true;
 
-    const headFile = this.resolveHeadFile(workspacePath);
+    const headFile = await this.resolveHeadFile(workspacePath);
     if (!headFile) return false;
 
     // The folder is now a git repo — update the DB, start watching, notify clients.
     this.workspaceRepo.setIsGitRepo(workspaceId, true);
-    this.watchWorkspace(workspaceId, workspacePath);
+    await this.watchWorkspace(workspaceId, workspacePath);
 
     logger.info("GitWatcherService: non-git workspace became a git repo", {
       workspaceId,

--- a/apps/server/src/services/pr-draft-service.ts
+++ b/apps/server/src/services/pr-draft-service.ts
@@ -73,7 +73,7 @@ export class PrDraftService {
       thread.mode,
       thread.worktree_path,
     );
-    const headBranch = this.gitService.getCurrentBranchAt(repoPath);
+    const headBranch = await this.gitService.getCurrentBranchAt(repoPath);
     if (!headBranch || headBranch === "HEAD") {
       throw new Error("Cannot generate PR draft: repository is in detached HEAD state or not a git repo");
     }

--- a/apps/server/src/services/snapshot-service.ts
+++ b/apps/server/src/services/snapshot-service.ts
@@ -4,74 +4,47 @@
  * for comparing snapshots.
  */
 
-import { injectable } from "tsyringe";
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
+import { injectable, inject } from "tsyringe";
 import { unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
-
-const execFile = promisify(execFileCb);
+import type { GitExecutor } from "./git-executor/index.js";
 
 /** Service for capturing and comparing git working tree snapshots. */
 @injectable()
 export class SnapshotService {
+  constructor(@inject("GitExecutor") private readonly gitExecutor: GitExecutor) {}
+
   /**
    * Capture the current working tree state as a tree object SHA.
    *
-   * Uses a temporary git index (via GIT_INDEX_FILE) to stage all working tree
-   * changes including untracked files without touching the real index. Returns
-   * the tree SHA directly - no commit object is created, so no git identity
-   * configuration is required.
+   * Clean trees resolve from HEAD with a cheap status check. Dirty trees use a
+   * temporary git index (via GIT_INDEX_FILE) to stage all working tree changes
+   * including untracked files without touching the real index.
    *
    * Identical working trees produce identical tree SHAs (content-addressable),
    * so consecutive calls on a clean tree return the same value.
-   *
-   * For unborn repos (no commits yet), read-tree is skipped and the tree is
-   * built from scratch. Throws on non-recoverable failures (disk full,
-   * permissions, not a git repo) so the caller can skip snapshot creation.
    */
   async captureRef(cwd: string): Promise<string> {
     const timeout = 10_000;
-    let tmpIndex = "";
 
-    // Resolve the git dir so the temp index lives on the same volume (Windows compatibility)
-    const { stdout: gitDirOut } = await execFile(
-      "git",
-      ["-C", cwd, "rev-parse", "--git-dir"],
-      { timeout, windowsHide: true },
+    const { stdout: statusOut } = await this.gitExecutor.exec(
+      ["-C", cwd, "status", "--porcelain"],
+      { timeout },
     );
-    const gitDirRaw = gitDirOut.trim();
-    // rev-parse --git-dir may return a relative path on some git versions
-    const gitDir = gitDirRaw.startsWith("/") || /^[A-Za-z]:/.test(gitDirRaw)
-      ? gitDirRaw
-      : join(cwd, gitDirRaw);
-
-    tmpIndex = `${gitDir}/mcode-index-${randomUUID()}`;
-    const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
-
-    try {
-      // Seed from HEAD tree; swallow failure for unborn repos (no commits yet)
+    if (statusOut.trim() === "") {
       try {
-        await execFile("git", ["-C", cwd, "read-tree", "HEAD"], { timeout, env, windowsHide: true });
+        const { stdout: treeOut } = await this.gitExecutor.exec(
+          ["-C", cwd, "rev-parse", "HEAD^{tree}"],
+          { timeout },
+        );
+        return treeOut.trim();
       } catch {
-        // Unborn repo or corrupt HEAD - proceed with empty index
+        // Unborn repo or missing HEAD: fall through to staged capture path.
       }
-
-      // Stage all working tree changes including untracked files
-      await execFile("git", ["-C", cwd, "add", "-A"], { timeout, env, windowsHide: true });
-
-      // Write the staged index as a tree object and return the SHA
-      const { stdout: treeOut } = await execFile(
-        "git",
-        ["-C", cwd, "write-tree"],
-        { timeout, env, windowsHide: true },
-      );
-      return treeOut.trim();
-    } finally {
-      // Fire-and-forget cleanup - no await to prevent hangs on locked files
-      unlink(tmpIndex).catch(() => {});
     }
+
+    return this.captureStagedTreeRef(cwd, timeout);
   }
 
   /** Get list of files changed between two refs (tree or commit SHAs). */
@@ -81,10 +54,9 @@ export class SnapshotService {
     }
 
     try {
-      const { stdout } = await execFile(
-        "git",
+      const { stdout } = await this.gitExecutor.exec(
         ["-C", cwd, "diff", "--name-only", refBefore, refAfter],
-        { timeout: 10_000, windowsHide: true },
+        { timeout: 10_000 },
       );
 
       const output = stdout.trim();
@@ -117,7 +89,7 @@ export class SnapshotService {
     }
 
     try {
-      const { stdout } = await execFile("git", args, { timeout: 10_000, windowsHide: true });
+      const { stdout } = await this.gitExecutor.exec(args, { timeout: 10_000 });
       const result = stdout.trim();
 
       if (maxLines) {
@@ -133,9 +105,8 @@ export class SnapshotService {
   /** Validate that a git ref still exists (not garbage collected). */
   async validateRef(cwd: string, ref: string): Promise<boolean> {
     try {
-      await execFile("git", ["-C", cwd, "cat-file", "-t", ref], {
+      await this.gitExecutor.exec(["-C", cwd, "cat-file", "-t", ref], {
         timeout: 10_000,
-        windowsHide: true,
       });
       return true;
     } catch {
@@ -152,10 +123,9 @@ export class SnapshotService {
     if (refBefore === refAfter) return [];
 
     try {
-      const { stdout } = await execFile(
-        "git",
+      const { stdout } = await this.gitExecutor.exec(
         ["-C", cwd, "diff", "--numstat", "--find-renames", refBefore, refAfter],
-        { timeout: 10_000, windowsHide: true },
+        { timeout: 10_000 },
       );
 
       return stdout
@@ -166,13 +136,50 @@ export class SnapshotService {
           const [addStr, delStr, ...pathParts] = line.split("\t");
           return {
             filePath: pathParts.join("\t"),
-            // Binary files show "-" instead of a number
             additions: addStr === "-" ? 0 : parseInt(addStr ?? "0", 10),
             deletions: delStr === "-" ? 0 : parseInt(delStr ?? "0", 10),
           };
         });
     } catch {
       return [];
+    }
+  }
+
+  /**
+   * Stage the full working tree via a temp index and return its tree SHA.
+   * Used for dirty trees and unborn repos where HEAD^{tree} is unavailable.
+   */
+  private async captureStagedTreeRef(cwd: string, timeout: number): Promise<string> {
+    let tmpIndex = "";
+
+    const { stdout: gitDirOut } = await this.gitExecutor.exec(
+      ["-C", cwd, "rev-parse", "--git-dir"],
+      { timeout },
+    );
+    const gitDirRaw = gitDirOut.trim();
+    const gitDir = gitDirRaw.startsWith("/") || /^[A-Za-z]:/.test(gitDirRaw)
+      ? gitDirRaw
+      : join(cwd, gitDirRaw);
+
+    tmpIndex = `${gitDir}/mcode-index-${randomUUID()}`;
+    const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
+
+    try {
+      try {
+        await this.gitExecutor.exec(["-C", cwd, "read-tree", "HEAD"], { timeout, env });
+      } catch {
+        // Unborn repo or corrupt HEAD - proceed with empty index
+      }
+
+      await this.gitExecutor.exec(["-C", cwd, "add", "-A"], { timeout, env });
+
+      const { stdout: treeOut } = await this.gitExecutor.exec(
+        ["-C", cwd, "write-tree"],
+        { timeout, env },
+      );
+      return treeOut.trim();
+    } finally {
+      unlink(tmpIndex).catch(() => {});
     }
   }
 }

--- a/apps/server/src/services/snapshot-service.ts
+++ b/apps/server/src/services/snapshot-service.ts
@@ -9,6 +9,7 @@ import { unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { GitExecutor } from "./git-executor/index.js";
+import { RealGitExecutor } from "./git-executor/real-git-executor.js";
 
 /** Service for capturing and comparing git working tree snapshots. */
 @injectable()
@@ -26,25 +27,33 @@ export class SnapshotService {
    * so consecutive calls on a clean tree return the same value.
    */
   async captureRef(cwd: string): Promise<string> {
-    const timeout = 10_000;
+    const timeout = RealGitExecutor.DEFAULT_TIMEOUT;
 
-    const { stdout: statusOut } = await this.gitExecutor.exec(
-      ["-C", cwd, "status", "--porcelain"],
-      { timeout },
-    );
-    if (statusOut.trim() === "") {
+    if (await this.isWorkingTreeClean(cwd, timeout)) {
       try {
         const { stdout: treeOut } = await this.gitExecutor.exec(
           ["-C", cwd, "rev-parse", "HEAD^{tree}"],
           { timeout },
         );
-        return treeOut.trim();
+        // Re-check after rev-parse: agent tools can write between status and tree lookup.
+        if (await this.isWorkingTreeClean(cwd, timeout)) {
+          return treeOut.trim();
+        }
       } catch {
         // Unborn repo or missing HEAD: fall through to staged capture path.
       }
     }
 
     return this.captureStagedTreeRef(cwd, timeout);
+  }
+
+  /** Return true when git reports no uncommitted changes in the working tree. */
+  private async isWorkingTreeClean(cwd: string, timeout: number): Promise<boolean> {
+    const { stdout } = await this.gitExecutor.exec(
+      ["-C", cwd, "status", "--porcelain"],
+      { timeout },
+    );
+    return stdout.trim() === "";
   }
 
   /** Get list of files changed between two refs (tree or commit SHAs). */
@@ -56,7 +65,7 @@ export class SnapshotService {
     try {
       const { stdout } = await this.gitExecutor.exec(
         ["-C", cwd, "diff", "--name-only", refBefore, refAfter],
-        { timeout: 10_000 },
+        { timeout: RealGitExecutor.DEFAULT_TIMEOUT },
       );
 
       const output = stdout.trim();
@@ -89,7 +98,9 @@ export class SnapshotService {
     }
 
     try {
-      const { stdout } = await this.gitExecutor.exec(args, { timeout: 10_000 });
+      const { stdout } = await this.gitExecutor.exec(args, {
+        timeout: RealGitExecutor.DEFAULT_TIMEOUT,
+      });
       const result = stdout.trim();
 
       if (maxLines) {
@@ -104,9 +115,12 @@ export class SnapshotService {
 
   /** Validate that a git ref still exists (not garbage collected). */
   async validateRef(cwd: string, ref: string): Promise<boolean> {
+    if (!ref || ref.startsWith("-")) {
+      return false;
+    }
     try {
       await this.gitExecutor.exec(["-C", cwd, "cat-file", "-t", ref], {
-        timeout: 10_000,
+        timeout: RealGitExecutor.DEFAULT_TIMEOUT,
       });
       return true;
     } catch {
@@ -125,7 +139,7 @@ export class SnapshotService {
     try {
       const { stdout } = await this.gitExecutor.exec(
         ["-C", cwd, "diff", "--numstat", "--find-renames", refBefore, refAfter],
-        { timeout: 10_000 },
+        { timeout: RealGitExecutor.DEFAULT_TIMEOUT },
       );
 
       return stdout

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -66,7 +66,7 @@ export class ThreadService {
         // the 100-character limit enforced by validateWorktreeName.
         const sanitized = sanitizeBranchForFolder(branch).slice(0, 91);
         const worktreeName = `${sanitized}-${shortId}`;
-        const info = this.gitService.createWorktree(
+        const info = await this.gitService.createWorktree(
           workspace.path,
           worktreeName,
           branch,

--- a/apps/server/src/services/workspace-service.ts
+++ b/apps/server/src/services/workspace-service.ts
@@ -3,7 +3,6 @@
  * Orchestrates two-phase workspace deletion: soft-delete + async cleanup.
  */
 
-import { execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
 import { injectable, inject } from "tsyringe";
@@ -14,6 +13,7 @@ import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { AttachmentService } from "./attachment-service";
 import { AgentService } from "./agent-service.js";
 import { logger } from "@mcode/shared";
+import type { GitExecutor } from "./git-executor/index.js";
 
 /** Handles workspace creation, listing, and two-phase deletion. */
 @injectable()
@@ -24,6 +24,7 @@ export class WorkspaceService {
     @inject(CleanupJobRepo) private readonly cleanupJobRepo: CleanupJobRepo,
     @inject(AttachmentService) private readonly attachmentService: AttachmentService,
     @inject(AgentService) private readonly agentService: AgentService,
+    @inject("GitExecutor") private readonly gitExecutor: GitExecutor,
   ) {}
 
   /**
@@ -33,7 +34,7 @@ export class WorkspaceService {
    * remain), it is evicted automatically. If cleanup is still in progress, force-deletes
    * the stale workspace so the user can re-add immediately.
    */
-  create(name: string, path: string): Workspace {
+  async create(name: string, path: string): Promise<Workspace> {
     const existing = this.workspaceRepo.findByPath(path);
     if (existing) {
       this.workspaceRepo.touch(existing.id);
@@ -49,7 +50,7 @@ export class WorkspaceService {
       this.forceDelete(stale.id);
     }
 
-    const isGitRepo = this.detectGitRepo(path);
+    const isGitRepo = await this.detectGitRepo(path);
     return this.workspaceRepo.create(name, path, isGitRepo);
   }
 
@@ -184,12 +185,9 @@ export class WorkspaceService {
   }
 
   /** Check whether a filesystem path is inside a git repository. */
-  private detectGitRepo(path: string): boolean {
+  private async detectGitRepo(path: string): Promise<boolean> {
     try {
-      execFileSync("git", ["-C", path, "rev-parse", "--git-dir"], {
-        stdio: "pipe",
-        windowsHide: true,
-      });
+      await this.gitExecutor.exec(["-C", path, "rev-parse", "--git-dir"]);
       return true;
     } catch {
       // Fall back to filesystem check when git is unavailable or fails to run

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -263,7 +263,7 @@ async function dispatch(
     case "workspace.list":
       return deps.workspaceService.list();
     case "workspace.create": {
-      const workspace = deps.workspaceService.create(params.name, params.path);
+      const workspace = await deps.workspaceService.create(params.name, params.path);
       try {
         deps.gitWatcherService.watchWorkspace(workspace.id, workspace.path);
       } catch (err) {
@@ -424,7 +424,7 @@ async function dispatch(
     case "git.checkout": {
       const ws = deps.workspaceService.findById(params.workspaceId);
       if (!ws?.is_git_repo) return;
-      deps.gitService.checkout(params.workspaceId, params.branch);
+      await deps.gitService.checkout(params.workspaceId, params.branch);
       return;
     }
     case "git.listWorktrees": {
@@ -435,7 +435,7 @@ async function dispatch(
     case "git.fetchBranch": {
       const ws = deps.workspaceService.findById(params.workspaceId);
       if (!ws?.is_git_repo) return;
-      deps.gitService.fetchBranch(
+      await deps.gitService.fetchBranch(
         params.workspaceId,
         params.branch,
         params.prNumber,

--- a/apps/web/e2e/composer-draft-thread-switch.spec.ts
+++ b/apps/web/e2e/composer-draft-thread-switch.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, type Page } from "@playwright/test";
+import { getDefaultSettings } from "@mcode/contracts";
+import {
+  interceptZustandStores,
+  mockWebSocketServer,
+} from "./helpers/e2e-helpers";
+
+const now = new Date().toISOString();
+
+const workspace = {
+  id: "ws-draft-test",
+  name: "Draft Test",
+  path: "/test/path",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+const threadA = {
+  id: "thread-a",
+  workspace_id: workspace.id,
+  title: "Thread A",
+  status: "paused" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  worktree_managed: false,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-sonnet-4-6",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const threadB = { ...threadA, id: "thread-b", title: "Thread B" };
+
+/** Seed the workspace store with two threads and open the chat view. */
+async function setupDraftSwitchChat(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ ws, threads }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stores: any[] = (window as any).__mcodeStores ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wsStore = stores.find((s: any) => {
+        const st = s.getState();
+        return "activeThreadId" in st && "threads" in st && "workspaces" in st;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({
+        workspaces: [ws],
+        threads,
+        activeWorkspaceId: ws.id,
+        activeThreadId: threads[0]?.id ?? null,
+        loading: false,
+        error: null,
+      });
+    },
+    { ws: workspace, threads: [threadA, threadB] },
+  );
+}
+
+/** Boot the app with two threads and an empty conversation for draft switching. */
+async function openDraftSwitchChat(page: Page): Promise<void> {
+  await page.addInitScript((wsId: string) => {
+    localStorage.setItem(
+      "mcode-expanded-projects",
+      JSON.stringify({ [wsId]: true }),
+    );
+  }, workspace.id);
+
+  await mockWebSocketServer(page, {
+    "workspace.enrich": { items: [] },
+    "workspace.list": [workspace],
+    "thread.list": [threadA, threadB],
+    "conversation.page": {
+      messages: [],
+      hasMore: false,
+      answeredPlanMessageIds: [],
+      narrativeByMessage: {},
+    },
+    "settings.get": getDefaultSettings(),
+    "provider.listModels": () => [
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", group: "Claude" },
+    ],
+  });
+  await interceptZustandStores(page);
+
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await page.waitForFunction(
+    () =>
+      (window as unknown as { __mcodeHydrationComplete?: boolean })
+        .__mcodeHydrationComplete === true,
+  );
+  await setupDraftSwitchChat(page);
+  await page.waitForSelector('[contenteditable="true"]', { timeout: 30_000 });
+}
+
+test.describe("composer draft thread switch", () => {
+  test.beforeEach(async ({ page }) => {
+    await openDraftSwitchChat(page);
+  });
+
+  test("restores per-thread draft text after switching away and back", async ({ page }) => {
+    const editor = page.locator('[contenteditable="true"]').last();
+    await editor.click();
+    await editor.fill("draft for thread A");
+
+    await page
+      .locator('[data-testid="thread-item"][data-thread-id="thread-b"]')
+      .click();
+    await editor.click();
+    await editor.fill("draft for thread B");
+    await expect(editor).toHaveText("draft for thread B");
+
+    await page
+      .locator('[data-testid="thread-item"][data-thread-id="thread-a"]')
+      .click();
+    await expect(editor).toHaveText("draft for thread A");
+  });
+});

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { GitFork, Loader2 } from "lucide-react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import {
+  useActiveWorkspaceThread,
+  useInterruptedThreadIds,
+  useParentThreadExists,
+} from "@/stores/workspace-selectors";
 import { useThreadStore } from "@/stores/threadStore";
 import { useActiveThreadRecord, readThreadRecord } from "@/stores/thread-selectors";
 import { useConnectionStore } from "@/stores/connectionStore";
@@ -101,7 +106,7 @@ function ThreadPreparingShell({
   const statusLabel = thread.clientPreparingContext
     ? preparingStatusLabel(thread.clientPreparingContext)
     : "Preparing…";
-  const threads = useWorkspaceStore((s) => s.threads);
+  const parentThreadExists = useParentThreadExists(thread.parent_thread_id);
 
   return (
     <div className="flex h-full flex-col bg-background" data-testid="thread-preparing-shell">
@@ -120,7 +125,7 @@ function ThreadPreparingShell({
           {activeWorkspaceId && (
             <Badge variant="secondary">{workspaceName}</Badge>
           )}
-          {thread.parent_thread_id && threads.some((t) => t.id === thread.parent_thread_id) && (
+          {thread.parent_thread_id && parentThreadExists && (
             <Tooltip>
               <TooltipTrigger
                 render={
@@ -170,7 +175,6 @@ export function ChatView() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const pendingNewThread = useWorkspaceStore((s) => s.pendingNewThread);
-  const threads = useWorkspaceStore((s) => s.threads);
   const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
   const updateThreadTitle = useWorkspaceStore((s) => s.updateThreadTitle);
   const setActiveThread = useWorkspaceStore((s) => s.setActiveThread);
@@ -188,7 +192,9 @@ export function ChatView() {
   const isAgentRunning = activeThreadId ? runningThreadIds.has(activeThreadId) : false;
 
   const workspaces = useWorkspaceStore((s) => s.workspaces);
-  const activeThread = threads.find((t) => t.id === activeThreadId);
+  const activeThread = useActiveWorkspaceThread((t) => t);
+  const parentThreadExists = useParentThreadExists(activeThread?.parent_thread_id);
+  const interruptedCandidates = useInterruptedThreadIds();
   const sessionError = useActiveThreadRecord((r) => r.error);
   const [dismissedError, setDismissedError] = useState<string | null>(null);
   const [interruptedThreadIds, setInterruptedThreadIds] = useState<string[]>([]);
@@ -226,17 +232,17 @@ export function ChatView() {
   // Always update so the banner clears when threads recover on their own.
   useEffect(() => {
     if (connectionStatus === "connected" && !bannerDismissed) {
-      const interrupted = threads
-        .filter((t) => t.status === "interrupted")
-        .map((t) => t.id);
-      // Use a functional update and bail out when content is identical to
-      // avoid a new array reference (and re-render) on every streaming token.
       setInterruptedThreadIds((prev) => {
-        if (prev.length === interrupted.length && prev.every((id, i) => id === interrupted[i])) return prev;
-        return interrupted;
+        if (
+          prev.length === interruptedCandidates.length &&
+          prev.every((id, i) => id === interruptedCandidates[i])
+        ) {
+          return prev;
+        }
+        return interruptedCandidates;
       });
     }
-  }, [connectionStatus, threads, bannerDismissed]);
+  }, [connectionStatus, interruptedCandidates, bannerDismissed]);
 
   /** Sends a continuation message to each interrupted thread, then hides the banner. */
   const handleResumeInterrupted = useCallback(
@@ -456,7 +462,7 @@ export function ChatView() {
           <Badge variant="secondary">
             {activeWorkspaceName}
           </Badge>
-          {activeThread.parent_thread_id && threads.some((t) => t.id === activeThread.parent_thread_id) && (
+          {activeThread.parent_thread_id && parentThreadExists && (
             <Tooltip>
               <TooltipTrigger
                 render={

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -3,6 +3,8 @@ import { useThreadStore, scheduleDrainAfterEdit, getHandoffStatus } from "@/stor
 import { useThreadRecord } from "@/stores/thread-selectors";
 import { getThreadRecord } from "@/stores/thread-record";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useWorkspaceThread } from "@/stores/workspace-selectors";
+import { resolveComposerSession, snapshotComposerDraft } from "@/lib/composer-session";
 import type { PermissionMode, InteractionMode, AttachmentMeta } from "@/transport";
 import { PERMISSION_MODES, INTERACTION_MODES, getTransport } from "@/transport";
 import {
@@ -30,7 +32,7 @@ import { cn } from "@/lib/utils";
 import { isWindows } from "@/lib/platform";
 import { isCursorPermissionLockedToFull } from "@/lib/cursor-permission";
 import { isGoalControlCommand } from "@/lib/goal-command";
-import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, supportsUltrathink, supports1MContextWindow, supportsThinkingToggle, resolveThreadModelId, normalizeReasoningLevelForModel, getCodexReasoningLevels, providerSupportsReasoningLevels } from "@/lib/model-registry";
+import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, supportsUltrathink, supports1MContextWindow, supportsThinkingToggle, normalizeReasoningLevelForModel, getCodexReasoningLevels, providerSupportsReasoningLevels } from "@/lib/model-registry";
 import { ModelSelector } from "./ModelSelector";
 import { ModeSelector, ALL_MODE_OPTIONS } from "./ModeSelector";
 import type { ComposerMode, ModeOption } from "./ModeSelector";
@@ -806,7 +808,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     if (prev && prev !== threadId) {
       const threadStillExists = useWorkspaceStore.getState().threads.some((t) => t.id === prev);
       if (threadStillExists) {
-        saveDraft(prev, draftRef.current);
+        saveDraft(prev, snapshotComposerDraft(draftRef.current));
       } else {
         // Thread was deleted; revoke any attachment blob URLs from the outgoing draft
         for (const att of draftRef.current.attachments) {
@@ -817,112 +819,73 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       }
     }
 
-    // Restore draft for the thread we're entering
-    if (threadId) {
-      const saved = getDraft(threadId);
-      if (saved) {
-        setInput(saved.input);
-        setAttachments(saved.attachments);
-        setModelId(saved.modelId);
-        if (saved.provider) setProvider(saved.provider);
-        setReasoning(normalizeReasoningLevelForModel(saved.modelId, saved.reasoning));
-        // Restore Lexical editor content
-        if (editorRef.current) {
-          const editor = editorRef.current;
-          editor.update(() => {
-            const root = $getRoot();
-            root.clear();
-            if (saved.input) {
-              const para = $createParagraphNode();
-              para.append($createTextNode(saved.input));
-              root.append(para);
-            } else {
-              root.append($createParagraphNode());
-            }
-          });
-        }
-        // Restore mode, permission, and copilot agent from thread settings (drafts don't save these)
-        const threadSettings = useThreadStore.getState().getThreadSettings(threadId);
-        setMode(threadSettings.interactionMode);
-        setAccess(threadSettings.permissionMode);
-        setCopilotAgent(threadSettings.copilotAgent ?? null);
-        setContextWindow(threadSettings.contextWindow ?? null);
-        setThinking(threadSettings.thinking ?? null);
-        setCodexFastMode(
-          saved.codexFastMode !== undefined
-            ? saved.codexFastMode
-            : (threadSettings.codexFastMode ?? null),
-        );
-      } else {
-        // No saved draft: use thread's persisted settings as-is
-        setInput("");
-        setAttachments([]);
-        const nextThread = useWorkspaceStore.getState().threads.find((t) => t.id === threadId);
-        const resolvedModelId = resolveThreadModelId(nextThread?.model, getDefaultModelId());
-        setModelId(resolvedModelId);
-        setProvider((nextThread?.provider as string) ?? getDefaultProviderId());
-        setReasoning(normalizeReasoningLevelForModel(
-          resolvedModelId,
-          nextThread?.reasoning_level
-            ? (nextThread.reasoning_level as ReasoningLevel)
-            : getDefaultReasoningLevel(),
-        ));
+    const session = resolveComposerSession({
+      threadId,
+      getDraft,
+      threadRow: threadId
+        ? useWorkspaceStore.getState().threads.find((t) => t.id === threadId)
+        : undefined,
+      threadSettings: threadId
+        ? (() => {
+            const s = useThreadStore.getState().getThreadSettings(threadId);
+            return {
+              interactionMode: s.interactionMode,
+              permissionMode: s.permissionMode,
+              copilotAgent: s.copilotAgent ?? null,
+              contextWindow: s.contextWindow ?? null,
+              thinking: s.thinking ?? null,
+              codexFastMode: s.codexFastMode ?? null,
+            };
+          })()
+        : {
+            interactionMode: INTERACTION_MODES.BUILD,
+            permissionMode: PERMISSION_MODES.FULL,
+            copilotAgent: null,
+            contextWindow: null,
+            thinking: null,
+            codexFastMode: null,
+          },
+      globalDefaults: (() => {
+        const { settings } = useSettingsStore.getState();
+        return {
+          interactionMode:
+            settings.agent.defaults.mode === "plan"
+              ? INTERACTION_MODES.PLAN
+              : INTERACTION_MODES.BUILD,
+          permissionMode: settings.agent.defaults.permission,
+        };
+      })(),
+    });
 
-        // Restore mode and permission from thread record
-        const { settings: globalSettings } = useSettingsStore.getState();
-        setMode(
-          nextThread?.interaction_mode === "plan"
-            ? INTERACTION_MODES.PLAN
-            : nextThread?.interaction_mode === "build"
-              ? INTERACTION_MODES.BUILD
-              : globalSettings.agent.defaults.mode === "plan"
-                ? INTERACTION_MODES.PLAN
-                : INTERACTION_MODES.BUILD,
-        );
-        setAccess(
-          nextThread?.permission_mode
-            ? (nextThread.permission_mode as PermissionMode)
-            : globalSettings.agent.defaults.permission,
-        );
-        setCopilotAgent(nextThread?.copilot_agent ?? null);
-        setContextWindow((nextThread?.context_window_mode as ContextWindowMode | null | undefined) ?? null);
-        setThinking(nextThread?.thinking ?? null);
-        setCodexFastMode(nextThread?.codex_fast_mode ?? null);
+    setInput(session.input);
+    setAttachments(session.attachments);
+    setModelId(session.modelId);
+    setProvider(session.provider);
+    setReasoning(session.reasoning);
+    setMode(session.interactionMode);
+    setAccess(session.permissionMode);
+    setCopilotAgent(session.copilotAgent);
+    setContextWindow(session.contextWindow);
+    setThinking(session.thinking);
+    setCodexFastMode(session.codexFastMode);
 
-        // Reset Lexical editor
-        if (editorRef.current) {
-          editorRef.current.update(() => {
-            const root = $getRoot();
-            root.clear();
-            root.append($createParagraphNode());
-          });
-        }
-      }
-    } else {
-      // Entering "new thread" mode: ensure clean slate
-      setInput("");
-      setAttachments([]);
-      setModelId(getDefaultModelId());
-      setProvider(getDefaultProviderId());
-      setReasoning(normalizeReasoningLevelForModel(getDefaultModelId(), getDefaultReasoningLevel()));
-      // Reset mode/access to persisted defaults
-      agentSettingsTouchedRef.current = false;
-      const { settings } = useSettingsStore.getState();
-      setMode(settings.agent.defaults.mode === "plan" ? INTERACTION_MODES.PLAN : INTERACTION_MODES.BUILD);
-      setAccess(settings.agent.defaults.permission);
-      setCopilotAgent(null);
-      setContextWindow(null);
-      setThinking(null);
-      setCodexFastMode(null);
-      if (editorRef.current) {
-        editorRef.current.update(() => {
-          const root = $getRoot();
-          root.clear();
+    if (editorRef.current) {
+      editorRef.current.update(() => {
+        const root = $getRoot();
+        root.clear();
+        if (session.input) {
+          const para = $createParagraphNode();
+          para.append($createTextNode(session.input));
+          root.append(para);
+        } else {
           root.append($createParagraphNode());
-        });
-      }
+        }
+      });
+    }
+
+    if (!threadId) {
+      agentSettingsTouchedRef.current = false;
       if (isNewThread) {
-        // Focus after the palette closes and Lexical has applied the empty root.
         queueMicrotask(() => {
           editorRef.current?.focus();
         });
@@ -934,9 +897,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   }, [threadId, isNewThread, saveDraft, getDraft]);
 
   const persistedInteractionMode = useThreadRecord(threadId, (r) => r.settings.interactionMode);
-  const threadRecordInteractionMode = useWorkspaceStore((s) => {
-    if (!threadId) return undefined;
-    const mode = s.threads.find((t) => t.id === threadId)?.interaction_mode;
+  const threadRecordInteractionMode = useWorkspaceThread(threadId, (t) => {
+    const mode = t?.interaction_mode;
     return mode === "plan" || mode === "build" ? mode : undefined;
   });
 
@@ -1096,8 +1058,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const workspacePath = workspaces.find((w) => w.id === workspaceId)?.path;
 
-  const threads = useWorkspaceStore((s) => s.threads);
-  const activeThread = threadId ? threads.find((t) => t.id === threadId) : undefined;
+  const activeThread = useWorkspaceThread(threadId, (t) => t);
   const isThreadScaffold = !!(
     activeThread?.clientPreparing || activeThread?.clientError
   );

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -3,7 +3,7 @@ import { useThreadStore, scheduleDrainAfterEdit, getHandoffStatus } from "@/stor
 import { useThreadRecord } from "@/stores/thread-selectors";
 import { getThreadRecord } from "@/stores/thread-record";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useWorkspaceThread } from "@/stores/workspace-selectors";
+import { useWorkspaceThread, readWorkspaceThread } from "@/stores/workspace-selectors";
 import { resolveComposerSession, snapshotComposerDraft } from "@/lib/composer-session";
 import type { PermissionMode, InteractionMode, AttachmentMeta } from "@/transport";
 import { PERMISSION_MODES, INTERACTION_MODES, getTransport } from "@/transport";
@@ -822,9 +822,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     const session = resolveComposerSession({
       threadId,
       getDraft,
-      threadRow: threadId
-        ? useWorkspaceStore.getState().threads.find((t) => t.id === threadId)
-        : undefined,
+      threadRow: threadId ? readWorkspaceThread(threadId) : undefined,
       threadSettings: threadId
         ? (() => {
             const s = useThreadStore.getState().getThreadSettings(threadId);

--- a/apps/web/src/lib/composer-session/index.test.ts
+++ b/apps/web/src/lib/composer-session/index.test.ts
@@ -85,7 +85,7 @@ describe("resolveComposerSession", () => {
 });
 
 describe("snapshotComposerDraft", () => {
-  it("copies attachments without sharing the array reference", () => {
+  it("copies attachments without sharing array or object references", () => {
     const draft: ComposerDraft = {
       input: "x",
       attachments: [{
@@ -101,6 +101,7 @@ describe("snapshotComposerDraft", () => {
     };
     const snap = snapshotComposerDraft(draft);
     expect(snap.attachments).not.toBe(draft.attachments);
+    expect(snap.attachments[0]).not.toBe(draft.attachments[0]);
     expect(snap.attachments).toEqual(draft.attachments);
   });
 });

--- a/apps/web/src/lib/composer-session/index.test.ts
+++ b/apps/web/src/lib/composer-session/index.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { PERMISSION_MODES, INTERACTION_MODES } from "@/transport";
+import type { ComposerDraft } from "@/stores/composerDraftStore";
+import { resolveComposerSession, snapshotComposerDraft } from "./index";
+
+const globalDefaults = {
+  interactionMode: INTERACTION_MODES.BUILD,
+  permissionMode: PERMISSION_MODES.FULL,
+};
+
+const threadSettings = {
+  interactionMode: INTERACTION_MODES.PLAN,
+  permissionMode: PERMISSION_MODES.SUPERVISED,
+  copilotAgent: "code-review",
+  contextWindow: "1m" as const,
+  thinking: true,
+  codexFastMode: false,
+};
+
+describe("resolveComposerSession", () => {
+  it("returns global defaults for new-thread mode", () => {
+    const session = resolveComposerSession({
+      threadId: undefined,
+      getDraft: () => undefined,
+      threadRow: undefined,
+      threadSettings,
+      globalDefaults,
+    });
+
+    expect(session.input).toBe("");
+    expect(session.attachments).toEqual([]);
+    expect(session.interactionMode).toBe(INTERACTION_MODES.BUILD);
+    expect(session.permissionMode).toBe(PERMISSION_MODES.FULL);
+    expect(session.copilotAgent).toBeNull();
+  });
+
+  it("restores a saved draft with thread settings for mode fields", () => {
+    const draft: ComposerDraft = {
+      input: "hello draft",
+      attachments: [],
+      modelId: "claude-sonnet-4-20250514",
+      provider: "claude",
+      reasoning: "medium",
+      codexFastMode: true,
+    };
+
+    const session = resolveComposerSession({
+      threadId: "thread-a",
+      getDraft: (id) => (id === "thread-a" ? draft : undefined),
+      threadRow: undefined,
+      threadSettings,
+      globalDefaults,
+    });
+
+    expect(session.input).toBe("hello draft");
+    expect(session.modelId).toBe("claude-sonnet-4-20250514");
+    expect(session.interactionMode).toBe(INTERACTION_MODES.PLAN);
+    expect(session.codexFastMode).toBe(true);
+  });
+
+  it("uses thread row defaults when no draft exists", () => {
+    const session = resolveComposerSession({
+      threadId: "thread-b",
+      getDraft: () => undefined,
+      threadRow: {
+        id: "thread-b",
+        model: "gpt-4.1",
+        provider: "openai",
+        reasoning_level: "high",
+        interaction_mode: "build",
+        permission_mode: "full",
+        copilot_agent: null,
+        context_window_mode: null,
+        thinking: null,
+        codex_fast_mode: null,
+      } as never,
+      threadSettings,
+      globalDefaults,
+    });
+
+    expect(session.input).toBe("");
+    expect(session.provider).toBe("openai");
+    expect(session.interactionMode).toBe(INTERACTION_MODES.BUILD);
+  });
+});
+
+describe("snapshotComposerDraft", () => {
+  it("copies attachments without sharing the array reference", () => {
+    const draft: ComposerDraft = {
+      input: "x",
+      attachments: [{
+        id: "a1",
+        name: "f.txt",
+        mimeType: "text/plain",
+        sizeBytes: 1,
+        previewUrl: "",
+        filePath: null,
+      }],
+      modelId: "m",
+      reasoning: "none",
+    };
+    const snap = snapshotComposerDraft(draft);
+    expect(snap.attachments).not.toBe(draft.attachments);
+    expect(snap.attachments).toEqual(draft.attachments);
+  });
+});

--- a/apps/web/src/lib/composer-session/index.ts
+++ b/apps/web/src/lib/composer-session/index.ts
@@ -1,0 +1,146 @@
+import type { PendingAttachment } from "@/components/chat/AttachmentPreview";
+import type { ComposerDraft } from "@/stores/composerDraftStore";
+import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
+import type { PermissionMode } from "@/transport";
+import { INTERACTION_MODES, type InteractionMode } from "@/transport";
+import type { WorkspaceThread } from "@/lib/workspace-thread";
+import {
+  getDefaultModelId,
+  getDefaultProviderId,
+  getDefaultReasoningLevel,
+  normalizeReasoningLevelForModel,
+  resolveThreadModelId,
+} from "@/lib/model-registry";
+
+/** Full per-thread composer state restored as one value on thread switch. */
+export interface ComposerSession {
+  input: string;
+  attachments: PendingAttachment[];
+  modelId: string;
+  provider: string;
+  reasoning: ReasoningLevel;
+  interactionMode: InteractionMode;
+  permissionMode: PermissionMode;
+  copilotAgent: string | null;
+  contextWindow: ContextWindowMode | null;
+  thinking: boolean | null;
+  codexFastMode: boolean | null;
+}
+
+/** Inputs for resolving a thread's composer session without React. */
+export interface ResolveComposerSessionInput {
+  threadId: string | undefined;
+  getDraft: (threadId: string) => ComposerDraft | undefined;
+  threadRow: WorkspaceThread | undefined;
+  threadSettings: {
+    interactionMode: InteractionMode;
+    permissionMode: PermissionMode;
+    copilotAgent: string | null;
+    contextWindow: ContextWindowMode | null;
+    thinking: boolean | null;
+    codexFastMode: boolean | null;
+  };
+  globalDefaults: {
+    interactionMode: InteractionMode;
+    permissionMode: PermissionMode;
+  };
+}
+
+/** Snapshot the outgoing thread draft for persistence. */
+export function snapshotComposerDraft(draft: ComposerDraft): ComposerDraft {
+  return { ...draft, attachments: [...draft.attachments] };
+}
+
+/**
+ * Resolve the composer session to install when entering a thread (or new-thread mode).
+ * Pure function: no DOM, no store writes.
+ */
+export function resolveComposerSession(input: ResolveComposerSessionInput): ComposerSession {
+  const { threadId, getDraft, threadRow, threadSettings, globalDefaults } = input;
+
+  if (!threadId) {
+    const modelId = getDefaultModelId();
+    return {
+      input: "",
+      attachments: [],
+      modelId,
+      provider: getDefaultProviderId(),
+      reasoning: normalizeReasoningLevelForModel(modelId, getDefaultReasoningLevel()),
+      interactionMode:
+        globalDefaults.interactionMode === INTERACTION_MODES.PLAN
+          ? INTERACTION_MODES.PLAN
+          : INTERACTION_MODES.BUILD,
+      permissionMode: globalDefaults.permissionMode,
+      copilotAgent: null,
+      contextWindow: null,
+      thinking: null,
+      codexFastMode: null,
+    };
+  }
+
+  const saved = getDraft(threadId);
+  if (saved) {
+    return {
+      input: saved.input,
+      attachments: saved.attachments,
+      modelId: saved.modelId,
+      provider: saved.provider ?? getDefaultProviderId(),
+      reasoning: normalizeReasoningLevelForModel(saved.modelId, saved.reasoning),
+      interactionMode: threadSettings.interactionMode,
+      permissionMode: threadSettings.permissionMode,
+      copilotAgent: threadSettings.copilotAgent,
+      contextWindow: threadSettings.contextWindow,
+      thinking: threadSettings.thinking,
+      codexFastMode:
+        saved.codexFastMode !== undefined
+          ? saved.codexFastMode
+          : threadSettings.codexFastMode,
+    };
+  }
+
+  const resolvedModelId = resolveThreadModelId(threadRow?.model, getDefaultModelId());
+  return {
+    input: "",
+    attachments: [],
+    modelId: resolvedModelId,
+    provider: (threadRow?.provider as string | undefined) ?? getDefaultProviderId(),
+    reasoning: normalizeReasoningLevelForModel(
+      resolvedModelId,
+      threadRow?.reasoning_level
+        ? (threadRow.reasoning_level as ReasoningLevel)
+        : getDefaultReasoningLevel(),
+    ),
+    interactionMode:
+      threadRow?.interaction_mode === "plan"
+        ? INTERACTION_MODES.PLAN
+        : threadRow?.interaction_mode === "build"
+          ? INTERACTION_MODES.BUILD
+          : globalDefaults.interactionMode === INTERACTION_MODES.PLAN
+            ? INTERACTION_MODES.PLAN
+            : INTERACTION_MODES.BUILD,
+    permissionMode:
+      (threadRow?.permission_mode as PermissionMode | null | undefined) ??
+      globalDefaults.permissionMode,
+    copilotAgent: threadRow?.copilot_agent ?? null,
+    contextWindow: (threadRow?.context_window_mode as ContextWindowMode | null | undefined) ?? null,
+    thinking: threadRow?.thinking ?? null,
+    codexFastMode: threadRow?.codex_fast_mode ?? null,
+  };
+}
+
+/** Convert live composer draft state into a {@link ComposerSession}. */
+export function composerSessionFromDraft(
+  draft: ComposerDraft,
+  threadSettings: ResolveComposerSessionInput["threadSettings"],
+): ComposerSession {
+  return resolveComposerSession({
+    threadId: "snapshot",
+    getDraft: () => draft,
+    threadRow: undefined,
+    threadSettings,
+    globalDefaults: {
+      interactionMode: threadSettings.interactionMode,
+      permissionMode: threadSettings.permissionMode,
+    },
+  });
+}

--- a/apps/web/src/lib/composer-session/index.ts
+++ b/apps/web/src/lib/composer-session/index.ts
@@ -48,7 +48,10 @@ export interface ResolveComposerSessionInput {
 
 /** Snapshot the outgoing thread draft for persistence. */
 export function snapshotComposerDraft(draft: ComposerDraft): ComposerDraft {
-  return { ...draft, attachments: [...draft.attachments] };
+  return {
+    ...draft,
+    attachments: draft.attachments.map((attachment) => ({ ...attachment })),
+  };
 }
 
 /**
@@ -82,7 +85,7 @@ export function resolveComposerSession(input: ResolveComposerSessionInput): Comp
   if (saved) {
     return {
       input: saved.input,
-      attachments: saved.attachments,
+      attachments: saved.attachments.map((attachment) => ({ ...attachment })),
       modelId: saved.modelId,
       provider: saved.provider ?? getDefaultProviderId(),
       reasoning: normalizeReasoningLevelForModel(saved.modelId, saved.reasoning),
@@ -126,21 +129,4 @@ export function resolveComposerSession(input: ResolveComposerSessionInput): Comp
     thinking: threadRow?.thinking ?? null,
     codexFastMode: threadRow?.codex_fast_mode ?? null,
   };
-}
-
-/** Convert live composer draft state into a {@link ComposerSession}. */
-export function composerSessionFromDraft(
-  draft: ComposerDraft,
-  threadSettings: ResolveComposerSessionInput["threadSettings"],
-): ComposerSession {
-  return resolveComposerSession({
-    threadId: "snapshot",
-    getDraft: () => draft,
-    threadRow: undefined,
-    threadSettings,
-    globalDefaults: {
-      interactionMode: threadSettings.interactionMode,
-      permissionMode: threadSettings.permissionMode,
-    },
-  });
 }

--- a/apps/web/src/stores/__tests__/workspace-selectors.render.test.tsx
+++ b/apps/web/src/stores/__tests__/workspace-selectors.render.test.tsx
@@ -1,0 +1,72 @@
+import { Profiler, type ProfilerOnRenderCallback } from "react";
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { useWorkspaceThread } from "@/stores/workspace-selectors";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import type { WorkspaceThread } from "@/lib/workspace-thread";
+
+function thread(id: string, title: string, status: WorkspaceThread["status"] = "paused"): WorkspaceThread {
+  return { id, title, status } as WorkspaceThread;
+}
+
+function ThreadTitleProbe({ threadId }: { threadId: string }) {
+  const title = useWorkspaceThread(threadId, (t) => t?.title);
+  return <span data-testid="title">{title}</span>;
+}
+
+describe("useWorkspaceThread render isolation", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({
+      threads: [thread("thread-a", "Thread A"), thread("thread-b", "Thread B")],
+      activeThreadId: "thread-a",
+    });
+  });
+
+  it("does not re-render when an unrelated thread row updates", () => {
+    const renderCounts = new Map<string, number>();
+    const onRender: ProfilerOnRenderCallback = (_id, _phase, _actualDuration, _baseDuration, _startTime, _commitTime) => {
+      renderCounts.set("probe", (renderCounts.get("probe") ?? 0) + 1);
+    };
+
+    render(
+      <Profiler id="probe" onRender={onRender}>
+        <ThreadTitleProbe threadId="thread-a" />
+      </Profiler>,
+    );
+
+    expect(renderCounts.get("probe")).toBe(1);
+
+    act(() => {
+      useWorkspaceStore.setState((state) => ({
+        threads: state.threads.map((row) =>
+          row.id === "thread-b" ? { ...row, title: "Thread B updated" } : row,
+        ),
+      }));
+    });
+
+    expect(renderCounts.get("probe")).toBe(1);
+  });
+
+  it("re-renders when the subscribed thread row changes", () => {
+    const renderCounts = new Map<string, number>();
+    const onRender: ProfilerOnRenderCallback = () => {
+      renderCounts.set("probe", (renderCounts.get("probe") ?? 0) + 1);
+    };
+
+    render(
+      <Profiler id="probe" onRender={onRender}>
+        <ThreadTitleProbe threadId="thread-a" />
+      </Profiler>,
+    );
+
+    act(() => {
+      useWorkspaceStore.setState((state) => ({
+        threads: state.threads.map((row) =>
+          row.id === "thread-a" ? { ...row, title: "Thread A updated" } : row,
+        ),
+      }));
+    });
+
+    expect(renderCounts.get("probe")).toBe(2);
+  });
+});

--- a/apps/web/src/stores/__tests__/workspace-selectors.test.ts
+++ b/apps/web/src/stores/__tests__/workspace-selectors.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { getWorkspaceThread } from "@/stores/workspace-selectors";
+import type { WorkspaceThread } from "@/lib/workspace-thread";
+
+function thread(id: string, title: string): WorkspaceThread {
+  return { id, title } as WorkspaceThread;
+}
+
+describe("getWorkspaceThread", () => {
+  it("returns one row without scanning unrelated updates", () => {
+    const threads = [thread("a", "A"), thread("b", "B")];
+    expect(getWorkspaceThread(threads, "b")?.title).toBe("B");
+  });
+
+  it("returns undefined for missing ids", () => {
+    expect(getWorkspaceThread([thread("a", "A")], "missing")).toBeUndefined();
+  });
+});

--- a/apps/web/src/stores/workspace-selectors.ts
+++ b/apps/web/src/stores/workspace-selectors.ts
@@ -1,0 +1,66 @@
+import { useShallow } from "zustand/shallow";
+import { useWorkspaceStore } from "./workspaceStore";
+import type { WorkspaceThread } from "@/lib/workspace-thread";
+
+/** Resolve one thread row from the workspace store threads list. */
+export function getWorkspaceThread(
+  threads: WorkspaceThread[],
+  threadId: string | null | undefined,
+): WorkspaceThread | undefined {
+  if (!threadId) return undefined;
+  return threads.find((t) => t.id === threadId);
+}
+
+/**
+ * Subscribe to one workspace thread row with shallow equality on the selected slice.
+ * Re-renders only when the selected slice for this thread changes, not when other
+ * threads update.
+ */
+export function useWorkspaceThread<T>(
+  threadId: string | null | undefined,
+  selector: (thread: WorkspaceThread | undefined) => T,
+): T {
+  return useWorkspaceStore(
+    useShallow((state) => {
+      const thread = getWorkspaceThread(state.threads, threadId);
+      return selector(thread);
+    }),
+  );
+}
+
+/**
+ * Subscribe to the active workspace thread row with shallow equality on the selected slice.
+ */
+export function useActiveWorkspaceThread<T>(
+  selector: (thread: WorkspaceThread | undefined) => T,
+): T {
+  return useWorkspaceStore(
+    useShallow((state) => {
+      const thread = getWorkspaceThread(state.threads, state.activeThreadId);
+      return selector(thread);
+    }),
+  );
+}
+
+/** Imperative read of one workspace thread row without subscribing. */
+export function readWorkspaceThread(threadId: string): WorkspaceThread | undefined {
+  return getWorkspaceThread(useWorkspaceStore.getState().threads, threadId);
+}
+
+/** IDs of threads whose server status is interrupted. */
+export function useInterruptedThreadIds(): string[] {
+  return useWorkspaceStore(
+    useShallow((state) =>
+      state.threads.filter((t) => t.status === "interrupted").map((t) => t.id),
+    ),
+  );
+}
+
+/** Whether a parent thread row still exists in the sidebar list. */
+export function useParentThreadExists(parentThreadId: string | null | undefined): boolean {
+  return useWorkspaceStore(
+    useShallow((state) =>
+      parentThreadId ? state.threads.some((t) => t.id === parentThreadId) : false,
+    ),
+  );
+}

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -300,7 +300,7 @@ export const WS_METHODS = lazySchema(() => ({
     result: z.string().nullable(),
   },
   "git.checkout": {
-    params: z.object({ workspaceId: z.string(), branch: z.string() }),
+    params: z.object({ workspaceId: z.string(), branch: GitRefSchema }),
     result: z.void(),
   },
   "git.listWorktrees": {
@@ -318,8 +318,8 @@ export const WS_METHODS = lazySchema(() => ({
   "git.log": {
     params: z.object({
       workspaceId: z.string(),
-      branch: z.string().optional(),
-      baseBranch: z.string().optional(),
+      branch: GitRefSchema.optional(),
+      baseBranch: GitRefSchema.optional(),
       limit: z.number().int().min(1).max(500).optional(),
       skip: z.number().int().min(0).optional(),
       includeStats: z.boolean().optional(),
@@ -513,7 +513,7 @@ export const WS_METHODS = lazySchema(() => ({
   "git.push": {
     params: z.object({
       workspaceId: z.string(),
-      branch: z.string(),
+      branch: GitRefSchema,
     }),
     result: z.object({ success: z.boolean() }),
   },


### PR DESCRIPTION
## What
Track 3 of epic #649: async git execution, clean-tree snapshot fast path, narrow thread selectors, and composer session restore on thread switch.

## Why
Sync git spawns blocked the server event loop. Full-thread subscriptions caused Composer re-renders during background streaming. Snapshot capture always built a temp index even on clean trees. Composer thread switches scattered draft state across effects.

## Key Changes
- Add GitExecutor with per-repo queue, rev-parse cache, and async git-service migration (#659)
- Skip temp index when status is clean; use HEAD tree ref (#660)
- Add useWorkspaceThread selectors; narrow ChatView and Composer subscriptions (#654)
- Add composer-session module with snapshot/restore and Playwright E2E (#655)
- Update git-service and workspace-repo tests for injected GitExecutor

Closes #654
Closes #655
Closes #659
Closes #660
Related to #649

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784048584&installation_id=129163861&pr_number=736&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F736&signature=b344f03516505f73465bc619252beff88abd897be711342f708708286faf68ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer drafts are now remembered per thread, so switching threads restores the correct unsaved content.
* **Improvements**
  * Improved Git reliability across startup and threaded workflows; Git-related operations now complete predictably, including worktree/HEAD change handling and safer ref handling.
  * Snapshot/diff capture now runs through a consistent Git execution path with better command-timeout behavior and ref validation.
* **Tests**
  * Added an end-to-end test for composer draft persistence across thread switching.
  * Refactored Git-related tests for stronger isolation and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->