### PR TITLE
feat: add git remote URL RPC

### DIFF
--- a/.codex/prompts/demo-desktop.md
+++ b/.codex/prompts/demo-desktop.md
@@ -1,12 +1,16 @@
 ---
-description: Launch the Electron desktop app under Playwright and screenshot the first window
+description: Launch the Electron desktop app under Playwright, screenshot the first window, and report renderer errors
+argument-hint: [feature-name]
 ---
 
-Goal: demo an Electron-specific feature in the running desktop app.
+Goal: demo the Electron-specific feature `$ARGUMENTS` in the running desktop app.
 
-Use this **only** for features that need the actual Electron runtime — native menus, tray, BrowserView, contextBridge IPC, deep links, window chrome. For anything that renders identically in the browser, prefer `/demo` (faster, Playwright MCP can drive it interactively).
+Use this **only** for features that need the actual Electron runtime — native menus, tray, BrowserView, contextBridge IPC, deep links, window chrome. For anything that renders identically in the browser, prefer `/demo` (Vite) — it is faster and the Playwright MCP can drive it interactively.
 
-1. Build the Electron bundles: `cd apps/desktop && bun run build`.
+1. Ensure the Electron bundles are built:
+   ```sh
+   cd apps/desktop && bun run build
+   ```
 2. Run `node scripts/agent/demo-desktop.mjs`. It launches Electron via Playwright's `_electron.launch()`, waits for the first window, screenshots to `apps/web/e2e/screenshots/demo-desktop/`, and prints renderer errors. It runs against an **isolated, empty data dir** by default (never your real `~/.mcode`), and the embedded server claims its own free port — so it never attaches to another running app. Pass `MCODE_DEMO_USE_REAL_DATA=1` only when you must demo against existing workspaces. If you write a **custom** desktop demo that seeds data over RPC, read the launched instance's `server.lock` from its `MCODE_DATA_DIR` for the port + token — never port-scan for a `/health`, or you may mutate the wrong database.
 3. Pass `--tour` for extra `tour-*.png` snapshots (`tour-02`, `tour-02b-active-chat` when a thread row opens, Changes via `mod+d`, Terminal via `mod+j`, Preview via `mod+shift+b`, `tour-06` header Changes when visible).
 4. Pass `--keep-open` to leave Electron running. Drive it programmatically using the `apps/desktop/e2e/electron-smoke.spec.ts` pattern (Playwright library, not the MCP — the MCP does not support Electron).

--- a/.codex/prompts/demo.md
+++ b/.codex/prompts/demo.md
@@ -1,12 +1,17 @@
 ---
-description: Boot the dev web app and drive it via Playwright MCP for a feature demo
+description: Boot the dev web app and prepare a Playwright MCP session for demoing a feature
+argument-hint: [feature-name]
 ---
 
-Goal: demo a feature end-to-end in the running web app.
+Goal: demo the feature `$ARGUMENTS` end-to-end in the running app.
 
 1. Run `node scripts/agent/demo.mjs`. It assumes the default port (5173) may be taken, claims the first free port, and boots an **isolated** `bun run dev:web` there — its own backend on a unique temp data dir and DB (`MCODE_DATA_DIR` + `MCODE_DB_PATH`), never your real `~/.mcode` and never the shared dev/worktree DB, so it always boots clean. It polls until ready, then prints the exact URL + a Playwright MCP entry point. Drive the URL it prints; never hardcode `localhost:5173`. (Set `MCODE_DEMO_URL` to reuse a server you already trust.)
-2. Use the Playwright MCP tools (registered in `.mcp.json`) to drive the feature: navigate, snapshot, screenshot to `apps/web/e2e/screenshots/demo/`, check console messages.
-3. Walk the golden path, then 1–2 edge cases.
-4. Report screenshot paths.
+2. Use the Playwright MCP tools to drive the feature:
+   - `mcp__playwright__browser_navigate` to the printed URL
+   - `mcp__playwright__browser_snapshot` to read the accessibility tree
+   - `mcp__playwright__browser_take_screenshot` to capture state to `apps/web/e2e/screenshots/demo/`
+   - `mcp__playwright__browser_console_messages` to surface any errors
+3. Walk the golden path for `$ARGUMENTS`, then 1–2 edge cases.
+4. Report screenshot paths so the user can review without re-running the app.
 
 See `docs/agents/demo.md` for the full runbook.

--- a/.codex/prompts/review-pr.md
+++ b/.codex/prompts/review-pr.md
@@ -1,12 +1,15 @@
 ---
-description: Review changes across four dimensions — security, performance, quality, correctness
+description: Run a 4-parallel-subagent code review (security, performance, quality, correctness)
+argument-hint: [pr-number-or-branch]
 ---
 
-Review the changes in the current branch / PR / argument-supplied ref across four dimensions. In Codex, run them as four sequential focused passes (or parallel chats if you have multiple agents):
+Review the changes in `$ARGUMENTS` (PR number, branch name, or HEAD if empty).
 
-1. **Security** — Electron contextBridge surface, child-process spawning, SQLite parameterization, XSS, secrets, log content. Reference `.claude/agents/security-reviewer.md` for the full checklist.
-2. **Performance** — bundle size, render hot paths, DB query patterns, the memory/startup targets in `AGENTS.md`.
-3. **Quality** — code style per `AGENTS.md`, JSDoc on exports, no needless abstractions, naming.
-4. **Correctness** — does the diff do what the PR description claims, edge cases, error handling at boundaries.
+Dispatch four subagents in parallel in a single message — do NOT run them sequentially:
 
-Then cross-reference findings, eliminate false positives, and present a single consolidated report grouped by severity (blocker / major / minor / nit).
+1. **Security** — use the `security-reviewer` subagent. Focus: Electron contextBridge surface, child-process spawning, SQLite parameterization, XSS, secrets.
+2. **Performance** — general-purpose subagent. Focus: bundle size, render hot paths, DB query patterns, memory targets in `AGENTS.md`.
+3. **Quality** — general-purpose subagent. Focus: code style per `AGENTS.md`, JSDoc on exports, no needless abstractions, naming.
+4. **Correctness** — general-purpose subagent. Focus: does the diff do what the PR/commit description claims, edge cases, error handling at boundaries.
+
+After all four return, cross-reference findings, eliminate false positives, and present a single consolidated report grouped by severity (blocker / major / minor / nit).

--- a/.codex/prompts/verify-e2e-desktop.md
+++ b/.codex/prompts/verify-e2e-desktop.md
@@ -4,6 +4,6 @@ description: Run Electron-only Playwright E2E specs (apps/desktop/e2e/)
 
 Run `cd apps/desktop && bun run e2e` and show the output.
 
-This drives the actual Electron app via Playwright's `_electron.launch()` and is heavier than the web `/verify-e2e`. Use it only when you change anything in `apps/desktop/src/main/` (native IPC, window/tray/menu, BrowserView, deep links) or anything that crosses the contextBridge.
+This drives the actual Electron app via Playwright's `_electron.launch()` and is heavier than the web `/verify-e2e`. Use it when you change anything in `apps/desktop/src/main/` (native IPC, window/tray/menu, BrowserView, deep links) or anything that crosses the contextBridge.
 
 For pure-renderer changes, `/verify-e2e` is the right tool — it covers the same React tree via Vite and is much faster.

--- a/.codex/prompts/verify-e2e.md
+++ b/.codex/prompts/verify-e2e.md
@@ -1,9 +1,9 @@
 ---
-description: Run Playwright E2E tests for the web app
+description: Run Playwright E2E tests and report results
 ---
 
 Run `bun run verify:e2e` and show the output.
 
-Requires `bun run dev:web` to be running, or the script will auto-start it.
+Requires the dev server (`bun run dev:web`) to be running, or the script will auto-start it.
 
-Use after UI changes that touch interactive components, keyboard navigation, focus trapping, responsive layout, accessibility semantics, floating overlays, or persisted state. See `docs/guides/agent-workflow.md` for the full trigger list.
+Use after UI changes that touch: interactive components, keyboard navigation, focus trapping, responsive layout, accessibility semantics, floating overlays, or persisted state. See `docs/guides/agent-workflow.md` for the full trigger list.

--- a/.codex/prompts/verify.md
+++ b/.codex/prompts/verify.md
@@ -1,7 +1,9 @@
 ---
-description: Run typecheck, lint, and unit tests across all packages
+description: Run typecheck, lint, and unit tests across all packages and report results
 ---
 
 Run `bun run verify` and show the output.
 
-If it fails, fix the errors and re-run until it passes. The Stop hook runs the same command before letting you finish a turn, so running it proactively saves a turn.
+If it fails, fix the errors and re-run until it passes. Do not claim completion without fresh passing output.
+
+This is the same command the Stop hook enforces, so running it proactively saves a turn.

--- a/apps/server/src/__tests__/git-service-push.test.ts
+++ b/apps/server/src/__tests__/git-service-push.test.ts
@@ -93,3 +93,64 @@ describe("GitService.diffStat", () => {
     );
   });
 });
+
+describe("GitService.getRemoteUrl", () => {
+  let gitService: GitService;
+  let execFn: ReturnType<typeof createMockGitExecutor>["execFn"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const mock = createMockGitExecutor();
+    execFn = mock.execFn;
+    gitService = new GitService({} as WorkspaceRepo, mock.executor);
+  });
+
+  it("normalizes SSH origin remotes to https web URLs", async () => {
+    execFn.mockResolvedValue({
+      stdout: "git@github.com:Mzeey-Empire/mcode.git\n",
+      stderr: "",
+    });
+
+    await expect(gitService.getRemoteUrl("/repo/mcode")).resolves.toEqual({
+      webUrl: "https://github.com/Mzeey-Empire/mcode",
+      label: "Mzeey-Empire/mcode",
+    });
+    expect(execFn).toHaveBeenCalledWith(
+      ["-C", "/repo/mcode", "remote", "get-url", "origin"],
+      expect.objectContaining({ timeout: 5_000 }),
+    );
+  });
+
+  it("falls back to the folder name when origin is missing", async () => {
+    execFn.mockRejectedValue(new Error("No such remote 'origin'"));
+
+    await expect(gitService.getRemoteUrl("/repo/local-only")).resolves.toEqual({
+      webUrl: null,
+      label: "local-only",
+    });
+  });
+
+  it("falls back to the folder name when origin is malformed", async () => {
+    execFn.mockResolvedValue({
+      stdout: "not-a-remote\n",
+      stderr: "",
+    });
+
+    await expect(gitService.getRemoteUrl("/repo/local-only")).resolves.toEqual({
+      webUrl: null,
+      label: "local-only",
+    });
+  });
+
+  it("falls back to the folder name when an SCP-like origin has an invalid host", async () => {
+    execFn.mockResolvedValue({
+      stdout: "git@github.com?x:Mzeey-Empire/mcode.git\n",
+      stderr: "",
+    });
+
+    await expect(gitService.getRemoteUrl("/repo/local-only")).resolves.toEqual({
+      webUrl: null,
+      label: "local-only",
+    });
+  });
+});

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -11,7 +11,7 @@ import { rm, rename, rmdir } from "fs/promises";
 import { existsSync, mkdirSync } from "fs";
 import { join, basename, dirname, resolve, relative, isAbsolute } from "path";
 import { getMcodeDir, validateBranchName, validateWorktreeName, logger } from "@mcode/shared";
-import type { GitBranch, WorktreeInfo, GitCommit, BranchComparison } from "@mcode/contracts";
+import type { GitBranch, WorktreeInfo, GitCommit, BranchComparison, GitRemoteUrl } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { GitExecutor } from "./git-executor/index.js";
 
@@ -140,6 +140,69 @@ function assertSafeRef(ref: string): void {
   }
 }
 
+function fallbackRemoteUrl(repoPath: string): GitRemoteUrl {
+  return {
+    webUrl: null,
+    label: basename(repoPath) || repoPath,
+  };
+}
+
+function normalizeRemotePath(pathname: string): string | null {
+  const trimmed = pathname.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  const withoutGitSuffix = trimmed.replace(/\.git$/i, "");
+  if (!withoutGitSuffix || /[\s\\?#]/.test(withoutGitSuffix)) {
+    return null;
+  }
+  const segments = withoutGitSuffix.split("/").filter(Boolean);
+  if (segments.length < 2 || segments.some((segment) => segment === "." || segment === "..")) {
+    return null;
+  }
+  return segments.join("/");
+}
+
+function isSafeRemoteHost(host: string): boolean {
+  const match = /^(?:[A-Za-z0-9-]+\.)*[A-Za-z0-9-]+(?::(?<port>\d{1,5}))?$/.exec(host);
+  if (!match) return false;
+  const port = match.groups?.port;
+  return port === undefined || Number(port) <= 65_535;
+}
+
+function buildHttpsRemote(host: string, remotePath: string): GitRemoteUrl | null {
+  const normalizedPath = normalizeRemotePath(remotePath);
+  if (!host || !isSafeRemoteHost(host) || !normalizedPath) return null;
+  try {
+    const parsed = new URL(`https://${host}/${normalizedPath}`);
+    if (parsed.username || parsed.password) return null;
+    return {
+      webUrl: parsed.toString().replace(/\/$/, ""),
+      label: normalizedPath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRemoteUrl(remote: string): GitRemoteUrl | null {
+  const trimmed = remote.trim();
+  if (!trimmed) return null;
+
+  const scpLike = /^(?<user>[^@\s]+)@(?<host>[^@:\s/]+):(?<path>.+)$/.exec(trimmed);
+  if (scpLike?.groups) {
+    return buildHttpsRemote(scpLike.groups.host ?? "", scpLike.groups.path ?? "");
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:" && parsed.protocol !== "ssh:") {
+      return null;
+    }
+    const host = parsed.protocol === "ssh:" ? parsed.hostname : parsed.host;
+    return buildHttpsRemote(host, parsed.pathname);
+  } catch {
+    return null;
+  }
+}
+
 /** Handles all git branch, worktree, checkout, and fetch operations. */
 @injectable()
 export class GitService {
@@ -180,6 +243,19 @@ export class GitService {
   async listWorktrees(workspaceId: string): Promise<WorktreeInfo[]> {
     const workspace = this.requireWorkspace(workspaceId);
     return this.listWorktreesForPath(workspace.path);
+  }
+
+  /** Resolve the origin remote as a normalized https URL and UI label. */
+  async getRemoteUrl(repoPath: string): Promise<GitRemoteUrl> {
+    try {
+      const { stdout } = await this.gitExecutor.exec(
+        ["-C", repoPath, "remote", "get-url", "origin"],
+        { timeout: 5_000 },
+      );
+      return normalizeRemoteUrl(stdout) ?? fallbackRemoteUrl(repoPath);
+    } catch {
+      return fallbackRemoteUrl(repoPath);
+    }
   }
 
   /** Check whether a filesystem path is a git-registered worktree for a repository. */

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -226,6 +226,27 @@ function resolveThreadRepoPath(deps: RouterDeps, threadId?: string): string | un
   return deps.gitService.resolveWorkingDir(ws.path, thread.mode, thread.worktree_path);
 }
 
+function resolveWorkspaceRepoPath(
+  deps: RouterDeps,
+  workspaceId: string,
+  threadId?: string,
+): string {
+  const workspace = deps.workspaceService.findById(workspaceId);
+  if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
+  if (!threadId) return workspace.path;
+
+  const thread = deps.threadRepo.findById(threadId);
+  if (!thread) throw new Error(`Thread not found: ${threadId}`);
+  if (thread.workspace_id !== workspaceId) {
+    throw new Error(`Thread ${threadId} does not belong to workspace ${workspaceId}`);
+  }
+  return deps.gitService.resolveWorkingDir(
+    workspace.path,
+    thread.mode,
+    thread.worktree_path,
+  );
+}
+
 async function teardownWorkspaceThreads(deps: RouterDeps, workspaceId: string): Promise<void> {
   const threads = deps.threadRepo.listAllByWorkspace(workspaceId);
   const results = await Promise.allSettled(
@@ -432,6 +453,10 @@ async function dispatch(
       if (!ws?.is_git_repo) return [];
       return deps.gitService.listWorktrees(params.workspaceId);
     }
+    case "git.getRemoteUrl":
+      return deps.gitService.getRemoteUrl(
+        resolveWorkspaceRepoPath(deps, params.workspaceId, params.threadId),
+      );
     case "git.fetchBranch": {
       const ws = deps.workspaceService.findById(params.workspaceId);
       if (!ws?.is_git_repo) return;

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -33,3 +33,85 @@ describe("routeMessage result validation seam", () => {
     );
   });
 });
+
+describe("routeMessage git.getRemoteUrl", () => {
+  it("resolves the git path from a workspace thread before calling GitService", async () => {
+    const getRemoteUrl = vi.fn().mockResolvedValue({
+      webUrl: "https://github.com/Mzeey-Empire/mcode",
+      label: "Mzeey-Empire/mcode",
+    });
+    const resolveWorkingDir = vi.fn().mockReturnValue("C:/repo-worktree");
+    const deps = {
+      workspaceService: {
+        findById: vi.fn().mockReturnValue({ id: "ws-1", path: "C:/repo" }),
+      },
+      threadRepo: {
+        findById: vi.fn().mockReturnValue({
+          id: "thread-1",
+          workspace_id: "ws-1",
+          mode: "worktree",
+          worktree_path: "C:/repo-worktree",
+        }),
+      },
+      gitService: {
+        getRemoteUrl,
+        resolveWorkingDir,
+      },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-remote",
+        method: "git.getRemoteUrl",
+        params: { workspaceId: "ws-1", threadId: "thread-1" },
+      }),
+      deps,
+    );
+
+    expect(response.result).toEqual({
+      webUrl: "https://github.com/Mzeey-Empire/mcode",
+      label: "Mzeey-Empire/mcode",
+    });
+    expect(resolveWorkingDir).toHaveBeenCalledWith(
+      "C:/repo",
+      "worktree",
+      "C:/repo-worktree",
+    );
+    expect(getRemoteUrl).toHaveBeenCalledWith("C:/repo-worktree");
+  });
+
+  it("rejects a thread from another workspace before running git", async () => {
+    const getRemoteUrl = vi.fn();
+    const deps = {
+      workspaceService: {
+        findById: vi.fn().mockReturnValue({ id: "ws-1", path: "C:/repo" }),
+      },
+      threadRepo: {
+        findById: vi.fn().mockReturnValue({
+          id: "thread-1",
+          workspace_id: "ws-2",
+          mode: "worktree",
+          worktree_path: "C:/repo-worktree",
+        }),
+      },
+      gitService: {
+        getRemoteUrl,
+        resolveWorkingDir: vi.fn(),
+      },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-remote",
+        method: "git.getRemoteUrl",
+        params: { workspaceId: "ws-1", threadId: "thread-1" },
+      }),
+      deps,
+    );
+
+    expect(response.error?.message).toContain(
+      "Thread thread-1 does not belong to workspace ws-1",
+    );
+    expect(getRemoteUrl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -178,6 +178,7 @@ export const mockTransport: McodeTransport = {
       isUnborn: false,
       isComparisonAvailable: false,
     }),
+  getRemoteUrl: vi.fn().mockResolvedValue({ webUrl: null, label: "test-project" }),
   getReviewDiffStats: vi.fn().mockResolvedValue({ additions: 0, deletions: 0 }),
   push: vi.fn().mockResolvedValue({ success: true }),
   generatePrDraft: vi.fn().mockResolvedValue({ title: "", body: "" }),

--- a/apps/web/src/transport/index.ts
+++ b/apps/web/src/transport/index.ts
@@ -8,7 +8,7 @@ import { useProviderModelsStore } from "@/stores/providerModelsStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 
 /** Re-exported transport and domain types for use across the web app. */
-export type { McodeTransport, Workspace, Thread, Message, ToolCall, HookExecution, GitBranch, WorktreeInfo, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, SkillInfo, PrInfo, PrDetail, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord, Settings, PartialSettings, PlanAnswer } from "./types";
+export type { McodeTransport, Workspace, Thread, Message, ToolCall, HookExecution, GitBranch, GitRemoteUrl, WorktreeInfo, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, SkillInfo, PrInfo, PrDetail, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord, Settings, PartialSettings, PlanAnswer } from "./types";
 export { PERMISSION_MODES, INTERACTION_MODES } from "./types";
 export { pushEmitter } from "./ws-transport";
 

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -33,6 +33,7 @@ import type {
   CreatePrResult,
   ChecksStatus,
   CopilotSubagent,
+  GitRemoteUrl,
   PermissionDecision,
   PermissionRequest,
   CreateAndSendResult,
@@ -50,6 +51,7 @@ export type {
   StoredAttachment,
   GitBranch,
   BranchComparison,
+  GitRemoteUrl,
   WorktreeInfo,
   PrInfo,
   PrDetail,
@@ -417,6 +419,8 @@ export interface McodeTransport {
   getBranchDiff(workspaceId: string, base?: string, target?: string, filePath?: string, maxLines?: number, threadId?: string): Promise<string>;
   /** Resolve the default Branch comparison (base→target per ADR 0007) plus the refs that populate the pickers. Pass threadId so "current branch" is the thread's worktree branch. */
   getBranchComparison(workspaceId: string, threadId?: string): Promise<BranchComparison>;
+  /** Resolve a workspace or thread checkout's origin remote into a normalized web URL and repository label. */
+  getRemoteUrl(workspaceId: string, threadId?: string): Promise<GitRemoteUrl>;
   /**
    * Return total additions and deletions for a Review-panel git view.
    * Ref semantics match the file-list methods so the stat total matches the

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -19,6 +19,7 @@ import type {
   GitCommit,
   ProviderModelInfo,
   CopilotSubagent,
+  GitRemoteUrl,
 } from "./types";
 import type { CreateAndSendResult } from "@mcode/contracts";
 import { emitPtyReconnectGap } from "@/components/terminal/ptyDataRegistry";
@@ -758,6 +759,8 @@ export function createWsTransport(
       rpc<string>("git.branchDiff", { workspaceId, base, target, filePath, maxLines, threadId }),
     getBranchComparison: (workspaceId, threadId?) =>
       rpc<BranchComparison>("git.branchComparison", { workspaceId, threadId }),
+    getRemoteUrl: (workspaceId, threadId?) =>
+      rpc<GitRemoteUrl>("git.getRemoteUrl", { workspaceId, threadId }),
     getReviewDiffStats: (params) =>
       rpc<{ additions: number; deletions: number }>("git.reviewDiffStats", params),
 

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -20,6 +20,18 @@ export const GitRefSchema = z
   .string()
   .regex(/^(?!-)[A-Za-z0-9._/-]+$/, "invalid git ref");
 
+/** Remote repository metadata resolved from a checkout's origin remote. */
+export const GitRemoteUrlSchema = z.object({
+  /** Normalized https web URL, or null when no usable remote exists. */
+  webUrl: z.string().url().refine((value) => value.startsWith("https://"), {
+    message: "webUrl must be an https URL",
+  }).nullable(),
+  /** Repository label shown in the UI, usually "org/repo". */
+  label: z.string().min(1),
+});
+/** Remote repository metadata resolved from git config. */
+export type GitRemoteUrl = z.infer<typeof GitRemoteUrlSchema>;
+
 /**
  * A resolved Branch comparison: the base→target ref pair the Review tab's Branch
  * view diffs (always three-dot, `base...target`), plus the refs available to

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -247,8 +247,8 @@ export type {
 } from "./models/permission.js";
 
 // Git / GitHub
-export { GitBranchSchema, WorktreeSchema, GitCommitSchema, BranchComparisonSchema } from "./git.js";
-export type { GitBranch, WorktreeInfo, GitCommit, BranchComparison } from "./git.js";
+export { GitBranchSchema, WorktreeSchema, GitCommitSchema, BranchComparisonSchema, GitRemoteUrlSchema } from "./git.js";
+export type { GitBranch, WorktreeInfo, GitCommit, BranchComparison, GitRemoteUrl } from "./git.js";
 
 export { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrParamsSchema, CreatePrResultSchema, CheckRunSchema, ChecksStatusSchema } from "./github.js";
 export type { PrInfo, PrDetail, PrDraft, CreatePrParams, CreatePrResult, CheckRun, ChecksStatus } from "./github.js";

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -10,7 +10,7 @@ import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { ThoughtSegmentRecordSchema } from "../models/thought-segment.js";
 import { HookExecutionRecordSchema } from "../models/hook-execution.js";
 import { NarrativeEntrySchema, TurnRangeSchema } from "../models/narrative-entry.js";
-import { GitBranchSchema, WorktreeSchema, BranchComparisonSchema, GitRefSchema } from "../git.js";
+import { GitBranchSchema, WorktreeSchema, BranchComparisonSchema, GitRefSchema, GitRemoteUrlSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
 import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema, ChecksStatusSchema } from "../github.js";
 import { SkillInfoSchema, SkillDiagnosticsSchema } from "../skills.js";
@@ -306,6 +306,13 @@ export const WS_METHODS = lazySchema(() => ({
   "git.listWorktrees": {
     params: z.object({ workspaceId: z.string() }),
     result: z.array(WorktreeSchema),
+  },
+  "git.getRemoteUrl": {
+    params: z.object({
+      workspaceId: z.string(),
+      threadId: z.string().optional(),
+    }),
+    result: GitRemoteUrlSchema,
   },
   "git.fetchBranch": {
     params: z.object({


### PR DESCRIPTION
## What
Adds the `git.getRemoteUrl` RPC for resolving a repository label and browser URL from a workspace or thread checkout.

## Why
The Thread Overview needs a repository row that can show `org/repo`, open the remote in a browser, and fall back to the folder name for local-only repos.

## Key Changes
- Added the `GitRemoteUrl` contract plus `git.getRemoteUrl` WebSocket route and web transport wrapper.
- Resolve workspace and thread paths on the server before running git, so clients cannot pass arbitrary filesystem paths.
- Normalize `origin` remotes to HTTPS web URLs and return a folder-name fallback for missing or malformed remotes.
- Added GitService and router tests for normalization, fallback behavior, and workspace/thread scoping.

Closes #759

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784364442&installation_id=129163861&pr_number=787&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F787&signature=5c96745978b66696de09e553e1bf5870b0fde06eb6e71493e1531bc134665a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Git remote repository URLs from workspace and optional thread checkouts, returning a normalized HTTPS link (when available) along with a repository label.
  * Exposed this data through the existing WebSocket transport as `git.getRemoteUrl`.

* **Tests**
  * Added coverage for remote URL normalization/validation behavior and for ensuring the correct workspace/thread context is used before resolving the remote URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->