### PR TITLE
feat: add thread overview popover

### DIFF
--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -53,6 +53,68 @@ const gitCommit = {
   date: now,
 };
 
+const snapshot = {
+  id: "snapshot-1",
+  message_id: "message-1",
+  thread_id: thread.id,
+  ref_before: "before",
+  ref_after: "after",
+  files_changed: ["apps/web/src/components/chat/HeaderActions.tsx"],
+  worktree_path: thread.worktree_path,
+  created_at: now,
+};
+
+const branches = [
+  {
+    name: "feat/consolidated-header",
+    shortSha: "abc1234",
+    type: "local" as const,
+    isCurrent: true,
+  },
+  {
+    name: "main",
+    shortSha: "def5678",
+    type: "local" as const,
+    isCurrent: false,
+  },
+  {
+    name: "feat/git-create-branch",
+    shortSha: "fed1234",
+    type: "local" as const,
+    isCurrent: false,
+  },
+  {
+    name: "feat/review-panel",
+    shortSha: "a1b2c3d",
+    type: "local" as const,
+    isCurrent: false,
+  },
+  {
+    name: "feat/settings-sync",
+    shortSha: "b2c3d4e",
+    type: "local" as const,
+    isCurrent: false,
+  },
+  {
+    name: "fix/thread-switching",
+    shortSha: "c3d4e5f",
+    type: "local" as const,
+    isCurrent: false,
+  },
+  {
+    name: "chore/e2e-fixtures",
+    shortSha: "d4e5f6a",
+    type: "local" as const,
+    isCurrent: false,
+  },
+  {
+    name: "docs/runtime-guide",
+    shortSha: "e5f6a7b",
+    type: "local" as const,
+    isCurrent: false,
+  },
+];
+
 test.describe("Consolidated chat header", () => {
   // Dock the right panel inline (not as a modal overlay) so the header toggle
   // stays clickable for the show/hide assertions. The default panel width is 50%
@@ -67,6 +129,16 @@ test.describe("Consolidated chat header", () => {
         JSON.stringify({ [wsId]: true }),
       );
     }, WS_ID);
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: async (text: string) => {
+            (window as unknown as { __mcodeCopiedText?: string }).__mcodeCopiedText = text;
+          },
+        },
+      });
+    });
 
     await mockWebSocketServer(page, {
       "workspace.list": [workspace],
@@ -78,6 +150,28 @@ test.describe("Consolidated chat header", () => {
       // Create PR affordance renders enabled.
       "github.branchPr": null,
       "git.log": [gitCommit],
+      "snapshot.listByThread": [snapshot],
+      "snapshot.getDiffStats": async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return [
+          {
+            filePath: "apps/web/src/components/chat/HeaderActions.tsx",
+            additions: 233,
+            deletions: 0,
+          },
+        ];
+      },
+      "git.listBranches": async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return branches;
+      },
+      "git.workingTreeFiles": (params) =>
+        (params as { staged?: boolean } | undefined)?.staged
+          ? ["apps/web/src/components/chat/HeaderActions.tsx"]
+          : [
+              "apps/web/src/components/chat/ThreadOverview.tsx",
+              "apps/web/e2e/chat-header-consolidated.spec.ts",
+            ],
     });
     await page.goto("/");
     await page.waitForSelector("[data-testid='thread-item']");
@@ -85,29 +179,75 @@ test.describe("Consolidated chat header", () => {
     await page.waitForSelector("[data-testid='chat-header-title']");
   });
 
-  test("keeps Open and the consolidated controls visible; Create PR lives in the menu", async ({ page }) => {
+  test("keeps Open and the Overview controls visible; Create PR lives in the popover", async ({ page }) => {
     await expect(page.getByRole("button", { name: /^open in /i })).toBeVisible();
     await expect(page.getByTestId("header-workspace-menu")).toBeVisible();
     await expect(page.getByTestId("header-panel-toggle")).toBeVisible();
-    // No standalone Create PR button in the header chrome — it lives in the menu
+    // No standalone Create PR button in the header chrome. It lives in Overview
     // (no PR exists yet for this thread, so the PR-status badge is absent too).
     await expect(page.getByRole("button", { name: /create pr/i })).toHaveCount(0);
   });
 
-  test("consolidated menu holds Changes / Branch / Commit or push / Create PR", async ({ page }) => {
+  test("Overview popover holds changes, local, branch, commit, and PR actions", async ({ page }) => {
     await page.getByTestId("header-workspace-menu").click();
 
+    await expect(page.locator('[data-slot="popover-content"]').first()).toBeVisible();
+    await expect(page.getByText("Environment", { exact: true })).toHaveCount(0);
     await expect(page.getByTestId("workspace-menu-changes")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-local")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-branch")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-commit")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-sources")).toHaveCount(0);
+    await expect(page.locator(".animate-popover-enter").first()).toBeVisible();
 
-    // The branch item surfaces the current branch name.
+    await expect(page.getByTestId("thread-overview-local")).toContainText("Local");
     await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/consolidated-header");
-    // Changes shows its keyboard shortcut hint (Ctrl+D on non-Mac, ⌘D on Mac).
-    await expect(page.getByTestId("workspace-menu-changes")).toContainText(/ctrl\+d|⌘d/i);
-    // Items present a pointer cursor to signal they're clickable.
+    await expect(page.getByTestId("thread-overview-change-loading")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-change-loading")).toHaveClass(
+      /animate-thread-overview-loading/,
+    );
+    await expect(page.getByTestId("thread-overview-change-summary")).toContainText("+233");
+    await expect(page.getByTestId("thread-overview-change-summary")).toContainText("-0");
     await expect(page.getByTestId("workspace-menu-changes")).toHaveCSS("cursor", "pointer");
+    await expect(page.getByTestId("thread-overview-local-popover")).toHaveCount(0);
+
+    await page.getByTestId("thread-overview-local").click();
+    await expect(page.getByTestId("thread-overview-local-popover")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-local-path")).toContainText(
+      "/test/path/.worktrees/feat-x",
+    );
+    await expect(page.getByTestId("thread-overview-local-branch")).toContainText(
+      "feat/consolidated-header",
+    );
+    await page.getByRole("button", { name: "Copy worktree path" }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(() => (window as unknown as { __mcodeCopiedText?: string }).__mcodeCopiedText),
+      )
+      .toBe("/test/path/.worktrees/feat-x");
+    await page.getByRole("button", { name: "Copy branch" }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(() => (window as unknown as { __mcodeCopiedText?: string }).__mcodeCopiedText),
+      )
+      .toBe("feat/consolidated-header");
+
+    await page.getByTestId("workspace-menu-branch").click();
+    await expect(page.getByTestId("thread-overview-branch-popover")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-branch-list")).not.toHaveClass(/h-60/);
+    await expect(page.getByRole("textbox", { name: "Search branches" })).toBeVisible();
+    await expect(page.getByTestId("thread-overview-current-branch")).toContainText(
+      "feat/consolidated-header",
+    );
+    await expect(page.getByTestId("thread-overview-branch-list")).toHaveClass(/h-60/);
+    await expect(page.getByTestId("thread-overview-branch-list")).toHaveJSProperty(
+      "clientHeight",
+      240,
+    );
+    await expect(page.getByTestId("thread-overview-current-branch")).toContainText(
+      "Uncommitted: 3 files",
+    );
   });
 
   test("panel toggle shows and hides the workspace-global right panel", async ({ page }) => {
@@ -124,7 +264,7 @@ test.describe("Consolidated chat header", () => {
     await expect(toggle).toHaveAttribute("aria-pressed", "false");
   });
 
-  test("Changes menu item opens the right panel", async ({ page }) => {
+  test("Changes row opens the right panel", async ({ page }) => {
     const toggle = page.getByTestId("header-panel-toggle");
     await expect(toggle).toHaveAttribute("aria-pressed", "false");
 

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ReactNode, ReactElement } from "react";
 import type { Thread } from "@/transport/types";
+import type { TurnSnapshot } from "@mcode/contracts";
 
 // vi.hoisted runs before vi.mock hoisting, so these are available in mock factories.
 const {
@@ -37,10 +38,16 @@ vi.mock("@/stores/diffStore", () => {
     hideRightPanel: vi.fn(),
     toggleRightPanel: vi.fn(),
     setRightPanelTab: vi.fn(),
+    setSnapshots: vi.fn(),
   };
   const store = Object.assign(
     vi.fn((selector: (s: unknown) => unknown) =>
-      selector({ rightPanelByThread: {}, snapshotsByThread: {}, ...actions }),
+      selector({
+        rightPanelByThread: {},
+        snapshotsByThread: {},
+        diffRevisionByScope: {},
+        ...actions,
+      }),
     ),
     { getState: vi.fn().mockReturnValue(actions) },
   );
@@ -66,6 +73,16 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuSeparator: () => <hr />,
 }));
 
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ render, children }: { render?: ReactElement; children?: ReactNode }) => (
+    <>{render ?? children}</>
+  ),
+  PopoverContent: ({ children }: { children: ReactNode }) => (
+    <div data-slot="popover-content">{children}</div>
+  ),
+}));
+
 vi.mock("@/hooks/useBranchPr", () => ({
   useBranchPr: (...args: unknown[]) => mockUseBranchPr(...args),
 }));
@@ -75,6 +92,12 @@ vi.mock("@/hooks/useHasCommitsAhead", () => ({
 }));
 
 import { HeaderActions } from "./HeaderActions";
+import {
+  getThreadOverviewCiDot,
+  hasVisibleThreadOverviewChangeSummary,
+  resolveThreadOverviewChangeSummary,
+  summarizeThreadChangeStats,
+} from "./ThreadOverview";
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {
@@ -265,6 +288,25 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.getByTestId("header-workspace-menu")).toBeInTheDocument();
   });
 
+  it("renders the thread overview rows", () => {
+    render(<HeaderActions thread={makeThread({ worktree_path: "/repo/worktrees/feat-x" })} />);
+    expect(screen.queryByText("Environment")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-menu-changes")).toHaveTextContent("Changes");
+    expect(screen.queryByTestId("thread-overview-change-summary")).not.toBeInTheDocument();
+    expect(screen.getByTestId("thread-overview-local")).toHaveTextContent("Local");
+    expect(screen.getByTestId("thread-overview-local")).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("/repo/worktrees/feat-x"),
+    );
+    expect(screen.getByTestId("thread-overview-local-popover")).toBeInTheDocument();
+    expect(screen.getByTestId("thread-overview-local-path")).toHaveTextContent(
+      "/repo/worktrees/feat-x",
+    );
+    expect(screen.getByTestId("thread-overview-local-branch")).toHaveTextContent("feat/my-feature");
+    expect(screen.getByTestId("workspace-menu-branch")).toHaveTextContent("feat/my-feature");
+    expect(screen.queryByTestId("thread-overview-sources")).not.toBeInTheDocument();
+  });
+
   it("renders a single dedicated right-panel toggle", () => {
     render(<HeaderActions thread={makeThread()} />);
     const toggle = screen.getByTestId("header-panel-toggle");
@@ -283,5 +325,187 @@ describe("HeaderActions - consolidated header", () => {
     render(<HeaderActions thread={makeThread({ mode: "direct" })} />);
     expect(screen.getByTestId("header-workspace-menu")).toBeInTheDocument();
     expect(screen.getByTestId("header-panel-toggle")).toBeInTheDocument();
+  });
+});
+
+describe("summarizeThreadChangeStats", () => {
+  it("sums additions and deletions across turn snapshots", () => {
+    expect(
+      summarizeThreadChangeStats(
+        [
+          { files_changed: ["src/a.ts", "src/b.ts"] },
+          { files_changed: ["src/b.ts", "src/c.ts"] },
+        ],
+        [
+          [
+            { filePath: "src/a.ts", additions: 12, deletions: 1 },
+            { filePath: "src/b.ts", additions: 5, deletions: 0 },
+          ],
+          [{ filePath: "src/c.ts", additions: 7, deletions: 3 }],
+        ],
+      ),
+    ).toEqual({ files: 3, additions: 24, deletions: 4 });
+  });
+});
+
+function makeSummaryTransport(
+  overrides: Partial<Parameters<typeof resolveThreadOverviewChangeSummary>[0]["transport"]> = {},
+): Parameters<typeof resolveThreadOverviewChangeSummary>[0]["transport"] {
+  return {
+    listSnapshots: vi.fn().mockResolvedValue([]),
+    getSnapshotDiffStats: vi.fn().mockResolvedValue([]),
+    getWorkingTreeFiles: vi.fn().mockResolvedValue([]),
+    getBranchComparison: vi.fn().mockResolvedValue({
+      base: null,
+      target: null,
+      refs: [],
+      isUnborn: false,
+      isComparisonAvailable: false,
+    }),
+    getBranchFiles: vi.fn().mockResolvedValue([]),
+    getReviewDiffStats: vi.fn().mockResolvedValue({ additions: 0, deletions: 0 }),
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<TurnSnapshot>): TurnSnapshot {
+  return {
+    id: "snapshot-1",
+    message_id: "message-1",
+    thread_id: "thread-1",
+    ref_before: "before",
+    ref_after: "after",
+    files_changed: [],
+    worktree_path: "/repo",
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("resolveThreadOverviewChangeSummary", () => {
+  it("uses the latest turn snapshot before git views", async () => {
+    const transport = makeSummaryTransport({
+      getSnapshotDiffStats: vi.fn().mockResolvedValue([
+        { filePath: "src/latest.ts", additions: 8, deletions: 2 },
+      ]),
+      getWorkingTreeFiles: vi.fn().mockResolvedValue(["src/manual.ts"]),
+    });
+
+    const result = await resolveThreadOverviewChangeSummary({
+      thread: { id: "thread-1", workspace_id: "ws-1" },
+      snapshots: [
+        makeSnapshot({ id: "old", files_changed: ["src/old.ts"] }),
+        makeSnapshot({ id: "noop", files_changed: [] }),
+        makeSnapshot({ id: "latest", files_changed: ["src/latest.ts"] }),
+      ],
+      transport,
+    });
+
+    expect(result.summary).toEqual({ files: 1, additions: 8, deletions: 2 });
+    expect(transport.getSnapshotDiffStats).toHaveBeenCalledWith("latest");
+    expect(transport.getWorkingTreeFiles).not.toHaveBeenCalled();
+  });
+
+  it("falls back to unstaged worktree changes before branch comparison", async () => {
+    const transport = makeSummaryTransport({
+      getWorkingTreeFiles: vi.fn().mockResolvedValue(["src/manual.ts"]),
+      getReviewDiffStats: vi.fn().mockResolvedValue({ additions: 5, deletions: 1 }),
+      getBranchComparison: vi.fn().mockResolvedValue({
+        base: "origin/main",
+        target: "feat/x",
+        refs: [],
+        isUnborn: false,
+        isComparisonAvailable: true,
+      }),
+    });
+
+    const result = await resolveThreadOverviewChangeSummary({
+      thread: { id: "thread-1", workspace_id: "ws-1" },
+      snapshots: [],
+      transport,
+    });
+
+    expect(result.summary).toEqual({ files: 1, additions: 5, deletions: 1 });
+    expect(transport.getReviewDiffStats).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      view: "unstaged",
+      threadId: "thread-1",
+    });
+    expect(transport.getBranchComparison).not.toHaveBeenCalled();
+  });
+
+  it("uses the default branch comparison when the thread has no turn or unstaged changes", async () => {
+    const transport = makeSummaryTransport({
+      getBranchComparison: vi.fn().mockResolvedValue({
+        base: "origin/main",
+        target: "feat/x",
+        refs: [],
+        isUnborn: false,
+        isComparisonAvailable: true,
+      }),
+      getBranchFiles: vi.fn().mockResolvedValue(["src/branch.ts"]),
+      getReviewDiffStats: vi.fn().mockResolvedValue({ additions: 13, deletions: 3 }),
+    });
+
+    const result = await resolveThreadOverviewChangeSummary({
+      thread: { id: "thread-1", workspace_id: "ws-1" },
+      snapshots: [],
+      transport,
+    });
+
+    expect(result.summary).toEqual({ files: 1, additions: 13, deletions: 3 });
+    expect(transport.getBranchFiles).toHaveBeenCalledWith(
+      "ws-1",
+      "origin/main",
+      "feat/x",
+      "thread-1",
+    );
+  });
+
+  it("hides the visible +/- summary when the resolved diff has no line delta", () => {
+    expect(
+      hasVisibleThreadOverviewChangeSummary({ files: 0, additions: 0, deletions: 0 }),
+    ).toBe(false);
+    expect(
+      hasVisibleThreadOverviewChangeSummary({ files: 1, additions: 0, deletions: 0 }),
+    ).toBe(false);
+    expect(
+      hasVisibleThreadOverviewChangeSummary({ files: 1, additions: 1, deletions: 0 }),
+    ).toBe(true);
+  });
+});
+
+describe("getThreadOverviewCiDot", () => {
+  const baseChecks = {
+    fetchedAt: 1,
+    runs: [],
+  };
+
+  it("shows red when an open PR has failing checks", () => {
+    expect(
+      getThreadOverviewCiDot(
+        { state: "OPEN" },
+        { ...baseChecks, aggregate: "failing" },
+      ),
+    ).toBe("red");
+  });
+
+  it("shows green when an open PR has passing checks", () => {
+    expect(
+      getThreadOverviewCiDot(
+        { state: "OPEN" },
+        { ...baseChecks, aggregate: "passing" },
+      ),
+    ).toBe("green");
+  });
+
+  it("hides the dot while checks are pending or absent", () => {
+    expect(
+      getThreadOverviewCiDot(
+        { state: "OPEN" },
+        { ...baseChecks, aggregate: "pending" },
+      ),
+    ).toBeNull();
+    expect(getThreadOverviewCiDot(null, { ...baseChecks, aggregate: "passing" })).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -1,22 +1,12 @@
-import { useCallback, useState } from "react";
-import { Menu, PanelRight, Diff, GitBranch, Upload, Check, GitPullRequest } from "lucide-react";
+import { useCallback } from "react";
+import { PanelRight } from "lucide-react";
 import { OpenInAppButton } from "./OpenInAppButton";
-import { CreatePrDialog } from "./CreatePrDialog";
-import { PrSplitButton } from "./PrSplitButton";
-import { useThreadGitActions } from "@/hooks/useThreadGitActions";
+import { ThreadOverview } from "./ThreadOverview";
 import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { toggleRightPanelAdaptive } from "@/lib/right-panel-layout";
-import { executeCommand } from "@/lib/command-registry";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Kbd } from "@/components/palette/Kbd";
 import { getKeybindingForCommand, formatKeybinding } from "@/lib/keybinding-manager";
 import { isMac } from "@/lib/platform";
 import type { Thread } from "@/transport";
@@ -26,40 +16,13 @@ interface HeaderActionsProps {
 }
 
 /**
- * Renders the consolidated chat-header actions: the PR affordance, the open-in
- * split button, a single workspace menu (Changes / Branch / Commit or push), and
- * a dedicated toggle for the workspace-global right panel. Polls GitHub for the
- * thread's PR and syncs state changes back to the workspace store.
+ * Renders the chat-header action strip: open-in, thread Overview, and the
+ * workspace-global right-panel toggle.
  */
 export function HeaderActions({ thread }: HeaderActionsProps) {
-  const [branchCopied, setBranchCopied] = useState(false);
-
-  // Commit-or-push + Create-PR orchestration is shared with the Review toolbar.
-  const {
-    prable,
-    pr,
-    hasCommitsAhead,
-    checks,
-    openPrDetail,
-    dirPath,
-    createPrOpen,
-    setCreatePrOpen,
-    handleCommitOrPush,
-    handleOpenPr,
-  } = useThreadGitActions(thread);
-
-  // Deduplicated count of files touched across the thread's loaded turn snapshots.
-  // Cheap, reactive, and always correct; the precise per-file +/- lives one click
-  // away in the Changes tab (no cumulative diff-stat endpoint exists to total here).
-  const changedFileCount = useDiffStore((s) => {
-    const snaps = s.snapshotsByThread[thread.id];
-    if (!snaps || snaps.length === 0) return 0;
-    const seen = new Set<string>();
-    for (const snap of snaps) {
-      for (const file of snap.files_changed) seen.add(file);
-    }
-    return seen.size;
-  });
+  const workspacePath = useWorkspaceStore((s) =>
+    s.workspaces.find((w) => w.id === thread.workspace_id)?.path ?? null,
+  );
 
   // Effective open/closed state for the workspace-global right panel.
   const panelVisible = useDiffStore((s) =>
@@ -73,47 +36,17 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
     toggleRightPanelAdaptive(thread.workspace_id, thread.id);
   }, [thread.workspace_id, thread.id]);
 
-  const openChanges = useCallback(() => {
-    executeCommand("changes.toggle");
-  }, []);
-
-  // Mirror the live keybinding so the menu hint stays correct if the user rebinds it.
-  const changesShortcut = formatKeybinding(
-    getKeybindingForCommand("changes.toggle")?.key ?? "mod+d",
-    isMac,
-  );
-
   // Live keycap for the right-panel toggle, shown in the button's tooltip.
   const panelShortcut = formatKeybinding(
     getKeybindingForCommand("rightPanel.toggle")?.key ?? "mod+alt+b",
     isMac,
   );
 
-  const copyBranch = useCallback(() => {
-    void navigator.clipboard?.writeText(thread.branch);
-    setBranchCopied(true);
-    setTimeout(() => setBranchCopied(false), 1500);
-  }, [thread.branch]);
-
   return (
     <div className="flex items-center justify-end gap-1">
       <div className="flex items-center gap-0.5 bg-muted/20 rounded-md px-1 py-0.5">
-        {/* Standalone affordance is the live PR status (badge + checks). Creating a
-            PR lives in the consolidated menu below; once a PR exists this takes over. */}
-        {prable && dirPath && pr && (
-          <PrSplitButton
-            pr={pr}
-            hasCommitsAhead={hasCommitsAhead}
-            onCreatePr={() => setCreatePrOpen(true)}
-            onOpenPr={handleOpenPr}
-            checks={checks}
-            threadId={thread.id}
-            prTitle={openPrDetail?.title}
-            prAuthor={openPrDetail?.author}
-          />
-        )}
         <OpenInAppButton
-          dirPath={dirPath}
+          dirPath={thread.worktree_path ?? workspacePath}
           threadId={thread.id}
           threadOverride={thread.default_open_in_app ?? null}
         />
@@ -121,74 +54,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
 
       <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
 
-      {/* Consolidated workspace menu — the mcode items, no "environment"/"sources" framing. */}
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              title="Workspace"
-              aria-label="Workspace menu"
-              data-testid="header-workspace-menu"
-              className="cursor-pointer text-foreground/70 hover:text-foreground hover:bg-muted/40"
-            >
-              <Menu size={14} />
-            </Button>
-          }
-        />
-        <DropdownMenuContent align="end" sideOffset={4} className="min-w-[200px]">
-          <DropdownMenuItem
-            onClick={openChanges}
-            data-testid="workspace-menu-changes"
-            className="flex cursor-pointer items-center justify-between gap-3 text-xs"
-          >
-            <span className="flex items-center gap-2">
-              <Diff size={14} className="text-muted-foreground" /> Changes
-            </span>
-            <span className="flex items-center gap-2">
-              {changedFileCount > 0 && (
-                <span className="font-mono text-[11px] text-muted-foreground">
-                  {changedFileCount} {changedFileCount === 1 ? "file" : "files"}
-                </span>
-              )}
-              <Kbd>{changesShortcut}</Kbd>
-            </span>
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={copyBranch}
-            data-testid="workspace-menu-branch"
-            className="flex cursor-pointer items-center justify-between gap-3 text-xs"
-          >
-            <span className="flex items-center gap-2">
-              <GitBranch size={14} className="text-muted-foreground" /> Branch
-            </span>
-            <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
-              {branchCopied && <Check size={12} className="text-primary" />}
-              <span className="max-w-[120px] truncate font-mono">{thread.branch}</span>
-            </span>
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={handleCommitOrPush}
-            data-testid="workspace-menu-commit"
-            className="flex cursor-pointer items-center gap-2 text-xs"
-          >
-            <Upload size={14} className="text-muted-foreground" /> Commit or push
-          </DropdownMenuItem>
-          {prable && !pr && (
-            <DropdownMenuItem
-              onClick={() => setCreatePrOpen(true)}
-              disabled={!hasCommitsAhead}
-              data-testid="workspace-menu-create-pr"
-              title={hasCommitsAhead === false ? "No commits ahead of base branch" : undefined}
-              className="flex cursor-pointer items-center gap-2 text-xs data-disabled:cursor-not-allowed"
-            >
-              <GitPullRequest size={14} className="text-muted-foreground" /> Create PR
-            </DropdownMenuItem>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <ThreadOverview thread={thread} />
 
       {/* Dedicated right-panel toggle for the workspace-global panel. */}
       <Tooltip>
@@ -216,16 +82,6 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
           <span className="text-foreground">{panelShortcut}</span>
         </TooltipContent>
       </Tooltip>
-
-      {prable && (
-        <CreatePrDialog
-          open={createPrOpen}
-          onOpenChange={setCreatePrOpen}
-          threadId={thread.id}
-          workspaceId={thread.workspace_id}
-          branch={thread.branch}
-        />
-      )}
     </div>
   );
 }

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1,0 +1,780 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  Copy,
+  Diff,
+  GitBranch,
+  GitPullRequest,
+  Laptop,
+  Menu,
+  Plus,
+  Search,
+  Upload,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { PrSplitButton } from "./PrSplitButton";
+import { CreatePrDialog } from "./CreatePrDialog";
+import { useThreadGitActions } from "@/hooks/useThreadGitActions";
+import { useDiffStore } from "@/stores/diffStore";
+import { executeCommand } from "@/lib/command-registry";
+import { cn } from "@/lib/utils";
+import {
+  getTransport,
+  type GitBranch as GitBranchRecord,
+  type McodeTransport,
+  type Thread,
+} from "@/transport";
+import type { ChecksStatus, TurnSnapshot } from "@mcode/contracts";
+
+/** CI dot shown on the Overview trigger for terminal check states. */
+export type ThreadOverviewCiDot = "red" | "green" | null;
+
+/** Props for {@link ThreadOverview}. */
+interface ThreadOverviewProps {
+  thread: Thread;
+}
+
+type SnapshotDiffStat = { filePath: string; additions: number; deletions: number };
+type ReviewDiffStat = { additions: number; deletions: number };
+type ThreadOverviewChangeSummaryTransport = Pick<
+  McodeTransport,
+  | "listSnapshots"
+  | "getSnapshotDiffStats"
+  | "getWorkingTreeFiles"
+  | "getBranchComparison"
+  | "getBranchFiles"
+  | "getReviewDiffStats"
+>;
+
+type LoadedBranchState =
+  | { status: "idle"; branches: GitBranchRecord[]; uncommittedFiles: number | null }
+  | { status: "loading"; branches: GitBranchRecord[]; uncommittedFiles: number | null }
+  | { status: "ready"; branches: GitBranchRecord[]; uncommittedFiles: number | null }
+  | { status: "error"; branches: GitBranchRecord[]; uncommittedFiles: number | null };
+type LoadStatus = "idle" | "loading" | "ready" | "error";
+type LocalCopyTarget = "path" | "branch";
+
+/** Aggregate change totals shown in the Overview popover. */
+export interface ThreadOverviewChangeSummary {
+  /** Unique changed file count across the snapshots. */
+  files: number;
+  /** Total added lines across snapshot diff stats. */
+  additions: number;
+  /** Total removed lines across snapshot diff stats. */
+  deletions: number;
+}
+
+const EMPTY_CHANGE_SUMMARY: ThreadOverviewChangeSummary = {
+  files: 0,
+  additions: 0,
+  deletions: 0,
+};
+
+const EMPTY_REVIEW_DIFF_STAT: ReviewDiffStat = {
+  additions: 0,
+  deletions: 0,
+};
+
+/**
+ * Derives the active thread's compact CI signal for the Overview trigger.
+ */
+export function getThreadOverviewCiDot(
+  pr: { state: string } | null,
+  checks: ChecksStatus | null,
+): ThreadOverviewCiDot {
+  if (!pr || pr.state.toLowerCase() !== "open" || !checks) return null;
+  if (checks.aggregate === "failing") return "red";
+  if (checks.aggregate === "passing") return "green";
+  return null;
+}
+
+function changedFilesLabel(count: number): string {
+  if (count === 0) return "No files";
+  return `${count} ${count === 1 ? "file" : "files"}`;
+}
+
+function uncommittedFilesLabel(count: number): string {
+  return `Uncommitted: ${count} ${count === 1 ? "file" : "files"}`;
+}
+
+function snapshotKey(snapshots: readonly Pick<TurnSnapshot, "id">[] | undefined): string {
+  return snapshots?.map((snapshot) => snapshot.id).join("|") ?? "";
+}
+
+function latestSnapshotWithChanges(
+  snapshots: readonly Pick<TurnSnapshot, "id" | "files_changed">[],
+): Pick<TurnSnapshot, "id" | "files_changed"> | null {
+  for (let index = snapshots.length - 1; index >= 0; index -= 1) {
+    const snapshot = snapshots[index];
+    if (snapshot.files_changed.length > 0) return snapshot;
+  }
+  return null;
+}
+
+function summarizeGitChangeStats(
+  files: readonly string[],
+  stat: ReviewDiffStat,
+): ThreadOverviewChangeSummary {
+  return {
+    files: new Set(files).size,
+    additions: stat.additions,
+    deletions: stat.deletions,
+  };
+}
+
+/**
+ * Sums turn snapshot diff stats for the compact thread-level change summary.
+ */
+export function summarizeThreadChangeStats(
+  snapshots: readonly Pick<TurnSnapshot, "files_changed">[],
+  perSnapshotStats: readonly (readonly SnapshotDiffStat[])[],
+): ThreadOverviewChangeSummary {
+  const files = new Set<string>();
+  for (const snapshot of snapshots) {
+    for (const file of snapshot.files_changed) files.add(file);
+  }
+
+  let additions = 0;
+  let deletions = 0;
+  for (const stats of perSnapshotStats) {
+    for (const stat of stats) {
+      files.add(stat.filePath);
+      additions += stat.additions;
+      deletions += stat.deletions;
+    }
+  }
+
+  return { files: files.size, additions, deletions };
+}
+
+/**
+ * Returns true when the compact summary should render a visible +/- total.
+ */
+export function hasVisibleThreadOverviewChangeSummary(
+  summary: ThreadOverviewChangeSummary,
+): boolean {
+  return summary.additions > 0 || summary.deletions > 0;
+}
+
+/**
+ * Resolves the Overview Changes row summary from the same priority as the
+ * Review default: latest turn, then unstaged worktree, then branch comparison.
+ */
+export async function resolveThreadOverviewChangeSummary({
+  thread,
+  snapshots,
+  transport,
+}: {
+  thread: Pick<Thread, "id" | "workspace_id">;
+  snapshots?: readonly TurnSnapshot[];
+  transport: ThreadOverviewChangeSummaryTransport;
+}): Promise<{ snapshots: TurnSnapshot[]; summary: ThreadOverviewChangeSummary }> {
+  const resolvedSnapshots = snapshots
+    ? [...snapshots]
+    : await transport.listSnapshots(thread.id).catch(() => []);
+  const latest = latestSnapshotWithChanges(resolvedSnapshots);
+
+  if (latest) {
+    const stats = await transport.getSnapshotDiffStats(latest.id).catch(() => []);
+    return {
+      snapshots: resolvedSnapshots,
+      summary: summarizeThreadChangeStats([latest], [stats]),
+    };
+  }
+
+  const unstagedFiles = await transport
+    .getWorkingTreeFiles(thread.workspace_id, false, thread.id)
+    .catch(() => []);
+  if (unstagedFiles.length > 0) {
+    const stat = await transport
+      .getReviewDiffStats({
+        workspaceId: thread.workspace_id,
+        view: "unstaged",
+        threadId: thread.id,
+      })
+      .catch(() => EMPTY_REVIEW_DIFF_STAT);
+    return {
+      snapshots: resolvedSnapshots,
+      summary: summarizeGitChangeStats(unstagedFiles, stat),
+    };
+  }
+
+  const comparison = await transport
+    .getBranchComparison(thread.workspace_id, thread.id)
+    .catch(() => null);
+  if (
+    !comparison ||
+    comparison.isUnborn ||
+    comparison.isComparisonAvailable === false ||
+    !comparison.base ||
+    !comparison.target
+  ) {
+    return { snapshots: resolvedSnapshots, summary: EMPTY_CHANGE_SUMMARY };
+  }
+
+  const [files, stat] = await Promise.all([
+    transport
+      .getBranchFiles(thread.workspace_id, comparison.base, comparison.target, thread.id)
+      .catch(() => []),
+    transport
+      .getReviewDiffStats({
+        workspaceId: thread.workspace_id,
+        view: "branch",
+        base: comparison.base,
+        target: comparison.target,
+        threadId: thread.id,
+      })
+      .catch(() => EMPTY_REVIEW_DIFF_STAT),
+  ]);
+
+  return {
+    snapshots: resolvedSnapshots,
+    summary: summarizeGitChangeStats(files, stat),
+  };
+}
+
+function branchRows(branches: readonly GitBranchRecord[], currentBranch: string): GitBranchRecord[] {
+  const localBranches = new Map<string, GitBranchRecord>();
+  for (const branch of branches) {
+    if (branch.type === "remote") continue;
+    if (!localBranches.has(branch.name)) localBranches.set(branch.name, branch);
+  }
+
+  if (!localBranches.has(currentBranch)) {
+    localBranches.set(currentBranch, {
+      name: currentBranch,
+      shortSha: "",
+      type: "local",
+      isCurrent: true,
+    });
+  }
+
+  return [...localBranches.values()].sort((a, b) => {
+    if (a.name === currentBranch) return -1;
+    if (b.name === currentBranch) return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+interface ThreadOverviewLocalMenuProps {
+  worktreePath: string | null;
+  branch: string;
+}
+
+function ThreadOverviewLocalMenu({ worktreePath, branch }: ThreadOverviewLocalMenuProps) {
+  const [copied, setCopied] = useState<LocalCopyTarget | null>(null);
+
+  const copyValue = useCallback(async (target: LocalCopyTarget, value: string) => {
+    await navigator.clipboard?.writeText(value);
+    setCopied(target);
+    window.setTimeout(() => setCopied(null), 1500);
+  }, []);
+
+  return (
+    <div data-testid="thread-overview-local-popover" className="animate-popover-enter p-2">
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5">
+          <span className="min-w-0">
+            <span className="block text-xs font-medium text-foreground">Worktree path</span>
+            <span
+              data-testid="thread-overview-local-path"
+              className="block max-w-56 truncate font-mono text-xs text-muted-foreground"
+            >
+              {worktreePath ?? "Unavailable"}
+            </span>
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            type="button"
+            aria-label="Copy worktree path"
+            disabled={!worktreePath}
+            onClick={() => {
+              if (worktreePath) void copyValue("path", worktreePath);
+            }}
+            className="shrink-0"
+          >
+            {copied === "path" ? <Check size={13} /> : <Copy size={13} />}
+          </Button>
+        </div>
+
+        <div className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5">
+          <span className="min-w-0">
+            <span className="block text-xs font-medium text-foreground">Branch</span>
+            <span
+              data-testid="thread-overview-local-branch"
+              className="block max-w-56 truncate font-mono text-xs text-muted-foreground"
+            >
+              {branch}
+            </span>
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            type="button"
+            aria-label="Copy branch"
+            onClick={() => void copyValue("branch", branch)}
+            className="shrink-0"
+          >
+            {copied === "branch" ? <Check size={13} /> : <Copy size={13} />}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ThreadOverviewBranchMenuProps {
+  thread: Thread;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function ThreadOverviewBranchMenu({
+  thread,
+  open,
+  onOpenChange,
+}: ThreadOverviewBranchMenuProps) {
+  const [search, setSearch] = useState("");
+  const [loaded, setLoaded] = useState<LoadedBranchState>({
+    status: "idle",
+    branches: [],
+    uncommittedFiles: null,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+    setLoaded((previous) => ({ ...previous, status: "loading" }));
+
+    const loadBranches = async () => {
+      try {
+        const [branches, unstaged, staged] = await Promise.all([
+          getTransport().listBranches(thread.workspace_id),
+          getTransport().getWorkingTreeFiles(thread.workspace_id, false, thread.id).catch(() => []),
+          getTransport().getWorkingTreeFiles(thread.workspace_id, true, thread.id).catch(() => []),
+        ]);
+
+        if (cancelled) return;
+        setLoaded({
+          status: "ready",
+          branches,
+          uncommittedFiles: new Set([...unstaged, ...staged]).size,
+        });
+      } catch {
+        if (!cancelled) {
+          setLoaded((previous) => ({ ...previous, status: "error" }));
+        }
+      }
+    };
+
+    void loadBranches();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, thread.id, thread.workspace_id]);
+
+  const branches = useMemo(
+    () => branchRows(loaded.branches, thread.branch),
+    [loaded.branches, thread.branch],
+  );
+  const visibleBranches = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return branches;
+    return branches.filter((branch) => branch.name.toLowerCase().includes(query));
+  }, [branches, search]);
+
+  const currentBranchUncommittedLabel =
+    loaded.uncommittedFiles !== null && loaded.uncommittedFiles > 0
+      ? uncommittedFilesLabel(loaded.uncommittedFiles)
+      : null;
+  const shouldConstrainBranchList = visibleBranches.length > 6;
+
+  return (
+    <div
+      data-testid="thread-overview-branch-popover"
+      className="animate-popover-enter p-2"
+    >
+      <div className="relative">
+        <Search
+          size={13}
+          aria-hidden
+          className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          size="xs"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search branches"
+          aria-label="Search branches"
+          className="h-7 pl-7"
+        />
+      </div>
+
+      <div className="px-1 pb-1 pt-3 text-xs text-muted-foreground">Branches</div>
+      <ScrollArea
+        data-testid="thread-overview-branch-list"
+        className={cn(shouldConstrainBranchList && "h-60")}
+      >
+        <div className="space-y-0.5 pr-2">
+          {loaded.status === "loading" && loaded.branches.length === 0
+            ? (
+                <div
+                  className="animate-thread-overview-loading h-8 overflow-hidden rounded-md bg-muted/35"
+                  aria-hidden
+                />
+              )
+            : null}
+
+          {loaded.status !== "loading" || loaded.branches.length > 0
+            ? visibleBranches.map((branch) => {
+                const isCurrent = branch.name === thread.branch || branch.isCurrent;
+                return (
+                  <Button
+                    key={branch.name}
+                    variant="ghost"
+                    size="sm"
+                    type="button"
+                    onClick={() => {
+                      if (isCurrent) onOpenChange(false);
+                    }}
+                    aria-current={isCurrent ? "true" : undefined}
+                    data-testid={isCurrent ? "thread-overview-current-branch" : undefined}
+                    className={cn(
+                      "h-auto w-full justify-between gap-3 px-2 py-1.5 text-left",
+                      isCurrent && "bg-muted text-foreground",
+                    )}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <GitBranch size={13} className="shrink-0 text-muted-foreground" />
+                      <span className="min-w-0">
+                        <span className="block truncate text-xs font-medium">{branch.name}</span>
+                        {isCurrent && currentBranchUncommittedLabel ? (
+                          <span className="block truncate text-xs font-normal text-muted-foreground">
+                            {currentBranchUncommittedLabel}
+                          </span>
+                        ) : null}
+                      </span>
+                    </span>
+                    {isCurrent ? <Check size={14} className="shrink-0 text-muted-foreground" /> : null}
+                  </Button>
+                );
+              })
+            : null}
+
+          {loaded.status !== "loading" && visibleBranches.length === 0 ? (
+            <div className="rounded-md px-2 py-2 text-xs text-muted-foreground">
+              No branches match
+            </div>
+          ) : null}
+
+          {loaded.status === "error" ? (
+            <div className="rounded-md px-2 py-2 text-xs text-muted-foreground">
+              Branches unavailable
+            </div>
+          ) : null}
+        </div>
+      </ScrollArea>
+
+      <Separator className="my-2" />
+      <Button
+        variant="ghost"
+        size="sm"
+        type="button"
+        disabled
+        className="h-8 w-full justify-start gap-2 px-2 text-xs disabled:opacity-60"
+      >
+        <Plus size={14} className="text-muted-foreground" />
+        Create and checkout new branch...
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Thread-scoped Overview popover for the chat header.
+ *
+ * It replaces the old workspace dropdown with status rows tied to the active
+ * thread: changed files, PR actions, and the thread's worktree mode.
+ */
+export function ThreadOverview({ thread }: ThreadOverviewProps) {
+  const [open, setOpen] = useState(false);
+  const [localOpen, setLocalOpen] = useState(false);
+  const [branchOpen, setBranchOpen] = useState(false);
+  const [loadedChangeSummary, setLoadedChangeSummary] = useState<{
+    threadId: string;
+    snapshotKey: string;
+    revision: number;
+    summary: ThreadOverviewChangeSummary;
+  } | null>(null);
+  const [changeSummaryStatus, setChangeSummaryStatus] = useState<LoadStatus>("idle");
+
+  const {
+    prable,
+    pr,
+    hasCommitsAhead,
+    checks,
+    openPrDetail,
+    dirPath,
+    createPrOpen,
+    setCreatePrOpen,
+    handleCommitOrPush,
+    handleOpenPr,
+  } = useThreadGitActions(thread);
+
+  const cachedSnapshots = useDiffStore((s) => s.snapshotsByThread[thread.id]);
+  const setSnapshots = useDiffStore((s) => s.setSnapshots);
+  const diffRevision = useDiffStore((s) => s.diffRevisionByScope[thread.id] ?? 0);
+  const cachedSnapshotKey = useMemo(() => snapshotKey(cachedSnapshots), [cachedSnapshots]);
+  const fallbackChangeSummary = useMemo(
+    () => {
+      const latest = latestSnapshotWithChanges(cachedSnapshots ?? []);
+      return latest ? summarizeThreadChangeStats([latest], []) : EMPTY_CHANGE_SUMMARY;
+    },
+    [cachedSnapshots],
+  );
+  const changeSummary =
+    loadedChangeSummary?.threadId === thread.id &&
+    loadedChangeSummary.snapshotKey === cachedSnapshotKey &&
+    loadedChangeSummary.revision === diffRevision
+      ? loadedChangeSummary.summary
+      : fallbackChangeSummary;
+  const showChangeSummary = hasVisibleThreadOverviewChangeSummary(changeSummary);
+  const isChangeSummaryLoading = open && changeSummaryStatus === "loading";
+
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+    setChangeSummaryStatus("loading");
+
+    const loadChangeSummary = async () => {
+      try {
+        const result = await resolveThreadOverviewChangeSummary({
+          thread: { id: thread.id, workspace_id: thread.workspace_id },
+          snapshots: cachedSnapshots,
+          transport: getTransport(),
+        });
+        if (cancelled) return;
+        if (!cachedSnapshots) setSnapshots(thread.id, result.snapshots);
+
+        setLoadedChangeSummary({
+          threadId: thread.id,
+          snapshotKey: snapshotKey(result.snapshots),
+          revision: diffRevision,
+          summary: result.summary,
+        });
+        setChangeSummaryStatus("ready");
+      } catch {
+        if (!cancelled) setChangeSummaryStatus("error");
+      }
+    };
+
+    void loadChangeSummary();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cachedSnapshotKey, cachedSnapshots, diffRevision, open, setSnapshots, thread.id, thread.workspace_id]);
+
+  const openChanges = useCallback(() => {
+    executeCommand("changes.toggle");
+  }, []);
+
+  const ciDot = useMemo(() => getThreadOverviewCiDot(pr, checks), [pr, checks]);
+  const modeLabel = thread.mode === "worktree" ? "Worktree" : "Direct";
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              title="Thread overview"
+              aria-label="Thread overview"
+              data-testid="header-workspace-menu"
+              className="relative cursor-pointer text-foreground/70 hover:bg-muted/40 hover:text-foreground"
+            >
+              <Menu size={14} />
+              {ciDot && (
+                <span
+                  data-testid={`thread-overview-ci-${ciDot}`}
+                  aria-hidden
+                  className={cn(
+                    "absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-background",
+                    ciDot === "red" && "bg-[var(--diff-remove-strong)]",
+                    ciDot === "green" && "bg-[var(--diff-add-strong)]",
+                  )}
+                />
+              )}
+            </Button>
+          }
+        />
+        <PopoverContent align="end" sideOffset={12} className="w-80 p-0">
+          <div className="animate-popover-enter p-1.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={openChanges}
+              data-testid="workspace-menu-changes"
+              aria-label={`Changes, ${changedFilesLabel(changeSummary.files)}`}
+              className="h-8 w-full cursor-pointer justify-between gap-3 px-2 text-left"
+            >
+              <span className="flex min-w-0 items-center gap-2">
+                <Diff size={14} className="shrink-0 text-muted-foreground" />
+                <span className="truncate text-xs font-medium">Changes</span>
+              </span>
+              {isChangeSummaryLoading ? (
+                <span
+                  data-testid="thread-overview-change-loading"
+                  aria-label="Loading changes"
+                  className="animate-thread-overview-loading h-3 w-14 shrink-0 overflow-hidden rounded-sm bg-muted/45"
+                />
+              ) : showChangeSummary ? (
+                <span
+                  data-testid="thread-overview-change-summary"
+                  aria-label={`${changeSummary.additions} additions, ${changeSummary.deletions} deletions`}
+                  className="flex shrink-0 items-center gap-1.5 font-mono text-xs tabular-nums"
+                >
+                  <span className="text-[var(--diff-add-strong)]">
+                    +{changeSummary.additions}
+                  </span>
+                  <span className="text-[var(--diff-remove-strong)]">
+                    -{changeSummary.deletions}
+                  </span>
+                </span>
+              ) : null}
+            </Button>
+
+            <Popover open={localOpen} onOpenChange={setLocalOpen}>
+              <PopoverTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    type="button"
+                    data-testid="thread-overview-local"
+                    aria-label={`${modeLabel}${dirPath ? `, ${dirPath}` : ""}`}
+                    className={cn(
+                      "h-8 w-full justify-between gap-3 px-2 text-left",
+                      localOpen && "bg-muted text-foreground",
+                    )}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Laptop size={14} className="shrink-0 text-muted-foreground" />
+                      <span className="truncate text-xs font-medium">Local</span>
+                    </span>
+                    <ChevronDown size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+                  </Button>
+                }
+              />
+              <PopoverContent
+                align="start"
+                side="left"
+                sideOffset={12}
+                className="w-80 p-0"
+              >
+                <ThreadOverviewLocalMenu worktreePath={dirPath} branch={thread.branch} />
+              </PopoverContent>
+            </Popover>
+
+            <Popover open={branchOpen} onOpenChange={setBranchOpen}>
+              <PopoverTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    type="button"
+                    data-testid="workspace-menu-branch"
+                    className={cn(
+                      "h-8 w-full justify-between gap-3 px-2 text-left",
+                      branchOpen && "bg-muted text-foreground",
+                    )}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <GitBranch size={14} className="shrink-0 text-muted-foreground" />
+                      <span className="truncate text-xs font-medium">{thread.branch}</span>
+                    </span>
+                    <ChevronDown size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+                  </Button>
+                }
+              />
+              <PopoverContent
+                align="start"
+                side="left"
+                sideOffset={12}
+                className="w-72 p-0"
+              >
+                <ThreadOverviewBranchMenu
+                  thread={thread}
+                  open={branchOpen}
+                  onOpenChange={setBranchOpen}
+                />
+              </PopoverContent>
+            </Popover>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCommitOrPush}
+              data-testid="workspace-menu-commit"
+              className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-xs"
+            >
+              <Upload size={14} className="text-muted-foreground" />
+              Commit or push
+            </Button>
+
+            {prable && !pr && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setCreatePrOpen(true)}
+                disabled={!hasCommitsAhead}
+                data-testid="workspace-menu-create-pr"
+                title={hasCommitsAhead === false ? "No commits ahead of base branch" : undefined}
+                className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-xs disabled:cursor-not-allowed"
+              >
+                <GitPullRequest size={14} className="text-muted-foreground" />
+                Create PR
+              </Button>
+            )}
+
+            {prable && pr && (
+              <div data-testid="thread-overview-pr" className="px-2 py-1.5">
+                <PrSplitButton
+                  pr={pr}
+                  hasCommitsAhead={hasCommitsAhead}
+                  onCreatePr={() => setCreatePrOpen(true)}
+                  onOpenPr={handleOpenPr}
+                  checks={checks}
+                  threadId={thread.id}
+                  prTitle={openPrDetail?.title}
+                  prAuthor={openPrDetail?.author}
+                />
+              </div>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {prable && (
+        <CreatePrDialog
+          open={createPrOpen}
+          onOpenChange={setCreatePrOpen}
+          threadId={thread.id}
+          workspaceId={thread.workspace_id}
+          branch={thread.branch}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -182,9 +182,48 @@
 .animate-chip-enter {
   animation: chip-enter 150ms ease-out;
 }
+@keyframes popover-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-2px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+.animate-popover-enter {
+  animation: popover-enter 160ms cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: top right;
+}
+@keyframes thread-overview-loading {
+  from { transform: translateX(-120%); }
+  to { transform: translateX(220%); }
+}
+.animate-thread-overview-loading {
+  position: relative;
+  isolation: isolate;
+}
+.animate-thread-overview-loading::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in oklch, var(--foreground), transparent 88%),
+    transparent
+  );
+  transform: translateX(-120%);
+  animation: thread-overview-loading 1.2s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  will-change: transform;
+}
 @media (prefers-reduced-motion: reduce) {
   .animate-fade-up-in,
   .animate-chip-enter,
+  .animate-popover-enter,
+  .animate-thread-overview-loading::after,
   .animate-collapsible-down,
   .animate-collapsible-up {
     animation: none;


### PR DESCRIPTION
## What
Adds the thread Overview popover to the chat header.

## Why
Issue #761 asks for a compact place to inspect thread-local git context and next actions from the header.

## Key Changes
- Replaces the old workspace dropdown contents with a ThreadOverview component for Changes, Local, Branch, Commit or push, and PR actions.
- Adds change-summary resolution from the latest turn snapshot, unstaged worktree changes, then branch comparison.
- Adds Local and Branch flyouts for copyable worktree details, branch search, uncommitted counts, loading states, and capped long lists.
- Adds focused unit and Playwright coverage for the overview rows, copy actions, change summary, and branch flyout sizing.

Closes #761

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784386665&installation_id=129163861&pr_number=789&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F789&signature=903ff0c35b79f900a50bf2cbf6330ff56141d24f6f4ce8801bcbd96324380613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced popover menu in chat header for thread overview actions, including managing changes, branches, and PR creation.
  * Added local and branch submenus with copy-to-clipboard functionality.
  * Integrated CI status indicator dots for thread overview.
  * Added smooth animations for popover entrance and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->