### PR TITLE
chore: widen PR CI to all workspace packages via root turbo commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,45 +17,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  lint-desktop:
-    name: Lint Desktop
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.2.14"
-      - run: bun install --frozen-lockfile
-      - run: bun run --cwd apps/desktop typecheck
-
-  lint-frontend:
-    name: Lint Frontend
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.2.14"
-      - run: bun install --frozen-lockfile
-      - run: bun run --cwd apps/web lint
-      - run: bun run --cwd apps/web typecheck
-
-  test-frontend:
-    name: Test Frontend
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.2.14"
-      - run: bun install --frozen-lockfile
-      - run: bun run --cwd apps/web test
-
-  test-server:
-    name: Test Server
+  typecheck:
+    name: Typecheck
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
-      # Server tests run under Node/vitest; skip Electron binary download and
+      # Typecheck reads Electron's bundled types, not its binary; skip the binary
+      # download and better-sqlite3 Electron prebuild so bun install does not flake
+      # on 504s.
+      SKIP_ELECTRON_REBUILD: "1"
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.14"
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+
+  lint:
+    name: Lint
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      # Lint runs ESLint under Node, not Electron; skip the binary download and
       # better-sqlite3 Electron prebuild so bun install does not flake on 504s.
       SKIP_ELECTRON_REBUILD: "1"
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
@@ -65,7 +48,24 @@ jobs:
         with:
           bun-version: "1.2.14"
       - run: bun install --frozen-lockfile
-      - run: bun run --cwd apps/server test
+      - run: bun run lint
+
+  test:
+    name: Test
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      # Unit tests run under Node/vitest with Electron fully mocked; skip the
+      # binary download and better-sqlite3 Electron prebuild so bun install does
+      # not flake on 504s.
+      SKIP_ELECTRON_REBUILD: "1"
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.14"
+      - run: bun install --frozen-lockfile
+      - run: bun run test
 
   build-check:
     name: Build Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     env:
       # Typecheck reads Electron's bundled types, not its binary; skip the binary
       # download and better-sqlite3 Electron prebuild so bun install does not flake
@@ -28,6 +30,8 @@ jobs:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.14"
@@ -37,6 +41,8 @@ jobs:
   lint:
     name: Lint
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     env:
       # Lint runs ESLint under Node, not Electron; skip the binary download and
       # better-sqlite3 Electron prebuild so bun install does not flake on 504s.
@@ -44,6 +50,8 @@ jobs:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.14"
@@ -53,6 +61,8 @@ jobs:
   test:
     name: Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
     env:
       # Unit tests run under Node/vitest with Electron fully mocked; skip the
       # binary download and better-sqlite3 Electron prebuild so bun install does
@@ -61,6 +71,8 @@ jobs:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.14"

--- a/apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs
+++ b/apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs
@@ -39,15 +39,17 @@ describe("electronArchToNpm", () => {
 
 describe("resolvePackagedServerDir", () => {
   it("resolves Windows and Linux paths under resources/", () => {
+    // Resolve to a host-absolute appOutDir so the assertion holds on every OS:
+    // a bare "C:/..." is absolute on Windows but relative on POSIX, which would
+    // make resolve() prepend the cwd and diverge from join().
+    const appOutDir = path.resolve("/dist/win-unpacked");
     expect(
       resolvePackagedServerDir({
-        appOutDir: "C:/dist/win-unpacked",
+        appOutDir,
         electronPlatformName: "win32",
         productFilename: "Mcode",
       }),
-    ).toBe(
-      path.join("C:/dist/win-unpacked", "resources", "app.asar.unpacked", "dist", "server"),
-    );
+    ).toBe(path.join(appOutDir, "resources", "app.asar.unpacked", "dist", "server"));
   });
 
   it("resolves macOS paths under Contents/Resources/", () => {


### PR DESCRIPTION
## What
Replace the per-package `--cwd` verification jobs in PR CI with three root turbo jobs (`typecheck`, `lint`, `test`) so every workspace package is verified on every PR.

## Why
PR CI verified only a subset of the workspace: web lint/typecheck/test, server test, desktop typecheck. The tests and typechecks for `packages/contracts` and `packages/shared`, the server typecheck, and the desktop unit tests never ran in CI, even though the local `bun run verify` gate covers them all. The turbo task graph already fans these out, so the root commands close the gap.

## Key Changes
- Removed jobs `lint-desktop`, `lint-frontend`, `test-frontend`, `test-server`.
- Added jobs `typecheck` (`bun run typecheck`), `lint` (`bun run lint`), `test` (`bun run test`) - each runs the root turbo command across all 5 packages.
- Kept the Electron skip env vars (`SKIP_ELECTRON_REBUILD`, `ELECTRON_SKIP_BINARY_DOWNLOAD`) on all three new jobs: typecheck reads Electron's bundled types, lint runs under Node, and unit tests mock Electron, so none need the binary and skipping its download avoids `bun install` 504 flakes.
- `pr-title` and `build-check` are unchanged; `build-check` keeps the real install for the V8 snapshot and smoke test.
- Jobs stay parallel (no `needs:` chains), so wall clock is still bounded by the long-pole `build-check` job.

## Config Changes
None

Closes #663

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784104517&installation_id=129163861&pr_number=737&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F737&signature=d9d998f6a8f4d368521317d97bf77364c4bebba02c30aa5e450bab242d45931a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored the CI workflow to consolidate app-scoped checks into three repository-level jobs for type-checking, linting, and testing.
  * Improved CI reliability by adjusting the install step to skip flaky binary downloads during non-bundling runs.
* **Tests**
  * Updated the development bundle path test to use OS-consistent absolute paths, improving cross-platform reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->