### PR TITLE
feat: polish thread overview and web links

### DIFF
--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -122,7 +122,10 @@ test.describe("Consolidated chat header", () => {
   // modal that intercepts the toggle click) on a wide desktop viewport.
   test.use({ viewport: { width: 1920, height: 1080 } });
 
+  let remoteUrlCalls: unknown[] = [];
+
   test.beforeEach(async ({ page }) => {
+    remoteUrlCalls = [];
     await page.addInitScript((wsId: string) => {
       localStorage.setItem(
         "mcode-expanded-projects",
@@ -138,6 +141,15 @@ test.describe("Consolidated chat header", () => {
           },
         },
       });
+    });
+    await page.addInitScript(() => {
+      const openedUrls: string[] = [];
+      (window as unknown as { __mcodeOpenedExternalUrls?: string[] })
+        .__mcodeOpenedExternalUrls = openedUrls;
+      window.open = ((url?: string | URL) => {
+        openedUrls.push(String(url ?? ""));
+        return null;
+      }) as typeof window.open;
     });
 
     await mockWebSocketServer(page, {
@@ -164,6 +176,13 @@ test.describe("Consolidated chat header", () => {
       "git.listBranches": async () => {
         await new Promise((resolve) => setTimeout(resolve, 250));
         return branches;
+      },
+      "git.getRemoteUrl": (params) => {
+        remoteUrlCalls.push(params);
+        return {
+          label: "Mzeey-Empire/mcode",
+          webUrl: "https://github.com/Mzeey-Empire/mcode",
+        };
       },
       "git.workingTreeFiles": (params) =>
         (params as { staged?: boolean } | undefined)?.staged
@@ -194,6 +213,7 @@ test.describe("Consolidated chat header", () => {
     await expect(page.locator('[data-slot="popover-content"]').first()).toBeVisible();
     await expect(page.getByText("Environment", { exact: true })).toHaveCount(0);
     await expect(page.getByTestId("workspace-menu-changes")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-repository")).toBeVisible();
     await expect(page.getByTestId("thread-overview-local")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-branch")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-commit")).toBeVisible();
@@ -202,6 +222,31 @@ test.describe("Consolidated chat header", () => {
     await expect(page.locator(".animate-popover-enter").first()).toBeVisible();
 
     await expect(page.getByTestId("thread-overview-local")).toContainText("Local");
+    await expect(page.getByTestId("thread-overview-repository")).toContainText(
+      "Repository",
+    );
+    await expect(page.getByTestId("thread-overview-repository")).toContainText(
+      "Mzeey-Empire/mcode",
+    );
+    await expect(page.getByTestId("thread-overview-repository-favicon-frame")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-repository-favicon")).toHaveAttribute(
+      "src",
+      "https://github.com/favicon.ico",
+    );
+    await expect(page.getByTestId("thread-overview-repository-favicon")).toHaveCSS(
+      "filter",
+      /drop-shadow/,
+    );
+    expect(remoteUrlCalls).toContainEqual({ workspaceId: WS_ID, threadId: thread.id });
+    await page.getByTestId("thread-overview-repository").click();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as unknown as { __mcodeOpenedExternalUrls?: string[] })
+            .__mcodeOpenedExternalUrls?.at(-1),
+        ),
+      )
+      .toBe("https://github.com/Mzeey-Empire/mcode");
     await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/consolidated-header");
     await expect(page.getByTestId("thread-overview-change-loading")).toBeVisible();
     await expect(page.getByTestId("thread-overview-change-loading")).toHaveClass(

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -115,6 +115,28 @@ const branches = [
   },
 ];
 
+/** The Overview body, whether docked (reflowed) or floating (popover). */
+const overviewContent = (page: import("@playwright/test").Page) =>
+  page.getByTestId("thread-overview-body");
+
+/** Opens the Overview if it isn't already (it auto-opens on wide viewports). */
+async function ensureOverviewOpen(page: import("@playwright/test").Page) {
+  const content = overviewContent(page);
+  if (!(await content.isVisible().catch(() => false))) {
+    await page.getByTestId("header-workspace-menu").click();
+  }
+  await expect(content).toBeVisible();
+}
+
+/** Closes the Overview if it auto-opened, so closed-state assertions are stable. */
+async function ensureOverviewClosed(page: import("@playwright/test").Page) {
+  const content = overviewContent(page);
+  if (await content.isVisible().catch(() => false)) {
+    await page.getByTestId("header-workspace-menu").click();
+  }
+  await expect(content).toBeHidden();
+}
+
 test.describe("Consolidated chat header", () => {
   // Dock the right panel inline (not as a modal overlay) so the header toggle
   // stays clickable for the show/hide assertions. The default panel width is 50%
@@ -199,6 +221,7 @@ test.describe("Consolidated chat header", () => {
   });
 
   test("keeps Open and the Overview controls visible; Create PR lives in the popover", async ({ page }) => {
+    await ensureOverviewClosed(page);
     await expect(page.getByRole("button", { name: /^open in /i })).toBeVisible();
     await expect(page.getByTestId("header-workspace-menu")).toBeVisible();
     await expect(page.getByTestId("header-panel-toggle")).toBeVisible();
@@ -208,9 +231,9 @@ test.describe("Consolidated chat header", () => {
   });
 
   test("Overview popover holds changes, local, branch, commit, and PR actions", async ({ page }) => {
-    await page.getByTestId("header-workspace-menu").click();
+    await ensureOverviewOpen(page);
 
-    await expect(page.locator('[data-slot="popover-content"]').first()).toBeVisible();
+    await expect(page.getByTestId("thread-overview-body")).toBeVisible();
     await expect(page.getByText("Environment", { exact: true })).toHaveCount(0);
     await expect(page.getByTestId("workspace-menu-changes")).toBeVisible();
     await expect(page.getByTestId("thread-overview-repository")).toBeVisible();
@@ -219,11 +242,11 @@ test.describe("Consolidated chat header", () => {
     await expect(page.getByTestId("workspace-menu-commit")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
     await expect(page.getByTestId("thread-overview-sources")).toHaveCount(0);
-    await expect(page.locator(".animate-popover-enter").first()).toBeVisible();
+    await expect(page.locator(".animate-overview-enter").first()).toBeVisible();
 
     await expect(page.getByTestId("thread-overview-local")).toContainText("Local");
     await expect(page.getByTestId("thread-overview-repository")).toContainText(
-      "Repository",
+      "REPOSITORY",
     );
     await expect(page.getByTestId("thread-overview-repository")).toContainText(
       "Mzeey-Empire/mcode",
@@ -235,10 +258,10 @@ test.describe("Consolidated chat header", () => {
     );
     await expect(page.getByTestId("thread-overview-repository-favicon")).toHaveCSS(
       "filter",
-      /drop-shadow/,
+      "invert(1)",
     );
     expect(remoteUrlCalls).toContainEqual({ workspaceId: WS_ID, threadId: thread.id });
-    await page.getByTestId("thread-overview-repository").click();
+    await page.getByTestId("thread-overview-repository-link").click();
     await expect
       .poll(() =>
         page.evaluate(() =>
@@ -248,10 +271,6 @@ test.describe("Consolidated chat header", () => {
       )
       .toBe("https://github.com/Mzeey-Empire/mcode");
     await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/consolidated-header");
-    await expect(page.getByTestId("thread-overview-change-loading")).toBeVisible();
-    await expect(page.getByTestId("thread-overview-change-loading")).toHaveClass(
-      /animate-thread-overview-loading/,
-    );
     await expect(page.getByTestId("thread-overview-change-summary")).toContainText("+233");
     await expect(page.getByTestId("thread-overview-change-summary")).toContainText("-0");
     await expect(page.getByTestId("workspace-menu-changes")).toHaveCSS("cursor", "pointer");
@@ -313,9 +332,26 @@ test.describe("Consolidated chat header", () => {
     const toggle = page.getByTestId("header-panel-toggle");
     await expect(toggle).toHaveAttribute("aria-pressed", "false");
 
-    await page.getByTestId("header-workspace-menu").click();
+    await ensureOverviewOpen(page);
     await page.getByTestId("workspace-menu-changes").click();
 
     await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("auto-opens the Overview when the viewport has room", async ({ page }) => {
+    // Wide describe viewport (1920px) leaves room, so the Overview sits open
+    // without a click. It steps aside on narrow viewports / when cramped.
+    await expect(overviewContent(page)).toBeVisible();
+    await expect(page.getByTestId("thread-overview-repository")).toBeVisible();
+  });
+
+  test("keeps the thread centered when the Overview has room beside it", async ({ page }) => {
+    await ensureOverviewOpen(page);
+
+    const messageAreaPaddingRight = await page
+      .locator("[data-testid='chat-view'] > .animate-fade-up-in")
+      .evaluate((node) => getComputedStyle(node).paddingRight);
+
+    expect(messageAreaPaddingRight).toBe("0px");
   });
 });

--- a/apps/web/e2e/overview-sources-demo.spec.ts
+++ b/apps/web/e2e/overview-sources-demo.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "@playwright/test";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+
+/**
+ * Visual demo: the Overview popover (repository row + Sources favicon grid),
+ * its space-aware auto-open, and humanized inline links in the transcript.
+ * Captures screenshots to e2e/screenshots/demo/ for review without a live app.
+ */
+
+const now = new Date("2026-06-19T00:00:00.000Z").toISOString();
+const WS_ID = "ws-demo";
+
+const workspace = {
+  id: WS_ID,
+  name: "CaravanFE",
+  path: "/tmp/caravanfe",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+const thread = {
+  id: "thread-demo",
+  workspace_id: WS_ID,
+  title: "Logo work",
+  status: "paused" as const,
+  mode: "worktree" as const,
+  worktree_path: "/tmp/caravanfe/.worktrees/feat-x",
+  branch: "feat/logo",
+  worktree_managed: true,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const baseMsg = {
+  thread_id: thread.id,
+  tool_calls: null,
+  files_changed: null,
+  cost_usd: null,
+  tokens_used: null,
+  timestamp: now,
+  attachments: null,
+  tool_call_count: 0,
+};
+
+const userMessage = {
+  ...baseMsg,
+  id: "user-demo",
+  role: "user" as const,
+  content: "we have been slapped with a subscribe page. any alternatives?",
+  sequence: 1,
+};
+
+const assistantMessage = {
+  ...baseMsg,
+  id: "assistant-demo",
+  role: "assistant" as const,
+  content: [
+    "Yep. Alternatives:",
+    "",
+    "1. SVGTrace: free, color SVG, layered output. https://svgtrace.com/",
+    "2. Adobe Express SVG converter: https://www.adobe.com/express/feature/image/convert/svg",
+    "3. Recraft SVG converter: https://www.recraft.ai/ai-image-vectorizer",
+    "4. The repo lives at https://github.com/milex-consulting/CaravanFE",
+    "5. Tracking issue: https://github.com/milex-consulting/CaravanFE/issues/42",
+    "",
+    "My pick: try SVGTrace next.",
+  ].join("\n"),
+  sequence: 2,
+};
+
+test.use({ viewport: { width: 1920, height: 1080 } });
+
+test("Overview sources + humanized links demo", async ({ page }) => {
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [thread],
+    "conversation.page": {
+      messages: [userMessage, assistantMessage],
+      hasMore: false,
+      answeredPlanMessageIds: [],
+      narrativeByMessage: {},
+    },
+    "narrative.list": { tools: [], thoughts: [], hooks: [] },
+    "github.branchPr": null,
+    "git.log": [{ sha: "abc1234", message: "feat: work", author: "Tester", date: now }],
+    "snapshot.listByThread": [],
+    "git.listBranches": [
+      { name: "feat/logo", shortSha: "abc1234", type: "local", isCurrent: true },
+    ],
+    "git.getRemoteUrl": {
+      label: "milex-consulting/CaravanFE",
+      webUrl: "https://github.com/milex-consulting/CaravanFE",
+    },
+    "git.workingTreeFiles": [],
+  });
+
+  await page.addInitScript((wsId: string) => {
+    localStorage.setItem("mcode-expanded-projects", JSON.stringify({ [wsId]: true }));
+  }, WS_ID);
+  await page.goto("/");
+  await page.waitForSelector("[data-testid='thread-item']");
+  await page.locator("[data-testid='thread-item']").first().click();
+  await page.waitForSelector("[data-testid='chat-header-title']");
+
+  // Humanized inline links in the transcript.
+  await expect(page.getByText("milex-consulting/CaravanFE#42")).toBeVisible();
+  await page.screenshot({ path: "e2e/screenshots/demo/transcript-humanized-links.png", fullPage: false });
+
+  // Wide viewport: the Overview opens by default and shows repo + Sources.
+  await expect(page.getByTestId("thread-overview-body")).toBeVisible();
+  await expect(page.getByTestId("thread-overview-repository")).toBeVisible();
+  await expect(page.getByTestId("thread-overview-sources")).toBeVisible();
+  const sourceCount = await page.getByTestId("thread-overview-source").count();
+  expect(sourceCount).toBeGreaterThanOrEqual(5);
+  await page.screenshot({ path: "e2e/screenshots/demo/overview-auto-open-sources.png", fullPage: false });
+
+  // Clicking elsewhere does not close the Overview; only the trigger/Escape do.
+  await page.getByTestId("chat-header-title").click();
+  await expect(page.getByTestId("thread-overview-body")).toBeVisible();
+
+  // Narrow viewport: the Overview steps aside (does not auto-open).
+  await page.setViewportSize({ width: 900, height: 900 });
+  await expect(page.getByTestId("thread-overview-body")).toHaveCount(0);
+  await page.screenshot({ path: "e2e/screenshots/demo/overview-narrow-closed.png", fullPage: false });
+
+  // Opened by hand on a small view, it floats over the chat (no reserved space).
+  await page.getByTestId("header-workspace-menu").click();
+  await expect(page.getByTestId("thread-overview-body")).toBeVisible();
+  await page.screenshot({ path: "e2e/screenshots/demo/overview-narrow-floating.png", fullPage: false });
+});

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -57,6 +57,17 @@ describe("MarkdownContent link handling", () => {
     expect(mockOpenExternalUrl).toHaveBeenCalledWith("https://example.com");
   });
 
+  it("renders assistant https links with a contrast-safe favicon", () => {
+    const { container } = render(<MarkdownContent content="[click me](https://example.com/path)" />);
+    const link = container.querySelector("a");
+    const favicon = screen.getByTestId("markdown-link-favicon");
+
+    expect(link).toHaveClass("text-primary");
+    expect(screen.getByTestId("markdown-link-favicon-frame")).toBeInTheDocument();
+    expect(favicon).toHaveAttribute("src", "https://example.com/favicon.ico");
+    expect(favicon.getAttribute("style")).toContain("drop-shadow");
+  });
+
   it("calls desktopBridge.openExternalUrl for http links", () => {
     render(<MarkdownContent content="[click](http://example.com)" />);
     const link = screen.getByText("click");
@@ -346,6 +357,15 @@ describe("MarkdownContent variant styling", () => {
       );
       const link = container.querySelector("a");
       expect(link?.className).toContain("text-primary-foreground");
+    });
+
+    it("renders user links with the same favicon treatment", () => {
+      render(<MarkdownContent content="[link](https://example.com)" variant="user" />);
+      expect(screen.getByTestId("markdown-link-favicon-frame")).toBeInTheDocument();
+      expect(screen.getByTestId("markdown-link-favicon")).toHaveAttribute(
+        "src",
+        "https://example.com/favicon.ico",
+      );
     });
 
     it("renders blockquote with border-primary-foreground/40", () => {

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -65,7 +65,50 @@ describe("MarkdownContent link handling", () => {
     expect(link).toHaveClass("text-primary");
     expect(screen.getByTestId("markdown-link-favicon-frame")).toBeInTheDocument();
     expect(favicon).toHaveAttribute("src", "https://example.com/favicon.ico");
-    expect(favicon.getAttribute("style")).toContain("drop-shadow");
+    expect(favicon).toHaveClass("favicon-image-shadow");
+  });
+
+  it("renders inline links without a chip background", () => {
+    const { container } = render(<MarkdownContent content="[click me](https://example.com)" />);
+    const link = container.querySelector("a");
+
+    expect(link?.className).not.toContain("bg-muted");
+    expect(link?.className).not.toContain("ring-1");
+    expect(link?.className).toContain("hover:underline");
+  });
+
+  it("renders GitHub links with the bare themed mark, not the contrast frame", () => {
+    render(<MarkdownContent content="[repo](https://github.com/owner/repo)" />);
+    const favicon = screen.getByTestId("markdown-link-favicon");
+
+    expect(favicon).toHaveClass("github-favicon-mark");
+    expect(favicon).not.toHaveClass("favicon-image-shadow");
+    expect(screen.getByTestId("markdown-link-favicon-frame").className).not.toContain("ring-1");
+  });
+
+  it("shows a bare GitHub repo URL as owner/repo but opens the full URL", () => {
+    render(<MarkdownContent content="https://github.com/milex-consulting/CaravanFE" />);
+    const link = screen.getByText("milex-consulting/CaravanFE");
+
+    expect(link.closest("a")).toHaveAttribute("title", "https://github.com/milex-consulting/CaravanFE");
+    fireEvent.click(link);
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith("https://github.com/milex-consulting/CaravanFE");
+  });
+
+  it("shows a bare GitHub issue URL as owner/repo#number", () => {
+    render(<MarkdownContent content="https://github.com/milex-consulting/CaravanFE/issues/42" />);
+    expect(screen.getByText("milex-consulting/CaravanFE#42")).toBeInTheDocument();
+  });
+
+  it("compacts a bare non-GitHub URL to host/path, dropping the protocol", () => {
+    render(<MarkdownContent content="https://www.example.com/docs/start/" />);
+    expect(screen.getByText("example.com/docs/start")).toBeInTheDocument();
+  });
+
+  it("never rewrites authored link text", () => {
+    render(<MarkdownContent content="[the repo](https://github.com/milex-consulting/CaravanFE)" />);
+    expect(screen.getByText("the repo")).toBeInTheDocument();
+    expect(screen.queryByText("milex-consulting/CaravanFE")).not.toBeInTheDocument();
   });
 
   it("calls desktopBridge.openExternalUrl for http links", () => {

--- a/apps/web/src/__tests__/message-sources.test.ts
+++ b/apps/web/src/__tests__/message-sources.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { extractThreadSources } from "../lib/message-sources";
+
+type Msg = { role: "user" | "assistant"; content: string };
+
+const msg = (role: Msg["role"], content: string): Msg => ({ role, content });
+
+describe("extractThreadSources", () => {
+  it("collects assistant links and derives HTTPS favicons", () => {
+    const sources = extractThreadSources([
+      msg("assistant", "See https://github.com/milex-consulting/CaravanFE for the repo."),
+    ]);
+    expect(sources).toEqual([
+      {
+        url: "https://github.com/milex-consulting/CaravanFE",
+        faviconUrl: "https://github.com/favicon.ico",
+      },
+    ]);
+  });
+
+  it("ignores user-pasted links", () => {
+    const sources = extractThreadSources([
+      msg("user", "https://example.com/from-user"),
+      msg("assistant", "Try https://example.com/from-assistant"),
+    ]);
+    expect(sources.map((s) => s.url)).toEqual(["https://example.com/from-assistant"]);
+  });
+
+  it("dedupes by full URL in first-seen order", () => {
+    const sources = extractThreadSources([
+      msg("assistant", "https://a.com/x and https://b.com/y"),
+      msg("assistant", "again https://a.com/x"),
+    ]);
+    expect(sources.map((s) => s.url)).toEqual(["https://a.com/x", "https://b.com/y"]);
+  });
+
+  it("strips trailing prose punctuation from URLs", () => {
+    const sources = extractThreadSources([msg("assistant", "Open https://example.com/page.")]);
+    expect(sources[0].url).toBe("https://example.com/page");
+  });
+
+  it("returns null favicon for http (non-HTTPS) hosts", () => {
+    const sources = extractThreadSources([msg("assistant", "http://insecure.test/path")]);
+    expect(sources[0]).toEqual({ url: "http://insecure.test/path", faviconUrl: null });
+  });
+
+  it("ignores non-http schemes", () => {
+    const sources = extractThreadSources([
+      msg("assistant", "mailto:x@y.com and ftp://z.com and javascript:alert(1)"),
+    ]);
+    expect(sources).toEqual([]);
+  });
+
+  it("bounds the result to 32 sources", () => {
+    const links = Array.from({ length: 50 }, (_, i) => `https://example.com/${i}`).join(" ");
+    const sources = extractThreadSources([msg("assistant", links)]);
+    expect(sources).toHaveLength(32);
+  });
+});

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -10,6 +10,7 @@ import { useThreadStore } from "@/stores/threadStore";
 import { useActiveThreadRecord, readThreadRecord } from "@/stores/thread-selectors";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useComposerDraftStore } from "@/stores/composerDraftStore";
+import { useOverviewStore } from "@/stores/overviewStore";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { MessageList } from "./MessageList";
@@ -27,6 +28,7 @@ import { useUiStore } from "@/stores/uiStore";
 import { preparingStatusLabel, type WorkspaceThread } from "@/lib/workspace-thread";
 import { useReplyStore } from "@/stores/replyStore";
 import { getTransport } from "@/transport";
+import { overviewResponsivePaddingRight } from "@/lib/composer-layout";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -202,6 +204,8 @@ export function ChatView() {
 
   const connectionStatus = useConnectionStore((s) => s.status);
   const sendMessage = useThreadStore((s) => s.sendMessage);
+  const reserveOverviewSpace = useOverviewStore((s) => s.reserveSpace);
+  const overviewPaddingRight = reserveOverviewSpace ? overviewResponsivePaddingRight() : undefined;
 
   const handleDismissCliError = useCallback(() => {
     setDismissedError(sessionError);
@@ -515,7 +519,10 @@ export function ChatView() {
           No `key` here: forcing remount on thread switch would destroy the
           virtualizer and discard cached row heights. MessageList resets its
           own per-thread state imperatively in a useEffect on activeThreadId. */}
-      <div className="animate-fade-up-in flex-1 min-h-0">
+      <div
+        className="animate-fade-up-in flex-1 min-h-0 transition-[padding] duration-200"
+        style={{ paddingRight: overviewPaddingRight }}
+      >
         {showEmptyState ? (
           <div className="flex h-full items-center justify-center">
             <EmptyState onPromptSelect={setPendingPrefill} />
@@ -535,7 +542,10 @@ export function ChatView() {
       )}
 
       {/* Composer area — plan question wizard floats above the composer input */}
-      <div className="relative flex-shrink-0">
+      <div
+        className="relative flex-shrink-0 transition-[padding] duration-200"
+        style={{ paddingRight: overviewPaddingRight }}
+      >
         <PlanQuestionWizard threadId={activeThread.id} />
         <Composer
           threadId={activeThread.id}

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -29,7 +29,10 @@ vi.mock("@/stores/terminalStore", () => ({
   ),
 }));
 
-vi.mock("@/stores/diffStore", () => {
+vi.mock("@/stores/diffStore", async (importOriginal) => {
+  // Keep the real width constants and layout helpers (composer-layout imports
+  // them); override only the store hook so the Overview reads stub panel state.
+  const actual = await importOriginal<typeof import("@/stores/diffStore")>();
   const getRightPanel = vi.fn().mockReturnValue({ visible: false, width: 380, activeTab: "tasks" });
   const actions = {
     getRightPanel,
@@ -38,6 +41,7 @@ vi.mock("@/stores/diffStore", () => {
     hideRightPanel: vi.fn(),
     toggleRightPanel: vi.fn(),
     setRightPanelTab: vi.fn(),
+    setRightPanelWidth: vi.fn(),
     setSnapshots: vi.fn(),
   };
   const store = Object.assign(
@@ -51,7 +55,7 @@ vi.mock("@/stores/diffStore", () => {
     ),
     { getState: vi.fn().mockReturnValue(actions) },
   );
-  return { useDiffStore: store };
+  return { ...actual, useDiffStore: store };
 });
 
 vi.mock("./OpenInAppButton", () => ({
@@ -296,7 +300,7 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.queryByText("Environment")).not.toBeInTheDocument();
     expect(screen.getByTestId("workspace-menu-changes")).toHaveTextContent("Changes");
     expect(screen.queryByTestId("thread-overview-change-summary")).not.toBeInTheDocument();
-    expect(screen.getByTestId("thread-overview-repository")).toHaveTextContent("Repository");
+    expect(screen.queryByTestId("thread-overview-repository")).not.toBeInTheDocument();
     expect(screen.getByTestId("thread-overview-local")).toHaveTextContent("Local");
     expect(screen.getByTestId("thread-overview-local")).toHaveAttribute(
       "aria-label",

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -93,9 +93,12 @@ vi.mock("@/hooks/useHasCommitsAhead", () => ({
 
 import { HeaderActions } from "./HeaderActions";
 import {
+  getRepositoryFaviconUrl,
+  getSafeRepositoryWebUrl,
   getThreadOverviewCiDot,
   hasVisibleThreadOverviewChangeSummary,
   resolveThreadOverviewChangeSummary,
+  resolveThreadOverviewRepository,
   summarizeThreadChangeStats,
 } from "./ThreadOverview";
 
@@ -293,6 +296,7 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.queryByText("Environment")).not.toBeInTheDocument();
     expect(screen.getByTestId("workspace-menu-changes")).toHaveTextContent("Changes");
     expect(screen.queryByTestId("thread-overview-change-summary")).not.toBeInTheDocument();
+    expect(screen.getByTestId("thread-overview-repository")).toHaveTextContent("Repository");
     expect(screen.getByTestId("thread-overview-local")).toHaveTextContent("Local");
     expect(screen.getByTestId("thread-overview-local")).toHaveAttribute(
       "aria-label",
@@ -325,6 +329,62 @@ describe("HeaderActions - consolidated header", () => {
     render(<HeaderActions thread={makeThread({ mode: "direct" })} />);
     expect(screen.getByTestId("header-workspace-menu")).toBeInTheDocument();
     expect(screen.getByTestId("header-panel-toggle")).toBeInTheDocument();
+  });
+});
+
+describe("Thread Overview repository helpers", () => {
+  it("keeps only HTTPS repository URLs for external open actions", () => {
+    expect(getSafeRepositoryWebUrl("https://github.com/Mzeey-Empire/mcode")).toBe(
+      "https://github.com/Mzeey-Empire/mcode",
+    );
+    expect(getSafeRepositoryWebUrl("http://github.com/Mzeey-Empire/mcode")).toBeNull();
+    expect(getSafeRepositoryWebUrl("javascript:alert(1)")).toBeNull();
+    expect(getSafeRepositoryWebUrl("not a url")).toBeNull();
+    expect(getSafeRepositoryWebUrl(null)).toBeNull();
+  });
+
+  it("derives a favicon URL from the safe repository origin", () => {
+    expect(getRepositoryFaviconUrl("https://github.com/Mzeey-Empire/mcode")).toBe(
+      "https://github.com/favicon.ico",
+    );
+    expect(getRepositoryFaviconUrl("http://github.com/Mzeey-Empire/mcode")).toBeNull();
+  });
+
+  it("resolves repository metadata for the active thread checkout", async () => {
+    const getRemoteUrl = vi.fn().mockResolvedValue({
+      label: "Mzeey-Empire/mcode",
+      webUrl: "https://github.com/Mzeey-Empire/mcode",
+    });
+
+    await expect(
+      resolveThreadOverviewRepository({
+        thread: { id: "thread-1", workspace_id: "ws-1" },
+        transport: { getRemoteUrl },
+      }),
+    ).resolves.toEqual({
+      label: "Mzeey-Empire/mcode",
+      webUrl: "https://github.com/Mzeey-Empire/mcode",
+      faviconUrl: "https://github.com/favicon.ico",
+    });
+    expect(getRemoteUrl).toHaveBeenCalledWith("ws-1", "thread-1");
+  });
+
+  it("keeps local-only repository metadata non-clickable", async () => {
+    await expect(
+      resolveThreadOverviewRepository({
+        thread: { id: "thread-1", workspace_id: "ws-1" },
+        transport: {
+          getRemoteUrl: vi.fn().mockResolvedValue({
+            label: "local-only",
+            webUrl: null,
+          }),
+        },
+      }),
+    ).resolves.toEqual({
+      label: "local-only",
+      webUrl: null,
+      faviconUrl: null,
+    });
   });
 });
 

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -2,15 +2,18 @@ import { memo, useMemo, lazy, Suspense } from "react";
 import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
+import { ExternalLink } from "lucide-react";
 import {
   isMcodeWorkspacePreviewUrl,
   mcodeWorkspacePreviewHref,
   looksLikeWorkspaceRelativeFileRef,
 } from "@mcode/contracts";
 import { CodeBlock } from "./CodeBlock";
+import { Favicon } from "@/components/ui/favicon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { resolveCodeBlockLanguage } from "@/lib/resolve-code-block-language";
 import { isMac } from "@/lib/platform";
+import { cn } from "@/lib/utils";
 import {
   isModifierClick,
   isPreviewableUrl,
@@ -93,6 +96,108 @@ function handleLinkClick(e: React.MouseEvent | React.KeyboardEvent, url: string)
   }
 }
 
+function resolveMarkdownHref(href: string | undefined, workspacePath: string | null): string | undefined {
+  if (!href) return undefined;
+  const raw = href.trim();
+  if (isMcodeWorkspacePreviewUrl(raw)) return raw;
+  if (workspacePath && looksLikeWorkspaceRelativeFileRef(raw)) {
+    return mcodeWorkspacePreviewHref(raw);
+  }
+
+  try {
+    const { protocol } = new URL(raw);
+    if (protocol === "https:" || protocol === "http:" || protocol === "mailto:") {
+      return raw;
+    }
+  } catch {
+    /* invalid URL */
+  }
+  return undefined;
+}
+
+function getLinkFaviconUrl(href: string | undefined): string | null {
+  if (!href) return null;
+  try {
+    const url = new URL(href);
+    if (url.protocol !== "https:") return null;
+    return `${url.origin}/favicon.ico`;
+  } catch {
+    return null;
+  }
+}
+
+interface MarkdownLinkProps {
+  href?: string;
+  children?: React.ReactNode;
+  variant: "assistant" | "user";
+  workspacePath: string | null;
+}
+
+function MarkdownLink({
+  href,
+  children,
+  variant,
+  workspacePath,
+}: MarkdownLinkProps) {
+  const isUser = variant === "user";
+  const safeHref = resolveMarkdownHref(href, workspacePath);
+  const isPreviewable = !!safeHref && isPreviewableUrl(safeHref);
+  const showHint = isPreviewable && hasPreview();
+  const faviconUrl = getLinkFaviconUrl(safeHref);
+  const anchor = (
+    <a
+      href={safeHref}
+      className={cn(
+        "inline-flex max-w-full items-center gap-1 rounded-[min(var(--radius-md),10px)] px-1.5 py-0.5 align-baseline no-underline ring-1 transition-colors",
+        isUser
+          ? "bg-primary-foreground/10 text-primary-foreground ring-primary-foreground/20 hover:bg-primary-foreground/15 hover:text-primary-foreground"
+          : "bg-muted/45 text-primary ring-border/60 hover:bg-muted hover:text-primary",
+      )}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-testid="markdown-link"
+      title={safeHref}
+      onClick={(e) => {
+        if (!safeHref) return;
+        if (isPreviewable) return handleLinkClick(e, safeHref);
+        e.preventDefault();
+        if (window.desktopBridge?.openExternalUrl) {
+          void window.desktopBridge.openExternalUrl(safeHref);
+        } else {
+          window.open(safeHref, "_blank", "noopener,noreferrer");
+        }
+      }}
+    >
+      <Favicon
+        src={faviconUrl}
+        frameTestId="markdown-link-favicon-frame"
+        imageTestId="markdown-link-favicon"
+        className="size-3.5 rounded-[3px]"
+        imageClassName="size-3 rounded-[2px]"
+      />
+      <span className="min-w-0 truncate">{children}</span>
+      {safeHref ? (
+        <ExternalLink
+          size={12}
+          aria-hidden
+          className={cn(
+            "shrink-0",
+            isUser ? "text-primary-foreground/75" : "text-muted-foreground",
+          )}
+        />
+      ) : null}
+    </a>
+  );
+
+  if (!showHint) return anchor;
+  return (
+    <Tooltip>
+      <TooltipTrigger render={anchor} />
+      <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 /**
  * Builds the static component overrides that depend on `variant` and workspace context.
  * Elements whose colors differ between assistant and user bubble are variant-conditional.
@@ -110,56 +215,11 @@ function makeStaticComponents(variant: "assistant" | "user", workspacePath: stri
     li: ({ children }: { children?: React.ReactNode }) => <li className="leading-relaxed">{children}</li>,
     strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-semibold">{children}</strong>,
     em: ({ children }: { children?: React.ReactNode }) => <em className="italic">{children}</em>,
-    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
-      let safeHref: string | undefined;
-      if (href) {
-        const raw = href.trim();
-        if (isMcodeWorkspacePreviewUrl(raw)) {
-          safeHref = raw;
-        } else if (workspacePath && looksLikeWorkspaceRelativeFileRef(raw)) {
-          safeHref = mcodeWorkspacePreviewHref(raw);
-        } else try {
-          const { protocol } = new URL(href);
-          if (protocol === "https:" || protocol === "http:" || protocol === "mailto:") {
-            safeHref = href;
-          }
-        } catch {
-          /* invalid URL */
-        }
-      }
-      const linkClass = isUser
-        ? "text-primary-foreground underline hover:opacity-80"
-        : "text-primary underline hover:text-primary";
-      const isPreviewable = !!safeHref && isPreviewableUrl(safeHref);
-      const showHint = isPreviewable && hasPreview();
-      const anchor = (
-        <a
-          href={safeHref}
-          className={linkClass}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => {
-            if (!safeHref) return;
-            if (isPreviewable) return handleLinkClick(e, safeHref);
-            e.preventDefault();
-            if (window.desktopBridge?.openExternalUrl) {
-              void window.desktopBridge.openExternalUrl(safeHref);
-            } else {
-              window.open(safeHref, "_blank", "noopener,noreferrer");
-            }
-          }}
-        >
-          {children}
-        </a>
-      );
-      if (!showHint) return anchor;
-      return (
-        <Tooltip>
-          <TooltipTrigger render={anchor} />
-          <TooltipContent side="top" className="text-xs">{previewHint}</TooltipContent>
-        </Tooltip>
-      );
-    },
+    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+      <MarkdownLink href={href} variant={variant} workspacePath={workspacePath}>
+        {children}
+      </MarkdownLink>
+    ),
     blockquote: ({ children }: { children?: React.ReactNode }) => (
       <blockquote
         className={

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -2,14 +2,14 @@ import { memo, useMemo, lazy, Suspense } from "react";
 import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Globe } from "lucide-react";
 import {
   isMcodeWorkspacePreviewUrl,
   mcodeWorkspacePreviewHref,
   looksLikeWorkspaceRelativeFileRef,
 } from "@mcode/contracts";
 import { CodeBlock } from "./CodeBlock";
-import { Favicon } from "@/components/ui/favicon";
+import { SiteFavicon } from "@/components/ui/favicon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { resolveCodeBlockLanguage } from "@/lib/resolve-code-block-language";
 import { isMac } from "@/lib/platform";
@@ -115,6 +115,47 @@ function resolveMarkdownHref(href: string | undefined, workspacePath: string | n
   return undefined;
 }
 
+/**
+ * Produces a compact, human-readable label for a bare URL so inline links read
+ * like the Overview repository row (`owner/repo`) instead of a raw `https://`
+ * string. GitHub repos collapse to `owner/repo`, issues and pull requests to
+ * `owner/repo#123`, commits to `owner/repo@shortsha`; every other URL drops the
+ * protocol and a leading `www.`, keeping `host/path`. Only used when the link's
+ * visible text is the URL itself; authored link text is never rewritten.
+ */
+function formatBareUrlLabel(rawHref: string): string {
+  try {
+    const url = new URL(rawHref);
+    const host = url.hostname.replace(/^www\./, "");
+    const path = url.pathname.replace(/\/+$/, "");
+    const segments = path.split("/").filter(Boolean);
+
+    if (host === "github.com" && segments.length >= 2) {
+      const ownerRepo = `${segments[0]}/${segments[1]}`;
+      if (segments.length >= 4 && (segments[2] === "issues" || segments[2] === "pull")) {
+        return `${ownerRepo}#${segments[3]}`;
+      }
+      if (segments.length >= 4 && segments[2] === "commit") {
+        return `${ownerRepo}@${segments[3].slice(0, 7)}`;
+      }
+      return ownerRepo;
+    }
+
+    return path ? `${host}${path}` : host;
+  } catch {
+    return rawHref;
+  }
+}
+
+/** Extracts plain text from link children when it is a single string node. */
+function getPlainTextChild(children: React.ReactNode): string | null {
+  if (typeof children === "string") return children;
+  if (Array.isArray(children) && children.length === 1 && typeof children[0] === "string") {
+    return children[0];
+  }
+  return null;
+}
+
 function getLinkFaviconUrl(href: string | undefined): string | null {
   if (!href) return null;
   try {
@@ -144,14 +185,16 @@ function MarkdownLink({
   const isPreviewable = !!safeHref && isPreviewableUrl(safeHref);
   const showHint = isPreviewable && hasPreview();
   const faviconUrl = getLinkFaviconUrl(safeHref);
+  const childText = getPlainTextChild(children);
+  const isBareUrlText =
+    !!childText && !!safeHref && (childText === href || childText === safeHref || HTTP_URL_RE.test(childText.trim()));
+  const label = isBareUrlText && safeHref ? formatBareUrlLabel(safeHref) : children;
   const anchor = (
     <a
       href={safeHref}
       className={cn(
-        "inline-flex max-w-full items-center gap-1 rounded-[min(var(--radius-md),10px)] px-1.5 py-0.5 align-baseline no-underline ring-1 transition-colors",
-        isUser
-          ? "bg-primary-foreground/10 text-primary-foreground ring-primary-foreground/20 hover:bg-primary-foreground/15 hover:text-primary-foreground"
-          : "bg-muted/45 text-primary ring-border/60 hover:bg-muted hover:text-primary",
+        "inline-flex max-w-full items-center gap-1 align-baseline no-underline transition-colors hover:underline",
+        isUser ? "text-primary-foreground" : "text-primary",
       )}
       target="_blank"
       rel="noopener noreferrer"
@@ -168,14 +211,13 @@ function MarkdownLink({
         }
       }}
     >
-      <Favicon
+      <SiteFavicon
         src={faviconUrl}
+        fallback={<Globe size={12} aria-hidden className="shrink-0 text-muted-foreground" />}
         frameTestId="markdown-link-favicon-frame"
         imageTestId="markdown-link-favicon"
-        className="size-3.5 rounded-[3px]"
-        imageClassName="size-3 rounded-[2px]"
       />
-      <span className="min-w-0 truncate">{children}</span>
+      <span className="min-w-0 truncate">{label}</span>
       {safeHref ? (
         <ExternalLink
           size={12}

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Check,
   ChevronDown,
@@ -15,16 +15,23 @@ import {
   Upload,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Favicon } from "@/components/ui/favicon";
+import { SiteFavicon } from "@/components/ui/favicon";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { PrSplitButton } from "./PrSplitButton";
 import { CreatePrDialog } from "./CreatePrDialog";
 import { useThreadGitActions } from "@/hooks/useThreadGitActions";
 import { useDiffStore } from "@/stores/diffStore";
+import { useThreadStore } from "@/stores/threadStore";
+import { useLayoutStore } from "@/stores/layoutStore";
+import { useOverviewStore } from "@/stores/overviewStore";
 import { executeCommand } from "@/lib/command-registry";
+import { getContentRowWidth, shouldAutoOpenOverview } from "@/lib/composer-layout";
+import { extractThreadSources, type ThreadSource } from "@/lib/message-sources";
+import { isModifierClick, isPreviewableUrl, openUrlInPreview } from "@/lib/open-url-in-preview";
 import { cn } from "@/lib/utils";
 import {
   getTransport,
@@ -32,7 +39,10 @@ import {
   type McodeTransport,
   type Thread,
 } from "@/transport";
-import type { ChecksStatus, TurnSnapshot } from "@mcode/contracts";
+import type { ChecksStatus, Message, TurnSnapshot } from "@mcode/contracts";
+
+/** Stable empty messages reference so the closed Overview never re-renders on new messages. */
+const EMPTY_MESSAGES: Message[] = [];
 
 /** CI dot shown on the Overview trigger for terminal check states. */
 export type ThreadOverviewCiDot = "red" | "green" | null;
@@ -323,22 +333,6 @@ function branchRows(branches: readonly GitBranchRecord[], currentBranch: string)
   });
 }
 
-interface RepositoryFaviconProps {
-  faviconUrl: string | null;
-  hasRemote: boolean;
-}
-
-function RepositoryFavicon({ faviconUrl, hasRemote }: RepositoryFaviconProps) {
-  return (
-    <Favicon
-      src={faviconUrl}
-      frameTestId="thread-overview-repository-favicon-frame"
-      imageTestId="thread-overview-repository-favicon"
-      fallback={hasRemote ? null : <GitBranch size={14} className="shrink-0 text-muted-foreground" />}
-    />
-  );
-}
-
 interface ThreadOverviewRepositoryRowProps {
   repository: ThreadOverviewRepository;
   status: LoadStatus;
@@ -350,70 +344,42 @@ function ThreadOverviewRepositoryRow({
   status,
   onOpen,
 }: ThreadOverviewRepositoryRowProps) {
-  const isLoading = status === "loading";
   const canOpen = status === "ready" && !!repository.webUrl;
-  const label = isLoading ? "Repository" : repository.label;
-  const valueIcon =
-    isLoading ? null : (
-      <RepositoryFavicon
-        faviconUrl={repository.faviconUrl}
-        hasRemote={canOpen}
-      />
-    );
-  const content = (
-    <>
-      <span className="flex min-w-0 items-center gap-2">
-        <Globe size={14} className="shrink-0 text-muted-foreground" />
-        <span className="truncate text-xs font-medium text-foreground">
-          Repository
-        </span>
-      </span>
-      {isLoading ? (
-        <span
-          data-testid="thread-overview-repository-loading"
-          aria-label="Loading repository"
-          className="animate-thread-overview-loading h-3 w-16 shrink-0 overflow-hidden rounded-sm bg-muted/45"
-        />
-      ) : canOpen ? (
-        <span className="flex min-w-0 max-w-[11rem] items-center justify-end gap-1.5">
-          {valueIcon}
-          <span className="truncate text-xs font-medium text-primary">{label}</span>
-          <ExternalLink size={13} aria-hidden className="shrink-0 text-muted-foreground" />
-        </span>
-      ) : (
-        <span className="flex min-w-0 max-w-[11rem] items-center justify-end gap-1.5">
-          {valueIcon}
-          <span className="truncate text-xs font-medium text-muted-foreground">{label}</span>
-        </span>
-      )}
-    </>
-  );
+  const label = repository.label;
 
-  if (canOpen) {
-    return (
-      <Button
-        variant="ghost"
-        size="sm"
-        type="button"
-        onClick={onOpen}
-        data-testid="thread-overview-repository"
-        aria-label={`Repository, ${label}, open remote`}
-        title={repository.webUrl ?? label}
-        className="h-8 w-full cursor-pointer justify-between gap-3 px-2 text-left"
-      >
-        {content}
-      </Button>
-    );
-  }
+  if (!canOpen) return null;
 
   return (
-    <div
-      data-testid="thread-overview-repository"
-      aria-label={`Repository, ${label}`}
-      title={label}
-      className="flex h-8 w-full items-center justify-between gap-3 rounded-[min(var(--radius-md),12px)] px-2 text-left"
-    >
-      {content}
+    <div className="grid animate-thread-overview-row-reveal">
+      <div className="min-h-0 overflow-hidden">
+        <div
+          data-testid="thread-overview-repository"
+          className="flex w-full flex-col gap-1.5 px-2 py-1.5"
+        >
+          <span className="font-mono text-xs font-medium uppercase leading-tight tracking-[0.18em] text-muted-foreground">
+            REPOSITORY
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            onClick={onOpen}
+            data-testid="thread-overview-repository-link"
+            aria-label={`Open ${label} on remote`}
+            title={repository.webUrl ?? label}
+            className="-mx-1.5 h-7 min-w-0 justify-start gap-1.5 rounded-md px-1.5 text-left text-primary hover:bg-muted/50 hover:text-primary focus-visible:ring-inset"
+          >
+            <SiteFavicon
+              src={repository.faviconUrl}
+              frameTestId="thread-overview-repository-favicon-frame"
+              imageTestId="thread-overview-repository-favicon"
+              fallback={<GitBranch size={14} className="shrink-0 text-muted-foreground" />}
+            />
+            <span className="truncate text-xs font-medium">{label}</span>
+            <ExternalLink size={12} aria-hidden className="shrink-0 text-muted-foreground" />
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -655,6 +621,56 @@ function ThreadOverviewBranchMenu({
   );
 }
 
+interface ThreadOverviewSourcesProps {
+  sources: ThreadSource[];
+  onOpen: (event: React.MouseEvent, url: string) => void;
+}
+
+/**
+ * Renders the deduped external links the assistant produced this thread as a
+ * compact favicon grid. Each chip shows its full URL on hover and reuses the
+ * standard link-open behavior (Ctrl/Cmd+click opens in the in-app preview,
+ * plain click opens the system browser).
+ */
+function ThreadOverviewSources({ sources, onOpen }: ThreadOverviewSourcesProps) {
+  if (sources.length === 0) return null;
+
+  return (
+    <div data-testid="thread-overview-sources" className="flex w-full flex-col gap-1.5 px-2 py-1.5">
+      <span className="font-mono text-xs font-medium uppercase leading-tight tracking-[0.18em] text-muted-foreground">
+        SOURCES
+      </span>
+      <div className="flex flex-wrap gap-1">
+        {sources.map((source) => (
+          <Tooltip key={source.url}>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  type="button"
+                  aria-label={source.url}
+                  data-testid="thread-overview-source"
+                  onClick={(event) => onOpen(event, source.url)}
+                  className="size-6 rounded-md hover:bg-muted/50"
+                >
+                  <SiteFavicon
+                    src={source.faviconUrl}
+                    fallback={<Globe size={13} className="text-muted-foreground" />}
+                  />
+                </Button>
+              }
+            />
+            <TooltipContent side="top" className="max-w-xs break-all text-xs">
+              {source.url}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /**
  * Thread-scoped Overview popover for the chat header.
  *
@@ -662,7 +678,6 @@ function ThreadOverviewBranchMenu({
  * thread: changed files, PR actions, and the thread's worktree mode.
  */
 export function ThreadOverview({ thread }: ThreadOverviewProps) {
-  const [open, setOpen] = useState(false);
   const [localOpen, setLocalOpen] = useState(false);
   const [branchOpen, setBranchOpen] = useState(false);
   const [loadedChangeSummary, setLoadedChangeSummary] = useState<{
@@ -677,6 +692,62 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
     repository: ThreadOverviewRepository;
   } | null>(null);
   const [changeSummaryStatus, setChangeSummaryStatus] = useState<LoadStatus>("idle");
+
+  // Space-aware open: the Overview sits open when there is room and steps aside
+  // when the right panel or a narrow viewport leaves none, until the user takes
+  // manual control of it for this thread.
+  const panelVisible = useDiffStore((s) => s.getRightPanelVisible(thread.workspace_id, thread.id));
+  const panelWidth = useDiffStore((s) => s.getRightPanel(thread.workspace_id, thread.id).width);
+  const measuredContentRowWidth = useLayoutStore((s) => s.contentRowWidth);
+  const [open, setOpen] = useState(false);
+  const autoManagedRef = useRef(true);
+  const lastAutoValueRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    autoManagedRef.current = true;
+  }, [thread.id]);
+
+  // Whether there is room for the Overview to open by default. Driven by the
+  // reactive content-row width so it tracks resizes and panel changes without
+  // racing the layout guard's measurement.
+  const hasRoom = useMemo(
+    () =>
+      shouldAutoOpenOverview({
+        contentRowWidth: measuredContentRowWidth || getContentRowWidth(),
+        rightPanelVisible: panelVisible,
+        rightPanelWidth: panelWidth,
+      }),
+    [measuredContentRowWidth, panelVisible, panelWidth],
+  );
+
+  // The Overview opens by default when there is room and steps aside when a
+  // narrow viewport or the right panel leaves none, until the user takes manual
+  // control of it for this thread. The echo guard ignores base-ui's onOpenChange
+  // when our own programmatic open/close round-trips.
+  useEffect(() => {
+    if (!autoManagedRef.current) return;
+    lastAutoValueRef.current = hasRoom;
+    setOpen(hasRoom);
+  }, [hasRoom]);
+
+  const handleOpenChange = useCallback((next: boolean, eventDetails?: { reason?: string }) => {
+    // Clicking elsewhere (or focus leaving) must not close the Overview; only the
+    // trigger button and Escape do. base-ui is controlled, so ignoring the change
+    // keeps it open.
+    if (!next && (eventDetails?.reason === "outside-press" || eventDetails?.reason === "focus-out")) {
+      return;
+    }
+    if (next !== lastAutoValueRef.current) autoManagedRef.current = false;
+    setOpen(next);
+  }, []);
+
+  // Reserve room on the right only when open AND there's space (wide view); on a
+  // small view the popover floats over the chat instead of squeezing it.
+  const setReserveSpace = useOverviewStore((s) => s.setReserveSpace);
+  useEffect(() => {
+    setReserveSpace(open && hasRoom);
+    return () => setReserveSpace(false);
+  }, [open, hasRoom, setReserveSpace]);
 
   const {
     prable,
@@ -799,39 +870,64 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
     window.open(repository.webUrl, "_blank", "noopener,noreferrer");
   }, [repository.webUrl]);
 
+  // Subscribe to messages only while the Overview is open so a closed popover
+  // never re-renders as the thread streams; sources are computed lazily here.
+  const sourceMessages = useThreadStore((s) =>
+    open ? (s.records.get(thread.id)?.messages ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
+  );
+  const sources = useMemo(
+    () => (open ? extractThreadSources(sourceMessages) : []),
+    [open, sourceMessages],
+  );
+
+  const openSource = useCallback(
+    (event: React.MouseEvent, url: string) => {
+      if (isModifierClick(event) && window.desktopBridge?.preview && isPreviewableUrl(url)) {
+        openUrlInPreview({ url, threadId: thread.id });
+        return;
+      }
+      if (window.desktopBridge?.openExternalUrl) {
+        void window.desktopBridge.openExternalUrl(url);
+      } else {
+        window.open(url, "_blank", "noopener,noreferrer");
+      }
+    },
+    [thread.id],
+  );
+
   const ciDot = useMemo(() => getThreadOverviewCiDot(pr, checks), [pr, checks]);
   const modeLabel = thread.mode === "worktree" ? "Worktree" : "Direct";
 
-  return (
-    <>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              title="Thread overview"
-              aria-label="Thread overview"
-              data-testid="header-workspace-menu"
-              className="relative cursor-pointer text-foreground/70 hover:bg-muted/40 hover:text-foreground"
-            >
-              <Menu size={14} />
-              {ciDot && (
-                <span
-                  data-testid={`thread-overview-ci-${ciDot}`}
-                  aria-hidden
-                  className={cn(
-                    "absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-background",
-                    ciDot === "red" && "bg-[var(--diff-remove-strong)]",
-                    ciDot === "green" && "bg-[var(--diff-add-strong)]",
-                  )}
-                />
-              )}
-            </Button>
-          }
+  const triggerButton = (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      type="button"
+      title="Thread overview"
+      aria-label="Thread overview"
+      data-testid="header-workspace-menu"
+      className={cn(
+        "relative cursor-pointer text-foreground/70 hover:bg-muted/40 hover:text-foreground",
+        open && "bg-muted text-foreground",
+      )}
+    >
+      <Menu size={14} />
+      {ciDot && (
+        <span
+          data-testid={`thread-overview-ci-${ciDot}`}
+          aria-hidden
+          className={cn(
+            "absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-background",
+            ciDot === "red" && "bg-[var(--diff-remove-strong)]",
+            ciDot === "green" && "bg-[var(--diff-add-strong)]",
+          )}
         />
-        <PopoverContent align="end" sideOffset={12} className="w-80 p-0">
-          <div className="animate-popover-enter p-1.5">
+      )}
+    </Button>
+  );
+
+  const overviewBody = (
+    <div data-testid="thread-overview-body" className="animate-overview-enter p-1.5">
             <Button
               variant="ghost"
               size="sm"
@@ -979,7 +1075,37 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
                 />
               </div>
             )}
-          </div>
+
+            {sources.length > 0 && (
+              <>
+                <Separator className="my-1.5" />
+                <ThreadOverviewSources sources={sources} onOpen={openSource} />
+              </>
+            )}
+    </div>
+  );
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger render={triggerButton} />
+        {/*
+          Pin the popover to the far right edge with a comfortable gap below the
+          trigger. NOTE: base-ui's alignOffset is inverted from what you'd expect
+          for align="end" — a POSITIVE value moves the popover LEFT, a NEGATIVE
+          value moves it RIGHT. The large negative offset overshoots to the right
+          so collision detection clamps it to `collisionPadding` from the edge.
+          collisionPadding matches the header's right padding (pr-4 = 16px) so the
+          popover's right edge lines up with the rightmost header icon.
+        */}
+        <PopoverContent
+          align="end"
+          sideOffset={18}
+          alignOffset={-40}
+          collisionPadding={8}
+          className="w-80 p-0"
+        >
+          {overviewBody}
         </PopoverContent>
       </Popover>
 

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -4,8 +4,10 @@ import {
   ChevronDown,
   Copy,
   Diff,
+  ExternalLink,
   GitBranch,
   GitPullRequest,
+  Globe,
   Laptop,
   Menu,
   Plus,
@@ -13,6 +15,7 @@ import {
   Upload,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Favicon } from "@/components/ui/favicon";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -50,6 +53,7 @@ type ThreadOverviewChangeSummaryTransport = Pick<
   | "getBranchFiles"
   | "getReviewDiffStats"
 >;
+type ThreadOverviewRepositoryTransport = Pick<McodeTransport, "getRemoteUrl">;
 
 type LoadedBranchState =
   | { status: "idle"; branches: GitBranchRecord[]; uncommittedFiles: number | null }
@@ -58,6 +62,16 @@ type LoadedBranchState =
   | { status: "error"; branches: GitBranchRecord[]; uncommittedFiles: number | null };
 type LoadStatus = "idle" | "loading" | "ready" | "error";
 type LocalCopyTarget = "path" | "branch";
+
+/** Repository metadata rendered by the Overview Repository row. */
+export interface ThreadOverviewRepository {
+  /** Label shown in the row, usually "org/repo". */
+  label: string;
+  /** Safe HTTPS web URL opened from the row, or null for local-only repos. */
+  webUrl: string | null;
+  /** HTTPS favicon URL for the remote host, or null when unavailable. */
+  faviconUrl: string | null;
+}
 
 /** Aggregate change totals shown in the Overview popover. */
 export interface ThreadOverviewChangeSummary {
@@ -80,6 +94,12 @@ const EMPTY_REVIEW_DIFF_STAT: ReviewDiffStat = {
   deletions: 0,
 };
 
+const EMPTY_REPOSITORY: ThreadOverviewRepository = {
+  label: "Repository",
+  webUrl: null,
+  faviconUrl: null,
+};
+
 /**
  * Derives the active thread's compact CI signal for the Overview trigger.
  */
@@ -100,6 +120,29 @@ function changedFilesLabel(count: number): string {
 
 function uncommittedFilesLabel(count: number): string {
   return `Uncommitted: ${count} ${count === 1 ? "file" : "files"}`;
+}
+
+/**
+ * Returns a repository URL only when it is safe for an external open action.
+ */
+export function getSafeRepositoryWebUrl(webUrl: string | null): string | null {
+  if (!webUrl) return null;
+  try {
+    const parsed = new URL(webUrl);
+    if (parsed.protocol !== "https:") return null;
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derives the favicon URL for a safe repository web URL.
+ */
+export function getRepositoryFaviconUrl(webUrl: string | null): string | null {
+  const safeUrl = getSafeRepositoryWebUrl(webUrl);
+  if (!safeUrl) return null;
+  return `${new URL(safeUrl).origin}/favicon.ico`;
 }
 
 function snapshotKey(snapshots: readonly Pick<TurnSnapshot, "id">[] | undefined): string {
@@ -238,6 +281,25 @@ export async function resolveThreadOverviewChangeSummary({
   };
 }
 
+/**
+ * Resolves the active thread checkout's repository label, safe URL, and favicon.
+ */
+export async function resolveThreadOverviewRepository({
+  thread,
+  transport,
+}: {
+  thread: Pick<Thread, "id" | "workspace_id">;
+  transport: ThreadOverviewRepositoryTransport;
+}): Promise<ThreadOverviewRepository> {
+  const remote = await transport.getRemoteUrl(thread.workspace_id, thread.id);
+  const webUrl = getSafeRepositoryWebUrl(remote.webUrl);
+  return {
+    label: remote.label,
+    webUrl,
+    faviconUrl: getRepositoryFaviconUrl(webUrl),
+  };
+}
+
 function branchRows(branches: readonly GitBranchRecord[], currentBranch: string): GitBranchRecord[] {
   const localBranches = new Map<string, GitBranchRecord>();
   for (const branch of branches) {
@@ -259,6 +321,101 @@ function branchRows(branches: readonly GitBranchRecord[], currentBranch: string)
     if (b.name === currentBranch) return 1;
     return a.name.localeCompare(b.name);
   });
+}
+
+interface RepositoryFaviconProps {
+  faviconUrl: string | null;
+  hasRemote: boolean;
+}
+
+function RepositoryFavicon({ faviconUrl, hasRemote }: RepositoryFaviconProps) {
+  return (
+    <Favicon
+      src={faviconUrl}
+      frameTestId="thread-overview-repository-favicon-frame"
+      imageTestId="thread-overview-repository-favicon"
+      fallback={hasRemote ? null : <GitBranch size={14} className="shrink-0 text-muted-foreground" />}
+    />
+  );
+}
+
+interface ThreadOverviewRepositoryRowProps {
+  repository: ThreadOverviewRepository;
+  status: LoadStatus;
+  onOpen: () => void;
+}
+
+function ThreadOverviewRepositoryRow({
+  repository,
+  status,
+  onOpen,
+}: ThreadOverviewRepositoryRowProps) {
+  const isLoading = status === "loading";
+  const canOpen = status === "ready" && !!repository.webUrl;
+  const label = isLoading ? "Repository" : repository.label;
+  const valueIcon =
+    isLoading ? null : (
+      <RepositoryFavicon
+        faviconUrl={repository.faviconUrl}
+        hasRemote={canOpen}
+      />
+    );
+  const content = (
+    <>
+      <span className="flex min-w-0 items-center gap-2">
+        <Globe size={14} className="shrink-0 text-muted-foreground" />
+        <span className="truncate text-xs font-medium text-foreground">
+          Repository
+        </span>
+      </span>
+      {isLoading ? (
+        <span
+          data-testid="thread-overview-repository-loading"
+          aria-label="Loading repository"
+          className="animate-thread-overview-loading h-3 w-16 shrink-0 overflow-hidden rounded-sm bg-muted/45"
+        />
+      ) : canOpen ? (
+        <span className="flex min-w-0 max-w-[11rem] items-center justify-end gap-1.5">
+          {valueIcon}
+          <span className="truncate text-xs font-medium text-primary">{label}</span>
+          <ExternalLink size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+        </span>
+      ) : (
+        <span className="flex min-w-0 max-w-[11rem] items-center justify-end gap-1.5">
+          {valueIcon}
+          <span className="truncate text-xs font-medium text-muted-foreground">{label}</span>
+        </span>
+      )}
+    </>
+  );
+
+  if (canOpen) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        type="button"
+        onClick={onOpen}
+        data-testid="thread-overview-repository"
+        aria-label={`Repository, ${label}, open remote`}
+        title={repository.webUrl ?? label}
+        className="h-8 w-full cursor-pointer justify-between gap-3 px-2 text-left"
+      >
+        {content}
+      </Button>
+    );
+  }
+
+  return (
+    <div
+      data-testid="thread-overview-repository"
+      aria-label={`Repository, ${label}`}
+      title={label}
+      className="flex h-8 w-full items-center justify-between gap-3 rounded-[min(var(--radius-md),12px)] px-2 text-left"
+    >
+      {content}
+    </div>
+  );
 }
 
 interface ThreadOverviewLocalMenuProps {
@@ -514,6 +671,11 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
     revision: number;
     summary: ThreadOverviewChangeSummary;
   } | null>(null);
+  const [loadedRepository, setLoadedRepository] = useState<{
+    threadId: string;
+    status: LoadStatus;
+    repository: ThreadOverviewRepository;
+  } | null>(null);
   const [changeSummaryStatus, setChangeSummaryStatus] = useState<LoadStatus>("idle");
 
   const {
@@ -548,6 +710,10 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
       : fallbackChangeSummary;
   const showChangeSummary = hasVisibleThreadOverviewChangeSummary(changeSummary);
   const isChangeSummaryLoading = open && changeSummaryStatus === "loading";
+  const loadedRepositoryForThread =
+    loadedRepository?.threadId === thread.id ? loadedRepository : null;
+  const repository = loadedRepositoryForThread?.repository ?? EMPTY_REPOSITORY;
+  const repositoryStatus = loadedRepositoryForThread?.status ?? "idle";
 
   useEffect(() => {
     if (!open) return;
@@ -584,9 +750,54 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
     };
   }, [cachedSnapshotKey, cachedSnapshots, diffRevision, open, setSnapshots, thread.id, thread.workspace_id]);
 
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+    setLoadedRepository({
+      threadId: thread.id,
+      status: "loading",
+      repository: EMPTY_REPOSITORY,
+    });
+
+    const loadRepository = async () => {
+      try {
+        const repository = await resolveThreadOverviewRepository({
+          thread: { id: thread.id, workspace_id: thread.workspace_id },
+          transport: getTransport(),
+        });
+        if (cancelled) return;
+        setLoadedRepository({ threadId: thread.id, status: "ready", repository });
+      } catch {
+        if (!cancelled) {
+          setLoadedRepository({
+            threadId: thread.id,
+            status: "error",
+            repository: { label: "Unavailable", webUrl: null, faviconUrl: null },
+          });
+        }
+      }
+    };
+
+    void loadRepository();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, thread.id, thread.workspace_id]);
+
   const openChanges = useCallback(() => {
     executeCommand("changes.toggle");
   }, []);
+
+  const openRepository = useCallback(() => {
+    if (!repository.webUrl) return;
+    if (window.desktopBridge?.openExternalUrl) {
+      void window.desktopBridge.openExternalUrl(repository.webUrl);
+      return;
+    }
+    window.open(repository.webUrl, "_blank", "noopener,noreferrer");
+  }, [repository.webUrl]);
 
   const ciDot = useMemo(() => getThreadOverviewCiDot(pr, checks), [pr, checks]);
   const modeLabel = thread.mode === "worktree" ? "Worktree" : "Direct";
@@ -654,6 +865,12 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
                 </span>
               ) : null}
             </Button>
+
+            <ThreadOverviewRepositoryRow
+              repository={repository}
+              status={repositoryStatus}
+              onOpen={openRepository}
+            />
 
             <Popover open={localOpen} onOpenChange={setLocalOpen}>
               <PopoverTrigger

--- a/apps/web/src/components/panels/plan/PlanDocument.test.tsx
+++ b/apps/web/src/components/panels/plan/PlanDocument.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PlanRecord } from "@mcode/contracts";
 import { PlanDocument, type PlanComment } from "./PlanDocument";
 
@@ -19,6 +19,11 @@ const makePlan = (contentMd: string): PlanRecord => ({
 const PLACEHOLDER = "What should change in this section?";
 
 describe("PlanDocument annotation", () => {
+  beforeAll(async () => {
+    // Keep the full parallel suite from spending this test's timeout budget on the lazy import.
+    await import("@/components/chat/MarkdownContent");
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/apps/web/src/components/ui/favicon.tsx
+++ b/apps/web/src/components/ui/favicon.tsx
@@ -18,6 +18,12 @@ export interface FaviconProps {
   className?: string;
   /** Additional classes for the image. */
   imageClassName?: string;
+  /**
+   * When true (default), wraps the image in a neutral contrast frame and adds
+   * the dual-halo shadow. Set false for marks that carry their own theming
+   * (e.g. a monochrome GitHub mark) so they read bare and inline.
+   */
+  framed?: boolean;
 }
 
 /**
@@ -35,6 +41,7 @@ export function Favicon({
   imageTestId,
   className,
   imageClassName,
+  framed = true,
 }: FaviconProps) {
   const [failed, setFailed] = useState(false);
 
@@ -46,7 +53,8 @@ export function Favicon({
     <span
       data-testid={frameTestId}
       className={cn(
-        "inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] bg-background/85 ring-1 ring-border/70",
+        "inline-flex size-4 shrink-0 items-center justify-center rounded-[4px]",
+        framed && "bg-background/85 ring-1 ring-border/70",
         className,
       )}
     >
@@ -57,12 +65,48 @@ export function Favicon({
         height={14}
         data-testid={imageTestId}
         onError={() => setFailed(true)}
-        className={cn("size-3.5 rounded-[3px]", imageClassName)}
-        style={{
-          filter:
-            "drop-shadow(0 0 1px rgb(255 255 255 / 0.95)) drop-shadow(0 0 1px rgb(0 0 0 / 0.75))",
-        }}
+        className={cn("size-3.5 rounded-[3px]", framed && "favicon-image-shadow", imageClassName)}
       />
     </span>
+  );
+}
+
+/** The favicon URL GitHub serves; used to switch to the bare themed mark. */
+const GITHUB_FAVICON_URL = "https://github.com/favicon.ico";
+
+/** Props for {@link SiteFavicon}. */
+export interface SiteFaviconProps {
+  /** HTTPS favicon URL, or null to render the fallback. */
+  src: string | null;
+  /** Fallback rendered when no favicon is available or loading fails. */
+  fallback?: ReactNode;
+  /** Test id for the outer frame. */
+  frameTestId?: string;
+  /** Test id for the image element. */
+  imageTestId?: string;
+}
+
+/**
+ * Renders a site favicon at link scale with one shared treatment: the GitHub
+ * mark drops the contrast frame and themes to the foreground (white on dark),
+ * every other favicon keeps the small contrast frame. Used by the Overview
+ * repository row and inline Markdown links so both render links identically.
+ */
+export function SiteFavicon({ src, fallback = null, frameTestId, imageTestId }: SiteFaviconProps) {
+  const isGitHub = src === GITHUB_FAVICON_URL;
+
+  return (
+    <Favicon
+      src={src}
+      fallback={fallback}
+      framed={!isGitHub}
+      frameTestId={frameTestId}
+      imageTestId={imageTestId}
+      className="size-3.5 rounded-[3px]"
+      imageClassName={cn(
+        "size-3 rounded-[2px]",
+        isGitHub && "size-3.5 rounded-none github-favicon-mark",
+      )}
+    />
   );
 }

--- a/apps/web/src/components/ui/favicon.tsx
+++ b/apps/web/src/components/ui/favicon.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** Props for {@link Favicon}. */
+export interface FaviconProps {
+  /** HTTPS favicon image URL. Null renders the fallback. */
+  src: string | null;
+  /** Accessible image alt text. Use an empty string for decorative favicons. */
+  alt?: string;
+  /** Optional fallback rendered when no favicon is available or loading fails. */
+  fallback?: ReactNode;
+  /** Test id for the outer contrast frame. */
+  frameTestId?: string;
+  /** Test id for the image element. */
+  imageTestId?: string;
+  /** Additional classes for the outer frame. */
+  className?: string;
+  /** Additional classes for the image. */
+  imageClassName?: string;
+}
+
+/**
+ * Renders a favicon inside a neutral contrast frame.
+ *
+ * Transparent monochrome favicons can vanish on either dark or light themes.
+ * The neutral frame plus dual halo preserves colored marks while keeping black
+ * and white edges visible.
+ */
+export function Favicon({
+  src,
+  alt = "",
+  fallback = null,
+  frameTestId,
+  imageTestId,
+  className,
+  imageClassName,
+}: FaviconProps) {
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => setFailed(false), [src]);
+
+  if (!src || failed) return <>{fallback}</>;
+
+  return (
+    <span
+      data-testid={frameTestId}
+      className={cn(
+        "inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] bg-background/85 ring-1 ring-border/70",
+        className,
+      )}
+    >
+      <img
+        src={src}
+        alt={alt}
+        width={14}
+        height={14}
+        data-testid={imageTestId}
+        onError={() => setFailed(true)}
+        className={cn("size-3.5 rounded-[3px]", imageClassName)}
+        style={{
+          filter:
+            "drop-shadow(0 0 1px rgb(255 255 255 / 0.95)) drop-shadow(0 0 1px rgb(0 0 0 / 0.75))",
+        }}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -16,13 +16,25 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
+  alignOffset,
+  collisionPadding,
   side,
   ...props
 }: PopoverPrimitive.Popup.Props &
-  Pick<PopoverPrimitive.Positioner.Props, "align" | "sideOffset" | "side">) {
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "sideOffset" | "alignOffset" | "collisionPadding" | "side"
+  >) {
   return (
     <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Positioner align={align} sideOffset={sideOffset} side={side} className="isolate z-50">
+      <PopoverPrimitive.Positioner
+        align={align}
+        sideOffset={sideOffset}
+        alignOffset={alignOffset}
+        collisionPadding={collisionPadding}
+        side={side}
+        className="isolate z-50"
+      >
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -158,6 +158,32 @@
   animation: fade-up-in 150ms ease-out;
 }
 
+/* Reveal for the Overview repository row. The row mounts only once a safe
+ * remote URL is known, so animating its entrance never flashes-then-hides.
+ * grid-template-rows 0fr -> 1fr eases the rows below it down instead of
+ * snapping, without animating height directly. */
+@keyframes thread-overview-row-reveal {
+  from { grid-template-rows: 0fr; opacity: 0; }
+  to   { grid-template-rows: 1fr; opacity: 1; }
+}
+.animate-thread-overview-row-reveal {
+  animation: thread-overview-row-reveal 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.favicon-image-shadow {
+  filter:
+    drop-shadow(0 0 1px rgb(255 255 255 / 0.95))
+    drop-shadow(0 0 1px rgb(0 0 0 / 0.75));
+}
+
+.github-favicon-mark {
+  filter: none;
+}
+
+.dark .github-favicon-mark {
+  filter: invert(1);
+}
+
 /* Radix Collapsible slide-open / slide-closed using the content's intrinsic
  * height via --radix-collapsible-content-height. */
 @keyframes collapsible-down {
@@ -196,6 +222,16 @@
   animation: popover-enter 160ms cubic-bezier(0.22, 1, 0.36, 1);
   transform-origin: top right;
 }
+/* Softer entrance for the thread Overview: it should settle into the top-right
+ * like a panel, not zoom out of the trigger icon, so it drops in without the
+ * corner-scale of the standard popover. */
+@keyframes overview-enter {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.animate-overview-enter {
+  animation: overview-enter 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
 @keyframes thread-overview-loading {
   from { transform: translateX(-120%); }
   to { transform: translateX(220%); }
@@ -224,6 +260,8 @@
   .animate-chip-enter,
   .animate-popover-enter,
   .animate-thread-overview-loading::after,
+  .animate-thread-overview-row-reveal,
+  .animate-overview-enter,
   .animate-collapsible-down,
   .animate-collapsible-up {
     animation: none;

--- a/apps/web/src/lib/__tests__/composer-layout.test.ts
+++ b/apps/web/src/lib/__tests__/composer-layout.test.ts
@@ -7,6 +7,13 @@ import {
   canFitSideBySidePanel,
   minContentWidthForSideBySidePanel,
   minOuterWidthForInlineSidebar,
+  overviewNoPaddingMinWidth,
+  overviewResponsivePaddingPx,
+  OVERVIEW_POPOVER_RESERVE_PX,
+  OVERVIEW_THREAD_CONTENT_MAX_WIDTH_PX,
+  OVERVIEW_THREAD_GAP_PX,
+  preferredSplitPanelWidth,
+  shouldAutoOpenOverview,
 } from "@/lib/composer-layout";
 import { COMPOSER_MIN_WIDTH, PANEL_MIN_WIDTH, PANEL_SPLIT_GAP_PX } from "@/stores/diffStore";
 
@@ -30,6 +37,62 @@ describe("composer-layout", () => {
     const need = minContentWidthForSideBySidePanel(440);
     expect(canFitSideBySidePanel(need, 440)).toBe(true);
     expect(canFitSideBySidePanel(need - 1, 440)).toBe(false);
+  });
+
+  it("opens the panel at half the content row by default", () => {
+    expect(preferredSplitPanelWidth(2000)).toBe(1000);
+  });
+
+  it("never lets the default panel width starve the composer", () => {
+    // A 900px row can't give half (450) and still leave the composer its min,
+    // so the panel is capped to what remains after the composer and gap.
+    const width = preferredSplitPanelWidth(900);
+    expect(width).toBe(900 - COMPOSER_MIN_WIDTH - PANEL_SPLIT_GAP_PX);
+    expect(width).toBeGreaterThanOrEqual(PANEL_MIN_WIDTH);
+  });
+
+  it("clamps the default panel width to the panel minimum on narrow rows", () => {
+    expect(preferredSplitPanelWidth(600)).toBe(PANEL_MIN_WIDTH);
+  });
+
+  it("auto-opens the Overview on a wide row with no panel", () => {
+    expect(
+      shouldAutoOpenOverview({ contentRowWidth: 1400, rightPanelVisible: false, rightPanelWidth: 440 }),
+    ).toBe(true);
+  });
+
+  it("does not auto-open the Overview on a narrow row", () => {
+    expect(
+      shouldAutoOpenOverview({ contentRowWidth: 800, rightPanelVisible: false, rightPanelWidth: 440 }),
+    ).toBe(false);
+  });
+
+  it("auto-opens beside an open panel only when both still fit", () => {
+    expect(
+      shouldAutoOpenOverview({ contentRowWidth: 1400, rightPanelVisible: true, rightPanelWidth: 440 }),
+    ).toBe(true);
+    expect(
+      shouldAutoOpenOverview({ contentRowWidth: 1400, rightPanelVisible: true, rightPanelWidth: 1000 }),
+    ).toBe(false);
+  });
+
+  it("keeps the centered thread unpadded when the Overview can sit beside it", () => {
+    expect(overviewNoPaddingMinWidth()).toBe(
+      OVERVIEW_THREAD_CONTENT_MAX_WIDTH_PX +
+        OVERVIEW_POPOVER_RESERVE_PX * 2 +
+        OVERVIEW_THREAD_GAP_PX * 2,
+    );
+    expect(overviewResponsivePaddingPx(overviewNoPaddingMinWidth())).toBe(0);
+  });
+
+  it("only shifts the thread by the collision amount on roomy Overview layouts", () => {
+    expect(overviewResponsivePaddingPx(overviewNoPaddingMinWidth() - 120)).toBe(120);
+  });
+
+  it("caps the Overview thread offset at the popover reserve on narrow layouts", () => {
+    expect(overviewResponsivePaddingPx(overviewNoPaddingMinWidth() - OVERVIEW_POPOVER_RESERVE_PX - 1)).toBe(
+      OVERVIEW_POPOVER_RESERVE_PX,
+    );
   });
 
   it("reports inline sidebar fit from outer-row width", () => {

--- a/apps/web/src/lib/composer-layout.ts
+++ b/apps/web/src/lib/composer-layout.ts
@@ -3,6 +3,7 @@ import {
   PANEL_MIN_WIDTH,
   PANEL_SPLIT_GAP_PX,
 } from "@/stores/diffStore";
+import { useLayoutStore } from "@/stores/layoutStore";
 
 /** Inline project-tree width (`Sidebar` uses Tailwind `w-72`). */
 export const SIDEBAR_WIDTH_PX = 288;
@@ -21,6 +22,7 @@ let measuredOuterRowWidth = 0;
 export function setLayoutMeasurements(contentRowWidth: number, outerRowWidth: number): void {
   measuredContentRowWidth = contentRowWidth;
   measuredOuterRowWidth = outerRowWidth;
+  useLayoutStore.getState().setContentRowWidth(contentRowWidth);
 }
 
 /** Width of the chat + right-panel split row, or a conservative fallback before mount. */
@@ -53,6 +55,78 @@ export function minOuterWidthForInlineSidebar(contentNeed: number): number {
 /** Whether the content row can host composer and an inline panel side by side. */
 export function canFitSideBySidePanel(contentRowWidth: number, panelWidth: number): boolean {
   return contentRowWidth >= minContentWidthForSideBySidePanel(panelWidth);
+}
+
+/**
+ * Preferred panel width when it first opens: a fraction (default half) of the
+ * content row, clamped so the panel never drops below its minimum and always
+ * leaves the composer its minimum width. Lets the panel open to ~50% of the
+ * thread view instead of a fixed size, while still degrading to a sane width on
+ * narrow viewports.
+ */
+export function preferredSplitPanelWidth(contentRowWidth: number, fraction = 0.5): number {
+  const target = Math.round(contentRowWidth * fraction);
+  const max = Math.max(PANEL_MIN_WIDTH, contentRowWidth - COMPOSER_MIN_WIDTH - PANEL_SPLIT_GAP_PX);
+  return Math.max(PANEL_MIN_WIDTH, Math.min(target, max));
+}
+
+/**
+ * Content-row width below which the Overview should not auto-open: on a narrow
+ * row it would crowd the chat, so the user opens it on demand instead.
+ */
+export const OVERVIEW_AUTO_OPEN_MIN_ROW = 1024;
+
+/** Visual thread column width from the shared `max-w-4xl` message/composer shell. */
+export const OVERVIEW_THREAD_CONTENT_MAX_WIDTH_PX = 896;
+
+/**
+ * Right-side popover footprint for Overview (`w-80`) plus collision padding. This
+ * is also the maximum padding we apply when the row is too narrow to keep the
+ * centered thread clear of the popover.
+ */
+export const OVERVIEW_POPOVER_RESERVE_PX = 328;
+
+/** Minimum breathing room between the centered thread column and the Overview. */
+export const OVERVIEW_THREAD_GAP_PX = 16;
+
+/**
+ * Whether the Overview should auto-open and "sit" given the current space. It
+ * stays closed on narrow rows, and when the right panel is open it only opens if
+ * chat and panel still fit side by side (i.e., the layout isn't cramped).
+ */
+export function shouldAutoOpenOverview(args: {
+  contentRowWidth: number;
+  rightPanelVisible: boolean;
+  rightPanelWidth: number;
+}): boolean {
+  const { contentRowWidth, rightPanelVisible, rightPanelWidth } = args;
+  if (contentRowWidth < OVERVIEW_AUTO_OPEN_MIN_ROW) return false;
+  if (rightPanelVisible && !canFitSideBySidePanel(contentRowWidth, rightPanelWidth)) return false;
+  return true;
+}
+
+/** Width at which a centered thread can sit beside the Overview with no offset. */
+export function overviewNoPaddingMinWidth(): number {
+  return OVERVIEW_THREAD_CONTENT_MAX_WIDTH_PX +
+    (OVERVIEW_POPOVER_RESERVE_PX * 2) +
+    (OVERVIEW_THREAD_GAP_PX * 2);
+}
+
+/** Right padding needed to keep centered thread content clear of the Overview. */
+export function overviewResponsivePaddingPx(contentWidth: number): number {
+  return Math.max(
+    0,
+    Math.min(OVERVIEW_POPOVER_RESERVE_PX, overviewNoPaddingMinWidth() - contentWidth),
+  );
+}
+
+/**
+ * CSS equivalent of {@link overviewResponsivePaddingPx}, using the container's
+ * own width so the chat stays centered on roomy screens and only steps left as
+ * much as the open Overview requires.
+ */
+export function overviewResponsivePaddingRight(): string {
+  return `clamp(0px, calc(${overviewNoPaddingMinWidth()}px - 100%), ${OVERVIEW_POPOVER_RESERVE_PX}px)`;
 }
 
 /** Whether the project tree can dock inline beside a content row of `contentNeed` px. */

--- a/apps/web/src/lib/message-sources.ts
+++ b/apps/web/src/lib/message-sources.ts
@@ -1,0 +1,70 @@
+import type { Message } from "@mcode/contracts";
+
+/** A deduped external link the assistant referenced during the thread. */
+export interface ThreadSource {
+  /** The full, canonical URL. Shown on hover and used to open the link. */
+  url: string;
+  /** HTTPS favicon URL for the host, or null when none can be derived. */
+  faviconUrl: string | null;
+}
+
+/** Matches HTTP(S) URLs inside message markdown. */
+const URL_RE = /https?:\/\/[^\s<>()[\]"'`]+/g;
+
+/** Trailing characters that markdown/prose commonly appends to a URL. */
+const TRAILING_PUNCTUATION_RE = /[.,;:!?]+$/;
+
+/**
+ * Caps how many sources we collect. The Overview is a glanceable surface, not a
+ * full bibliography, and the scan runs over every assistant message, so the work
+ * stays bounded even on long threads.
+ */
+const MAX_SOURCES = 32;
+
+/**
+ * Derives the favicon URL for an external link, or null for non-HTTPS hosts
+ * (favicons are only fetched over HTTPS).
+ */
+function deriveFaviconUrl(parsed: URL): string | null {
+  return parsed.protocol === "https:" ? `${parsed.origin}/favicon.ico` : null;
+}
+
+/**
+ * Extracts the deduped list of external links the assistant produced across a
+ * thread's messages, in first-seen order. Only assistant messages count as
+ * sources; user-pasted links are excluded. Deduped by full URL so the same page
+ * cited twice appears once. Intended to be computed lazily (only when the
+ * Overview is open) so it never runs during streaming.
+ */
+export function extractThreadSources(
+  messages: readonly Pick<Message, "role" | "content">[],
+): ThreadSource[] {
+  const seen = new Set<string>();
+  const sources: ThreadSource[] = [];
+
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+
+    const matches = message.content.match(URL_RE);
+    if (!matches) continue;
+
+    for (const match of matches) {
+      const url = match.replace(TRAILING_PUNCTUATION_RE, "");
+      if (seen.has(url)) continue;
+
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        continue;
+      }
+      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") continue;
+
+      seen.add(url);
+      sources.push({ url, faviconUrl: deriveFaviconUrl(parsed) });
+      if (sources.length >= MAX_SOURCES) return sources;
+    }
+  }
+
+  return sources;
+}

--- a/apps/web/src/lib/right-panel-layout.ts
+++ b/apps/web/src/lib/right-panel-layout.ts
@@ -1,10 +1,22 @@
-import { useDiffStore } from "@/stores/diffStore";
+import { getDefaultPanelWidthPx, useDiffStore } from "@/stores/diffStore";
 import { useUiStore } from "@/stores/uiStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import {
   canFitSideBySidePanel,
   getContentRowWidth,
+  preferredSplitPanelWidth,
 } from "@/lib/composer-layout";
+
+/**
+ * On first open, size the panel to ~half the content row instead of the fixed
+ * default. Only applies while the scope still carries the built-in default
+ * width, so a width the user has dragged is never overridden.
+ */
+function applyHalfWidthIfUntouched(workspaceId: string, threadId?: string | null): void {
+  const diff = useDiffStore.getState();
+  if (diff.getRightPanel(workspaceId, threadId).width !== getDefaultPanelWidthPx()) return;
+  diff.setRightPanelWidth(workspaceId, threadId, preferredSplitPanelWidth(getContentRowWidth()));
+}
 
 /**
  * After opening the right panel, maximize it when the content row cannot fit
@@ -29,6 +41,7 @@ export function showRightPanelAdaptive(
   threadId?: string | null,
 ): void {
   useDiffStore.getState().showRightPanel(workspaceId, threadId);
+  applyHalfWidthIfUntouched(workspaceId, threadId);
   applyMaximizeIfCramped(workspaceId, threadId);
 }
 
@@ -47,6 +60,7 @@ export function toggleRightPanelAdaptive(
     useUiStore.getState().setRightPanelMaximized(false);
     return;
   }
+  applyHalfWidthIfUntouched(workspaceId, threadId);
   applyMaximizeIfCramped(workspaceId, threadId);
 }
 

--- a/apps/web/src/stores/layoutStore.ts
+++ b/apps/web/src/stores/layoutStore.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+
+/**
+ * Reactive mirror of the live content-row width published by the composer
+ * layout guard. Components that need to react to the chat area resizing (e.g.
+ * the Overview deciding whether it can dock) subscribe here instead of racing a
+ * window `resize` listener against the guard's ResizeObserver.
+ */
+interface LayoutState {
+  /** Current content-row width in CSS pixels, or 0 before first measurement. */
+  contentRowWidth: number;
+  setContentRowWidth: (width: number) => void;
+}
+
+/** Store backing reactive content-row width subscriptions. */
+export const useLayoutStore = create<LayoutState>((set) => ({
+  contentRowWidth: 0,
+  setContentRowWidth: (width) =>
+    set((state) => (state.contentRowWidth === width ? state : { contentRowWidth: width })),
+}));

--- a/apps/web/src/stores/overviewStore.ts
+++ b/apps/web/src/stores/overviewStore.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+
+/**
+ * Shares whether the chat area should reserve room on the right for the open
+ * Overview. True only when the Overview is open AND there is room to sit beside
+ * the chat; on small viewports it stays false so the Overview floats over the
+ * content instead of squeezing it. The Overview itself is always a transient
+ * popover; this is only a layout hint, not a dock.
+ */
+interface OverviewState {
+  reserveSpace: boolean;
+  setReserveSpace: (reserveSpace: boolean) => void;
+}
+
+/** Store backing the chat area's "make room for the open Overview" padding. */
+export const useOverviewStore = create<OverviewState>((set) => ({
+  reserveSpace: false,
+  setReserveSpace: (reserveSpace) =>
+    set((state) => (state.reserveSpace === reserveSpace ? state : { reserveSpace })),
+}));


### PR DESCRIPTION
## What
Polishes the thread Overview links and applies the same compact link treatment to bare web links in chat messages.

## Why
Issue #762 needs repository links to read as compact repo links with favicons, while the Overview keeps Repository as a plain section header. The same treatment makes bare HTTP links in normal threads easier to scan.

## Key Changes
- Shows the Overview repository as a section header with the safe remote link underneath, and hides it when no remote URL is known.
- Adds space-aware Overview behavior so it opens on wide layouts, floats on narrow layouts, and only offsets the chat when needed.
- Adds a Sources section for assistant-provided web links in the Overview.
- Renders bare Markdown URLs with compact labels such as owner/repo, owner/repo#42, or host/path while keeping authored link text unchanged.
- Shares favicon rendering across Overview and Markdown links, including a themed GitHub mark in dark mode.

Closes #762

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784392481&installation_id=129163861&pr_number=790&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F790&signature=99e00d64d3a59ebb8f606ef090dec4124f3263f16012a321b4f727f5c414b1b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread Overview now displays repository information with favicon
  * Links render with favicons and humanized URL labels (e.g., "owner/repo")
  * Overview auto-opens on wider viewports for improved discoverability
  * Sources section in Overview shows extracted links with favicons

* **Improvements**
  * Enhanced responsive layout behavior for the Overview panel
  * Better link handling with compact URL display formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->