### PR TITLE
fix: overview checks flyout and recap clipping

### DIFF
--- a/apps/server/src/__tests__/thread-recap-prompt.test.ts
+++ b/apps/server/src/__tests__/thread-recap-prompt.test.ts
@@ -86,11 +86,18 @@ describe("sanitizeThreadRecap", () => {
     );
   });
 
-  it("clips long output near 220 characters", () => {
+  it("preserves ordinary multi-sentence output without adding an ellipsis", () => {
     const result = sanitizeThreadRecap("x".repeat(400));
 
-    expect(result).toHaveLength(220);
-    expect(result.endsWith("...")).toBe(true);
+    expect(result).toHaveLength(400);
+    expect(result.endsWith("...")).toBe(false);
+  });
+
+  it("hard-caps pathological output without adding a visible ellipsis", () => {
+    const result = sanitizeThreadRecap("x".repeat(1_200));
+
+    expect(result).toHaveLength(1_000);
+    expect(result.endsWith("...")).toBe(false);
   });
 });
 

--- a/apps/server/src/services/thread-recap-prompt.ts
+++ b/apps/server/src/services/thread-recap-prompt.ts
@@ -7,7 +7,8 @@ export interface ThreadRecapMessage {
 /** Maximum prompt material characters accepted before recap prompt assembly. */
 export const THREAD_RECAP_MAX_MATERIAL_CHARS = 16_000;
 
-const THREAD_RECAP_OUTPUT_CHARS = 220;
+const THREAD_RECAP_TARGET_CHARS = 220;
+const THREAD_RECAP_MAX_OUTPUT_CHARS = 1_000;
 
 function escapePromptXmlText(value: string): string {
   return value
@@ -44,7 +45,7 @@ You write a short recap of what the user is working on in this conversation.
 - Prefer concrete nouns and verbs from the conversation
 - Return one to three plain sentences
 - No markdown, bullets, quotes, prefixes, or labels
-- Stay under ${THREAD_RECAP_OUTPUT_CHARS} characters
+- Aim for under ${THREAD_RECAP_TARGET_CHARS} characters
 </rules>
 
 <previous-recap>
@@ -67,8 +68,8 @@ export function sanitizeThreadRecap(text: string): string {
     .replace(/^["'`]+|["'`]+$/g, "")
     .trim();
 
-  if (oneLine.length <= THREAD_RECAP_OUTPUT_CHARS) return oneLine;
-  return `${oneLine.slice(0, THREAD_RECAP_OUTPUT_CHARS - 3).trimEnd()}...`;
+  if (oneLine.length <= THREAD_RECAP_MAX_OUTPUT_CHARS) return oneLine;
+  return oneLine.slice(0, THREAD_RECAP_MAX_OUTPUT_CHARS).trimEnd();
 }
 
 /**

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -592,7 +592,7 @@ test.describe("Consolidated chat header CI trigger state", () => {
     await expect(page.getByTestId("thread-overview-body")).toBeHidden();
   });
 
-  test("shows CI summary below the PR row and expands details from it", async ({ page }) => {
+  test("shows CI summary below the PR row and toggles details from it", async ({ page }) => {
     await ws.sendPush("thread.checksUpdated", {
       threadId: openPrThread.id,
       checks: failingChecksWithRuns(),
@@ -606,9 +606,27 @@ test.describe("Consolidated chat header CI trigger state", () => {
     await expect(summary).not.toContainText("Checks failing");
     await expect(summary).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
     await expect(summary).toHaveCSS("border-top-color", "rgba(0, 0, 0, 0)");
+    const statusCircle = page.getByTestId("thread-overview-ci-status-circle");
+    await expect(statusCircle).toBeVisible();
+    await expect(statusCircle).toHaveClass(/rounded-full/);
+    await expect(statusCircle).toHaveCSS("background-image", /conic-gradient/);
 
     await summary.hover();
+    await expect(page.getByTestId("thread-overview-ci-popover")).toHaveCount(0);
+
+    await summary.click();
     await expect(page.getByText("Test Web E2E (shard 1/4)")).toBeVisible();
     await expect(page.getByText("Typecheck")).toBeVisible();
+    await expect(summary).toHaveAttribute("aria-expanded", "true");
+
+    await summary.click();
+    await expect(page.getByTestId("thread-overview-ci-popover")).toHaveCount(0);
+    await expect(summary).toHaveAttribute("aria-expanded", "false");
+
+    await summary.click();
+    await expect(page.getByTestId("thread-overview-ci-popover")).toBeVisible();
+    await page.getByTestId("workspace-menu-branch").click();
+    await expect(page.getByTestId("thread-overview-ci-popover")).toHaveCount(0);
+    await expect(page.getByTestId("thread-overview-branch-popover")).toBeVisible();
   });
 });

--- a/apps/web/e2e/overview-sources-demo.spec.ts
+++ b/apps/web/e2e/overview-sources-demo.spec.ts
@@ -100,7 +100,7 @@ test.use({ viewport: { width: 1920, height: 1080 } });
 
 test("Overview sources + humanized links demo", async ({ page }) => {
   const recapText =
-    "Checking SVG alternatives and wiring the Overview surface so the team can compare options without reopening the transcript.";
+    "Checking SVG alternatives and wiring the Overview surface so the team can compare options without reopening the transcript. The current pass keeps source links, repository context, and recap details visible together so returning users can recover the thread state without scanning prior messages.";
   let resolveRecap!: (value: { text: string }) => void;
   const recapResult = new Promise<{ text: string }>((resolve) => {
     resolveRecap = resolve;
@@ -159,15 +159,18 @@ test("Overview sources + humanized links demo", async ({ page }) => {
   await page.screenshot({ path: "e2e/screenshots/demo/overview-recap-skeleton.png", fullPage: false });
   resolveRecap({ text: recapText });
   await expect(page.getByTestId("thread-overview-recap-text")).toContainText("Checking SVG alternatives");
+  await expect(page.getByTestId("thread-overview-recap-text")).toContainText("without scanning prior messages");
+  await expect(page.getByTestId("thread-overview-recap-text")).not.toContainText("...");
   await expect(page.getByTestId("thread-overview-recap-skeleton")).toHaveCount(0);
   const recapTextStyles = await page.getByTestId("thread-overview-recap-text").evaluate((node) => {
     const styles = window.getComputedStyle(node);
     return {
       textOverflow: styles.textOverflow,
       whiteSpace: styles.whiteSpace,
+      clipped: node.scrollHeight > node.clientHeight,
     };
   });
-  expect(recapTextStyles).toEqual({ textOverflow: "clip", whiteSpace: "normal" });
+  expect(recapTextStyles).toEqual({ textOverflow: "clip", whiteSpace: "normal", clipped: false });
   await expect(page.getByTestId("thread-overview-repository")).toBeVisible();
   await expect(page.getByTestId("thread-overview-sources")).toBeVisible();
   const recapFollowsSources = await page.evaluate(() => {

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -130,6 +130,7 @@ export function ChecksPopover({
   onOpenChange,
 }: ChecksPopoverProps) {
   const triggerRef = useRef<HTMLDivElement | null>(null);
+  const flyoutRef = useRef<HTMLDivElement | null>(null);
   const [position, setPosition] = useState<FlyoutPosition | null>(null);
 
   const sortedRuns = useMemo(() => {
@@ -147,16 +148,6 @@ export function ChecksPopover({
     setPosition(calculateFlyoutPosition(triggerRef.current));
   }, []);
 
-  const openFlyout = useCallback(() => {
-    updatePosition();
-    onOpenChange?.(true);
-  }, [onOpenChange, updatePosition]);
-
-  const toggleFlyout = useCallback(() => {
-    updatePosition();
-    onOpenChange?.(!open);
-  }, [onOpenChange, open, updatePosition]);
-
   useEffect(() => {
     if (!open) return;
     updatePosition();
@@ -168,6 +159,22 @@ export function ChecksPopover({
     };
   }, [open, updatePosition]);
 
+  useEffect(() => {
+    if (!open) return;
+
+    const closeOnOutsidePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (triggerRef.current?.contains(target) || flyoutRef.current?.contains(target)) return;
+      onOpenChange?.(false);
+    };
+
+    document.addEventListener("pointerdown", closeOnOutsidePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutsidePointerDown);
+    };
+  }, [onOpenChange, open]);
+
   const flyoutStyle: CSSProperties | undefined = position
     ? { left: position.left, top: position.top, width: FLYOUT_WIDTH }
     : undefined;
@@ -176,6 +183,7 @@ export function ChecksPopover({
       <div
         role="dialog"
         data-testid="thread-overview-ci-popover"
+        ref={flyoutRef}
         style={flyoutStyle}
         className="fixed z-50 overflow-hidden rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl"
       >
@@ -193,14 +201,7 @@ export function ChecksPopover({
 
   return (
     <>
-      <div
-        ref={triggerRef}
-        onPointerDown={openFlyout}
-        onClick={toggleFlyout}
-        onMouseEnter={openFlyout}
-        onFocus={openFlyout}
-        className="w-full"
-      >
+      <div ref={triggerRef} className="w-full">
         {children}
       </div>
 

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1,9 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent } from "react";
 import {
   Check,
   ChevronDown,
-  CircleCheck,
-  CircleX,
   Copy,
   Diff,
   ExternalLink,
@@ -43,7 +41,7 @@ import { CreatePrDialog } from "./CreatePrDialog";
 import { useThreadGitActions } from "@/hooks/useThreadGitActions";
 import { useThreadRecap } from "@/hooks/useThreadRecap";
 import {
-  CI_ICON_STROKE,
+  getBreakdown,
   getCiOverviewSummaryLabel,
   getCiSummaryHeadline,
 } from "@/lib/ci-status";
@@ -106,6 +104,14 @@ type LoadedBranchState =
   | { status: "error"; branches: GitBranchRecord[]; uncommittedFiles: number | null };
 type LoadStatus = "idle" | "loading" | "ready" | "error";
 type LocalCopyTarget = "path" | "branch";
+type CiSegmentName = "failing" | "running" | "passing" | "other";
+
+const CI_SEGMENT_COLORS: Record<CiSegmentName, string> = {
+  failing: "var(--diff-remove-strong)",
+  running: "#e7a90b",
+  passing: "var(--diff-add-strong)",
+  other: "var(--muted-foreground)",
+};
 
 /** Repository metadata rendered by the Overview Repository row. */
 export interface ThreadOverviewRepository {
@@ -1058,6 +1064,42 @@ export function getPrRowDetail(
   return null;
 }
 
+function getCiStatusCircleStyle(checks: ChecksStatus): CSSProperties {
+  const breakdown = getBreakdown(checks);
+  const total = breakdown.total || 1;
+  const segments = ([
+    { name: "failing", count: breakdown.failing },
+    { name: "running", count: breakdown.running },
+    { name: "passing", count: breakdown.passing },
+    { name: "other", count: breakdown.other },
+  ] satisfies Array<{ name: CiSegmentName; count: number }>).filter((segment) => segment.count > 0);
+
+  if (segments.length === 0) {
+    return { background: "var(--muted)" };
+  }
+
+  let cursor = 0;
+  const stops = segments.map((segment) => {
+    const start = cursor;
+    cursor += (segment.count / total) * 100;
+    const end = Math.min(100, cursor);
+    return `${CI_SEGMENT_COLORS[segment.name]} ${start}% ${end}%`;
+  });
+
+  return { background: `conic-gradient(${stops.join(", ")})` };
+}
+
+function ThreadOverviewCiStatusCircle({ checks }: { checks: ChecksStatus }) {
+  return (
+    <span
+      aria-hidden
+      data-testid="thread-overview-ci-status-circle"
+      className="size-3 shrink-0 rounded-full border border-border/70"
+      style={getCiStatusCircleStyle(checks)}
+    />
+  );
+}
+
 interface ThreadOverviewPrRowProps {
   pr: ThreadOverviewPr;
   hasCommitsAhead: boolean | null;
@@ -1131,18 +1173,6 @@ function ThreadOverviewPrActiveRow({
     checks != null &&
     checks.aggregate !== "no_checks";
   const canOpenChecks = hasChecksData && threadId.length > 0;
-  const SummaryIcon =
-    checks?.aggregate === "passing"
-      ? CircleCheck
-      : checks?.aggregate === "failing"
-        ? CircleX
-        : Loader2;
-  const summaryIconClass =
-    checks?.aggregate === "passing"
-      ? "text-[var(--diff-add-strong)]"
-      : checks?.aggregate === "failing"
-        ? "text-[var(--diff-remove-strong)]"
-        : "text-[#e7a90b]";
 
   useEffect(() => {
     if (!canOpenChecks) return;
@@ -1169,27 +1199,17 @@ function ThreadOverviewPrActiveRow({
           size="sm"
           data-testid="thread-overview-pr-status"
           aria-label={`CI checks, ${getCiSummaryHeadline(checks)}`}
+          aria-expanded={checksOpen}
+          aria-haspopup="dialog"
           title={getCiSummaryHeadline(checks)}
-          onPointerDown={() => setChecksOpen(true)}
           onClick={(event) => {
             event.stopPropagation();
-            setChecksOpen(true);
+            setChecksOpen((open) => !open);
           }}
-          onMouseEnter={() => setChecksOpen(true)}
-          onFocus={() => setChecksOpen(true)}
           className="ml-6 flex h-6 w-[calc(100%-1.5rem)] cursor-pointer justify-between rounded-none border-transparent bg-transparent px-0 text-left text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent"
         >
           <span className="flex min-w-0 items-center gap-2">
-            <SummaryIcon
-              size={13}
-              strokeWidth={CI_ICON_STROKE}
-              aria-hidden
-              className={cn(
-                "shrink-0",
-                summaryIconClass,
-                checks.aggregate === "pending" && "status-spin",
-              )}
-            />
+            <ThreadOverviewCiStatusCircle checks={checks} />
             <span className="truncate text-xs">
               {getCiOverviewSummaryLabel(checks)}
             </span>


### PR DESCRIPTION
## What
Fixes two Thread Overview issues: CI checks now open only from the summary click and toggle closed, and Recap text no longer gets a generated ellipsis for normal multi-sentence output.

## Why
The checks list could appear on hover or focus, stay open behind sibling Overview menus, and ignore a second summary click. Recap output was cut at 220 characters before the UI could wrap it.

## Key Changes
- Remove hover and focus auto-open paths from the checks flyout and add outside-pointer dismissal.
- Make the checks summary button own its expanded state.
- Change Recap sanitization to keep normal longer output and hard-cap only unusually long responses.
- Extend Playwright and Vitest coverage for checks toggling, sibling dropdown dismissal, and full Recap rendering.

Related to: none provided.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785420507&installation_id=129163861&pr_number=827&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F827&signature=812c1eee6e03ce83487c21b5ceba777898fb70f4b7db42933ba0f3df8d437d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->