### PR TITLE
fix(desktop): drop redundant icon.icns extraResource that broke macOS nightly packaging

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -70,10 +70,6 @@
       {
         "from": "build/icon.ico",
         "to": "icon.ico"
-      },
-      {
-        "from": "build/icon.icns",
-        "to": "icon.icns"
       }
     ],
     "asarUnpack": [


### PR DESCRIPTION
## What

Remove the `build/icon.icns` entry from the global `extraResources` block in `apps/desktop/package.json`.

## Why

PR #739 ("scale dock icon for taskbar parity") added `build/icon.icns` to `extraResources`. On macOS, `extraResources` are copied into `Contents/Resources/`, so `to: "icon.icns"` resolves to `Contents/Resources/icon.icns` - the **exact path electron-builder already populates from `mac.icon`**. The second write fails:

```
⨯ EEXIST: file already exists, link '.../build/icon.icns' -> '.../Mcode.app/Contents/Resources/icon.icns'  failedTask=build
```

This broke the macOS packaging step (both arm64 and x64) on every Nightly Desktop run since 2026-06-15. Windows (06-13) and the runs before #739 landed were green. Linux/Windows are unaffected because their `extraResources` land elsewhere and the icon is embedded differently (Windows reads `icon.ico`, Linux reads `icon.png`).

## Key changes

- `apps/desktop/package.json`: removed the redundant `{ from: build/icon.icns, to: icon.icns }` extraResource.

This does **not** revert #739's intent. The rescaled dock icon comes from the `build/icon.icns` asset placed by `mac.icon`, and the runtime lookup `join(process.resourcesPath, "icon.icns")` still resolves to `Contents/Resources/icon.icns`.

## Configuration changes

None.

## Related issues/PRs

- Relates to #739 (introduced the regression)
- Fixes the failed Nightly Desktop run https://github.com/Mzeey-Empire/mcode/actions/runs/27682079828

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784289862&installation_id=129163861&pr_number=784&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F784&signature=1526a7cec244f93bccf14d9e9acdd611802f014283e704634025416483ede5e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->