### PR TITLE
fix(diff): render mermaid diagrams and fix half-diff syntax highlighting

### DIFF
--- a/apps/web/e2e/diff-preview-mermaid.spec.ts
+++ b/apps/web/e2e/diff-preview-mermaid.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { Thread, TurnSnapshot } from "@mcode/contracts";
+import { getDefaultSettings } from "@mcode/contracts";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+
+/**
+ * Regression for the diff-view mermaid bug: fenced ```mermaid blocks rendered
+ * as raw `<pre><code class="language-mermaid">` text inside the markdown diff
+ * preview instead of a diagram. This drives the real Changes -> Cumulative ->
+ * file -> Preview path so the genuine DiffPreview -> DiffPreviewMarkdown ->
+ * MermaidBlock pipeline (with the real mermaid library) executes in Chromium,
+ * and asserts a rendered <svg> stands in for the fence.
+ */
+
+const now = new Date().toISOString();
+
+const WORKSPACE = {
+  id: "ws-diff-mermaid",
+  name: "Diff Mermaid",
+  path: "/tmp/diff-mermaid",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+const THREAD: Thread = {
+  id: "thread-diff-mermaid",
+  workspace_id: WORKSPACE.id,
+  title: "Diff Mermaid Thread",
+  status: "paused",
+  mode: "direct",
+  worktree_path: null,
+  branch: "main",
+  worktree_managed: false,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const MD_FILE = "docs/schema.md";
+
+const SNAPSHOT: TurnSnapshot = {
+  id: "s1",
+  message_id: "m-s1",
+  thread_id: THREAD.id,
+  ref_before: "aaaaaaa",
+  ref_after: "bbbbbbb",
+  files_changed: [MD_FILE],
+  worktree_path: null,
+  created_at: now,
+};
+
+// A unified diff that adds a markdown file whose body contains a mermaid
+// erDiagram fence (the exact shape from the bug report). Built with plain
+// strings so the triple backticks don't collide with the template literal.
+const MERMAID_MD_DIFF = [
+  "@@ -0,0 +1,11 @@",
+  "+# Database Schema",
+  "+",
+  "+```mermaid",
+  "+erDiagram",
+  "+    USER ||--o{ ORDER : places",
+  "+    ORDER ||--|{ LINE_ITEM : contains",
+  "+```",
+  "+",
+  "+## Relationships",
+  "+",
+  "+The diagram shows the core entities.",
+].join("\n");
+
+const SETTINGS = getDefaultSettings();
+
+/** Seeds the active thread + turn snapshot and opens the Changes tab. */
+async function openThreadChanges(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ workspace, thread, wid, tid, snapshot }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const getState = (s: unknown) =>
+        (s as { getState: () => Record<string, unknown> }).getState();
+      const wsStore = stores.find(
+        (s) => "activeThreadId" in getState(s) && "threads" in getState(s),
+      );
+      (wsStore as { setState: (p: unknown) => void } | undefined)?.setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: [thread],
+        activeThreadId: tid,
+      });
+      const diffStore = stores.find(
+        (s) => "showRightPanel" in getState(s) && "setSnapshots" in getState(s),
+      );
+      const api = (
+        diffStore as {
+          getState: () => {
+            setSnapshots: (id: string, snaps: unknown) => void;
+            showRightPanel: (id: string, threadId?: string) => void;
+            setRightPanelTab: (id: string, t: string) => void;
+          };
+        }
+      ).getState();
+      api.setSnapshots(tid, [snapshot]);
+      api.showRightPanel(wid, tid);
+      api.setRightPanelTab(wid, "changes");
+    },
+    { workspace: WORKSPACE, thread: THREAD, wid: WORKSPACE.id, tid: THREAD.id, snapshot: SNAPSHOT },
+  );
+}
+
+test.describe("Diff preview: mermaid fences render as diagrams", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [THREAD],
+      "settings.get": SETTINGS,
+      "snapshot.listByThread": [SNAPSHOT],
+      "snapshot.getDiff": MERMAID_MD_DIFF,
+      "snapshot.getCumulativeDiff": MERMAID_MD_DIFF,
+      "diffSummary.get": null,
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1920, height: 1000 });
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean })
+          .__mcodeHydrationComplete === true,
+      { timeout: 30_000 },
+    );
+  });
+
+  test("renders the mermaid diagram instead of raw fenced code", async ({ page }) => {
+    await openThreadChanges(page);
+
+    // Switch to the Cumulative view, whose file list is the snapshot's
+    // files_changed and whose per-file diff comes from getCumulativeDiff.
+    const switcher = page.getByTestId("review-view-switcher");
+    await expect(switcher).toBeVisible({ timeout: 5_000 });
+    await switcher.click();
+    await page.getByTestId("review-view-cumulative").click();
+    await expect(switcher).toContainText("Cumulative");
+
+    const fileRow = page.locator(`[data-review-file="${MD_FILE}"]`);
+    await expect(fileRow).toBeVisible();
+
+    // Expand the file to load and show its diff.
+    await fileRow.locator("button").first().click();
+
+    // Toggle the markdown Preview. The rail collapses to an icon strip; hover
+    // expands it so the labelled action is reliably clickable.
+    const rail = fileRow.locator('nav[aria-label="File actions"]');
+    await expect(rail).toBeVisible();
+    await rail.hover();
+    await fileRow.getByRole("button", { name: "Show rendered preview" }).click();
+
+    // The fix routes the fence to MermaidBlock. Wait for the lazy preview chunk
+    // to mount its container (the "mermaid" header bar) rather than the raw
+    // <pre><code class="language-mermaid"> the bug produced.
+    await expect(fileRow.getByText("mermaid", { exact: true })).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // mermaid.render sets the diagram <svg> id to "mermaid-...". Scoping by that
+    // id avoids matching the SideRail's lucide icon <svg>s — the real proof the
+    // diagram drew rather than falling back to an error banner or raw code.
+    await expect(fileRow.locator('svg[id^="mermaid-"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // The bug's raw fallback must not survive.
+    await expect(fileRow.locator("code.language-mermaid")).toHaveCount(0);
+
+    await page.screenshot({
+      path: "e2e/screenshots/demo-desktop/diff-preview-mermaid.png",
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/src/components/diff/DiffPreviewMarkdown.tsx
+++ b/apps/web/src/components/diff/DiffPreviewMarkdown.tsx
@@ -1,7 +1,53 @@
-import { useMemo } from "react";
-import ReactMarkdown from "react-markdown";
+import { useMemo, lazy, Suspense } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { makeRemarkDiffMarkers } from "@/lib/remark-diff-markers";
+
+/** Lazy-loaded MermaidBlock - only fetched when a mermaid fence appears in the preview. */
+const LazyMermaidBlock = lazy(() => import("../chat/MermaidBlock"));
+
+/**
+ * react-markdown component overrides for the diff preview. The only behavior
+ * we add over the defaults is mermaid handling: fenced ```mermaid blocks must
+ * render as diagrams, not raw code (the diff preview previously showed them as
+ * plain text). Everything else falls through to react-markdown defaults so the
+ * diff markers and global typography styles keep working.
+ */
+const COMPONENTS: Components = {
+  pre({ node, children, ...props }) {
+    // Unwrap the <pre> wrapper around a mermaid fence so the rendered diagram
+    // isn't boxed inside code-block styling. Non-mermaid code blocks keep their
+    // <pre> (and the data-diff-added marker the remark plugin attaches).
+    const child = node?.children?.[0];
+    const className = child?.type === "element" ? child.properties?.className : undefined;
+    const isMermaid = Array.isArray(className) && className.includes("language-mermaid");
+    if (isMermaid) return <>{children}</>;
+    return <pre {...props}>{children}</pre>;
+  },
+  code({ node: _node, className, children, ...props }) {
+    const langMatch = /language-(\S+)/.exec(className ?? "");
+    if (langMatch?.[1] === "mermaid") {
+      const code = String(children).replace(/\n$/, "");
+      return (
+        <Suspense
+          fallback={
+            <pre className="rounded bg-muted/30 p-3 text-[12px] font-mono overflow-x-auto">
+              <code>{code}</code>
+            </pre>
+          }
+        >
+          {/* Preview reconstructs the final file content, so it is never mid-stream. */}
+          <LazyMermaidBlock code={code} isStreaming={false} />
+        </Suspense>
+      );
+    }
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  },
+};
 
 /** Props for the inner Markdown renderer used by DiffPreview. */
 interface DiffPreviewMarkdownProps {
@@ -72,7 +118,9 @@ export default function DiffPreviewMarkdown({
         "[&_td]:border [&_td]:border-border/40 [&_td]:px-2 [&_td]:py-1",
       ].join(" ")}
     >
-      <ReactMarkdown remarkPlugins={remarkPlugins}>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={remarkPlugins} components={COMPONENTS}>
+        {content}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/apps/web/src/components/diff/__tests__/DiffPreviewMarkdown.test.tsx
+++ b/apps/web/src/components/diff/__tests__/DiffPreviewMarkdown.test.tsx
@@ -1,6 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import DiffPreviewMarkdown from "../DiffPreviewMarkdown";
+
+// MermaidBlock is lazy-loaded by DiffPreviewMarkdown; stub it so the test
+// asserts the routing decision (mermaid fence -> MermaidBlock) without pulling
+// in the real mermaid library and its async render lifecycle.
+vi.mock("../../chat/MermaidBlock", () => ({
+  default: ({ code, isStreaming }: { code: string; isStreaming: boolean }) => (
+    <div data-testid="mermaid-block" data-streaming={String(isStreaming)}>
+      {code}
+    </div>
+  ),
+}));
 
 /**
  * End-to-end test of the diff-preview render path. Confirms the remark
@@ -50,6 +61,20 @@ describe("DiffPreviewMarkdown", () => {
     // renders <code> inside <pre>. The data attribute lands on the <code>.
     const code = pre?.querySelector("code");
     expect(code).toHaveAttribute("data-diff-added", "true");
+  });
+
+  it("renders mermaid fences as a diagram instead of raw code", async () => {
+    const content = ["# Diagram", "", "```mermaid", "graph TD; A-->B;", "```"].join("\n");
+    const { container } = render(
+      <DiffPreviewMarkdown content={content} addedLines={new Set()} />,
+    );
+
+    const block = await screen.findByTestId("mermaid-block");
+    expect(block).toHaveTextContent("graph TD; A-->B;");
+    // Preview content is the final reconstructed file, never mid-stream.
+    expect(block).toHaveAttribute("data-streaming", "false");
+    // The raw <pre><code class="language-mermaid"> fallback must not survive.
+    expect(container.querySelector("code.language-mermaid")).toBeNull();
   });
 
   it("renders without any data-diff-added markers when no lines were added", () => {

--- a/apps/web/src/hooks/useDiffHighlighter.test.ts
+++ b/apps/web/src/hooks/useDiffHighlighter.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { parseDiffLines } from "@/lib/diff-parser";
+import type { TokenSpan } from "@/workers/shiki.worker";
+
+// Shared mock state for the Shiki worker client. Hoisted so the vi.mock factory
+// (which runs before imports) can close over the same references the test reads.
+const mock = vi.hoisted(() => {
+  const postMessage = vi.fn();
+  return {
+    postMessage,
+    fakeWorker: { postMessage } as unknown as Worker,
+    pending: new Map<string, (response: unknown) => void>(),
+  };
+});
+
+vi.mock("@/lib/shiki-worker-client", () => ({
+  getWorker: () => mock.fakeWorker,
+  workerGeneration: 0,
+  pending: mock.pending,
+  nextRequestId: (prefix: string) => `${prefix}-test`,
+}));
+
+import { useDiffHighlighter } from "./useDiffHighlighter";
+
+/** Shape of the message posted to the worker, narrowed for assertions. */
+interface PostedTokenizeMessage {
+  id: string;
+  type: "tokenize";
+  blocks: Array<{ blockId: string; code: string; language: string; theme: string }>;
+}
+
+/** Reads the most recent tokenize message posted to the mocked worker. */
+function lastPostedMessage(): PostedTokenizeMessage {
+  const calls = mock.postMessage.mock.calls;
+  return calls[calls.length - 1][0] as PostedTokenizeMessage;
+}
+
+/**
+ * Resolves the pending worker request with one synthetic token per code line.
+ * Each token's content is `${blockId}#${lineIdx}` so tests can assert which
+ * block a diff line's tokens were sourced from.
+ */
+function resolveWorkerEcho(): void {
+  const msg = lastPostedMessage();
+  const results = msg.blocks.map((b) => ({
+    blockId: b.blockId,
+    lines: b.code.split("\n").map((_, lineIdx) => [
+      { content: `${b.blockId}#${lineIdx}`, color: "#abcdef" } satisfies TokenSpan,
+    ]),
+  }));
+  act(() => {
+    mock.pending.get(msg.id)?.({ id: msg.id, type: "tokenize", results });
+  });
+}
+
+// Two non-contiguous hunks. The first contains context + an add; the second a
+// remove, an add, and context. The hidden gap between line 3 and line 50 is the
+// seam that the old single-block implementation glued over.
+const TWO_HUNK_DIFF = [
+  "@@ -1,2 +1,3 @@",
+  " const header = 1;",
+  "+const added1 = 2;",
+  " const ctx1 = 3;",
+  "@@ -50,2 +60,2 @@",
+  "-const removed = 4;",
+  "+const added2 = 5;",
+  " const ctx2 = 6;",
+].join("\n");
+
+describe("useDiffHighlighter", () => {
+  beforeEach(() => {
+    mock.postMessage.mockReset();
+    mock.pending.clear();
+  });
+
+  it("tokenizes each hunk as its own block so multi-line state cannot bleed across the hidden gap", () => {
+    const lines = parseDiffLines(TWO_HUNK_DIFF);
+
+    renderHook(() => useDiffHighlighter(lines, "typescript", "github-dark"));
+
+    const { blocks } = lastPostedMessage();
+    const blockIds = blocks.map((b) => b.blockId);
+
+    // Per-hunk segmentation: old + new fragment for each of the two hunks.
+    // The pre-fix implementation glued everything into exactly one "old" and
+    // one "new" block, which is what let an unterminated comment in hunk 1
+    // mis-tokenize all of hunk 2.
+    expect(blockIds).toEqual(["old:0", "new:0", "old:1", "new:1"]);
+
+    // No single block may contain content drawn from two different hunks.
+    for (const b of blocks) {
+      const hasHunk1 = b.code.includes("header") || b.code.includes("added1");
+      const hasHunk2 =
+        b.code.includes("removed") ||
+        b.code.includes("added2") ||
+        b.code.includes("ctx2");
+      expect(hasHunk1 && hasHunk2).toBe(false);
+    }
+  });
+
+  it("maps each diff line's tokens to its own hunk's block (no cross-hunk bleed)", () => {
+    const lines = parseDiffLines(TWO_HUNK_DIFF);
+
+    const { result } = renderHook(() =>
+      useDiffHighlighter(lines, "typescript", "github-dark"),
+    );
+
+    // Before the worker responds, callers fall back to plain text.
+    expect(result.current.getLineTokens(2)).toBeNull();
+
+    resolveWorkerEcho();
+
+    // Line indices follow parseDiffLines order:
+    //   1 context, 2 add (hunk 1) | 5 remove, 6 add, 7 context (hunk 2).
+    const tokenContent = (i: number) => result.current.getLineTokens(i)?.[0]?.content;
+
+    // Hunk 1: context and add come from the new fragment of hunk 0.
+    expect(tokenContent(1)).toBe("new:0#0");
+    expect(tokenContent(2)).toBe("new:0#1");
+
+    // Hunk 2 must source from hunk-1 blocks, never hunk-0 — the regression guard.
+    expect(tokenContent(5)).toBe("old:1#0"); // removed line -> old fragment
+    expect(tokenContent(6)).toBe("new:1#0"); // added line -> new fragment
+    expect(tokenContent(7)).toBe("new:1#1"); // context line -> new fragment
+  });
+
+  it("does not call the worker for plain-text (unknown language) diffs", () => {
+    const lines = parseDiffLines(TWO_HUNK_DIFF);
+
+    renderHook(() => useDiffHighlighter(lines, "text", "github-dark"));
+
+    expect(mock.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useDiffHighlighter.ts
+++ b/apps/web/src/hooks/useDiffHighlighter.ts
@@ -15,15 +15,29 @@ interface TokenizeResponse {
   }>;
 }
 
+/** Locates a diff line's tokens within a specific worker block. */
+interface BlockRef {
+  /** Worker block identifier (e.g. "old:0", "new:1"). */
+  blockId: string;
+  /** Zero-based line index within that block. */
+  lineIdx: number;
+}
+
 /**
  * Two-pass syntax highlighting for diff lines using the Shiki Web Worker.
  *
- * Assembles an "old" block (context + removed lines) and a "new" block
- * (context + added lines) so each block represents a coherent file state,
- * giving accurate cross-line token highlighting. Both blocks are sent in a
- * single worker message to minimise round trips.
+ * For each hunk it assembles an "old" fragment (context + removed lines) and a
+ * "new" fragment (context + added lines). Each fragment is a coherent,
+ * contiguous slice of the file, so Shiki gets accurate cross-line state.
  *
- * @returns `getLineTokens(i)` — returns the token array for diff line `i`, or
+ * Crucially, hunks are tokenized as separate blocks rather than glued into one
+ * old/new block. Gluing non-contiguous hunks lets a multi-line construct opened
+ * in one hunk (an unterminated block comment, template literal, etc.) bleed past
+ * the hidden gap and mis-tokenize every following line as plain comment/string
+ * text. Per-hunk blocks contain that state. All blocks ride a single worker
+ * message to minimise round trips.
+ *
+ * @returns `getLineTokens(i)` - returns the token array for diff line `i`, or
  *   `null` while highlighting is pending (callers should fall back to plain text).
  */
 export function useDiffHighlighter(
@@ -35,41 +49,62 @@ export function useDiffHighlighter(
   const [tokenMap, setTokenMap] = useState<Map<number, TokenSpan[]>>(new Map());
   const currentRequestId = useRef<string | null>(null);
 
-  // Build the two code blocks and their index maps in one pass over the diff lines.
-  const { oldBlock, newBlock, oldIndexMap, newIndexMap } = useMemo(() => {
-    const oldLines: string[] = [];
-    const newLines: string[] = [];
-    // Maps diff line index → block line index
-    const oldIdxMap = new Map<number, number>();
-    const newIdxMap = new Map<number, number>();
+  // Segment the diff into per-hunk old/new fragments in one pass, recording for
+  // each diff line which block and block-line its tokens will come from.
+  const { blocks, oldIndexMap, newIndexMap } = useMemo(() => {
+    const built: Array<{ blockId: string; code: string }> = [];
+    const oldIdxMap = new Map<number, BlockRef>();
+    const newIdxMap = new Map<number, BlockRef>();
+
+    let hunk = 0;
+    let oldLines: string[] = [];
+    let newLines: string[] = [];
+
+    // Emit the accumulated hunk fragments as blocks and advance the hunk index.
+    const flush = () => {
+      if (oldLines.length === 0 && newLines.length === 0) return;
+      if (oldLines.length > 0) built.push({ blockId: `old:${hunk}`, code: oldLines.join("\n") });
+      if (newLines.length > 0) built.push({ blockId: `new:${hunk}`, code: newLines.join("\n") });
+      oldLines = [];
+      newLines = [];
+      hunk++;
+    };
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
+      if (line.type === "header") {
+        // A hunk header (`@@`) breaks contiguity: close the current fragment so
+        // the next hunk tokenizes from a clean grammar state.
+        if (line.content.startsWith("@@")) flush();
+        continue;
+      }
       if (line.type === "context") {
-        oldIdxMap.set(i, oldLines.length);
-        newIdxMap.set(i, newLines.length);
+        oldIdxMap.set(i, { blockId: `old:${hunk}`, lineIdx: oldLines.length });
+        newIdxMap.set(i, { blockId: `new:${hunk}`, lineIdx: newLines.length });
         oldLines.push(line.content);
         newLines.push(line.content);
       } else if (line.type === "remove") {
-        oldIdxMap.set(i, oldLines.length);
+        oldIdxMap.set(i, { blockId: `old:${hunk}`, lineIdx: oldLines.length });
         oldLines.push(line.content);
       } else if (line.type === "add") {
-        newIdxMap.set(i, newLines.length);
+        newIdxMap.set(i, { blockId: `new:${hunk}`, lineIdx: newLines.length });
         newLines.push(line.content);
       }
-      // header lines get no entry in either map
     }
+    flush();
 
-    return {
-      oldBlock: oldLines.join("\n"),
-      newBlock: newLines.join("\n"),
-      oldIndexMap: oldIdxMap,
-      newIndexMap: newIdxMap,
-    };
+    return { blocks: built, oldIndexMap: oldIdxMap, newIndexMap: newIdxMap };
   }, [lines]);
 
+  // Stable, value-based key for the effect deps so re-renders that produce an
+  // equivalent block set don't re-issue a worker request.
+  const blocksSignature = useMemo(
+    () => blocks.map((b) => `${b.blockId} ${b.code}`).join(""),
+    [blocks],
+  );
+
   useEffect(() => {
-    if (!enabled || language === "text" || (oldBlock === "" && newBlock === "")) {
+    if (!enabled || language === "text" || blocks.length === 0) {
       setTokenMap(new Map());
       return;
     }
@@ -99,33 +134,26 @@ export function useDiffHighlighter(
       const res = response as TokenizeResponse | null;
       if (!res || res.type !== "tokenize") return;
 
-      const map = new Map<number, TokenSpan[]>();
-
+      // Index the per-hunk token lines by block id for O(1) lookup.
+      const byBlock = new Map<string, TokenSpan[][]>();
       for (const result of res.results) {
         if (result.error || result.lines.length === 0) continue;
+        byBlock.set(result.blockId, result.lines);
+      }
 
-        if (result.blockId === "old") {
-          // Map old-block token lines back to diff line indices
-          for (const [diffIdx, blockIdx] of oldIndexMap) {
-            const tokens = result.lines[blockIdx];
-            if (tokens) {
-              // For context lines, prefer the new-block result (applied later);
-              // remove lines are only in old block so set them here unconditionally.
-              const lineType = lines[diffIdx]?.type;
-              if (lineType === "remove") {
-                map.set(diffIdx, tokens);
-              }
-            }
-          }
-        } else if (result.blockId === "new") {
-          // Map new-block token lines back to diff line indices
-          for (const [diffIdx, blockIdx] of newIndexMap) {
-            const tokens = result.lines[blockIdx];
-            if (tokens) {
-              map.set(diffIdx, tokens);
-            }
-          }
-        }
+      const map = new Map<number, TokenSpan[]>();
+
+      // New fragments cover context + added lines.
+      for (const [diffIdx, ref] of newIndexMap) {
+        const tokens = byBlock.get(ref.blockId)?.[ref.lineIdx];
+        if (tokens) map.set(diffIdx, tokens);
+      }
+      // Old fragments cover removed lines (context already came from the new
+      // fragment above; removed lines exist only in the old fragment).
+      for (const [diffIdx, ref] of oldIndexMap) {
+        if (lines[diffIdx]?.type !== "remove") continue;
+        const tokens = byBlock.get(ref.blockId)?.[ref.lineIdx];
+        if (tokens) map.set(diffIdx, tokens);
       }
 
       setTokenMap(map);
@@ -134,17 +162,16 @@ export function useDiffHighlighter(
     worker.postMessage({
       id,
       type: "tokenize",
-      blocks: [
-        { blockId: "old", code: oldBlock, language, theme },
-        { blockId: "new", code: newBlock, language, theme },
-      ],
+      blocks: blocks.map((b) => ({ blockId: b.blockId, code: b.code, language, theme })),
     });
 
     return () => {
       pending.delete(id);
       currentRequestId.current = null;
     };
-  }, [oldBlock, newBlock, language, theme, enabled]);
+    // blocks, oldIndexMap and newIndexMap all derive from the same memo as
+    // blocksSignature, so the signature alone captures every block-related change.
+  }, [blocksSignature, language, theme, enabled]);
 
   const getLineTokens = useCallback(
     (index: number) => tokenMap.get(index) ?? null,


### PR DESCRIPTION
## What
Two related fixes to the markdown diff view:

1. Mermaid fenced blocks in the markdown diff preview now render as diagrams instead of raw `<pre><code class="language-mermaid">` text.
2. Syntax highlighting no longer drops out for part of a multi-hunk diff (the "half diffs are not highlighted" bug).

## Why
- **Mermaid:** the diff preview routed ` ```mermaid ` fences to the generic code path, so the diagram source showed as raw code rather than a rendered graph.
- **Half-diff highlighting:** `useDiffHighlighter` glued every hunk into a single "old" block and a single "new" block before handing them to the Shiki worker. When a multi-line construct opened in one hunk (a JSDoc block comment, a template literal, etc.) but its closer sat in the hidden gap between hunks, the glued block stayed in an unterminated state and Shiki tokenized every following line as one comment/string run. That column rendered as plain dim text with no highlighting.

## Key Changes
- `DiffPreviewMarkdown.tsx`: route mermaid fences to `MermaidBlock` so they render as diagrams; the raw `code.language-mermaid` fallback no longer survives.
- `useDiffHighlighter.ts`: tokenize each hunk's old/new fragment as its own Shiki block instead of gluing all hunks together. A `@@` header flushes the current fragment so the next hunk starts from a clean grammar state and any unterminated construct is contained at the seam. All per-hunk blocks still ride a single worker message, so there is no extra round trip. The public `getLineTokens` API is unchanged, so `SideBySideDiff` and `UnifiedDiff` need no edits.
- Tests: new `useDiffHighlighter.test.ts` asserts per-hunk segmentation and that each diff line's tokens are sourced from its own hunk's block; new `diff-preview-mermaid.spec.ts` Playwright spec drives the real Changes -> Cumulative -> Preview path and asserts a rendered `<svg>` replaces the fence; `DiffPreviewMarkdown.test.tsx` extended for the mermaid routing decision.

## Verification
- `bun run verify`: Typecheck PASS, Lint PASS, unit tests green (the per-hunk highlighting cases and the mermaid routing test included).
- Live: confirmed in the running app. Mermaid fences render as diagrams; in a 2-hunk diff with an unterminated block comment in the first hunk, the previously-dim column went from 1 real theme color per line to many (full highlighting on both columns).

## Config Changes
None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784131351&installation_id=129163861&pr_number=741&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F741&signature=e77612e8fb01e11bd4bcd7cd1e169fc5ae0c074e8b217b29e4322e19fdc6d534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->