### PR TITLE
feat: show API-key session cost in thread overview

### DIFF
--- a/apps/server/src/providers/claude/__tests__/claude-usage-billing-mode.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-usage-billing-mode.test.ts
@@ -1,0 +1,77 @@
+import "reflect-metadata";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mockQuery,
+}));
+
+vi.mock("@mcode/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcode/shared")>();
+  return {
+    ...actual,
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  };
+});
+
+import { ClaudeProvider } from "../claude-provider.js";
+
+function provider(): ClaudeProvider {
+  return new ClaudeProvider(
+    { getEnv: () => ({}) } as any,
+    { addProcess: () => {}, removeProcess: () => {}, killAll: async () => {} } as any,
+  );
+}
+
+function withUsageSources(
+  claude: ClaudeProvider,
+  {
+    oauthAvailable,
+    categories = [],
+  }: {
+    oauthAvailable: boolean;
+    categories?: Awaited<ReturnType<ClaudeProvider["getUsage"]>>["quotaCategories"];
+  },
+): ClaudeProvider {
+  (claude as any).oauthUsageSource = {
+    isAvailable: vi.fn().mockResolvedValue(oauthAvailable),
+  };
+  (claude as any).usageSource = {
+    fetch: vi.fn().mockResolvedValue(categories),
+  };
+  return claude;
+}
+
+describe("ClaudeProvider usage billing mode", () => {
+  it("marks OAuth usage as plan even when session cost exists", async () => {
+    const claude = withUsageSources(provider(), { oauthAvailable: true });
+    (claude as any).lastSessionCostUsd = 12.34;
+
+    await expect(claude.getUsage()).resolves.toMatchObject({
+      providerId: "claude",
+      billingMode: "plan",
+      sessionCostUsd: 12.34,
+    });
+  });
+
+  it("marks finite session cost without OAuth as API-key usage", async () => {
+    const claude = withUsageSources(provider(), { oauthAvailable: false });
+    (claude as any).lastSessionCostUsd = 12.34;
+
+    await expect(claude.getUsage()).resolves.toMatchObject({
+      providerId: "claude",
+      billingMode: "api_key",
+      sessionCostUsd: 12.34,
+    });
+  });
+
+  it("marks usage as unknown when OAuth is absent and session cost is missing", async () => {
+    const claude = withUsageSources(provider(), { oauthAvailable: false });
+
+    await expect(claude.getUsage()).resolves.toMatchObject({
+      providerId: "claude",
+      billingMode: "unknown",
+    });
+  });
+});

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -24,6 +24,7 @@ import type {
   GoalState,
   GoalLookupResult,
   ProviderModelInfo,
+  ProviderBillingMode,
   ProviderUsageInfo,
   QuotaCategory,
   PermissionDecision,
@@ -379,8 +380,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
   private lastServiceTier?: "standard" | "priority" | "batch";
   private lastNumTurns?: number;
   private lastDurationMs?: number;
+  private readonly oauthUsageSource = new AnthropicOAuthUsageSource(readAnthropicOauthToken);
   private readonly usageSource: CompositeUsageSource = new CompositeUsageSource([
-    new AnthropicOAuthUsageSource(readAnthropicOauthToken),
+    this.oauthUsageSource,
     new AnthropicHeaderUsageSource(),
   ]);
 
@@ -1829,11 +1831,13 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
               // Invalidate the usage cache so the warm-refresh call from the
               // client picks up fresh plan utilization after this turn.
               this.usageSource.invalidate();
+              const billingMode = await this.resolveBillingMode();
               this.emit("event", {
                 type: AgentEventType.QuotaUpdate,
                 threadId,
                 providerId: "claude",
                 categories: [],
+                billingMode,
                 sessionCostUsd: this.lastSessionCostUsd,
                 serviceTier: this.lastServiceTier,
                 numTurns: this.lastNumTurns,
@@ -2541,6 +2545,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
   /** Returns Claude plan utilization plus accumulated session stats. */
   async getUsage(): Promise<ProviderUsageInfo> {
     let categories: QuotaCategory[] | null = null;
+    const billingMode = await this.resolveBillingMode();
     try {
       categories = await this.usageSource.fetch();
     } catch (error) {
@@ -2551,11 +2556,19 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     return {
       providerId: "claude",
       quotaCategories: categories ?? [],
+      billingMode,
       sessionCostUsd: this.lastSessionCostUsd,
       serviceTier: this.lastServiceTier,
       numTurns: this.lastNumTurns,
       durationMs: this.lastDurationMs,
     };
+  }
+
+  /** Resolves Claude's provider-owned billing mode without exposing credentials. */
+  private async resolveBillingMode(): Promise<ProviderBillingMode> {
+    if (await this.oauthUsageSource.isAvailable()) return "plan";
+    if (Number.isFinite(this.lastSessionCostUsd)) return "api_key";
+    return "unknown";
   }
 
   /** Fetch available Claude models from the Anthropic REST API. */

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -111,6 +111,7 @@ import {
   getRepositoryFaviconUrl,
   getSafeRepositoryWebUrl,
   getThreadOverviewCiDot,
+  formatThreadOverviewSessionCost,
   formatThreadOverviewUsage,
   hasVisibleThreadOverviewChangeSummary,
   resolveThreadOverviewChangeSummary,
@@ -419,6 +420,77 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.queryByRole("progressbar", { name: "5-hour usage" })).not.toBeInTheDocument();
   });
 
+  it("hides empty or unlimited-only usage without API-key billing mode", () => {
+    seedThreadUsage("thread-1", {
+      providerId: "claude",
+      billingMode: "plan",
+      quotaCategories: [
+        {
+          label: "Pay-as-you-go",
+          used: 2,
+          total: null,
+          remainingPercent: 1,
+          isUnlimited: true,
+        },
+      ],
+    });
+
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
+
+    expect(screen.queryByTestId("thread-overview-usage")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pay-as-you-go")).not.toBeInTheDocument();
+  });
+
+  it("renders API-key session cost when provider billing mode proves it", () => {
+    seedThreadUsage("thread-1", {
+      providerId: "claude",
+      billingMode: "api_key",
+      quotaCategories: [],
+      sessionCostUsd: 12.34,
+    });
+
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
+
+    const usageTrigger = screen.getByTestId("thread-overview-usage");
+    expect(usageTrigger).toHaveAttribute("aria-label", "Usage, $12.34 session");
+    expect(usageTrigger).toHaveTextContent("$12.34 session");
+    expect(screen.queryByTestId("thread-overview-usage-details")).not.toBeInTheDocument();
+  });
+
+  it("suppresses session cost for plan billing mode even when cost exists", () => {
+    seedThreadUsage("thread-1", {
+      providerId: "claude",
+      billingMode: "plan",
+      quotaCategories: [],
+      sessionCostUsd: 12.34,
+    });
+
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
+
+    expect(screen.queryByTestId("thread-overview-usage")).not.toBeInTheDocument();
+    expect(screen.queryByText("$12.34 session")).not.toBeInTheDocument();
+  });
+
+  it("suppresses session cost when billing mode is missing or unknown", () => {
+    seedThreadUsage("thread-1", {
+      providerId: "claude",
+      quotaCategories: [],
+      sessionCostUsd: 12.34,
+    });
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
+    expect(screen.queryByTestId("thread-overview-usage")).not.toBeInTheDocument();
+
+    useThreadStore.setState({ records: new Map() });
+    seedThreadUsage("thread-1", {
+      providerId: "claude",
+      billingMode: "unknown",
+      quotaCategories: [],
+      sessionCostUsd: 12.34,
+    });
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
+    expect(screen.queryByText("$12.34 session")).not.toBeInTheDocument();
+  });
+
   it("prefills commit-or-push from the PR row when the branch is not ahead", () => {
     mockUseHasCommitsAhead.mockReturnValue(false);
     renderHeaderActions();
@@ -531,6 +603,41 @@ describe("formatThreadOverviewUsage", () => {
       }),
     ).toBeNull();
     expect(formatThreadOverviewUsage(undefined)).toBeNull();
+  });
+
+  it("renders session cost only for API-key billing mode", () => {
+    expect(
+      formatThreadOverviewSessionCost({
+        providerId: "claude",
+        billingMode: "api_key",
+        quotaCategories: [],
+        sessionCostUsd: 12.34,
+      }),
+    ).toBe("$12.34 session");
+    expect(
+      formatThreadOverviewUsage({
+        providerId: "claude",
+        billingMode: "api_key",
+        quotaCategories: [],
+        sessionCostUsd: 12.34,
+      }),
+    ).toBe("$12.34 session");
+    expect(
+      formatThreadOverviewUsage({
+        providerId: "claude",
+        billingMode: "plan",
+        quotaCategories: [],
+        sessionCostUsd: 12.34,
+      }),
+    ).toBeNull();
+    expect(
+      formatThreadOverviewUsage({
+        providerId: "claude",
+        billingMode: "unknown",
+        quotaCategories: [],
+        sessionCostUsd: 12.34,
+      }),
+    ).toBeNull();
   });
 
   it("does not fabricate Codex quota before provider quota data arrives", () => {

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -197,6 +197,18 @@ function usageCategoryFillClass(category: QuotaCategory): string {
 }
 
 /**
+ * Returns the Overview session-cost label only for provider-proven API-key billing.
+ */
+export function formatThreadOverviewSessionCost(
+  usageInfo: ProviderUsageInfo | undefined,
+): string | null {
+  if (usageInfo?.billingMode !== "api_key") return null;
+  const sessionCostUsd = usageInfo.sessionCostUsd;
+  if (typeof sessionCostUsd !== "number" || !Number.isFinite(sessionCostUsd)) return null;
+  return `$${sessionCostUsd.toFixed(2)} session`;
+}
+
+/**
  * Returns capped quota categories in priority order for the Overview Usage panel.
  */
 export function getThreadOverviewUsageCategories(
@@ -221,27 +233,54 @@ export function formatThreadOverviewUsage(
   providerId = usageInfo?.providerId,
 ): string | null {
   const categories = getThreadOverviewUsageCategories(usageInfo, providerId);
-  if (categories.length === 0) return null;
+  const costSummary = formatThreadOverviewSessionCost(usageInfo);
 
-  return categories
-    .slice(0, 2)
-    .map((category) => {
-      const percent = Math.round(usageCategoryPercent(category));
-      return `${usageCategoryShortLabel(category.label)} ${percent}%`;
-    })
-    .join(", ");
+  const quotaSummary = categories.length > 0
+    ? categories
+      .slice(0, 2)
+      .map((category) => {
+        const percent = Math.round(usageCategoryPercent(category));
+        return `${usageCategoryShortLabel(category.label)} ${percent}%`;
+      })
+      .join(", ")
+    : null;
+
+  return [quotaSummary, costSummary].filter(Boolean).join(", ") || null;
 }
 
 interface ThreadOverviewUsageBarsProps {
   categories: QuotaCategory[];
   summary: string;
+  sessionCostSummary: string | null;
 }
 
 const THREAD_OVERVIEW_USAGE_DETAILS_ID = "thread-overview-usage-details-panel";
 
 /** Expandable quota usage row for the Thread Overview popover. */
-function ThreadOverviewUsageBars({ categories, summary }: ThreadOverviewUsageBarsProps) {
+function ThreadOverviewUsageBars({
+  categories,
+  summary,
+  sessionCostSummary,
+}: ThreadOverviewUsageBarsProps) {
   const [open, setOpen] = useState(true);
+
+  if (categories.length === 0) {
+    return (
+      <div
+        data-testid="thread-overview-usage"
+        aria-label={`Usage, ${summary}`}
+        className="flex h-8 w-full items-center justify-between gap-3 px-2 text-left"
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          <Gauge size={14} aria-hidden className="shrink-0 text-muted-foreground" />
+          <span className="truncate text-xs font-medium">Usage</span>
+        </span>
+        <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+          {summary}
+        </span>
+      </div>
+    );
+  }
 
   return (
     <Collapsible
@@ -321,6 +360,14 @@ function ThreadOverviewUsageBars({ categories, summary }: ThreadOverviewUsageBar
               </div>
             );
           })}
+          {sessionCostSummary ? (
+            <div className="flex items-baseline justify-between gap-3 pt-0.5">
+              <span className="min-w-0 truncate text-xs text-foreground/80">Session cost</span>
+              <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                {sessionCostSummary}
+              </span>
+            </div>
+          ) : null}
         </div>
       </AnimatedCollapsible>
     </Collapsible>
@@ -1515,6 +1562,10 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
     () => formatThreadOverviewUsage(usageInfo, thread.provider),
     [thread.provider, usageInfo],
   );
+  const sessionCostSummary = useMemo(
+    () => formatThreadOverviewSessionCost(usageInfo),
+    [usageInfo],
+  );
   const fetchProviderUsage = useThreadStore((state) => state.fetchProviderUsage);
 
   useEffect(() => {
@@ -1801,8 +1852,12 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
               </Popover>
             )}
 
-            {usageSummary && usageCategories.length > 0 && (
-              <ThreadOverviewUsageBars categories={usageCategories} summary={usageSummary} />
+            {usageSummary && (
+              <ThreadOverviewUsageBars
+                categories={usageCategories}
+                summary={usageSummary}
+                sessionCostSummary={sessionCostSummary}
+              />
             )}
 
             {branchlessCreatePr ? (

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, ToolCallRecord, ThoughtSegmentRecord } from "@/transport";
-import type { ContextWindowMode, MessageMention, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory, GoalLookupResult, GoalState } from "@mcode/contracts";
+import type { ContextWindowMode, MessageMention, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory, ProviderBillingMode, GoalLookupResult, GoalState } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import type { ThoughtSegment } from "@/components/chat/narrative/types";
 import { PlanQuestionSchema, PERMISSION_MODES, INTERACTION_MODES, isGoalOpen } from "@mcode/contracts";
@@ -2656,6 +2656,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const categories = Array.isArray(params.categories)
         ? (params.categories as QuotaCategory[])
         : [];
+      const billingMode = params.billingMode as ProviderBillingMode | undefined;
       const sessionCostUsd = params.sessionCostUsd as number | undefined;
       const serviceTier = params.serviceTier as "standard" | "priority" | "batch" | undefined;
       const numTurns = params.numTurns as number | undefined;
@@ -2671,6 +2672,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
                 [providerId]: {
                   providerId,
                   quotaCategories: categories.length > 0 ? categories : (existing?.quotaCategories ?? []),
+                  billingMode: billingMode ?? existing?.billingMode,
                   sessionCostUsd: sessionCostUsd ?? existing?.sessionCostUsd,
                   serviceTier: serviceTier ?? existing?.serviceTier,
                   numTurns: numTurns ?? existing?.numTurns,

--- a/docs/agents/issue-765-overview-usage-row-brief.md
+++ b/docs/agents/issue-765-overview-usage-row-brief.md
@@ -132,8 +132,8 @@ Rendering rules:
 - Prefer category labels over provider-specific prose.
 - Show multiple relevant categories when space allows, for example `5-hour 42%, weekly 18%` or `API 63%, Auto 21%`.
 - If there is one category, show `Label 42%`.
-- If no capped category exists, show `usage unavailable`.
-- Do not render dollar amounts in this row.
+- If no capped category or provider-proven API-key session cost exists, hide the Usage row.
+- Do not render dollar amounts from quota categories in this row.
 - Add `data-testid="thread-overview-usage"`.
 
 ## Security Requirements
@@ -148,7 +148,7 @@ Rendering rules:
 
 ## Non-Goals
 
-- No pricing display in the Overview row.
+- No pricing display from quota categories in the Overview row.
 - No token cost display in the Overview row.
 - No paid overage display in the Overview row.
 - No dashboard scraping.
@@ -164,7 +164,7 @@ Rendering rules:
 - Cursor shows Auto or Composer usage percentage when the configured Admin API response supplies it.
 - Copilot shows a normalized quota category from existing `quotaSnapshots`.
 - Codex shows a quota category only when a supported machine-readable source exists.
-- Empty provider usage renders exactly `usage unavailable`.
+- Empty provider usage hides the Overview Usage row.
 - The Overview row reads the active provider from `thread.provider`.
 - Switching providers reads a different `usageByProvider` entry.
 - Opening the Overview does not start an unbounded poll or duplicate fetch loop.
@@ -194,7 +194,7 @@ Frontend:
   - Cursor API plus Auto categories
   - empty usage state
   - active provider switch
-  - cost fields ignored
+  - cost fields ignored unless provider-owned billing mode proves API-key usage
 
 ## Verification
 
@@ -203,7 +203,7 @@ For implementation work, verify in this order:
 1. Start the app with `node scripts/agent/demo.mjs` and open the printed URL.
 2. Seed or use a thread with Claude categories and observe `5-hour` or `weekly` usage in Overview.
 3. Seed or use a thread with Cursor percentage categories and observe API and Auto usage in Overview.
-4. Confirm no dollar amounts render in the Overview Usage row.
+4. Confirm dollar amounts render only for provider-proven API-key session cost.
 5. Confirm no browser console errors.
 6. Run `bun run verify`.
 7. Run focused E2E when changed:
@@ -214,12 +214,12 @@ For implementation work, verify in this order:
 
 Use this language in the PR body after implementation:
 
-> Implements the Overview Usage row and the provider-backed usage limit sources together. The row renders capped limit utilization only: Claude five-hour and weekly limits, Cursor API and Auto or Composer percentages when the Admin API supplies them, and existing Copilot quota snapshots. It deliberately excludes API prices, token costs, session cost, overage spend, and dashboard scraping.
+> Implements the Overview Usage row and the provider-backed usage limit sources together. The row renders capped limit utilization: Claude five-hour and weekly limits, Cursor API and Auto or Composer percentages when the Admin API supplies them, and existing Copilot quota snapshots. It excludes API prices, token costs, paid overage, and dashboard scraping.
 
 If Codex has no supported machine-readable usage source, add:
 
-> Codex remains `usage unavailable` because the current provider has no documented machine-readable account-limit source to normalize into `QuotaCategory`.
+> Codex hides the Overview Usage row until the provider has a documented machine-readable account-limit or API-key session-cost source.
 
 ## Implementation Prompt
 
-Implement GitHub issue #765 in this worktree with the revised scope in this brief. Add the Overview Usage row and provider-backed usage limit plumbing. Reuse Claude and Copilot usage sources. Add Cursor usage limits through a bounded, configured Admin API source. Investigate Codex and add `getUsage` only if a supported machine-readable source exists. Render capped usage-limit percentages only. Do not render prices, token costs, session cost, paid overage, or scraped dashboard data. Add focused backend and frontend tests, run live verification, then run `bun run verify`.
+Implement GitHub issue #765 in this worktree with the revised scope in this brief. Add the Overview Usage row and provider-backed usage limit plumbing. Reuse Claude and Copilot usage sources. Add Cursor usage limits through a bounded, configured Admin API source. Investigate Codex and add `getUsage` only if a supported machine-readable source exists. Render capped usage-limit percentages, plus provider-proven API-key session cost when available. Do not render prices, token costs, paid overage, or scraped dashboard data. Add focused backend and frontend tests, run live verification, then run `bun run verify`.

--- a/docs/prd/2026-06-16-thread-overview-epic-2-overview-surface.md
+++ b/docs/prd/2026-06-16-thread-overview-epic-2-overview-surface.md
@@ -30,7 +30,7 @@ The `header-workspace-menu` becomes a thread-scoped popover, the Overview (`Thre
 11. As a developer, I want the Overview to show my thread's worktree path and branch, so that I know where the code lives.
 12. As a developer, I want to copy the branch name from the Overview, so that I can paste it elsewhere.
 13. As a developer, I want the Overview to show my active provider's usage and cost, so that I can judge remaining budget for this thread.
-14. As a developer on a provider without usage reporting, I want the Usage row to say usage is unavailable, so that the row degrades cleanly rather than erroring.
+14. As a developer on a provider without useful usage data, I want the Overview to hide the Usage row, so that the popover stays focused.
 15. As a developer, I want to create a new branch from the Overview that is created and checked out in place, so that I can branch this thread without a fork.
 16. As a developer, I want the new-branch action to reject unsafe branch names, so that I cannot inject arguments into the git command.
 17. As a developer, I want a CI status dot on the Overview trigger, so that I can see at a glance whether my thread's checks are failing or passing without opening the popover.
@@ -42,7 +42,7 @@ The `header-workspace-menu` becomes a thread-scoped popover, the Overview (`Thre
 - **Enrich, do not replace blindly.** `HeaderActions.tsx`'s `header-workspace-menu` becomes `ThreadOverview`, a popover. The existing PR affordances (`PrSplitButton`, `ChecksPopover`, `CreatePrDialog`) and the `useThreadGitActions(thread)` data (`prable`, `pr`, `hasCommitsAhead`, `checks`, `openPrDetail`, `dirPath`, commit-or-push, open-PR) are reused, not rebuilt.
 - **New RPC `git.getRemoteUrl`.** `GitService.getRemoteUrl(path)` runs `git remote get-url origin`, normalizes SSH and `.git` suffixes to an https web URL, derives the `org/repo` label, and falls back to the directory basename with a null URL when there is no remote. Normalization is server-side, validated once at the boundary. Follows the `diffSummary.*` wiring idiom (WS_METHODS entry, router case, named transport wrapper).
 - **New RPC `git.createBranch`.** `GitService.createBranch(path, name)` runs `git checkout -b <name>` (create plus checkout). The name is validated against a git-ref allowlist before exec (reject empty, leading `-`, whitespace, `..`, shell metacharacters); fail closed. Returns the created branch.
-- **Usage row reuses the existing path.** It reads `usageByProvider[thread.provider]` from the thread record, already populated by `fetchProviderUsage`. No new fetch and no new server code; providers without `getUsage` already return an empty-but-valid shape.
+- **Usage row reuses the existing path.** It reads `usageByProvider[thread.provider]` from the thread record, already populated by `fetchProviderUsage`. The row renders capped quota categories when present, or provider-proven API-key session cost when available. If neither exists, the row is hidden.
 - **CI blob is a pure derivation.** `(pr, checks) -> "red" | "green" | null` over the `checks`/`pr` already in `useThreadGitActions`. Red when failing, green when all passed, null otherwise. Active-thread scope.
 - **Changes row** triggers the existing `changes.toggle` command and relies on Epic 1 for the per-thread default (soft dependency - works without it).
 

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { lazySchema } from "../utils/lazySchema.js";
-import { QuotaCategorySchema } from "../providers/usage.js";
+import { ProviderBillingModeSchema, QuotaCategorySchema } from "../providers/usage.js";
 import { StoredAttachmentSchema } from "../models/attachment.js";
 import { GoalStateSchema } from "../models/goal.js";
 
@@ -209,6 +209,7 @@ export const AgentEventSchema = lazySchema(() =>
       threadId: z.string(),
       providerId: z.string(),
       categories: z.array(QuotaCategorySchema()),
+      billingMode: ProviderBillingModeSchema().optional(),
       sessionCostUsd: z.number().optional(),
       serviceTier: z.enum(["standard", "priority", "batch"]).optional(),
       numTurns: z.number().int().optional(),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -372,11 +372,13 @@ export type {
 export {
   TurnUsageSchema,
   QuotaCategorySchema,
+  ProviderBillingModeSchema,
   ProviderUsageInfoSchema,
 } from "./providers/usage.js";
 export type {
   TurnUsage,
   QuotaCategory,
+  ProviderBillingMode,
   ProviderUsageInfo,
 } from "./providers/usage.js";
 

--- a/packages/contracts/src/providers/usage.ts
+++ b/packages/contracts/src/providers/usage.ts
@@ -36,6 +36,14 @@ export const QuotaCategorySchema = lazySchema(() =>
 /** TypeScript type inferred from QuotaCategorySchema. */
 export type QuotaCategory = z.infer<ReturnType<typeof QuotaCategorySchema>>;
 
+/** Provider-owned billing mode for usage and cost display decisions. */
+export const ProviderBillingModeSchema = lazySchema(() =>
+  z.enum(["api_key", "plan", "unknown"]),
+);
+
+/** TypeScript type inferred from ProviderBillingModeSchema. */
+export type ProviderBillingMode = z.infer<ReturnType<typeof ProviderBillingModeSchema>>;
+
 /** Provider-level usage state. Quota and cost only - context/turn data is thread-scoped. */
 export const ProviderUsageInfoSchema = lazySchema(() =>
   z.object({
@@ -43,6 +51,8 @@ export const ProviderUsageInfoSchema = lazySchema(() =>
     providerId: z.string(),
     /** All quota buckets reported by this provider. */
     quotaCategories: z.array(QuotaCategorySchema()),
+    /** Provider-owned discriminator for whether usage is billed by API key, plan, or unknown mode. */
+    billingMode: ProviderBillingModeSchema().optional(),
     /** Accumulated cost for the current session in USD. Absent when the provider does not report cost. */
     sessionCostUsd: z.number().optional(),
     /** API service tier used for the last turn (Claude only). */


### PR DESCRIPTION
## What
Adds provider-owned billing mode to usage state so Thread Overview can show API-key session cost while hiding empty usage.

## Why
Issue #754 treats empty usage as noise. The Overview should stay quiet unless it has quota limits or API-key session cost to show.

## Key Changes
- Added `billingMode` to provider usage and quota update contracts.
- Set Claude billing mode from OAuth availability and finite session cost.
- Updated Thread Overview to render quota bars, API-key session cost, or no Usage row.
- Added web and Claude provider tests.
- Updated stale docs that still required `usage unavailable`.

Closes #754

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785410999&installation_id=129163861&pr_number=822&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F822&signature=3399d17037d287131eece00a28c7019b83af46c4510c0346c1ec222442871ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added billing-mode-aware usage details across the app, including clearer session cost display when API-key billing applies.
  * Overview usage now shows session cost when available and hides the usage row when no useful usage data exists.

* **Bug Fixes**
  * Improved usage display behavior so “plan” and “unknown” billing modes no longer show session-cost pricing.
  * Preserved billing mode updates as usage data changes, keeping the UI in sync with the latest provider info.

* **Tests**
  * Added coverage for billing mode handling and usage-row display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->