### PR TITLE
fix(ci): tolerate missing mac arm64 mksnapshot

### DIFF
--- a/apps/desktop/scripts/generate-snapshot.mjs
+++ b/apps/desktop/scripts/generate-snapshot.mjs
@@ -10,7 +10,7 @@
  */
 
 import { build } from "esbuild";
-import { execFileSync } from "child_process";
+import { spawn } from "child_process";
 import { renameSync, existsSync, mkdirSync, unlinkSync, rmSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -81,11 +81,46 @@ if (!existsSync(mksnapshot)) {
   process.exit(1);
 }
 
-execFileSync(
-  mksnapshot,
-  [resolve(snapshotDir, "snapshot-entry.js"), "--output_dir", snapshotDir],
-  { stdio: "inherit" },
-);
+const snapshotResult = await new Promise((resolveResult) => {
+  const child = spawn(
+    mksnapshot,
+    [resolve(snapshotDir, "snapshot-entry.js"), "--output_dir", snapshotDir],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let output = "";
+  const appendOutput = (chunk, write) => {
+    const text = chunk.toString();
+    output = `${output}${text}`.slice(-20_000);
+    write(text);
+  };
+
+  child.stdout.on("data", (chunk) =>
+    appendOutput(chunk, process.stdout.write.bind(process.stdout)),
+  );
+  child.stderr.on("data", (chunk) =>
+    appendOutput(chunk, process.stderr.write.bind(process.stderr)),
+  );
+  child.on("error", (error) => resolveResult({ error, status: null, output }));
+  child.on("close", (status) => resolveResult({ error: null, status, output }));
+});
+
+if (snapshotResult.error) {
+  console.error(snapshotResult.error);
+  process.exit(1);
+}
+
+if (snapshotResult.status !== 0) {
+  if (snapshotResult.output.includes("Could not find mksnapshot")) {
+    console.warn(
+      "Skipping V8 snapshot: electron-mksnapshot did not install a native mksnapshot binary for this platform. " +
+      "The app will start without a custom snapshot.",
+    );
+    rmSync(snapshotDir, { recursive: true, force: true });
+    process.exit(0);
+  }
+
+  process.exit(snapshotResult.status ?? 1);
+}
 
 // ---------------------------------------------------------------------------
 // Step 3: Rename to browser-specific snapshot


### PR DESCRIPTION
## What
Make desktop snapshot generation skip cleanly when `electron-mksnapshot` reports that its native `mksnapshot` binary is missing.

## Why
The Nightly Desktop macOS arm64 job failed in `Generate V8 snapshot` with `ERROR: Could not find mksnapshot`. Packaging already supports builds without a custom browser V8 snapshot.

## Key Changes
- Stream `mksnapshot` stdout and stderr while keeping recent output for error matching.
- Treat only the known missing-native-binary message as a no-snapshot build and keep other snapshot failures fatal.
- Remove the partial snapshot directory before exiting the skipped path.

Related to https://github.com/Mzeey-Empire/mcode/actions/runs/27961288907

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784734226&installation_id=129163861&pr_number=798&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F798&signature=50e0b7ee8e03d74af89dae7740b2a3664fa9f57ea72ff2267bdf24f9dd511b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and diagnostics for the desktop app build process when snapshot generation fails.
  * Enhanced graceful fallback behavior when snapshot creation encounters issues, allowing the app to proceed with degraded functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->