### PR TITLE
docs: Thread Overview design (glossary, ADRs, spec, epic PRDs)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -209,6 +209,23 @@ The specific message in the parent thread that a fork is created from. Has a
 or `assistant` (forking from the agent's reply; intent is "follow up about
 what was just said"). The role shapes how the handoff is framed.
 
+### Create branch
+An [[Overview]] action that runs `git checkout -b <name>` in the active thread's
+own working directory: it creates a branch at the current HEAD and switches the
+thread onto it. **Same thread, same worktree, new branch** - no child thread, no
+handoff; the thread's `branch` updates in place. Backed by a net-new
+`git.createBranch` RPC (create + checkout); the app otherwise only checks out
+*existing* branches.
+
+Not to be confused with [[Fork]]. The two share one git primitive (a branch
+pointer) in exactly one case, which is why they are easy to collapse, but they
+are different actions: Create branch moves *this* thread onto a new branch right
+here, whereas Fork spawns a *new* thread - and only its new-worktree variant
+also creates a branch (in a *separate* worktree; existing-worktree reuses that
+worktree's branch, and new-local does no branch op at all). One line each:
+Create branch = "this thread, new branch, here"; Fork = "a new thread, possibly
+elsewhere."
+
 ## Chat lifecycle
 
 ### Turn
@@ -517,11 +534,22 @@ error (if any). Used by the View doc dialog and by the fallback banner copy.
 
 ## Related but distinct
 
-### Cross-provider switch (deferred)
-Swapping a thread's provider mid-conversation. Uses the same handoff
-primitive as a fork but with the implicit anchor being the thread's last
-message, and the same thread continues with the new provider. Not yet
-implemented; was a deferred item in the chat-fork handoff feature (PR #499).
+### Cross-provider switch
+Swapping a thread's provider mid-conversation. The **same thread continues**:
+its id, message history, and worktree are unchanged; only the active provider
+swaps. The outgoing provider generates a handoff (B/D ladder, anchored at the
+thread's last message), and the incoming provider reads that doc to pick up
+context. The thread's persisted messages stay intact; only the new provider's
+in-memory context comes from the handoff.
+
+Swap-back (A → B → A) is the same process repeated: each direction is one
+handoff. The outgoing session is abandoned and eventually evicted by the
+session runtime's idle timer; swap-back spawns a fresh session on the
+returning provider with a new handoff, not a resumed session.
+
+Surfaced in the [[Overview]] as the **Switch provider** action, kept distinct
+from the Overview's Fork actions (which spawn a new thread). Was a deferred item
+in the chat-fork handoff feature (PR #499); un-deferred for the Overview epic.
 
 ### Compaction
 A separate mechanism that summarizes a thread's older turns into a single
@@ -529,6 +557,57 @@ compact summary stored on the thread itself, used to keep long threads
 within their own provider's context window. Distinct from a fork handoff,
 though the orchestrator does consult `last_compact_summary` when building a
 deterministic path-D handoff.
+
+## Thread overview
+
+### Overview
+The chat-header popover that recaps the active thread's working context (its
+changes, current branch, and pull-request state) and hosts the git actions for
+that thread (Commit-or-push, Create PR). An enrichment of the former plain
+header menu (`header-workspace-menu`) into a live status surface, modelled on
+Codex's "Environment" panel. Code symbol: `ThreadOverview`.
+
+**Thread-scoped.** The Overview lives in the chat header, which renders only
+when a thread is active. With no thread open there is no Overview; the
+workspace-root view of changes and branches stays the Review tab's job.
+
+The Overview offers two ways to take the thread further, split by what each does
+to *this* thread. Both anchor at the thread tail (not a picked message):
+
+**[[Fork]]** - spawns a *new* child thread; this thread stays untouched. Three
+targets:
+
+- **New worktree** - child thread in New-worktree mode + handoff.
+- **Existing worktree** - child thread in Existing-worktree mode + handoff.
+- **New local thread** - child thread in Direct mode + handoff.
+
+**Switch provider** - a [[cross-provider switch]]: *this same thread* continues
+(id, history, worktree unchanged) and only the provider driving it swaps, with a
+handoff generated from the outgoing provider. Swap-back is the same process.
+
+Handoff is always-on for both - it is the mechanism, not a standalone menu item.
+The split keeps "spawn a copy" (Fork) visually distinct from "change this
+thread's driver" (Switch provider); the two can re-merge into one list later if
+the distinction does not earn its place.
+
+_Avoid_: calling this surface "Summary." [[Summary]] is the AI prose lens of
+the Cumulative diff (a diff-to-prose toggle inside the Review tab), a different
+surface. The Overview is a status-and-actions menu, not a diff lens.
+
+### Recap
+A short AI-generated one-line "what you're working on" for the active thread,
+shown at the top of the [[Overview]]. Produced by a stateless server RPC (our
+utility model) and cached **in memory per thread, never persisted** (resets on
+restart). Generation is deliberately frugal: panel-gated (runs only while the
+Overview is open), idle-debounced (fires after the thread goes quiet, ~12s
+first / ~35s refresh, never mid-turn), and signature-gated (regenerates only
+when user/assistant messages materially change, feeding just the new messages
+plus the previous recap). See ADR-0013.
+
+_Avoid_: confusing the Recap with [[Summary]] or [[Overview]]. [[Summary]]
+summarizes the **code diff** (a Review-tab lens); the Recap summarizes
+**conversational intent**. [[Overview]] is the **surface** that hosts the Recap,
+not the recap text itself.
 
 ## Right panel
 

--- a/docs/adr/0004-workspace-global-right-panel-singleton-tabs.md
+++ b/docs/adr/0004-workspace-global-right-panel-singleton-tabs.md
@@ -4,6 +4,11 @@ status: accepted
 
 # The right panel splits its state: open/closed is per-thread, width and tab are workspace-global; singleton tabs keep their own scope
 
+> **Proposed revision:** ADR-0012 moves *all* panel container state (including
+> width and active tab) to per-thread, with a workspace-level fallback. If
+> accepted, it supersedes the state-split decision below; the singleton-tabs and
+> per-tab-scope decisions here still stand.
+
 ## Context
 
 The right panel was entirely thread-scoped: `RightPanel.tsx` returns `null`

--- a/docs/adr/0011-review-default-view-per-thread.md
+++ b/docs/adr/0011-review-default-view-per-thread.md
@@ -1,0 +1,73 @@
+---
+status: proposed
+---
+
+# The Review tab's default view is chosen per thread from change state, and a manual pick sticks
+
+## Context
+
+Today `viewMode` in `diffStore` is a single **global**, **unpersisted** field.
+`defaultReviewView(scope)` returns `last-turn` for a thread and `unstaged`
+threadless, and the only auto-selection is a `DiffToolbar` effect that resets the
+view when the current one falls out of the active scope. There is no per-thread
+memory and no "the user picked this" flag.
+
+The new thread [[Overview]] surfaces a **Changes** row that opens the Review tab.
+When it opens, the view should land on what the user most likely wants for *that*
+thread without forcing a manual pick, and without overriding a choice they have
+already made. The originating request was "default to branch view if the user
+hadn't previously modified it"; grilling refined that into a change-state default
+plus a sticky per-thread override.
+
+## Decision
+
+On opening the Review tab for a thread, the default view is chosen from the
+thread's **change state**:
+
+- the thread has **turn-registered changes** (at least one turn snapshot with
+  changed files - the same signal the header's `changedFileCount` already uses)
+  -> **Last turn**
+- else the **working tree is dirty** (manual edits, no turn) -> **Unstaged**
+- else (clean) -> **Branch**
+
+The default **re-evaluates live** as change state changes - the first turn's
+changes flip Branch -> Last turn - **until the user picks a view** from the
+switcher. A manual pick sets a **per-thread override** that sticks; after that,
+no auto-defaulting happens for that thread.
+
+The override is remembered **per thread, in memory only** (resets on app
+restart). The mechanism mirrors the existing `branchManuallySelected` guard in
+`workspaceStore`, which protects the composer branch picker from live
+`branch.changed` events the same way.
+
+## Considered Options
+
+- **Two-way default (turn changes -> Last turn; else Branch).** The original
+  cut. Rejected: a working tree dirtied only by manual edits with no turn would
+  default to Branch, whose three-dot range (ADR-0007) shows only committed work
+  and therefore **hides** those uncommitted edits. The three-way default closes
+  the hole by routing manual-only dirt to Unstaged.
+- **Compute once on open, never re-evaluate.** Rejected: a thread opened before
+  its first turn would stay pinned to Branch even after the agent produced
+  changes - the opposite of what the user is looking at the panel for.
+- **Persist the per-thread override across restarts.** Deferred: `viewMode` is
+  ephemeral today, so in-memory per-thread is cheap and enough for v1; durable
+  storage is a clean later add.
+- **Keep the single global `viewMode` (status quo).** Rejected: switching threads
+  carries the previous thread's view, and there is no way to express a per-thread
+  default at all.
+
+## Consequences
+
+- `diffStore` gains per-thread view state plus a per-thread override flag,
+  replacing (or layering over) the single global `viewMode`. This is the
+  costly-to-reverse part of the decision.
+- The new default logic must coexist with the existing `DiffToolbar`
+  scope-recovery effect, which still fires when the active view falls out of the
+  current scope (for example thread -> threadless while on a turn-only view).
+- `clearThread` must drop the thread's view and override entries so a deleted
+  thread leaves no dangling state, mirroring the `rightPanelVisibleByThread`
+  cleanup ADR-0004 already requires.
+- The override resets on app restart, so a user who pinned Cumulative sees the
+  change-state default again next launch until they re-pin. Acceptable for v1;
+  revisit if it grates.

--- a/docs/adr/0012-right-panel-state-per-thread.md
+++ b/docs/adr/0012-right-panel-state-per-thread.md
@@ -1,0 +1,74 @@
+---
+status: proposed
+---
+
+# Right-panel container state is per-thread, with a workspace-level fallback for the threadless and not-yet-customized cases
+
+## Context
+
+ADR-0004 split the panel container state: open/closed per-thread, but **width
+and active tab workspace-global**, so "the two settings users do not want to
+re-set on every thread" would be shared, while a threadless shell stayed
+possible. Open-tabs and active-tab therefore persist across thread switches: open
+a Terminal on thread A and it is still the active tab when you move to thread B.
+
+Product judgment has shifted. A thread is a self-contained unit of work -
+reinforced by the new [[Overview]] - and its panel layout (which tabs are open,
+which is active, how wide, whether it is showing) should belong to the thread,
+not bleed across siblings. Switching threads should restore *that* thread's
+panel, not carry the previous thread's tabs. The one requirement from ADR-0004
+that still stands: the panel must work with **no thread** (Browser/Terminal
+against the workspace root).
+
+## Decision
+
+**All** panel container state - visibility, width, active tab, and the open-tabs
+set - is **per-thread**.
+
+A single **workspace-level fallback** record of the same shape is used in two
+cases:
+
+1. **Threadless** - when no thread is active, the panel reads and writes the
+   fallback, preserving ADR-0004's workspace-root Browser/Terminal shell.
+2. **Not-yet-customized thread** - a thread with no saved panel state inherits
+   the fallback on first open, then **diverges the moment it changes any panel
+   state**, after which its own per-thread record is authoritative.
+
+This single mechanism removes ADR-0004's main objection: an untouched thread
+shows the fallback set, so you do not re-open Terminal on every thread; the split
+only happens once you deliberately customize a thread's panel.
+
+Unchanged from ADR-0004: tabs are **singletons** with internal multiplicity
+(Browser pages, Terminal shells); each **tab type keeps its own content scope**
+(Browser/Terminal/Files against the workspace root or the thread worktree; Review
+dual-scope; Scope thread-only). This ADR revises only *where the container state
+lives*.
+
+## Considered Options
+
+- **Keep ADR-0004's split (per-thread visibility, workspace-global width + active
+  tab).** Rejected by current product judgment: carrying the previous thread's
+  open tabs and active tab into a different thread is the exact friction being
+  removed.
+- **Per-thread tabs but keep width workspace-global (the first, narrow
+  revision).** Rejected: width should follow the thread too, so the whole
+  container state lives at one scope instead of being split across two.
+- **Everything per-thread with no fallback.** Rejected: breaks the threadless
+  panel ADR-0004 deliberately enabled (no tab set when no thread) and lands every
+  new thread on an empty panel.
+
+## Consequences
+
+- ADR-0004's `rightPanelByWorkspace` (width, active tab) plus
+  `rightPanelVisibleByThread` split is replaced by a **per-thread panel-state
+  map** plus **one workspace-level fallback record**. This re-introduces a
+  per-thread container store (closer to the pre-0004 `rightPanelByThread`), now
+  with an explicit fallback for the threadless and uninitialized cases. This is
+  the costly-to-reverse part.
+- Reads must go through an accessor that falls through to the fallback until the
+  thread writes its own entry (copy-on-write), never reaching into a slice
+  directly - the same discipline ADR-0004 set with `getRightPanelVisible`.
+- `clearThread` drops the deleted thread's whole panel-state entry (ADR-0004
+  already required this for visibility; it now covers the full record).
+- ADR-0004's "width and active tab are workspace-global" decision is superseded.
+  Its singleton-tabs and per-tab-scope decisions still stand.

--- a/docs/adr/0013-thread-recap-generation-and-caching.md
+++ b/docs/adr/0013-thread-recap-generation-and-caching.md
@@ -1,0 +1,114 @@
+---
+status: proposed
+---
+
+# The thread recap is generated lazily by a stateless RPC and cached in memory per thread, never persisted
+
+## Context
+
+The thread [[Overview]] surfaces a **Recap** - a short AI-generated one-line
+"what you're working on" for the active thread. The user's one hard constraint
+was that it must not spam the model or waste tokens.
+
+A sibling fork in this codebase's lineage (Synara, by Emanuele-web04 - same
+monorepo shape, same thread / turn / provider / worktree / handoff model,
+rebranded and since diverged) has already shipped exactly this feature, fully
+cost-controlled. Its trigger and caching model is the prior art this decision
+adapts. Synara's own divergences from us - a `gpt-5.4-mini` text-generation
+default and a client-side `localStorage` cache - are noted below where they are
+deliberately not followed.
+
+The app already has one durable AI-text feature, the diff [[Summary]]
+(`diff_summaries` table + `diffSummary.*` RPC via `UtilityCompletionService`).
+The open question was whether the recap should live the same way. It should not:
+the diff summary is a **durable record** of what a branch did (expensive to
+recompute over a large diff, user-triggered), whereas the recap is **ephemeral
+live UI** (cheap to recompute, useful only while on screen). Treating them as the
+same class was the wrong instinct.
+
+## Decision
+
+The recap is **generated lazily by a stateless server RPC and cached in memory
+per thread; it is never persisted.**
+
+**Generation - stateless RPC.** A new `recap.generate`-style RPC runs the
+`UtilityCompletionService` (our cheap utility model, not Synara's
+`gpt-5.4-mini`) over bounded conversation material and returns the recap text.
+The server **stores nothing**: no `recaps` table, no migration, no thread-row
+field. This is the deliberate divergence from the diff [[Summary]], which does
+persist server-side.
+
+**Caching - in memory, per thread, client-side.** The client store keeps a
+`recapByThread` map of `{ text, signature, coveredMessageId }`, held for the
+session and **not persisted**. `clearThread` drops the entry. On restart the map
+is empty, so the first panel-open per thread regenerates once - one cheap call,
+the only cost of not persisting, and accepted.
+
+This places the recap in the same family as **ADR-0011** (review default view)
+and **ADR-0012** (panel container state): per-thread, in-memory, resets on
+restart. It does **not** join the diff summary's durable-table family.
+
+**Trigger - lazy, gated, debounced (adapted from Synara).** A client hook owns
+all of it; generation is an opt-in side effect of the open panel, never wired
+into the transcript render or turn-event hot path:
+
+- **Panel-gated.** Generates only while the [[Overview]] is open. Never opened ->
+  never a single call.
+- **Idle-debounced.** Fires only after the thread goes quiet - ~12s before the
+  first recap, ~35s before a refresh. Every new message resets the clock. Nothing
+  fires mid-turn or while the assistant is streaming.
+- **Signature staleness.** A cheap hash of `[last message id, role, length, turn
+  state, pending flags]` gates the call; it is skipped when the signature matches
+  the cached, in-flight, or last-failed value. Only **user and assistant**
+  messages advance the signature - tool and work-log noise never trigger a
+  regenerate.
+- **Incremental delta.** After the first recap, only the new messages since
+  `coveredMessageId` (bounded - last ~4, ~600 chars each) plus the previous
+  recap text are sent; the prompt instructs the model to return the previous
+  recap unchanged when nothing meaningful changed.
+- **Bounded input.** First pass ~6 messages, hard char caps per section, output
+  clipped to ~220 chars, utility model at low reasoning effort.
+
+## Considered Options
+
+- **Persist server-side, mirroring the diff `Summary` (`recaps` table + RPC).**
+  Rejected. The recap is ephemeral live UI, not a durable record; durable storage
+  buys only "skip one regeneration per thread per restart" - a single cheap call
+  - while costing a table, a migration, and server-held state. This was the first
+  recommendation; product feedback ("do we need to save it given it changes?")
+  correctly pushed it down a tier.
+- **Persist client-side in `localStorage` (Synara's actual choice).** Rejected.
+  Same marginal gain (survive restart) at the cost of serialization, an
+  LRU-eviction policy (Synara caps at 80 threads), and showing stale recap text
+  on the first paint after restart. Not worth it for a single-install desktop app
+  with no cross-device sync to gain.
+- **No cache - regenerate on every panel open.** Rejected. Opening the Overview N
+  times would cost N generations - exactly the token spam being designed out.
+- **Eager generation (per turn, or in the background).** Rejected by the core
+  token constraint: it would fire for threads no one inspects and on every turn.
+- **Full re-summarize each time (no delta).** Rejected. Re-reading the whole
+  transcript on every refresh wastes tokens; the incremental delta plus
+  previous-recap passthrough is strictly cheaper and more stable.
+
+## Consequences
+
+- A new **stateless** `recap.generate`-style RPC takes bounded material plus the
+  previous recap and returns text via `UtilityCompletionService`. The RPC
+  contract and the client store shape are the costly-to-reverse part of this
+  decision.
+- The client store gains an in-memory `recapByThread` map (`text`, `signature`,
+  `coveredMessageId`), not persisted, dropped by `clearThread` - mirroring the
+  ADR-0011 / ADR-0012 cleanup discipline.
+- A client hook (mirroring Synara's `useThreadRecap`) owns the panel-gate, idle
+  debounce, signature staleness, and delta assembly. It must stay an opt-in side
+  effect of the open panel and must not run from the transcript render or
+  turn-event path.
+- The recap reuses the diff summary's `UtilityCompletionService` call path but
+  **not** its storage - a deliberate split: two AI-text features cache at
+  different tiers because one is a durable record and the other is ephemeral UI.
+  A future reader should not "unify" them onto one table.
+- The recap prompt and model are ours (utility model, low effort), not Synara's
+  `gpt-5.4-mini`; the prompt is adapted, not copied.
+- On restart the first Overview open per thread regenerates once. Acceptable, and
+  consistent with ADR-0011's accepted "resets on restart" trade-off; revisit only
+  if it grates.

--- a/docs/prd/2026-06-16-thread-overview-epic-1-panel-state.md
+++ b/docs/prd/2026-06-16-thread-overview-epic-1-panel-state.md
@@ -1,0 +1,59 @@
+# PRD - Per-thread panel state
+
+**Epic:** 1 of 4 (Thread Overview)
+**GitHub:** epic #753; sub-issues #757 (Review default), #758 (panel container state)
+**Date:** 2026-06-16
+**Status:** ready-for-agent
+**Arch spec:** [2026-06-16-thread-overview-design.md](../specs/2026-06-16-thread-overview-design.md)
+**ADRs:** [0011](../adr/0011-review-default-view-per-thread.md), [0012](../adr/0012-right-panel-state-per-thread.md)
+
+## Problem Statement
+
+I work across several threads in a workspace. Today the Review tab and the right panel do not belong to the thread I am on. The Review view is a single global selection, so switching threads carries the previous thread's view. The panel's open tabs, width, and visibility bleed across sibling threads. When I open Changes for a thread, it does not land on the view that matches that thread's state - a thread whose agent just produced changes can still show Branch, which hides uncommitted work. I have to re-orient the panel every time I switch threads.
+
+## Solution
+
+Each thread remembers its own Review view and its own panel layout. When I open Changes, the Review tab lands on the view that fits that thread's change state: Last turn if the agent registered changes, Unstaged if I have manual edits with no turn, Branch if the tree is clean. The default keeps up with the thread live until I pick a view myself, after which my pick sticks for that thread. The panel's tabs, width, and visibility follow the thread, not the workspace, with a single workspace-level fallback so the threadless Browser/Terminal shell still works and a brand-new thread does not land on an empty panel.
+
+## User Stories
+
+1. As a developer switching between threads, I want each thread's Review tab to open on the view that matches its change state, so that I see the most relevant diff without re-selecting.
+2. As a developer whose agent just produced its first turn, I want the Review default to flip from Branch to Last turn live, so that I am not stuck looking at a view that hides the new work.
+3. As a developer with only manual edits and no turn yet, I want the Review default to be Unstaged, so that my uncommitted edits are visible rather than hidden behind Branch's committed-only range.
+4. As a developer on a clean thread, I want the Review default to be Branch, so that I see the branch's committed work.
+5. As a developer who picked a specific Review view, I want that pick to stick for that thread, so that auto-defaulting stops overriding my choice.
+6. As a developer who picked a view on one thread, I want a sibling thread to keep its own default, so that my pick does not leak across threads.
+7. As a developer, I want the right panel's open tabs to belong to each thread, so that opening a Terminal on thread A does not change what thread B shows.
+8. As a developer, I want the panel width and active tab to follow the thread, so that each thread restores its own layout when I switch to it.
+9. As a developer, I want panel visibility to be per-thread, so that opening the panel on one thread leaves it closed on its siblings.
+10. As a developer opening a brand-new thread, I want it to inherit the workspace fallback layout on first open, so that it does not start on a blank panel.
+11. As a developer who customizes a thread's panel, I want it to diverge from the fallback the moment I change it, so that my customization is the thread's own from then on.
+12. As a developer with no thread open, I want the Browser/Terminal panel to still work against the workspace root, so that the threadless shell from ADR-0004 keeps functioning.
+13. As a developer deleting a thread, I want its Review view, override flag, and panel state cleaned up, so that no dangling state survives.
+14. As a developer who restarts the app, I want the change-state default to apply again until I re-pin, so that the in-memory reset is predictable.
+
+## Implementation Decisions
+
+- **Review default becomes a per-thread, change-state choice.** Extend `defaultReviewView` from the current 2-way (thread -> Last turn, threadless -> Unstaged) to the 3-way default in ADR-0011: turn-registered changes -> Last turn; else dirty working tree -> Unstaged; else -> Branch. The turn-changes signal is the same one the header's changed-file count already uses.
+- **A sticky per-thread override.** `diffStore` gains per-thread Review view state plus a per-thread "user picked" flag. The default re-evaluates live until the flag is set; a manual pick sets it and stops auto-defaulting for that thread. The mechanism mirrors the existing `branchManuallySelected` guard in `workspaceStore`.
+- **All panel container state goes per-thread** (visibility, width, active tab, open-tabs set), per ADR-0012, read through a copy-on-write accessor that falls back to one workspace-level record until the thread writes its own entry. This supersedes ADR-0004's per-thread-visibility / workspace-global-width-and-tab split; ADR-0004's singleton-tabs and per-tab-scope decisions still stand.
+- **Cleanup.** `clearThread` drops the thread's Review view, override flag, and panel-state record.
+- **In-memory only.** Both the override and the panel state reset on restart, consistent with the ADRs; durable storage is a clean later add.
+- **Coexistence.** The new default logic must coexist with the existing `DiffToolbar` scope-recovery effect, which still fires when the active view falls out of the current scope.
+
+## Testing Decisions
+
+- A good test asserts external behavior - the view or panel state a thread shows after a sequence of actions - not the store's internal shape.
+- **Modules tested:** `diffStore` (per-thread view, override, panel state, `clearThread` cleanup) and `review-views` (the extended `defaultReviewView`).
+- **Prior art:** `diffStore.test.ts` already tests `clearThread` cleanup and the per-thread `getRightPanelVisible` accessor with a pure Zustand pattern (seed state, call action, read back). `review-views.test.ts` already tests `defaultReviewView` as a pure function. Extend both - no new test seam is needed.
+- Cases to add: the 3-way default for each change state; the override stops live re-evaluation; the override is per-thread; the copy-on-write fallback resolves to the workspace record until a thread diverges; `clearThread` drops every per-thread entry.
+
+## Out of Scope
+
+- The Overview surface itself - this epic only moves the state model; the surface lands in Epic 2.
+- Persisting the override or panel state across restarts.
+- Changing tab content scopes (Browser/Terminal/Files/Review/Scope keep their ADR-0004 scopes).
+
+## Further Notes
+
+This epic ships store-only changes with no UI surface of its own, so it can land and be verified before any Overview UI depends on it. Epic 2's Changes row consumes the new default; the dependency is soft - the Changes row works without this epic, just with the old global default.

--- a/docs/prd/2026-06-16-thread-overview-epic-2-overview-surface.md
+++ b/docs/prd/2026-06-16-thread-overview-epic-2-overview-surface.md
@@ -1,0 +1,64 @@
+# PRD - Thread Overview surface and git/context rows
+
+**Epic:** 2 of 4 (Thread Overview)
+**GitHub:** epic #754; sub-issues #759-#767
+**Date:** 2026-06-16
+**Status:** ready-for-agent
+**Arch spec:** [2026-06-16-thread-overview-design.md](../specs/2026-06-16-thread-overview-design.md)
+**ADRs:** consumes [0011](../adr/0011-review-default-view-per-thread.md) (soft), [0012](../adr/0012-right-panel-state-per-thread.md)
+
+## Problem Statement
+
+The thread header tells me almost nothing about the thread I am in. The `header-workspace-menu` is a thin dropdown - Changes, Branch, Commit-or-push, Create PR - and the rest of the thread's context is invisible. I cannot see, in one place, what repository the thread targets, which worktree and branch it runs on, how much provider budget is left, or the live PR and CI state. I have to hunt across the sidebar, the composer status bar, and the PR button to assemble a picture of a single thread.
+
+## Solution
+
+The `header-workspace-menu` becomes a thread-scoped popover, the Overview (`ThreadOverview`), that recaps the thread and hosts its git and context rows in one vertical list: a Recap slot (filled by Epic 3), Changes (opens the Review tab on this thread's default view), Repository (the `org/repo` it targets, opens in the browser), PR (live status with commit-or-push, create PR, and open PR), Mode (the worktree and branch, with copy), Usage (the active provider's quota and cost), and Create branch (a new branch created and checked out in place). A small CI status dot on the trigger shows red when checks are failing and green when they pass, scoped to the active thread, visible without opening the popover.
+
+## User Stories
+
+1. As a developer, I want a single Overview popover on the thread header, so that I can see and act on the whole thread context in one place.
+2. As a developer, I want the Overview to show my thread's changed-file count and open the Review tab, so that I can jump straight to the diff.
+3. As a developer, I want the Review tab to land on my thread's default view when I open it from the Overview, so that I see the most relevant diff without re-selecting (consumes Epic 1).
+4. As a developer, I want the Overview to show the repository the thread targets as `org/repo`, so that I know which remote my work lands on.
+5. As a developer, I want to click the repository row to open the remote in my browser, so that I can reach the GitHub page without copying a URL.
+6. As a developer on a thread with no remote, I want the repository row to fall back to the folder name, so that the row is still meaningful for a local-only repo.
+7. As a developer, I want the Overview to show my PR's live status and CI, so that I know whether my branch is mergeable.
+8. As a developer with uncommitted work, I want a commit-or-push action in the Overview, so that I can push without leaving the thread.
+9. As a developer with commits ahead and no PR, I want a Create PR action in the Overview, so that I can open a PR in place.
+10. As a developer with an open PR, I want to open it from the Overview, so that I can reach the PR page directly.
+11. As a developer, I want the Overview to show my thread's worktree path and branch, so that I know where the code lives.
+12. As a developer, I want to copy the branch name from the Overview, so that I can paste it elsewhere.
+13. As a developer, I want the Overview to show my active provider's usage and cost, so that I can judge remaining budget for this thread.
+14. As a developer on a provider without usage reporting, I want the Usage row to say usage is unavailable, so that the row degrades cleanly rather than erroring.
+15. As a developer, I want to create a new branch from the Overview that is created and checked out in place, so that I can branch this thread without a fork.
+16. As a developer, I want the new-branch action to reject unsafe branch names, so that I cannot inject arguments into the git command.
+17. As a developer, I want a CI status dot on the Overview trigger, so that I can see at a glance whether my thread's checks are failing or passing without opening the popover.
+18. As a developer, I want the CI dot to show nothing when there is no PR or checks are pending, so that the signal is meaningful only when it matters.
+19. As a developer, I want the Overview to be scoped to the active thread, so that it always reflects the thread I am looking at.
+
+## Implementation Decisions
+
+- **Enrich, do not replace blindly.** `HeaderActions.tsx`'s `header-workspace-menu` becomes `ThreadOverview`, a popover. The existing PR affordances (`PrSplitButton`, `ChecksPopover`, `CreatePrDialog`) and the `useThreadGitActions(thread)` data (`prable`, `pr`, `hasCommitsAhead`, `checks`, `openPrDetail`, `dirPath`, commit-or-push, open-PR) are reused, not rebuilt.
+- **New RPC `git.getRemoteUrl`.** `GitService.getRemoteUrl(path)` runs `git remote get-url origin`, normalizes SSH and `.git` suffixes to an https web URL, derives the `org/repo` label, and falls back to the directory basename with a null URL when there is no remote. Normalization is server-side, validated once at the boundary. Follows the `diffSummary.*` wiring idiom (WS_METHODS entry, router case, named transport wrapper).
+- **New RPC `git.createBranch`.** `GitService.createBranch(path, name)` runs `git checkout -b <name>` (create plus checkout). The name is validated against a git-ref allowlist before exec (reject empty, leading `-`, whitespace, `..`, shell metacharacters); fail closed. Returns the created branch.
+- **Usage row reuses the existing path.** It reads `usageByProvider[thread.provider]` from the thread record, already populated by `fetchProviderUsage`. No new fetch and no new server code; providers without `getUsage` already return an empty-but-valid shape.
+- **CI blob is a pure derivation.** `(pr, checks) -> "red" | "green" | null` over the `checks`/`pr` already in `useThreadGitActions`. Red when failing, green when all passed, null otherwise. Active-thread scope.
+- **Changes row** triggers the existing `changes.toggle` command and relies on Epic 1 for the per-thread default (soft dependency - works without it).
+
+## Testing Decisions
+
+- A good test asserts what the user sees and the side effect they trigger, not the component internals.
+- **Modules tested:** `GitService` (`getRemoteUrl`, `createBranch`), the CI-blob pure function, and the `ThreadOverview` popover behavior.
+- **Prior art:** `GitService` tests use an injected mock git executor (`git-service-push.test.ts`) - assert the SSH->https normalization output, the folder-name fallback, the exec args for `createBranch`, and that the arg-injection guard fires on an unsafe name. The CI blob is a trivial pure function test. For the popover, extend `chat-header-consolidated.spec.ts` (it already drives `header-workspace-menu` -> `workspace-menu-changes`) and follow `sidebar-usage-popover.spec.ts` for popover mechanics (mock WS, inject Zustand, open, assert `[data-slot="popover-content"]`, dismiss). Cover: each row renders, Changes opens Review, Repository opens the remote, the PR actions appear when applicable, the CI dot shows red and green.
+
+## Out of Scope
+
+- The Recap row content and its generation - Epic 3 fills the slot.
+- The Fork group and Switch provider - Epic 4.
+- Removing the now-redundant chrome (header project/workspace badge, composer status bar) - a fast-follow after the Overview ships.
+- Implementing `getUsage` for Codex and Cursor - the row degrades gracefully; this is a later add.
+
+## Further Notes
+
+This epic is the shell every other row plugs into. It depends softly on Epic 1 (the Changes row's default) and hard-blocks Epics 3 and 4, which fill the Recap slot and the continuation actions respectively. The two new git RPCs are the only net-new server contracts here; everything else reuses an existing path.

--- a/docs/prd/2026-06-16-thread-overview-epic-3-thread-recap.md
+++ b/docs/prd/2026-06-16-thread-overview-epic-3-thread-recap.md
@@ -1,0 +1,56 @@
+# PRD - Thread Recap
+
+**Epic:** 3 of 4 (Thread Overview)
+**GitHub:** epic #755; sub-issues #768-#771
+**Date:** 2026-06-16
+**Status:** ready-for-agent
+**Arch spec:** [2026-06-16-thread-overview-design.md](../specs/2026-06-16-thread-overview-design.md)
+**ADR:** [0013](../adr/0013-thread-recap-generation-and-caching.md)
+**Reference:** Synara (github.com/Emanuele-web04/synara) - the trigger and caching model this epic adapts.
+
+## Problem Statement
+
+I cannot tell at a glance what a thread is about. The thread title is terse and deterministic, and to remember what a thread was doing I have to scroll back and read it. With several threads open, re-orienting on each one is friction. I want a plain-language line that tells me what I am working on in this thread - but not at the cost of token spam from a model that fires on every turn or for threads I never look at.
+
+## Solution
+
+A short AI-generated one-line recap at the top of the Overview - "what you're working on" for the active thread. It is generated cheaply and lazily: only while the Overview is open, only after the thread goes quiet, only when the conversation has materially changed, and only over the new messages since the last recap. It updates as the thread evolves and is cached for the session so reopening the panel costs nothing. It never fires mid-turn and never runs for a thread whose Overview I never open.
+
+## User Stories
+
+1. As a developer, I want a one-line recap of what a thread is doing at the top of its Overview, so that I can re-orient without reading the transcript.
+2. As a developer, I want the recap to update as the thread evolves, so that it stays accurate after new turns.
+3. As a developer, I want the recap to cost near-zero tokens, so that the feature does not waste my budget.
+4. As a developer, I want the recap to generate only while the Overview is open, so that threads I never inspect never trigger a call.
+5. As a developer, I want the recap to wait until the thread goes quiet, so that it does not fire mid-turn or while the assistant is streaming.
+6. As a developer, I want the recap to regenerate only when the conversation materially changes, so that tool noise and work-log churn do not trigger it.
+7. As a developer, I want a refresh to send only the new messages since the last recap plus the previous recap, so that re-summarizing the whole transcript does not waste tokens.
+8. As a developer, I want the recap to stay unchanged when nothing meaningful changed, so that a refresh does not churn the line for no reason.
+9. As a developer, I want the recap cached for the session, so that reopening the Overview does not regenerate it.
+10. As a developer who restarts the app, I want the first Overview open per thread to regenerate the recap once, so that the in-memory reset is acceptable and predictable.
+11. As a developer, I want the recap clipped to a short single line, so that it fits the Overview row.
+
+## Implementation Decisions
+
+- **Stateless generation RPC.** A new `recap.generate` RPC takes the client-selected bounded material (`threadId` for telemetry only, `messages`, `previousRecap`) and returns `{ text }`. The server stores nothing - no table, no migration, no thread-row field. This is the deliberate divergence from the durable diff Summary.
+- **Server prompt builder.** A `RecapService` with a pure `buildThreadRecapPrompt(messages, previousRecap)` and `sanitizeThreadRecap(text)` (mirroring `buildDiffSummaryPrompt` and Synara's `textGenerationShared`), calling `UtilityCompletionService.complete` (our haiku utility model, low reasoning effort, not Synara's `gpt-5.4-mini`). The prompt instructs the model to return the previous recap unchanged when nothing material changed. Output clipped to ~220 chars.
+- **In-memory client cache.** `threadStore` gains `recapByThread: Record<threadId, { text, signature, coveredMessageId }>`, never persisted, dropped by `clearThread`. On restart the first panel-open per thread regenerates once - the accepted cost of not persisting.
+- **A trigger hook owns all gating.** A `useThreadRecap` hook (mirroring Synara's `useThreadRecap`) is panel-gated (runs only while the Overview is open), idle-debounced (~12s first / ~35s refresh, reset on each new message, never mid-turn), signature-gated (a cheap hash of `[last message id, role, length, turn state, pending flags]`; only user/assistant messages advance it; skipped when the signature matches the cached, in-flight, or last-failed value), and incremental (after the first recap, send only the delta since `coveredMessageId` - bounded to ~4 messages, ~600 chars each - plus the previous recap). First pass is bounded to ~6 messages.
+- **No hot-path coupling.** The hook is an opt-in side effect of the open panel and must never run from the transcript render or the turn-event path.
+
+## Testing Decisions
+
+- A good test asserts the decision the system makes - whether to schedule a generation, and the prompt/output shape - not the React hook internals.
+- **Modules tested:** the pure `buildThreadRecapPrompt` / `sanitizeThreadRecap`, the pure scheduling decision (`shouldScheduleThreadRecapGeneration`) and signature hash, and the `recapByThread` cache cleanup.
+- **Prior art:** `diff-summary-prompt.test.ts` tests `buildDiffSummaryPrompt` as a pure function with no mocks - mirror it for the recap prompt and sanitizer. `utility-completion-service.test.ts` mocks the provider registry and asserts `complete()` - reuse that path; the recap RPC handler stays a thin pass-through and is not separately unit-tested (consistent with `diffSummary.*`). Synara's `threadRecap.ts` is the model for the pure scheduling decision. The hook's end-to-end behavior is covered by the Overview E2E (panel-gated, no call when closed).
+- Cases to add: the scheduler returns false when the panel is closed, mid-turn, signature-unchanged, or in-flight, and true only when idle and materially changed; the prompt includes the previous recap and only the delta; sanitize clips to the char cap; `clearThread` drops the cache entry.
+
+## Out of Scope
+
+- Persisting the recap server-side or in localStorage (Synara's choice) - intentionally in-memory.
+- Eager or per-turn generation.
+- A "regenerate now" button or any user-triggered generation - the trigger is automatic and gated.
+
+## Further Notes
+
+This epic carries the user's one hard constraint - no token spam - which is why its cost control is isolated here rather than folded into the surface epic. It hard-depends on Epic 2 for the panel and the panel-open gate. Synara already shipped this feature cost-controlled; adapt its trigger and caching, but the prompt and model are ours.

--- a/docs/prd/2026-06-16-thread-overview-epic-4-fork-switch-provider.md
+++ b/docs/prd/2026-06-16-thread-overview-epic-4-fork-switch-provider.md
@@ -1,0 +1,54 @@
+# PRD - Fork and Switch provider
+
+**Epic:** 4 of 4 (Thread Overview)
+**GitHub:** epic #756; sub-issues #772-#776
+**Date:** 2026-06-16
+**Status:** ready-for-agent
+**Arch spec:** [2026-06-16-thread-overview-design.md](../specs/2026-06-16-thread-overview-design.md)
+**ADR:** a cross-provider-switch ADR is written when this piece is built; the mechanics are in `CONTEXT.md` (Fork, Switch provider, Cross-provider switch).
+
+## Problem Statement
+
+To take a thread further I have to leave its context. There is no in-thread way to spawn a copy of the work along a different path, and there is no way to change the provider driving a thread without losing everything it has built up. If I want a different model or provider to continue this exact thread - same history, same worktree - I have to start over cold. Forking and provider-switching are different intentions ("a new thread" versus "this thread, new driver"), and neither is reachable from the thread itself.
+
+## Solution
+
+Two continuation actions in the Overview, split by what each does to this thread. Fork spawns a new child thread and leaves this one untouched, with three targets: a new worktree, an existing worktree, or a new local thread (Direct mode) - each carrying a handoff from this thread. Switch provider keeps this same thread (id, history, worktree unchanged) and swaps only the provider driving it, generating a handoff from the outgoing provider so the new one continues with context. Switching back is the same action in reverse. Handoff is always-on for both; it is the mechanism, not a menu item.
+
+## User Stories
+
+1. As a developer, I want to fork this thread into a new worktree from the Overview, so that I can explore a different path in isolation while this thread stays as it is.
+2. As a developer, I want to fork into an existing worktree, so that I can continue the work where another worktree already lives.
+3. As a developer, I want to fork into a new local thread (Direct mode), so that I can branch the conversation without a worktree.
+4. As a developer forking a thread, I want the child to carry a handoff from this thread, so that the new thread continues with context rather than cold.
+5. As a developer, I want forking to leave this thread untouched, so that I keep the original line of work.
+6. As a developer, I want to switch the provider driving this thread from the Overview, so that a different provider continues the same thread with its history and worktree intact.
+7. As a developer switching provider, I want a handoff generated from the outgoing provider, so that the incoming provider picks up with context rather than starting cold.
+8. As a developer, I want to switch the provider back later, so that I can move between providers on the same thread freely.
+9. As a developer, I want Fork and Switch provider visually distinct in the Overview, so that I do not confuse spawning a copy with changing this thread's driver.
+10. As a developer, I want switching provider to keep the thread id and history, so that nothing about the thread is lost in the swap.
+
+## Implementation Decisions
+
+- **Fork reuses the existing flow.** The Fork group is a new entry point into `agent.createAndSend` with `parentThreadId` (and optional `forkedFromMessageId`), which already creates a child thread in the chosen mode (worktree / existing-worktree -> worktree + `existingWorktreePath` / direct) and attaches the handoff via `HandoffCoordinator.deliverHandoff`. The mode resolution mirrors `workspaceStore.branchThread`. No server changes for Fork.
+- **Switch provider is a new orchestration RPC.** `thread.switchProvider(threadId, provider, model?)` generates a handoff from the outgoing provider and swaps the provider in place. The pieces it reuses already exist: `thread.provider` is mutable (`threadRepo.updateProvider`), `agent.send` already accepts an explicit `provider` that re-persists it and broadcasts `thread.modelUpdated`, and `HandoffCoordinator.deliverHandoff` works when `childThreadId` equals the parent thread id.
+- **The seq-anchor fix.** The handoff coordinator persists its internal handoff system message at a hardcoded `seq = 1`. On an existing thread with `nextSeq > 1` that collides. The switch path must write the internal message at the thread's current `nextSeq`, not a constant. This is the one structural change the switch requires beyond wiring the new RPC.
+- **Flow.** Switch provider: generate the handoff from the current provider (coordinator targeted at the same thread id, writing at `nextSeq`), update the persisted provider, broadcast `thread.modelUpdated`; the next user send drives the new provider with the handoff already in place.
+- **An ADR is written when this is built**, capturing the same-thread-switch mechanism and the seq-anchor decision; the product mechanics are already settled in `CONTEXT.md`.
+
+## Testing Decisions
+
+- A good test asserts the observable outcome of a switch or fork - the thread's provider, the presence and placement of the handoff message, the broadcast - not the orchestration internals.
+- **Modules tested:** the `thread.switchProvider` orchestration (provider updated, handoff generated against the same thread id, internal message written at `nextSeq` not `1`, `thread.modelUpdated` broadcast) and the Overview's Fork and Switch actions.
+- **Prior art:** the handoff builder and coordinator have pure-function tests (`handoff-builder.test.ts`) - assert the switch path's handoff content and the seq anchor there. Fork already has end-to-end coverage through the existing create-and-send flow; the Overview's Fork group is a new entry point, covered by the Overview E2E. The RPC handler stays thin and is not separately unit-tested, consistent with the other `agent.*` and `handoff.*` handlers.
+- A specific regression to lock: switching provider on a thread with prior messages writes the internal handoff message at `nextSeq` and does not collide at `seq = 1`.
+
+## Out of Scope
+
+- Changing the handoff B/A/D ladder mechanism - the switch reuses it as-is.
+- The cross-provider-switch ADR document - written when the piece is built, not part of this PRD.
+- Any change to how Fork creates threads - it reuses the existing flow unchanged.
+
+## Further Notes
+
+This is the heaviest behavioral epic: it spawns threads and drives the handoff machinery and a same-thread provider swap. It hard-depends on Epic 2 (the actions live in the shell). The seq-anchor collision is the single real hazard and is the reason the switch carries its own epic rather than riding along in the surface work.

--- a/docs/specs/2026-06-16-thread-overview-design.md
+++ b/docs/specs/2026-06-16-thread-overview-design.md
@@ -1,0 +1,304 @@
+# Thread Overview
+
+**Date:** 2026-06-16
+**Status:** Design
+**Related ADRs:** [0011](../adr/0011-review-default-view-per-thread.md) (Review default view per thread), [0012](../adr/0012-right-panel-state-per-thread.md) (right-panel state per thread), [0013](../adr/0013-thread-recap-generation-and-caching.md) (thread recap generation and caching)
+**Related specs:** [2026-04-14](2026-04-14-usage-tracking-design.md) (usage tracking), [2026-04-22](2026-04-22-dynamic-context-window-design.md) (dynamic context window)
+**Reference implementation:** Synara (github.com/Emanuele-web04/synara), a diverged sibling fork that already shipped the Recap. Adapt, do not cherry-pick.
+**Epics:** #753 (per-thread panel state), #754 (Overview surface), #755 (Thread Recap), #756 (Fork & Switch provider). Sub-issues #757-#776.
+
+This is the shared architectural backbone for four epics. It pins the system shape, the new RPC contracts, the store changes, and the cross-cutting data flows once, so each epic's PRD and issues reference one consistent design. It does not restate the product rationale already grilled into `CONTEXT.md` (Overview, Recap, Fork, Switch provider, Create branch) or the trade-offs already settled in ADRs 0011 / 0012 / 0013.
+
+## Problem
+
+A thread's working context is scattered across the header. The current `header-workspace-menu` is a thin dropdown (Changes, Branch, Commit-or-push, Create PR) that answers "what git actions can I take" but not "what is this thread, where does its code live, how much budget is left, and how do I take it further." A user mid-thread cannot see, in one place: a plain-language recap of what the thread is doing, the repository it targets, the worktree and branch it runs on, its provider usage, and the full set of ways to continue (commit, PR, fork, switch provider, branch). Codex's Environment panel solves this for its world; mcode has no equivalent thread-scoped surface.
+
+## Solution
+
+Enrich the existing `header-workspace-menu` into a thread-scoped header popover, **Overview** (code symbol `ThreadOverview`). It recaps the active thread's working context and hosts its git and continuation actions as a vertical list of rows:
+
+| Row | Shows | Action | Backing |
+|-----|-------|--------|---------|
+| **Recap** | AI one-line "what you're working on" | none (display) | new `recap.generate` RPC, in-memory cache (ADR-0013) |
+| **Changes** | changed-file count | opens Review tab | existing `changes.toggle`; lands on the ADR-0011 per-thread default |
+| **Repository** | `org/repo` (or folder name) | opens the remote in the browser | new `git.getRemoteUrl` RPC |
+| **PR** | live PR status + CI | commit-or-push, create PR, open PR | reuse `PrSplitButton` / `ChecksPopover` / `useThreadGitActions` |
+| **Mode** | worktree path + branch | copy branch | existing thread fields |
+| **Usage** | active provider's quota / cost | none (display) | reuse `usageByProvider[thread.provider]` (no new fetch) |
+| **Create branch** | current branch | `git checkout -b` in place | new `git.createBranch` RPC |
+| **Fork** | new worktree / existing worktree / new local thread | spawns a child thread + handoff | reuse `agent.createAndSend` + `HandoffCoordinator` |
+| **Switch provider** | provider list | swaps this thread's provider + handoff | new `thread.switchProvider` RPC |
+
+A **CI notification blob** on the trigger (red = failing, green = passing, nothing otherwise) is scoped to the active thread and visible without opening the popover.
+
+### Goals
+
+- One thread-scoped surface for context recap plus every continuation action.
+- Reuse before rebuild: the PR stack, the usage slice, the fork flow, and the handoff coordinator already exist. Three small read RPCs (`recap.generate`, `git.getRemoteUrl`, `git.createBranch`) and one orchestration RPC (`thread.switchProvider`) are the only net-new server contracts.
+- Keep the cost of the Recap near zero (ADR-0013).
+
+### Non-goals
+
+- Removing the now-redundant chrome (header project/workspace badge, composer status bar). Deferred to a fast-follow once the Overview proves itself.
+- A "Send to cloud" action or a "Sources" row. Out of scope.
+- Implementing `getUsage` for providers that lack it (Codex, Cursor). The Usage row degrades gracefully (see below); these are a clean later add.
+
+## System architecture
+
+```mermaid
+graph TD
+    subgraph web["apps/web"]
+        TO["ThreadOverview popover<br/>(enriches HeaderActions)"]
+        UTGA["useThreadGitActions"]
+        URC["useThreadRecap hook<br/>(panel-gated trigger)"]
+        DS["diffStore<br/>(ADR-0011 / 0012 state)"]
+        TS["threadStore<br/>(usageByProvider, recapByThread)"]
+        WST["workspaceStore<br/>(fork via branchThread)"]
+        TR["ws-transport<br/>(named RPC wrappers)"]
+    end
+    subgraph contracts["packages/contracts"]
+        WM["WS_METHODS<br/>(+ recap.generate, git.getRemoteUrl,<br/>git.createBranch, thread.switchProvider)"]
+    end
+    subgraph server["apps/server"]
+        WR["ws-router dispatch"]
+        RS["RecapService<br/>(buildThreadRecapPrompt + UtilityCompletionService)"]
+        GS["GitService<br/>(getRemoteUrl, createBranch)"]
+        AS["agent-service<br/>(createBranchedThread, sendMessage)"]
+        HC["HandoffCoordinator"]
+    end
+
+    TO --> UTGA & URC & DS & TS & WST
+    TO --> TR
+    URC --> TR
+    TR --> WM --> WR
+    WR --> RS & GS & AS
+    AS --> HC
+```
+
+The Overview is a presentation surface over data that already flows. The only new server work is the three read RPCs, the `RecapService`, the two `GitService` methods, and the `thread.switchProvider` orchestration.
+
+## New RPC contracts
+
+All four follow the canonical `diffSummary.*` idiom: an entry inside the `WS_METHODS` `lazySchema` factory (no per-entry `lazySchema` wrapping), a `case` in `ws-router`'s dispatch switch reading injected `RouterDeps`, and a named typed wrapper on the client transport object (callers use `getTransport().generateRecap(...)`, never a generic string dispatch).
+
+### `recap.generate`
+
+Stateless. The client owns the trigger and assembles the bounded material; the server builds the prompt, runs the utility model, and **stores nothing** (ADR-0013).
+
+```ts
+"recap.generate": {
+  params: z.object({
+    threadId: z.string(),                 // telemetry only; server reads no repo
+    messages: z.array(z.object({          // client-selected: first-pass window or delta
+      role: z.enum(["user", "assistant"]),
+      content: z.string(),
+    })),
+    previousRecap: z.string().nullable(),
+  }),
+  result: z.object({ text: z.string() }),
+}
+```
+
+Server: a `RecapService` with a pure `buildThreadRecapPrompt(messages, previousRecap)` and `sanitizeThreadRecap(text)` (mirroring `buildDiffSummaryPrompt` and Synara's `textGenerationShared`), calling `UtilityCompletionService.complete` (our haiku utility model, low reasoning effort). The prompt instructs the model to return the previous recap unchanged when nothing material changed. Output clipped to ~220 chars.
+
+### `git.getRemoteUrl`
+
+```ts
+"git.getRemoteUrl": {
+  params: z.object({ path: z.string() }),
+  result: z.object({
+    webUrl: z.string().nullable(),  // normalized https, null when no remote
+    label: z.string(),              // "org/repo" or folder-name fallback
+  }),
+}
+```
+
+Server: `GitService.getRemoteUrl(path)` runs `git -C <path> remote get-url origin`, normalizes SSH (`git@github.com:org/repo.git`) and `.git` suffixes to an https web URL, derives the `org/repo` label, and falls back to the directory basename with `webUrl: null` when there is no remote. Normalization lives server-side so it is validated once at the boundary and tested in one place.
+
+### `git.createBranch`
+
+```ts
+"git.createBranch": {
+  params: z.object({ path: z.string(), name: z.string() }),
+  result: z.object({ branch: z.string() }),
+}
+```
+
+Server: `GitService.createBranch(path, name)` runs `git -C <path> checkout -b <name>` (create plus checkout in one step) and returns the created branch. The name crosses a process boundary into a subprocess, so it is validated against a git-ref allowlist before the exec: reject empty, leading `-`, whitespace, `..`, and shell metacharacters. Fail closed.
+
+### `thread.switchProvider`
+
+Orchestration. Swaps the provider driving an existing thread (same id, history, worktree) and generates a handoff from the outgoing provider. See the dedicated section below for the mechanism and its hazard.
+
+```ts
+"thread.switchProvider": {
+  params: z.object({
+    threadId: z.string(),
+    provider: ProviderIdSchema,
+    model: z.string().optional(),
+  }),
+  result: z.object({ ok: z.boolean() }),
+}
+```
+
+## Store and state changes
+
+### Review default view per thread (ADR-0011)
+
+`diffStore` gains per-thread Review view state plus a per-thread "user picked" override flag. `defaultReviewView` extends from the current 2-way (`thread` -> `last-turn`, `threadless` -> `unstaged`) to the 3-way change-state default: turn-registered changes -> Last turn; else dirty working tree -> Unstaged; else -> Branch. The default re-evaluates live until the user picks a view, after which the per-thread override sticks. Mechanism mirrors the existing `branchManuallySelected` guard. In-memory, dropped by `clearThread`.
+
+### Right-panel container state per thread (ADR-0012)
+
+All panel container state (visibility, width, active tab, open-tabs set) becomes per-thread, read through a copy-on-write accessor that falls back to a single workspace-level record until a thread writes its own entry. Supersedes ADR-0004's per-thread-visibility / workspace-global-width-and-tab split. `clearThread` drops the whole per-thread record.
+
+### Recap cache (ADR-0013)
+
+`threadStore` gains an in-memory `recapByThread: Record<threadId, { text, signature, coveredMessageId }>`, never persisted, dropped by `clearThread`. A `useThreadRecap` hook owns the trigger: panel-gated (runs only while the Overview is open), idle-debounced (~12s first / ~35s refresh, reset on each new message, never mid-turn), signature-gated (hash of `[last message id, role, length, turn state, pending flags]`; only user/assistant messages advance it), and incremental (after the first recap, send only the delta since `coveredMessageId` plus the previous recap). The hook is an opt-in side effect of the open panel and never runs from the transcript render or turn-event path.
+
+### Usage row (reuse, no new fetch)
+
+The Usage row reads `usageByProvider[thread.provider]` from the active thread record, already populated by `fetchProviderUsage` (on `session.usageUpdated` and on thread/provider switch) per the usage-tracking spec. It renders the same `ProviderUsageInfo` shape (`quotaCategories`, `sessionCostUsd`, `serviceTier`, `numTurns`, `durationMs`) the sidebar panel renders. For providers without `getUsage` (Codex, Cursor) the router already returns `{ providerId, quotaCategories: [] }`, so the row shows "usage unavailable" with no new code.
+
+## Data flows
+
+### Recap generation trigger
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant P as ThreadOverview (open)
+    participant H as useThreadRecap
+    participant T as ws-transport
+    participant R as RecapService
+    U->>P: opens Overview
+    P->>H: panel open = true
+    H->>H: compute signature
+    alt signature unchanged or matches cache/in-flight
+        H-->>P: render cached recap
+    else stale and thread idle >= 12s/35s
+        H->>H: assemble bounded delta + previousRecap
+        H->>T: recap.generate(threadId, messages, previousRecap)
+        T->>R: dispatch
+        R->>R: buildThreadRecapPrompt -> UtilityCompletionService -> sanitize
+        R-->>H: { text }
+        H->>H: write recapByThread[threadId]
+        H-->>P: render recap
+    end
+    Note over H: never fires mid-turn / while streaming;<br/>panel closed -> no calls at all
+```
+
+### Cross-provider switch
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant O as ThreadOverview
+    participant T as ws-transport
+    participant W as ws-router
+    participant H as HandoffCoordinator
+    participant A as agent-service
+    U->>O: Switch provider -> Codex
+    O->>T: thread.switchProvider(threadId, "codex")
+    T->>W: dispatch
+    W->>H: deliverHandoff(parent = thread, childThreadId = thread.id, childProvider = codex)
+    Note over H: writes internal system message at nextSeq (NOT seq 1)<br/>produces providerWireOverride
+    W->>A: threadRepo.updateProvider(threadId, "codex")
+    A-->>O: broadcast thread.modelUpdated
+    Note over O,A: next user send drives Codex with the handoff already in place
+```
+
+### Fork (reuses existing flow)
+
+Fork is already wired: `agent.createAndSend` with `parentThreadId` (and optional `forkedFromMessageId`) creates a child thread in the chosen mode (worktree / existing-worktree / direct), then `HandoffCoordinator.deliverHandoff` attaches the handoff to the child's first send. The Overview's Fork group is a new entry point into this flow, not new flow. No server changes.
+
+## The CI notification blob
+
+A small status dot on the Overview trigger, derived purely from the active thread's PR checks already in `useThreadGitActions` (`checks`, `pr`):
+
+```ts
+function ciBlob(pr, checks): "red" | "green" | null {
+  if (!pr || !checks) return null;          // no PR or no checks -> no dot
+  if (checks.failing > 0) return "red";
+  if (checks.allPassed) return "green";
+  return null;                              // pending -> no dot
+}
+```
+
+Scoped to the active thread only. It reuses the existing checks channel; it is a pure derivation with no new data source.
+
+## Cross-provider switch: the seq-anchor hazard
+
+The switch is **already half-wired**. `thread.provider` is mutable (`threadRepo.updateProvider`), and `agent.send` already accepts an optional `provider` that, when explicitly passed, re-persists the provider and broadcasts `thread.modelUpdated`. What is missing is the handoff from the outgoing provider on an in-place switch: the `HandoffCoordinator` is only ever called from `createBranchedThread`.
+
+The coordinator does not require a new thread - `deliverHandoff` accepts `childThreadId` and works when it equals the parent thread id. The one real hazard: the coordinator persists its internal handoff system message at a **hardcoded `seq = 1`**. On an existing thread with `nextSeq > 1`, that collides. Epic 4 must change the switch path to write the internal message at the thread's current `nextSeq`, not a constant `1`. This is the single structural change the switch requires beyond wiring the new RPC; everything else (provider update, broadcast, wire override) already exists. This is why the switch carries its own epic.
+
+## Epic decomposition and dependency graph
+
+```mermaid
+graph TD
+    E1["epic 1: per-thread panel state<br/>ADR-0011 + 0012 - store only"]
+    E2["epic 2: Overview surface<br/>+ git / context rows"]
+    E3["epic 3: Thread Recap<br/>ADR-0013 - token-gated"]
+    E4["epic 4: Fork & Switch provider"]
+    FF["fast-follow: remove old chrome"]
+    E1 -. soft .-> E2
+    E2 --> E3
+    E2 --> E4
+    E2 -. then .-> FF
+```
+
+| Epic | Delivers | New contracts | Depends on |
+|------|----------|---------------|------------|
+| 1 (#753) - per-thread panel state | ADR-0011 + ADR-0012 store changes | none | none |
+| 2 (#754) - Overview surface + rows | `ThreadOverview` popover, Changes / Repository / Create branch / Mode / Usage / PR rows + CI blob | `git.getRemoteUrl`, `git.createBranch` | 1 (soft - Changes row works without it, just with the old default) |
+| 3 (#755) - Thread Recap | `recap.generate` + cache + trigger hook + Recap row | `recap.generate` | 2 (hard - fills a row, needs the panel gate) |
+| 4 (#756) - Fork & Switch provider | Fork group + cross-provider switch (+ the seq-anchor fix) | `thread.switchProvider` | 2 (hard - actions live in the shell) |
+
+Epics 3 and 4 are parallel once 2 lands. The chrome-removal fast-follow is a follow-up to 2, not its own epic.
+
+## Testing strategy
+
+Test at the highest existing seam. Prior art and new seams, per area:
+
+| Area | Seam | Prior art |
+|------|------|-----------|
+| `GitService.getRemoteUrl` / `createBranch` | mock-executor unit test; assert normalization, exec args, and the createBranch arg-injection guard | `git-service-push.test.ts` |
+| Recap | pure `buildThreadRecapPrompt` / `sanitizeThreadRecap`; reuse the already-tested `UtilityCompletionService` | `diff-summary-prompt.test.ts`, `utility-completion-service.test.ts` |
+| ADR-0011 default | extend `defaultReviewView` + per-thread override + `clearThread` cleanup | `review-views.test.ts`, `diffStore.test.ts` |
+| ADR-0012 panel state | copy-on-write fallback accessor | `diffStore.test.ts` `getRightPanelVisible` cases |
+| Recap scheduling | pure `shouldScheduleThreadRecapGeneration` + signature hash | Synara `threadRecap.ts` (hook is a thin wrapper, covered by E2E) |
+| CI blob | pure `(pr, checks) -> "red" \| "green" \| null` | new, trivial |
+| Overview popover | extend `chat-header-consolidated.spec.ts` (drives `header-workspace-menu`); follow `sidebar-usage-popover.spec.ts` mechanics | both exist |
+
+The RPC handlers stay thin pass-throughs and are not separately unit-tested - consistent with `diffSummary.*` and `handoff.*`, whose logic lives in tested builders and services, not their router cases.
+
+## Security and defensive considerations
+
+- **`git.createBranch` name** crosses into a subprocess. Validate against a git-ref allowlist (reject empty, leading `-`, whitespace, `..`, shell metacharacters) before exec. Fail closed.
+- **`git.getRemoteUrl`** normalizes an externally-controlled git config value. Normalize once at the boundary; return `null` rather than a half-parsed URL when the remote is malformed or absent.
+- **`recap.generate` input** is bounded by the client (first pass ~6 messages, ~600 chars each, delta ~4 messages), and the server clips output to ~220 chars. The utility model runs at low reasoning effort. No unbounded retention: the recap cache is in-memory and per-thread.
+- **`thread.switchProvider` seq anchor**: write the internal handoff message at `nextSeq`, never a constant, to avoid a primary-key collision on a non-empty thread.
+
+## Deferred and out of scope
+
+- **Chrome removal** (header badge, composer status bar) - fast-follow after the Overview ships.
+- **`getUsage` for Codex / Cursor** - the Usage row degrades gracefully; implement later.
+- **Persisting the Recap, the Review override, or the panel state across restarts** - all intentionally in-memory (ADRs 0011 / 0012 / 0013); revisit only if the reset grates.
+- **Send to cloud, Sources** - not part of this surface.
+
+## Files touched (by epic, indicative)
+
+| Epic | Package | Area |
+|------|---------|------|
+| 1 | `apps/web` | `diffStore`, `review-views`, `DiffToolbar` |
+| 2 | `packages/contracts` | `ws/methods.ts` (`git.getRemoteUrl`, `git.createBranch`) |
+| 2 | `apps/server` | `git-service.ts`, `ws-router.ts` |
+| 2 | `apps/web` | `HeaderActions.tsx` -> `ThreadOverview`, `useThreadGitActions`, `ws-transport` |
+| 3 | `packages/contracts` | `ws/methods.ts` (`recap.generate`) |
+| 3 | `apps/server` | new `RecapService` + prompt builder, `ws-router.ts` |
+| 3 | `apps/web` | `threadStore` (`recapByThread`), new `useThreadRecap` hook, Recap row |
+| 4 | `packages/contracts` | `ws/methods.ts` (`thread.switchProvider`) |
+| 4 | `apps/server` | `ws-router.ts`, `HandoffCoordinator` (seq anchor), `agent-service` |
+| 4 | `apps/web` | Fork group + Switch provider in `ThreadOverview`, `ws-transport` |
+
+File paths are indicative and may drift; the contracts, store shapes, and flows above are the durable part.


### PR DESCRIPTION
## What

Publishes the **Thread Overview** design as docs: a domain glossary update, three ADRs, one architecture spec, and four epic PRDs. Docs only - no code or behavior change.

## Why

The Thread Overview feature was designed and decomposed into a 4-epic GitHub backlog (#753-#776). These documents are the durable design of record those issues point back to, so the design lives in the repo rather than only in the tracker.

## Key changes

- **Glossary** (`CONTEXT.md`) - defines the Overview surface, Recap, and Create branch; un-defers and rewrites Cross-provider switch as the Switch provider action.
- **ADRs** - `0011` Review default view per thread, `0012` right-panel state per thread (supersedes part of `0004`, which gets a proposed-revision note), `0013` thread recap generation and caching.
- **Architecture spec** (`docs/specs/2026-06-16-thread-overview-design.md`) - the shared backbone: rows and data sources, the four new RPC contracts, store changes, sequence diagrams, the cross-provider seq-anchor hazard, and the epic dependency graph.
- **Epic PRDs** (`docs/prd/`) - one per epic: panel state, Overview surface, thread recap, fork and switch provider.

## Related issues/PRs

- Epics: #753, #754, #755, #756
- Sub-issues: #757-#776
- Revises ADR-0004 (#744)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784210374&installation_id=129163861&pr_number=777&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F777&signature=b58ee38fb65bb87ffe8d7a97e770a1a97eb35d3df89436707e332a7e8b967d2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->