### PR TITLE
fix: keep turn diffs in sync between chat and Review panel

### DIFF
--- a/apps/server/src/services/turn-finalizer.ts
+++ b/apps/server/src/services/turn-finalizer.ts
@@ -75,6 +75,8 @@ export class TurnFinalizer {
   private readonly bufferedAttachmentsByThread = new Map<string, StoredAttachment[]>();
   /** Threads whose assistant row was already materialized this turn (e.g. eagerly for a plan FK). */
   private readonly materializedThreads = new Set<string>();
+  /** Serializes finalize calls per thread so a slow git snapshot cannot drop a later turn. */
+  private readonly finalizeChainByThread = new Map<string, Promise<void>>();
 
   constructor(
     private readonly messageRepo: MessageRepo,
@@ -190,6 +192,20 @@ export class TurnFinalizer {
    * against it.
    */
   async finalize(threadId: string, outcome: TurnOutcome): Promise<void> {
+    const tail = this.finalizeChainByThread.get(threadId) ?? Promise.resolve();
+    const next = tail.then(() => this.runFinalizeOnce(threadId, outcome));
+    this.finalizeChainByThread.set(threadId, next);
+    try {
+      await next;
+    } finally {
+      if (this.finalizeChainByThread.get(threadId) === next) {
+        this.finalizeChainByThread.delete(threadId);
+      }
+    }
+  }
+
+  /** Runs one finalize pass; concurrent calls for the same thread are queued by {@link finalize}. */
+  private async runFinalizeOnce(threadId: string, outcome: TurnOutcome): Promise<void> {
     if (this.persistingThreads.has(threadId)) return;
     this.persistingThreads.add(threadId);
     try {

--- a/apps/web/src/__tests__/threadStore-turn-persist.test.ts
+++ b/apps/web/src/__tests__/threadStore-turn-persist.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useThreadStore } from "@/stores/threadStore";
+import {
+  resetThreadStoreForTests,
+  readThreadField,
+  seedThreadRecord,
+} from "@/stores/thread-store-test-utils";
+import { mockTransport, createMockMessage } from "./mocks/transport";
+
+vi.mock("@/transport", async () => ({
+  ...(await vi.importActual("@/transport")),
+  getTransport: () => mockTransport,
+}));
+
+const THREAD_ID = "thread-turn-persist";
+
+describe("handleTurnPersisted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetThreadStoreForTests({ currentThreadId: THREAD_ID });
+  });
+
+  it("attributes file changes to the pending turn after auto-dequeue advances currentTurnMessageId", () => {
+    const turnOneId = "assistant-turn-1";
+    const turnTwoId = "assistant-turn-2";
+    useThreadStore.setState({
+      records: seedThreadRecord(THREAD_ID, {
+        messages: [
+          createMockMessage({
+            id: "user-1",
+            thread_id: THREAD_ID,
+            role: "user",
+            content: "first",
+          }),
+          createMockMessage({
+            id: turnOneId,
+            thread_id: THREAD_ID,
+            role: "assistant",
+            content: "first answer",
+          }),
+          createMockMessage({
+            id: "user-2",
+            thread_id: THREAD_ID,
+            role: "user",
+            content: "second",
+          }),
+          createMockMessage({
+            id: turnTwoId,
+            thread_id: THREAD_ID,
+            role: "assistant",
+            content: "second answer",
+          }),
+        ],
+        pendingTurnPersistLocalMessageId: turnOneId,
+        currentTurnMessageId: turnTwoId,
+      }),
+    });
+
+    useThreadStore.getState().handleTurnPersisted({
+      threadId: THREAD_ID,
+      messageId: "server-turn-1",
+      toolCallCount: 2,
+      filesChanged: ["src/a.ts"],
+    });
+
+    expect(readThreadField(THREAD_ID, (r) => r.persistedFilesChanged[turnOneId])).toEqual([
+      "src/a.ts",
+    ]);
+    expect(readThreadField(THREAD_ID, (r) => r.persistedFilesChanged[turnTwoId])).toBeUndefined();
+    expect(readThreadField(THREAD_ID, (r) => r.serverMessageIds[turnOneId])).toBe("server-turn-1");
+    expect(readThreadField(THREAD_ID, (r) => r.pendingTurnPersistLocalMessageId)).toBe("");
+  });
+
+  it("materializes an empty assistant row for tools-only turns", () => {
+    useThreadStore.setState({
+      records: seedThreadRecord(THREAD_ID, {
+        messages: [
+          createMockMessage({
+            id: "user-1",
+            thread_id: THREAD_ID,
+            role: "user",
+            content: "do work",
+          }),
+        ],
+      }),
+    });
+
+    useThreadStore.getState().handleTurnPersisted({
+      threadId: THREAD_ID,
+      messageId: "server-tools-only",
+      toolCallCount: 3,
+      filesChanged: ["README.md"],
+    });
+
+    const messages = readThreadField(THREAD_ID, (r) => r.messages);
+    expect(messages.some((m) => m.id === "server-tools-only" && m.role === "assistant")).toBe(
+      true,
+    );
+    expect(readThreadField(THREAD_ID, (r) => r.persistedFilesChanged["server-tools-only"])).toEqual(
+      ["README.md"],
+    );
+  });
+});

--- a/apps/web/src/components/diff/LastTurnView.tsx
+++ b/apps/web/src/components/diff/LastTurnView.tsx
@@ -2,6 +2,9 @@ import { useEffect } from "react";
 import type { TurnSnapshot } from "@mcode/contracts";
 import { getTransport } from "@/transport";
 import { useDiffStore } from "@/stores/diffStore";
+import { useThreadStore } from "@/stores/threadStore";
+import { getThreadRecord } from "@/stores/thread-record";
+import { refreshTurnSnapshotsAfterPersist } from "@/lib/turn-snapshot-refresh";
 import { FileList } from "./FileList";
 
 /** Props for LastTurnView. */
@@ -17,10 +20,28 @@ interface LastTurnViewProps {
  * threads. See CONTEXT.md → "Review tab".
  */
 export function LastTurnView({ snapshots, threadId }: LastTurnViewProps) {
+  /** Files the chat banner already knows about for the latest turn with edits. */
+  const pendingReviewFiles = useThreadStore((s) => {
+    const rec = getThreadRecord(s.records, threadId);
+    const msgId = rec.latestTurnWithChanges;
+    if (!msgId) return null;
+    const files = rec.persistedFilesChanged[msgId];
+    return files && files.length > 0 ? files : null;
+  });
+
   // Walk from the newest snapshot back to the first one that actually changed
   // files; earlier no-op turns (e.g. plan-only) are skipped so the view always
   // lands on a meaningful diff.
   const latest = [...snapshots].reverse().find((s) => s.files_changed.length > 0);
+
+  // Chat (`threadStore`) learns about file changes on `turn.persisted` immediately;
+  // Review reads `diffStore` snapshots, which can lag or stay empty if the panel
+  // loaded before the turn finished. Self-heal when the two stores disagree.
+  useEffect(() => {
+    if (!pendingReviewFiles) return;
+    if (latest) return;
+    refreshTurnSnapshotsAfterPersist(threadId, pendingReviewFiles);
+  }, [threadId, pendingReviewFiles, latest]);
 
   // Report this turn's total +/- to the toolbar (summed from per-file stats).
   const setReviewDiffStat = useDiffStore((s) => s.setReviewDiffStat);
@@ -59,6 +80,19 @@ export function LastTurnView({ snapshots, threadId }: LastTurnViewProps) {
   }, [latestId, setReviewDiffStat]);
 
   if (!latest) {
+    if (pendingReviewFiles) {
+      return (
+        <div className="flex items-center justify-center gap-1.5 py-10">
+          {[0, 150, 300].map((delay) => (
+            <div
+              key={delay}
+              className="h-1 w-1 rounded-full bg-muted-foreground/25 animate-pulse"
+              style={{ animationDelay: `${delay}ms` }}
+            />
+          ))}
+        </div>
+      );
+    }
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 py-14">
         <span aria-hidden="true" className="font-mono text-[28px] leading-none text-muted-foreground/15">

--- a/apps/web/src/lib/__tests__/turn-snapshot-refresh.test.ts
+++ b/apps/web/src/lib/__tests__/turn-snapshot-refresh.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { refreshTurnSnapshotsAfterPersist } from "@/lib/turn-snapshot-refresh";
+import { mockTransport, createMockThread } from "@/__tests__/mocks/transport";
+
+vi.mock("@/transport", async () => ({
+  ...(await vi.importActual("@/transport")),
+  getTransport: () => mockTransport,
+}));
+
+const THREAD_ID = "thread-refresh";
+
+describe("refreshTurnSnapshotsAfterPersist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDiffStore.setState({
+      snapshotsByThread: {},
+      snapshotsPendingByThread: {},
+      diffRevisionByScope: {},
+      rightPanelByWorkspace: {},
+      rightPanelVisibleByThread: {},
+      viewMode: "last-turn",
+    });
+    useWorkspaceStore.setState({
+      activeThreadId: THREAD_ID,
+      threads: [
+        createMockThread({
+          id: THREAD_ID,
+          workspace_id: "ws-1",
+          has_file_changes: true,
+        }),
+      ],
+    });
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: "snap-1",
+        thread_id: THREAD_ID,
+        message_id: "msg-1",
+        files_changed: ["src/a.ts"],
+        ref_before: "aaa",
+        ref_after: "bbb",
+        worktree_path: null,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+  });
+
+  it("loaded snapshots when the Review panel had never fetched them", async () => {
+    refreshTurnSnapshotsAfterPersist(THREAD_ID, ["src/a.ts"]);
+    await vi.waitFor(() => {
+      expect(mockTransport.listSnapshots).toHaveBeenCalledWith(THREAD_ID);
+    });
+    expect(useDiffStore.getState().snapshotsByThread[THREAD_ID]).toHaveLength(1);
+  });
+
+  it("skipped refetch while the cumulative view is open on the active thread", () => {
+    useDiffStore.setState({
+      snapshotsByThread: { [THREAD_ID]: [] },
+      rightPanelByWorkspace: {
+        "ws-1": { activeTab: "changes", openTabs: ["changes"], width: 400 },
+      },
+      rightPanelVisibleByThread: { [THREAD_ID]: true },
+      viewMode: "cumulative",
+    });
+
+    refreshTurnSnapshotsAfterPersist(THREAD_ID, ["src/a.ts"]);
+
+    expect(mockTransport.listSnapshots).not.toHaveBeenCalled();
+    expect(useDiffStore.getState().snapshotsPendingByThread[THREAD_ID]).toBe(true);
+  });
+});

--- a/apps/web/src/lib/__tests__/turn-snapshot-refresh.test.ts
+++ b/apps/web/src/lib/__tests__/turn-snapshot-refresh.test.ts
@@ -58,7 +58,7 @@ describe("refreshTurnSnapshotsAfterPersist", () => {
     useDiffStore.setState({
       snapshotsByThread: { [THREAD_ID]: [] },
       rightPanelByWorkspace: {
-        "ws-1": { activeTab: "changes", openTabs: ["changes"], width: 400 },
+        "ws-1": { visible: true, activeTab: "changes", openTabs: ["changes"], width: 400 },
       },
       rightPanelVisibleByThread: { [THREAD_ID]: true },
       viewMode: "cumulative",

--- a/apps/web/src/lib/turn-snapshot-refresh.ts
+++ b/apps/web/src/lib/turn-snapshot-refresh.ts
@@ -1,0 +1,42 @@
+import { getTransport } from "@/transport";
+import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+/**
+ * Refresh turn snapshots after `turn.persisted` when a turn touched files.
+ * Centralizes the Review panel update so chat (`threadStore`) and Changes
+ * (`diffStore`) stay aligned on the same turn-end event.
+ */
+export function refreshTurnSnapshotsAfterPersist(
+  threadId: string,
+  filesChanged: string[],
+): void {
+  if (filesChanged.length === 0) return;
+
+  useDiffStore.getState().bumpDiffRevision(threadId);
+
+  try {
+    const transport = getTransport();
+    const snap = useDiffStore.getState();
+    const wsState = useWorkspaceStore.getState();
+    const workspaceId = wsState.threads.find((t) => t.id === threadId)?.workspace_id;
+    const panel = workspaceId ? snap.rightPanelByWorkspace[workspaceId] : undefined;
+    const isViewingAllChanges =
+      wsState.activeThreadId === threadId &&
+      snap.rightPanelVisibleByThread[threadId] === true &&
+      panel?.activeTab === "changes" &&
+      snap.viewMode === "cumulative";
+
+    if (isViewingAllChanges) {
+      useDiffStore.getState().markSnapshotsPending(threadId, true);
+      return;
+    }
+
+    void transport
+      .listSnapshots(threadId)
+      .then((snapshots) => useDiffStore.getState().setSnapshots(threadId, snapshots))
+      .catch(() => { /* non-critical */ });
+  } catch {
+    // Transport not initialized — ignore (startup race / tests).
+  }
+}

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -95,6 +95,12 @@ export interface ThreadRecord {
   toolCalls: ToolCall[];
   agentStartTime?: number;
   currentTurnMessageId: string;
+  /**
+   * Local assistant message id for a turn whose `turn.persisted` event has not
+   * arrived yet. Survives `resetTurnEphemeral` so auto-dequeue cannot steal
+   * file-change attribution from the prior turn.
+   */
+  pendingTurnPersistLocalMessageId: string;
   currentTurnResponseKey: string;
   assistantResponseKeys: Record<string, string>;
   thoughtSegments: ThoughtSegment[];
@@ -150,6 +156,7 @@ export function createEmptyThreadRecord(): ThreadRecord {
     streamingPreview: "",
     toolCalls: [],
     currentTurnMessageId: "",
+    pendingTurnPersistLocalMessageId: "",
     currentTurnResponseKey: "",
     assistantResponseKeys: {},
     thoughtSegments: [],

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -224,6 +224,70 @@ function resetTurnEphemeral(_rec: ThreadRecord): Partial<ThreadRecord> {
   };
 }
 
+/**
+ * Resolve the client-side message id that should receive a `turn.persisted`
+ * payload. Never uses {@link ThreadRecord.currentTurnMessageId} alone because
+ * auto-dequeue can advance it before the prior turn's async snapshot finishes.
+ */
+function resolveTurnPersistLocalMessageId(
+  rec: ThreadRecord,
+  serverMessageId: string,
+): string {
+  if (rec.pendingTurnPersistLocalMessageId) {
+    return rec.pendingTurnPersistLocalMessageId;
+  }
+  for (const [localId, mappedServerId] of Object.entries(rec.serverMessageIds)) {
+    if (mappedServerId === serverMessageId) {
+      return localId;
+    }
+  }
+  if (rec.messages.some((m) => m.id === serverMessageId)) {
+    return serverMessageId;
+  }
+  return serverMessageId;
+}
+
+/** Queue the local assistant id until matching `turn.persisted` clears it. */
+function queuePendingTurnPersistLocalMessageId(
+  rec: ThreadRecord,
+  localMessageId: string,
+): string {
+  if (rec.pendingTurnPersistLocalMessageId) {
+    return rec.pendingTurnPersistLocalMessageId;
+  }
+  return localMessageId;
+}
+
+/**
+ * Ensure the transcript contains an assistant row for persisted turn metadata.
+ * Tools-only turns may materialize on the server without a client `session.message`.
+ */
+function ensureAssistantMessageForTurnPersist(
+  rec: ThreadRecord,
+  threadId: string,
+  localMessageId: string,
+): Message[] | undefined {
+  if (rec.messages.some((m) => m.id === localMessageId)) {
+    return undefined;
+  }
+  const placeholder: Message = {
+    id: localMessageId,
+    thread_id: threadId,
+    role: "assistant",
+    content: "",
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: new Date().toISOString(),
+    sequence: rec.messages.length + 1,
+    attachments: null,
+    model: null,
+  };
+  const { messages } = capMessages([...rec.messages, placeholder]);
+  return messages;
+}
+
 /** Returns a React key shared by the live and just-persisted final response. */
 function createTurnResponseKey(threadId: string): string {
   return `turn-response:${threadId}:${crypto.randomUUID()}`;
@@ -1046,6 +1110,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           streamingPreview: "",
           toolCalls: [],
           currentTurnMessageId: "",
+          pendingTurnPersistLocalMessageId: "",
           currentTurnResponseKey: "",
           assistantResponseKeys: {},
           oldestLoadedSequence: 0,
@@ -1597,7 +1662,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       markPriorToolCallsComplete();
       const content = (params.content as string) || "";
       const attachments = parseStoredAttachments(params.attachments);
-      if (content || attachments.length > 0) {
+      if (content || attachments.length > 0 || params.messageId) {
         const message: Message = {
           id: (params.messageId as string) || crypto.randomUUID(),
           thread_id: threadId,
@@ -2207,6 +2272,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             streaming: "",
             streamingPreview: "",
             currentTurnMessageId: message.id,
+            pendingTurnPersistLocalMessageId: queuePendingTurnPersistLocalMessageId(
+              rec,
+              message.id,
+            ),
             currentTurnResponseKey: nextLiveKey,
             assistantResponseKeys: {
               ...rec.assistantResponseKeys,
@@ -2262,6 +2331,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             toolCalls: completedCalls,
             permissions: [] as StoredPermission[],
             rateLimit: undefined,
+            ...(rec.currentTurnMessageId
+              ? {
+                  pendingTurnPersistLocalMessageId: queuePendingTurnPersistLocalMessageId(
+                    rec,
+                    rec.currentTurnMessageId,
+                  ),
+                }
+              : {}),
           };
 
           if (dedupedGuardrail && state.currentThreadId === threadId) {
@@ -2655,21 +2732,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         }
       }
 
-      let localMsgId = payload.messageId;
-      const trackedMsgId = rec.currentTurnMessageId;
-      if (trackedMsgId) {
-        localMsgId = trackedMsgId;
-      } else if (state.currentThreadId === payload.threadId) {
-        for (let i = rec.messages.length - 1; i >= 0; i--) {
-          if (rec.messages[i].role === "assistant") {
-            localMsgId = rec.messages[i].id;
-            break;
-          }
-        }
-      }
+      let localMsgId = resolveTurnPersistLocalMessageId(rec, payload.messageId);
+      const ensuredMessages =
+        payload.filesChanged.length > 0 || payload.toolCallCount > 0
+          ? ensureAssistantMessageForTurnPersist(rec, payload.threadId, localMsgId)
+          : undefined;
 
       return {
         records: patchThreadRecord(state.records, payload.threadId, {
+          ...(ensuredMessages ? { messages: ensuredMessages } : {}),
           persistedToolCallCounts: {
             ...rec.persistedToolCallCounts,
             [localMsgId]: payload.toolCallCount,
@@ -2686,6 +2757,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             ...rec.serverMessageIds,
             [localMsgId]: payload.messageId,
           },
+          pendingTurnPersistLocalMessageId:
+            rec.pendingTurnPersistLocalMessageId === localMsgId
+              ? ""
+              : rec.pendingTurnPersistLocalMessageId,
           interruptStopFileNotice,
           awaitingUserStopPersist,
         }),

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -2732,7 +2732,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         }
       }
 
-      let localMsgId = resolveTurnPersistLocalMessageId(rec, payload.messageId);
+      const localMsgId = resolveTurnPersistLocalMessageId(rec, payload.messageId);
       const ensuredMessages =
         payload.filesChanged.length > 0 || payload.toolCallCount > 0
           ? ensureAssistantMessageForTurnPersist(rec, payload.threadId, localMsgId)

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -4,6 +4,7 @@ import { pushEmitter } from "./ws-transport";
 import { getTransport } from "@/transport";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore } from "@/stores/diffStore";
+import { refreshTurnSnapshotsAfterPersist } from "@/lib/turn-snapshot-refresh";
 import { useThreadStore } from "@/stores/threadStore";
 import { getThreadRecord, patchThreadRecord } from "@/stores/thread-record";
 import { useTerminalStore } from "@/stores/terminalStore";
@@ -294,49 +295,15 @@ export function startPushListeners(): void {
       };
       useThreadStore.getState().handleTurnPersisted(payload);
 
-      const snap = useDiffStore.getState();
-      const hasSnapshots = snap.snapshotsByThread[payload.threadId] !== undefined;
-      const hasCommits = snap.commitsByThread[payload.threadId] !== undefined;
-      if (!hasSnapshots && !hasCommits) return;
+      refreshTurnSnapshotsAfterPersist(payload.threadId, payload.filesChanged);
 
-      // Only refetch snapshots / mark the cumulative view pending when the
-      // persisted turn actually touched files. Chat-only turns (no tool
-      // writes) would otherwise surface a "New changes" affordance with
-      // nothing new to show.
       const hasFileChanges = payload.filesChanged.length > 0;
-      if (hasFileChanges) {
-        useDiffStore.getState().bumpDiffRevision(payload.threadId);
-      }
+      if (!hasFileChanges) return;
 
       try {
         const transport = getTransport();
-        if (hasSnapshots && hasFileChanges) {
-          const wsState = useWorkspaceStore.getState();
-          const workspaceId = wsState.threads.find(
-            (t) => t.id === payload.threadId,
-          )?.workspace_id;
-          const panel = workspaceId
-            ? snap.rightPanelByWorkspace[workspaceId]
-            : undefined;
-          // Open/closed is per-thread; width and tab are workspace-global. Only
-          // defer when this thread is on screen with its panel open on Changes.
-          const isViewingAllChanges =
-            wsState.activeThreadId === payload.threadId &&
-            snap.rightPanelVisibleByThread[payload.threadId] === true &&
-            panel?.activeTab === "changes" &&
-            snap.viewMode === "cumulative";
-
-          if (isViewingAllChanges) {
-            useDiffStore.getState().markSnapshotsPending(payload.threadId, true);
-          } else {
-            transport
-              .listSnapshots(payload.threadId)
-              .then((snapshots) =>
-                useDiffStore.getState().setSnapshots(payload.threadId, snapshots),
-              )
-              .catch(() => { /* non-critical */ });
-          }
-        }
+        const snap = useDiffStore.getState();
+        const hasCommits = snap.commitsByThread[payload.threadId] !== undefined;
 
         if (hasCommits) {
           const thread = useWorkspaceStore


### PR DESCRIPTION
## Summary

- Fix missed turn diffs where the chat banner showed file changes but Review (Last turn) stayed on "No changes yet"
- Fix file-change attribution races when auto-dequeue starts the next turn before the prior turn's async git snapshot finishes
- Queue server-side turn finalization so a slow snapshot cannot drop a later turn's persist

## What

Turn diffs were split across two client stores. `turn.persisted` updated `threadStore` (chat banner) but `diffStore` snapshots were sometimes never refreshed, especially when the Review panel loaded before the turn finished or when auto-dequeue advanced `currentTurnMessageId` early.

## Why

Users reported intermittent missed turn diffs across all providers. The chat compose area and Review panel could disagree on the same completed turn.

## Key changes

- Add `pendingTurnPersistLocalMessageId` so `turn.persisted` attributes files to the correct turn after auto-dequeue
- Centralize snapshot refresh in `refreshTurnSnapshotsAfterPersist()` on every `turn.persisted` with file changes
- `LastTurnView` self-heals when chat knows about files but snapshots are empty (loading pulse + refetch)
- Accept empty `session.message` rows when a server `messageId` is present (tools-only turns)
- Queue `TurnFinalizer.finalize` per thread so overlapping finalizes are not dropped

## Configuration changes

None.

## Test plan

- [x] `vitest` - `threadStore-turn-persist.test.ts` (2 tests)
- [x] `vitest` - `turn-snapshot-refresh.test.ts` (2 tests)
- [x] `vitest` - `turn-finalizer.test.ts` (24 tests)
- [ ] Manual: run a long agent turn that edits files; confirm chat banner and Review Last turn list the same files
- [ ] Manual: let auto-dequeue fire a follow-up before diffs appear; confirm files stay on the correct turn
- [ ] Manual: open Review on Last turn before the turn completes; confirm panel catches up after `turn.persisted`

## Related issues/PRs

Relates to user report of missed turn diffs on forked/worktree threads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784218588&installation_id=129163861&pr_number=781&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F781&signature=2e7af3e3b0069f746ed7192341b340f341373c3055aa0a284ea34c7cf1fb1c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of file change tracking when working with multiple concurrent threads.

* **New Features**
  * Added visual loading indicator while fetching the latest file changes in the diff view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->