### PR TITLE
feat: add typed Codex mentions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -794,6 +794,13 @@ Each shares a name with a dev-tooling concept used by contributors who
 develop Mcode itself (documented in `AGENTS.md`); the entries here refer
 to the runtime, user-facing version only.
 
+### @ mention
+A composer reference inserted from the `@` mention picker. Mentions are typed
+and rendered as highlighted references in the composer and user transcript: a
+file mention references a workspace file, while a sub-agent mention requests a
+provider agent for part of the turn.
+_Avoid_: treating every `@...` string as a file path.
+
 ### Skill
 A reusable agent capability the end user can attach to their threads
 inside the Mcode app — domain knowledge or a multi-step workflow the
@@ -818,10 +825,9 @@ lives in the composer's Lexical plugin (`SlashCommandPlugin`,
 slash commands under `.claude/commands/` etc. (which are for
 contributors).
 
-`/` is the **only** composer gesture, for every provider. Providers with
-their own native invocation syntax (Codex's `$` mentions) get a
-translation at the provider boundary; the user never types the native
-syntax in Mcode.
+Slash commands use `/` as their composer gesture. Providers with their own
+native invocation syntax (Codex's `$` mentions) get a translation at the
+provider boundary; the user never types the native syntax in Mcode.
 
 Slash commands sit in one of three availability layers:
 

--- a/apps/server/drizzle/0014_message_mentions.sql
+++ b/apps/server/drizzle/0014_message_mentions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `messages` ADD `mentions` text;

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1781371200000,
       "tag": "0013_thread_perf_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1782172800000,
+      "tag": "0014_message_mentions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/__tests__/message-repo.test.ts
+++ b/apps/server/src/__tests__/message-repo.test.ts
@@ -18,6 +18,7 @@ function createTestDb(): Database.Database {
       timestamp TEXT NOT NULL,
       sequence INTEGER NOT NULL,
       attachments TEXT,
+      mentions TEXT,
       reply_to_message_id TEXT,
       quoted_text TEXT,
       model TEXT,
@@ -66,7 +67,7 @@ describe("MessageRepo", () => {
       const stmt = db.prepare(
         `EXPLAIN QUERY PLAN
 WITH page AS (
-  SELECT m.id, m.thread_id, m.role, m.content, m.tool_calls, m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence, m.attachments, m.reply_to_message_id, m.quoted_text, m.model
+  SELECT m.id, m.thread_id, m.role, m.content, m.tool_calls, m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence, m.attachments, m.mentions, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal
   FROM messages m
   WHERE m.thread_id = ? AND m.is_internal = 0
   ORDER BY m.sequence DESC
@@ -224,6 +225,35 @@ ORDER BY page.sequence ASC`,
       expect(found).not.toBeNull();
       expect(found!.reply_to_message_id).toBe(original.id);
       expect(found!.quoted_text).toBe("some quote");
+    });
+  });
+
+  describe("create with mention metadata", () => {
+    it("round-trips selected typed mentions", () => {
+      const mentions = [{
+        id: "mention-1",
+        kind: "file" as const,
+        label: "src/app.ts",
+        path: "src/app.ts",
+        range: { start: 6, end: 17 },
+      }];
+
+      const created = repo.create(
+        "thread-1",
+        "user",
+        "check @src/app.ts",
+        1,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        mentions,
+      );
+      const fetched = repo.findByIdInThread("thread-1", created.id);
+
+      expect(created.mentions).toEqual(mentions);
+      expect(fetched?.mentions).toEqual(mentions);
     });
   });
 

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -197,6 +197,69 @@ describe("CodexProvider first turn on new session", () => {
     ], expect.anything());
   });
 
+  it("sends selected file mentions as native Codex mention input", async () => {
+    const provider = makeProvider();
+
+    await provider.sendTurn({
+      sessionId: "mcode-mentioned-file",
+      threadId: "mentioned-file",
+      message: "check @src/app.ts",
+      mentions: [{
+        id: "mention-1",
+        kind: "file",
+        label: "src/app.ts",
+        path: "src/app.ts",
+        range: { start: 6, end: 17 },
+      }],
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "auto",
+    });
+
+    for (let i = 0; i < 20 && sendTurnMock.mock.calls.length === 0; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(sendTurnMock.mock.calls[0][0]).toEqual([
+      { type: "mention", name: "src/app.ts", path: "src/app.ts" },
+      { type: "text", text: "check @src/app.ts" },
+    ]);
+  });
+
+  it("sends selected agent mentions as Codex subagent URI input", async () => {
+    const provider = makeProvider();
+
+    await provider.sendTurn({
+      sessionId: "mcode-mentioned-agent",
+      threadId: "mentioned-agent",
+      message: "ask @planner",
+      mentions: [{
+        id: "mention-agent-1",
+        kind: "agent",
+        label: "planner",
+        name: "planner",
+        path: "C:\\Users\\Test\\.codex\\agents\\planner.toml",
+        provider: "codex",
+        range: { start: 4, end: 12 },
+      }],
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "auto",
+    });
+
+    for (let i = 0; i < 20 && sendTurnMock.mock.calls.length === 0; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(sendTurnMock.mock.calls[0][0]).toEqual([
+      { type: "text", text: "ask subagent://planner" },
+    ]);
+  });
+
   it("expands Codex prompt commands before turn/start", async () => {
     const promptDir = mkdtempSync(join(tmpdir(), "codex-provider-prompt-"));
     try {

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -34,6 +34,7 @@ import type {
   AgentEvent,
   AttachmentMeta,
   GoalState,
+  MessageMention,
   PermissionDecision,
   PermissionRequest,
   ProviderModelInfo,
@@ -152,6 +153,7 @@ async function buildCodexInput(
   message: string,
   attachments?: AttachmentMeta[],
   skills: readonly SkillInfo[] = [],
+  mentions: readonly MessageMention[] = [],
 ): Promise<TurnInputPart[]> {
   const inputs: TurnInputPart[] = [];
 
@@ -168,10 +170,47 @@ async function buildCodexInput(
     }
   }
 
-  const invocation = await resolveCodexSlashInvocation(message, skills);
+  for (const mention of mentions) {
+    if (mention.kind !== "file") continue;
+    inputs.push({
+      type: "mention",
+      name: mention.label,
+      path: mention.path,
+    });
+  }
+
+  const wireMessage = rewriteAgentMentionsAsSubagentUris(message, mentions);
+  const invocation = await resolveCodexSlashInvocation(wireMessage, skills);
   if (invocation.skillItem) inputs.push(invocation.skillItem);
   inputs.push({ type: "text", text: invocation.text });
   return inputs;
+}
+
+function rewriteAgentMentionsAsSubagentUris(
+  message: string,
+  mentions: readonly MessageMention[],
+): string {
+  let text = message;
+  const agentMentions = mentions
+    .filter((mention) => mention.kind === "agent")
+    .sort((a, b) => b.range.start - a.range.start);
+
+  for (const mention of agentMentions) {
+    const displayText = `@${mention.label}`;
+    if (
+      mention.range.start < 0 ||
+      mention.range.end > text.length ||
+      text.slice(mention.range.start, mention.range.end) !== displayText
+    ) {
+      continue;
+    }
+    text =
+      text.slice(0, mention.range.start) +
+      `subagent://${mention.name}` +
+      text.slice(mention.range.end);
+  }
+
+  return text;
 }
 
 /** Translates Mcode slash invocations into Codex-native skill or prompt input. */
@@ -511,7 +550,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     }
     const {
       sessionId, message, cwd, model, permissionMode,
-      reasoningLevel, attachments,
+      reasoningLevel, attachments, mentions,
     } = req;
     const codexFastMode = req.providerOptions.fastMode;
 
@@ -520,7 +559,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
     let input: TurnInputPart[];
     try {
-      input = await buildCodexInput(message, attachments, skillCatalog);
+      input = await buildCodexInput(message, attachments, skillCatalog, mentions);
     } catch (err) {
       if (!(err instanceof CodexPromptResolutionError)) throw err;
       logger.debug("Codex prompt expansion failed", {

--- a/apps/server/src/providers/codex/codex-types.ts
+++ b/apps/server/src/providers/codex/codex-types.ts
@@ -77,7 +77,8 @@ export interface ThreadResumeResult {
 export type TurnInputPart =
   | { type: "text"; text: string }
   | { type: "localImage"; path: string }
-  | { type: "skill"; name: string; path: string };
+  | { type: "skill"; name: string; path: string }
+  | { type: "mention"; name: string; path: string };
 
 /** Parameters for the `turn/start` RPC method. */
 export interface TurnStartParams {

--- a/apps/server/src/repositories/message-repo.ts
+++ b/apps/server/src/repositories/message-repo.ts
@@ -8,6 +8,7 @@ import { injectable, inject } from "tsyringe";
 import type Database from "better-sqlite3";
 import type {
   Message,
+  MessageMention,
   MessageRole,
   StoredAttachment,
 } from "@mcode/contracts";
@@ -24,6 +25,7 @@ interface MessageRow {
   timestamp: string;
   sequence: number;
   attachments: string | null;
+  mentions: string | null;
   reply_to_message_id: string | null;
   quoted_text: string | null;
   model: string | null;
@@ -87,6 +89,7 @@ function rowToMessage(row: MessageRow): Message {
     attachments: parseJsonField(row.attachments) as
       | StoredAttachment[]
       | null,
+    mentions: parseJsonField(row.mentions) as MessageMention[] | null,
     reply_to_message_id: row.reply_to_message_id,
     quoted_text: row.quoted_text,
     model: row.model,
@@ -101,10 +104,10 @@ function rowToMessage(row: MessageRow): Message {
 }
 
 const MESSAGE_COLUMNS =
-  "id, thread_id, role, content, tool_calls, files_changed, cost_usd, tokens_used, timestamp, sequence, attachments, reply_to_message_id, quoted_text, model, is_internal";
+  "id, thread_id, role, content, tool_calls, files_changed, cost_usd, tokens_used, timestamp, sequence, attachments, mentions, reply_to_message_id, quoted_text, model, is_internal";
 
 const MESSAGE_COLUMNS_PREFIXED =
-  "m.id, m.thread_id, m.role, m.content, m.tool_calls, m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence, m.attachments, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal";
+  "m.id, m.thread_id, m.role, m.content, m.tool_calls, m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence, m.attachments, m.mentions, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal";
 
 /**
  * Pre-aggregates tool call counts for the selected page only.
@@ -180,6 +183,7 @@ export class MessageRepo {
     quotedText?: string,
     model?: string | null,
     isInternal?: boolean,
+    mentions?: MessageMention[],
   ): Message {
     const id = randomUUID();
     const now = new Date().toISOString();
@@ -187,16 +191,20 @@ export class MessageRepo {
       attachments && attachments.length > 0
         ? JSON.stringify(attachments)
         : null;
+    const mentionsJson =
+      mentions && mentions.length > 0
+        ? JSON.stringify(mentions)
+        : null;
     const modelValue = model ?? null;
     const isInternalValue = isInternal ? 1 : 0;
 
     this.db
       .prepare(
-        "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence, attachments, reply_to_message_id, quoted_text, model, is_internal) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence, attachments, mentions, reply_to_message_id, quoted_text, model, is_internal) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
       )
       .run(
         id, threadId, role, content, now, sequence,
-        attachmentsJson, replyToMessageId ?? null, quotedText ?? null, modelValue, isInternalValue,
+        attachmentsJson, mentionsJson, replyToMessageId ?? null, quotedText ?? null, modelValue, isInternalValue,
       );
 
     return {
@@ -211,6 +219,7 @@ export class MessageRepo {
       timestamp: now,
       sequence,
       attachments: attachments ?? null,
+      mentions: mentions ?? null,
       reply_to_message_id: replyToMessageId ?? null,
       quoted_text: quotedText ?? null,
       model: modelValue,
@@ -241,6 +250,7 @@ export class MessageRepo {
     sequence: number;
     model?: string | null;
     attachments?: StoredAttachment[];
+    mentions?: MessageMention[];
   }): Message {
     const now = new Date().toISOString();
     const modelValue = input.model ?? null;
@@ -248,12 +258,16 @@ export class MessageRepo {
       input.attachments && input.attachments.length > 0
         ? JSON.stringify(input.attachments)
         : null;
+    const mentionsJson =
+      input.mentions && input.mentions.length > 0
+        ? JSON.stringify(input.mentions)
+        : null;
 
     const result = this.db
       .prepare(
-        "INSERT OR IGNORE INTO messages (id, thread_id, role, content, timestamp, sequence, attachments, model, is_internal) VALUES (?, ?, 'assistant', ?, ?, ?, ?, ?, 0)",
+        "INSERT OR IGNORE INTO messages (id, thread_id, role, content, timestamp, sequence, attachments, mentions, model, is_internal) VALUES (?, ?, 'assistant', ?, ?, ?, ?, ?, ?, 0)",
       )
-      .run(input.id, input.threadId, input.content, now, input.sequence, attachmentsJson, modelValue);
+      .run(input.id, input.threadId, input.content, now, input.sequence, attachmentsJson, mentionsJson, modelValue);
 
     const attachments =
       result.changes === 0 && input.attachments && input.attachments.length > 0
@@ -272,6 +286,7 @@ export class MessageRepo {
       timestamp: now,
       sequence: input.sequence,
       attachments,
+      mentions: input.mentions ?? null,
       reply_to_message_id: null,
       quoted_text: null,
       model: modelValue,
@@ -396,6 +411,7 @@ ORDER BY m.sequence ASC`,
   (
     length(CAST(COALESCE(m.files_changed, '') AS BLOB)) +
     length(CAST(COALESCE(m.attachments, '') AS BLOB)) +
+    length(CAST(COALESCE(m.mentions, '') AS BLOB)) +
     length(CAST(COALESCE(m.quoted_text, '') AS BLOB))
   ) AS metadata_bytes
 FROM messages m
@@ -514,7 +530,7 @@ LIMIT ?`,
       `SELECT
   m.id, m.thread_id, m.role, m.content, NULL AS tool_calls,
   m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence,
-  m.attachments, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal,
+  m.attachments, m.mentions, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal,
   ${toolCallCountSql}
 FROM messages m
 WHERE m.id = ?`,
@@ -523,7 +539,7 @@ WHERE m.id = ?`,
       `SELECT
   m.id, m.thread_id, m.role, substr(m.content, 1, ?) AS content, NULL AS tool_calls,
   m.files_changed, m.cost_usd, m.tokens_used, m.timestamp, m.sequence,
-  m.attachments, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal,
+  m.attachments, m.mentions, m.reply_to_message_id, m.quoted_text, m.model, m.is_internal,
   ${toolCallCountSql}
 FROM messages m
 WHERE m.id = ?`,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -25,6 +25,7 @@ import type {
   PermissionRequest,
   PlanOutput,
   PlanAction,
+  MessageMention,
 } from "@mcode/contracts";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
@@ -39,6 +40,7 @@ import { TaskRepo, type StoredTask } from "../repositories/task-repo";
 import { PlanQuestionAnswersRepo } from "../repositories/plan-question-answers-repo";
 import { GitService } from "./git-service";
 import { AttachmentService } from "./attachment-service";
+import { FileService } from "./file-service";
 import { SnapshotService } from "./snapshot-service";
 import { MemoryPressureService, type MemoryPressureSnapshot } from "./memory-pressure-service";
 import { broadcast } from "../transport/push";
@@ -69,6 +71,23 @@ import type { TurnOutcome } from "./turn-outcome.js";
  */
 function escapeXml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+const FILE_INJECTION_SEPARATOR = "\n\n---\n";
+
+function buildInjectedFileMessage(
+  text: string,
+  files: Array<{ path: string; content: string }>,
+): string {
+  if (files.length === 0) return text;
+  const fileBlocks = files
+    .map((file) => {
+      const escapedContent = file.content.replace(/<\/file>/gi, "<\\/file>");
+      const escapedPath = file.path.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+      return `<file path="${escapedPath}">\n${escapedContent}\n</file>`;
+    })
+    .join("\n");
+  return `${text}${FILE_INJECTION_SEPARATOR}${fileBlocks}`;
 }
 
 /**
@@ -241,6 +260,7 @@ export class AgentService {
     private readonly narrativeStore: NarrativeStore,
     @inject(PlanQuestionService)
     private readonly planQuestionService: PlanQuestionService,
+    @inject(FileService) private readonly fileService?: FileService,
   ) {
     this.turnFinalizer = new TurnFinalizer(
       this.messageRepo,
@@ -300,6 +320,7 @@ export class AgentService {
      */
     messageDisplayContent?: string,
     planAction?: PlanAction,
+    mentions: MessageMention[] = [],
   ): Promise<void> {
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
@@ -337,6 +358,14 @@ export class AgentService {
     if (!workspace) {
       throw new Error(`Workspace not found: ${thread.workspace_id}`);
     }
+
+    const validatedMentions = this.validateMessageMentions({
+      workspaceId: workspace.id,
+      threadId,
+      content,
+      mentions,
+      provider: effectiveProvider,
+    });
 
     // Route the message through the mcode-native command namespace before it
     // reaches the provider. The router probes each command's required
@@ -433,6 +462,9 @@ export class AgentService {
         stored.length > 0 ? stored : undefined,
         replyToMessageId,
         quotedText,
+        undefined,
+        undefined,
+        validatedMentions.length > 0 ? validatedMentions : undefined,
       );
       if (markPlanAnswerForMessageId) {
         // INSERT OR IGNORE inside the repo skips PK collisions (idempotent
@@ -594,7 +626,15 @@ export class AgentService {
       threadId,
     } satisfies AgentEvent);
 
-    const providerMessage = providerWireOverride ?? wirePayload;
+    let providerMessage = providerWireOverride ?? wirePayload;
+    if (effectiveProvider !== "codex") {
+      providerMessage = this.injectMentionFileContents({
+        workspaceId: workspace.id,
+        threadId,
+        text: providerMessage,
+        mentions: validatedMentions,
+      });
+    }
 
     // Run the command's deferred dispatch side effect now, as late as possible
     // before dispatch. If sendTurn throws synchronously or rejects, the catch
@@ -640,6 +680,7 @@ export class AgentService {
       sessionId: sessionName,
       threadId,
       message: providerMessage,
+      mentions: validatedMentions.length > 0 ? validatedMentions : undefined,
       cwd,
       model: resolvedModel,
       fallbackModel,
@@ -770,6 +811,69 @@ export class AgentService {
     broadcast("plan.dismissed", { threadId, assistantMessageId });
   }
 
+  private validateMessageMentions(input: {
+    workspaceId: string;
+    threadId: string;
+    content: string;
+    mentions: readonly MessageMention[];
+    provider: ProviderId;
+  }): MessageMention[] {
+    const sorted = [...input.mentions].sort((a, b) => a.range.start - b.range.start);
+    let previousEnd = 0;
+
+    for (const mention of sorted) {
+      const displayText = `@${mention.label}`;
+      if (
+        mention.range.end > input.content.length ||
+        input.content.slice(mention.range.start, mention.range.end) !== displayText
+      ) {
+        throw new Error(`Invalid mention range for @${mention.label}`);
+      }
+      if (mention.range.start < previousEnd) {
+        throw new Error("Mention ranges must not overlap");
+      }
+      previousEnd = mention.range.end;
+
+      if (mention.kind === "file") {
+        if (!this.fileService) {
+          throw new Error("File mention validation is unavailable");
+        }
+        this.fileService.validateMentionPath(input.workspaceId, mention.path, input.threadId);
+        continue;
+      }
+
+      if (input.provider !== "codex") {
+        throw new Error("Agent mentions are only supported by Codex");
+      }
+    }
+
+    return sorted;
+  }
+
+  private injectMentionFileContents(input: {
+    workspaceId: string;
+    threadId: string;
+    text: string;
+    mentions: readonly MessageMention[];
+  }): string {
+    const uniquePaths = new Set<string>();
+    const files: Array<{ path: string; content: string }> = [];
+
+    for (const mention of input.mentions) {
+      if (mention.kind !== "file" || uniquePaths.has(mention.path)) continue;
+      if (!this.fileService) {
+        throw new Error("File mention injection is unavailable");
+      }
+      uniquePaths.add(mention.path);
+      files.push({
+        path: mention.path,
+        content: this.fileService.read(input.workspaceId, mention.path, input.threadId),
+      });
+    }
+
+    return buildInjectedFileMessage(input.text, files);
+  }
+
   /**
    * Create a new thread and immediately send the first message.
    * Generates a title from the content, creates the thread, sends,
@@ -796,13 +900,14 @@ export class AgentService {
     thinking?: boolean,
     codexFastMode?: boolean,
     displayContent?: string,
+    mentions: MessageMention[] = [],
   ): Promise<Thread & { warnings?: string[] }> {
     const title = truncateTitle(displayContent ?? content);
 
     if (parentThreadId) {
       return this.createBranchedThread({
         workspaceId, content, model, permissionMode, mode, branch,
-        existingWorktreePath, attachments, reasoningLevel, provider,
+        existingWorktreePath, attachments, mentions, reasoningLevel, provider,
         interactionMode, parentThreadId, forkedFromMessageId, title,
         maxBudgetUsd, maxTurns,
         copilotAgent,
@@ -911,6 +1016,8 @@ export class AgentService {
       undefined,
       undefined,
       displayContent,
+      undefined,
+      mentions,
     ).catch((err) => {
       logger.error("createAndSend initial send failed", {
         threadId: thread.id,
@@ -937,6 +1044,7 @@ export class AgentService {
     branch: string;
     existingWorktreePath?: string;
     attachments: AttachmentMeta[];
+    mentions: MessageMention[];
     reasoningLevel?: ReasoningLevel;
     provider: ProviderId;
     interactionMode?: InteractionMode;
@@ -953,7 +1061,7 @@ export class AgentService {
   }): Promise<Thread & { warnings?: string[] }> {
     const {
       workspaceId, content, model, permissionMode, mode, branch,
-      existingWorktreePath, attachments, reasoningLevel, provider,
+      existingWorktreePath, attachments, mentions, reasoningLevel, provider,
       interactionMode, parentThreadId, forkedFromMessageId, title,
       maxBudgetUsd, maxTurns,
       copilotAgent,
@@ -1119,6 +1227,8 @@ export class AgentService {
       undefined,
       undefined,
       displayContent,
+      undefined,
+      mentions,
     ).catch((err) => {
       logger.error("createBranchedThread initial send failed", {
         threadId: thread.id,

--- a/apps/server/src/services/file-service.ts
+++ b/apps/server/src/services/file-service.ts
@@ -54,9 +54,35 @@ export class FileService {
     relativePath: string,
     threadId?: string,
   ): string {
+    const canonicalPath = this.validateWorkspaceRelativePath(
+      workspaceId,
+      relativePath,
+      threadId,
+    );
+
+    return readFileSync(canonicalPath, "utf-8");
+  }
+
+  /**
+   * Validate that a relative file mention resolves to an existing file inside
+   * the workspace or thread working directory.
+   */
+  validateMentionPath(
+    workspaceId: string,
+    relativePath: string,
+    threadId?: string,
+  ): void {
+    this.validateWorkspaceRelativePath(workspaceId, relativePath, threadId);
+  }
+
+  private validateWorkspaceRelativePath(
+    workspaceId: string,
+    relativePath: string,
+    threadId?: string,
+  ): string {
     const rootDir = this.resolveWorkingDir(workspaceId, threadId);
 
-    if (isAbsolute(relativePath) || relativePath.includes("..")) {
+    if (isAbsolute(relativePath) || relativePath.includes("..") || relativePath.includes("\0")) {
       throw new Error(`Invalid file path: ${relativePath}`);
     }
 
@@ -100,7 +126,7 @@ export class FileService {
       );
     }
 
-    return readFileSync(canonicalPath, "utf-8");
+    return canonicalPath;
   }
 
   /**

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -223,6 +223,22 @@ export function applySchemaPatches(db: Database.Database): void {
   if (toolCols.length > 0 && !toolCols.includes("output_artifact_path")) {
     addToolCallColumn("output_artifact_path TEXT");
   }
+
+  const messageCols = (
+    db.prepare("PRAGMA table_info(messages)").all() as Array<{ name: string }>
+  ).map((r) => r.name);
+  if (messageCols.length > 0 && !messageCols.includes("mentions")) {
+    try {
+      db.prepare("ALTER TABLE messages ADD COLUMN mentions TEXT").run();
+    } catch (err) {
+      if (
+        !(err instanceof Error) ||
+        !err.message.includes("duplicate column name")
+      ) {
+        throw err;
+      }
+    }
+  }
 }
 
 function runMigrations(db: Database.Database): void {

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -101,6 +101,7 @@ export const messages = sqliteTable(
     timestamp: text("timestamp").notNull().default(timestampDefault),
     sequence: integer("sequence").notNull(),
     attachments: text("attachments"),
+    mentions: text("mentions"),
     replyToMessageId: text("reply_to_message_id").references((): AnySQLiteColumn => messages.id, { onDelete: "set null" }),
     quotedText: text("quoted_text"),
     /**

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -5,9 +5,9 @@
  */
 
 import { randomUUID } from "crypto";
-import { mkdir, writeFile } from "fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import type { WebSocket } from "ws";
 
 import {
@@ -66,6 +66,67 @@ import type { ThreadTeardownService } from "../services/thread-teardown-service.
 
 function teardownFailureMessage(result: PromiseRejectedResult): string {
   return result.reason instanceof Error ? result.reason.message : String(result.reason);
+}
+
+interface CodexAgentMentionInfo {
+  name: string;
+  path: string;
+  description?: string;
+}
+
+function tomlStringValue(body: string, key: string): string | undefined {
+  const match = new RegExp(`^${key}\\s*=\\s*"([^"]*)"`, "m").exec(body);
+  return match?.[1]?.trim() || undefined;
+}
+
+async function scanCodexAgentDir(dir: string): Promise<CodexAgentMentionInfo[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const agents: CodexAgentMentionInfo[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".toml")) continue;
+    const path = join(dir, entry);
+    try {
+      const body = await readFile(path, "utf8");
+      const fallbackName = entry.slice(0, -".toml".length);
+      const name = tomlStringValue(body, "name") ?? fallbackName;
+      const description = tomlStringValue(body, "description");
+      agents.push({ name, path, ...(description ? { description } : {}) });
+    } catch {
+      // Ignore malformed or unreadable agent files; diagnostics belong in the agent editor.
+    }
+  }
+  return agents;
+}
+
+async function discoverCodexAgents(deps: RouterDeps, workspaceId?: string, threadId?: string): Promise<CodexAgentMentionInfo[]> {
+  const dirs = [join(homedir(), ".codex", "agents")];
+  if (workspaceId) {
+    const workspace = deps.workspaceService.findById(workspaceId);
+    if (workspace) {
+      let cwd = workspace.path;
+      if (threadId) {
+        const thread = deps.threadRepo.findById(threadId);
+        if (thread && thread.workspace_id === workspaceId) {
+          cwd = deps.gitService.resolveWorkingDir(workspace.path, thread.mode, thread.worktree_path);
+        }
+      }
+      dirs.push(join(cwd, ".codex", "agents"));
+    }
+  }
+
+  const byName = new Map<string, CodexAgentMentionInfo>();
+  for (const dir of dirs) {
+    for (const agent of await scanCodexAgentDir(dir)) {
+      byName.set(agent.name, agent);
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /** Service dependencies for the router. */
@@ -564,6 +625,7 @@ async function dispatch(
         params.quotedText,
         params.displayContent,
         params.planAction,
+        params.mentions,
       );
       return;
     case "agent.createAndSend":
@@ -588,6 +650,7 @@ async function dispatch(
         params.thinking,
         params.codexFastMode,
         params.displayContent,
+        params.mentions,
       );
     case "agent.stop":
       await deps.agentService.stopSession(params.threadId);
@@ -874,6 +937,9 @@ async function dispatch(
     }
     case "providers.listAvailability": {
       return deps.providerAvailability.listAvailability();
+    }
+    case "provider.codexAgents": {
+      return discoverCodexAgents(deps, params.workspaceId, params.threadId);
     }
     case "provider.copilotAgents": {
       const workspace = deps.workspaceService.findById(params.workspaceId);

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -176,6 +176,8 @@ export async function mockWebSocketServer(
         result = [];
       } else if (method === "providers.listAvailability") {
         result = [];
+      } else if (method === "provider.codexAgents") {
+        result = [];
       } else if (method === "narrative.list") {
         // Assistant messages mount <PersistedNarrative>, which calls this RPC and
         // spreads the result into buildPersistedNarrativeItems. The generic

--- a/apps/web/e2e/typed-mentions.spec.ts
+++ b/apps/web/e2e/typed-mentions.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+} from "./helpers/e2e-helpers";
+import { getDefaultSettings } from "@mcode/contracts";
+
+const WORKSPACE = {
+  id: "ws-typed-mentions",
+  name: "Typed Mentions",
+  path: "/tmp/typed-mentions",
+  provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const THREAD = {
+  id: "thread-typed-mentions",
+  workspace_id: WORKSPACE.id,
+  title: "Codex mentions",
+  status: "active" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: "gpt-5.2-codex",
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "codex",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: "medium",
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+  codex_fast_mode: null,
+};
+
+async function setupCodexChat(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ ws, th }) => {
+      const stores: Array<{ getState: () => Record<string, unknown>; setState: (value: unknown) => void }> =
+        (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown>; setState: (value: unknown) => void }> }).__mcodeStores ?? [];
+      const wsStore = stores.find((store) => {
+        const state = store.getState();
+        return "activeThreadId" in state && "threads" in state && "workspaces" in state;
+      });
+      if (!wsStore) throw new Error("[E2E] workspace store not found");
+      wsStore.setState({
+        workspaces: [ws],
+        threads: [th],
+        activeWorkspaceId: ws.id,
+        activeThreadId: th.id,
+        loading: false,
+        error: null,
+      });
+    },
+    { ws: WORKSPACE, th: THREAD },
+  );
+}
+
+test("Codex @ autocomplete groups agents and files, then sends selected agent metadata", async ({ page }) => {
+  let sendParams: unknown;
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await mockWebSocketServer(page, {
+    "workspace.enrich": { items: [] },
+    "settings.get": getDefaultSettings(),
+    "provider.codexAgents": [
+      {
+        name: "planner",
+        path: "C:/Users/example/.codex/agents/planner.toml",
+        description: "Plans implementation work.",
+      },
+    ],
+    "file.list": ["src/app.ts", "src/components/chat/Composer.tsx"],
+    "agent.send": (params) => {
+      sendParams = params;
+      return null;
+    },
+  });
+  await interceptZustandStores(page);
+  await page.goto("/");
+  await page.waitForFunction(
+    () => (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete === true,
+  );
+  await setupCodexChat(page);
+
+  const editor = page.locator('[contenteditable="true"]');
+  await expect(editor).toBeVisible({ timeout: 30_000 });
+  await editor.click();
+  await page.keyboard.type("@");
+
+  const popup = page.getByRole("listbox", { name: "Mention suggestions" });
+  await expect(popup).toBeVisible();
+  await expect(popup.getByText("Agents", { exact: true })).toBeVisible();
+  await expect(popup.getByText("Files", { exact: true })).toBeVisible();
+  await expect(popup.getByRole("option", { name: /planner/ })).toBeVisible();
+  await expect(popup.getByRole("option", { name: /src\/app\.ts/ })).toBeVisible();
+
+  await page.getByRole("option", { name: /planner/ }).click();
+  await expect(editor).toContainText("planner");
+  await expect(page.getByRole("listbox", { name: "Mention suggestions" })).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect.poll(() => sendParams).toBeTruthy();
+  expect(sendParams).toMatchObject({
+    threadId: THREAD.id,
+    content: "@planner",
+    mentions: [
+      {
+        kind: "agent",
+        label: "planner",
+        name: "planner",
+        path: "C:/Users/example/.codex/agents/planner.toml",
+        provider: "codex",
+        range: { start: 0, end: 8 },
+      },
+    ],
+  });
+});

--- a/apps/web/src/__tests__/mention-node.test.ts
+++ b/apps/web/src/__tests__/mention-node.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { createEditor } from "lexical";
+import { $createParagraphNode, $createTextNode, $getRoot, createEditor } from "lexical";
 import {
   MentionNode,
   $createMentionNode,
   $isMentionNode,
 } from "@/components/chat/lexical/MentionNode";
+import { extractComposerMessage } from "@/components/chat/lexical/cursor-utils";
 
 function createTestEditor() {
   return createEditor({
@@ -81,5 +82,31 @@ describe("MentionNode", () => {
   it("$isMentionNode returns false for non-MentionNode", () => {
     expect($isMentionNode(null)).toBe(false);
     expect($isMentionNode(undefined)).toBe(false);
+  });
+
+  it("extracts selected mentions with JavaScript string offsets", () => {
+    const editor = createTestEditor();
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode("😀 see "));
+        paragraph.append($createMentionNode("src/app.ts"));
+        paragraph.append($createTextNode(" and @plain"));
+        root.append(paragraph);
+      },
+      { discrete: true },
+    );
+
+    expect(extractComposerMessage(editor)).toEqual({
+      text: "😀 see @src/app.ts and @plain",
+      mentions: [{
+        id: expect.any(String),
+        kind: "file",
+        label: "src/app.ts",
+        path: "src/app.ts",
+        range: { start: 7, end: 18 },
+      }],
+    });
   });
 });

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -130,6 +130,7 @@ export const mockTransport: McodeTransport = {
   readClipboardImage: vi.fn().mockResolvedValue(null),
   saveClipboardFile: vi.fn().mockResolvedValue(null),
   listWorkspaceFiles: vi.fn().mockResolvedValue([]),
+  listCodexAgents: vi.fn().mockResolvedValue([]),
   readFileContent: vi.fn().mockResolvedValue(""),
   listOpenInApps: vi.fn().mockResolvedValue([]),
   openIn: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -43,10 +43,17 @@ const LazyWorktreePicker = lazy(() => import("./WorktreePicker"));
 import { CopilotAgentSelector } from "./CopilotAgentSelector";
 import { AttachmentPreview } from "./AttachmentPreview";
 import type { PendingAttachment } from "./AttachmentPreview";
-import { useFileAutocomplete, clearFileListCache } from "./useFileAutocomplete";
+import { useFileAutocomplete, clearFileListCache, type MentionSuggestion } from "./useFileAutocomplete";
 import { useFileTagPopup, FileTagPopup } from "./FileTagPopup";
 import { SpellcheckContextMenu } from "./SpellcheckContextMenu";
-import { ComposerEditor, insertMentionNode, insertSlashCommandNode } from "./lexical";
+import {
+  ComposerEditor,
+  $createTypedMentionNode,
+  extractComposerMessage,
+  insertMentionNode,
+  insertSlashCommandNode,
+  type MentionNodeData,
+} from "./lexical";
 import { TerminalStatusIndicator } from "./TerminalStatusIndicator";
 import { useTaskStore } from "@/stores/taskStore";
 import { useDiffStore } from "@/stores/diffStore";
@@ -54,7 +61,6 @@ import {
   hideRightPanelAdaptive,
   showRightPanelAdaptive,
 } from "@/lib/right-panel-layout";
-import { extractFileRefs, buildInjectedMessage } from "@/lib/file-tags";
 import { resolveBranchName } from "@/lib/branch-name";
 import { useSlashCommand } from "./useSlashCommand";
 import type { Command } from "./useSlashCommand";
@@ -85,6 +91,7 @@ import {
 import type {
   AttachedBrowserCapture,
   ContextWindowMode,
+  MessageMention,
   ReasoningLevel,
   ProviderId,
   GoalState,
@@ -120,6 +127,68 @@ function resolveOutboundDisplayContent(
   displayInjected: string | undefined,
 ): string {
   return (displayInjected ?? rawInput).trim();
+}
+
+function writeComposerContent(
+  editor: LexicalEditor,
+  text: string,
+  mentionRanges: readonly MessageMention[] = [],
+  italic = false,
+): void {
+  editor.update(() => {
+    const root = $getRoot();
+    root.clear();
+    let paragraph = $createParagraphNode();
+    const sortedMentions = [...mentionRanges].sort((a, b) => a.range.start - b.range.start);
+    let cursor = 0;
+
+    const appendText = (value: string) => {
+      const parts = value.split("\n");
+      for (let i = 0; i < parts.length; i++) {
+        if (i > 0) {
+          root.append(paragraph);
+          paragraph = $createParagraphNode();
+        }
+        if (parts[i]) {
+          const node = $createTextNode(parts[i]);
+          if (italic) node.setFormat(2);
+          paragraph.append(node);
+        }
+      }
+    };
+
+    for (const mention of sortedMentions) {
+      if (
+        mention.range.start < cursor ||
+        mention.range.end > text.length ||
+        text.slice(mention.range.start, mention.range.end) !== `@${mention.label}`
+      ) {
+        continue;
+      }
+      appendText(text.slice(cursor, mention.range.start));
+      const nodeMention =
+        mention.kind === "file"
+          ? {
+              id: mention.id,
+              kind: mention.kind,
+              label: mention.label,
+              path: mention.path,
+            }
+          : {
+              id: mention.id,
+              kind: mention.kind,
+              label: mention.label,
+              name: mention.name,
+              path: mention.path,
+              provider: mention.provider,
+            };
+      paragraph.append($createTypedMentionNode(nodeMention));
+      cursor = mention.range.end;
+    }
+
+    appendText(text.slice(cursor));
+    root.append(paragraph);
+  });
 }
 
 /**
@@ -621,6 +690,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const clearReply = useReplyStore((s) => s.clearReply);
 
   const [input, setInput] = useState("");
+  const [mentions, setMentions] = useState<MessageMention[]>([]);
   const [modelId, setModelId] = useState(getDefaultModelId());
   // Track provider explicitly: multiple providers share the same model IDs
   // (e.g. "gpt-5.3-codex" exists in both Codex and Copilot), so deriving the
@@ -659,7 +729,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
    * Text queued for send while the child thread's handoff context is still generating.
    * Fires automatically when handoff status transitions to ready or fallback.
    */
-  const [queuedSend, setQueuedSend] = useState<string | null>(null);
+  const [queuedSend, setQueuedSend] = useState<{
+    content: string;
+    displayContent: string;
+    mentions: MessageMention[];
+  } | null>(null);
   // Tracks whether we have seen the handoff transition away from "generating"
   // at least once since this thread was opened. Guards against queueing a
   // message when the user types during the server-initiated first turn on a
@@ -678,6 +752,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const prevThreadIdRef = useRef<string | undefined>(threadId);
   const draftRef = useRef<{
     input: string;
+    mentions: MessageMention[];
     attachments: PendingAttachment[];
     modelId: string;
     provider: string;
@@ -685,7 +760,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     contextWindow?: ContextWindowMode;
     thinking?: boolean;
     codexFastMode?: boolean | null;
-  }>({ input, attachments, modelId, provider, reasoning });
+  }>({ input, mentions, attachments, modelId, provider, reasoning });
   /** Tracks whether the user toggled mode/access before settings finished loading. */
   const agentSettingsTouchedRef = useRef(false);
   /** Set to true by the thread-switch effect; cleared by the model-sync effect.
@@ -698,6 +773,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   useEffect(() => {
     draftRef.current = {
       input,
+      mentions,
       attachments,
       modelId,
       provider,
@@ -855,6 +931,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     });
 
     setInput(session.input);
+    setMentions(session.mentions);
     setAttachments(session.attachments);
     setModelId(session.modelId);
     setProvider(session.provider);
@@ -867,17 +944,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     setCodexFastMode(session.codexFastMode);
 
     if (editorRef.current) {
-      editorRef.current.update(() => {
-        const root = $getRoot();
-        root.clear();
-        if (session.input) {
-          const para = $createParagraphNode();
-          para.append($createTextNode(session.input));
-          root.append(para);
-        } else {
-          root.append($createParagraphNode());
-        }
-      });
+      writeComposerContent(editorRef.current, session.input, session.mentions);
     }
 
     if (!threadId) {
@@ -934,17 +1001,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   useEffect(() => {
     if (!branchFromMessageId || !branchFromMessageContent || !editorRef.current) return;
     const text = branchFromMessageContent;
-    editorRef.current.update(() => {
-      const root = $getRoot();
-      root.clear();
-      const para = $createParagraphNode();
-      const textNode = $createTextNode(text);
-      // Lexical format bitmask: 2 = italic
-      textNode.setFormat(2);
-      para.append(textNode);
-      root.append(para);
-    });
+    writeComposerContent(editorRef.current, text, [], true);
     setInput(branchFromMessageContent);
+    setMentions([]);
     editorRef.current.focus();
   // Only fire when branch mode is newly activated (branchFromMessageId transitions from falsy to truthy).
   }, [branchFromMessageId]);
@@ -953,14 +1012,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   useEffect(() => {
     if (!pendingPrefill) return;
     setInput(pendingPrefill);
+    setMentions([]);
     if (editorRef.current) {
-      editorRef.current.update(() => {
-        const root = $getRoot();
-        root.clear();
-        const para = $createParagraphNode();
-        para.append($createTextNode(pendingPrefill));
-        root.append(para);
-      });
+      writeComposerContent(editorRef.current, pendingPrefill);
       clearPendingPrefill();
       editorRef.current.focus();
     }
@@ -974,47 +1028,18 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     const text = composerRecallFromStop.text;
     clearComposerRecallFromStop(threadId);
     setInput(text);
+    setMentions([]);
     if (editorRef.current) {
-      editorRef.current.update(() => {
-        const root = $getRoot();
-        root.clear();
-        const para = $createParagraphNode();
-        para.append($createTextNode(text));
-        root.append(para);
-      });
+      writeComposerContent(editorRef.current, text);
       editorRef.current.focus();
     }
   }, [composerRecallFromStop, threadId, clearComposerRecallFromStop]);
 
   // Ref to the latest queuedSend value so the handoff-fire effect doesn't need it as
   // a reactive dep (which would re-run the effect on every keystroke while queued).
-  const queuedSendRef = useRef<string | null>(null);
+  const queuedSendRef = useRef<typeof queuedSend>(null);
   queuedSendRef.current = queuedSend;
 
-  const fileAutocomplete = useFileAutocomplete({
-    workspaceId,
-    threadId,
-  });
-
-  const handleFileSelect = useCallback((filePath: string) => {
-    fileAutocomplete.selectFile(filePath);
-    if (editorRef.current) {
-      insertMentionNode(
-        editorRef.current,
-        filePath,
-        fileAutocomplete.triggerStart,
-        fileAutocomplete.query.length,
-      );
-    }
-  }, [fileAutocomplete]);
-
-  const filePopup = useFileTagPopup({
-    files: fileAutocomplete.filteredFiles,
-    query: fileAutocomplete.query,
-    isOpen: fileAutocomplete.isOpen,
-    onSelect: handleFileSelect,
-    onDismiss: fileAutocomplete.dismiss,
-  });
   const sendMessage = useThreadStore((s) => s.sendMessage);
   const stopAgent = useThreadStore((s) => s.stopAgent);
   const branchThread = useWorkspaceStore((s) => s.branchThread);
@@ -1074,6 +1099,53 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const providerReason: "disabled" | "cli_missing" | null = providerUnusable
     ? (!availability!.enabled ? "disabled" : "cli_missing")
     : null;
+
+  const fileAutocomplete = useFileAutocomplete({
+    workspaceId,
+    threadId,
+    providerId: effectiveProviderId,
+  });
+
+  const handleMentionSelect = useCallback((item: MentionSuggestion) => {
+    fileAutocomplete.selectSuggestion(item);
+    if (!editorRef.current) return;
+
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `mention-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const mention: MentionNodeData =
+      item.kind === "agent"
+        ? {
+            id,
+            kind: "agent",
+            label: item.label,
+            name: item.name,
+            path: item.path,
+            provider: item.provider,
+          }
+        : {
+            id,
+            kind: "file",
+            label: item.label,
+            path: item.path,
+          };
+
+    insertMentionNode(
+      editorRef.current,
+      mention,
+      fileAutocomplete.triggerStart,
+      fileAutocomplete.query.length,
+    );
+  }, [fileAutocomplete]);
+
+  const filePopup = useFileTagPopup({
+    items: fileAutocomplete.suggestions,
+    query: fileAutocomplete.query,
+    isOpen: fileAutocomplete.isOpen,
+    onSelect: handleMentionSelect,
+    onDismiss: fileAutocomplete.dismiss,
+  });
 
   const branches = useWorkspaceStore((s) => s.branches);
   const branchesLoading = useWorkspaceStore((s) => s.branchesLoading);
@@ -1323,6 +1395,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     (
       attachmentsSnapshot: PendingAttachment[],
       inputSnapshot: string,
+      mentionsSnapshot: MessageMention[],
     ): Omit<QueuedMessage, "id" | "queuedAt"> => {
       const attachmentMetas: AttachmentMeta[] = attachmentsSnapshot.map((att) => ({
         id: att.id,
@@ -1335,6 +1408,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       return {
         content: trimmedInput,
         displayContent: trimmedInput,
+        mentions: mentionsSnapshot.length > 0 ? mentionsSnapshot : undefined,
         attachments: attachmentMetas,
         model: modelId,
         permissionMode: access,
@@ -1382,7 +1456,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       // content back to the queue at its original slot before swapping in
       // the new one.
       if (editingFromQueue && (input.trim().length > 0 || attachments.length > 0)) {
-        const payload = captureComposerForRequeue(attachments, input);
+        const payload = captureComposerForRequeue(attachments, input, mentions);
         useQueueStore.getState().insertAt(
           threadId,
           editingFromQueue.originalIndex,
@@ -1398,15 +1472,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       useQueueStore.getState().setEditingThreadId(threadId);
 
       const text = popped.displayContent || popped.content;
+      const poppedMentions = popped.mentions ?? [];
       setInput(text);
+      setMentions(poppedMentions);
       if (editorRef.current) {
-        editorRef.current.update(() => {
-          const root = $getRoot();
-          root.clear();
-          const para = $createParagraphNode();
-          if (text) para.append($createTextNode(text));
-          root.append(para);
-        });
+        writeComposerContent(editorRef.current, text, poppedMentions);
       }
 
       if (popped.attachments.length > 0) {
@@ -1444,6 +1514,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       editingFromQueue,
       input,
       attachments,
+      mentions,
       captureComposerForRequeue,
       setInput,
       setAttachments,
@@ -1473,6 +1544,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       useQueueStore.getState().insertAt(threadId, editingFromQueue.originalIndex, {
         content: original.content,
         displayContent: original.displayContent,
+        mentions: original.mentions,
         attachments: original.attachments,
         model: original.model,
         permissionMode: original.permissionMode,
@@ -1492,6 +1564,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     useQueueStore.getState().setEditingThreadId(null);
     scheduleDrainAfterEdit(threadId);
     setInput("");
+    setMentions([]);
     setAttachments([]);
     if (editorRef.current) {
       editorRef.current.update(() => {
@@ -1521,14 +1594,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     setCustomBranchName(detectedPr.branch);
     const prefill = `Review PR #${detectedPr.number}: ${detectedPr.title}`;
     setInput(prefill);
+    setMentions([]);
     // Also populate the Lexical editor so the user sees the prefilled text
-    editorRef.current?.update(() => {
-      const root = $getRoot();
-      root.clear();
-      const para = $createParagraphNode();
-      para.append($createTextNode(prefill));
-      root.append(para);
-    });
+    if (editorRef.current) writeComposerContent(editorRef.current, prefill);
     setDetectedPr(null);
     setPrDismissed(false);
   }, [detectedPr, workspaceId, setComposerMode, fetchBranch, setNewThreadBranch, setNamingMode, setCustomBranchName]);
@@ -1757,30 +1825,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     editorRef.current?.focus();
   }, [addFiles]);
 
-  /** Resolve @file tags into injected content for the agent wire payload. */
-  const injectFileContent = useCallback(async (rawInput: string): Promise<{ content: string; display?: string }> => {
-    const refs = extractFileRefs(rawInput);
-    if (refs.length > 0 && workspaceId) {
-      try {
-        const transport = getTransport();
-        const fileContents = await Promise.all(
-          refs.map(async (path) => {
-            try {
-              const content = await transport.readFileContent(workspaceId, path, threadId);
-              return { path, content };
-            } catch { return null; }
-          }),
-        );
-        const validFiles = fileContents.filter(
-          (f): f is { path: string; content: string } => f !== null,
-        );
-        const injected = buildInjectedMessage(rawInput, validFiles);
-        return { content: injected, display: injected !== rawInput ? rawInput : undefined };
-      } catch { /* fall through */ }
-    }
-    return { content: rawInput };
-  }, [workspaceId, threadId]);
-
   /** Collect attachment metadata for RPC and revoke preview URLs. */
   const collectAndClearAttachments = useCallback((): AttachmentMeta[] => {
     const metas: AttachmentMeta[] = [];
@@ -1819,7 +1863,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   }, [attachments]);
 
   const handleSend = useCallback(async () => {
-    const rawInput = input;
+    const composerMessage = editorRef.current
+      ? extractComposerMessage(editorRef.current)
+      : { text: input, mentions };
+    const rawInput = composerMessage.text;
+    const selectedMentions = composerMessage.mentions;
     const trimmed = rawInput.trim();
     if (trimmed.length === 0 && attachments.length === 0) {
       // Empty submit while editing a queued message = the user emptied it
@@ -1853,7 +1901,11 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         ? getHandoffStatus(getThreadRecord(useThreadStore.getState().records, threadId))
         : undefined;
       if (status === "generating" && hasSeenHandoffTransition) {
-        setQueuedSend(trimmed);
+        setQueuedSend({
+          content: trimmed,
+          displayContent: trimmed,
+          mentions: selectedMentions,
+        });
         return;
       }
     }
@@ -1870,6 +1922,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       const payload = {
         content,
         displayContent: displayContentResolved,
+        mentions: selectedMentions.length > 0 ? selectedMentions : undefined,
         attachments: currentAttachments,
         model: modelId,
         permissionMode: access,
@@ -1905,6 +1958,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       useQueueStore.getState().setEditingThreadId(null);
 
       setInput("");
+      setMentions([]);
       if (threadId) clearDraftFromStore(threadId);
       if (threadId) clearReply(threadId);
       if (editorRef.current) {
@@ -1940,23 +1994,20 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       )
     ) {
       const captureRows = buildAttachedBrowserCaptures(attachments);
-      const { content: injectedContent, display: displayInjected } = await injectFileContent(rawInput);
       let content: string;
       try {
         content =
-          captureRows.length === 0 ? injectedContent : appendBrowserCaptureFence(injectedContent, captureRows);
+          captureRows.length === 0 ? rawInput : appendBrowserCaptureFence(rawInput, captureRows);
         content = content.trim();
       } catch (e) {
         const msg = e instanceof Error ? e.message : "Invalid page preview payload";
         useToastStore.getState().show("error", "Could not send message", msg);
         return;
       }
-      const displayContentResolved = resolveOutboundDisplayContent(rawInput, displayInjected);
+      const displayContentResolved = resolveOutboundDisplayContent(rawInput, undefined);
       enqueueCurrentComposerMessage(content, displayContentResolved, captureRows);
       return;
     }
-
-    const { content: injectedContent, display: displayInjected } = await injectFileContent(rawInput);
 
     // Validate worktree mode requirements
     if (isNewThread && newThreadMode === "worktree" && namingMode === "custom" && !customBranchName.trim()) {
@@ -1983,14 +2034,14 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     let messageContent: string;
     try {
       messageContent =
-        captureRows.length === 0 ? injectedContent : appendBrowserCaptureFence(injectedContent, captureRows);
+        captureRows.length === 0 ? rawInput : appendBrowserCaptureFence(rawInput, captureRows);
       messageContent = messageContent.trim();
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Invalid page preview payload";
       useToastStore.getState().show("error", "Could not send message", msg);
       return;
     }
-    const outboundDisplay = resolveOutboundDisplayContent(rawInput, displayInjected);
+    const outboundDisplay = resolveOutboundDisplayContent(rawInput, undefined);
 
     // ---- Normal send path ----
 
@@ -2008,6 +2059,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
 
     setInput("");
+    setMentions([]);
     if (editorRef.current) {
       editorRef.current.update(() => {
         const root = $getRoot();
@@ -2042,6 +2094,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           thinking ?? undefined,
           provider === "codex" && codexFastMode !== null ? codexFastMode : undefined,
           outboundDisplay,
+          selectedMentions,
         );
     } else if (branchFromMessageId && threadId) {
       // Branch mode: create a child thread from the quoted message instead of sending.
@@ -2079,6 +2132,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         contextWindow: contextWindow ?? undefined,
         thinking: thinking ?? undefined,
         codexFastMode: provider === "codex" && codexFastMode !== null ? codexFastMode : undefined,
+        mentions: selectedMentions,
       });
       onBranchModeExit?.();
     } else if (threadId) {
@@ -2097,6 +2151,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         provider === "codex" && codexFastMode !== null ? codexFastMode : undefined,
         replyContext?.messageId,
         replyContext?.quotedText,
+        undefined,
+        selectedMentions,
       );
     }
 
@@ -2114,7 +2170,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
 
     editorRef.current?.focus();
-  }, [input, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, contextWindow, thinking, codexFastMode, namingMode, customBranchName, selectedWorktree, injectFileContent, collectAndClearAttachments, clearDraftFromStore, isThreadScaffold, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, branchAutoPreview, onBranchModeExit, replyContext, clearReply, editingFromQueue, slashCommand]);
+  }, [input, mentions, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, contextWindow, thinking, codexFastMode, namingMode, customBranchName, selectedWorktree, collectAndClearAttachments, clearDraftFromStore, isThreadScaffold, branchFromMessageId, branchExecMode, branchTargetBranch, branchNamingMode, branchCustomName, branchWorktreePath, activeThread, branchThread, branchAutoPreview, onBranchModeExit, replyContext, clearReply, editingFromQueue, slashCommand]);
 
   // Reset the handoff-transition-seen flag whenever the user switches threads
   // so the guard below evaluates correctly for each new child thread.
@@ -2137,25 +2193,34 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   useEffect(() => {
     if (!threadId) return;
     if (handoffStatus !== "ready" && handoffStatus !== "fallback") return;
-    const text = queuedSendRef.current;
-    if (!text) return;
+    const queued = queuedSendRef.current;
+    if (!queued) return;
     setQueuedSend(null);
     useThreadStore.getState().sendMessage(
       threadId,
-      text.trim(),
+      queued.content,
       modelId,
       access,
       undefined,
-      text.trim(),
+      queued.displayContent,
       reasoning,
       provider,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      queued.mentions,
     );
   // modelId/access/reasoning/provider intentionally read from render-time values via closure;
   // handoffStatus is the sole reactive trigger so we don't re-fire on unrelated changes.
   }, [handoffStatus, threadId]);
 
-  const handleEditorChange = useCallback((text: string) => {
+  const handleEditorChange = useCallback((text: string, nextMentions: MessageMention[]) => {
     setInput(text);
+    setMentions(nextMentions);
   }, []);
 
   const handleSlashSelect = useCallback((cmd: Command) => {
@@ -2291,6 +2356,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 next.codexFastMode,
                 next.replyToMessageId,
                 next.quotedText,
+                undefined,
+                next.mentions,
               );
               const activeReply = useReplyStore.getState().getReply(threadId);
               if (
@@ -2326,6 +2393,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 popped.codexFastMode,
                 popped.replyToMessageId,
                 popped.quotedText,
+                undefined,
+                popped.mentions,
               );
               const activeReply = useReplyStore.getState().getReply(threadId);
               if (
@@ -2446,9 +2515,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             placeholder={isStaleWorktree ? "Worktree directory no longer exists. This thread is read-only." : planPending ? "Answer the planning questions above" : branchFromMessageId ? "What should the branch work on?" : editingFromQueue ? "Edit the queued message - send to save." : replyContext ? "Type your reply..." : isAgentRunning ? "Queue a follow-up..." : "Message Mcode..."}
           />
           <FileTagPopup
-            files={fileAutocomplete.filteredFiles}
+            items={fileAutocomplete.suggestions}
             isOpen={fileAutocomplete.isOpen}
-            onSelect={handleFileSelect}
+            onSelect={handleMentionSelect}
             listRef={filePopup.listRef}
             selectedIndex={filePopup.selectedIndex}
           />

--- a/apps/web/src/components/chat/FileTagPopup.test.tsx
+++ b/apps/web/src/components/chat/FileTagPopup.test.tsx
@@ -1,16 +1,39 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { renderHook, act, render, screen } from "@testing-library/react";
 import type { RefObject } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
 import { useFileTagPopup, FileTagPopup } from "./FileTagPopup";
+import type { MentionSuggestion } from "./useFileAutocomplete";
 
-// Mock the virtualizer so component tests control which virtual items are
-// "rendered" without needing real scroll dimensions from jsdom.
-vi.mock("@tanstack/react-virtual");
+const items: MentionSuggestion[] = [
+  {
+    id: "agent:planner",
+    kind: "agent",
+    group: "Agents",
+    label: "planner",
+    name: "planner",
+    path: "C:/Users/example/.codex/agents/planner.toml",
+    provider: "codex",
+    description: "Plans implementation work.",
+  },
+  {
+    id: "file:src/a.ts",
+    kind: "file",
+    group: "Files",
+    label: "src/a.ts",
+    path: "src/a.ts",
+  },
+  {
+    id: "file:src/b.ts",
+    kind: "file",
+    group: "Files",
+    label: "src/b.ts",
+    path: "src/b.ts",
+  },
+];
 
 describe("useFileTagPopup", () => {
   const defaultProps = {
-    files: ["src/a.ts", "src/b.ts", "src/c.ts"],
+    items,
     query: "",
     isOpen: true,
     onSelect: vi.fn(),
@@ -74,7 +97,7 @@ describe("useFileTagPopup", () => {
     expect(result.current.selectedIndex).toBe(0);
   });
 
-  it("resets selectedIndex when files change", () => {
+  it("resets selectedIndex when items change", () => {
     const { result, rerender } = renderHook(
       (props) => useFileTagPopup(props),
       { initialProps: defaultProps },
@@ -86,11 +109,11 @@ describe("useFileTagPopup", () => {
       } as unknown as React.KeyboardEvent);
     });
     expect(result.current.selectedIndex).toBe(1);
-    rerender({ ...defaultProps, files: ["src/x.ts", "src/y.ts"] });
+    rerender({ ...defaultProps, items: items.slice(0, 2) });
     expect(result.current.selectedIndex).toBe(0);
   });
 
-  it("calls onSelect with selected file on Enter", () => {
+  it("calls onSelect with selected item on Enter", () => {
     const onSelect = vi.fn();
     const { result } = renderHook(() =>
       useFileTagPopup({ ...defaultProps, onSelect }),
@@ -101,10 +124,10 @@ describe("useFileTagPopup", () => {
         preventDefault: vi.fn(),
       } as unknown as React.KeyboardEvent);
     });
-    expect(onSelect).toHaveBeenCalledWith("src/a.ts");
+    expect(onSelect).toHaveBeenCalledWith(items[0]);
   });
 
-  it("calls onSelect with selected file on Tab", () => {
+  it("calls onSelect with selected item on Tab", () => {
     const onSelect = vi.fn();
     const { result } = renderHook(() =>
       useFileTagPopup({ ...defaultProps, onSelect }),
@@ -119,7 +142,7 @@ describe("useFileTagPopup", () => {
         preventDefault: vi.fn(),
       } as unknown as React.KeyboardEvent);
     });
-    expect(onSelect).toHaveBeenCalledWith("src/b.ts");
+    expect(onSelect).toHaveBeenCalledWith(items[1]);
   });
 
   it("calls onDismiss on Escape", () => {
@@ -160,37 +183,61 @@ describe("FileTagPopup", () => {
   const mockListRef = { current: null } as RefObject<HTMLDivElement | null>;
   const onSelect = vi.fn();
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    // Default stub: virtualizer renders no items (mirrors jsdom behavior).
-    // Individual tests override this when they need to inspect virtual output.
-    vi.mocked(useVirtualizer).mockReturnValue({
-      getVirtualItems: () => [],
-      getTotalSize: () => 0,
-      scrollToIndex: vi.fn(),
-    } as unknown as ReturnType<typeof useVirtualizer>);
-  });
-
-  it("renders all items when below virtual threshold", () => {
-    const files = Array.from({ length: 10 }, (_, i) => `src/file${i}.ts`);
+  it("renders grouped agent and file items", () => {
     render(
       <FileTagPopup
-        files={files}
+        items={items}
         isOpen={true}
         onSelect={onSelect}
         listRef={mockListRef}
         selectedIndex={0}
       />,
     );
-    const options = screen.getAllByRole("option");
-    expect(options).toHaveLength(10);
+
+    expect(screen.getByText("Agents")).toBeInTheDocument();
+    expect(screen.getByText("Files")).toBeInTheDocument();
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+    expect(screen.getByText("planner")).toBeInTheDocument();
+    expect(screen.getAllByText("src/")).toHaveLength(2);
+  });
+
+  it("keeps group labels sticky while scrolling within long sections", () => {
+    render(
+      <FileTagPopup
+        items={items}
+        isOpen={true}
+        onSelect={onSelect}
+        listRef={mockListRef}
+        selectedIndex={0}
+      />,
+    );
+
+    expect(screen.getByText("Agents").className).toContain("sticky");
+    expect(screen.getByText("Files").className).toContain("sticky");
+  });
+
+  it("renders agent suggestions with a muted non-robot glyph", () => {
+    render(
+      <FileTagPopup
+        items={items}
+        isOpen={true}
+        onSelect={onSelect}
+        listRef={mockListRef}
+        selectedIndex={0}
+      />,
+    );
+
+    const agentOption = screen.getByRole("option", { name: /planner/i });
+    const icon = agentOption.querySelector("svg");
+    expect(icon?.className.baseVal).toContain("text-muted-foreground/55");
+    expect(icon?.className.baseVal).not.toContain("text-primary");
+    expect(agentOption.querySelector(".lucide-bot")).toBeNull();
   });
 
   it("accepts selectedIndex prop and marks the correct item", () => {
-    const files = ["src/a.ts", "src/b.ts", "src/c.ts"];
     render(
       <FileTagPopup
-        files={files}
+        items={items}
         isOpen={true}
         onSelect={onSelect}
         listRef={mockListRef}
@@ -205,7 +252,7 @@ describe("FileTagPopup", () => {
   it("renders nothing when closed", () => {
     render(
       <FileTagPopup
-        files={["src/a.ts"]}
+        items={[items[0]]}
         isOpen={false}
         onSelect={onSelect}
         listRef={mockListRef}
@@ -213,52 +260,5 @@ describe("FileTagPopup", () => {
       />,
     );
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
-  });
-
-  it("uses native rendering at threshold boundary (20 items)", () => {
-    // 20 items == VIRTUAL_THRESHOLD: strict > check means this is non-virtual.
-    const files = Array.from({ length: 20 }, (_, i) => `src/file${i}.ts`);
-    render(
-      <FileTagPopup
-        files={files}
-        isOpen={true}
-        onSelect={onSelect}
-        listRef={mockListRef}
-        selectedIndex={0}
-      />,
-    );
-    expect(screen.getAllByRole("option")).toHaveLength(20);
-  });
-
-  it("uses virtual rendering above threshold and marks selected item", () => {
-    // 21 items crosses VIRTUAL_THRESHOLD (20). Override the mock to return a
-    // controlled window of virtual rows so we can assert aria-selected without
-    // relying on jsdom scroll dimensions.
-    vi.mocked(useVirtualizer).mockReturnValueOnce({
-      getVirtualItems: () => [
-        { key: "0", index: 0, start: 0, size: 28 },
-        { key: "1", index: 1, start: 28, size: 28 },
-        { key: "2", index: 2, start: 56, size: 28 },
-      ],
-      getTotalSize: () => 588,
-      scrollToIndex: vi.fn(),
-    } as unknown as ReturnType<typeof useVirtualizer>);
-
-    const files = Array.from({ length: 21 }, (_, i) => `src/file${i}.ts`);
-    render(
-      <FileTagPopup
-        files={files}
-        isOpen={true}
-        onSelect={onSelect}
-        listRef={mockListRef}
-        selectedIndex={1}
-      />,
-    );
-
-    const options = screen.getAllByRole("option");
-    expect(options).toHaveLength(3);
-    expect(options[0]).toHaveAttribute("aria-selected", "false");
-    expect(options[1]).toHaveAttribute("aria-selected", "true");
-    expect(options[2]).toHaveAttribute("aria-selected", "false");
   });
 });

--- a/apps/web/src/components/chat/FileTagPopup.tsx
+++ b/apps/web/src/components/chat/FileTagPopup.tsx
@@ -1,29 +1,27 @@
 // apps/web/src/components/chat/FileTagPopup.tsx
 import { useRef, useEffect, useCallback, useState, memo } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn } from "@/lib/utils";
 import { getFileIcon, getFileIconColor } from "@/lib/file-icons";
+import type { MentionSuggestion } from "./useFileAutocomplete";
+import { StackedLayersIcon } from "./narrative/StackedLayersIcon";
 
 const ITEM_HEIGHT = 28; // px per row (py-1.5 + 14px icon)
 const VISIBLE_ITEMS = 8;
-// Virtualizing below this count adds more overhead (scroll listeners, index
-// math) than it saves; native rendering of ≤20 rows has no measurable cost.
-const VIRTUAL_THRESHOLD = 20;
 
 /** Options for the useFileTagPopup keyboard-navigation hook. */
 interface FileTagPopupOptions {
-  files: string[];
+  items: MentionSuggestion[];
   query: string;
   isOpen: boolean;
-  onSelect: (filePath: string) => void;
+  onSelect: (item: MentionSuggestion) => void;
   onDismiss: () => void;
 }
 
 /** Props for the FileTagPopup display component. */
 interface FileTagPopupProps {
-  files: string[];
+  items: MentionSuggestion[];
   isOpen: boolean;
-  onSelect: (filePath: string) => void;
+  onSelect: (item: MentionSuggestion) => void;
   /** Ref forwarded from useFileTagPopup — used by the parent for focus management. */
   listRef: React.RefObject<HTMLDivElement | null>;
   /** Controlled selection index driven by useFileTagPopup state. */
@@ -39,7 +37,7 @@ function splitPath(path: string): { dir: string; name: string } {
 
 /** Hook for keyboard navigation within the file tag popup. */
 export function useFileTagPopup({
-  files,
+  items,
   query,
   isOpen,
   onSelect,
@@ -51,20 +49,20 @@ export function useFileTagPopup({
   // when Enter/Tab fires in the same synchronous batch as a preceding Arrow key.
   const selectedIndexRef = useRef(0);
 
-  // Reset selection when files or query change
+  // Reset selection when items or query change
   useEffect(() => {
     setSelectedIndex(0);
     selectedIndexRef.current = 0;
-  }, [files, query]);
+  }, [items, query]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent): boolean => {
-      if (!isOpen || files.length === 0) return false;
+      if (!isOpen || items.length === 0) return false;
 
       if (e.key === "ArrowDown") {
         e.preventDefault();
         setSelectedIndex((prev) => {
-          const next = Math.min(prev + 1, files.length - 1);
+          const next = Math.min(prev + 1, items.length - 1);
           selectedIndexRef.current = next;
           return next;
         });
@@ -83,7 +81,7 @@ export function useFileTagPopup({
         e.preventDefault();
         // Read from ref so we get the value set by a preceding Arrow key in
         // the same synchronous event batch, not the stale closure snapshot.
-        const selected = files[selectedIndexRef.current];
+        const selected = items[selectedIndexRef.current];
         if (selected) onSelect(selected);
         return true;
       }
@@ -94,7 +92,7 @@ export function useFileTagPopup({
       }
       return false;
     },
-    [isOpen, files, onSelect, onDismiss],
+    [isOpen, items, onSelect, onDismiss],
   );
 
   return { handleKeyDown, listRef, selectedIndex };
@@ -105,99 +103,87 @@ export function useFileTagPopup({
  * Memoized so only the two rows whose `selected` prop flips re-render on
  * each navigation keypress.
  */
-const FileRow = memo(function FileRow({
-  filePath,
+const SuggestionRow = memo(function SuggestionRow({
+  item,
   selected,
   onSelect,
 }: {
-  filePath: string;
+  item: MentionSuggestion;
   selected: boolean;
-  onSelect: (filePath: string) => void;
+  onSelect: (item: MentionSuggestion) => void;
 }) {
-  const { dir, name } = splitPath(filePath);
-  const Icon = getFileIcon(filePath);
+  const isFile = item.kind === "file";
+  const { dir, name } = isFile ? splitPath(item.path) : { dir: "", name: item.label };
+  const Icon = isFile ? getFileIcon(item.path) : StackedLayersIcon;
   return (
     <button
       type="button"
       role="option"
       aria-selected={selected}
       data-file-item
-      onClick={() => onSelect(filePath)}
+      onClick={() => onSelect(item)}
       className={cn(
-        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs",
-        "hover:bg-accent hover:text-accent-foreground",
+        "group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors duration-100",
+        "hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none",
         selected && "bg-accent text-accent-foreground",
       )}
     >
-      <Icon size={14} className={cn("shrink-0", getFileIconColor(filePath))} />
-      <span className="truncate">
-        <span className="text-muted-foreground">{dir}</span>
+      <Icon
+        size={14}
+        className={cn(
+          "size-3.5 shrink-0",
+          isFile
+            ? getFileIconColor(item.path)
+            : "text-muted-foreground/55 group-hover:text-accent-foreground/70 group-focus-visible:text-accent-foreground/70 group-aria-selected:text-accent-foreground/70",
+        )}
+      />
+      <span className="min-w-0 flex-1 truncate">
+        <span className="text-muted-foreground group-hover:text-accent-foreground/70 group-focus-visible:text-accent-foreground/70 group-aria-selected:text-accent-foreground/70">{dir}</span>
         <span className="font-medium">{name}</span>
       </span>
+      {item.kind === "agent" && item.description ? (
+        <span className="min-w-0 flex-[1.2] truncate text-muted-foreground group-hover:text-accent-foreground/70 group-focus-visible:text-accent-foreground/70 group-aria-selected:text-accent-foreground/70">
+          {item.description}
+        </span>
+      ) : null}
     </button>
   );
 });
 
 /** Dropdown popup displaying file suggestions for @ tagging. */
 export function FileTagPopup({
-  files,
+  items,
   isOpen,
   onSelect,
   listRef,
   selectedIndex,
 }: FileTagPopupProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const isVirtualized = files.length > VIRTUAL_THRESHOLD;
-
-  const virtualizer = useVirtualizer({
-    count: isVirtualized ? files.length : 0,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => ITEM_HEIGHT,
-    overscan: 4,
-    // Opt out of react-virtual's flushSync(rerender) on sync measurement; it
-    // fires inside the library's commit-phase layout effect and trips React's
-    // "flushSync called from inside a lifecycle method" warning. A popup list
-    // does not need a synchronous re-render.
-    useFlushSync: false,
-  });
-
-  // Keep a stable ref to the virtualizer so the scroll effect below doesn't
-  // re-run on every render — the virtualizer object reference can change each
-  // render even though the instance is effectively the same.
-  const virtualizerRef = useRef(virtualizer);
-  virtualizerRef.current = virtualizer;
 
   useEffect(() => {
     if (!isOpen) return;
-    if (isVirtualized) {
-      // Virtual path: delegate to the virtualizer, which maps indices to scroll
-      // offsets without querying the DOM.
-      virtualizerRef.current.scrollToIndex(selectedIndex, { align: "auto" });
-    } else {
-      // Non-virtual path: target the wrapper div by data-index attribute.
-      // We use the wrapper div (not the button) because scrollIntoView on a
-      // fixed-height container works best on the outermost positioned element.
-      const el = scrollRef.current?.querySelector(
-        `[data-index="${selectedIndex}"]`,
-      );
-      if (el && typeof (el as HTMLElement).scrollIntoView === "function") {
-        (el as HTMLElement).scrollIntoView({ block: "nearest" });
-      }
+    const el = scrollRef.current?.querySelector(
+      `[data-index="${selectedIndex}"]`,
+    );
+    if (el && typeof (el as HTMLElement).scrollIntoView === "function") {
+      (el as HTMLElement).scrollIntoView({ block: "nearest" });
     }
-  }, [selectedIndex, isOpen, isVirtualized, files]);
+  }, [selectedIndex, isOpen, items]);
 
-  if (!isOpen || files.length === 0) return null;
+  if (!isOpen || items.length === 0) return null;
 
   const maxHeight = Math.min(
     VISIBLE_ITEMS * ITEM_HEIGHT,
-    files.length * ITEM_HEIGHT,
+    items.length * ITEM_HEIGHT + 48,
   );
+  let renderedIndex = 0;
+  let currentGroup: MentionSuggestion["group"] | null = null;
 
   return (
     <div
       ref={listRef}
       role="listbox"
-      aria-label="File suggestions"
+      aria-label="Mention suggestions"
       className="absolute bottom-full left-0 z-50 mb-1 w-full overflow-hidden rounded-lg border border-border bg-popover shadow-lg"
     >
       <div
@@ -205,45 +191,27 @@ export function FileTagPopup({
         className="p-1"
         style={{ maxHeight, overflowY: "auto" }}
       >
-        {isVirtualized ? (
-          <div
-            role="presentation"
-            style={{
-              height: virtualizer.getTotalSize(),
-              position: "relative",
-            }}
-          >
-            {virtualizer.getVirtualItems().map((vi) => (
-              <div
-                key={vi.key}
-                role="presentation"
-                data-index={vi.index}
-                style={{
-                  position: "absolute",
-                  top: vi.start,
-                  width: "100%",
-                  height: vi.size,
-                }}
-              >
-                <FileRow
-                  filePath={files[vi.index]}
-                  selected={vi.index === selectedIndex}
+        {items.map((item) => {
+          const index = renderedIndex++;
+          const showGroup = item.group !== currentGroup;
+          currentGroup = item.group;
+          return (
+            <div key={item.id} role="presentation">
+              {showGroup ? (
+                <div className="sticky top-0 z-10 bg-popover px-2 py-1 text-xs font-medium text-muted-foreground/70">
+                  {item.group}
+                </div>
+              ) : null}
+              <div role="presentation" data-index={index}>
+                <SuggestionRow
+                  item={item}
+                  selected={index === selectedIndex}
                   onSelect={onSelect}
                 />
               </div>
-            ))}
-          </div>
-        ) : (
-          files.map((filePath, i) => (
-            <div key={filePath} role="presentation" data-index={i}>
-              <FileRow
-                filePath={filePath}
-                selected={i === selectedIndex}
-                onSelect={onSelect}
-              />
             </div>
-          ))
-        )}
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, useCallback, useRef, useEffect, lazy, Suspense } from "react";
+import { memo, useMemo, useState, useCallback, useRef, useEffect, lazy, Suspense, type ReactNode } from "react";
 import type { Message } from "@/transport";
 import { ImageIcon, RotateCcw, Copy, Check, GitFork, AlertCircle, Reply, Target } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -72,6 +72,43 @@ function parseUserGoalCommand(content: string): { condition: string } | null {
   const lower = arg.toLowerCase();
   if (lower === "clear" || lower === "reset" || lower === "show") return null;
   return { condition: arg };
+}
+
+function MentionedUserText({
+  text,
+  mentions,
+}: {
+  text: string;
+  mentions: NonNullable<Message["mentions"]>;
+}) {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  const sorted = [...mentions].sort((a, b) => a.range.start - b.range.start);
+
+  for (const mention of sorted) {
+    if (
+      mention.range.start < cursor ||
+      mention.range.end > text.length ||
+      text.slice(mention.range.start, mention.range.end) !== `@${mention.label}`
+    ) {
+      continue;
+    }
+    if (mention.range.start > cursor) {
+      nodes.push(text.slice(cursor, mention.range.start));
+    }
+    nodes.push(
+      <span
+        key={`${mention.id}-${mention.range.start}`}
+        className="rounded-md bg-primary-foreground/20 px-1 py-0.5 font-medium"
+      >
+        {text.slice(mention.range.start, mention.range.end)}
+      </span>,
+    );
+    cursor = mention.range.end;
+  }
+
+  if (cursor < text.length) nodes.push(text.slice(cursor));
+  return <span className="whitespace-pre-wrap">{nodes}</span>;
 }
 
 /**
@@ -606,9 +643,13 @@ export const MessageBubble = memo(function MessageBubble({
 
           {userDisplayText.trim() && (
             <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
-              <Suspense fallback={null}>
-                <LazyMarkdownContent content={userDisplayText} isStreaming={false} variant="user" />
-              </Suspense>
+              {!userGoal && message.mentions?.length ? (
+                <MentionedUserText text={userDisplayText} mentions={message.mentions} />
+              ) : (
+                <Suspense fallback={null}>
+                  <LazyMarkdownContent content={userDisplayText} isStreaming={false} variant="user" />
+                </Suspense>
+              )}
             </div>
           )}
 

--- a/apps/web/src/components/chat/lexical/ComposerEditor.tsx
+++ b/apps/web/src/components/chat/lexical/ComposerEditor.tsx
@@ -7,15 +7,16 @@ import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { type EditorState, type LexicalEditor } from "lexical";
+import type { MessageMention } from "@mcode/contracts";
 import { MentionNode } from "./MentionNode";
 import { SlashCommandNode } from "./SlashCommandNode";
 import { MentionPlugin } from "./MentionPlugin";
 import { SlashCommandPlugin } from "./SlashCommandPlugin";
 import { KeyboardPlugin } from "./KeyboardPlugin";
-import { getPlainTextFromEditor } from "./cursor-utils";
+import { extractComposerMessage } from "./cursor-utils";
 
 interface ComposerEditorProps {
-  onChange: (text: string) => void;
+  onChange: (text: string, mentions: MessageMention[]) => void;
   onSubmit: () => void;
   /** Called when @ trigger is detected - drives file autocomplete popup */
   onMentionTrigger: (text: string, cursorPos: number) => void;
@@ -95,8 +96,8 @@ export function ComposerEditor({
 
   const handleChange = useCallback(
     (_editorState: EditorState, editor: LexicalEditor) => {
-      const text = getPlainTextFromEditor(editor);
-      onChange(text);
+      const message = extractComposerMessage(editor);
+      onChange(message.text, message.mentions);
     },
     [onChange],
   );

--- a/apps/web/src/components/chat/lexical/MentionNode.tsx
+++ b/apps/web/src/components/chat/lexical/MentionNode.tsx
@@ -13,6 +13,7 @@ import {
   type NodeKey,
   type SerializedLexicalNode,
 } from "lexical";
+import type { MessageMention } from "@mcode/contracts";
 import { resolveIcon, type ResolvedIcon } from "@/lib/vscode-icons";
 import { basename } from "@/lib/path";
 
@@ -23,8 +24,21 @@ import { basename } from "@/lib/path";
 /** JSON-serialized form of a MentionNode for editor state persistence. */
 export interface SerializedMentionNode extends SerializedLexicalNode {
   readonly type: "mention";
-  readonly filePath: string;
+  readonly id?: string;
+  readonly kind?: MessageMention["kind"];
+  readonly label?: string;
+  readonly filePath?: string;
+  readonly path?: string;
+  readonly name?: string;
+  readonly provider?: string;
 }
+
+/** Mention metadata stored by the editor before range offsets are computed. */
+export type MentionNodeData = MessageMention extends infer T
+  ? T extends MessageMention
+    ? Omit<T, "range">
+    : never
+  : never;
 
 // ---------------------------------------------------------------------------
 // MentionChip (React component rendered by decorate())
@@ -33,8 +47,8 @@ export interface SerializedMentionNode extends SerializedLexicalNode {
 const CHIP_CLASS =
   "inline-flex items-center gap-1 rounded-md border bg-sky-500/20 ring-1 ring-sky-500/30 px-1.5 py-0.5 text-xs align-baseline";
 
-function MentionChip({ filePath }: { readonly filePath: string }): JSX.Element {
-  const name = basename(filePath);
+function MentionChip({ mention }: { readonly mention: MentionNodeData }): JSX.Element {
+  const name = mention.kind === "file" ? basename(mention.path) : mention.label;
   const [icon, setIcon] = useState<ResolvedIcon | null>(null);
 
   useEffect(() => {
@@ -71,25 +85,29 @@ function MentionChip({ filePath }: { readonly filePath: string }): JSX.Element {
 
 /** Inline decorator node rendering an @file mention chip. */
 export class MentionNode extends DecoratorNode<JSX.Element> {
-  __filePath: string;
+  __mention: MentionNodeData;
 
   static getType(): string {
     return "mention";
   }
 
   static clone(node: MentionNode): MentionNode {
-    return new MentionNode(node.__filePath, node.__key);
+    return new MentionNode(node.__mention, node.__key);
   }
 
-  constructor(filePath: string, key?: NodeKey) {
+  constructor(mention: MentionNodeData, key?: NodeKey) {
     super(key);
-    this.__filePath = filePath;
+    this.__mention = mention;
   }
 
   // -- Accessors ------------------------------------------------------------
 
   getFilePath(): string {
-    return this.getLatest().__filePath;
+    return this.getLatest().__mention.path;
+  }
+
+  getMentionData(): MentionNodeData {
+    return this.getLatest().__mention;
   }
 
   // -- Behavior -------------------------------------------------------------
@@ -99,7 +117,7 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
   }
 
   getTextContent(): string {
-    return `@${this.getFilePath()}`;
+    return `@${this.getMentionData().label}`;
   }
 
   // -- DOM ------------------------------------------------------------------
@@ -119,19 +137,34 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
   exportJSON(): SerializedMentionNode {
     return {
       type: "mention",
-      filePath: this.__filePath,
+      id: this.__mention.id,
+      kind: this.__mention.kind,
+      label: this.__mention.label,
+      filePath: this.__mention.kind === "file" ? this.__mention.path : undefined,
+      path: this.__mention.path,
+      name: this.__mention.kind === "agent" ? this.__mention.name : undefined,
+      provider: this.__mention.kind === "agent" ? this.__mention.provider : undefined,
       version: 1,
     };
   }
 
   static importJSON(serializedNode: SerializedMentionNode): MentionNode {
-    return $createMentionNode(serializedNode.filePath);
+    const path = serializedNode.path ?? serializedNode.filePath ?? serializedNode.label ?? "";
+    return $createTypedMentionNode({
+      id: serializedNode.id ?? createMentionId(),
+      kind: serializedNode.kind ?? "file",
+      label: serializedNode.label ?? path,
+      path,
+      ...(serializedNode.kind === "agent" && serializedNode.name
+        ? { name: serializedNode.name, provider: serializedNode.provider }
+        : {}),
+    } as MentionNodeData);
   }
 
   // -- Decoration -----------------------------------------------------------
 
   decorate(_editor: LexicalEditor, _config: EditorConfig): JSX.Element {
-    return <MentionChip filePath={this.__filePath} />;
+    return <MentionChip mention={this.__mention} />;
   }
 }
 
@@ -141,7 +174,17 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
 
 /** Create a new MentionNode for the given file path. */
 export function $createMentionNode(filePath: string): MentionNode {
-  return new MentionNode(filePath);
+  return $createTypedMentionNode({
+    id: createMentionId(),
+    kind: "file",
+    label: filePath,
+    path: filePath,
+  });
+}
+
+/** Create a new MentionNode for typed mention metadata. */
+export function $createTypedMentionNode(mention: MentionNodeData): MentionNode {
+  return new MentionNode(mention);
 }
 
 /** Type guard: returns true when the node is a MentionNode. */
@@ -149,4 +192,11 @@ export function $isMentionNode(
   node: LexicalNode | null | undefined,
 ): node is MentionNode {
   return node instanceof MentionNode;
+}
+
+function createMentionId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `mention-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }

--- a/apps/web/src/components/chat/lexical/MentionPlugin.tsx
+++ b/apps/web/src/components/chat/lexical/MentionPlugin.tsx
@@ -7,7 +7,7 @@ import {
   TextNode,
   type LexicalEditor,
 } from "lexical";
-import { $createMentionNode } from "./MentionNode";
+import { $createTypedMentionNode, type MentionNodeData } from "./MentionNode";
 
 /** Props for the MentionPlugin that detects @-triggers in the editor. */
 interface MentionPluginProps {
@@ -92,7 +92,7 @@ export function MentionPlugin({
  */
 export function insertMentionNode(
   editor: LexicalEditor,
-  filePath: string,
+  mention: MentionNodeData,
   triggerStart: number,
   queryLength: number,
 ): void {
@@ -110,7 +110,7 @@ export function insertMentionNode(
     const beforeAt = textContent.slice(0, triggerStart);
     const afterQuery = textContent.slice(triggerStart + 1 + queryLength);
 
-    const mentionNode = $createMentionNode(filePath);
+    const mentionNode = $createTypedMentionNode(mention);
     const trailingText = afterQuery.length > 0 ? afterQuery : " ";
     const afterNode = $createTextNode(trailingText);
 

--- a/apps/web/src/components/chat/lexical/cursor-utils.ts
+++ b/apps/web/src/components/chat/lexical/cursor-utils.ts
@@ -1,14 +1,21 @@
 import { $getRoot, $isElementNode, type LexicalEditor } from "lexical";
+import type { MessageMention } from "@mcode/contracts";
 import { $isMentionNode } from "./MentionNode";
 import { $isSlashCommandNode } from "./SlashCommandNode";
 
+/** Composer text and selected typed mentions with JS string offsets. */
+export interface ExtractedComposerMessage {
+  readonly text: string;
+  readonly mentions: MessageMention[];
+}
+
 /**
- * Extract plain text from the editor state, converting decorator nodes
- * back to their text representations (@path, /command).
- * This is the "collapsed" form used for message sending.
+ * Extract collapsed composer text and metadata from selected mention nodes.
+ * Plain typed @foo text remains text because it is not represented by a node.
  */
-export function getPlainTextFromEditor(editor: LexicalEditor): string {
+export function extractComposerMessage(editor: LexicalEditor): ExtractedComposerMessage {
   let text = "";
+  const mentions: MessageMention[] = [];
   editor.getEditorState().read(() => {
     const root = $getRoot();
     const paragraphs = root.getChildren();
@@ -22,7 +29,10 @@ export function getPlainTextFromEditor(editor: LexicalEditor): string {
       const children = paragraph.getChildren();
       for (const child of children) {
         if ($isMentionNode(child)) {
-          text += `@${child.getFilePath()}`;
+          const mentionText = child.getTextContent();
+          const start = text.length;
+          text += mentionText;
+          mentions.push({ ...child.getMentionData(), range: { start, end: text.length } });
         } else if ($isSlashCommandNode(child)) {
           text += `/${child.getCommandName()}`;
         } else {
@@ -31,7 +41,16 @@ export function getPlainTextFromEditor(editor: LexicalEditor): string {
       }
     }
   });
-  return text;
+  return { text, mentions };
+}
+
+/**
+ * Extract plain text from the editor state, converting decorator nodes
+ * back to their text representations (@path, /command).
+ * This is the "collapsed" form used for message sending.
+ */
+export function getPlainTextFromEditor(editor: LexicalEditor): string {
+  return extractComposerMessage(editor).text;
 }
 
 /**
@@ -39,18 +58,11 @@ export function getPlainTextFromEditor(editor: LexicalEditor): string {
  * Used to build the tagged files set for content injection.
  */
 export function extractMentionPaths(editor: LexicalEditor): string[] {
-  const pathSet = new Set<string>();
-  editor.getEditorState().read(() => {
-    const root = $getRoot();
-    const paragraphs = root.getChildren();
-    for (const paragraph of paragraphs) {
-      if (!$isElementNode(paragraph)) continue;
-      for (const child of paragraph.getChildren()) {
-        if ($isMentionNode(child)) {
-          pathSet.add(child.getFilePath());
-        }
-      }
-    }
-  });
-  return [...pathSet];
+  return [
+    ...new Set(
+      extractComposerMessage(editor).mentions
+        .filter((mention) => mention.kind === "file")
+        .map((mention) => mention.path),
+    ),
+  ];
 }

--- a/apps/web/src/components/chat/lexical/index.ts
+++ b/apps/web/src/components/chat/lexical/index.ts
@@ -1,5 +1,6 @@
 export { ComposerEditor } from "./ComposerEditor";
-export { MentionNode, $createMentionNode, $isMentionNode } from "./MentionNode";
+export { MentionNode, $createMentionNode, $createTypedMentionNode, $isMentionNode } from "./MentionNode";
+export type { MentionNodeData } from "./MentionNode";
 export {
   SlashCommandNode,
   $createSlashCommandNode,
@@ -7,4 +8,5 @@ export {
 } from "./SlashCommandNode";
 export { insertMentionNode } from "./MentionPlugin";
 export { insertSlashCommandNode } from "./SlashCommandPlugin";
-export { getPlainTextFromEditor, extractMentionPaths } from "./cursor-utils";
+export { getPlainTextFromEditor, extractMentionPaths, extractComposerMessage } from "./cursor-utils";
+export type { ExtractedComposerMessage } from "./cursor-utils";

--- a/apps/web/src/components/chat/useFileAutocomplete.ts
+++ b/apps/web/src/components/chat/useFileAutocomplete.ts
@@ -4,15 +4,35 @@ import { getTransport } from "@/transport";
 interface UseFileAutocompleteOptions {
   workspaceId?: string;
   threadId?: string;
+  providerId?: string;
 }
+
+export type MentionSuggestion =
+  | {
+      id: string;
+      kind: "agent";
+      group: "Agents";
+      label: string;
+      name: string;
+      path: string;
+      provider: "codex";
+      description?: string;
+    }
+  | {
+      id: string;
+      kind: "file";
+      group: "Files";
+      label: string;
+      path: string;
+    };
 
 interface UseFileAutocompleteResult {
   isOpen: boolean;
-  filteredFiles: string[];
+  suggestions: MentionSuggestion[];
   query: string;
   triggerStart: number;
   handleInputChange: (text: string, cursorPos: number) => void;
-  selectFile: (filePath: string) => string;
+  selectSuggestion: (suggestion: MentionSuggestion) => MentionSuggestion;
   dismiss: () => void;
 }
 
@@ -27,6 +47,12 @@ const fileListCache = new Map<string, string[]>();
 /** In-flight fetch promises keyed by scope, so concurrent callers reuse the same request. */
 const inFlightFetches = new Map<string, Promise<string[]>>();
 
+/** Cache Codex agent suggestions per scope. */
+const codexAgentCache = new Map<string, MentionSuggestion[]>();
+
+/** In-flight Codex agent fetches keyed by scope. */
+const inFlightAgentFetches = new Map<string, Promise<MentionSuggestion[]>>();
+
 /**
  * Clear the cached file list for a scope.
  * Pass workspaceId (and optionally threadId) to clear a specific scope,
@@ -34,9 +60,12 @@ const inFlightFetches = new Map<string, Promise<string[]>>();
  */
 export function clearFileListCache(workspaceId?: string, threadId?: string): void {
   if (workspaceId) {
-    fileListCache.delete(scopeKey(workspaceId, threadId));
+    const key = scopeKey(workspaceId, threadId);
+    fileListCache.delete(key);
+    codexAgentCache.delete(key);
   } else {
     fileListCache.clear();
+    codexAgentCache.clear();
   }
 }
 
@@ -50,10 +79,12 @@ export function clearFileListCache(workspaceId?: string, threadId?: string): voi
 export function useFileAutocomplete({
   workspaceId,
   threadId,
+  providerId,
 }: UseFileAutocompleteOptions): UseFileAutocompleteResult {
   const [isOpen, setIsOpen] = useState(false);
   const [allFiles, setAllFiles] = useState<string[]>([]);
-  const [filteredFiles, setFilteredFiles] = useState<string[]>([]);
+  const [allAgents, setAllAgents] = useState<MentionSuggestion[]>([]);
+  const [suggestions, setSuggestions] = useState<MentionSuggestion[]>([]);
   const [query, setQuery] = useState("");
   const [triggerStart, setTriggerStart] = useState(-1);
 
@@ -64,6 +95,7 @@ export function useFileAutocomplete({
     if (key !== prevScopeRef.current) {
       prevScopeRef.current = key;
       setAllFiles([]);
+      setAllAgents([]);
     }
   }, [workspaceId, threadId]);
 
@@ -113,6 +145,59 @@ export function useFileAutocomplete({
     return files;
   }, [workspaceId, threadId]);
 
+  const loadAgents = useCallback(async (): Promise<MentionSuggestion[]> => {
+    if (!workspaceId || providerId !== "codex") return [];
+
+    const key = scopeKey(workspaceId, threadId);
+    const cached = codexAgentCache.get(key);
+    if (cached) {
+      setAllAgents(cached);
+      return cached;
+    }
+
+    const existing = inFlightAgentFetches.get(key);
+    if (existing) {
+      const agents = await existing;
+      setAllAgents(agents);
+      return agents;
+    }
+
+    const fetchPromise = getTransport()
+      .listCodexAgents(workspaceId, threadId)
+      .then((agents) =>
+        agents.map((agent) => ({
+          id: `agent:${agent.path}`,
+          kind: "agent" as const,
+          group: "Agents" as const,
+          label: agent.name,
+          name: agent.name,
+          path: agent.path,
+          provider: "codex" as const,
+          ...(agent.description ? { description: agent.description } : {}),
+        })),
+      )
+      .then((agents) => {
+        codexAgentCache.set(key, agents);
+        return agents;
+      })
+      .catch((err) => {
+        console.error("[useFileAutocomplete] Failed to load Codex agents:", err);
+        return [] as MentionSuggestion[];
+      })
+      .finally(() => {
+        inFlightAgentFetches.delete(key);
+      });
+
+    inFlightAgentFetches.set(key, fetchPromise);
+
+    const agents = await fetchPromise;
+    const currentKey = scopeKey(workspaceId, threadId);
+    if (currentKey === key) {
+      setAllAgents(agents);
+    }
+    return agents;
+  }, [workspaceId, threadId, providerId]);
+
   const handleInputChange = useCallback(
     async (text: string, cursorPos: number) => {
       // Find the @ trigger: scan backwards from cursor
@@ -146,26 +231,47 @@ export function useFileAutocomplete({
       // Lazy load file list on first @ trigger.
       // Always prefer the direct return from loadFiles() over the
       // closure-captured allFiles, which may be stale after an async gap.
-      const loaded = allFiles.length === 0 ? await loadFiles() : undefined;
+      const [loadedFiles, loadedAgents] = await Promise.all([
+        allFiles.length === 0 ? loadFiles() : Promise.resolve(undefined),
+        providerId === "codex" && allAgents.length === 0 ? loadAgents() : Promise.resolve(undefined),
+      ]);
+      const loaded = loadedFiles;
       const files = loaded ?? allFiles;
+      const agents = providerId === "codex" ? (loadedAgents ?? allAgents) : [];
 
-      // Filter: plain substring match
+      const fileSuggestions: MentionSuggestion[] = files.map((filePath) => ({
+        id: `file:${filePath}`,
+        kind: "file",
+        group: "Files",
+        label: filePath,
+        path: filePath,
+      }));
+
+      const allSuggestions = [...agents, ...fileSuggestions];
+      const matches = (suggestion: MentionSuggestion) => {
+        if (q.length === 0) return true;
+        const haystack =
+          suggestion.kind === "agent"
+            ? `${suggestion.label} ${suggestion.description ?? ""}`.toLowerCase()
+            : suggestion.path.toLowerCase();
+        return haystack.includes(q);
+      };
       const filtered =
         q.length === 0
-          ? files.slice(0, 100) // Show first 100 when no query
-          : files.filter((f) => f.toLowerCase().includes(q)).slice(0, 100);
+          ? [...agents.slice(0, 20), ...fileSuggestions.slice(0, 80)]
+          : allSuggestions.filter(matches).slice(0, 100);
 
-      setFilteredFiles(filtered);
+      setSuggestions(filtered);
       setIsOpen(true);
     },
-    [isOpen, allFiles, loadFiles],
+    [isOpen, allFiles, allAgents, loadFiles, loadAgents, providerId],
   );
 
-  const selectFile = useCallback((filePath: string): string => {
+  const selectSuggestion = useCallback((suggestion: MentionSuggestion): MentionSuggestion => {
     setIsOpen(false);
     setQuery("");
     setTriggerStart(-1);
-    return filePath;
+    return suggestion;
   }, []);
 
   const dismiss = useCallback(() => {
@@ -176,11 +282,11 @@ export function useFileAutocomplete({
 
   return {
     isOpen,
-    filteredFiles,
+    suggestions,
     query,
     triggerStart,
     handleInputChange,
-    selectFile,
+    selectSuggestion,
     dismiss,
   };
 }

--- a/apps/web/src/lib/composer-session/index.ts
+++ b/apps/web/src/lib/composer-session/index.ts
@@ -1,6 +1,6 @@
 import type { PendingAttachment } from "@/components/chat/AttachmentPreview";
 import type { ComposerDraft } from "@/stores/composerDraftStore";
-import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
+import type { ContextWindowMode, MessageMention, ReasoningLevel } from "@mcode/contracts";
 import type { PermissionMode } from "@/transport";
 import { INTERACTION_MODES, type InteractionMode } from "@/transport";
 import type { WorkspaceThread } from "@/lib/workspace-thread";
@@ -15,6 +15,7 @@ import {
 /** Full per-thread composer state restored as one value on thread switch. */
 export interface ComposerSession {
   input: string;
+  mentions: MessageMention[];
   attachments: PendingAttachment[];
   modelId: string;
   provider: string;
@@ -50,6 +51,10 @@ export interface ResolveComposerSessionInput {
 export function snapshotComposerDraft(draft: ComposerDraft): ComposerDraft {
   return {
     ...draft,
+    mentions: draft.mentions?.map((mention) => ({
+      ...mention,
+      range: { ...mention.range },
+    })),
     attachments: draft.attachments.map((attachment) => ({ ...attachment })),
   };
 }
@@ -65,6 +70,7 @@ export function resolveComposerSession(input: ResolveComposerSessionInput): Comp
     const modelId = getDefaultModelId();
     return {
       input: "",
+      mentions: [],
       attachments: [],
       modelId,
       provider: getDefaultProviderId(),
@@ -85,6 +91,7 @@ export function resolveComposerSession(input: ResolveComposerSessionInput): Comp
   if (saved) {
     return {
       input: saved.input,
+      mentions: saved.mentions ?? [],
       attachments: saved.attachments.map((attachment) => ({ ...attachment })),
       modelId: saved.modelId,
       provider: saved.provider ?? getDefaultProviderId(),
@@ -104,6 +111,7 @@ export function resolveComposerSession(input: ResolveComposerSessionInput): Comp
   const resolvedModelId = resolveThreadModelId(threadRow?.model, getDefaultModelId());
   return {
     input: "",
+    mentions: [],
     attachments: [],
     modelId: resolvedModelId,
     provider: (threadRow?.provider as string | undefined) ?? getDefaultProviderId(),

--- a/apps/web/src/stores/composerDraftStore.ts
+++ b/apps/web/src/stores/composerDraftStore.ts
@@ -1,10 +1,11 @@
 import { create } from "zustand";
 import type { PendingAttachment } from "@/components/chat/AttachmentPreview";
-import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
+import type { ContextWindowMode, MessageMention, ReasoningLevel } from "@mcode/contracts";
 
 /** Draft state for a single composer instance, keyed by thread ID. */
 export interface ComposerDraft {
   input: string;
+  mentions?: MessageMention[];
   attachments: PendingAttachment[];
   modelId: string;
   /** Provider ID stored alongside the model because multiple providers share model IDs. */

--- a/apps/web/src/stores/queueStore.ts
+++ b/apps/web/src/stores/queueStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { AttachmentMeta, PermissionMode } from "@/transport";
-import type { ContextWindowMode, ReasoningLevel } from "@mcode/contracts";
+import type { ContextWindowMode, MessageMention, ReasoningLevel } from "@mcode/contracts";
 import { releaseBrowserCaptureSpills } from "@/lib/browser-capture-spill";
 
 /** A message waiting to be sent while the thread is busy with another turn. */
@@ -9,6 +9,8 @@ export interface QueuedMessage {
   content: string;
   /** Optional display-only variant of content (e.g. stripped of internal markup). */
   displayContent?: string;
+  /** Selected typed mentions with offsets into content. Plain typed @text is not included. */
+  mentions?: MessageMention[];
   attachments: AttachmentMeta[];
   model: string;
   permissionMode: PermissionMode;
@@ -66,6 +68,7 @@ interface QueueState {
     messageId: string,
     content: string,
     displayContent?: string,
+    mentions?: MessageMention[],
   ) => void;
   /**
    * Move a queued message to a new index (0-based). Indices are clamped to the
@@ -181,7 +184,7 @@ export const useQueueStore = create<QueueState>((set, get) => ({
     });
   },
 
-  editMessage: (threadId, messageId, content, displayContent) => {
+  editMessage: (threadId, messageId, content, displayContent, mentions) => {
     set((state) => {
       const current = state.queues[threadId];
       if (!current) return state;
@@ -191,6 +194,7 @@ export const useQueueStore = create<QueueState>((set, get) => ({
         ...current[idx],
         content,
         displayContent: displayContent ?? content,
+        mentions,
       };
       const nextList = [...current];
       nextList[idx] = updated;

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, ToolCallRecord, ThoughtSegmentRecord } from "@/transport";
-import type { ContextWindowMode, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory, GoalState } from "@mcode/contracts";
+import type { ContextWindowMode, MessageMention, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory, GoalState } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import type { ThoughtSegment } from "@/components/chat/narrative/types";
 import { PlanQuestionSchema, PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
@@ -67,7 +67,7 @@ interface ThreadState {
   // Message actions
   loadMessages: (threadId: string) => Promise<void>;
   loadOlderMessages: (threadId: string) => Promise<void>;
-  sendMessage: (threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], displayContent?: string, reasoningLevel?: ReasoningLevel, provider?: string, copilotAgent?: string, contextWindow?: ContextWindowMode, thinking?: boolean, codexFastMode?: boolean, replyToMessageId?: string, quotedText?: string, planAction?: import("@mcode/contracts").PlanAction) => Promise<void>;
+  sendMessage: (threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], displayContent?: string, reasoningLevel?: ReasoningLevel, provider?: string, copilotAgent?: string, contextWindow?: ContextWindowMode, thinking?: boolean, codexFastMode?: boolean, replyToMessageId?: string, quotedText?: string, planAction?: import("@mcode/contracts").PlanAction, mentions?: MessageMention[]) => Promise<void>;
   stopAgent: (threadId: string) => Promise<void>;
   /** Replace runningThreadIds with the authoritative server snapshot. Called on WS (re)connect. */
   hydrateRunningThreads: (ids: string[]) => void;
@@ -199,6 +199,8 @@ export function scheduleDrainAfterEdit(threadId: string): void {
             next.codexFastMode,
             next.replyToMessageId,
             next.quotedText,
+            undefined,
+            next.mentions,
           );
         } catch {
           void releaseBrowserCaptureSpills(next.browserCaptureSpillPaths ?? []);
@@ -871,7 +873,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * message to local state, marks the thread as running, then dispatches
    * to the transport layer. On failure, rolls back the running state.
    */
-  sendMessage: async (threadId, content, model, permissionMode, attachments, displayContent, reasoningLevel, provider, copilotAgent, contextWindow, thinking, codexFastMode, replyToMessageId, quotedText, planAction) => {
+  sendMessage: async (threadId, content, model, permissionMode, attachments, displayContent, reasoningLevel, provider, copilotAgent, contextWindow, thinking, codexFastMode, replyToMessageId, quotedText, planAction, mentions) => {
     evictCachedRecord(threadId);
 
     // A `/goal` control form (show/clear/reset/bare) never starts a provider
@@ -907,6 +909,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         mimeType: a.mimeType,
         sizeBytes: a.sizeBytes,
       })) ?? null,
+      mentions: mentions && mentions.length > 0 ? mentions : null,
       reply_to_message_id: replyToMessageId ?? null,
       quoted_text: quotedText ?? null,
     };
@@ -978,6 +981,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         replyToMessageId,
         quotedText,
         planAction,
+        mentions,
       );
     } catch (e) {
       if (planAction === "revise") {
@@ -2559,6 +2563,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
                   next.codexFastMode,
                   next.replyToMessageId,
                   next.quotedText,
+                  undefined,
+                  next.mentions,
                 );
               } catch {
                 void releaseBrowserCaptureSpills(next.browserCaptureSpillPaths ?? []);

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -5,7 +5,7 @@ import {
   buildPlaceholderWorkspaceThread,
   titleFromMessageContent,
 } from "@/lib/workspace-thread";
-import type { ChecksStatus, CreateAndSendResult } from "@mcode/contracts";
+import type { ChecksStatus, CreateAndSendResult, MessageMention } from "@mcode/contracts";
 import { getTransport } from "@/transport";
 import { useThreadStore } from "./threadStore";
 import { deleteThreadRecord, patchThreadRecord } from "./thread-record";
@@ -85,6 +85,8 @@ interface PendingThreadCreation {
   content: string;
   /** Persisted/UI caption when outbound `content` includes hidden augmentation. */
   displayContent?: string;
+  /** Selected typed mentions with offsets into content. */
+  mentions?: MessageMention[];
   model: string;
   permissionMode?: PermissionMode;
   transportMode: "direct" | "worktree";
@@ -124,6 +126,7 @@ async function runCreateAndSend(pending: PendingThreadCreation): Promise<CreateA
     pending.thinking,
     pending.codexFastMode,
     pending.displayContent,
+    pending.mentions,
   );
 }
 /**
@@ -204,6 +207,7 @@ interface WorkspaceState {
     thinking?: boolean,
     codexFastMode?: boolean,
     displayContent?: string,
+    mentions?: MessageMention[],
   ) => Promise<Thread>;
   /** Branch an existing thread into a new child with handoff context. */
   branchThread: (params: {
@@ -224,6 +228,7 @@ interface WorkspaceState {
     contextWindow?: ContextWindowMode;
     thinking?: boolean;
     codexFastMode?: boolean;
+    mentions?: MessageMention[];
   }) => Promise<Thread>;
   /**
    * Re-run server creation for a placeholder thread after {@link WorkspaceThread.clientError}.
@@ -717,6 +722,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     thinking,
     codexFastMode,
     displayContent,
+    mentions,
   ) => {
     const workspaceId = get().activeWorkspaceId;
     if (!workspaceId) throw new Error("No workspace selected");
@@ -762,6 +768,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       contextWindow,
       thinking,
       codexFastMode,
+      mentions,
     };
 
     const captionForUi = displayContent ?? content;
@@ -855,6 +862,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       contextWindow: params.contextWindow,
       thinking: params.thinking,
       codexFastMode: params.codexFastMode,
+      mentions: params.mentions,
     };
 
     const branchCaptionForUi = params.displayContent ?? params.content;

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -38,6 +38,7 @@ import type {
   PermissionRequest,
   CreateAndSendResult,
   ConversationPage,
+  MessageMention,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
@@ -66,11 +67,19 @@ export type {
   PlanAnswer,
   PlanAction,
   ProviderModelInfo,
+  MessageMention,
 } from "@mcode/contracts";
 
 export type { PaginatedMessages, ConversationPage, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord, TurnSnapshot, CopilotSubagent } from "@mcode/contracts";
 
 export { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
+
+/** Codex sub-agent metadata exposed for @ mention autocomplete. */
+export interface CodexAgentMentionInfo {
+  name: string;
+  path: string;
+  description?: string;
+}
 
 /** In-progress tool call tracked by the frontend streaming layer. */
 export interface ToolCall {
@@ -201,6 +210,7 @@ export interface McodeTransport {
     replyToMessageId?: string,
     quotedText?: string,
     planAction?: PlanAction,
+    mentions?: MessageMention[],
   ): Promise<void>;
   createAndSendMessage(
     workspaceId: string,
@@ -221,6 +231,7 @@ export interface McodeTransport {
     thinking?: boolean,
     codexFastMode?: boolean,
     displayContent?: string,
+    mentions?: MessageMention[],
   ): Promise<CreateAndSendResult>;
   stopAgent(threadId: string): Promise<void>;
   /** Respond to a tool permission request from the agent. */
@@ -301,6 +312,8 @@ export interface McodeTransport {
 
   // File operations (@ file tagging)
   listWorkspaceFiles(workspaceId: string, threadId?: string): Promise<string[]>;
+  /** List Codex sub-agents available for @ mention autocomplete. */
+  listCodexAgents(workspaceId?: string, threadId?: string): Promise<CodexAgentMentionInfo[]>;
   readFileContent(workspaceId: string, relativePath: string, threadId?: string): Promise<string>;
 
   // Open-in app actions

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -19,6 +19,7 @@ import type {
   GitCommit,
   ProviderModelInfo,
   CopilotSubagent,
+  CodexAgentMentionInfo,
   GitRemoteUrl,
 } from "./types";
 import type { CreateAndSendResult } from "@mcode/contracts";
@@ -558,6 +559,7 @@ export function createWsTransport(
       replyToMessageId?,
       quotedText?,
       planAction?,
+      mentions?,
     ) => {
       const state = useSettingsStore.getState();
       const guardrails = state.loaded
@@ -580,6 +582,7 @@ export function createWsTransport(
         ...(quotedText && { quotedText }),
         ...(displayContent !== undefined && { displayContent }),
         ...(planAction !== undefined && { planAction }),
+        ...(mentions !== undefined && { mentions }),
         ...guardrails,
       });
     },
@@ -602,6 +605,7 @@ export function createWsTransport(
       thinking?,
       codexFastMode?,
       displayContent?,
+      mentions?,
     ) => {
       const state = useSettingsStore.getState();
       const guardrails = state.loaded
@@ -626,6 +630,7 @@ export function createWsTransport(
         thinking,
         ...(codexFastMode !== undefined && { codexFastMode }),
         ...(displayContent !== undefined && { displayContent }),
+        ...(mentions !== undefined && { mentions }),
         ...guardrails,
       });
     },
@@ -803,6 +808,8 @@ export function createWsTransport(
     /** Fetches all available Copilot sub-agents for the given workspace (built-in + user + project). */
     listCopilotAgents: (workspaceId) =>
       rpc<CopilotSubagent[]>("provider.copilotAgents", { workspaceId }),
+    listCodexAgents: (workspaceId, threadId?) =>
+      rpc<CodexAgentMentionInfo[]>("provider.codexAgents", { workspaceId, threadId }),
     listProviderAvailability: () =>
       rpc<ProviderAvailability[]>("providers.listAvailability", {}),
 

--- a/docs/adr/0014-persist-typed-mention-metadata.md
+++ b/docs/adr/0014-persist-typed-mention-metadata.md
@@ -1,0 +1,11 @@
+# Persist typed @ mention metadata beside message text
+
+Mcode uses `@` for a shared composer mention picker whose results can be files, provider sub-agents, and later other reference types. We will persist each selected mention as typed metadata beside the readable message text, with enough identity and range data to render the composer transcript and serialize provider-specific payloads without reparsing raw `@...` strings.
+
+For Codex, typed file and sub-agent mentions serialize to native app-server `mention` input parts with `name` and `path`; Mcode does not inline file contents or agent instructions for selected mentions when the provider can resolve them. Codex mention suggestions should come from the app-server where it exposes the needed catalog or search API, such as `fuzzyFileSearch` for files. Providers without native mention support keep the existing fallback behavior, such as file-content injection.
+
+`/` commands and `@` mentions should share one grouped suggestion UI primitive with separate data sources and section labels. This keeps keyboard behavior, loading states, and provider-scoped grouping consistent while preserving the different semantics of commands and mentions. Codex may expose the same underlying entry through both surfaces: `/` invokes or expands it as a command or skill, while `@` inserts it as a typed mention for provider-native resolution.
+
+## Considered Options
+
+Parsing message text on demand would avoid schema work, but it would make file paths, provider agent names, and future mention targets compete for the same plain-text pattern. Typed metadata adds storage and migration work, but keeps transcript rendering and provider serialization deterministic after reload.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -47,6 +47,13 @@ export { MessageSchema, PaginatedMessagesSchema } from "./models/message.js";
 export type { Message, PaginatedMessages } from "./models/message.js";
 
 export {
+  MessageMentionSchema,
+  MessageMentionsSchema,
+  MAX_MESSAGE_MENTIONS,
+} from "./models/mention.js";
+export type { MessageMention } from "./models/mention.js";
+
+export {
   GoalControlsSchema,
   GoalStateSchema,
   GoalStatusSchema,

--- a/packages/contracts/src/models/mention.ts
+++ b/packages/contracts/src/models/mention.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const MAX_MESSAGE_MENTIONS = 50;
+export const MENTION_ID_MAX_LENGTH = 128;
+export const MENTION_LABEL_MAX_LENGTH = 512;
+export const MENTION_PATH_MAX_LENGTH = 4096;
+
+const CONTROL_CHAR_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/;
+const PATH_CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/;
+
+const MentionRangeSchema = z.object({
+  start: z.number().int().min(0),
+  end: z.number().int().min(1),
+}).refine((range) => range.end > range.start, {
+  message: "Mention range end must be greater than start",
+});
+
+const MentionTextSchema = z.string()
+  .min(1)
+  .max(MENTION_LABEL_MAX_LENGTH)
+  .refine((value) => !CONTROL_CHAR_RE.test(value), {
+    message: "Mention text must not contain control characters",
+  });
+
+const MentionPathSchema = z.string()
+  .min(1)
+  .max(MENTION_PATH_MAX_LENGTH)
+  .refine((value) => !PATH_CONTROL_CHAR_RE.test(value), {
+    message: "Mention path must not contain control characters",
+  });
+
+const MentionBaseSchema = z.object({
+  id: z.string().min(1).max(MENTION_ID_MAX_LENGTH),
+  label: MentionTextSchema,
+  range: MentionRangeSchema,
+});
+
+/** Typed metadata for a selected composer mention. */
+export const MessageMentionSchema = z.discriminatedUnion("kind", [
+  MentionBaseSchema.extend({
+    kind: z.literal("file"),
+    path: MentionPathSchema,
+  }),
+  MentionBaseSchema.extend({
+    kind: z.literal("agent"),
+    name: MentionTextSchema,
+    path: MentionPathSchema,
+    provider: z.string().min(1).max(64).optional(),
+  }),
+]);
+
+/** Bounded list of typed mention metadata stored on a message. */
+export const MessageMentionsSchema = z.array(MessageMentionSchema).max(MAX_MESSAGE_MENTIONS);
+
+export type MessageMention = z.infer<typeof MessageMentionSchema>;

--- a/packages/contracts/src/models/message.ts
+++ b/packages/contracts/src/models/message.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { MessageRoleSchema } from "./enums.js";
 import { StoredAttachmentSchema } from "./attachment.js";
 import { lazySchema } from "../utils/lazySchema.js";
+import { MessageMentionsSchema } from "./mention.js";
 
 /** Message schema matching the SQLite row shape. */
 export const MessageSchema = lazySchema(() =>
@@ -17,6 +18,7 @@ export const MessageSchema = lazySchema(() =>
     timestamp: z.string(),
     sequence: z.number(),
     attachments: z.array(StoredAttachmentSchema).nullable(),
+    mentions: MessageMentionsSchema.nullable().optional(),
     tool_call_count: z.number().optional(),
     reply_to_message_id: z.string().nullable().optional(),
     quoted_text: z.string().nullable().optional(),

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -1,6 +1,7 @@
 import type { AgentEvent } from "../events/agent-event.js";
 import type { InteractionMode } from "../models/enums.js";
 import type { AttachmentMeta } from "../models/attachment.js";
+import type { MessageMention } from "../models/mention.js";
 import type { GoalState } from "../models/goal.js";
 import type { PermissionDecision, PermissionRequest } from "../models/permission.js";
 import type { ContextWindowMode, ReasoningLevel } from "../models/settings.js";
@@ -49,6 +50,8 @@ export interface TurnRequest<P extends ProviderId = ProviderId> {
   threadId: string;
   /** User input text (already wire-wrapped by the orchestrator when needed). */
   message: string;
+  /** Selected composer mentions with JS string-offset ranges in `message`. */
+  mentions?: MessageMention[];
   attachments?: AttachmentMeta[];
   /** Working directory: the thread's effective worktree or workspace path. */
   cwd: string;

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -3,6 +3,7 @@ import { WorkspaceSchema, WorkspaceEnrichmentSchema } from "../models/workspace.
 import { ThreadSchema, RecentThreadSchema } from "../models/thread.js";
 import { ThreadModeSchema, PermissionModeSchema, InteractionModeSchema } from "../models/enums.js";
 import { PaginatedMessagesSchema } from "../models/message.js";
+import { MessageMentionsSchema } from "../models/mention.js";
 import { ConversationPageSchema } from "../models/conversation-page.js";
 import { AttachmentMetaSchema } from "../models/attachment.js";
 import { MAX_ATTACHMENTS } from "../models/file-types.js";
@@ -55,6 +56,8 @@ export const SendMessageSchema = lazySchema(() =>
     model: z.string().optional(),
     permissionMode: PermissionModeSchema.optional(),
     attachments: z.array(AttachmentMetaSchema).max(MAX_ATTACHMENTS).optional(),
+    /** Typed metadata for selected composer mentions. Plain @text is omitted. */
+    mentions: MessageMentionsSchema.optional(),
     reasoningLevel: ReasoningLevelSchema.optional(),
     provider: ProviderIdSchema.optional(),
     /** When "plan", the server wraps the message with the plan-mode question prompt. */
@@ -99,6 +102,8 @@ export const CreateAndSendSchema = lazySchema(() =>
     branch: z.string().optional(),
     existingWorktreePath: z.string().optional(),
     attachments: z.array(AttachmentMetaSchema).max(MAX_ATTACHMENTS).optional(),
+    /** Typed metadata for selected composer mentions. Plain @text is omitted. */
+    mentions: MessageMentionsSchema.optional(),
     reasoningLevel: ReasoningLevelSchema.optional(),
     provider: ProviderIdSchema.optional(),
     /** When "plan", the server wraps the message with the plan-mode question prompt. */
@@ -785,6 +790,18 @@ export const WS_METHODS = lazySchema(() => ({
       workspaceId: z.string(),
     }),
     result: z.array(CopilotSubagentSchema()),
+  },
+  /** Fetches Codex sub-agent definitions available for @ mentions. */
+  "provider.codexAgents": {
+    params: z.object({
+      workspaceId: z.string().optional(),
+      threadId: z.string().optional(),
+    }),
+    result: z.array(z.object({
+      name: z.string(),
+      path: z.string(),
+      description: z.string().optional(),
+    })),
   },
   "providers.listAvailability": {
     params: z.object({}),


### PR DESCRIPTION
## What
Adds typed mention metadata for selected composer mentions, with Codex-aware handling for agents and files.

## Why
Codex supports both `@` for files and `@` for sub-agents, so the app needs to distinguish selected autocomplete mentions from plain text before sending a turn.

## Key Changes
- Stores selected mention metadata on messages and drafts, then renders selected mentions in the composer and transcript.
- Groups `@` autocomplete into Agents and Files for Codex threads.
- Sends selected Codex agent mentions as `subagent://<name>` text and keeps plain typed `@name` unchanged.
- Sends selected Codex file mentions through native mention parts instead of injecting file content.
- Polishes the mention popup with a quieter sub-agent glyph and selected-state contrast.
- Adds provider, persistence, editor, and Playwright coverage for typed mentions.

Closes #796

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784730355&installation_id=129163861&pr_number=797&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F797&signature=63dbf158003e6f4595e0ad0e5bbbd39930f17bbe3e7db28068f339cb0ef8ba57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed `@` mention support for files and Codex agents in the message composer
  * Mention autocomplete popup displays available files and agents with keyboard navigation
  * User messages now render mentions with distinct styling
  * Mentions are persisted with messages and sent to providers for native handling
  * Added Codex agent discovery to populate mention suggestions

* **Tests**
  * Added E2E test verifying mention autocomplete and message submission with mention metadata

* **Documentation**
  * Added architecture decision record documenting typed mention design and serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->