### PR TITLE
fix: sync thread checkout labels

### DIFF
--- a/apps/server/src/__tests__/thread-service.test.ts
+++ b/apps/server/src/__tests__/thread-service.test.ts
@@ -35,6 +35,7 @@ describe("ThreadService.delete", () => {
       checkout: vi.fn(),
       listWorktrees: vi.fn(),
       fetchBranch: vi.fn(),
+      getCurrentBranchAt: vi.fn(),
     } as unknown as GitService;
     mockAttachmentService = { removeForThread: vi.fn() } as unknown as AttachmentService;
     mockHandoffStorage = {
@@ -244,6 +245,38 @@ describe("ThreadService.delete", () => {
       branch: "feat/from-thread",
       checkout_state: "named",
       base_branch: null,
+    });
+  });
+
+  it("syncs a branchless thread worktree to a named external branch", async () => {
+    const ws = workspaceRepo.create("test", "/tmp/test");
+    const thread = threadRepo.create(ws.id, "Branchless", "worktree", "main", true, "claude", undefined, "branchless", "main");
+    threadRepo.updateWorktreePath(thread.id, "/tmp/wt/main");
+    (mockGitService.getCurrentBranchAt as ReturnType<typeof vi.fn>).mockResolvedValue("feat/external");
+
+    const result = await threadService.syncCheckoutFromHead(thread.id);
+
+    expect(result?.changed).toBe(true);
+    expect(result?.thread).toMatchObject({
+      branch: "feat/external",
+      checkout_state: "named",
+      base_branch: null,
+    });
+  });
+
+  it("syncs a named thread worktree to detached HEAD", async () => {
+    const ws = workspaceRepo.create("test", "/tmp/test");
+    const thread = threadRepo.create(ws.id, "Named", "worktree", "feat/base");
+    threadRepo.updateWorktreePath(thread.id, "/tmp/wt/base");
+    (mockGitService.getCurrentBranchAt as ReturnType<typeof vi.fn>).mockResolvedValue("HEAD");
+
+    const result = await threadService.syncCheckoutFromHead(thread.id);
+
+    expect(result?.changed).toBe(true);
+    expect(result?.thread).toMatchObject({
+      branch: "HEAD",
+      checkout_state: "branchless",
+      base_branch: "feat/base",
     });
   });
 });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -274,6 +274,9 @@ const ciWatcherService = new CiWatcherService(githubService, (channel, data) => 
   broadcast(channel as Parameters<typeof broadcast>[0], data as Parameters<typeof broadcast>[1]);
   portPush.send(channel as Parameters<typeof portPush.send>[0], data as Parameters<typeof portPush.send>[1]);
 });
+gitWatcherService.setThreadCheckoutChangedListener((threadId) => {
+  ciWatcherService.unwatch(threadId);
+});
 
 // Wire up PTY sender to broadcast push events
 terminalService.setSender({
@@ -352,6 +355,11 @@ if (removed > 0) {
 const allWorkspaces = workspaceRepo.listAll();
 for (const ws of allWorkspaces) {
   gitWatcherService.watchWorkspace(ws.id, ws.path);
+  for (const thread of threadService.list(ws.id)) {
+    if (thread.mode === "worktree" && thread.worktree_path) {
+      gitWatcherService.watchThreadWorktree(thread.id, thread.worktree_path);
+    }
+  }
   if (!ws.is_git_repo && existsSync(join(ws.path, ".git"))) {
     workspaceRepo.setIsGitRepo(ws.id, true);
     logger.info("Corrected stale is_git_repo=false at startup", { workspaceId: ws.id, path: ws.path });

--- a/apps/server/src/repositories/__tests__/thread-repo.test.ts
+++ b/apps/server/src/repositories/__tests__/thread-repo.test.ts
@@ -77,6 +77,71 @@ describe("ThreadRepo.updateCheckoutToNamedBranch", () => {
   });
 });
 
+describe("ThreadRepo.updateCheckoutFromHead", () => {
+  let threadRepo: ThreadRepo;
+  let workspaceId: string;
+
+  beforeEach(() => {
+    const db = openMemoryDatabase();
+    container.reset();
+    container.registerInstance("Database", db);
+    threadRepo = container.resolve(ThreadRepo);
+    const workspaceRepo = container.resolve(WorkspaceRepo);
+    const ws = workspaceRepo.create("test-ws", "/tmp/ws", false);
+    workspaceId = ws.id;
+  });
+
+  it("promotes a branchless checkout to a named branch and clears stale PR metadata", () => {
+    const thread = threadRepo.create(workspaceId, "t", "worktree", "main", true, "claude", undefined, "branchless", "main");
+    threadRepo.updatePr(thread.id, 12, "OPEN");
+
+    const result = threadRepo.updateCheckoutFromHead(thread.id, "feat/new", "named", null);
+
+    expect(result?.changed).toBe(true);
+    expect(result?.thread).toMatchObject({
+      branch: "feat/new",
+      checkout_state: "named",
+      base_branch: null,
+      pr_number: null,
+      pr_status: null,
+    });
+  });
+
+  it("updates a named checkout to another named branch", () => {
+    const thread = threadRepo.create(workspaceId, "t", "worktree", "feat/old");
+
+    const result = threadRepo.updateCheckoutFromHead(thread.id, "feat/new", "named", null);
+
+    expect(result?.changed).toBe(true);
+    expect(result?.thread.branch).toBe("feat/new");
+    expect(result?.thread.checkout_state).toBe("named");
+  });
+
+  it("updates a named checkout to detached HEAD with previous branch as base", () => {
+    const thread = threadRepo.create(workspaceId, "t", "worktree", "feat/base");
+
+    const result = threadRepo.updateCheckoutFromHead(thread.id, "HEAD", "branchless", "feat/base");
+
+    expect(result?.changed).toBe(true);
+    expect(result?.thread).toMatchObject({
+      branch: "HEAD",
+      checkout_state: "branchless",
+      base_branch: "feat/base",
+    });
+  });
+
+  it("does not clear PR metadata when checkout branch and state are unchanged", () => {
+    const thread = threadRepo.create(workspaceId, "t", "worktree", "feat/same");
+    threadRepo.updatePr(thread.id, 34, "OPEN");
+
+    const result = threadRepo.updateCheckoutFromHead(thread.id, "feat/same", "named", null);
+
+    expect(result?.changed).toBe(false);
+    expect(result?.thread.pr_number).toBe(34);
+    expect(result?.thread.pr_status).toBe("OPEN");
+  });
+});
+
 describe("Migration 019 backfill", () => {
   it("backfills has_file_changes = 1 for threads with non-empty file changes in any snapshot", () => {
     const db = openMemoryDatabase();

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -323,6 +323,46 @@ export class ThreadRepo {
     return this.findById(id);
   }
 
+  /**
+   * Persist an externally observed checkout state for a worktree thread.
+   * Clears stale PR metadata only when the branch or checkout discriminator changed.
+   */
+  updateCheckoutFromHead(
+    id: string,
+    branch: string,
+    checkoutState: "named" | "branchless",
+    baseBranch: string | null,
+  ): { thread: Thread; changed: boolean } | null {
+    const current = this.findById(id);
+    if (!current) return null;
+
+    const changed =
+      current.branch !== branch || current.checkout_state !== checkoutState;
+    if (
+      !changed &&
+      current.base_branch === baseBranch
+    ) {
+      return { thread: current, changed: false };
+    }
+
+    const now = new Date().toISOString();
+    this.db
+      .prepare(
+        `UPDATE threads
+         SET branch = ?,
+             checkout_state = ?,
+             base_branch = ?,
+             pr_number = CASE WHEN ? THEN NULL ELSE pr_number END,
+             pr_status = CASE WHEN ? THEN NULL ELSE pr_status END,
+             updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(branch, checkoutState, baseBranch, changed ? 1 : 0, changed ? 1 : 0, now, id);
+
+    const thread = this.findById(id);
+    return thread ? { thread, changed } : null;
+  }
+
   /** Soft-delete a thread by setting deleted_at and status to "deleted". */
   softDelete(id: string): boolean {
     const now = new Date().toISOString();

--- a/apps/server/src/services/git-watcher-service.test.ts
+++ b/apps/server/src/services/git-watcher-service.test.ts
@@ -119,6 +119,26 @@ describe("GitWatcherService", () => {
     expect(listener).toHaveBeenCalledWith("thread-1");
   });
 
+  it("still broadcasts checkout changes when the checkout-changed listener throws", async () => {
+    service.setThreadCheckoutChangedListener(() => {
+      throw new Error("listener failed");
+    });
+    await service.watchThreadWorktree("thread-1", "/repo-wt");
+
+    callbacks[0]("change", "HEAD");
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(broadcastMock).toHaveBeenCalledWith("thread.checkoutChanged", {
+      threadId: "thread-1",
+      workspaceId: "ws-1",
+      branch: "feat/thread",
+      checkoutState: "named",
+      baseBranch: null,
+      prNumber: null,
+      prStatus: null,
+    });
+  });
+
   it("does not invoke the checkout-changed listener when sync reports no checkout change", async () => {
     const listener = vi.fn();
     (threadService.syncCheckoutFromHead as ReturnType<typeof vi.fn>).mockResolvedValueOnce({

--- a/apps/server/src/services/git-watcher-service.test.ts
+++ b/apps/server/src/services/git-watcher-service.test.ts
@@ -1,0 +1,144 @@
+import "reflect-metadata";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FSWatcher } from "fs";
+import { EventEmitter } from "events";
+
+const { watchMock, existsSyncMock, broadcastMock } = vi.hoisted(() => ({
+  watchMock: vi.fn(),
+  existsSyncMock: vi.fn(() => true),
+  broadcastMock: vi.fn(),
+}));
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    watch: watchMock,
+    existsSync: existsSyncMock,
+  };
+});
+
+vi.mock("../transport/push", () => ({
+  broadcast: broadcastMock,
+}));
+
+import { GitWatcherService } from "./git-watcher-service";
+import type { WorkspaceRepo } from "../repositories/workspace-repo";
+import type { GitExecutor } from "./git-executor/index";
+import type { GitService } from "./git-service";
+import type { ThreadService } from "./thread-service";
+
+class MockWatcher extends EventEmitter {
+  close = vi.fn();
+}
+
+describe("GitWatcherService", () => {
+  let callbacks: Array<(eventType: string, filename: string) => void>;
+  let service: GitWatcherService;
+  let gitService: GitService;
+  let threadService: ThreadService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    callbacks = [];
+    watchMock.mockReset();
+    existsSyncMock.mockReturnValue(true);
+    broadcastMock.mockReset();
+    watchMock.mockImplementation((_path: string, cb: (eventType: string, filename: string) => void) => {
+      callbacks.push(cb);
+      return new MockWatcher() as unknown as FSWatcher;
+    });
+
+    const gitExecutor = {
+      exec: vi.fn().mockResolvedValue({ stdout: ".git\n" }),
+    } as unknown as GitExecutor;
+    gitService = {
+      getCurrentBranchAt: vi.fn().mockResolvedValue("main"),
+    } as unknown as GitService;
+    threadService = {
+      syncCheckoutFromHead: vi.fn().mockResolvedValue({
+        changed: true,
+        thread: {
+          id: "thread-1",
+          workspace_id: "ws-1",
+          branch: "feat/thread",
+          checkout_state: "named",
+          base_branch: null,
+          pr_number: null,
+          pr_status: null,
+        },
+      }),
+    } as unknown as ThreadService;
+    service = new GitWatcherService(
+      {} as WorkspaceRepo,
+      gitExecutor,
+      gitService,
+      threadService,
+    );
+  });
+
+  it("broadcasts branch.changed for workspace HEAD changes", async () => {
+    await service.watchWorkspace("ws-1", "/repo");
+
+    callbacks[0]("change", "HEAD");
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(gitService.getCurrentBranchAt).toHaveBeenCalledWith("/repo");
+    expect(broadcastMock).toHaveBeenCalledWith("branch.changed", {
+      workspaceId: "ws-1",
+      branch: "main",
+    });
+  });
+
+  it("syncs and broadcasts thread.checkoutChanged for thread worktree HEAD changes", async () => {
+    await service.watchThreadWorktree("thread-1", "/repo-wt");
+
+    callbacks[0]("change", "HEAD");
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(threadService.syncCheckoutFromHead).toHaveBeenCalledWith("thread-1");
+    expect(broadcastMock).toHaveBeenCalledWith("thread.checkoutChanged", {
+      threadId: "thread-1",
+      workspaceId: "ws-1",
+      branch: "feat/thread",
+      checkoutState: "named",
+      baseBranch: null,
+      prNumber: null,
+      prStatus: null,
+    });
+  });
+
+  it("invokes the checkout-changed listener when sync reports a changed checkout", async () => {
+    const listener = vi.fn();
+    service.setThreadCheckoutChangedListener(listener);
+    await service.watchThreadWorktree("thread-1", "/repo-wt");
+
+    callbacks[0]("change", "HEAD");
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(listener).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("does not invoke the checkout-changed listener when sync reports no checkout change", async () => {
+    const listener = vi.fn();
+    (threadService.syncCheckoutFromHead as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      changed: false,
+      thread: {
+        id: "thread-1",
+        workspace_id: "ws-1",
+        branch: "feat/thread",
+        checkout_state: "named",
+        base_branch: null,
+        pr_number: 12,
+        pr_status: "OPEN",
+      },
+    });
+    service.setThreadCheckoutChangedListener(listener);
+    await service.watchThreadWorktree("thread-1", "/repo-wt");
+
+    callbacks[0]("change", "HEAD");
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/git-watcher-service.ts
+++ b/apps/server/src/services/git-watcher-service.ts
@@ -12,6 +12,7 @@ import { broadcast } from "../transport/push";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { GitExecutor } from "./git-executor/index.js";
 import type { GitService } from "./git-service.js";
+import { ThreadService } from "./thread-service.js";
 
 /** Debounce delay in milliseconds to batch rapid HEAD file writes (e.g., during rebase). */
 const DEBOUNCE_MS = 200;
@@ -31,12 +32,20 @@ interface WatcherEntry {
 @injectable()
 export class GitWatcherService {
   private readonly watchers = new Map<string, WatcherEntry>();
+  private readonly threadWatchers = new Map<string, WatcherEntry>();
+  private onThreadCheckoutChanged: ((threadId: string) => void) | null = null;
 
   constructor(
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
     @inject("GitExecutor") private readonly gitExecutor: GitExecutor,
     @inject("GitService") private readonly gitService: GitService,
+    @inject(ThreadService) private readonly threadService: ThreadService,
   ) {}
+
+  /** Register a callback invoked after a thread checkout branch/state changes. */
+  setThreadCheckoutChangedListener(listener: ((threadId: string) => void) | null): void {
+    this.onThreadCheckoutChanged = listener;
+  }
 
   /**
    * Resolve the absolute path to the HEAD file for the given workspace path.
@@ -146,6 +155,74 @@ export class GitWatcherService {
   }
 
   /**
+   * Start watching a worktree thread's HEAD file for external checkout changes.
+   */
+  async watchThreadWorktree(threadId: string, worktreePath: string): Promise<void> {
+    if (this.threadWatchers.has(threadId)) return;
+
+    const headFile = await this.resolveHeadFile(worktreePath);
+    if (!headFile) return;
+
+    const headDir = dirname(headFile);
+    const headName = basename(headFile);
+
+    let fsWatcher: FSWatcher;
+    try {
+      fsWatcher = watch(headDir, (_, filename) => {
+        if ((filename ?? headName) !== headName) return;
+
+        const entry = this.threadWatchers.get(threadId);
+        if (!entry) return;
+
+        if (entry.timer !== null) {
+          clearTimeout(entry.timer);
+        }
+        entry.timer = setTimeout(() => {
+          entry.timer = null;
+          void this.threadService.syncCheckoutFromHead(threadId).then((result) => {
+            if (!result?.changed) return;
+            const { thread } = result;
+            this.onThreadCheckoutChanged?.(thread.id);
+            broadcast("thread.checkoutChanged", {
+              threadId: thread.id,
+              workspaceId: thread.workspace_id,
+              branch: thread.branch,
+              checkoutState: thread.checkout_state,
+              baseBranch: thread.base_branch,
+              prNumber: thread.pr_number,
+              prStatus: thread.pr_status,
+            });
+          }).catch((err) => {
+            logger.warn("GitWatcherService: failed to sync thread checkout after HEAD change", {
+              threadId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        }, DEBOUNCE_MS);
+      });
+
+      fsWatcher.on("error", (err) => {
+        logger.warn("GitWatcherService: thread watcher error, stopping watch", {
+          threadId,
+          headDir,
+          error: err.message,
+        });
+        this.unwatchThreadWorktree(threadId);
+      });
+    } catch (err) {
+      logger.warn("GitWatcherService: thread fs.watch failed, degrading gracefully", {
+        threadId,
+        headDir,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    this.threadWatchers.set(threadId, { watcher: fsWatcher, timer: null });
+    logger.info("GitWatcherService: watching thread HEAD", { threadId, headDir, headName });
+  }
+
+  /**
    * Attempt to start watching a workspace that was previously detected as non-git.
    * Called on thread.list to catch `git init` within a session.
    * Returns true if the workspace is now a git repo and the watcher was started.
@@ -194,11 +271,32 @@ export class GitWatcherService {
     logger.info("GitWatcherService: stopped watching", { workspaceId });
   }
 
+  /** Stop watching a thread worktree HEAD file. */
+  unwatchThreadWorktree(threadId: string): void {
+    const entry = this.threadWatchers.get(threadId);
+    if (!entry) return;
+
+    if (entry.timer !== null) {
+      clearTimeout(entry.timer);
+    }
+    try {
+      entry.watcher.close();
+    } catch {
+      // Ignore close errors
+    }
+    this.threadWatchers.delete(threadId);
+    logger.info("GitWatcherService: stopped watching thread", { threadId });
+  }
+
   /** Close all active watchers. Called on server shutdown. */
   dispose(): void {
     const ids = [...this.watchers.keys()];
     for (const id of ids) {
       this.unwatchWorkspace(id);
+    }
+    const threadIds = [...this.threadWatchers.keys()];
+    for (const id of threadIds) {
+      this.unwatchThreadWorktree(id);
     }
     logger.info("GitWatcherService: all watchers disposed");
   }

--- a/apps/server/src/services/git-watcher-service.ts
+++ b/apps/server/src/services/git-watcher-service.ts
@@ -182,7 +182,14 @@ export class GitWatcherService {
           void this.threadService.syncCheckoutFromHead(threadId).then((result) => {
             if (!result?.changed) return;
             const { thread } = result;
-            this.onThreadCheckoutChanged?.(thread.id);
+            try {
+              this.onThreadCheckoutChanged?.(thread.id);
+            } catch (err) {
+              logger.warn("GitWatcherService: checkout-change listener failed", {
+                threadId: thread.id,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
             broadcast("thread.checkoutChanged", {
               threadId: thread.id,
               workspaceId: thread.workspace_id,

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -288,4 +288,27 @@ export class ThreadService {
   findById(threadId: string): Thread | null {
     return this.threadRepo.findById(threadId);
   }
+
+  /**
+   * Sync a worktree thread's persisted checkout state from its current Git HEAD.
+   */
+  async syncCheckoutFromHead(threadId: string): Promise<{ thread: Thread; changed: boolean } | null> {
+    const thread = this.threadRepo.findById(threadId);
+    if (!thread || thread.mode !== "worktree" || !thread.worktree_path) return null;
+
+    const currentBranch = await this.gitService.getCurrentBranchAt(thread.worktree_path);
+    const detached = !currentBranch || currentBranch === "HEAD";
+    const branch = detached ? "HEAD" : currentBranch;
+    const checkoutState = detached ? "branchless" : "named";
+    const baseBranch = detached
+      ? thread.base_branch ?? (thread.branch !== "HEAD" ? thread.branch : null)
+      : null;
+
+    return this.threadRepo.updateCheckoutFromHead(
+      threadId,
+      branch,
+      checkoutState,
+      baseBranch,
+    );
+  }
 }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -308,8 +308,24 @@ function resolveWorkspaceRepoPath(
   );
 }
 
+function watchReturnedThreadWorktree(deps: RouterDeps, thread: unknown): void {
+  const maybeThread = thread as { id?: string; mode?: string; worktree_path?: string | null } | null;
+  if (maybeThread?.mode !== "worktree" || !maybeThread.worktree_path || !maybeThread.id) return;
+  void Promise.resolve(
+    deps.gitWatcherService?.watchThreadWorktree?.(maybeThread.id, maybeThread.worktree_path),
+  ).catch((err) => {
+    logger.warn("Failed to start thread worktree watcher", {
+      threadId: maybeThread.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}
+
 async function teardownWorkspaceThreads(deps: RouterDeps, workspaceId: string): Promise<void> {
   const threads = deps.threadRepo.listAllByWorkspace(workspaceId);
+  for (const thread of threads) {
+    deps.gitWatcherService?.unwatchThreadWorktree?.(thread.id);
+  }
   const results = await Promise.allSettled(
     threads.map((thread) => deps.threadTeardownService.teardownThread(thread.id)),
   );
@@ -411,16 +427,20 @@ async function dispatch(
     }
     case "thread.recent":
       return deps.threadService.listRecent(params.limit);
-    case "thread.create":
-      return deps.threadService.create(
+    case "thread.create": {
+      const thread = await deps.threadService.create(
         params.workspaceId,
         params.title,
         params.mode,
         params.branch,
         { branchless: params.mode === "worktree" },
       );
+      watchReturnedThreadWorktree(deps, thread);
+      return thread;
+    }
     case "thread.delete": {
       deps.ciWatcherService.unwatch(params.threadId);
+      deps.gitWatcherService?.unwatchThreadWorktree?.(params.threadId);
       await deps.threadTeardownService.teardownThread(params.threadId);
       return await deps.threadService.delete(
         params.threadId,
@@ -639,8 +659,8 @@ async function dispatch(
         params.mentions,
       );
       return;
-    case "agent.createAndSend":
-      return deps.agentService.createAndSend(
+    case "agent.createAndSend": {
+      const thread = await deps.agentService.createAndSend(
         params.workspaceId,
         params.content,
         params.model,
@@ -664,6 +684,9 @@ async function dispatch(
         params.displayContent,
         params.mentions,
       );
+      watchReturnedThreadWorktree(deps, thread);
+      return thread;
+    }
     case "agent.stop":
       await deps.agentService.stopSession(params.threadId);
       return;

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -323,9 +323,6 @@ function watchReturnedThreadWorktree(deps: RouterDeps, thread: unknown): void {
 
 async function teardownWorkspaceThreads(deps: RouterDeps, workspaceId: string): Promise<void> {
   const threads = deps.threadRepo.listAllByWorkspace(workspaceId);
-  for (const thread of threads) {
-    deps.gitWatcherService?.unwatchThreadWorktree?.(thread.id);
-  }
   const results = await Promise.allSettled(
     threads.map((thread) => deps.threadTeardownService.teardownThread(thread.id)),
   );
@@ -334,6 +331,9 @@ async function teardownWorkspaceThreads(deps: RouterDeps, workspaceId: string): 
     throw new Error(
       `Workspace teardown failed for ${workspaceId}: ${failures.map(teardownFailureMessage).join("; ")}`,
     );
+  }
+  for (const thread of threads) {
+    deps.gitWatcherService?.unwatchThreadWorktree?.(thread.id);
   }
 }
 
@@ -440,12 +440,15 @@ async function dispatch(
     }
     case "thread.delete": {
       deps.ciWatcherService.unwatch(params.threadId);
-      deps.gitWatcherService?.unwatchThreadWorktree?.(params.threadId);
       await deps.threadTeardownService.teardownThread(params.threadId);
-      return await deps.threadService.delete(
+      const deleted = await deps.threadService.delete(
         params.threadId,
         params.cleanupWorktree,
       );
+      if (deleted) {
+        deps.gitWatcherService?.unwatchThreadWorktree?.(params.threadId);
+      }
+      return deleted;
     }
     case "thread.updateTitle":
       return deps.threadService.updateTitle(

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -292,6 +292,168 @@ describe("routeMessage thread.create", () => {
   });
 });
 
+describe("routeMessage workspace.delete watcher teardown", () => {
+  it("keeps thread worktree watchers when any workspace thread teardown fails", async () => {
+    const unwatchThreadWorktree = vi.fn();
+    const deleteWorkspace = vi.fn();
+    const deps = {
+      threadRepo: {
+        listAllByWorkspace: vi.fn().mockReturnValue([{ id: "thread-1" }, { id: "thread-2" }]),
+      },
+      threadTeardownService: {
+        teardownThread: vi
+          .fn()
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error("teardown failed")),
+      },
+      gitWatcherService: {
+        unwatchThreadWorktree,
+      },
+      workspaceService: {
+        delete: deleteWorkspace,
+      },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-workspace-delete",
+        method: "workspace.delete",
+        params: { id: "ws-1" },
+      }),
+      deps,
+    );
+
+    expect(response.error?.message).toContain("Workspace teardown failed for ws-1");
+    expect(unwatchThreadWorktree).not.toHaveBeenCalled();
+    expect(deleteWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("unwatches thread worktrees after all workspace thread teardowns succeed", async () => {
+    const unwatchThreadWorktree = vi.fn();
+    const teardownThread = vi.fn().mockResolvedValue(undefined);
+    const deps = {
+      threadRepo: {
+        listAllByWorkspace: vi.fn().mockReturnValue([{ id: "thread-1" }, { id: "thread-2" }]),
+      },
+      threadTeardownService: {
+        teardownThread,
+      },
+      gitWatcherService: {
+        unwatchThreadWorktree,
+        unwatchWorkspace: vi.fn(),
+      },
+      workspaceService: {
+        delete: vi.fn().mockReturnValue(true),
+      },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-workspace-delete",
+        method: "workspace.delete",
+        params: { id: "ws-1" },
+      }),
+      deps,
+    );
+
+    expect(response.result).toBe(true);
+    expect(unwatchThreadWorktree).toHaveBeenCalledWith("thread-1");
+    expect(unwatchThreadWorktree).toHaveBeenCalledWith("thread-2");
+    expect(teardownThread.mock.invocationCallOrder[1]).toBeLessThan(
+      unwatchThreadWorktree.mock.invocationCallOrder[0],
+    );
+  });
+});
+
+describe("routeMessage thread.delete watcher teardown", () => {
+  function createThreadDeleteDeps(options: {
+    teardown?: () => Promise<void>;
+    deleteThread?: () => Promise<boolean>;
+  } = {}) {
+    const unwatchThreadWorktree = vi.fn();
+    const teardownThread = vi
+      .fn()
+      .mockImplementation(options.teardown ?? (() => Promise.resolve()));
+    const deleteThread = vi
+      .fn()
+      .mockImplementation(options.deleteThread ?? (() => Promise.resolve(true)));
+    const deps = {
+      ciWatcherService: {
+        unwatch: vi.fn(),
+      },
+      gitWatcherService: {
+        unwatchThreadWorktree,
+      },
+      threadTeardownService: {
+        teardownThread,
+      },
+      threadService: {
+        delete: deleteThread,
+      },
+    } as unknown as RouterDeps;
+    return { deps, unwatchThreadWorktree, teardownThread, deleteThread };
+  }
+
+  it("keeps the thread worktree watcher when thread teardown fails", async () => {
+    const { deps, unwatchThreadWorktree, deleteThread } = createThreadDeleteDeps({
+      teardown: () => Promise.reject(new Error("teardown failed")),
+    });
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-thread-delete",
+        method: "thread.delete",
+        params: { threadId: "thread-1", cleanupWorktree: true },
+      }),
+      deps,
+    );
+
+    expect(response.error?.message).toContain("teardown failed");
+    expect(unwatchThreadWorktree).not.toHaveBeenCalled();
+    expect(deleteThread).not.toHaveBeenCalled();
+  });
+
+  it("keeps the thread worktree watcher when thread delete returns false", async () => {
+    const { deps, unwatchThreadWorktree } = createThreadDeleteDeps({
+      deleteThread: () => Promise.resolve(false),
+    });
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-thread-delete",
+        method: "thread.delete",
+        params: { threadId: "thread-1", cleanupWorktree: true },
+      }),
+      deps,
+    );
+
+    expect(response.result).toBe(false);
+    expect(unwatchThreadWorktree).not.toHaveBeenCalled();
+  });
+
+  it("unwatches the thread worktree after thread teardown and delete succeed", async () => {
+    const { deps, unwatchThreadWorktree, teardownThread, deleteThread } = createThreadDeleteDeps();
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-thread-delete",
+        method: "thread.delete",
+        params: { threadId: "thread-1", cleanupWorktree: true },
+      }),
+      deps,
+    );
+
+    expect(response.result).toBe(true);
+    expect(unwatchThreadWorktree).toHaveBeenCalledWith("thread-1");
+    expect(teardownThread.mock.invocationCallOrder[0]).toBeLessThan(
+      unwatchThreadWorktree.mock.invocationCallOrder[0],
+    );
+    expect(deleteThread.mock.invocationCallOrder[0]).toBeLessThan(
+      unwatchThreadWorktree.mock.invocationCallOrder[0],
+    );
+  });
+});
+
 describe("routeMessage github.createPr", () => {
   const namedThread = {
     id: "thread-1",

--- a/apps/web/e2e/branchless-create-pr.spec.ts
+++ b/apps/web/e2e/branchless-create-pr.spec.ts
@@ -51,6 +51,23 @@ const thread: Thread = {
   forked_from_message_id: null,
 };
 
+const namedThread: Thread = {
+  ...thread,
+  id: "thread-named-checkout",
+  title: "Named Checkout Thread",
+  worktree_path: "/tmp/branchless-pr/.worktrees/named-checkout",
+  branch: "feat/named-checkout",
+  checkout_state: "named",
+  base_branch: null,
+};
+
+const gitCommit = {
+  sha: "abc1234",
+  message: "feat: branchless worktree",
+  author: "Tester",
+  date: now,
+};
+
 async function ensureOverviewOpen(page: Page): Promise<void> {
   const overview = page.getByTestId("thread-overview-body");
   if (!(await overview.isVisible().catch(() => false))) {
@@ -91,7 +108,7 @@ test.describe("Branchless Create PR", () => {
       },
       "git.log": (params) => {
         gitLogCalls.push(params);
-        return [];
+        return [gitCommit];
       },
       "git.createBranch": (params) => {
         createBranchCalls.push(params);
@@ -119,14 +136,32 @@ test.describe("Branchless Create PR", () => {
     await page.waitForSelector("[data-testid='chat-header-title']");
 
     await ensureOverviewOpen(page);
-    await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-create-branch")).toBeVisible();
+    await expect(page.getByTestId("workspace-menu-branch")).toHaveCount(0);
+    await expect(page.getByTestId("workspace-menu-create-pr")).toHaveCount(0);
+    await expect(page.getByTestId("workspace-menu-commit")).toBeDisabled();
     expect(branchPrCalls).toEqual([]);
     expect(gitLogCalls).toEqual([]);
 
+    await page.getByTestId("thread-overview-create-branch").click();
+    await expect(page.getByRole("heading", { name: "Work here" })).toBeVisible();
+    await page.getByLabel("Branch name").fill("feat/issue 801");
+    await expect(page.getByLabel("Branch name")).toHaveValue("feat/issue-801");
+    await page.getByRole("button", { name: "Create" }).click();
+
+    await expect.poll(() => getWorkspaceThread(page)).toMatchObject({
+      branch: "feat/issue-801",
+      checkout_state: "named",
+      base_branch: null,
+    });
+    await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/issue-801");
+    await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
+
+    await page.getByTestId("workspace-menu-branch").click();
+    await expect(page.getByTestId("thread-overview-create-checkout-branch")).toBeEnabled();
+    await page.keyboard.press("Escape");
+
     await page.getByTestId("workspace-menu-create-pr").click();
-    await expect(page.getByRole("heading", { name: "Name branch for PR" })).toBeVisible();
-    await page.getByLabel("Branch name").fill("feat/issue-801");
-    await page.getByRole("button", { name: "Create branch and continue" }).click();
 
     await expect(page.getByRole("heading", { name: "Create pull request" })).toBeVisible();
     const prDialog = page.getByLabel("Create pull request");
@@ -140,10 +175,75 @@ test.describe("Branchless Create PR", () => {
         threadId: thread.id,
       },
     ]);
-    await expect.poll(() => getWorkspaceThread(page)).toMatchObject({
-      branch: "feat/issue-801",
-      checkout_state: "named",
-      base_branch: null,
+  });
+
+  test.describe("named checkout branch availability", () => {
+    async function renderNamedThread(
+      page: Page,
+      options: {
+        commits: typeof gitCommit[];
+        stagedFiles: string[];
+        unstagedFiles: string[];
+      },
+    ): Promise<void> {
+      await interceptZustandStores(page);
+      await mockWebSocketServer(page, {
+        "workspace.list": [workspace],
+        "workspace.enrich": { items: [] },
+        "thread.list": [namedThread],
+        "github.branchPr": null,
+        "git.log": options.commits,
+        "git.listBranches": [
+          { name: "feat/named-checkout", type: "local", isCurrent: true, shortSha: "abc1234" },
+          { name: "main", type: "local", isCurrent: false, shortSha: "def5678" },
+        ],
+        "git.getRemoteUrl": {
+          label: "Mzeey-Empire/mcode",
+          webUrl: "https://github.com/Mzeey-Empire/mcode",
+        },
+        "snapshot.listByThread": [],
+        "git.workingTreeFiles": (params) =>
+          (params as { staged?: boolean } | undefined)?.staged
+            ? options.stagedFiles
+            : options.unstagedFiles,
+      });
+
+      await page.goto("/");
+      await seedActiveThread(page, workspace, namedThread, []);
+      await page.waitForSelector("[data-testid='chat-header-title']");
+      await ensureOverviewOpen(page);
+      await page.getByTestId("workspace-menu-branch").click();
+      await expect(page.getByTestId("thread-overview-branch-popover")).toBeVisible();
+    }
+
+    test("disables Create branch checkout when there are no commits or files", async ({ page }) => {
+      await renderNamedThread(page, {
+        commits: [],
+        stagedFiles: [],
+        unstagedFiles: [],
+      });
+
+      await expect(page.getByTestId("thread-overview-create-checkout-branch")).toBeDisabled();
+    });
+
+    test("enables Create branch checkout when there are staged files", async ({ page }) => {
+      await renderNamedThread(page, {
+        commits: [],
+        stagedFiles: ["apps/web/src/components/chat/HeaderActions.tsx"],
+        unstagedFiles: [],
+      });
+
+      await expect(page.getByTestId("thread-overview-create-checkout-branch")).toBeEnabled();
+    });
+
+    test("enables Create branch checkout when there are unstaged files", async ({ page }) => {
+      await renderNamedThread(page, {
+        commits: [],
+        stagedFiles: [],
+        unstagedFiles: ["apps/web/src/components/chat/ThreadOverview.tsx"],
+      });
+
+      await expect(page.getByTestId("thread-overview-create-checkout-branch")).toBeEnabled();
     });
   });
 });

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -284,7 +284,7 @@ test.describe("Consolidated chat header", () => {
     await expect(page.getByTestId("thread-overview-sources")).toHaveCount(0);
     await expect(page.locator(".animate-overview-enter").first()).toBeVisible();
 
-    await expect(page.getByTestId("thread-overview-local")).toContainText("Local");
+    await expect(page.getByTestId("thread-overview-local")).toContainText("Worktree");
     await expect(page.getByTestId("thread-overview-repository")).toContainText(
       "REPOSITORY",
     );
@@ -356,6 +356,7 @@ test.describe("Consolidated chat header", () => {
     await expect(page.getByTestId("thread-overview-current-branch")).toContainText(
       "Uncommitted: 3 files",
     );
+    await expect(page.getByTestId("thread-overview-create-checkout-branch")).toBeEnabled();
   });
 
   test("panel toggle shows and hides the workspace-global right panel", async ({ page }) => {

--- a/apps/web/src/components/chat/Composer.footer-checkout.test.tsx
+++ b/apps/web/src/components/chat/Composer.footer-checkout.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+describe("Composer footer checkout label", () => {
+  it("uses the shared checkout label helper for the locked existing-thread branch control", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(resolve(here, "Composer.tsx"), "utf8");
+
+    expect(source).toContain('import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";');
+    expect(source).toContain("selectedBranch={resolveThreadCheckoutLabel(activeThread)}");
+  });
+});

--- a/apps/web/src/components/chat/Composer.footer-checkout.test.tsx
+++ b/apps/web/src/components/chat/Composer.footer-checkout.test.tsx
@@ -9,6 +9,7 @@ describe("Composer footer checkout label", () => {
     const source = readFileSync(resolve(here, "Composer.tsx"), "utf8");
 
     expect(source).toContain('import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";');
+    expect(source).toContain(") : activeThread && isGitRepo ? (");
     expect(source).toContain("selectedBranch={resolveThreadCheckoutLabel(activeThread)}");
   });
 });

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -3049,7 +3049,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                 /></Suspense>
               </>
             )
-          ) : activeThread?.branch && isGitRepo ? (
+          ) : activeThread && isGitRepo ? (
             <BranchPicker
               branches={[]}
               selectedBranch={resolveThreadCheckoutLabel(activeThread)}

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -103,6 +103,7 @@ import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore
 import { useElementWidth } from "@/hooks/useElementWidth";
 import { ProviderUnavailableBanner } from "./ProviderUnavailableBanner";
 import { appendBrowserCaptureFence } from "@/lib/browser-capture-append";
+import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";
 import {
   collectBrowserCaptureSpillPaths,
   collectSpillPathsFromPendingAttachments,
@@ -3051,7 +3052,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           ) : activeThread?.branch && isGitRepo ? (
             <BranchPicker
               branches={[]}
-              selectedBranch={activeThread.branch}
+              selectedBranch={resolveThreadCheckoutLabel(activeThread)}
               onSelect={() => {}}
               loading={false}
               locked={true}

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -359,7 +359,7 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.getByTestId("workspace-menu-changes")).toHaveTextContent("Changes");
     expect(screen.queryByTestId("thread-overview-change-summary")).not.toBeInTheDocument();
     expect(screen.queryByTestId("thread-overview-repository")).not.toBeInTheDocument();
-    expect(screen.getByTestId("thread-overview-local")).toHaveTextContent("Local");
+    expect(screen.getByTestId("thread-overview-local")).toHaveTextContent("Worktree");
     expect(screen.getByTestId("thread-overview-local")).toHaveAttribute(
       "aria-label",
       expect.stringContaining("/repo/worktrees/feat-x"),

--- a/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
@@ -177,6 +177,8 @@ describe("ThreadOverview branchless Create PR", () => {
   beforeEach(() => {
     const thread = makeThread();
     mockWorkspaceState.threads = [thread];
+    mockWorkspaceState.prUrlsByThreadId = {};
+    mockWorkspaceState.checksById = {};
     mockWorkspaceState.worktreesLoadedForWorkspace = "ws-1";
     mockCreateBranch.mockReset().mockResolvedValue({ branch: "feat/issue-801" });
   });
@@ -215,6 +217,46 @@ describe("ThreadOverview branchless Create PR", () => {
     });
     expect(mockWorkspaceState.worktreesLoadedForWorkspace).toBeNull();
     expect(screen.queryByTestId("create-pr-dialog")).not.toBeInTheDocument();
+  });
+
+  it("clears stale PR metadata and caches when creating a named branch", async () => {
+    mockWorkspaceState.threads = [
+      makeThread({
+        pr_number: 42,
+        pr_status: "OPEN",
+      }),
+    ];
+    mockWorkspaceState.prUrlsByThreadId = {
+      "thread-1": "https://example.test/pr/42",
+      other: "https://example.test/pr/7",
+    };
+    mockWorkspaceState.checksById = {
+      "thread-1": { aggregate: "passing", runs: [], fetchedAt: 1 },
+      other: { aggregate: "no_checks", runs: [], fetchedAt: 2 },
+    };
+    render(<ThreadOverview thread={mockWorkspaceState.threads[0]} />);
+
+    fireEvent.click(screen.getByTestId("thread-overview-create-branch"));
+    fireEvent.change(screen.getByLabelText("Branch name"), {
+      target: { value: "feat/issue 801" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(mockWorkspaceState.threads[0]).toMatchObject({
+        branch: "feat/issue-801",
+        checkout_state: "named",
+        base_branch: null,
+        pr_number: null,
+        pr_status: null,
+      });
+    });
+    expect(mockWorkspaceState.prUrlsByThreadId).toEqual({
+      other: "https://example.test/pr/7",
+    });
+    expect(mockWorkspaceState.checksById).toEqual({
+      other: { aggregate: "no_checks", runs: [], fetchedAt: 2 },
+    });
   });
 
   it("keeps the branch creation dialog open when branch creation fails", async () => {

--- a/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
@@ -187,14 +187,21 @@ describe("ThreadOverview branchless Create PR", () => {
     expect(canStartBranchlessCreatePr(makeThread({ mode: "direct" }))).toBe(false);
   });
 
-  it("creates a named branch before opening the existing PR dialog", async () => {
+  it("creates a named branch from the branchless worktree row", async () => {
     render(<ThreadOverview thread={makeThread()} />);
 
-    fireEvent.click(screen.getByTestId("workspace-menu-create-pr"));
+    expect(screen.getByText("HEAD")).toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-menu-branch")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-menu-commit")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("thread-overview-create-branch"));
+    expect(screen.getByRole("heading", { name: "Work here" })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Branch name"), {
-      target: { value: "feat/issue-801" },
+      target: { value: "feat/issue 801" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Create branch and continue" }));
+    expect(screen.getByLabelText("Branch name")).toHaveValue("feat/issue-801");
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
       expect(mockCreateBranch).toHaveBeenCalledWith("ws-1", "feat/issue-801", "thread-1");
@@ -207,20 +214,18 @@ describe("ThreadOverview branchless Create PR", () => {
       base_branch: null,
     });
     expect(mockWorkspaceState.worktreesLoadedForWorkspace).toBeNull();
-    expect(await screen.findByTestId("create-pr-dialog")).toBeInTheDocument();
-    expect(screen.getByTestId("create-pr-branch")).toHaveTextContent("feat/issue-801");
-    expect(screen.getByTestId("create-pr-base")).toHaveTextContent("main");
+    expect(screen.queryByTestId("create-pr-dialog")).not.toBeInTheDocument();
   });
 
-  it("keeps the branch-name step open when branch creation fails", async () => {
+  it("keeps the branch creation dialog open when branch creation fails", async () => {
     mockCreateBranch.mockRejectedValueOnce(new Error("branch exists"));
     render(<ThreadOverview thread={makeThread()} />);
 
-    fireEvent.click(screen.getByTestId("workspace-menu-create-pr"));
+    fireEvent.click(screen.getByTestId("thread-overview-create-branch"));
     fireEvent.change(screen.getByLabelText("Branch name"), {
       target: { value: "feat/issue-801" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Create branch and continue" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("branch exists");
     expect(screen.queryByTestId("create-pr-dialog")).not.toBeInTheDocument();

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1117,9 +1117,17 @@ function updateThreadToNamedBranch(threadId: string, branch: string): void {
             branch,
             checkout_state: "named" as const,
             base_branch: null,
+            pr_number: null,
+            pr_status: null,
           }
         : candidate,
     ),
+    prUrlsByThreadId: Object.fromEntries(
+      Object.entries(state.prUrlsByThreadId).filter(([candidateId]) => candidateId !== threadId),
+    ),
+    checksById: Object.fromEntries(
+      Object.entries(state.checksById).filter(([candidateId]) => candidateId !== threadId),
+    ) as typeof state.checksById,
     worktreesLoadedForWorkspace: null,
   }));
 }

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -51,6 +51,7 @@ import { extractThreadSources, type ThreadSource } from "@/lib/message-sources";
 import { isModifierClick, isPreviewableUrl, openUrlInPreview } from "@/lib/open-url-in-preview";
 import { sanitizeCustomBranchInput, trimTrailingBranchChars } from "@/lib/branch-name";
 import { cn } from "@/lib/utils";
+import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";
 import {
   getTransport,
   type GitBranch as GitBranchRecord,
@@ -650,16 +651,18 @@ interface ThreadOverviewBranchMenuProps {
   thread: Thread;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onCreateBranch: () => void;
+  hasCommitsAhead: boolean | null;
 }
 
 function ThreadOverviewBranchMenu({
   thread,
   open,
   onOpenChange,
+  onCreateBranch,
+  hasCommitsAhead,
 }: ThreadOverviewBranchMenuProps) {
   const [search, setSearch] = useState("");
-  const [newBranchName, setNewBranchName] = useState("");
-  const [createState, setCreateState] = useState<"idle" | "creating" | "error">("idle");
   const [loaded, setLoaded] = useState<LoadedBranchState>({
     status: "idle",
     branches: [],
@@ -716,6 +719,11 @@ function ThreadOverviewBranchMenu({
       ? uncommittedFilesLabel(loaded.uncommittedFiles)
       : null;
   const shouldConstrainBranchList = visibleBranches.length > 6;
+  const canCreateCheckoutBranch =
+    thread.checkout_state === "named" &&
+    loaded.status === "ready" &&
+    (hasCommitsAhead === true ||
+      (loaded.uncommittedFiles !== null && loaded.uncommittedFiles > 0));
 
   return (
     <div
@@ -804,65 +812,27 @@ function ThreadOverviewBranchMenu({
       </ScrollArea>
 
       <Separator className="my-2" />
-      {thread.checkout_state === "branchless" ? (
-        <div className="space-y-2 px-1 pb-1">
-          <Input
-            size="xs"
-            value={newBranchName}
-            onChange={(event) => {
-              setNewBranchName(event.target.value);
-              if (createState === "error") setCreateState("idle");
-            }}
-            placeholder="Branch name"
-            aria-label="New branch name"
-          />
-          <Button
-            variant="ghost"
-            size="sm"
-            type="button"
-            disabled={!newBranchName.trim() || createState === "creating"}
-            data-testid="thread-overview-create-branch"
-            className="h-8 w-full justify-start gap-2 px-2 text-xs disabled:opacity-60"
-            onClick={async () => {
-              const name = newBranchName.trim();
-              if (!name) return;
-              setCreateState("creating");
-              try {
-                const result = await getTransport().createBranch(thread.workspace_id, name, thread.id);
-                useWorkspaceStore.setState((state) => ({
-                  threads: state.threads.map((item) =>
-                    item.id === thread.id
-                      ? { ...item, branch: result.branch, checkout_state: "named" as const, base_branch: null }
-                      : item,
-                  ),
-                  worktreesLoadedForWorkspace: null,
-                }));
-                setCreateState("idle");
-                onOpenChange(false);
-              } catch {
-                setCreateState("error");
-              }
-            }}
-          >
-            <Plus size={14} className="text-muted-foreground" />
-            {createState === "creating" ? "Creating branch..." : "Create branch"}
-          </Button>
-          {createState === "error" ? (
-            <div className="px-1 text-xs text-destructive">Branch could not be created.</div>
-          ) : null}
-        </div>
-      ) : (
-        <Button
-          variant="ghost"
-          size="sm"
-          type="button"
-          disabled
-          className="h-8 w-full justify-start gap-2 px-2 text-xs disabled:opacity-60"
-        >
-          <Plus size={14} className="text-muted-foreground" />
-          Create and checkout new branch...
-        </Button>
-      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        type="button"
+        disabled={!canCreateCheckoutBranch}
+        data-testid="thread-overview-create-checkout-branch"
+        className="h-8 w-full justify-start gap-2 px-2 text-xs disabled:opacity-60"
+        title={
+          canCreateCheckoutBranch
+            ? "Create and checkout a new branch"
+            : "Detected changes required"
+        }
+        onClick={() => {
+          if (!canCreateCheckoutBranch) return;
+          onOpenChange(false);
+          onCreateBranch();
+        }}
+      >
+        <Plus size={14} className="text-muted-foreground" />
+        Create and checkout new branch...
+      </Button>
     </div>
   );
 }
@@ -963,34 +933,13 @@ interface ThreadOverviewPrRowProps {
   onCommitOrPush: () => void;
   onCreatePr: () => void;
   onOpenPr: (url: string, event?: MouseEvent) => void;
-  branchless?: boolean;
 }
 
 function ThreadOverviewPrActionRow({
   hasCommitsAhead,
   onCommitOrPush,
   onCreatePr,
-  branchless = false,
-}: Pick<ThreadOverviewPrRowProps, "hasCommitsAhead" | "onCommitOrPush" | "onCreatePr" | "branchless">) {
-  if (branchless) {
-    return (
-      <div data-testid="thread-overview-pr">
-        <Button
-          variant="ghost"
-          size="sm"
-          type="button"
-          data-testid="workspace-menu-create-pr"
-          className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground"
-          onClick={onCreatePr}
-          title="Name this worktree branch before creating a pull request"
-        >
-          <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
-          <span className="font-medium">Create PR</span>
-        </Button>
-      </div>
-    );
-  }
-
+}: Pick<ThreadOverviewPrRowProps, "hasCommitsAhead" | "onCommitOrPush" | "onCreatePr">) {
   if (hasCommitsAhead === false) {
     return (
       <div data-testid="thread-overview-pr">
@@ -1121,7 +1070,6 @@ function ThreadOverviewPrRow({
   onCommitOrPush,
   onCreatePr,
   onOpenPr,
-  branchless,
 }: ThreadOverviewPrRowProps) {
   if (!pr) {
     return (
@@ -1129,7 +1077,6 @@ function ThreadOverviewPrRow({
         hasCommitsAhead={hasCommitsAhead}
         onCommitOrPush={onCommitOrPush}
         onCreatePr={onCreatePr}
-        branchless={branchless}
       />
     );
   }
@@ -1147,30 +1094,51 @@ function ThreadOverviewPrRow({
   );
 }
 
-interface BranchlessCreatePrDialogProps {
+interface CreateThreadBranchDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   thread: Thread;
-  baseBranch: string;
-  onCreated: (branch: string, baseBranch: string) => void;
+  title: string;
+  description: string;
+  submitLabel: string;
+  onCreated: (branch: string) => void;
 }
 
 function branchCreationErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err || "Unknown error");
 }
 
-function BranchlessCreatePrDialog({
+function updateThreadToNamedBranch(threadId: string, branch: string): void {
+  useWorkspaceStore.setState((state) => ({
+    threads: state.threads.map((candidate) =>
+      candidate.id === threadId
+        ? {
+            ...candidate,
+            branch,
+            checkout_state: "named" as const,
+            base_branch: null,
+          }
+        : candidate,
+    ),
+    worktreesLoadedForWorkspace: null,
+  }));
+}
+
+function CreateThreadBranchDialog({
   open,
   onOpenChange,
   thread,
-  baseBranch,
+  title,
+  description,
+  submitLabel,
   onCreated,
-}: BranchlessCreatePrDialogProps) {
+}: CreateThreadBranchDialogProps) {
   const [branchName, setBranchName] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const branchInputRef = useRef<HTMLInputElement>(null);
   const finalBranchName = trimTrailingBranchChars(branchName.trim());
+  const errorId = "create-thread-branch-error";
 
   useEffect(() => {
     if (!open) return;
@@ -1191,27 +1159,15 @@ function BranchlessCreatePrDialog({
     try {
       const result = await getTransport().createBranch(thread.workspace_id, name, thread.id);
       const nextBranch = result.branch || name;
-      useWorkspaceStore.setState((state) => ({
-        threads: state.threads.map((candidate) =>
-          candidate.id === thread.id
-            ? {
-                ...candidate,
-                branch: nextBranch,
-                checkout_state: "named" as const,
-                base_branch: null,
-              }
-            : candidate,
-        ),
-        worktreesLoadedForWorkspace: null,
-      }));
+      updateThreadToNamedBranch(thread.id, nextBranch);
       onOpenChange(false);
-      onCreated(nextBranch, baseBranch);
+      onCreated(nextBranch);
     } catch (err) {
       setError(branchCreationErrorMessage(err));
     } finally {
       setSubmitting(false);
     }
-  }, [baseBranch, finalBranchName, onCreated, onOpenChange, submitting, thread.id, thread.workspace_id]);
+  }, [finalBranchName, onCreated, onOpenChange, submitting, thread.id, thread.workspace_id]);
 
   return (
     <Dialog open={open} onOpenChange={submitting ? undefined : onOpenChange}>
@@ -1225,22 +1181,22 @@ function BranchlessCreatePrDialog({
           </div>
           <div className="min-w-0 flex-1">
             <DialogTitle className="text-sm font-medium leading-none">
-              Name branch for PR
+              {title}
             </DialogTitle>
             <DialogDescription className="mt-1 max-w-[36ch] text-pretty text-xs leading-5 text-muted-foreground">
-              Creates the branch at the current commit in this worktree, then opens the PR form.
+              {description}
             </DialogDescription>
           </div>
         </div>
 
         <div className="px-5 py-4">
           <div className="space-y-1.5">
-            <label htmlFor="branchless-pr-branch" className="text-xs text-muted-foreground">
+            <label htmlFor="create-thread-branch" className="text-xs text-muted-foreground">
               Branch name
             </label>
             <Input
               ref={branchInputRef}
-              id="branchless-pr-branch"
+              id="create-thread-branch"
               value={branchName}
               onChange={(event) => {
                 setBranchName(sanitizeCustomBranchInput(event.target.value));
@@ -1255,14 +1211,14 @@ function BranchlessCreatePrDialog({
               disabled={submitting}
               placeholder="feat/my-change"
               aria-invalid={error ? "true" : undefined}
-              aria-describedby={error ? "branchless-pr-branch-error" : undefined}
+              aria-describedby={error ? errorId : undefined}
               className="font-mono"
             />
           </div>
 
           {error ? (
             <div
-              id="branchless-pr-branch-error"
+              id={errorId}
               role="alert"
               className="mt-3 break-words rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive"
             >
@@ -1278,10 +1234,10 @@ function BranchlessCreatePrDialog({
           <Button
             onClick={() => void handleSubmit()}
             disabled={submitting || !finalBranchName}
-            className="min-w-[11.5rem] gap-1.5"
+            className="min-w-[7rem] gap-1.5"
           >
             {submitting ? <Loader2 className="size-3.5 animate-spin" aria-hidden="true" /> : null}
-            Create branch and continue
+            {submitLabel}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -1298,7 +1254,7 @@ function BranchlessCreatePrDialog({
 export function ThreadOverview({ thread }: ThreadOverviewProps) {
   const [localOpen, setLocalOpen] = useState(false);
   const [branchOpen, setBranchOpen] = useState(false);
-  const [branchlessCreatePrOpen, setBranchlessCreatePrOpen] = useState(false);
+  const [createBranchOpen, setCreateBranchOpen] = useState(false);
   const [createdBranchForPr, setCreatedBranchForPr] = useState<string | null>(null);
   const [createdBranchBaseForPr, setCreatedBranchBaseForPr] = useState<string | null>(null);
   const [loadedChangeSummary, setLoadedChangeSummary] = useState<{
@@ -1331,7 +1287,7 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
   useEffect(() => {
     setCreatedBranchForPr(null);
     setCreatedBranchBaseForPr(null);
-    setBranchlessCreatePrOpen(false);
+    setCreateBranchOpen(false);
   }, [thread.id]);
 
   // Whether there is room for the Overview to open by default. Driven by the
@@ -1389,9 +1345,9 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
     handleOpenPr,
   } = useThreadGitActions(thread);
   const branchlessCreatePr = canStartBranchlessCreatePr(thread);
-  const canShowPrActions = prable || branchlessCreatePr;
+  const canShowPrActions = prable;
   const createPrBranch = createdBranchForPr ?? thread.branch;
-  const branchlessBaseBranch = thread.base_branch ?? thread.branch;
+  const createBranchBaseBranch = thread.base_branch ?? thread.branch;
 
   const cachedSnapshots = useDiffStore((s) => s.snapshotsByThread[thread.id]);
   const setSnapshots = useDiffStore((s) => s.setSnapshots);
@@ -1546,10 +1502,7 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
 
   const ciDot = useMemo(() => getThreadOverviewCiDot(pr, checks), [pr, checks]);
   const modeLabel = thread.mode === "worktree" ? "Worktree" : "Direct";
-  const checkoutLabel =
-    thread.checkout_state === "branchless"
-      ? `HEAD from ${thread.base_branch ?? thread.branch}`
-      : thread.branch;
+  const checkoutLabel = resolveThreadCheckoutLabel(thread);
 
   const triggerButton = (
     <Button
@@ -1637,7 +1590,7 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
                   >
                     <span className="flex min-w-0 items-center gap-2">
                       <Laptop size={14} className="shrink-0 text-muted-foreground" />
-                      <span className="truncate text-xs font-medium">Local</span>
+                      <span className="truncate text-xs font-medium">{modeLabel}</span>
                     </span>
                     <ChevronDown size={13} aria-hidden className="shrink-0 text-muted-foreground" />
                   </Button>
@@ -1653,44 +1606,76 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
               </PopoverContent>
             </Popover>
 
-            <Popover open={branchOpen} onOpenChange={setBranchOpen}>
-              <PopoverTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    type="button"
-                    data-testid="workspace-menu-branch"
-                    className={cn(
-                      "h-8 w-full justify-between gap-3 px-2 text-left",
-                      branchOpen && "bg-muted text-foreground",
-                    )}
-                  >
-                    <span className="flex min-w-0 items-center gap-2">
-                      <GitBranch size={14} className="shrink-0 text-muted-foreground" />
-                      <span className="truncate text-xs font-medium">{checkoutLabel}</span>
-                    </span>
-                    <ChevronDown size={13} aria-hidden className="shrink-0 text-muted-foreground" />
-                  </Button>
-                }
-              />
-              <PopoverContent
-                align="start"
-                side="left"
-                sideOffset={12}
-                className="w-72 p-0"
+            {branchlessCreatePr ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                data-testid="thread-overview-create-branch"
+                className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground"
+                onClick={() => setCreateBranchOpen(true)}
+                title="Create a branch in this worktree"
               >
-                <ThreadOverviewBranchMenu
-                  thread={thread}
-                  open={branchOpen}
-                  onOpenChange={setBranchOpen}
+                <GitBranch size={14} className="shrink-0 text-muted-foreground" />
+                <span className="font-medium">Create branch</span>
+              </Button>
+            ) : (
+              <Popover open={branchOpen} onOpenChange={setBranchOpen}>
+                <PopoverTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      type="button"
+                      data-testid="workspace-menu-branch"
+                      className={cn(
+                        "h-8 w-full justify-between gap-3 px-2 text-left",
+                        branchOpen && "bg-muted text-foreground",
+                      )}
+                    >
+                      <span className="flex min-w-0 items-center gap-2">
+                        <GitBranch size={14} className="shrink-0 text-muted-foreground" />
+                        <span className="truncate text-xs font-medium">{checkoutLabel}</span>
+                      </span>
+                      <ChevronDown size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+                    </Button>
+                  }
                 />
-              </PopoverContent>
-            </Popover>
+                <PopoverContent
+                  align="start"
+                  side="left"
+                  sideOffset={12}
+                  className="w-72 p-0"
+                >
+                  <ThreadOverviewBranchMenu
+                    thread={thread}
+                    open={branchOpen}
+                    onOpenChange={setBranchOpen}
+                    onCreateBranch={() => setCreateBranchOpen(true)}
+                    hasCommitsAhead={hasCommitsAhead}
+                  />
+                </PopoverContent>
+              </Popover>
+            )}
 
             {usageSummary && usageCategories.length > 0 && (
               <ThreadOverviewUsageBars categories={usageCategories} summary={usageSummary} />
             )}
+
+            {branchlessCreatePr ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                disabled
+                data-testid="workspace-menu-commit"
+                className="h-8 w-full justify-start gap-2 px-2 text-left text-xs text-foreground/75 disabled:cursor-not-allowed disabled:opacity-50"
+                title="Create a branch before committing or pushing"
+              >
+                <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+                <span className="font-medium">Commit or push</span>
+              </Button>
+            ) : null}
 
             {canShowPrActions && (
               <ThreadOverviewPrRow
@@ -1700,15 +1685,8 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
                 openPrDetail={openPrDetail}
                 threadId={thread.id}
                 onCommitOrPush={handleCommitOrPush}
-                onCreatePr={() => {
-                  if (branchlessCreatePr) {
-                    setBranchlessCreatePrOpen(true);
-                    return;
-                  }
-                  setCreatePrOpen(true);
-                }}
+                onCreatePr={() => setCreatePrOpen(true)}
                 onOpenPr={handleOpenPr}
-                branchless={branchlessCreatePr}
               />
             )}
 
@@ -1745,19 +1723,18 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
         </PopoverContent>
       </Popover>
 
-      {branchlessCreatePr && (
-        <BranchlessCreatePrDialog
-          open={branchlessCreatePrOpen}
-          onOpenChange={setBranchlessCreatePrOpen}
-          thread={thread}
-          baseBranch={branchlessBaseBranch}
-          onCreated={(branch, baseBranch) => {
-            setCreatedBranchForPr(branch);
-            setCreatedBranchBaseForPr(baseBranch);
-            setCreatePrOpen(true);
-          }}
-        />
-      )}
+      <CreateThreadBranchDialog
+        open={createBranchOpen}
+        onOpenChange={setCreateBranchOpen}
+        thread={thread}
+        title="Work here"
+        description="Create a branch to commit changes, push, and create a PR from this worktree."
+        submitLabel="Create"
+        onCreated={(branch) => {
+          setCreatedBranchForPr(branch);
+          setCreatedBranchBaseForPr(createBranchBaseBranch);
+        }}
+      />
 
       {(prable || createdBranchForPr) && (
         <CreatePrDialog

--- a/apps/web/src/lib/__tests__/checkout-label.test.ts
+++ b/apps/web/src/lib/__tests__/checkout-label.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveThreadCheckoutLabel } from "../checkout-label";
+
+describe("resolveThreadCheckoutLabel", () => {
+  it("returns a named branch", () => {
+    expect(resolveThreadCheckoutLabel({ branch: "feat/x", checkout_state: "named" })).toBe("feat/x");
+  });
+
+  it("returns HEAD for a branchless checkout with a base branch", () => {
+    expect(resolveThreadCheckoutLabel({ branch: "main", checkout_state: "branchless" })).toBe("HEAD");
+  });
+
+  it("returns HEAD when the branch value is HEAD", () => {
+    expect(resolveThreadCheckoutLabel({ branch: "HEAD", checkout_state: "named" })).toBe("HEAD");
+  });
+
+  it("falls back to HEAD for an empty branch", () => {
+    expect(resolveThreadCheckoutLabel({ branch: "", checkout_state: "named" })).toBe("HEAD");
+  });
+});

--- a/apps/web/src/lib/checkout-label.ts
+++ b/apps/web/src/lib/checkout-label.ts
@@ -1,0 +1,14 @@
+import type { Thread } from "@/transport";
+
+/**
+ * Resolves the user-facing checkout label for a thread row or header control.
+ */
+export function resolveThreadCheckoutLabel(
+  thread: Pick<Thread, "branch" | "checkout_state"> | null | undefined,
+): string {
+  if (!thread) return "HEAD";
+  if (thread.checkout_state === "branchless" || thread.branch === "HEAD") {
+    return "HEAD";
+  }
+  return thread.branch || "HEAD";
+}

--- a/apps/web/src/transport/ws-events.test.ts
+++ b/apps/web/src/transport/ws-events.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Thread } from "@/transport";
+
+vi.mock("@/transport", () => ({
+  getTransport: vi.fn(),
+}));
+
+import { pushEmitter } from "./ws-transport";
+import { startPushListeners, stopPushListeners } from "./ws-events";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: "thread-1",
+    workspace_id: "ws-1",
+    title: "Thread",
+    status: "active",
+    mode: "worktree",
+    worktree_path: "/repo-wt",
+    branch: "feat/old",
+    checkout_state: "named",
+    base_branch: null,
+    worktree_managed: true,
+    issue_number: null,
+    pr_number: 10,
+    pr_status: "OPEN",
+    sdk_session_id: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    model: null,
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
+    codex_fast_mode: null,
+    copilot_agent: null,
+    default_open_in_app: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    last_compact_summary: null,
+    has_file_changes: false,
+    ...overrides,
+  };
+}
+
+describe("ws-events thread.checkoutChanged", () => {
+  beforeEach(() => {
+    stopPushListeners();
+    useWorkspaceStore.setState({
+      threads: [makeThread()],
+      prUrlsByThreadId: { "thread-1": "https://example.test/pr/10", other: "keep" },
+      checksById: {
+        "thread-1": { aggregate: "passing", runs: [], fetchedAt: 1 },
+        other: { aggregate: "no_checks", runs: [], fetchedAt: 2 },
+      },
+    });
+  });
+
+  it("patches thread checkout fields and clears stale PR/check caches", () => {
+    startPushListeners();
+
+    pushEmitter.emit("thread.checkoutChanged", {
+      threadId: "thread-1",
+      workspaceId: "ws-1",
+      branch: "HEAD",
+      checkoutState: "branchless",
+      baseBranch: "feat/old",
+      prNumber: null,
+      prStatus: null,
+    });
+
+    const state = useWorkspaceStore.getState();
+    expect(state.threads[0]).toMatchObject({
+      branch: "HEAD",
+      checkout_state: "branchless",
+      base_branch: "feat/old",
+      pr_number: null,
+      pr_status: null,
+    });
+    expect(state.prUrlsByThreadId).toEqual({ other: "keep" });
+    expect(state.checksById).toEqual({
+      other: { aggregate: "no_checks", runs: [], fetchedAt: 2 },
+    });
+  });
+});

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -265,6 +265,52 @@ export function startPushListeners(): void {
     }),
   );
 
+  // thread.checkoutChanged: thread worktree HEAD changed outside Mcode
+  unsubs.push(
+    pushEmitter.on("thread.checkoutChanged", (data) => {
+      const {
+        threadId,
+        workspaceId,
+        branch,
+        checkoutState,
+        baseBranch,
+        prNumber,
+        prStatus,
+      } = data as {
+        threadId: string;
+        workspaceId: string;
+        branch: string;
+        checkoutState: "named" | "branchless";
+        baseBranch: string | null;
+        prNumber: number | null;
+        prStatus: string | null;
+      };
+      if (!threadId || !workspaceId || !branch) return;
+      useWorkspaceStore.setState((ws) => {
+        const prUrlsByThreadId = { ...ws.prUrlsByThreadId };
+        const checksById = { ...ws.checksById };
+        delete prUrlsByThreadId[threadId];
+        delete checksById[threadId];
+        return {
+          threads: ws.threads.map((t) =>
+            t.id === threadId
+              ? {
+                  ...t,
+                  branch,
+                  checkout_state: checkoutState,
+                  base_branch: baseBranch,
+                  pr_number: prNumber,
+                  pr_status: prStatus,
+                }
+              : t,
+          ),
+          prUrlsByThreadId,
+          checksById,
+        };
+      });
+    }),
+  );
+
   // files.changed: invalidate file autocomplete cache
   unsubs.push(
     pushEmitter.on("files.changed", (data) => {

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -47,6 +47,15 @@ export const WS_CHANNELS = {
     model: z.string(),
     provider: z.string(),
   }),
+  "thread.checkoutChanged": z.object({
+    threadId: z.string(),
+    workspaceId: z.string(),
+    branch: z.string(),
+    checkoutState: z.enum(["named", "branchless"]),
+    baseBranch: z.string().nullable(),
+    prNumber: z.number().nullable(),
+    prStatus: z.string().nullable(),
+  }),
   "files.changed": z.object({
     workspaceId: z.string(),
     threadId: z.string().optional(),

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -47,15 +47,17 @@ export const WS_CHANNELS = {
     model: z.string(),
     provider: z.string(),
   }),
-  "thread.checkoutChanged": z.object({
-    threadId: z.string(),
-    workspaceId: z.string(),
-    branch: z.string(),
-    checkoutState: z.enum(["named", "branchless"]),
-    baseBranch: z.string().nullable(),
-    prNumber: z.number().nullable(),
-    prStatus: z.string().nullable(),
-  }),
+  "thread.checkoutChanged": lazySchema(() =>
+    z.object({
+      threadId: z.string(),
+      workspaceId: z.string(),
+      branch: z.string(),
+      checkoutState: z.enum(["named", "branchless"]),
+      baseBranch: z.string().nullable(),
+      prNumber: z.number().nullable(),
+      prStatus: z.string().nullable(),
+    }),
+  )(),
   "files.changed": z.object({
     workspaceId: z.string(),
     threadId: z.string().optional(),


### PR DESCRIPTION
## What
Sync thread checkout labels with the actual worktree checkout. Branchless and detached worktrees now show `HEAD` in the composer footer and Overview.

## Why
Branchless worktrees store their base branch in `thread.branch`, which made the footer show the base branch instead of `HEAD`. External branch changes also left the UI and thread row stale.

## Key Changes
- Add a shared checkout-label helper for Composer and ThreadOverview.
- Add `thread.checkoutChanged` push handling and server-side worktree HEAD watchers.
- Persist external checkout changes for named, branchless, and detached worktree states.
- Clear stale PR and check state when checkout identity changes.
- Add server, web, and Playwright coverage for branchless and external checkout behavior.

Related to branchless worktree checkout UX.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784906225&installation_id=129163861&pr_number=808&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F808&signature=ba7e42a37c45302b4a382014125d47b15694db52c4e767790f2455e657a06fc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically sync thread checkout details when a worktree branch/HEAD changes, and push updates to the UI via a new checkout-changed event.
  * Improved checkout labeling across the app: worktree threads show **“Worktree”**, detached shows **“HEAD”**.
  * Added a streamlined “Create and checkout new branch…” flow from thread views, with a reusable dialog for creating branches.
* **Bug Fixes**
  * Clear stale PR number/status and related cached metadata appropriately when checkout state changes (including named ↔ branchless and detached HEAD cases).
  * Improved watcher behavior so thread worktree updates remain correct after restart and during thread/workspace lifecycle changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->