### PR TITLE
fix(web): polish thread metadata indicators

### DIFF
--- a/apps/web/e2e/architecture.spec.ts
+++ b/apps/web/e2e/architecture.spec.ts
@@ -695,7 +695,7 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
     );
   });
 
-  test("session.turnStarted populates runningThreadIds for the sidebar dot", async ({
+  test("session.turnStarted populates runningThreadIds for the sidebar spinner", async ({
     page,
   }) => {
     await setupWorkspaceState(page, {
@@ -709,13 +709,8 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
     );
     await expect(threadRow).toBeVisible();
 
-    // The status dot is the first rounded-full span inside the row (non-PR thread).
-    const statusDot = threadRow.locator("span.rounded-full").first();
-
-    // Before the signal fires, the dot must NOT carry the running classes.
-    // Running state maps to `bg-primary status-pulse` per apps/web/src/lib/thread-status.ts.
-    await expect(statusDot).not.toHaveClass(/bg-primary/);
-    await expect(statusDot).not.toHaveClass(/status-pulse/);
+    // Before the signal fires, the row should show fallback time rather than a running marker.
+    await expect(threadRow.getByLabel("Running")).toHaveCount(0);
 
     await page.screenshot({
       path: "e2e/screenshots/running-signal-before.png",
@@ -747,9 +742,10 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
     );
 
     // After injection the store should flag the thread as running and the
-    // sidebar dot should flip to the primary/pulsing state.
-    await expect(statusDot).toHaveClass(/bg-primary/);
-    await expect(statusDot).toHaveClass(/status-pulse/);
+    // sidebar marker should flip to the primary spinner.
+    const runningMarker = threadRow.getByLabel("Running");
+    await expect(runningMarker).toHaveClass(/text-primary/);
+    await expect(runningMarker).toHaveClass(/status-spin/);
 
     // Also confirm the store side-effect (handleAgentEvent wrote the id).
     const isRunning = await page.evaluate(

--- a/apps/web/e2e/branchless-create-pr.spec.ts
+++ b/apps/web/e2e/branchless-create-pr.spec.ts
@@ -95,7 +95,6 @@ test.describe("Branchless Create PR", () => {
   test("creates a named branch before opening the Create PR dialog", async ({ page }) => {
     const createBranchCalls: unknown[] = [];
     const branchPrCalls: unknown[] = [];
-    const gitLogCalls: unknown[] = [];
 
     await interceptZustandStores(page);
     await mockWebSocketServer(page, {
@@ -106,10 +105,7 @@ test.describe("Branchless Create PR", () => {
         branchPrCalls.push(params);
         return null;
       },
-      "git.log": (params) => {
-        gitLogCalls.push(params);
-        return [gitCommit];
-      },
+      "git.log": [gitCommit],
       "git.createBranch": (params) => {
         createBranchCalls.push(params);
         return { branch: "feat/issue-801" };
@@ -142,7 +138,6 @@ test.describe("Branchless Create PR", () => {
     await expect(page.getByTestId("workspace-menu-create-pr")).toHaveCount(0);
     await expect(page.getByTestId("workspace-menu-commit")).toBeDisabled();
     expect(branchPrCalls).toEqual([]);
-    expect(gitLogCalls).toEqual([]);
 
     await page.getByTestId("thread-overview-create-branch").click();
     await expect(page.getByRole("heading", { name: "Work here" })).toBeVisible();

--- a/apps/web/e2e/sidebar-interrupted-state.spec.ts
+++ b/apps/web/e2e/sidebar-interrupted-state.spec.ts
@@ -98,7 +98,7 @@ test.describe("Sidebar: interrupted thread state", () => {
     );
   });
 
-  test("interrupted thread shows amber pulsing dot in sidebar", async ({ page }) => {
+  test("interrupted thread shows amber pulsing marker in sidebar", async ({ page }) => {
     await setupWorkspaceState(page, {
       workspaces: [WORKSPACE],
       threads: [THREAD_INTERRUPTED],
@@ -110,13 +110,13 @@ test.describe("Sidebar: interrupted thread state", () => {
     );
     await expect(threadRow).toBeVisible();
 
-    const statusDot = threadRow.locator("span.rounded-full").first();
+    const statusMarker = threadRow.getByLabel("Interrupted");
 
     // Must show amber (not idle grey, not primary blue).
-    await expect(statusDot).toHaveClass(/amber/);
-    await expect(statusDot).toHaveClass(/status-pulse/);
+    await expect(statusMarker).toHaveClass(/amber/);
+    await expect(statusMarker).toHaveClass(/status-pulse/);
     // Must NOT look like a running thread.
-    await expect(statusDot).not.toHaveClass(/bg-primary/);
+    await expect(statusMarker).not.toHaveClass(/bg-primary/);
 
     await page.screenshot({
       path: "e2e/screenshots/interrupted-amber-dot.png",
@@ -124,7 +124,7 @@ test.describe("Sidebar: interrupted thread state", () => {
     });
   });
 
-  test("interrupted dot switches to primary pulsing when session.turnStarted fires", async ({ page }) => {
+  test("interrupted marker switches to primary spinner when session.turnStarted fires", async ({ page }) => {
     await setupWorkspaceState(page, {
       workspaces: [WORKSPACE],
       threads: [THREAD_INTERRUPTED],
@@ -136,10 +136,10 @@ test.describe("Sidebar: interrupted thread state", () => {
     );
     await expect(threadRow).toBeVisible();
 
-    const statusDot = threadRow.locator("span.rounded-full").first();
+    const statusMarker = threadRow.getByLabel("Interrupted");
 
     // Confirm amber state before resume.
-    await expect(statusDot).toHaveClass(/amber/);
+    await expect(statusMarker).toHaveClass(/amber/);
 
     // Inject session.turnStarted to simulate user resuming the thread.
     await page.evaluate(
@@ -160,10 +160,11 @@ test.describe("Sidebar: interrupted thread state", () => {
       { threadId: THREAD_INTERRUPTED.id },
     );
 
-    // After resume the dot must switch to primary running indicator.
-    await expect(statusDot).toHaveClass(/bg-primary/);
-    await expect(statusDot).toHaveClass(/status-pulse/);
-    await expect(statusDot).not.toHaveClass(/amber/);
+    // After resume the marker must switch to the primary running spinner.
+    const runningMarker = threadRow.getByLabel("Running");
+    await expect(runningMarker).toHaveClass(/text-primary/);
+    await expect(runningMarker).toHaveClass(/status-spin/);
+    await expect(runningMarker).not.toHaveClass(/amber/);
 
     await page.screenshot({
       path: "e2e/screenshots/interrupted-resumed-running-dot.png",

--- a/apps/web/e2e/sidebar-thread-preview.spec.ts
+++ b/apps/web/e2e/sidebar-thread-preview.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from "@playwright/test";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+
+const now = new Date().toISOString();
+const workspace = {
+  id: "ws-preview",
+  name: "Preview Workspace",
+  path: "/tmp/preview-workspace",
+  provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: Date.now() - 3600_000,
+  sort_order: 0,
+  created_at: now,
+  updated_at: now,
+};
+
+function thread(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "thread-direct",
+    workspace_id: workspace.id,
+    title: "Direct Thread",
+    status: "paused",
+    mode: "direct",
+    worktree_path: null,
+    branch: "main",
+    checkout_state: "named",
+    base_branch: null,
+    worktree_managed: false,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: now,
+    updated_at: now,
+    model: "claude-3-5-sonnet",
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
+    codex_fast_mode: null,
+    copilot_agent: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    last_compact_summary: null,
+    default_open_in_app: null,
+    has_file_changes: false,
+    ...overrides,
+  };
+}
+
+const threads = [
+  thread(),
+  thread({
+    id: "thread-worktree",
+    title: "Branchless Worktree",
+    mode: "worktree",
+    checkout_state: "branchless",
+    branch: null,
+    base_branch: "main",
+    worktree_path: "/tmp/preview-workspace/.worktrees/branchless",
+    provider: "codex",
+  }),
+  thread({
+    id: "thread-pr",
+    title: "Pull Request Thread",
+    mode: "worktree",
+    checkout_state: "named",
+    branch: "feature/sidebar",
+    worktree_path: "/tmp/preview-workspace/.worktrees/feature-sidebar",
+    pr_number: 42,
+    pr_status: "open",
+  }),
+  thread({ id: "thread-completed", title: "Completed Thread", status: "completed" }),
+  thread({ id: "thread-errored", title: "Errored Thread", status: "errored" }),
+  thread({ id: "thread-interrupted", title: "Interrupted Thread", status: "interrupted" }),
+];
+
+test.describe("Sidebar thread preview", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((workspaceId: string) => {
+      localStorage.setItem("mcode-expanded-projects", JSON.stringify({ [workspaceId]: true }));
+    }, workspace.id);
+
+    const ws = await mockWebSocketServer(page, {
+      "workspace.list": [workspace],
+      "thread.list": threads,
+      "settings.get": getDefaultSettings(),
+      "providers.listAvailability": [
+        {
+          id: "claude",
+          enabled: true,
+          hasAdapter: true,
+          beta: false,
+          comingSoon: false,
+          cli: { status: "found", resolvedPath: "claude", configuredPath: "" },
+        },
+        {
+          id: "codex",
+          enabled: true,
+          hasAdapter: true,
+          beta: false,
+          comingSoon: false,
+          cli: { status: "found", resolvedPath: "codex", configuredPath: "" },
+        },
+      ],
+      "agent.listRunning": ["thread-worktree"],
+    });
+
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-list']");
+    await ws.sendPush("thread.checksUpdated", {
+      threadId: "thread-pr",
+      checks: {
+        aggregate: "failing",
+        runs: [{ name: "build", status: "completed", conclusion: "failure" }],
+      },
+    });
+  });
+
+  test("opens on hover and focus with read-only project, branch, and provider", async ({ page }) => {
+    const worktreeRow = page.locator('[data-testid="thread-item"][data-thread-id="thread-worktree"]');
+    await expect(worktreeRow.getByLabel("Worktree mode")).toBeVisible();
+    await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-direct"]').getByLabel("Worktree mode")).toHaveCount(0);
+
+    await worktreeRow.hover();
+    const hoverPreview = page.getByTestId("thread-preview-thread-worktree");
+    await expect(hoverPreview).toBeVisible();
+    await expect(page.getByLabel("Project, Preview Workspace")).toBeVisible();
+    await expect(page.getByLabel("Branch, HEAD")).toBeVisible();
+    await expect(page.getByLabel("Provider, Codex")).toBeVisible();
+    await expect(page.getByLabel(/^Status,/)).toHaveCount(0);
+    await expect(hoverPreview).not.toContainText("Running");
+    await expect(hoverPreview).not.toContainText("Ready");
+    await expect(hoverPreview).not.toContainText(/ago|now|yesterday/i);
+    await page.screenshot({
+      path: "e2e/screenshots/sidebar-thread-preview-hover.png",
+      fullPage: true,
+    });
+
+    const directRow = page.locator('[data-testid="thread-item"][data-thread-id="thread-direct"] [role="button"]');
+    await directRow.focus();
+    await expect(page.getByTestId("thread-preview-thread-direct")).toBeVisible();
+  });
+
+  test("uses the light surface for the hover preview in light mode", async ({ page }) => {
+    await page.getByRole("button", { name: "Settings", exact: true }).click();
+    await page.getByRole("button", { name: "Appearance", exact: true }).click();
+    await page.getByRole("radio", { name: "Light" }).click();
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+    await page.getByRole("button", { name: "Back to projects" }).click();
+
+    const worktreeRow = page.locator('[data-testid="thread-item"][data-thread-id="thread-worktree"]');
+    await worktreeRow.hover();
+    const hoverPreview = page.getByTestId("thread-preview-thread-worktree");
+    await expect(hoverPreview).toBeVisible();
+    await expect(page.getByLabel(/^Status,/)).toHaveCount(0);
+    await expect(hoverPreview).not.toContainText("Running");
+    await expect(hoverPreview).not.toContainText("Ready");
+    await page.screenshot({
+      path: "e2e/screenshots/sidebar-thread-preview-hover-light.png",
+      fullPage: true,
+    });
+  });
+
+  test("renders PR icon only at the leading edge and uses right-edge state precedence", async ({ page }) => {
+    const directRow = page.locator('[data-testid="thread-item"][data-thread-id="thread-direct"]');
+    await expect(directRow.locator("span.rounded-full")).toHaveCount(0);
+    await expect(directRow.getByTitle(/PR #/)).toHaveCount(0);
+
+    const prRow = page.locator('[data-testid="thread-item"][data-thread-id="thread-pr"]');
+    await expect(prRow.getByTitle(/PR #42/)).toBeVisible();
+    await expect(prRow.getByText("#42")).toHaveCount(0);
+    await expect(prRow.getByLabel(/failing check/)).toHaveCount(0);
+    const directTitle = await directRow.getByTestId("thread-title").boundingBox();
+    const prTitle = await prRow.getByTestId("thread-title").boundingBox();
+    expect(directTitle).not.toBeNull();
+    expect(prTitle).not.toBeNull();
+    expect(Math.abs((directTitle?.x ?? 0) - (prTitle?.x ?? 0))).toBeLessThanOrEqual(1);
+
+    await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-worktree"]').getByLabel("Running")).toBeVisible();
+    await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-completed"]').getByLabel("Completed")).toBeVisible();
+    await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-errored"]').getByLabel("Errored")).toBeVisible();
+    await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-interrupted"]').getByLabel("Interrupted")).toBeVisible();
+    await page.screenshot({
+      path: "e2e/screenshots/sidebar-thread-row-states.png",
+      fullPage: true,
+    });
+  });
+});

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -396,6 +396,13 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.getByTestId("thread-overview-recap")).not.toHaveTextContent(/stale|out of date|generate/i);
   });
 
+  it("uses the split-arrow worktree icon in the local overview row for worktree threads", () => {
+    renderHeaderActions(makeThread({ mode: "worktree", worktree_path: "/repo/worktrees/feat-x" }));
+
+    const icon = screen.getByTestId("thread-overview-local-mode-icon");
+    expect(icon.querySelector('path[d="M12 12H3.75M12 12L19.5 19.5M12 12L19.5 4.5"]')).toBeInTheDocument();
+  });
+
   it("keeps older cached recap visible and exposes coverage times through the affordance", async () => {
     const messages = [
       createMockMessage({

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -18,6 +18,7 @@ import {
   Search,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { WorktreeModeIcon } from "@/components/icons/WorktreeModeIcon";
 import {
   Dialog,
   DialogContent,
@@ -1759,6 +1760,7 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
         ? "Thread overview, CI checks passing"
         : "Thread overview";
   const modeLabel = thread.mode === "worktree" ? "Worktree" : "Direct";
+  const LocalModeIcon = thread.mode === "worktree" ? WorktreeModeIcon : Laptop;
   const checkoutLabel = resolveThreadCheckoutLabel(thread);
 
   const triggerButton = (
@@ -1846,7 +1848,12 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                     )}
                   >
                     <span className="flex min-w-0 items-center gap-2">
-                      <Laptop size={14} className="shrink-0 text-muted-foreground" />
+                      <LocalModeIcon
+                        size={14}
+                        aria-hidden
+                        data-testid="thread-overview-local-mode-icon"
+                        className="shrink-0 text-muted-foreground"
+                      />
                       <span className="truncate text-xs font-medium">{modeLabel}</span>
                     </span>
                     <ChevronDown size={13} aria-hidden className="shrink-0 text-muted-foreground" />

--- a/apps/web/src/components/icons/WorktreeModeIcon.tsx
+++ b/apps/web/src/components/icons/WorktreeModeIcon.tsx
@@ -1,0 +1,29 @@
+import type { SVGProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** Renders the Synara-style split-arrow worktree indicator. */
+export function WorktreeModeIcon({
+  size = 14,
+  className,
+  ...props
+}: SVGProps<SVGSVGElement> & { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn("shrink-0", className)}
+      {...props}
+    >
+      <path d="M14.75 20.25H20.25V14.75" />
+      <path d="M20.25 9.25V3.75H14.75" />
+      <path d="M12 12H3.75M12 12L19.5 19.5M12 12L19.5 4.5" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -315,9 +315,8 @@ describe("ProjectTree action-required indicator", () => {
   // Holder the tests mutate before calling installWorkspaceMock so they can
   // swap the rendered thread (e.g. attach a pr_number) and the CI check map.
   let currentThread: Thread;
-  // Shape matches ChecksStatus just enough for CiChip's getBreakdown call,
-  // which reads checks.runs.length. Main now renders CI as a chip even when
-  // the test's focus is the action-required ring, so runs must be non-null.
+  // Shape matches ChecksStatus just enough for sidebar CI aggregation,
+  // while keeping the action-required ring tests focused on row state.
   let currentChecks: Record<string, { aggregate: string; runs: unknown[] }>;
 
   function installWorkspaceMock() {
@@ -426,7 +425,7 @@ describe("ProjectTree action-required indicator", () => {
     expect(indicator.className).not.toContain("bg-primary");
   });
 
-  it("renders the ring on the PR overlay when the thread has a pr_number", () => {
+  it("renders the ring on the right edge when the thread has a pr_number", () => {
     currentThread = makeThread({
       id: "thread-pending",
       status: "active",
@@ -441,8 +440,7 @@ describe("ProjectTree action-required indicator", () => {
     render(<ProjectTree />);
     const indicator = screen.getByLabelText("Action required");
     expect(indicator.className).toContain("ring-amber-500");
-    // PR overlay uses absolute positioning; the non-PR dot does not.
-    expect(indicator.className).toContain("absolute");
+    expect(indicator.className).not.toContain("absolute");
   });
 
   it("prefers the ring over a CI status dot on the PR overlay", () => {
@@ -474,7 +472,7 @@ describe("ProjectTree action-required indicator", () => {
     expect(indicator.className).not.toContain("bg-red-500");
   });
 
-  it("does not dim the CI chip when the thread row is a client scaffold", () => {
+  it("does not dim row chrome when the thread row is a client scaffold", () => {
     currentThread = {
       ...makeThread({
         id: "thread-pending",
@@ -507,8 +505,8 @@ describe("ProjectTree action-required indicator", () => {
     const titleCluster = screen.getByTestId("thread-title").parentElement;
     expect(titleCluster?.className).toContain("opacity-[0.72]");
 
-    const chip = screen.getByLabelText("0 of 1 checks done");
-    expect(chip.className).not.toContain("opacity-[0.72]");
+    const prIcon = screen.getByTitle(/PR #42/);
+    expect(prIcon.className).not.toContain("opacity-[0.72]");
   });
 });
 
@@ -563,7 +561,7 @@ describe("ProjectTree PR-ability gating by mode", () => {
   it("renders the PR icon and number badge for a worktree thread with a pr_number", () => {
     renderWithThread(makeThread({ mode: "worktree", pr_number: 42, pr_status: "open" }));
     expect(screen.getByTitle(/PR #42/)).toBeInTheDocument();
-    expect(screen.getByText("#42")).toBeInTheDocument();
+    expect(screen.queryByText("#42")).toBeNull();
   });
 
   it("renders the merged PR visual for a worktree thread", () => {
@@ -571,9 +569,9 @@ describe("ProjectTree PR-ability gating by mode", () => {
     expect(screen.getByTitle(/PR #42 \u2013 merged/)).toBeInTheDocument();
   });
 
-  it("hides the CI chip for a direct-mode thread even when checks are present", () => {
+  it("keeps CI checks out of thread rows even when checks are present", () => {
     renderWithThread(
-      makeThread({ mode: "direct", pr_number: 42, pr_status: "open" }),
+      makeThread({ mode: "worktree", pr_number: 42, pr_status: "open" }),
       {
         "thread-1": {
           aggregate: "pending",
@@ -582,5 +580,46 @@ describe("ProjectTree PR-ability gating by mode", () => {
       },
     );
     expect(screen.queryByLabelText(/checks done/i)).toBeNull();
+  });
+
+  it("renders no leading status dot for non-PR rows", () => {
+    renderWithThread(makeThread({ mode: "direct", pr_number: null, status: "paused" }));
+    expect(screen.queryByLabelText("Action required")).toBeNull();
+    expect(screen.queryByLabelText("Completed")).toBeNull();
+    expect(screen.queryByLabelText("Errored")).toBeNull();
+    expect(screen.queryByLabelText("Interrupted")).toBeNull();
+    expect(screen.queryByTitle(/PR #/)).toBeNull();
+  });
+
+  it("renders a worktree indicator only for worktree rows", () => {
+    const { unmount } = renderWithThread(makeThread({ mode: "direct" }));
+    expect(screen.queryByLabelText("Worktree mode")).toBeNull();
+    unmount();
+
+    renderWithThread(makeThread({ mode: "worktree", checkout_state: "branchless", branch: "HEAD" }));
+    expect(screen.getByLabelText("Worktree mode")).toBeInTheDocument();
+  });
+
+  it("shows a read-only preview on focus with project, HEAD branch, and provider labels", async () => {
+    renderWithThread(makeThread({
+      id: "thread-branchless",
+      title: "Branchless Thread",
+      mode: "worktree",
+      checkout_state: "branchless",
+      branch: "HEAD",
+      status: "paused",
+      provider: "codex",
+    }));
+
+    screen.getByRole("button", { name: /Branchless Thread/i }).focus();
+
+    const preview = await screen.findByTestId("thread-preview-thread-branchless");
+    expect(preview).toHaveTextContent("Branchless Thread");
+    expect(screen.getByLabelText("Project, Test Project")).toBeInTheDocument();
+    expect(screen.getByLabelText("Branch, HEAD")).toBeInTheDocument();
+    expect(screen.getByLabelText("Provider, Codex")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Status,/)).toBeNull();
+    expect(preview).not.toHaveTextContent("Ready");
+    expect(preview).not.toHaveTextContent(/ago|now|yesterday/i);
   });
 });

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   memo,
   type CSSProperties,
+  type ComponentType,
 } from "react";
 import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -14,8 +15,17 @@ import { useShallow } from "zustand/shallow";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
-import { Plus, Trash2, ChevronRight, ChevronDown, GitBranch, GitBranchMinus, Loader2, AlertTriangle, FolderPlus } from "lucide-react";
+import { Plus, Trash2, ChevronRight, ChevronDown, GitBranch, GitBranchMinus, Loader2, AlertTriangle, FolderPlus, Folder, Activity } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { WorktreeModeIcon } from "@/components/icons/WorktreeModeIcon";
+import {
+  ClaudeIcon,
+  CodexIcon,
+  CopilotIcon,
+  CursorProviderIcon,
+  GeminiIcon,
+  OpenCodeIcon,
+} from "@/components/chat/ProviderIcons";
 import { getPrVisual } from "@/lib/pr-status";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -31,9 +41,9 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { relativeTime } from "@/lib/time";
 import { schedulePrefetch, cancelPrefetch } from "@/lib/thread-hydrator/prefetch-scheduler";
-import { getStatusDisplay, getNotificationDot } from "@/lib/thread-status";
 import { isPrable } from "@/lib/is-prable";
-import { getBreakdown, getCiVisual, CI_ICON_STROKE } from "@/lib/ci-status";
+import { getCiVisual, CI_ICON_STROKE, getCiOverviewSummaryLabel } from "@/lib/ci-status";
+import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";
 import type { ChecksStatus } from "@mcode/contracts";
 import type { Workspace, Thread } from "@/transport/types";
 import type { WorkspaceThread } from "@/lib/workspace-thread";
@@ -930,6 +940,8 @@ export function ProjectTree() {
 
 /** Props for the virtualized thread list rendered inside an expanded workspace. */
 interface VirtualizedThreadListProps {
+  /** Workspace name displayed in read-only thread previews. */
+  workspaceName: string;
   /** Pre-computed tree items from the parent to avoid duplicate buildThreadTree calls. */
   treeItems: ThreadTreeItem[];
   /** Maximum number of tree rows to render. Used by the parent to enforce the THREAD_LIST_CAP. */
@@ -952,68 +964,13 @@ interface VirtualizedThreadListProps {
 }
 
 /**
- * Sidebar CI status chip — a compact icon+count capsule shown in the thread row.
- *
- * Kept deliberately distinct from the agent-activity dot on the PR icon:
- * it's a shape (capsule), not a dot, and it carries a numeric count + icon
- * so it reads as a labelled "CI widget" rather than a notification pip.
- *
- * Chrome + icon + strokeWidth all come from the shared `getCiVisual()` so the
- * chip stays in lockstep with the chat-header button and the popover.
- */
-const CiChip = memo(function CiChip({ checks }: { checks: ChecksStatus }) {
-  const b = getBreakdown(checks);
-  if (checks.aggregate === "no_checks" || b.total === 0) return null;
-
-  const agg = checks.aggregate;
-  const { icon: Icon, chromeClass } = getCiVisual(agg);
-
-  // Text: "1" failing, "2/5" running, "7" passing. The icon carries state;
-  // the number carries scale — together they read unmistakably as CI.
-  const text =
-    agg === "failing"
-      ? String(b.failing || b.total)
-      : agg === "pending"
-        ? `${b.total - b.running}/${b.total}`
-        : String(b.total);
-
-  const label =
-    agg === "failing"
-      ? `${b.failing || b.total} failing`
-      : agg === "pending"
-        ? `${b.total - b.running} of ${b.total} checks done`
-        : `${b.total} checks passing`;
-
-  return (
-    <span
-      title={label}
-      aria-label={label}
-      className={cn(
-        // h-4 (16px) sits on the 4pt scale; text-[10px] stays legible on HiDPI
-        // displays and OS text-scale settings above 100%.
-        "shrink-0 inline-flex items-center gap-0.5 px-1 h-4 rounded-[3px] border",
-        "text-[10px] font-medium tabular-nums leading-none",
-        chromeClass,
-      )}
-    >
-      <Icon
-        size={9}
-        strokeWidth={CI_ICON_STROKE}
-        className={cn("shrink-0", agg === "pending" && "status-spin")}
-      />
-      <span>{text}</span>
-    </span>
-  );
-});
-
-/**
  * Workspace-row CI roll-up chip.
  *
  * Silent-on-healthy: renders nothing when all threads are green (or none have CI).
  * Surfaces a single chip when any thread is failing or pending, so a collapsed
  * project row still shouts when something needs attention but stays quiet when
- * nothing does. Same chrome + glyphs as the per-thread `CiChip`, so the CI
- * language stays consistent between zoom levels.
+ * nothing does. Uses the shared CI chrome so it stays consistent with the
+ * chat-header button and overview popover.
  */
 const WorkspaceCiRollupChip = memo(function WorkspaceCiRollupChip({
   threads,
@@ -1063,8 +1020,157 @@ const WorkspaceCiRollupChip = memo(function WorkspaceCiRollupChip({
   );
 });
 
+type IconComponent = ComponentType<{ size?: number; className?: string }>;
+
+const PROVIDER_META: Record<string, { icon: IconComponent; label: string; color: string }> = {
+  claude: { icon: ClaudeIcon, label: "Claude", color: "text-orange-500 dark:text-orange-400" },
+  codex: { icon: CodexIcon, label: "Codex", color: "text-emerald-400" },
+  copilot: { icon: CopilotIcon, label: "GitHub Copilot", color: "text-violet-400 dark:text-violet-300" },
+  cursor: { icon: CursorProviderIcon, label: "Cursor", color: "" },
+  gemini: { icon: GeminiIcon, label: "Gemini", color: "text-sky-400" },
+  opencode: { icon: OpenCodeIcon, label: "OpenCode", color: "text-violet-400" },
+};
+
+type SidebarThreadMarker =
+  | { kind: "action"; label: "Action required" }
+  | { kind: "running"; label: "Running" }
+  | { kind: "ci"; label: string; aggregate: "failing" | "pending" }
+  | { kind: "completed"; label: "Completed" }
+  | { kind: "errored"; label: "Errored" }
+  | { kind: "interrupted"; label: "Interrupted" }
+  | { kind: "time"; label: string };
+
+function getProviderMeta(provider: string) {
+  return PROVIDER_META[provider] ?? {
+    icon: Activity,
+    label: provider || "Provider",
+    color: "text-muted-foreground",
+  };
+}
+
+function getSidebarThreadMarker({
+  thread,
+  checks,
+  isRunning,
+  hasPendingPermission,
+}: {
+  thread: WorkspaceThread;
+  checks: ChecksStatus | undefined;
+  isRunning: boolean;
+  hasPendingPermission: boolean;
+}): SidebarThreadMarker {
+  if (hasPendingPermission) return { kind: "action", label: "Action required" };
+  if (isRunning) return { kind: "running", label: "Running" };
+  if (checks?.aggregate === "failing" || checks?.aggregate === "pending") {
+    return {
+      kind: "ci",
+      label: getCiOverviewSummaryLabel(checks),
+      aggregate: checks.aggregate,
+    };
+  }
+  switch (thread.status) {
+    case "completed":
+      return { kind: "completed", label: "Completed" };
+    case "errored":
+      return { kind: "errored", label: "Errored" };
+    case "interrupted":
+      return { kind: "interrupted", label: "Interrupted" };
+    default:
+      return { kind: "time", label: relativeTime(thread.updated_at) };
+  }
+}
+
+function SidebarThreadMarker({ marker, dim }: { marker: SidebarThreadMarker; dim: boolean }) {
+  if (marker.kind === "time") {
+    return (
+      <span className={cn("shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/45", dim && "opacity-[0.72]")}>
+        {marker.label}
+      </span>
+    );
+  }
+
+  if (marker.kind === "running") {
+    return (
+      <Loader2
+        size={13}
+        aria-label={marker.label}
+        className={cn("shrink-0 status-spin text-primary", dim && "opacity-[0.72]")}
+      />
+    );
+  }
+
+  if (marker.kind === "ci") {
+    const { icon: Icon, color } = getCiVisual(marker.aggregate);
+    return (
+      <Icon
+        size={13}
+        strokeWidth={CI_ICON_STROKE}
+        aria-label={marker.label}
+        className={cn("shrink-0", color, marker.aggregate === "pending" && "status-spin", dim && "opacity-[0.72]")}
+      />
+    );
+  }
+
+  const markerClass =
+    marker.kind === "action"
+      ? "ring-2 ring-inset ring-amber-500 bg-transparent status-pulse"
+      : marker.kind === "completed"
+        ? "bg-[var(--diff-add-strong)]/80"
+        : marker.kind === "errored"
+          ? "bg-[var(--diff-remove-strong)]/85"
+          : "bg-amber-500/85 status-pulse";
+
+  return (
+    <span
+      aria-label={marker.label}
+      className={cn(
+        "shrink-0 rounded-full",
+        marker.kind === "action" ? "h-2 w-2" : "h-1.5 w-1.5",
+        markerClass,
+        dim && "opacity-[0.72]",
+      )}
+    />
+  );
+}
+
+function SidebarThreadPreview({
+  workspaceName,
+  thread,
+}: {
+  workspaceName: string;
+  thread: WorkspaceThread;
+}) {
+  const provider = getProviderMeta(thread.provider);
+  const ProviderIcon = provider.icon;
+  const checkoutLabel = resolveThreadCheckoutLabel(thread);
+
+  return (
+    <div data-testid={`thread-preview-${thread.id}`} className="w-64 space-y-2 text-popover-foreground">
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1 font-medium text-xs leading-5">
+          {thread.title}
+        </div>
+        <span aria-label={`Provider, ${provider.label}`} className={cn("shrink-0 pt-0.5", provider.color)}>
+          <ProviderIcon size={14} />
+        </span>
+      </div>
+      <div className="grid gap-1.5">
+        <div aria-label={`Project, ${workspaceName}`} className="flex min-w-0 items-center gap-2">
+          <Folder size={13} aria-hidden className="shrink-0 opacity-75" />
+          <span className="truncate text-xs">{workspaceName}</span>
+        </div>
+        <div aria-label={`Branch, ${checkoutLabel}`} className="flex min-w-0 items-center gap-2">
+          <GitBranch size={13} aria-hidden className="shrink-0 opacity-75" />
+          <span className="truncate font-mono text-xs">{checkoutLabel}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /** Renders a virtualized, scrollable list of threads for a single workspace. */
 function VirtualizedThreadList({
+  workspaceName,
   treeItems: allTreeItems,
   maxVisible,
   activeThreadId,
@@ -1163,12 +1269,21 @@ function VirtualizedThreadList({
     >
       {virtualizer.getVirtualItems().map((virtualItem) => {
         const { thread, depth } = treeItems[virtualItem.index];
-        const status = getStatusDisplay(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
+        const isRunning = runningThreadIds.has(thread.id);
+        const hasPendingPermission = pendingPermissionThreadIds.has(thread.id);
+        const checks = checksById[thread.id];
+        const marker = getSidebarThreadMarker({
+          thread,
+          checks,
+          isRunning,
+          hasPendingPermission,
+        });
         const isEditing = inlineEdit?.threadId === thread.id;
         // Only PR-able (worktree) threads surface PR affordances. A direct-mode
         // thread shows its branch/agent status, never a PR icon, even if a PR
         // number happens to be attached.
         const prable = isPrable(thread);
+        const showEndMarker = !(prable && thread.pr_number != null && marker.kind === "ci");
         // Worktree thread whose directory no longer exists on disk.
         // Only check threads from the workspace whose worktrees are loaded — comparing
         // against a different workspace's worktree list would produce false positives.
@@ -1188,9 +1303,123 @@ function VirtualizedThreadList({
           : !providerRow.enabled
             ? "Provider disabled"
             : "CLI not found";
-        // Opacity on the row would compound onto CiChip; dim only the title cluster and timestamp.
+        // Opacity on the row would compound onto status markers; dim only the title cluster and timestamp.
         const scaffoldDim =
           (thread.clientPreparing || thread.clientError) && "opacity-[0.72]";
+        const row = (
+          <div
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (isEditing) return;
+              // Keyboard navigation fires immediately — no double-click semantics for keyboard users.
+              // Enter/Space always navigates; rename must be triggered via mouse double-click.
+              if ((e.key === "Enter" || e.key === " ") && e.target === e.currentTarget) {
+                e.preventDefault();
+                onSelectThread(thread.id);
+              }
+            }}
+            onClick={() => handleThreadClick(thread.id, thread.title)}
+            onDoubleClick={() => handleThreadDoubleClick(thread.id, thread.title)}
+            onContextMenu={(e) => onThreadContextMenu(e, thread)}
+            onMouseEnter={() => {
+              if (!thread.clientPreparing && !thread.clientError) {
+                schedulePrefetch(thread.id);
+              }
+            }}
+            onMouseLeave={cancelPrefetch}
+            className={cn(
+              "group/row relative flex items-center gap-2 rounded-md pr-2 py-1 text-[13px] cursor-pointer transition-colors",
+              activeThreadId === thread.id
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground"
+            )}
+            style={{ paddingLeft: `${24 + depth * 12}px` }}
+          >
+            {prable && thread.pr_number != null ? (() => {
+              const { Icon: PrIcon, color: prColor } = getPrVisual(thread.pr_status);
+              return (
+                <span
+                  title={`PR #${thread.pr_number} \u2013 ${thread.pr_status ?? "open"}`}
+                  className="absolute top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center"
+                  style={{ left: `${6 + depth * 12}px` }}
+                >
+                  <PrIcon size={12} className={prColor} />
+                </span>
+              );
+            })() : null}
+            <div
+              className={cn(
+                "flex min-w-0 flex-1 items-center gap-2",
+                scaffoldDim,
+              )}
+            >
+            {isEditing ? (
+              <Input
+                type="text"
+                size="xs"
+                value={inlineEdit.title}
+                onChange={(e) => onInlineEditChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (!e.nativeEvent.isComposing) {
+                    if (e.key === "Enter") onInlineEditCommit();
+                    if (e.key === "Escape") onInlineEditCancel();
+                  }
+                  e.stopPropagation();
+                }}
+                onBlur={onInlineEditCommit}
+                autoFocus
+                onClick={(e) => e.stopPropagation()}
+                className="flex-1 border-ring"
+              />
+            ) : (
+              <>
+                <span className={cn("truncate flex-1", isStaleWorktree && "text-[var(--diff-remove-strong)]/85 line-through")} data-testid="thread-title">
+                  {isStaleWorktree && (
+                    <Tooltip>
+                      <TooltipTrigger render={<AlertTriangle size={11} className="inline mr-1 align-text-bottom text-[var(--diff-remove-strong)]/80" />} />
+                      <TooltipContent side="right" className="text-xs">Worktree directory no longer exists</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {thread.title}
+                </span>
+                {thread.mode === "worktree" && (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <WorktreeModeIcon
+                          size={12}
+                          data-testid={`thread-worktree-indicator-${thread.id}`}
+                          aria-label="Worktree mode"
+                          className="text-muted-foreground/65"
+                        />
+                      }
+                    />
+                    <TooltipContent side="right" className="text-xs">Worktree</TooltipContent>
+                  </Tooltip>
+                )}
+              </>
+            )}
+            {!isEditing && unusable && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      data-testid={`sidebar-unusable-${thread.id}`}
+                      className="ml-1 shrink-0 inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/60"
+                      aria-label={unusableReason}
+                    />
+                  }
+                />
+                <TooltipContent side="right" className="text-xs">{unusableReason}</TooltipContent>
+              </Tooltip>
+            )}
+            </div>
+            {!isEditing && showEndMarker && (
+              <SidebarThreadMarker marker={marker} dim={Boolean(scaffoldDim)} />
+            )}
+          </div>
+        );
         return (
           <div
             key={thread.id}
@@ -1205,146 +1434,16 @@ function VirtualizedThreadList({
               transform: `translateY(${virtualItem.start - scrollMargin}px)`,
             }}
           >
-              <div
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (isEditing) return;
-                  // Keyboard navigation fires immediately — no double-click semantics for keyboard users.
-                  // Enter/Space always navigates; rename must be triggered via mouse double-click.
-                  if ((e.key === "Enter" || e.key === " ") && e.target === e.currentTarget) {
-                    e.preventDefault();
-                    onSelectThread(thread.id);
-                  }
-                }}
-                onClick={() => handleThreadClick(thread.id, thread.title)}
-                onDoubleClick={() => handleThreadDoubleClick(thread.id, thread.title)}
-                onContextMenu={(e) => onThreadContextMenu(e, thread)}
-                onMouseEnter={() => {
-                  if (!thread.clientPreparing && !thread.clientError) {
-                    schedulePrefetch(thread.id);
-                  }
-                }}
-                onMouseLeave={cancelPrefetch}
-                className={cn(
-                  "group/row flex items-center gap-2 rounded-md pr-2 py-1 text-[13px] cursor-pointer transition-colors",
-                  activeThreadId === thread.id
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground"
-                )}
-                style={{ paddingLeft: `${8 + depth * 12}px` }}
-              >
-                <div
-                  className={cn(
-                    "flex min-w-0 flex-1 items-center gap-2",
-                    scaffoldDim,
-                  )}
-                >
-                {prable && thread.pr_number != null ? (() => {
-                  const { Icon: PrIcon, color: prColor } = getPrVisual(thread.pr_status);
-                  const agentDot = getNotificationDot(thread, runningThreadIds.has(thread.id), pendingPermissionThreadIds.has(thread.id));
-                  // Only the agent signal lives on the PR icon — a top-right dot.
-                  // CI status is surfaced as a labelled chip in the row's end-section
-                  // so it cannot be confused with an agent-activity dot.
-                  return (
-                    <span
-                      title={`PR #${thread.pr_number} \u2013 ${thread.pr_status ?? "open"}`}
-                      className="relative shrink-0"
-                    >
-                      <PrIcon size={12} className={prColor} />
-                      {agentDot && (
-                        <span
-                          aria-label={agentDot.shape === "ring" ? "Action required" : undefined}
-                          className={cn(
-                            "absolute rounded-full",
-                            // Ring variant sizes up slightly and drops the background ring so the
-                            // amber ring isn't confused with the 1px separator ring used on dots.
-                            agentDot.shape === "ring"
-                              ? "-top-1 -right-1 h-2 w-2"
-                              : "-top-0.5 -right-0.5 h-1.5 w-1.5 ring-1 ring-background",
-                            agentDot.dotClass,
-                            agentDot.animate && "status-pulse",
-                          )}
-                        />
-                      )}
-                    </span>
-                  );
-                })() : (
-                  <span
-                    aria-label={status.shape === "ring" ? "Action required" : undefined}
-                    className={cn(
-                      "shrink-0 rounded-full",
-                      status.shape === "ring" ? "h-2 w-2" : "h-1.5 w-1.5",
-                      status.dotClass,
-                    )}
-                  />
-                )}
-                {status.label && (
-                  <span className={cn("shrink-0 font-mono text-[9.5px] uppercase tracking-[0.12em]", status.color)}>
-                    {status.label}
-                  </span>
-                )}
-                {isEditing ? (
-                  <Input
-                    type="text"
-                    size="xs"
-                    value={inlineEdit.title}
-                    onChange={(e) => onInlineEditChange(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (!e.nativeEvent.isComposing) {
-                        if (e.key === "Enter") onInlineEditCommit();
-                        if (e.key === "Escape") onInlineEditCancel();
-                      }
-                      e.stopPropagation();
-                    }}
-                    onBlur={onInlineEditCommit}
-                    autoFocus
-                    onClick={(e) => e.stopPropagation()}
-                    className="flex-1 border-ring"
-                  />
-                ) : (
-                  <span className={cn("truncate flex-1", isStaleWorktree && "text-[var(--diff-remove-strong)]/85 line-through")} data-testid="thread-title">
-                    {isStaleWorktree && (
-                      <Tooltip>
-                        <TooltipTrigger render={<AlertTriangle size={11} className="inline mr-1 align-text-bottom text-[var(--diff-remove-strong)]/80" />} />
-                        <TooltipContent side="right" className="text-xs">Worktree directory no longer exists</TooltipContent>
-                      </Tooltip>
-                    )}
-                    {thread.title}
-                  </span>
-                )}
-                {!isEditing && unusable && (
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <span
-                          data-testid={`sidebar-unusable-${thread.id}`}
-                          className="ml-1 shrink-0 inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/60"
-                          aria-label={unusableReason}
-                        />
-                      }
-                    />
-                    <TooltipContent side="right" className="text-xs">{unusableReason}</TooltipContent>
-                  </Tooltip>
-                )}
-                </div>
-                {!isEditing && prable && thread.pr_number != null && checksById[thread.id] && (
-                  <CiChip checks={checksById[thread.id]} />
-                )}
-                {!isEditing && (
-                  <span
-                    className={cn(
-                      "shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/45",
-                      scaffoldDim,
-                    )}
-                  >
-                    {prable && thread.pr_number != null && (
-                      <span className="mr-1 opacity-80">#{thread.pr_number}</span>
-                    )}
-                    {relativeTime(thread.updated_at)}
-                  </span>
-                )}
-              </div>
+              {isEditing ? (
+                row
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger render={row} />
+                  <TooltipContent side="right" align="start" sideOffset={8} variant="surface" className="max-w-none p-3">
+                    <SidebarThreadPreview workspaceName={workspaceName} thread={thread} />
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
           );
         })}
@@ -1556,6 +1655,7 @@ const ProjectNode = memo(function ProjectNode({
             </div>
           ) : (
             <VirtualizedThreadList
+              workspaceName={workspace.name}
               treeItems={treeItems}
               maxVisible={maxVisible}
               activeThreadId={activeThreadId}

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -23,19 +23,26 @@ function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
+type TooltipContentProps = TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  > & {
+    variant?: "inverse" | "surface"
+  }
+
 function TooltipContent({
   className,
   side = "top",
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
+  variant = "inverse",
   children,
   ...props
-}: TooltipPrimitive.Popup.Props &
-  Pick<
-    TooltipPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+}: TooltipContentProps) {
+  const isSurface = variant === "surface"
+
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
@@ -48,13 +55,21 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            "pointer-events-none z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "pointer-events-none z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            isSurface
+              ? "border border-border bg-popover text-popover-foreground shadow-lg"
+              : "bg-foreground text-background",
             className
           )}
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow
+            className={cn(
+              "z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5",
+              isSurface ? "bg-popover fill-popover" : "bg-foreground fill-foreground"
+            )}
+          />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
## What
Updates sidebar and Thread Overview metadata indicators for worktree threads.

## Why
Thread rows need to stay glanceable while showing worktree, PR, provider, branch, and run state without extra text or duplicate status noise.

## Key Changes
- Replaced worktree glyphs with the Synara-style split-arrow icon in the sidebar and Thread Overview local row.
- Moved thread row state to the right edge, using the primary spinner while a thread runs and hiding the updated time in that state.
- Added read-only hover previews with provider, project, and branch details in theme-aware tooltip surfaces.
- Kept PR rows to a single leading PR icon and removed the extra failing-check icon from the far right.
- Added focused unit and Playwright coverage for sidebar previews, row markers, and the Thread Overview worktree icon.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785515354&installation_id=129163861&pr_number=831&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F831&signature=31cee747104959c20a8231da3eaac933370af19fefd4b6a389718af4c6427a49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->