### PR TITLE
chore(desktop): name processes by env and fix server binary icon

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcode-desktop",
   "version": "0.12.0",
-  "description": "Mcode AI agent orchestration desktop app",
+  "description": "Mcode Desktop",
   "author": {
     "name": "Mzeey Empire",
     "email": "cjnwob@gmail.com"

--- a/apps/desktop/scripts/__tests__/build-server-binary.test.mjs
+++ b/apps/desktop/scripts/__tests__/build-server-binary.test.mjs
@@ -20,7 +20,13 @@ vi.mock("resedit", () => {
   };
 
   const VersionInfo = { createEmpty: vi.fn(() => versionInstance) };
-  const Resource = { VersionInfo };
+  const fromEntries = vi.fn(() => []);
+  const replaceIconsForResource = vi.fn();
+  const IconGroupEntry = { fromEntries, replaceIconsForResource };
+  const Resource = { VersionInfo, IconGroupEntry };
+
+  const iconFileInstance = { icons: [{ data: new ArrayBuffer(4) }] };
+  const Data = { IconFile: { from: vi.fn(() => iconFileInstance) } };
 
   const exeInstance = { generate: vi.fn(() => new ArrayBuffer(8)) };
   const NtExecutable = { from: vi.fn(() => exeInstance) };
@@ -32,11 +38,15 @@ vi.mock("resedit", () => {
     NtExecutable,
     NtExecutableResource,
     Resource,
+    Data,
     __mocks: {
       setFileVersion,
       setProductVersion,
       setStringValues,
       outputToResourceEntries,
+      fromEntries,
+      replaceIconsForResource,
+      iconFileInstance,
       exeInstance,
       resInstance,
       versionInstance,
@@ -255,6 +265,55 @@ describe("stampWindowsVersionInfo", () => {
       expect.any(Object),
       expect.objectContaining({ CompanyName: "Acme Corp" }),
     );
+  });
+
+  it("stamps the favicon icon group when iconPath is provided", async () => {
+    const { stampWindowsVersionInfo } = await import("../build-server-binary.mjs");
+    const { __mocks: { fromEntries, replaceIconsForResource }, Data } = await import("resedit");
+
+    const exePath = path.join(tmpDir, "mcode-server.exe");
+    await writeFile(exePath, Buffer.from([0x4d, 0x5a]));
+    const iconPath = path.join(tmpDir, "icon.ico");
+    await writeFile(iconPath, Buffer.from([0x00, 0x00, 0x01, 0x00]));
+
+    await stampWindowsVersionInfo(exePath, {
+      fileDescription: "Mcode Server",
+      productName: "Mcode Server",
+      companyName: "Mcode",
+      fileVersion: "1.0.0.0",
+      productVersion: "1.0.0.0",
+      originalFilename: "mcode-server.exe",
+      iconPath,
+    });
+
+    expect(Data.IconFile.from).toHaveBeenCalledTimes(1);
+    // No pre-existing groups in the mock → falls back to icon group id 1.
+    expect(replaceIconsForResource).toHaveBeenCalledWith(
+      expect.any(Array),
+      1,
+      1033,
+      expect.any(Array),
+    );
+    expect(fromEntries).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips icon stamping when iconPath is omitted", async () => {
+    const { stampWindowsVersionInfo } = await import("../build-server-binary.mjs");
+    const { __mocks: { replaceIconsForResource } } = await import("resedit");
+
+    const exePath = path.join(tmpDir, "mcode-server.exe");
+    await writeFile(exePath, Buffer.from([0x4d, 0x5a]));
+
+    await stampWindowsVersionInfo(exePath, {
+      fileDescription: "Mcode Server",
+      productName: "Mcode Server",
+      companyName: "Mcode",
+      fileVersion: "1.0.0.0",
+      productVersion: "1.0.0.0",
+      originalFilename: "mcode-server.exe",
+    });
+
+    expect(replaceIconsForResource).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -61,6 +61,9 @@ export default async function afterPack(context) {
     : "0";
   const appVersion = `${major}.${minor}.${patch}.${fourth}`;
   const companyName = context.packager.appInfo.companyName ?? "Mcode";
+  // Stamp the app favicon onto the win32 server binary so Task Manager shows it
+  // instead of a generic icon. resedit ignores this on non-win32 platforms.
+  const winIconPath = resolve(desktopRoot, "build", "icon.ico");
 
   // The renamed copy at Contents/Resources/bin/mcode-server is co-signed by
   // electron-builder via the `mac.binaries` entry in package.json, so it
@@ -72,6 +75,7 @@ export default async function afterPack(context) {
     executableName: context.packager.executableName,
     appVersion,
     companyName,
+    iconPath: existsSync(winIconPath) ? winIconPath : undefined,
   });
 
   console.log("[after-pack] Built renamed server binary");

--- a/apps/desktop/scripts/build-server-binary.mjs
+++ b/apps/desktop/scripts/build-server-binary.mjs
@@ -54,10 +54,12 @@ export function resolveBinaryPaths({ appOutDir, electronPlatformName, productFil
  * @param {string} info.fileVersion - dotted quad e.g. "1.2.3.0"
  * @param {string} info.productVersion - dotted quad
  * @param {string} info.originalFilename
+ * @param {string} [info.iconPath] - absolute path to a .ico; when set, its icons
+ *   replace the binary's icon group so the server shows the app favicon.
  * @returns {Promise<void>}
  */
 export async function stampWindowsVersionInfo(exePath, info) {
-  const { NtExecutable, NtExecutableResource, Resource } = await import("resedit");
+  const { NtExecutable, NtExecutableResource, Resource, Data } = await import("resedit");
   const buf = await readFile(exePath);
   const exe = NtExecutable.from(buf);
   const res = NtExecutableResource.from(exe);
@@ -82,6 +84,23 @@ export async function stampWindowsVersionInfo(exePath, info) {
     },
   );
   versionInfo.outputToResourceEntries(res.entries);
+
+  // The renamed copy inherits no usable icon, so Task Manager falls back to a
+  // generic glyph. Stamp the app favicon onto the binary's icon group, reusing
+  // the existing group id so Windows treats it as the executable icon.
+  if (info.iconPath) {
+    const iconBuf = await readFile(info.iconPath);
+    const iconFile = Data.IconFile.from(iconBuf);
+    const existingGroups = Resource.IconGroupEntry.fromEntries(res.entries);
+    const iconGroupId = existingGroups.length > 0 ? existingGroups[0].id : 1;
+    Resource.IconGroupEntry.replaceIconsForResource(
+      res.entries,
+      iconGroupId,
+      1033,
+      iconFile.icons.map((icon) => icon.data),
+    );
+  }
+
   res.outputResource(exe);
 
   await writeFile(exePath, Buffer.from(exe.generate()));
@@ -100,6 +119,8 @@ export async function stampWindowsVersionInfo(exePath, info) {
  * @param {string} [args.executableName] - Linux executable name (defaults to productFilename).
  * @param {string} [args.appVersion] - dotted quad like "1.2.3.0"; required on win32
  * @param {string} [args.companyName] - default "Mcode"
+ * @param {string} [args.iconPath] - absolute path to a .ico stamped onto the
+ *   win32 binary so it shows the app favicon instead of a generic icon.
  */
 export async function buildServerBinary({
   appOutDir,
@@ -108,6 +129,7 @@ export async function buildServerBinary({
   executableName,
   appVersion,
   companyName = "Mcode",
+  iconPath,
 }) {
   const { srcBinary, dstBinary } = resolveBinaryPaths({
     appOutDir,
@@ -225,6 +247,7 @@ export async function buildServerBinary({
       fileVersion: appVersion,
       productVersion: appVersion,
       originalFilename: "mcode-server.exe",
+      iconPath,
     });
   }
 }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -678,6 +678,12 @@ if (process.platform === "win32") {
   app.setAppUserModelId(APP_ID);
 }
 
+// Tag the dev main process so `ps`/console output distinguishes it from a
+// packaged instance. process.title does not change app.getName() or the
+// userData path, so dev and prod still share data-dir resolution. On packaged
+// Windows the Task Manager name comes from the exe VERSIONINFO, not this.
+process.title = isDesktopDev() ? "Mcode Desktop (dev)" : "Mcode Desktop";
+
 app.whenReady().then(async () => {
   try {
     console.log(`[perf] App ready: ${(performance.now() - STARTUP_TIME).toFixed(1)}ms`);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -68,8 +68,11 @@ import type { JobObject } from "./services/job-object.js";
 // process.title affects `ps`/`top`/`htop` output on Unix and the console window
 // title. On Windows, Task Manager pulls the display name from the binary's
 // VERSIONINFO instead — that's set at packaging time by the build-server-binary
-// helper, so process.title has no effect there but is harmless to set.
-process.title = "Mcode Server";
+// helper, so process.title has no effect there but is harmless to set. The
+// "(dev)" suffix tags the standalone dev server so it is distinguishable from a
+// packaged instance in `ps` and the console window title.
+process.title =
+  process.env.NODE_ENV === "production" ? "Mcode Server" : "Mcode Server (dev)";
 
 const PREFERRED_PORT = parseInt(process.env.MCODE_PORT ?? "19400", 10);
 const MAX_PORT_ATTEMPTS = 10;


### PR DESCRIPTION
## What

Make the app processes identify themselves clearly in OS process viewers, and give the packaged server binary the app favicon.

## Why

In Task Manager the desktop tree showed the long marketing string "Mcode AI agent orchestration desktop app", and the renamed `mcode-server.exe` showed a generic icon because nothing ever stamped one onto it. There was also no way to tell a dev instance from a packaged one.

## Key changes

- **Server binary favicon (win32):** `stampWindowsVersionInfo` now stamps `build/icon.ico` onto the binarys icon group (reusing the existing group id) during the existing afterPack VERSIONINFO pass. resedit v3 `Data.IconFile` + `Resource.IconGroupEntry.replaceIconsForResource`. No-op on non-win32 and when no icon is found.
- **Desktop name:** package.json `description` -> "Mcode Desktop", which electron-builder stamps as the exe FileDescription (the Task Manager "Name" column). `productName` stays "Mcode", so the exe filename, install path, and update artifacts are unchanged.
- **Env tagging:** the standalone dev server and the dev desktop main process get a "(dev)" suffix via `process.title` (affects `ps`/console only; does not change `app.getName()` or the userData path). Packaged prod stays clean: "Mcode Desktop" / "Mcode Server".
- Extended `build-server-binary.test.mjs` with icon-stamping coverage (stamps when `iconPath` set, skips when omitted).

## Verification

- `node scripts/agent/verify-fast.mjs` (typecheck + lint): pass.
- `apps/desktop` unit tests: 17/17 pass (including 2 new icon tests).
- `apps/web` + `@mcode/server` + `@mcode/shared` unit suites: pass (one frontend `openEditor` flake on first run, green on clean re-run; this branch touches no web code).
- Note: the win32 icon/VERSIONINFO stamping only runs inside `electron-builder` afterPack, so the visual result requires a packaged Windows build to confirm end to end.

## Notes / limitations

- On packaged Windows, the Task Manager name comes from the exe VERSIONINFO, so `process.title` is a dev-only convenience there (Unix `ps` and the console window title do reflect it).
- This is intentionally separate from the per-thread Review work in #778.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784216877&installation_id=129163861&pr_number=779&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F779&signature=2878984ed1c209223645393df9bd1dda48343085832c95babaa7768285ef7fed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Process titles now distinguish development and production environments for better system monitoring and identification
  * Windows application icon properly integrated into server binary during build process

* **Chores**
  * Updated app description to "Mcode Desktop"

* **Tests**
  * Enhanced test coverage for Windows icon stamping functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->