### PR TITLE
fix: preserve branchless base branch

### DIFF
--- a/apps/server/src/__tests__/thread-service.test.ts
+++ b/apps/server/src/__tests__/thread-service.test.ts
@@ -214,12 +214,12 @@ describe("ThreadService.delete", () => {
       ws.id,
       "Branchless Thread",
       "worktree",
-      "main",
+      "release",
       true,
       "claude",
       undefined,
       "branchless",
-      "main",
+      "release",
     );
     threadRepo.updateWorktreePath(thread.id, "/tmp/wt/main");
     (mockGitService.resolveWorkingDir as ReturnType<typeof vi.fn>).mockReturnValue("/tmp/wt/main");
@@ -244,13 +244,13 @@ describe("ThreadService.delete", () => {
     expect(threadRepo.findById(thread.id)).toMatchObject({
       branch: "feat/from-thread",
       checkout_state: "named",
-      base_branch: null,
+      base_branch: "release",
     });
   });
 
   it("syncs a branchless thread worktree to a named external branch", async () => {
     const ws = workspaceRepo.create("test", "/tmp/test");
-    const thread = threadRepo.create(ws.id, "Branchless", "worktree", "main", true, "claude", undefined, "branchless", "main");
+    const thread = threadRepo.create(ws.id, "Branchless", "worktree", "release", true, "claude", undefined, "branchless", "release");
     threadRepo.updateWorktreePath(thread.id, "/tmp/wt/main");
     (mockGitService.getCurrentBranchAt as ReturnType<typeof vi.fn>).mockResolvedValue("feat/external");
 
@@ -260,7 +260,7 @@ describe("ThreadService.delete", () => {
     expect(result?.thread).toMatchObject({
       branch: "feat/external",
       checkout_state: "named",
-      base_branch: null,
+      base_branch: "release",
     });
   });
 

--- a/apps/server/src/repositories/__tests__/thread-repo.test.ts
+++ b/apps/server/src/repositories/__tests__/thread-repo.test.ts
@@ -55,25 +55,25 @@ describe("ThreadRepo.updateCheckoutToNamedBranch", () => {
     workspaceId = ws.id;
   });
 
-  it("clears base_branch when a branchless checkout becomes a named branch", () => {
+  it("preserves base_branch when a branchless checkout becomes a named branch", () => {
     const thread = threadRepo.create(
       workspaceId,
       "branchless",
       "worktree",
-      "main",
+      "release",
       true,
       "claude",
       undefined,
       "branchless",
-      "main",
+      "release",
     );
 
     const updated = threadRepo.updateCheckoutToNamedBranch(thread.id, "feat/named");
 
     expect(updated?.checkout_state).toBe("named");
     expect(updated?.branch).toBe("feat/named");
-    expect(updated?.base_branch).toBeNull();
-    expect(threadRepo.findById(thread.id)?.base_branch).toBeNull();
+    expect(updated?.base_branch).toBe("release");
+    expect(threadRepo.findById(thread.id)?.base_branch).toBe("release");
   });
 });
 
@@ -91,8 +91,8 @@ describe("ThreadRepo.updateCheckoutFromHead", () => {
     workspaceId = ws.id;
   });
 
-  it("promotes a branchless checkout to a named branch and clears stale PR metadata", () => {
-    const thread = threadRepo.create(workspaceId, "t", "worktree", "main", true, "claude", undefined, "branchless", "main");
+  it("promotes a branchless checkout to a named branch, preserves base_branch, and clears stale PR metadata", () => {
+    const thread = threadRepo.create(workspaceId, "t", "worktree", "release", true, "claude", undefined, "branchless", "release");
     threadRepo.updatePr(thread.id, 12, "OPEN");
 
     const result = threadRepo.updateCheckoutFromHead(thread.id, "feat/new", "named", null);
@@ -101,7 +101,7 @@ describe("ThreadRepo.updateCheckoutFromHead", () => {
     expect(result?.thread).toMatchObject({
       branch: "feat/new",
       checkout_state: "named",
-      base_branch: null,
+      base_branch: "release",
       pr_number: null,
       pr_status: null,
     });

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -316,7 +316,7 @@ export class ThreadRepo {
     const now = new Date().toISOString();
     const result = this.db
       .prepare(
-        "UPDATE threads SET branch = ?, checkout_state = 'named', base_branch = NULL, updated_at = ? WHERE id = ?",
+        "UPDATE threads SET branch = ?, checkout_state = 'named', updated_at = ? WHERE id = ?",
       )
       .run(branch, now, id);
     if (result.changes === 0) return null;
@@ -338,9 +338,13 @@ export class ThreadRepo {
 
     const changed =
       current.branch !== branch || current.checkout_state !== checkoutState;
+    const nextBaseBranch =
+      checkoutState === "named" && current.checkout_state === "branchless" && baseBranch === null
+        ? current.base_branch
+        : baseBranch;
     if (
       !changed &&
-      current.base_branch === baseBranch
+      current.base_branch === nextBaseBranch
     ) {
       return { thread: current, changed: false };
     }
@@ -357,7 +361,7 @@ export class ThreadRepo {
              updated_at = ?
          WHERE id = ?`,
       )
-      .run(branch, checkoutState, baseBranch, changed ? 1 : 0, changed ? 1 : 0, now, id);
+      .run(branch, checkoutState, nextBaseBranch, changed ? 1 : 0, changed ? 1 : 0, now, id);
 
     const thread = this.findById(id);
     return thread ? { thread, changed } : null;

--- a/apps/web/e2e/branchless-create-pr.spec.ts
+++ b/apps/web/e2e/branchless-create-pr.spec.ts
@@ -24,9 +24,9 @@ const thread: Thread = {
   status: "paused",
   mode: "worktree",
   worktree_path: "/tmp/branchless-pr/.worktrees/thread-branchless-pr",
-  branch: "main",
+  branch: "release",
   checkout_state: "branchless",
-  base_branch: "main",
+  base_branch: "release",
   worktree_managed: true,
   issue_number: null,
   pr_number: null,
@@ -136,6 +136,7 @@ test.describe("Branchless Create PR", () => {
     await page.waitForSelector("[data-testid='chat-header-title']");
 
     await ensureOverviewOpen(page);
+    await expect(page.getByText("HEAD").first()).toBeVisible();
     await expect(page.getByTestId("thread-overview-create-branch")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-branch")).toHaveCount(0);
     await expect(page.getByTestId("workspace-menu-create-pr")).toHaveCount(0);
@@ -152,7 +153,7 @@ test.describe("Branchless Create PR", () => {
     await expect.poll(() => getWorkspaceThread(page)).toMatchObject({
       branch: "feat/issue-801",
       checkout_state: "named",
-      base_branch: null,
+      base_branch: "release",
     });
     await expect(page.getByTestId("workspace-menu-branch")).toContainText("feat/issue-801");
     await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
@@ -166,7 +167,7 @@ test.describe("Branchless Create PR", () => {
     await expect(page.getByRole("heading", { name: "Create pull request" })).toBeVisible();
     const prDialog = page.getByLabel("Create pull request");
     await expect(prDialog.getByText("feat/issue-801")).toBeVisible();
-    await expect(prDialog.getByRole("button", { name: "Base branch" })).toContainText("main");
+    await expect(prDialog.getByRole("button", { name: "Base branch" })).toContainText("release");
 
     expect(createBranchCalls).toEqual([
       {

--- a/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
@@ -178,7 +178,9 @@ describe("ThreadOverview branchless Create PR", () => {
   });
 
   it("creates a named branch from the branchless worktree row", async () => {
-    render(<ThreadOverview thread={makeThread()} threadPaneWidth={1400} />);
+    const thread = makeThread({ branch: "release", base_branch: "release" });
+    mockWorkspaceState.threads = [thread];
+    render(<ThreadOverview thread={thread} threadPaneWidth={1400} />);
 
     expect(screen.getByText("HEAD")).toBeInTheDocument();
     expect(screen.queryByTestId("workspace-menu-branch")).not.toBeInTheDocument();
@@ -201,7 +203,7 @@ describe("ThreadOverview branchless Create PR", () => {
       id: "thread-1",
       branch: "feat/issue-801",
       checkout_state: "named",
-      base_branch: null,
+      base_branch: "release",
     });
     expect(mockWorkspaceState.worktreesLoadedForWorkspace).toBeNull();
     expect(screen.queryByTestId("create-pr-dialog")).not.toBeInTheDocument();
@@ -212,6 +214,7 @@ describe("ThreadOverview branchless Create PR", () => {
       makeThread({
         pr_number: 42,
         pr_status: "OPEN",
+        base_branch: "release",
       }),
     ];
     mockWorkspaceState.prUrlsByThreadId = {
@@ -234,7 +237,7 @@ describe("ThreadOverview branchless Create PR", () => {
       expect(mockWorkspaceState.threads[0]).toMatchObject({
         branch: "feat/issue-801",
         checkout_state: "named",
-        base_branch: null,
+        base_branch: "release",
         pr_number: null,
         pr_status: null,
       });

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1117,7 +1117,6 @@ function updateThreadToNamedBranch(threadId: string, branch: string): void {
             ...candidate,
             branch,
             checkout_state: "named" as const,
-            base_branch: null,
             pr_number: null,
             pr_status: null,
           }


### PR DESCRIPTION
## What
Preserve `base_branch` when a branchless thread becomes a named branch.

## Why
Issue #799 requires Create PR to default to the branch the branchless worktree started from. The UI should still show `HEAD` while the thread is branchless.

## Key Changes
- Keep `base_branch` during server checkout promotion and client optimistic branch updates.
- Cover a non-`main` base branch in server, web, and Playwright tests.
- Assert the branchless composer label still shows `HEAD`.

Closes #799

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784971558&installation_id=129163861&pr_number=810&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F810&signature=eee47e5b2ef533b689f64d4888d99209b78803c42b7dfc88d183097fcf7274a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original base branch when converting a branchless thread/worktree into a named branch.
  * Updated Create PR and branch-related UI behavior to keep the correct base branch (instead of clearing it).
  * Ensured checkout state and branch details remain consistent after transitioning to a named branch.
* **Tests**
  * Adjusted server and web tests to match the corrected base branch and checkout transition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->