### PR TITLE
fix(codex): expand custom prompt slash commands

### DIFF
--- a/apps/server/src/__tests__/snapshot-service.integration.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.integration.test.ts
@@ -8,6 +8,7 @@ import { SnapshotService } from "../services/snapshot-service";
 import { RealGitExecutor } from "../services/git-executor/real-git-executor.js";
 
 const GIT_REPO_SETUP_TIMEOUT_MS = 30_000;
+const GIT_OPERATION_TIMEOUT_MS = 30_000;
 
 /**
  * Integration tests for SnapshotService using real git repositories.
@@ -26,7 +27,18 @@ function createGitRepo(): string {
   // Create an initial file and commit so HEAD exists
   writeFileSync(join(tmpDir, "existing.txt"), "line one\nline two\nline three\n");
   execFileSync("git", ["-C", tmpDir, "add", "existing.txt"]);
-  execFileSync("git", ["-C", tmpDir, "commit", "-m", "initial commit"]);
+  const tree = execFileSync("git", ["-C", tmpDir, "write-tree"], { encoding: "utf8" }).trim();
+  const commit = execFileSync("git", ["-C", tmpDir, "commit-tree", tree, "-m", "initial commit"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Mcode Test",
+      GIT_AUTHOR_EMAIL: "test@mcode.test",
+      GIT_COMMITTER_NAME: "Mcode Test",
+      GIT_COMMITTER_EMAIL: "test@mcode.test",
+    },
+  }).trim();
+  execFileSync("git", ["-C", tmpDir, "update-ref", "refs/heads/main", commit]);
 
   return tmpDir;
 }
@@ -66,7 +78,7 @@ describe("SnapshotService integration", () => {
 
     const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
     expect(files).toContain("newfile.ts");
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   it("modified tracked files appear in getFilesChanged", async () => {
     const refBefore = await service.captureRef(tmpDir);
@@ -79,7 +91,7 @@ describe("SnapshotService integration", () => {
 
     const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
     expect(files).toContain("existing.txt");
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   it("both new and modified files appear in getFilesChanged", async () => {
     const refBefore = await service.captureRef(tmpDir);
@@ -94,7 +106,7 @@ describe("SnapshotService integration", () => {
     const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
     expect(files).toContain("existing.txt");
     expect(files).toContain("brand-new.ts");
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   it("clean tree returns the same ref for consecutive captureRef calls", async () => {
     // No changes between the two captures
@@ -105,7 +117,7 @@ describe("SnapshotService integration", () => {
 
     const files = await service.getFilesChanged(tmpDir, refA, refB);
     expect(files).toHaveLength(0);
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   it("getDiff includes new file content", async () => {
     const refBefore = await service.captureRef(tmpDir);
@@ -119,7 +131,7 @@ describe("SnapshotService integration", () => {
     expect(diff).toContain("hello.ts");
     // Added lines are prefixed with '+' in unified diff
     expect(diff).toContain("+export function hello()");
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   it("getDiffStats counts new file additions", async () => {
     const newFileContent = "line 1\nline 2\nline 3\n";
@@ -137,7 +149,7 @@ describe("SnapshotService integration", () => {
     expect(fileStat).toBeDefined();
     expect(fileStat!.additions).toBe(expectedLineCount);
     expect(fileStat!.deletions).toBe(0);
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   it("gitignored files are excluded from getFilesChanged", async () => {
     const refBefore = await service.captureRef(tmpDir);
@@ -154,7 +166,7 @@ describe("SnapshotService integration", () => {
     // The .gitignore itself and visible.txt are tracked changes
     expect(files).toContain(".gitignore");
     expect(files).toContain("visible.txt");
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 });
 
 describe("SnapshotService integration - unborn repo", () => {
@@ -164,7 +176,7 @@ describe("SnapshotService integration - unborn repo", () => {
   beforeEach(() => {
     service = new SnapshotService(new RealGitExecutor());
     tmpDir = createUnbornRepo();
-  }, GIT_REPO_SETUP_TIMEOUT_MS);
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
@@ -178,7 +190,7 @@ describe("SnapshotService integration - unborn repo", () => {
     // Should return a valid 40-char hex tree SHA, not empty
     expect(ref).toMatch(/^[0-9a-f]{40}$/);
     expect(ref).not.toBe("4b825dc642cb6eb9a060e54bf899d69f82cf7109"); // not the empty tree
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   it("detects new files between snapshots in unborn repo", async () => {
     const refBefore = await service.captureRef(tmpDir);
@@ -191,7 +203,7 @@ describe("SnapshotService integration - unborn repo", () => {
 
     const files = await service.getFilesChanged(tmpDir, refBefore, refAfter);
     expect(files).toContain("hello.ts");
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 
   it("clean unborn repo returns the same (empty) tree SHA", async () => {
     const refA = await service.captureRef(tmpDir);
@@ -200,5 +212,5 @@ describe("SnapshotService integration - unborn repo", () => {
     expect(refA).toBe(refB);
     // Should be a valid 40-char hex tree SHA
     expect(refA).toMatch(/^[0-9a-f]{40}$/);
-  });
+  }, GIT_OPERATION_TIMEOUT_MS);
 });

--- a/apps/server/src/providers/codex/__tests__/codex-prompt.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-prompt.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { SkillInfo } from "@mcode/contracts";
+import {
+  expandCodexPromptTemplate,
+  resolveCodexPromptInvocation,
+} from "../codex-prompt.js";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "codex-prompt-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Codex custom prompt expansion", () => {
+  it("expands positional, named, raw argument, and literal dollar placeholders", () => {
+    const expanded = expandCodexPromptTemplate(
+      "File: $FILE\nTitle: $PR_TITLE\nFirst: $1\nAll: $ARGUMENTS\nCost: $$5",
+      'FILES="ignored" alpha FILE=src/index.ts PR_TITLE="Add hero"',
+    );
+
+    expect(expanded).toBe(
+      'File: src/index.ts\nTitle: Add hero\nFirst: alpha\nAll: FILES="ignored" alpha FILE=src/index.ts PR_TITLE="Add hero"\nCost: $5',
+    );
+  });
+
+  it("expands a discovered /prompts:name invocation from the prompt file body", async () => {
+    const dir = tempDir();
+    const promptPath = join(dir, "draftpr.md");
+    writeFileSync(
+      promptPath,
+      "---\ndescription: Draft a PR\n---\nCreate PR for $FILES with title $PR_TITLE.",
+    );
+    const catalog: SkillInfo[] = [{
+      name: "prompts:draftpr",
+      nativeName: "draftpr",
+      description: "Draft a PR",
+      kind: "command",
+      source: "user",
+      providers: ["codex"],
+      path: promptPath,
+    }];
+
+    await expect(
+      resolveCodexPromptInvocation(
+        '/prompts:draftpr FILES="src/a.ts src/b.ts" PR_TITLE="Add files"',
+        catalog,
+      ),
+    ).resolves.toBe("Create PR for src/a.ts src/b.ts with title Add files.");
+  });
+
+  it("does not expand a prompt command by its native basename", async () => {
+    const dir = tempDir();
+    const promptPath = join(dir, "draftpr.md");
+    writeFileSync(promptPath, "Create PR for $ARGUMENTS.");
+    const catalog: SkillInfo[] = [{
+      name: "prompts:draftpr",
+      nativeName: "draftpr",
+      description: "Draft a PR",
+      kind: "command",
+      source: "user",
+      providers: ["codex"],
+      path: promptPath,
+    }];
+
+    await expect(resolveCodexPromptInvocation("/draftpr src/a.ts", catalog)).resolves.toBeNull();
+  });
+});

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -1,7 +1,8 @@
 import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 
 vi.mock("@mcode/shared", () => ({
   getMcodeDir: () => process.env.MCODE_DATA_DIR ?? ".",
@@ -194,6 +195,83 @@ describe("CodexProvider first turn on new session", () => {
       { type: "skill", name: "control-in-app-browser", path: skillPath },
       { type: "text", text: "$control-in-app-browser inspect localhost" },
     ], expect.anything());
+  });
+
+  it("expands Codex prompt commands before turn/start", async () => {
+    const promptDir = mkdtempSync(join(tmpdir(), "codex-provider-prompt-"));
+    try {
+      const promptPath = join(promptDir, "draftpr.md");
+      writeFileSync(
+        promptPath,
+        "---\ndescription: Draft a PR\n---\nDraft a PR for $FILES titled $PR_TITLE. Args: $ARGUMENTS",
+      );
+      const provider = makeProvider(vi.fn(() => [{
+        name: "prompts:draftpr",
+        nativeName: "draftpr",
+        description: "Draft a PR",
+        kind: "command",
+        source: "user",
+        providers: ["codex"],
+        path: promptPath,
+      }]));
+
+      await provider.sendTurn({
+        sessionId: "mcode-prompt-turn",
+        threadId: "prompt-turn",
+        message: '/prompts:draftpr FILES="src/a.ts src/b.ts" PR_TITLE="Add files"',
+        cwd: process.cwd(),
+        model: "gpt-5.4",
+        interactionMode: "build",
+        providerOptions: {},
+        permissionMode: "auto",
+      });
+
+      for (let i = 0; i < 20 && sendTurnMock.mock.calls.length === 0; i++) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+
+      expect(sendTurnMock.mock.calls[0][0]).toEqual([{
+        type: "text",
+        text: 'Draft a PR for src/a.ts src/b.ts titled Add files. Args: FILES="src/a.ts src/b.ts" PR_TITLE="Add files"',
+      }]);
+    } finally {
+      rmSync(promptDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits a controlled error when a listed Codex prompt cannot be read", async () => {
+    const provider = makeProvider(vi.fn(() => [{
+      name: "prompts:draftpr",
+      nativeName: "draftpr",
+      description: "Draft a PR",
+      kind: "command",
+      source: "user",
+      providers: ["codex"],
+      path: join(tmpdir(), "missing-codex-prompt.md"),
+    }]));
+    const events: AgentEvent[] = [];
+    provider.on("event", (event: AgentEvent) => events.push(event));
+
+    await provider.sendTurn({
+      sessionId: "mcode-missing-prompt",
+      threadId: "missing-prompt",
+      message: "/prompts:draftpr src/a.ts",
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "auto",
+    });
+
+    expect(sendTurnMock).not.toHaveBeenCalled();
+    expect(events).toEqual([
+      {
+        type: AgentEventType.Error,
+        threadId: "missing-prompt",
+        error: "Could not load Codex prompt /prompts:draftpr. Refresh commands and try again.",
+      },
+      { type: AgentEventType.Ended, threadId: "missing-prompt" },
+    ]);
   });
 
   it("leaves unknown slash commands unchanged", async () => {

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -240,38 +240,43 @@ describe("CodexProvider first turn on new session", () => {
   });
 
   it("emits a controlled error when a listed Codex prompt cannot be read", async () => {
-    const provider = makeProvider(vi.fn(() => [{
-      name: "prompts:draftpr",
-      nativeName: "draftpr",
-      description: "Draft a PR",
-      kind: "command",
-      source: "user",
-      providers: ["codex"],
-      path: join(tmpdir(), "missing-codex-prompt.md"),
-    }]));
-    const events: AgentEvent[] = [];
-    provider.on("event", (event: AgentEvent) => events.push(event));
+    const promptDir = mkdtempSync(join(tmpdir(), "missing-codex-prompt-"));
+    try {
+      const provider = makeProvider(vi.fn(() => [{
+        name: "prompts:draftpr",
+        nativeName: "draftpr",
+        description: "Draft a PR",
+        kind: "command",
+        source: "user",
+        providers: ["codex"],
+        path: join(promptDir, "draftpr.md"),
+      }]));
+      const events: AgentEvent[] = [];
+      provider.on("event", (event: AgentEvent) => events.push(event));
 
-    await provider.sendTurn({
-      sessionId: "mcode-missing-prompt",
-      threadId: "missing-prompt",
-      message: "/prompts:draftpr src/a.ts",
-      cwd: process.cwd(),
-      model: "gpt-5.4",
-      interactionMode: "build",
-      providerOptions: {},
-      permissionMode: "auto",
-    });
-
-    expect(sendTurnMock).not.toHaveBeenCalled();
-    expect(events).toEqual([
-      {
-        type: AgentEventType.Error,
+      await provider.sendTurn({
+        sessionId: "mcode-missing-prompt",
         threadId: "missing-prompt",
-        error: "Could not load Codex prompt /prompts:draftpr. Refresh commands and try again.",
-      },
-      { type: AgentEventType.Ended, threadId: "missing-prompt" },
-    ]);
+        message: "/prompts:draftpr src/a.ts",
+        cwd: process.cwd(),
+        model: "gpt-5.4",
+        interactionMode: "build",
+        providerOptions: {},
+        permissionMode: "auto",
+      });
+
+      expect(sendTurnMock).not.toHaveBeenCalled();
+      expect(events).toEqual([
+        {
+          type: AgentEventType.Error,
+          threadId: "missing-prompt",
+          error: "Could not load Codex prompt /prompts:draftpr. Refresh commands and try again.",
+        },
+        { type: AgentEventType.Ended, threadId: "missing-prompt" },
+      ]);
+    } finally {
+      rmSync(promptDir, { recursive: true, force: true });
+    }
   });
 
   it("leaves unknown slash commands unchanged", async () => {

--- a/apps/server/src/providers/codex/codex-prompt.ts
+++ b/apps/server/src/providers/codex/codex-prompt.ts
@@ -1,0 +1,194 @@
+import { readFile, stat } from "fs/promises";
+import type { SkillInfo } from "@mcode/contracts";
+
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+const MAX_PROMPT_TEMPLATE_BYTES = 256 * 1024;
+const MAX_PROMPT_TEMPLATE_CACHE_ENTRIES = 64;
+
+export interface CodexSlashInvocation {
+  requestedName: string;
+  args: string;
+}
+
+/** Error shown when a listed Codex prompt can no longer be expanded safely. */
+export class CodexPromptResolutionError extends Error {
+  constructor(
+    readonly promptName: string,
+    cause: unknown,
+  ) {
+    super(`Could not load Codex prompt /${promptName}. Refresh commands and try again.`);
+    this.name = "CodexPromptResolutionError";
+    (this as Error & { cause?: unknown }).cause = cause;
+  }
+}
+
+interface ParsedPromptArguments {
+  raw: string;
+  positional: string[];
+  named: Map<string, string>;
+}
+
+interface CachedPromptTemplate {
+  size: number;
+  mtimeMs: number;
+  template: string;
+}
+
+const promptTemplateCache = new Map<string, CachedPromptTemplate>();
+
+function stripFrontmatter(content: string): string {
+  return content.replace(FRONTMATTER_RE, "");
+}
+
+function tokenizePromptArguments(raw: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch === "\\" && i + 1 < raw.length) {
+      current += raw[i + 1];
+      i += 1;
+      continue;
+    }
+    if ((ch === "'" || ch === "\"") && quote === null) {
+      quote = ch;
+      continue;
+    }
+    if (ch === quote) {
+      quote = null;
+      continue;
+    }
+    if (quote === null && /\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function parsePromptArguments(raw: string): ParsedPromptArguments {
+  const trimmed = raw.trim();
+  const positional: string[] = [];
+  const named = new Map<string, string>();
+
+  for (const token of tokenizePromptArguments(trimmed)) {
+    const namedMatch = /^([A-Z][A-Z0-9_]*)=(.*)$/.exec(token);
+    if (namedMatch) {
+      named.set(namedMatch[1], namedMatch[2]);
+      continue;
+    }
+    positional.push(token);
+  }
+
+  return { raw: trimmed, positional, named };
+}
+
+async function readCodexPromptTemplate(path: string): Promise<string> {
+  const templateStats = await stat(path);
+  if (templateStats.size > MAX_PROMPT_TEMPLATE_BYTES) {
+    throw new Error(`Codex prompt template is too large: ${path}`);
+  }
+
+  const cached = promptTemplateCache.get(path);
+  if (
+    cached &&
+    cached.size === templateStats.size &&
+    cached.mtimeMs === templateStats.mtimeMs
+  ) {
+    promptTemplateCache.delete(path);
+    promptTemplateCache.set(path, cached);
+    return cached.template;
+  }
+
+  const template = stripFrontmatter(await readFile(path, "utf8"));
+  promptTemplateCache.set(path, {
+    size: templateStats.size,
+    mtimeMs: templateStats.mtimeMs,
+    template,
+  });
+  while (promptTemplateCache.size > MAX_PROMPT_TEMPLATE_CACHE_ENTRIES) {
+    const oldestKey = promptTemplateCache.keys().next().value as string | undefined;
+    if (!oldestKey) break;
+    promptTemplateCache.delete(oldestKey);
+  }
+  return template;
+}
+
+/** Parses a Codex slash invocation without resolving it against a catalog. */
+export function parseCodexSlashInvocation(message: string): CodexSlashInvocation | null {
+  const withoutLeadingSpace = message.trimStart();
+  const match = /^\/([^\s]+)(?:\s+([\s\S]*))?$/.exec(withoutLeadingSpace);
+  if (!match) return null;
+  return {
+    requestedName: match[1],
+    args: match[2] ?? "",
+  };
+}
+
+/**
+ * Returns true when a catalog entry is the selected Codex custom prompt.
+ */
+export function isCodexPromptCommand(
+  item: SkillInfo,
+  requestedName: string,
+): item is SkillInfo & { path: string } {
+  return (
+    item.kind === "command" &&
+    Boolean(item.path) &&
+    item.name === requestedName
+  );
+}
+
+/**
+ * Expands a Codex custom-prompt template with the same placeholder forms
+ * documented for `~/.codex/prompts`.
+ */
+export function expandCodexPromptTemplate(template: string, rawArgs: string): string {
+  const args = parsePromptArguments(rawArgs);
+  const dollarSentinel = "\0CODEX_LITERAL_DOLLAR\0";
+  return template
+    .replace(/\$\$/g, dollarSentinel)
+    .replace(/\$(ARGUMENTS|[1-9]|[A-Z][A-Z0-9_]*)\b/g, (_match, key: string) => {
+      if (key === "ARGUMENTS") return args.raw;
+      if (/^[1-9]$/.test(key)) return args.positional[Number(key) - 1] ?? "";
+      return args.named.get(key) ?? "";
+    })
+    .replaceAll(dollarSentinel, "$");
+}
+
+/** Expands a discovered Codex prompt command from its cached template file. */
+export async function expandCodexPromptCommand(
+  command: SkillInfo & { path: string },
+  rawArgs: string,
+): Promise<string> {
+  try {
+    const template = await readCodexPromptTemplate(command.path);
+    return expandCodexPromptTemplate(template, rawArgs);
+  } catch (err) {
+    throw new CodexPromptResolutionError(command.name, err);
+  }
+}
+
+/**
+ * Expands a selected Codex prompt slash invocation, or returns null when the
+ * message is not a known prompt command.
+ */
+export async function resolveCodexPromptInvocation(
+  message: string,
+  catalog: readonly SkillInfo[],
+): Promise<string | null> {
+  const invocation = parseCodexSlashInvocation(message);
+  if (!invocation) return null;
+
+  const command = catalog.find((item) => isCodexPromptCommand(item, invocation.requestedName));
+  if (!command) return null;
+  return expandCodexPromptCommand(command, invocation.args);
+}

--- a/apps/server/src/providers/codex/codex-prompt.ts
+++ b/apps/server/src/providers/codex/codex-prompt.ts
@@ -5,6 +5,7 @@ const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 const MAX_PROMPT_TEMPLATE_BYTES = 256 * 1024;
 const MAX_PROMPT_TEMPLATE_CACHE_ENTRIES = 64;
 
+/** Parsed slash-command name and raw argument string for Codex command resolution. */
 export interface CodexSlashInvocation {
   requestedName: string;
   args: string;

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -58,6 +58,12 @@ import {
   mapDecisionToCodexResponse,
   synthesizeCodexPermissionRequest,
 } from "./codex-permission-mapper.js";
+import {
+  CodexPromptResolutionError,
+  expandCodexPromptCommand,
+  isCodexPromptCommand,
+  parseCodexSlashInvocation,
+} from "./codex-prompt.js";
 
 /**
  * Liveness-probe interval for a silent turn, not a turn deadline. The timer
@@ -142,11 +148,11 @@ interface PendingPermissionEntry {
  * Images become `localImage` parts; non-image files become sanitised text notes
  * that omit internal filesystem paths to prevent prompt injection.
  */
-function buildCodexInput(
+async function buildCodexInput(
   message: string,
   attachments?: AttachmentMeta[],
   skills: readonly SkillInfo[] = [],
-): TurnInputPart[] {
+): Promise<TurnInputPart[]> {
   const inputs: TurnInputPart[] = [];
 
   for (const att of attachments ?? []) {
@@ -162,36 +168,44 @@ function buildCodexInput(
     }
   }
 
-  const invocation = resolveCodexSkillInvocation(message, skills);
+  const invocation = await resolveCodexSlashInvocation(message, skills);
   if (invocation.skillItem) inputs.push(invocation.skillItem);
   inputs.push({ type: "text", text: invocation.text });
   return inputs;
 }
 
-/** Translates an Mcode slash skill invocation into Codex's native skill input. */
-function resolveCodexSkillInvocation(
+/** Translates Mcode slash invocations into Codex-native skill or prompt input. */
+async function resolveCodexSlashInvocation(
   message: string,
   skills: readonly SkillInfo[],
-): { text: string; skillItem?: TurnInputPart } {
-  const withoutLeadingSpace = message.trimStart();
-  const match = /^\/([^\s]+)(?:\s+([\s\S]*))?$/.exec(withoutLeadingSpace);
-  if (!match) return { text: message };
+): Promise<{ text: string; skillItem?: TurnInputPart }> {
+  const slash = parseCodexSlashInvocation(message);
+  if (!slash) return { text: message };
 
-  const requestedName = match[1];
-  const skill = skills.find(
-    (item) =>
-      item.kind === "skill" &&
-      (item.name === requestedName || item.nativeName === requestedName),
-  );
-  if (!skill) return { text: message };
+  let promptCommand: (SkillInfo & { path: string }) | undefined;
+  for (const item of skills) {
+    if (item.name !== slash.requestedName && item.nativeName !== slash.requestedName) continue;
 
-  const nativeName = skill.nativeName ?? skill.name.split(":").pop() ?? skill.name;
-  const args = match[2]?.trimStart() ?? "";
-  const text = `$${nativeName}${args ? ` ${args}` : ""}`;
-  return {
-    text,
-    ...(skill.path ? { skillItem: { type: "skill" as const, name: nativeName, path: skill.path } } : {}),
-  };
+    if (item.kind === "skill") {
+      const nativeName = item.nativeName ?? item.name.split(":").pop() ?? item.name;
+      const args = slash.args.trimStart();
+      const text = `$${nativeName}${args ? ` ${args}` : ""}`;
+      return {
+        text,
+        ...(item.path ? { skillItem: { type: "skill" as const, name: nativeName, path: item.path } } : {}),
+      };
+    }
+
+    if (!promptCommand && isCodexPromptCommand(item, slash.requestedName)) {
+      promptCommand = item;
+    }
+  }
+
+  if (promptCommand) {
+    return { text: await expandCodexPromptCommand(promptCommand, slash.args) };
+  }
+
+  return { text: message };
 }
 
 /** Maps Codex native skill scope into Mcode's source labels. */
@@ -503,8 +517,20 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
 
     const nativeSkills = await this.listSkills(cwd);
     const skillCatalog = this.skillService.list(cwd, "codex", nativeSkills);
-    const input = buildCodexInput(message, attachments, skillCatalog);
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
+    let input: TurnInputPart[];
+    try {
+      input = await buildCodexInput(message, attachments, skillCatalog);
+    } catch (err) {
+      if (!(err instanceof CodexPromptResolutionError)) throw err;
+      logger.debug("Codex prompt expansion failed", {
+        promptName: err.promptName,
+        cause: err.cause instanceof Error ? err.cause.message : String(err.cause),
+      });
+      this.emit("event", { type: AgentEventType.Error, threadId, error: err.message } satisfies AgentEvent);
+      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      return;
+    }
 
     const sandbox = permissionMode === "full" ? "danger-full-access" : "workspace-write";
 

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -393,16 +393,20 @@ describe("SkillService", () => {
       expect(codexDeploy!.description).toBe("Codex deploy");
     });
 
-    it("tags commands from ~/.codex/commands with providers=['codex']", () => {
-      const cmdDir = join(fakeHome, ".codex", "commands");
+    it("tags prompts from ~/.codex/prompts as Codex prompt commands", () => {
+      const cmdDir = join(fakeHome, ".codex", "prompts");
       mkdirSync(cmdDir, { recursive: true });
-      writeMd(join(cmdDir, "deploy.md"), { description: "Codex deploy command" });
+      const promptPath = join(cmdDir, "deploy.md");
+      writeMd(promptPath, { description: "Codex deploy prompt" });
 
       const items = new SkillService().list(undefined, "codex");
 
-      const cmd = items.find((i) => i.name === "deploy");
+      const cmd = items.find((i) => i.name === "prompts:deploy");
       expect(cmd).toBeDefined();
       expect(cmd!.kind).toBe("command");
+      expect(cmd!.description).toBe("Codex deploy prompt");
+      expect(cmd!.nativeName).toBe("deploy");
+      expect(cmd!.path).toBe(promptPath);
       expect(cmd!.providers).toEqual(["codex"]);
     });
 

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -1,9 +1,10 @@
 /**
  * Skill and command scanning service.
  * Walks user, project, agent, and plugin directories looking for both
- * `skills/` (each subdirectory is a skill) and `commands/` (each .md file
- * is a command). Mirrors Claude Code's native discovery, extended to cover
- * Codex and Copilot provider directories, plus Cursor `.cursor/skills` and commands.
+ * `skills/` (each subdirectory is a skill), provider command directories, and
+ * Codex's `prompts/` directory. Mirrors Claude Code's native discovery,
+ * extended to cover Codex and Copilot provider directories, plus Cursor
+ * `.cursor/skills` and commands.
  */
 
 import { injectable } from "tsyringe";
@@ -345,6 +346,8 @@ interface ScanRoot {
   providers: string[];
   /** "skills" scans for subdirs with SKILL.md, "commands" scans for *.md files, "both" does both. */
   kind: "skills" | "commands" | "both";
+  /** Optional namespace prefix applied to markdown command files. */
+  prefix?: string;
 }
 
 /** Build the ordered list of directories to scan for skills and commands. */
@@ -363,7 +366,7 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
 
     // Codex ecosystem
     { path: join(codexDir, "skills"), source: "user", providers: ["codex"], kind: "skills" },
-    { path: join(codexDir, "commands"), source: "user", providers: ["codex"], kind: "commands" },
+    { path: join(codexDir, "prompts"), source: "user", providers: ["codex"], kind: "commands", prefix: "prompts" },
 
     // Copilot ecosystem
     { path: join(copilotDir, "skills"), source: "user", providers: ["copilot"], kind: "skills" },
@@ -389,7 +392,6 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
 
       // Codex project-level
       { path: join(cwd, ".codex", "skills"), source: "project", providers: ["codex"], kind: "skills" },
-      { path: join(cwd, ".codex", "commands"), source: "project", providers: ["codex"], kind: "commands" },
 
       // Cross-provider project-level
       { path: join(cwd, ".agents", "skills"), source: "project", providers: ["codex"], kind: "skills" },
@@ -513,7 +515,7 @@ export class SkillService {
         scanSkillsDir(ctx, root.path, "", root.source, root.providers);
       }
       if (root.kind === "commands" || root.kind === "both") {
-        scanCommandsDir(ctx, root.path, "", root.source, root.providers);
+        scanCommandsDir(ctx, root.path, root.prefix ?? "", root.source, root.providers);
       }
     }
 

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -10,6 +10,15 @@ function tmp() {
   return mkdtempSync(join(tmpdir(), "skill-watch-"));
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  expect(predicate()).toBe(true);
+}
+
 describe("SkillWatcherService", () => {
   let dir: string;
   let svc: SkillService;
@@ -34,7 +43,7 @@ describe("SkillWatcherService", () => {
     // Trigger a change event
     writeFileSync(join(dir, "skills", "marker.txt"), "x");
 
-    await new Promise((r) => setTimeout(r, 350)); // > debounce window
+    await waitFor(() => invalidateSpy.mock.calls.length > 0);
     expect(invalidateSpy).toHaveBeenCalled();
   });
 
@@ -47,7 +56,8 @@ describe("SkillWatcherService", () => {
       writeFileSync(join(dir, "skills", `f${i}.txt`), "x");
     }
 
-    await new Promise((r) => setTimeout(r, 350));
+    await waitFor(() => invalidateSpy.mock.calls.length > 0);
+    await new Promise((r) => setTimeout(r, 250));
     expect(invalidateSpy.mock.calls.length).toBe(1);
   });
 
@@ -69,7 +79,8 @@ describe("SkillWatcherService", () => {
     // invalidate once — so call count alone is insufficient. The real
     // assertion is that we never registered a second underlying watcher.
     writeFileSync(join(target, "marker.txt"), "x");
-    await new Promise((r) => setTimeout(r, 350));
+    await waitFor(() => invalidateSpy.mock.calls.length > 0);
+    await new Promise((r) => setTimeout(r, 250));
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
 
     // stopAll() must close every registered watcher; if dedup leaked a second
@@ -97,12 +108,13 @@ describe("SkillWatcherService", () => {
     // for the parent, which alone could satisfy a naive call-count assert.
     // Clearing the spy after this isolates the next assertion to the
     // late-registered root's own watcher.
-    await new Promise((r) => setTimeout(r, 350));
+    await waitFor(() => invalidateSpy.mock.calls.length > 0);
     invalidateSpy.mockClear();
 
     // A change inside the late-registered root must invalidate exactly once.
     writeFileSync(join(root, "marker.txt"), "x");
-    await new Promise((r) => setTimeout(r, 350));
+    await waitFor(() => invalidateSpy.mock.calls.length > 0);
+    await new Promise((r) => setTimeout(r, 250));
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -114,6 +126,7 @@ describe("SkillWatcherService", () => {
 
     // Should watch all the new provider roots
     expect(watchedPaths.some((p) => p.includes(".codex"))).toBe(true);
+    expect(watchedPaths.some((p) => p.replace(/\\/g, "/").includes(".codex/prompts"))).toBe(true);
     expect(watchedPaths.some((p) => p.includes(".agents"))).toBe(true);
     expect(watchedPaths.some((p) => p.replace(/\\/g, "/").includes(".cursor/skills"))).toBe(true);
   });
@@ -138,12 +151,13 @@ describe("SkillWatcherService", () => {
     // Create the missing codex root after start() — the codexParent watcher
     // should detect this and auto-register codexRoot.
     mkdirSync(codexRoot, { recursive: true });
-    await new Promise((r) => setTimeout(r, 350));
+    await waitFor(() => invalidateSpy.mock.calls.length > 0);
     invalidateSpy.mockClear();
 
     // A change inside the late-registered codex root must invalidate
     writeFileSync(join(codexRoot, "marker.txt"), "x");
-    await new Promise((r) => setTimeout(r, 350));
+    await waitFor(() => invalidateSpy.mock.calls.length > 0);
+    await new Promise((r) => setTimeout(r, 250));
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -85,7 +85,7 @@ export class SkillWatcherService {
       join(claudeDir, ".agents", "skills"),
       // Codex roots
       join(codexDir, "skills"),
-      join(codexDir, "commands"),
+      join(codexDir, "prompts"),
       join(codexDir, "plugins"),
       join(codexRuntimeDir, "plugins"),
       // Cross-provider roots

--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -63,6 +63,13 @@ const THREAD_CURSOR = {
   model: "cursor-auto",
 };
 
+/** Codex-backed thread — prompt commands must be scoped to Codex. */
+const THREAD_CODEX = {
+  ...THREAD,
+  provider: "codex" as const,
+  model: "gpt-5.2-codex",
+};
+
 /** Varied skills payload covering multiple kinds and sources. */
 const FIXTURE_SKILLS = [
   { name: "superpowers:brainstorming", description: "Generate ideas creatively", kind: "skill", source: "user" },
@@ -248,7 +255,43 @@ test.describe("Slash command popup", () => {
     });
   });
 
-  test("06 - long plugin skill list opens without React flushSync warning", async ({ page }) => {
+  test("06 - codex provider thread shows prompt commands in completion", async ({ page }) => {
+    let listParams: { cwd?: string; providerId?: string } | undefined;
+    const codexPrompts = [
+      {
+        name: "prompts:draftpr",
+        description: "Draft a pull request",
+        kind: "command" as const,
+        source: "user" as const,
+        providers: ["codex"],
+        nativeName: "draftpr",
+      },
+    ];
+
+    await mockWebSocketServer(page, {
+      "workspace.list": [WORKSPACE],
+      "thread.list": [THREAD_CODEX],
+      "message.list": [],
+      "skill.list": (params) => {
+        listParams = params as { cwd?: string; providerId?: string };
+        return codexPrompts;
+      },
+    });
+
+    await openPopup(page, "/prompts");
+
+    expect(listParams?.providerId).toBe("codex");
+
+    const popup = page.locator("[data-slash-popup]");
+    await expect(popup.getByText("/prompts:draftpr")).toBeVisible();
+
+    await page.screenshot({
+      path: "e2e/screenshots/slash-command/06-codex-prompt-command.png",
+      fullPage: true,
+    });
+  });
+
+  test("07 - long plugin skill list opens without React flushSync warning", async ({ page }) => {
     const flushSyncWarnings: string[] = [];
     page.on("console", (msg) => {
       const text = msg.text();


### PR DESCRIPTION
## What
Adds Codex custom prompt discovery and expansion for slash commands.

## Why
Codex custom prompts live in `~/.codex/prompts` and run as `/prompts:name`. Mcode scanned the old commands path, so Codex threads could show skill completions while prompt commands stayed unexpanded before `turn/start`.

## Key Changes
- Scan and watch `~/.codex/prompts` as Codex-only `prompts:` commands.
- Expand prompt templates before `turn/start`, including frontmatter, positional args, named args, `$ARGUMENTS`, and `$$`.
- Keep Codex skill rewrites as `$nativeName`; Claude behavior is unchanged.
- Cache prompt templates by size and mtime, cap the cache, and emit a controlled error for stale prompt files.
- Add server tests and a Codex prompt-completion e2e case.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784593881&installation_id=129163861&pr_number=792&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F792&signature=6951896c0b34e2cc9fac209e93c91e13a73ae33e78d82226e3dd8bb4cc754e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Codex slash prompt command support with template expansion and argument substitution.
  * Prompts are now discovered from `~/.codex/prompts`, including being watched for changes.
  * Updated slash-completion behavior to show Codex prompt entries (e.g., `/prompts:draftpr`).

* **Bug Fixes**
  * Improved handling when prompt templates can’t be loaded; the provider now emits error/end events and stops processing.

* **Tests**
  * Expanded unit, integration, and e2e coverage for prompt parsing/expansion and provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->