### PR TITLE
fix: preserve thread overview trigger during status updates

### DIFF
--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -569,6 +569,29 @@ test.describe("Consolidated chat header CI trigger state", () => {
     await expect(page.getByTestId("thread-overview-ci-red")).toHaveCount(0);
   });
 
+  test("keeps a trigger click active when CI status changes during the click", async ({ page }) => {
+    const trigger = page.getByTestId("header-workspace-menu");
+    await expect(page.getByTestId("thread-overview-body")).toBeVisible();
+
+    const box = await trigger.boundingBox();
+    expect(box).not.toBeNull();
+    const center = {
+      x: box!.x + box!.width / 2,
+      y: box!.y + box!.height / 2,
+    };
+
+    await page.mouse.move(center.x, center.y);
+    await page.mouse.down();
+    await ws.sendPush("thread.checksUpdated", {
+      threadId: openPrThread.id,
+      checks: checks("failing"),
+    });
+    await waitForChecksAggregate(page, openPrThread.id, "failing");
+    await page.mouse.up();
+
+    await expect(page.getByTestId("thread-overview-body")).toBeHidden();
+  });
+
   test("shows CI summary below the PR row and expands details from it", async ({ page }) => {
     await ws.sendPush("thread.checksUpdated", {
       threadId: openPrThread.id,

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1648,7 +1648,6 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
 
   const triggerButton = (
     <Button
-      key={triggerStatus}
       variant="ghost"
       size="icon-xs"
       type="button"


### PR DESCRIPTION
## What
Fix a timing bug where the Thread Overview trigger could miss a click while its CI status changed.

## Why
The trigger used the CI-derived status text as a React key. When checks updated during a mouse press, React replaced the trigger element between mouse down and mouse up, so the click was dropped.

## Key Changes
- Keep the Overview trigger mounted while its title, aria-label, and CI dot update.
- Add a Playwright regression that starts a trigger click, pushes a CI status update, releases the click, and confirms the Overview closes.

## Verification
- `cd apps/web; $env:CI='1'; bun run e2e chat-header-consolidated.spec.ts --grep "keeps a trigger click active"` failed before the fix and passed after it.
- `cd apps/web; bun run test -- HeaderActions.test.tsx ThreadOverview.branchless-pr.test.tsx` passed, 44 tests.
- `cd apps/web; $env:CI='1'; bun run e2e chat-header-consolidated.spec.ts` passed, 9 tests.
- `bun run verify` passed.
- `cd apps/web; $env:CI='1'; bun run e2e` passed, 292 passed and 2 skipped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785411483&installation_id=129163861&pr_number=823&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F823&signature=4c4f003c5122c19d65293fe7f08c3be6e2e029f8b4ca5d777f33af039ac33b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->