### PR TITLE
fix: deliver checkout updates to inactive threads

### DIFF
--- a/apps/server/src/transport/push.test.ts
+++ b/apps/server/src/transport/push.test.ts
@@ -126,6 +126,31 @@ describe("broadcast", () => {
     expect(b).toHaveLength(1);
   });
 
+  it("broadcasts thread metadata events to clients subscribed to other threads", () => {
+    const a: Array<{ buf: Buffer; binary: boolean }> = [];
+    const b: Array<{ buf: Buffer; binary: boolean }> = [];
+    const wsA = fakeOpenSocket(a);
+    const wsB = fakeOpenSocket(b);
+    addClient(wsA);
+    addClient(wsB);
+    subscribeClientToThread(wsA, "thread-a");
+    subscribeClientToThread(wsB, "thread-b");
+
+    broadcast("thread.checkoutChanged", {
+      threadId: "thread-a",
+      workspaceId: "ws-1",
+      branch: "feat/thread",
+      checkoutState: "named",
+      baseBranch: null,
+      prNumber: null,
+      prStatus: null,
+    });
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+    expect(JSON.parse(b[0].buf.toString("utf-8")).data.threadId).toBe("thread-a");
+  });
+
   it("lets tests swap validating and pass-through payload adapters", () => {
     const validating: Array<{ buf: Buffer; binary: boolean }> = [];
     const validatingWs = fakeOpenSocket(validating);

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -10,6 +10,7 @@ import { getTransportPayloadValidator } from "./payload-validation.js";
 
 const clients = new Set<WebSocket>();
 const threadSubscriptions = new Map<WebSocket, Set<string>>();
+const SUBSCRIPTION_SCOPED_CHANNELS = new Set<WsChannelName>(["agent.event"]);
 
 let _sessionCount = 0;
 const sessionChangeListeners: ((count: number) => void)[] = [];
@@ -117,10 +118,17 @@ export function broadcast(
     data: validation.data,
   });
   const threadId = payloadThreadId(validation.data);
+  const requiresThreadSubscription = SUBSCRIPTION_SCOPED_CHANNELS.has(channel);
 
   for (const ws of clients) {
     if (ws.readyState === ws.OPEN) {
-      if (threadId && !threadSubscriptions.get(ws)?.has(threadId)) continue;
+      if (
+        requiresThreadSubscription &&
+        threadId &&
+        !threadSubscriptions.get(ws)?.has(threadId)
+      ) {
+        continue;
+      }
       ws.send(payload);
     }
   }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -541,6 +541,20 @@ async function dispatch(
         params.threadId,
         params.name,
       );
+      if (params.threadId) {
+        const thread = deps.threadService.findById(params.threadId);
+        if (thread) {
+          broadcast("thread.checkoutChanged", {
+            threadId: thread.id,
+            workspaceId: thread.workspace_id,
+            branch: thread.branch,
+            checkoutState: thread.checkout_state,
+            baseBranch: thread.base_branch,
+            prNumber: thread.pr_number,
+            prStatus: thread.pr_status,
+          });
+        }
+      }
       return { branch };
     }
     case "git.listWorktrees": {

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -1,10 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
 import { routeMessage, type RouterDeps } from "./ws-router.js";
+import { _resetForTest, addClient } from "./push.js";
 import {
   resetTransportPayloadValidatorForTest,
   setTransportPayloadValidatorForTest,
   type TransportPayloadValidator,
 } from "./payload-validation.js";
+
+function fakeOpenSocket(received: Array<{ buf: Buffer; binary: boolean }>): WebSocket {
+  const ws: Partial<WebSocket> = {
+    readyState: 1,
+    OPEN: 1,
+    send: ((data: unknown, opts?: { binary?: boolean }) => {
+      const buf = Buffer.isBuffer(data)
+        ? data
+        : Buffer.from(data as Uint8Array);
+      received.push({ buf, binary: !!opts?.binary });
+    }) as WebSocket["send"],
+  };
+  return ws as WebSocket;
+}
 
 describe("routeMessage result validation seam", () => {
   afterEach(() => {
@@ -117,11 +133,27 @@ describe("routeMessage git.getRemoteUrl", () => {
 });
 
 describe("routeMessage git.createBranch", () => {
-  it("delegates branch creation and checkout-state persistence to ThreadService", async () => {
+  afterEach(() => {
+    _resetForTest();
+  });
+
+  it("delegates branch creation, then broadcasts the persisted checkout state", async () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    addClient(fakeOpenSocket(received));
     const createBranchForThread = vi.fn().mockResolvedValue("feat/from-thread");
+    const findById = vi.fn().mockReturnValue({
+      id: "thread-1",
+      workspace_id: "ws-1",
+      branch: "feat/from-thread",
+      checkout_state: "named",
+      base_branch: null,
+      pr_number: null,
+      pr_status: null,
+    });
     const deps = {
       threadService: {
         createBranchForThread,
+        findById,
       },
     } as unknown as RouterDeps;
 
@@ -140,6 +172,19 @@ describe("routeMessage git.createBranch", () => {
       "thread-1",
       "feat/from-thread",
     );
+    expect(findById).toHaveBeenCalledWith("thread-1");
+    expect(JSON.parse(received[0].buf.toString("utf-8"))).toMatchObject({
+      channel: "thread.checkoutChanged",
+      data: {
+        threadId: "thread-1",
+        workspaceId: "ws-1",
+        branch: "feat/from-thread",
+        checkoutState: "named",
+        baseBranch: null,
+        prNumber: null,
+        prStatus: null,
+      },
+    });
   });
 
   it("returns an error when the new branch cannot be attached to the thread", async () => {


### PR DESCRIPTION
## What
Fix server push routing so checkout metadata updates reach connected clients even when they are viewing another thread.

## Why
Thread rows can change outside the active conversation, including when a branch is created for a thread. The previous push routing filtered every payload with a `threadId` by active subscription, which dropped checkout updates for inactive threads.

## Key Changes
- Scope subscription filtering to `agent.event`.
- Broadcast `thread.checkoutChanged` after `git.createBranch` persists the thread checkout row.
- Add transport tests for cross-thread checkout metadata delivery and branch-create broadcast payloads.

## Verification
- `cd apps/server && bun run test -- src/transport/push.test.ts src/transport/ws-router.validation.test.ts`
- Live WebSocket check against a temporary repo: a client subscribed to another thread received `thread.checkoutChanged` after `git.createBranch`.
- `bun run verify`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784974711&installation_id=129163861&pr_number=812&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F812&signature=cd4ba63f091b94a3a92c9668ef4d92b1c0390815a5a83f02feb26dbc9bb70e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creating a branch for a thread now also sends a thread checkout update to connected clients, keeping thread state in sync across views.
  * Thread-related push events now follow subscription-aware delivery rules more consistently, improving who receives updates.

* **Bug Fixes**
  * Improved routing so checkout changes are delivered with the correct thread details, including branch and pull request status information.
  * Expanded test coverage to better verify websocket update delivery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->