### PR TITLE
feat(goal): sync goal state across providers

### DIFF
--- a/apps/server/src/__tests__/agent-service-goal-lookup.test.ts
+++ b/apps/server/src/__tests__/agent-service-goal-lookup.test.ts
@@ -57,8 +57,9 @@ function clearableProvider(opts: {
   id?: "codex" | "claude";
   clearResult: boolean | Error;
   getResult?: GoalState | undefined;
+  getLookupResult?: GoalLookupResult;
 }): IGoalCapable {
-  return {
+  const provider = {
     id: opts.id ?? "codex",
     supportsCompletion: false,
     sessionForkOnResume: "unsupported",
@@ -75,6 +76,13 @@ function clearableProvider(opts: {
       : vi.fn().mockResolvedValue(opts.clearResult),
     getGoal: vi.fn().mockResolvedValue(opts.getResult),
   };
+  if (opts.getLookupResult) {
+    return {
+      ...provider,
+      getGoalLookup: vi.fn().mockResolvedValue(opts.getLookupResult),
+    };
+  }
+  return provider;
 }
 
 describe("AgentService.getThreadGoal", () => {
@@ -195,6 +203,32 @@ describe("AgentService.clearThreadGoal", () => {
     expect(provider.getGoal).not.toHaveBeenCalled();
   });
 
+  it("preserves Codex cache provenance when clear succeeds without native authority", async () => {
+    const provider = clearableProvider({
+      id: "codex",
+      clearResult: true,
+      getLookupResult: {
+        goal: null,
+        authoritative: false,
+        source: "codex-cache",
+        reason: "not-materialized",
+      },
+    });
+    const service = makeService({
+      thread: { id: "thread-1", provider: "codex" },
+      provider,
+    });
+
+    await expect(service.clearThreadGoal("thread-1")).resolves.toEqual({
+      goal: null,
+      authoritative: false,
+      source: "codex-cache",
+      reason: "not-materialized",
+    });
+    expect(provider.clearGoal).toHaveBeenCalledWith("mcode-thread-1");
+    expect(provider.getGoalLookup).toHaveBeenCalledWith("mcode-thread-1");
+  });
+
   it("uses the Claude wrapper source when Claude clear succeeds", async () => {
     const provider = clearableProvider({ id: "claude", clearResult: true });
     const service = makeService({
@@ -219,14 +253,38 @@ describe("AgentService.clearThreadGoal", () => {
     await expect(service.clearThreadGoal("thread-1")).resolves.toEqual({
       goal: openGoal,
       authoritative: false,
-      source: "codex-native",
+      source: "codex-cache",
       reason: "missing",
     });
     expect(provider.getGoal).toHaveBeenCalledTimes(1);
   });
 
-  it("reads once after clear false and returns authoritative missing when no goal is open", async () => {
+  it("reads once after clear false and returns non-authoritative cache missing when no goal is open", async () => {
     const provider = clearableProvider({ clearResult: false, getResult: { ...openGoal, status: "complete" } });
+    const service = makeService({
+      thread: { id: "thread-1", provider: "codex" },
+      provider,
+    });
+
+    await expect(service.clearThreadGoal("thread-1")).resolves.toEqual({
+      goal: null,
+      authoritative: false,
+      source: "codex-cache",
+      reason: "missing",
+    });
+    expect(provider.getGoal).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses lookup provenance after clear false when the provider reports it", async () => {
+    const provider = clearableProvider({
+      clearResult: false,
+      getLookupResult: {
+        goal: null,
+        authoritative: true,
+        source: "codex-native",
+        reason: "missing",
+      },
+    });
     const service = makeService({
       thread: { id: "thread-1", provider: "codex" },
       provider,
@@ -238,7 +296,8 @@ describe("AgentService.clearThreadGoal", () => {
       source: "codex-native",
       reason: "missing",
     });
-    expect(provider.getGoal).toHaveBeenCalledTimes(1);
+    expect(provider.getGoal).not.toHaveBeenCalled();
+    expect(provider.getGoalLookup).toHaveBeenCalledWith("mcode-thread-1");
   });
 
   it("surfaces provider clear errors without follow-up reads", async () => {

--- a/apps/server/src/__tests__/agent-service-goal-lookup.test.ts
+++ b/apps/server/src/__tests__/agent-service-goal-lookup.test.ts
@@ -1,0 +1,254 @@
+import "reflect-metadata";
+import { describe, expect, it, vi } from "vitest";
+import { AgentService } from "../services/agent-service";
+import type { GoalLookupResult, GoalState, IAgentProvider, IGoalCapable } from "@mcode/contracts";
+
+const openGoal: GoalState = {
+  threadId: "thread-1",
+  objective: "ship lookup",
+  status: "active",
+  tokenBudget: null,
+  tokensUsed: 0,
+  timeUsedSeconds: 0,
+  createdAt: 1,
+  updatedAt: 1,
+  providerId: "codex",
+  source: "codex",
+  controls: { canInspect: true, canClear: true },
+};
+
+function makeService(opts: {
+  thread?: { id: string; provider: string | null };
+  provider: Partial<IAgentProvider>;
+}): AgentService {
+  const service = Object.create(AgentService.prototype) as AgentService & {
+    threadRepo: { findById: ReturnType<typeof vi.fn> };
+    providerRegistry: { resolve: ReturnType<typeof vi.fn> };
+  };
+  service.threadRepo = {
+    findById: vi.fn().mockReturnValue(opts.thread ?? null),
+  };
+  service.providerRegistry = {
+    resolve: vi.fn().mockReturnValue(opts.provider),
+  };
+  return service;
+}
+
+function goalProvider(result: GoalLookupResult): IGoalCapable {
+  return {
+    id: "codex",
+    supportsCompletion: false,
+    sessionForkOnResume: "unsupported",
+    forker: {} as IGoalCapable["forker"],
+    maxInputCharactersPerTurn: 16_000,
+    sendTurn: vi.fn(),
+    stopSession: vi.fn(),
+    shutdown: vi.fn(),
+    listModels: vi.fn().mockResolvedValue([]),
+    on: vi.fn(),
+    setGoal: vi.fn(),
+    clearGoal: vi.fn(),
+    getGoal: vi.fn(),
+    getGoalLookup: vi.fn().mockResolvedValue(result),
+  };
+}
+
+function clearableProvider(opts: {
+  id?: "codex" | "claude";
+  clearResult: boolean | Error;
+  getResult?: GoalState | undefined;
+}): IGoalCapable {
+  return {
+    id: opts.id ?? "codex",
+    supportsCompletion: false,
+    sessionForkOnResume: "unsupported",
+    forker: {} as IGoalCapable["forker"],
+    maxInputCharactersPerTurn: 16_000,
+    sendTurn: vi.fn(),
+    stopSession: vi.fn(),
+    shutdown: vi.fn(),
+    listModels: vi.fn().mockResolvedValue([]),
+    on: vi.fn(),
+    setGoal: vi.fn(),
+    clearGoal: opts.clearResult instanceof Error
+      ? vi.fn().mockRejectedValue(opts.clearResult)
+      : vi.fn().mockResolvedValue(opts.clearResult),
+    getGoal: vi.fn().mockResolvedValue(opts.getResult),
+  };
+}
+
+describe("AgentService.getThreadGoal", () => {
+  it("rejects unknown thread ids before provider access", async () => {
+    const providerRegistry = { resolve: vi.fn() };
+    const service = Object.create(AgentService.prototype) as AgentService & {
+      threadRepo: { findById: ReturnType<typeof vi.fn> };
+      providerRegistry: typeof providerRegistry;
+    };
+    service.threadRepo = { findById: vi.fn().mockReturnValue(null) };
+    service.providerRegistry = providerRegistry;
+
+    await expect(service.getThreadGoal("missing")).rejects.toThrow("Thread not found: missing");
+    expect(providerRegistry.resolve).not.toHaveBeenCalled();
+  });
+
+  it("returns unsupported result for non-goal-capable providers", async () => {
+    const service = makeService({
+      thread: { id: "thread-1", provider: "copilot" },
+      provider: {
+        id: "copilot",
+        supportsCompletion: false,
+        sessionForkOnResume: "unsupported",
+        forker: {},
+        maxInputCharactersPerTurn: 16_000,
+        sendTurn: vi.fn(),
+        stopSession: vi.fn(),
+        shutdown: vi.fn(),
+        listModels: vi.fn(),
+        on: vi.fn(),
+      } as unknown as IAgentProvider,
+    });
+
+    await expect(service.getThreadGoal("thread-1")).resolves.toEqual({
+      goal: null,
+      authoritative: true,
+      source: "unsupported",
+      reason: "unsupported-provider",
+    });
+  });
+
+  it("returns provider lookup metadata for goal-capable providers", async () => {
+    const result: GoalLookupResult = {
+      goal: openGoal,
+      authoritative: false,
+      source: "codex-cache",
+      reason: "not-materialized",
+    };
+    const provider = goalProvider(result);
+    const service = makeService({
+      thread: { id: "thread-1", provider: "codex" },
+      provider,
+    });
+
+    await expect(service.getThreadGoal("thread-1")).resolves.toEqual(result);
+    expect(provider.getGoalLookup).toHaveBeenCalledWith("mcode-thread-1");
+  });
+
+  it("normalizes non-open provider goals to null", async () => {
+    const service = makeService({
+      thread: { id: "thread-1", provider: "codex" },
+      provider: goalProvider({
+        goal: { ...openGoal, status: "complete" },
+        authoritative: true,
+        source: "codex-native",
+        reason: "closed",
+      }),
+    });
+
+    await expect(service.getThreadGoal("thread-1")).resolves.toEqual({
+      goal: null,
+      authoritative: true,
+      source: "codex-native",
+      reason: "closed",
+    });
+  });
+});
+
+describe("AgentService.clearThreadGoal", () => {
+  it("returns unsupported result for non-goal-capable providers", async () => {
+    const service = makeService({
+      thread: { id: "thread-1", provider: "copilot" },
+      provider: {
+        id: "copilot",
+        supportsCompletion: false,
+        sessionForkOnResume: "unsupported",
+        forker: {},
+        maxInputCharactersPerTurn: 16_000,
+        sendTurn: vi.fn(),
+        stopSession: vi.fn(),
+        shutdown: vi.fn(),
+        listModels: vi.fn(),
+        on: vi.fn(),
+      } as unknown as IAgentProvider,
+    });
+
+    await expect(service.clearThreadGoal("thread-1")).resolves.toEqual({
+      goal: null,
+      authoritative: true,
+      source: "unsupported",
+      reason: "unsupported-provider",
+    });
+  });
+
+  it("returns authoritative null when Codex native clear succeeds", async () => {
+    const provider = clearableProvider({ id: "codex", clearResult: true });
+    const service = makeService({
+      thread: { id: "thread-1", provider: "codex" },
+      provider,
+    });
+
+    await expect(service.clearThreadGoal("thread-1")).resolves.toEqual({
+      goal: null,
+      authoritative: true,
+      source: "codex-native",
+    });
+    expect(provider.clearGoal).toHaveBeenCalledWith("mcode-thread-1");
+    expect(provider.getGoal).not.toHaveBeenCalled();
+  });
+
+  it("uses the Claude wrapper source when Claude clear succeeds", async () => {
+    const provider = clearableProvider({ id: "claude", clearResult: true });
+    const service = makeService({
+      thread: { id: "thread-1", provider: "claude" },
+      provider,
+    });
+
+    await expect(service.clearThreadGoal("thread-1")).resolves.toEqual({
+      goal: null,
+      authoritative: true,
+      source: "claude-wrapper",
+    });
+  });
+
+  it("reads once after clear false and returns non-authoritative open goal", async () => {
+    const provider = clearableProvider({ clearResult: false, getResult: openGoal });
+    const service = makeService({
+      thread: { id: "thread-1", provider: "codex" },
+      provider,
+    });
+
+    await expect(service.clearThreadGoal("thread-1")).resolves.toEqual({
+      goal: openGoal,
+      authoritative: false,
+      source: "codex-native",
+      reason: "missing",
+    });
+    expect(provider.getGoal).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads once after clear false and returns authoritative missing when no goal is open", async () => {
+    const provider = clearableProvider({ clearResult: false, getResult: { ...openGoal, status: "complete" } });
+    const service = makeService({
+      thread: { id: "thread-1", provider: "codex" },
+      provider,
+    });
+
+    await expect(service.clearThreadGoal("thread-1")).resolves.toEqual({
+      goal: null,
+      authoritative: true,
+      source: "codex-native",
+      reason: "missing",
+    });
+    expect(provider.getGoal).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces provider clear errors without follow-up reads", async () => {
+    const provider = clearableProvider({ clearResult: new Error("native clear failed"), getResult: openGoal });
+    const service = makeService({
+      thread: { id: "thread-1", provider: "codex" },
+      provider,
+    });
+
+    await expect(service.clearThreadGoal("thread-1")).rejects.toThrow("native clear failed");
+    expect(provider.getGoal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/commands/__tests__/goal-command.test.ts
+++ b/apps/server/src/commands/__tests__/goal-command.test.ts
@@ -203,6 +203,32 @@ describe("GoalCommand", () => {
         /No active goal/,
       );
     });
+
+    it("reports no active goal when the provider returns a completed goal", async () => {
+      const provider = fakeGoalCapableProvider();
+      provider.getGoal.mockReturnValueOnce({
+        threadId,
+        objective: "ship the feature",
+        status: "complete",
+        tokenBudget: null,
+        tokensUsed: 0,
+        timeUsedSeconds: 19,
+        createdAt: 1,
+        updatedAt: 20,
+        providerId: "codex",
+        source: "codex",
+        controls: { canInspect: true, canClear: false },
+      } satisfies GoalState);
+      const cmd = build();
+
+      const outcome = await cmd.handle(ctx("/goal show", provider));
+
+      expect(outcome.kind).toBe("handled");
+      const { messages } = messageRepo.listByThread(threadId, 100);
+      expect(messages.find((m) => m.role === "assistant")?.content).toMatch(
+        /No active goal/,
+      );
+    });
   });
 
   describe("CLEAR form", () => {

--- a/apps/server/src/commands/__tests__/goal-command.test.ts
+++ b/apps/server/src/commands/__tests__/goal-command.test.ts
@@ -41,10 +41,16 @@ function fakeGoalCapableProvider() {
     setGoal: vi.fn<(sid: string, condition: string) => GoalState>((_, condition) => makeGoal(condition)),
     clearGoal: vi.fn<(sid: string) => boolean>(() => true),
     getGoal: vi.fn<(sid: string) => GoalState | undefined>(() => undefined),
+    hasNativeGoalCommand: vi.fn<(sid: string) => boolean>(() => false),
+    setNativeGoalMirror: vi.fn<(sid: string, condition: string) => GoalState>((_, condition) => makeGoal(condition)),
+    clearNativeGoalMirror: vi.fn<(sid: string) => boolean>(() => true),
   }) as unknown as IAgentProvider & {
     setGoal: ReturnType<typeof vi.fn>;
     clearGoal: ReturnType<typeof vi.fn>;
     getGoal: ReturnType<typeof vi.fn>;
+    hasNativeGoalCommand: ReturnType<typeof vi.fn>;
+    setNativeGoalMirror: ReturnType<typeof vi.fn>;
+    clearNativeGoalMirror: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -228,6 +234,40 @@ describe("GoalCommand", () => {
       expect(messages.find((m) => m.role === "assistant")?.content).toMatch(
         /No active goal/,
       );
+    });
+
+    it("uses exact native /goal wire text when Claude support is proven", async () => {
+      const provider = fakeGoalCapableProvider();
+      provider.hasNativeGoalCommand.mockReturnValueOnce(true);
+      const cmd = build();
+
+      const outcome = await cmd.handle(ctx("/goal analyse this branch", provider));
+
+      expect(outcome.kind).toBe("rewrite");
+      if (outcome.kind !== "rewrite") throw new Error("expected rewrite");
+      expect(outcome.content).toBe("/goal analyse this branch");
+
+      await outcome.onDispatch?.();
+      expect(provider.setGoal).not.toHaveBeenCalled();
+      expect(provider.setNativeGoalMirror).toHaveBeenCalledWith(
+        `mcode-${threadId}`,
+        "analyse this branch",
+      );
+    });
+
+    it("does not clear the native mirror from control command rollback", async () => {
+      const provider = fakeGoalCapableProvider();
+      provider.hasNativeGoalCommand.mockReturnValueOnce(true);
+      const cmd = build();
+
+      const outcome = await cmd.handle(ctx("/goal clear", provider));
+
+      expect(outcome.kind).toBe("rewrite");
+      if (outcome.kind !== "rewrite") throw new Error("expected rewrite");
+      expect(outcome.content).toBe("/goal off");
+
+      await outcome.onRollback?.();
+      expect(provider.clearNativeGoalMirror).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/commands/goal-command.ts
+++ b/apps/server/src/commands/goal-command.ts
@@ -23,6 +23,23 @@ interface GoalCommandDeps {
 const GOAL_COMMAND = /^\s*\/goal\b\s*(.*)$/s;
 const MAX_GOAL_OBJECTIVE_CHARS = 4000;
 
+interface ClaudeNativeGoalCommandProvider {
+  hasNativeGoalCommand(sessionId: string): boolean;
+  setNativeGoalMirror(sessionId: string, condition: string): GoalState;
+  clearNativeGoalMirror(sessionId: string): boolean;
+}
+
+function asClaudeNativeGoalCommandProvider(
+  provider: IAgentProvider,
+): ClaudeNativeGoalCommandProvider | null {
+  const candidate = provider as Partial<ClaudeNativeGoalCommandProvider>;
+  return typeof candidate.hasNativeGoalCommand === "function" &&
+    typeof candidate.setNativeGoalMirror === "function" &&
+    typeof candidate.clearNativeGoalMirror === "function"
+    ? (candidate as ClaudeNativeGoalCommandProvider)
+    : null;
+}
+
 /**
  * The `/goal` app-native command. Holds only server-lifetime deps; the resolved
  * provider arrives per send via {@link CommandContext}. Any provider that
@@ -68,10 +85,20 @@ export class GoalCommand implements McodeCommand {
 
     const arg = match[1].trim();
     const lower = arg.toLowerCase();
+    const session = this.sessionName(threadId);
+    const native = asClaudeNativeGoalCommandProvider(ctx.provider);
+    const useNative = native?.hasNativeGoalCommand(session) === true;
     const isControl =
       arg === "" || lower === "show" || lower === "clear" || lower === "reset";
 
     if (isControl) {
+      if (useNative) {
+        const nativeContent = lower === "clear" || lower === "reset" ? "/goal off" : "/goal";
+        return {
+          kind: "rewrite",
+          content: nativeContent,
+        };
+      }
       let replyText: string;
       if (arg === "" || lower === "show") {
         const current = await capable.getGoal(this.sessionName(threadId));
@@ -101,7 +128,21 @@ export class GoalCommand implements McodeCommand {
     // transcript. The setGoal() install is deferred to onDispatch (run by the
     // caller just before sendTurn) so a send failure can't leave a stale goal;
     // onRollback clears it if the send fails.
-    const session = this.sessionName(threadId);
+    if (useNative) {
+      return {
+        kind: "rewrite",
+        content: `/goal ${arg}`,
+        onDispatch: async () => {
+          const goal = native.setNativeGoalMirror(session, arg);
+          this.broadcastGoalUpdated(threadId, goal);
+        },
+        onRollback: async () => {
+          native.clearNativeGoalMirror(session);
+          this.broadcastGoalCleared(threadId, "rollback");
+        },
+      };
+    }
+
     return {
       kind: "rewrite",
       content:

--- a/apps/server/src/commands/goal-command.ts
+++ b/apps/server/src/commands/goal-command.ts
@@ -5,6 +5,7 @@ import {
   AgentEventType,
   type GoalState,
   isGoalCapable,
+  isGoalOpen,
 } from "@mcode/contracts";
 import type { MessageRepo } from "../repositories/message-repo.js";
 import type { CommandContext, CommandOutcome, McodeCommand } from "./command-router.js";
@@ -74,7 +75,7 @@ export class GoalCommand implements McodeCommand {
       let replyText: string;
       if (arg === "" || lower === "show") {
         const current = await capable.getGoal(this.sessionName(threadId));
-        replyText = current
+        replyText = isGoalOpen(current)
           ? `Active goal: "${current.objective}". Use \`/goal clear\` to remove it.`
           : `No active goal. Use \`/goal <condition>\` to set one.`;
       } else {

--- a/apps/server/src/providers/claude/__tests__/claude-goal-command-parser.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-goal-command-parser.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseClaudeGoalCommandResult } from "../claude-goal-command-parser.js";
+
+const zeroTurnResult = { type: "result", num_turns: 0 };
+
+describe("parseClaudeGoalCommandResult", () => {
+  it("accepts observed zero-turn native goal responses", () => {
+    expect(parseClaudeGoalCommandResult("Goal active: say hi (not yet evaluated)", zeroTurnResult)).toEqual({
+      kind: "active",
+      objective: "say hi",
+    });
+    expect(parseClaudeGoalCommandResult("No goal set. Usage: `/goal <condition>`", zeroTurnResult)).toEqual({
+      kind: "empty",
+    });
+    expect(parseClaudeGoalCommandResult("No goal set", zeroTurnResult)).toEqual({
+      kind: "empty",
+    });
+    expect(parseClaudeGoalCommandResult("Goal cleared: wait until user says mcode-stop-probe", zeroTurnResult)).toEqual({
+      kind: "cleared",
+      objective: "wait until user says mcode-stop-probe",
+    });
+    expect(parseClaudeGoalCommandResult("/goal isn't available in this environment.", zeroTurnResult)).toEqual({
+      kind: "unavailable",
+    });
+  });
+
+  it("rejects missing or nonzero result records", () => {
+    for (const text of [
+      "Goal active: say hi (not yet evaluated)",
+      "No goal set",
+      "Goal cleared: wait until user says mcode-stop-probe",
+      "/goal isn't available in this environment.",
+    ]) {
+      expect(parseClaudeGoalCommandResult(text, { type: "result", num_turns: 1 })).toBeNull();
+      expect(parseClaudeGoalCommandResult(text, null)).toBeNull();
+    }
+  });
+
+  it("rejects ordinary assistant and Stop-hook feedback text", () => {
+    expect(parseClaudeGoalCommandResult("I set a goal for you.", zeroTurnResult)).toBeNull();
+    expect(parseClaudeGoalCommandResult(
+      'Goal not yet met: "say hi". Continue working until the goal is satisfied.',
+      zeroTurnResult,
+    )).toBeNull();
+  });
+});

--- a/apps/server/src/providers/claude/__tests__/claude-native-goal-support.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-native-goal-support.test.ts
@@ -1,0 +1,120 @@
+import "reflect-metadata";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AgentEventType } from "@mcode/contracts";
+
+const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mockQuery,
+}));
+
+vi.mock("@mcode/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcode/shared")>();
+  return {
+    ...actual,
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+});
+
+import { ClaudeProvider } from "../claude-provider.js";
+
+function provider(): ClaudeProvider {
+  return new ClaudeProvider(
+    { getEnv: () => ({}) } as any,
+    { addProcess: () => {}, removeProcess: () => {}, killAll: async () => {} } as any,
+  );
+}
+
+function makeAsyncIterable(messages: Record<string, unknown>[]) {
+  const iterable = (async function* () {
+    for (const message of messages) yield message;
+  })();
+  return Object.assign(iterable, {
+    close: vi.fn(),
+    interrupt: vi.fn(),
+    setPermissionMode: vi.fn(),
+    setModel: vi.fn(),
+    getStderr: vi.fn(() => ""),
+  });
+}
+
+function nativeSessionEntry(pushMessage: ReturnType<typeof vi.fn>, pendingToolUses = new Set<string>()) {
+  return {
+    sessionId: "mcode-thread-1",
+    cwd: process.cwd(),
+    query: { close: vi.fn() },
+    pushMessage,
+    closeQueue: vi.fn(),
+    model: "claude-sonnet-4-6",
+    permissionMode: "default",
+    contextWindowMode: undefined,
+    lastUsedAt: Date.now(),
+    pendingToolUses,
+    hasFiredToolThisTurn: false,
+  };
+}
+
+describe("ClaudeProvider native goal support detection", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("enables native mode only when system/init slash_commands contains goal", () => {
+    const claude = provider();
+
+    claude.observeNativeGoalCommands("mcode-thread-1", ["goal"], "2.1.186");
+    claude.observeNativeGoalCommands("mcode-thread-2", [], "2.1.186");
+
+    expect(claude.hasNativeGoalCommand("mcode-thread-1")).toBe(true);
+    expect(claude.hasNativeGoalCommand("mcode-thread-2")).toBe(false);
+  });
+
+  it("does not enable native mode from version telemetry alone", () => {
+    const claude = provider();
+
+    expect(claude.hasNativeGoalCommand("mcode-thread-1")).toBe(false);
+  });
+
+  it("still emits system status events after observing slash_commands", async () => {
+    mockQuery.mockReturnValueOnce(makeAsyncIterable([
+      { type: "system", subtype: "init", slash_commands: ["goal"], claude_code_version: "2.1.186" },
+      { type: "system", subtype: "status", status: "compacting" },
+    ]));
+    const claude = provider();
+    const events: Array<{ type: string; active?: boolean }> = [];
+    claude.on("event", (event) => events.push(event as { type: string; active?: boolean }));
+
+    await claude.sendTurn({
+      sessionId: "mcode-thread-1",
+      threadId: "thread-1",
+      message: "hello",
+      cwd: process.cwd(),
+      model: "claude-sonnet-4-6",
+      permissionMode: "default",
+      interactionMode: "build",
+      providerOptions: {},
+    });
+
+    for (let i = 0; i < 20 && !events.some((event) => event.type === AgentEventType.Compacting); i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(claude.hasNativeGoalCommand("mcode-thread-1")).toBe(true);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: AgentEventType.Compacting,
+      active: true,
+    }));
+  });
+
+  it("does not enqueue native /goal when the pooled session is busy", async () => {
+    const claude = provider();
+    const pushMessage = vi.fn();
+    claude.observeNativeGoalCommands("mcode-thread-1", ["goal"], "2.1.186");
+    (claude as any).runtime = {
+      get: vi.fn(() => nativeSessionEntry(pushMessage, new Set(["tool-1"]))),
+    };
+
+    await expect(claude.runNativeGoalCommand("mcode-thread-1", "/goal", 10)).resolves.toBeNull();
+    expect(pushMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/providers/claude/claude-goal-command-parser.ts
+++ b/apps/server/src/providers/claude/claude-goal-command-parser.ts
@@ -1,0 +1,55 @@
+/** Parsed result from Claude Code's native `/goal` command response. */
+export type ClaudeGoalCommandParseResult =
+  | { kind: "active"; objective: string }
+  | { kind: "cleared"; objective: string }
+  | { kind: "empty" }
+  | { kind: "unavailable" };
+
+const ACTIVE_PREFIX = "Goal active: ";
+const CLEARED_PREFIX = "Goal cleared: ";
+const UNAVAILABLE_TEXT = "/goal isn't available in this environment.";
+
+/** Minimal shape of the Claude SDK result record needed to prove a slash-command response. */
+export interface ClaudeGoalCommandResultRecord {
+  readonly type?: unknown;
+  readonly num_turns?: unknown;
+}
+
+/**
+ * Parses only observed synthetic Claude Code `/goal` command output.
+ *
+ * Native slash-command responses are authoritative only when paired with a
+ * `result` record whose `num_turns` is zero. Ordinary assistant text, Stop-hook
+ * feedback, and normal model turns must fail closed.
+ */
+export function parseClaudeGoalCommandResult(
+  assistantText: string | null | undefined,
+  result: ClaudeGoalCommandResultRecord | null | undefined,
+): ClaudeGoalCommandParseResult | null {
+  if (typeof assistantText !== "string") return null;
+  if (result?.type !== "result" || result.num_turns !== 0) return null;
+
+  const text = assistantText.trim();
+  if (text.startsWith(ACTIVE_PREFIX)) {
+    const raw = text.slice(ACTIVE_PREFIX.length).trim();
+    const objective = raw.endsWith(" (not yet evaluated)")
+      ? raw.slice(0, -" (not yet evaluated)".length).trim()
+      : raw;
+    return objective.length > 0 ? { kind: "active", objective } : null;
+  }
+
+  if (text.startsWith(CLEARED_PREFIX)) {
+    const objective = text.slice(CLEARED_PREFIX.length).trim();
+    return { kind: "cleared", objective };
+  }
+
+  if (text.startsWith("No goal set")) {
+    return { kind: "empty" };
+  }
+
+  if (text === UNAVAILABLE_TEXT) {
+    return { kind: "unavailable" };
+  }
+
+  return null;
+}

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -10,7 +10,7 @@ import { readFile } from "fs/promises";
 import { query as sdkQuery } from "@anthropic-ai/claude-agent-sdk";
 import type { Query, SDKUserMessage, PostCompactHookInput, StopHookInput, CanUseTool } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "@mcode/shared";
-import { AgentEventType, isVirtualBrowserContextAttachment } from "@mcode/contracts";
+import { AgentEventType, isGoalOpen, isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import type {
   IAgentProvider,
   IGoalCapable,
@@ -22,6 +22,7 @@ import type {
   AgentEvent,
   AttachmentMeta,
   GoalState,
+  GoalLookupResult,
   ProviderModelInfo,
   ProviderUsageInfo,
   QuotaCategory,
@@ -2288,6 +2289,17 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
   getGoal(sessionId: string): GoalState | undefined {
     const entry = this.goalsBySession.get(sessionId);
     return entry ? this.toGoalState(sessionId, entry) : undefined;
+  }
+
+  /** Return non-authoritative Claude-wrapper goal lookup metadata. */
+  getGoalLookup(sessionId: string): GoalLookupResult {
+    const goal = this.getGoal(sessionId);
+    return {
+      goal: isGoalOpen(goal) ? goal : null,
+      authoritative: false,
+      source: "claude-wrapper",
+      ...(goal ? {} : { reason: "missing" }),
+    };
   }
 
   /** Convert internal Claude goal metadata into the provider-neutral state. */

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -10,7 +10,7 @@ import { readFile } from "fs/promises";
 import { query as sdkQuery } from "@anthropic-ai/claude-agent-sdk";
 import type { Query, SDKUserMessage, PostCompactHookInput, StopHookInput, CanUseTool } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "@mcode/shared";
-import { AgentEventType, isGoalOpen, isVirtualBrowserContextAttachment } from "@mcode/contracts";
+import { AgentEventType, isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import type {
   IAgentProvider,
   IGoalCapable,
@@ -46,6 +46,7 @@ import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/ses
 import { listDirectChildren } from "../../services/process-kill.js";
 import { CleanForker } from "../../services/handoff/session-forker.js";
 import type { SessionForker } from "@mcode/contracts";
+import { parseClaudeGoalCommandResult } from "./claude-goal-command-parser.js";
 
 /**
  * Default model slug used for side-channel and fallback paths.
@@ -82,6 +83,8 @@ interface ClaudeGoalEntry {
   readonly createdAt: number;
   readonly updatedAt: number;
 }
+
+type ClaudeNativeGoalSupport = "unknown" | "supported" | "unsupported";
 
 /**
  * Per-session state owned by the {@link SessionRuntime}. Holds the live SDK
@@ -336,6 +339,10 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
    * server restarts.
    */
   private goalsBySession = new Map<string, ClaudeGoalEntry>();
+  /** Native Claude Code `/goal` mirrors keyed by Mcode session id. */
+  private nativeGoalsBySession = new Map<string, ClaudeGoalEntry>();
+  /** Per-session native `/goal` capability, proven only by `system/init.slash_commands`. */
+  private nativeGoalSupportBySession = new Map<string, ClaudeNativeGoalSupport>();
   /**
    * Session IDs for which a stop was requested before the session was created.
    * Checked by doSendMessage after session creation; if found the session is
@@ -1712,6 +1719,10 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
                 awaitingResume = false;
                 break;
               }
+              const nativeGoalResult = parseClaudeGoalCommandResult(lastAssistantText, anyMsg);
+              if (nativeGoalResult) {
+                this.applyNativeGoalCommandResult(sessionId, nativeGoalResult);
+              }
               if (lastAssistantText) {
                 this.emit("event", {
                   type: AgentEventType.Message,
@@ -1844,11 +1855,20 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
             }
 
             case "system": {
+              if ((anyMsg.subtype as string) === "init") {
+                const slashCommands = anyMsg.slash_commands;
+                if (Array.isArray(slashCommands)) {
+                  this.observeNativeGoalCommands(
+                    sessionId,
+                    slashCommands,
+                    anyMsg.claude_code_version,
+                  );
+                }
               // subtype 'status' carries the SDK's compaction state.
               // Only emit a compacting event on known transitions to avoid
               // spurious "active: false" from unrelated status strings (e.g.
               // "idle", "ready") that the SDK may send during session lifecycle.
-              if ((anyMsg.subtype as string) === "status") {
+              } else if ((anyMsg.subtype as string) === "status") {
                 const sdkStatus = (anyMsg as { status?: string | null }).status;
                 if (sdkStatus === "compacting" && !sessionCompacting) {
                   sessionCompacting = true;
@@ -2264,9 +2284,115 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     };
   }
 
+  /** Return whether native Claude Code `/goal` has been proven for this session. */
+  hasNativeGoalCommand(sessionId: string): boolean {
+    return this.nativeGoalSupportBySession.get(sessionId) === "supported";
+  }
+
+  /** Records Claude Code slash-command availability observed from `system/init`. */
+  observeNativeGoalCommands(
+    sessionId: string,
+    slashCommands: readonly unknown[],
+    claudeCodeVersion?: unknown,
+  ): void {
+    const supported = slashCommands.includes("goal");
+    this.nativeGoalSupportBySession.set(
+      sessionId,
+      supported ? "supported" : "unsupported",
+    );
+    logger.debug("Claude native goal support observed", {
+      sessionId,
+      supported,
+      claudeCodeVersion,
+    });
+  }
+
+  /** Mark the native `/goal` command unavailable after Claude reports it disabled. */
+  private markNativeGoalUnavailable(sessionId: string): void {
+    this.nativeGoalSupportBySession.set(sessionId, "unsupported");
+    this.nativeGoalsBySession.delete(sessionId);
+  }
+
+  /** Install a local mirror for a native Claude Code goal command already dispatched. */
+  setNativeGoalMirror(sessionId: string, condition: string): GoalState {
+    const now = Date.now();
+    const existing = this.nativeGoalsBySession.get(sessionId);
+    const entry: ClaudeGoalEntry = {
+      objective: condition,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    this.nativeGoalsBySession.set(sessionId, entry);
+    return this.toGoalState(sessionId, entry);
+  }
+
+  /** Clear the local mirror for a native Claude Code goal command. */
+  clearNativeGoalMirror(sessionId: string): boolean {
+    return this.nativeGoalsBySession.delete(sessionId);
+  }
+
+  /** Apply a fail-closed native `/goal` parse result to the in-memory mirror. */
+  private applyNativeGoalCommandResult(
+    sessionId: string,
+    result: NonNullable<ReturnType<typeof parseClaudeGoalCommandResult>>,
+  ): void {
+    if (result.kind === "unavailable") {
+      this.markNativeGoalUnavailable(sessionId);
+      this.emit(`_nativeGoalCommandResult:${sessionId}`, result);
+      return;
+    }
+    if (result.kind === "active") {
+      this.setNativeGoalMirror(sessionId, result.objective);
+      this.emit(`_nativeGoalCommandResult:${sessionId}`, result);
+      return;
+    }
+    if (result.kind === "cleared" || result.kind === "empty") {
+      this.nativeGoalsBySession.delete(sessionId);
+    }
+    this.emit(`_nativeGoalCommandResult:${sessionId}`, result);
+  }
+
+  /** Dispatch a native `/goal` command into an idle Claude session and wait for its proven command result. */
+  async runNativeGoalCommand(
+    sessionId: string,
+    command: "/goal" | "/goal off",
+    timeoutMs = 20_000,
+  ): Promise<NonNullable<ReturnType<typeof parseClaudeGoalCommandResult>> | null> {
+    const entry = this.runtime.get(sessionId);
+    if (
+      !entry ||
+      this.nativeGoalSupportBySession.get(sessionId) !== "supported" ||
+      this.isBusy(entry)
+    ) {
+      return null;
+    }
+
+    const eventName = `_nativeGoalCommandResult:${sessionId}`;
+    const current = this.runtime.get(sessionId);
+    if (!current || current !== entry || this.isBusy(current)) {
+      return null;
+    }
+    const resultPromise = new Promise<NonNullable<ReturnType<typeof parseClaudeGoalCommandResult>> | null>((resolve) => {
+      let settled = false;
+      const done = (result: NonNullable<ReturnType<typeof parseClaudeGoalCommandResult>> | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.removeListener(eventName, onResult);
+        resolve(result);
+      };
+      const onResult = (result: NonNullable<ReturnType<typeof parseClaudeGoalCommandResult>>) => done(result);
+      const timer = setTimeout(() => done(null), timeoutMs);
+      this.once(eventName, onResult);
+    });
+
+    entry.pushMessage(toUserMessage(command, sessionId));
+    return resultPromise;
+  }
+
   /**
-   * Install a Claude-wrapper goal. Claude can enforce a stop gate, but cannot
-   * currently report achieved/paused/blocked lifecycle state back to Mcode.
+   * Install a Claude-wrapper goal. Claude can enforce a stop gate, but native
+   * `/goal` sessions keep their own mirror and bypass this Stop hook state.
    */
   setGoal(sessionId: string, condition: string): GoalState {
     const now = Date.now();
@@ -2287,15 +2413,23 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
 
   /** Return the active Claude-wrapper goal state for a session, or undefined. */
   getGoal(sessionId: string): GoalState | undefined {
-    const entry = this.goalsBySession.get(sessionId);
+    const entry = this.nativeGoalsBySession.get(sessionId) ?? this.goalsBySession.get(sessionId);
     return entry ? this.toGoalState(sessionId, entry) : undefined;
   }
 
   /** Return non-authoritative Claude-wrapper goal lookup metadata. */
   getGoalLookup(sessionId: string): GoalLookupResult {
-    const goal = this.getGoal(sessionId);
+    const nativeGoal = this.nativeGoalsBySession.get(sessionId);
+    if (nativeGoal) {
+      return {
+        goal: this.toGoalState(sessionId, nativeGoal),
+        authoritative: false,
+        source: "claude-cache",
+      };
+    }
+    const goal = this.goalsBySession.get(sessionId);
     return {
-      goal: isGoalOpen(goal) ? goal : null,
+      goal: goal ? this.toGoalState(sessionId, goal) : null,
       authoritative: false,
       source: "claude-wrapper",
       ...(goal ? {} : { reason: "missing" }),
@@ -2336,6 +2470,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       }
     }
     this.goalsBySession.delete(sessionId);
+    this.nativeGoalsBySession.delete(sessionId);
     const entry = this.runtime.get(sessionId);
     if (entry) {
       // The runtime's stop runs interrupt (closeQueue) → close (query.close) →
@@ -2504,6 +2639,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     this.pendingSpawnTurns.clear();
     this.sdkSessionIds.clear();
     this.goalsBySession.clear();
+    this.nativeGoalsBySession.clear();
+    this.nativeGoalSupportBySession.clear();
     logger.info("ClaudeProvider shutdown complete");
   }
 }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -34,6 +34,7 @@ import type {
   AgentEvent,
   AttachmentMeta,
   GoalState,
+  GoalLookupResult,
   MessageMention,
   PermissionDecision,
   PermissionRequest,
@@ -42,7 +43,7 @@ import type {
   QuotaCategory,
   SkillInfo,
 } from "@mcode/contracts";
-import { AgentEventType, CODEX_STATIC_MODELS, isVirtualBrowserContextAttachment } from "@mcode/contracts";
+import { AgentEventType, CODEX_STATIC_MODELS, isGoalOpen, isVirtualBrowserContextAttachment } from "@mcode/contracts";
 import { checkCodexVersion, meetsMinVersion } from "./codex-version.js";
 import { CodexAppServer, warmCodexAppServer } from "./codex-app-server.js";
 import type { CodexApprovalRequest } from "./codex-app-server.js";
@@ -637,8 +638,10 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
   /** Mirror goal events from the mapper into the provider cache. */
   private recordGoalEvent(sessionId: string, event: AgentEvent): void {
     if (event.type === AgentEventType.GoalUpdated) {
-      this.goalsBySession.set(sessionId, event.goal);
-      if (event.goal.status === "complete") {
+      if (isGoalOpen(event.goal)) {
+        this.goalsBySession.set(sessionId, event.goal);
+      } else {
+        this.goalsBySession.delete(sessionId);
         this.pendingGoalObjectives.delete(sessionId);
       }
       return;
@@ -651,7 +654,11 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
 
   /** Emit a goal update and update the local mirror. */
   private emitGoalUpdated(sessionId: string, goal: GoalState): void {
-    this.goalsBySession.set(sessionId, goal);
+    if (isGoalOpen(goal)) {
+      this.goalsBySession.set(sessionId, goal);
+    } else {
+      this.goalsBySession.delete(sessionId);
+    }
     this.emit("event", {
       type: AgentEventType.GoalUpdated,
       threadId: goal.threadId ?? this.threadIdFromSession(sessionId),
@@ -722,7 +729,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
   async getGoal(sessionId: string): Promise<GoalState | undefined> {
     const state = this.runtime.get(sessionId);
     if (!state?.server.isAlive) {
-      return this.goalsBySession.get(sessionId);
+      const cachedGoal = this.goalsBySession.get(sessionId);
+      return isGoalOpen(cachedGoal) ? cachedGoal : undefined;
     }
     const nativeGoal = await state.server.getGoal();
     if (!nativeGoal) {
@@ -730,8 +738,54 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       return undefined;
     }
     const goal = this.mapCodexGoal(sessionId, nativeGoal);
+    if (!isGoalOpen(goal)) {
+      this.goalsBySession.delete(sessionId);
+      return undefined;
+    }
     this.goalsBySession.set(sessionId, goal);
     return goal;
+  }
+
+  /** Return active goal lookup metadata without spawning inactive Codex sessions. */
+  async getGoalLookup(sessionId: string): Promise<GoalLookupResult> {
+    const state = this.runtime.get(sessionId);
+    if (!state?.server.isAlive) {
+      const cachedGoal = this.goalsBySession.get(sessionId);
+      return {
+        goal: isGoalOpen(cachedGoal) ? cachedGoal : null,
+        authoritative: false,
+        source: "codex-cache",
+        reason: "not-materialized",
+      };
+    }
+
+    const nativeGoal = await state.server.getGoal();
+    if (!nativeGoal) {
+      this.goalsBySession.delete(sessionId);
+      return {
+        goal: null,
+        authoritative: true,
+        source: "codex-native",
+      };
+    }
+
+    const goal = this.mapCodexGoal(sessionId, nativeGoal);
+    if (!isGoalOpen(goal)) {
+      this.goalsBySession.delete(sessionId);
+      return {
+        goal: null,
+        authoritative: true,
+        source: "codex-native",
+        reason: "closed",
+      };
+    }
+
+    this.goalsBySession.set(sessionId, goal);
+    return {
+      goal,
+      authoritative: true,
+      source: "codex-native",
+    };
   }
 
   /**

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { container } from "tsyringe";
 import type Database from "better-sqlite3";
-import type { Thread, IProviderRegistry, GoalState, AgentEvent } from "@mcode/contracts";
+import type { Thread, IProviderRegistry, GoalState, AgentEvent, GoalLookupResult } from "@mcode/contracts";
 import { AgentEventType } from "@mcode/contracts";
 import { openMemoryDatabase } from "../../store/database.js";
 import { ThreadRepo } from "../../repositories/thread-repo.js";
@@ -76,6 +76,18 @@ function buildService(db: Database.Database) {
     setGoal: vi.fn<(sid: string, condition: string) => GoalState>((_, condition) => makeGoal(condition)),
     clearGoal: vi.fn<(sid: string) => boolean>(() => true),
     getGoal: vi.fn<(sid: string) => GoalState | undefined>(() => undefined),
+    getGoalLookup: vi.fn<(_sid: string) => GoalLookupResult>(() => ({
+      goal: null,
+      authoritative: false,
+      source: "claude-wrapper" as const,
+      reason: "missing" as const,
+    })),
+    hasNativeGoalCommand: vi.fn<(sid: string) => boolean>(() => false),
+    setNativeGoalMirror: vi.fn<(sid: string, condition: string) => GoalState>((_, condition) => makeGoal(condition)),
+    clearNativeGoalMirror: vi.fn<(sid: string) => boolean>(() => true),
+    runNativeGoalCommand: vi.fn<() => Promise<{ kind: "active"; objective: string } | { kind: "cleared"; objective: string } | { kind: "empty" } | { kind: "unavailable" } | null>>(
+      () => Promise.resolve(null),
+    ),
   });
   // A provider lacking the goal capability (no setGoal/clearGoal/getGoal).
   // `/goal` must pass through to this provider as plain text.
@@ -195,6 +207,28 @@ describe("AgentService.sendMessage — /goal command", () => {
     expect(userMsg?.content).toBe("/goal analyse this branch");
   });
 
+  it("native Claude /goal sends exact slash-command wire text", async () => {
+    const { svc, providerStub } = buildService(db);
+    providerStub.hasNativeGoalCommand.mockReturnValue(true);
+
+    await svc.sendMessage(
+      thread.id,
+      "/goal analyse this branch",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+
+    expect(providerStub.setGoal).not.toHaveBeenCalled();
+    expect(providerStub.setNativeGoalMirror).toHaveBeenCalledWith(
+      `mcode-${thread.id}`,
+      "analyse this branch",
+    );
+    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal analyse this branch");
+  });
+
   it("completes a direct say-goal when the assistant says the requested text", async () => {
     const { svc, providerStub } = buildService(db);
     const events: AgentEvent[] = [];
@@ -306,6 +340,25 @@ describe("AgentService.sendMessage — /goal command", () => {
     );
     // ...and the catch ran onRollback so the gate does not leak into the next turn.
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
+  });
+
+  it("keeps the native goal mirror when a native control send fails", async () => {
+    const { svc, providerStub } = buildService(db);
+    providerStub.hasNativeGoalCommand.mockReturnValue(true);
+    providerStub.sendTurn.mockRejectedValueOnce(new Error("provider boom"));
+
+    await svc.sendMessage(
+      thread.id,
+      "/goal clear",
+      "default",
+      "claude-sonnet-4-6",
+      [],
+      undefined,
+      "claude",
+    );
+
+    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal off");
+    expect(providerStub.clearNativeGoalMirror).not.toHaveBeenCalled();
   });
 
   it("/goal clear short-circuits — clears the goal, does NOT invoke the provider, broadcasts a Message pill without Ended", async () => {
@@ -520,5 +573,156 @@ describe("AgentService.sendMessage — /goal command", () => {
     const contents = messageRepo.listByThread(thread.id, 100).messages.map((m) => m.content);
     expect(contents).toContain("/goal clear");
     expect(contents.some((content) => content.includes("Goal cleared"))).toBe(true);
+  });
+
+  it("thread.goal.clear during an active native Claude turn returns busy cache and keeps mirror", async () => {
+    const { svc, providerStub } = buildService(db);
+    const activeGoal: GoalState = {
+      threadId: thread.id,
+      objective: "wait",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 0,
+      timeUsedSeconds: 0,
+      createdAt: 1,
+      updatedAt: 1,
+      providerId: "claude",
+      source: "claude",
+      controls: { canInspect: true, canClear: true },
+    };
+    providerStub.hasNativeGoalCommand.mockReturnValue(true);
+    providerStub.getGoalLookup.mockReturnValue({
+      goal: activeGoal,
+      authoritative: false,
+      source: "claude-cache",
+    });
+
+    await svc.sendMessage(thread.id, "first turn", "default", "claude-sonnet-4-6", [], undefined, "claude");
+
+    await expect(svc.clearThreadGoal(thread.id)).resolves.toEqual({
+      goal: activeGoal,
+      authoritative: false,
+      source: "claude-cache",
+      reason: "busy",
+    });
+    expect(providerStub.runNativeGoalCommand).not.toHaveBeenCalled();
+    expect(providerStub.clearGoal).not.toHaveBeenCalled();
+  });
+
+  it("idle native thread.goal.clear dispatches /goal off and returns authoritative native clear", async () => {
+    const { svc, providerStub } = buildService(db);
+    providerStub.hasNativeGoalCommand.mockReturnValue(true);
+    providerStub.runNativeGoalCommand.mockResolvedValue({ kind: "cleared", objective: "wait" });
+
+    await expect(svc.clearThreadGoal(thread.id)).resolves.toEqual({
+      goal: null,
+      authoritative: true,
+      source: "claude-native-command",
+    });
+    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(`mcode-${thread.id}`, "/goal off");
+    expect(providerStub.clearGoal).not.toHaveBeenCalled();
+  });
+
+  it("post-turn native refresh emits complete then cleared once when status says no goal set", async () => {
+    const { svc, providerStub } = buildService(db);
+    const events: AgentEvent[] = [];
+    const activeGoal: GoalState = {
+      threadId: thread.id,
+      objective: "say hi",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 0,
+      timeUsedSeconds: 0,
+      createdAt: Date.now() - 1_000,
+      updatedAt: Date.now() - 1_000,
+      providerId: "claude",
+      source: "claude",
+      controls: { canInspect: true, canClear: true },
+    };
+    providerStub.hasNativeGoalCommand.mockReturnValue(true);
+    providerStub.getGoal.mockReturnValue(activeGoal);
+    providerStub.runNativeGoalCommand.mockResolvedValue({ kind: "empty" });
+    providerStub.on("event", (event: AgentEvent) => events.push(event));
+    svc.init();
+
+    providerStub.emit("event", {
+      type: AgentEventType.TurnStarted,
+      threadId: thread.id,
+    } satisfies AgentEvent);
+    providerStub.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: thread.id,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 1,
+      tokensOut: 0,
+      providerId: "claude",
+    } satisfies AgentEvent);
+
+    for (let i = 0; i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(`mcode-${thread.id}`, "/goal");
+    const goalEvents = events.filter(
+      (event) => event.type === AgentEventType.GoalUpdated || event.type === AgentEventType.GoalCleared,
+    );
+    expect(goalEvents).toEqual([
+      expect.objectContaining({
+        type: AgentEventType.GoalUpdated,
+        goal: expect.objectContaining({ status: "complete", objective: "say hi" }),
+      }),
+      expect.objectContaining({
+        type: AgentEventType.GoalCleared,
+        reason: "completed",
+      }),
+    ]);
+  });
+
+  it("post-turn native refresh does not enqueue /goal if a new turn starts after reading the cache", async () => {
+    const { svc, providerStub } = buildService(db);
+    const activeGoal: GoalState = {
+      threadId: thread.id,
+      objective: "say hi",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 0,
+      timeUsedSeconds: 0,
+      createdAt: Date.now() - 1_000,
+      updatedAt: Date.now() - 1_000,
+      providerId: "claude",
+      source: "claude",
+      controls: { canInspect: true, canClear: true },
+    };
+    let resolveGoal!: (goal: GoalState) => void;
+    providerStub.hasNativeGoalCommand.mockReturnValue(true);
+    providerStub.getGoal.mockImplementation(() => new Promise<GoalState>((resolve) => {
+      resolveGoal = resolve;
+    }) as unknown as GoalState);
+    svc.init();
+
+    providerStub.emit("event", {
+      type: AgentEventType.TurnStarted,
+      threadId: thread.id,
+    } satisfies AgentEvent);
+    providerStub.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: thread.id,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 1,
+      tokensOut: 0,
+      providerId: "claude",
+    } satisfies AgentEvent);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    providerStub.emit("event", {
+      type: AgentEventType.TurnStarted,
+      threadId: thread.id,
+    } satisfies AgentEvent);
+    resolveGoal(activeGoal);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(providerStub.runNativeGoalCommand).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { container } from "tsyringe";
 import type Database from "better-sqlite3";
-import type { Thread, IProviderRegistry, GoalState } from "@mcode/contracts";
+import type { Thread, IProviderRegistry, GoalState, AgentEvent } from "@mcode/contracts";
 import { AgentEventType } from "@mcode/contracts";
 import { openMemoryDatabase } from "../../store/database.js";
 import { ThreadRepo } from "../../repositories/thread-repo.js";
@@ -193,6 +193,94 @@ describe("AgentService.sendMessage — /goal command", () => {
     const { messages } = messageRepo.listByThread(thread.id, 100);
     const userMsg = messages.find((m) => m.role === "user");
     expect(userMsg?.content).toBe("/goal analyse this branch");
+  });
+
+  it("completes a direct say-goal when the assistant says the requested text", async () => {
+    const { svc, providerStub } = buildService(db);
+    const events: AgentEvent[] = [];
+    const activeGoal: GoalState = {
+      threadId: thread.id,
+      objective: "say hi",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 0,
+      timeUsedSeconds: 3,
+      createdAt: Date.now() - 3_000,
+      updatedAt: Date.now() - 3_000,
+      providerId: "claude",
+      source: "claude",
+      controls: { canInspect: true, canClear: true },
+    };
+    providerStub.getGoal
+      .mockReturnValueOnce(activeGoal)
+      .mockReturnValue(undefined);
+    providerStub.on("event", (event: AgentEvent) => events.push(event));
+    svc.init();
+
+    providerStub.emit("event", {
+      type: AgentEventType.Message,
+      threadId: thread.id,
+      content: "hi",
+      tokens: null,
+    } satisfies AgentEvent);
+
+    for (let i = 0; i < 20 && providerStub.clearGoal.mock.calls.length === 0; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: AgentEventType.GoalUpdated,
+        threadId: thread.id,
+        goal: expect.objectContaining({
+          objective: "say hi",
+          status: "complete",
+          providerId: "claude",
+          controls: expect.objectContaining({ canClear: false }),
+        }),
+      }),
+      expect.objectContaining({
+        type: AgentEventType.GoalCleared,
+        threadId: thread.id,
+        providerId: "claude",
+        reason: "completed",
+      }),
+    ]));
+    expect(events.some(
+      (event) =>
+        event.type === AgentEventType.Message &&
+        /^Goal achieved in \d+s\.$/.test(event.content),
+    )).toBe(false);
+  });
+
+  it("does not complete broad goals from an arbitrary assistant answer", async () => {
+    const { svc, providerStub } = buildService(db);
+    providerStub.getGoal.mockReturnValueOnce({
+      threadId: thread.id,
+      objective: "fix the bug",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 0,
+      timeUsedSeconds: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      providerId: "claude",
+      source: "claude",
+      controls: { canInspect: true, canClear: true },
+    } satisfies GoalState);
+    svc.init();
+
+    providerStub.emit("event", {
+      type: AgentEventType.Message,
+      threadId: thread.id,
+      content: "done",
+      tokens: null,
+    } satisfies AgentEvent);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(providerStub.clearGoal).not.toHaveBeenCalled();
   });
 
   it("rolls the installed goal back when the send fails so no Stop-hook gate lingers", async () => {

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -317,6 +317,45 @@ describe("AgentService.sendMessage — /goal command", () => {
     expect(providerStub.clearGoal).not.toHaveBeenCalled();
   });
 
+  it("does not emit direct-response completion events when provider clear returns false", async () => {
+    const { svc, providerStub } = buildService(db);
+    const events: AgentEvent[] = [];
+    providerStub.clearGoal.mockResolvedValueOnce(false);
+    providerStub.getGoal
+      .mockReturnValueOnce({
+        threadId: thread.id,
+        objective: "say hi",
+        status: "active",
+        tokenBudget: null,
+        tokensUsed: 0,
+        timeUsedSeconds: 3,
+        createdAt: Date.now() - 3_000,
+        updatedAt: Date.now() - 3_000,
+        providerId: "claude",
+        source: "claude",
+        controls: { canInspect: true, canClear: true },
+      } satisfies GoalState)
+      .mockReturnValue(undefined);
+    providerStub.on("event", (event: AgentEvent) => events.push(event));
+    svc.init();
+
+    providerStub.emit("event", {
+      type: AgentEventType.Message,
+      threadId: thread.id,
+      content: "hi",
+      tokens: null,
+    } satisfies AgentEvent);
+
+    for (let i = 0; i < 20 && providerStub.clearGoal.mock.calls.length === 0; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
+    expect(events.some((event) => event.type === AgentEventType.GoalUpdated)).toBe(false);
+    expect(events.some((event) => event.type === AgentEventType.GoalCleared)).toBe(false);
+  });
+
   it("rolls the installed goal back when the send fails so no Stop-hook gate lingers", async () => {
     const { svc, providerStub } = buildService(db);
     providerStub.sendTurn.mockRejectedValueOnce(new Error("provider boom"));
@@ -607,6 +646,55 @@ describe("AgentService.sendMessage — /goal command", () => {
     });
     expect(providerStub.runNativeGoalCommand).not.toHaveBeenCalled();
     expect(providerStub.clearGoal).not.toHaveBeenCalled();
+  });
+
+  it("does not re-enter native Claude goal refresh while its own /goal read is in flight", async () => {
+    const { svc, providerStub } = buildService(db);
+    const activeGoal: GoalState = {
+      threadId: thread.id,
+      objective: "wait",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 0,
+      timeUsedSeconds: 0,
+      createdAt: 1,
+      updatedAt: 1,
+      providerId: "claude",
+      source: "claude",
+      controls: { canInspect: true, canClear: true },
+    };
+    let resolveNativeRead!: (value: { kind: "active"; objective: string }) => void;
+    providerStub.hasNativeGoalCommand.mockReturnValue(true);
+    providerStub.getGoal.mockReturnValue(activeGoal);
+    providerStub.runNativeGoalCommand.mockReturnValue(new Promise((resolve) => {
+      resolveNativeRead = resolve;
+    }));
+    svc.init();
+
+    providerStub.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: thread.id,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 1,
+      tokensOut: 0,
+    } satisfies AgentEvent);
+
+    for (let i = 0; i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    providerStub.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: thread.id,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 1,
+      tokensOut: 0,
+    } satisfies AgentEvent);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledTimes(1);
+    resolveNativeRead({ kind: "active", objective: activeGoal.objective });
   });
 
   it("idle native thread.goal.clear dispatches /goal off and returns authoritative native clear", async () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -191,6 +191,7 @@ function parseHarnessTaskId(output: string): string | null {
 @injectable()
 export class AgentService {
   private readonly activeSessionIds = new Set<string>();
+  private readonly nativeGoalRefreshInFlight = new Set<string>();
   private initialized = false;
   /** Running context token estimate, per thread. Reset on compaction start; overwritten on turnComplete. */
   private lastContextByThread = new Map<string, number>();
@@ -1467,24 +1468,29 @@ export class AgentService {
     const source = providerId === "codex" ? "codex-native" as const : "claude-wrapper" as const;
     const cleared = await provider.clearGoal(sessionId);
     if (cleared) {
+      if (providerId === "codex" && provider.getGoalLookup) {
+        const lookup = await provider.getGoalLookup(sessionId);
+        if (lookup.source !== "codex-native" || lookup.authoritative !== true) {
+          return {
+            ...lookup,
+            goal: isGoalOpen(lookup.goal) ? lookup.goal : null,
+          };
+        }
+      }
       return { goal: null, authoritative: true, source };
     }
 
-    const goalAfterClear = await provider.getGoal(sessionId);
-    const currentGoal = isGoalOpen(goalAfterClear) ? goalAfterClear : null;
-    if (currentGoal) {
-      return {
-        goal: currentGoal,
-        authoritative: false,
-        source,
-        reason: "missing",
-      };
-    }
+    const lookup = provider.getGoalLookup
+      ? await provider.getGoalLookup(sessionId)
+      : {
+          goal: await provider.getGoal(sessionId),
+          authoritative: false,
+          source: providerId === "codex" ? "codex-cache" as const : "claude-wrapper" as const,
+          reason: "missing" as const,
+        };
     return {
-      goal: null,
-      authoritative: true,
-      source,
-      reason: "missing",
+      ...lookup,
+      goal: isGoalOpen(lookup.goal) ? lookup.goal : null,
     };
   }
 
@@ -2541,6 +2547,7 @@ export class AgentService {
 
   private refreshNativeClaudeGoalAfterTurn(threadId: string): void {
     if (this.activeSessionIds.has(threadId)) return;
+    if (this.nativeGoalRefreshInFlight.has(threadId)) return;
     const thread = this.threadRepo.findById(threadId);
     if (!thread || thread.provider !== "claude") return;
     const provider = this.providerRegistry.resolve("claude");
@@ -2551,30 +2558,35 @@ export class AgentService {
     }
 
     void (async () => {
-      const before = await provider.getGoal(sessionId);
-      if (!isGoalOpen(before)) return;
-      if (this.activeSessionIds.has(threadId)) return;
-      const result = await nativeClaude.runNativeGoalCommand(sessionId, "/goal");
-      if (result?.kind === "empty") {
-        const nowMs = Date.now();
-        this.emitProviderEvent(provider, {
-          type: AgentEventType.GoalUpdated,
-          threadId,
-          goal: {
-            ...before,
-            status: "complete",
-            timeUsedSeconds: elapsedGoalSeconds(before, nowMs),
-            updatedAt: nowMs,
-            controls: { ...before.controls, canClear: false },
-          },
-        } satisfies AgentEvent);
-        this.emitProviderEvent(provider, {
-          type: AgentEventType.GoalCleared,
-          threadId,
-          providerId: before.providerId ?? "claude",
-          reason: "completed",
-          turnId: before.turnId ?? null,
-        } satisfies AgentEvent);
+      this.nativeGoalRefreshInFlight.add(threadId);
+      try {
+        const before = await provider.getGoal(sessionId);
+        if (!isGoalOpen(before)) return;
+        if (this.activeSessionIds.has(threadId)) return;
+        const result = await nativeClaude.runNativeGoalCommand(sessionId, "/goal");
+        if (result?.kind === "empty") {
+          const nowMs = Date.now();
+          this.emitProviderEvent(provider, {
+            type: AgentEventType.GoalUpdated,
+            threadId,
+            goal: {
+              ...before,
+              status: "complete",
+              timeUsedSeconds: elapsedGoalSeconds(before, nowMs),
+              updatedAt: nowMs,
+              controls: { ...before.controls, canClear: false },
+            },
+          } satisfies AgentEvent);
+          this.emitProviderEvent(provider, {
+            type: AgentEventType.GoalCleared,
+            threadId,
+            providerId: before.providerId ?? "claude",
+            reason: "completed",
+            turnId: before.turnId ?? null,
+          } satisfies AgentEvent);
+        }
+      } finally {
+        this.nativeGoalRefreshInFlight.delete(threadId);
       }
     })().catch((err: unknown) => {
       logger.warn("Native Claude goal refresh failed", {
@@ -2596,8 +2608,7 @@ export class AgentService {
       }
 
       const cleared = await provider.clearGoal(sessionId);
-      const remainingGoal = cleared ? undefined : await provider.getGoal(sessionId);
-      if (!cleared && isGoalOpen(remainingGoal)) {
+      if (!cleared) {
         logger.warn("Direct-response goal matched but provider did not clear it", {
           threadId: event.threadId,
           providerId: goal.providerId,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -115,6 +115,22 @@ const GOAL_ACHIEVED_RECEIPT_RE = /^Goal achieved in \d+s\.$/;
 const DIRECT_RESPONSE_GOAL_RE = /^\s*(?:say|reply|respond|answer)(?:\s+with)?\s+(.+?)\s*$/i;
 type AgentMessageEvent = Extract<AgentEvent, { type: "message" }>;
 
+interface ClaudeNativeGoalProvider {
+  hasNativeGoalCommand(sessionId: string): boolean;
+  runNativeGoalCommand(
+    sessionId: string,
+    command: "/goal" | "/goal off",
+  ): Promise<{ kind: "active"; objective: string } | { kind: "cleared"; objective: string } | { kind: "empty" } | { kind: "unavailable" } | null>;
+}
+
+function asClaudeNativeGoalProvider(provider: IAgentProvider): ClaudeNativeGoalProvider | null {
+  const candidate = provider as Partial<ClaudeNativeGoalProvider>;
+  return typeof candidate.hasNativeGoalCommand === "function" &&
+    typeof candidate.runNativeGoalCommand === "function"
+    ? (candidate as ClaudeNativeGoalProvider)
+    : null;
+}
+
 function stripSurroundingGoalQuotes(value: string): string {
   const text = value.trim();
   const pairs: Array<[string, string]> = [
@@ -1406,6 +1422,48 @@ export class AgentService {
     }
 
     const sessionId = `mcode-${threadId}`;
+    const nativeClaude = asClaudeNativeGoalProvider(provider);
+    if (nativeClaude?.hasNativeGoalCommand(sessionId) === true) {
+      const lookup = provider.getGoalLookup
+        ? await provider.getGoalLookup(sessionId)
+        : { goal: await provider.getGoal(sessionId), authoritative: false, source: "claude-cache" as const };
+      const currentGoal = isGoalOpen(lookup.goal) ? lookup.goal : null;
+      if (currentGoal && this.activeSessionIds.has(threadId)) {
+        return {
+          goal: currentGoal,
+          authoritative: false,
+          source: "claude-cache",
+          reason: "busy",
+        };
+      }
+
+      const result = await nativeClaude.runNativeGoalCommand(sessionId, "/goal off");
+      if (result?.kind === "cleared" || result?.kind === "empty") {
+        return {
+          goal: null,
+          authoritative: true,
+          source: "claude-native-command",
+        };
+      }
+      if (result?.kind === "unavailable") {
+        return {
+          goal: currentGoal,
+          authoritative: false,
+          source: "claude-cache",
+          reason: currentGoal ? "missing" : "not-materialized",
+        };
+      }
+      const goalAfterNativeClear = provider.getGoalLookup
+        ? (await provider.getGoalLookup(sessionId)).goal
+        : await provider.getGoal(sessionId);
+      return {
+        goal: isGoalOpen(goalAfterNativeClear) ? goalAfterNativeClear : currentGoal,
+        authoritative: false,
+        source: "claude-cache",
+        reason: "missing",
+      };
+    }
+
     const source = providerId === "codex" ? "codex-native" as const : "claude-wrapper" as const;
     const cleared = await provider.clearGoal(sessionId);
     if (cleared) {
@@ -2272,6 +2330,7 @@ export class AgentService {
           if (!this.compactionInProgressByThread.has(event.threadId)) {
             this.trackSessionEnded(event.threadId);
             this.disarmTurnRetryWindow(event.threadId);
+            void this.refreshNativeClaudeGoalAfterTurn(event.threadId);
           }
 
           // Persist context usage so the tracker shows immediately on thread reload.
@@ -2478,6 +2537,51 @@ export class AgentService {
     };
     if (typeof emitter.emit !== "function") return;
     emitter.emit.call(provider, "event", event);
+  }
+
+  private refreshNativeClaudeGoalAfterTurn(threadId: string): void {
+    if (this.activeSessionIds.has(threadId)) return;
+    const thread = this.threadRepo.findById(threadId);
+    if (!thread || thread.provider !== "claude") return;
+    const provider = this.providerRegistry.resolve("claude");
+    const nativeClaude = asClaudeNativeGoalProvider(provider);
+    const sessionId = `mcode-${threadId}`;
+    if (nativeClaude?.hasNativeGoalCommand(sessionId) !== true || !isGoalCapable(provider)) {
+      return;
+    }
+
+    void (async () => {
+      const before = await provider.getGoal(sessionId);
+      if (!isGoalOpen(before)) return;
+      if (this.activeSessionIds.has(threadId)) return;
+      const result = await nativeClaude.runNativeGoalCommand(sessionId, "/goal");
+      if (result?.kind === "empty") {
+        const nowMs = Date.now();
+        this.emitProviderEvent(provider, {
+          type: AgentEventType.GoalUpdated,
+          threadId,
+          goal: {
+            ...before,
+            status: "complete",
+            timeUsedSeconds: elapsedGoalSeconds(before, nowMs),
+            updatedAt: nowMs,
+            controls: { ...before.controls, canClear: false },
+          },
+        } satisfies AgentEvent);
+        this.emitProviderEvent(provider, {
+          type: AgentEventType.GoalCleared,
+          threadId,
+          providerId: before.providerId ?? "claude",
+          reason: "completed",
+          turnId: before.turnId ?? null,
+        } satisfies AgentEvent);
+      }
+    })().catch((err: unknown) => {
+      logger.warn("Native Claude goal refresh failed", {
+        threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   }
 
   private maybeCompleteDirectResponseGoal(provider: IAgentProvider, event: AgentMessageEvent): void {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -9,7 +9,7 @@ import { injectable, inject, delay } from "tsyringe";
 import { existsSync, statSync } from "fs";
 import { isAbsolute } from "path";
 import { logger, validateBranchName } from "@mcode/shared";
-import { AgentEventType, isSessionEvictable } from "@mcode/contracts";
+import { AgentEventType, isGoalCapable, isGoalOpen, isSessionEvictable } from "@mcode/contracts";
 import type {
   Thread,
   AttachmentMeta,
@@ -26,6 +26,8 @@ import type {
   PlanOutput,
   PlanAction,
   MessageMention,
+  GoalState,
+  GoalLookupResult,
 } from "@mcode/contracts";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
@@ -110,6 +112,55 @@ const FORK_HISTORY_BUDGET_BYTES = 1_000_000;
 const FORK_HISTORY_PAGE_SIZE = 100;
 const FORK_HISTORY_MAX_MESSAGES = 500;
 const GOAL_ACHIEVED_RECEIPT_RE = /^Goal achieved in \d+s\.$/;
+const DIRECT_RESPONSE_GOAL_RE = /^\s*(?:say|reply|respond|answer)(?:\s+with)?\s+(.+?)\s*$/i;
+type AgentMessageEvent = Extract<AgentEvent, { type: "message" }>;
+
+function stripSurroundingGoalQuotes(value: string): string {
+  const text = value.trim();
+  const pairs: Array<[string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ["`", "`"],
+    ["“", "”"],
+    ["‘", "’"],
+  ];
+  for (const [open, close] of pairs) {
+    if (text.startsWith(open) && text.endsWith(close) && text.length >= open.length + close.length) {
+      return text.slice(open.length, text.length - close.length).trim();
+    }
+  }
+  return text;
+}
+
+function normalizeDirectResponseGoalText(value: string): string {
+  return stripSurroundingGoalQuotes(value)
+    .replace(/\s+/g, " ")
+    .replace(/[.!?]+$/g, "")
+    .trim()
+    .toLowerCase();
+}
+
+function directResponseGoalTarget(objective: string): string | null {
+  const match = DIRECT_RESPONSE_GOAL_RE.exec(objective);
+  if (!match) return null;
+  const target = normalizeDirectResponseGoalText(match[1]);
+  return target.length > 0 ? target : null;
+}
+
+function satisfiesDirectResponseGoal(goal: GoalState, content: string): boolean {
+  const target = directResponseGoalTarget(goal.objective);
+  if (!target) return false;
+  return normalizeDirectResponseGoalText(content) === target;
+}
+
+function goalTimestampMs(value: number): number {
+  return value < 1_000_000_000_000 ? value * 1000 : value;
+}
+
+function elapsedGoalSeconds(goal: GoalState, nowMs: number): number {
+  const elapsed = Math.floor((nowMs - goalTimestampMs(goal.createdAt)) / 1000);
+  return Math.max(goal.timeUsedSeconds, elapsed, 0);
+}
 
 /**
  * Extract the harness-assigned task id from a `TaskCreate` result line such as
@@ -1307,6 +1358,78 @@ export class AgentService {
     }
   }
 
+  /** Return a thread's active open goal without starting provider work. */
+  async getThreadGoal(threadId: string): Promise<GoalLookupResult> {
+    const thread = this.threadRepo.findById(threadId);
+    if (!thread) throw new Error(`Thread not found: ${threadId}`);
+
+    const providerId = (thread.provider ?? "claude") as ProviderId;
+    const provider = this.providerRegistry.resolve(providerId);
+    if (!isGoalCapable(provider)) {
+      return {
+        goal: null,
+        authoritative: true,
+        source: "unsupported",
+        reason: "unsupported-provider",
+      };
+    }
+
+    const sessionId = `mcode-${threadId}`;
+    const result = provider.getGoalLookup
+      ? await provider.getGoalLookup(sessionId)
+      : {
+          goal: await provider.getGoal(sessionId),
+          authoritative: false,
+          source: providerId === "codex" ? "codex-cache" as const : "claude-wrapper" as const,
+          reason: "missing" as const,
+        };
+    return {
+      ...result,
+      goal: isGoalOpen(result.goal) ? result.goal : null,
+    };
+  }
+
+  /** Clear a thread's active goal without writing transcript rows or starting a turn. */
+  async clearThreadGoal(threadId: string): Promise<GoalLookupResult> {
+    const thread = this.threadRepo.findById(threadId);
+    if (!thread) throw new Error(`Thread not found: ${threadId}`);
+
+    const providerId = (thread.provider ?? "claude") as ProviderId;
+    const provider = this.providerRegistry.resolve(providerId);
+    if (!isGoalCapable(provider)) {
+      return {
+        goal: null,
+        authoritative: true,
+        source: "unsupported",
+        reason: "unsupported-provider",
+      };
+    }
+
+    const sessionId = `mcode-${threadId}`;
+    const source = providerId === "codex" ? "codex-native" as const : "claude-wrapper" as const;
+    const cleared = await provider.clearGoal(sessionId);
+    if (cleared) {
+      return { goal: null, authoritative: true, source };
+    }
+
+    const goalAfterClear = await provider.getGoal(sessionId);
+    const currentGoal = isGoalOpen(goalAfterClear) ? goalAfterClear : null;
+    if (currentGoal) {
+      return {
+        goal: currentGoal,
+        authoritative: false,
+        source,
+        reason: "missing",
+      };
+    }
+    return {
+      goal: null,
+      authoritative: true,
+      source,
+      reason: "missing",
+    };
+  }
+
   /** Stop the active turn and discard any pooled provider session for a deleted thread. */
   async teardownSession(threadId: string): Promise<void> {
     const sessionId = `mcode-${threadId}`;
@@ -1915,6 +2038,7 @@ export class AgentService {
               error: err instanceof Error ? err.message : String(err),
             });
           }
+          this.maybeCompleteDirectResponseGoal(provider, event);
           // A Message event marks the end of the turn. Any Agent calls still
           // on the stack are implicitly done - clear the stack so the next turn
           // starts clean (narrative-pipeline.md Trap 2 end-of-turn clear).
@@ -2346,6 +2470,63 @@ export class AgentService {
    */
   private normalizeProviderError(message: string, provider: string): string {
     return normalizeAgentProviderError(provider, message);
+  }
+
+  private emitProviderEvent(provider: IAgentProvider, event: AgentEvent): void {
+    const emitter = provider as unknown as {
+      emit?: (eventName: "event", event: AgentEvent) => boolean;
+    };
+    if (typeof emitter.emit !== "function") return;
+    emitter.emit.call(provider, "event", event);
+  }
+
+  private maybeCompleteDirectResponseGoal(provider: IAgentProvider, event: AgentMessageEvent): void {
+    if (!isGoalCapable(provider)) return;
+    if (GOAL_ACHIEVED_RECEIPT_RE.test(event.content.trim())) return;
+
+    const sessionId = `mcode-${event.threadId}`;
+    void (async () => {
+      const goal = await provider.getGoal(sessionId);
+      if (!isGoalOpen(goal) || !satisfiesDirectResponseGoal(goal, event.content)) {
+        return;
+      }
+
+      const cleared = await provider.clearGoal(sessionId);
+      const remainingGoal = cleared ? undefined : await provider.getGoal(sessionId);
+      if (!cleared && isGoalOpen(remainingGoal)) {
+        logger.warn("Direct-response goal matched but provider did not clear it", {
+          threadId: event.threadId,
+          providerId: goal.providerId,
+          objective: goal.objective,
+        });
+        return;
+      }
+
+      const nowMs = Date.now();
+      this.emitProviderEvent(provider, {
+        type: AgentEventType.GoalUpdated,
+        threadId: event.threadId,
+        goal: {
+          ...goal,
+          status: "complete",
+          timeUsedSeconds: elapsedGoalSeconds(goal, nowMs),
+          updatedAt: nowMs,
+          controls: { ...goal.controls, canClear: false },
+        },
+      } satisfies AgentEvent);
+      this.emitProviderEvent(provider, {
+        type: AgentEventType.GoalCleared,
+        threadId: event.threadId,
+        providerId: goal.providerId ?? "unknown",
+        reason: "completed",
+        turnId: goal.turnId ?? null,
+      } satisfies AgentEvent);
+    })().catch((err: unknown) => {
+      logger.warn("Direct-response goal completion check failed", {
+        threadId: event.threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   }
 
   /**

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -472,6 +472,10 @@ async function dispatch(
     case "thread.markViewed":
       deps.threadService.markViewed(params.threadId);
       return;
+    case "thread.goal.get":
+      return deps.agentService.getThreadGoal(params.threadId);
+    case "thread.goal.clear":
+      return deps.agentService.clearThreadGoal(params.threadId);
     case "thread.search":
       return deps.threadService.search({
         query: params.query,

--- a/apps/web/e2e/thread-goal-switch.spec.ts
+++ b/apps/web/e2e/thread-goal-switch.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "@playwright/test";
+import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+
+const now = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+const workspace = {
+  id: "ws-goal-switch",
+  name: "Goal Switch Workspace",
+  path: "/tmp/goal-switch",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: now,
+  updated_at: now,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+};
+
+function thread(id: string, title: string) {
+  return {
+    id,
+    workspace_id: workspace.id,
+    title,
+    status: "paused" as const,
+    mode: "direct" as const,
+    worktree_path: null,
+    branch: "main",
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "gpt-5.2-codex",
+    provider: "codex",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    checkout_state: "named",
+    base_branch: null,
+    thinking: null,
+    codex_fast_mode: null,
+    copilot_agent: null,
+    default_open_in_app: null,
+    last_compact_summary: null,
+    has_file_changes: false,
+  };
+}
+
+function message(threadId: string, id: string, content: string) {
+  return {
+    id,
+    thread_id: threadId,
+    role: "user" as const,
+    content,
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: now,
+    sequence: 1,
+    attachments: null,
+  };
+}
+
+test("thread switch A/B/A renders active goal for only the matching thread", async ({ page }) => {
+  await interceptZustandStores(page);
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [
+      thread("thread-a", "Goal Thread A"),
+      thread("thread-b", "No Goal Thread B"),
+    ],
+    "conversation.page": (params) => {
+      const threadId = (params as { threadId: string }).threadId;
+      return {
+        messages: [
+          message(threadId, `${threadId}-user`, threadId === "thread-a" ? "Alpha request" : "Beta request"),
+        ],
+        hasMore: false,
+        answeredPlanMessageIds: [],
+        narrativeByMessage: {},
+      };
+    },
+    "thread.goal.get": (params) => {
+      const threadId = (params as { threadId: string }).threadId;
+      if (threadId === "thread-a") {
+        return {
+          goal: {
+            threadId,
+            objective: "Keep Alpha active",
+            status: "active",
+            tokenBudget: null,
+            tokensUsed: 0,
+            timeUsedSeconds: 0,
+            createdAt: 1,
+            updatedAt: 1,
+            providerId: "codex",
+            source: "codex",
+            controls: { canInspect: true, canClear: true },
+          },
+          authoritative: false,
+          source: "codex-cache",
+          reason: "not-materialized",
+        };
+      }
+      return {
+        goal: null,
+        authoritative: false,
+        source: "codex-cache",
+        reason: "not-materialized",
+      };
+    },
+  });
+
+  await page.goto("/");
+  await page.getByRole("option", { name: /Goal Switch Workspace/ }).click();
+  await page.getByRole("button", { name: /Goal Switch Workspace 2/ }).click();
+  await page.waitForSelector("[data-testid='thread-item']");
+
+  const threadItems = page.locator("[data-testid='thread-item']");
+  await threadItems.nth(0).click();
+  await expect(page.getByTestId("active-goal-bar")).toContainText("Keep Alpha active");
+
+  await threadItems.nth(1).click();
+  await expect(page.getByTestId("active-goal-bar")).toHaveCount(0);
+
+  await threadItems.nth(0).click();
+  await expect(page.getByTestId("active-goal-bar")).toContainText("Keep Alpha active");
+});

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -783,6 +783,17 @@ describe("subagent count via markPriorToolCallsComplete", () => {
     expect(rec.messages.map((message) => message.id)).toEqual(["answer-1", "goal-1"]);
   });
 
+  it("keeps near-match goal receipt text as a normal assistant response", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.message",
+      params: { messageId: "answer-1", content: "Goal achieved in 19s. Here is the summary." },
+    });
+
+    const rec = readThreadField("thread-1", (record) => record);
+    expect(rec.currentTurnMessageId).toBe("answer-1");
+    expect(rec.assistantResponseKeys["answer-1"]).toBeDefined();
+  });
+
   it("clears active goal state when a goal update is complete", () => {
     useThreadStore.getState().handleAgentEvent("thread-1", {
       method: "session.goalUpdated",

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -4,6 +4,7 @@ import {
   getTestThreadToolCalls,
   getTestThreadError,
   getTestThreadLastFallback,
+  readThreadField,
 } from "@/stores/thread-store-test-utils";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -762,5 +763,89 @@ describe("subagent count via markPriorToolCallsComplete", () => {
     expect(countActiveSubagentCalls(getTestThreadToolCalls("thread-1"))).toBe(
       2,
     );
+  });
+
+  it("does not let goal receipts claim current turn response identity", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.message",
+      params: { messageId: "answer-1", content: "The rendering bug is fixed." },
+    });
+
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.message",
+      params: { messageId: "goal-1", content: "Goal achieved in 19s." },
+    });
+
+    const rec = readThreadField("thread-1", (record) => record);
+    expect(rec.currentTurnMessageId).toBe("answer-1");
+    expect(rec.assistantResponseKeys["answer-1"]).toBeDefined();
+    expect(rec.assistantResponseKeys["goal-1"]).toBeUndefined();
+    expect(rec.messages.map((message) => message.id)).toEqual(["answer-1", "goal-1"]);
+  });
+
+  it("clears active goal state when a goal update is complete", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.goalUpdated",
+      params: {
+        goal: {
+          objective: "fix rendering",
+          status: "active",
+          tokenBudget: null,
+          tokensUsed: 0,
+          timeUsedSeconds: 0,
+          createdAt: 1,
+          updatedAt: 1,
+          source: "claude",
+          controls: { canInspect: true, canClear: true },
+        },
+      },
+    });
+    expect(readThreadField("thread-1", (record) => record.goal?.status)).toBe("active");
+
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.goalUpdated",
+      params: {
+        goal: {
+          objective: "fix rendering",
+          status: "complete",
+          tokenBudget: null,
+          tokensUsed: 10,
+          timeUsedSeconds: 19,
+          createdAt: 1,
+          updatedAt: 20,
+          source: "codex",
+          controls: { canInspect: true, canClear: false },
+        },
+      },
+    });
+
+    expect(readThreadField("thread-1", (record) => record.goal)).toBeNull();
+  });
+
+  it("clears active goal state when a goalCleared event arrives", () => {
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.goalUpdated",
+      params: {
+        goal: {
+          objective: "say hi",
+          status: "active",
+          tokenBudget: null,
+          tokensUsed: 0,
+          timeUsedSeconds: 0,
+          createdAt: 1,
+          updatedAt: 1,
+          source: "codex",
+          controls: { canInspect: true, canClear: true },
+        },
+      },
+    });
+    expect(readThreadField("thread-1", (record) => record.goal?.objective)).toBe("say hi");
+
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.goalCleared",
+      params: { providerId: "codex", reason: "completed" },
+    });
+
+    expect(readThreadField("thread-1", (record) => record.goal)).toBeNull();
   });
 });

--- a/apps/web/src/__tests__/goal-clear-unsupported.test.ts
+++ b/apps/web/src/__tests__/goal-clear-unsupported.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GoalState } from "@mcode/contracts";
+import { useThreadStore } from "@/stores/threadStore";
+import {
+  resetThreadStoreForTests,
+  seedThreadRecord,
+} from "@/stores/thread-store-test-utils";
+import { createEmptyThreadRecord } from "@/stores/thread-record";
+import {
+  cacheRecord,
+  clearRecordCache,
+  getCachedRecord,
+} from "@/lib/thread-hydrator/record-cache";
+import { mockTransport } from "./mocks/transport";
+
+vi.mock("@/transport", async () => ({
+  ...(await vi.importActual("@/transport")),
+  getTransport: () => mockTransport,
+}));
+
+const goal: GoalState = {
+  threadId: "thread-unsupported",
+  objective: "Clear stale unsupported goal",
+  status: "active",
+  tokenBudget: null,
+  tokensUsed: 0,
+  timeUsedSeconds: 0,
+  createdAt: 1,
+  updatedAt: 1,
+  providerId: "copilot",
+  source: "mcode",
+  controls: { canInspect: true, canClear: true },
+};
+
+describe("threadStore.clearThreadGoal", () => {
+  beforeEach(() => {
+    clearRecordCache();
+    resetThreadStoreForTests();
+    vi.clearAllMocks();
+  });
+
+  it("applies unsupported authoritative null clear results to live and cached goal state", async () => {
+    const threadId = "thread-unsupported";
+    useThreadStore.setState({
+      records: seedThreadRecord(threadId, { goal }),
+    });
+    cacheRecord(threadId, { ...createEmptyThreadRecord(), goal });
+    (mockTransport.clearThreadGoal as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      goal: null,
+      authoritative: true,
+      source: "unsupported",
+      reason: "unsupported-provider",
+    });
+
+    await useThreadStore.getState().clearThreadGoal(threadId);
+
+    expect(useThreadStore.getState().records.get(threadId)?.goal).toBeNull();
+    expect(getCachedRecord(threadId)?.goal).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/goal-clear-unsupported.test.ts
+++ b/apps/web/src/__tests__/goal-clear-unsupported.test.ts
@@ -57,4 +57,23 @@ describe("threadStore.clearThreadGoal", () => {
     expect(useThreadStore.getState().records.get(threadId)?.goal).toBeNull();
     expect(getCachedRecord(threadId)?.goal).toBeNull();
   });
+
+  it("preserves live and cached goals for non-authoritative null clear results", async () => {
+    const threadId = "thread-cache";
+    useThreadStore.setState({
+      records: seedThreadRecord(threadId, { goal }),
+    });
+    cacheRecord(threadId, { ...createEmptyThreadRecord(), goal });
+    (mockTransport.clearThreadGoal as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      goal: null,
+      authoritative: false,
+      source: "codex-cache",
+      reason: "missing",
+    });
+
+    await useThreadStore.getState().clearThreadGoal(threadId);
+
+    expect(useThreadStore.getState().records.get(threadId)?.goal).toEqual(goal);
+    expect(getCachedRecord(threadId)?.goal).toEqual(goal);
+  });
 });

--- a/apps/web/src/__tests__/mocks/transport.ts
+++ b/apps/web/src/__tests__/mocks/transport.ts
@@ -120,6 +120,18 @@ export const mockTransport: McodeTransport = {
   listRunning: vi.fn().mockResolvedValue([]),
   subscribeThread: vi.fn().mockResolvedValue(undefined),
   unsubscribeThread: vi.fn().mockResolvedValue(undefined),
+  getThreadGoal: vi.fn().mockResolvedValue({
+    goal: null,
+    authoritative: true,
+    source: "unsupported",
+    reason: "unsupported-provider",
+  }),
+  clearThreadGoal: vi.fn().mockResolvedValue({
+    goal: null,
+    authoritative: true,
+    source: "unsupported",
+    reason: "unsupported-provider",
+  }),
   getMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
   loadConversationPage: vi.fn(),
   createAndSendMessage: vi.fn(),

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -25,6 +25,7 @@ import {
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -85,6 +86,7 @@ import {
   MCODE_BROWSER_CONTEXT_ATTACHMENT_MIME,
   isVirtualBrowserContextAttachment,
   attachmentAcceptAttribute,
+  isGoalOpen,
 } from "@mcode/contracts";
 import type {
   AttachedBrowserCapture,
@@ -557,6 +559,16 @@ function formatGoalElapsed(seconds: number): string {
   return `${hours}h ${remainingMinutes}m`;
 }
 
+function formatGoalDate(value: number): string {
+  return new Date(goalTimestampMs(value)).toLocaleString();
+}
+
+function normalizeGoalActionError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return "Try again.";
+}
+
 function goalStatusLabel(status: GoalState["status"]): string {
   switch (status) {
     case "paused":
@@ -575,7 +587,8 @@ function goalStatusLabel(status: GoalState["status"]): string {
   }
 }
 
-function ActiveGoalBar({
+/** Shows the active provider goal and exposes app-level goal actions. */
+export function ActiveGoalBar({
   threadId,
   goal,
 }: {
@@ -583,20 +596,78 @@ function ActiveGoalBar({
   goal: GoalState | null | undefined;
 }) {
   const [now, setNow] = useState(() => Date.now());
-  const sendMessage = useThreadStore((s) => s.sendMessage);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [refreshError, setRefreshError] = useState(false);
+  const [isRefreshingGoal, setIsRefreshingGoal] = useState(false);
+  const [isClearingGoal, setIsClearingGoal] = useState(false);
+  const [lookupSource, setLookupSource] = useState<string | null>(null);
+  const [lookupReason, setLookupReason] = useState<string | null>(null);
+  const refreshThreadGoal = useThreadStore((s) => s.refreshThreadGoal);
+  const clearThreadGoal = useThreadStore((s) => s.clearThreadGoal);
 
   useEffect(() => {
-    if (!goal || goal.status === "complete") return;
+    if (!isGoalOpen(goal)) return;
     const id = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(id);
-  }, [goal?.createdAt, goal?.status]);
+  }, [goal]);
 
-  if (!goal || goal.status === "complete") return null;
+  if (!isGoalOpen(goal)) return null;
 
   const createdAt = goalTimestampMs(goal.createdAt);
   const elapsed = Math.max(goal.timeUsedSeconds, Math.floor((now - createdAt) / 1000));
   const canInspect = goal.controls.canInspect === true;
   const canClear = goal.controls.canClear === true;
+  const openDetails = (open: boolean) => {
+    setDetailsOpen(open);
+    if (!open) return;
+    setIsRefreshingGoal(true);
+    setRefreshError(false);
+    void refreshThreadGoal(threadId)
+      .then((lookup) => {
+        setLookupSource(lookup.source);
+        setLookupReason(lookup.reason ?? null);
+      })
+      .catch(() => {
+        setRefreshError(true);
+      })
+      .finally(() => {
+        setIsRefreshingGoal(false);
+      });
+  };
+  const handleClearGoal = () => {
+    if (isClearingGoal) return;
+    setIsClearingGoal(true);
+    void clearThreadGoal(threadId)
+      .then((lookup) => {
+        setLookupSource(lookup.source);
+        setLookupReason(lookup.reason ?? null);
+        if (lookup.source === "unsupported") {
+          useToastStore.getState().show(
+            "error",
+            "Goal controls unavailable",
+            "This provider does not support app-level goal controls.",
+          );
+          return;
+        }
+        if (lookup.goal && !lookup.authoritative) {
+          useToastStore.getState().show(
+            "info",
+            "Goal was not cleared",
+            "The provider did not report an active goal to clear.",
+          );
+        }
+      })
+      .catch((error) => {
+        useToastStore.getState().show(
+          "error",
+          "Could not clear goal",
+          normalizeGoalActionError(error),
+        );
+      })
+      .finally(() => {
+        setIsClearingGoal(false);
+      });
+  };
 
   return (
     <div
@@ -605,32 +676,91 @@ function ActiveGoalBar({
     >
       <div className="min-w-0 flex items-center gap-2">
         <Target size={13} className="shrink-0 text-primary" aria-hidden="true" />
-        <span className="shrink-0 font-medium text-foreground">
+        <Badge variant="secondary" size="sm" className="shrink-0">
           {goalStatusLabel(goal.status)}
-        </span>
+        </Badge>
         <span className="shrink-0 text-muted-foreground/80">·</span>
         <span className="shrink-0 tabular-nums">{formatGoalElapsed(elapsed)}</span>
         <span className="truncate text-muted-foreground/80">{goal.objective}</span>
       </div>
       <div className="flex shrink-0 items-center gap-1">
+        {isClearingGoal && !detailsOpen && (
+          <span className="text-muted-foreground">Clearing...</span>
+        )}
         {canInspect && (
-          <Tooltip>
-            <TooltipTrigger
-              render={
+          <Popover open={detailsOpen} onOpenChange={openDetails}>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <PopoverTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                        aria-label="Show active goal"
+                      >
+                        <Info size={13} />
+                      </Button>
+                    }
+                  />
+                }
+              />
+              <TooltipContent>Show active goal</TooltipContent>
+            </Tooltip>
+            <PopoverContent align="end" sideOffset={8} className="w-80 space-y-3 p-3 text-xs">
+              <div className="space-y-1">
+                <div className="font-medium text-foreground">{goal.objective}</div>
+                <div className="text-muted-foreground">{goalStatusLabel(goal.status)}</div>
+              </div>
+              <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-muted-foreground">
+                <span>Elapsed</span>
+                <span className="text-foreground">{formatGoalElapsed(elapsed)}</span>
+                <span>Tokens used</span>
+                <span className="text-foreground tabular-nums">{goal.tokensUsed}</span>
+                {goal.tokenBudget != null && (
+                  <>
+                    <span>Token budget</span>
+                    <span className="text-foreground tabular-nums">{goal.tokenBudget}</span>
+                  </>
+                )}
+                <span>Goal source</span>
+                <span className="text-foreground">{goal.source}</span>
+                <span>Updated</span>
+                <span className="text-foreground">{formatGoalDate(goal.updatedAt)}</span>
+                <span>Lookup source</span>
+                <span className="text-foreground">{lookupSource ?? "Refreshing"}</span>
+                {lookupReason && (
+                  <>
+                    <span>Lookup reason</span>
+                    <span className="text-foreground">{lookupReason}</span>
+                  </>
+                )}
+              </div>
+              {(isRefreshingGoal || refreshError || isClearingGoal) && (
+                <div className="text-muted-foreground">
+                  {isClearingGoal
+                    ? "Clearing..."
+                    : refreshError
+                      ? "Could not refresh goal details."
+                      : "Refreshing..."}
+                </div>
+              )}
+              {canClear && (
                 <Button
                   type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                  aria-label="Show active goal"
-                  onClick={() => void sendMessage(threadId, "/goal show")}
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  disabled={isClearingGoal}
+                  onClick={handleClearGoal}
                 >
-                  <Info size={13} />
+                  {isClearingGoal ? "Clearing..." : "Clear"}
                 </Button>
-              }
-            />
-            <TooltipContent>Show active goal</TooltipContent>
-          </Tooltip>
+              )}
+            </PopoverContent>
+          </Popover>
         )}
         {canClear && (
           <Tooltip>
@@ -642,7 +772,8 @@ function ActiveGoalBar({
                   size="icon"
                   className="h-6 w-6 text-muted-foreground hover:text-destructive"
                   aria-label="Clear active goal"
-                  onClick={() => void sendMessage(threadId, "/goal clear")}
+                  disabled={isClearingGoal}
+                  onClick={handleClearGoal}
                 >
                   <Trash2 size={13} />
                 </Button>

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -617,8 +617,23 @@ export function ActiveGoalBar({
   const [isClearingGoal, setIsClearingGoal] = useState(false);
   const [lookupSource, setLookupSource] = useState<string | null>(null);
   const [lookupReason, setLookupReason] = useState<string | null>(null);
+  const actionScopeRef = useRef({ threadId, refreshRequestId: 0, clearRequestId: 0 });
   const refreshThreadGoal = useThreadStore((s) => s.refreshThreadGoal);
   const clearThreadGoal = useThreadStore((s) => s.clearThreadGoal);
+
+  useEffect(() => {
+    actionScopeRef.current = {
+      threadId,
+      refreshRequestId: actionScopeRef.current.refreshRequestId + 1,
+      clearRequestId: actionScopeRef.current.clearRequestId + 1,
+    };
+    setDetailsOpen(false);
+    setRefreshError(false);
+    setIsRefreshingGoal(false);
+    setIsClearingGoal(false);
+    setLookupSource(null);
+    setLookupReason(null);
+  }, [threadId]);
 
   useEffect(() => {
     if (!isGoalOpen(goal)) return;
@@ -635,25 +650,53 @@ export function ActiveGoalBar({
   const openDetails = (open: boolean) => {
     setDetailsOpen(open);
     if (!open) return;
+    const refreshRequestId = actionScopeRef.current.refreshRequestId + 1;
+    actionScopeRef.current = { ...actionScopeRef.current, threadId, refreshRequestId };
     setIsRefreshingGoal(true);
     setRefreshError(false);
     void refreshThreadGoal(threadId)
       .then((lookup) => {
+        if (
+          actionScopeRef.current.threadId !== threadId ||
+          actionScopeRef.current.refreshRequestId !== refreshRequestId
+        ) return;
         setLookupSource(lookup.source);
         setLookupReason(lookup.reason ?? null);
       })
       .catch(() => {
+        if (
+          actionScopeRef.current.threadId !== threadId ||
+          actionScopeRef.current.refreshRequestId !== refreshRequestId
+        ) return;
         setRefreshError(true);
       })
       .finally(() => {
+        if (
+          actionScopeRef.current.threadId !== threadId ||
+          actionScopeRef.current.refreshRequestId !== refreshRequestId
+        ) return;
         setIsRefreshingGoal(false);
       });
   };
   const handleClearGoal = () => {
     if (isClearingGoal) return;
+    const refreshRequestId = actionScopeRef.current.refreshRequestId + 1;
+    const clearRequestId = actionScopeRef.current.clearRequestId + 1;
+    actionScopeRef.current = {
+      ...actionScopeRef.current,
+      threadId,
+      refreshRequestId,
+      clearRequestId,
+    };
+    setIsRefreshingGoal(false);
+    setRefreshError(false);
     setIsClearingGoal(true);
     void clearThreadGoal(threadId)
       .then((lookup) => {
+        if (
+          actionScopeRef.current.threadId !== threadId ||
+          actionScopeRef.current.clearRequestId !== clearRequestId
+        ) return;
         setLookupSource(lookup.source);
         setLookupReason(lookup.reason ?? null);
         if (lookup.source === "unsupported") {
@@ -673,6 +716,10 @@ export function ActiveGoalBar({
         }
       })
       .catch((error) => {
+        if (
+          actionScopeRef.current.threadId !== threadId ||
+          actionScopeRef.current.clearRequestId !== clearRequestId
+        ) return;
         useToastStore.getState().show(
           "error",
           "Could not clear goal",
@@ -680,6 +727,10 @@ export function ActiveGoalBar({
         );
       })
       .finally(() => {
+        if (
+          actionScopeRef.current.threadId !== threadId ||
+          actionScopeRef.current.clearRequestId !== clearRequestId
+        ) return;
         setIsClearingGoal(false);
       });
   };

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -17,6 +17,7 @@ import { AnsweredSummary } from "./plan-questions/AnsweredSummary";
 import { PlanCard } from "./PlanCard";
 import { PLAN_ANSWER_MESSAGE_PREFIX } from "@mcode/contracts";
 import { DeltaBlock } from "./narrative/DeltaBlock";
+import { parseGoalStatusNotice } from "@/lib/goal-message";
 
 /**
  * Returns true when the assistant message body collapses to nothing visible
@@ -33,28 +34,6 @@ function isAssistantContentEmpty(content: string): boolean {
 }
 
 /** Parses the message content of a synthetic agent-error system message. Returns the error text, or null if not an agent error. */
-/**
- * Detect /goal-command confirmations emitted by AgentService. Returns a
- * structured render hint when the assistant message is one of the goal
- * status messages, or null for ordinary model output.
- */
-function parseGoalStatus(content: string): {
-  label: string;
-  condition?: string;
-  hint?: string;
-} | null {
-  const text = content.trim();
-  let m = /^Goal set: "([\s\S]+?)"\./.exec(text);
-  if (m) return { label: "Goal set", condition: m[1], hint: "/goal clear to remove" };
-  m = /^Active goal: "([\s\S]+?)"\./.exec(text);
-  if (m) return { label: "Active goal", condition: m[1], hint: "/goal clear to remove" };
-  m = /^Goal achieved in (\d+)s\./.exec(text);
-  if (m) return { label: "Goal achieved", hint: `${m[1]}s` };
-  if (/^Goal cleared\./.test(text)) return { label: "Goal cleared" };
-  if (/^No active goal\./.test(text)) return { label: "No active goal", hint: "/goal <condition> to set one" };
-  return null;
-}
-
 /**
  * Detect a user-typed /goal SET form (`/goal <condition>` with non-empty,
  * non-control argument). The server rewrites the wire payload into a
@@ -551,7 +530,7 @@ export const MessageBubble = memo(function MessageBubble({
   // chat-control notices, not model output — render them as a compact pill
   // rather than a full bubble.
   if (message.role === "assistant") {
-    const goal = parseGoalStatus(textContent);
+    const goal = parseGoalStatusNotice(textContent);
     if (goal) {
       // "Goal achieved" is the agent-side payoff — give it the same legible
       // receipt vocabulary as the user's "Sent as goal" marker rather than a

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -32,6 +32,7 @@ import { NarrativeIndicator } from "./narrative/NarrativeIndicator";
 import { PersistedLateHooks } from "./PersistedLateHooks";
 import { StickyUserMessage, STICKY_USER_MESSAGE_ESTIMATED_HEIGHT } from "./StickyUserMessage";
 import { registerCommand } from "@/lib/command-registry";
+import { isGoalStatusNotice } from "@/lib/goal-message";
 import { shouldShowStickyUserMessage, type StickyVisibilityVirtualizer } from "./sticky-user-message-visibility";
 import { resolveUserMessagePreview } from "./user-message-preview";
 
@@ -484,10 +485,12 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   }
 
   const volatileItems = useMemo(() => {
-    const lastMsg = messages[messages.length - 1];
+    const lastAssistantAnswer = [...messages]
+      .reverse()
+      .find((message) => message.role === "assistant" && !isGoalStatusNotice(message.content));
     const committedAssistantBody =
-      currentThreadId && !isAgentRunning && lastMsg?.role === "assistant"
-        ? lastMsg.content
+      currentThreadId && !isAgentRunning && lastAssistantAnswer
+        ? lastAssistantAnswer.content
         : undefined;
     return volatileItemsBuilderRef.current!(
       toolCalls,

--- a/apps/web/src/components/chat/__tests__/ActiveGoalBar.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ActiveGoalBar.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GoalLookupResult, GoalState } from "@mcode/contracts";
+
+const sendMessage = vi.fn();
+const refreshThreadGoal = vi.fn();
+const clearThreadGoal = vi.fn();
+const showToast = vi.fn();
+
+vi.mock("@/stores/threadStore", () => ({
+  useThreadStore: (selector: (state: unknown) => unknown) =>
+    selector({ sendMessage, refreshThreadGoal, clearThreadGoal }),
+  scheduleDrainAfterEdit: vi.fn(),
+  getHandoffStatus: vi.fn(),
+}));
+
+vi.mock("@/stores/toastStore", () => ({
+  useToastStore: {
+    getState: () => ({ show: showToast }),
+  },
+}));
+
+import { ActiveGoalBar } from "../Composer";
+
+const goal: GoalState = {
+  threadId: "thread-1",
+  objective: "Ship app-level goal controls",
+  status: "active",
+  tokenBudget: 1000,
+  tokensUsed: 42,
+  timeUsedSeconds: 12,
+  createdAt: 1_767_000_000,
+  updatedAt: 1_767_000_010,
+  providerId: "codex",
+  source: "codex",
+  controls: { canInspect: true, canClear: true },
+};
+
+function lookup(overrides: Partial<GoalLookupResult> = {}): GoalLookupResult {
+  return {
+    goal,
+    authoritative: true,
+    source: "codex-native",
+    ...overrides,
+  };
+}
+
+describe("ActiveGoalBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refreshThreadGoal.mockResolvedValue(lookup());
+    clearThreadGoal.mockResolvedValue(lookup({ goal: null }));
+  });
+
+  it("opens details through refreshThreadGoal and does not send a chat message", async () => {
+    render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Show active goal"));
+
+    expect(refreshThreadGoal).toHaveBeenCalledWith("thread-1");
+    expect(sendMessage).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getAllByText("Ship app-level goal controls").length).toBeGreaterThanOrEqual(2),
+    );
+    expect(screen.getByText("Tokens used")).toBeInTheDocument();
+    expect(screen.getByText("Token budget")).toBeInTheDocument();
+    expect(screen.getByText("Goal source")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("codex-native")).toBeInTheDocument());
+  });
+
+  it("keeps prior details visible and shows refresh failure inline", async () => {
+    refreshThreadGoal.mockRejectedValue(new Error("offline"));
+    render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Show active goal"));
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Ship app-level goal controls").length).toBeGreaterThanOrEqual(2),
+    );
+    expect(await screen.findByText("Could not refresh goal details.")).toBeInTheDocument();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("clears through clearThreadGoal and does not send a chat message", async () => {
+    render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Clear active goal"));
+
+    expect(clearThreadGoal).toHaveBeenCalledWith("thread-1");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("disables visible clear controls and shows pending text while clearing", async () => {
+    let resolveClear!: (result: GoalLookupResult) => void;
+    clearThreadGoal.mockReturnValue(new Promise((resolve) => {
+      resolveClear = resolve;
+    }));
+    render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Show active goal"));
+    await userEvent.click(await screen.findByRole("button", { name: "Clear" }));
+
+    expect(screen.getAllByText("Clearing...").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole("button", { name: "Clearing..." })).toBeDisabled();
+    resolveClear(lookup({ goal: null }));
+  });
+
+  it("shows a not-cleared toast for non-authoritative open-goal results", async () => {
+    clearThreadGoal.mockResolvedValue(lookup({ authoritative: false }));
+    render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Clear active goal"));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(
+        "info",
+        "Goal was not cleared",
+        "The provider did not report an active goal to clear.",
+      ),
+    );
+  });
+
+  it("shows an unavailable toast for unsupported clear results", async () => {
+    clearThreadGoal.mockResolvedValue(lookup({
+      goal: null,
+      source: "unsupported",
+      reason: "unsupported-provider",
+    }));
+    render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Clear active goal"));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(
+        "error",
+        "Goal controls unavailable",
+        "This provider does not support app-level goal controls.",
+      ),
+    );
+  });
+
+  it("shows the normalized RPC error when clear throws", async () => {
+    clearThreadGoal.mockRejectedValue(new Error("clear failed"));
+    render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Clear active goal"));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith("error", "Could not clear goal", "clear failed"),
+    );
+  });
+});

--- a/apps/web/src/components/chat/__tests__/ActiveGoalBar.test.tsx
+++ b/apps/web/src/components/chat/__tests__/ActiveGoalBar.test.tsx
@@ -37,6 +37,12 @@ const goal: GoalState = {
   controls: { canInspect: true, canClear: true },
 };
 
+const otherGoal: GoalState = {
+  ...goal,
+  threadId: "thread-2",
+  objective: "Review the branch",
+};
+
 function lookup(overrides: Partial<GoalLookupResult> = {}): GoalLookupResult {
   return {
     goal,
@@ -106,6 +112,39 @@ describe("ActiveGoalBar", () => {
     resolveClear(lookup({ goal: null }));
   });
 
+  it("does not leave refresh pending when same-thread clear overlaps details refresh", async () => {
+    let resolveRefresh!: (result: GoalLookupResult) => void;
+    let resolveClear!: (result: GoalLookupResult) => void;
+    refreshThreadGoal.mockReturnValueOnce(new Promise((resolve) => {
+      resolveRefresh = resolve;
+    }));
+    clearThreadGoal.mockReturnValueOnce(new Promise((resolve) => {
+      resolveClear = resolve;
+    }));
+    render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Show active goal"));
+    await userEvent.click(await screen.findByRole("button", { name: "Clear" }));
+
+    await waitFor(() => expect(screen.getAllByText("Clearing...").length).toBeGreaterThanOrEqual(1));
+    resolveClear(lookup({
+      goal: null,
+      authoritative: false,
+      source: "codex-cache",
+      reason: "not-materialized",
+    }));
+    await waitFor(() => expect(screen.queryByText("Clearing...")).not.toBeInTheDocument());
+    expect(screen.getByText("codex-cache")).toBeInTheDocument();
+    expect(screen.getByText("not-materialized")).toBeInTheDocument();
+
+    resolveRefresh(lookup({ source: "codex-native", reason: "missing" }));
+    await waitFor(() => expect(screen.queryByText("Refreshing...")).not.toBeInTheDocument());
+    expect(screen.getByText("codex-cache")).toBeInTheDocument();
+    expect(screen.getByText("not-materialized")).toBeInTheDocument();
+    expect(screen.queryByText("codex-native")).not.toBeInTheDocument();
+    expect(screen.queryByText("missing")).not.toBeInTheDocument();
+  });
+
   it("shows a not-cleared toast for non-authoritative open-goal results", async () => {
     clearThreadGoal.mockResolvedValue(lookup({ authoritative: false }));
     render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
@@ -149,5 +188,24 @@ describe("ActiveGoalBar", () => {
     await waitFor(() =>
       expect(showToast).toHaveBeenCalledWith("error", "Could not clear goal", "clear failed"),
     );
+  });
+
+  it("resets details and ignores stale refresh results after thread changes", async () => {
+    let resolveRefresh!: (result: GoalLookupResult) => void;
+    refreshThreadGoal.mockReturnValueOnce(new Promise((resolve) => {
+      resolveRefresh = resolve;
+    }));
+    const { rerender } = render(<ActiveGoalBar threadId="thread-1" goal={goal} />);
+
+    await userEvent.click(screen.getByLabelText("Show active goal"));
+    expect(refreshThreadGoal).toHaveBeenCalledWith("thread-1");
+
+    rerender(<ActiveGoalBar threadId="thread-2" goal={otherGoal} />);
+    resolveRefresh(lookup({ source: "codex-native", reason: "missing" }));
+    await waitFor(() => expect(screen.queryByText("Lookup source")).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByLabelText("Show active goal"));
+    expect(screen.getAllByText("Review the branch").length).toBeGreaterThanOrEqual(2);
+    await waitFor(() => expect(screen.getByText("codex-native")).toBeInTheDocument());
   });
 });

--- a/apps/web/src/components/chat/__tests__/virtual-items-goal.test.ts
+++ b/apps/web/src/components/chat/__tests__/virtual-items-goal.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { Message, ToolCall } from "@/transport/types";
+import {
+  buildStableItems,
+  buildVirtualItems,
+  buildVolatileItems,
+} from "../virtual-items";
+
+function message(
+  id: string,
+  role: Message["role"],
+  content: string,
+  sequence: number,
+): Message {
+  return {
+    id,
+    thread_id: "thread-1",
+    role,
+    content,
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: "2026-06-29T00:00:00.000Z",
+    sequence,
+    attachments: null,
+  };
+}
+
+function toolCall(): ToolCall {
+  return {
+    id: "tool-1",
+    toolName: "Read",
+    toolInput: {},
+    isComplete: true,
+    isError: false,
+    output: null,
+    parentToolCallId: undefined,
+    startedAt: 1,
+  };
+}
+
+describe("goal notices in chat virtual items", () => {
+  it("anchors live turn artifacts to the assistant answer before a goal receipt", () => {
+    const messages = [
+      message("user-1", "user", "/goal fix rendering", 1),
+      message("answer-1", "assistant", "The rendering bug is fixed.", 2),
+      message("goal-1", "assistant", "Goal achieved in 19s.", 3),
+    ];
+    const stableItems = buildStableItems(messages);
+    const volatileItems = buildVolatileItems(
+      [toolCall()],
+      false,
+      1,
+      "",
+      [],
+      [],
+      [],
+      { threadId: "thread-1" },
+      "The rendering bug is fixed.",
+    );
+
+    const items = buildVirtualItems(stableItems, volatileItems, true);
+    const narrativeIndex = items.findIndex((item) => item.type === "narrative-flow");
+    const answerIndex = items.findIndex(
+      (item) => item.type === "message" && item.message.id === "answer-1",
+    );
+    const receiptIndex = items.findIndex(
+      (item) => item.type === "message" && item.message.id === "goal-1",
+    );
+
+    expect(narrativeIndex).toBeGreaterThan(-1);
+    expect(answerIndex).toBeGreaterThan(-1);
+    expect(receiptIndex).toBeGreaterThan(-1);
+    expect(narrativeIndex).toBeLessThan(answerIndex);
+    expect(answerIndex).toBeLessThan(receiptIndex);
+  });
+});

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -2,6 +2,7 @@ import type { PermissionDecision } from "@mcode/contracts";
 import type { Message, ToolCall, HookExecution } from "@/transport/types";
 import type { ThoughtSegment } from "./narrative/types";
 import { computeLiveStreamingText } from "./narrative/build-narrative";
+import { isGoalStatusNotice } from "@/lib/goal-message";
 
 /** Compile-time exhaustive check; throws at runtime for unhandled discriminants. */
 function assertNever(value: never): never {
@@ -581,16 +582,23 @@ export function buildVirtualItems(
   // Split volatile items: narrative-flow goes before the last assistant
   // message; permission requests go after it.
 
-  // Find the last assistant message, skipping any trailing items that appear
-  // after the message bubble (turn-changes, persisted-late-hooks,
-  // persisted-turn-footer).
+  // Find the last assistant answer, skipping trailing chrome and goal notices.
   let lastAssistantIdx = stableItems.length - 1;
   while (lastAssistantIdx >= 0) {
     const item = stableItems[lastAssistantIdx];
     if (
       item.type === "turn-changes" ||
       item.type === "persisted-late-hooks" ||
-      item.type === "persisted-turn-footer"
+      item.type === "persisted-turn-footer" ||
+      item.type === "persisted-narrative"
+    ) {
+      lastAssistantIdx--;
+      continue;
+    }
+    if (
+      item.type === "message" &&
+      item.message.role === "assistant" &&
+      isGoalStatusNotice(item.message.content)
     ) {
       lastAssistantIdx--;
       continue;

--- a/apps/web/src/lib/goal-lookup.ts
+++ b/apps/web/src/lib/goal-lookup.ts
@@ -1,0 +1,12 @@
+import { isGoalOpen } from "@mcode/contracts";
+import type { GoalLookupResult, GoalState } from "@mcode/contracts";
+
+/** Resolves a goal lookup result against the currently cached open goal. */
+export function resolveGoalLookupGoal(
+  lookup: GoalLookupResult,
+  currentGoal: GoalState | null | undefined,
+): GoalState | null {
+  const goal = isGoalOpen(lookup.goal) ? lookup.goal : null;
+  if (!goal && !lookup.authoritative && isGoalOpen(currentGoal)) return currentGoal;
+  return goal;
+}

--- a/apps/web/src/lib/goal-message.ts
+++ b/apps/web/src/lib/goal-message.ts
@@ -8,14 +8,14 @@ export interface GoalStatusNotice {
 /** Parses server-emitted goal lifecycle messages from assistant content. */
 export function parseGoalStatusNotice(content: string): GoalStatusNotice | null {
   const text = content.trim();
-  let match = /^Goal set: "([\s\S]+?)"\./.exec(text);
+  let match = /^Goal set: "([\s\S]+?)"\.$/.exec(text);
   if (match) return { label: "Goal set", condition: match[1], hint: "/goal clear to remove" };
-  match = /^Active goal: "([\s\S]+?)"\./.exec(text);
+  match = /^Active goal: "([\s\S]+?)"\.$/.exec(text);
   if (match) return { label: "Active goal", condition: match[1], hint: "/goal clear to remove" };
-  match = /^Goal achieved in (\d+)s\./.exec(text);
+  match = /^Goal achieved in (\d+)s\.$/.exec(text);
   if (match) return { label: "Goal achieved", hint: `${match[1]}s` };
-  if (/^Goal cleared\./.test(text)) return { label: "Goal cleared" };
-  if (/^No active goal\./.test(text)) return { label: "No active goal", hint: "/goal <condition> to set one" };
+  if (/^Goal cleared\.$/.test(text)) return { label: "Goal cleared" };
+  if (/^No active goal\.$/.test(text)) return { label: "No active goal", hint: "/goal <condition> to set one" };
   return null;
 }
 

--- a/apps/web/src/lib/goal-message.ts
+++ b/apps/web/src/lib/goal-message.ts
@@ -1,0 +1,25 @@
+/** Render hint for an assistant message that represents goal lifecycle state. */
+export interface GoalStatusNotice {
+  label: string;
+  condition?: string;
+  hint?: string;
+}
+
+/** Parses server-emitted goal lifecycle messages from assistant content. */
+export function parseGoalStatusNotice(content: string): GoalStatusNotice | null {
+  const text = content.trim();
+  let match = /^Goal set: "([\s\S]+?)"\./.exec(text);
+  if (match) return { label: "Goal set", condition: match[1], hint: "/goal clear to remove" };
+  match = /^Active goal: "([\s\S]+?)"\./.exec(text);
+  if (match) return { label: "Active goal", condition: match[1], hint: "/goal clear to remove" };
+  match = /^Goal achieved in (\d+)s\./.exec(text);
+  if (match) return { label: "Goal achieved", hint: `${match[1]}s` };
+  if (/^Goal cleared\./.test(text)) return { label: "Goal cleared" };
+  if (/^No active goal\./.test(text)) return { label: "No active goal", hint: "/goal <condition> to set one" };
+  return null;
+}
+
+/** Returns true when assistant content is a goal lifecycle notice. */
+export function isGoalStatusNotice(content: string): boolean {
+  return parseGoalStatusNotice(content) !== null;
+}

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -33,6 +33,7 @@ import { shallowEqualBy } from "@/lib/shallowEqualBy";
 import { coerceTaskStatus } from "@/stores/taskStore";
 import { getTransport } from "@/transport";
 import { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
+import type { GoalState } from "@mcode/contracts";
 
 vi.mock("@/transport", async () => ({
   ...(await vi.importActual("@/transport")),
@@ -44,6 +45,22 @@ const THREAD_B = "thread-b";
 
 const msgA = createMockMessage({ id: "a1", thread_id: THREAD_A, content: "hello A", sequence: 1 });
 const msgB = createMockMessage({ id: "b1", thread_id: THREAD_B, content: "hello B", sequence: 1 });
+
+function makeGoal(threadId = THREAD_A): GoalState {
+  return {
+    threadId,
+    objective: `goal for ${threadId}`,
+    status: "active",
+    tokenBudget: null,
+    tokensUsed: 0,
+    timeUsedSeconds: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    providerId: "codex",
+    source: "codex",
+    controls: { canInspect: true, canClear: true },
+  };
+}
 
 function makeCachedRecord(messages = [msgA]): ThreadRecord {
   return {
@@ -101,6 +118,12 @@ function resetStores() {
   (mockTransport.getThreadTasks as ReturnType<typeof vi.fn>).mockResolvedValue(null);
   (mockTransport.getThreadPlans as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   (mockTransport.loadTurn as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  (mockTransport.getThreadGoal as ReturnType<typeof vi.fn>).mockResolvedValue({
+    goal: null,
+    authoritative: false,
+    source: "codex-cache",
+    reason: "not-materialized",
+  });
 
   useWorkspaceStore.setState({
     threads: [
@@ -149,6 +172,59 @@ describe("ThreadHydrator", () => {
     expect(getTestActiveMessages()).toEqual([msgA]);
     expect(readActiveThreadField((r) => r.loading)).toBe(false);
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
+  });
+
+  it("preserves an existing open goal when lookup returns non-authoritative null", async () => {
+    const goal = makeGoal();
+    resetThreadStoreForTests({
+      records: new Map<string, ThreadRecord>([
+        [THREAD_A, { ...createEmptyThreadRecord(), goal }],
+      ]),
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(readActiveThreadField((r) => r.goal)).toEqual(goal);
+    expect(getCachedRecord(THREAD_A)?.goal).toEqual(goal);
+  });
+
+  it("clears live and cached goals when lookup returns authoritative null", async () => {
+    const goal = makeGoal();
+    cacheRecord(THREAD_A, { ...makeCachedRecord(), goal });
+    (mockTransport.getThreadGoal as ReturnType<typeof vi.fn>).mockResolvedValue({
+      goal: null,
+      authoritative: true,
+      source: "unsupported",
+      reason: "unsupported-provider",
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => {
+      expect(readActiveThreadField((r) => r.goal)).toBeNull();
+    });
+
+    expect(getCachedRecord(THREAD_A)?.goal).toBeNull();
+  });
+
+  it("applies lookup goals only to the requested thread", async () => {
+    const goalA = makeGoal(THREAD_A);
+    const goalB = makeGoal(THREAD_B);
+    resetThreadStoreForTests({
+      records: new Map<string, ThreadRecord>([
+        [THREAD_B, { ...createEmptyThreadRecord(), goal: goalB }],
+      ]),
+    });
+    (mockTransport.getThreadGoal as ReturnType<typeof vi.fn>).mockResolvedValue({
+      goal: goalA,
+      authoritative: false,
+      source: "codex-cache",
+      reason: "not-materialized",
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(useThreadStore.getState().records.get(THREAD_A)?.goal).toEqual(goalA);
+    expect(useThreadStore.getState().records.get(THREAD_B)?.goal).toEqual(goalB);
   });
 
   it("skips auxiliary fanout on cache hit within the TTL window", async () => {

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -10,6 +10,8 @@ import {
   patchThreadRecord,
 } from "@/stores/thread-record";
 import type { ThreadRecord } from "@/stores/thread-record";
+import { isGoalOpen } from "@mcode/contracts";
+import type { GoalLookupResult } from "@mcode/contracts";
 import type {
   HydrateMode,
   ThreadHydratorDeps,
@@ -116,6 +118,7 @@ export class ThreadHydrator {
     const cached = getCachedRecord(threadId);
     if (cached) {
       this.restoreFromCache(threadId, cached);
+      void this.refreshThreadGoal(threadId);
       this.auxiliaryHydrator.hydrate(threadId, {
         freshnessTtlMs: HYDRATION_TTL_MS,
         force: opts?.force,
@@ -183,6 +186,35 @@ export class ThreadHydrator {
     });
   }
 
+  /** Apply lookup result semantics to the live record and record cache. */
+  private applyGoalLookup(threadId: string, lookup: GoalLookupResult): void {
+    const goal = isGoalOpen(lookup.goal) ? lookup.goal : null;
+    this.deps.setState((state: ThreadHydratorWriteState) => {
+      const current = getThreadRecord(state.records, threadId);
+      if (!goal && !lookup.authoritative && isGoalOpen(current.goal)) {
+        return {};
+      }
+      return {
+        records: patchThreadRecord(state.records, threadId, { goal }),
+      };
+    });
+
+    const cached = getCachedRecord(threadId);
+    if (!cached) return;
+    if (!goal && !lookup.authoritative && isGoalOpen(cached.goal)) return;
+    cacheRecord(threadId, { ...cached, goal });
+  }
+
+  /** Refresh one thread's active goal without blocking main hydration. */
+  private async refreshThreadGoal(threadId: string): Promise<void> {
+    try {
+      const lookup = await this.transport().getThreadGoal(threadId);
+      this.applyGoalLookup(threadId, lookup);
+    } catch {
+      // Best-effort hydration: message load remains the authoritative error surface.
+    }
+  }
+
   /** Cache-miss path: reset volatile state, fetch RPCs, commit, populate cache. */
   private async fetchAndCommit(threadId: string, opts?: ThreadHydratorOptions): Promise<void> {
     const { getState, setState } = this.deps;
@@ -239,11 +271,13 @@ export class ThreadHydrator {
       const workspaceThread = this.deps.getWorkspaceThread(threadId);
       const shouldFetchSnapshots = workspaceThread?.has_file_changes !== false;
 
-      const [pageResult, snapshots] = await Promise.all([
+      const goalLookupPromise = this.transport().getThreadGoal(threadId).catch(() => null);
+      const [pageResult, snapshots, goalLookup] = await Promise.all([
         this.transport().loadConversationPage(threadId, MESSAGE_FETCH_SIZE),
         shouldFetchSnapshots
           ? this.transport().listSnapshots(threadId).catch(() => [] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>)
           : Promise.resolve([] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>),
+        goalLookupPromise,
       ]);
 
       if (getState().currentThreadId !== threadId) return;
@@ -283,6 +317,9 @@ export class ThreadHydrator {
       }
 
       cacheRecord(threadId, getThreadRecord(getState().records, threadId));
+      if (goalLookup) {
+        this.applyGoalLookup(threadId, goalLookup);
+      }
     } catch (e) {
       if (getState().currentThreadId === threadId) {
         setState((state: ThreadHydratorWriteState) => ({

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -10,8 +10,8 @@ import {
   patchThreadRecord,
 } from "@/stores/thread-record";
 import type { ThreadRecord } from "@/stores/thread-record";
-import { isGoalOpen } from "@mcode/contracts";
 import type { GoalLookupResult } from "@mcode/contracts";
+import { resolveGoalLookupGoal } from "@/lib/goal-lookup";
 import type {
   HydrateMode,
   ThreadHydratorDeps,
@@ -188,12 +188,9 @@ export class ThreadHydrator {
 
   /** Apply lookup result semantics to the live record and record cache. */
   private applyGoalLookup(threadId: string, lookup: GoalLookupResult): void {
-    const goal = isGoalOpen(lookup.goal) ? lookup.goal : null;
     this.deps.setState((state: ThreadHydratorWriteState) => {
       const current = getThreadRecord(state.records, threadId);
-      if (!goal && !lookup.authoritative && isGoalOpen(current.goal)) {
-        return {};
-      }
+      const goal = resolveGoalLookupGoal(lookup, current.goal);
       return {
         records: patchThreadRecord(state.records, threadId, { goal }),
       };
@@ -201,7 +198,7 @@ export class ThreadHydrator {
 
     const cached = getCachedRecord(threadId);
     if (!cached) return;
-    if (!goal && !lookup.authoritative && isGoalOpen(cached.goal)) return;
+    const goal = resolveGoalLookupGoal(lookup, cached.goal);
     cacheRecord(threadId, { ...cached, goal });
   }
 

--- a/apps/web/src/lib/thread-hydrator/types.ts
+++ b/apps/web/src/lib/thread-hydrator/types.ts
@@ -1,5 +1,5 @@
 import type { Message, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord } from "@/transport";
-import type { TurnSnapshot, PermissionRequest, PlanRecord, NarrativeEntry, ConversationPage } from "@mcode/contracts";
+import type { TurnSnapshot, PermissionRequest, PlanRecord, NarrativeEntry, ConversationPage, GoalLookupResult } from "@mcode/contracts";
 import type { TaskItem } from "@/stores/taskStore";
 import type { PlanQuestion } from "@mcode/contracts";
 import type { ThreadRecord } from "@/stores/thread-record";
@@ -37,6 +37,7 @@ export interface ThreadHydratorTransport {
   listSnapshots(threadId: string): Promise<TurnSnapshot[]>;
   listNarrative(messageId: string): Promise<NarrativeBatchResult[string]>;
   loadTurn(threadId: string): Promise<NarrativeEntry[]>;
+  getThreadGoal(threadId: string): Promise<GoalLookupResult>;
   listPendingPermissions(threadId: string): Promise<PermissionRequest[]>;
   getThreadTasks(
     threadId: string,

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -24,6 +24,7 @@ import { shallowEqualBy } from "@/lib/shallowEqualBy";
 import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
 import { releaseBrowserCaptureSpills } from "@/lib/browser-capture-spill";
 import { isGoalControlCommand } from "@/lib/goal-command";
+import { resolveGoalLookupGoal } from "@/lib/goal-lookup";
 import { isGoalStatusNotice } from "@/lib/goal-message";
 import {
   createThreadHydrator,
@@ -633,10 +634,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   };
 
   const applyGoalLookup = (threadId: string, lookup: GoalLookupResult): void => {
-    const goal = lookup.authoritative || isGoalOpen(lookup.goal) ? lookup.goal : null;
+    const current = getRec(threadId);
+    const goal = resolveGoalLookupGoal(lookup, current.goal);
     patchRec(threadId, { goal });
     const cached = getCachedRecord(threadId);
-    if (cached) cacheRecord(threadId, { ...cached, goal });
+    if (cached) cacheRecord(threadId, { ...cached, goal: resolveGoalLookupGoal(lookup, cached.goal) });
   };
 
   /**

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,9 +1,9 @@
 import { create } from "zustand";
 import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, ToolCallRecord, ThoughtSegmentRecord } from "@/transport";
-import type { ContextWindowMode, MessageMention, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory, GoalState } from "@mcode/contracts";
+import type { ContextWindowMode, MessageMention, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory, GoalLookupResult, GoalState } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import type { ThoughtSegment } from "@/components/chat/narrative/types";
-import { PlanQuestionSchema, PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
+import { PlanQuestionSchema, PERMISSION_MODES, INTERACTION_MODES, isGoalOpen } from "@mcode/contracts";
 import { getTransport } from "@/transport";
 import { useWorkspaceStore } from "./workspaceStore";
 import { useQueueStore } from "./queueStore";
@@ -24,6 +24,7 @@ import { shallowEqualBy } from "@/lib/shallowEqualBy";
 import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
 import { releaseBrowserCaptureSpills } from "@/lib/browser-capture-spill";
 import { isGoalControlCommand } from "@/lib/goal-command";
+import { isGoalStatusNotice } from "@/lib/goal-message";
 import {
   createThreadHydrator,
   registerThreadHydrator,
@@ -117,6 +118,10 @@ interface ThreadState {
   /** Mark a permission request as settled with its decision. */
   resolvePermissionRequest: (requestId: string, decision: PermissionDecision) => void;
   handleAgentEvent: (threadId: string, event: Record<string, unknown>) => void;
+  /** Refresh the provider-neutral goal lookup for a thread and update cached thread state. */
+  refreshThreadGoal: (threadId: string) => Promise<GoalLookupResult>;
+  /** Clear the active goal through the app RPC and update cached thread state. */
+  clearThreadGoal: (threadId: string) => Promise<GoalLookupResult>;
 
   /**
    * Fetch the persisted narrative (tools, thoughts, hooks) for an assistant
@@ -625,6 +630,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     patch: Partial<ThreadRecord> | ((current: ThreadRecord) => Partial<ThreadRecord>),
   ) => {
     set((s) => ({ records: patchThreadRecord(s.records, threadId, patch) }));
+  };
+
+  const applyGoalLookup = (threadId: string, lookup: GoalLookupResult): void => {
+    const goal = lookup.authoritative || isGoalOpen(lookup.goal) ? lookup.goal : null;
+    patchRec(threadId, { goal });
+    const cached = getCachedRecord(threadId);
+    if (cached) cacheRecord(threadId, { ...cached, goal });
   };
 
   /**
@@ -1526,6 +1538,18 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     });
   },
 
+  refreshThreadGoal: async (threadId) => {
+    const lookup = await getTransport().getThreadGoal(threadId);
+    applyGoalLookup(threadId, lookup);
+    return lookup;
+  },
+
+  clearThreadGoal: async (threadId) => {
+    const lookup = await getTransport().clearThreadGoal(threadId);
+    applyGoalLookup(threadId, lookup);
+    return lookup;
+  },
+
   loadNarrativeForMessage: async (messageId) => {
     const currentId = get().currentThreadId;
     if (!currentId) return;
@@ -1623,13 +1647,18 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (method === "session.goalUpdated") {
       const goal = params.goal as GoalState | undefined;
       if (goal) {
-        patchRec(threadId, { goal });
+        const openGoal = isGoalOpen(goal) ? goal : null;
+        patchRec(threadId, { goal: openGoal });
+        const cached = getCachedRecord(threadId);
+        if (cached) cacheRecord(threadId, { ...cached, goal: openGoal });
       }
       return;
     }
 
     if (method === "session.goalCleared") {
       patchRec(threadId, { goal: null });
+      const cached = getCachedRecord(threadId);
+      if (cached) cacheRecord(threadId, { ...cached, goal: null });
       return;
     }
 
@@ -1706,6 +1735,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (method === "session.message") {
       markPriorToolCallsComplete();
       const content = (params.content as string) || "";
+      const isGoalNotice = isGoalStatusNotice(content);
       const attachments = parseStoredAttachments(params.attachments);
       if (content || attachments.length > 0 || params.messageId) {
         const message: Message = {
@@ -1732,19 +1762,32 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             lastSeg && lastSeg.endedAt === undefined
               ? [...segments.slice(0, -1), { ...lastSeg, endedAt: Date.now() }]
               : segments;
-          const { responseKey, nextLiveKey } = claimTurnResponseKey(
-            rec,
-            threadId,
-            message.id,
-          );
+
+          const responseIdentityPatch: Partial<
+            Pick<
+              ThreadRecord,
+              "assistantResponseKeys" | "currentTurnMessageId" | "currentTurnResponseKey"
+            >
+          > = isGoalNotice
+            ? {}
+            : (() => {
+                const { responseKey, nextLiveKey } = claimTurnResponseKey(
+                  rec,
+                  threadId,
+                  message.id,
+                );
+                return {
+                  currentTurnMessageId: message.id,
+                  currentTurnResponseKey: nextLiveKey,
+                  assistantResponseKeys: {
+                    ...rec.assistantResponseKeys,
+                    [message.id]: responseKey,
+                  },
+                };
+              })();
 
           const turnPatch = {
-            currentTurnMessageId: message.id,
-            currentTurnResponseKey: nextLiveKey,
-            assistantResponseKeys: {
-              ...rec.assistantResponseKeys,
-              [message.id]: responseKey,
-            },
+            ...responseIdentityPatch,
             streaming: "",
             streamingPreview: "",
             thoughtSegments: closedSegments,
@@ -1798,10 +1841,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               attachments: message.attachments,
             });
             const { messages: capped, evicted } = capMessages(replaced);
-            const prunedAssistantResponseKeys = pruneAssistantResponseKeys(
-              nextAssistantResponseKeys,
-              capped,
-            );
+            const prunedAssistantResponseKeys = pruneAssistantResponseKeys(nextAssistantResponseKeys, capped);
             return {
               records: patchThreadRecord(state.records, threadId, {
                 ...turnPatch,
@@ -1819,7 +1859,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
           const { messages: capped, evicted } = capMessages([...rec.messages, message]);
           const prunedAssistantResponseKeys = pruneAssistantResponseKeys(
-            turnPatch.assistantResponseKeys,
+            responseIdentityPatch.assistantResponseKeys ?? rec.assistantResponseKeys,
             capped,
           );
           return {

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -39,6 +39,7 @@ import type {
   CreateAndSendResult,
   ConversationPage,
   MessageMention,
+  GoalLookupResult,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
@@ -268,6 +269,10 @@ export interface McodeTransport {
   subscribeThread(threadId: string): Promise<void>;
   /** Remove this client connection's push subscription for a thread. */
   unsubscribeThread(threadId: string): Promise<void>;
+  /** Fetch the current active goal for a thread without starting provider work. */
+  getThreadGoal(threadId: string): Promise<GoalLookupResult>;
+  /** Clear the current active goal for a thread without sending a chat message. */
+  clearThreadGoal(threadId: string): Promise<GoalLookupResult>;
 
   // Thread mutations
   updateThreadTitle(threadId: string, title: string): Promise<boolean>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -24,7 +24,7 @@ import type {
 } from "./types";
 import type { CreateAndSendResult } from "@mcode/contracts";
 import { emitPtyReconnectGap } from "@/components/terminal/ptyDataRegistry";
-import type { PaginatedMessages, ConversationPage, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability } from "@mcode/contracts";
+import type { PaginatedMessages, ConversationPage, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability, GoalLookupResult } from "@mcode/contracts";
 import type { ReasoningLevel } from "@mcode/contracts";
 import {
   TERMINAL_DATA_TAG,
@@ -653,6 +653,10 @@ export function createWsTransport(
     listRunning: () => rpc<string[]>("agent.listRunning", {}),
     subscribeThread: (threadId) => rpc<void>("push.subscribeThread", { threadId }),
     unsubscribeThread: (threadId) => rpc<void>("push.unsubscribeThread", { threadId }),
+    getThreadGoal: (threadId) =>
+      rpc<GoalLookupResult>("thread.goal.get", { threadId }),
+    clearThreadGoal: (threadId) =>
+      rpc<GoalLookupResult>("thread.goal.clear", { threadId }),
 
     // Messages
     getMessages: (threadId, limit, before?) =>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -55,10 +55,22 @@ export type { MessageMention } from "./models/mention.js";
 
 export {
   GoalControlsSchema,
+  GoalLookupReasonSchema,
+  GoalLookupResultSchema,
+  GoalLookupSourceSchema,
   GoalStateSchema,
   GoalStatusSchema,
+  isGoalOpen,
+  isGoalStatusOpen,
 } from "./models/goal.js";
-export type { GoalControls, GoalState, GoalStatus } from "./models/goal.js";
+export type {
+  GoalControls,
+  GoalLookupReason,
+  GoalLookupResult,
+  GoalLookupSource,
+  GoalState,
+  GoalStatus,
+} from "./models/goal.js";
 
 export {
   ConversationPageSchema,

--- a/packages/contracts/src/models/__tests__/goal.test.ts
+++ b/packages/contracts/src/models/__tests__/goal.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  GoalLookupReasonSchema,
+  GoalLookupResultSchema,
+  GoalLookupSourceSchema,
+  WS_METHODS,
+  isGoalOpen,
+  isGoalStatusOpen,
+  type GoalState,
+} from "../../index.js";
+
+function goal(status: GoalState["status"]): GoalState {
+  return {
+    objective: "ship the feature",
+    status,
+    tokenBudget: null,
+    tokensUsed: 0,
+    timeUsedSeconds: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    source: "mcode",
+    controls: {},
+  };
+}
+
+describe("goal status helpers", () => {
+  it("treats every non-complete goal status as open", () => {
+    expect(isGoalStatusOpen("active")).toBe(true);
+    expect(isGoalStatusOpen("paused")).toBe(true);
+    expect(isGoalStatusOpen("blocked")).toBe(true);
+    expect(isGoalStatusOpen("usageLimited")).toBe(true);
+    expect(isGoalStatusOpen("budgetLimited")).toBe(true);
+  });
+
+  it("treats complete and missing goals as not open", () => {
+    expect(isGoalStatusOpen("complete")).toBe(false);
+    expect(isGoalOpen(goal("complete"))).toBe(false);
+    expect(isGoalOpen(null)).toBe(false);
+    expect(isGoalOpen(undefined)).toBe(false);
+  });
+
+  it("narrows open goal states", () => {
+    const current = goal("active");
+
+    if (!isGoalOpen(current)) {
+      throw new Error("expected an open goal");
+    }
+
+    expect(current.objective).toBe("ship the feature");
+  });
+});
+
+describe("goal lookup contract", () => {
+  it("accepts the exact lookup source and reason vocabularies", () => {
+    expect(GoalLookupSourceSchema().options).toEqual([
+      "codex-native",
+      "codex-cache",
+      "claude-wrapper",
+      "unsupported",
+    ]);
+    expect(GoalLookupReasonSchema().options).toEqual([
+      "not-materialized",
+      "closed",
+      "missing",
+      "unsupported-provider",
+    ]);
+  });
+
+  it("registers thread goal app RPC params and result validation", () => {
+    const getMethod = WS_METHODS()["thread.goal.get"];
+    const clearMethod = WS_METHODS()["thread.goal.clear"];
+
+    expect(getMethod.params.parse({ threadId: "thread-1" })).toEqual({ threadId: "thread-1" });
+    expect(clearMethod.params.parse({ threadId: "thread-1" })).toEqual({ threadId: "thread-1" });
+    expect(clearMethod.result.parse({
+      goal: null,
+      authoritative: true,
+      source: "unsupported",
+      reason: "unsupported-provider",
+    })).toEqual({
+      goal: null,
+      authoritative: true,
+      source: "unsupported",
+      reason: "unsupported-provider",
+    });
+    expect(() => GoalLookupResultSchema().parse({
+      goal: null,
+      authoritative: true,
+      source: "cursor-cache",
+    })).toThrow();
+  });
+});

--- a/packages/contracts/src/models/__tests__/goal.test.ts
+++ b/packages/contracts/src/models/__tests__/goal.test.ts
@@ -56,6 +56,8 @@ describe("goal lookup contract", () => {
       "codex-native",
       "codex-cache",
       "claude-wrapper",
+      "claude-native-command",
+      "claude-cache",
       "unsupported",
     ]);
     expect(GoalLookupReasonSchema().options).toEqual([
@@ -63,6 +65,7 @@ describe("goal lookup contract", () => {
       "closed",
       "missing",
       "unsupported-provider",
+      "busy",
     ]);
   });
 

--- a/packages/contracts/src/models/goal.ts
+++ b/packages/contracts/src/models/goal.ts
@@ -46,12 +46,12 @@ export type GoalState = z.infer<ReturnType<typeof GoalStateSchema>>;
 
 /** Identifies where a thread-goal lookup result came from. */
 export const GoalLookupSourceSchema = lazySchema(() =>
-  z.enum(["codex-native", "codex-cache", "claude-wrapper", "unsupported"]),
+  z.enum(["codex-native", "codex-cache", "claude-wrapper", "claude-native-command", "claude-cache", "unsupported"]),
 );
 
 /** Identifies why a thread-goal lookup returned no authoritative open goal. */
 export const GoalLookupReasonSchema = lazySchema(() =>
-  z.enum(["not-materialized", "closed", "missing", "unsupported-provider"]),
+  z.enum(["not-materialized", "closed", "missing", "unsupported-provider", "busy"]),
 );
 
 /** Provider-neutral active-goal lookup result for thread switch hydration. */

--- a/packages/contracts/src/models/goal.ts
+++ b/packages/contracts/src/models/goal.ts
@@ -43,3 +43,42 @@ export const GoalStateSchema = lazySchema(() =>
 
 /** Normalized goal metadata surfaced by providers that support thread goals. */
 export type GoalState = z.infer<ReturnType<typeof GoalStateSchema>>;
+
+/** Identifies where a thread-goal lookup result came from. */
+export const GoalLookupSourceSchema = lazySchema(() =>
+  z.enum(["codex-native", "codex-cache", "claude-wrapper", "unsupported"]),
+);
+
+/** Identifies why a thread-goal lookup returned no authoritative open goal. */
+export const GoalLookupReasonSchema = lazySchema(() =>
+  z.enum(["not-materialized", "closed", "missing", "unsupported-provider"]),
+);
+
+/** Provider-neutral active-goal lookup result for thread switch hydration. */
+export const GoalLookupResultSchema = lazySchema(() =>
+  z.object({
+    goal: GoalStateSchema().nullable(),
+    authoritative: z.boolean(),
+    source: GoalLookupSourceSchema(),
+    reason: GoalLookupReasonSchema().optional(),
+  }),
+);
+
+/** Identifies where a thread-goal lookup result came from. */
+export type GoalLookupSource = z.infer<ReturnType<typeof GoalLookupSourceSchema>>;
+
+/** Identifies why a thread-goal lookup returned no authoritative open goal. */
+export type GoalLookupReason = z.infer<ReturnType<typeof GoalLookupReasonSchema>>;
+
+/** Provider-neutral active-goal lookup result for thread switch hydration. */
+export type GoalLookupResult = z.infer<ReturnType<typeof GoalLookupResultSchema>>;
+
+/** Returns true while a goal still needs provider or user follow-up. */
+export function isGoalOpen(goal: GoalState | null | undefined): goal is GoalState {
+  return goal != null && isGoalStatusOpen(goal.status);
+}
+
+/** Returns true for every non-terminal goal status. */
+export function isGoalStatusOpen(status: GoalStatus): boolean {
+  return status !== "complete";
+}

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -2,7 +2,7 @@ import type { AgentEvent } from "../events/agent-event.js";
 import type { InteractionMode } from "../models/enums.js";
 import type { AttachmentMeta } from "../models/attachment.js";
 import type { MessageMention } from "../models/mention.js";
-import type { GoalState } from "../models/goal.js";
+import type { GoalLookupResult, GoalState } from "../models/goal.js";
 import type { PermissionDecision, PermissionRequest } from "../models/permission.js";
 import type { ContextWindowMode, ReasoningLevel } from "../models/settings.js";
 import type { SkillInfo } from "../skills.js";
@@ -193,6 +193,8 @@ export interface IGoalCapable extends IAgentProvider {
   clearGoal(sessionId: string): boolean | Promise<boolean>;
   /** Return the active goal state for a session, or undefined. */
   getGoal(sessionId: string): GoalState | undefined | Promise<GoalState | undefined>;
+  /** Return active goal lookup metadata without spawning or resuming provider work. */
+  getGoalLookup?(sessionId: string): GoalLookupResult | Promise<GoalLookupResult>;
 }
 
 /**

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -32,6 +32,7 @@ import { ProviderUsageInfoSchema } from "../providers/usage.js";
 import { ProviderAvailabilitySchema } from "../providers/availability.js";
 import { CopilotSubagentSchema, CopilotAgentNameSchema } from "../providers/copilot-agent.js";
 import { PermissionDecisionSchema, PermissionRequestSchema } from "../models/permission.js";
+import { GoalLookupResultSchema } from "../models/goal.js";
 
 /** Maximum recap input messages accepted by recap.generate. */
 export const RECAP_MAX_MESSAGES = 80;
@@ -271,6 +272,16 @@ export const WS_METHODS = lazySchema(() => ({
   "thread.markViewed": {
     params: z.object({ threadId: z.string() }),
     result: z.void(),
+  },
+  /** Return the active open goal for a thread without starting provider work. */
+  "thread.goal.get": {
+    params: z.object({ threadId: z.string() }),
+    result: GoalLookupResultSchema(),
+  },
+  /** Clear the active goal for a thread without sending a chat message. */
+  "thread.goal.clear": {
+    params: z.object({ threadId: z.string() }),
+    result: GoalLookupResultSchema(),
   },
   "thread.syncPrs": {
     params: z.object({ workspaceId: z.string() }),


### PR DESCRIPTION
## What
Adds provider-backed goal lookup and clearing for Codex and Claude, including thread-switch hydration. Claude now uses native Claude Code `/goal` when `system/init.slash_commands` proves the command exists, with wrapper fallback when unavailable.

## Why
The goal bar could lag behind the selected thread, Codex goal actions were routed through chat messages, and direct goals such as `say hi` could stay active after the assistant produced the requested answer. Claude also used an Mcode-only Stop-hook wrapper, so its behavior did not match the official `/goal` lifecycle.

## Key Changes
- Adds normalized goal contracts, `thread.goal.get`, and `thread.goal.clear`.
- Uses Codex app-server goal state when a live Codex thread is available, with cache fallback for inactive threads.
- Uses Claude Code native `/goal` only after observed `slash_commands` support, with fail-closed parsing for synthetic status and clear results.
- Keeps the Claude wrapper fallback when native `/goal` is unavailable.
- Handles busy Claude native clears without silently clearing the goal bar, and refreshes native status after turns before marking a goal complete.
- Hydrates the goal bar during thread switches and routes View/Clear through RPC and store actions.
- Marks direct-response goals complete from provider assistant messages without adding a synthetic chat receipt.
- Adds server, contract, web, and Playwright coverage for lookup, clearing, direct completion, unsupported clear, thread switching, and Claude native command behavior.

## Verification
- `bun run --cwd apps/server test src/commands/__tests__/goal-command.test.ts src/services/__tests__/agent-service-goal-command.test.ts src/providers/claude/__tests__/claude-goal-command-parser.test.ts src/providers/claude/__tests__/claude-native-goal-support.test.ts`: 35 passed
- `bun run --cwd packages/contracts test src/models/__tests__/goal.test.ts`: 5 passed
- `bun run verify`: typecheck, lint, and unit tests passed
- `git diff --cached --check`: no whitespace errors before commit
- Staged secret-pattern scan: no matches
- Reviewer QA runtime smoke: `bun run dev:web` started backend and Vite successfully

## Security
- No auth, SQL, file upload, dependency, lockfile, or secret handling changes.
- `bun audit` reported existing dependency advisories, not introduced by this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785336173&installation_id=129163861&pr_number=817&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F817&signature=6eab115be59d25789b9ce018d0b4c161acf8e9b06f26366d4733ac0f4ef13b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added thread goal lookup/clear APIs end-to-end (WebSocket, store, and UI).
  * Introduced native Claude goal mirroring with automatic post-turn refresh.
  * Updated the active goal experience with a status badge, details popover, and richer lookup metadata.
  * Added direct-response goal auto-completion from assistant messages.
* **Bug Fixes**
  * Completed goals are treated as inactive across views and UI.
  * Clearing unsupported or non-authoritative goals updates state consistently.
  * Goal-status notices no longer disrupt assistant message identity bookkeeping.
  * Thread switching and goal refresh/clear behavior now preserves the correct active goal state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->