### PR TITLE
ci: cache workflow dependencies and add timeouts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: write
 
+env:
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
+
 jobs:
   build:
     # Skip nightly per-build releases: the dedicated `nightly-desktop.yml`
@@ -48,6 +51,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun install cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-${{ matrix.target-arch || 'default' }}-bun-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,13 +40,20 @@ jobs:
             target-arch: "x64"
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
         with:
-          bun-version: "1.2.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-${{ matrix.target-arch || 'default' }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target-arch || 'default' }}-bun-
+            ${{ runner.os }}-bun-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -149,6 +156,7 @@ jobs:
     # try to upload `latest-mac.yml` into a nightly release).
     if: ${{ (github.event.release.tag_name || inputs.tag) && !contains(github.event.release.tag_name, '-nightly.') }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Download arm64 yml
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   pr-title:
     name: PR Title
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
@@ -20,6 +21,7 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
     permissions:
       contents: read
     env:
@@ -28,6 +30,8 @@ jobs:
       # on 504s.
       SKIP_ELECTRON_REBUILD: "1"
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,14 +46,27 @@ jobs:
           test -f "$node_dir/include/node/common.gypi"
           echo "npm_config_nodedir=$node_dir" >> "$GITHUB_ENV"
       - uses: oven-sh/setup-bun@v2
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
         with:
-          bun-version: "1.2.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - name: Cache Turbo outputs
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-typecheck-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-typecheck-
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
 
   lint:
     name: Lint
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
     permissions:
       contents: read
     env:
@@ -57,6 +74,8 @@ jobs:
       # better-sqlite3 Electron prebuild so bun install does not flake on 504s.
       SKIP_ELECTRON_REBUILD: "1"
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,14 +90,36 @@ jobs:
           test -f "$node_dir/include/node/common.gypi"
           echo "npm_config_nodedir=$node_dir" >> "$GITHUB_ENV"
       - uses: oven-sh/setup-bun@v2
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
         with:
-          bun-version: "1.2.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - name: Cache Turbo outputs
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-lint-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-lint-
+      - name: Cache ESLint results
+        uses: actions/cache@v4
+        with:
+          path: apps/web/node_modules/.cache/.eslintcache
+          key: ${{ runner.os }}-eslint-${{ hashFiles('bun.lock', 'apps/web/eslint.config.*', 'apps/web/src/**/*.{ts,tsx,js,jsx}') }}
+          restore-keys: |
+            ${{ runner.os }}-eslint-
       - run: bun install --frozen-lockfile
       - run: bun run lint
+        env:
+          DEBUG: eslint:lint-result-cache
 
   test:
     name: Test
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
     permissions:
       contents: read
     env:
@@ -87,6 +128,8 @@ jobs:
       # not flake on 504s.
       SKIP_ELECTRON_REBUILD: "1"
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,8 +144,20 @@ jobs:
           test -f "$node_dir/include/node/common.gypi"
           echo "npm_config_nodedir=$node_dir" >> "$GITHUB_ENV"
       - uses: oven-sh/setup-bun@v2
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
         with:
-          bun-version: "1.2.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - name: Cache Turbo outputs
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-test-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-test-
       - run: bun install --frozen-lockfile
       - run: bun run test
 
@@ -141,8 +196,13 @@ jobs:
           test -f "$node_dir/include/node/common.gypi"
           echo "npm_config_nodedir=$node_dir" >> "$GITHUB_ENV"
       - uses: oven-sh/setup-bun@v2
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
         with:
-          bun-version: "1.2.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
 
       # Read the resolved version straight from the lockfile (the source of truth
@@ -192,6 +252,10 @@ jobs:
   build-check:
     name: Build Check
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 20
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -204,11 +268,22 @@ jobs:
           test -f "$node_dir/include/node/common.gypi"
           echo "npm_config_nodedir=$node_dir" >> "$GITHUB_ENV"
       - uses: oven-sh/setup-bun@v2
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
         with:
-          bun-version: "1.2.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - name: Cache Turbo outputs
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-
       - run: bun install --frozen-lockfile
-      - run: bun run --cwd apps/web build
-      - run: bun run --cwd apps/desktop build
+      - run: bun run build
 
       - name: Generate V8 snapshot
         run: bun apps/desktop/scripts/generate-snapshot.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
+
 jobs:
   pr-title:
     name: PR Title
@@ -48,6 +51,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun install cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -55,6 +59,7 @@ jobs:
             ${{ runner.os }}-bun-
       - name: Cache Turbo outputs
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: .turbo/cache
           key: ${{ runner.os }}-turbo-typecheck-${{ github.sha }}
@@ -92,6 +97,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun install cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -99,6 +105,7 @@ jobs:
             ${{ runner.os }}-bun-
       - name: Cache Turbo outputs
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: .turbo/cache
           key: ${{ runner.os }}-turbo-lint-${{ github.sha }}
@@ -106,6 +113,7 @@ jobs:
             ${{ runner.os }}-turbo-lint-
       - name: Cache ESLint results
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: apps/web/node_modules/.cache/.eslintcache
           key: ${{ runner.os }}-eslint-${{ hashFiles('bun.lock', 'apps/web/eslint.config.*', 'apps/web/src/**/*.{ts,tsx,js,jsx}') }}
@@ -146,6 +154,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun install cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -153,6 +162,7 @@ jobs:
             ${{ runner.os }}-bun-
       - name: Cache Turbo outputs
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: .turbo/cache
           key: ${{ runner.os }}-turbo-test-${{ github.sha }}
@@ -198,6 +208,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun install cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -219,6 +230,7 @@ jobs:
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
@@ -270,6 +282,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun install cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -277,6 +290,7 @@ jobs:
             ${{ runner.os }}-bun-
       - name: Cache Turbo outputs
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: .turbo/cache
           key: ${{ runner.os }}-turbo-build-${{ github.sha }}

--- a/.github/workflows/desktop-package-dry-run.yml
+++ b/.github/workflows/desktop-package-dry-run.yml
@@ -19,6 +19,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
+
 jobs:
   package-linux-desktop:
     name: Package Linux Desktop
@@ -33,6 +36,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun install cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/desktop-package-dry-run.yml
+++ b/.github/workflows/desktop-package-dry-run.yml
@@ -23,6 +23,7 @@ jobs:
   package-linux-desktop:
     name: Package Linux Desktop
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -30,8 +31,13 @@ jobs:
           persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
         with:
-          bun-version: "1.2.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -209,7 +209,7 @@ jobs:
         shell: bash
         run: |
           if /usr/bin/pgrep oahd >/dev/null 2>&1 || /usr/bin/arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
-            /usr/bin/arch -x86_64 node apps/desktop/scripts/smoke-test.mjs
+            node apps/desktop/scripts/smoke-test.mjs
           else
             echo "Skipping x64 packaged-server smoke: Rosetta is unavailable on this macOS runner."
           fi

--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   setup:
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
       last_nightly_tag: ${{ steps.check.outputs.last_nightly_tag }}
@@ -140,13 +141,20 @@ jobs:
             target-arch: "x64"
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
+      - name: Cache Bun install cache
+        uses: actions/cache@v4
         with:
-          bun-version: "1.2.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-${{ matrix.target-arch || 'default' }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target-arch || 'default' }}-bun-
+            ${{ runner.os }}-bun-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -195,6 +203,16 @@ jobs:
       - name: Smoke test packaged server
         if: matrix.target-arch == '' || matrix.target-arch == 'arm64'
         run: node apps/desktop/scripts/smoke-test.mjs
+
+      - name: Smoke test packaged server under Rosetta
+        if: runner.os == 'macOS' && matrix.target-arch == 'x64'
+        shell: bash
+        run: |
+          if /usr/bin/pgrep oahd >/dev/null 2>&1 || /usr/bin/arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
+            /usr/bin/arch -x86_64 node apps/desktop/scripts/smoke-test.mjs
+          else
+            echo "Skipping x64 packaged-server smoke: Rosetta is unavailable on this macOS runner."
+          fi
 
       - name: Verify Linux artifacts on Ubuntu 22.04
         if: runner.os == 'Linux'
@@ -256,6 +274,7 @@ jobs:
     needs: [setup, build]
     if: needs.setup.outputs.should_build == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Download arm64 yml
         continue-on-error: true

--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -13,6 +13,9 @@ concurrency:
   group: nightly-desktop
   cancel-in-progress: true
 
+env:
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
+
 permissions:
   contents: write
 
@@ -149,6 +152,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Cache Bun install cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-${{ matrix.target-arch || 'default' }}-bun-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   release-please:
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
 
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
## What
Adds workflow timeouts, removes pinned setup-bun versions, adds CI caches for Bun, Turbo, and ESLint, and runs the nightly macOS x64 packaged-server smoke check under Rosetta when available.

## Why
Issues #668, #669, and #672 track CI reliability, warm-run performance, and the missing macOS x64 nightly smoke check.

## Key Changes
- Adds job timeouts across CI, packaging, nightly, and release workflows.
- Lets setup-bun read the Bun version from packageManager.
- Persists the Bun install cache, Turbo local cache, and ESLint cache.
- Runs the macOS x64 nightly packaged-server smoke check through Rosetta, or logs why the runner cannot run it.

Closes #668
Closes #669
Closes #672

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785413251&installation_id=129163861&pr_number=825&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F825&signature=5abf72a14c106a8813fae32235126bc7395c20ce3cf122a8bb09c532c4f8a627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and packaging reliability by adding execution limits to long-running jobs.
  * Increased cache usage across CI and release workflows to speed up repeated runs and reduce flakiness.
* **Performance**
  * Faster CI, nightly, and release-related runs through better reuse of installed tools and build outputs.
* **New Features**
  * Added an additional packaged-server smoke test for macOS builds when supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->