### PR TITLE
ci: add desktop packaging dry run

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,16 +26,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-4vcpu-windows-2025
+          - os: blacksmith-2vcpu-windows-2025
             build-args: ""
             target-arch: ""
-          - os: blacksmith-4vcpu-ubuntu-2404
+          - os: blacksmith-2vcpu-ubuntu-2404
             build-args: ""
             target-arch: ""
-          - os: blacksmith-12vcpu-macos-26
+          - os: blacksmith-6vcpu-macos-26
             build-args: "--mac --arm64"
             target-arch: "arm64"
-          - os: blacksmith-12vcpu-macos-26
+          - os: blacksmith-6vcpu-macos-26
             build-args: "--mac --x64"
             target-arch: "x64"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   pr-title:
     name: PR Title
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
@@ -19,7 +19,7 @@ jobs:
 
   typecheck:
     name: Typecheck
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     env:
@@ -49,7 +49,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     env:
@@ -78,7 +78,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     env:
@@ -108,7 +108,7 @@ jobs:
 
   test-web-e2e:
     name: Test Web E2E (shard ${{ matrix.shard }}/4)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     # GitHub Actions sets CI=true, so playwright.config.ts switches to
@@ -191,7 +191,7 @@ jobs:
 
   build-check:
     name: Build Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/desktop-package-dry-run.yml
+++ b/.github/workflows/desktop-package-dry-run.yml
@@ -1,0 +1,59 @@
+name: Desktop Package Dry Run
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/desktop-package-dry-run.yml"
+      - ".github/workflows/nightly-desktop.yml"
+      - ".github/workflows/build-release.yml"
+      - "apps/desktop/**"
+      - "scripts/build-server-dev-bundle.mjs"
+      - "package.json"
+      - "bun.lock"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  package-linux-desktop:
+    name: Package Linux Desktop
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build main and renderer
+        run: bun run --cwd apps/desktop build
+
+      - name: Generate V8 snapshot
+        run: bun apps/desktop/scripts/generate-snapshot.mjs
+
+      - name: Install Python setuptools
+        shell: bash
+        run: python3 -m pip install setuptools --break-system-packages 2>/dev/null || python3 -m pip install setuptools 2>/dev/null || pip install setuptools 2>/dev/null || true
+
+      - name: Ensure Claude SDK platform package
+        run: node apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
+
+      - name: Package with electron-builder
+        run: node apps/desktop/scripts/ci-package.mjs
+
+      - name: Smoke test packaged server
+        run: node apps/desktop/scripts/smoke-test.mjs
+
+      - name: Verify Linux artifacts on Ubuntu 22.04
+        run: bash apps/desktop/scripts/verify-linux-artifacts-ubuntu22.sh

--- a/.github/workflows/desktop-package-dry-run.yml
+++ b/.github/workflows/desktop-package-dry-run.yml
@@ -49,11 +49,8 @@ jobs:
       - name: Ensure Claude SDK platform package
         run: node apps/desktop/scripts/ensure-claude-sdk-platform-package.mjs
 
-      - name: Package with electron-builder
-        run: node apps/desktop/scripts/ci-package.mjs
+      - name: Package unpacked app with electron-builder
+        run: node apps/desktop/scripts/ci-package.mjs --linux dir
 
       - name: Smoke test packaged server
         run: node apps/desktop/scripts/smoke-test.mjs
-
-      - name: Verify Linux artifacts on Ubuntu 22.04
-        run: bash apps/desktop/scripts/verify-linux-artifacts-ubuntu22.sh

--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   setup:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
       last_nightly_tag: ${{ steps.check.outputs.last_nightly_tag }}
@@ -126,16 +126,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-4vcpu-windows-2025
+          - os: blacksmith-2vcpu-windows-2025
             build-args: ""
             target-arch: ""
-          - os: blacksmith-4vcpu-ubuntu-2404
+          - os: blacksmith-2vcpu-ubuntu-2404
             build-args: ""
             target-arch: ""
-          - os: blacksmith-12vcpu-macos-26
+          - os: blacksmith-6vcpu-macos-26
             build-args: "--mac --arm64"
             target-arch: "arm64"
-          - os: blacksmith-12vcpu-macos-26
+          - os: blacksmith-6vcpu-macos-26
             build-args: "--mac --x64"
             target-arch: "x64"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
## What
Adds a PR workflow that runs the Linux desktop packaging path when desktop or packaging files change.

## Why
Issue 666 notes that PR CI built the app and smoke-tested the bundle, but did not exercise electron-builder or the Claude SDK platform-package step before merge.

## Key Changes
- Adds a path-filtered desktop packaging dry-run workflow for pull requests to main.
- Runs electron-builder against the unpacked Linux app and smoke-tests the packaged server without release creation or uploads.
- Leaves AppImage and deb artifact verification in nightly and release workflows.
- Moves Blacksmith workflow jobs to the smallest documented runner tiers: 2 vCPU for Linux and Windows, 6 vCPU for macOS.

Closes #666