### PR TITLE
fix(web): keep preview webview interactive under overlays

### DIFF
--- a/apps/desktop/e2e/electron-smoke.spec.ts
+++ b/apps/desktop/e2e/electron-smoke.spec.ts
@@ -13,10 +13,22 @@
  */
 import { test, expect, _electron as electron } from "@playwright/test";
 import { existsSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const DESKTOP_DIR = resolve(__dirname, "..");
 const MAIN_BUNDLE = join(DESKTOP_DIR, "dist", "main", "main.cjs");
+
+function electronLaunchEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key !== "ELECTRON_RUN_AS_NODE" && value !== undefined) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
 
 test.describe("Electron smoke", () => {
   test.beforeAll(() => {
@@ -28,7 +40,11 @@ test.describe("Electron smoke", () => {
   });
 
   test("first window opens and has the expected title", async () => {
-    const app = await electron.launch({ args: ["."], cwd: DESKTOP_DIR });
+    const app = await electron.launch({
+      args: ["."],
+      cwd: DESKTOP_DIR,
+      env: electronLaunchEnv(),
+    });
     const rendererErrors: string[] = [];
 
     try {

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -17,6 +17,9 @@ let ipcOnHandlers: Record<string, (...args: unknown[]) => unknown> = {};
 /** Tracks WebContentsView instances created during a test. */
 let createdViews: ReturnType<typeof makeWebContentsView>[] = [];
 
+/** Mock Electron webContents registry for renderer-hosted webview adoption. */
+const mockWebContentsById = new Map<number, ReturnType<typeof makeWebContentsView>["webContents"]>();
+
 /** Shared preview partition returned by the Electron session mock. */
 const previewPartition = {
   setPermissionRequestHandler: vi.fn(),
@@ -53,15 +56,21 @@ function makeWebContentsView() {
     getZoomFactor: vi.fn().mockReturnValue(1),
     setZoomFactor: vi.fn(),
     on: vi.fn(),
+    once: vi.fn(),
+    removeListener: vi.fn(),
     removeAllListeners: vi.fn(),
     setWindowOpenHandler: vi.fn(),
     setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn().mockResolvedValue(undefined),
+    capturePage: vi.fn().mockResolvedValue({
+      toPNG: vi.fn(() => Buffer.from("png-bytes")),
+    }),
     send: vi.fn(),
   };
   const view = {
     webContents,
     setBounds: vi.fn(),
+    getBounds: vi.fn().mockReturnValue(VALID_BOUNDS),
   };
   createdViews.push(view);
   return view;
@@ -103,6 +112,10 @@ vi.mock("electron", () => ({
   }),
   BrowserWindow: {
     fromWebContents: vi.fn(),
+    getAllWindows: vi.fn(() => testWindows),
+  },
+  webContents: {
+    fromId: vi.fn((id: number) => mockWebContentsById.get(id) ?? null),
   },
   ipcMain: {
     handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
@@ -127,7 +140,7 @@ vi.mock("@mcode/contracts", async () => {
   const actual = await vi.importActual<typeof import("@mcode/contracts")>("@mcode/contracts");
   return {
     ...actual,
-    clampMcodeBrowserCaptureV2: vi.fn(),
+    clampMcodeBrowserCaptureV2: vi.fn((value) => value),
     isBrowserCaptureSpillAppDataPath: vi.fn().mockReturnValue(false),
     MCODE_BROWSER_CAPTURE_V2_STRING_MAX: 100_000,
   };
@@ -135,7 +148,7 @@ vi.mock("@mcode/contracts", async () => {
 
 vi.mock("@mcode/shared", () => ({
   getMcodeDir: vi.fn().mockReturnValue("/tmp/mcode"),
-  redactMcodeBrowserCaptureV2: vi.fn(),
+  redactMcodeBrowserCaptureV2: vi.fn((value) => value),
   spillWorkspaceDirSegment: vi.fn().mockReturnValue("ws"),
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
@@ -206,6 +219,7 @@ let handlersRegistered = false;
 
 beforeEach(() => {
   createdViews = [];
+  mockWebContentsById.clear();
   previewPartition.clearStorageData.mockClear();
   previewPartition.clearCache.mockClear();
   if (!handlersRegistered) {
@@ -1205,6 +1219,126 @@ describe("preview-browser", () => {
   });
 
   describe("design mode (Phase G)", () => {
+    it("element pick uses the active adopted webview when no native view exists", async () => {
+      vi.useFakeTimers();
+      try {
+        const win = createWindow();
+        const ev = fakeEvent(win);
+
+        await ipcHandlers["preview:sync"]!(ev, {
+          visible: false,
+          bounds: VALID_BOUNDS,
+          threadId: "thread-webview",
+          resumeUrlHint: "https://example.com",
+          workspaceId: "ws-1",
+        });
+
+        const adopted = makeWebContentsView().webContents;
+        adopted.executeJavaScript
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce(JSON.stringify({ state: "cancelled", seq: 1 }));
+        mockWebContentsById.set(42, adopted);
+
+        const adoptedResult = await ipcHandlers["preview:adopt-webview"]!(ev, {
+          threadId: "thread-webview",
+          tabId: sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId,
+          webContentsId: 42,
+        });
+        expect(adoptedResult).toEqual({ ok: true });
+        expect(sessions.get(win.id)!.view).toBeNull();
+
+        const capturePromise = ipcHandlers["preview:capture-picture-element-pick"]!(
+          ev,
+        ) as Promise<unknown>;
+        await Promise.resolve();
+
+        expect(adopted.executeJavaScript).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(120);
+        await expect(capturePromise).resolves.toEqual({ ok: false, error: "cancelled" });
+        expect(adopted.executeJavaScript).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("element pick capture stays on the same adopted webview through commit", async () => {
+      vi.useFakeTimers();
+      try {
+        const win = createWindow();
+        const ev = fakeEvent(win);
+        await ipcHandlers["preview:sync"]!(ev, {
+          visible: false,
+          bounds: VALID_BOUNDS,
+          threadId: "thread-webview",
+          resumeUrlHint: "https://example.com",
+          workspaceId: "ws-1",
+        });
+
+        const adopted = makeWebContentsView().webContents;
+        adopted.getURL.mockReturnValue("https://example.com/page");
+        adopted.executeJavaScript
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce(JSON.stringify({ state: "commit", seq: 1, x: 10, y: 20 }))
+          .mockResolvedValueOnce(
+            JSON.stringify({
+              ok: true,
+              bounds: { x: 8, y: 18, width: 120, height: 80 },
+              selectorHint: "button.primary",
+              htmlExcerpt: "<button>Attach</button>",
+            }),
+          )
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce(JSON.stringify({ visibleText: "Attach", scrollX: 0, scrollY: 0 }));
+        mockWebContentsById.set(43, adopted);
+
+        const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId;
+        await ipcHandlers["preview:adopt-webview"]!(ev, {
+          threadId: "thread-webview",
+          tabId,
+          webContentsId: 43,
+        });
+
+        const capturePromise = ipcHandlers["preview:capture-picture-element-pick"]!(
+          ev,
+        ) as Promise<{ ok: true; meta: { sizeBytes: number }; previewBytes: Uint8Array }>;
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(120);
+        const result = await capturePromise;
+
+        expect(result.ok).toBe(true);
+        expect(result.meta.sizeBytes).toBeGreaterThan(0);
+        expect(result.previewBytes.length).toBeGreaterThan(0);
+        expect(adopted.capturePage).toHaveBeenCalledWith({ x: 8, y: 18, width: 120, height: 80 });
+        expect(adopted.executeJavaScript).toHaveBeenCalledTimes(5);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("element pick still falls back to the native WebContentsView", async () => {
+      vi.useFakeTimers();
+      try {
+        const win = createWindow();
+        await showPreview(win);
+        const view = createdViews[0]!;
+        view.webContents.executeJavaScript
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce(JSON.stringify({ state: "cancelled", seq: 1 }));
+
+        const capturePromise = ipcHandlers["preview:capture-picture-element-pick"]!(
+          fakeEvent(win),
+        ) as Promise<unknown>;
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(120);
+
+        await expect(capturePromise).resolves.toEqual({ ok: false, error: "cancelled" });
+        expect(view.webContents.executeJavaScript).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("setViewport applies a named preset and centers within panel bounds", async () => {
       const win = createWindow();
       await showPreview(win);

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -142,31 +142,41 @@ export function registerNavigationHandlers(): void {
       s.workspaceId = typeof ws === "string" && ws.trim().length > 0 ? ws.trim() : null;
       const b = payload.bounds;
       bumpPerf("setPanelBoundsCalls");
-      if (!payload.visible || !b || b.width < 4 || b.height < 4) {
+      const hasValidBounds = b && b.width >= 4 && b.height >= 4;
+      const tid = payload.threadId ?? null;
+      const switchedThread = tid != null && tid !== s.lastPreviewThreadId;
+      const prevBounds = s.lastBounds;
+      const incomingBounds = hasValidBounds
+        ? { x: b.x, y: b.y, width: b.width, height: b.height }
+        : null;
+      if (hasValidBounds) {
+        s.lastBounds = incomingBounds;
+        if (tid != null) {
+          ensureThreadTabSet(s, tid);
+        }
+        s.lastPreviewThreadId = tid;
+      }
+      if (!payload.visible || !incomingBounds) {
         hidePreview(win, s);
         onPreviewHidden(win, s);
         return;
       }
 
-      const prevBounds = s.lastBounds;
+      const bounds = incomingBounds;
       const sameBounds =
         prevBounds !== null &&
-        prevBounds.x === b.x &&
-        prevBounds.y === b.y &&
-        prevBounds.width === b.width &&
-        prevBounds.height === b.height;
+        prevBounds.x === bounds.x &&
+        prevBounds.y === bounds.y &&
+        prevBounds.width === bounds.width &&
+        prevBounds.height === bounds.height;
       if (sameBounds) {
         bumpPerf("setPanelBoundsNoopSkips");
       } else {
         bumpPerf("setPanelBoundsViewportUpdates");
       }
 
-      s.lastBounds = { x: b.x, y: b.y, width: b.width, height: b.height };
-
       const hintRaw = payload.resumeUrlHint?.trim() ?? "";
       const hint = hintRaw.length > 0 && isAllowedPreviewUrl(hintRaw) ? hintRaw : null;
-      const tid = payload.threadId ?? null;
-      const switchedThread = tid != null && tid !== s.lastPreviewThreadId;
       const safeHint = await validateResumeUrl(hint);
 
       // Detach the prior thread's active view BEFORE picking the new one so
@@ -174,17 +184,12 @@ export function registerNavigationHandlers(): void {
       if (switchedThread && s.view) {
         unmountView(win, s.view);
       }
-      if (tid != null) {
-        ensureThreadTabSet(s, tid);
-      }
-      s.lastPreviewThreadId = tid;
-
       // ensureView resolves the (now-current) thread's active tab and either
       // returns its existing webContents or creates a fresh one. On a thread
       // switch this picks up the warm WebContentsView the user left behind,
       // so their scroll/form state survives.
       const view = ensureView(win, s);
-      view.setBounds(s.lastBounds);
+      view.setBounds(bounds);
       mountView(win, view);
 
       const wc = view.webContents;

--- a/apps/desktop/src/main/preview/preview-overlay.ts
+++ b/apps/desktop/src/main/preview/preview-overlay.ts
@@ -12,6 +12,7 @@ import {
   type Bounds,
   type PreviewSession,
   getSession,
+  getActiveTab,
   clearIdle,
   resetIdle,
 } from "./preview-session.js";
@@ -25,6 +26,7 @@ import {
   sanitizeSelectorHintFromGuest,
   scrubHtmlExcerptForOutbound,
 } from "./preview-capture.js";
+import { findAdoptedWebContents } from "./preview-webview-adopt.js";
 
 /**
  * Element-pick runs entirely inside the guest page: capture-phase event handlers block
@@ -516,9 +518,20 @@ async function removeRgMarqueeHighlighter(wc: WebContents): Promise<void> {
   }
 }
 
-/** Prefer WebContentsView bounds; shell-reported rect can lag ResizeObserver. */
-function hostBoundsForHitTest(s: PreviewSession): Bounds | null {
-  if (s.view && !s.view.webContents.isDestroyed()) {
+function resolveActiveCaptureWebContents(s: PreviewSession): WebContents | null {
+  const threadId = s.lastPreviewThreadId;
+  if (threadId) {
+    const activeTab = getActiveTab(s, threadId);
+    const adopted = findAdoptedWebContents(threadId, activeTab.id);
+    if (adopted && !adopted.isDestroyed()) return adopted;
+  }
+  if (s.view && !s.view.webContents.isDestroyed()) return s.view.webContents;
+  return null;
+}
+
+/** Prefer WebContentsView bounds for native captures; webview captures use shell bounds. */
+function hostBoundsForHitTest(s: PreviewSession, webContents: WebContents): Bounds | null {
+  if (s.view?.webContents === webContents && !s.view.webContents.isDestroyed()) {
     try {
       const b = s.view.getBounds();
       if (b.width > 0 && b.height > 0) {
@@ -901,17 +914,18 @@ export function abortOverlayCapture(s: PreviewSession, error: string): void {
     clearTimeout(s.regionPollTimer);
     s.regionPollTimer = null;
   }
-  if (s.view && !s.view.webContents.isDestroyed()) {
+  const webContents = pending?.webContents ?? resolveActiveCaptureWebContents(s);
+  if (webContents && !webContents.isDestroyed()) {
     // Both modes are in-guest now. Tear down the right one based on pending
     // mode; when pending is null (cancel-without-session), strip both as a
     // belt-and-suspenders.
     if (pending?.mode === "region") {
-      void removeRgMarqueeHighlighter(s.view.webContents);
+      void removeRgMarqueeHighlighter(webContents);
     } else if (pending?.mode === "element") {
-      void removeEpPickHighlighter(s.view.webContents);
+      void removeEpPickHighlighter(webContents);
     } else {
-      void removeRgMarqueeHighlighter(s.view.webContents);
-      void removeEpPickHighlighter(s.view.webContents);
+      void removeRgMarqueeHighlighter(webContents);
+      void removeEpPickHighlighter(webContents);
     }
   }
   destroySelectionOverlayOnly(s);
@@ -977,7 +991,8 @@ export function registerOverlayHandlers(): void {
       }
 
       if (!s.lastBounds) return { ok: false, error: "no-bounds" };
-      if (!s.view || s.view.webContents.isDestroyed()) {
+      const webContents = resolveActiveCaptureWebContents(s);
+      if (!webContents) {
         return { ok: false, error: "no-preview" };
       }
 
@@ -991,11 +1006,11 @@ export function registerOverlayHandlers(): void {
           resolve(r);
         };
 
-        s.overlayPending = { mode: "region", finish: finishOnce, hostWin: win };
-        beginOverlaySession(s, s.view!.webContents);
+        s.overlayPending = { mode: "region", finish: finishOnce, hostWin: win, webContents };
+        beginOverlaySession(s, webContents);
 
         void (async (): Promise<void> => {
-          await injectRgMarqueeHighlighter(s.view!.webContents);
+          await injectRgMarqueeHighlighter(webContents);
           schedulePollRegion(s, win);
         })();
       });
@@ -1014,7 +1029,8 @@ export function registerOverlayHandlers(): void {
       }
 
       if (!s.lastBounds) return { ok: false, error: "no-bounds" };
-      if (!s.view || s.view.webContents.isDestroyed()) {
+      const webContents = resolveActiveCaptureWebContents(s);
+      if (!webContents) {
         return { ok: false, error: "no-preview" };
       }
 
@@ -1028,11 +1044,11 @@ export function registerOverlayHandlers(): void {
           resolve(r);
         };
 
-        s.overlayPending = { mode: "element", finish: finishOnce, hostWin: win };
-        beginOverlaySession(s, s.view!.webContents);
+        s.overlayPending = { mode: "element", finish: finishOnce, hostWin: win, webContents };
+        beginOverlaySession(s, webContents);
 
         void (async (): Promise<void> => {
-          await injectEpPickHighlighter(s.view!.webContents);
+          await injectEpPickHighlighter(webContents);
           schedulePoll(s, win);
         })();
       });
@@ -1079,14 +1095,15 @@ async function runRegionPollTick(s: PreviewSession, hostWin: BrowserWindow): Pro
     abortOverlayCapture(s, "no-window");
     return;
   }
-  if (!s.view || s.view.webContents.isDestroyed()) {
+  const webContents = pending.webContents;
+  if (webContents.isDestroyed()) {
     abortOverlayCapture(s, "no-preview");
     return;
   }
 
   let payload: RgPollPayload | null = null;
   try {
-    const raw: unknown = await s.view.webContents.executeJavaScript(RG_POLL_JS, true);
+    const raw: unknown = await webContents.executeJavaScript(RG_POLL_JS, true);
     const text = typeof raw === "string" ? raw : JSON.stringify(raw);
     payload = JSON.parse(text) as RgPollPayload;
   } catch {
@@ -1098,9 +1115,9 @@ async function runRegionPollTick(s: PreviewSession, hostWin: BrowserWindow): Pro
 
   if (!payload || payload.state === "gone") {
     // Guest reloaded / navigated. Re-inject so the next tick can resume.
-    if (s.view && !s.view.webContents.isDestroyed()) {
+    if (!webContents.isDestroyed()) {
       try {
-        await s.view.webContents.executeJavaScript(RG_INJECT_JS, true);
+        await webContents.executeJavaScript(RG_INJECT_JS, true);
       } catch {
         /* navigation still in flight */
       }
@@ -1143,7 +1160,8 @@ async function finishRegionCapture(s: PreviewSession, rect: Bounds): Promise<voi
     s.regionPollTimer = null;
   }
 
-  if (!s.view || s.view.webContents.isDestroyed()) {
+  const webContents = pending.webContents;
+  if (webContents.isDestroyed()) {
     if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
     pending.finish({ ok: false, error: "no-preview" });
     return;
@@ -1151,7 +1169,7 @@ async function finishRegionCapture(s: PreviewSession, rect: Bounds): Promise<voi
 
   const lb = s.lastBounds;
   if (!lb) {
-    await removeRgMarqueeHighlighter(s.view.webContents);
+    await removeRgMarqueeHighlighter(webContents);
     if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
     pending.finish({ ok: false, error: "no-bounds" });
     return;
@@ -1159,15 +1177,15 @@ async function finishRegionCapture(s: PreviewSession, rect: Bounds): Promise<voi
 
   const r = clampRectInPlace(rect, lb.width, lb.height);
   if (r.width < 4 || r.height < 4) {
-    await removeRgMarqueeHighlighter(s.view.webContents);
+    await removeRgMarqueeHighlighter(webContents);
     if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
     pending.finish({ ok: false, error: "region-too-small" });
     return;
   }
 
   try {
-    await removeRgMarqueeHighlighter(s.view.webContents);
-    const image = await s.view.webContents.capturePage(r);
+    await removeRgMarqueeHighlighter(webContents);
+    const image = await webContents.capturePage(r);
     const buffer = image.toPNG();
     if (buffer.length === 0) {
       if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
@@ -1176,7 +1194,7 @@ async function finishRegionCapture(s: PreviewSession, rect: Bounds): Promise<voi
     }
 
     const id = randomUUID();
-    const stem = previewCaptureFileStem(s.view.webContents.getURL());
+    const stem = previewCaptureFileStem(webContents.getURL());
     const name = `preview-region-${stem}-${Date.now()}.png`;
     const tempDir = join(app.getPath("temp"), "mcode-attachments");
     await mkdir(tempDir, { recursive: true });
@@ -1192,7 +1210,7 @@ async function finishRegionCapture(s: PreviewSession, rect: Bounds): Promise<voi
     };
 
     const capture = await buildBrowserCapturePayload(
-      s.view.webContents,
+      webContents,
       r,
       s.consoleBuffer,
       snapshotFailedRequestsForCapture(s),
@@ -1236,14 +1254,15 @@ async function runElementPickPollTick(s: PreviewSession, hostWin: BrowserWindow)
     abortOverlayCapture(s, "no-window");
     return;
   }
-  if (!s.view || s.view.webContents.isDestroyed()) {
+  const webContents = pending.webContents;
+  if (webContents.isDestroyed()) {
     abortOverlayCapture(s, "no-preview");
     return;
   }
 
   let payload: EpPollPayload | null = null;
   try {
-    const raw: unknown = await s.view.webContents.executeJavaScript(EP_POLL_JS, true);
+    const raw: unknown = await webContents.executeJavaScript(EP_POLL_JS, true);
     const text = typeof raw === "string" ? raw : JSON.stringify(raw);
     payload = JSON.parse(text) as EpPollPayload;
   } catch {
@@ -1255,9 +1274,9 @@ async function runElementPickPollTick(s: PreviewSession, hostWin: BrowserWindow)
 
   if (!payload || payload.state === "gone") {
     // Guest reloaded / navigated. Re-inject so the next tick can resume.
-    if (s.view && !s.view.webContents.isDestroyed()) {
+    if (!webContents.isDestroyed()) {
       try {
-        await s.view.webContents.executeJavaScript(EP_INJECT_JS, true);
+        await webContents.executeJavaScript(EP_INJECT_JS, true);
       } catch {
         /* navigation still in flight */
       }
@@ -1303,7 +1322,8 @@ async function finishElementPickCapture(
     s.elementPickPollTimer = null;
   }
 
-  if (!s.view || s.view.webContents.isDestroyed()) {
+  const webContents = pending.webContents;
+  if (webContents.isDestroyed()) {
     if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
     pending.finish({ ok: false, error: "no-preview" });
     return;
@@ -1311,15 +1331,15 @@ async function finishElementPickCapture(
 
   const lb = s.lastBounds;
   if (!lb) {
-    await removeEpPickHighlighter(s.view.webContents);
+    await removeEpPickHighlighter(webContents);
     if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
     pending.finish({ ok: false, error: "no-bounds" });
     return;
   }
 
-  const hit = await runElementHitTest(s.view.webContents, x, y, hostBoundsForHitTest(s));
+  const hit = await runElementHitTest(webContents, x, y, hostBoundsForHitTest(s, webContents));
   if (!hit || !hit.ok) {
-    await removeEpPickHighlighter(s.view.webContents);
+    await removeEpPickHighlighter(webContents);
     if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
     pending.finish({ ok: false, error: "no-hit" });
     return;
@@ -1327,15 +1347,15 @@ async function finishElementPickCapture(
 
   const r = clampRectInPlace(hit.bounds, lb.width, lb.height);
   if (r.width < 4 || r.height < 4) {
-    await removeEpPickHighlighter(s.view.webContents);
+    await removeEpPickHighlighter(webContents);
     if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
     pending.finish({ ok: false, error: "region-too-small" });
     return;
   }
 
   try {
-    await removeEpPickHighlighter(s.view.webContents);
-    const image = await s.view.webContents.capturePage(r);
+    await removeEpPickHighlighter(webContents);
+    const image = await webContents.capturePage(r);
     const buffer = image.toPNG();
     if (buffer.length === 0) {
       if (!pending.hostWin.isDestroyed()) resetIdle(pending.hostWin, s);
@@ -1344,7 +1364,7 @@ async function finishElementPickCapture(
     }
 
     const id = randomUUID();
-    const stem = previewCaptureFileStem(s.view.webContents.getURL());
+    const stem = previewCaptureFileStem(webContents.getURL());
     const name = `preview-element-${stem}-${Date.now()}.png`;
     const tempDir = join(app.getPath("temp"), "mcode-attachments");
     await mkdir(tempDir, { recursive: true });
@@ -1360,7 +1380,7 @@ async function finishElementPickCapture(
     };
 
     const capture = await buildBrowserCapturePayload(
-      s.view.webContents,
+      webContents,
       r,
       s.consoleBuffer,
       snapshotFailedRequestsForCapture(s),

--- a/apps/desktop/src/main/preview/preview-session.ts
+++ b/apps/desktop/src/main/preview/preview-session.ts
@@ -3,7 +3,7 @@
  * All other preview modules import from here rather than maintaining their own state.
  */
 
-import { BrowserWindow, WebContentsView } from "electron";
+import { BrowserWindow, WebContentsView, type WebContents } from "electron";
 import { randomUUID } from "node:crypto";
 import type {
   AttachmentMeta,
@@ -91,7 +91,12 @@ export interface PreviewSession {
    */
   selectionOverlay: BrowserWindow | null;
   overlayPending:
-    | { mode: "region" | "element"; finish: (r: CaptureFinishResult) => void; hostWin: BrowserWindow }
+    | {
+        mode: "region" | "element";
+        finish: (r: CaptureFinishResult) => void;
+        hostWin: BrowserWindow;
+        webContents: WebContents;
+      }
     | null;
   /**
    * Active element-pick poll handle. The pick runs entirely inside the guest

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -340,6 +340,11 @@ test.describe("PreviewPanel — loaded header", () => {
     await expect(page.getByLabel("More browser tools")).toBeVisible();
   });
 
+  test("rail and header stay borderless at the rounded panel corner", async ({ page }) => {
+    await expect(page.getByTestId("activity-rail")).not.toHaveClass(/border-r/);
+    await expect(page.getByTestId("browser-header")).not.toHaveClass(/border-b/);
+  });
+
   test("loaded bar shows the page title centered in the URL field", async ({ page }) => {
     await expect(page.getByLabel("Preview URL")).toHaveValue("Example");
   });

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -353,6 +353,26 @@ test.describe("PreviewPanel — loaded header", () => {
     expect(railBackground).toBe(headerBackground);
   });
 
+  test("chat and right panel meet at the draggable split line", async ({ page }) => {
+    const main = page.locator("main").first();
+    const panel = page.getByTestId("right-panel");
+    const separator = page.getByRole("separator", { name: "Resize panel" });
+
+    const [mainBox, panelBox] = await Promise.all([
+      main.boundingBox(),
+      panel.boundingBox(),
+    ]);
+    expect(mainBox).not.toBeNull();
+    expect(panelBox).not.toBeNull();
+    expect(Math.abs(mainBox!.x + mainBox!.width - panelBox!.x)).toBeLessThanOrEqual(1);
+
+    await expect(separator).toBeVisible();
+    const lineBackground = await separator.locator("span").evaluate((el) =>
+      getComputedStyle(el).backgroundColor,
+    );
+    expect(lineBackground).not.toBe("rgba(0, 0, 0, 0)");
+  });
+
   test("loaded bar shows the page title centered in the URL field", async ({ page }) => {
     await expect(page.getByLabel("Preview URL")).toHaveValue("Example");
   });

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -364,6 +364,9 @@ test.describe("PreviewPanel — loaded header", () => {
     await page.getByLabel("More browser tools").click();
     const menu = page.getByTestId("browser-overflow-menu");
     await expect(menu).toBeVisible();
+    await expect(menu).toHaveClass(/pointer-events-auto/);
+    await expect(menu.locator("..")).toHaveClass(/pointer-events-none/);
+    await expect(page.locator("[data-base-ui-inert][role='presentation']")).toHaveCount(0);
     await expect(menu.getByText("New page")).toBeVisible();
     await expect(menu.getByText("Force reload")).toBeVisible();
     await expect(menu.getByText("Dump page content")).toBeVisible();

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -341,8 +341,16 @@ test.describe("PreviewPanel — loaded header", () => {
   });
 
   test("rail and header stay borderless at the rounded panel corner", async ({ page }) => {
-    await expect(page.getByTestId("activity-rail")).not.toHaveClass(/border-r/);
-    await expect(page.getByTestId("browser-header")).not.toHaveClass(/border-b/);
+    const rail = page.getByTestId("activity-rail");
+    const header = page.getByTestId("browser-header");
+    await expect(rail).not.toHaveClass(/border-r/);
+    await expect(header).not.toHaveClass(/border-b/);
+
+    const [railBackground, headerBackground] = await Promise.all([
+      rail.evaluate((el) => getComputedStyle(el).backgroundColor),
+      header.evaluate((el) => getComputedStyle(el).backgroundColor),
+    ]);
+    expect(railBackground).toBe(headerBackground);
   });
 
   test("loaded bar shows the page title centered in the URL field", async ({ page }) => {

--- a/apps/web/e2e/ui-improvements-floating.spec.ts
+++ b/apps/web/e2e/ui-improvements-floating.spec.ts
@@ -2,11 +2,10 @@ import { test, expect, type Page } from "@playwright/test";
 import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
 
 /**
- * E2E coverage for the floating-panel UI overhaul:
+ * E2E coverage for the shell UI:
  *  1. Composer overflow popover (replaces inline Mode/Permissions/Tasks toggles).
  *  2. Right panel modal overlay at narrow viewports (<768px).
- *  3. Floating panel surfaces (page chrome darker than panel background, no
- *     inter-panel border lines).
+ *  3. Docked shell surfaces with dividers instead of visible gaps.
  */
 
 const now = new Date().toISOString();
@@ -143,12 +142,12 @@ test.describe("Composer options — narrow viewport (below md)", () => {
   });
 });
 
-test.describe("Floating panel surfaces", () => {
+test.describe("Docked shell surfaces", () => {
   test.beforeEach(async ({ page }) => {
     await mockWebSocketServer(page);
   });
 
-  test("page chrome uses --page token (darker than --background)", async ({ page }) => {
+  test("page chrome keeps a separate --page token", async ({ page }) => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
@@ -164,31 +163,49 @@ test.describe("Floating panel surfaces", () => {
     expect(tokens.page).not.toBe("");
     expect(tokens.background).not.toBe("");
 
-    // They must differ — page chrome is intentionally tone-shifted from panel bg.
+    // They must differ so the project tree can use chrome tone beside content.
     expect(tokens.page).not.toBe(tokens.background);
   });
 
-  test("main content panel uses rounded corners (no inter-panel border)", async ({ page }) => {
+  test("main content joins the shell without rounded internal corners", async ({ page }) => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
     const main = page.locator("main").first();
     const radius = await main.evaluate((el) => getComputedStyle(el).borderRadius);
-    // Tailwind rounded-lg compiles to non-zero radius.
-    expect(radius).not.toBe("0px");
-    expect(radius).not.toBe("");
+    expect(radius).toBe("0px");
   });
 
-  test("no inter-panel border on Sidebar (right edge)", async ({ page }) => {
+  test("sidebar uses page tone and touches the main content with a divider", async ({ page }) => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    // The sidebar's container shouldn't carry a right border anymore.
-    const sidebarRoot = page.locator(".bg-sidebar").first();
-    const rightBorder = await sidebarRoot.evaluate((el) =>
+    const sidebar = page.getByTestId("sidebar-docked");
+    const main = page.locator("main").first();
+    const metrics = await page.evaluate(() => {
+      const probe = document.createElement("div");
+      probe.className = "bg-page";
+      document.body.append(probe);
+      const pageBackground = getComputedStyle(probe).backgroundColor;
+      probe.remove();
+      return { pageBackground };
+    });
+    const sidebarBackground = await sidebar.evaluate((el) =>
+      getComputedStyle(el).backgroundColor,
+    );
+    const rightBorder = await sidebar.evaluate((el) =>
       getComputedStyle(el).borderRightWidth,
     );
-    expect(rightBorder).toBe("0px");
+    const [sidebarBox, mainBox] = await Promise.all([
+      sidebar.boundingBox(),
+      main.boundingBox(),
+    ]);
+
+    expect(sidebarBackground).toBe(metrics.pageBackground);
+    expect(rightBorder).toBe("1px");
+    expect(sidebarBox).not.toBeNull();
+    expect(mainBox).not.toBeNull();
+    expect(Math.abs(sidebarBox!.x + sidebarBox!.width - mainBox!.x)).toBeLessThanOrEqual(1);
   });
 });
 
@@ -220,19 +237,19 @@ test.describe("Right panel modal overlay (narrow viewport)", () => {
   });
 });
 
-test.describe("Visual regression — floating layout", () => {
+test.describe("Visual regression — docked layout", () => {
   test.beforeEach(async ({ page }) => {
     await mockWebSocketServer(page);
     // Must be called before page.goto so zustand.js is intercepted on load.
     await interceptZustandStores(page);
   });
 
-  test("captures wide-viewport screenshot (1280×800) showing floating panels", async ({ page }, testInfo) => {
+  test("captures wide-viewport screenshot (1280×800) showing docked panels", async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("/");
     await page.waitForLoadState("networkidle");
     await page.screenshot({
-      path: testInfo.outputPath("floating-wide.png"),
+      path: testInfo.outputPath("docked-wide.png"),
       fullPage: false,
     });
   });
@@ -242,7 +259,7 @@ test.describe("Visual regression — floating layout", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
     await page.screenshot({
-      path: testInfo.outputPath("floating-narrow.png"),
+      path: testInfo.outputPath("docked-narrow.png"),
       fullPage: false,
     });
   });

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -329,7 +329,7 @@ describe("diffStore", () => {
   });
 
   describe("maxPanelWidthInSplit", () => {
-    it("reserves composer min width and split gap from the row width", () => {
+    it("reserves composer min width from the row width", () => {
       const split = 1200;
       expect(maxPanelWidthInSplit(split)).toBe(
         split - COMPOSER_MIN_WIDTH - PANEL_SPLIT_GAP_PX,

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -323,18 +323,15 @@ export function App() {
   return (
     <TerminalPoolSlotProvider>
     <TooltipProvider delay={400}>
-      {/* Floating-panel layout: page chrome is a darker tone (--page) with small
-          gaps between panels. Each panel renders as a rounded surface that
-          appears lifted off the chrome — no inter-panel divider lines required. */}
       <div className="flex h-screen flex-col overflow-hidden bg-page text-foreground">
         <ConnectionBanner />
-        <div ref={outerRowRef} className="flex flex-1 gap-1.5 overflow-hidden p-1.5">
+        <div ref={outerRowRef} className="flex flex-1 overflow-hidden">
           {/* Docked project tree: hidden when collapsed, force-shown in settings,
               or shown as a float (see below). Maximize hides only the chat pane. */}
           {(!sidebarCollapsed || settingsOpen) && !sidebarFloating && (
             <div
               data-testid="sidebar-docked"
-              className="flex shrink-0 overflow-hidden rounded-lg shadow-sm"
+              className="flex shrink-0 overflow-hidden border-r border-border/45 bg-page"
             >
               <Sidebar
                 settingsOpen={settingsOpen}
@@ -370,12 +367,12 @@ export function App() {
           <div
             ref={contentRowRef}
             data-testid="content-row"
-            className="flex min-w-0 flex-1 gap-1.5 overflow-hidden"
+            className="flex min-w-0 flex-1 overflow-hidden"
           >
             {/* Chat / settings / landing: hidden when the right panel is maximized. */}
             {!rightPanelMaximized && (
             <main
-              className="flex-1 overflow-hidden rounded-lg bg-background shadow-sm"
+              className="flex-1 overflow-hidden bg-background"
               style={{ minWidth: COMPOSER_MIN_WIDTH }}
             >
               {settingsOpen ? (

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -450,7 +450,7 @@ export function ActivityRail({
   return (
     <div
       data-testid="activity-rail"
-      className="flex w-12 flex-none flex-col items-center gap-1 border-r border-border/40 py-2"
+      className="flex w-12 flex-none flex-col items-center gap-1 bg-foreground/[0.025] py-2"
     >
       {/* Maximize / restore sits at the rail head (not the foot) so it stays in
           the first tab stop and never scrolls off-screen on short viewports. */}

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -450,7 +450,7 @@ export function ActivityRail({
   return (
     <div
       data-testid="activity-rail"
-      className="flex w-12 flex-none flex-col items-center gap-1 bg-foreground/[0.025] py-2"
+      className="flex w-12 flex-none flex-col items-center gap-1 bg-background py-2"
     >
       {/* Maximize / restore sits at the rail head (not the foot) so it stays in
           the first tab stop and never scrolls off-screen on short viewports. */}

--- a/apps/web/src/components/panels/BrowserHeader.tsx
+++ b/apps/web/src/components/panels/BrowserHeader.tsx
@@ -154,7 +154,7 @@ export function BrowserHeader({
   return (
     <div
       data-testid="browser-header"
-      className="flex h-10 flex-none items-center gap-1 border-b border-border/60 px-2"
+      className="flex h-10 flex-none items-center gap-1 bg-background px-2"
     >
       <Tooltip>
         <TooltipTrigger

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -75,6 +75,11 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
     forceHidden: showWebviewPreview,
   });
   const [webviewSrc, setWebviewSrc] = useState<string | null>(null);
+  const webviewSrcRef = useRef<string | null>(null);
+  const setTrackedWebviewSrc = useCallback((nextSrc: string | null): void => {
+    webviewSrcRef.current = nextSrc;
+    setWebviewSrc(nextSrc);
+  }, []);
   const [webviewNavError, setWebviewNavError] = useState<string | null>(null);
   const [webviewCanBack, setWebviewCanBack] = useState(false);
   const [webviewCanFwd, setWebviewCanFwd] = useState(false);
@@ -122,15 +127,21 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
     tabs.tabSet?.activeTabId ?? PREVIEW_WEBVIEW_FALLBACK_TAB_ID;
 
   useEffect(() => {
+    webviewSrcRef.current = webviewSrc;
+  }, [webviewSrc]);
+
+  useEffect(() => {
     if (!showWebviewPreview) return;
     const stored = bridge.storedUrl.trim();
     if (!stored) {
-      setWebviewSrc(null);
+      setTrackedWebviewSrc(null);
       setWebviewPageStatus({ url: null, title: null, favicon: null, phase: "loaded" });
       return;
     }
-    setWebviewSrc(stored);
-  }, [bridge.storedUrl, showWebviewPreview, threadId]);
+    if (webviewRef.current?.getUrl() === stored) return;
+    if (webviewSrcRef.current === stored) return;
+    setTrackedWebviewSrc(stored);
+  }, [bridge.storedUrl, setTrackedWebviewSrc, showWebviewPreview, threadId]);
 
   const onWebviewPageStatus = useCallback((status: PreviewPageStatus): void => {
     setWebviewPageStatus(status);
@@ -150,17 +161,26 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
           return;
         }
         useDiffStore.getState().setPreviewUrlForThread(threadId, result.url);
-        setWebviewSrc(result.url);
         setWebviewPageStatus({
           url: result.url,
           title: null,
           favicon: null,
           phase: "loading",
         });
-        webviewRef.current?.navigate(result.url);
+        const liveUrl = webviewRef.current?.getUrl();
+        const mountedSrc = webviewSrcRef.current;
+        if (liveUrl === result.url) {
+          webviewRef.current?.reload();
+          return;
+        }
+        if (mountedSrc === result.url) {
+          webviewRef.current?.navigate(result.url);
+          return;
+        }
+        setTrackedWebviewSrc(result.url);
       });
     },
-    [bridge, threadId],
+    [bridge, setTrackedWebviewSrc, threadId],
   );
 
   const onWebviewOpenExternal = useCallback((): void => {

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -78,6 +78,12 @@ function realUrl(url: string | null | undefined): string | null {
   return url;
 }
 
+function isExpectedNavigationAbort(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { code?: unknown; errno?: unknown };
+  return candidate.code === "ERR_ABORTED" || candidate.errno === -3;
+}
+
 export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewProps>(
   function PreviewWebview(
     {
@@ -136,7 +142,21 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         const el = ref.current;
         if (!el) return;
         if (el.loadURL) {
-          void el.loadURL(url);
+          void el.loadURL(url).catch((error: unknown) => {
+            if (isExpectedNavigationAbort(error)) return;
+            onPageStatus?.({
+              url: realUrl(url),
+              title: null,
+              favicon: null,
+              phase: "error",
+              error: {
+                kind: "network",
+                code: "ERR_FAILED",
+                message: "Navigation failed.",
+              },
+            });
+            emitNavigationState();
+          });
         } else {
           el.src = url;
         }
@@ -175,7 +195,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         return (await Promise.resolve(ref.current?.getZoomFactor?.())) ?? factor;
       },
     }),
-    [readUrl],
+    [emitNavigationState, onPageStatus, readUrl],
   );
 
   useEffect(() => {

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -298,7 +298,7 @@ export function RightPanel() {
             }
       }
       className={cn(
-        "relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-lg bg-background shadow-sm focus:outline-none",
+        "relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background focus:outline-none",
         "transition-[width,min-width,max-width,opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
         !panelVisible && "pointer-events-none translate-x-2 opacity-0",
         panelVisible && "translate-x-0 opacity-100",
@@ -323,7 +323,7 @@ export function RightPanel() {
         aria-orientation="vertical"
         aria-label="Resize panel"
         tabIndex={0}
-        className="group absolute inset-y-0 left-0 z-20 flex w-3 cursor-col-resize items-stretch justify-center focus:outline-none"
+        className="group absolute inset-y-0 left-0 z-20 flex w-2 cursor-col-resize items-stretch justify-start focus:outline-none"
         onMouseDown={onDragStart}
         onDoubleClick={() => {
           const maxWidth = getMaxPanelWidth();
@@ -347,14 +347,11 @@ export function RightPanel() {
           }
         }}
       >
-        {/* Grip: transparent at rest (the panel's radius and shadow already
-            separate it from the chat — a resting hairline is redundant and
-            reads as a stray line). It brightens on hover, focus, and active
-            drag. Inset vertically (my-2.5) so it clears the panel's rounded
-            corners instead of being clipped by overflow-hidden. */}
+        {/* The split line is the resize affordance; keep it visible so the
+            docked panes separate by line, not by gap. */}
         <span
           aria-hidden
-          className="pointer-events-none my-2.5 w-px shrink-0 rounded-full bg-transparent transition-colors group-hover:bg-border group-focus-visible:w-0.5 group-focus-visible:bg-ring group-active:w-0.5 group-active:bg-muted-foreground/60"
+          className="pointer-events-none w-px shrink-0 bg-border/45 transition-colors group-hover:bg-border group-focus-visible:w-0.5 group-focus-visible:bg-ring group-active:w-0.5 group-active:bg-muted-foreground/60"
         />
       </div>
       )}

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -5,7 +5,7 @@
  * 1. Unavailable state - when desktopBridge.preview is absent.
  * 2. Full panel state - when desktopBridge.preview is present (hooks mocked).
  */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { getDefaultSettings } from "@mcode/contracts";
 
@@ -80,6 +80,72 @@ function mockBridgeState(overrides: Record<string, unknown> = {}) {
     onSetZoom: vi.fn().mockResolvedValue(1),
   };
   return { ...state, ...overrides };
+}
+
+function installMockWebviewMethods(options: {
+  readonly loadURL?: (url: string) => Promise<void>;
+  readonly getURL?: () => string;
+  readonly getWebContentsId?: () => number;
+  readonly reload?: () => void;
+}): () => void {
+  const proto = HTMLElement.prototype as HTMLElement & {
+    loadURL?: (url: string) => Promise<void>;
+    getURL?: () => string;
+    getWebContentsId?: () => number;
+    reload?: () => void;
+  };
+  const loadURLDescriptor = Object.getOwnPropertyDescriptor(proto, "loadURL");
+  const getURLDescriptor = Object.getOwnPropertyDescriptor(proto, "getURL");
+  const getWebContentsIdDescriptor = Object.getOwnPropertyDescriptor(
+    proto,
+    "getWebContentsId",
+  );
+  const reloadDescriptor = Object.getOwnPropertyDescriptor(proto, "reload");
+  if (options.loadURL) {
+    Object.defineProperty(proto, "loadURL", {
+      configurable: true,
+      value: options.loadURL,
+    });
+  }
+  if (options.getURL) {
+    Object.defineProperty(proto, "getURL", {
+      configurable: true,
+      value: options.getURL,
+    });
+  }
+  Object.defineProperty(proto, "getWebContentsId", {
+    configurable: true,
+    value: options.getWebContentsId ?? (() => 1),
+  });
+  if (options.reload) {
+    Object.defineProperty(proto, "reload", {
+      configurable: true,
+      value: options.reload,
+    });
+  }
+
+  return () => {
+    if (loadURLDescriptor) {
+      Object.defineProperty(proto, "loadURL", loadURLDescriptor);
+    } else {
+      delete proto.loadURL;
+    }
+    if (getURLDescriptor) {
+      Object.defineProperty(proto, "getURL", getURLDescriptor);
+    } else {
+      delete proto.getURL;
+    }
+    if (getWebContentsIdDescriptor) {
+      Object.defineProperty(proto, "getWebContentsId", getWebContentsIdDescriptor);
+    } else {
+      delete proto.getWebContentsId;
+    }
+    if (reloadDescriptor) {
+      Object.defineProperty(proto, "reload", reloadDescriptor);
+    } else {
+      delete proto.reload;
+    }
+  };
 }
 
 describe("PreviewPanel — unavailable state", () => {
@@ -266,6 +332,136 @@ describe("PreviewPanel — full panel state", () => {
     expect(mockUsePreviewBridge).toHaveBeenLastCalledWith(
       expect.objectContaining({ forceHidden: true }),
     );
+  });
+
+  it("navigates changed webview URLs through src without an extra loadURL call", async () => {
+    useSettingsStore.getState()._applyPush({
+      ...getDefaultSettings(),
+      preview: {
+        ...getDefaultSettings().preview,
+        rendering: { engine: "webview" },
+      },
+    });
+    const resolveNavigation = vi
+      .fn()
+      .mockResolvedValue({ ok: true, url: "https://about.google/" });
+    mockUsePreviewBridge.mockReturnValue(
+      mockBridgeState({
+        storedUrl: "https://google.com/",
+        resolveNavigation,
+      }),
+    );
+
+    const loadURL = vi.fn().mockResolvedValue(undefined);
+    const restoreWebviewMethods = installMockWebviewMethods({
+      loadURL,
+      getURL: () => "https://google.com/",
+    });
+
+    try {
+      render(<PreviewPanel threadId="thread-1" />);
+
+      const input = screen.getByLabelText("Preview URL");
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "https://about.google/" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(resolveNavigation).toHaveBeenCalledWith("https://about.google/");
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("preview-webview")).toHaveAttribute(
+          "src",
+          "https://about.google/",
+        );
+      });
+      expect(loadURL).not.toHaveBeenCalled();
+    } finally {
+      restoreWebviewMethods();
+    }
+  });
+
+  it("does not rewrite src when stored URL already matches the live webview URL", async () => {
+    useSettingsStore.getState()._applyPush({
+      ...getDefaultSettings(),
+      preview: {
+        ...getDefaultSettings().preview,
+        rendering: { engine: "webview" },
+      },
+    });
+    let liveUrl = "https://google.com/";
+    const restoreWebviewMethods = installMockWebviewMethods({
+      getURL: () => liveUrl,
+    });
+
+    try {
+      mockUsePreviewBridge.mockReturnValue(
+        mockBridgeState({ storedUrl: "https://google.com/" }),
+      );
+      const { rerender } = render(<PreviewPanel threadId="thread-1" />);
+      const webview = screen.getByTestId("preview-webview");
+      expect(webview).toHaveAttribute("src", "https://google.com/");
+
+      liveUrl = "https://about.google/";
+      mockUsePreviewBridge.mockReturnValue(
+        mockBridgeState({ storedUrl: "https://about.google/" }),
+      );
+      rerender(<PreviewPanel threadId="thread-1" />);
+      await waitFor(() => {
+        expect(screen.getByTestId("preview-webview")).toHaveAttribute(
+          "src",
+          "https://google.com/",
+        );
+      });
+    } finally {
+      restoreWebviewMethods();
+    }
+  });
+
+  it("reloads instead of loadURL when navigating to the live webview URL", async () => {
+    useSettingsStore.getState()._applyPush({
+      ...getDefaultSettings(),
+      preview: {
+        ...getDefaultSettings().preview,
+        rendering: { engine: "webview" },
+      },
+    });
+    const resolveNavigation = vi
+      .fn()
+      .mockResolvedValue({ ok: true, url: "https://google.com/" });
+    mockUsePreviewBridge.mockReturnValue(
+      mockBridgeState({
+        storedUrl: "https://google.com/",
+        resolveNavigation,
+      }),
+    );
+
+    const loadURL = vi.fn().mockResolvedValue(undefined);
+    const reload = vi.fn();
+    const restoreWebviewMethods = installMockWebviewMethods({
+      loadURL,
+      reload,
+      getURL: () => "https://google.com/",
+    });
+
+    try {
+      render(<PreviewPanel threadId="thread-1" />);
+
+      const input = screen.getByLabelText("Preview URL");
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "https://google.com/" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(resolveNavigation).toHaveBeenCalledWith("https://google.com/");
+      });
+      await waitFor(() => {
+        expect(reload).toHaveBeenCalledTimes(1);
+      });
+      expect(loadURL).not.toHaveBeenCalled();
+    } finally {
+      restoreWebviewMethods();
+    }
   });
 
   it("keeps the live webview mounted while the overflow menu is open", async () => {

--- a/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
+++ b/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
@@ -212,7 +212,7 @@ describe("usePreviewBridge", () => {
     ).toBe(true);
   });
 
-  it("hides the native BrowserView during overlays without a freeze-frame", async () => {
+  it("hides the native BrowserView during overlays while preserving panel bounds", async () => {
     const mockPreview = makeMockPreview();
     window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
 
@@ -234,7 +234,7 @@ describe("usePreviewBridge", () => {
     expect(mockPreview.sync).toHaveBeenCalledWith(
       expect.objectContaining({
         visible: false,
-        bounds: null,
+        bounds: { x: 10, y: 20, width: 800, height: 600 },
         threadId: "t-1",
       }),
     );

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -168,7 +168,7 @@ export function usePreviewBridge({
       const suppressed = !forceHidden && usePreviewSuppressionStore.getState().count > 0;
       const effectiveVisible =
         visible && !forceHidden && !suppressed && phaseRef.current !== "error";
-      if (!effectiveVisible || !el) {
+      if (!el) {
         await preview.sync({
           visible: false,
           bounds: null,
@@ -179,14 +179,25 @@ export function usePreviewBridge({
         return;
       }
       const r = el.getBoundingClientRect();
+      const bounds = {
+        x: Math.round(r.left),
+        y: Math.round(r.top),
+        width: Math.round(r.width),
+        height: Math.round(r.height),
+      };
+      if (!effectiveVisible) {
+        await preview.sync({
+          visible: false,
+          bounds,
+          threadId,
+          resumeUrlHint: hint,
+          workspaceId: workspaceId ?? null,
+        });
+        return;
+      }
       await preview.sync({
         visible: true,
-        bounds: {
-          x: Math.round(r.left),
-          y: Math.round(r.top),
-          width: Math.round(r.width),
-          height: Math.round(r.height),
-        },
+        bounds,
         threadId,
         resumeUrlHint: hint,
         workspaceId: workspaceId ?? null,

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1128,6 +1128,12 @@ function VirtualizedThreadList({
     }
   }, [inlineEdit, onSelectThread, onStartInlineEdit]);
 
+  const handleThreadDoubleClick = useCallback((threadId: string, title: string) => {
+    if (inlineEdit?.threadId === threadId) return;
+    lastClickTimeRef.current.delete(threadId);
+    onStartInlineEdit(threadId, title);
+  }, [inlineEdit, onStartInlineEdit]);
+
   // Recompute offset from the outer scroll viewport after each layout pass.
   // Stays in sync when workspaces above expand/collapse.
   useLayoutEffect(() => {
@@ -1212,6 +1218,7 @@ function VirtualizedThreadList({
                   }
                 }}
                 onClick={() => handleThreadClick(thread.id, thread.title)}
+                onDoubleClick={() => handleThreadDoubleClick(thread.id, thread.title)}
                 onContextMenu={(e) => onThreadContextMenu(e, thread)}
                 onMouseEnter={() => {
                   if (!thread.clientPreparing && !thread.clientError) {

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -41,7 +41,7 @@ export function Sidebar({
   };
 
   return (
-    <div className="flex h-full w-72 max-w-[55vw] flex-col bg-sidebar md:max-w-none">
+    <div className="flex h-full w-72 max-w-[55vw] flex-col bg-page md:max-w-none">
       {/* Header */}
       <div className="flex h-11 items-center justify-between border-b border-border/40 pl-2 pr-2.5">
         {settingsOpen ? (

--- a/apps/web/src/components/ui/__tests__/overlay-pointer-events.test.tsx
+++ b/apps/web/src/components/ui/__tests__/overlay-pointer-events.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "../popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../select";
+
+function getFixedInertBackdrops() {
+  return Array.from(document.querySelectorAll<HTMLElement>("[data-base-ui-inert][role='presentation']")).filter(
+    (element) => element.style.position === "fixed" && element.style.inset === "0px",
+  );
+}
+
+describe("overlay pointer event boundaries", () => {
+  it("keeps dropdown positioners pointer-transparent while content remains interactive", async () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger render={<button type="button">Open</button>} />
+        <DropdownMenuContent data-testid="dropdown-content">
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    const content = await screen.findByTestId("dropdown-content");
+    expect(content.parentElement).toHaveClass("pointer-events-none");
+    expect(content).toHaveClass("pointer-events-auto");
+  });
+
+  it("keeps dropdown menus from rendering an inert outside backdrop by default", async () => {
+    render(
+      <>
+        <button type="button">Outside target</button>
+        <DropdownMenu open>
+          <DropdownMenuTrigger render={<button type="button">Open</button>} />
+          <DropdownMenuContent data-testid="dropdown-content">
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </>,
+    );
+
+    await screen.findByTestId("dropdown-content");
+    expect(getFixedInertBackdrops()).toHaveLength(0);
+  });
+
+  it("keeps popover positioners pointer-transparent while content remains interactive", async () => {
+    render(
+      <Popover open>
+        <PopoverTrigger render={<button type="button">Open</button>} />
+        <PopoverContent data-testid="popover-content">Content</PopoverContent>
+      </Popover>,
+    );
+
+    const content = await screen.findByTestId("popover-content");
+    expect(content.parentElement).toHaveClass("pointer-events-none");
+    expect(content).toHaveClass("pointer-events-auto");
+  });
+
+  it("keeps select popups from rendering an inert outside backdrop by default", async () => {
+    render(
+      <>
+        <button type="button">Outside target</button>
+        <Select open defaultValue="one">
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent data-testid="select-content">
+            <SelectItem value="one">One</SelectItem>
+          </SelectContent>
+        </Select>
+      </>,
+    );
+
+    await screen.findByTestId("select-content");
+    expect(getFixedInertBackdrops()).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -6,8 +6,11 @@ import { CheckIcon, ChevronRightIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
-  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+/**
+ * Dropdown menu root that allows pointer interaction outside the popup by default.
+ */
+function DropdownMenu({ modal = false, ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" modal={modal} {...props} />
 }
 
 function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
@@ -23,11 +26,15 @@ function DropdownMenuContent({
   Pick<MenuPrimitive.Positioner.Props, "align" | "sideOffset">) {
   return (
     <MenuPrimitive.Portal>
-      <MenuPrimitive.Positioner sideOffset={sideOffset} align={align} className="isolate z-50">
+      <MenuPrimitive.Positioner
+        sideOffset={sideOffset}
+        align={align}
+        className="pointer-events-none isolate z-50"
+      >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            "min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md",
+            "pointer-events-auto min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md",
             className,
           )}
           {...props}
@@ -133,11 +140,11 @@ function DropdownMenuSubTrigger({
 function DropdownMenuSubContent({ className, ...props }: MenuPrimitive.Popup.Props) {
   return (
     <MenuPrimitive.Portal>
-      <MenuPrimitive.Positioner className="isolate z-50">
+      <MenuPrimitive.Positioner className="pointer-events-none isolate z-50">
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-sub-content"
           className={cn(
-            "min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-lg",
+            "pointer-events-auto min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-lg",
             className,
           )}
           {...props}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -33,12 +33,12 @@ function PopoverContent({
         alignOffset={alignOffset}
         collisionPadding={collisionPadding}
         side={side}
-        className="isolate z-50"
+        className="pointer-events-none isolate z-50"
       >
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "w-72 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+            "pointer-events-auto w-72 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none",
             className,
           )}
           {...props}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -6,7 +6,15 @@ import { Select as SelectPrimitive } from "@base-ui/react/select"
 import { cn } from "@/lib/utils"
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
 
-const Select = SelectPrimitive.Root
+/**
+ * Select root that allows pointer interaction outside the popup by default.
+ */
+function Select<Value, Multiple extends boolean | undefined = false>({
+  modal = false,
+  ...props
+}: SelectPrimitive.Root.Props<Value, Multiple>) {
+  return <SelectPrimitive.Root modal={modal} {...props} />
+}
 
 function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
   return (
@@ -78,12 +86,12 @@ function SelectContent({
         align={align}
         alignOffset={alignOffset}
         alignItemWithTrigger={alignItemWithTrigger}
-        className="isolate z-50"
+        className="pointer-events-none isolate z-50"
       >
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn("pointer-events-auto relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         >
           <SelectScrollUpButton />

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -43,12 +43,12 @@ function TooltipContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
-        className="isolate z-50"
+        className="pointer-events-none isolate z-50"
       >
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "pointer-events-none z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             className
           )}
           {...props}

--- a/apps/web/src/lib/__tests__/composer-layout.test.ts
+++ b/apps/web/src/lib/__tests__/composer-layout.test.ts
@@ -18,7 +18,7 @@ import {
 import { COMPOSER_MIN_WIDTH, PANEL_MIN_WIDTH, PANEL_SPLIT_GAP_PX } from "@/stores/diffStore";
 
 describe("composer-layout", () => {
-  it("computes side-by-side minimum from composer, gap, and panel width", () => {
+  it("computes side-by-side minimum from composer, divider, and panel width", () => {
     expect(minContentWidthForSideBySidePanel(440)).toBe(
       COMPOSER_MIN_WIDTH + PANEL_SPLIT_GAP_PX + 440,
     );
@@ -27,7 +27,7 @@ describe("composer-layout", () => {
     );
   });
 
-  it("computes inline sidebar minimum from content need and column gap", () => {
+  it("computes inline sidebar minimum from content need and column divider", () => {
     expect(minOuterWidthForInlineSidebar(COMPOSER_MIN_WIDTH)).toBe(
       COMPOSER_MIN_WIDTH + LAYOUT_COLUMN_GAP_PX + SIDEBAR_WIDTH_PX,
     );

--- a/apps/web/src/lib/composer-layout.ts
+++ b/apps/web/src/lib/composer-layout.ts
@@ -8,8 +8,8 @@ import { useLayoutStore } from "@/stores/layoutStore";
 /** Inline project-tree width (`Sidebar` uses Tailwind `w-72`). */
 export const SIDEBAR_WIDTH_PX = 288;
 
-/** Gap between the project tree and the chat/panel row in App.tsx (`gap-1.5`). */
-export const LAYOUT_COLUMN_GAP_PX = 6;
+/** Gap between the project tree and the chat/panel row in App.tsx. */
+export const LAYOUT_COLUMN_GAP_PX = 0;
 
 /** Live measurements from App layout refs; updated by {@link setLayoutMeasurements}. */
 let measuredContentRowWidth = 0;
@@ -28,13 +28,13 @@ export function setLayoutMeasurements(contentRowWidth: number, outerRowWidth: nu
 /** Width of the chat + right-panel split row, or a conservative fallback before mount. */
 export function getContentRowWidth(): number {
   if (measuredContentRowWidth > 0) return measuredContentRowWidth;
-  return Math.max(COMPOSER_MIN_WIDTH, window.innerWidth - SIDEBAR_WIDTH_PX - 24);
+  return Math.max(COMPOSER_MIN_WIDTH, window.innerWidth - SIDEBAR_WIDTH_PX);
 }
 
 /** Width of the row that may include an inline project tree, or a fallback before mount. */
 export function getOuterRowWidth(): number {
   if (measuredOuterRowWidth > 0) return measuredOuterRowWidth;
-  return window.innerWidth - 12;
+  return window.innerWidth;
 }
 
 /**

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -407,6 +407,36 @@ describe("ThreadHydrator", () => {
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
   });
 
+  it("reuses an in-flight background prefetch when the same thread becomes active", async () => {
+    let resolvePage!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePage = resolve;
+        }),
+    );
+
+    const background = hydrator.hydrate(THREAD_A, "background");
+    await vi.waitFor(() => {
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+    });
+
+    const active = hydrator.hydrate(THREAD_A, "active");
+    await Promise.resolve();
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+
+    resolvePage({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([background, active]);
+
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
+  });
+
   it("bumps load epoch on each hydrate so stale pagination is discarded", async () => {
     resetThreadStoreForTests({
       records: new Map<string, ThreadRecord>([

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -38,6 +38,7 @@ export const BACKGROUND_PREFETCH_LIMIT = 100;
 export class ThreadHydrator {
   private readonly auxiliaryHydrator: AuxiliaryHydrator;
   private readonly activeHydrates = new Map<string, Promise<void>>();
+  private readonly backgroundHydrates = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: ThreadHydratorDeps) {
     this.auxiliaryHydrator = new AuxiliaryHydrator({
@@ -77,6 +78,29 @@ export class ThreadHydrator {
   private async hydrateBackground(threadId: string): Promise<void> {
     if (hasCachedRecord(threadId)) return;
 
+    const active = this.activeHydrates.get(threadId);
+    if (active) {
+      await active;
+      return;
+    }
+
+    const inFlight = this.backgroundHydrates.get(threadId);
+    if (inFlight) {
+      await inFlight;
+      return;
+    }
+
+    const hydrate = this.fetchAndCacheBackground(threadId).finally(() => {
+      if (this.backgroundHydrates.get(threadId) === hydrate) {
+        this.backgroundHydrates.delete(threadId);
+      }
+    });
+    this.backgroundHydrates.set(threadId, hydrate);
+    await hydrate;
+  }
+
+  /** Cache-only fetch used by sidebar hover prefetches. */
+  private async fetchAndCacheBackground(threadId: string): Promise<void> {
     try {
       const workspaceThread = this.deps.getWorkspaceThread(threadId);
       const shouldFetchSnapshots = workspaceThread?.has_file_changes !== false;
@@ -117,13 +141,7 @@ export class ThreadHydrator {
 
     const cached = getCachedRecord(threadId);
     if (cached) {
-      this.restoreFromCache(threadId, cached);
-      void this.refreshThreadGoal(threadId);
-      this.auxiliaryHydrator.hydrate(threadId, {
-        freshnessTtlMs: HYDRATION_TTL_MS,
-        force: opts?.force,
-        commitFileChangesToStore: true,
-      });
+      this.restoreCachedActive(threadId, cached, opts);
       return;
     }
 
@@ -133,13 +151,54 @@ export class ThreadHydrator {
       return;
     }
 
-    const hydrate = this.fetchAndCommit(threadId, opts).finally(() => {
+    const hydrate = this.fetchActiveReusingBackground(threadId, opts).finally(() => {
       if (this.activeHydrates.get(threadId) === hydrate) {
         this.activeHydrates.delete(threadId);
       }
     });
     this.activeHydrates.set(threadId, hydrate);
     await hydrate;
+  }
+
+  /** Active-thread cache miss path, reusing hover prefetches when available. */
+  private async fetchActiveReusingBackground(
+    threadId: string,
+    opts?: ThreadHydratorOptions,
+  ): Promise<void> {
+    const background = this.backgroundHydrates.get(threadId);
+    if (background) {
+      this.prepareActiveLoad(threadId);
+      await background;
+
+      if (this.deps.getState().currentThreadId !== threadId) return;
+
+      const cached = getCachedRecord(threadId);
+      if (cached) {
+        this.restoreCachedActive(threadId, cached, opts, { bumpLoadEpoch: false });
+        return;
+      }
+
+      await this.fetchAndCommit(threadId, opts, { skipPrepare: true });
+      return;
+    }
+
+    await this.fetchAndCommit(threadId, opts);
+  }
+
+  /** Restore cached data to the active store and refresh auxiliary data. */
+  private restoreCachedActive(
+    threadId: string,
+    cached: ThreadRecord,
+    opts?: ThreadHydratorOptions,
+    restoreOpts?: { bumpLoadEpoch?: boolean },
+  ): void {
+    this.restoreFromCache(threadId, cached, restoreOpts);
+    void this.refreshThreadGoal(threadId);
+    this.auxiliaryHydrator.hydrate(threadId, {
+      freshnessTtlMs: HYDRATION_TTL_MS,
+      force: opts?.force,
+      commitFileChangesToStore: true,
+    });
   }
 
   /**
@@ -151,7 +210,11 @@ export class ThreadHydrator {
    * are typically stale relative to whatever the auxiliary writes settle to.
    * The auxiliary fanout that runs after restoration will refresh them anyway.
    */
-  private restoreFromCache(threadId: string, cached: ThreadRecord): void {
+  private restoreFromCache(
+    threadId: string,
+    cached: ThreadRecord,
+    opts?: { bumpLoadEpoch?: boolean },
+  ): void {
     this.deps.setState((state: ThreadHydratorWriteState) => {
       const current = getThreadRecord(state.records, threadId);
       // The cache snapshot predates in-flight narration, so for a running
@@ -174,7 +237,7 @@ export class ThreadHydrator {
           ...cached,
           error: null,
           loading: false,
-          loadEpoch: current.loadEpoch + 1,
+          loadEpoch: opts?.bumpLoadEpoch === false ? current.loadEpoch : current.loadEpoch + 1,
           isLoadingMore: false,
           lastHydratedAt: current.lastHydratedAt,
           permissions: current.permissions,
@@ -212,8 +275,8 @@ export class ThreadHydrator {
     }
   }
 
-  /** Cache-miss path: reset volatile state, fetch RPCs, commit, populate cache. */
-  private async fetchAndCommit(threadId: string, opts?: ThreadHydratorOptions): Promise<void> {
+  /** Prepare the live record for an active-thread load before the RPC settles. */
+  private prepareActiveLoad(threadId: string): void {
     const { getState, setState } = this.deps;
     const isRunning = getState().runningThreadIds.has(threadId);
 
@@ -244,24 +307,38 @@ export class ThreadHydrator {
           currentThreadId: threadId,
         };
       });
-    } else {
-      setState((state: ThreadHydratorWriteState) => {
-        const current = getThreadRecord(state.records, threadId);
-        return {
-          records: patchThreadRecord(state.records, threadId, {
-            loading: true,
-            error: null,
-            messages: [],
-            persistedToolCallCounts: {},
-            persistedFilesChanged: {},
-            latestTurnWithChanges: null,
-            isLoadingMore: false,
-            loadEpoch: current.loadEpoch + 1,
-            settings: this.deps.getWorkspaceThreadSettings(threadId),
-          }),
-          currentThreadId: threadId,
-        };
-      });
+      return;
+    }
+
+    setState((state: ThreadHydratorWriteState) => {
+      const current = getThreadRecord(state.records, threadId);
+      return {
+        records: patchThreadRecord(state.records, threadId, {
+          loading: true,
+          error: null,
+          messages: [],
+          persistedToolCallCounts: {},
+          persistedFilesChanged: {},
+          latestTurnWithChanges: null,
+          isLoadingMore: false,
+          loadEpoch: current.loadEpoch + 1,
+          settings: this.deps.getWorkspaceThreadSettings(threadId),
+        }),
+        currentThreadId: threadId,
+      };
+    });
+  }
+
+  /** Cache-miss path: reset volatile state, fetch RPCs, commit, populate cache. */
+  private async fetchAndCommit(
+    threadId: string,
+    opts?: ThreadHydratorOptions,
+    commitOpts?: { skipPrepare?: boolean },
+  ): Promise<void> {
+    const { getState, setState } = this.deps;
+
+    if (!commitOpts?.skipPrepare) {
+      this.prepareActiveLoad(threadId);
     }
 
     try {

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -32,8 +32,8 @@ export const PANEL_MIN_WIDTH = 384;
  * cannot swallow the project tree and still crush the composer to one column.
  */
 export const COMPOSER_MIN_WIDTH = 480;
-/** Gap between chat main and right panel in App.tsx (`gap-1.5`). */
-export const PANEL_SPLIT_GAP_PX = 6;
+/** Gap between chat main and right panel in App.tsx. The visible split is a draggable line. */
+export const PANEL_SPLIT_GAP_PX = 0;
 /**
  * The panel's default width — a fixed value, not a fraction of the viewport, so
  * the panel opens at the same size on every startup, on every view, regardless of

--- a/docs/design/browser-view-compositing.md
+++ b/docs/design/browser-view-compositing.md
@@ -35,6 +35,7 @@ Use a hidden JSON setting:
 - Values: `"webContentsView"`, `"webview"`
 - Default: `"webContentsView"`
 - The `"webview"` flag uses the renderer-hosted `<webview>` path in every build.
+- After webview reaches parity, keep `webContentsView` hidden for one release as rollback, then remove it.
 - Settings UI: no row until `<webview>` passes parity and cross-platform overlay proof
 - Rollback: set `"webContentsView"` or delete the key
 - Environment override: none for v1
@@ -46,7 +47,7 @@ This follows the settings guide's max depth: `preview.rendering.engine`.
 | Feature | Webview Migration Requirement |
 |---------|-------------------------------|
 | Browser chrome, omnibox, nav buttons, favicon, title | React remains owner. Page status feeds the same state. |
-| Overlay behavior | Native path hides the native view while overlays are open. Webview path proves overlays render above the guest without snapshot hiding. |
+| Overlay behavior | Native path hides the native view while overlays are open. Webview path uses normal React stacking. Non-modal overlays only intercept pointer events on visible content; modal backdrops may block the page. |
 | Empty state and localhost quick-open | Keep behavior. Navigation still enters through main-process validation. |
 | Navigation, history, reload, force reload, open external | Route commands to the active guest record. |
 | Tabs and page switcher | Host tab identity remains source of truth. Renderer owns warm webview lifetime under the flag. |
@@ -60,7 +61,7 @@ This follows the settings guide's max depth: `preview.rendering.engine`.
 | Design mode viewport and inspect | Inspect can keep `executeJavaScript`. Viewport sizing moves to renderer CSS. |
 | Crash recovery and cooldown | Adopted webview crash surfaces the same error state and cooldown behavior. |
 | `window.open`, popups, permissions | Deny popups or route allowed URLs externally. Deny permissions by default. |
-| Scrollbar CSS injection | Reapply for webview guests if the visual policy still matters. |
+| Scrollbar CSS injection | Keep the same fallback scrollbar policy in both hosts while the host switch exists. The fallback uses no `!important` rules, so page-authored scrollbar styles win. Remove native-path injection when `WebContentsView` is removed. |
 | Zoom, cookies, cache, guest DevTools | Route to active guest. DevTools remains disabled for webview until a dev-only policy is added. |
 | Perf counters and dev HUD | Keep counters meaningful for both engines, adding webview adoption and overlay counters if needed. |
 
@@ -166,6 +167,9 @@ Promote `PreviewWebview` from adoption helper to active flagged surface. It moun
 Acceptance:
 
 - Loaded page, empty state, error state, thread switch, last-tab close, and panel hide match native behavior.
+- Webview guests receive the same thin preview scrollbar fallback after attach and after document navigation, without `!important` rules.
+- Page-authored scrollbar styles take precedence over the preview fallback in both hosts.
+- Native-path scrollbar injection stays only while `WebContentsView` remains available.
 - Native path stays available in the same build.
 
 ### Slice 4: Navigation, Status, and Security Parity
@@ -208,6 +212,8 @@ After slice 0 and parity tests pass, rely on normal React stacking for webview. 
 Acceptance:
 
 - Webview path uses normal React overlay stacking.
+- Non-modal overlay positioners are pointer-transparent and do not render an inert outside backdrop, so uncovered webview pixels still receive hover and pointer events.
+- Modal overlays may block the page while open.
 - Native path detaches while overlays are open and does not render a snapshot.
 - Dialog and dropdown tests assert that no freeze-frame element is rendered.
 
@@ -257,7 +263,6 @@ A visible Settings row would invite normal users onto an incomplete engine.
 
 - Should inactive warm webview tabs stay mounted, or unmount before discard?
 - Should guest DevTools work for webview guests in dev builds?
-- Does scrollbar CSS injection still matter for renderer-hosted webviews?
 
 ## References
 


### PR DESCRIPTION
## What
Keep the hidden renderer-hosted webview preview interactive under ordinary app overlays, stop duplicate webview URL loads from surfacing benign Electron `ERR_ABORTED (-3)` noise, and dock the app shell panes without visible gaps.

## Why
The webview engine is the migration path for preview overlays. A changed URL was being loaded twice: once through React `src` and again through `loadURL()`. Google redirects made that show up as repeated `GUEST_VIEW_MANAGER_CALL` errors.

The app shell also had small page-chrome gaps and rounded internal pane corners between the project tree, chat view, and right panel. Those separators made the shell read as disconnected panels instead of one docked workspace.

## Key Changes
- Keep non-modal popup wrappers pointer-transparent so uncovered webview pixels still receive hover and pointer events.
- For changed webview URLs, update the mounted `src` and skip the extra `loadURL()` call.
- Treat same-live-URL submissions as reloads.
- Stop stored URL updates from rewriting `src` when the guest already reports that URL.
- Ignore expected `ERR_ABORTED` and `errno -3` rejections from imperative webview loads.
- Preserve the BrowserView default path.
- Match the browser activity rail color to the browser header.
- Dock the project tree, chat view, and right panel with no inter-pane gaps or internal rounded corners.
- Use a visible draggable hairline as the chat and right-panel separator.

## Verification
- `apps/web: bunx vitest run src/components/ui/__tests__/overlay-pointer-events.test.tsx`, 4 passed.
- `apps/web: bunx vitest run src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts`, 15 passed.
- `apps/web: bunx vitest run src/components/panels/__tests__/PreviewPanel.test.tsx`, 17 passed.
- `apps/web: bunx vitest run src/components/panels/__tests__/PreviewPanel.test.tsx src/components/panels/hooks/__tests__/usePreviewBridge.test.ts src/components/panels/hooks/__tests__/usePreviewCapture.test.ts src/stores/__tests__/previewTabsStore.test.ts src/stores/__tests__/previewSuppressionStore.test.ts`, 93 passed.
- `apps/desktop: bunx vitest run src/main/__tests__/preview-browser.test.ts src/main/__tests__/preview-webview-adopt.test.ts src/main/__tests__/browser-use-router.test.ts`, 82 passed.
- `packages/contracts: bun run test -- src/models/__tests__/settings.test.ts src/models/__tests__/browser-preview-clamp.test.ts`, 18 passed.
- `apps/web: bunx vitest run src/__tests__/diffStore.test.ts src/lib/__tests__/composer-layout.test.ts`, 85 passed.
- `apps/web: PLAYWRIGHT_BASE_URL=http://localhost:5174 bunx playwright test e2e/preview-chrome.spec.ts e2e/ui-improvements-floating.spec.ts e2e/responsive-shell-resize.spec.ts`, 29 passed.
- `apps/web: PLAYWRIGHT_BASE_URL=http://localhost:5174 bun run e2e`, 294 passed, 2 skipped.
- `apps/desktop: bun run build`, passed.
- `apps/desktop: MCODE_DATA_DIR=<temp> MCODE_PORT=19418 MCODE_HOST=127.0.0.1 bunx playwright test e2e/electron-smoke.spec.ts --reporter=list`, 1 passed.
- Live Electron probe with `preview.rendering.engine = "webview"`: opened the Browser overflow menu over a local page, hovered a page button through the overlay, and the guest reported `hover: true`, hover color applied, and no `GUEST_VIEW_MANAGER_CALL` or `ERR_ABORTED` logs.
- Visual check of the generated docked-shell screenshot: project tree is flush to the shell edge, chat joins the shell without rounded inner corners, and the main split is a thin divider instead of a gap.
- `bun run verify`, passed: typecheck, lint, and full unit suite.

## Known Gap
- Webview design capture returns `no-bounds` because capture handlers still rely on BrowserView `s.view.webContents`. `docs/design/browser-view-compositing.md` Slice 5 covers that parity work, and `reviewer_qa` approved keeping it outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved preview panel behavior for the webview engine with better URL syncing and correct reload/navigation handling.
  * Double-clicking a thread now more reliably starts inline rename.

* **Bug Fixes**
  * Fixed pointer interaction boundaries for dropdowns, popovers, selects, and tooltips so only the popup remains clickable.
  * Updated preview panel header/rail visuals and right-panel split styling for cleaner, borderless rendering.
  * Improved thread hydration to reuse in-flight background loads.

* **Tests**
  * Added/expanded UI regression and unit coverage around pointer-event behavior, preview layouts, and hydration reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->