### PR TITLE
fix(tasks): reflect Claude TaskUpdate lifecycle in the Scope view

### DIFF
--- a/apps/server/src/repositories/__tests__/task-repo.test.ts
+++ b/apps/server/src/repositories/__tests__/task-repo.test.ts
@@ -86,6 +86,56 @@ describe("TaskRepo", () => {
     ]);
   });
 
+  it("appendTask replaces a task with the same harness id in the same group", () => {
+    const threadId = makeThread("append-id");
+    repo.appendTask(threadId, { id: "1", content: "first", status: "pending", group: "Tasks" });
+    repo.appendTask(threadId, { id: "1", content: "first again", status: "in_progress", group: "Tasks" });
+    expect(repo.get(threadId)).toEqual([
+      { id: "1", content: "first again", status: "in_progress", group: "Tasks" },
+    ]);
+  });
+
+  it("appendTask keeps colliding harness ids when they belong to different groups", () => {
+    const threadId = makeThread("append-id-collide");
+    repo.appendTask(threadId, { id: "1", content: "main one", status: "pending", group: "Tasks" });
+    repo.appendTask(threadId, { id: "1", content: "sub one", status: "pending", group: "Sub-agent" });
+    expect(repo.get(threadId)).toEqual([
+      { id: "1", content: "main one", status: "pending", group: "Tasks" },
+      { id: "1", content: "sub one", status: "pending", group: "Sub-agent" },
+    ]);
+  });
+
+  it("updateTask patches status and reports whether a task matched", () => {
+    const threadId = makeThread("update");
+    repo.appendTask(threadId, { id: "1", content: "task one", status: "pending", group: "Tasks" });
+    expect(repo.updateTask(threadId, "1", { status: "completed" })).toBe(true);
+    expect(repo.get(threadId)).toEqual([
+      { id: "1", content: "task one", status: "completed", group: "Tasks" },
+    ]);
+    expect(repo.updateTask(threadId, "missing", { status: "completed" })).toBe(false);
+  });
+
+  it("updateTask scopes by group when harness ids collide across groups", () => {
+    const threadId = makeThread("update-scoped");
+    repo.appendTask(threadId, { id: "1", content: "main one", status: "pending", group: "Tasks" });
+    repo.appendTask(threadId, { id: "1", content: "sub one", status: "pending", group: "Sub-agent" });
+    repo.updateTask(threadId, "1", { status: "completed" }, "Sub-agent");
+    expect(repo.get(threadId)).toEqual([
+      { id: "1", content: "main one", status: "pending", group: "Tasks" },
+      { id: "1", content: "sub one", status: "completed", group: "Sub-agent" },
+    ]);
+  });
+
+  it("removeTask deletes the task with the given harness id scoped to its group", () => {
+    const threadId = makeThread("remove");
+    repo.appendTask(threadId, { id: "1", content: "main one", status: "pending", group: "Tasks" });
+    repo.appendTask(threadId, { id: "1", content: "sub one", status: "pending", group: "Sub-agent" });
+    repo.removeTask(threadId, "1", "Tasks");
+    expect(repo.get(threadId)).toEqual([
+      { id: "1", content: "sub one", status: "pending", group: "Sub-agent" },
+    ]);
+  });
+
   it("delete removes the row", () => {
     const threadId = makeThread("3");
     repo.upsert(threadId, [{ content: "x", status: "pending" }]);

--- a/apps/server/src/repositories/__tests__/task-repo.test.ts
+++ b/apps/server/src/repositories/__tests__/task-repo.test.ts
@@ -126,6 +126,26 @@ describe("TaskRepo", () => {
     ]);
   });
 
+  it("updateTask leaves every task untouched when an id collides across groups and the group matches none", () => {
+    const threadId = makeThread("update-ambiguous");
+    repo.appendTask(threadId, { id: "1", content: "main one", status: "pending", group: "Tasks" });
+    repo.appendTask(threadId, { id: "1", content: "sub one", status: "pending", group: "Sub-agent" });
+    expect(repo.updateTask(threadId, "1", { status: "completed" }, "Unknown")).toBe(false);
+    expect(repo.get(threadId)).toEqual([
+      { id: "1", content: "main one", status: "pending", group: "Tasks" },
+      { id: "1", content: "sub one", status: "pending", group: "Sub-agent" },
+    ]);
+  });
+
+  it("updateTask falls back to the sole global match when the group is unknown", () => {
+    const threadId = makeThread("update-global-recover");
+    repo.appendTask(threadId, { id: "1", content: "only one", status: "pending", group: "Tasks" });
+    expect(repo.updateTask(threadId, "1", { status: "completed" }, "Unresolved")).toBe(true);
+    expect(repo.get(threadId)).toEqual([
+      { id: "1", content: "only one", status: "completed", group: "Tasks" },
+    ]);
+  });
+
   it("removeTask deletes the task with the given harness id scoped to its group", () => {
     const threadId = makeThread("remove");
     repo.appendTask(threadId, { id: "1", content: "main one", status: "pending", group: "Tasks" });

--- a/apps/server/src/repositories/task-repo.ts
+++ b/apps/server/src/repositories/task-repo.ts
@@ -86,24 +86,27 @@ export class TaskRepo {
   }
 
   /**
-   * Locate the index of the task with the given harness id. Prefers a match
-   * scoped to `group` (harness ids collide across sub-agents) and falls back to
-   * a global id match so an update still lands when the group is unknown (e.g.
-   * the creating sub-agent call has been evicted from the buffer). Returns -1
-   * when no task matches.
+   * Locate the index of the task with the given harness id. A match scoped to
+   * `group` always wins (harness ids collide across sub-agents). Without a scoped
+   * hit, it falls back to a global id match only when exactly one task carries
+   * that id, so an update still lands when the group is unknown (e.g. the
+   * creating sub-agent call has been evicted from the buffer) without ever
+   * mutating the wrong task on an ambiguous collision. Returns -1 when no
+   * unambiguous match exists.
    */
   private findTaskIndex(
     tasks: readonly StoredTask[],
     id: string,
     group?: string,
   ): number {
-    if (group != null) {
-      const scoped = tasks.findIndex(
-        (task) => (task.group ?? "Tasks") === group && task.id === id,
-      );
-      if (scoped >= 0) return scoped;
+    const globalMatches: number[] = [];
+    for (let i = 0; i < tasks.length; i += 1) {
+      const task = tasks[i];
+      if (task.id !== id) continue;
+      if (group != null && (task.group ?? "Tasks") === group) return i;
+      globalMatches.push(i);
     }
-    return tasks.findIndex((task) => task.id === id);
+    return globalMatches.length === 1 ? globalMatches[0] : -1;
   }
 
   /**

--- a/apps/server/src/repositories/task-repo.ts
+++ b/apps/server/src/repositories/task-repo.ts
@@ -15,8 +15,17 @@ import { logger } from "@mcode/shared";
  * restarts instead of being silently coerced to `pending` on rehydrate.
  */
 export interface StoredTask {
+  /**
+   * Harness-assigned task id from the Task* tool family (e.g. "1"). Used to
+   * correlate later `TaskUpdate` calls to the task they mutate. Optional so
+   * legacy TodoWrite/update_plan tasks (which have no harness id) still
+   * persist and round-trip.
+   */
+  id?: string;
   content: string;
   status: "pending" | "in_progress" | "completed" | "cancelled";
+  /** Present-continuous label shown while the task is in_progress. */
+  activeForm?: string;
   /** Group label for the task. Sub-agent tasks use the agent's description. */
   group?: string;
 }
@@ -57,16 +66,83 @@ export class TaskRepo {
     this.stmtUpsert.run(threadId, JSON.stringify(merged));
   }
 
-  /** Append or replace a single task in the persisted task list. */
+  /**
+   * Append or replace a single task in the persisted task list. Harness ids are
+   * unique only within a group (each agent and sub-agent numbers its own list),
+   * so identity is (group, id) when an id is present; otherwise it falls back to
+   * content + group for legacy TodoWrite/update_plan tasks.
+   */
   appendTask(threadId: string, task: StoredTask): void {
     const existing = this.get(threadId) ?? [];
     const group = task.group ?? "Tasks";
-    const otherTasks = existing.filter(
-      (existingTask) =>
-        existingTask.content !== task.content ||
-        (existingTask.group ?? "Tasks") !== group,
-    );
+    const otherTasks = existing.filter((existingTask) => {
+      const sameGroup = (existingTask.group ?? "Tasks") === group;
+      if (task.id != null && existingTask.id != null) {
+        return !(sameGroup && existingTask.id === task.id);
+      }
+      return existingTask.content !== task.content || !sameGroup;
+    });
     this.stmtUpsert.run(threadId, JSON.stringify([...otherTasks, task]));
+  }
+
+  /**
+   * Locate the index of the task with the given harness id. Prefers a match
+   * scoped to `group` (harness ids collide across sub-agents) and falls back to
+   * a global id match so an update still lands when the group is unknown (e.g.
+   * the creating sub-agent call has been evicted from the buffer). Returns -1
+   * when no task matches.
+   */
+  private findTaskIndex(
+    tasks: readonly StoredTask[],
+    id: string,
+    group?: string,
+  ): number {
+    if (group != null) {
+      const scoped = tasks.findIndex(
+        (task) => (task.group ?? "Tasks") === group && task.id === id,
+      );
+      if (scoped >= 0) return scoped;
+    }
+    return tasks.findIndex((task) => task.id === id);
+  }
+
+  /**
+   * Apply a partial update to the persisted task with the given harness id.
+   * Returns true when a matching task was found and updated. No-op (returns
+   * false) when the id is unknown, so callers can detect uncorrelated updates.
+   */
+  updateTask(
+    threadId: string,
+    id: string,
+    patch: Partial<Pick<StoredTask, "status" | "content" | "activeForm">>,
+    group?: string,
+  ): boolean {
+    const existing = this.get(threadId);
+    if (!existing) return false;
+    const index = this.findTaskIndex(existing, id, group);
+    if (index < 0) return false;
+    const next = existing.map((task, i) =>
+      i === index
+        ? {
+            ...task,
+            ...(patch.status !== undefined ? { status: patch.status } : {}),
+            ...(patch.content !== undefined ? { content: patch.content } : {}),
+            ...(patch.activeForm !== undefined ? { activeForm: patch.activeForm } : {}),
+          }
+        : task,
+    );
+    this.stmtUpsert.run(threadId, JSON.stringify(next));
+    return true;
+  }
+
+  /** Remove the persisted task with the given harness id (TaskUpdate deleted). */
+  removeTask(threadId: string, id: string, group?: string): void {
+    const existing = this.get(threadId);
+    if (!existing) return;
+    const index = this.findTaskIndex(existing, id, group);
+    if (index < 0) return;
+    const next = existing.filter((_, i) => i !== index);
+    this.stmtUpsert.run(threadId, JSON.stringify(next));
   }
 
   /** Retrieve the persisted task list for a thread, or null if none exists. */

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -72,6 +72,8 @@ interface Built {
   toolBulk: ReturnType<typeof vi.fn>;
   taskAppend: ReturnType<typeof vi.fn>;
   taskUpsertGroup: ReturnType<typeof vi.fn>;
+  taskUpdate: ReturnType<typeof vi.fn>;
+  taskRemove: ReturnType<typeof vi.fn>;
 }
 
 function build(): Built {
@@ -133,11 +135,15 @@ function build(): Built {
   } as unknown as MemoryPressureService;
   const taskAppend = vi.fn();
   const taskUpsertGroup = vi.fn();
+  const taskUpdate = vi.fn(() => true);
+  const taskRemove = vi.fn();
   const taskRepo = {
     get: vi.fn(() => []),
     upsert: vi.fn(),
     upsertGroup: taskUpsertGroup,
     appendTask: taskAppend,
+    updateTask: taskUpdate,
+    removeTask: taskRemove,
   } as unknown as TaskRepo;
   const settingsService = {
     get: vi.fn(() => ({
@@ -196,7 +202,7 @@ function build(): Built {
   // sendMessage uses (beginTurn + resetTurnCounters).
   narrativeStore.beginTurn(THREAD_ID);
   narrativeStore.resetTurnCounters(THREAD_ID);
-  return { service, providerEmitter, thoughtBulk, hookBulk, toolBulk, taskAppend, taskUpsertGroup };
+  return { service, providerEmitter, thoughtBulk, hookBulk, toolBulk, taskAppend, taskUpsertGroup, taskUpdate, taskRemove };
 }
 
 describe("AgentService narrative persistence", () => {
@@ -204,9 +210,11 @@ describe("AgentService narrative persistence", () => {
     vi.clearAllMocks();
   });
 
-  it("persists TaskCreate tool calls for Scope hydration", () => {
+  it("persists TaskCreate at result time keyed by the harness-assigned id", () => {
     const { providerEmitter, taskAppend } = build();
 
+    // The harness assigns the task id only in the result, so the create must be
+    // buffered on ToolUse and persisted on ToolResult.
     providerEmitter.emit("event", {
       type: AgentEventType.ToolUse,
       threadId: THREAD_ID,
@@ -215,14 +223,100 @@ describe("AgentService narrative persistence", () => {
       toolInput: {
         subject: "Buy groceries",
         description: "Pick up milk, eggs, bread",
+        activeForm: "Buying groceries",
       },
+    });
+    expect(taskAppend).not.toHaveBeenCalled();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolResult,
+      threadId: THREAD_ID,
+      toolCallId: "task-create-1",
+      output: "Task #1 created successfully: Buy groceries",
+      isError: false,
     });
 
     expect(taskAppend).toHaveBeenCalledWith(THREAD_ID, {
+      id: "1",
       content: "Buy groceries - Pick up milk, eggs, bread",
       status: "pending",
+      activeForm: "Buying groceries",
       group: "Tasks",
     });
+  });
+
+  it("does not persist a TaskCreate whose result errored", () => {
+    const { providerEmitter, taskAppend } = build();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolUse,
+      threadId: THREAD_ID,
+      toolCallId: "task-create-err",
+      toolName: "TaskCreate",
+      toolInput: { subject: "Doomed", description: "never lands" },
+    });
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolResult,
+      threadId: THREAD_ID,
+      toolCallId: "task-create-err",
+      output: "Task #2 created successfully",
+      isError: true,
+    });
+
+    expect(taskAppend).not.toHaveBeenCalled();
+  });
+
+  it("applies a TaskUpdate status transition to the persisted task by harness id", () => {
+    const { providerEmitter, taskUpdate } = build();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolUse,
+      threadId: THREAD_ID,
+      toolCallId: "task-update-1",
+      toolName: "TaskUpdate",
+      toolInput: { taskId: "1", status: "in_progress" },
+    });
+
+    expect(taskUpdate).toHaveBeenCalledWith(
+      THREAD_ID,
+      "1",
+      { status: "in_progress" },
+      "Tasks",
+    );
+  });
+
+  it("removes the persisted task when a TaskUpdate sets status deleted", () => {
+    const { providerEmitter, taskRemove, taskUpdate } = build();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolUse,
+      threadId: THREAD_ID,
+      toolCallId: "task-update-del",
+      toolName: "TaskUpdate",
+      toolInput: { taskId: "3", status: "deleted" },
+    });
+
+    expect(taskRemove).toHaveBeenCalledWith(THREAD_ID, "3", "Tasks");
+    expect(taskUpdate).not.toHaveBeenCalled();
+  });
+
+  it("patches subject and activeForm via TaskUpdate without a status change", () => {
+    const { providerEmitter, taskUpdate } = build();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolUse,
+      threadId: THREAD_ID,
+      toolCallId: "task-update-edit",
+      toolName: "TaskUpdate",
+      toolInput: { taskId: "1", subject: "Run unit tests", activeForm: "Running unit tests" },
+    });
+
+    expect(taskUpdate).toHaveBeenCalledWith(
+      THREAD_ID,
+      "1",
+      { content: "Run unit tests", activeForm: "Running unit tests" },
+      "Tasks",
+    );
   });
 
   it("persists Codex update_plan tool calls for Scope hydration", () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -92,6 +92,15 @@ const FORK_HISTORY_PAGE_SIZE = 100;
 const FORK_HISTORY_MAX_MESSAGES = 500;
 const GOAL_ACHIEVED_RECEIPT_RE = /^Goal achieved in \d+s\.$/;
 
+/**
+ * Extract the harness-assigned task id from a `TaskCreate` result line such as
+ * "Task #1 created successfully: ...". Returns null when no id is present.
+ */
+function parseHarnessTaskId(output: string): string | null {
+  const match = /#(\d+)/.exec(output);
+  return match ? match[1] : null;
+}
+
 /** Orchestrates agent sessions, message sending, and event forwarding. */
 @injectable()
 export class AgentService {
@@ -1286,6 +1295,94 @@ export class AgentService {
     });
   }
 
+  /**
+   * Persist a `TaskCreate` once its result arrives. The harness assigns the task
+   * id (returned only in the result, e.g. "Task #1 created successfully: ...")
+   * and that id is what later `TaskUpdate` calls reference, so the task can only
+   * be stored with a stable identity here, not at tool-use time. Input fields
+   * (subject/description/activeForm) are read back from the buffered tool call.
+   */
+  private handleTaskCreateResult(
+    threadId: string,
+    toolCallId: string,
+    output: string,
+    isError: boolean,
+  ): void {
+    if (isError) return;
+    const buffered = this.narrativeStore
+      .getBufferedToolCalls(threadId)
+      .find((tc) => tc.toolCallId === toolCallId);
+    if (!buffered || buffered.toolName !== "TaskCreate") return;
+    const harnessId = parseHarnessTaskId(output);
+    if (!harnessId) return;
+    const input = buffered._rawToolInput ?? {};
+    const content = this.taskCreateContent(input);
+    if (!content) return;
+    const group = buffered.parentToolCallId
+      ? this.resolveAgentGroupLabel(threadId, buffered.parentToolCallId)
+      : "Tasks";
+    const activeForm =
+      typeof input.activeForm === "string" && input.activeForm.trim().length > 0
+        ? input.activeForm.trim()
+        : undefined;
+    try {
+      this.taskRepo.appendTask(threadId, {
+        id: harnessId,
+        content,
+        status: "pending",
+        ...(activeForm ? { activeForm } : {}),
+        group,
+      });
+    } catch (err) {
+      logger.warn("TaskCreate task not persisted", {
+        threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Apply a `TaskUpdate` to the persisted task list so the Scope view reflects
+   * status transitions, deletions, and subject/activeForm edits after reload.
+   * Matches the task by its harness id scoped to `group` (ids collide across
+   * sub-agents); `deleted` removes it.
+   */
+  private applyTaskUpdate(
+    threadId: string,
+    toolInput: Record<string, unknown>,
+    group: string,
+  ): void {
+    const taskId =
+      toolInput.taskId != null && String(toolInput.taskId).length > 0
+        ? String(toolInput.taskId)
+        : "";
+    if (!taskId) return;
+    try {
+      if (toolInput.status === "deleted") {
+        this.taskRepo.removeTask(threadId, taskId, group);
+        return;
+      }
+      const patch: Partial<Pick<StoredTask, "status" | "content" | "activeForm">> = {};
+      if (toolInput.status !== undefined) {
+        patch.status = this.coerceStoredTaskStatus(toolInput.status);
+      }
+      if (typeof toolInput.subject === "string" && toolInput.subject.trim().length > 0) {
+        patch.content = toolInput.subject.trim();
+      }
+      if (typeof toolInput.activeForm === "string" && toolInput.activeForm.trim().length > 0) {
+        patch.activeForm = toolInput.activeForm.trim();
+      }
+      if (Object.keys(patch).length > 0) {
+        this.taskRepo.updateTask(threadId, taskId, patch, group);
+      }
+    } catch (err) {
+      logger.warn("TaskUpdate not persisted", {
+        threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   /** Number of currently active sessions. */
   activeCount(): number {
     return this.activeSessionIds.size;
@@ -1859,6 +1956,13 @@ export class AgentService {
               ...(event.outputArtifactPath ? { outputArtifactPath: event.outputArtifactPath } : {}),
             },
           );
+          // Persist a just-created task now that the harness has assigned its id.
+          this.handleTaskCreateResult(
+            event.threadId,
+            event.toolCallId,
+            event.output,
+            event.isError,
+          );
         }
 
         if (event.type === AgentEventType.TurnStarted) {
@@ -2317,24 +2421,15 @@ ${userMessage}`;
       }
     }
 
-    if (event.toolName === "TaskCreate") {
-      const content = this.taskCreateContent(event.toolInput);
-      if (!content) return;
+    // TaskCreate is persisted at result time (see handleTaskCreateResult): the
+    // harness-assigned task id needed to correlate later TaskUpdate calls only
+    // appears in the TaskCreate result, never in its input.
+
+    if (event.toolName === "TaskUpdate") {
       const group = parentToolCallId
         ? this.resolveAgentGroupLabel(threadId, parentToolCallId)
         : "Tasks";
-      try {
-        this.taskRepo.appendTask(threadId, {
-          content,
-          status: this.coerceStoredTaskStatus(event.toolInput.status),
-          group,
-        });
-      } catch (err) {
-        logger.warn("TaskCreate task not persisted", {
-          threadId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
+      this.applyTaskUpdate(threadId, event.toolInput, group);
     }
 
     if (event.toolName === "update_plan") {

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -308,6 +308,108 @@ describe("handleAgentEvent branches", () => {
     ]);
   });
 
+  it("captures the harness task id from a TaskCreate result", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-create-1",
+        toolName: "TaskCreate",
+        toolInput: { subject: "Buy groceries", description: "milk, eggs", activeForm: "Buying groceries" },
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolResult",
+      params: {
+        toolCallId: "task-create-1",
+        output: "Task #1 created successfully: Buy groceries",
+        isError: false,
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "task-create-1",
+        harnessTaskId: "1",
+        content: "Buy groceries - milk, eggs",
+        status: "pending",
+        activeForm: "Buying groceries",
+        group: "Tasks",
+      },
+    ]);
+  });
+
+  it("applies a TaskUpdate status transition by harness task id", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-create-1",
+        toolName: "TaskCreate",
+        toolInput: { subject: "Buy groceries", description: "milk, eggs" },
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolResult",
+      params: { toolCallId: "task-create-1", output: "Task #1 created successfully", isError: false },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-update-1",
+        toolName: "TaskUpdate",
+        toolInput: { taskId: "1", status: "in_progress", activeForm: "Buying groceries" },
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      {
+        id: "task-create-1",
+        harnessTaskId: "1",
+        content: "Buy groceries - milk, eggs",
+        status: "in_progress",
+        activeForm: "Buying groceries",
+        group: "Tasks",
+      },
+    ]);
+  });
+
+  it("removes a task when a TaskUpdate sets status deleted", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-create-1",
+        toolName: "TaskCreate",
+        toolInput: { subject: "Buy groceries" },
+      },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolResult",
+      params: { toolCallId: "task-create-1", output: "Task #1 created successfully", isError: false },
+    });
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-update-1",
+        toolName: "TaskUpdate",
+        toolInput: { taskId: "1", status: "deleted" },
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([]);
+  });
+
+  it("ignores a TaskUpdate that matches no known task", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-update-orphan",
+        toolName: "TaskUpdate",
+        toolInput: { taskId: "99", status: "completed" },
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toBeUndefined();
+  });
+
   it("session.toolUse updates parent scope tasks from Codex update_plan calls", () => {
     useThreadStore.getState().handleAgentEvent("thread-1", {
       method: "session.toolUse",

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -410,6 +410,33 @@ describe("handleAgentEvent branches", () => {
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toBeUndefined();
   });
 
+  it("leaves both tasks untouched when a TaskUpdate id collides across groups and the resolved group matches neither", () => {
+    // Two sub-agents each number their own list, so harness id "1" exists in two
+    // groups. An update whose group resolves to "Tasks" (no parent Agent call)
+    // matches neither sub-agent group, so the ambiguous collision must be a no-op
+    // rather than silently mutating an arbitrary one of the two.
+    useTaskStore.getState().setTaskGroup("thread-1", "Sub-agent A", [
+      { id: "sa-1", harnessTaskId: "1", content: "child A", status: "pending", group: "Sub-agent A" },
+    ]);
+    useTaskStore.getState().setTaskGroup("thread-1", "Sub-agent B", [
+      { id: "sb-1", harnessTaskId: "1", content: "child B", status: "pending", group: "Sub-agent B" },
+    ]);
+
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: {
+        toolCallId: "task-update-collide",
+        toolName: "TaskUpdate",
+        toolInput: { taskId: "1", status: "completed" },
+      },
+    });
+
+    expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
+      { id: "sa-1", harnessTaskId: "1", content: "child A", status: "pending", group: "Sub-agent A" },
+      { id: "sb-1", harnessTaskId: "1", content: "child B", status: "pending", group: "Sub-agent B" },
+    ]);
+  });
+
   it("session.toolUse updates parent scope tasks from Codex update_plan calls", () => {
     useThreadStore.getState().handleAgentEvent("thread-1", {
       method: "session.toolUse",

--- a/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
@@ -304,6 +304,41 @@ describe("AuxiliaryHydrator", () => {
     });
   });
 
+  it("committed persisted tasks that differ only in identity fields so harnessTaskId reaches the store", async () => {
+    // The live task matches on content/status/group but lacks the harness id, so
+    // a gate that ignored identity fields would skip the write and later
+    // TaskUpdate correlation by harnessTaskId would never land.
+    const liveTask: TaskItem = {
+      id: "task-live",
+      content: "Run tests",
+      status: "in_progress",
+      group: "Tasks",
+    };
+    (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: "1",
+        content: "Run tests",
+        status: "in_progress",
+        group: "Tasks",
+      },
+    ]);
+
+    const aux = createAux({ getTasksForThread: () => [liveTask] });
+    aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
+
+    await vi.waitFor(() => {
+      expect(setTasksForThread).toHaveBeenCalledWith(THREAD_ID, [
+        {
+          id: "1",
+          harnessTaskId: "1",
+          content: "Run tests",
+          status: "in_progress",
+          group: "Tasks",
+        },
+      ]);
+    });
+  });
+
   it("backfilled file-change snapshots for thin cache entries on threads with changes", async () => {
     (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([
       {

--- a/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
@@ -276,6 +276,34 @@ describe("AuxiliaryHydrator", () => {
     });
   });
 
+  it("carried the harness task id and activeForm from persisted Task* tasks", async () => {
+    (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: "1",
+        content: "Run tests",
+        status: "in_progress",
+        activeForm: "Running tests",
+        group: "Tasks",
+      },
+    ]);
+
+    const aux = createAux({ getTasksForThread: () => [] });
+    aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
+
+    await vi.waitFor(() => {
+      expect(setTasksForThread).toHaveBeenCalledWith(THREAD_ID, [
+        {
+          id: "1",
+          harnessTaskId: "1",
+          content: "Run tests",
+          activeForm: "Running tests",
+          status: "in_progress",
+          group: "Tasks",
+        },
+      ]);
+    });
+  });
+
   it("backfilled file-change snapshots for thin cache entries on threads with changes", async () => {
     (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([
       {

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -102,8 +102,10 @@ export class AuxiliaryHydrator {
       .getThreadTasks(threadId)
       .then((tasks) => {
         const items = (tasks ?? []).map((t, i) => ({
-          id: String(i),
+          id: t.id ?? String(i),
+          harnessTaskId: t.id,
           content: t.content,
+          activeForm: t.activeForm,
           status: coerceTaskStatus(t.status),
           group: t.group ?? "Tasks",
         }));

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -120,7 +120,16 @@ export class AuxiliaryHydrator {
               ];
             })()
           : items;
-        if (!shallowEqualBy(merged, currentTasks, ["content", "status", "group"])) {
+        if (
+          !shallowEqualBy(merged, currentTasks, [
+            "id",
+            "harnessTaskId",
+            "content",
+            "activeForm",
+            "status",
+            "group",
+          ])
+        ) {
           this.deps.setTasksForThread(threadId, merged);
         }
       })

--- a/apps/web/src/lib/thread-hydrator/types.ts
+++ b/apps/web/src/lib/thread-hydrator/types.ts
@@ -40,7 +40,7 @@ export interface ThreadHydratorTransport {
   listPendingPermissions(threadId: string): Promise<PermissionRequest[]>;
   getThreadTasks(
     threadId: string,
-  ): Promise<Array<{ content: string; status: string; group?: string }> | null>;
+  ): Promise<Array<{ id?: string; content: string; status: string; activeForm?: string; group?: string }> | null>;
   getThreadPlans(threadId: string): Promise<PlanRecord[]>;
 }
 

--- a/apps/web/src/stores/taskStore.ts
+++ b/apps/web/src/stores/taskStore.ts
@@ -25,6 +25,12 @@ export function coerceTaskStatus(raw: unknown): TaskStatus {
 /** A single task item within a group. */
 export interface TaskItem {
   readonly id: string;
+  /**
+   * Harness-assigned task id from the Task* tool family (e.g. "1"), captured
+   * from the TaskCreate result. Used to correlate later TaskUpdate calls to the
+   * task they mutate. Absent for legacy TodoWrite/update_plan tasks.
+   */
+  readonly harnessTaskId?: string;
   /** Imperative form shown when not active (e.g. "Run tests"). */
   readonly content: string;
   /** Present continuous form shown when active (e.g. "Running tests"). Falls back to content if not provided. */

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -402,6 +402,15 @@ function taskTextFromToolInput(toolInput: Record<string, unknown>): string | nul
   return `${subject} - ${description}`;
 }
 
+/**
+ * Extract the harness-assigned task id from a `TaskCreate` result line such as
+ * "Task #1 created successfully: ...". Returns null when no id is present.
+ */
+function parseHarnessTaskId(output: string): string | null {
+  const match = /#(\d+)/.exec(output);
+  return match ? match[1] : null;
+}
+
 function updatePlanTasksFromToolInput(toolInput: Record<string, unknown>): TaskItem[] {
   const entries =
     Array.isArray(toolInput.plan)
@@ -1828,11 +1837,16 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         const group = resolvedParentToolCallId
           ? resolveAgentGroupLabel(existingCalls, resolvedParentToolCallId)
           : "Tasks";
+        const activeForm =
+          typeof toolInput.activeForm === "string" && toolInput.activeForm.trim().length > 0
+            ? toolInput.activeForm.trim()
+            : undefined;
         const taskItem: TaskItem = {
           id: toolCallId || String(toolInput.id ?? content),
           content,
           status: coerceTaskStatus(toolInput.status ?? "pending"),
           group,
+          ...(activeForm !== undefined ? { activeForm } : {}),
         };
         const existingTasks = useTaskStore.getState().tasksByThread[threadId] ?? [];
         const groupTasks = existingTasks.filter((task) => task.group === group);
@@ -1840,6 +1854,58 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           threadId,
           group,
           [...groupTasks.filter((task) => task.id !== taskItem.id), taskItem],
+        );
+      };
+      const applyTaskUpdate = (
+        toolInput: Record<string, unknown>,
+        resolvedParentToolCallId: string | undefined,
+      ) => {
+        if (toolName !== "TaskUpdate") return;
+        const harnessTaskId = toolInput.taskId != null ? String(toolInput.taskId) : "";
+        if (!harnessTaskId) return;
+
+        const group = resolvedParentToolCallId
+          ? resolveAgentGroupLabel(existingCalls, resolvedParentToolCallId)
+          : "Tasks";
+        const allTasks = useTaskStore.getState().tasksByThread[threadId] ?? [];
+        // Prefer a task scoped to this group; fall back to a global harnessTaskId
+        // match so an update still lands when the group cannot be resolved (e.g.
+        // the create's parent Agent call has been evicted from the buffer).
+        const target =
+          allTasks.find((t) => t.group === group && t.harnessTaskId === harnessTaskId)
+          ?? allTasks.find((t) => t.harnessTaskId === harnessTaskId);
+        if (!target) return;
+
+        const groupTasks = allTasks.filter((t) => t.group === target.group);
+        if (toolInput.status === "deleted") {
+          useTaskStore.getState().setTaskGroup(
+            threadId,
+            target.group,
+            groupTasks.filter((t) => t !== target),
+          );
+          return;
+        }
+
+        // Only `subject` maps to the displayed content. A description-only edit
+        // does not rewrite content, matching the server's persisted behavior.
+        const nextSubject =
+          typeof toolInput.subject === "string" && toolInput.subject.trim().length > 0
+            ? toolInput.subject.trim()
+            : undefined;
+        const nextActiveForm =
+          typeof toolInput.activeForm === "string" && toolInput.activeForm.trim().length > 0
+            ? toolInput.activeForm.trim()
+            : undefined;
+        const patched: TaskItem = {
+          ...target,
+          ...(toolInput.status !== undefined ? { status: coerceTaskStatus(toolInput.status) } : {}),
+          ...(nextSubject ? { content: nextSubject } : {}),
+          ...(nextActiveForm !== undefined ? { activeForm: nextActiveForm } : {}),
+        };
+        useTaskStore.getState().setTaskGroup(
+          threadId,
+          target.group,
+          groupTasks.map((t) => (t === target ? patched : t)),
         );
       };
       const applyUpdatePlanTasks = (
@@ -1886,6 +1952,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             });
             applyTodoWriteTasks(mergedInput, resolvedParentToolCallId);
             applyTaskCreate(mergedInput, resolvedParentToolCallId);
+            applyTaskUpdate(mergedInput, resolvedParentToolCallId);
             applyUpdatePlanTasks(mergedInput, resolvedParentToolCallId);
           }
           return;
@@ -1902,6 +1969,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // multiple sub-agents each get their own collapsible section.
       applyTodoWriteTasks(incomingInput, parentToolCallId);
       applyTaskCreate(incomingInput, parentToolCallId);
+      applyTaskUpdate(incomingInput, parentToolCallId);
       applyUpdatePlanTasks(incomingInput, parentToolCallId);
 
       const toolCall: ToolCall = {
@@ -1950,6 +2018,28 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         rawToolInput && typeof rawToolInput === "object" && !Array.isArray(rawToolInput)
           ? rawToolInput as Record<string, unknown>
           : {};
+      // The harness only reveals its task id in the TaskCreate result, so capture
+      // it here onto the task the create produced. Later TaskUpdate calls correlate
+      // by this id; without it status transitions and deletions never land.
+      const resultCall = toolCallId
+        ? getRec(threadId).toolCalls.find((tc) => tc.id === toolCallId)
+        : undefined;
+      if (resultCall?.toolName === "TaskCreate" && !isError) {
+        const harnessTaskId = parseHarnessTaskId(output);
+        if (harnessTaskId) {
+          const allTasks = useTaskStore.getState().tasksByThread[threadId] ?? [];
+          const target = allTasks.find((t) => t.id === toolCallId);
+          if (target && target.harnessTaskId !== harnessTaskId) {
+            useTaskStore.getState().setTaskGroup(
+              threadId,
+              target.group,
+              allTasks
+                .filter((t) => t.group === target.group)
+                .map((t) => (t.id === toolCallId ? { ...t, harnessTaskId } : t)),
+            );
+          }
+        }
+      }
       set((state) => {
         const calls = getThreadRecord(state.records, threadId).toolCalls;
         // Try matching by ID first; fall back to the first incomplete tool call

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1868,12 +1868,16 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           ? resolveAgentGroupLabel(existingCalls, resolvedParentToolCallId)
           : "Tasks";
         const allTasks = useTaskStore.getState().tasksByThread[threadId] ?? [];
-        // Prefer a task scoped to this group; fall back to a global harnessTaskId
-        // match so an update still lands when the group cannot be resolved (e.g.
-        // the create's parent Agent call has been evicted from the buffer).
-        const target =
-          allTasks.find((t) => t.group === group && t.harnessTaskId === harnessTaskId)
-          ?? allTasks.find((t) => t.harnessTaskId === harnessTaskId);
+        // Prefer a task scoped to this group. Fall back to a global harnessTaskId
+        // match only when exactly one task carries the id, so an update still
+        // lands when the group cannot be resolved (e.g. the create's parent Agent
+        // call has been evicted from the buffer) without updating the wrong task
+        // on an ambiguous sub-agent collision.
+        const scoped = allTasks.find(
+          (t) => t.group === group && t.harnessTaskId === harnessTaskId,
+        );
+        const globalMatches = allTasks.filter((t) => t.harnessTaskId === harnessTaskId);
+        const target = scoped ?? (globalMatches.length === 1 ? globalMatches[0] : undefined);
         if (!target) return;
 
         const groupTasks = allTasks.filter((t) => t.group === target.group);

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -377,8 +377,8 @@ export interface McodeTransport {
   /** Fetch a thread's full server-ordered narrative as a flat, chronological list. */
   loadTurn(threadId: string): Promise<import("@mcode/contracts").NarrativeEntry[]>;
 
-  /** Fetch persisted task list for a thread (from last TodoWrite). */
-  getThreadTasks(threadId: string): Promise<Array<{ content: string; status: "pending" | "in_progress" | "completed" | "cancelled"; group?: string }> | null>;
+  /** Fetch persisted task list for a thread (TodoWrite / Task* tool family). */
+  getThreadTasks(threadId: string): Promise<Array<{ id?: string; content: string; status: "pending" | "in_progress" | "completed" | "cancelled"; activeForm?: string; group?: string }> | null>;
 
   /** Fetch persisted plans for a thread (hydration on page load). */
   getThreadPlans(threadId: string): Promise<import("@mcode/contracts").PlanRecord[]>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -713,7 +713,7 @@ export function createWsTransport(
 
     // Thread tasks
     getThreadTasks: (threadId: string) =>
-      rpc<Array<{ content: string; status: "pending" | "in_progress" | "completed" | "cancelled"; group?: string }> | null>(
+      rpc<Array<{ id?: string; content: string; status: "pending" | "in_progress" | "completed" | "cancelled"; activeForm?: string; group?: string }> | null>(
         "thread.getTasks", { threadId },
       ),
 

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -685,8 +685,13 @@ export const WS_METHODS = lazySchema(() => ({
     params: z.object({ threadId: z.string() }),
     result: z
       .array(z.object({
+        // Harness-assigned task id (Task* tool family). Optional so legacy
+        // TodoWrite/update_plan tasks without an id still round-trip.
+        id: z.string().optional(),
         content: z.string(),
         status: z.enum(["pending", "in_progress", "completed", "cancelled"]),
+        // Present-continuous label shown while the task is in_progress.
+        activeForm: z.string().optional(),
         group: z.string().optional(),
       }))
       .nullable(),


### PR DESCRIPTION
## What
Reflect the Claude provider's full `TaskCreate` / `TaskUpdate` lifecycle in the Scope (Task) view. Status transitions, deletions, and subject/activeForm edits now update the panel live and survive a reload.

## Why
`TaskCreate` / `TaskUpdate` replaced the legacy `TodoWrite` system, but only `TaskCreate` was intercepted. `TaskUpdate` events were dropped, so a task sat on "pending" in the Scope view for the whole turn and deletions never landed. The harness reveals its task id only in the `TaskCreate` result, so an update could not be correlated to the task it created.

## Key Changes
- **Harness id correlation** - capture the task id from the `TaskCreate` result text and store it on the created task, on both the server (`taskRepo`, for reconnect hydration) and the client (live view).
- **Server** (`agent-service.ts`, `task-repo.ts`) - persist `TaskCreate` at result time; apply `TaskUpdate` status / content / activeForm patches and `deleted` removals through `taskRepo`.
- **Client** (`threadStore.ts`, `taskStore.ts`) - apply `TaskUpdate` transitions and removals in the live Scope view; only `subject` rewrites displayed content (parity with server), and `deleted` is checked before status coercion.
- **Collision safety** - task identity is scoped to `(group, id)` with a global fallback, so sub-agents that each number their own list do not cross-update.
- **Contracts + hydrator** (`methods.ts`, `auxiliary-hydrator.ts`, transport types) - carry `id` / `activeForm` through `thread.getTasks` so the lifecycle survives a reload.
- **Tests** - repo `(group, id)` identity, server persist / update / remove, client interception, and hydration round-trip.

## Verification
- `bun run verify` green (typecheck + lint + tests: server 164 files / 1420 tests, frontend 195 files / 1711 tests).
- Demoed end-to-end in the running app against the live Scope view: create x3 → in_progress → complete/start-next → delete (edge) → orphan update no-op (edge) → legacy `TodoWrite` regression. 0 console errors. Screenshots under `apps/web/e2e/screenshots/demo/`.

## Config Changes
None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784301707&installation_id=129163861&pr_number=786&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F786&signature=03ad8d5f821842684ec9d50585f06adb836787e7291c9ec05465a7fb351fda25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks now carry a persistent harness identifier to reliably correlate later updates after session restarts.
  * Added task update and removal handling, including support for editing `activeForm` and transitioning `status`.
  * Task creation now captures and displays `activeForm` during “in progress”.
  * Improved group-aware deduplication and collision-safe task targeting.
* **Bug Fixes**
  * Correctly scopes updates/removals to the right task when identifiers collide across different groups.
* **Tests**
  * Expanded unit and integration coverage for update/remove behavior and collision scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->