### PR TITLE
fix(cursor): retry resource_exhausted with an invisible jittered backoff

### DIFF
--- a/apps/server/src/providers/cursor/__tests__/cursor-acp-transient-retry.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-acp-transient-retry.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
   CURSOR_ACP_CONTINUE_AFTER_DISCONNECT_PROMPT,
+  CURSOR_RATE_LIMIT_RETRY_JITTER_MS,
   buildCursorAcpContinueAfterDisconnectPrompt,
+  computeCursorRateLimitBackoffMs,
+  interruptibleDelay,
   isLikelyTransientCursorPromptFailure,
   looksLikeAcpConnectionClosed,
+  looksLikeCursorRateLimit,
   looksLikeUpstreamStreamCancel,
   shouldSuppressCursorPromptError,
 } from "../cursor-acp-transient-retry.js";
@@ -65,5 +69,60 @@ describe("isLikelyTransientCursorPromptFailure", () => {
     expect(
       isLikelyTransientCursorPromptFailure('status CANCEL detected on stream :path "/rpc"'),
     ).toBe(false);
+  });
+});
+
+describe("looksLikeCursorRateLimit", () => {
+  it("detects the minified ConnectError resource_exhausted shape", () => {
+    expect(looksLikeCursorRateLimit("v: [resource_exhausted] Error")).toBe(true);
+    expect(looksLikeCursorRateLimit("Error: [RESOURCE_EXHAUSTED] rate limited")).toBe(true);
+  });
+
+  it("treats rate limits as transient so the prompt loop retries them", () => {
+    expect(isLikelyTransientCursorPromptFailure("v: [resource_exhausted] Error")).toBe(true);
+  });
+
+  it("ignores unrelated messages", () => {
+    expect(looksLikeCursorRateLimit("Internal Server Error")).toBe(false);
+    expect(looksLikeCursorRateLimit("resourceexhausted")).toBe(false);
+  });
+});
+
+describe("computeCursorRateLimitBackoffMs", () => {
+  it("adds zero jitter at the bottom of the random range", () => {
+    expect(computeCursorRateLimitBackoffMs(3000, () => 0)).toBe(3000);
+  });
+
+  it("adds full jitter at the top of Math.random's [0, 1) range", () => {
+    expect(computeCursorRateLimitBackoffMs(3000, () => 0.999999)).toBe(
+      3000 + CURSOR_RATE_LIMIT_RETRY_JITTER_MS,
+    );
+  });
+
+  it("never produces a negative delay from a misconfigured base", () => {
+    expect(computeCursorRateLimitBackoffMs(-5000, () => 0)).toBe(0);
+    expect(computeCursorRateLimitBackoffMs(Number.NaN, () => 0)).toBe(0);
+  });
+
+  it("floors a fractional base to whole milliseconds", () => {
+    expect(computeCursorRateLimitBackoffMs(3000.9, () => 0)).toBe(3000);
+  });
+});
+
+describe("interruptibleDelay", () => {
+  it("resolves immediately when already aborted", async () => {
+    let resolved = false;
+    await interruptibleDelay(10_000, () => true).then(() => {
+      resolved = true;
+    });
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves immediately for a non-positive delay", async () => {
+    await expect(interruptibleDelay(0, () => false)).resolves.toBeUndefined();
+  });
+
+  it("resolves once a short delay elapses", async () => {
+    await expect(interruptibleDelay(5, () => false, 1)).resolves.toBeUndefined();
   });
 });

--- a/apps/server/src/providers/cursor/cursor-acp-transient-retry.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-transient-retry.ts
@@ -48,6 +48,81 @@ const UPSTREAM_CANCEL_RE =
   /\[canceled\]|http\/2\s+stream\s+closed|cancell?ed[^\n]{0,120}stream|\berror\s+code\s+CANCEL\b|\(0x8\)|RST_STREAM/i;
 
 /**
+ * Cursor backend rate limit, surfaced as the Connect/gRPC `resource_exhausted`
+ * status (code 8). `cursor-agent` serializes it as a minified `ConnectError`,
+ * e.g. `v: [resource_exhausted] Error`. Per Cursor's docs this is almost always
+ * short-term burst throttling (too many requests in a short window), not a hard
+ * usage quota — so the right recovery is a brief backoff then a single retry.
+ */
+const CURSOR_RATE_LIMIT_RE = /\bresource_exhausted\b/i;
+
+/**
+ * Upper bound of random jitter (ms) added to the configured rate-limit backoff.
+ * The trigger is concurrency — several turns trip the limit at the same instant —
+ * so de-correlating the retries with jitter avoids re-creating the same burst.
+ */
+export const CURSOR_RATE_LIMIT_RETRY_JITTER_MS = 2000;
+
+/**
+ * Returns true when a Cursor prompt failed because the backend rate-limited the
+ * request (`resource_exhausted`). Distinct from {@link looksLikeUpstreamStreamCancel}
+ * because the recovery differs: a rate limit needs a backoff before retrying.
+ *
+ * @param message - Serialized error (`Error.message` or stderr snippet).
+ */
+export function looksLikeCursorRateLimit(message: string): boolean {
+  return CURSOR_RATE_LIMIT_RE.test(message);
+}
+
+/**
+ * Computes the rate-limit retry delay: a configured base plus random jitter in
+ * `[0, {@link CURSOR_RATE_LIMIT_RETRY_JITTER_MS}]`. A non-finite or negative base
+ * clamps to zero so a misconfigured setting can never produce a negative delay.
+ *
+ * @param baseMs - Configured base backoff (`provider.cursor.rateLimitRetryBackoffMs`).
+ * @param rand - Source of `[0, 1)` randomness; injectable for deterministic tests.
+ */
+export function computeCursorRateLimitBackoffMs(
+  baseMs: number,
+  rand: () => number = Math.random,
+): number {
+  const safeBase = Number.isFinite(baseMs) && baseMs > 0 ? Math.floor(baseMs) : 0;
+  const jitter = Math.floor(rand() * (CURSOR_RATE_LIMIT_RETRY_JITTER_MS + 1));
+  return safeBase + jitter;
+}
+
+/**
+ * Sleeps for `ms`, resolving early as soon as `shouldAbort()` returns true so a
+ * user Stop during a rate-limit backoff is honored promptly instead of forcing
+ * the full wait. Polls the abort predicate on a bounded interval; resolves
+ * immediately when `ms <= 0` or already aborted.
+ *
+ * @param ms - Delay in milliseconds.
+ * @param shouldAbort - Predicate polled to cut the wait short (e.g. pending Stop).
+ * @param stepMs - Poll interval; clamped to at most `ms` so short waits stay tight.
+ */
+export function interruptibleDelay(
+  ms: number,
+  shouldAbort: () => boolean,
+  stepMs = 150,
+): Promise<void> {
+  return new Promise((resolve) => {
+    if (ms <= 0 || shouldAbort()) {
+      resolve();
+      return;
+    }
+    const deadline = Date.now() + ms;
+    const tick = Math.max(1, Math.min(stepMs, ms));
+    const timer = setInterval(() => {
+      if (shouldAbort() || Date.now() >= deadline) {
+        clearInterval(timer);
+        resolve();
+      }
+    }, tick);
+  });
+}
+
+/**
  * Returns true when the message resembles Cursor upstream closing an HTTP or gRPC stream.
  * Pair with intent flags before deciding whether to show an error toast.
  *
@@ -91,6 +166,7 @@ export function isLikelyTransientCursorPromptFailure(message: string): boolean {
   return (
     TRANSIENT_RE.test(message) ||
     looksLikeUpstreamStreamCancel(message) ||
-    looksLikeAcpConnectionClosed(message)
+    looksLikeAcpConnectionClosed(message) ||
+    looksLikeCursorRateLimit(message)
   );
 }

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -80,6 +80,9 @@ import { buildCursorAskQuestionExtResponse } from "./cursor-acp-ask-question.js"
 import {
   buildCursorAcpContinueAfterDisconnectPrompt,
   looksLikeAcpConnectionClosed,
+  looksLikeCursorRateLimit,
+  computeCursorRateLimitBackoffMs,
+  interruptibleDelay,
   isLikelyTransientCursorPromptFailure,
   shouldSuppressCursorPromptError,
 } from "./cursor-acp-transient-retry.js";
@@ -1061,6 +1064,24 @@ export class CursorProvider
             promptMessage = buildCursorAcpContinueAfterDisconnectPrompt(originalUserMessage);
             promptAttachments = originalAttachments;
             isContinueRetry = true;
+            continue;
+          }
+          // Rate limit (`resource_exhausted`): the backend rejected the request
+          // before doing any work, so resend the SAME prompt after a jittered
+          // backoff. The wait stays invisible in the thread — runTurn emits no
+          // Error/Ended while it sleeps, so the turn reads as ordinary latency.
+          if (looksLikeCursorRateLimit(raw)) {
+            const backoffMs = computeCursorRateLimitBackoffMs(cursorCfg.rateLimitRetryBackoffMs);
+            logger.warn("Cursor ACP prompt rate-limited; backing off before one retry", {
+              threadId: currentEntry.threadId,
+              attempt,
+              backoffMs,
+              error: raw,
+            });
+            await interruptibleDelay(backoffMs, () => currentEntry.pendingUserStopAbort);
+            if (currentEntry.pendingUserStopAbort) {
+              throw attemptErr;
+            }
             continue;
           }
           logger.warn("Cursor ACP prompt retry after transient CLI failure", {

--- a/apps/server/src/services/__tests__/provider-agent-error-normalize.test.ts
+++ b/apps/server/src/services/__tests__/provider-agent-error-normalize.test.ts
@@ -32,4 +32,22 @@ describe("normalizeAgentProviderError", () => {
     const once = normalizeAgentProviderError("cursor", "Internal Server Error");
     expect(normalizeAgentProviderError("cursor", once)).toEqual(once);
   });
+
+  it("rewrites the minified resource_exhausted rate limit for Cursor", () => {
+    const raw = "v: [resource_exhausted] Error";
+    const out = normalizeAgentProviderError("cursor", raw);
+    expect(out).toContain("rate-limiting");
+    expect(out).toContain("switch to a Fast model");
+    expect(out).toContain(raw);
+  });
+
+  it("does not wrap resource_exhausted wording for non-Cursor providers", () => {
+    const raw = "v: [resource_exhausted] Error";
+    expect(normalizeAgentProviderError("claude", raw)).toBe(raw);
+  });
+
+  it("does not recursively wrap the Cursor rate-limit message", () => {
+    const once = normalizeAgentProviderError("cursor", "v: [resource_exhausted] Error");
+    expect(normalizeAgentProviderError("cursor", once)).toEqual(once);
+  });
 });

--- a/apps/server/src/services/provider-agent-error-normalize.ts
+++ b/apps/server/src/services/provider-agent-error-normalize.ts
@@ -15,6 +15,21 @@ function cursorUpstreamPreamble(original: string): string {
   ].join("\n");
 }
 
+/** Matches the Connect/gRPC `resource_exhausted` status (code 8) in any casing. */
+const CURSOR_RATE_LIMIT_RE = /\bresource_exhausted\b/i;
+
+function cursorRateLimitMessage(original: string): string {
+  return [
+    `Cursor's servers are rate-limiting requests for this model (resource_exhausted).`,
+    `This is almost always short-term burst throttling from too many requests at once, not a usage cap.`,
+    ``,
+    `Wait a few seconds and resend, switch to a Fast model, or run fewer agents at the same time.`,
+    ``,
+    `Original:`,
+    original,
+  ].join("\n");
+}
+
 /**
  * Applies provider-specific substitutions for repetitive failure patterns.
  *
@@ -22,6 +37,14 @@ function cursorUpstreamPreamble(original: string): string {
  * @param message - Raw error string from a provider or subprocess.
  */
 export function normalizeAgentProviderError(providerId: string, message: string): string {
+  if (
+    providerId === "cursor" &&
+    !message.startsWith("Cursor's servers are rate-limiting") &&
+    CURSOR_RATE_LIMIT_RE.test(message)
+  ) {
+    return cursorRateLimitMessage(message);
+  }
+
   const cursorPreambleAlready =
     message.startsWith("The Cursor CLI reported an upstream error");
   if (

--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -38,6 +38,7 @@ Per-setting reference for Mcode's `settings.json`. For schema conventions and st
 | `provider.cursor.fullPreambleEveryNTurns` | integer | `12` | 0-999 | - | With sticky shortening, force a fresh full preamble every N prompts for that subprocess. `0` turns this off. |
 | `provider.cursor.idleSessionTtlMinutes` | integer | `20` | 5-240 | - | Idle minutes before tearing down an unused `cursor-agent` subprocess. |
 | `provider.cursor.retryTransientFailuresOnce` | boolean | `true` | - | - | Retry `session/prompt` once when the failure looks like a transient CLI or HTTP transport flake. |
+| `provider.cursor.rateLimitRetryBackoffMs` | integer | `3000` | 0-60000 | - | Base delay before the single retry of a `resource_exhausted` rate-limited prompt. A random jitter of 0-2000ms is added so concurrent turns do not retry in lockstep. The wait is invisible in the thread (reads as normal model latency); a Stop ends it early. |
 | `provider.cursor.verboseFailureLogs` | boolean | `true` | - | - | On Cursor prompt failure, append recent stderr lines to structured logs when available. |
 | `provider.cursor.traceSessionUpdates` | boolean | `false` | - | - | When true, writes sanitized Cursor ACP `session/update` payloads and mapped agent events to daily server logs (skips noisy `agent_message_chunk` streaming). Inspect `$MCODE_DATA_DIR/logs/` for timelines. |
 | `provider.cursor.autoAnswerAskQuestions` | boolean | `true` | - | - | For blocking `cursor/ask_question`, auto-select recommended or first selectable options. When false, answer as skipped only. |

--- a/packages/contracts/src/models/__tests__/settings.test.ts
+++ b/packages/contracts/src/models/__tests__/settings.test.ts
@@ -47,6 +47,7 @@ describe("settings.provider.cursor", () => {
       fullPreambleEveryNTurns: 12,
       idleSessionTtlMinutes: 20,
       retryTransientFailuresOnce: true,
+      rateLimitRetryBackoffMs: 3000,
       verboseFailureLogs: true,
       traceSessionUpdates: false,
       autoAnswerAskQuestions: true,

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -361,6 +361,13 @@ export const SettingsSchema = lazySchema(() =>
              * (timeouts, opaque 502/503, etc.).
              */
             retryTransientFailuresOnce: z.boolean().default(true),
+            /**
+             * Base backoff (ms) before the single retry of a rate-limited prompt
+             * (`resource_exhausted`). A random jitter up to 2s is added on top so
+             * concurrent rate-limited turns don't all retry at the same instant and
+             * re-trip Cursor's burst limit. Zero retries immediately.
+             */
+            rateLimitRetryBackoffMs: z.number().int().min(0).max(60_000).default(3000),
             /** Attach stderr tail excerpts to Cursor failure logs (debugging only). */
             verboseFailureLogs: z.boolean().default(true),
             /**
@@ -621,6 +628,7 @@ export const PartialSettingsSchema = lazySchema(() =>
             fullPreambleEveryNTurns: z.number().int().min(0).max(999).optional(),
             idleSessionTtlMinutes: z.number().int().min(5).max(240).optional(),
             retryTransientFailuresOnce: z.boolean().optional(),
+            rateLimitRetryBackoffMs: z.number().int().min(0).max(60_000).optional(),
             verboseFailureLogs: z.boolean().optional(),
             traceSessionUpdates: z.boolean().optional(),
             autoAnswerAskQuestions: z.boolean().optional(),


### PR DESCRIPTION
## What

Cursor's `resource_exhausted` rate limit no longer leaks into the thread as a raw `v: [resource_exhausted] Error`. The provider now backs off briefly and retries the prompt once, invisibly. If that retry still fails, the error is rewritten into a friendly, actionable message.

## Why

Cursor's backend surfaces burst throttling as a minified Connect/gRPC `ConnectError` (status code 8). `cursor-agent` serializes it as `v: [resource_exhausted] Error`, which surfaced verbatim in chat and read like a crash. Per Cursor's docs this is almost always short-term burst throttling (too many requests in a short window), not a usage cap, so the correct recovery is a brief backoff and a single resend, not an error.

The trigger is concurrency: several turns trip the limit at the same instant. A fixed delay would make them all retry in lockstep and re-create the same burst, so the backoff carries random jitter to de-correlate the retries.

## Key Changes

- **Detection** (`cursor-acp-transient-retry.ts`): `looksLikeCursorRateLimit` matches `resource_exhausted`; it joins `isLikelyTransientCursorPromptFailure` so the existing prompt-retry loop treats a rate limit as retryable.
- **Backoff** (`cursor-provider.ts`): on a rate-limited prompt, `runTurn` sleeps `computeCursorRateLimitBackoffMs` (base + 0-2s jitter) via `interruptibleDelay`, then resends the same prompt. The sleep emits no Error/Ended event, so the turn reads as ordinary model latency. A pending user Stop cuts the wait short and aborts the retry.
- **Single, capped retry**: reuses the existing `maxAttempts` cap and `retryTransientFailuresOnce` gate. The backoff applies only to the `resource_exhausted` class, not to the ACP-reconnect or generic-transient paths.
- **Friendly fallback** (`provider-agent-error-normalize.ts`): if the one retry still fails, the broadcast-boundary normalizer rewrites the raw cursor error into a message telling the user to wait and resend, switch to a Fast model, or run fewer agents. Guarded against double-wrapping and scoped to `providerId === "cursor"`.
- **Tests**: unit coverage for detection, backoff math (zero/full jitter, negative/NaN base clamped, fractional floor), `interruptibleDelay` early-abort, normalizer rewrite-once behaviour, and the new setting default.
- **Docs**: settings reference row for the new key.

## Config Changes

Adds one setting:

| Setting | Type | Default | Range | Description |
|---------|------|---------|-------|-------------|
| `provider.cursor.rateLimitRetryBackoffMs` | integer | `3000` | `0`-`60000` | Base delay (ms) before the single retry of a `resource_exhausted` rate-limited prompt. A random jitter of 0-2000ms is added so concurrent turns do not retry in lockstep. The wait is invisible in the thread; a Stop ends it early. `0` retries immediately. |

No env vars or secrets.

## Verification

- `bun run verify` (full gate: typecheck + lint + unit tests) green.
- Live demo on an isolated dev stack: drove a real Composer 2.5 turn end-to-end. The turn rendered the in-progress `Thinking…` state where a backoff would hide, completed cleanly, and persisted under `provider="cursor"` with no console errors. The friendly-message path is proven deterministically (`normalizeAgentProviderError("cursor", "Error: v: [resource_exhausted] Error")` returns the rewritten message).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784283443&installation_id=129163861&pr_number=782&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F782&signature=b9bc39ee33b5d127ba4a25f47ec8b39e1f7be2406de7c9412788d15d931ffe49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cursor provider now automatically retries rate-limited prompts with jittered backoff delays (can be interrupted by Stop).
  * Added `provider.cursor.rateLimitRetryBackoffMs` setting (default 3000ms, range 0-60000ms) to configure retry delay.
  * Improved error messages for rate-limit scenarios with actionable guidance.

* **Tests**
  * Expanded test coverage for rate-limit detection and retry utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->