### PR TITLE
fix(diff): keep the picked Branch comparison ref sticky across re-resolves

### DIFF
--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import type { BranchComparison, GitBranch } from "@mcode/contracts";
 import {
   useDiffStore,
   PANEL_MIN_WIDTH,
@@ -32,6 +33,10 @@ describe("diffStore", () => {
       lineWrapByThread: {},
       inlineDiffCache: {},
       diffRevisionByScope: {},
+      branchComparison: null,
+      branchComparisonKey: null,
+      branchManuallySelectedByScope: {},
+      branchResolvedRevisionByScope: {},
     });
   });
 
@@ -99,6 +104,99 @@ describe("diffStore", () => {
       setReviewViewForThread("thread-2", "branch");
       clearThread("thread-1");
       expect(getReviewView("thread-2", { hasTurnChanges: true, isDirty: false })).toBe("branch");
+    });
+  });
+
+  // The Branch comparison operand must survive a turn-driven re-resolve. A
+  // `files.changed`/`turn.persisted` event bumps the scope revision, which
+  // re-fetches the server default; without the sticky guard that fetch would
+  // clobber the user's picked target. See ADR-0007.
+  describe("sticky Branch comparison operand", () => {
+    const ref = (name: string, isCurrent = false): GitBranch => ({
+      name,
+      shortSha: "abc1234",
+      type: name.startsWith("origin/") ? "remote" : "local",
+      isCurrent,
+    });
+    const comparison = (target: string | null): BranchComparison => ({
+      base: "feature",
+      target,
+      refs: [ref("feature", true), ref("main"), ref("origin/main")],
+      isUnborn: false,
+      isComparisonAvailable: true,
+    });
+    const key = "ws-1:thread-1";
+
+    it("records the resolved revision and seeds the comparison for a scope", () => {
+      const { resolveBranchComparison } = useDiffStore.getState();
+      resolveBranchComparison(comparison("main"), key, 3);
+      const state = useDiffStore.getState();
+      expect(state.branchComparison?.target).toBe("main");
+      expect(state.branchComparisonKey).toBe(key);
+      expect(state.branchResolvedRevisionByScope[key]).toBe(3);
+    });
+
+    it("preserves a manual target pick across a revision-bump re-resolve", () => {
+      const { resolveBranchComparison, setBranchTarget } = useDiffStore.getState();
+      resolveBranchComparison(comparison("main"), key, 1);
+      setBranchTarget("origin/main"); // user picks a different ref
+
+      // A turn re-resolves the server default (target "main") at a new revision.
+      resolveBranchComparison(comparison("main"), key, 2);
+
+      const state = useDiffStore.getState();
+      expect(state.branchComparison?.target).toBe("origin/main");
+      expect(state.branchResolvedRevisionByScope[key]).toBe(2);
+    });
+
+    it("falls back to the server default when the picked ref no longer exists", () => {
+      const { resolveBranchComparison, setBranchTarget } = useDiffStore.getState();
+      resolveBranchComparison(comparison("main"), key, 1);
+      setBranchTarget("origin/main");
+
+      // The picked ref is gone from the freshly resolved set (e.g. branch deleted).
+      const withoutOrigin: BranchComparison = {
+        ...comparison("main"),
+        refs: [ref("feature", true), ref("main")],
+      };
+      resolveBranchComparison(withoutOrigin, key, 2);
+
+      expect(useDiffStore.getState().branchComparison?.target).toBe("main");
+    });
+
+    it("does not preserve a pick across a scope change", () => {
+      const { resolveBranchComparison, setBranchTarget } = useDiffStore.getState();
+      resolveBranchComparison(comparison("main"), key, 1);
+      setBranchTarget("origin/main");
+
+      // A different scope resolves fresh — the prior scope's pick must not leak.
+      resolveBranchComparison(comparison("main"), "ws-1:thread-2", 1);
+
+      expect(useDiffStore.getState().branchComparison?.target).toBe("main");
+    });
+
+    it("drops the scope's sticky state on clearThread", () => {
+      const { resolveBranchComparison, setBranchTarget, clearThread } = useDiffStore.getState();
+      resolveBranchComparison(comparison("main"), key, 1);
+      setBranchTarget("origin/main");
+
+      clearThread("thread-1");
+
+      const state = useDiffStore.getState();
+      expect(state.branchManuallySelectedByScope[key]).toBeUndefined();
+      expect(state.branchResolvedRevisionByScope[key]).toBeUndefined();
+    });
+
+    it("drops the scope's sticky state on clearWorkspace", () => {
+      const { resolveBranchComparison, setBranchTarget, clearWorkspace } = useDiffStore.getState();
+      resolveBranchComparison(comparison("main"), key, 1);
+      setBranchTarget("origin/main");
+
+      clearWorkspace("ws-1");
+
+      const state = useDiffStore.getState();
+      expect(state.branchManuallySelectedByScope[key]).toBeUndefined();
+      expect(state.branchResolvedRevisionByScope[key]).toBeUndefined();
     });
   });
 

--- a/apps/web/src/components/diff/BranchRefPicker.tsx
+++ b/apps/web/src/components/diff/BranchRefPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowRight, Check, ChevronDown } from "lucide-react";
 import type { BranchComparison, GitBranch } from "@mcode/contracts";
 import { Button } from "@/components/ui/button";
@@ -34,37 +34,38 @@ function useResolveBranchComparison(
   diffScopeRevision: number,
 ): { comparison: BranchComparison | null; loading: boolean } {
   const comparison = useDiffStore((s) => s.branchComparison);
-  const setBranchComparison = useDiffStore((s) => s.setBranchComparison);
+  const resolveBranchComparison = useDiffStore((s) => s.resolveBranchComparison);
   const [loading, setLoading] = useState(false);
   const key = scopeKey(workspaceId, threadId);
-  const resolvedRevisionRef = useRef<number | null>(null);
 
   useEffect(() => {
     const state = useDiffStore.getState();
+    // The "already resolved for this scope+revision" guard is store-backed (not a
+    // component ref) so it survives a remount and skips a redundant re-fetch.
     if (
       state.branchComparisonKey === key &&
       state.branchComparison &&
-      resolvedRevisionRef.current === diffScopeRevision
+      state.branchResolvedRevisionByScope[key] === diffScopeRevision
     ) {
       setLoading(false);
       return;
     }
 
     let cancelled = false;
-    resolvedRevisionRef.current = diffScopeRevision;
     setLoading(true);
     void getTransport()
       .getBranchComparison(workspaceId, threadId)
       .then((result) => {
         if (cancelled) return;
-        setBranchComparison(normalizeToCurrentComparison(result), key);
+        resolveBranchComparison(normalizeToCurrentComparison(result), key, diffScopeRevision);
         setLoading(false);
       })
       .catch(() => {
         if (cancelled) return;
-        setBranchComparison(
+        resolveBranchComparison(
           { base: null, target: null, refs: [], isUnborn: false, isComparisonAvailable: false },
           key,
+          diffScopeRevision,
         );
         setLoading(false);
       });
@@ -72,7 +73,7 @@ function useResolveBranchComparison(
     return () => {
       cancelled = true;
     };
-  }, [key, workspaceId, threadId, diffScopeRevision, setBranchComparison]);
+  }, [key, workspaceId, threadId, diffScopeRevision, resolveBranchComparison]);
 
   return { comparison, loading };
 }

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -139,6 +139,24 @@ function omitInlineDiffCacheByPrefix(
   return next;
 }
 
+/** Copy a record, dropping entries whose key ends with `suffix`. */
+function omitByKeySuffix<V>(record: Record<string, V>, suffix: string): Record<string, V> {
+  const next: Record<string, V> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (!key.endsWith(suffix)) next[key] = value;
+  }
+  return next;
+}
+
+/** Copy a record, dropping entries whose key starts with `prefix`. */
+function omitByKeyPrefix<V>(record: Record<string, V>, prefix: string): Record<string, V> {
+  const next: Record<string, V> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (!key.startsWith(prefix)) next[key] = value;
+  }
+  return next;
+}
+
 /**
  * Resolves the effective panel record for a scope (ADR-0012 copy-on-write read).
  * A thread with its own record uses it; otherwise it falls through to the
@@ -259,6 +277,22 @@ interface DiffState {
    */
   branchComparisonKey: string | null;
   /**
+   * Per-scope "the user manually picked a Branch comparison operand" flag, keyed
+   * by the same `workspaceId:threadId` scope as {@link branchComparisonKey}. While
+   * set, re-resolution preserves the user's picked ref (when it still exists)
+   * instead of reverting to the server default - so a turn-driven `diffRevision`
+   * bump or a picker remount no longer clobbers the selection. Mirrors
+   * `reviewViewManuallySelectedByThread` (ADR-0011).
+   */
+  branchManuallySelectedByScope: Record<string, boolean>;
+  /**
+   * The `diffRevision` each scope's {@link branchComparison} was last resolved at,
+   * keyed by scope. Store-backed (not a component ref) so the "already resolved for
+   * this scope+revision" guard survives a picker remount and skips a redundant
+   * re-fetch.
+   */
+  branchResolvedRevisionByScope: Record<string, number>;
+  /**
    * The commit the Commit view's picker has resolved to, by SHA. `null` means
    * the picker has not resolved the current scope yet, or the scope has no
    * commits. This is the Commit comparison's picked operand: the Review toolbar's
@@ -357,8 +391,16 @@ interface DiffState {
    * auto-defaulting for that thread. See ADR-0011.
    */
   setReviewViewForThread: (threadId: string, mode: DiffViewMode) => void;
-  /** Store a resolved Branch comparison for a scope, keyed for staleness tracking. */
-  setBranchComparison: (comparison: BranchComparison | null, key: string | null) => void;
+  /**
+   * Apply a freshly resolved Branch comparison for a scope, recording the revision
+   * it was resolved at and preserving the user's manually picked target when that
+   * scope is flagged and the picked ref still exists.
+   */
+  resolveBranchComparison: (
+    comparison: BranchComparison,
+    key: string,
+    revision: number,
+  ) => void;
   /** Override the base ref of the active Branch comparison (no-op if none resolved). */
   setBranchBase: (ref: string) => void;
   /** Override the target ref of the active Branch comparison (no-op if none resolved). */
@@ -410,6 +452,8 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   reviewViewManuallySelectedByThread: {},
   branchComparison: null,
   branchComparisonKey: null,
+  branchManuallySelectedByScope: {},
+  branchResolvedRevisionByScope: {},
   selectedCommitSha: null,
   renderMode: "unified",
   reviewFileCount: null,
@@ -511,13 +555,36 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       diffContent: null,
       selectedCommitSha: null,
     })),
-  setBranchComparison: (comparison, key) =>
-    set({ branchComparison: comparison, branchComparisonKey: key }),
+  resolveBranchComparison: (comparison, key, revision) =>
+    set((s) => {
+      const sameScope = s.branchComparisonKey === key;
+      const priorTarget = sameScope ? s.branchComparison?.target ?? null : null;
+      // Preserve a manual pick across re-resolution, but only when the chosen ref
+      // still exists in the freshly resolved set (a deleted branch must fall back).
+      const keepTarget =
+        s.branchManuallySelectedByScope[key] === true &&
+        priorTarget !== null &&
+        comparison.refs.some((ref) => ref.name === priorTarget);
+      return {
+        branchComparison: keepTarget
+          ? { ...comparison, target: priorTarget }
+          : comparison,
+        branchComparisonKey: key,
+        branchResolvedRevisionByScope: {
+          ...s.branchResolvedRevisionByScope,
+          [key]: revision,
+        },
+      };
+    }),
   setBranchBase: (ref) =>
     set((s) =>
-      s.branchComparison
+      s.branchComparison && s.branchComparisonKey
         ? {
             branchComparison: { ...s.branchComparison, base: ref },
+            branchManuallySelectedByScope: {
+              ...s.branchManuallySelectedByScope,
+              [s.branchComparisonKey]: true,
+            },
             // Changing an operand invalidates the selected file's diff.
             selectedFile: null,
             diffContent: null,
@@ -526,9 +593,13 @@ export const useDiffStore = create<DiffState>((set, get) => ({
     ),
   setBranchTarget: (ref) =>
     set((s) =>
-      s.branchComparison
+      s.branchComparison && s.branchComparisonKey
         ? {
             branchComparison: { ...s.branchComparison, target: ref },
+            branchManuallySelectedByScope: {
+              ...s.branchManuallySelectedByScope,
+              [s.branchComparisonKey]: true,
+            },
             selectedFile: null,
             diffContent: null,
           }
@@ -624,6 +695,14 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       delete reviewViewManuallySelectedByThread[threadId];
       const diffRevisionByScope = { ...state.diffRevisionByScope };
       delete diffRevisionByScope[threadId];
+      const branchManuallySelectedByScope = omitByKeySuffix(
+        state.branchManuallySelectedByScope,
+        `:${threadId}`,
+      );
+      const branchResolvedRevisionByScope = omitByKeySuffix(
+        state.branchResolvedRevisionByScope,
+        `:${threadId}`,
+      );
 
       const inlineDiffCache = omitInlineDiffCacheByPrefix(state.inlineDiffCache, `${threadId}:`);
 
@@ -643,6 +722,8 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         reviewViewByThread,
         reviewViewManuallySelectedByThread,
         diffRevisionByScope,
+        branchManuallySelectedByScope,
+        branchResolvedRevisionByScope,
         inlineDiffCache,
         ...(selectionBelongsToThread
           ? { selectedFile: null, diffContent: null, diffLoading: false }
@@ -658,10 +739,18 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       const hasInlineDiffCache = Object.keys(state.inlineDiffCache).some((key) =>
         key.startsWith(cachePrefix),
       );
+      const hasBranchScope =
+        Object.keys(state.branchManuallySelectedByScope).some((key) =>
+          key.startsWith(cachePrefix),
+        ) ||
+        Object.keys(state.branchResolvedRevisionByScope).some((key) =>
+          key.startsWith(cachePrefix),
+        );
       if (
         !(workspaceId in state.rightPanelFallbackByWorkspace) &&
         !(workspaceId in state.diffRevisionByScope) &&
-        !hasInlineDiffCache
+        !hasInlineDiffCache &&
+        !hasBranchScope
       ) {
         return {};
       }
@@ -672,6 +761,14 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       return {
         rightPanelFallbackByWorkspace,
         diffRevisionByScope,
+        branchManuallySelectedByScope: omitByKeyPrefix(
+          state.branchManuallySelectedByScope,
+          cachePrefix,
+        ),
+        branchResolvedRevisionByScope: omitByKeyPrefix(
+          state.branchResolvedRevisionByScope,
+          cachePrefix,
+        ),
         inlineDiffCache: omitInlineDiffCacheByPrefix(state.inlineDiffCache, cachePrefix),
       };
     }),


### PR DESCRIPTION
## What
Keep the Branch view's manually picked comparison ref selected when the diff re-resolves. A per-turn diff revision bump or a panel remount no longer reverts the user's chosen target to the server default.

## Why
The Branch view re-resolved its comparison operand on every per-turn diff revision bump (`files.changed` / `turn.persisted`) and on every remount. Each re-resolve overwrote a user's manually picked target with the server default. The guard against redundant re-fetches lived in a component `useRef`, which reset to `null` on remount, so toggling the Review view away and back also dropped the pick.

The fix stays entirely at the operand layer. The `files.changed` and diff invalidation plumbing is unchanged, so turn-diff freshness is preserved.

## Key Changes
- Add `branchResolvedRevisionByScope` to the diff store: records the revision a scope was resolved at. The resolve guard is now store-backed, so it survives a remount instead of resetting like the old `useRef`.
- Add `branchManuallySelectedByScope`: marks a scope whose target the user picked. `resolveBranchComparison` preserves that target on re-resolve when the ref still exists, and falls back to the server default when the picked ref is gone.
- Rewire `BranchRefPicker` to read the store-backed guard and call `resolveBranchComparison`; remove the orphaned `useRef` and `setBranchComparison`.
- Both maps are scoped per `workspaceId:threadId` and cleared on `clearThread` and `clearWorkspace` (no cross-scope leak).
- Add 7 unit tests in `diffStore.test.ts` covering: revision recorded; manual pick preserved across a revision-bump re-resolve; fallback when the picked ref is deleted; no cross-scope leak; cleared on `clearThread`; cleared on `clearWorkspace`.

## Config Changes
None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784300265&installation_id=129163861&pr_number=785&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F785&signature=bfb9eac23e57a95b57f70b9bda534b59143a580a573636f009545f40120804f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branch comparison selections are now sticky across operations, preserving your manually selected branch targets.
  * Automatically falls back to server default when a previously selected branch reference no longer exists.
  * Selections remain scoped and don't leak across different contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->