### PR TITLE
fix: preserve Composer worktree checkout flow

### DIFF
--- a/apps/server/src/__tests__/git-service-branch-comparison.test.ts
+++ b/apps/server/src/__tests__/git-service-branch-comparison.test.ts
@@ -223,6 +223,27 @@ describe("GitService.resolveBranchComparison", () => {
     });
   });
 
+  it("does not expose git's detached pseudo-ref as a selectable branch", async () => {
+    setup({
+      current: "HEAD",
+      branches: [
+        { full: "(no branch)", short: "(no branch)", head: true },
+        { full: "refs/heads/main", short: "main" },
+        { full: "refs/remotes/origin/main", short: "origin/main" },
+      ],
+    });
+
+    const result = await gitService.resolveBranchComparison("ws", REPO);
+
+    expect(result).toMatchObject({
+      base: "origin/main",
+      target: "HEAD",
+      isUnborn: false,
+      isComparisonAvailable: true,
+    });
+    expect(result.refs.map((ref) => ref.name)).not.toContain("(no branch)");
+  });
+
   it("reports an explicit empty state on an unborn branch", async () => {
     setup({
       current: "main",

--- a/apps/server/src/services/__tests__/agent-service-existing-worktree.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-existing-worktree.test.ts
@@ -7,6 +7,7 @@ import { WorkspaceRepo } from "../../repositories/workspace-repo";
 import { MessageRepo } from "../../repositories/message-repo";
 import { AgentService } from "../agent-service";
 import type { GitService } from "../git-service";
+import type { ThreadService } from "../thread-service";
 
 function createAgentServiceHarness() {
   const db: Database.Database = openMemoryDatabase();
@@ -16,6 +17,9 @@ function createAgentServiceHarness() {
   const gitService = {
     listWorktrees: vi.fn(),
   } as unknown as GitService;
+  const threadService = {
+    create: vi.fn(),
+  } as unknown as ThreadService;
   const service = new AgentService(
     threadRepo,
     workspaceRepo,
@@ -23,7 +27,7 @@ function createAgentServiceHarness() {
     gitService,
     {} as never,
     {} as never,
-    {} as never,
+    threadService,
     {} as never,
     {} as never,
     {} as never,
@@ -42,10 +46,53 @@ function createAgentServiceHarness() {
   );
   vi.spyOn(service, "sendMessage").mockResolvedValue(undefined);
 
-  return { db, threadRepo, workspaceRepo, gitService, service };
+  return { db, threadRepo, workspaceRepo, gitService, threadService, service };
 }
 
 describe("AgentService.createAndSend existing worktree attach", () => {
+  it("creates a new worktree as branchless from the selected base branch", async () => {
+    const { threadRepo, workspaceRepo, threadService, service } = createAgentServiceHarness();
+    const workspace = workspaceRepo.create("Repo", "/repo");
+    const createdThread = {
+      ...threadRepo.create(
+        workspace.id,
+        "Work from feature base",
+        "worktree",
+        "feature/base",
+        true,
+        "claude",
+        undefined,
+        "branchless",
+        "feature/base",
+      ),
+      worktree_path: "/repo/.worktrees/feature-base",
+    };
+    vi.mocked(threadService.create).mockResolvedValue(createdThread);
+
+    const thread = await service.createAndSend(
+      workspace.id,
+      "Work from feature base",
+      "claude-sonnet-4-6",
+      "default",
+      "worktree",
+      "feature/base",
+    );
+
+    expect(threadService.create).toHaveBeenCalledWith(
+      workspace.id,
+      "Work from feature base",
+      "worktree",
+      "feature/base",
+      { branchless: true },
+    );
+    expect(thread).toMatchObject({
+      mode: "worktree",
+      branch: "feature/base",
+      checkout_state: "branchless",
+      base_branch: "feature/base",
+    });
+  });
+
   it("attaches a detached existing worktree as branchless with the selected base branch", async () => {
     const { workspaceRepo, gitService, service } = createAgentServiceHarness();
     const workspace = workspaceRepo.create("Repo", "/repo");

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -1120,6 +1120,9 @@ export class GitService {
       const [fullRefname, refname, shortSha, head, worktreepath] = trimmed.split("|||");
       // Skip remote HEAD symrefs (refs/remotes/*/HEAD)
       if (!fullRefname || !refname || /\/HEAD$/.test(fullRefname)) continue;
+      // Detached checkouts appear as "(no branch)" in `git branch --format`.
+      // They are display-only pseudo refs; diff callers use HEAD instead.
+      if (fullRefname === "(no branch)" || refname === "(no branch)") continue;
 
       let type: GitBranch["type"];
       if (worktreepath && worktreepath.length > 0) {

--- a/apps/web/e2e/composer-checkout-dialog.spec.ts
+++ b/apps/web/e2e/composer-checkout-dialog.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Page } from "@playwright/test";
+import { getDefaultSettings, type GitBranch, type Thread, type Workspace } from "@mcode/contracts";
+import {
+  interceptZustandStores,
+  mockWebSocketServer,
+  type RpcOverrides,
+} from "./helpers/e2e-helpers";
+
+const WORKSPACE: Workspace = {
+  id: "ws-checkout-dialog",
+  name: "Checkout Dialog",
+  path: "/tmp/checkout-dialog",
+  provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const BRANCHES: GitBranch[] = [
+  { name: "main", type: "local", isCurrent: true, shortSha: "1111111" },
+  { name: "feature/base", type: "local", isCurrent: false, shortSha: "2222222" },
+];
+
+function createdThread(mode: "direct" | "worktree", branch: string): Thread {
+  return {
+    id: `created-${mode}`,
+    workspace_id: WORKSPACE.id,
+    title: "Created thread",
+    status: "active",
+    mode: mode === "worktree" ? "worktree" : "direct",
+    worktree_path: mode === "worktree" ? "/tmp/checkout-dialog/.worktrees/feature-base" : null,
+    branch,
+    checkout_state: mode === "worktree" ? "branchless" : "named",
+    base_branch: mode === "worktree" ? branch : null,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    model: null,
+    deleted_at: null,
+    worktree_managed: mode === "worktree",
+    sdk_session_id: null,
+    provider: "claude",
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    copilot_agent: null,
+  };
+}
+
+async function seedNewThreadComposer(page: Page, mode: "direct" | "worktree"): Promise<void> {
+  await page.evaluate(
+    ({ workspace, branches, selectedMode }) => {
+      const stores =
+        (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown>; setState: (patch: Record<string, unknown>) => void }> }).__mcodeStores ?? [];
+      const workspaceStore = stores.find((store) => {
+        const state = store.getState();
+        return "activeThreadId" in state && "threads" in state && "workspaces" in state;
+      });
+      if (!workspaceStore) throw new Error("[E2E] workspace store not found");
+      workspaceStore.setState({
+        workspaces: [workspace],
+        activeWorkspaceId: workspace.id,
+        threads: [],
+        activeThreadId: null,
+        pendingNewThread: true,
+        branches,
+        branchesLoading: false,
+        newThreadMode: selectedMode,
+        newThreadBranch: "feature/base",
+        selectedWorktree: null,
+        worktrees: [],
+      });
+    },
+    { workspace: WORKSPACE, branches: BRANCHES, selectedMode: mode },
+  );
+  await expect(page.locator('[contenteditable="true"]')).toBeVisible({ timeout: 10_000 });
+}
+
+async function typeDraftAndSend(page: Page, text: string): Promise<void> {
+  const editor = page.locator('[contenteditable="true"]').first();
+  await editor.click();
+  await editor.fill(text);
+  await page.getByRole("button", { name: "Send message" }).click();
+}
+
+test.describe("Composer checkout dialog", () => {
+  test("uses an app dialog for Direct checkout cancel and skips checkout for New worktree", async ({ page }) => {
+    const rpcCalls: Array<{ method: string; params: unknown }> = [];
+    const overrides: RpcOverrides = {
+      "settings.get": getDefaultSettings(),
+      "git.listBranches": BRANCHES,
+      "git.currentBranch": (params) => {
+        rpcCalls.push({ method: "git.currentBranch", params });
+        return "main";
+      },
+      "git.checkout": (params) => {
+        rpcCalls.push({ method: "git.checkout", params });
+        return null;
+      },
+      "agent.createAndSend": (params) => {
+        rpcCalls.push({ method: "agent.createAndSend", params });
+        const mode =
+          params && typeof params === "object" && "mode" in params && params.mode === "worktree"
+            ? "worktree"
+            : "direct";
+        const branch =
+          params && typeof params === "object" && "branch" in params && typeof params.branch === "string"
+            ? params.branch
+            : "main";
+        return createdThread(mode, branch);
+      },
+    };
+
+    await mockWebSocketServer(page, overrides);
+    await interceptZustandStores(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await seedNewThreadComposer(page, "direct");
+    await typeDraftAndSend(page, "direct draft");
+
+    await expect(page.getByRole("dialog", { name: "Switch branch?" })).toBeVisible();
+    await expect(page.locator('[contenteditable="true"]').first()).toContainText("direct draft");
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByRole("dialog", { name: "Switch branch?" })).toHaveCount(0);
+    await expect(page.locator('[contenteditable="true"]').first()).toContainText("direct draft");
+    expect(rpcCalls.map((call) => call.method)).toContain("git.currentBranch");
+    expect(rpcCalls.some((call) => call.method === "git.checkout")).toBe(false);
+    expect(rpcCalls.some((call) => call.method === "agent.createAndSend")).toBe(false);
+
+    rpcCalls.length = 0;
+    await seedNewThreadComposer(page, "worktree");
+    await typeDraftAndSend(page, "worktree draft");
+
+    await expect(page.getByRole("dialog", { name: "Switch branch?" })).toHaveCount(0);
+    expect(rpcCalls.some((call) => call.method === "git.currentBranch")).toBe(false);
+    expect(rpcCalls.some((call) => call.method === "git.checkout")).toBe(false);
+    const createCall = rpcCalls.find((call) => call.method === "agent.createAndSend");
+    expect(createCall?.params).toMatchObject({
+      mode: "worktree",
+      branch: "feature/base",
+    });
+  });
+});

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -25,6 +25,15 @@ import {
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -246,6 +255,12 @@ interface ComposerProps {
   branchFromMessageContent?: string;
   /** Called when the user exits fork mode (X button or Escape). */
   onBranchModeExit?: () => void;
+}
+
+interface PendingCheckoutConfirmation {
+  currentBranch: string;
+  targetBranch: string;
+  onConfirm: () => Promise<void>;
 }
 
 type AccessMode = PermissionMode;
@@ -733,6 +748,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     displayContent: string;
     mentions: MessageMention[];
   } | null>(null);
+  const [pendingCheckoutConfirmation, setPendingCheckoutConfirmation] =
+    useState<PendingCheckoutConfirmation | null>(null);
+  const [checkoutConfirming, setCheckoutConfirming] = useState(false);
   // Tracks whether we have seen the handoff transition away from "generating"
   // at least once since this thread was opened. Guards against queueing a
   // message when the user types during the server-initiated first turn on a
@@ -1247,12 +1265,19 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     [setNewThreadMode, loadWorktrees, workspaceId],
   );
 
+  useEffect(() => {
+    if (isNewThread && composerMode !== newThreadMode) {
+      setComposerModeLocal(newThreadMode);
+    }
+  }, [isNewThread, composerMode, newThreadMode]);
+
   // Sync composerMode with thread's persisted mode when switching threads
   useEffect(() => {
+    if (isNewThread) return;
     const mode = activeThread?.mode === "worktree" ? "worktree" : "direct";
     setComposerModeLocal(mode);
     setNewThreadMode(mode);
-  }, [activeThread?.mode, setNewThreadMode]);
+  }, [activeThread?.mode, isNewThread, setNewThreadMode]);
 
   // Force direct mode for non-git workspaces — worktree modes are not available without git
   useEffect(() => {
@@ -2001,22 +2026,12 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       return;
     }
 
-    // Validate worktree mode requirements
-    if (isNewThread && newThreadMode === "existing-worktree" && !selectedWorktree) {
-      return;
-    }
+    const submittedNewThreadMode = composerMode;
+    const submittedNewThreadBranch = newThreadBranch;
 
-    // Checkout confirmation for local mode when a different branch is selected
-    if (isNewThread && isGitRepo && newThreadMode === "direct" && newThreadBranch && workspaceId) {
-      const currentBranch = await useWorkspaceStore.getState().getCurrentBranch(workspaceId);
-      if (currentBranch && newThreadBranch !== currentBranch) {
-        const confirmed = window.confirm(
-          `You're on "${currentBranch}" but selected "${newThreadBranch}". Switch to "${newThreadBranch}"? This will checkout the branch.`,
-        );
-        if (!confirmed) return;
-        await useWorkspaceStore.getState().checkoutBranch(workspaceId, newThreadBranch);
-        clearFileListCache(workspaceId);
-      }
+    // Validate worktree mode requirements
+    if (isNewThread && submittedNewThreadMode === "existing-worktree" && !selectedWorktree) {
+      return;
     }
 
     const captureRows = buildAttachedBrowserCaptures(attachments);
@@ -2032,60 +2047,63 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
     const outboundDisplay = resolveOutboundDisplayContent(rawInput, undefined);
 
-    // ---- Normal send path ----
+    const continueSend = async () => {
+      // ---- Normal send path ----
 
-    if (
-      shouldQueueActiveThreadSubmit(
-        threadId,
-        isAgentRunning,
-        branchFromMessageId,
-        isNewThread,
-        trimmed,
-      )
-    ) {
-      enqueueCurrentComposerMessage(messageContent, outboundDisplay, captureRows);
-      return;
-    }
+      if (
+        shouldQueueActiveThreadSubmit(
+          threadId,
+          isAgentRunning,
+          branchFromMessageId,
+          isNewThread,
+          trimmed,
+        )
+      ) {
+        enqueueCurrentComposerMessage(messageContent, outboundDisplay, captureRows);
+        return;
+      }
 
-    setInput("");
-    setMentions([]);
-    if (editorRef.current) {
-      editorRef.current.update(() => {
-        const root = $getRoot();
-        root.clear();
-        root.append($createParagraphNode());
-      });
-    }
-    setDetectedPr(null);
-    setPrDismissed(false);
-    // Edit mode ends on send regardless of which path we took.
-    editingOriginalRef.current = null;
-    setEditingFromQueue(null);
-    useQueueStore.getState().setEditingThreadId(null);
-    const currentAttachments = collectAndClearAttachments();
-    if (threadId) clearDraftFromStore(threadId);
-    // Hide the reply bar with the composer reset; sendMessage still receives reply IDs from this render.
-    if (threadId) clearReply(threadId);
+      setInput("");
+      setMentions([]);
+      if (editorRef.current) {
+        editorRef.current.update(() => {
+          const root = $getRoot();
+          root.clear();
+          root.append($createParagraphNode());
+        });
+      }
+      setDetectedPr(null);
+      setPrDismissed(false);
+      // Edit mode ends on send regardless of which path we took.
+      editingOriginalRef.current = null;
+      setEditingFromQueue(null);
+      useQueueStore.getState().setEditingThreadId(null);
+      const currentAttachments = collectAndClearAttachments();
+      if (threadId) clearDraftFromStore(threadId);
+      // Hide the reply bar with the composer reset; sendMessage still receives reply IDs from this render.
+      if (threadId) clearReply(threadId);
 
-    if (isNewThread && workspaceId) {
-      await useWorkspaceStore
-        .getState()
-        .createAndSendMessage(
-          messageContent,
-          modelId,
-          access,
-          currentAttachments.length > 0 ? currentAttachments : undefined,
-          reasoning,
-          provider,
-          mode,
-          provider === "copilot" ? (copilotAgent ?? undefined) : undefined,
-          contextWindow ?? undefined,
-          thinking ?? undefined,
-          provider === "codex" && codexFastMode !== null ? codexFastMode : undefined,
-          outboundDisplay,
-          selectedMentions,
-        );
-    } else if (branchFromMessageId && threadId) {
+      if (isNewThread && workspaceId) {
+        setNewThreadMode(submittedNewThreadMode);
+        setNewThreadBranch(submittedNewThreadBranch);
+        await useWorkspaceStore
+          .getState()
+          .createAndSendMessage(
+            messageContent,
+            modelId,
+            access,
+            currentAttachments.length > 0 ? currentAttachments : undefined,
+            reasoning,
+            provider,
+            mode,
+            provider === "copilot" ? (copilotAgent ?? undefined) : undefined,
+            contextWindow ?? undefined,
+            thinking ?? undefined,
+            provider === "codex" && codexFastMode !== null ? codexFastMode : undefined,
+            outboundDisplay,
+            selectedMentions,
+          );
+      } else if (branchFromMessageId && threadId) {
       // Branch mode: create a child thread from the quoted message instead of sending.
       let branchMode: "direct" | "worktree" | "existing-worktree" = "direct";
       let branchBranch = branchTargetBranch || activeThread?.branch || "";
@@ -2126,42 +2144,62 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         mentions: selectedMentions,
       });
       onBranchModeExit?.();
-    } else if (threadId) {
-      await sendMessage(
-        threadId,
-        messageContent,
-        modelId,
-        access,
-        currentAttachments.length > 0 ? currentAttachments : undefined,
-        outboundDisplay,
-        reasoning,
-        provider,
-        provider === "copilot" ? (copilotAgent ?? undefined) : undefined,
-        contextWindow ?? undefined,
-        thinking ?? undefined,
-        provider === "codex" && codexFastMode !== null ? codexFastMode : undefined,
-        replyContext?.messageId,
-        replyContext?.quotedText,
-        undefined,
-        selectedMentions,
-      );
-    }
+      } else if (threadId) {
+        await sendMessage(
+          threadId,
+          messageContent,
+          modelId,
+          access,
+          currentAttachments.length > 0 ? currentAttachments : undefined,
+          outboundDisplay,
+          reasoning,
+          provider,
+          provider === "copilot" ? (copilotAgent ?? undefined) : undefined,
+          contextWindow ?? undefined,
+          thinking ?? undefined,
+          provider === "codex" && codexFastMode !== null ? codexFastMode : undefined,
+          replyContext?.messageId,
+          replyContext?.quotedText,
+          undefined,
+          selectedMentions,
+        );
+      }
 
-    // Auto-save last-used mode and access as defaults (model defaults are managed in Settings)
-    const { settings, loaded, update: updateSettings } = useSettingsStore.getState();
-    if (loaded && (mode !== settings.agent.defaults.mode || access !== settings.agent.defaults.permission)) {
-      void updateSettings({
-        agent: {
-          defaults: {
-            mode,
-            permission: access,
+      // Auto-save last-used mode and access as defaults (model defaults are managed in Settings)
+      const { settings, loaded, update: updateSettings } = useSettingsStore.getState();
+      if (loaded && (mode !== settings.agent.defaults.mode || access !== settings.agent.defaults.permission)) {
+        void updateSettings({
+          agent: {
+            defaults: {
+              mode,
+              permission: access,
+            },
           },
-        },
-      });
+        });
+      }
+
+      editorRef.current?.focus();
+    };
+
+    // Checkout confirmation for Direct mode when a different branch is selected.
+    if (isNewThread && isGitRepo && submittedNewThreadMode === "direct" && submittedNewThreadBranch && workspaceId) {
+      const currentBranch = await useWorkspaceStore.getState().getCurrentBranch(workspaceId);
+      if (currentBranch && submittedNewThreadBranch !== currentBranch) {
+        setPendingCheckoutConfirmation({
+          currentBranch,
+          targetBranch: submittedNewThreadBranch,
+          onConfirm: async () => {
+            await useWorkspaceStore.getState().checkoutBranch(workspaceId, submittedNewThreadBranch);
+            clearFileListCache(workspaceId);
+            await continueSend();
+          },
+        });
+        return;
+      }
     }
 
-    editorRef.current?.focus();
-  }, [input, mentions, attachments, isAgentRunning, isNewThread, newThreadMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, contextWindow, thinking, codexFastMode, selectedWorktree, collectAndClearAttachments, clearDraftFromStore, isThreadScaffold, branchFromMessageId, branchExecMode, branchTargetBranch, branchWorktreePath, branchWorktreeIsDetached, activeThread, branchThread, onBranchModeExit, replyContext, clearReply, editingFromQueue, slashCommand]);
+    await continueSend();
+  }, [input, mentions, attachments, isAgentRunning, isNewThread, composerMode, newThreadBranch, workspaceId, threadId, sendMessage, modelId, provider, reasoning, mode, access, copilotAgent, contextWindow, thinking, codexFastMode, selectedWorktree, collectAndClearAttachments, clearDraftFromStore, isThreadScaffold, branchFromMessageId, branchExecMode, branchTargetBranch, branchWorktreePath, branchWorktreeIsDetached, activeThread, branchThread, onBranchModeExit, replyContext, clearReply, editingFromQueue, slashCommand, isGitRepo, setNewThreadMode, setNewThreadBranch]);
 
   // Reset the handoff-transition-seen flag whenever the user switches threads
   // so the guard below evaluates correctly for each new child thread.
@@ -2299,6 +2337,25 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       setShowReasoningPicker(false);
     }
   }, [reasoningLevels.length, has1MCapability, hasThinkingCapability, provider]);
+
+  const cancelCheckoutConfirmation = useCallback(() => {
+    if (checkoutConfirming) return;
+    setPendingCheckoutConfirmation(null);
+    editorRef.current?.focus();
+  }, [checkoutConfirming]);
+
+  const confirmCheckoutAndSend = useCallback(async () => {
+    const pending = pendingCheckoutConfirmation;
+    if (!pending || checkoutConfirming) return;
+    setCheckoutConfirming(true);
+    try {
+      await pending.onConfirm();
+      setPendingCheckoutConfirmation(null);
+    } finally {
+      setCheckoutConfirming(false);
+      editorRef.current?.focus();
+    }
+  }, [pendingCheckoutConfirmation, checkoutConfirming]);
 
   return (
     <div className="relative px-8 py-4">
@@ -3070,6 +3127,31 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         onDismiss={slashCommand.onDismiss}
         onRetry={slashCommand.onRetry}
       />
+      <Dialog
+        open={pendingCheckoutConfirmation !== null}
+        onOpenChange={(open) => {
+          if (!open) cancelCheckoutConfirmation();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Switch branch?</DialogTitle>
+            <DialogDescription>
+              {pendingCheckoutConfirmation
+                ? `You're on "${pendingCheckoutConfirmation.currentBranch}" but selected "${pendingCheckoutConfirmation.targetBranch}". Switch to "${pendingCheckoutConfirmation.targetBranch}" before starting the thread?`
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose render={<Button variant="outline" disabled={checkoutConfirming} />}>
+              Cancel
+            </DialogClose>
+            <Button onClick={confirmCheckoutAndSend} disabled={checkoutConfirming}>
+              {checkoutConfirming ? "Switching..." : "Switch and send"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -1,0 +1,267 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Composer } from "../Composer";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { resetThreadStoreForTests } from "@/stores/thread-store-test-utils";
+import { mockTransport, createMockThread, createMockWorkspace } from "@/__tests__/mocks/transport";
+import type { GitBranch } from "@/transport";
+
+let lastComposerText = "";
+
+const branch = (name: string, isCurrent = false): GitBranch => ({
+  name,
+  shortSha: "abc1234",
+  type: "local",
+  isCurrent,
+});
+
+vi.mock("@/transport", async () => ({
+  ...(await vi.importActual("@/transport")),
+  getTransport: () => mockTransport,
+}));
+
+vi.mock("../lexical", () => ({
+  ComposerEditor: ({
+    onChange,
+    editorRef,
+  }: {
+    onChange: (text: string, mentions: []) => void;
+    editorRef: React.MutableRefObject<{ update: (fn: () => void) => void; focus: () => void } | null>;
+  }) => {
+    React.useEffect(() => {
+      editorRef.current = {
+        update: vi.fn(),
+        focus: vi.fn(),
+      };
+    }, [editorRef]);
+
+    return (
+      <textarea
+        aria-label="Message Mcode"
+        onChange={(event) => {
+          lastComposerText = event.target.value;
+          onChange(event.target.value, []);
+        }}
+      />
+    );
+  },
+  $createTypedMentionNode: vi.fn(),
+  extractComposerMessage: vi.fn(() => ({ text: lastComposerText, mentions: [] })),
+  insertMentionNode: vi.fn(),
+  insertSlashCommandNode: vi.fn(),
+}));
+
+vi.mock("../useFileAutocomplete", () => ({
+  clearFileListCache: vi.fn(),
+  useFileAutocomplete: () => ({
+    suggestions: [],
+    query: "",
+    isOpen: false,
+    triggerStart: 0,
+    selectSuggestion: vi.fn(),
+    handleInputChange: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+vi.mock("../useSlashCommand", () => ({
+  useSlashCommand: () => ({
+    state: null,
+    selectedIndex: 0,
+    anchorRect: null,
+    isOpen: false,
+    onInputChange: vi.fn(),
+    onDismiss: vi.fn(),
+    onSelect: vi.fn(),
+    onKeyDown: vi.fn(),
+    onRetry: vi.fn(),
+  }),
+}));
+
+vi.mock("../ModeSelector", () => ({
+  ALL_MODE_OPTIONS: [
+    { value: "direct", label: "Direct" },
+    { value: "worktree", label: "New worktree" },
+    { value: "existing-worktree", label: "Existing worktree" },
+  ],
+  ModeSelector: ({ mode }: { mode: string }) => <div data-testid="mode-selector">{mode}</div>,
+}));
+
+vi.mock("../BranchPicker", () => ({
+  BranchPicker: ({ selectedBranch }: { selectedBranch: string }) => (
+    <div data-testid="branch-picker">{selectedBranch}</div>
+  ),
+}));
+
+vi.mock("../WorktreePicker", () => ({
+  default: () => <div data-testid="worktree-picker" />,
+}));
+
+vi.mock("../ModelSelector", () => ({
+  ModelSelector: () => <div />,
+}));
+
+vi.mock("../CopilotAgentSelector", () => ({
+  CopilotAgentSelector: () => <div />,
+}));
+
+vi.mock("../AttachmentPreview", () => ({
+  AttachmentPreview: () => <div />,
+}));
+
+vi.mock("../FileTagPopup", () => ({
+  FileTagPopup: () => <div />,
+  useFileTagPopup: () => ({
+    listRef: { current: null },
+    selectedIndex: 0,
+    onKeyDown: vi.fn(),
+  }),
+}));
+
+vi.mock("../SpellcheckContextMenu", () => ({
+  SpellcheckContextMenu: () => <div />,
+}));
+
+vi.mock("../TerminalStatusIndicator", () => ({
+  TerminalStatusIndicator: () => <div />,
+}));
+
+vi.mock("../PrDetectedCard", () => ({
+  PrDetectedCard: () => <div />,
+}));
+
+vi.mock("../ComposerQueueList", () => ({
+  ComposerQueueList: () => <div />,
+}));
+
+vi.mock("../ContextTracker", () => ({
+  ContextTracker: () => <div />,
+}));
+
+vi.mock("../CompactingBanner", () => ({
+  CompactingBanner: () => <div />,
+}));
+
+vi.mock("../RetryBanner", () => ({
+  RetryBanner: () => <div />,
+}));
+
+vi.mock("../InterruptStopBanner", () => ({
+  InterruptStopBanner: () => <div />,
+}));
+
+vi.mock("../SlashCommandPopup", () => ({
+  SlashCommandPopup: () => <div />,
+}));
+
+vi.mock("../ProviderUnavailableBanner", () => ({
+  ProviderUnavailableBanner: () => <div />,
+}));
+
+function seedComposerState(mode: "direct" | "worktree" | "existing-worktree") {
+  const workspace = createMockWorkspace({ id: "ws-1", is_git_repo: true });
+  useWorkspaceStore.setState({
+    workspaces: [workspace],
+    activeWorkspaceId: workspace.id,
+    threads: [],
+    activeThreadId: null,
+    branches: [branch("main", true), branch("feature/base")],
+    newThreadMode: mode,
+    newThreadBranch: "feature/base",
+    selectedWorktree: mode === "existing-worktree"
+      ? { name: "existing", path: "/repo/.worktrees/existing", branch: "feature/base", managed: true }
+      : null,
+    worktrees: [],
+  });
+  return workspace;
+}
+
+async function typeAndSend() {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("Message Mcode"), "Build this");
+  await user.click(screen.getByLabelText("Send message"));
+  return user;
+}
+
+describe("Composer checkout confirmation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    lastComposerText = "";
+    resetThreadStoreForTests({ runningThreadIds: new Set() });
+    useWorkspaceStore.setState({
+      workspaces: [],
+      activeWorkspaceId: null,
+      threads: [],
+      activeThreadId: null,
+      branches: [],
+      newThreadMode: "direct",
+      newThreadBranch: "main",
+      selectedWorktree: null,
+    });
+    vi.spyOn(window, "confirm").mockImplementation(() => {
+      throw new Error("native confirm should not be used");
+    });
+    vi.spyOn(window, "alert").mockImplementation(() => {
+      throw new Error("native alert should not be used");
+    });
+    (mockTransport.getCurrentBranch as ReturnType<typeof vi.fn>).mockResolvedValue("main");
+    (mockTransport.checkoutBranch as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockThread({ id: "thread-created", workspace_id: "ws-1", branch: "feature/base" }),
+    );
+  });
+
+  it("confirms Direct branch checkout in an app dialog before sending", async () => {
+    seedComposerState("direct");
+    render(<Composer isNewThread workspaceId="ws-1" />);
+
+    const user = await typeAndSend();
+
+    expect(window.confirm).not.toHaveBeenCalled();
+    expect(window.alert).not.toHaveBeenCalled();
+    expect(await screen.findByRole("dialog", { name: "Switch branch?" })).toBeInTheDocument();
+    expect(mockTransport.createAndSendMessage).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Switch and send" }));
+
+    await waitFor(() => expect(mockTransport.checkoutBranch).toHaveBeenCalledWith("ws-1", "feature/base"));
+    await waitFor(() => expect(mockTransport.createAndSendMessage).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Switch branch?" })).not.toBeInTheDocument());
+  }, 15_000);
+
+  it("canceling the Direct dialog keeps the draft and skips checkout and send", async () => {
+    seedComposerState("direct");
+    render(<Composer isNewThread workspaceId="ws-1" />);
+
+    const user = await typeAndSend();
+    await screen.findByRole("dialog", { name: "Switch branch?" });
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Switch branch?" })).not.toBeInTheDocument());
+    expect(mockTransport.checkoutBranch).not.toHaveBeenCalled();
+    expect(mockTransport.createAndSendMessage).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Message Mcode")).toHaveValue("Build this");
+    expect(screen.getByLabelText("Send message")).toBeEnabled();
+  });
+
+  it("does not inspect or checkout the workspace branch for worktree modes", async () => {
+    for (const mode of ["worktree", "existing-worktree"] as const) {
+      vi.clearAllMocks();
+      seedComposerState(mode);
+      const { unmount } = render(<Composer isNewThread workspaceId="ws-1" />);
+      await waitFor(() => expect(screen.getByTestId("mode-selector")).toHaveTextContent(mode));
+
+      await typeAndSend();
+
+      await waitFor(() => expect(mockTransport.createAndSendMessage).toHaveBeenCalled());
+      expect(mockTransport.getCurrentBranch).not.toHaveBeenCalled();
+      expect(mockTransport.checkoutBranch).not.toHaveBeenCalled();
+      expect(screen.queryByRole("dialog", { name: "Switch branch?" })).not.toBeInTheDocument();
+
+      unmount();
+    }
+  });
+});


### PR DESCRIPTION
## What
Fixes Composer branch handling when starting a new thread from a selected branch, and prevents detached worktrees from passing Git's `(no branch)` pseudo-ref into review diff stats.

## Why
Changing the branch for a Direct local thread can require checking out the workspace. New worktree and existing worktree flows should not switch the workspace checkout. Canceling the Direct checkout prompt should also leave the composer usable.

Detached worktrees can show `(no branch)` in `git branch --format` output. That value is not a real ref, so the Review panel should never send it to diff-stat RPCs.

## Key Changes
- Replaced the native checkout confirmation with the app Dialog component.
- Scoped checkout preflight to Direct new-thread sends.
- Kept New worktree and Existing worktree sends from calling current-branch or checkout RPCs.
- Filtered Git's detached `(no branch)` pseudo-ref from branch listings.
- Added coverage for canceling the checkout dialog, preserving drafts, and sending New worktree requests with the selected base branch.
- Added server coverage for New worktree branchless creation and detached branch comparison.

## Verification
- `cd apps/web && bun run test src/components/chat/__tests__/Composer.checkout-dialog.test.tsx`: 1 file passed, 3 tests passed.
- `cd apps/server && bun run test src/services/__tests__/agent-service-existing-worktree.test.ts`: 1 file passed, 4 tests passed.
- `cd apps/server && bun run test src/__tests__/git-service-branch-comparison.test.ts`: 1 file passed, 16 tests passed.
- `cd apps/web && bun x playwright test e2e/composer-checkout-dialog.spec.ts`: 1 test passed.
- `bun run verify`: Typecheck, lint, and unit tests passed.
- `cd apps/web && bun run e2e`: 287 passed, 2 skipped.