### PR TITLE
fix: stabilize terminal thread lifecycle

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,6 +27,7 @@
     "@mcode/shared": "workspace:*",
     "better-sqlite3": "^12.0.0",
     "electron-updater": "^6.8.3",
+    "koffi": "^2.16.1",
     "node-pty": "^1.0.0",
     "uuid": "^11.1.0",
     "which": "^5.0.0"
@@ -60,6 +61,7 @@
       "dist/**/*",
       "package.json",
       "node_modules/better-sqlite3/**/*",
+      "node_modules/koffi/**/*",
       "node_modules/node-pty/**/*"
     ],
     "extraResources": [
@@ -75,6 +77,7 @@
     "asarUnpack": [
       "dist/server/**",
       "node_modules/better-sqlite3/**",
+      "node_modules/koffi/**",
       "node_modules/node-pty/**"
     ],
     "publish": {

--- a/apps/desktop/scripts/ci-package.mjs
+++ b/apps/desktop/scripts/ci-package.mjs
@@ -5,7 +5,7 @@
  *  1. electron-builder detects bun from PATH/lockfile and incorrectly invokes
  *     it via Node.js. We strip bun directories from PATH so it falls back to npm.
  *  2. npm does not support bun's workspace:* protocol. We strip workspace:*
- *     references but keep real-versioned deps (better-sqlite3, node-pty) so
+ *     references but keep real-versioned deps (better-sqlite3, koffi, node-pty) so
  *     electron-builder can install and rebuild the native bindings for the
  *     target platform.
  *  3. bun hoists native deps to sibling workspaces. We run `npm install` to
@@ -26,7 +26,7 @@ const pkgPath = resolve(desktopRoot, "package.json");
 
 // ---------------------------------------------------------------------------
 // 1. Strip workspace:* deps — npm cannot install them. Keep real-versioned
-//    deps (better-sqlite3, node-pty) so npm installs and electron-builder
+//    deps (better-sqlite3, koffi, node-pty) so npm installs and electron-builder
 //    rebuilds their native bindings. All other server JS is bundled in server.cjs.
 // ---------------------------------------------------------------------------
 

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -7,7 +7,7 @@
  * exits 0 on success, 1 on failure.
  *
  * This catches:
- * - Missing native modules (better-sqlite3, node-pty)
+ * - Missing native modules (better-sqlite3, koffi, node-pty)
  * - Broken asarUnpack configuration
  * - Server startup crashes invisible in the packaged app
  * - Import/require resolution failures in the CJS bundle
@@ -52,6 +52,7 @@ function findUnpackedServer() {
       renamedBinary: resolve(releaseDir, "win-unpacked/resources/bin/mcode-server.exe"),
       electron: resolve(releaseDir, "win-unpacked/Mcode.exe"),
       sqlite: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
+      koffi: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/koffi"),
     },
     // Linux (electron-builder uses package name as binary name)
     {
@@ -59,6 +60,7 @@ function findUnpackedServer() {
       renamedBinary: resolve(releaseDir, "linux-unpacked/resources/bin/mcode-server"),
       electron: resolve(releaseDir, "linux-unpacked/mcode-desktop"),
       sqlite: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
+      koffi: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/koffi"),
     },
     // macOS Intel
     {
@@ -66,6 +68,7 @@ function findUnpackedServer() {
       renamedBinary: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/bin/mcode-server"),
       electron: resolve(releaseDir, "mac/Mcode.app/Contents/MacOS/Mcode"),
       sqlite: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
+      koffi: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/koffi"),
     },
     // macOS ARM
     {
@@ -73,6 +76,7 @@ function findUnpackedServer() {
       renamedBinary: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/bin/mcode-server"),
       electron: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/MacOS/Mcode"),
       sqlite: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
+      koffi: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/koffi"),
     },
   ];
 
@@ -89,7 +93,7 @@ function findUnpackedServer() {
       const nodeBinding = resolve(c.sqlite, "better_sqlite3.node");
       const binding = existsSync(electronBinding) ? electronBinding : existsSync(nodeBinding) ? nodeBinding : undefined;
       const electronDir = useRenamed ? dirname(c.electron) : undefined;
-      return { server: c.server, electron: runtime, binding, electronDir };
+      return { server: c.server, electron: runtime, binding, electronDir, koffi: c.koffi };
     }
   }
   return null;
@@ -149,6 +153,13 @@ if (found.binding) {
 }
 
 if (!bundleOnly) {
+  if (!found.koffi || !existsSync(found.koffi)) {
+    console.error(`[smoke-test] ERROR: koffi native module missing at ${found.koffi}`);
+    console.error("  package config should include node_modules/koffi in files and asarUnpack.");
+    process.exit(1);
+  }
+  console.log(`[smoke-test] koffi module: ${found.koffi}`);
+
   const sdkTarget = inferPackagedSdkTarget(found.server);
   const claudeCli = findClaudeSdkCliPath(found.server, sdkTarget.platform, sdkTarget.arch);
   if (!claudeCli) {

--- a/apps/web/e2e/terminal-remount-lifecycle.spec.ts
+++ b/apps/web/e2e/terminal-remount-lifecycle.spec.ts
@@ -119,6 +119,35 @@ async function openTerminalTab(
   );
 }
 
+/** Closes the right-panel terminal tab via store state. */
+async function closeTerminalTab(
+  page: import("@playwright/test").Page,
+  workspaceId: string,
+  threadId: string,
+): Promise<void> {
+  await page.evaluate(
+    ({ wid, tid }) => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const diffStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "closeRightPanelTab" in st;
+      });
+      if (!diffStore) return;
+      (diffStore as {
+        getState: () => {
+          closeRightPanelTab: (
+            id: string,
+            threadId: string | null,
+            tab: string,
+          ) => void;
+        };
+      }).getState().closeRightPanelTab(wid, tid, "terminal");
+    },
+    { wid: workspaceId, tid: threadId },
+  );
+}
+
 /**
  * Adds a terminal to the store for a thread. In the new model this registers
  * the shell session so TerminalPoolHost knows to mount a view for it.
@@ -266,9 +295,6 @@ test.describe("Terminal remount lifecycle (ADR-0010)", () => {
 
     // The module initialises the counter to 0 on load and increments on mount.
     const counter = await liveTerminalCounter(page);
-    // counter may still be null if the module hasn't loaded; that is the honest
-    // infra-gap skip preserved from terminal-leak.spec.ts.
-    test.skip(counter === null, "TerminalView module not loaded (mock infra gap)");
     expect(counter).toBe(1);
   });
 
@@ -390,13 +416,144 @@ test.describe("Terminal remount lifecycle (ADR-0010)", () => {
       expect(mountMs).toBeGreaterThanOrEqual(0);
     } else {
       // Timing hook not set (unlikely in dev mode). Fall back to the WS counter.
-      // skip if we cannot confirm either way (mock infra limitation).
-      test.skip(
-        state.reattachCalls === 0,
-        "terminal.reattach counter and timing hook both unavailable (mock infra gap)",
-      );
       expect(state.reattachCalls).toBeGreaterThanOrEqual(1);
     }
+  });
+
+  test("closing and reopening the terminal tab disposes only the view", async ({
+    page,
+  }) => {
+    const calls: {
+      reattach: Array<{ ptyId?: string; lastSeq?: number }>;
+      kill: number;
+      killByThread: number;
+    } = { reattach: [], kill: 0, killByThread: 0 };
+    let replaySeq = 0;
+
+    const wsController = await mockWebSocketServer(page, {
+      ...BASE_OVERRIDES,
+      "terminal.reattach": (params: unknown) => {
+        calls.reattach.push(params as { ptyId?: string; lastSeq?: number });
+        replaySeq += 1;
+        return { gapped: false };
+      },
+      "terminal.kill": () => {
+        calls.kill += 1;
+        return true;
+      },
+      "terminal.killByThread": () => {
+        calls.killByThread += 1;
+        return true;
+      },
+    });
+    await interceptZustandStores(page);
+    await page.setViewportSize({ width: 1920, height: 900 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __mcodeHydrationComplete?: boolean })
+          .__mcodeHydrationComplete === true,
+      { timeout: 30_000 },
+    );
+
+    await seedAndOpenTerminal(page, "thread-a", "pty-thread-a");
+    await expect(page.locator(".xterm").first()).toBeVisible({ timeout: 20_000 });
+
+    const originalPty = await page.evaluate(() => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const termStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "terminals" in st && "ptyToThread" in st;
+      }) as { getState: () => { terminals: Record<string, { id: string }[]> } };
+      return termStore.getState().terminals["thread-a"]?.[0]?.id ?? null;
+    });
+    expect(originalPty).toBe("pty-thread-a");
+
+    await page.evaluate(() => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const termStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "removeTerminal" in st && "removeAllTerminals" in st;
+      }) as {
+        getState: () => Record<string, unknown>;
+        setState: (patch: Record<string, unknown>) => void;
+      };
+      const state = termStore.getState();
+      const counters = { removeTerminal: 0, removeAllTerminals: 0 };
+      const removeTerminal = state.removeTerminal as (...args: unknown[]) => unknown;
+      const removeAllTerminals = state.removeAllTerminals as (...args: unknown[]) => unknown;
+      (window as unknown as { __mcodeTerminalCloseCounters?: typeof counters })
+        .__mcodeTerminalCloseCounters = counters;
+      termStore.setState({
+        removeTerminal: (...args: unknown[]) => {
+          counters.removeTerminal += 1;
+          return removeTerminal(...args);
+        },
+        removeAllTerminals: (...args: unknown[]) => {
+          counters.removeAllTerminals += 1;
+          return removeAllTerminals(...args);
+        },
+      });
+    });
+
+    await closeTerminalTab(page, WS_ID, "thread-a");
+    await expect(page.locator(".xterm")).toHaveCount(0, { timeout: 10_000 });
+    await expect(page.locator("[aria-hidden='true'] .xterm")).toHaveCount(0);
+    await expect
+      .poll(() => liveTerminalCounter(page), { timeout: 10_000 })
+      .toBe(0);
+
+    const afterClose = await page.evaluate(() => {
+      const stores: unknown[] =
+        (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
+      const termStore = stores.find((s: unknown) => {
+        const st = (s as { getState: () => Record<string, unknown> }).getState();
+        return "terminals" in st && "removeTerminal" in st;
+      }) as {
+        getState: () => {
+          terminals: Record<string, { id: string }[]>;
+        };
+      };
+      const state = termStore.getState();
+      const counters = (window as unknown as {
+        __mcodeTerminalCloseCounters?: {
+          removeTerminal: number;
+          removeAllTerminals: number;
+        };
+      }).__mcodeTerminalCloseCounters;
+      return {
+        ptyId: state.terminals["thread-a"]?.[0]?.id ?? null,
+        removeTerminal: counters?.removeTerminal ?? null,
+        removeAllTerminals: counters?.removeAllTerminals ?? null,
+      };
+    });
+    expect(afterClose.ptyId).toBe(originalPty);
+    expect(afterClose.removeTerminal).toBe(0);
+    expect(afterClose.removeAllTerminals).toBe(0);
+    expect(calls.kill).toBe(0);
+    expect(calls.killByThread).toBe(0);
+
+    await openTerminalTab(page, WS_ID, "thread-a");
+    await expect(page.locator(".xterm").first()).toBeVisible({ timeout: 20_000 });
+
+    expect(calls.reattach.length).toBeGreaterThanOrEqual(2);
+    expect(calls.reattach.at(-1)).toEqual({
+      ptyId: "pty-thread-a",
+      lastSeq: -1,
+    });
+
+    await wsController.sendPush("terminal.data", {
+      ptyId: "pty-thread-a",
+      data: `scrollback-after-reopen-${replaySeq}\r\n`,
+      seq: replaySeq + 100,
+    });
+    await expect(page.locator(".xterm")).toContainText(
+      /scrollback-after-reopen-/,
+      { timeout: 10_000 },
+    );
   });
 
   // --- Scenario still valid in the new model ---

--- a/apps/web/src/components/terminal/TerminalPoolHost.tsx
+++ b/apps/web/src/components/terminal/TerminalPoolHost.tsx
@@ -1,7 +1,7 @@
 import { createPortal } from "react-dom";
 import { useEffect, useLayoutEffect, useMemo } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useDiffStore, createDefaultRightPanelState } from "@/stores/diffStore";
+import { useDiffStore } from "@/stores/diffStore";
 import {
   TERMINAL_PANEL_DEFAULTS,
   useTerminalStore,
@@ -32,23 +32,15 @@ export function TerminalPoolHost() {
   const terminalScopeId = activeThreadId ?? activeWorkspaceId;
   // The whole panel record is per-thread, falling back to the workspace record
   // for the threadless shell and uncustomized threads (ADR-0012).
-  const storedPanel = useDiffStore((s) =>
-    activeWorkspaceId
-      ? (activeThreadId ? s.rightPanelByThread[activeThreadId] : undefined) ??
-        s.rightPanelFallbackByWorkspace[activeWorkspaceId]
-      : undefined,
-  );
-  const panelState = useMemo(
-    () => storedPanel ?? createDefaultRightPanelState(),
-    [storedPanel],
-  );
-  const panelVisible = useDiffStore((s) =>
-    activeWorkspaceId
-      ? s.getRightPanelVisible(activeWorkspaceId, activeThreadId)
-      : false,
-  );
-  const terminalTabVisible =
-    panelVisible && panelState.activeTab === "terminal";
+  const terminalTabVisible = useDiffStore((s) => {
+    if (!activeWorkspaceId) return false;
+    const panel = s.getRightPanel(activeWorkspaceId, activeThreadId);
+    return (
+      panel.visible &&
+      panel.activeTab === "terminal" &&
+      panel.openTabs.includes("terminal")
+    );
+  });
 
   // #749: warm the xterm module cache as soon as the terminal tab opens so the
   // first view mounts without paying the cold dynamic-import cost.

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@mcode/shared": "workspace:*",
         "better-sqlite3": "^12.0.0",
         "electron-updater": "^6.8.3",
+        "koffi": "^2.16.1",
         "node-pty": "^1.0.0",
         "uuid": "^11.1.0",
         "which": "^5.0.0",


### PR DESCRIPTION
## What
Fix terminal tab close and reopen behavior for terminal threads.

## Why
Terminal threads depend on disposable terminal views with persistent server-side shell sessions. The previous host logic could keep an xterm mounted after the Terminal tab was closed, and the desktop bundle did not package `koffi` for Windows JobObject cleanup.

## Key Changes
- Gate `TerminalPoolHost` on panel visibility, active tab, and `openTabs.includes("terminal")` before mounting `TerminalView`.
- Add Playwright coverage for close and reopen: zero mounted xterms after close, no terminal kill or store removal, same PTY retained, `terminal.reattach` with `lastSeq: -1`, and output after reopen.
- Package `koffi` with the desktop app and check for it in packaged smoke tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785325624&installation_id=129163861&pr_number=816&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F816&signature=af609c096b91b3232edabd6a433c81261a585746776d2c9a79ad0e2603d96c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop packaging so the app includes a required native module at runtime on all supported platforms.
  * Fixed terminal tab behavior so closing it only hides the view, while reopening restores the existing session and scrollback instead of killing the terminal.

* **New Features**
  * Added stronger validation in packaged desktop builds to catch missing native modules before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->