### PR TITLE
docs: terminal view detach architecture (ADR-0010)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,17 +31,30 @@ Always add JSDoc/TSDoc docstrings to all exported functions, components, types, 
 
 Comments explain **why**, not **what**. The code itself shows what it does.
 
-## Defensive Programming and Performance
+## Defensive Programming
 
-Validate assumptions at process and trust boundaries: external input, filesystem paths, IPC payloads, provider events, child-process environment, and persisted settings.
+Default to defensive code. Treat missing validation as a bug, not a shortcut.
+Assume inputs, timing, and process state can be wrong unless proven at a boundary.
 
-Prefer allowlists, typed schemas, bounded values, explicit errors, and exhaustive handling. Fail closed for security-sensitive paths.
+**Where to validate:** process and trust boundaries only. External input, filesystem
+paths, IPC and WebSocket payloads, provider events, child-process environment,
+persisted settings, and anything crossing a package or thread boundary.
 
-Normalize once at the boundary. Avoid repeated defensive checks inside hot paths unless a real invariant can be broken there.
+**How to validate:** allowlists over blocklists; typed schemas (Zod in
+`packages/contracts`); bounded values; explicit errors; exhaustive `switch` on
+discriminated unions. Fail closed on security-sensitive paths.
 
-Defensive code should also bound work: cap payload sizes, limit recursion and fan-out, set timeouts, cancel stale work, and avoid unbounded queues.
+**Where not to validate:** hot paths and inner loops. Normalize and validate once
+at the boundary, then trust invariants inside. Do not re-parse, re-check, or
+re-clamp the same value on every iteration.
 
-When a check could be expensive, measure it or move it to the boundary.
+**Bound all work:** cap payload and buffer sizes; limit recursion, fan-out, and
+queue depth; set timeouts; cancel stale async work; evict oldest when a ring
+buffer fills. Unbounded retention is never acceptable, even "temporarily."
+
+**Performance:** defensive checks that could be expensive belong at the boundary
+or behind a cheap guard. Measure before adding validation inside a hot path. When
+in doubt, bound the work first, optimize second.
 
 ## UI Components
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -555,6 +555,48 @@ type is creatable, the add affordance opens it directly instead of showing
 a menu; when none are, the add affordance is hidden. The empty panel and
 the add menu present this same creatable-types set.
 
+### Terminal tab
+The right-panel tab that hosts one or more **shell sessions** against the
+active **terminal scope** (a thread when one is active, otherwise the
+workspace root). Singleton at the panel level; multiplicity is internal
+(one tab, many shells).
+
+### Terminal scope
+The thread or workspace a shell session runs against. When a thread is
+active, shells open in that thread's working directory (worktree or
+workspace root per composer mode). With no thread, the scope is the
+workspace and shells open at the workspace root.
+_Avoid_: Using "thread id" alone when the scope may be a workspace.
+
+### Shell session
+A running shell process (e.g. PowerShell, bash) tied to one terminal scope.
+Survives thread switches and terminal-tab hides; the process keeps running
+until the user kills it or closes the shell. Output keeps draining into
+server-side scrollback even when no terminal view is mounted.
+_Avoid_: PTY (implementation term), terminal instance (ambiguous with the view).
+
+### Active shell
+The one shell session whose terminal view is mounted. At most one terminal
+view exists in the app: the active shell on the active terminal scope, while
+the Terminal tab and right panel are open.
+_Avoid_: Mounting a view for every open shell (background shells stay
+server-side only).
+
+### Terminal view
+The in-app rendering of one shell session's output in the Terminal tab.
+Only the **active shell** has a view; others keep running without one.
+Remounting replays retained scrollback and opens at the latest output
+(follow). Restoring the prior scroll position within scrollback is a
+planned follow-up, not v1.
+_Avoid_: xterm (implementation term), conflating with shell session.
+
+### Scrollback
+How many lines of shell output are retained for a shell session, set by
+`terminal.scrollback`. The same limit applies on the server (for replay when
+the terminal view remounts) and in the mounted terminal view. Output beyond
+the limit is dropped oldest-first.
+_Avoid_: Treating scrollback as a client-only display setting.
+
 ### Review tab
 The right-panel tab that shows code changes. **Dual-scope**: its
 git-working-tree views (Unstaged, Staged, Commit, Branch) read the

--- a/docs/adr/0010-terminal-view-detach-shell-session-persists.md
+++ b/docs/adr/0010-terminal-view-detach-shell-session-persists.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+---
+
+# Terminal views detach; shell sessions persist with server-side scrollback
+
+## Context
+
+The integrated terminal kept every open shell's renderer mounted in a
+persistent pool (`TerminalPoolHost`), hidden with CSS across thread switches.
+That preserved scroll position but scaled memory and main-thread cost with
+every long-running shell, causing lag on Windows and making multi-thread
+sessions unusable.
+
+The server already had `terminal.reattach` and a replay buffer, but the
+512 KB cap was sized for WebSocket reconnect, not for scrollback. The
+`terminal.scrollback` setting applied only to the client xterm buffer.
+
+ADR-0002 established discard semantics for browser preview tabs. The terminal
+needed an equivalent split: kill the expensive view, keep the cheap session.
+
+## Decision
+
+Split **shell session** (server PTY, long-lived) from **terminal view**
+(client renderer, disposable).
+
+- **Shell sessions** survive thread switches, tab hides, and view disposal.
+  Output always drains into server-side scrollback, even with no mounted view.
+  Pause/resume applies only to client backpressure when a view is mounted and
+  cannot keep up, not to "nobody is watching."
+- **Terminal views** mount for at most one shell at a time: the active shell
+  on the active terminal scope, while the Terminal tab and right panel are
+  open. All other shells run headless.
+- **Scrollback** uses one knob: `terminal.scrollback` drives both server
+  retention (for reattach replay) and the mounted view's buffer. Output
+  beyond the limit is dropped oldest-first.
+- **Remount** replays retained scrollback via `terminal.reattach` and opens
+  at the latest output (follow). Smart scroll-position restore is a planned
+  follow-up, not v1.
+- **Mount/unmount speed** is a first-class requirement: remount must feel
+  instant; optimize replay and xterm init accordingly.
+
+## Considered Options
+
+- **Persistent xterm pool (rejected).** Status quo; N hidden renderers, lag
+  and memory grow with open shells.
+- **Dispose views without server scrollback (rejected).** Saves memory but
+  loses history on thread switch; unusable for long-running builds.
+- **Separate server scrollback cap (rejected).** Two knobs confuse users;
+  one setting should mean one retention policy.
+- **Mount all shells for the active scope (rejected).** Up to four xterm
+  instances per thread; still too heavy for the idle-memory target.
+- **Detach views, persist scrollback server-side, max one mounted view
+  (chosen).** Mirrors ADR-0002's discard pattern; reuses existing reattach
+  infrastructure once the replay buffer is sized from `terminal.scrollback`.
+
+## Consequences
+
+- `TerminalPoolHost`'s always-mounted pool is replaced by mount-on-demand
+  for the active shell only. Background shell tabs remount on select.
+- Server replay buffer capacity must derive from `terminal.scrollback`, not
+  the fixed 512 KB default.
+- Tab switches within a thread trigger remount + replay; this must be fast
+  enough to feel seamless.
+- Smart follow (restore scroll position when the user had scrolled up) is
+  deferred; v1 always follows latest output on remount.
+- E2E specs that assume all terminals stay mounted (`__mcodeLiveTerminals`,
+  scroll-on-thread-switch harness) need updating for the new lifecycle.


### PR DESCRIPTION
## What
Documents the agreed terminal architecture refactor: detach terminal views, persist shell sessions, and unify scrollback retention.

## Why
The integrated terminal persistent pool keeps every xterm mounted, causing lag and memory growth on long-running shells across threads. This PR records the target design before implementation.

## Key Changes
- Add ADR-0010: shell sessions persist, terminal views detach, one mounted view max, server scrollback sized from `terminal.scrollback`, follow-on-remount for v1
- Expand CONTEXT.md with terminal tab glossary (shell session, terminal view, active shell, scrollback, terminal scope)
- Strengthen AGENTS.md defensive programming guidance (boundaries, bounded work, no hot-path re-validation)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784159297&installation_id=129163861&pr_number=744&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F744&signature=64b46d13ceae4eaf91ecee2e72a676989590ef20985d64d37329d6b969eb1e4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized defensive programming guidance with clearer subsections on validation strategies and boundary checks.
  * Added terminal-related terminology definitions to the glossary, covering terminal tabs, shell sessions, and scrollback behavior.
  * Documented terminal lifecycle architecture decision, including server-side session persistence and view mount-on-demand behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->