### PR TITLE
feat(web): add CI checks to thread overview

### DIFF
--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "@playwright/test";
-import { mockWebSocketServer } from "./helpers/e2e-helpers";
+import {
+  interceptZustandStores,
+  mockWebSocketServer,
+  type WsController,
+} from "./helpers/e2e-helpers";
 import { getDefaultSettings } from "@mcode/contracts";
 
 const MOCK_SETTINGS = getDefaultSettings();
@@ -46,6 +50,18 @@ const thread = {
   permission_mode: null,
   parent_thread_id: null,
   forked_from_message_id: null,
+};
+
+const openPrThread = {
+  ...thread,
+  pr_number: 42,
+  pr_status: "open",
+};
+
+const openPr = {
+  number: 42,
+  state: "OPEN",
+  url: "https://github.com/Mzeey-Empire/mcode/pull/42",
 };
 
 const usage = {
@@ -140,6 +156,76 @@ const branches = [
 /** The Overview body, whether docked (reflowed) or floating (popover). */
 const overviewContent = (page: import("@playwright/test").Page) =>
   page.getByTestId("thread-overview-body");
+
+async function waitForHydration(page: import("@playwright/test").Page): Promise<void> {
+  await page.waitForFunction(
+    () => (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete === true,
+  );
+}
+
+async function waitForChecksAggregate(
+  page: import("@playwright/test").Page,
+  threadId: string,
+  aggregate: "passing" | "failing" | "pending",
+): Promise<void> {
+  await page.waitForFunction(
+    ({ tid, agg }) => {
+      const stores =
+        (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown> }> })
+          .__mcodeStores ?? [];
+      const workspaceStore = stores.find((store) => {
+        const state = store.getState();
+        return "checksById" in state && "threads" in state && "workspaces" in state;
+      });
+      const checksById = workspaceStore?.getState().checksById as
+        | Record<string, { aggregate?: string }>
+        | undefined;
+      return checksById?.[tid]?.aggregate === agg;
+    },
+    { tid: threadId, agg: aggregate },
+  );
+}
+
+function checks(aggregate: "passing" | "failing" | "pending") {
+  return {
+    aggregate,
+    runs: [],
+    fetchedAt: Date.now(),
+  };
+}
+
+function failingChecksWithRuns() {
+  return {
+    aggregate: "failing" as const,
+    fetchedAt: Date.now(),
+    runs: [
+      {
+        name: "Test Web E2E (shard 1/4)",
+        status: "completed" as const,
+        conclusion: "failure" as const,
+        startedAt: new Date(Date.now() - 120_000).toISOString(),
+        completedAt: new Date().toISOString(),
+        durationMs: 120_000,
+      },
+      {
+        name: "Test",
+        status: "in_progress" as const,
+        conclusion: null,
+        startedAt: new Date(Date.now() - 8_000).toISOString(),
+        completedAt: null,
+        durationMs: null,
+      },
+      {
+        name: "Typecheck",
+        status: "completed" as const,
+        conclusion: "success" as const,
+        startedAt: new Date(Date.now() - 42_000).toISOString(),
+        completedAt: new Date().toISOString(),
+        durationMs: 42_000,
+      },
+    ],
+  };
+}
 
 /** Opens the Overview if it isn't already (it auto-opens on wide viewports). */
 async function ensureOverviewOpen(page: import("@playwright/test").Page) {
@@ -398,5 +484,106 @@ test.describe("Consolidated chat header", () => {
       .evaluate((node) => getComputedStyle(node).paddingRight);
 
     expect(messageAreaPaddingRight).toBe("0px");
+  });
+});
+
+test.describe("Consolidated chat header CI trigger state", () => {
+  test.use({ viewport: { width: 1920, height: 1080 } });
+
+  let ws: WsController;
+
+  test.beforeEach(async ({ page }) => {
+    await interceptZustandStores(page);
+    await page.addInitScript((wsId: string) => {
+      localStorage.setItem(
+        "mcode-expanded-projects",
+        JSON.stringify({ [wsId]: true }),
+      );
+    }, WS_ID);
+
+    ws = await mockWebSocketServer(page, {
+      "workspace.list": [workspace],
+      "workspace.enrich": { items: [] },
+      "workspace.touchLastOpened": null,
+      "thread.list": [openPrThread],
+      "settings.get": MOCK_SETTINGS,
+      "provider.getUsage": usage,
+      "github.branchPr": openPr,
+      "git.log": [gitCommit],
+      "snapshot.listByThread": [snapshot],
+      "snapshot.getDiffStats": [],
+      "git.listBranches": branches,
+      "git.getRemoteUrl": {
+        label: "Mzeey-Empire/mcode",
+        webUrl: "https://github.com/Mzeey-Empire/mcode",
+      },
+      "git.workingTreeFiles": [],
+    });
+
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-item']");
+    await page.locator("[data-testid='thread-item']").first().click();
+    await page.waitForSelector("[data-testid='chat-header-title']");
+    await waitForHydration(page);
+  });
+
+  test("updates the Overview trigger CI dot for pending, failing, and passing checks", async ({ page }) => {
+    const trigger = page.getByTestId("header-workspace-menu");
+    await expect(page.getByTestId("thread-overview-pr")).toContainText("PR #42");
+
+    await expect(trigger).toHaveAttribute("aria-label", "Thread overview");
+    await expect(trigger).toHaveAttribute("title", "Thread overview");
+    await expect(page.getByTestId("thread-overview-ci-red")).toHaveCount(0);
+    await expect(page.getByTestId("thread-overview-ci-green")).toHaveCount(0);
+
+    await ws.sendPush("thread.checksUpdated", {
+      threadId: openPrThread.id,
+      checks: checks("pending"),
+    });
+    await waitForChecksAggregate(page, openPrThread.id, "pending");
+
+    await expect(trigger).toHaveAttribute("aria-label", "Thread overview");
+    await expect(page.getByTestId("thread-overview-ci-red")).toHaveCount(0);
+    await expect(page.getByTestId("thread-overview-ci-green")).toHaveCount(0);
+
+    await ws.sendPush("thread.checksUpdated", {
+      threadId: openPrThread.id,
+      checks: checks("failing"),
+    });
+    await waitForChecksAggregate(page, openPrThread.id, "failing");
+
+    await expect(trigger).toHaveAttribute("aria-label", "Thread overview, CI checks failing");
+    await expect(trigger).toHaveAttribute("title", "Thread overview, CI checks failing");
+    await expect(page.getByTestId("thread-overview-ci-red")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-ci-green")).toHaveCount(0);
+
+    await ws.sendPush("thread.checksUpdated", {
+      threadId: openPrThread.id,
+      checks: checks("passing"),
+    });
+    await waitForChecksAggregate(page, openPrThread.id, "passing");
+
+    await expect(trigger).toHaveAttribute("aria-label", "Thread overview, CI checks passing");
+    await expect(trigger).toHaveAttribute("title", "Thread overview, CI checks passing");
+    await expect(page.getByTestId("thread-overview-ci-green")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-ci-red")).toHaveCount(0);
+  });
+
+  test("shows CI summary below the PR row and expands details from it", async ({ page }) => {
+    await ws.sendPush("thread.checksUpdated", {
+      threadId: openPrThread.id,
+      checks: failingChecksWithRuns(),
+    });
+    await waitForChecksAggregate(page, openPrThread.id, "failing");
+    await ensureOverviewOpen(page);
+
+    const summary = page.getByTestId("thread-overview-pr-status");
+    await expect(summary).toHaveAttribute("aria-label", /1 failing/);
+    await expect(summary).toHaveAttribute("aria-label", /1 green/);
+    await expect(summary).not.toContainText("Checks failing");
+
+    await summary.hover();
+    await expect(page.getByText("Test Web E2E (shard 1/4)")).toBeVisible();
+    await expect(page.getByText("Typecheck")).toBeVisible();
   });
 });

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -581,6 +581,8 @@ test.describe("Consolidated chat header CI trigger state", () => {
     await expect(summary).toHaveAttribute("aria-label", /1 failing/);
     await expect(summary).toHaveAttribute("aria-label", /1 green/);
     await expect(summary).not.toContainText("Checks failing");
+    await expect(summary).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(summary).toHaveCSS("border-top-color", "rgba(0, 0, 0, 0)");
 
     await summary.hover();
     await expect(page.getByText("Test Web E2E (shard 1/4)")).toBeVisible();

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -1,101 +1,92 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
-import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
-import { CircleCheck, CircleX, Loader2, RefreshCw, ExternalLink, MinusCircle } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+  CircleCheck,
+  CircleX,
+  Loader2,
+  MinusCircle,
+  type LucideIcon,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
-import { getTransport } from "@/transport";
-import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { getCiVisual, getBreakdown, getLeadRunningName, CI_ICON_STROKE } from "@/lib/ci-status";
+import { CI_ICON_STROKE } from "@/lib/ci-status";
 import type { ChecksStatus, CheckRun } from "@mcode/contracts";
-import { openGitHubUrl } from "@/lib/open-url-in-preview";
 
 /** Props for {@link ChecksPopover}. */
 interface ChecksPopoverProps {
-  /** Thread ID used for refresh requests. */
-  threadId: string;
-  /** GitHub PR URL, used for the "View on GitHub" link. */
-  prUrl: string;
-  /** Optional PR title shown in the header. */
-  prTitle?: string;
-  /** Optional PR author shown below the title. */
-  prAuthor?: string;
   /** Latest CI check status to display. */
   checks: ChecksStatus;
-  /** Trigger element rendered inside the popover trigger. */
-  children: React.ReactNode;
-  /**
-   * Controlled open state. When provided the popover becomes fully controlled,
-   * letting callers (e.g. a keyboard shortcut handler) open it programmatically.
-   * When omitted the popover is uncontrolled and opens on click.
-   */
+  /** Trigger element rendered as the CI summary row. */
+  children: ReactElement;
+  /** Controlled open state. */
   open?: boolean;
-  /** Paired with `open` — called when Base UI wants to change the open state. */
+  /** Called when the local flyout open state should change. */
   onOpenChange?: (open: boolean) => void;
 }
 
-/** Lanes that runs can land in — controls grouping, colour, and sort priority. */
-type Lane = "failing" | "running" | "passing" | "other";
-
-/** Lane metadata used for the section header chrome. Only the failing lane carries a wash
- *  so the popover stays calm: urgency is carried by one surface, not three. */
-const LANE_META: Record<Lane, { label: string; icon: typeof CircleCheck; iconClass: string; wash: string; accent: string }> = {
-  failing: {
-    label: "Failing",
-    icon: CircleX,
-    iconClass: "text-[var(--diff-remove-strong)]",
-    wash: "bg-[var(--diff-remove-strong)]/[0.05]",
-    accent: "text-[var(--diff-remove-strong)]",
-  },
-  running: {
-    label: "Running",
-    icon: Loader2,
-    iconClass: "text-primary",
-    wash: "",
-    accent: "text-primary",
-  },
-  passing: {
-    label: "Passing",
-    icon: CircleCheck,
-    iconClass: "text-[var(--diff-add-strong)]",
-    wash: "",
-    accent: "text-[var(--diff-add-strong)]/85",
-  },
-  other: {
-    // "Other" rather than "Skipped" — this bucket also holds cancelled, neutral,
-    // action_required, and stale conclusions; calling them all skipped misleads triage.
-    label: "Other",
-    icon: MinusCircle,
-    iconClass: "text-muted-foreground/60",
-    wash: "",
-    accent: "text-muted-foreground",
-  },
-};
-
-function laneOf(run: CheckRun): Lane {
-  if (run.status !== "completed") return "running";
-  if (run.conclusion === "failure" || run.conclusion === "timed_out") return "failing";
-  if (run.conclusion === "success") return "passing";
-  return "other";
+interface CheckRunVisual {
+  icon: LucideIcon;
+  iconClassName: string;
+  label: string;
+  labelClassName: string;
+  spinning?: boolean;
 }
 
-/** Status icon for an individual check run, colour-matched to its lane. */
-function RunIcon({ run }: { run: CheckRun }) {
-  const lane = laneOf(run);
-  const Meta = LANE_META[lane];
-  return (
-    <Meta.icon
-      size={12}
-      className={cn(
-        Meta.iconClass,
-        "shrink-0",
-        lane === "running" && "status-spin",
-      )}
-      strokeWidth={CI_ICON_STROKE}
-    />
-  );
+interface FlyoutPosition {
+  left: number;
+  top: number;
 }
 
-/** Format a duration in milliseconds to a human-readable string. */
+const FLYOUT_WIDTH = 356;
+const FLYOUT_MAX_HEIGHT = 320;
+const FLYOUT_GAP = 8;
+const VIEWPORT_PADDING = 8;
+
+function getRunVisual(run: CheckRun): CheckRunVisual {
+  if (run.status !== "completed") {
+    return {
+      icon: Loader2,
+      iconClassName: "text-primary",
+      label: "Running",
+      labelClassName: "text-muted-foreground",
+      spinning: true,
+    };
+  }
+
+  switch (run.conclusion) {
+    case "success":
+      return {
+        icon: CircleCheck,
+        iconClassName: "text-[var(--diff-add-strong)]",
+        label: "Succeeded",
+        labelClassName: "text-muted-foreground",
+      };
+    case "failure":
+    case "timed_out":
+      return {
+        icon: CircleX,
+        iconClassName: "text-[var(--diff-remove-strong)]",
+        label: "Failed",
+        labelClassName: "text-muted-foreground",
+      };
+    default:
+      return {
+        icon: MinusCircle,
+        iconClassName: "text-muted-foreground/80",
+        label: run.conclusion ? run.conclusion.replace(/_/g, " ") : "Completed",
+        labelClassName: "text-muted-foreground",
+      };
+  }
+}
+
+/** Format a duration in milliseconds to a compact human-readable string. */
 function formatDuration(ms: number): string {
   if (ms < 1000) return "<1s";
   const secs = Math.round(ms / 1000);
@@ -105,343 +96,141 @@ function formatDuration(ms: number): string {
   return remainSecs > 0 ? `${mins}m ${remainSecs}s` : `${mins}m`;
 }
 
-/** Compute elapsed time since a startedAt timestamp, as a live-updating formatted string. */
-function useLiveElapsed(startedAtIso: string | null | undefined, active: boolean): string | null {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (!active || !startedAtIso) return;
-    const id = setInterval(() => setNow(Date.now()), 1_000);
-    return () => clearInterval(id);
-  }, [active, startedAtIso]);
-  if (!startedAtIso) return null;
-  const started = new Date(startedAtIso).getTime();
-  if (isNaN(started)) return null;
-  return formatDuration(now - started);
+function getMeasuredTrigger(trigger: HTMLElement): HTMLElement {
+  return trigger.firstElementChild instanceof HTMLElement
+    ? trigger.firstElementChild
+    : trigger;
 }
 
-/** Summarise the aggregate CI state as a headline string, e.g. "3 of 5 running". */
-function aggregateHeadline(checks: ChecksStatus, elapsedLive: string | null): string {
-  const b = getBreakdown(checks);
-  switch (checks.aggregate) {
-    case "passing":
-      return b.total === 1 ? "1 check passed" : `All ${b.total} checks passed`;
-    case "failing":
-      // Count only actually-passing runs as "green" — skipped/cancelled/neutral sit
-      // in b.other and must not be conflated with success.
-      return b.failing === 1
-        ? `1 failing · ${b.passing} green`
-        : `${b.failing} of ${b.total} failing`;
-    case "pending":
-      return elapsedLive
-        ? `${b.total - b.running}/${b.total} · running for ${elapsedLive}`
-        : `${b.total - b.running} of ${b.total} running`;
-    case "no_checks":
-      return "No checks configured";
-  }
+function calculateFlyoutPosition(trigger: HTMLElement): FlyoutPosition {
+  const rect = getMeasuredTrigger(trigger).getBoundingClientRect();
+  const canOpenRight =
+    rect.right + FLYOUT_GAP + FLYOUT_WIDTH + VIEWPORT_PADDING <= window.innerWidth;
+  const preferredLeft = canOpenRight
+    ? rect.right + FLYOUT_GAP
+    : rect.left - FLYOUT_GAP - FLYOUT_WIDTH;
+  const left = Math.max(
+    VIEWPORT_PADDING,
+    Math.min(preferredLeft, window.innerWidth - FLYOUT_WIDTH - VIEWPORT_PADDING),
+  );
+  const top = Math.max(
+    VIEWPORT_PADDING,
+    Math.min(rect.top, window.innerHeight - FLYOUT_MAX_HEIGHT - VIEWPORT_PADDING),
+  );
+  return { left, top };
 }
 
 /**
- * Popover that shows PR metadata and per-lane grouped CI check run details.
- *
- * Layout: premium editorial hierarchy.
- * - Chrome header: large status icon + aggregate headline + PR title/author
- * - Live progress strip when aggregate is pending
- * - Grouped run lanes: Failing → Running → Passing → Skipped
- *   - failing lane is auto-expanded with a red wash for urgency
- *   - each run carries a live elapsed time while running
- * - Footer: freshness label, refresh button, GitHub link
+ * Flat CI job flyout anchored to the Overview CI summary row.
  */
 export function ChecksPopover({
-  threadId,
-  prUrl,
-  prTitle,
-  prAuthor,
   checks,
   children,
   open,
   onOpenChange,
 }: ChecksPopoverProps) {
-  const [refreshing, setRefreshing] = useState(false);
-  const [refreshError, setRefreshError] = useState(false);
-  const [now, setNow] = useState(() => Date.now());
+  const triggerRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<FlyoutPosition | null>(null);
 
-  // Keep the staleness label current while the popover is mounted.
-  useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 1_000);
-    return () => clearInterval(timer);
-  }, []);
-
-  const handleRefresh = useCallback(async () => {
-    setRefreshing(true);
-    setRefreshError(false);
-    try {
-      const fresh = await getTransport().checkStatus(threadId, true);
-      useWorkspaceStore.setState((ws) => ({
-        checksById: { ...ws.checksById, [threadId]: fresh },
-      }));
-    } catch {
-      setRefreshError(true);
-    } finally {
-      setRefreshing(false);
-    }
-  }, [threadId]);
-
-  const handleOpenGitHub = useCallback(
-    (event: React.MouseEvent) => {
-      openGitHubUrl(prUrl, threadId, event);
-    },
-    [prUrl, threadId],
-  );
-
-  // Deep-link into GitHub's PR checks tab so devs can jump straight to the run logs
-  // from the failing-lane header. Uses the same protocol/host guard as handleOpenGitHub.
-  const handleOpenChecksTab = useCallback(
-    (event: React.MouseEvent) => {
-      openGitHubUrl(`${prUrl}/checks`, threadId, event);
-    },
-    [prUrl, threadId],
-  );
-
-  // Group runs by lane, ordered by priority.
-  const laned = useMemo(() => {
-    const groups: Record<Lane, CheckRun[]> = { failing: [], running: [], passing: [], other: [] };
-    for (const r of checks.runs) groups[laneOf(r)].push(r);
-    return groups;
+  const sortedRuns = useMemo(() => {
+    const priority = (run: CheckRun): number => {
+      if (run.status !== "completed") return 0;
+      if (run.conclusion === "success") return 1;
+      if (run.conclusion === "failure" || run.conclusion === "timed_out") return -1;
+      return 2;
+    };
+    return [...checks.runs].sort((a, b) => priority(a) - priority(b));
   }, [checks.runs]);
 
-  const breakdown = useMemo(() => getBreakdown(checks), [checks]);
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current) return;
+    setPosition(calculateFlyoutPosition(triggerRef.current));
+  }, []);
 
-  // Lead running job for the subtitle ("currently running: lint").
-  const leadRunning = useMemo(
-    () => (checks.aggregate === "pending" ? getLeadRunningName(checks) : null),
-    [checks],
-  );
-  // Elapsed time of the lead running run, live-updating.
-  const leadRunningStartedAt = useMemo(() => {
-    if (checks.aggregate !== "pending") return null;
-    const r = checks.runs.find((x) => x.status !== "completed");
-    return r?.startedAt ?? null;
-  }, [checks]);
-  const liveElapsed = useLiveElapsed(leadRunningStartedAt, checks.aggregate === "pending");
+  const openFlyout = useCallback(() => {
+    updatePosition();
+    onOpenChange?.(true);
+  }, [onOpenChange, updatePosition]);
 
-  const elapsed = Math.round((now - checks.fetchedAt) / 1000);
-  const staleLabel =
-    elapsed < 5
-      ? "just now"
-      : elapsed < 60
-        ? `${elapsed}s ago`
-        : `${Math.floor(elapsed / 60)}m ago`;
+  const toggleFlyout = useCallback(() => {
+    updatePosition();
+    onOpenChange?.(!open);
+  }, [onOpenChange, open, updatePosition]);
 
-  const visual = getCiVisual(checks.aggregate);
-  const StatusIcon = visual.icon;
+  useEffect(() => {
+    if (!open) return;
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [open, updatePosition]);
 
-  // Visible lane order (skip empty).
-  const laneOrder: Lane[] = ["failing", "running", "passing", "other"];
-  const visibleLanes = laneOrder.filter((l) => laned[l].length > 0);
-
-  // Progress bar fill ratio — completed / total, used when pending.
-  const progressPercent = breakdown.total > 0
-    ? Math.round(((breakdown.passing + breakdown.failing + breakdown.other) / breakdown.total) * 100)
-    : 0;
+  const flyoutStyle: CSSProperties | undefined = position
+    ? { left: position.left, top: position.top, width: FLYOUT_WIDTH }
+    : undefined;
+  const flyout =
+    open && position ? (
+      <div
+        role="dialog"
+        data-testid="thread-overview-ci-popover"
+        style={flyoutStyle}
+        className="fixed z-50 overflow-hidden rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl"
+      >
+        <div className="max-h-[320px] overflow-y-auto py-1 scrollbar-on-hover">
+          {sortedRuns.length > 0 ? (
+            sortedRuns.map((run, index) => (
+              <RunRow key={`${run.name}-${index}`} run={run} />
+            ))
+          ) : (
+            <div className="px-4 py-3 text-xs text-muted-foreground">No checks configured</div>
+          )}
+        </div>
+      </div>
+    ) : null;
 
   return (
-    <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverTrigger
-        className="inline-flex cursor-pointer"
-        aria-label="View CI check details"
+    <>
+      <div
+        ref={triggerRef}
+        onPointerDown={openFlyout}
+        onClick={toggleFlyout}
+        onMouseEnter={openFlyout}
+        onFocus={openFlyout}
+        className="w-full"
       >
         {children}
-      </PopoverTrigger>
-      <PopoverContent side="bottom" align="start" sideOffset={8} className="w-[340px] p-0 overflow-hidden">
-        {/* Header chrome */}
-        <div className={cn("px-4 pt-3.5 pb-3", visual.surface)}>
-          <div className="flex items-start gap-2.5">
-            <StatusIcon
-              size={18}
-              className={cn(
-                "shrink-0 mt-0.5",
-                visual.color,
-                checks.aggregate === "pending" && "status-spin",
-              )}
-              strokeWidth={CI_ICON_STROKE}
-            />
-            <div className="min-w-0 flex-1">
-              <div className="text-sm font-semibold text-foreground leading-tight">
-                {aggregateHeadline(checks, liveElapsed)}
-              </div>
-              {prTitle ? (
-                <div className="text-[11px] text-muted-foreground truncate mt-1 leading-snug">
-                  <span className="text-foreground/75">{prTitle}</span>
-                  {prAuthor && <span className="opacity-70"> · by {prAuthor}</span>}
-                </div>
-              ) : leadRunning ? (
-                <div className="text-[11px] text-muted-foreground truncate mt-1 leading-snug">
-                  Currently running: <span className="text-foreground/75">{leadRunning}</span>
-                </div>
-              ) : null}
-            </div>
-          </div>
+      </div>
 
-          {/* Progress strip — pending only */}
-          {checks.aggregate === "pending" && breakdown.total > 0 && (
-            <div className="mt-3 h-[3px] w-full rounded-full bg-muted/50 overflow-hidden">
-              <div
-                className="h-full bg-primary/90 transition-[width] duration-500 ease-out"
-                style={{ width: `${progressPercent}%` }}
-              />
-            </div>
-          )}
-        </div>
-
-        {/* Lane groups */}
-        <div className="max-h-72 overflow-y-auto scrollbar-on-hover">
-          {visibleLanes.map((lane, laneIdx) => {
-            const runs = laned[lane];
-            const meta = LANE_META[lane];
-            const LaneIcon = meta.icon;
-            return (
-              <section
-                key={lane}
-                className={cn(
-                  "group",
-                  laneIdx > 0 && "border-t border-border/30",
-                  meta.wash,
-                )}
-              >
-                <header className="flex items-center gap-1.5 px-4 pt-2 pb-1">
-                  <LaneIcon
-                    size={10}
-                    className={cn(
-                      meta.iconClass,
-                      lane === "running" && "status-spin",
-                    )}
-                    strokeWidth={CI_ICON_STROKE}
-                  />
-                  <span className={cn("text-[10px] font-semibold uppercase tracking-wider", meta.accent)}>
-                    {meta.label}
-                  </span>
-                  <span className="text-[10px] text-muted-foreground tabular-nums ml-1">
-                    {runs.length}
-                  </span>
-                  {/* Failing lane gets a jump-to-logs affordance. Keeps the header quiet
-                   * until hover, then reveals an external-link chip that deep-links to the
-                   * PR's checks tab where run logs live. */}
-                  {lane === "failing" && (
-                    <button
-                      type="button"
-                      onClick={handleOpenChecksTab}
-                      title="Open run logs on GitHub"
-                      className="ml-auto inline-flex items-center gap-1 text-[10px] text-[var(--diff-remove-strong)]/70 hover:text-[var(--diff-remove-strong)] opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity tracking-wider uppercase"
-                    >
-                      <span>view logs</span>
-                      <ExternalLink size={9} strokeWidth={CI_ICON_STROKE} />
-                    </button>
-                  )}
-                </header>
-                <ul className="pb-1.5">
-                  {runs.map((run, idx) => (
-                    // Composite key: matrix builds can produce duplicate `run.name`
-                    // across OS/Node legs, so the index disambiguates the React key.
-                    <RunRow key={`${run.name}-${idx}`} run={run} />
-                  ))}
-                </ul>
-              </section>
-            );
-          })}
-          {breakdown.total === 0 && (
-            <div className="text-xs text-muted-foreground text-center py-5">
-              No checks configured
-            </div>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="border-t border-border/50" />
-        <div className="flex items-center justify-between px-4 py-2">
-          <button
-            onClick={handleOpenGitHub}
-            className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <ExternalLink size={10} className="opacity-60" />
-            View on GitHub
-          </button>
-          <div className="flex items-center gap-1.5">
-            {refreshError ? (
-              <button
-                type="button"
-                onClick={handleRefresh}
-                disabled={refreshing}
-                title="Last refresh failed — click to retry"
-                className="inline-flex items-center gap-1 text-[10px] text-[var(--diff-remove-strong)] hover:text-[var(--diff-remove-strong)]/80 transition-colors tabular-nums disabled:opacity-60"
-              >
-                <span>refresh failed</span>
-                <span className="underline underline-offset-2">retry</span>
-              </button>
-            ) : (
-              <>
-                <span className="text-[10px] text-muted-foreground tabular-nums">
-                  refreshed {staleLabel}
-                </span>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={handleRefresh}
-                  disabled={refreshing}
-                  aria-label="Refresh checks"
-                >
-                  <RefreshCw
-                    size={10}
-                    strokeWidth={CI_ICON_STROKE}
-                    className={cn(refreshing && "status-spin")}
-                  />
-                </Button>
-              </>
-            )}
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
+      {flyout ? createPortal(flyout, document.body) : null}
+    </>
   );
 }
 
-/** Single run row with live elapsed time while running, or static duration once completed. */
+/** Single CI run row in the flat Codex-style job list. */
 function RunRow({ run }: { run: CheckRun }) {
-  const lane = laneOf(run);
-  const isRunning = lane === "running";
-  const live = useLiveElapsed(run.startedAt, isRunning);
-
-  const tailLabel = isRunning
-    ? live ?? "running"
-    : run.durationMs != null
-      ? formatDuration(run.durationMs)
-      : null;
-
-  const tailClass = isRunning
-    ? "text-primary/90"
-    : lane === "failing"
-      ? "text-[var(--diff-remove-strong)]/90"
-      : "text-muted-foreground/80";
+  const visual = getRunVisual(run);
+  const Icon = visual.icon;
+  const title =
+    run.durationMs != null && run.status === "completed"
+      ? `${visual.label} in ${formatDuration(run.durationMs)}`
+      : visual.label;
 
   return (
-    <li
-      className={cn(
-        "flex items-center gap-2.5 px-4 py-[5px] text-xs",
-      )}
-    >
-      <RunIcon run={run} />
-      <span
-        className={cn(
-          "truncate flex-1",
-          lane === "failing" ? "text-[var(--diff-remove-strong)] font-medium" : "text-foreground/80",
-        )}
-      >
+    <div className="flex h-[30px] min-h-[30px] items-center gap-2 px-3.5 text-sm" title={title}>
+      <Icon
+        size={16}
+        strokeWidth={CI_ICON_STROKE}
+        className={cn("shrink-0", visual.iconClassName, visual.spinning && "status-spin")}
+      />
+      <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
         {run.name}
       </span>
-      {tailLabel && (
-        <span className={cn("font-mono text-[10px] shrink-0 tabular-nums", tailClass)}>
-          {tailLabel}
-        </span>
-      )}
-    </li>
+      <span className={cn("shrink-0 text-xs", visual.labelClassName)}>
+        {visual.label}
+      </span>
+    </div>
   );
 }

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -76,7 +76,7 @@ export function PrSplitButton({
                 <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
                 <span className="truncate text-xs font-medium">{label}</span>
               </span>
-              <span className="flex shrink-0 items-center gap-1">
+              <span className="flex shrink-0 items-center gap-1.5">
                 {trailing ? (
                   <span
                     className="flex items-center"

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } fr
 import {
   Check,
   ChevronDown,
+  CircleCheck,
+  CircleX,
   Copy,
   Diff,
   ExternalLink,
@@ -17,7 +19,6 @@ import {
   Search,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -41,6 +42,11 @@ import { ChecksPopover } from "./ChecksPopover";
 import { CreatePrDialog } from "./CreatePrDialog";
 import { useThreadGitActions } from "@/hooks/useThreadGitActions";
 import { useThreadRecap } from "@/hooks/useThreadRecap";
+import {
+  CI_ICON_STROKE,
+  getCiOverviewSummaryLabel,
+  getCiSummaryHeadline,
+} from "@/lib/ci-status";
 import { useDiffStore } from "@/stores/diffStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useThreadRecord } from "@/stores/thread-selectors";
@@ -979,9 +985,9 @@ function getPrRowStatus(
   if (pr) {
     const state = pr.state.toLowerCase();
     if (state === "open") {
-      if (checks?.aggregate === "failing") return { label: "Checks failing", tone: "danger" };
-      if (checks?.aggregate === "passing") return { label: "Checks passing", tone: "positive" };
-      if (checks?.aggregate === "pending") return { label: "Checks running", tone: "neutral" };
+      if (checks?.aggregate === "failing") return { label: getCiSummaryHeadline(checks), tone: "danger" };
+      if (checks?.aggregate === "passing") return { label: getCiSummaryHeadline(checks), tone: "positive" };
+      if (checks?.aggregate === "pending") return { label: getCiSummaryHeadline(checks), tone: "neutral" };
       return { label: null, tone: "positive" };
     }
     if (state === "merged") return { label: "Merged", tone: "positive" };
@@ -1073,19 +1079,23 @@ function ThreadOverviewPrActiveRow({
   const [checksOpen, setChecksOpen] = useState(false);
   const status = getPrRowStatus(pr, hasCommitsAhead, checks);
   const detailText = getPrRowDetail(pr, openPrDetail);
-  const badgeVariant =
-    status.tone === "danger"
-      ? "destructive"
-      : status.tone === "positive"
-        ? "secondary"
-        : status.tone === "muted"
-          ? "outline"
-          : "ghost";
   const hasChecksData =
     pr.state.toLowerCase() === "open" &&
     checks != null &&
     checks.aggregate !== "no_checks";
   const canOpenChecks = hasChecksData && threadId.length > 0;
+  const SummaryIcon =
+    checks?.aggregate === "passing"
+      ? CircleCheck
+      : checks?.aggregate === "failing"
+        ? CircleX
+        : Loader2;
+  const summaryIconClass =
+    checks?.aggregate === "passing"
+      ? "text-[var(--diff-add-strong)]"
+      : checks?.aggregate === "failing"
+        ? "text-[var(--diff-remove-strong)]"
+        : "text-[#e7a90b]";
 
   useEffect(() => {
     if (!canOpenChecks) return;
@@ -1098,46 +1108,82 @@ function ThreadOverviewPrActiveRow({
     return dispose;
   }, [canOpenChecks]);
 
-  const statusBadge = status.label ? (
-    <Badge
-      variant={badgeVariant}
-      size="sm"
-      data-testid="thread-overview-pr-status"
-      className={cn("max-w-32 truncate", canOpenChecks && "cursor-pointer")}
-    >
-      {status.label}
-    </Badge>
-  ) : null;
-
   const rowLabel = detailText ?? `PR #${pr.number}`;
-  const trailingBadge =
-    statusBadge && canOpenChecks ? (
+  const checksSummary =
+    checks && canOpenChecks ? (
       <ChecksPopover
-        threadId={threadId}
-        prUrl={pr.url}
-        prTitle={openPrDetail?.title}
-        prAuthor={openPrDetail?.author}
         checks={checks!}
         open={checksOpen}
         onOpenChange={setChecksOpen}
       >
-        {statusBadge}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-testid="thread-overview-pr-status"
+          aria-label={`CI checks, ${getCiSummaryHeadline(checks)}`}
+          title={getCiSummaryHeadline(checks)}
+          onPointerDown={() => setChecksOpen(true)}
+          onClick={(event) => {
+            event.stopPropagation();
+            setChecksOpen(true);
+          }}
+          onMouseEnter={() => setChecksOpen(true)}
+          onFocus={() => setChecksOpen(true)}
+          className={cn(
+            "ml-6 flex h-7 w-[calc(100%-1.5rem)] cursor-pointer justify-between rounded-md border border-border/35 bg-muted/20 px-2 text-left hover:bg-muted/35",
+            checks.aggregate === "failing" && "border-[var(--diff-remove-strong)]/20 bg-[var(--diff-remove-strong)]/[0.07] hover:bg-[var(--diff-remove-strong)]/[0.1]",
+            checks.aggregate === "pending" && "border-[#e7a90b]/20 bg-[#e7a90b]/[0.07] hover:bg-[#e7a90b]/[0.1]",
+            checks.aggregate === "passing" && "border-[var(--diff-add-strong)]/20 bg-[var(--diff-add-strong)]/[0.07] hover:bg-[var(--diff-add-strong)]/[0.1]",
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <SummaryIcon
+              size={13}
+              strokeWidth={CI_ICON_STROKE}
+              aria-hidden
+              className={cn(
+                "shrink-0",
+                summaryIconClass,
+                checks.aggregate === "pending" && "status-spin",
+              )}
+            />
+            <span className="truncate text-xs text-foreground/85">
+              {getCiOverviewSummaryLabel(checks)}
+            </span>
+          </span>
+          <ChevronDown
+            size={12}
+            aria-hidden
+            className={cn(
+              "shrink-0 text-muted-foreground transition-transform duration-150",
+              checksOpen && "rotate-180",
+            )}
+          />
+        </Button>
       </ChecksPopover>
     ) : (
-      statusBadge
+      status.label ? (
+        <span
+          data-testid="thread-overview-pr-status"
+          className="ml-6 inline-flex h-6 items-center rounded-md px-2 text-[11px] text-muted-foreground"
+        >
+          {status.label}
+        </span>
+      ) : null
     );
 
   return (
-    <div data-testid="thread-overview-pr">
+    <div data-testid="thread-overview-pr" className="space-y-1">
       <PrSplitButton
         pr={pr}
         label={rowLabel}
         onCreatePr={onCreatePr}
         onOpenPr={onOpenPr}
-        trailing={trailingBadge}
         primaryButtonTestId="workspace-menu-open-pr"
         newPrButtonTestId="workspace-menu-new-pr"
       />
+      {checksSummary}
     </div>
   );
 }
@@ -1596,16 +1642,23 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
   );
 
   const ciDot = useMemo(() => getThreadOverviewCiDot(pr, checks), [pr, checks]);
+  const triggerStatus =
+    ciDot === "red"
+      ? "Thread overview, CI checks failing"
+      : ciDot === "green"
+        ? "Thread overview, CI checks passing"
+        : "Thread overview";
   const modeLabel = thread.mode === "worktree" ? "Worktree" : "Direct";
   const checkoutLabel = resolveThreadCheckoutLabel(thread);
 
   const triggerButton = (
     <Button
+      key={triggerStatus}
       variant="ghost"
       size="icon-xs"
       type="button"
-      title="Thread overview"
-      aria-label="Thread overview"
+      title={triggerStatus}
+      aria-label={triggerStatus}
       data-testid="header-workspace-menu"
       className={cn(
         "relative cursor-pointer text-foreground/70 hover:bg-muted/40 hover:text-foreground",

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1130,12 +1130,7 @@ function ThreadOverviewPrActiveRow({
           }}
           onMouseEnter={() => setChecksOpen(true)}
           onFocus={() => setChecksOpen(true)}
-          className={cn(
-            "ml-6 flex h-7 w-[calc(100%-1.5rem)] cursor-pointer justify-between rounded-md border border-border/35 bg-muted/20 px-2 text-left hover:bg-muted/35",
-            checks.aggregate === "failing" && "border-[var(--diff-remove-strong)]/20 bg-[var(--diff-remove-strong)]/[0.07] hover:bg-[var(--diff-remove-strong)]/[0.1]",
-            checks.aggregate === "pending" && "border-[#e7a90b]/20 bg-[#e7a90b]/[0.07] hover:bg-[#e7a90b]/[0.1]",
-            checks.aggregate === "passing" && "border-[var(--diff-add-strong)]/20 bg-[var(--diff-add-strong)]/[0.07] hover:bg-[var(--diff-add-strong)]/[0.1]",
-          )}
+          className="ml-6 flex h-6 w-[calc(100%-1.5rem)] cursor-pointer justify-between rounded-none border-transparent bg-transparent px-0 text-left text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent"
         >
           <span className="flex min-w-0 items-center gap-2">
             <SummaryIcon
@@ -1148,7 +1143,7 @@ function ThreadOverviewPrActiveRow({
                 checks.aggregate === "pending" && "status-spin",
               )}
             />
-            <span className="truncate text-xs text-foreground/85">
+            <span className="truncate text-xs">
               {getCiOverviewSummaryLabel(checks)}
             </span>
           </span>

--- a/apps/web/src/components/diff/__tests__/GitDiffView.test.tsx
+++ b/apps/web/src/components/diff/__tests__/GitDiffView.test.tsx
@@ -43,7 +43,7 @@ describe("GitDiffView commit selection", () => {
       expect(transport.getCommitFiles).toHaveBeenCalledWith("ws-1", "bbbbbbbb2"),
     );
 
-    expect(screen.getAllByText("selected.ts").length).toBeGreaterThan(0);
+    await waitFor(() => expect(screen.getAllByText("selected.ts").length).toBeGreaterThan(0));
     expect(transport.getGitLog).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/panels/plan/PlanDocument.test.tsx
+++ b/apps/web/src/components/panels/plan/PlanDocument.test.tsx
@@ -22,7 +22,7 @@ describe("PlanDocument annotation", () => {
   beforeAll(async () => {
     // Keep the full parallel suite from spending this test's timeout budget on the lazy import.
     await import("@/components/chat/MarkdownContent");
-  });
+  }, 30_000);
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/components/sidebar/__tests__/sidebar-settings-button.test.tsx
+++ b/apps/web/src/components/sidebar/__tests__/sidebar-settings-button.test.tsx
@@ -41,7 +41,7 @@ describe('Sidebar "Edit settings.json" button', () => {
 
     const mod = await import("../Sidebar");
     Sidebar = mod.Sidebar as typeof Sidebar;
-  });
+  }, 30_000);
 
   afterAll(() => {
     delete (window as unknown as Record<string, unknown>).desktopBridge;

--- a/apps/web/src/lib/ci-status.ts
+++ b/apps/web/src/lib/ci-status.ts
@@ -130,6 +130,49 @@ export function getInlineHeadline(checks: ChecksStatus): string | null {
   return null;
 }
 
+/** Returns the compact Codex-style CI summary used by the PR pill and popover. */
+export function getCiSummaryHeadline(
+  checks: ChecksStatus,
+  liveElapsed: string | null = null,
+): string {
+  const b = getBreakdown(checks);
+  switch (checks.aggregate) {
+    case "passing":
+      return b.total === 1 ? "1 check passed" : `All ${b.total} checks passed`;
+    case "failing":
+      return b.failing === 1
+        ? `1 failing · ${b.passing} green`
+        : `${b.failing} failing · ${b.passing} green`;
+    case "pending":
+      return liveElapsed
+        ? `${b.total - b.running}/${b.total} · running for ${liveElapsed}`
+        : `${b.running} running · ${b.passing} green`;
+    case "no_checks":
+      return "No checks configured";
+  }
+}
+
+/** Returns the compact visible Overview CI row label. */
+export function getCiOverviewSummaryLabel(checks: ChecksStatus): string {
+  const b = getBreakdown(checks);
+  switch (checks.aggregate) {
+    case "pending": {
+      const count = b.running;
+      return `${count} pending ${count === 1 ? "check" : "checks"}`;
+    }
+    case "failing": {
+      const count = b.failing;
+      return `${count} failing ${count === 1 ? "check" : "checks"}`;
+    }
+    case "passing": {
+      const count = b.passing;
+      return `${count} succeeded ${count === 1 ? "check" : "checks"}`;
+    }
+    case "no_checks":
+      return "No checks";
+  }
+}
+
 /** Find the first still-running check, for "currently running: lint" microcopy. */
 export function getLeadRunningName(checks: ChecksStatus): string | null {
   const running = checks.runs.find((r: CheckRun) => r.status !== "completed");

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -79,6 +79,8 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./src/test-setup.ts",
     pool: "threads",
+    minWorkers: 1,
+    maxWorkers: 4,
     exclude: ["e2e/**", "node_modules/**"],
     env: {
       NODE_ENV: "test",


### PR DESCRIPTION
## What
Adds a CI summary row below PR details in Thread Overview and a flat status flyout for check runs.

## Why
Issues 766 and 767 need the Overview to surface CI status where users already inspect the PR, with an expanded view that stays attached to the row.

## Key Changes
- Renders compact CI summary labels and Overview trigger dots for failing and passing checks.
- Replaces the grouped checks popover with a portal-mounted flat job list anchored to the summary row.
- Uses semantic app tokens for popup surfaces and status colors instead of hard-coded popup colors.
- Adds Playwright coverage for status updates and expanded details, plus full-suite test timing stability.

Closes #766
Closes #767

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785343431&installation_id=129163861&pr_number=820&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F820&signature=8dd19f840ea0f14e0ccfdb65a2ef2b2a3ce2490318c3db9e5b7b8c7f0d63b3d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the thread overview CI display with clearer pass/fail/pending indicators and updated summary text.
  * Added a streamlined checks flyout that shows individual CI runs and their statuses.
  * The PR trigger area now uses a more compact layout.

* **Bug Fixes**
  * CI status details now update more reliably as checks change.
  * The thread overview button label and accessibility text now reflect the current CI state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->