### PR TITLE
feat: add overview PR row and actions

### DIFF
--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -239,6 +239,7 @@ test.describe("Consolidated chat header", () => {
     await expect(page.getByTestId("thread-overview-repository")).toBeVisible();
     await expect(page.getByTestId("thread-overview-local")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-branch")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-pr")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-commit")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
     await expect(page.getByTestId("thread-overview-sources")).toHaveCount(0);
@@ -271,6 +272,9 @@ test.describe("Consolidated chat header", () => {
       )
       .toBe("https://github.com/Mzeey-Empire/mcode");
     await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/consolidated-header");
+    await expect(page.getByTestId("thread-overview-pr")).toContainText("Pull request");
+    await expect(page.getByTestId("thread-overview-pr-status")).toContainText("Ready");
+    await expect(page.getByTestId("thread-overview-pr-detail")).toContainText("No PR yet");
     await expect(page.getByTestId("thread-overview-change-summary")).toContainText("+233");
     await expect(page.getByTestId("thread-overview-change-summary")).toContainText("-0");
     await expect(page.getByTestId("workspace-menu-changes")).toHaveCSS("cursor", "pointer");

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -230,7 +230,7 @@ test.describe("Consolidated chat header", () => {
     await expect(page.getByRole("button", { name: /create pr/i })).toHaveCount(0);
   });
 
-  test("Overview popover holds changes, local, branch, commit, and PR actions", async ({ page }) => {
+  test("Overview popover holds changes, local, branch, and PR actions", async ({ page }) => {
     await ensureOverviewOpen(page);
 
     await expect(page.getByTestId("thread-overview-body")).toBeVisible();
@@ -240,8 +240,8 @@ test.describe("Consolidated chat header", () => {
     await expect(page.getByTestId("thread-overview-local")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-branch")).toBeVisible();
     await expect(page.getByTestId("thread-overview-pr")).toBeVisible();
-    await expect(page.getByTestId("workspace-menu-commit")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
+    await expect(page.getByTestId("workspace-menu-commit")).toHaveCount(0);
     await expect(page.getByTestId("thread-overview-sources")).toHaveCount(0);
     await expect(page.locator(".animate-overview-enter").first()).toBeVisible();
 
@@ -272,9 +272,10 @@ test.describe("Consolidated chat header", () => {
       )
       .toBe("https://github.com/Mzeey-Empire/mcode");
     await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/consolidated-header");
-    await expect(page.getByTestId("thread-overview-pr")).toContainText("Pull request");
-    await expect(page.getByTestId("thread-overview-pr-status")).toContainText("Ready");
-    await expect(page.getByTestId("thread-overview-pr-detail")).toContainText("No PR yet");
+    await expect(page.getByTestId("thread-overview-pr")).toContainText("Create PR");
+    await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-pr-status")).toHaveCount(0);
+    await expect(page.getByTestId("thread-overview-pr-detail")).toHaveCount(0);
     await expect(page.getByTestId("thread-overview-change-summary")).toContainText("+233");
     await expect(page.getByTestId("thread-overview-change-summary")).toContainText("-0");
     await expect(page.getByTestId("workspace-menu-changes")).toHaveCSS("cursor", "pointer");

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -166,6 +166,8 @@ export async function mockWebSocketServer(
           answeredPlanMessageIds: [],
           narrativeByMessage: {},
         };
+      } else if (method === "thread.recent") {
+        result = [];
       } else if (method === "permission.listPending") {
         result = [];
       } else if (method === "thread.getTasks") {
@@ -187,16 +189,28 @@ export async function mockWebSocketServer(
       else if (method === "push.subscribeThread" || method === "push.unsubscribeThread") result = undefined;
       else if (method === "agent.dismissPlanQuestions") result = undefined;
       else if (method === "plan.list") result = [];
+      else if (method === "skill.list") result = [];
       else if (method === "thread.syncPrs") result = [];
+      else if (method === "workspace.touchLastOpened") result = null;
       else if (method === "workspace.enrich") result = { items: [] };
       else if (method === "app.version") result = "0.0.1-test";
       else if (method === "config.discover") result = {};
+      else if (method === "terminal.listActive") result = [];
+      else if (method === "git.listWorktrees") result = [];
+      else if (method === "git.branchComparison") result = null;
       // Settings round-trip through the page-session store-of-record so a
       // UI-driven change (theme, concurrency) is reflected on the next read.
       else if (method === "settings.get") result = currentSettings;
       else if (method === "settings.update") {
         currentSettings = deepMerge(currentSettings, msg.params) as Settings;
         result = currentSettings;
+      }
+      else if (method === "provider.getUsage") {
+        const providerId =
+          msg.params && typeof msg.params === "object" && "providerId" in msg.params
+            ? String((msg.params as { providerId?: unknown }).providerId)
+            : "claude";
+        result = { providerId, quotaCategories: [] };
       }
       else if (method === "workspace.reorder") result = { ok: true };
       // ADR-0010: TerminalView calls terminal.reattach on every mount to replay

--- a/apps/web/e2e/overview-sources-demo.spec.ts
+++ b/apps/web/e2e/overview-sources-demo.spec.ts
@@ -81,6 +81,7 @@ const assistantMessage = {
     "3. Recraft SVG converter: https://www.recraft.ai/ai-image-vectorizer",
     "4. The repo lives at https://github.com/milex-consulting/CaravanFE",
     "5. Tracking issue: https://github.com/milex-consulting/CaravanFE/issues/42",
+    "6. Screenshot artifact: [local-unseeded-app.png](/tmp/screens/local-unseeded-app.png)",
     "",
     "My pick: try SVGTrace next.",
   ].join("\n"),
@@ -106,6 +107,9 @@ test("Overview sources + humanized links demo", async ({ page }) => {
     "git.listBranches": [
       { name: "feat/logo", shortSha: "abc1234", type: "local", isCurrent: true },
     ],
+    "git.listWorktrees": [
+      { name: "feat-x", path: "/tmp/caravanfe/.worktrees/feat-x", branch: "feat/logo", managed: true },
+    ],
     "git.getRemoteUrl": {
       label: "milex-consulting/CaravanFE",
       webUrl: "https://github.com/milex-consulting/CaravanFE",
@@ -123,6 +127,7 @@ test("Overview sources + humanized links demo", async ({ page }) => {
 
   // Humanized inline links in the transcript.
   await expect(page.getByText("milex-consulting/CaravanFE#42")).toBeVisible();
+  await expect(page.getByTestId("markdown-link-file-icon")).toBeVisible();
   await page.screenshot({ path: "e2e/screenshots/demo/transcript-humanized-links.png", fullPage: false });
 
   // Wide viewport: the Overview opens by default and shows repo + Sources.

--- a/apps/web/e2e/pr-row-demo.spec.ts
+++ b/apps/web/e2e/pr-row-demo.spec.ts
@@ -137,10 +137,37 @@ test("PR row demo: view open PR", async ({ page }) => {
 
   await openOverview(page);
 
-  await expect(page.getByTestId("workspace-menu-open-pr")).toContainText("View PR #790");
-  await expect(page.getByRole("button", { name: "Open PR menu" })).toBeVisible();
+  await expect(page.getByTestId("workspace-menu-open-pr")).toContainText("PR #790");
 
   await page.locator("[data-testid='thread-overview-pr']").screenshot({
     path: "e2e/screenshots/demo/pr-row-view-open.png",
+  });
+
+  await page.getByTestId("workspace-menu-open-pr").click();
+  await expect(page.getByTestId("thread-overview-pr-popover")).toBeVisible();
+  await expect(page.getByTestId("workspace-menu-open-pr-action")).toContainText("Open PR #790");
+  await expect(page.getByTestId("workspace-menu-new-pr")).toContainText("Create new PR");
+
+  const triggerBox = await page.getByTestId("workspace-menu-open-pr").boundingBox();
+  const popoverBox = await page.getByTestId("thread-overview-pr-popover").boundingBox();
+  expect(triggerBox).not.toBeNull();
+  expect(popoverBox).not.toBeNull();
+  if (triggerBox && popoverBox) {
+    expect(popoverBox.x + popoverBox.width).toBeLessThanOrEqual(triggerBox.x + 4);
+    expect(popoverBox.y).toBeLessThan(triggerBox.y + triggerBox.height);
+  }
+
+  await page.locator("[data-testid='thread-overview-body']").screenshot({
+    path: "e2e/screenshots/demo/pr-row-menu-open.png",
+  });
+
+  await page.screenshot({
+    path: "e2e/screenshots/demo/pr-row-menu-open-wide.png",
+    clip: {
+      x: Math.max(0, (popoverBox?.x ?? 0) - 16),
+      y: Math.max(0, (triggerBox?.y ?? 0) - 16),
+      width: (triggerBox?.x ?? 0) + (triggerBox?.width ?? 0) - Math.max(0, (popoverBox?.x ?? 0) - 16) + 16,
+      height: Math.max(triggerBox?.height ?? 0, popoverBox?.height ?? 0) + 32,
+    },
   });
 });

--- a/apps/web/e2e/pr-row-demo.spec.ts
+++ b/apps/web/e2e/pr-row-demo.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "@playwright/test";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+
+/**
+ * Visual demo: Overview PR row action flow across branch readiness and PR states.
+ * Captures screenshots to e2e/screenshots/demo/ for review without a live app.
+ */
+
+const now = new Date("2026-06-19T00:00:00.000Z").toISOString();
+const WS_ID = "ws-pr-demo";
+
+const workspace = {
+  id: WS_ID,
+  name: "mcode",
+  path: "/tmp/mcode",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+const thread = {
+  id: "thread-pr-demo",
+  workspace_id: WS_ID,
+  title: "PR row polish",
+  status: "paused" as const,
+  mode: "worktree" as const,
+  worktree_path: "/tmp/mcode/.worktrees/feat-pr-row",
+  branch: "feat/pr-row-and-actions",
+  worktree_managed: true,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+test.use({ viewport: { width: 1280, height: 900 } });
+
+async function openOverview(page: import("@playwright/test").Page) {
+  await page.addInitScript((wsId: string) => {
+    localStorage.setItem("mcode-expanded-projects", JSON.stringify({ [wsId]: true }));
+  }, WS_ID);
+  await page.goto("/");
+  await page.waitForSelector("[data-testid='thread-item']");
+  await page.locator("[data-testid='thread-item']").first().click();
+  await page.waitForSelector("[data-testid='chat-header-title']");
+  await page.getByTestId("header-workspace-menu").click();
+  await expect(page.getByTestId("thread-overview-body")).toBeVisible();
+}
+
+test("PR row demo: ready to create", async ({ page }) => {
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [thread],
+    "github.branchPr": null,
+    "git.log": [{ sha: "abc1234", message: "feat: pr row", author: "Tester", date: now }],
+    "git.listBranches": [
+      { name: "feat/pr-row-and-actions", shortSha: "abc1234", type: "local", isCurrent: true },
+    ],
+    "git.getRemoteUrl": {
+      label: "Mzeey-Empire/mcode",
+      webUrl: "https://github.com/Mzeey-Empire/mcode",
+    },
+    "git.workingTreeFiles": [],
+  });
+
+  await openOverview(page);
+
+  await expect(page.getByTestId("workspace-menu-create-pr")).toContainText("Create PR");
+  await expect(page.getByTestId("thread-overview-pr-status")).toHaveCount(0);
+
+  await page.locator("[data-testid='thread-overview-pr']").screenshot({
+    path: "e2e/screenshots/demo/pr-row-ready-create.png",
+  });
+});
+
+test("PR row demo: push commits first", async ({ page }) => {
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [thread],
+    "github.branchPr": null,
+    "git.log": [],
+    "git.listBranches": [
+      { name: "feat/pr-row-and-actions", shortSha: "abc1234", type: "local", isCurrent: true },
+    ],
+    "git.getRemoteUrl": {
+      label: "Mzeey-Empire/mcode",
+      webUrl: "https://github.com/Mzeey-Empire/mcode",
+    },
+    "git.workingTreeFiles": ["apps/web/src/components/chat/ThreadOverview.tsx"],
+  });
+
+  await openOverview(page);
+
+  await expect(page.getByTestId("workspace-menu-commit")).toContainText("Commit or push");
+  await expect(page.getByTestId("workspace-menu-create-pr")).toHaveCount(0);
+
+  await page.locator("[data-testid='thread-overview-pr']").screenshot({
+    path: "e2e/screenshots/demo/pr-row-commit-first.png",
+  });
+});
+
+test("PR row demo: view open PR", async ({ page }) => {
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [{ ...thread, pr_number: 790, pr_status: "OPEN" }],
+    "github.branchPr": {
+      number: 790,
+      state: "OPEN",
+      url: "https://github.com/Mzeey-Empire/mcode/pull/790",
+    },
+    "git.log": [{ sha: "abc1234", message: "feat: pr row", author: "Tester", date: now }],
+    "git.listBranches": [
+      { name: "feat/pr-row-and-actions", shortSha: "abc1234", type: "local", isCurrent: true },
+    ],
+    "git.getRemoteUrl": {
+      label: "Mzeey-Empire/mcode",
+      webUrl: "https://github.com/Mzeey-Empire/mcode",
+    },
+    "git.workingTreeFiles": [],
+  });
+
+  await openOverview(page);
+
+  await expect(page.getByTestId("workspace-menu-open-pr")).toContainText("View PR #790");
+  await expect(page.getByRole("button", { name: "Open PR menu" })).toBeVisible();
+
+  await page.locator("[data-testid='thread-overview-pr']").screenshot({
+    path: "e2e/screenshots/demo/pr-row-view-open.png",
+  });
+});

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -86,6 +86,13 @@ describe("MarkdownContent link handling", () => {
     expect(screen.getByTestId("markdown-link-favicon-frame").className).not.toContain("ring-1");
   });
 
+  it("renders local file links with the file icon component, not a site favicon", () => {
+    render(<MarkdownContent content="[local-unseeded-app.png](/tmp/screens/local-unseeded-app.png)" />);
+
+    expect(screen.getByTestId("markdown-link-file-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("markdown-link-favicon-frame")).not.toBeInTheDocument();
+  });
+
   it("shows a bare GitHub repo URL as owner/repo but opens the full URL", () => {
     render(<MarkdownContent content="https://github.com/milex-consulting/CaravanFE" />);
     const link = screen.getByText("milex-consulting/CaravanFE");
@@ -216,6 +223,8 @@ describe("MarkdownContent workspace preview navigation", () => {
     const { container } = render(<MarkdownContent content="[doc](mcode-workspace:///sub/page.html)" />);
     const link = container.querySelector("a");
     expect(link).toBeTruthy();
+    expect(screen.getByTestId("markdown-link-file-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("markdown-link-favicon-frame")).not.toBeInTheDocument();
     await act(async () => {
       fireEvent.click(link!, { ctrlKey: true });
       await vi.runAllTimersAsync();

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -201,10 +201,12 @@ describe("HeaderActions - Create PR menu item", () => {
     expect(item).not.toBeDisabled();
   });
 
-  it("disables Create PR when no commits ahead of base", () => {
+  it("shows Commit or push instead of Create PR when no commits ahead of base", () => {
     mockUseHasCommitsAhead.mockReturnValue(false);
     render(<HeaderActions thread={makeThread()} />);
-    expect(screen.getByTestId("workspace-menu-create-pr")).toBeDisabled();
+    expect(screen.getByTestId("workspace-menu-commit")).toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("thread-overview-pr-status")).not.toBeInTheDocument();
   });
 
   it("disables Create PR while loading (null)", () => {
@@ -227,28 +229,29 @@ describe("HeaderActions - Create PR menu item", () => {
     expect(screen.getByTestId("workspace-menu-create-pr")).toBeInTheDocument();
   });
 
-  it("hides Create PR and shows the PR badge when a PR already exists", () => {
+  it("hides Create PR and shows View PR when a PR already exists", () => {
     mockUseBranchPr.mockReturnValue({ number: 42, state: "OPEN", url: "https://github.com/test/pr/42" });
     render(<HeaderActions thread={makeThread()} />);
     expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
-    expect(screen.getByText("PR #42")).toBeInTheDocument();
-    expect(screen.queryByTestId("thread-overview-pr-status")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("thread-overview-pr-detail")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-menu-open-pr")).toHaveTextContent("View PR #42");
   });
 
-  it("explains why Create PR is disabled when no commits", () => {
+  it("explains commit-or-push when no commits are ahead", () => {
     mockUseHasCommitsAhead.mockReturnValue(false);
     render(<HeaderActions thread={makeThread()} />);
-    expect(screen.getByTestId("workspace-menu-create-pr")).toHaveAttribute(
+    expect(screen.getByTestId("workspace-menu-commit")).toHaveAttribute(
       "title",
-      expect.stringContaining("No commits"),
+      expect.stringContaining("commit and push"),
     );
   });
 
-  it("has no disabled-reason title when loading (null)", () => {
+  it("shows a loading title while commits-ahead state is unknown", () => {
     mockUseHasCommitsAhead.mockReturnValue(null);
     render(<HeaderActions thread={makeThread()} />);
-    expect(screen.getByTestId("workspace-menu-create-pr")).not.toHaveAttribute("title");
+    expect(screen.getByTestId("workspace-menu-create-pr")).toHaveAttribute(
+      "title",
+      expect.stringContaining("Waiting for commits"),
+    );
   });
 });
 
@@ -323,13 +326,14 @@ describe("HeaderActions - consolidated header", () => {
     );
     expect(screen.getByTestId("thread-overview-local-branch")).toHaveTextContent("feat/my-feature");
     expect(screen.getByTestId("workspace-menu-branch")).toHaveTextContent("feat/my-feature");
-    expect(screen.getByTestId("thread-overview-pr")).toHaveTextContent("Pull request");
-    expect(screen.getByTestId("thread-overview-pr-status")).toHaveTextContent("Ready");
-    expect(screen.getByTestId("thread-overview-pr-detail")).toHaveTextContent("No PR yet");
+    expect(screen.getByTestId("thread-overview-pr")).toHaveTextContent("Create PR");
+    expect(screen.queryByTestId("thread-overview-pr-status")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("thread-overview-pr-detail")).not.toBeInTheDocument();
     expect(screen.queryByTestId("thread-overview-sources")).not.toBeInTheDocument();
   });
 
-  it("prefills commit-or-push from the PR row", () => {
+  it("prefills commit-or-push from the PR row when the branch is not ahead", () => {
+    mockUseHasCommitsAhead.mockReturnValue(false);
     render(<HeaderActions thread={makeThread()} />);
     fireEvent.click(screen.getByTestId("workspace-menu-commit"));
     expect(mockSetPendingPrefill).toHaveBeenCalledWith(COMMIT_PREFILL);

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ReactNode, ReactElement } from "react";
 import type { Thread } from "@/transport/types";
@@ -8,10 +8,12 @@ import type { TurnSnapshot } from "@mcode/contracts";
 const {
   mockUseBranchPr,
   mockUseHasCommitsAhead,
+  mockSetPendingPrefill,
   mockWorkspaceSelector,
 } = vi.hoisted(() => ({
   mockUseBranchPr: vi.fn().mockReturnValue(null),
   mockUseHasCommitsAhead: vi.fn().mockReturnValue(null),
+  mockSetPendingPrefill: vi.fn(),
   mockWorkspaceSelector: vi.fn(),
 }));
 
@@ -22,6 +24,12 @@ vi.mock("@/stores/workspaceStore", () => {
   );
   return { useWorkspaceStore: store };
 });
+
+vi.mock("@/stores/composerDraftStore", () => ({
+  useComposerDraftStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ setPendingPrefill: mockSetPendingPrefill }),
+  ),
+}));
 
 vi.mock("@/stores/terminalStore", () => ({
   useTerminalStore: vi.fn((selector: (s: unknown) => unknown) =>
@@ -96,6 +104,7 @@ vi.mock("@/hooks/useHasCommitsAhead", () => ({
 }));
 
 import { HeaderActions } from "./HeaderActions";
+import { COMMIT_PREFILL } from "@/hooks/useThreadGitActions";
 import {
   getRepositoryFaviconUrl,
   getSafeRepositoryWebUrl,
@@ -223,6 +232,8 @@ describe("HeaderActions - Create PR menu item", () => {
     render(<HeaderActions thread={makeThread()} />);
     expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
     expect(screen.getByText("PR #42")).toBeInTheDocument();
+    expect(screen.getByTestId("thread-overview-pr-status")).toHaveTextContent("Open");
+    expect(screen.getByTestId("thread-overview-pr-detail")).toHaveTextContent("#42");
   });
 
   it("explains why Create PR is disabled when no commits", () => {
@@ -312,7 +323,16 @@ describe("HeaderActions - consolidated header", () => {
     );
     expect(screen.getByTestId("thread-overview-local-branch")).toHaveTextContent("feat/my-feature");
     expect(screen.getByTestId("workspace-menu-branch")).toHaveTextContent("feat/my-feature");
+    expect(screen.getByTestId("thread-overview-pr")).toHaveTextContent("Pull request");
+    expect(screen.getByTestId("thread-overview-pr-status")).toHaveTextContent("Ready");
+    expect(screen.getByTestId("thread-overview-pr-detail")).toHaveTextContent("No PR yet");
     expect(screen.queryByTestId("thread-overview-sources")).not.toBeInTheDocument();
+  });
+
+  it("prefills commit-or-push from the PR row", () => {
+    render(<HeaderActions thread={makeThread()} />);
+    fireEvent.click(screen.getByTestId("workspace-menu-commit"));
+    expect(mockSetPendingPrefill).toHaveBeenCalledWith(COMMIT_PREFILL);
   });
 
   it("renders a single dedicated right-panel toggle", () => {

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -232,8 +232,8 @@ describe("HeaderActions - Create PR menu item", () => {
     render(<HeaderActions thread={makeThread()} />);
     expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
     expect(screen.getByText("PR #42")).toBeInTheDocument();
-    expect(screen.getByTestId("thread-overview-pr-status")).toHaveTextContent("Open");
-    expect(screen.getByTestId("thread-overview-pr-detail")).toHaveTextContent("#42");
+    expect(screen.queryByTestId("thread-overview-pr-status")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("thread-overview-pr-detail")).not.toBeInTheDocument();
   });
 
   it("explains why Create PR is disabled when no commits", () => {

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -233,7 +233,7 @@ describe("HeaderActions - Create PR menu item", () => {
     mockUseBranchPr.mockReturnValue({ number: 42, state: "OPEN", url: "https://github.com/test/pr/42" });
     render(<HeaderActions thread={makeThread()} />);
     expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
-    expect(screen.getByTestId("workspace-menu-open-pr")).toHaveTextContent("View PR #42");
+    expect(screen.getByTestId("workspace-menu-open-pr")).toHaveTextContent("PR #42");
   });
 
   it("explains commit-or-push when no commits are ahead", () => {

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -9,6 +9,7 @@ import {
   looksLikeWorkspaceRelativeFileRef,
 } from "@mcode/contracts";
 import { CodeBlock } from "./CodeBlock";
+import { FileTypeIcon } from "@/components/ui/file-type-icon";
 import { SiteFavicon } from "@/components/ui/favicon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { resolveCodeBlockLanguage } from "@/lib/resolve-code-block-language";
@@ -52,6 +53,12 @@ const LazyMermaidBlock = lazy(() => import("./MermaidBlock"));
 
 /** Matches a standalone HTTP(S) URL (used to detect URLs inside inline code spans). */
 const HTTP_URL_RE = /^https?:\/\/\S+$/;
+
+/** Schemes that should keep site-style link chrome rather than file chrome. */
+const EXTERNAL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+/** Common basename shape for a file reference shown in Markdown. */
+const FILE_BASENAME_RE = /^[^/\\]+\.[A-Za-z0-9][A-Za-z0-9-]*$/;
 
 /** Tooltip label for the Ctrl/Cmd+click preview hint. */
 const previewHint = `${isMac ? "\u2318" : "Ctrl"}+click to open in preview`;
@@ -167,6 +174,42 @@ function getLinkFaviconUrl(href: string | undefined): string | null {
   }
 }
 
+function workspacePreviewPath(href: string): string | null {
+  if (!isMcodeWorkspacePreviewUrl(href)) return null;
+  try {
+    const url = new URL(href);
+    return decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeDisplayFileRef(value: string | undefined): boolean {
+  if (!value) return false;
+  const trimmed = value.trim().replace(/^<|>$/g, "");
+  if (!trimmed) return false;
+  if (isMcodeWorkspacePreviewUrl(trimmed)) return true;
+  if (EXTERNAL_SCHEME_RE.test(trimmed)) return false;
+
+  const normalized = trimmed.replace(/\\/g, "/");
+  const basename = normalized.split("/").filter(Boolean).at(-1) ?? normalized;
+  if (!FILE_BASENAME_RE.test(basename)) return false;
+  return normalized.includes("/") || normalized.startsWith(".") || trimmed.startsWith("/");
+}
+
+function getMarkdownFileIconPath(args: {
+  href: string | undefined;
+  safeHref: string | undefined;
+  childText: string | null;
+}): string | null {
+  const previewPath = args.safeHref ? workspacePreviewPath(args.safeHref) : null;
+  if (previewPath) return previewPath;
+
+  if (looksLikeDisplayFileRef(args.href)) return args.href!.trim().replace(/^<|>$/g, "");
+  if (looksLikeDisplayFileRef(args.childText ?? undefined)) return args.childText!.trim();
+  return null;
+}
+
 interface MarkdownLinkProps {
   href?: string;
   children?: React.ReactNode;
@@ -186,6 +229,7 @@ function MarkdownLink({
   const showHint = isPreviewable && hasPreview();
   const faviconUrl = getLinkFaviconUrl(safeHref);
   const childText = getPlainTextChild(children);
+  const fileIconPath = getMarkdownFileIconPath({ href, safeHref, childText });
   const isBareUrlText =
     !!childText && !!safeHref && (childText === href || childText === safeHref || HTTP_URL_RE.test(childText.trim()));
   const label = isBareUrlText && safeHref ? formatBareUrlLabel(safeHref) : children;
@@ -211,12 +255,18 @@ function MarkdownLink({
         }
       }}
     >
-      <SiteFavicon
-        src={faviconUrl}
-        fallback={<Globe size={12} aria-hidden className="shrink-0 text-muted-foreground" />}
-        frameTestId="markdown-link-favicon-frame"
-        imageTestId="markdown-link-favicon"
-      />
+      {fileIconPath ? (
+        <span data-testid="markdown-link-file-icon" className="inline-flex shrink-0">
+          <FileTypeIcon filePath={fileIconPath} size={13} />
+        </span>
+      ) : (
+        <SiteFavicon
+          src={faviconUrl}
+          fallback={<Globe size={12} aria-hidden className="shrink-0 text-muted-foreground" />}
+          frameTestId="markdown-link-favicon-frame"
+          imageTestId="markdown-link-favicon"
+        />
+      )}
       <span className="min-w-0 truncate">{label}</span>
       {safeHref ? (
         <ExternalLink

--- a/apps/web/src/components/chat/PrSplitButton.test.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.test.tsx
@@ -3,144 +3,47 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { PrSplitButton } from "./PrSplitButton";
 
 const noop = () => {};
+const openPr = { number: 42, url: "https://github.com/o/r/pull/42", state: "OPEN" as const };
 
 describe("PrSplitButton", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  // ── No PR ──────────────────────────────────────────────────────────────────
+  it("renders View PR with the PR number for an active PR", () => {
+    render(<PrSplitButton pr={openPr} onCreatePr={noop} onOpenPr={noop} />);
 
-  it("renders Create PR enabled when pr is null and hasCommitsAhead is true", () => {
-    render(<PrSplitButton pr={null} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    expect(screen.getByRole("button", { name: /create pr/i })).not.toBeDisabled();
-  });
-
-  it("renders Create PR disabled when pr is null and hasCommitsAhead is false", () => {
-    render(<PrSplitButton pr={null} hasCommitsAhead={false} onCreatePr={noop} onOpenPr={noop} />);
-    expect(screen.getByRole("button", { name: /create pr/i })).toBeDisabled();
-  });
-
-  it("renders Create PR disabled when pr is null and hasCommitsAhead is null (loading)", () => {
-    render(<PrSplitButton pr={null} hasCommitsAhead={null} onCreatePr={noop} onOpenPr={noop} />);
-    expect(screen.getByRole("button", { name: /create pr/i })).toBeDisabled();
-  });
-
-  it("calls onCreatePr when Create PR is clicked", () => {
-    const onCreatePr = vi.fn();
-    render(<PrSplitButton pr={null} hasCommitsAhead={true} onCreatePr={onCreatePr} onOpenPr={noop} />);
-    fireEvent.click(screen.getByRole("button", { name: /create pr/i }));
-    expect(onCreatePr).toHaveBeenCalledTimes(1);
-  });
-
-  // ── PR open ────────────────────────────────────────────────────────────────
-
-  const openPr = { number: 42, url: "https://github.com/o/r/pull/42", state: "OPEN" };
-
-  it("renders PR #42 when pr state is OPEN (uppercase — normalised)", () => {
-    render(<PrSplitButton pr={openPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    expect(screen.getByText("PR #42")).toBeInTheDocument();
-  });
-
-  it("applies sage accent chrome when pr is open with no CI data", () => {
-    render(<PrSplitButton pr={openPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    const btn = screen.getByText("PR #42").closest("button");
-    // Open PRs without CI data use the tokenized sage (--diff-add-strong) so the button still reads as healthy.
-    expect(btn?.className).toContain("text-[var(--diff-add-strong)]");
-  });
-
-  it("does not render chevron button when pr state is open", () => {
-    render(<PrSplitButton pr={openPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    expect(screen.queryByRole("button", { name: /open pr menu/i })).not.toBeInTheDocument();
-  });
-
-  it("calls onOpenPr with the url when PR badge is clicked", () => {
-    const onOpenPr = vi.fn();
-    render(<PrSplitButton pr={openPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={onOpenPr} />);
-    fireEvent.click(screen.getByText("PR #42"));
-    expect(onOpenPr).toHaveBeenCalledWith(
-      "https://github.com/o/r/pull/42",
-      expect.objectContaining({ type: "click" }),
+    expect(screen.getByRole("button", { name: "View PR #42" })).toHaveAttribute(
+      "title",
+      "View PR #42",
     );
-  });
-
-  // ── PR merged ──────────────────────────────────────────────────────────────
-
-  const mergedPr = { number: 42, url: "https://github.com/o/r/pull/42", state: "MERGED" };
-
-  it("renders PR #42 merged when pr state is MERGED", () => {
-    render(<PrSplitButton pr={mergedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    expect(screen.getByText(/pr #42 merged/i)).toBeInTheDocument();
-  });
-
-  it("applies primary accent chrome when pr state is merged", () => {
-    render(<PrSplitButton pr={mergedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    const btn = screen.getByText(/pr #42 merged/i).closest("button");
-    // Merged PRs use the tokenized primary accent — aligns with getPrVisual() elsewhere.
-    expect(btn?.className).toContain("text-primary/70");
-  });
-
-  it("renders chevron button when pr state is merged", () => {
-    render(<PrSplitButton pr={mergedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
     expect(screen.getByRole("button", { name: /open pr menu/i })).toBeInTheDocument();
   });
 
-  it("opens dropdown when chevron is clicked on merged PR", () => {
-    render(<PrSplitButton pr={mergedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    fireEvent.click(screen.getByRole("button", { name: /open pr menu/i }));
-    expect(screen.getByText(/view on github/i)).toBeInTheDocument();
-    expect(screen.getByText(/create new pr/i)).toBeInTheDocument();
-  });
-
-  it("calls onCreatePr and closes dropdown when Create new PR is clicked", () => {
-    const onCreatePr = vi.fn();
-    render(<PrSplitButton pr={mergedPr} hasCommitsAhead={true} onCreatePr={onCreatePr} onOpenPr={noop} />);
-    fireEvent.click(screen.getByRole("button", { name: /open pr menu/i }));
-    fireEvent.click(screen.getByText(/create new pr/i));
-    expect(onCreatePr).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText(/view on github/i)).not.toBeInTheDocument();
-  });
-
-  it("calls onOpenPr with the pr url when View on GitHub is clicked", () => {
+  it("calls onOpenPr from the View PR action", () => {
     const onOpenPr = vi.fn();
-    render(<PrSplitButton pr={mergedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={onOpenPr} />);
-    fireEvent.click(screen.getByRole("button", { name: /open pr menu/i }));
-    fireEvent.click(screen.getByText(/view on github/i));
+    render(<PrSplitButton pr={openPr} onCreatePr={noop} onOpenPr={onOpenPr} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "View PR #42" }));
     expect(onOpenPr).toHaveBeenCalledWith(
       "https://github.com/o/r/pull/42",
       expect.objectContaining({ type: "click" }),
     );
   });
 
-  // ── PR closed ──────────────────────────────────────────────────────────────
-
-  const closedPr = { number: 42, url: "https://github.com/o/r/pull/42", state: "CLOSED" };
-
-  it("renders PR #42 closed and applies destructive accent chrome when pr state is CLOSED", () => {
-    render(<PrSplitButton pr={closedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    expect(screen.getByText(/pr #42 closed/i)).toBeInTheDocument();
-    const btn = screen.getByText(/pr #42 closed/i).closest("button");
-    // Closed PRs use the tokenized destructive accent so theme switches read consistently.
-    expect(btn?.className).toContain("text-destructive/70");
-  });
-
-  it("renders chevron and dropdown for closed PR", () => {
-    render(<PrSplitButton pr={closedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />);
-    fireEvent.click(screen.getByRole("button", { name: /open pr menu/i }));
-    expect(screen.getByText(/view on github/i)).toBeInTheDocument();
-    expect(screen.getByText(/create new pr/i)).toBeInTheDocument();
-  });
-
-  it("closes dropdown when clicking outside", () => {
+  it("offers Create new PR from the menu", () => {
+    const onCreatePr = vi.fn();
     render(
-      <div>
-        <PrSplitButton pr={mergedPr} hasCommitsAhead={true} onCreatePr={noop} onOpenPr={noop} />
-        <div data-testid="outside">outside</div>
-      </div>
+      <PrSplitButton
+        pr={openPr}
+        onCreatePr={onCreatePr}
+        onOpenPr={noop}
+        newPrButtonTestId="workspace-menu-new-pr"
+      />,
     );
+
     fireEvent.click(screen.getByRole("button", { name: /open pr menu/i }));
-    expect(screen.getByText(/view on github/i)).toBeInTheDocument();
-    fireEvent.mouseDown(screen.getByTestId("outside"));
-    expect(screen.queryByText(/view on github/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("workspace-menu-new-pr"));
+    expect(onCreatePr).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/chat/PrSplitButton.test.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.test.tsx
@@ -10,39 +10,54 @@ describe("PrSplitButton", () => {
     vi.clearAllMocks();
   });
 
-  it("renders View PR with the PR number for an active PR", () => {
-    render(<PrSplitButton pr={openPr} onCreatePr={noop} onOpenPr={noop} />);
-
-    expect(screen.getByRole("button", { name: "View PR #42" })).toHaveAttribute(
-      "title",
-      "View PR #42",
+  it("renders the PR label and row trigger for an active PR", () => {
+    render(
+      <PrSplitButton
+        pr={openPr}
+        label="PR #42"
+        onCreatePr={noop}
+        onOpenPr={noop}
+        primaryButtonTestId="workspace-menu-open-pr"
+      />,
     );
-    expect(screen.getByRole("button", { name: /open pr menu/i })).toBeInTheDocument();
+
+    expect(screen.getByTestId("workspace-menu-open-pr")).toHaveTextContent("PR #42");
   });
 
-  it("calls onOpenPr from the View PR action", () => {
+  it("calls onOpenPr from the popover action", () => {
     const onOpenPr = vi.fn();
-    render(<PrSplitButton pr={openPr} onCreatePr={noop} onOpenPr={onOpenPr} />);
+    render(
+      <PrSplitButton
+        pr={openPr}
+        label="PR #42"
+        onCreatePr={noop}
+        onOpenPr={onOpenPr}
+        primaryButtonTestId="workspace-menu-open-pr"
+      />,
+    );
 
-    fireEvent.click(screen.getByRole("button", { name: "View PR #42" }));
+    fireEvent.click(screen.getByTestId("workspace-menu-open-pr"));
+    fireEvent.click(screen.getByTestId("workspace-menu-open-pr-action"));
     expect(onOpenPr).toHaveBeenCalledWith(
       "https://github.com/o/r/pull/42",
       expect.objectContaining({ type: "click" }),
     );
   });
 
-  it("offers Create new PR from the menu", () => {
+  it("offers Create new PR from the popover", () => {
     const onCreatePr = vi.fn();
     render(
       <PrSplitButton
         pr={openPr}
+        label="PR #42"
         onCreatePr={onCreatePr}
         onOpenPr={noop}
+        primaryButtonTestId="workspace-menu-open-pr"
         newPrButtonTestId="workspace-menu-new-pr"
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /open pr menu/i }));
+    fireEvent.click(screen.getByTestId("workspace-menu-open-pr"));
     fireEvent.click(screen.getByTestId("workspace-menu-new-pr"));
     expect(onCreatePr).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -1,30 +1,28 @@
 import { useState } from "react";
 import { ChevronDown, GitPullRequest } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
 /** Props for {@link PrSplitButton}. */
 interface PrSplitButtonProps {
   /** Active pull request for this branch. */
   pr: { number: number; url: string; state: "OPEN" | "MERGED" | "CLOSED" | string };
+  /** Primary row label, usually the PR title or PR number. */
+  label: string;
   /** Called when the user wants to open CreatePrDialog. */
   onCreatePr: () => void;
   /** Called with the PR URL when the user wants to open it in the browser or preview. */
   onOpenPr: (url: string, event?: React.MouseEvent) => void;
-  /** Optional test id for the PR primary action. */
+  /** Optional trailing content rendered before the menu chevron (for example a CI badge). */
+  trailing?: React.ReactNode;
+  /** Optional test id for the PR row trigger. */
   primaryButtonTestId?: string;
+  /** Optional test id for the open action inside the popover. */
+  openActionTestId?: string;
   /** Optional test id for the follow-up create action in the menu. */
   newPrButtonTestId?: string;
 }
-
-const ACTION_CLASS =
-  "h-6 px-2 text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground";
 
 function prStateTitle(pr: PrSplitButtonProps["pr"]): string {
   const state = pr.state.toLowerCase();
@@ -33,67 +31,107 @@ function prStateTitle(pr: PrSplitButtonProps["pr"]): string {
   return `View PR #${pr.number}`;
 }
 
+function openPrLabel(pr: PrSplitButtonProps["pr"]): string {
+  const state = pr.state.toLowerCase();
+  if (state === "merged") return `Open merged PR #${pr.number}`;
+  if (state === "closed") return `Open closed PR #${pr.number}`;
+  return `Open PR #${pr.number}`;
+}
+
 /**
- * Split button for an active pull request in the Overview row.
+ * Overview row for an active pull request.
  *
- * Primary action opens the current PR. The chevron menu exposes Create new PR
- * without crowding the row when only one PR exists.
+ * Uses the same full-row Popover trigger as Local and Branch so the actions panel
+ * opens to the left of the Overview column instead of under the chevron.
  */
 export function PrSplitButton({
   pr,
+  label,
   onCreatePr,
   onOpenPr,
+  trailing,
   primaryButtonTestId,
+  openActionTestId = "workspace-menu-open-pr-action",
   newPrButtonTestId,
 }: PrSplitButtonProps) {
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const state = pr.state.toLowerCase();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <div className="relative inline-flex shrink-0">
-      <div className="inline-flex rounded-md">
-        <Button
-          variant="ghost"
-          size="xs"
-          type="button"
-          data-testid={primaryButtonTestId}
-          className={cn(
-            ACTION_CLASS,
-            "rounded-r-none",
-            state === "closed" && "text-destructive/80 hover:text-destructive",
-            state === "merged" && "text-primary/80 hover:text-primary",
-          )}
-          title={prStateTitle(pr)}
-          onClick={(event) => onOpenPr(pr.url, event)}
-        >
-          View PR #{pr.number}
-        </Button>
-
-        <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
-          <DropdownMenuTrigger
-            aria-label="Open PR menu"
-            className={cn(
-              "inline-flex items-center rounded-r-md border-l border-border/20 px-1.5 h-6 text-xs transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              "text-foreground/75 hover:bg-muted/40 hover:text-foreground",
-            )}
-          >
-            <ChevronDown
-              size={11}
-              className={cn("transition-transform duration-150", dropdownOpen && "rotate-180")}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" sideOffset={4} className="min-w-[170px] text-xs">
-            <DropdownMenuItem
-              data-testid={newPrButtonTestId}
-              onClick={() => onCreatePr()}
-              className="gap-2 text-foreground/75"
+    <div data-testid="workspace-menu-open-pr-split">
+      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="sm"
+              type="button"
+              data-testid={primaryButtonTestId}
+              aria-label={`Pull request, ${label}`}
+              className={cn(
+                "h-8 w-full justify-between gap-3 px-2 text-left",
+                menuOpen && "bg-muted text-foreground",
+              )}
             >
-              <GitPullRequest size={11} className="opacity-75" />
-              Create new PR
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+              <span className="flex min-w-0 items-center gap-2">
+                <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+                <span className="truncate text-xs font-medium">{label}</span>
+              </span>
+              <span className="flex shrink-0 items-center gap-1">
+                {trailing ? (
+                  <span
+                    className="flex items-center"
+                    onClick={(event) => event.stopPropagation()}
+                    onPointerDown={(event) => event.stopPropagation()}
+                  >
+                    {trailing}
+                  </span>
+                ) : null}
+                <ChevronDown
+                  size={13}
+                  aria-hidden
+                  className={cn(
+                    "shrink-0 text-muted-foreground transition-transform duration-150",
+                    menuOpen && "rotate-180",
+                  )}
+                />
+              </span>
+            </Button>
+          }
+        />
+        <PopoverContent align="start" side="left" sideOffset={12} className="w-72 p-0">
+          <div data-testid="thread-overview-pr-popover" className="animate-popover-enter space-y-0.5 p-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              type="button"
+              data-testid={openActionTestId}
+              title={prStateTitle(pr)}
+              className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground"
+              onClick={(event) => {
+                setMenuOpen(false);
+                onOpenPr(pr.url, event);
+              }}
+            >
+              <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+              <span className="font-medium">{openPrLabel(pr)}</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              type="button"
+              data-testid={newPrButtonTestId}
+              className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground"
+              onClick={() => {
+                setMenuOpen(false);
+                onCreatePr();
+              }}
+            >
+              <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+              <span className="font-medium">Create new PR</span>
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
     </div>
   );
 }

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -39,6 +39,10 @@ interface PrSplitButtonProps {
   prTitle?: string;
   /** PR author shown in ChecksPopover header. */
   prAuthor?: string;
+  /** Optional test id for the no-PR create action. */
+  createButtonTestId?: string;
+  /** Optional test id for the PR primary action. */
+  primaryButtonTestId?: string;
 }
 
 /** Compact segmented progress pills showing pass / fail / running / pending slots. */
@@ -93,7 +97,18 @@ function ProgressPills({ checks }: { checks: ChecksStatus }) {
  *   + headline (e.g. "2/5" running, "1 failing", "5 passing"), themed by CI aggregate
  * - Merged / closed PR → coloured primary + chevron with secondary actions
  */
-export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, checks, threadId, prTitle, prAuthor }: PrSplitButtonProps) {
+export function PrSplitButton({
+  pr,
+  hasCommitsAhead,
+  onCreatePr,
+  onOpenPr,
+  checks,
+  threadId,
+  prTitle,
+  prAuthor,
+  createButtonTestId,
+  primaryButtonTestId,
+}: PrSplitButtonProps) {
   const [checksOpen, setChecksOpen] = useState(false);
   // Chevron dropdown open state: kept so the chevron glyph can rotate in sync with
   // the base-ui primitive's open state. The primitive itself owns focus trap,
@@ -126,6 +141,7 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
       <Button
         variant="ghost"
         size="xs"
+        data-testid={createButtonTestId}
         className="gap-1 text-xs text-foreground/70 hover:text-foreground hover:bg-muted/40 h-6"
         onClick={onCreatePr}
         disabled={!hasCommitsAhead}
@@ -213,6 +229,7 @@ export function PrSplitButton({ pr, hasCommitsAhead, onCreatePr, onOpenPr, check
         aggregate === "pending" && "border-primary/25",
         !showChevron && "rounded-r",
       )}
+      data-testid={primaryButtonTestId}
       title={titleAttr}
       onClick={handlePrimaryClick}
     >

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -1,330 +1,98 @@
-import { useState, useEffect } from "react";
-import { Github, ChevronDown, GitPullRequest } from "lucide-react";
+import { useState } from "react";
+import { ChevronDown, GitPullRequest } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { ChecksPopover } from "./ChecksPopover";
-import {
-  getBreakdown,
-  getInlineHeadline,
-  getLeadFailingName,
-  getCiVisual,
-  CI_ICON_STROKE,
-} from "@/lib/ci-status";
-import { registerCommand } from "@/lib/command-registry";
-import type { ChecksStatus } from "@mcode/contracts";
-import { isModifierClick } from "@/lib/open-url-in-preview";
 
 /** Props for {@link PrSplitButton}. */
 interface PrSplitButtonProps {
-  /** Null when no PR exists for this branch. */
-  pr: { number: number; url: string; state: "OPEN" | "MERGED" | "CLOSED" | string } | null;
-  /** Null while the initial commits-ahead poll is in flight. */
-  hasCommitsAhead: boolean | null;
+  /** Active pull request for this branch. */
+  pr: { number: number; url: string; state: "OPEN" | "MERGED" | "CLOSED" | string };
   /** Called when the user wants to open CreatePrDialog. */
   onCreatePr: () => void;
   /** Called with the PR URL when the user wants to open it in the browser or preview. */
   onOpenPr: (url: string, event?: React.MouseEvent) => void;
-  /** CI check status for this thread, if available. */
-  checks?: ChecksStatus | null;
-  /** Thread ID for manual refresh via ChecksPopover. */
-  threadId?: string;
-  /** PR title shown in ChecksPopover header. */
-  prTitle?: string;
-  /** PR author shown in ChecksPopover header. */
-  prAuthor?: string;
-  /** Optional test id for the no-PR create action. */
-  createButtonTestId?: string;
   /** Optional test id for the PR primary action. */
   primaryButtonTestId?: string;
+  /** Optional test id for the follow-up create action in the menu. */
+  newPrButtonTestId?: string;
 }
 
-/** Compact segmented progress pills showing pass / fail / running / pending slots. */
-function ProgressPills({ checks }: { checks: ChecksStatus }) {
-  const b = getBreakdown(checks);
-  if (b.total === 0) return null;
+const ACTION_CLASS =
+  "h-6 px-2 text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground";
 
-  // Cap rendered pills at 5 so the chat header stays compact even when a PR has 20+ jobs.
-  // A +N badge indicates the overflow.
-  const MAX_PILLS = 5;
-  const capped = b.total > MAX_PILLS;
-  const renderTotal = capped ? MAX_PILLS : b.total;
-
-  // Build the visible pill list: failing first, then running, then passing, then other.
-  type Slot = "fail" | "run" | "pass" | "other";
-  const slots: Slot[] = [];
-  for (let i = 0; i < b.failing; i++) slots.push("fail");
-  for (let i = 0; i < b.running; i++) slots.push("run");
-  for (let i = 0; i < b.passing; i++) slots.push("pass");
-  for (let i = 0; i < b.other; i++) slots.push("other");
-  const visible = slots.slice(0, renderTotal);
-
-  return (
-    <span className="inline-flex items-center gap-[3px]">
-      {visible.map((slot, i) => (
-        <span
-          key={i}
-          className={cn(
-            "h-[5px] w-[5px] rounded-full transition-colors",
-            slot === "fail" && "bg-[var(--diff-remove-strong)]",
-            slot === "run" && "bg-primary status-pulse",
-            slot === "pass" && "bg-[var(--diff-add-strong)]",
-            slot === "other" && "bg-muted-foreground/40",
-          )}
-        />
-      ))}
-      {capped && (
-        <span className="text-[10px] text-muted-foreground tabular-nums ml-0.5">
-          +{b.total - MAX_PILLS}
-        </span>
-      )}
-    </span>
-  );
+function prStateTitle(pr: PrSplitButtonProps["pr"]): string {
+  const state = pr.state.toLowerCase();
+  if (state === "merged") return `View merged PR #${pr.number}`;
+  if (state === "closed") return `View closed PR #${pr.number}`;
+  return `View PR #${pr.number}`;
 }
 
 /**
- * Split button for PR actions in the chat header.
+ * Split button for an active pull request in the Overview row.
  *
- * Three layouts depending on PR state:
- * - No PR → "Create PR" button (disabled until commits land)
- * - Open PR with checks → primary button wraps ChecksPopover, shows inline progress pills
- *   + headline (e.g. "2/5" running, "1 failing", "5 passing"), themed by CI aggregate
- * - Merged / closed PR → coloured primary + chevron with secondary actions
+ * Primary action opens the current PR. The chevron menu exposes Create new PR
+ * without crowding the row when only one PR exists.
  */
 export function PrSplitButton({
   pr,
-  hasCommitsAhead,
   onCreatePr,
   onOpenPr,
-  checks,
-  threadId,
-  prTitle,
-  prAuthor,
-  createButtonTestId,
   primaryButtonTestId,
+  newPrButtonTestId,
 }: PrSplitButtonProps) {
-  const [checksOpen, setChecksOpen] = useState(false);
-  // Chevron dropdown open state: kept so the chevron glyph can rotate in sync with
-  // the base-ui primitive's open state. The primitive itself owns focus trap,
-  // Escape, outside-click, and keyboard nav — we no longer roll those manually.
   const [dropdownOpen, setDropdownOpen] = useState(false);
-
-  // Register a global command to open the checks popover for the active thread.
-  // Only the PrSplitButton currently mounted for the active thread has real checks
-  // data, so a single registration here naturally targets the right PR.
-  const canOpenChecks =
-    pr != null &&
-    pr.state.toLowerCase() === "open" &&
-    checks != null &&
-    checks.aggregate !== "no_checks" &&
-    threadId != null;
-  useEffect(() => {
-    if (!canOpenChecks) return;
-    const dispose = registerCommand({
-      id: "checks.open",
-      title: "Open CI checks for active thread",
-      category: "Git",
-      handler: () => setChecksOpen(true),
-    });
-    return dispose;
-  }, [canOpenChecks]);
-
-  // No PR — show Create PR button
-  if (!pr) {
-    return (
-      <Button
-        variant="ghost"
-        size="xs"
-        data-testid={createButtonTestId}
-        className="gap-1 text-xs text-foreground/70 hover:text-foreground hover:bg-muted/40 h-6"
-        onClick={onCreatePr}
-        disabled={!hasCommitsAhead}
-        title={hasCommitsAhead === false ? "No commits ahead of base branch" : undefined}
-      >
-        <GitPullRequest size={12} />
-        <span>Create PR</span>
-      </Button>
-    );
-  }
-
   const state = pr.state.toLowerCase();
-  const isOpen = state === "open";
-  const hasChecksData = checks != null && checks.aggregate !== "no_checks" && isOpen;
-  const aggregate = hasChecksData ? checks!.aggregate : null;
-  const inlineHeadline = hasChecksData ? getInlineHeadline(checks!) : null;
-  const leadFailing = aggregate === "failing" ? getLeadFailingName(checks!) : null;
-
-  // Single chrome derivation: CI visual when we have data, otherwise state-based accent.
-  // `chromeClass` + `hoverSurface` both come from `getCiVisual` so base and hover
-  // washes stay tuned to each other — no more drift if one opacity is adjusted.
-  const ciVisual = hasChecksData ? getCiVisual(aggregate!) : null;
-
-  const mergedClosedAccent = state === "merged"
-    ? "text-primary/70 hover:text-primary bg-muted/10 hover:bg-muted/20"
-    : state === "closed"
-      ? "text-destructive/70 hover:text-destructive bg-muted/10 hover:bg-muted/20"
-      : null;
-
-  const openNoCiAccent = isOpen && !hasChecksData
-    ? "text-[var(--diff-add-strong)]/85 hover:text-[var(--diff-add-strong)] bg-muted/10 hover:bg-muted/20"
-    : null;
-
-  const chromeClass = ciVisual
-    ? `${ciVisual.chromeClass} ${ciVisual.hoverSurface}`
-    : mergedClosedAccent ?? openNoCiAccent ?? "bg-muted/10 hover:bg-muted/20";
-
-  // Keep state-terminal suffix in the label text ("merged"/"closed") so the button reads
-  // correctly even when colour alone is ambiguous. Open PRs drop the suffix — the CI rail
-  // carries the live state signal there.
-  const label = state === "merged"
-    ? `PR #${pr.number} merged`
-    : state === "closed"
-      ? `PR #${pr.number} closed`
-      : `PR #${pr.number}`;
-
-  const showChevron = state === "merged" || state === "closed";
-  const usePopover = hasChecksData && threadId != null;
-
-  // Tiny status-icon shown as part of the CI rail when CI is active — sourced from the
-  // shared CI visual so chip/button/popover use identical glyphs.
-  const LeadIcon = ciVisual?.icon ?? null;
-
-  const titleAttr = aggregate === "failing" && leadFailing
-    ? `${leadFailing} failing`
-    : aggregate === "pending"
-      ? "Checks running"
-      : aggregate === "passing"
-        ? "All checks passing"
-        : state === "merged"
-          ? "Pull request merged"
-          : state === "closed"
-            ? "Pull request closed"
-            : "Pull request open";
-
-  const handlePrimaryClick = (event: React.MouseEvent) => {
-    if (isModifierClick(event)) {
-      event.preventDefault();
-      event.stopPropagation();
-      onOpenPr(pr.url, event);
-      return;
-    }
-    if (!usePopover) {
-      onOpenPr(pr.url, event);
-    }
-  };
-
-  const primaryButton = (
-    <button
-      type="button"
-      className={cn(
-        "relative inline-flex items-center gap-1.5 px-2 h-6 rounded-l text-xs transition-colors border border-transparent",
-        "font-medium tabular-nums",
-        chromeClass,
-        aggregate === "pending" && "border-primary/25",
-        !showChevron && "rounded-r",
-      )}
-      data-testid={primaryButtonTestId}
-      title={titleAttr}
-      onClick={handlePrimaryClick}
-    >
-      <Github size={12} className="opacity-70 shrink-0" />
-      <span className="text-foreground/85">{label}</span>
-
-      {/* CI rail: divider · icon · pills · headline. Only when open + has data. */}
-      {hasChecksData && (
-        <span className="inline-flex items-center gap-1.5 pl-1.5 ml-0.5 border-l border-current/15">
-          {LeadIcon && (
-            <LeadIcon
-              size={11}
-              className={cn(
-                "shrink-0",
-                aggregate === "pending" && "status-spin",
-              )}
-              strokeWidth={CI_ICON_STROKE}
-            />
-          )}
-          <ProgressPills checks={checks!} />
-          {inlineHeadline && (
-            <span className="text-[11px] opacity-85 whitespace-nowrap">
-              {inlineHeadline}
-            </span>
-          )}
-        </span>
-      )}
-
-      {/* Indeterminate bottom-edge progress strip when running.
-       * Wrapped in motion-reduce:hidden so reduced-motion users don't see a stationary
-       * partial bar (which would look like a broken progress indicator).
-       * The Loader icon already conveys pending state without motion. */}
-      {aggregate === "pending" && (
-        <span
-          aria-hidden
-          className="absolute inset-x-1 bottom-0 h-[1.5px] overflow-hidden rounded-full motion-reduce:hidden"
-        >
-          <span className="block h-full w-1/3 bg-primary/80 animate-ci-slide" />
-        </span>
-      )}
-    </button>
-  );
 
   return (
-    <div className="relative inline-flex">
-      <div className="inline-flex rounded">
-        {usePopover ? (
-          <ChecksPopover
-            threadId={threadId!}
-            prUrl={pr.url}
-            prTitle={prTitle}
-            prAuthor={prAuthor}
-            checks={checks!}
-            open={checksOpen}
-            onOpenChange={setChecksOpen}
-          >
-            {primaryButton}
-          </ChecksPopover>
-        ) : (
-          primaryButton
-        )}
+    <div className="relative inline-flex shrink-0">
+      <div className="inline-flex rounded-md">
+        <Button
+          variant="ghost"
+          size="xs"
+          type="button"
+          data-testid={primaryButtonTestId}
+          className={cn(
+            ACTION_CLASS,
+            "rounded-r-none",
+            state === "closed" && "text-destructive/80 hover:text-destructive",
+            state === "merged" && "text-primary/80 hover:text-primary",
+          )}
+          title={prStateTitle(pr)}
+          onClick={(event) => onOpenPr(pr.url, event)}
+        >
+          View PR #{pr.number}
+        </Button>
 
-        {showChevron && (
-          <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
-            <DropdownMenuTrigger
-              aria-label="Open PR menu"
-              className={cn(
-                "inline-flex items-center px-1.5 h-6 text-xs border-l border-border/20 rounded-r transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                mergedClosedAccent ?? "bg-muted/10 hover:bg-muted/20",
-              )}
+        <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
+          <DropdownMenuTrigger
+            aria-label="Open PR menu"
+            className={cn(
+              "inline-flex items-center rounded-r-md border-l border-border/20 px-1.5 h-6 text-xs transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              "text-foreground/75 hover:bg-muted/40 hover:text-foreground",
+            )}
+          >
+            <ChevronDown
+              size={11}
+              className={cn("transition-transform duration-150", dropdownOpen && "rotate-180")}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" sideOffset={4} className="min-w-[170px] text-xs">
+            <DropdownMenuItem
+              data-testid={newPrButtonTestId}
+              onClick={() => onCreatePr()}
+              className="gap-2 text-foreground/75"
             >
-              <ChevronDown
-                size={11}
-                className={cn("transition-transform duration-150", dropdownOpen && "rotate-180")}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" sideOffset={4} className="min-w-[170px] text-xs">
-              <DropdownMenuItem
-                onClick={(e) => onOpenPr(pr.url, e)}
-                className="text-foreground/75 gap-2"
-              >
-                <Github size={11} className="opacity-75" />
-                View on GitHub
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={() => onCreatePr()}
-                className="text-foreground/75 gap-2"
-              >
-                <GitPullRequest size={11} className="opacity-75" />
-                Create new PR
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+              <GitPullRequest size={11} className="opacity-75" />
+              Create new PR
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -813,47 +813,32 @@ function ThreadOverviewPrActiveRow({
     </Badge>
   ) : null;
 
-  return (
-    <div
-      data-testid="thread-overview-pr"
-      className="flex w-full items-center justify-between gap-2 px-2 py-1.5"
-    >
-      <div className="flex min-w-0 items-center gap-2">
-        <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
-        <div className="min-w-0">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <span className="truncate text-xs font-medium">Pull request</span>
-            {statusBadge && canOpenChecks ? (
-              <ChecksPopover
-                threadId={threadId}
-                prUrl={pr.url}
-                prTitle={openPrDetail?.title}
-                prAuthor={openPrDetail?.author}
-                checks={checks!}
-                open={checksOpen}
-                onOpenChange={setChecksOpen}
-              >
-                {statusBadge}
-              </ChecksPopover>
-            ) : (
-              statusBadge
-            )}
-          </div>
-          {detailText ? (
-            <span
-              data-testid="thread-overview-pr-detail"
-              className="block truncate text-xs text-muted-foreground"
-            >
-              {detailText}
-            </span>
-          ) : null}
-        </div>
-      </div>
+  const rowLabel = detailText ?? `PR #${pr.number}`;
+  const trailingBadge =
+    statusBadge && canOpenChecks ? (
+      <ChecksPopover
+        threadId={threadId}
+        prUrl={pr.url}
+        prTitle={openPrDetail?.title}
+        prAuthor={openPrDetail?.author}
+        checks={checks!}
+        open={checksOpen}
+        onOpenChange={setChecksOpen}
+      >
+        {statusBadge}
+      </ChecksPopover>
+    ) : (
+      statusBadge
+    );
 
+  return (
+    <div data-testid="thread-overview-pr">
       <PrSplitButton
         pr={pr}
+        label={rowLabel}
         onCreatePr={onCreatePr}
         onOpenPr={onOpenPr}
+        trailing={trailingBadge}
         primaryButtonTestId="workspace-menu-open-pr"
         newPrButtonTestId="workspace-menu-new-pr"
       />

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -15,6 +15,7 @@ import {
   Upload,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { SiteFavicon } from "@/components/ui/favicon";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -671,6 +672,130 @@ function ThreadOverviewSources({ sources, onOpen }: ThreadOverviewSourcesProps) 
   );
 }
 
+type ThreadOverviewPr = { number: number; url: string; state: string } | null;
+type PrRowTone = "positive" | "danger" | "neutral" | "muted";
+
+function getPrRowStatus(
+  pr: ThreadOverviewPr,
+  hasCommitsAhead: boolean | null,
+  checks: ChecksStatus | null,
+): { label: string; tone: PrRowTone } {
+  if (pr) {
+    const state = pr.state.toLowerCase();
+    if (state === "open") {
+      if (checks?.aggregate === "failing") return { label: "Checks failing", tone: "danger" };
+      if (checks?.aggregate === "passing") return { label: "Checks passing", tone: "positive" };
+      if (checks?.aggregate === "pending") return { label: "Checks running", tone: "neutral" };
+      return { label: "Open", tone: "positive" };
+    }
+    if (state === "merged") return { label: "Merged", tone: "positive" };
+    if (state === "closed") return { label: "Closed", tone: "danger" };
+    return { label: pr.state, tone: "neutral" };
+  }
+
+  if (hasCommitsAhead === true) return { label: "Ready", tone: "neutral" };
+  if (hasCommitsAhead === false) return { label: "No commits ahead", tone: "muted" };
+  return { label: "Checking", tone: "muted" };
+}
+
+interface ThreadOverviewPrRowProps {
+  pr: ThreadOverviewPr;
+  hasCommitsAhead: boolean | null;
+  checks: ChecksStatus | null;
+  openPrDetail: { title?: string; author?: string } | null;
+  threadId: string;
+  onCommitOrPush: () => void;
+  onCreatePr: () => void;
+  onOpenPr: (url: string, event?: React.MouseEvent) => void;
+}
+
+function ThreadOverviewPrRow({
+  pr,
+  hasCommitsAhead,
+  checks,
+  openPrDetail,
+  threadId,
+  onCommitOrPush,
+  onCreatePr,
+  onOpenPr,
+}: ThreadOverviewPrRowProps) {
+  const status = getPrRowStatus(pr, hasCommitsAhead, checks);
+  const badgeVariant =
+    status.tone === "danger"
+      ? "destructive"
+      : status.tone === "positive"
+        ? "secondary"
+        : status.tone === "muted"
+          ? "outline"
+          : "ghost";
+
+  return (
+    <div
+      data-testid="thread-overview-pr"
+      className="flex w-full items-center justify-between gap-2 px-2 py-1.5"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-xs font-medium">Pull request</span>
+            <Badge
+              variant={badgeVariant}
+              size="sm"
+              data-testid="thread-overview-pr-status"
+              className="max-w-32 truncate"
+            >
+              {status.label}
+            </Badge>
+          </div>
+          <span
+            data-testid="thread-overview-pr-detail"
+            className="block truncate text-xs text-muted-foreground"
+          >
+            {pr ? `#${pr.number}` : "No PR yet"}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                type="button"
+                onClick={onCommitOrPush}
+                data-testid="workspace-menu-commit"
+                aria-label="Commit or push"
+                className="cursor-pointer text-foreground/70 hover:text-foreground"
+              >
+                <Upload size={13} className="text-muted-foreground" />
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom" className="text-xs">
+            Commit or push
+          </TooltipContent>
+        </Tooltip>
+
+        <PrSplitButton
+          pr={pr}
+          hasCommitsAhead={hasCommitsAhead}
+          onCreatePr={onCreatePr}
+          onOpenPr={onOpenPr}
+          checks={checks}
+          threadId={threadId}
+          prTitle={openPrDetail?.title}
+          prAuthor={openPrDetail?.author}
+          createButtonTestId="workspace-menu-create-pr"
+          primaryButtonTestId="workspace-menu-open-pr"
+        />
+      </div>
+    </div>
+  );
+}
+
 /**
  * Thread-scoped Overview popover for the chat header.
  *
@@ -1035,45 +1160,17 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
               </PopoverContent>
             </Popover>
 
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleCommitOrPush}
-              data-testid="workspace-menu-commit"
-              className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-xs"
-            >
-              <Upload size={14} className="text-muted-foreground" />
-              Commit or push
-            </Button>
-
-            {prable && !pr && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setCreatePrOpen(true)}
-                disabled={!hasCommitsAhead}
-                data-testid="workspace-menu-create-pr"
-                title={hasCommitsAhead === false ? "No commits ahead of base branch" : undefined}
-                className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-xs disabled:cursor-not-allowed"
-              >
-                <GitPullRequest size={14} className="text-muted-foreground" />
-                Create PR
-              </Button>
-            )}
-
-            {prable && pr && (
-              <div data-testid="thread-overview-pr" className="px-2 py-1.5">
-                <PrSplitButton
-                  pr={pr}
-                  hasCommitsAhead={hasCommitsAhead}
-                  onCreatePr={() => setCreatePrOpen(true)}
-                  onOpenPr={handleOpenPr}
-                  checks={checks}
-                  threadId={thread.id}
-                  prTitle={openPrDetail?.title}
-                  prAuthor={openPrDetail?.author}
-                />
-              </div>
+            {prable && (
+              <ThreadOverviewPrRow
+                pr={pr}
+                hasCommitsAhead={hasCommitsAhead}
+                checks={checks}
+                openPrDetail={openPrDetail}
+                threadId={thread.id}
+                onCommitOrPush={handleCommitOrPush}
+                onCreatePr={() => setCreatePrOpen(true)}
+                onOpenPr={handleOpenPr}
+              />
             )}
 
             {sources.length > 0 && (

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import {
   Check,
   ChevronDown,
@@ -12,7 +12,6 @@ import {
   Menu,
   Plus,
   Search,
-  Upload,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -23,13 +22,14 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { PrSplitButton } from "./PrSplitButton";
+import { ChecksPopover } from "./ChecksPopover";
 import { CreatePrDialog } from "./CreatePrDialog";
 import { useThreadGitActions } from "@/hooks/useThreadGitActions";
 import { useDiffStore } from "@/stores/diffStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useLayoutStore } from "@/stores/layoutStore";
 import { useOverviewStore } from "@/stores/overviewStore";
-import { executeCommand } from "@/lib/command-registry";
+import { executeCommand, registerCommand } from "@/lib/command-registry";
 import { getContentRowWidth, shouldAutoOpenOverview } from "@/lib/composer-layout";
 import { extractThreadSources, type ThreadSource } from "@/lib/message-sources";
 import { isModifierClick, isPreviewableUrl, openUrlInPreview } from "@/lib/open-url-in-preview";
@@ -698,6 +698,17 @@ function getPrRowStatus(
   return { label: "Checking", tone: "muted" };
 }
 
+/**
+ * Derives the PR row subtitle from PR state and branch readiness.
+ */
+export function getPrRowDetail(
+  pr: ThreadOverviewPr,
+  openPrDetail: { title?: string } | null,
+): string | null {
+  if (pr) return openPrDetail?.title?.trim() || null;
+  return null;
+}
+
 interface ThreadOverviewPrRowProps {
   pr: ThreadOverviewPr;
   hasCommitsAhead: boolean | null;
@@ -706,7 +717,148 @@ interface ThreadOverviewPrRowProps {
   threadId: string;
   onCommitOrPush: () => void;
   onCreatePr: () => void;
-  onOpenPr: (url: string, event?: React.MouseEvent) => void;
+  onOpenPr: (url: string, event?: MouseEvent) => void;
+}
+
+function ThreadOverviewPrActionRow({
+  hasCommitsAhead,
+  onCommitOrPush,
+  onCreatePr,
+}: Pick<ThreadOverviewPrRowProps, "hasCommitsAhead" | "onCommitOrPush" | "onCreatePr">) {
+  if (hasCommitsAhead === false) {
+    return (
+      <div data-testid="thread-overview-pr">
+        <Button
+          variant="ghost"
+          size="sm"
+          type="button"
+          data-testid="workspace-menu-commit"
+          className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground"
+          onClick={onCommitOrPush}
+          title="Ask the agent to commit and push the changes"
+        >
+          <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+          <span className="font-medium">Commit or push</span>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="thread-overview-pr">
+      <Button
+        variant="ghost"
+        size="sm"
+        type="button"
+        data-testid="workspace-menu-create-pr"
+        className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        onClick={onCreatePr}
+        disabled={!hasCommitsAhead}
+        title={hasCommitsAhead ? "Create pull request" : "Waiting for commits ahead of base branch"}
+      >
+        <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+        <span className="font-medium">Create PR</span>
+      </Button>
+    </div>
+  );
+}
+
+function ThreadOverviewPrActiveRow({
+  pr,
+  hasCommitsAhead,
+  checks,
+  openPrDetail,
+  threadId,
+  onCreatePr,
+  onOpenPr,
+}: Required<Pick<ThreadOverviewPrRowProps, "pr" | "hasCommitsAhead" | "checks" | "openPrDetail" | "threadId" | "onCreatePr" | "onOpenPr">> & {
+  pr: NonNullable<ThreadOverviewPrRowProps["pr"]>;
+}) {
+  const [checksOpen, setChecksOpen] = useState(false);
+  const status = getPrRowStatus(pr, hasCommitsAhead, checks);
+  const detailText = getPrRowDetail(pr, openPrDetail);
+  const badgeVariant =
+    status.tone === "danger"
+      ? "destructive"
+      : status.tone === "positive"
+        ? "secondary"
+        : status.tone === "muted"
+          ? "outline"
+          : "ghost";
+  const hasChecksData =
+    pr.state.toLowerCase() === "open" &&
+    checks != null &&
+    checks.aggregate !== "no_checks";
+  const canOpenChecks = hasChecksData && threadId.length > 0;
+
+  useEffect(() => {
+    if (!canOpenChecks) return;
+    const dispose = registerCommand({
+      id: "checks.open",
+      title: "Open CI checks for active thread",
+      category: "Git",
+      handler: () => setChecksOpen(true),
+    });
+    return dispose;
+  }, [canOpenChecks]);
+
+  const statusBadge = status.label ? (
+    <Badge
+      variant={badgeVariant}
+      size="sm"
+      data-testid="thread-overview-pr-status"
+      className={cn("max-w-32 truncate", canOpenChecks && "cursor-pointer")}
+    >
+      {status.label}
+    </Badge>
+  ) : null;
+
+  return (
+    <div
+      data-testid="thread-overview-pr"
+      className="flex w-full items-center justify-between gap-2 px-2 py-1.5"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-xs font-medium">Pull request</span>
+            {statusBadge && canOpenChecks ? (
+              <ChecksPopover
+                threadId={threadId}
+                prUrl={pr.url}
+                prTitle={openPrDetail?.title}
+                prAuthor={openPrDetail?.author}
+                checks={checks!}
+                open={checksOpen}
+                onOpenChange={setChecksOpen}
+              >
+                {statusBadge}
+              </ChecksPopover>
+            ) : (
+              statusBadge
+            )}
+          </div>
+          {detailText ? (
+            <span
+              data-testid="thread-overview-pr-detail"
+              className="block truncate text-xs text-muted-foreground"
+            >
+              {detailText}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <PrSplitButton
+        pr={pr}
+        onCreatePr={onCreatePr}
+        onOpenPr={onOpenPr}
+        primaryButtonTestId="workspace-menu-open-pr"
+        newPrButtonTestId="workspace-menu-new-pr"
+      />
+    </div>
+  );
 }
 
 function ThreadOverviewPrRow({
@@ -719,85 +871,26 @@ function ThreadOverviewPrRow({
   onCreatePr,
   onOpenPr,
 }: ThreadOverviewPrRowProps) {
-  const status = getPrRowStatus(pr, hasCommitsAhead, checks);
-  const detailText = pr ? openPrDetail?.title?.trim() || null : "No PR yet";
-  const badgeVariant =
-    status.tone === "danger"
-      ? "destructive"
-      : status.tone === "positive"
-        ? "secondary"
-        : status.tone === "muted"
-          ? "outline"
-          : "ghost";
+  if (!pr) {
+    return (
+      <ThreadOverviewPrActionRow
+        hasCommitsAhead={hasCommitsAhead}
+        onCommitOrPush={onCommitOrPush}
+        onCreatePr={onCreatePr}
+      />
+    );
+  }
 
   return (
-    <div
-      data-testid="thread-overview-pr"
-      className="flex w-full items-center justify-between gap-2 px-2 py-1.5"
-    >
-      <div className="flex min-w-0 items-center gap-2">
-        <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
-        <div className="min-w-0">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <span className="truncate text-xs font-medium">Pull request</span>
-            {status.label && (
-              <Badge
-                variant={badgeVariant}
-                size="sm"
-                data-testid="thread-overview-pr-status"
-                className="max-w-32 truncate"
-              >
-                {status.label}
-              </Badge>
-            )}
-          </div>
-          {detailText && (
-            <span
-              data-testid="thread-overview-pr-detail"
-              className="block truncate text-xs text-muted-foreground"
-            >
-              {detailText}
-            </span>
-          )}
-        </div>
-      </div>
-
-      <div className="flex shrink-0 items-center gap-1">
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                type="button"
-                onClick={onCommitOrPush}
-                data-testid="workspace-menu-commit"
-                aria-label="Commit or push"
-                className="cursor-pointer text-foreground/70 hover:text-foreground"
-              >
-                <Upload size={13} className="text-muted-foreground" />
-              </Button>
-            }
-          />
-          <TooltipContent side="bottom" className="text-xs">
-            Commit or push
-          </TooltipContent>
-        </Tooltip>
-
-        <PrSplitButton
-          pr={pr}
-          hasCommitsAhead={hasCommitsAhead}
-          onCreatePr={onCreatePr}
-          onOpenPr={onOpenPr}
-          checks={checks}
-          threadId={threadId}
-          prTitle={openPrDetail?.title}
-          prAuthor={openPrDetail?.author}
-          createButtonTestId="workspace-menu-create-pr"
-          primaryButtonTestId="workspace-menu-open-pr"
-        />
-      </div>
-    </div>
+    <ThreadOverviewPrActiveRow
+      pr={pr}
+      hasCommitsAhead={hasCommitsAhead}
+      checks={checks}
+      openPrDetail={openPrDetail}
+      threadId={threadId}
+      onCreatePr={onCreatePr}
+      onOpenPr={onOpenPr}
+    />
   );
 }
 

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -679,14 +679,14 @@ function getPrRowStatus(
   pr: ThreadOverviewPr,
   hasCommitsAhead: boolean | null,
   checks: ChecksStatus | null,
-): { label: string; tone: PrRowTone } {
+): { label: string | null; tone: PrRowTone } {
   if (pr) {
     const state = pr.state.toLowerCase();
     if (state === "open") {
       if (checks?.aggregate === "failing") return { label: "Checks failing", tone: "danger" };
       if (checks?.aggregate === "passing") return { label: "Checks passing", tone: "positive" };
       if (checks?.aggregate === "pending") return { label: "Checks running", tone: "neutral" };
-      return { label: "Open", tone: "positive" };
+      return { label: null, tone: "positive" };
     }
     if (state === "merged") return { label: "Merged", tone: "positive" };
     if (state === "closed") return { label: "Closed", tone: "danger" };
@@ -720,6 +720,7 @@ function ThreadOverviewPrRow({
   onOpenPr,
 }: ThreadOverviewPrRowProps) {
   const status = getPrRowStatus(pr, hasCommitsAhead, checks);
+  const detailText = pr ? openPrDetail?.title?.trim() || null : "No PR yet";
   const badgeVariant =
     status.tone === "danger"
       ? "destructive"
@@ -739,21 +740,25 @@ function ThreadOverviewPrRow({
         <div className="min-w-0">
           <div className="flex min-w-0 items-center gap-1.5">
             <span className="truncate text-xs font-medium">Pull request</span>
-            <Badge
-              variant={badgeVariant}
-              size="sm"
-              data-testid="thread-overview-pr-status"
-              className="max-w-32 truncate"
-            >
-              {status.label}
-            </Badge>
+            {status.label && (
+              <Badge
+                variant={badgeVariant}
+                size="sm"
+                data-testid="thread-overview-pr-status"
+                className="max-w-32 truncate"
+              >
+                {status.label}
+              </Badge>
+            )}
           </div>
-          <span
-            data-testid="thread-overview-pr-detail"
-            className="block truncate text-xs text-muted-foreground"
-          >
-            {pr ? `#${pr.number}` : "No PR yet"}
-          </span>
+          {detailText && (
+            <span
+              data-testid="thread-overview-pr-detail"
+              className="block truncate text-xs text-muted-foreground"
+            >
+              {detailText}
+            </span>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## What
Adds a Pull request row to the chat Overview for worktree threads. The row uses the PR actions for commit or push, create, open, and checks.

## Why
Issue #764 moves PR handling into the Overview so the header has one place for thread-scoped status and actions.

## Key Changes
- Adds the Overview PR row through `useThreadGitActions`, `PrSplitButton`, `CreatePrDialog`, and check state.
- Shows `PR #42` once for open PR rows and hides the redundant open status pill when checks are absent.
- Updates focused header action tests for create and open PR states.

Closes #764

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784684694&installation_id=129163861&pr_number=795&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F795&signature=a4946dee99915e3a9d20d9c40796acca88c65d7dac64831eb530ac025998373c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File icons now display for local file paths in markdown links, replacing standard site favicons.
  * Redesigned PR split button with improved action flow for creating and managing pull requests.

* **UI/UX Improvements**
  * Reorganized commit and PR actions in chat header for clearer workflow and better separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->