### PR TITLE
fix(server): preserve file diffs across overlapping turns

### DIFF
--- a/apps/server/src/services/__tests__/turn-finalizer.test.ts
+++ b/apps/server/src/services/__tests__/turn-finalizer.test.ts
@@ -469,6 +469,96 @@ describe("TurnFinalizer.finalize — git snapshot write", () => {
     });
   });
 
+  it("does not let an older finalize clear a newer turn ref while snapshot capture is still running", async () => {
+    let resolveFirstCapture: ((ref: string) => void) | undefined;
+    const captureRef = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveFirstCapture = resolve;
+          }),
+      )
+      .mockResolvedValueOnce("second-after");
+    const getFilesChanged = vi.fn(
+      async (_cwd: string, refBefore: string) =>
+        refBefore === "first-before" ? ["first.ts"] : ["second.ts"],
+    );
+    const messageRepo = {
+      listByThread: vi.fn(() => ({
+        messages: [{ id: "msg-1", role: "assistant", sequence: 2, content: "" }],
+      })),
+      create: vi.fn(),
+    } as unknown as MessageRepo;
+    const threadRepo = { findById: vi.fn(() => ({ model: null })) } as unknown as ThreadRepo;
+    const narrativeStore = {
+      getBufferedToolCalls: vi.fn(() => []),
+      hasBufferedNarrative: vi.fn(() => true),
+      persistNarrative: vi.fn(() => ({ toolCallCount: 0 })),
+      clearTurn: vi.fn(),
+    } as unknown as NarrativeStore;
+    const snapshotService = { captureRef, getFilesChanged } as unknown as SnapshotService;
+    const turnSnapshotRepo = { create: vi.fn() } as unknown as TurnSnapshotRepo;
+    const db = {
+      transaction: vi.fn((fn: (files: string[]) => void) => fn),
+      prepare: vi.fn(() => ({ run: vi.fn() })),
+    } as unknown as Database.Database;
+    const finalizer = new TurnFinalizer(
+      messageRepo,
+      threadRepo,
+      narrativeStore,
+      snapshotService,
+      turnSnapshotRepo,
+      db,
+    );
+
+    finalizer.recordTurnRef(THREAD, "first-before", "/workspace");
+    const first = finalizer.finalize(THREAD, "completed");
+
+    await vi.waitFor(() => expect(captureRef).toHaveBeenCalledTimes(1));
+    finalizer.recordTurnRef(THREAD, "second-before", "/workspace");
+    resolveFirstCapture?.("first-after");
+    await first;
+
+    await finalizer.finalize(THREAD, "completed");
+
+    expect(captureRef).toHaveBeenCalledTimes(2);
+    expect(turnSnapshotRepo.create).toHaveBeenNthCalledWith(1, {
+      messageId: "msg-1",
+      threadId: THREAD,
+      refBefore: "first-before",
+      refAfter: "first-after",
+      filesChanged: ["first.ts"],
+      worktreePath: null,
+    });
+    expect(turnSnapshotRepo.create).toHaveBeenNthCalledWith(2, {
+      messageId: "msg-1",
+      threadId: THREAD,
+      refBefore: "second-before",
+      refAfter: "second-after",
+      filesChanged: ["second.ts"],
+      worktreePath: null,
+    });
+  });
+
+  it("does not let a finalize without a ref clear a newer turn ref before cleanup", async () => {
+    const { finalizer, turnSnapshotRepo } = build(["second.ts"]);
+    const first = finalizer.finalize(THREAD, "completed");
+    queueMicrotask(() => finalizer.recordTurnRef(THREAD, "second-before", "/workspace"));
+
+    await first;
+    await finalizer.finalize(THREAD, "completed");
+
+    expect(turnSnapshotRepo.create).toHaveBeenCalledWith({
+      messageId: "msg-1",
+      threadId: THREAD,
+      refBefore: "second-before",
+      refAfter: "def222",
+      filesChanged: ["second.ts"],
+      worktreePath: null,
+    });
+  });
+
   it("runs the idempotent has_file_changes update when files changed", async () => {
     const { finalizer, db, runSpy } = build(["src/index.ts"]);
     finalizer.recordTurnRef(THREAD, "abc111", "/workspace");

--- a/apps/server/src/services/turn-finalizer.ts
+++ b/apps/server/src/services/turn-finalizer.ts
@@ -208,13 +208,14 @@ export class TurnFinalizer {
   private async runFinalizeOnce(threadId: string, outcome: TurnOutcome): Promise<void> {
     if (this.persistingThreads.has(threadId)) return;
     this.persistingThreads.add(threadId);
+    const turnRef = this.turnRefBefore.get(threadId);
     try {
       // TurnSubstance guard: nothing worth keeping → leave no assistant row.
       if (!this.hasRecordableActivity(threadId)) {
         // This turn persisted no row, so a late hook for it must be discarded
         // rather than mis-attached to the previous turn's still-cached id.
         this.lastPersistedMessageIdByThread.delete(threadId);
-        this.clearTurn(threadId);
+        this.clearTurn(threadId, turnRef);
         return;
       }
 
@@ -224,7 +225,7 @@ export class TurnFinalizer {
         // the wrong (preceding) message id. Drop the prior id for the same
         // reason as the empty-turn branch: a late hook has no row to attach to.
         this.lastPersistedMessageIdByThread.delete(threadId);
-        this.clearTurn(threadId);
+        this.clearTurn(threadId, turnRef);
         return;
       }
 
@@ -240,7 +241,7 @@ export class TurnFinalizer {
         outcome,
       );
 
-      const filesChanged = await this.captureSnapshot(threadId, messageId);
+      const filesChanged = await this.captureSnapshot(threadId, messageId, turnRef);
 
       broadcast("turn.persisted", {
         threadId,
@@ -249,7 +250,7 @@ export class TurnFinalizer {
         filesChanged,
       });
 
-      this.clearTurn(threadId);
+      this.clearTurn(threadId, turnRef);
     } finally {
       this.persistingThreads.delete(threadId);
     }
@@ -261,8 +262,11 @@ export class TurnFinalizer {
    * flag in one transaction. Returns an empty list when no ref was recorded or
    * the working tree is unchanged.
    */
-  private async captureSnapshot(threadId: string, messageId: string): Promise<string[]> {
-    const refData = this.turnRefBefore.get(threadId);
+  private async captureSnapshot(
+    threadId: string,
+    messageId: string,
+    refData: TurnRef | undefined,
+  ): Promise<string[]> {
     if (!refData) return [];
     try {
       const refAfter = await this.snapshotService.captureRef(refData.cwd);
@@ -381,8 +385,10 @@ export class TurnFinalizer {
    * agentCallStack are reset on the next TurnStarted (not here) so late hooks
    * arriving after the turn can still increment the completed turn's counter.
    */
-  private clearTurn(threadId: string): void {
-    this.turnRefBefore.delete(threadId);
+  private clearTurn(threadId: string, turnRef: TurnRef | undefined): void {
+    if (turnRef !== undefined && this.turnRefBefore.get(threadId) === turnRef) {
+      this.turnRefBefore.delete(threadId);
+    }
     this.streamingAssistantTextByThread.delete(threadId);
     this.bufferedBodyByThread.delete(threadId);
     this.bufferedAttachmentsByThread.delete(threadId);


### PR DESCRIPTION
## What
Fix turn snapshot finalization so older finalizers cannot clear newer recorded git refs while cleanup is still pending.

## Why
Changed-file lists can disappear for local, no-origin repos when turns overlap. The finalizer keyed `turnRefBefore` only by `threadId`, so one turn could delete the next turn's ref during cleanup.

## Key Changes
- Capture the turn ref once at finalize start and pass it through snapshot capture.
- Clear the saved ref only when a captured ref exists and still matches the finalized turn.
- Add regression coverage for both stale defined refs and the undefined-ref cleanup race.

## Verification
- `git diff --check` exited 0. Git printed CRLF warnings for the two touched files.
- `cd apps/server; bun run test -- src/services/__tests__/turn-finalizer.test.ts src/__tests__/snapshot-service.integration.test.ts`
  - Test Files 2 passed (2)
  - Tests 36 passed (36)
- Direct Bun runtime invocation created one snapshot row with `refBefore: "second-before"` and `filesChanged: ["second.ts"]`.
- Live demo used an isolated local repo with no origin on branch `feature/local-turns`. Last turn showed `src/second.ts` and `src/story.ts`; all turns showed `notes/local.md`, `src/second.ts`, and `src/story.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a concurrency issue where overlapping turn finalizations could clear or overwrite the wrong git snapshot reference. Snapshot capture now consistently uses the originally captured reference data, preventing mismatched diffs.
* **Tests**
  * Added regression coverage to verify older finalizations can’t interfere with newer queued turn reference updates during pending snapshot capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->