### PR TITLE
fix: responsive shell panel behavior

### DIFF
--- a/apps/web/e2e/responsive-shell-resize.spec.ts
+++ b/apps/web/e2e/responsive-shell-resize.spec.ts
@@ -1,0 +1,255 @@
+import { expect, test, type Page } from "@playwright/test";
+import type { Thread } from "@mcode/contracts";
+import {
+  mockWebSocketServer,
+  interceptZustandStores,
+  seedActiveThread,
+} from "./helpers/e2e-helpers";
+
+const now = new Date("2026-06-25T00:00:00.000Z").toISOString();
+
+const WORKSPACE = {
+  id: "ws-responsive-shell",
+  name: "Responsive Shell",
+  path: "/tmp/responsive-shell",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+const WORKSPACE_TWO = {
+  ...WORKSPACE,
+  id: "ws-responsive-shell-two",
+  name: "Responsive Shell Two",
+  path: "/tmp/responsive-shell-two",
+  last_opened_at: Date.now() - 1000,
+  sort_order: 1,
+};
+
+const WORKSPACES = [WORKSPACE, WORKSPACE_TWO];
+
+const THREAD: Thread = {
+  id: "thread-responsive-shell",
+  workspace_id: WORKSPACE.id,
+  title: "Responsive Thread",
+  status: "paused",
+  mode: "direct",
+  worktree_path: null,
+  branch: "main",
+  worktree_managed: false,
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  sdk_session_id: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-3-5-sonnet",
+  provider: "claude",
+  deleted_at: null,
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+const THREADS: Thread[] = Array.from({ length: 10 }, (_, index) => ({
+  ...THREAD,
+  id: index === 0 ? THREAD.id : `${THREAD.id}-${index}`,
+  title: index === 0 ? THREAD.title : `Responsive Thread ${index + 1}`,
+  updated_at: new Date(Date.parse(now) + index * 1000).toISOString(),
+}));
+
+const THREADS_TWO: Thread[] = Array.from({ length: 8 }, (_, index) => ({
+  ...THREAD,
+  id: `thread-responsive-shell-two-${index}`,
+  workspace_id: WORKSPACE_TWO.id,
+  title: `Second Project Thread ${index + 1}`,
+  updated_at: new Date(Date.parse(now) + index * 1000).toISOString(),
+}));
+
+const ALL_THREADS = [...THREADS, ...THREADS_TWO];
+
+async function openChangesPanel(page: Page): Promise<void> {
+  await page.getByTestId("header-panel-toggle").click();
+  await page.evaluate(
+    ({ wid, tid }) => {
+      const stores =
+        (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown> }> })
+          .__mcodeStores ?? [];
+      const diffStore = stores.find((s) => {
+        const state = s.getState();
+        return "showRightPanel" in state && "setRightPanelTab" in state;
+      });
+      if (!diffStore) throw new Error("[E2E] diff store not found");
+      const api = diffStore.getState() as {
+        setRightPanelTab: (workspaceId: string, threadId: string | null, tab: string) => void;
+      };
+      api.setRightPanelTab(wid, tid, "changes");
+    },
+    { wid: WORKSPACE.id, tid: THREAD.id },
+  );
+}
+
+async function shellState(page: Page): Promise<{
+  sidebarCollapsed: boolean;
+  sidebarCollapsedByLayout: boolean;
+  rightPanelVisible: boolean;
+  rightPanelMaximized: boolean;
+  rightPanelMaximizedByLayout: boolean;
+}> {
+  return page.evaluate(
+    ({ wid, tid }) => {
+      const stores =
+        (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown> }> })
+          .__mcodeStores ?? [];
+      const uiStore = stores.find((s) => {
+        const state = s.getState();
+        return "rightPanelMaximized" in state && "sidebarCollapsed" in state;
+      });
+      const diffStore = stores.find((s) => {
+        const state = s.getState();
+        return "getRightPanelVisible" in state;
+      });
+      if (!uiStore || !diffStore) throw new Error("[E2E] shell stores not found");
+      const ui = uiStore.getState() as {
+        sidebarCollapsed: boolean;
+        sidebarCollapsedByLayout: boolean;
+        rightPanelMaximized: boolean;
+        rightPanelMaximizedByLayout: boolean;
+      };
+      const diff = diffStore.getState() as {
+        getRightPanelVisible: (workspaceId: string, threadId?: string) => boolean;
+      };
+      return {
+        sidebarCollapsed: ui.sidebarCollapsed,
+        sidebarCollapsedByLayout: ui.sidebarCollapsedByLayout,
+        rightPanelVisible: diff.getRightPanelVisible(wid, tid),
+        rightPanelMaximized: ui.rightPanelMaximized,
+        rightPanelMaximizedByLayout: ui.rightPanelMaximizedByLayout,
+      };
+    },
+    { wid: WORKSPACE.id, tid: THREAD.id },
+  );
+}
+
+test.describe("responsive shell resizing", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWebSocketServer(page, {
+      "workspace.list": WORKSPACES,
+      "thread.list": ALL_THREADS,
+      "conversation.page": {
+        messages: [],
+        hasMore: false,
+        answeredPlanMessageIds: [],
+        narrativeByMessage: {},
+      },
+      "github.branchPr": null,
+      "git.getRemoteUrl": {
+        label: "local/responsive-shell",
+        webUrl: "https://github.com/local/responsive-shell",
+      },
+      "git.workingTreeFiles": [],
+      "git.branchComparison": null,
+      "snapshot.listByThread": [],
+    });
+    await interceptZustandStores(page);
+    await page.addInitScript((workspaceIds: string[]) => {
+      localStorage.setItem(
+        "mcode-expanded-projects",
+        JSON.stringify(Object.fromEntries(workspaceIds.map((id) => [id, true]))),
+      );
+    }, WORKSPACES.map((workspace) => workspace.id));
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+        true,
+      { timeout: 30_000 },
+    );
+    await seedActiveThread(page, WORKSPACE, THREAD);
+    await page.evaluate((payload) => {
+      const stores =
+        (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown>; setState: (patch: Record<string, unknown>) => void }> })
+          .__mcodeStores ?? [];
+      const workspaceStore = stores.find((s) => {
+        const state = s.getState();
+        return "activeThreadId" in state && "threads" in state;
+      });
+      if (!workspaceStore) throw new Error("[E2E] workspace store not found");
+      workspaceStore.setState({ workspaces: payload.workspaces, threads: payload.threads });
+    }, { workspaces: WORKSPACES, threads: ALL_THREADS });
+  });
+
+  test("preserves open panels on shrink and restores layout-owned state on grow", async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await expect(page.getByTestId("thread-overview-body")).toBeVisible();
+    await expect(page.getByTestId("thread-item")).toHaveCount(12);
+    await expect
+      .poll(async () =>
+        page.getByTestId("chat-composer-stage").evaluate((node) =>
+          Number.parseFloat(getComputedStyle(node).paddingRight),
+        ),
+      )
+      .toBeGreaterThan(0);
+
+    const preOpenChatBox = await page.getByTestId("chat-view").boundingBox();
+    expect(preOpenChatBox).not.toBeNull();
+
+    await openChangesPanel(page);
+    await expect(page.getByTestId("right-panel")).toBeVisible();
+    await expect
+      .poll(async () => (await page.getByTestId("right-panel").boundingBox())?.width ?? 0)
+      .toBeGreaterThan(preOpenChatBox!.width * 0.49);
+    await expect
+      .poll(async () => (await page.getByTestId("right-panel").boundingBox())?.width ?? 0)
+      .toBeLessThan(preOpenChatBox!.width * 0.51);
+    await expect(page.getByTestId("thread-overview-body")).toHaveCount(0);
+    await expect(page.getByTestId("chat-composer-stage")).toHaveCSS("padding-right", "0px");
+    await expect.poll(() => shellState(page)).toMatchObject({
+      sidebarCollapsed: false,
+      rightPanelVisible: true,
+      rightPanelMaximized: false,
+    });
+
+    for (const width of [1250, 1180, 1040, 900, 640]) {
+      await page.setViewportSize({ width, height: 900 });
+    }
+
+    await expect.poll(() => shellState(page)).toMatchObject({
+      sidebarCollapsed: true,
+      sidebarCollapsedByLayout: true,
+      rightPanelVisible: true,
+      rightPanelMaximized: true,
+      rightPanelMaximizedByLayout: true,
+    });
+    await expect(page.getByTestId("right-panel")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-body")).toHaveCount(0);
+
+    for (const width of [900, 1040, 1180, 1250, 1600]) {
+      await page.setViewportSize({ width, height: 900 });
+    }
+
+    await expect.poll(() => shellState(page)).toMatchObject({
+      sidebarCollapsed: false,
+      sidebarCollapsedByLayout: false,
+      rightPanelVisible: true,
+      rightPanelMaximized: false,
+      rightPanelMaximizedByLayout: false,
+    });
+    await expect(page.getByTestId("sidebar-docked")).toBeVisible();
+    await expect(page.getByTestId("right-panel")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-body")).toHaveCount(0);
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -28,6 +28,7 @@ import { useUiStore } from "@/stores/uiStore";
 import { preparingStatusLabel, type WorkspaceThread } from "@/lib/workspace-thread";
 import { useReplyStore } from "@/stores/replyStore";
 import { getTransport } from "@/transport";
+import { useElementWidth } from "@/hooks/useElementWidth";
 import { overviewResponsivePaddingRight } from "@/lib/composer-layout";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
@@ -204,6 +205,8 @@ export function ChatView() {
 
   const connectionStatus = useConnectionStore((s) => s.status);
   const sendMessage = useThreadStore((s) => s.sendMessage);
+  const chatPaneRef = useRef<HTMLDivElement>(null);
+  const threadPaneWidth = useElementWidth(chatPaneRef);
   const reserveOverviewSpace = useOverviewStore((s) => s.reserveSpace);
   const overviewPaddingRight = reserveOverviewSpace ? overviewResponsivePaddingRight() : undefined;
 
@@ -443,7 +446,7 @@ export function ChatView() {
   const showEmptyState = !hasMessages && !isAgentRunning;
 
   return (
-    <div className="flex h-full flex-col bg-background" data-testid="chat-view">
+    <div ref={chatPaneRef} className="flex h-full flex-col bg-background" data-testid="chat-view">
       {/* Header */}
       <div className="flex h-11 items-center justify-between border-b border-border pr-4 pl-2">
         <div className="flex items-center gap-2">
@@ -484,7 +487,7 @@ export function ChatView() {
             </Tooltip>
           )}
         </div>
-        <HeaderActions thread={activeThread} />
+        <HeaderActions thread={activeThread} threadPaneWidth={threadPaneWidth} />
       </div>
 
       {/* Interrupted sessions banner — shown after server restart when threads were mid-task */}
@@ -520,6 +523,7 @@ export function ChatView() {
           virtualizer and discard cached row heights. MessageList resets its
           own per-thread state imperatively in a useEffect on activeThreadId. */}
       <div
+        data-testid="chat-message-stage"
         className="animate-fade-up-in flex-1 min-h-0 transition-[padding] duration-200"
         style={{ paddingRight: overviewPaddingRight }}
       >
@@ -543,6 +547,7 @@ export function ChatView() {
 
       {/* Composer area — plan question wizard floats above the composer input */}
       <div
+        data-testid="chat-composer-stage"
         className="relative flex-shrink-0 transition-[padding] duration-200"
         style={{ paddingRight: overviewPaddingRight }}
       >

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -216,6 +216,10 @@ function defaultWorkspaceState() {
   };
 }
 
+function renderHeaderActions(thread: Thread = makeThread()) {
+  return render(<HeaderActions thread={thread} threadPaneWidth={1400} />);
+}
+
 describe("HeaderActions - Create PR menu item", () => {
   beforeEach(() => {
     useThreadStore.setState({ records: new Map() });
@@ -229,7 +233,7 @@ describe("HeaderActions - Create PR menu item", () => {
 
   it("offers Create PR in the consolidated menu on a worktree thread", () => {
     mockUseHasCommitsAhead.mockReturnValue(true);
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     const item = screen.getByTestId("workspace-menu-create-pr");
     expect(item).toBeInTheDocument();
     expect(item).not.toBeDisabled();
@@ -237,7 +241,7 @@ describe("HeaderActions - Create PR menu item", () => {
 
   it("shows Commit or push instead of Create PR when no commits ahead of base", () => {
     mockUseHasCommitsAhead.mockReturnValue(false);
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     expect(screen.getByTestId("workspace-menu-commit")).toBeInTheDocument();
     expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
     expect(screen.queryByTestId("thread-overview-pr-status")).not.toBeInTheDocument();
@@ -245,32 +249,32 @@ describe("HeaderActions - Create PR menu item", () => {
 
   it("disables Create PR while loading (null)", () => {
     mockUseHasCommitsAhead.mockReturnValue(null);
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     expect(screen.getByTestId("workspace-menu-create-pr")).toBeDisabled();
   });
 
   it("enables Create PR when commits exist ahead", () => {
     mockUseHasCommitsAhead.mockReturnValue(true);
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     expect(screen.getByTestId("workspace-menu-create-pr")).not.toBeDisabled();
   });
 
   it("offers Create PR on a named worktree thread regardless of branch name", () => {
     mockUseHasCommitsAhead.mockReturnValue(true);
-    render(<HeaderActions thread={makeThread({ branch: "main" })} />);
+    renderHeaderActions(makeThread({ branch: "main" }));
     expect(screen.getByTestId("workspace-menu-create-pr")).toBeInTheDocument();
   });
 
   it("hides Create PR and shows View PR when a PR already exists", () => {
     mockUseBranchPr.mockReturnValue({ number: 42, state: "OPEN", url: "https://github.com/test/pr/42" });
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     expect(screen.queryByTestId("workspace-menu-create-pr")).not.toBeInTheDocument();
     expect(screen.getByTestId("workspace-menu-open-pr")).toHaveTextContent("PR #42");
   });
 
   it("explains commit-or-push when no commits are ahead", () => {
     mockUseHasCommitsAhead.mockReturnValue(false);
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     expect(screen.getByTestId("workspace-menu-commit")).toHaveAttribute(
       "title",
       expect.stringContaining("commit and push"),
@@ -279,7 +283,7 @@ describe("HeaderActions - Create PR menu item", () => {
 
   it("shows a loading title while commits-ahead state is unknown", () => {
     mockUseHasCommitsAhead.mockReturnValue(null);
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     expect(screen.getByTestId("workspace-menu-create-pr")).toHaveAttribute(
       "title",
       expect.stringContaining("Waiting for commits"),
@@ -298,40 +302,40 @@ describe("HeaderActions - PR-ability gating by mode", () => {
   });
 
   it("does not show the Create PR button for a direct-mode thread", () => {
-    render(<HeaderActions thread={makeThread({ mode: "direct" })} />);
+    renderHeaderActions(makeThread({ mode: "direct" }));
     expect(screen.queryByRole("button", { name: /create pr/i })).not.toBeInTheDocument();
   });
 
   it("does not mount the create-PR dialog for a direct-mode thread", () => {
-    render(<HeaderActions thread={makeThread({ mode: "direct" })} />);
+    renderHeaderActions(makeThread({ mode: "direct" }));
     expect(screen.queryByTestId("create-pr-dialog")).not.toBeInTheDocument();
   });
 
   it("mounts the create-PR dialog for a worktree thread", () => {
-    render(<HeaderActions thread={makeThread({ mode: "worktree" })} />);
+    renderHeaderActions(makeThread({ mode: "worktree" }));
     expect(screen.getByTestId("create-pr-dialog")).toBeInTheDocument();
   });
 
   it("does not mount the create-PR dialog for a branchless worktree thread", () => {
-    render(<HeaderActions thread={makeThread({ checkout_state: "branchless", base_branch: "main" })} />);
+    renderHeaderActions(makeThread({ checkout_state: "branchless", base_branch: "main" }));
     expect(screen.queryByTestId("create-pr-dialog")).not.toBeInTheDocument();
   });
 
   it("skips PR polling for a direct-mode thread", () => {
-    render(<HeaderActions thread={makeThread({ mode: "direct", branch: "feat/x" })} />);
+    renderHeaderActions(makeThread({ mode: "direct", branch: "feat/x" }));
     // Non-PR-able threads must not poll GitHub: both hooks receive null inputs.
     expect(mockUseBranchPr).toHaveBeenCalledWith(null, expect.anything());
     expect(mockUseHasCommitsAhead).toHaveBeenCalledWith("", null, undefined);
   });
 
   it("polls GitHub for a worktree thread", () => {
-    render(<HeaderActions thread={makeThread({ mode: "worktree", branch: "feat/x" })} />);
+    renderHeaderActions(makeThread({ mode: "worktree", branch: "feat/x" }));
     expect(mockUseBranchPr).toHaveBeenCalledWith("feat/x", expect.anything());
     expect(mockUseHasCommitsAhead).toHaveBeenCalledWith("ws-1", "feat/x", "thread-1");
   });
 
   it("skips PR polling for a branchless worktree thread", () => {
-    render(<HeaderActions thread={makeThread({ checkout_state: "branchless", base_branch: "main" })} />);
+    renderHeaderActions(makeThread({ checkout_state: "branchless", base_branch: "main" }));
     expect(mockUseBranchPr).toHaveBeenCalledWith(null, expect.anything());
     expect(mockUseHasCommitsAhead).toHaveBeenCalledWith("", null, undefined);
   });
@@ -349,12 +353,12 @@ describe("HeaderActions - consolidated header", () => {
   });
 
   it("renders the consolidated workspace menu trigger", () => {
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     expect(screen.getByTestId("header-workspace-menu")).toBeInTheDocument();
   });
 
   it("renders the thread overview rows", () => {
-    render(<HeaderActions thread={makeThread({ worktree_path: "/repo/worktrees/feat-x" })} />);
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
     expect(screen.queryByText("Environment")).not.toBeInTheDocument();
     expect(screen.getByTestId("workspace-menu-changes")).toHaveTextContent("Changes");
     expect(screen.queryByTestId("thread-overview-change-summary")).not.toBeInTheDocument();
@@ -380,7 +384,7 @@ describe("HeaderActions - consolidated header", () => {
 
   it("renders usage limits as compact progress bars when quota data exists", () => {
     seedThreadUsage("thread-1", CLAUDE_USAGE);
-    render(<HeaderActions thread={makeThread({ worktree_path: "/repo/worktrees/feat-x" })} />);
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
 
     const usageTrigger = screen.getByTestId("thread-overview-usage");
     expect(usageTrigger).toHaveAttribute("aria-label", "Usage, 5-hour 12%, weekly 47%");
@@ -409,7 +413,7 @@ describe("HeaderActions - consolidated header", () => {
   });
 
   it("does not render Codex usage before provider quota data arrives", () => {
-    render(<HeaderActions thread={makeThread({ provider: "codex" })} />);
+    renderHeaderActions(makeThread({ provider: "codex" }));
 
     expect(screen.queryByTestId("thread-overview-usage")).not.toBeInTheDocument();
     expect(screen.queryByRole("progressbar", { name: "5-hour usage" })).not.toBeInTheDocument();
@@ -417,27 +421,27 @@ describe("HeaderActions - consolidated header", () => {
 
   it("prefills commit-or-push from the PR row when the branch is not ahead", () => {
     mockUseHasCommitsAhead.mockReturnValue(false);
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     fireEvent.click(screen.getByTestId("workspace-menu-commit"));
     expect(mockSetPendingPrefill).toHaveBeenCalledWith(COMMIT_PREFILL);
   });
 
   it("renders a single dedicated right-panel toggle", () => {
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     const toggle = screen.getByTestId("header-panel-toggle");
     expect(toggle).toBeInTheDocument();
     expect(toggle).toHaveAttribute("aria-pressed", "false");
   });
 
   it("collapses the old per-tab toggle icons (no terminal/preview/changes buttons)", () => {
-    render(<HeaderActions thread={makeThread()} />);
+    renderHeaderActions();
     expect(screen.queryByRole("button", { name: /toggle terminal/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /toggle preview/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /toggle changes/i })).not.toBeInTheDocument();
   });
 
   it("keeps the consolidated menu and panel toggle on a direct-mode thread", () => {
-    render(<HeaderActions thread={makeThread({ mode: "direct" })} />);
+    renderHeaderActions(makeThread({ mode: "direct" }));
     expect(screen.getByTestId("header-workspace-menu")).toBeInTheDocument();
     expect(screen.getByTestId("header-panel-toggle")).toBeInTheDocument();
   });

--- a/apps/web/src/components/chat/HeaderActions.tsx
+++ b/apps/web/src/components/chat/HeaderActions.tsx
@@ -13,13 +13,15 @@ import type { Thread } from "@/transport";
 /** Props for {@link HeaderActions}. */
 interface HeaderActionsProps {
   thread: Thread;
+  /** Current width of the chat pane that owns the composer and thread timeline. */
+  threadPaneWidth: number;
 }
 
 /**
  * Renders the chat-header action strip: open-in, thread Overview, and the
  * workspace-global right-panel toggle.
  */
-export function HeaderActions({ thread }: HeaderActionsProps) {
+export function HeaderActions({ thread, threadPaneWidth }: HeaderActionsProps) {
   const workspacePath = useWorkspaceStore((s) =>
     s.workspaces.find((w) => w.id === thread.workspace_id)?.path ?? null,
   );
@@ -54,7 +56,7 @@ export function HeaderActions({ thread }: HeaderActionsProps) {
 
       <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
 
-      <ThreadOverview thread={thread} />
+      <ThreadOverview thread={thread} threadPaneWidth={threadPaneWidth} />
 
       {/* Dedicated right-panel toggle for the workspace-global panel. */}
       <Tooltip>

--- a/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
@@ -81,18 +81,6 @@ vi.mock("@/stores/diffStore", async (importOriginal) => {
   };
 });
 
-vi.mock("@/stores/layoutStore", () => ({
-  useLayoutStore: vi.fn((selector: (state: unknown) => unknown) =>
-    selector({ contentRowWidth: 1200 }),
-  ),
-}));
-
-vi.mock("@/stores/overviewStore", () => ({
-  useOverviewStore: vi.fn((selector: (state: unknown) => unknown) =>
-    selector({ setReserveSpace: vi.fn() }),
-  ),
-}));
-
 vi.mock("@/stores/threadStore", () => ({
   useThreadStore: vi.fn((selector: (state: unknown) => unknown) =>
     selector({ records: new Map(), fetchProviderUsage: vi.fn() }),
@@ -190,7 +178,7 @@ describe("ThreadOverview branchless Create PR", () => {
   });
 
   it("creates a named branch from the branchless worktree row", async () => {
-    render(<ThreadOverview thread={makeThread()} />);
+    render(<ThreadOverview thread={makeThread()} threadPaneWidth={1400} />);
 
     expect(screen.getByText("HEAD")).toBeInTheDocument();
     expect(screen.queryByTestId("workspace-menu-branch")).not.toBeInTheDocument();
@@ -234,7 +222,7 @@ describe("ThreadOverview branchless Create PR", () => {
       "thread-1": { aggregate: "passing", runs: [], fetchedAt: 1 },
       other: { aggregate: "no_checks", runs: [], fetchedAt: 2 },
     };
-    render(<ThreadOverview thread={mockWorkspaceState.threads[0]} />);
+    render(<ThreadOverview thread={mockWorkspaceState.threads[0]} threadPaneWidth={1400} />);
 
     fireEvent.click(screen.getByTestId("thread-overview-create-branch"));
     fireEvent.change(screen.getByLabelText("Branch name"), {
@@ -261,7 +249,7 @@ describe("ThreadOverview branchless Create PR", () => {
 
   it("keeps the branch creation dialog open when branch creation fails", async () => {
     mockCreateBranch.mockRejectedValueOnce(new Error("branch exists"));
-    render(<ThreadOverview thread={makeThread()} />);
+    render(<ThreadOverview thread={makeThread()} threadPaneWidth={1400} />);
 
     fireEvent.click(screen.getByTestId("thread-overview-create-branch"));
     fireEvent.change(screen.getByLabelText("Branch name"), {

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -43,10 +43,9 @@ import { useDiffStore } from "@/stores/diffStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useThreadRecord } from "@/stores/thread-selectors";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useLayoutStore } from "@/stores/layoutStore";
 import { useOverviewStore } from "@/stores/overviewStore";
 import { executeCommand, registerCommand } from "@/lib/command-registry";
-import { getContentRowWidth, shouldAutoOpenOverview } from "@/lib/composer-layout";
+import { shouldAutoOpenOverview } from "@/lib/composer-layout";
 import { extractThreadSources, type ThreadSource } from "@/lib/message-sources";
 import { isModifierClick, isPreviewableUrl, openUrlInPreview } from "@/lib/open-url-in-preview";
 import { sanitizeCustomBranchInput, trimTrailingBranchChars } from "@/lib/branch-name";
@@ -75,6 +74,8 @@ export type ThreadOverviewCiDot = "red" | "green" | null;
 /** Props for {@link ThreadOverview}. */
 interface ThreadOverviewProps {
   thread: Thread;
+  /** Width of the chat pane that contains this thread's timeline and composer. */
+  threadPaneWidth: number;
 }
 
 type SnapshotDiffStat = { filePath: string; additions: number; deletions: number };
@@ -1259,7 +1260,7 @@ function CreateThreadBranchDialog({
  * It replaces the old workspace dropdown with status rows tied to the active
  * thread: changed files, PR actions, and the thread's worktree mode.
  */
-export function ThreadOverview({ thread }: ThreadOverviewProps) {
+export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps) {
   const [localOpen, setLocalOpen] = useState(false);
   const [branchOpen, setBranchOpen] = useState(false);
   const [createBranchOpen, setCreateBranchOpen] = useState(false);
@@ -1282,8 +1283,6 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
   // when the right panel or a narrow viewport leaves none, until the user takes
   // manual control of it for this thread.
   const panelVisible = useDiffStore((s) => s.getRightPanelVisible(thread.workspace_id, thread.id));
-  const panelWidth = useDiffStore((s) => s.getRightPanel(thread.workspace_id, thread.id).width);
-  const measuredContentRowWidth = useLayoutStore((s) => s.contentRowWidth);
   const [open, setOpen] = useState(false);
   const autoManagedRef = useRef(true);
   const lastAutoValueRef = useRef<boolean | null>(null);
@@ -1298,17 +1297,15 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
     setCreateBranchOpen(false);
   }, [thread.id]);
 
-  // Whether there is room for the Overview to open by default. Driven by the
-  // reactive content-row width so it tracks resizes and panel changes without
-  // racing the layout guard's measurement.
+  // Whether there is room for the Overview to open by default. The chat pane
+  // width, not the surrounding split row, is the signal that matches what the
+  // user sees when the right panel opens.
   const hasRoom = useMemo(
     () =>
       shouldAutoOpenOverview({
-        contentRowWidth: measuredContentRowWidth || getContentRowWidth(),
-        rightPanelVisible: panelVisible,
-        rightPanelWidth: panelWidth,
+        threadPaneWidth,
       }),
-    [measuredContentRowWidth, panelVisible, panelWidth],
+    [threadPaneWidth],
   );
 
   // The Overview opens by default when there is room and steps aside when a
@@ -1332,13 +1329,19 @@ export function ThreadOverview({ thread }: ThreadOverviewProps) {
     setOpen(next);
   }, []);
 
-  // Reserve room on the right only when open AND there's space (wide view); on a
-  // small view the popover floats over the chat instead of squeezing it.
+  useEffect(() => {
+    if (!panelVisible || hasRoom || !open) return;
+
+    lastAutoValueRef.current = false;
+    autoManagedRef.current = true;
+    setOpen(false);
+  }, [hasRoom, open, panelVisible]);
+
   const setReserveSpace = useOverviewStore((s) => s.setReserveSpace);
   useEffect(() => {
-    setReserveSpace(open && hasRoom);
+    setReserveSpace(open && hasRoom && !panelVisible);
     return () => setReserveSpace(false);
-  }, [open, hasRoom, setReserveSpace]);
+  }, [hasRoom, open, panelVisible, setReserveSpace]);
 
   const {
     prable,

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -205,7 +205,9 @@ export function RightPanel() {
 
     const clampToSplit = () => {
       const max = maxPanelWidthInSplit(split.clientWidth);
-      if (panelWidthRef.current > max) setRightPanelWidth(activeWorkspaceId, activeThreadId, max);
+      if (panelWidthRef.current > max) {
+        setRightPanelWidth(activeWorkspaceId, activeThreadId, max, "preserve");
+      }
     };
 
     clampToSplit();
@@ -240,6 +242,7 @@ export function RightPanel() {
           activeWorkspaceId!,
           activeThreadId,
           Math.max(PANEL_MIN_WIDTH, Math.min(startWidth + delta, maxWidth)),
+          "user",
         );
       };
 
@@ -278,6 +281,7 @@ export function RightPanel() {
   return (
     <div
       ref={panelRootRef}
+      data-testid="right-panel"
       style={
         !panelVisible
           ? {
@@ -328,7 +332,7 @@ export function RightPanel() {
             panelWidth >= PANEL_WIDE_WIDTH
               ? narrow
               : Math.min(PANEL_WIDE_WIDTH, maxWidth);
-          setRightPanelWidth(activeWorkspaceId!, activeThreadId, Math.max(PANEL_MIN_WIDTH, target));
+          setRightPanelWidth(activeWorkspaceId!, activeThreadId, Math.max(PANEL_MIN_WIDTH, target), "user");
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
@@ -339,7 +343,7 @@ export function RightPanel() {
               panelWidth >= PANEL_WIDE_WIDTH
                 ? narrow
                 : Math.min(PANEL_WIDE_WIDTH, maxWidth);
-            setRightPanelWidth(activeWorkspaceId!, activeThreadId, Math.max(PANEL_MIN_WIDTH, target));
+            setRightPanelWidth(activeWorkspaceId!, activeThreadId, Math.max(PANEL_MIN_WIDTH, target), "user");
           }
         }}
       >

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -41,6 +41,7 @@ import {
   DndContext,
   closestCenter,
   KeyboardSensor,
+  MeasuringStrategy,
   PointerSensor,
   useSensor,
   useSensors,
@@ -80,6 +81,12 @@ const EMPTY_THREADS: WorkspaceThread[] = [];
 
 /** Stable empty Set used as a sentinel when status filters don't need running/permission state. */
 const EMPTY_ID_SET = new Set<string>();
+const PROJECT_DND_MODIFIERS = [restrictToVerticalAxis];
+const PROJECT_DND_MEASURING = {
+  droppable: {
+    strategy: MeasuringStrategy.BeforeDragging,
+  },
+} as const;
 
 /**
  * Returns `prev` if it contains the same elements in the same order as `next`
@@ -674,7 +681,8 @@ export function ProjectTree() {
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
-            modifiers={[restrictToVerticalAxis]}
+            modifiers={PROJECT_DND_MODIFIERS}
+            measuring={PROJECT_DND_MEASURING}
             autoScroll={projectTreeAutoScroll}
             onDragStart={handleProjectDragStart}
             onDragEnd={handleProjectDragEnd}

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -63,7 +63,7 @@ export function Sidebar({
             <Button
               variant="ghost"
               size="icon-sm"
-              onClick={collapseSidebar}
+              onClick={() => collapseSidebar()}
               aria-label="Collapse sidebar"
               className="text-muted-foreground"
             >

--- a/apps/web/src/hooks/useComposerLayoutGuard.ts
+++ b/apps/web/src/hooks/useComposerLayoutGuard.ts
@@ -9,7 +9,6 @@ import {
   minOuterWidthForInlineSidebar,
   setLayoutMeasurements,
 } from "@/lib/composer-layout";
-import { hideRightPanelAdaptive } from "@/lib/right-panel-layout";
 
 /** Inputs that affect composer-first layout enforcement. */
 export interface ComposerLayoutGuardOptions {
@@ -32,6 +31,7 @@ export function useComposerLayoutGuard(
   const sidebarCollapsed = useUiStore((s) => s.sidebarCollapsed);
   const sidebarFloating = useUiStore((s) => s.sidebarFloating);
   const rightPanelMaximized = useUiStore((s) => s.rightPanelMaximized);
+  const rightPanelMaximizedByLayout = useUiStore((s) => s.rightPanelMaximizedByLayout);
 
   useEffect(() => {
     if (opts.settingsOpen || opts.showLanding || !opts.activeWorkspaceId) return;
@@ -55,19 +55,39 @@ export function useComposerLayoutGuard(
       const panelInline = panelVisible && !ui.rightPanelMaximized;
       const sidebarDocked = !ui.sidebarCollapsed && !ui.sidebarFloating;
 
+      if (
+        panelVisible &&
+        ui.rightPanelMaximized &&
+        ui.rightPanelMaximizedByLayout &&
+        canFitSideBySidePanel(contentWidth, panelWidth)
+      ) {
+        ui.setRightPanelMaximized(false);
+        return;
+      }
+
+      if (ui.sidebarCollapsedByLayout) {
+        const contentNeed = panelInline
+          ? minContentWidthForSideBySidePanel(panelWidth)
+          : COMPOSER_MIN_WIDTH;
+        if (canFitInlineSidebar(outerWidth, contentNeed) && contentWidth >= contentNeed) {
+          ui.restoreSidebarFromLayoutCollapse();
+          return;
+        }
+      }
+
       if (panelInline && sidebarDocked) {
         const needAll = minOuterWidthForInlineSidebar(
           minContentWidthForSideBySidePanel(panelWidth),
         );
         if (outerWidth < needAll) {
-          hideRightPanelAdaptive(activeWorkspaceId, activeThreadId);
-          ui.collapseSidebar();
+          ui.setRightPanelMaximized(true, "layout");
+          ui.collapseSidebar("layout");
           return;
         }
       }
 
       if (panelInline && !canFitSideBySidePanel(contentWidth, panelWidth)) {
-        hideRightPanelAdaptive(activeWorkspaceId, activeThreadId);
+        ui.setRightPanelMaximized(true, "layout");
         return;
       }
 
@@ -78,7 +98,7 @@ export function useComposerLayoutGuard(
         : COMPOSER_MIN_WIDTH;
 
       if (contentWidth < contentNeed || !canFitInlineSidebar(outerWidth, contentNeed)) {
-        ui.collapseSidebar();
+        ui.collapseSidebar("layout");
       }
     };
 
@@ -110,5 +130,6 @@ export function useComposerLayoutGuard(
     sidebarCollapsed,
     sidebarFloating,
     rightPanelMaximized,
+    rightPanelMaximizedByLayout,
   ]);
 }

--- a/apps/web/src/lib/__tests__/composer-layout.test.ts
+++ b/apps/web/src/lib/__tests__/composer-layout.test.ts
@@ -55,25 +55,16 @@ describe("composer-layout", () => {
     expect(preferredSplitPanelWidth(600)).toBe(PANEL_MIN_WIDTH);
   });
 
-  it("auto-opens the Overview on a wide row with no panel", () => {
-    expect(
-      shouldAutoOpenOverview({ contentRowWidth: 1400, rightPanelVisible: false, rightPanelWidth: 440 }),
-    ).toBe(true);
+  it("auto-opens the Overview when the chat pane itself is wide", () => {
+    expect(shouldAutoOpenOverview({ threadPaneWidth: 1400 })).toBe(true);
   });
 
-  it("does not auto-open the Overview on a narrow row", () => {
-    expect(
-      shouldAutoOpenOverview({ contentRowWidth: 800, rightPanelVisible: false, rightPanelWidth: 440 }),
-    ).toBe(false);
+  it("does not auto-open the Overview when the chat pane itself is narrow", () => {
+    expect(shouldAutoOpenOverview({ threadPaneWidth: 800 })).toBe(false);
   });
 
-  it("auto-opens beside an open panel only when both still fit", () => {
-    expect(
-      shouldAutoOpenOverview({ contentRowWidth: 1400, rightPanelVisible: true, rightPanelWidth: 440 }),
-    ).toBe(true);
-    expect(
-      shouldAutoOpenOverview({ contentRowWidth: 1400, rightPanelVisible: true, rightPanelWidth: 1000 }),
-    ).toBe(false);
+  it("treats a right-panel-squeezed chat pane as too narrow even on a wide row", () => {
+    expect(shouldAutoOpenOverview({ threadPaneWidth: 960 })).toBe(false);
   });
 
   it("keeps the centered thread unpadded when the Overview can sit beside it", () => {

--- a/apps/web/src/lib/__tests__/right-panel-layout.test.ts
+++ b/apps/web/src/lib/__tests__/right-panel-layout.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { setLayoutMeasurements } from "@/lib/composer-layout";
+import {
+  hideRightPanelAdaptive,
+  showRightPanelAdaptive,
+} from "@/lib/right-panel-layout";
+import { useDiffStore } from "@/stores/diffStore";
+import { useUiStore } from "@/stores/uiStore";
+
+function resetDiffStore() {
+  useDiffStore.setState({
+    previewUrlByThread: {},
+    rightPanelByThread: {},
+    rightPanelFallbackByWorkspace: {},
+    snapshotsByThread: {},
+    snapshotsLoadingByThread: {},
+    snapshotsPendingByThread: {},
+    commitsByThread: {},
+    commitsLoadingByThread: {},
+    selectedFile: null,
+    diffContent: null,
+    diffLoading: false,
+    viewMode: "last-turn",
+    reviewViewByThread: {},
+    reviewViewManuallySelectedByThread: {},
+    selectedCommitSha: null,
+    renderMode: "unified",
+    lineWrapByThread: {},
+    inlineDiffCache: {},
+    diffRevisionByScope: {},
+    branchComparison: null,
+    branchComparisonKey: null,
+    branchManuallySelectedByScope: {},
+    branchResolvedRevisionByScope: {},
+  });
+}
+
+function resetUiStore() {
+  useUiStore.setState({
+    sidebarCollapsed: false,
+    sidebarCollapsedByLayout: false,
+    sidebarFloating: false,
+    shortcutHelpOpen: false,
+    rightPanelMaximized: false,
+    rightPanelMaximizedByLayout: false,
+  });
+}
+
+describe("right-panel-layout", () => {
+  beforeEach(() => {
+    resetDiffStore();
+    resetUiStore();
+    setLayoutMeasurements(1200, 1200);
+  });
+
+  it("recomputes auto-owned panel width from the current chat row on each open", () => {
+    showRightPanelAdaptive("ws-1", "thread-1");
+    expect(useDiffStore.getState().getRightPanel("ws-1", "thread-1")).toMatchObject({
+      width: 600,
+      widthSource: "auto",
+    });
+
+    hideRightPanelAdaptive("ws-1", "thread-1");
+    setLayoutMeasurements(1000, 1000);
+    showRightPanelAdaptive("ws-1", "thread-1");
+
+    expect(useDiffStore.getState().getRightPanel("ws-1", "thread-1")).toMatchObject({
+      width: 500,
+      widthSource: "auto",
+    });
+  });
+
+  it("does not overwrite a user-owned panel width on reopen", () => {
+    showRightPanelAdaptive("ws-1", "thread-1");
+    useDiffStore.getState().setRightPanelWidth("ws-1", "thread-1", 520, "user");
+
+    hideRightPanelAdaptive("ws-1", "thread-1");
+    setLayoutMeasurements(1400, 1400);
+    showRightPanelAdaptive("ws-1", "thread-1");
+
+    expect(useDiffStore.getState().getRightPanel("ws-1", "thread-1")).toMatchObject({
+      width: 520,
+      widthSource: "user",
+    });
+  });
+});

--- a/apps/web/src/lib/composer-layout.ts
+++ b/apps/web/src/lib/composer-layout.ts
@@ -71,38 +71,30 @@ export function preferredSplitPanelWidth(contentRowWidth: number, fraction = 0.5
 }
 
 /**
- * Content-row width below which the Overview should not auto-open: on a narrow
- * row it would crowd the chat, so the user opens it on demand instead.
+ * Chat-pane width below which the Overview should not auto-open: on a narrow
+ * composer surface it would crowd the thread, so the user opens it on demand
+ * only when the right panel is not squeezing the pane.
  */
 export const OVERVIEW_AUTO_OPEN_MIN_ROW = 1024;
 
 /** Visual thread column width from the shared `max-w-4xl` message/composer shell. */
 export const OVERVIEW_THREAD_CONTENT_MAX_WIDTH_PX = 896;
 
-/**
- * Right-side popover footprint for Overview (`w-80`) plus collision padding. This
- * is also the maximum padding we apply when the row is too narrow to keep the
- * centered thread clear of the popover.
- */
+/** Right-side popover footprint for Overview (`w-80`) plus collision padding. */
 export const OVERVIEW_POPOVER_RESERVE_PX = 328;
 
 /** Minimum breathing room between the centered thread column and the Overview. */
 export const OVERVIEW_THREAD_GAP_PX = 16;
 
 /**
- * Whether the Overview should auto-open and "sit" given the current space. It
- * stays closed on narrow rows, and when the right panel is open it only opens if
- * chat and panel still fit side by side (i.e., the layout isn't cramped).
+ * Whether the Overview should auto-open given the actual chat pane width.
+ * The split row can stay wide while the right panel squeezes the thread; only
+ * the pane that contains the composer is a trustworthy signal.
  */
 export function shouldAutoOpenOverview(args: {
-  contentRowWidth: number;
-  rightPanelVisible: boolean;
-  rightPanelWidth: number;
+  threadPaneWidth: number;
 }): boolean {
-  const { contentRowWidth, rightPanelVisible, rightPanelWidth } = args;
-  if (contentRowWidth < OVERVIEW_AUTO_OPEN_MIN_ROW) return false;
-  if (rightPanelVisible && !canFitSideBySidePanel(contentRowWidth, rightPanelWidth)) return false;
-  return true;
+  return args.threadPaneWidth >= OVERVIEW_AUTO_OPEN_MIN_ROW;
 }
 
 /** Width at which a centered thread can sit beside the Overview with no offset. */
@@ -121,9 +113,8 @@ export function overviewResponsivePaddingPx(contentWidth: number): number {
 }
 
 /**
- * CSS equivalent of {@link overviewResponsivePaddingPx}, using the container's
- * own width so the chat stays centered on roomy screens and only steps left as
- * much as the open Overview requires.
+ * CSS equivalent of {@link overviewResponsivePaddingPx}, using the chat pane's
+ * own width. The right panel disables this reserve before it can squeeze chat.
  */
 export function overviewResponsivePaddingRight(): string {
   return `clamp(0px, calc(${overviewNoPaddingMinWidth()}px - 100%), ${OVERVIEW_POPOVER_RESERVE_PX}px)`;

--- a/apps/web/src/lib/right-panel-layout.ts
+++ b/apps/web/src/lib/right-panel-layout.ts
@@ -1,4 +1,4 @@
-import { getDefaultPanelWidthPx, useDiffStore } from "@/stores/diffStore";
+import { useDiffStore } from "@/stores/diffStore";
 import { useUiStore } from "@/stores/uiStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import {
@@ -8,14 +8,18 @@ import {
 } from "@/lib/composer-layout";
 
 /**
- * On first open, size the panel to ~half the content row instead of the fixed
- * default. Only applies while the scope still carries the built-in default
- * width, so a width the user has dragged is never overridden.
+ * On auto-owned opens, size the panel to ~half the current content row. A width
+ * the user dragged is marked user-owned and is never overridden here.
  */
 function applyHalfWidthIfUntouched(workspaceId: string, threadId?: string | null): void {
   const diff = useDiffStore.getState();
-  if (diff.getRightPanel(workspaceId, threadId).width !== getDefaultPanelWidthPx()) return;
-  diff.setRightPanelWidth(workspaceId, threadId, preferredSplitPanelWidth(getContentRowWidth()));
+  if (diff.getRightPanel(workspaceId, threadId).widthSource === "user") return;
+  diff.setRightPanelWidth(
+    workspaceId,
+    threadId,
+    preferredSplitPanelWidth(getContentRowWidth()),
+    "auto",
+  );
 }
 
 /**
@@ -30,7 +34,7 @@ export function applyMaximizeIfCramped(
 ): void {
   const panelWidth = useDiffStore.getState().getRightPanel(workspaceId, threadId).width;
   if (canFitSideBySidePanel(getContentRowWidth(), panelWidth)) return;
-  useUiStore.getState().setRightPanelMaximized(true);
+  useUiStore.getState().setRightPanelMaximized(true, "layout");
 }
 
 /**

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -92,6 +92,8 @@ export interface SelectedFile {
 export type RightPanelState = {
   readonly visible: boolean;
   readonly width: number;
+  /** Whether width came from adaptive auto-open sizing or an explicit user resize. */
+  readonly widthSource?: "auto" | "user";
   /**
    * The singleton tab types the user has opened, in open order. Empty means no
    * tab is open and the panel shows the card-grid empty state (ADR-0004). Tab
@@ -112,6 +114,7 @@ export function createDefaultRightPanelState(): RightPanelState {
   return {
     visible: false,
     width: getDefaultPanelWidthPx(),
+    widthSource: "auto",
     openTabs: [],
     activeTab: "tasks",
   };
@@ -225,6 +228,7 @@ function setPanelVisible(
 export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
   visible: false,
   width: PANEL_DEFAULT_WIDTH,
+  widthSource: "auto",
   openTabs: [],
   activeTab: "tasks",
 } as const;
@@ -369,7 +373,12 @@ interface DiffState {
   showRightPanel: (workspaceId: string, threadId?: string | null) => void;
   /** Close the panel for a thread (per-thread) or the threadless shell (workspace). */
   hideRightPanel: (workspaceId: string, threadId?: string | null) => void;
-  setRightPanelWidth: (workspaceId: string, threadId: string | null | undefined, width: number) => void;
+  setRightPanelWidth: (
+    workspaceId: string,
+    threadId: string | null | undefined,
+    width: number,
+    source?: "auto" | "user" | "preserve",
+  ) => void;
   setRightPanelTab: (workspaceId: string, threadId: string | null | undefined, tab: RightPanelTab) => void;
   /**
    * Close (remove) a singleton tab from the open set. When the closed tab was
@@ -488,12 +497,13 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   hideRightPanel: (workspaceId, threadId) =>
     set((state) => setPanelVisible(state, workspaceId, threadId, false)),
 
-  setRightPanelWidth: (workspaceId, threadId, width) =>
+  setRightPanelWidth: (workspaceId, threadId, width, source = "user") =>
     set((state) => {
       const current = effectiveRightPanel(state, workspaceId, threadId);
       return writeRightPanel(state, workspaceId, threadId, {
         ...current,
         width: clampWidth(width),
+        widthSource: source === "preserve" ? current.widthSource : source,
       });
     }),
 

--- a/apps/web/src/stores/overviewStore.ts
+++ b/apps/web/src/stores/overviewStore.ts
@@ -1,18 +1,12 @@
 import { create } from "zustand";
 
-/**
- * Shares whether the chat area should reserve room on the right for the open
- * Overview. True only when the Overview is open AND there is room to sit beside
- * the chat; on small viewports it stays false so the Overview floats over the
- * content instead of squeezing it. The Overview itself is always a transient
- * popover; this is only a layout hint, not a dock.
- */
 interface OverviewState {
+  /** Whether the chat pane should reserve the right side for the open Overview. */
   reserveSpace: boolean;
   setReserveSpace: (reserveSpace: boolean) => void;
 }
 
-/** Store backing the chat area's "make room for the open Overview" padding. */
+/** Shares the Overview layout hint with the chat pane that owns the composer. */
 export const useOverviewStore = create<OverviewState>((set) => ({
   reserveSpace: false,
   setReserveSpace: (reserveSpace) =>

--- a/apps/web/src/stores/uiStore.ts
+++ b/apps/web/src/stores/uiStore.ts
@@ -12,6 +12,8 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 interface UiState {
   /** Whether the sidebar is collapsed. */
   sidebarCollapsed: boolean;
+  /** Whether the layout guard, not the user, collapsed the sidebar. */
+  sidebarCollapsedByLayout: boolean;
   /**
    * When true the project tree is open as a left-anchored floating panel rather
    * than a docked column (composer-first cramped layouts).
@@ -25,13 +27,17 @@ interface UiState {
    * the panel keeps its stored width, so toggling back restores side-by-side.
    */
   rightPanelMaximized: boolean;
+  /** Whether cramped layout, not the user, maximized the right panel. */
+  rightPanelMaximizedByLayout: boolean;
 
   /** Toggle sidebar collapsed state (expands floating when inline will not fit). */
   toggleSidebar: () => void;
   /** Expand the project tree inline when there is room, otherwise as a float. */
   expandSidebar: () => void;
   /** Collapse the project tree and exit floating mode. */
-  collapseSidebar: () => void;
+  collapseSidebar: (source?: "user" | "layout") => void;
+  /** Restore a sidebar that was collapsed only to protect the layout. */
+  restoreSidebarFromLayoutCollapse: () => void;
   /** Dismiss the floating project tree without changing docked expand state. */
   closeFloatingSidebar: () => void;
   /** Set shortcut help dialog open state. */
@@ -39,7 +45,7 @@ interface UiState {
   /** Toggle the right panel between maximized (full content area) and side-by-side. */
   toggleRightPanelMaximized: () => void;
   /** Set the right panel maximized state explicitly. */
-  setRightPanelMaximized: (maximized: boolean) => void;
+  setRightPanelMaximized: (maximized: boolean, source?: "user" | "layout") => void;
 }
 
 /** Minimum content-row width needed given the current right-panel visibility. */
@@ -60,9 +66,11 @@ function contentNeedForSidebarDock(rightPanelMaximized: boolean): number {
 /** Zustand store for global UI toggle state. Command palette state lives in commandPaletteStore. */
 export const useUiStore = create<UiState>((set, get) => ({
   sidebarCollapsed: false,
+  sidebarCollapsedByLayout: false,
   sidebarFloating: false,
   shortcutHelpOpen: false,
   rightPanelMaximized: false,
+  rightPanelMaximizedByLayout: false,
 
   toggleSidebar: () => {
     if (get().sidebarCollapsed) get().expandSidebar();
@@ -73,14 +81,30 @@ export const useUiStore = create<UiState>((set, get) => ({
     const inline =
       canFitInlineSidebar(getOuterRowWidth(), contentNeed) &&
       getContentRowWidth() >= contentNeed;
-    set({ sidebarCollapsed: false, sidebarFloating: !inline });
+    set({ sidebarCollapsed: false, sidebarCollapsedByLayout: false, sidebarFloating: !inline });
   },
-  collapseSidebar: () => set({ sidebarCollapsed: true, sidebarFloating: false }),
-  closeFloatingSidebar: () => set({ sidebarFloating: false, sidebarCollapsed: true }),
+  collapseSidebar: (source = "user") =>
+    set({
+      sidebarCollapsed: true,
+      sidebarCollapsedByLayout: source === "layout",
+      sidebarFloating: false,
+    }),
+  restoreSidebarFromLayoutCollapse: () => {
+    if (!get().sidebarCollapsedByLayout) return;
+    set({ sidebarCollapsed: false, sidebarCollapsedByLayout: false, sidebarFloating: false });
+  },
+  closeFloatingSidebar: () =>
+    set({ sidebarFloating: false, sidebarCollapsed: true, sidebarCollapsedByLayout: false }),
   setShortcutHelpOpen: (open) =>
     set({ shortcutHelpOpen: open }),
   toggleRightPanelMaximized: () =>
-    set((s) => ({ rightPanelMaximized: !s.rightPanelMaximized })),
-  setRightPanelMaximized: (maximized) =>
-    set({ rightPanelMaximized: maximized }),
+    set((s) => ({
+      rightPanelMaximized: !s.rightPanelMaximized,
+      rightPanelMaximizedByLayout: false,
+    })),
+  setRightPanelMaximized: (maximized, source = "user") =>
+    set({
+      rightPanelMaximized: maximized,
+      rightPanelMaximizedByLayout: maximized && source === "layout",
+    }),
 }));


### PR DESCRIPTION
## What
Fixes responsive behavior for the web app shell when the project tree, chat pane, right panel, and thread overview compete for space.

## Why
Resizing could leave the right panel squeezed or hidden, and the thread overview could stay open in a cramped chat pane after the right panel opened.

## Key Changes
- Track layout-owned sidebar collapse and right-panel maximize state so the shell can protect the composer on shrink and restore inline layout on grow.
- Size auto-owned right panels to 50% of the current chat row on open, while preserving widths set by drag or snap resize.
- Drive thread overview auto-open from the measured chat pane width, close it when the right panel leaves too little room, and reserve composer-lane space only when the right panel is closed.
- Stabilize project-tree drag measurement during resize by using stable DnD modifiers and before-dragging measurement.
- Add regression coverage for responsive resizing and adaptive panel sizing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784971565&installation_id=129163861&pr_number=811&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F811&signature=49427c6937c32cc5db8dec933fe009e2464a180431d9e33d24754423104ab6c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved responsive behavior for the chat layout as the window is resized.
  * The overview panel now opens and closes more reliably based on available chat width.
  * Right panel resizing now preserves user-set sizes and adapts better to layout changes.

* **Bug Fixes**
  * Fixed sidebar and right panel state so they restore correctly after the layout changes.
  * Improved panel resizing behavior when dragging, snapping, or reopening panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->