### PR TITLE
feat: add recap coverage hint

### DIFF
--- a/apps/web/e2e/overview-sources-demo.spec.ts
+++ b/apps/web/e2e/overview-sources-demo.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { mockWebSocketServer } from "./helpers/e2e-helpers";
+import { interceptZustandStores, mockWebSocketServer } from "./helpers/e2e-helpers";
 
 /**
  * Visual demo: the Overview popover (repository row + Sources favicon grid),
@@ -94,6 +94,7 @@ const followUpMessage = {
   role: "user" as const,
   content: "Great, show that in the Overview too.",
   sequence: 3,
+  timestamp: "2026-06-19T00:17:00.000Z",
 };
 
 test.use({ viewport: { width: 1920, height: 1080 } });
@@ -106,6 +107,7 @@ test("Overview sources + humanized links demo", async ({ page }) => {
     resolveRecap = resolve;
   });
 
+  await interceptZustandStores(page);
   await mockWebSocketServer(page, {
     "workspace.list": [workspace],
     "thread.list": [thread],
@@ -160,6 +162,47 @@ test("Overview sources + humanized links demo", async ({ page }) => {
   resolveRecap({ text: recapText });
   await expect(page.getByTestId("thread-overview-recap-text")).toContainText("Checking SVG alternatives");
   await expect(page.getByTestId("thread-overview-recap-skeleton")).toHaveCount(0);
+  await page.evaluate((threadId) => {
+    type StoreHandle = {
+      getState: () => Record<string, unknown>;
+      setState: (state: Record<string, unknown>) => void;
+    };
+    const stores = (window as unknown as { __mcodeStores?: StoreHandle[] }).__mcodeStores ?? [];
+    const threadStore = stores.find((store) => {
+      const state = store.getState();
+      return "recapByThread" in state && "records" in state;
+    });
+    const state = threadStore?.getState();
+    if (!threadStore || !state) throw new Error("Thread store unavailable");
+
+    threadStore.setState({
+      recapByThread: {
+        ...(state.recapByThread as Record<string, unknown>),
+        [threadId]: {
+          text: "Cached recap stays readable while newer activity exists.",
+          signature: "older-signature",
+          coveredMessageId: "assistant-demo",
+          generatedAt: "2026-06-19T00:01:00.000Z",
+        },
+      },
+    });
+  }, thread.id);
+  await expect(page.getByTestId("thread-overview-recap-text")).toContainText(
+    "Cached recap stays readable",
+  );
+  await page.getByTestId("thread-overview-recap").screenshot({
+    path: "e2e/screenshots/demo/overview-recap-coverage-row.png",
+  });
+  await page.getByTestId("thread-overview-recap-coverage").hover();
+  await expect(page.getByText(/Covered through/)).toBeVisible();
+  await expect(page.getByText(/Latest activity/)).toBeVisible();
+  await page.screenshot({
+    path: "e2e/screenshots/demo/overview-recap-coverage-tooltip.png",
+    fullPage: false,
+  });
+  await page.getByTestId("thread-overview-recap-coverage").focus();
+  await expect(page.getByText(/Covered through/)).toBeVisible();
+  await expect(page.getByTestId("thread-overview-recap")).not.toContainText(/stale|out of date|generate/i);
   const recapTextStyles = await page.getByTestId("thread-overview-recap-text").evaluate((node) => {
     const styles = window.getComputedStyle(node);
     return {

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { ReactNode, ReactElement } from "react";
 import type { Thread } from "@/transport/types";
 import type { ProviderUsageInfo, TurnSnapshot } from "@mcode/contracts";
+import { createMockMessage } from "@/__tests__/mocks/transport";
 
 // vi.hoisted runs before vi.mock hoisting, so these are available in mock factories.
 const {
@@ -106,7 +107,12 @@ vi.mock("@/hooks/useHasCommitsAhead", () => ({
 import { HeaderActions } from "./HeaderActions";
 import { COMMIT_PREFILL } from "@/hooks/useThreadGitActions";
 import { useThreadStore } from "@/stores/threadStore";
-import { patchThreadRecord } from "@/stores/thread-record";
+import { createEmptyThreadRecord, patchThreadRecord } from "@/stores/thread-record";
+import {
+  createThreadRecapSignature,
+  filterThreadRecapMessages,
+  resetThreadRecapRequestStateForTest,
+} from "@/hooks/useThreadRecap";
 import {
   getRepositoryFaviconUrl,
   getSafeRepositoryWebUrl,
@@ -222,7 +228,8 @@ function renderHeaderActions(thread: Thread = makeThread()) {
 
 describe("HeaderActions - Create PR menu item", () => {
   beforeEach(() => {
-    useThreadStore.setState({ records: new Map() });
+    resetThreadRecapRequestStateForTest();
+    useThreadStore.setState({ records: new Map(), recapByThread: {}, runningThreadIds: new Set() });
     const state = defaultWorkspaceState();
     mockWorkspaceSelector.mockImplementation(
       (selector: (s: unknown) => unknown) => selector(state),
@@ -380,6 +387,66 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.queryByTestId("thread-overview-usage")).not.toBeInTheDocument();
     expect(screen.queryByTestId("thread-overview-usage-popover")).not.toBeInTheDocument();
     expect(screen.queryByTestId("thread-overview-sources")).not.toBeInTheDocument();
+    expect(screen.getByTestId("thread-overview-recap-text")).toHaveTextContent("No recap yet");
+    expect(screen.getByTestId("thread-overview-recap-refresh")).toHaveAttribute(
+      "aria-label",
+      "Refresh recap",
+    );
+    expect(screen.getByTestId("thread-overview-recap")).not.toHaveTextContent(/stale|out of date|generate/i);
+  });
+
+  it("keeps older cached recap visible and exposes coverage times through the affordance", async () => {
+    const messages = [
+      createMockMessage({
+        id: "u1",
+        thread_id: "thread-1",
+        role: "user",
+        content: "Start the recap work.",
+        sequence: 1,
+        timestamp: "2026-06-25T10:00:00.000Z",
+      }),
+      createMockMessage({
+        id: "a2",
+        thread_id: "thread-1",
+        role: "assistant",
+        content: "Cached stopping point.",
+        sequence: 2,
+        timestamp: "2026-06-25T10:01:00.000Z",
+      }),
+      createMockMessage({
+        id: "u3",
+        thread_id: "thread-1",
+        role: "user",
+        content: "Newer follow-up.",
+        sequence: 3,
+        timestamp: "2026-06-25T10:04:00.000Z",
+      }),
+    ];
+    const coveredMessages = filterThreadRecapMessages(messages.slice(0, 2));
+    useThreadStore.setState({
+      records: new Map([["thread-1", { ...createEmptyThreadRecord(), messages }]]),
+      runningThreadIds: new Set(["thread-1"]),
+    });
+    useThreadStore.getState().recordThreadRecapGeneration({
+      threadId: "thread-1",
+      text: "Cached recap stays readable.",
+      signature: createThreadRecapSignature(coveredMessages),
+      coveredMessageId: "a2",
+      generatedAt: "2026-06-25T10:02:00.000Z",
+      source: "automatic",
+    });
+
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-overview-recap-text")).toHaveTextContent(
+        "Cached recap stays readable.",
+      );
+    });
+    const coverage = screen.getByTestId("thread-overview-recap-coverage");
+    expect(coverage).toHaveAttribute("aria-label", expect.stringContaining("Covered through"));
+    expect(coverage).toHaveAttribute("aria-label", expect.stringContaining("Latest activity"));
+    expect(screen.getByTestId("thread-overview-recap")).not.toHaveTextContent(/stale|out of date|generate/i);
   });
 
   it("renders usage limits as compact progress bars when quota data exists", () => {

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -11,6 +11,7 @@ import {
   GitBranch,
   GitPullRequest,
   Globe,
+  Info,
   Laptop,
   Loader2,
   Menu,
@@ -590,19 +591,38 @@ function ThreadOverviewRepositoryRow({
 
 interface ThreadOverviewRecapRowProps {
   recapText: string | null;
+  hasCoverageGap: boolean;
+  coveredThrough: string | null;
+  latestActivityAt: string | null;
   isGenerating: boolean;
   error: string | null;
   onRefresh: () => void;
 }
 
+function formatThreadRecapTime(timestamp: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
 function ThreadOverviewRecapRow({
   recapText,
+  hasCoverageGap,
+  coveredThrough,
+  latestActivityAt,
   isGenerating,
   error,
   onRefresh,
 }: ThreadOverviewRecapRowProps) {
-  const label = recapText ?? (error ? "Recap unavailable" : "Generate recap");
+  const label = recapText ?? (error ? "Recap unavailable" : "No recap yet");
   const refreshLabel = isGenerating ? "Refreshing recap" : "Refresh recap";
+  const coverageLabel = hasCoverageGap && coveredThrough && latestActivityAt
+    ? {
+      coveredThrough: formatThreadRecapTime(coveredThrough),
+      latestActivityAt: formatThreadRecapTime(latestActivityAt),
+    }
+    : null;
 
   return (
     <div
@@ -611,25 +631,49 @@ function ThreadOverviewRecapRow({
     >
       <div className="flex min-w-0 items-center justify-between gap-2">
         <span className="shrink-0 text-xs font-medium text-muted-foreground">Recap</span>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                type="button"
-                data-testid="thread-overview-recap-refresh"
-                aria-label={refreshLabel}
-                disabled={isGenerating}
-                onClick={onRefresh}
-                className={cn("-mr-1 shrink-0", isGenerating && "text-muted-foreground/45")}
-              >
-                <RefreshCw size={13} aria-hidden />
-              </Button>
-            }
-          />
-          <TooltipContent>{refreshLabel}</TooltipContent>
-        </Tooltip>
+        <div className="-mr-1 flex shrink-0 items-center gap-0.5">
+          {coverageLabel ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    type="button"
+                    data-testid="thread-overview-recap-coverage"
+                    aria-label={`Covered through ${coverageLabel.coveredThrough}. Latest activity ${coverageLabel.latestActivityAt}`}
+                    className="shrink-0 text-muted-foreground/55 hover:text-muted-foreground focus-visible:text-muted-foreground"
+                  >
+                    <Info size={12} aria-hidden />
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom" align="end" className="flex-col items-start gap-0.5">
+                <span>Covered through {coverageLabel.coveredThrough}</span>
+                <span>Latest activity {coverageLabel.latestActivityAt}</span>
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  type="button"
+                  data-testid="thread-overview-recap-refresh"
+                  aria-label={refreshLabel}
+                  disabled={isGenerating}
+                  onClick={onRefresh}
+                  className={cn("shrink-0", isGenerating && "text-muted-foreground/45")}
+                >
+                  <RefreshCw size={13} aria-hidden />
+                </Button>
+              }
+            />
+            <TooltipContent>{refreshLabel}</TooltipContent>
+          </Tooltip>
+        </div>
       </div>
       {isGenerating ? (
         <div
@@ -1843,6 +1887,9 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
             <Separator className="my-1.5" />
             <ThreadOverviewRecapRow
               recapText={threadRecap.recapText}
+              hasCoverageGap={threadRecap.hasCoverageGap}
+              coveredThrough={threadRecap.coveredThrough}
+              latestActivityAt={threadRecap.latestActivityAt}
               isGenerating={threadRecap.isGenerating}
               error={threadRecap.error}
               onRefresh={() => void threadRecap.refresh()}

--- a/apps/web/src/hooks/useThreadRecap.test.tsx
+++ b/apps/web/src/hooks/useThreadRecap.test.tsx
@@ -7,6 +7,7 @@ import {
   buildThreadRecapPayload,
   createThreadRecapSignature,
   filterThreadRecapMessages,
+  getThreadRecapCoverageGap,
   resetThreadRecapRequestStateForTest,
   shouldScheduleThreadRecapGeneration,
   useThreadRecap,
@@ -183,6 +184,84 @@ describe("thread recap signatures and payloads", () => {
   });
 });
 
+describe("thread recap coverage gap", () => {
+  it("returns no affordance metadata for fresh, missing, or invalid coverage", () => {
+    const messages = [
+      recapMessage("u1", 1, "user", "first", "2026-06-25T10:00:00.000Z"),
+      recapMessage("a2", 2, "assistant", "second", "2026-06-25T10:01:00.000Z"),
+      recapMessage("u3", 3, "user", "third", "2026-06-25T10:02:00.000Z"),
+    ];
+    const signature = createThreadRecapSignature(messages);
+    const cached = {
+      text: "fresh",
+      signature,
+      coveredMessageId: "u3",
+      generatedAt: new Date(NOW).toISOString(),
+    };
+
+    expect(getThreadRecapCoverageGap({ messages, cached: undefined, signature })).toEqual({
+      hasCoverageGap: false,
+      coveredThrough: null,
+      latestActivityAt: null,
+    });
+    expect(getThreadRecapCoverageGap({ messages, cached, signature })).toEqual({
+      hasCoverageGap: false,
+      coveredThrough: null,
+      latestActivityAt: null,
+    });
+    expect(
+      getThreadRecapCoverageGap({
+        messages,
+        cached: { ...cached, signature: "old", coveredMessageId: "missing" },
+        signature,
+      }),
+    ).toEqual({
+      hasCoverageGap: false,
+      coveredThrough: null,
+      latestActivityAt: null,
+    });
+    expect(
+      getThreadRecapCoverageGap({
+        messages: messages.map((message) =>
+          message.id === "u3" ? { ...message, timestamp: "not-a-date" } : message,
+        ),
+        cached: { ...cached, signature: "old", coveredMessageId: "a2" },
+        signature,
+      }),
+    ).toEqual({
+      hasCoverageGap: false,
+      coveredThrough: null,
+      latestActivityAt: null,
+    });
+  });
+
+  it("returns coverage and latest timestamps when cached text trails loaded activity", () => {
+    const messages = [
+      recapMessage("u1", 1, "user", "first", "2026-06-25T10:00:00.000Z"),
+      recapMessage("a2", 2, "assistant", "second", "2026-06-25T10:01:00.000Z"),
+      recapMessage("u3", 3, "user", "third", "2026-06-25T10:02:00.000Z"),
+    ];
+    const signature = createThreadRecapSignature(messages);
+
+    expect(
+      getThreadRecapCoverageGap({
+        messages,
+        cached: {
+          text: "older",
+          signature: "old",
+          coveredMessageId: "a2",
+          generatedAt: new Date(NOW).toISOString(),
+        },
+        signature,
+      }),
+    ).toEqual({
+      hasCoverageGap: true,
+      coveredThrough: "2026-06-25T10:01:00.000Z",
+      latestActivityAt: "2026-06-25T10:02:00.000Z",
+    });
+  });
+});
+
 describe("useThreadRecap", () => {
   beforeEach(() => {
     resetThreadRecapRequestStateForTest();
@@ -218,6 +297,38 @@ describe("useThreadRecap", () => {
     expect(useThreadStore.getState().recapByThread[THREAD_ID]?.text).toBe("Fresh recap");
   });
 
+  it("keeps cached recap visible and reports coverage metadata for newer loaded activity", () => {
+    const messages = [
+      ...hookMessages("2026-06-25T10:00:00.000Z"),
+      createMockMessage({
+        id: "a4",
+        thread_id: THREAD_ID,
+        role: "assistant",
+        content: "Later eligible answer.",
+        sequence: 4,
+        timestamp: "2026-06-25T10:03:00.000Z",
+      }),
+    ];
+    const coveredMessages = filterThreadRecapMessages(messages.slice(0, 3));
+    useThreadStore.getState().recordThreadRecapGeneration({
+      threadId: THREAD_ID,
+      text: "Cached recap",
+      signature: createThreadRecapSignature(coveredMessages),
+      coveredMessageId: "u3",
+      generatedAt: new Date(NOW).toISOString(),
+      source: "automatic",
+    });
+
+    const { result } = renderHook(() =>
+      useThreadRecap({ threadId: THREAD_ID, messages, overviewOpen: false }),
+    );
+
+    expect(result.current.recapText).toBe("Cached recap");
+    expect(result.current.hasCoverageGap).toBe(true);
+    expect(result.current.coveredThrough).toBe("2026-06-25T10:00:00.000Z");
+    expect(result.current.latestActivityAt).toBe("2026-06-25T10:03:00.000Z");
+  });
+
   it("manual refresh dedupes a matching in-flight request", async () => {
     let resolveRpc!: (value: { text: string }) => void;
     vi.mocked(mockTransport.generateRecap).mockReturnValue(
@@ -241,6 +352,72 @@ describe("useThreadRecap", () => {
       expect(mockTransport.generateRecap).toHaveBeenCalledTimes(1);
     });
     expect(useThreadStore.getState().recapByThread[THREAD_ID]?.text).toBe("Deduped recap");
+  });
+
+  it("reports pending state while manual refresh is in flight", async () => {
+    let resolveRpc!: (value: { text: string }) => void;
+    vi.mocked(mockTransport.generateRecap).mockReturnValue(
+      new Promise((resolve) => {
+        resolveRpc = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useThreadRecap({ threadId: THREAD_ID, messages: hookMessages(), overviewOpen: false }),
+    );
+
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isGenerating).toBe(true);
+    });
+
+    await act(async () => {
+      resolveRpc({ text: "Finished recap" });
+      await refreshPromise;
+    });
+
+    expect(result.current.isGenerating).toBe(false);
+  });
+
+  it("reports manual refresh failures without dropping cached metadata", async () => {
+    vi.mocked(mockTransport.generateRecap).mockRejectedValue(new Error("provider failed"));
+
+    const { result } = renderHook(() =>
+      useThreadRecap({ threadId: THREAD_ID, messages: hookMessages(), overviewOpen: false }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.error).toBe("provider failed");
+    expect(result.current.recapText).toBeNull();
+  });
+
+  it("returns no coverage affordance for a fresh same-signature cache", () => {
+    const messages = hookMessages("2026-06-25T10:00:00.000Z");
+    const signature = createThreadRecapSignature(filterThreadRecapMessages(messages));
+    useThreadStore.getState().recordThreadRecapGeneration({
+      threadId: THREAD_ID,
+      text: "Fresh cached recap",
+      signature,
+      coveredMessageId: "u3",
+      generatedAt: new Date(NOW).toISOString(),
+      source: "automatic",
+    });
+
+    const { result } = renderHook(() =>
+      useThreadRecap({ threadId: THREAD_ID, messages, overviewOpen: false }),
+    );
+
+    expect(result.current.recapText).toBe("Fresh cached recap");
+    expect(result.current.hasCoverageGap).toBe(false);
+    expect(result.current.coveredThrough).toBeNull();
+    expect(result.current.latestActivityAt).toBeNull();
   });
 
   it("runs automatic generation when the Overview opens from closed and gates pass", async () => {

--- a/apps/web/src/hooks/useThreadRecap.ts
+++ b/apps/web/src/hooks/useThreadRecap.ts
@@ -59,6 +59,12 @@ export interface ThreadRecapScheduleInput {
 export interface UseThreadRecapResult {
   /** Current session-cached recap text, if one exists. */
   recapText: string | null;
+  /** Whether the cached recap covers an older eligible message than the latest one loaded. */
+  hasCoverageGap: boolean;
+  /** Timestamp of the message covered by the cached recap, if a gap is derivable. */
+  coveredThrough: string | null;
+  /** Timestamp of the latest eligible message, if a gap is derivable. */
+  latestActivityAt: string | null;
   /** Whether generation is currently in flight for this thread/signature. */
   isGenerating: boolean;
   /** Last manual or automatic generation failure for the current thread. */
@@ -209,6 +215,45 @@ export function buildThreadRecapPayload(
 }
 
 /**
+ * Derives whether cached recap coverage trails the latest loaded eligible message.
+ */
+export function getThreadRecapCoverageGap({
+  messages,
+  cached,
+  signature,
+}: {
+  /** Filtered persisted user and assistant messages. */
+  messages: readonly ThreadRecapMessage[];
+  /** Existing session-only cache entry for the thread, if any. */
+  cached: ThreadRecapCacheEntry | undefined;
+  /** Current deterministic message signature. */
+  signature: string;
+}): Pick<UseThreadRecapResult, "hasCoverageGap" | "coveredThrough" | "latestActivityAt"> {
+  const noGap = {
+    hasCoverageGap: false,
+    coveredThrough: null,
+    latestActivityAt: null,
+  };
+  if (!cached) return noGap;
+  if (cached.signature === signature) return noGap;
+
+  const coveredIndex = messages.findIndex((message) => message.id === cached.coveredMessageId);
+  const coveredMessage = coveredIndex >= 0 ? messages[coveredIndex] : undefined;
+  const latestMessage = messages.at(-1);
+  if (!coveredMessage || !latestMessage || coveredIndex >= messages.length - 1) return noGap;
+
+  const coveredTime = Date.parse(coveredMessage.timestamp);
+  const latestTime = Date.parse(latestMessage.timestamp);
+  if (!Number.isFinite(coveredTime) || !Number.isFinite(latestTime)) return noGap;
+
+  return {
+    hasCoverageGap: true,
+    coveredThrough: coveredMessage.timestamp,
+    latestActivityAt: latestMessage.timestamp,
+  };
+}
+
+/**
  * Generates and caches a thread Recap on manual refresh or stale re-orientation.
  */
 export function useThreadRecap({
@@ -229,6 +274,10 @@ export function useThreadRecap({
     [filteredMessages],
   );
   const cached = useThreadStore((state) => state.recapByThread?.[threadId]);
+  const coverageGap = useMemo(
+    () => getThreadRecapCoverageGap({ messages: filteredMessages, cached, signature }),
+    [cached, filteredMessages, signature],
+  );
   const recordThreadRecapGeneration = useThreadStore((state) => state.recordThreadRecapGeneration);
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -371,6 +420,7 @@ export function useThreadRecap({
 
   return {
     recapText: cached?.text ?? null,
+    ...coverageGap,
     isGenerating,
     error,
     refresh: useCallback(() => generate("manual"), [generate]),


### PR DESCRIPTION
## What
Adds a quiet coverage hint to the Thread Overview Recap row when the cached recap stops before newer loaded activity.

## Why
Users can keep reading the cached recap without being told it is stale. The hover hint shows where the recap stopped and where the latest activity is.

## Key Changes
- Derives coverage metadata from the cached recap's covered message and the latest loaded user or assistant message.
- Shows a small info icon beside the Recap actions when that coverage differs.
- Updates unit and e2e coverage for the cached recap, tooltip, and hidden stale/generate copy.

Closes #771
Related to #755

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785411759&installation_id=129163861&pr_number=824&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F824&signature=7d8d7a5ac00071a5e99814fd899962b4b914e75c39113468c65cf9b8aeceba3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->