### PR TITLE
feat: add git create branch RPC

### DIFF
--- a/apps/server/src/__tests__/git-service-push.test.ts
+++ b/apps/server/src/__tests__/git-service-push.test.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { validateBranchName } from "@mcode/shared";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import { GitService } from "../services/git-service";
 import { createMockGitExecutor } from "../services/git-executor/__tests__/mock-git-executor.js";
@@ -67,12 +68,55 @@ describe("GitService.push", () => {
   });
 });
 
+describe("GitService.createBranch", () => {
+  let gitService: GitService;
+  let execFn: ReturnType<typeof createMockGitExecutor>["execFn"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validateBranchName).mockImplementation(() => undefined);
+    const mock = createMockGitExecutor();
+    execFn = mock.execFn;
+    gitService = new GitService({} as WorkspaceRepo, mock.executor);
+  });
+
+  it("creates and checks out the branch with argv-safe git args", async () => {
+    execFn.mockResolvedValue({ stdout: "", stderr: "" });
+
+    await expect(gitService.createBranch("/repo", "feat/create-branch")).resolves.toBe(
+      "feat/create-branch",
+    );
+
+    expect(execFn).toHaveBeenCalledWith([
+      "-C",
+      "/repo",
+      "checkout",
+      "-b",
+      "feat/create-branch",
+    ]);
+  });
+
+  it.each([
+    "",
+    "--force",
+    "feat/has space",
+    "feat/../escape",
+    "feat;rm",
+    "feat$(whoami)",
+    "HEAD",
+  ])("rejects unsafe branch name %j before exec", async (name) => {
+    await expect(gitService.createBranch("/repo", name)).rejects.toThrow();
+    expect(execFn).not.toHaveBeenCalled();
+  });
+});
+
 describe("GitService.diffStat", () => {
   let gitService: GitService;
   let execFn: ReturnType<typeof createMockGitExecutor>["execFn"];
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(validateBranchName).mockImplementation(() => undefined);
     const mock = createMockGitExecutor();
     execFn = mock.execFn;
     gitService = new GitService({} as WorkspaceRepo, mock.executor);

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -140,6 +140,13 @@ function assertSafeRef(ref: string): void {
   }
 }
 
+function assertSafeBranchCreationName(name: string): void {
+  validateBranchName(name);
+  if (!/^(?!-)[A-Za-z0-9._/-]+$/.test(name) || name.includes("..") || name === "HEAD") {
+    throw new Error(`Branch name contains invalid characters: ${name}`);
+  }
+}
+
 function fallbackRemoteUrl(repoPath: string): GitRemoteUrl {
   return {
     webUrl: null,
@@ -237,6 +244,13 @@ export class GitService {
     validateBranchName(branch);
     const workspace = this.requireWorkspace(workspaceId);
     await this.gitExecutor.exec(["-C", workspace.path, "checkout", branch]);
+  }
+
+  /** Create and checkout a new branch in the repository at the given path. */
+  async createBranch(path: string, name: string): Promise<string> {
+    assertSafeBranchCreationName(name);
+    await this.gitExecutor.exec(["-C", path, "checkout", "-b", name]);
+    return name;
   }
 
   /** List all git worktrees registered for a workspace. */

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -448,6 +448,11 @@ async function dispatch(
       await deps.gitService.checkout(params.workspaceId, params.branch);
       return;
     }
+    case "git.createBranch": {
+      const path = resolveWorkspaceRepoPath(deps, params.workspaceId, params.threadId);
+      const branch = await deps.gitService.createBranch(path, params.name);
+      return { branch };
+    }
     case "git.listWorktrees": {
       const ws = deps.workspaceService.findById(params.workspaceId);
       if (!ws?.is_git_repo) return [];

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -115,3 +115,103 @@ describe("routeMessage git.getRemoteUrl", () => {
     expect(getRemoteUrl).not.toHaveBeenCalled();
   });
 });
+
+describe("routeMessage git.createBranch", () => {
+  it("resolves the git path from a workspace thread before creating the branch", async () => {
+    const createBranch = vi.fn().mockResolvedValue("feat/from-thread");
+    const resolveWorkingDir = vi.fn().mockReturnValue("C:/repo-worktree");
+    const deps = {
+      workspaceService: {
+        findById: vi.fn().mockReturnValue({ id: "ws-1", path: "C:/repo" }),
+      },
+      threadRepo: {
+        findById: vi.fn().mockReturnValue({
+          id: "thread-1",
+          workspace_id: "ws-1",
+          mode: "worktree",
+          worktree_path: "C:/repo-worktree",
+        }),
+      },
+      gitService: {
+        createBranch,
+        resolveWorkingDir,
+      },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-create",
+        method: "git.createBranch",
+        params: { workspaceId: "ws-1", threadId: "thread-1", name: "feat/from-thread" },
+      }),
+      deps,
+    );
+
+    expect(response.result).toEqual({ branch: "feat/from-thread" });
+    expect(resolveWorkingDir).toHaveBeenCalledWith(
+      "C:/repo",
+      "worktree",
+      "C:/repo-worktree",
+    );
+    expect(createBranch).toHaveBeenCalledWith("C:/repo-worktree", "feat/from-thread");
+  });
+
+  it("rejects a thread from another workspace before creating a branch", async () => {
+    const createBranch = vi.fn();
+    const deps = {
+      workspaceService: {
+        findById: vi.fn().mockReturnValue({ id: "ws-1", path: "C:/repo" }),
+      },
+      threadRepo: {
+        findById: vi.fn().mockReturnValue({
+          id: "thread-1",
+          workspace_id: "ws-2",
+          mode: "worktree",
+          worktree_path: "C:/repo-worktree",
+        }),
+      },
+      gitService: {
+        createBranch,
+        resolveWorkingDir: vi.fn(),
+      },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-create",
+        method: "git.createBranch",
+        params: { workspaceId: "ws-1", threadId: "thread-1", name: "feat/from-thread" },
+      }),
+      deps,
+    );
+
+    expect(response.error?.message).toContain(
+      "Thread thread-1 does not belong to workspace ws-1",
+    );
+    expect(createBranch).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid branch names before dispatch", async () => {
+    const createBranch = vi.fn();
+    const deps = {
+      workspaceService: {
+        findById: vi.fn().mockReturnValue({ id: "ws-1", path: "C:/repo" }),
+      },
+      gitService: {
+        createBranch,
+      },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-create",
+        method: "git.createBranch",
+        params: { workspaceId: "ws-1", name: "bad;name" },
+      }),
+      deps,
+    );
+
+    expect(response.error?.code).toBe("INVALID_PARAMS");
+    expect(createBranch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -106,6 +106,7 @@ export const mockTransport: McodeTransport = {
   listBranches: vi.fn().mockResolvedValue([]),
   getCurrentBranch: vi.fn().mockResolvedValue("main"),
   checkoutBranch: vi.fn().mockResolvedValue(undefined),
+  createBranch: vi.fn().mockResolvedValue({ branch: "feat/test" }),
   listWorktrees: vi.fn().mockResolvedValue([]),
   sendMessage: vi.fn().mockResolvedValue(1),
   stopAgent: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -180,6 +180,7 @@ export interface McodeTransport {
   listBranches(workspaceId: string): Promise<GitBranch[]>;
   getCurrentBranch(workspaceId: string): Promise<string | null>;
   checkoutBranch(workspaceId: string, branch: string): Promise<void>;
+  createBranch(workspaceId: string, name: string, threadId?: string): Promise<{ branch: string }>;
   listWorktrees(workspaceId: string): Promise<WorktreeInfo[]>;
 
   // Agent commands

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -532,6 +532,12 @@ export function createWsTransport(
     getCurrentBranch: (workspaceId) => rpc<string | null>("git.currentBranch", { workspaceId }),
     checkoutBranch: (workspaceId, branch) =>
       rpc<void>("git.checkout", { workspaceId, branch }),
+    createBranch: (workspaceId, name, threadId) =>
+      rpc<{ branch: string }>("git.createBranch", {
+        workspaceId,
+        name,
+        ...(threadId ? { threadId } : {}),
+      }),
     listWorktrees: (workspaceId) => rpc<WorktreeInfo[]>("git.listWorktrees", { workspaceId }),
 
     // Agent

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -20,6 +20,19 @@ export const GitRefSchema = z
   .string()
   .regex(/^(?!-)[A-Za-z0-9._/-]+$/, "invalid git ref");
 
+/**
+ * A user-supplied branch name safe for creating a new branch. This is stricter
+ * than a generic ref because it rejects reserved names and traversal-like
+ * sequences before they cross into a mutating git command.
+ */
+export const GitBranchNameSchema = z
+  .string()
+  .min(1)
+  .max(250)
+  .regex(/^(?!-)[A-Za-z0-9._/-]+$/, "invalid git branch name")
+  .refine((name) => !name.includes(".."), "invalid git branch name")
+  .refine((name) => name !== "HEAD", "invalid git branch name");
+
 /** Remote repository metadata resolved from a checkout's origin remote. */
 export const GitRemoteUrlSchema = z.object({
   /** Normalized https web URL, or null when no usable remote exists. */

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -10,7 +10,7 @@ import { ToolCallRecordSchema } from "../models/tool-call-record.js";
 import { ThoughtSegmentRecordSchema } from "../models/thought-segment.js";
 import { HookExecutionRecordSchema } from "../models/hook-execution.js";
 import { NarrativeEntrySchema, TurnRangeSchema } from "../models/narrative-entry.js";
-import { GitBranchSchema, WorktreeSchema, BranchComparisonSchema, GitRefSchema, GitRemoteUrlSchema } from "../git.js";
+import { GitBranchSchema, WorktreeSchema, BranchComparisonSchema, GitRefSchema, GitRemoteUrlSchema, GitBranchNameSchema } from "../git.js";
 import { GitCommitSchema } from "../models/git-commit.js";
 import { PrInfoSchema, PrDetailSchema, PrDraftSchema, CreatePrResultSchema, ChecksStatusSchema } from "../github.js";
 import { SkillInfoSchema, SkillDiagnosticsSchema } from "../skills.js";
@@ -302,6 +302,14 @@ export const WS_METHODS = lazySchema(() => ({
   "git.checkout": {
     params: z.object({ workspaceId: z.string(), branch: GitRefSchema }),
     result: z.void(),
+  },
+  "git.createBranch": {
+    params: z.object({
+      workspaceId: z.string(),
+      threadId: z.string().optional(),
+      name: GitBranchNameSchema,
+    }),
+    result: z.object({ branch: z.string() }),
   },
   "git.listWorktrees": {
     params: z.object({ workspaceId: z.string() }),


### PR DESCRIPTION
## What
Add the `git.createBranch` RPC for creating and checking out a new branch from a registered workspace or thread checkout.

## Why
Issue #760 needs a server-side branch creation path for the Thread Overview work. The RPC must reject unsafe branch names before Git runs.

## Key Changes
- Added `GitService.createBranch(path, name)`, backed by `git checkout -b`, with branch-name validation before exec.
- Added the `git.createBranch` WS contract, router case, and web transport method.
- Resolve workspace and thread paths on the server so clients cannot send arbitrary filesystem paths.
- Added service and router tests for exec args, unsafe names, thread path resolution, and cross-workspace rejection.

Closes #760

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784370401&installation_id=129163861&pr_number=788&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F788&signature=0d7d43706be769bd27016be667aed89ec77c5982b1fb7e2688158f125ed6dd16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->