### PR TITLE
feat: add overview recap section

### DIFF
--- a/apps/web/e2e/overview-sources-demo.spec.ts
+++ b/apps/web/e2e/overview-sources-demo.spec.ts
@@ -88,14 +88,29 @@ const assistantMessage = {
   sequence: 2,
 };
 
+const followUpMessage = {
+  ...baseMsg,
+  id: "user-follow-up-demo",
+  role: "user" as const,
+  content: "Great, show that in the Overview too.",
+  sequence: 3,
+};
+
 test.use({ viewport: { width: 1920, height: 1080 } });
 
 test("Overview sources + humanized links demo", async ({ page }) => {
+  const recapText =
+    "Checking SVG alternatives and wiring the Overview surface so the team can compare options without reopening the transcript.";
+  let resolveRecap!: (value: { text: string }) => void;
+  const recapResult = new Promise<{ text: string }>((resolve) => {
+    resolveRecap = resolve;
+  });
+
   await mockWebSocketServer(page, {
     "workspace.list": [workspace],
     "thread.list": [thread],
     "conversation.page": {
-      messages: [userMessage, assistantMessage],
+      messages: [userMessage, assistantMessage, followUpMessage],
       hasMore: false,
       answeredPlanMessageIds: [],
       narrativeByMessage: {},
@@ -115,6 +130,7 @@ test("Overview sources + humanized links demo", async ({ page }) => {
       webUrl: "https://github.com/milex-consulting/CaravanFE",
     },
     "git.workingTreeFiles": [],
+    "recap.generate": () => recapResult,
   });
 
   await page.addInitScript((wsId: string) => {
@@ -130,10 +146,37 @@ test("Overview sources + humanized links demo", async ({ page }) => {
   await expect(page.getByTestId("markdown-link-file-icon")).toBeVisible();
   await page.screenshot({ path: "e2e/screenshots/demo/transcript-humanized-links.png", fullPage: false });
 
-  // Wide viewport: the Overview opens by default and shows repo + Sources.
+  // Wide viewport: the Overview opens by default and shows repo, Sources, and the closing Recap.
   await expect(page.getByTestId("thread-overview-body")).toBeVisible();
+  await expect(page.getByTestId("thread-overview-recap")).toBeVisible();
+  await expect(page.getByTestId("thread-overview-recap-skeleton")).toBeVisible();
+  await expect(page.getByTestId("thread-overview-recap-refresh")).toBeDisabled();
+  const refreshIconClass = await page
+    .getByTestId("thread-overview-recap-refresh")
+    .locator("svg")
+    .getAttribute("class");
+  expect(refreshIconClass ?? "").not.toContain("animate-spin");
+  await page.screenshot({ path: "e2e/screenshots/demo/overview-recap-skeleton.png", fullPage: false });
+  resolveRecap({ text: recapText });
+  await expect(page.getByTestId("thread-overview-recap-text")).toContainText("Checking SVG alternatives");
+  await expect(page.getByTestId("thread-overview-recap-skeleton")).toHaveCount(0);
+  const recapTextStyles = await page.getByTestId("thread-overview-recap-text").evaluate((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      textOverflow: styles.textOverflow,
+      whiteSpace: styles.whiteSpace,
+    };
+  });
+  expect(recapTextStyles).toEqual({ textOverflow: "clip", whiteSpace: "normal" });
   await expect(page.getByTestId("thread-overview-repository")).toBeVisible();
   await expect(page.getByTestId("thread-overview-sources")).toBeVisible();
+  const recapFollowsSources = await page.evaluate(() => {
+    const sources = document.querySelector('[data-testid="thread-overview-sources"]');
+    const recap = document.querySelector('[data-testid="thread-overview-recap"]');
+    if (!sources || !recap) return false;
+    return Boolean(sources.compareDocumentPosition(recap) & Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+  expect(recapFollowsSources).toBe(true);
   const sourceCount = await page.getByTestId("thread-overview-source").count();
   expect(sourceCount).toBeGreaterThanOrEqual(5);
   await page.screenshot({ path: "e2e/screenshots/demo/overview-auto-open-sources.png", fullPage: false });

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -207,6 +207,7 @@ export const mockTransport: McodeTransport = {
     model: "mock-model",
     createdAt: new Date().toISOString(),
   }),
+  generateRecap: vi.fn().mockResolvedValue({ text: "Mock recap" }),
   readLatestHandoff: vi.fn().mockResolvedValue(null),
 };
 

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -13,6 +13,7 @@ import {
   Loader2,
   Menu,
   Plus,
+  RefreshCw,
   Search,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -39,6 +40,7 @@ import { PrSplitButton } from "./PrSplitButton";
 import { ChecksPopover } from "./ChecksPopover";
 import { CreatePrDialog } from "./CreatePrDialog";
 import { useThreadGitActions } from "@/hooks/useThreadGitActions";
+import { useThreadRecap } from "@/hooks/useThreadRecap";
 import { useDiffStore } from "@/stores/diffStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useThreadRecord } from "@/stores/thread-selectors";
@@ -576,6 +578,84 @@ function ThreadOverviewRepositoryRow({
           </Button>
         </div>
       </div>
+    </div>
+  );
+}
+
+interface ThreadOverviewRecapRowProps {
+  recapText: string | null;
+  isGenerating: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}
+
+function ThreadOverviewRecapRow({
+  recapText,
+  isGenerating,
+  error,
+  onRefresh,
+}: ThreadOverviewRecapRowProps) {
+  const label = recapText ?? (error ? "Recap unavailable" : "Generate recap");
+  const refreshLabel = isGenerating ? "Refreshing recap" : "Refresh recap";
+
+  return (
+    <div
+      data-testid="thread-overview-recap"
+      className="w-full px-2.5 py-2.5"
+    >
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <span className="shrink-0 text-xs font-medium text-muted-foreground">Recap</span>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                type="button"
+                data-testid="thread-overview-recap-refresh"
+                aria-label={refreshLabel}
+                disabled={isGenerating}
+                onClick={onRefresh}
+                className={cn("-mr-1 shrink-0", isGenerating && "text-muted-foreground/45")}
+              >
+                <RefreshCw size={13} aria-hidden />
+              </Button>
+            }
+          />
+          <TooltipContent>{refreshLabel}</TooltipContent>
+        </Tooltip>
+      </div>
+      {isGenerating ? (
+        <div
+          data-testid="thread-overview-recap-skeleton"
+          role="status"
+          aria-label={refreshLabel}
+          className="mt-2 flex w-full flex-col gap-1.5"
+        >
+          <span className="sr-only">{refreshLabel}</span>
+          {[0, 1, 2].map((i) => (
+            <span
+              key={i}
+              aria-hidden
+              className="h-2.5 rounded-full bg-muted/80 animate-[plan-fade_1.8s_ease-in-out_infinite]"
+              style={{
+                width: `${[88, 76, 48][i]}%`,
+                animationDelay: `${i * 0.16}s`,
+              }}
+            />
+          ))}
+        </div>
+      ) : (
+        <p
+          data-testid="thread-overview-recap-text"
+          className={cn(
+            "mt-2 max-w-[26rem] whitespace-normal break-words text-xs leading-[1.45]",
+            recapText ? "text-foreground/85" : "text-muted-foreground",
+          )}
+        >
+          {label}
+        </p>
+      )}
     </div>
   );
 }
@@ -1490,6 +1570,11 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
   const sourceMessages = useThreadStore((s) =>
     open ? (s.records.get(thread.id)?.messages ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
   );
+  const threadRecap = useThreadRecap({
+    threadId: thread.id,
+    messages: sourceMessages,
+    overviewOpen: open,
+  });
   const sources = useMemo(
     () => (open ? extractThreadSources(sourceMessages) : []),
     [open, sourceMessages],
@@ -1706,6 +1791,14 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                 <ThreadOverviewSources sources={sources} onOpen={openSource} />
               </>
             )}
+
+            <Separator className="my-1.5" />
+            <ThreadOverviewRecapRow
+              recapText={threadRecap.recapText}
+              isGenerating={threadRecap.isGenerating}
+              error={threadRecap.error}
+              onRefresh={() => void threadRecap.refresh()}
+            />
     </div>
   );
 

--- a/apps/web/src/hooks/useThreadRecap.test.tsx
+++ b/apps/web/src/hooks/useThreadRecap.test.tsx
@@ -1,0 +1,338 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockMessage, mockTransport } from "@/__tests__/mocks/transport";
+import { createEmptyThreadRecord } from "@/stores/thread-record";
+import { useThreadStore } from "@/stores/threadStore";
+import {
+  buildThreadRecapPayload,
+  createThreadRecapSignature,
+  filterThreadRecapMessages,
+  resetThreadRecapRequestStateForTest,
+  shouldScheduleThreadRecapGeneration,
+  useThreadRecap,
+  type ThreadRecapMessage,
+} from "./useThreadRecap";
+
+vi.mock("@/transport", async () => ({
+  getTransport: () => mockTransport,
+}));
+
+const THREAD_ID = "thread-recap";
+const NOW = Date.parse("2026-06-25T12:00:00.000Z");
+const OLD = "2000-01-01T00:00:00.000Z";
+const FRESH = new Date(NOW - 60 * 1000).toISOString();
+
+function recapMessage(
+  id: string,
+  sequence: number,
+  role: "user" | "assistant",
+  content = `${role} ${sequence}`,
+  timestamp = OLD,
+): ThreadRecapMessage {
+  return { id, sequence, role, content, timestamp };
+}
+
+const enoughMessages = [
+  recapMessage("u1", 1, "user"),
+  recapMessage("a2", 2, "assistant"),
+  recapMessage("u3", 3, "user"),
+];
+
+function hookMessages(timestamp = OLD) {
+  return [
+    createMockMessage({
+      id: "u1",
+      thread_id: THREAD_ID,
+      role: "user",
+      content: "We need a compact recap.",
+      sequence: 1,
+      timestamp,
+    }),
+    createMockMessage({
+      id: "a2",
+      thread_id: THREAD_ID,
+      role: "assistant",
+      content: "I checked the design and cache shape.",
+      sequence: 2,
+      timestamp,
+    }),
+    createMockMessage({
+      id: "u3",
+      thread_id: THREAD_ID,
+      role: "user",
+      content: "Wire it into Overview.",
+      sequence: 3,
+      timestamp,
+    }),
+  ];
+}
+
+describe("thread recap scheduling", () => {
+  it("allows stale idle threads with enough changed conversation", () => {
+    const signature = createThreadRecapSignature(enoughMessages);
+    expect(
+      shouldScheduleThreadRecapGeneration({
+        messages: enoughMessages,
+        cached: undefined,
+        isRunning: false,
+        now: NOW,
+        signature,
+        autoCapReached: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks short, running, fresh, cached, in-flight, failed, and capped auto requests", () => {
+    const signature = createThreadRecapSignature(enoughMessages);
+    const cached = {
+      text: "cached",
+      signature,
+      coveredMessageId: "u3",
+      generatedAt: new Date(NOW).toISOString(),
+    };
+    const base = {
+      messages: enoughMessages,
+      cached: undefined,
+      isRunning: false,
+      now: NOW,
+      signature,
+      autoCapReached: false,
+    };
+
+    expect(shouldScheduleThreadRecapGeneration({ ...base, messages: enoughMessages.slice(0, 2) })).toBe(false);
+    expect(shouldScheduleThreadRecapGeneration({ ...base, isRunning: true })).toBe(false);
+    expect(
+      shouldScheduleThreadRecapGeneration({
+        ...base,
+        messages: enoughMessages.map((message, index) => (
+          index === 2 ? { ...message, timestamp: FRESH } : message
+        )),
+      }),
+    ).toBe(false);
+    expect(shouldScheduleThreadRecapGeneration({ ...base, cached })).toBe(false);
+    expect(
+      shouldScheduleThreadRecapGeneration({
+        ...base,
+        inFlight: { threadId: THREAD_ID, signature },
+      }),
+    ).toBe(false);
+    expect(
+      shouldScheduleThreadRecapGeneration({
+        ...base,
+        lastFailed: { threadId: THREAD_ID, signature },
+      }),
+    ).toBe(false);
+    expect(shouldScheduleThreadRecapGeneration({ ...base, autoCapReached: true })).toBe(false);
+  });
+});
+
+describe("thread recap signatures and payloads", () => {
+  it("ignores tool, work-log, system, and internal message noise", () => {
+    const withNoise = [
+      createMockMessage({ id: "system", role: "system", content: "Context compacted", sequence: 0 }),
+      createMockMessage({ id: "u1", role: "user", content: "Build recap", sequence: 1 }),
+      createMockMessage({ id: "tool", role: "assistant", content: "tool output", sequence: 2, is_internal: true }),
+      createMockMessage({ id: "a3", role: "assistant", content: "Done", sequence: 3 }),
+    ];
+    const withoutNoise = [
+      createMockMessage({ id: "u1", role: "user", content: "Build recap", sequence: 1 }),
+      createMockMessage({ id: "a3", role: "assistant", content: "Done", sequence: 3 }),
+    ];
+
+    expect(createThreadRecapSignature(filterThreadRecapMessages(withNoise))).toBe(
+      createThreadRecapSignature(filterThreadRecapMessages(withoutNoise)),
+    );
+  });
+
+  it("changes the signature when user or assistant content changes", () => {
+    const first = createThreadRecapSignature([
+      recapMessage("u1", 1, "user", "Build recap"),
+      recapMessage("a2", 2, "assistant", "Done"),
+    ]);
+    const second = createThreadRecapSignature([
+      recapMessage("u1", 1, "user", "Build better recap"),
+      recapMessage("a2", 2, "assistant", "Done"),
+    ]);
+
+    expect(second).not.toBe(first);
+  });
+
+  it("bounds first payloads and later delta payloads", () => {
+    const messages = Array.from({ length: 8 }, (_, index) =>
+      recapMessage(
+        `m${index + 1}`,
+        index + 1,
+        index % 2 === 0 ? "user" : "assistant",
+        "x".repeat(700),
+      ),
+    );
+    const first = buildThreadRecapPayload(messages, undefined);
+    expect(first.messages).toHaveLength(6);
+    expect(first.messages.every((message) => message.content.length === 600)).toBe(true);
+    expect(first.previousRecap).toBeNull();
+    expect(first.coveredMessageId).toBe("m8");
+
+    const later = buildThreadRecapPayload(messages, {
+      text: "previous recap",
+      signature: "old",
+      coveredMessageId: "m3",
+      generatedAt: new Date(NOW).toISOString(),
+    });
+    expect(later.messages.map((message) => message.id)).toEqual(["m5", "m6", "m7", "m8"]);
+    expect(later.previousRecap).toBe("previous recap");
+  });
+});
+
+describe("useThreadRecap", () => {
+  beforeEach(() => {
+    resetThreadRecapRequestStateForTest();
+    vi.mocked(mockTransport.generateRecap).mockReset();
+    vi.mocked(mockTransport.generateRecap).mockResolvedValue({ text: "Fresh recap" });
+    useThreadStore.setState({
+      recapByThread: {},
+      runningThreadIds: new Set(),
+    });
+  });
+
+  it("manual refresh bypasses fresh and same-signature cache gates", async () => {
+    const messages = hookMessages(FRESH);
+    const signature = createThreadRecapSignature(filterThreadRecapMessages(messages));
+    useThreadStore.getState().recordThreadRecapGeneration({
+      threadId: THREAD_ID,
+      text: "Cached recap",
+      signature,
+      coveredMessageId: "u3",
+      generatedAt: new Date(NOW).toISOString(),
+      source: "automatic",
+    });
+
+    const { result } = renderHook(() =>
+      useThreadRecap({ threadId: THREAD_ID, messages, overviewOpen: false }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockTransport.generateRecap).toHaveBeenCalledTimes(1);
+    expect(useThreadStore.getState().recapByThread[THREAD_ID]?.text).toBe("Fresh recap");
+  });
+
+  it("manual refresh dedupes a matching in-flight request", async () => {
+    let resolveRpc!: (value: { text: string }) => void;
+    vi.mocked(mockTransport.generateRecap).mockReturnValue(
+      new Promise((resolve) => {
+        resolveRpc = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useThreadRecap({ threadId: THREAD_ID, messages: hookMessages(), overviewOpen: false }),
+    );
+
+    await act(async () => {
+      const first = result.current.refresh();
+      const second = result.current.refresh();
+      resolveRpc({ text: "Deduped recap" });
+      await Promise.all([first, second]);
+    });
+
+    await waitFor(() => {
+      expect(mockTransport.generateRecap).toHaveBeenCalledTimes(1);
+    });
+    expect(useThreadStore.getState().recapByThread[THREAD_ID]?.text).toBe("Deduped recap");
+  });
+
+  it("runs automatic generation when the Overview opens from closed and gates pass", async () => {
+    const messages = hookMessages();
+    const { rerender } = renderHook(
+      ({ overviewOpen }) =>
+        useThreadRecap({ threadId: THREAD_ID, messages, overviewOpen }),
+      { initialProps: { overviewOpen: false } },
+    );
+
+    rerender({ overviewOpen: true });
+
+    await waitFor(() => {
+      expect(mockTransport.generateRecap).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("runs automatic generation on initial mount when the Overview is already open", async () => {
+    renderHook(() =>
+      useThreadRecap({ threadId: THREAD_ID, messages: hookMessages(), overviewOpen: true }),
+    );
+
+    await waitFor(() => {
+      expect(mockTransport.generateRecap).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("waits for eligible messages after initial mount when the Overview is already open", async () => {
+    const messages = hookMessages();
+    const noMessages: ReturnType<typeof hookMessages> = [];
+    const { rerender } = renderHook(
+      ({ messages }) =>
+        useThreadRecap({ threadId: THREAD_ID, messages, overviewOpen: true }),
+      { initialProps: { messages: noMessages } },
+    );
+
+    rerender({ messages });
+
+    await waitFor(() => {
+      expect(mockTransport.generateRecap).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not run automatic generation for same-thread message rerenders while Overview stays open", async () => {
+    const initialMessages = hookMessages();
+    const { rerender } = renderHook(
+      ({ messages, overviewOpen }) =>
+        useThreadRecap({ threadId: THREAD_ID, messages, overviewOpen }),
+      { initialProps: { messages: initialMessages, overviewOpen: false } },
+    );
+
+    rerender({ messages: initialMessages, overviewOpen: true });
+    await waitFor(() => {
+      expect(mockTransport.generateRecap).toHaveBeenCalledTimes(1);
+    });
+    vi.mocked(mockTransport.generateRecap).mockClear();
+
+    const staleChangedMessages = [
+      ...hookMessages(),
+      createMockMessage({
+        id: "a4",
+        thread_id: THREAD_ID,
+        role: "assistant",
+        content: "A stale appended message should not be a trigger.",
+        sequence: 4,
+        timestamp: OLD,
+      }),
+    ];
+
+    rerender({ messages: staleChangedMessages, overviewOpen: true });
+
+    await waitFor(() => {
+      expect(mockTransport.generateRecap).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it("runs automatic generation when focus returns and gates pass", async () => {
+    const messages = hookMessages();
+    useThreadStore.setState({
+      records: new Map([[THREAD_ID, { ...createEmptyThreadRecord(), messages }]]),
+    });
+
+    renderHook(() =>
+      useThreadRecap({ threadId: THREAD_ID, messages, overviewOpen: false }),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() => {
+      expect(mockTransport.generateRecap).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/hooks/useThreadRecap.ts
+++ b/apps/web/src/hooks/useThreadRecap.ts
@@ -1,0 +1,378 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getTransport } from "@/transport";
+import type { Message } from "@/transport";
+import { useThreadStore, type ThreadRecapCacheEntry } from "@/stores/threadStore";
+
+const STALE_RECAP_MS = 5 * 60 * 1000;
+const MIN_FILTERED_MESSAGES = 3;
+const FIRST_RECAP_MESSAGE_LIMIT = 6;
+const DELTA_RECAP_MESSAGE_LIMIT = 4;
+const RECAP_MESSAGE_CONTENT_LIMIT = 600;
+
+type ThreadRecapSource = "manual" | "automatic";
+
+/** A persisted user or assistant message that can influence a thread Recap. */
+export interface ThreadRecapMessage {
+  /** Stable persisted message id. */
+  id: string;
+  /** Thread-local ordering used to make signatures deterministic. */
+  sequence: number;
+  /** Conversational role accepted by the recap RPC. */
+  role: "user" | "assistant";
+  /** Message body used for signature and bounded generation payloads. */
+  content: string;
+  /** Persisted timestamp used to determine whether the thread is stale. */
+  timestamp: string;
+}
+
+/** In-flight or failed Recap request marker used by the scheduler. */
+export interface ThreadRecapRequestMarker {
+  /** Thread whose recap request is being tracked. */
+  threadId: string;
+  /** Deterministic signature for the filtered messages. */
+  signature: string;
+}
+
+/** Inputs for deciding whether an automatic Recap generation should run. */
+export interface ThreadRecapScheduleInput {
+  /** Filtered persisted user and assistant messages. */
+  messages: readonly ThreadRecapMessage[];
+  /** Existing session-only cache entry for the thread, if any. */
+  cached: ThreadRecapCacheEntry | undefined;
+  /** Whether an agent turn is currently running for the thread. */
+  isRunning: boolean;
+  /** Current wall-clock time in milliseconds. */
+  now: number;
+  /** Stale threshold in milliseconds. */
+  staleMs?: number;
+  /** Current deterministic message signature. */
+  signature: string;
+  /** In-flight request marker to dedupe against. */
+  inFlight?: ThreadRecapRequestMarker;
+  /** Last failed automatic request marker. */
+  lastFailed?: ThreadRecapRequestMarker;
+  /** Whether this thread/signature already used its automatic session cap. */
+  autoCapReached: boolean;
+}
+
+/** Result returned by {@link useThreadRecap}. */
+export interface UseThreadRecapResult {
+  /** Current session-cached recap text, if one exists. */
+  recapText: string | null;
+  /** Whether generation is currently in flight for this thread/signature. */
+  isGenerating: boolean;
+  /** Last manual or automatic generation failure for the current thread. */
+  error: string | null;
+  /** Request a manual recap refresh, deduping only matching in-flight work. */
+  refresh: () => Promise<void>;
+}
+
+const inFlightRequests = new Map<string, Promise<void>>();
+const lastFailedByThread = new Map<string, ThreadRecapRequestMarker>();
+const automaticRequests = new Set<string>();
+
+/** Clears module-level Recap request guards for isolated unit tests. */
+export function resetThreadRecapRequestStateForTest(): void {
+  inFlightRequests.clear();
+  lastFailedByThread.clear();
+  automaticRequests.clear();
+}
+
+function requestKey(threadId: string, signature: string): string {
+  return `${threadId}:${signature}`;
+}
+
+function getThreadStoreState(): ReturnType<typeof useThreadStore.getState> | null {
+  const store = useThreadStore as typeof useThreadStore & {
+    getState?: typeof useThreadStore.getState;
+  };
+  return typeof store.getState === "function" ? store.getState() : null;
+}
+
+function clipContent(content: string): string {
+  return content.length > RECAP_MESSAGE_CONTENT_LIMIT
+    ? content.slice(0, RECAP_MESSAGE_CONTENT_LIMIT)
+    : content;
+}
+
+/**
+ * Returns only persisted user and assistant messages that can affect a Recap.
+ */
+export function filterThreadRecapMessages(messages: readonly Message[]): ThreadRecapMessage[] {
+  return messages
+    .filter((message): message is Message & { role: "user" | "assistant" } =>
+      (message.role === "user" || message.role === "assistant") &&
+      message.is_internal !== true &&
+      typeof message.id === "string" &&
+      Number.isFinite(message.sequence) &&
+      typeof message.content === "string",
+    )
+    .map((message) => ({
+      id: message.id,
+      sequence: message.sequence,
+      role: message.role,
+      content: message.content,
+      timestamp: message.timestamp,
+    }))
+    .sort((a, b) => a.sequence - b.sequence);
+}
+
+/**
+ * Builds a deterministic Recap signature from message identity and content only.
+ */
+export function createThreadRecapSignature(messages: readonly ThreadRecapMessage[]): string {
+  let hash = 2166136261;
+  const update = (text: string) => {
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+  };
+
+  for (const message of messages) {
+    update(message.id);
+    update("\u001f");
+    update(String(message.sequence));
+    update("\u001f");
+    update(message.role);
+    update("\u001f");
+    update(message.content);
+    update("\u001e");
+  }
+
+  return hash.toString(36);
+}
+
+/**
+ * Returns whether the filtered conversation has enough substance for auto Recap.
+ */
+export function hasEnoughThreadRecapSubstance(
+  messages: readonly ThreadRecapMessage[],
+): boolean {
+  return (
+    messages.length >= MIN_FILTERED_MESSAGES &&
+    messages.some((message) => message.role === "assistant")
+  );
+}
+
+/**
+ * Decides whether an automatic Recap generation should be scheduled.
+ */
+export function shouldScheduleThreadRecapGeneration(input: ThreadRecapScheduleInput): boolean {
+  const staleMs = input.staleMs ?? STALE_RECAP_MS;
+  if (input.isRunning) return false;
+  if (input.autoCapReached) return false;
+  if (!hasEnoughThreadRecapSubstance(input.messages)) return false;
+
+  const lastMessage = input.messages.at(-1);
+  if (!lastMessage) return false;
+  const lastMessageTime = Date.parse(lastMessage.timestamp);
+  if (!Number.isFinite(lastMessageTime)) return false;
+  if (input.now - lastMessageTime < staleMs) return false;
+
+  if (input.cached?.signature === input.signature) return false;
+  if (input.inFlight?.signature === input.signature) return false;
+  if (input.lastFailed?.signature === input.signature) return false;
+
+  return true;
+}
+
+/**
+ * Selects the bounded message payload for the recap RPC.
+ */
+export function buildThreadRecapPayload(
+  messages: readonly ThreadRecapMessage[],
+  cached: ThreadRecapCacheEntry | undefined,
+): {
+  messages: Array<{ id: string; role: "user" | "assistant"; content: string }>;
+  previousRecap: string | null;
+  coveredMessageId: string | null;
+} {
+  const selected = (() => {
+    if (!cached) return messages.slice(-FIRST_RECAP_MESSAGE_LIMIT);
+    const coveredIndex = messages.findIndex((message) => message.id === cached.coveredMessageId);
+    const delta = coveredIndex >= 0 ? messages.slice(coveredIndex + 1) : messages;
+    if (delta.length > 0) return delta.slice(-DELTA_RECAP_MESSAGE_LIMIT);
+    return messages.slice(-1);
+  })();
+  const last = selected.at(-1);
+
+  return {
+    messages: selected.map((message) => ({
+      id: message.id,
+      role: message.role,
+      content: clipContent(message.content),
+    })),
+    previousRecap: cached?.text ?? null,
+    coveredMessageId: last?.id ?? null,
+  };
+}
+
+/**
+ * Generates and caches a thread Recap on manual refresh or stale re-orientation.
+ */
+export function useThreadRecap({
+  threadId,
+  messages,
+  overviewOpen,
+}: {
+  /** Thread whose Recap should be managed. */
+  threadId: string;
+  /** Persisted messages available to the Overview. */
+  messages: readonly Message[];
+  /** Whether the Overview is open, used as a re-orientation signal. */
+  overviewOpen: boolean;
+}): UseThreadRecapResult {
+  const filteredMessages = useMemo(() => filterThreadRecapMessages(messages), [messages]);
+  const signature = useMemo(
+    () => createThreadRecapSignature(filteredMessages),
+    [filteredMessages],
+  );
+  const cached = useThreadStore((state) => state.recapByThread?.[threadId]);
+  const recordThreadRecapGeneration = useThreadStore((state) => state.recordThreadRecapGeneration);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const latestStateRef = useRef({
+    threadId,
+    cached,
+    filteredMessages,
+    recordThreadRecapGeneration,
+  });
+  latestStateRef.current = {
+    threadId,
+    cached,
+    filteredMessages,
+    recordThreadRecapGeneration,
+  };
+
+  const generate = useCallback(async (
+    source: ThreadRecapSource,
+    messageOverride?: readonly Message[],
+  ) => {
+    const {
+      threadId: currentThreadId,
+      cached: renderCached,
+      filteredMessages: renderFilteredMessages,
+      recordThreadRecapGeneration: recordGeneration,
+    } = latestStateRef.current;
+    const storeState = getThreadStoreState();
+    const currentCached = storeState?.recapByThread?.[currentThreadId] ?? renderCached;
+    const recapMessages = messageOverride
+      ? filterThreadRecapMessages(messageOverride)
+      : renderFilteredMessages;
+    const currentSignature = createThreadRecapSignature(recapMessages);
+    const key = requestKey(currentThreadId, currentSignature);
+    const existing = inFlightRequests.get(key);
+    if (existing) {
+      setIsGenerating(true);
+      await existing.finally(() => setIsGenerating(false));
+      return;
+    }
+
+    if (source === "automatic") {
+      const marker = { threadId: currentThreadId, signature: currentSignature };
+      const shouldRun = shouldScheduleThreadRecapGeneration({
+        messages: recapMessages,
+        cached: currentCached,
+        isRunning: storeState?.runningThreadIds?.has(currentThreadId) ?? false,
+        now: Date.now(),
+        signature: currentSignature,
+        inFlight: inFlightRequests.has(key) ? marker : undefined,
+        lastFailed: lastFailedByThread.get(currentThreadId),
+        autoCapReached: automaticRequests.has(key),
+      });
+      if (!shouldRun) return;
+      automaticRequests.add(key);
+    }
+
+    const payload = buildThreadRecapPayload(recapMessages, currentCached);
+    if (!payload.coveredMessageId || payload.messages.length === 0) return;
+
+    setIsGenerating(true);
+    setError(null);
+
+    const promise = getTransport()
+      .generateRecap(
+        currentThreadId,
+        payload.messages.map(({ role, content }) => ({ role, content })),
+        payload.previousRecap,
+      )
+      .then((result) => {
+        recordGeneration({
+          threadId: currentThreadId,
+          text: result.text,
+          signature: currentSignature,
+          coveredMessageId: payload.coveredMessageId!,
+          generatedAt: new Date().toISOString(),
+          source,
+        });
+        if (lastFailedByThread.get(currentThreadId)?.signature === currentSignature) {
+          lastFailedByThread.delete(currentThreadId);
+        }
+      })
+      .catch((err: unknown) => {
+        lastFailedByThread.set(currentThreadId, {
+          threadId: currentThreadId,
+          signature: currentSignature,
+        });
+        setError(err instanceof Error ? err.message : "Recap unavailable");
+      })
+      .finally(() => {
+        inFlightRequests.delete(key);
+        setIsGenerating(false);
+      });
+
+    inFlightRequests.set(key, promise);
+    await promise;
+  }, []);
+
+  const overviewOpenAutoAttemptedRef = useRef(false);
+  useEffect(() => {
+    if (!overviewOpen) {
+      overviewOpenAutoAttemptedRef.current = false;
+      return;
+    }
+    if (overviewOpenAutoAttemptedRef.current) return;
+
+    const storeState = getThreadStoreState();
+    const key = requestKey(threadId, signature);
+    const shouldRun = shouldScheduleThreadRecapGeneration({
+      messages: filteredMessages,
+      cached: storeState?.recapByThread?.[threadId] ?? cached,
+      isRunning: storeState?.runningThreadIds?.has(threadId) ?? false,
+      now: Date.now(),
+      signature,
+      inFlight: inFlightRequests.has(key) ? { threadId, signature } : undefined,
+      lastFailed: lastFailedByThread.get(threadId),
+      autoCapReached: automaticRequests.has(key),
+    });
+    if (!shouldRun) return;
+
+    overviewOpenAutoAttemptedRef.current = true;
+    void generate("automatic");
+  }, [cached, filteredMessages, generate, overviewOpen, signature, threadId]);
+
+  useEffect(() => {
+    const onFocus = () => {
+      const latestMessages = getThreadStoreState()?.records.get(threadId)?.messages ?? [];
+      void generate("automatic", latestMessages);
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [generate, threadId]);
+
+  const previousThreadIdRef = useRef(threadId);
+  useEffect(() => {
+    if (previousThreadIdRef.current === threadId) return;
+    previousThreadIdRef.current = threadId;
+    const latestMessages = getThreadStoreState()?.records.get(threadId)?.messages ?? [];
+    void generate("automatic", latestMessages);
+  }, [generate, threadId]);
+
+  return {
+    recapText: cached?.text ?? null,
+    isGenerating,
+    error,
+    refresh: useCallback(() => generate("manual"), [generate]),
+  };
+}

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -508,6 +508,12 @@ export interface McodeTransport {
     model: string;
     createdAt: string;
   }>;
+  /** Generate a stateless one-line conversational recap from bounded messages. */
+  generateRecap(
+    threadId: string,
+    messages: Array<{ role: "user" | "assistant"; content: string }>,
+    previousRecap: string | null,
+  ): Promise<{ text: string }>;
 
   // Memory pressure
   /** Notify server of window background/foreground state for memory management. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -836,6 +836,8 @@ export function createWsTransport(
         model: string;
         createdAt: string;
       }>("diffSummary.generate", { threadId }),
+    generateRecap: (threadId, messages, previousRecap) =>
+      rpc<{ text: string }>("recap.generate", { threadId, messages, previousRecap }),
 
     readLatestHandoff: (threadId: string) =>
       rpc<{


### PR DESCRIPTION
## What
Adds a Recap section to the thread Overview panel. It appears after Sources and shows a generated summary for eligible threads or manual refreshes.

## Why
Issue #770 asks for a compact recap in Overview so users can re-orient without rereading the transcript.

## Key Changes
- Added `useThreadRecap` to filter, sign, cap, dedupe, and cache recap requests.
- Wired web transport to `recap.generate` and rendered Recap at the bottom of Overview.
- Replaced loading status pills with skeleton loading, a static refresh icon, and wrapping text.
- Covered hook behavior and the Overview demo flow with unit and Playwright assertions.

Closes #770

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784994570&installation_id=129163861&pr_number=815&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F815&signature=952eaf77fd50cc6987c53299592adc44f8098503b62b08de1a2d4ed2ee9441c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Recap** section in the thread Overview, showing a short summary of the conversation.
  * Recaps can refresh manually and display a loading state while being generated.
  * Overview now opens with recap content available on larger screens and updates automatically as new messages arrive or when the view regains focus.

* **Bug Fixes**
  * Improved recap placement and rendering so it appears in the expected order alongside Sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->