### PR TITLE
docs: plan branchless worktrees

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,31 +66,43 @@ _Avoid_: using "project" in code or schema; reserve it for user-facing copy.
 
 ### Worktree
 A git worktree provisioned under a workspace so a thread can run against
-an isolated checkout of the repo on its own branch. Standard git semantics
-— one repository, multiple working directories — applied as an isolation
-primitive: each worktree-mode thread runs against its own files, its own
-branch, and (in dev mode) its own database.
+an isolated checkout of the repo. Standard git semantics, one repository
+with multiple working directories, applied as an isolation primitive: each
+worktree-mode thread runs against its own files and, in dev mode, its own
+database. A worktree-mode thread may start without its own branch; the user
+can create that branch later from the Overview.
 
 **A worktree is not 1:1 with a thread.** Multiple threads can share the
 same worktree via the composer's "Existing worktree" mode. A thread can
 also run *without* a worktree, directly against the workspace's main
-checkout — see "Direct mode" below.
+checkout. See "Direct mode" below.
 
 Worktrees are persistent and removed manually. When a user deletes a
 thread, an option to delete its worktree is offered alongside; the
 worktree can also be kept and reused for future threads.
 
+### Branchless worktree
+A worktree that has no named branch yet. It starts from a selected base
+branch and lets the thread run in isolation before the user decides whether
+the work needs a branch. In branch-facing UI, the current ref is shown as
+`HEAD` with a short commit hash rather than as the selected base branch.
+In Review comparisons, the target is shown as `HEAD` and the base remains
+the selected base branch for that worktree.
+_Avoid_: Headless worktree
+
+### Thread checkout state
+The thread's current git position. A worktree thread is either on a named
+branch or in a branchless worktree with a base branch and current `HEAD`;
+callers must not infer this state from the branch label alone.
+_Avoid_: Treating `HEAD` as a branch name
+
 ### PR-able thread
 A thread the app can open a pull request from. A thread is PR-able only
-when it runs in an isolated worktree; direct-mode threads are never
-PR-able, because they run against the workspace's main checkout and there
-is nothing to open a pull request from. This single notion gates every PR
-affordance: the thread-row PR icon, the chat header's Create PR button,
-and the background PR and commits-ahead polling. A non-PR-able thread
-shows its branch/agent status instead of a PR glyph, offers no Create PR
-button, and is never polled against GitHub, even if a PR number happens to
-be attached to it. A user who wants a pull request from local work creates
-a worktree.
+when it runs in an isolated worktree on a named branch; direct-mode and
+branchless worktree threads are not PR-able yet. This single notion gates
+background PR and commits-ahead polling. A branchless thread can still use
+the Create PR entry point, but that flow must ask for a branch name and
+create the branch before opening the pull request.
 
 ## Composer
 
@@ -99,7 +111,7 @@ The mode the composer is in when the user creates a new thread, determining
 whether the thread runs against the workspace's main checkout or against a
 worktree, and whether that worktree is new or pre-existing. Three modes:
 **Direct**, **New worktree**, **Existing worktree**. Once a thread has been
-created, its mode is fixed for the life of the thread — the composer shows
+created, its mode is fixed for the life of the thread. The composer shows
 the chosen mode in read-only form rather than as a fourth mode.
 
 ### Direct mode
@@ -108,20 +120,16 @@ No isolation: file edits affect the user's primary working directory and
 current branch. The default when a workspace is not a git repo.
 
 ### New worktree mode
-Composer mode where the thread provisions a fresh git worktree on a new
-branch. Used when the user wants isolation and a clean branch for the work
-about to be done. Code identifier: `"worktree"`.
+Composer mode where the thread provisions a fresh git worktree from a
+selected base branch without requiring the user to name a new branch first.
+Used when the user wants isolation before deciding whether the work needs a
+branch. Code identifier: `"worktree"`.
 
 ### Existing worktree mode
 Composer mode where the thread attaches to a worktree that already exists.
-Enables multiple threads to share one worktree — e.g. follow-up work on
-the same branch without re-creating the directory.
-
-### Naming mode (Auto / Custom)
-Sub-control of New worktree mode controlling how the new branch is named.
-**Auto** generates a branch name from the thread's first message;
-**Custom** lets the user type one explicitly. Auto is the default, but the
-user can change the default to Custom from settings.
+Enables multiple threads to share one worktree, such as follow-up work on
+the same branch without re-creating the directory. Existing worktree mode can
+also attach to a branchless worktree.
 
 ### Composer session
 The composer's per-thread state, treated as one value: draft text,
@@ -221,8 +229,8 @@ Not to be confused with [[Fork]]. The two share one git primitive (a branch
 pointer) in exactly one case, which is why they are easy to collapse, but they
 are different actions: Create branch moves *this* thread onto a new branch right
 here, whereas Fork spawns a *new* thread - and only its new-worktree variant
-also creates a branch (in a *separate* worktree; existing-worktree reuses that
-worktree's branch, and new-local does no branch op at all). One line each:
+also creates a separate worktree; existing-worktree reuses that worktree's
+branch, and new-local does no branch op at all. One line each:
 Create branch = "this thread, new branch, here"; Fork = "a new thread, possibly
 elsewhere."
 
@@ -573,6 +581,11 @@ workspace-root view of changes and branches stays the Review tab's job.
 
 The Overview offers two ways to take the thread further, split by what each does
 to *this* thread. Both anchor at the thread tail (not a picked message):
+
+For branchless worktrees, the Overview shows the checkout as `HEAD` from the
+selected base branch and makes Create branch the next git action. After Create
+branch succeeds, the Overview shows the named branch like any other worktree
+thread.
 
 **[[Fork]]** - spawns a *new* child thread; this thread stays untouched. Three
 targets:

--- a/docs/adr/0015-branchless-worktrees-for-new-isolated-threads.md
+++ b/docs/adr/0015-branchless-worktrees-for-new-isolated-threads.md
@@ -1,0 +1,39 @@
+---
+status: proposed
+---
+
+# Branchless worktrees for new isolated threads
+
+New isolated threads should create a branchless worktree from a selected base
+branch, then let the user create a named branch only when that branch matters.
+This removes upfront Auto, Custom, and AI branch-naming decisions from the
+composer while keeping the thread isolated from the workspace checkout.
+
+## Decision
+
+`New worktree` creates a branchless worktree from the user's selected base
+branch. The thread records an explicit checkout state so callers know whether
+the worktree is on a named branch or on `HEAD` from a saved base branch.
+
+Branchless threads are not PR-able until a named branch exists. `Create branch`
+turns the same worktree into a normal branch worktree in place. `Create PR` on a
+branchless thread first asks for a branch name, creates the branch, then
+continues through the PR flow.
+
+Review comparisons for branchless worktrees use the saved base branch as the
+base and `HEAD` as the target. Review may temporarily compare another base to
+`HEAD`, but that picker state does not change the thread's saved base branch.
+
+## Consequences
+
+- The composer keeps `New worktree` and its base-branch picker, but drops the
+  upfront branch-name controls.
+- `worktree.naming.*` settings should disappear from the UI and docs. Existing
+  persisted settings remain tolerated during load and migration.
+- Overview shows branchless worktrees as `HEAD` from the selected base branch
+  and makes `Create branch` the next git action.
+- PR, push, commits-ahead polling, and PR-check polling must key off checkout
+  state instead of treating every worktree thread as PR-able.
+- The implementation should expose one canonical checkout-state contract rather
+  than spreading `branch === "HEAD"` checks across Review, Overview, PR actions,
+  and git services.

--- a/docs/prd/2026-06-22-branchless-worktrees-handoff.md
+++ b/docs/prd/2026-06-22-branchless-worktrees-handoff.md
@@ -1,0 +1,55 @@
+# Branchless worktrees handoff
+
+## Purpose
+
+This handoff gives implementation agents the map for the branchless worktrees
+epic. The full product scope lives in GitHub issues; this file records where to
+start, which decisions are settled, and which skills to load.
+
+## Primary references
+
+- Epic: https://github.com/Mzeey-Empire/mcode/issues/799
+- Slice 1: https://github.com/Mzeey-Empire/mcode/issues/800
+- Slice 2: https://github.com/Mzeey-Empire/mcode/issues/801
+- Slice 3: https://github.com/Mzeey-Empire/mcode/issues/802
+- ADR: `docs/adr/0015-branchless-worktrees-for-new-isolated-threads.md`
+- Glossary: `CONTEXT.md`
+
+## Issue graph
+
+```text
+#799 branchless worktrees epic
+└── #800 create and use branchless new worktrees
+    ├── #801 create pull requests from branchless worktrees
+    └── #802 attach existing branchless worktrees
+```
+
+`#801` and `#802` are blocked by `#800`.
+
+## Settled language
+
+- Use **Branchless worktree** in product and domain docs.
+- Use detached `HEAD` only when talking about git implementation details.
+- Do not treat `HEAD` as a branch name.
+- Thread checkout state is the source of truth for named branch versus
+  branchless state.
+
+## Implementation notes
+
+- Keep slices vertical. Do not land a schema-only or UI-only partial that leaves
+  branchless worktrees unusable.
+- Slice 1 must let a user create a branchless worktree, run a thread, inspect
+  Review, read Overview, and create a branch in place.
+- Review compares saved base branch to `HEAD` for branchless worktrees. Review
+  picker changes are inspection state and must not mutate the saved base branch.
+- Branchless threads are not PR-able until Create branch succeeds.
+- Settings should tolerate old `worktree.naming.*` values, but the user-facing
+  settings and composer naming controls should go away.
+
+## Suggested skills
+
+- `implement` for issue execution.
+- `tdd` if changing checkout-state contracts, git service behavior, or PR gates.
+- `design-dna` or `impeccable` for Overview, composer, or Create PR UI changes.
+- `security-review` for mutating git RPCs or any path/ref input boundary.
+- `verify-live` before claiming any runtime behavior is complete.


### PR DESCRIPTION
## What

Document the branchless worktrees plan and publish the implementation issue map.

## Why

New isolated threads should not require a branch name before the user knows whether the work needs a branch. The plan records the product language, checkout-state model, Review behavior, PR gates, and implementation sequencing for other agents.

## Key Changes

- Updated `CONTEXT.md` with Branchless worktree and Thread checkout state terminology.
- Added ADR-0015 for the branchless worktree decision.
- Added a branch handoff document linking the epic, child issues, ADR, and settled implementation notes.
- Created and linked epic #799 with child issues #800, #801, and #802.

Related to #799, #800, #801, #802

## Verification

- `node C:\Users\cjnwo\.codex\skills\gpt-writing\scripts\scan-tells.js docs\adr\0015-branchless-worktrees-for-new-isolated-threads.md` -> CLEAN
- `node C:\Users\cjnwo\.codex\skills\gpt-writing\scripts\scan-tells.js docs\prd\2026-06-22-branchless-worktrees-handoff.md` -> CLEAN
- `git diff --cached --check` -> passed before commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784746331&installation_id=129163861&pr_number=803&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F803&signature=7c2f94b055baff4df09262109dbcd4abc2a8c46e889994e177354d129f958d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced branchless worktrees that don't require upfront branch naming; convert to named branches using "Create branch" action
  * PR workflow now prompts for a branch name when creating a PR from a branchless thread

* **Documentation**
  * Updated glossary and composer mode guides with clarified worktree behavior and PR eligibility rules
  * Added architectural decision and handoff documentation for branchless worktree feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->