### PR TITLE
feat(diff): per-thread Review default view with sticky override (ADR-0011)

### DIFF
--- a/apps/web/e2e/right-panel-commit-picker.spec.ts
+++ b/apps/web/e2e/right-panel-commit-picker.spec.ts
@@ -185,13 +185,15 @@ async function openThreadCommitView(page: Page): Promise<void> {
           getState: () => {
             showRightPanel: (id: string, threadId?: string) => void;
             setRightPanelTab: (id: string, t: string) => void;
-            setViewMode: (m: string) => void;
+            setReviewViewForThread: (threadId: string, m: string) => void;
           };
         }
       ).getState();
       api.showRightPanel(wid, tid);
       api.setRightPanelTab(wid, "changes");
-      api.setViewMode("commit");
+      // In a thread, selecting a view is a sticky per-thread pick (ADR-0011);
+      // a bare setViewMode would be reverted by the live default effect.
+      api.setReviewViewForThread(tid, "commit");
     },
     { workspace: WORKSPACE, thread: THREAD, wid: WORKSPACE.id, tid: THREAD.id },
   );

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -25,6 +25,8 @@ describe("diffStore", () => {
       diffContent: null,
       diffLoading: false,
       viewMode: "last-turn",
+      reviewViewByThread: {},
+      reviewViewManuallySelectedByThread: {},
       selectedCommitSha: null,
       renderMode: "unified",
       lineWrapByThread: {},
@@ -48,6 +50,64 @@ describe("diffStore", () => {
       setSelectedCommitSha("abc1234");
       setViewMode("commit");
       expect(useDiffStore.getState().selectedCommitSha).toBeNull();
+    });
+  });
+
+  // The Review default is per-thread and sticky: it re-evaluates from the
+  // thread's change state until the user picks a view, after which the pick
+  // sticks for that thread only. See ADR-0011.
+  describe("per-thread Review view default + sticky override", () => {
+    const clean = { hasTurnChanges: false, isDirty: false } as const;
+
+    it("resolves the change-state default until the user picks a view", () => {
+      const { getReviewView } = useDiffStore.getState();
+      // Turn changes -> Last turn; dirty-only -> Unstaged; clean -> Branch.
+      expect(getReviewView("thread-1", { hasTurnChanges: true, isDirty: false })).toBe("last-turn");
+      expect(getReviewView("thread-1", { hasTurnChanges: false, isDirty: true })).toBe("unstaged");
+      expect(getReviewView("thread-1", clean)).toBe("branch");
+    });
+
+    it("re-evaluates live as change state changes while no pick is made", () => {
+      const { getReviewView } = useDiffStore.getState();
+      // A thread opened clean shows Branch...
+      expect(getReviewView("thread-1", clean)).toBe("branch");
+      // ...then the first turn's changes flip it to Last turn, with no pick.
+      expect(getReviewView("thread-1", { hasTurnChanges: true, isDirty: false })).toBe("last-turn");
+    });
+
+    it("sticks to the user's pick and stops re-evaluating change state", () => {
+      const { setReviewViewForThread, getReviewView } = useDiffStore.getState();
+      setReviewViewForThread("thread-1", "cumulative");
+      expect(useDiffStore.getState().viewMode).toBe("cumulative");
+      // Even when turn changes arrive, the pinned view wins.
+      expect(getReviewView("thread-1", { hasTurnChanges: true, isDirty: true })).toBe("cumulative");
+    });
+
+    it("keeps the override per thread — a sibling keeps its own default", () => {
+      const { setReviewViewForThread, getReviewView } = useDiffStore.getState();
+      setReviewViewForThread("thread-1", "staged");
+      expect(getReviewView("thread-1", { hasTurnChanges: true, isDirty: false })).toBe("staged");
+      // thread-2 never picked, so it still follows the live default.
+      expect(getReviewView("thread-2", { hasTurnChanges: true, isDirty: false })).toBe("last-turn");
+    });
+
+    it("drops both the picked view and the override flag on clearThread", () => {
+      const { setReviewViewForThread, clearThread, getReviewView } = useDiffStore.getState();
+      setReviewViewForThread("thread-1", "staged");
+      clearThread("thread-1");
+      const state = useDiffStore.getState();
+      expect(state.reviewViewByThread["thread-1"]).toBeUndefined();
+      expect(state.reviewViewManuallySelectedByThread["thread-1"]).toBeUndefined();
+      // Back to the live change-state default after cleanup.
+      expect(getReviewView("thread-1", clean)).toBe("branch");
+    });
+
+    it("clearThread leaves a sibling thread's override intact", () => {
+      const { setReviewViewForThread, clearThread, getReviewView } = useDiffStore.getState();
+      setReviewViewForThread("thread-1", "staged");
+      setReviewViewForThread("thread-2", "branch");
+      clearThread("thread-1");
+      expect(getReviewView("thread-2", { hasTurnChanges: true, isDirty: false })).toBe("branch");
     });
   });
 

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -53,15 +53,11 @@ describe("diffStore", () => {
     });
   });
 
-  // The Review default is per-thread and sticky: it re-evaluates from the
-  // thread's change state until the user picks a view, after which the pick
-  // sticks for that thread only. See ADR-0011.
   describe("per-thread Review view default + sticky override", () => {
     const clean = { hasTurnChanges: false, isDirty: false } as const;
 
     it("resolves the change-state default until the user picks a view", () => {
       const { getReviewView } = useDiffStore.getState();
-      // Turn changes -> Last turn; dirty-only -> Unstaged; clean -> Branch.
       expect(getReviewView("thread-1", { hasTurnChanges: true, isDirty: false })).toBe("last-turn");
       expect(getReviewView("thread-1", { hasTurnChanges: false, isDirty: true })).toBe("unstaged");
       expect(getReviewView("thread-1", clean)).toBe("branch");
@@ -69,9 +65,7 @@ describe("diffStore", () => {
 
     it("re-evaluates live as change state changes while no pick is made", () => {
       const { getReviewView } = useDiffStore.getState();
-      // A thread opened clean shows Branch...
       expect(getReviewView("thread-1", clean)).toBe("branch");
-      // ...then the first turn's changes flip it to Last turn, with no pick.
       expect(getReviewView("thread-1", { hasTurnChanges: true, isDirty: false })).toBe("last-turn");
     });
 
@@ -79,7 +73,6 @@ describe("diffStore", () => {
       const { setReviewViewForThread, getReviewView } = useDiffStore.getState();
       setReviewViewForThread("thread-1", "cumulative");
       expect(useDiffStore.getState().viewMode).toBe("cumulative");
-      // Even when turn changes arrive, the pinned view wins.
       expect(getReviewView("thread-1", { hasTurnChanges: true, isDirty: true })).toBe("cumulative");
     });
 
@@ -87,7 +80,6 @@ describe("diffStore", () => {
       const { setReviewViewForThread, getReviewView } = useDiffStore.getState();
       setReviewViewForThread("thread-1", "staged");
       expect(getReviewView("thread-1", { hasTurnChanges: true, isDirty: false })).toBe("staged");
-      // thread-2 never picked, so it still follows the live default.
       expect(getReviewView("thread-2", { hasTurnChanges: true, isDirty: false })).toBe("last-turn");
     });
 
@@ -98,7 +90,6 @@ describe("diffStore", () => {
       const state = useDiffStore.getState();
       expect(state.reviewViewByThread["thread-1"]).toBeUndefined();
       expect(state.reviewViewManuallySelectedByThread["thread-1"]).toBeUndefined();
-      // Back to the live change-state default after cleanup.
       expect(getReviewView("thread-1", clean)).toBe("branch");
     });
 

--- a/apps/web/src/components/chat/TurnChangeSummary.tsx
+++ b/apps/web/src/components/chat/TurnChangeSummary.tsx
@@ -105,8 +105,10 @@ export function TurnChangeSummary({ messageId, filesChanged, isLatestTurn, manua
     const store = useDiffStore.getState();
     showRightPanelAdaptive(workspaceId, threadId);
     store.setRightPanelTab(workspaceId, "changes");
-    // "View all diffs" lands on the thread's cumulative diff across every turn.
-    store.setViewMode("cumulative");
+    // "View all diffs" is a deliberate pick: land on the thread's cumulative diff
+    // and pin it as the per-thread override so the change-state default does not
+    // revert it (ADR-0011).
+    store.setReviewViewForThread(threadId, "cumulative");
 
     // Ensure snapshots are loaded so the panel can display this turn
     if (!store.snapshotsByThread[threadId]) {

--- a/apps/web/src/components/chat/TurnChangeSummary.tsx
+++ b/apps/web/src/components/chat/TurnChangeSummary.tsx
@@ -105,9 +105,8 @@ export function TurnChangeSummary({ messageId, filesChanged, isLatestTurn, manua
     const store = useDiffStore.getState();
     showRightPanelAdaptive(workspaceId, threadId);
     store.setRightPanelTab(workspaceId, "changes");
-    // "View all diffs" is a deliberate pick: land on the thread's cumulative diff
-    // and pin it as the per-thread override so the change-state default does not
-    // revert it (ADR-0011).
+    // Pin cumulative as the per-thread override so the live default cannot revert
+    // this deliberate pick (ADR-0011).
     store.setReviewViewForThread(threadId, "cumulative");
 
     // Ensure snapshots are loaded so the panel can display this turn

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -46,10 +46,7 @@ export function DiffToolbar() {
     s.workspaces.find((w) => w.id === s.activeWorkspaceId)?.is_git_repo ?? false,
   );
 
-  // Change-state signals that pick the per-thread default (ADR-0011). Turn
-  // changes come free from the loaded snapshots (the same signal the header's
-  // changed-file count uses); working-tree dirtiness is probed below. The
-  // per-thread override flag re-renders the effect when the user pins a view.
+  // Change-state signals for the per-thread default (ADR-0011).
   const reviewViewManuallySelected = useDiffStore((s) =>
     activeThreadId ? (s.reviewViewManuallySelectedByThread[activeThreadId] ?? false) : false,
   );
@@ -85,11 +82,8 @@ export function DiffToolbar() {
     diffScopeRevision,
   });
 
-  // In a thread, drive the rendered view from the per-thread resolver: it
-  // re-evaluates the change-state default live until the user pins a view, after
-  // which it returns the sticky pick (ADR-0011). Threadless keeps the original
-  // scope-recovery behavior — it has no per-thread override. Both clamp to a
-  // visible, non-blocked view.
+  // A thread follows the per-thread resolver (live default until pinned);
+  // threadless keeps the scope-recovery fallback. See ADR-0011.
   useEffect(() => {
     if (viewModes.length === 0) return;
     if (activeThreadId) {
@@ -172,8 +166,7 @@ export function DiffToolbar() {
                   disabled={disabled}
                   onClick={() => {
                     if (disabled) return;
-                    // A pick in a thread sets the sticky per-thread override; the
-                    // threadless shell has no override and just swaps the view.
+                    // A pick in a thread sets the sticky per-thread override.
                     if (activeThreadId) setReviewViewForThread(activeThreadId, mode.id);
                     else setViewMode(mode.id);
                   }}
@@ -317,11 +310,9 @@ function useCommitAvailability({
 }
 
 /**
- * Probes whether the active scope's working tree has uncommitted changes, the
- * `isDirty` signal for the per-thread Review default (ADR-0011). Reads the
- * unstaged working-tree file list (the thread's checkout when threaded, the
- * workspace root otherwise) and refetches when `diffScopeRevision` bumps on a
- * filesystem or turn event. Returns false while loading, off-git, or on error.
+ * Probes whether the active scope's working tree has uncommitted changes — the
+ * `isDirty` signal for the per-thread Review default (ADR-0011). Refetches on
+ * `diffScopeRevision` bumps; returns false while loading, off-git, or on error.
  */
 function useWorkingTreeDirty({
   activeWorkspaceId,

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -25,6 +25,8 @@ export function DiffToolbar() {
   const reviewFileCount = useDiffStore((s) => s.reviewFileCount);
   const reviewDiffStat = useDiffStore((s) => s.reviewDiffStat);
   const setViewMode = useDiffStore((s) => s.setViewMode);
+  const setReviewViewForThread = useDiffStore((s) => s.setReviewViewForThread);
+  const getReviewView = useDiffStore((s) => s.getReviewView);
   const [viewMenuOpen, setViewMenuOpen] = useState(false);
   const [commitProbeNonce, setCommitProbeNonce] = useState(0);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
@@ -44,6 +46,22 @@ export function DiffToolbar() {
     s.workspaces.find((w) => w.id === s.activeWorkspaceId)?.is_git_repo ?? false,
   );
 
+  // Change-state signals that pick the per-thread default (ADR-0011). Turn
+  // changes come free from the loaded snapshots (the same signal the header's
+  // changed-file count uses); working-tree dirtiness is probed below. The
+  // per-thread override flag re-renders the effect when the user pins a view.
+  const reviewViewManuallySelected = useDiffStore((s) =>
+    activeThreadId ? (s.reviewViewManuallySelectedByThread[activeThreadId] ?? false) : false,
+  );
+  const pinnedReviewView = useDiffStore((s) =>
+    activeThreadId ? s.reviewViewByThread[activeThreadId] : undefined,
+  );
+  const hasTurnChanges = useDiffStore((s) => {
+    if (!activeThreadId) return false;
+    const snaps = s.snapshotsByThread[activeThreadId];
+    return !!snaps && snaps.some((snap) => snap.files_changed.length > 0);
+  });
+
   // The Review tab is dual-scope: threadless yields the git working-tree views,
   // a thread yields the turn views. Runtime gates drop the git views in a
   // non-git workspace.
@@ -60,10 +78,28 @@ export function DiffToolbar() {
     diffScopeRevision,
     commitProbeNonce,
   });
+  const workingTreeDirty = useWorkingTreeDirty({
+    activeWorkspaceId,
+    activeThreadId,
+    isGitRepo,
+    diffScopeRevision,
+  });
 
-  // Recover when the active view falls out of the current scope or gating.
+  // In a thread, drive the rendered view from the per-thread resolver: it
+  // re-evaluates the change-state default live until the user pins a view, after
+  // which it returns the sticky pick (ADR-0011). Threadless keeps the original
+  // scope-recovery behavior — it has no per-thread override. Both clamp to a
+  // visible, non-blocked view.
   useEffect(() => {
     if (viewModes.length === 0) return;
+    if (activeThreadId) {
+      const want = getReviewView(activeThreadId, { hasTurnChanges, isDirty: workingTreeDirty });
+      const blockedCommit = want === "commit" && commitAvailability === "empty";
+      const target =
+        viewModes.some((m) => m.id === want) && !blockedCommit ? want : viewModes[0].id;
+      if (viewMode !== target) setViewMode(target);
+      return;
+    }
     if (
       !viewModes.some((m) => m.id === viewMode) ||
       (viewMode === "commit" && commitAvailability === "empty")
@@ -71,7 +107,19 @@ export function DiffToolbar() {
       const fallback = defaultReviewView(scope);
       setViewMode(viewModes.some((m) => m.id === fallback) ? fallback : viewModes[0].id);
     }
-  }, [commitAvailability, viewMode, viewModes, scope, setViewMode]);
+  }, [
+    activeThreadId,
+    getReviewView,
+    reviewViewManuallySelected,
+    pinnedReviewView,
+    hasTurnChanges,
+    workingTreeDirty,
+    commitAvailability,
+    viewMode,
+    viewModes,
+    scope,
+    setViewMode,
+  ]);
 
   const activeView = useMemo(
     () => viewModes.find((m) => m.id === viewMode),
@@ -123,7 +171,11 @@ export function DiffToolbar() {
                   key={mode.id}
                   disabled={disabled}
                   onClick={() => {
-                    if (!disabled) setViewMode(mode.id);
+                    if (disabled) return;
+                    // A pick in a thread sets the sticky per-thread override; the
+                    // threadless shell has no override and just swaps the view.
+                    if (activeThreadId) setReviewViewForThread(activeThreadId, mode.id);
+                    else setViewMode(mode.id);
                   }}
                   data-testid={`review-view-${mode.id}`}
                   data-active={active ? "true" : undefined}
@@ -262,4 +314,52 @@ function useCommitAvailability({
   ]);
 
   return availability;
+}
+
+/**
+ * Probes whether the active scope's working tree has uncommitted changes, the
+ * `isDirty` signal for the per-thread Review default (ADR-0011). Reads the
+ * unstaged working-tree file list (the thread's checkout when threaded, the
+ * workspace root otherwise) and refetches when `diffScopeRevision` bumps on a
+ * filesystem or turn event. Returns false while loading, off-git, or on error.
+ */
+function useWorkingTreeDirty({
+  activeWorkspaceId,
+  activeThreadId,
+  isGitRepo,
+  diffScopeRevision,
+}: {
+  activeWorkspaceId: string | null;
+  activeThreadId: string | null;
+  isGitRepo: boolean;
+  diffScopeRevision: number;
+}): boolean {
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (!activeWorkspaceId || !isGitRepo) {
+      setDirty(false);
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const files = await getTransport().getWorkingTreeFiles(
+          activeWorkspaceId,
+          false,
+          activeThreadId ?? undefined,
+        );
+        if (!cancelled) setDirty(files.length > 0);
+      } catch {
+        if (!cancelled) setDirty(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeWorkspaceId, activeThreadId, isGitRepo, diffScopeRevision]);
+
+  return dirty;
 }

--- a/apps/web/src/lib/__tests__/review-views.test.ts
+++ b/apps/web/src/lib/__tests__/review-views.test.ts
@@ -118,13 +118,39 @@ describe("visibleReviewViews — runtime gates", () => {
   });
 });
 
-describe("defaultReviewView", () => {
-  it("defaults a thread to the last-turn diff", () => {
-    expect(defaultReviewView("thread")).toBe("last-turn");
+describe("defaultReviewView — 3-way change-state default (ADR-0011)", () => {
+  it("defaults threadless to the unstaged working-tree diff regardless of change state", () => {
+    expect(defaultReviewView("threadless")).toBe("unstaged");
+    expect(defaultReviewView("threadless", { hasTurnChanges: true, isDirty: false })).toBe(
+      "unstaged",
+    );
+    expect(defaultReviewView("threadless", { hasTurnChanges: false, isDirty: false })).toBe(
+      "unstaged",
+    );
   });
 
-  it("defaults threadless to the unstaged working-tree diff", () => {
-    expect(defaultReviewView("threadless")).toBe("unstaged");
+  it("defaults a thread with turn-registered changes to Last turn", () => {
+    expect(defaultReviewView("thread", { hasTurnChanges: true, isDirty: false })).toBe(
+      "last-turn",
+    );
+    // Turn changes win even when the working tree is also dirty.
+    expect(defaultReviewView("thread", { hasTurnChanges: true, isDirty: true })).toBe(
+      "last-turn",
+    );
+  });
+
+  it("defaults a thread with only a dirty working tree (no turn) to Unstaged", () => {
+    expect(defaultReviewView("thread", { hasTurnChanges: false, isDirty: true })).toBe(
+      "unstaged",
+    );
+  });
+
+  it("defaults a clean thread (no turn, no dirt) to Branch", () => {
+    expect(defaultReviewView("thread", { hasTurnChanges: false, isDirty: false })).toBe("branch");
+  });
+
+  it("defaults a thread to Branch when no change state is supplied (conservative)", () => {
+    expect(defaultReviewView("thread")).toBe("branch");
   });
 });
 

--- a/apps/web/src/lib/review-views.ts
+++ b/apps/web/src/lib/review-views.ts
@@ -94,11 +94,33 @@ export function visibleReviewViews(
 }
 
 /**
- * The default view for a scope: the most recent turn's diff in a thread
- * (`"last-turn"`, the default glance), and the unstaged working-tree diff when
- * threadless. Used to seed the toolbar and to recover when the active view falls
- * out of scope.
+ * The thread change-state inputs that pick a thread's default Review view, per
+ * ADR-0011. Both are cheap, reactive signals the panel already has: turn changes
+ * from the loaded turn snapshots (the same signal the header's changed-file count
+ * uses) and working-tree dirtiness from the git status probe.
  */
-export function defaultReviewView(scope: PanelScope): DiffViewMode {
-  return scope === "thread" ? "last-turn" : "unstaged";
+export interface ReviewChangeState {
+  /** The thread has at least one turn snapshot with changed files. */
+  readonly hasTurnChanges: boolean;
+  /** The thread's working tree has uncommitted changes (manual edits). */
+  readonly isDirty: boolean;
+}
+
+/**
+ * The default Review view for a scope. Threadless has no turns, so it always
+ * defaults to the unstaged working-tree diff. A thread picks from its change
+ * state (ADR-0011): turn-registered changes -> Last turn; else a dirty working
+ * tree -> Unstaged (Branch's committed-only three-dot range would hide manual
+ * edits); else the clean tree -> Branch. Passing no change state yields the
+ * conservative Branch default for a thread. Used to seed the toolbar and to
+ * recover when the active view falls out of scope.
+ */
+export function defaultReviewView(
+  scope: PanelScope,
+  changeState?: ReviewChangeState,
+): DiffViewMode {
+  if (scope === "threadless") return "unstaged";
+  if (changeState?.hasTurnChanges) return "last-turn";
+  if (changeState?.isDirty) return "unstaged";
+  return "branch";
 }

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { TurnSnapshot, GitCommit, BranchComparison } from "@mcode/contracts";
+import { defaultReviewView, type ReviewChangeState } from "@/lib/review-views";
 
 export type { GitCommit, BranchComparison };
 
@@ -194,8 +195,21 @@ interface DiffState {
    * Absent entry means closed. See ADR-0004.
    */
   readonly rightPanelVisibleByThread: Record<string, boolean>;
-  /** View mode within the Changes tab. */
+  /** View mode within the Changes tab (the single rendered view). */
   viewMode: DiffViewMode;
+  /**
+   * Per-thread remembered Review view, keyed by thread ID. Written when the user
+   * picks a view for a thread; read back to restore that pick when returning to
+   * the thread. In-memory only; dropped by {@link clearThread}. See ADR-0011.
+   */
+  readonly reviewViewByThread: Record<string, DiffViewMode>;
+  /**
+   * Per-thread "the user picked a view" override flag, keyed by thread ID. While
+   * unset, the Review default re-evaluates live from the thread's change state;
+   * once set, the pick sticks and auto-defaulting stops for that thread. Mirrors
+   * the `branchManuallySelected` guard in workspaceStore. See ADR-0011.
+   */
+  readonly reviewViewManuallySelectedByThread: Record<string, boolean>;
   /**
    * The Branch view's current→selected comparison for the current scope, or null
    * until the picker resolves it. Drives both the ref picker and the rendered
@@ -296,6 +310,18 @@ interface DiffState {
    */
   closeRightPanelTab: (workspaceId: string, tab: RightPanelTab) => void;
   setViewMode: (mode: DiffViewMode) => void;
+  /**
+   * Resolve the Review view a thread should show: the user's sticky pick when
+   * they have chosen one, otherwise the change-state default (re-evaluated live
+   * from `changeState`). See ADR-0011.
+   */
+  getReviewView: (threadId: string, changeState: ReviewChangeState) => DiffViewMode;
+  /**
+   * Record a manual Review view pick for a thread: stores the view, sets the
+   * sticky per-thread override, and makes it the rendered view. Stops live
+   * auto-defaulting for that thread. See ADR-0011.
+   */
+  setReviewViewForThread: (threadId: string, mode: DiffViewMode) => void;
   /** Store a resolved Branch comparison for a scope, keyed for staleness tracking. */
   setBranchComparison: (comparison: BranchComparison | null, key: string | null) => void;
   /** Override the base ref of the active Branch comparison (no-op if none resolved). */
@@ -345,6 +371,8 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   rightPanelByWorkspace: {},
   rightPanelVisibleByThread: {},
   viewMode: "last-turn",
+  reviewViewByThread: {},
+  reviewViewManuallySelectedByThread: {},
   branchComparison: null,
   branchComparisonKey: null,
   selectedCommitSha: null,
@@ -435,6 +463,26 @@ export const useDiffStore = create<DiffState>((set, get) => ({
 
   setViewMode: (mode) =>
     set({ viewMode: mode, selectedFile: null, diffContent: null, selectedCommitSha: null }),
+  getReviewView: (threadId, changeState) => {
+    const state = get();
+    if (state.reviewViewManuallySelectedByThread[threadId]) {
+      return state.reviewViewByThread[threadId] ?? defaultReviewView("thread", changeState);
+    }
+    return defaultReviewView("thread", changeState);
+  },
+  setReviewViewForThread: (threadId, mode) =>
+    set((s) => ({
+      viewMode: mode,
+      reviewViewByThread: { ...s.reviewViewByThread, [threadId]: mode },
+      reviewViewManuallySelectedByThread: {
+        ...s.reviewViewManuallySelectedByThread,
+        [threadId]: true,
+      },
+      // Match setViewMode's resets so a fresh pick clears stale selection/operand.
+      selectedFile: null,
+      diffContent: null,
+      selectedCommitSha: null,
+    })),
   setBranchComparison: (comparison, key) =>
     set({ branchComparison: comparison, branchComparisonKey: key }),
   setBranchBase: (ref) =>
@@ -542,6 +590,10 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       delete lineWrapByThread[threadId];
       const rightPanelVisibleByThread = { ...state.rightPanelVisibleByThread };
       delete rightPanelVisibleByThread[threadId];
+      const reviewViewByThread = { ...state.reviewViewByThread };
+      delete reviewViewByThread[threadId];
+      const reviewViewManuallySelectedByThread = { ...state.reviewViewManuallySelectedByThread };
+      delete reviewViewManuallySelectedByThread[threadId];
       const diffRevisionByScope = { ...state.diffRevisionByScope };
       delete diffRevisionByScope[threadId];
 
@@ -560,6 +612,8 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         previewUrlByThread: previewUrls,
         lineWrapByThread,
         rightPanelVisibleByThread,
+        reviewViewByThread,
+        reviewViewManuallySelectedByThread,
         diffRevisionByScope,
         inlineDiffCache,
         ...(selectionBelongsToThread


### PR DESCRIPTION
## What

Make the Review tab's default view per-thread and sticky. Each thread opens on the view that matches its change state, and the default re-evaluates live until the user picks a view, after which the pick sticks for that thread (in-memory only).

## Why

Today `viewMode` is a single global, so switching threads carries the previous thread's view and a thread whose agent just produced changes can still show Branch, hiding uncommitted work. This is Epic 1 of the Thread Overview work (the store-only state model that Epic 2's Changes row consumes).

## Key Changes

- Extend `defaultReviewView` to the 3-way change-state default: turn-registered changes -> Last turn; else dirty working tree -> Unstaged; else -> Branch. Threadless keeps the unstaged default (no turns).
- Add per-thread `reviewViewByThread` + `reviewViewManuallySelectedByThread` to `diffStore`, mirroring the `branchManuallySelected` guard, with `getReviewView` (resolver) and `setReviewViewForThread` (sticky pick). `clearThread` drops both.
- Wire `DiffToolbar`: a thread drives its view from the resolver (live default until pinned); threadless keeps the original scope-recovery effect; switcher picks set the per-thread override; a bounded working-tree dirty probe feeds `isDirty`.
- Route "View all diffs" in `TurnChangeSummary` through the override so the live default does not revert it.
- Extend `diffStore.test.ts` and `review-views.test.ts` (the test seam prescribed by the PRD).

## Config Changes

None

## Related issues/PRs

Closes #757
Relates to #753

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784213597&installation_id=129163861&pr_number=778&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F778&signature=8855b27710ccde25060aa42f50bee4510564a9275a65b6f9844c1790b99d4812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->