### PR TITLE
fix(server): cancel CI checks during worktree cleanup

### DIFF
--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -16,12 +16,20 @@ function makeChecks(aggregate: ChecksStatus["aggregate"]): ChecksStatus {
 
 describe("CiWatcherService", () => {
   let watcher: CiWatcherService;
-  let mockGithubService: { getCheckRuns: ReturnType<typeof vi.fn> };
+  let mockGithubService: {
+    getCheckRuns: ReturnType<typeof vi.fn>;
+    cancelCheckRuns: ReturnType<typeof vi.fn>;
+    cancelAllInFlight: ReturnType<typeof vi.fn>;
+  };
   let mockBroadcast: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    mockGithubService = { getCheckRuns: vi.fn() };
+    mockGithubService = {
+      getCheckRuns: vi.fn(),
+      cancelCheckRuns: vi.fn().mockResolvedValue(undefined),
+      cancelAllInFlight: vi.fn().mockResolvedValue(undefined),
+    };
     // Default: return no_checks so watch() immediate fetch resolves without side effects.
     mockGithubService.getCheckRuns.mockResolvedValue(makeChecks("no_checks"));
     mockBroadcast = vi.fn();
@@ -31,8 +39,8 @@ describe("CiWatcherService", () => {
     );
   });
 
-  afterEach(() => {
-    watcher.dispose();
+  afterEach(async () => {
+    await watcher.dispose();
     vi.useRealTimers();
   });
 
@@ -45,6 +53,43 @@ describe("CiWatcherService", () => {
     watcher.watch("t1", 42, "main", "/repo");
     watcher.unwatch("t1");
     expect(watcher.isWatching("t1")).toBe(false);
+  });
+
+  it("teardownThread() removes the entry and cancels an in-flight check fetch", async () => {
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
+
+    await watcher.teardownThread("t1");
+
+    expect(watcher.isWatching("t1")).toBe(false);
+    expect(mockGithubService.cancelCheckRuns).toHaveBeenCalledWith("main", "/repo");
+  });
+
+  it("dispose() cancels all in-flight GitHub CLI processes", async () => {
+    await watcher.dispose();
+
+    expect(mockGithubService.cancelAllInFlight).toHaveBeenCalled();
+  });
+
+  it("unwatch() clears post-push bump timers before they fetch checks", async () => {
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
+    mockGithubService.getCheckRuns.mockClear();
+
+    watcher.scheduleBumpAfterPush("t1");
+    watcher.unwatch("t1");
+    await vi.advanceTimersByTimeAsync(25_000);
+
+    expect(mockGithubService.getCheckRuns).not.toHaveBeenCalled();
+  });
+
+  it("dispose() clears post-push bump timers before they fetch checks", async () => {
+    watcher.watch("t1", 42, "main", "/repo", { skipInitialFetch: true });
+    mockGithubService.getCheckRuns.mockClear();
+
+    watcher.scheduleBumpAfterPush("t1");
+    await watcher.dispose();
+    await vi.advanceTimersByTimeAsync(25_000);
+
+    expect(mockGithubService.getCheckRuns).not.toHaveBeenCalled();
   });
 
   it("broadcasts when check state changes on tick", async () => {

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -1,13 +1,21 @@
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "events";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 
 const { mockExecFile } = vi.hoisted(() => ({
   mockExecFile: vi.fn(),
 }));
+const { mockKillProcessTree } = vi.hoisted(() => ({
+  mockKillProcessTree: vi.fn(),
+}));
 
 vi.mock("child_process", () => ({
   execFile: mockExecFile,
+}));
+
+vi.mock("../services/process-kill.js", () => ({
+  killProcessTree: mockKillProcessTree,
 }));
 
 vi.mock("@mcode/shared", () => ({
@@ -19,11 +27,24 @@ import { GithubService } from "../services/github-service";
 
 type CallbackFn = (error: Error | null, stdout: string, stderr: string) => void;
 
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  maxTurns = 100,
+): Promise<void> {
+  for (let i = 0; i < maxTurns; i++) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error(message);
+}
+
 describe("GithubService.getCheckRuns", () => {
   let ghService: GithubService;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockKillProcessTree.mockResolvedValue(undefined);
     ghService = new GithubService({} as WorkspaceRepo);
     vi.spyOn(ghService, "resolveRepoSlug").mockResolvedValue("owner/test-repo");
   });
@@ -373,6 +394,95 @@ describe("GithubService.getCheckRuns", () => {
     expect(execFileCallCount).toBe(1);
     expect(result1.aggregate).toBe("passing");
     expect(result2.aggregate).toBe("passing");
+  });
+
+  it("cancelCheckRuns terminates the active gh process for that branch and repo", async () => {
+    let child!: EventEmitter & { pid: number };
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, _cb: CallbackFn) => {
+        child = Object.assign(new EventEmitter(), { pid: 4321 });
+        return child;
+      },
+    );
+
+    const pending = ghService.getCheckRuns("main", "/repo");
+    while (!child) {
+      await Promise.resolve();
+    }
+
+    await ghService.cancelCheckRuns("main", "/repo");
+    const result = await pending;
+
+    expect(mockKillProcessTree).toHaveBeenCalledWith(4321);
+    expect(result.aggregate).toBe("no_checks");
+  });
+
+  it("cancelCheckRuns resolves a lookup queued behind the concurrency gate before it spawns gh", async () => {
+    const children: Array<EventEmitter & { pid: number }> = [];
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, _cb: CallbackFn) => {
+        const child = Object.assign(new EventEmitter(), { pid: 5000 + children.length });
+        children.push(child);
+        return child;
+      },
+    );
+
+    const active = [
+      ghService.getCheckRuns("active-1", "/repo"),
+      ghService.getCheckRuns("active-2", "/repo"),
+      ghService.getCheckRuns("active-3", "/repo"),
+    ];
+    await waitFor(() => children.length === 3, "three active gh processes did not start");
+
+    const queued = ghService.getCheckRuns("queued", "/repo");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(children).toHaveLength(3);
+
+    await ghService.cancelCheckRuns("queued", "/repo");
+    await expect(queued).resolves.toMatchObject({ aggregate: "no_checks" });
+
+    await ghService.cancelAllInFlight();
+    await Promise.all(active);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(children).toHaveLength(3);
+  });
+
+  it("cancelCheckRuns resolves a lookup while repo slug resolution is still pending", async () => {
+    let resolveSlug!: (slug: string) => void;
+    vi.mocked(ghService.resolveRepoSlug).mockImplementationOnce(
+      () => new Promise<string>((resolve) => { resolveSlug = resolve; }),
+    );
+
+    const pending = ghService.getCheckRuns("main", "/repo");
+    await waitFor(
+      () => vi.mocked(ghService.resolveRepoSlug).mock.calls.length > 0,
+      "slug resolution did not start",
+    );
+
+    await ghService.cancelCheckRuns("main", "/repo");
+    await expect(pending).resolves.toMatchObject({ aggregate: "no_checks" });
+    resolveSlug("owner/test-repo");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("cancelForRepoPath terminates active gh processes for normalized matching repo paths", async () => {
+    let child!: EventEmitter & { pid: number };
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, _cb: CallbackFn) => {
+        child = Object.assign(new EventEmitter(), { pid: 6789 });
+        return child;
+      },
+    );
+
+    const pending = ghService.getCheckRuns("main", "C:\\Repo\\Worktree\\");
+    await waitFor(() => Boolean(child), "gh process did not start");
+
+    await ghService.cancelForRepoPath("c:/repo/worktree");
+    await expect(pending).resolves.toMatchObject({ aggregate: "no_checks" });
+
+    expect(mockKillProcessTree).toHaveBeenCalledWith(6789);
   });
 });
 

--- a/apps/server/src/__tests__/thread-delete-teardown-rpc.test.ts
+++ b/apps/server/src/__tests__/thread-delete-teardown-rpc.test.ts
@@ -20,7 +20,18 @@ function workspaceRequest(method: "workspace.delete" | "workspace.forceDelete"):
 
 function threadDeps(): RouterDeps {
   return {
-    ciWatcherService: { unwatch: vi.fn() },
+    ciWatcherService: {
+      teardownThread: vi.fn().mockResolvedValue(undefined),
+    },
+    githubService: {
+      cancelForRepoPath: vi.fn().mockResolvedValue(undefined),
+    },
+    threadRepo: {
+      findById: vi.fn().mockReturnValue({
+        id: "t-delete",
+        worktree_path: "C:/repo-worktree",
+      }),
+    },
     threadTeardownService: { teardownThread: vi.fn().mockResolvedValue(undefined) },
     threadService: { delete: vi.fn().mockReturnValue(true) },
   } as unknown as RouterDeps;
@@ -30,7 +41,16 @@ function workspaceDeps(): RouterDeps {
   return {
     gitWatcherService: { unwatchWorkspace: vi.fn() },
     threadRepo: {
-      listAllByWorkspace: vi.fn().mockReturnValue([{ id: "t-1" }, { id: "t-2" }]),
+      listAllByWorkspace: vi.fn().mockReturnValue([
+        { id: "t-1", worktree_path: "C:/repo-worktree-1" },
+        { id: "t-2", worktree_path: "C:/repo-worktree-2" },
+      ]),
+    },
+    githubService: {
+      cancelForRepoPath: vi.fn().mockResolvedValue(undefined),
+    },
+    ciWatcherService: {
+      teardownThread: vi.fn().mockResolvedValue(undefined),
     },
     threadTeardownService: { teardownThread: vi.fn().mockResolvedValue(undefined) },
     workspaceService: {
@@ -44,7 +64,10 @@ describe("thread.delete teardown", () => {
   it("tears down runtime resources before deleting the thread row", async () => {
     const d = threadDeps();
     const calls: string[] = [];
-    vi.mocked(d.ciWatcherService.unwatch).mockImplementation(() => {
+    vi.mocked(d.githubService.cancelForRepoPath).mockImplementation(async () => {
+      calls.push("github");
+    });
+    vi.mocked(d.ciWatcherService.teardownThread).mockImplementation(async () => {
       calls.push("ci");
     });
     vi.mocked(d.threadTeardownService.teardownThread).mockImplementation(async () => {
@@ -58,9 +81,11 @@ describe("thread.delete teardown", () => {
     const response = await routeMessage(threadDeleteRequest("t-delete"), d);
 
     expect(response).toEqual({ id: "delete-1", result: true });
+    expect(d.githubService.cancelForRepoPath).toHaveBeenCalledWith("C:/repo-worktree");
+    expect(d.ciWatcherService.teardownThread).toHaveBeenCalledWith("t-delete");
     expect(d.threadTeardownService.teardownThread).toHaveBeenCalledWith("t-delete");
     expect(d.threadService.delete).toHaveBeenCalledWith("t-delete", false);
-    expect(calls).toEqual(["ci", "teardown", "delete"]);
+    expect(calls).toEqual(["github", "ci", "teardown", "delete"]);
   });
 
   it("does not hide the thread when resource teardown fails", async () => {
@@ -83,6 +108,12 @@ describe("workspace delete teardown", () => {
   it("tears down child threads before soft-deleting the workspace", async () => {
     const d = workspaceDeps();
     const calls: string[] = [];
+    vi.mocked(d.githubService.cancelForRepoPath).mockImplementation(async (worktreePath) => {
+      calls.push(`github:${worktreePath}`);
+    });
+    vi.mocked(d.ciWatcherService.teardownThread).mockImplementation(async (threadId) => {
+      calls.push(`ci:${threadId}`);
+    });
     vi.mocked(d.threadTeardownService.teardownThread).mockImplementation(async (threadId) => {
       calls.push(`teardown:${threadId}`);
     });
@@ -95,9 +126,21 @@ describe("workspace delete teardown", () => {
 
     expect(response).toEqual({ id: "workspace-delete-1", result: true });
     expect(d.threadRepo.listAllByWorkspace).toHaveBeenCalledWith("workspace-1");
+    expect(d.githubService.cancelForRepoPath).toHaveBeenCalledWith("C:/repo-worktree-1");
+    expect(d.githubService.cancelForRepoPath).toHaveBeenCalledWith("C:/repo-worktree-2");
+    expect(d.ciWatcherService.teardownThread).toHaveBeenCalledWith("t-1");
+    expect(d.ciWatcherService.teardownThread).toHaveBeenCalledWith("t-2");
     expect(d.threadTeardownService.teardownThread).toHaveBeenCalledWith("t-1");
     expect(d.threadTeardownService.teardownThread).toHaveBeenCalledWith("t-2");
-    expect(calls).toEqual(["teardown:t-1", "teardown:t-2", "delete"]);
+    expect(calls).toEqual([
+      "github:C:/repo-worktree-1",
+      "github:C:/repo-worktree-2",
+      "ci:t-1",
+      "ci:t-2",
+      "teardown:t-1",
+      "teardown:t-2",
+      "delete",
+    ]);
   });
 
   it("does not hide the workspace when child thread teardown fails", async () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -712,8 +712,8 @@ async function shutdown(): Promise<void> {
   // 8a. Dispose cleanup worker
   cleanupWorker.dispose();
 
-  // 8b. Dispose CI check watcher timers
-  ciWatcherService.dispose();
+  // 8b. Dispose CI check watcher timers and in-flight GitHub CLI children
+  await ciWatcherService.dispose();
 
   // 9. Close all WebSocket clients and shut down the WS server
   for (const client of wss.clients) {

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -35,6 +35,7 @@ export class CiWatcherService {
   private passive = new Map<string, WatchEntry>();
   private activeTimer: ReturnType<typeof setInterval> | null = null;
   private passiveTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly bumpTimers = new Map<string, Set<ReturnType<typeof setTimeout>>>();
   private activeTicking = false;
   private passiveTicking = false;
 
@@ -79,9 +80,19 @@ export class CiWatcherService {
   unwatch(threadId: string): void {
     this.active.delete(threadId);
     this.passive.delete(threadId);
+    this.clearBumpTimers(threadId);
     if (this.active.size === 0) this.stopActiveTimer();
     // Stop the passive timer independently — it's not needed just because active is non-empty.
     if (this.passive.size === 0) this.stopPassiveTimer();
+  }
+
+  /** Remove a thread from the watcher and cancel its in-flight GitHub check process. */
+  async teardownThread(threadId: string): Promise<void> {
+    const entry = this.active.get(threadId) ?? this.passive.get(threadId);
+    this.unwatch(threadId);
+    if (entry) {
+      await this.githubService.cancelCheckRuns(entry.branch, entry.repoPath);
+    }
   }
 
   /** Check if a thread is being watched. */
@@ -160,8 +171,17 @@ export class CiWatcherService {
   scheduleBumpAfterPush(threadId: string): void {
     const entry = this.active.get(threadId) ?? this.passive.get(threadId);
     if (!entry) return;
+    this.clearBumpTimers(threadId);
+    const timers = new Set<ReturnType<typeof setTimeout>>();
+    this.bumpTimers.set(threadId, timers);
     for (const delay of POST_PUSH_BUMP_DELAYS_MS) {
-      setTimeout(() => { void this.bump(threadId); }, delay).unref?.();
+      const timer = setTimeout(() => {
+        timers.delete(timer);
+        if (timers.size === 0) this.bumpTimers.delete(threadId);
+        void this.bump(threadId);
+      }, delay);
+      timer.unref?.();
+      timers.add(timer);
     }
   }
 
@@ -231,9 +251,15 @@ export class CiWatcherService {
   }
 
   /** Clean up all timers. Called on server shutdown. */
-  dispose(): void {
+  async dispose(): Promise<void> {
+    for (const threadId of [...this.bumpTimers.keys()]) {
+      this.clearBumpTimers(threadId);
+    }
     this.stopActiveTimer();
     this.stopPassiveTimer();
+    this.active.clear();
+    this.passive.clear();
+    await this.githubService.cancelAllInFlight();
   }
 
   private startActiveTimer(): void {
@@ -266,6 +292,13 @@ export class CiWatcherService {
       clearInterval(this.passiveTimer);
       this.passiveTimer = null;
     }
+  }
+
+  private clearBumpTimers(threadId: string): void {
+    const timers = this.bumpTimers.get(threadId);
+    if (!timers) return;
+    for (const timer of timers) clearTimeout(timer);
+    this.bumpTimers.delete(threadId);
   }
 
   /** Returns true when `next` differs semantically from `cached` (aggregate, run count, or per-run status/conclusion). */

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -5,9 +5,10 @@
  */
 
 import { injectable, inject } from "tsyringe";
-import { execFile } from "child_process";
+import { execFile, type ChildProcess } from "child_process";
 import type { PrInfo, PrDetail, ChecksStatus, CheckRun } from "@mcode/contracts";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
+import { killProcessTree } from "./process-kill.js";
 
 /**
  * Handles GitHub PR lookups and listing via the `gh` CLI.
@@ -26,7 +27,9 @@ export class GithubService {
   private readonly slugCache = new Map<string, { promise: Promise<string>; expiresAt: number }>();
 
   /** In-flight deduplication map for getCheckRuns to avoid redundant concurrent fetches. */
-  private readonly checkRunsInflight = new Map<string, Promise<ChecksStatus>>();
+  private readonly checkRunsInflight = new Map<string, CheckRunsInflight>();
+  /** Live gh subprocesses keyed by the repository path that owns their cwd. */
+  private readonly activeProcesses = new Set<TrackedGithubProcess>();
 
   /** Maximum number of gh subprocesses that may run concurrently. */
   private readonly maxConcurrent = 3;
@@ -36,6 +39,102 @@ export class GithubService {
   constructor(
     @inject(WorkspaceRepo) private readonly workspaceRepo: WorkspaceRepo,
   ) {}
+
+  /**
+   * Cancel an in-flight check-run lookup for one branch and repository path.
+   * Used before thread/worktree deletion so a running `gh` child cannot keep
+   * the worktree directory open on Windows.
+   */
+  async cancelCheckRuns(branch: string, repoPath: string): Promise<void> {
+    const key = this.inflightKey(branch, repoPath);
+    const inflight = this.checkRunsInflight.get(key);
+    if (inflight) {
+      inflight.cancelled = true;
+      this.checkRunsInflight.delete(key);
+      inflight.resolve(noChecks());
+    }
+
+    const normalized = normalizeRepoPath(repoPath);
+    await this.cancelProcesses(
+      (process) => process.checkRunsKey === key || process.repoPath === normalized,
+    );
+  }
+
+  /**
+   * Cancel every tracked gh subprocess running from a repository path.
+   * This is a broader cleanup hook for worktree removal and shutdown paths.
+   */
+  async cancelForRepoPath(repoPath: string): Promise<void> {
+    const normalized = normalizeRepoPath(repoPath);
+    for (const [key, inflight] of this.checkRunsInflight) {
+      if (inflight.repoPath !== normalized) continue;
+      inflight.cancelled = true;
+      this.checkRunsInflight.delete(key);
+      inflight.resolve(noChecks());
+    }
+    await this.cancelProcesses((process) => process.repoPath === normalized);
+  }
+
+  /** Cancel every in-flight gh subprocess owned by this service. */
+  async cancelAllInFlight(): Promise<void> {
+    for (const inflight of this.checkRunsInflight.values()) {
+      inflight.cancelled = true;
+      inflight.resolve(noChecks());
+    }
+    this.checkRunsInflight.clear();
+    await this.cancelProcesses(() => true);
+  }
+
+  private inflightKey(branch: string, repoPath: string): string {
+    return `${normalizeRepoPath(repoPath) ?? repoPath}\0${branch}`;
+  }
+
+  private trackProcess(
+    child: ChildProcess | undefined,
+    meta: { repoPath?: string | null; checkRunsKey?: string | null },
+  ): TrackedGithubProcess | null {
+    if (!child || typeof child.once !== "function") return null;
+
+    let tracked!: TrackedGithubProcess;
+    let finish!: () => void;
+    const done = new Promise<void>((resolve) => {
+      let finished = false;
+      finish = () => {
+        if (finished) return;
+        finished = true;
+        this.activeProcesses.delete(tracked);
+        resolve();
+      };
+    });
+
+    tracked = {
+      child,
+      repoPath: normalizeRepoPath(meta.repoPath),
+      checkRunsKey: meta.checkRunsKey ?? null,
+      done,
+      finish,
+    };
+
+    this.activeProcesses.add(tracked);
+    child.once("exit", finish);
+    child.once("close", finish);
+    child.once("error", finish);
+    return tracked;
+  }
+
+  private async cancelProcesses(
+    predicate: (process: TrackedGithubProcess) => boolean,
+  ): Promise<void> {
+    const matches = [...this.activeProcesses].filter(predicate);
+    await Promise.all(matches.map(async (tracked) => {
+      const pid = tracked.child.pid;
+      if (typeof pid === "number" && pid > 0) {
+        await killProcessTree(pid);
+      }
+      tracked.finish();
+      await tracked.done;
+    }));
+  }
 
   /**
    * Acquire a slot in the concurrency gate.
@@ -65,11 +164,13 @@ export class GithubService {
   /** Look up the PR associated with a branch in the given working directory. */
   getBranchPr(branch: string, cwd: string): Promise<PrInfo | null> {
     return new Promise((resolve) => {
-      execFile(
+      let tracked: TrackedGithubProcess | null = null;
+      const child = execFile(
         "gh",
         ["pr", "view", branch, "--json", "number,url,state"],
         { cwd, encoding: "utf-8", timeout: 10_000, windowsHide: true },
         (error, stdout) => {
+          tracked?.finish();
           if (error || !stdout) {
             resolve(null);
             return;
@@ -97,6 +198,7 @@ export class GithubService {
           }
         },
       );
+      tracked = this.trackProcess(child, { repoPath: cwd });
     });
   }
 
@@ -106,7 +208,8 @@ export class GithubService {
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
 
     return new Promise((resolve) => {
-      execFile(
+      let tracked: TrackedGithubProcess | null = null;
+      const child = execFile(
         "gh",
         [
           "pr",
@@ -118,6 +221,7 @@ export class GithubService {
         ],
         { cwd: workspace.path, encoding: "utf-8", timeout: 15_000, windowsHide: true },
         (error, stdout) => {
+          tracked?.finish();
           if (error || !stdout) {
             resolve([]);
             return;
@@ -153,6 +257,7 @@ export class GithubService {
           }
         },
       );
+      tracked = this.trackProcess(child, { repoPath: workspace.path });
     });
   }
 
@@ -182,11 +287,13 @@ export class GithubService {
     }
 
     return new Promise((resolve, reject) => {
-      execFile(
+      let tracked: TrackedGithubProcess | null = null;
+      const child = execFile(
         "gh",
         args,
         { cwd: input.cwd, encoding: "utf-8", timeout: 30_000, windowsHide: true },
         (error, stdout) => {
+          tracked?.finish();
           if (error) {
             reject(error);
             return;
@@ -203,6 +310,7 @@ export class GithubService {
           resolve({ number, url });
         },
       );
+      tracked = this.trackProcess(child, { repoPath: input.cwd });
     });
   }
 
@@ -223,32 +331,11 @@ export class GithubService {
       return { aggregate: "no_checks", runs: [], fetchedAt: Date.now() };
     }
 
-    const inflightKey = `${repoPath}\0${branch}`;
+    const inflightKey = this.inflightKey(branch, repoPath);
 
     // M6: Return an existing in-flight promise if one exists for this branch+repo pair.
     const inflight = this.checkRunsInflight.get(inflightKey);
-    if (inflight) return inflight;
-
-    const slug = await this.resolveRepoSlug(repoPath);
-
-    // Check again after async slug resolution - another caller may have already started the fetch.
-    const inflight2 = this.checkRunsInflight.get(inflightKey);
-    if (inflight2) return inflight2;
-
-    await this.acquire();
-
-    // Check once more after acquiring the semaphore slot.
-    const inflight3 = this.checkRunsInflight.get(inflightKey);
-    if (inflight3) { this.release(); return inflight3; }
-
-    let released = false;
-    /** Releases the concurrency slot at most once, guarding against double-release. */
-    const releaseOnce = (): void => {
-      if (!released) {
-        released = true;
-        this.release();
-      }
-    };
+    if (inflight) return inflight.promise;
 
     /** Explicit conclusion mapping - unknown values default to failure (conservative). */
     const conclusionMap: Record<string, CheckRun["conclusion"]> = {
@@ -261,129 +348,171 @@ export class GithubService {
       action_required: "failure", // blocks merge like a failure
     };
 
-    // Capture resolve externally so the inflight map can be set BEFORE execFile is called,
-    // preventing a race where a synchronous mock callback fires inside the Promise constructor
-    // and sees the map entry missing.
+    // Register before any await so deletion/shutdown can cancel queued or slug-resolving fetches.
     let resolvePromise!: (value: ChecksStatus) => void;
     const promise = new Promise<ChecksStatus>((res) => { resolvePromise = res; });
+    const inflightController: CheckRunsInflight = {
+      promise,
+      resolve: resolvePromise,
+      repoPath: normalizeRepoPath(repoPath),
+      branch,
+      cancelled: false,
+    };
+    this.checkRunsInflight.set(inflightKey, inflightController);
 
-    // Register before spawning - any concurrent caller arriving now will reuse this promise.
-    this.checkRunsInflight.set(inflightKey, promise);
+    const activeProcess: { current: TrackedGithubProcess | null } = { current: null };
+    let acquired = false;
+    let released = false;
+    /** Releases the concurrency slot at most once, guarding against double-release. */
+    const releaseOnce = (): void => {
+      if (acquired && !released) {
+        released = true;
+        this.release();
+      }
+    };
 
-    execFile(
-      "gh",
-      [
-        "api",
-        `repos/${slug}/commits/${encodeURIComponent(branch)}/check-runs`,
-        "--cache", "5s",
-        "-H", "Accept: application/vnd.github+json",
-        "--jq", ".check_runs | map({name: .name, status: .status, conclusion: .conclusion, startedAt: .started_at, completedAt: .completed_at, appId: .app.id})",
-      ],
-      { cwd: repoPath, encoding: "utf-8", timeout: 15_000, maxBuffer: 2 * 1024 * 1024, windowsHide: true },
-      (error, stdout) => {
-        releaseOnce();
-        this.checkRunsInflight.delete(inflightKey);
-        const now = Date.now();
-        if (error || !stdout) {
-          resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
+    void (async () => {
+      try {
+        const slug = await this.resolveRepoSlug(repoPath);
+        if (inflightController.cancelled) return;
+
+        await this.acquire();
+        acquired = true;
+        if (inflightController.cancelled) {
+          releaseOnce();
           return;
         }
-        try {
-          const items = JSON.parse(stdout) as Array<{
-            name?: string;
-            status?: string;
-            conclusion?: string | null;
-            startedAt?: string | null;
-            completedAt?: string | null;
-            appId?: number | null;
-          }>;
 
-          if (items.length === 0) {
-            resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
-            return;
-          }
-
-          const rawRuns = items.map((item) => {
-            // M1: Missing status defaults to in_progress (not completed) to avoid false-green aggregate.
-            const status = (item.status ?? "in_progress") as CheckRun["status"];
-            // H1: Unknown conclusion values are mapped conservatively to failure.
-            const rawConclusion = item.conclusion ?? null;
-            const conclusion: CheckRun["conclusion"] = rawConclusion === null
-              ? null
-              : (conclusionMap[rawConclusion] ?? "failure");
-
-            let durationMs: number | null = null;
-            if (status === "completed" && item.startedAt && item.completedAt) {
-              durationMs = new Date(item.completedAt).getTime() - new Date(item.startedAt).getTime();
+        const child = execFile(
+          "gh",
+          [
+            "api",
+            `repos/${slug}/commits/${encodeURIComponent(branch)}/check-runs`,
+            "--cache", "5s",
+            "-H", "Accept: application/vnd.github+json",
+            "--jq", ".check_runs | map({name: .name, status: .status, conclusion: .conclusion, startedAt: .started_at, completedAt: .completed_at, appId: .app.id})",
+          ],
+          { cwd: repoPath, encoding: "utf-8", timeout: 15_000, maxBuffer: 2 * 1024 * 1024, windowsHide: true },
+          (error, stdout) => {
+            activeProcess.current?.finish();
+            releaseOnce();
+            if (this.checkRunsInflight.get(inflightKey) === inflightController) {
+              this.checkRunsInflight.delete(inflightKey);
             }
-
-            return {
-              name: item.name ?? "unknown",
-              status,
-              conclusion,
-              durationMs,
-              startedAt: item.startedAt ?? null,
-              // appId is used only for dedup scoping — it is stripped before the result is returned.
-              appId: typeof item.appId === "number" ? item.appId : 0,
-            };
-          });
-
-          // D1: Deduplicate runs with the same (name, appId), keeping the most recently started one.
-          // GitHub returns check runs from every check suite on a commit, so re-runs or
-          // workflows triggered by multiple events produce duplicate entries (e.g., a passing
-          // run from suite A alongside a failing run from the newly-triggered suite B).
-          // Without dedup the aggregate can be stale and the list shows ghost duplicates.
-          //
-          // The dedup key includes appId so that two different GitHub Apps that both create a
-          // check named "validate-pr" (e.g., GitHub Actions + Greptile) are NOT collapsed —
-          // only runs from the same app are candidates for deduplication.
-          //
-          // Tie-breaking: null startedAt maps to "" which is lexicographically less than any
-          // ISO string, so a run with a known timestamp always wins over one without. When
-          // two runs share the same timestamp (or both are null), the first in API response
-          // order is kept — GitHub does not guarantee ordering between suite siblings, so
-          // either choice is equivalent.
-          const dedupMap = new Map<string, typeof rawRuns[0]>();
-          for (const run of rawRuns) {
-            const key = `${run.name}\0${run.appId}`;
-            const existing = dedupMap.get(key);
-            const existingTs = existing?.startedAt ?? "";
-            const runTs = run.startedAt ?? "";
-            if (!existing || runTs > existingTs) {
-              dedupMap.set(key, run);
+            if (inflightController.cancelled) return;
+            const now = Date.now();
+            if (error || !stdout) {
+              resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
+              return;
             }
-          }
-          // Strip the internal appId field before passing runs to the caller.
-          const runs: CheckRun[] = [...dedupMap.values()].map(({ appId: _appId, ...run }) => run);
+            try {
+              const items = JSON.parse(stdout) as Array<{
+                name?: string;
+                status?: string;
+                conclusion?: string | null;
+                startedAt?: string | null;
+                completedAt?: string | null;
+                appId?: number | null;
+              }>;
 
-          let aggregate: "passing" | "failing" | "pending" | "no_checks";
-          if (runs.some((r) => r.conclusion === "failure" || r.conclusion === "timed_out")) {
-            aggregate = "failing";
-          } else if (runs.some((r) => r.status !== "completed")) {
-            aggregate = "pending";
-          } else {
-            aggregate = "passing";
-          }
+              if (items.length === 0) {
+                resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
+                return;
+              }
 
-          // If all runs completed but none succeeded (all skipped/cancelled/neutral),
-          // treat as no_checks to avoid a misleading green badge.
-          if (aggregate === "passing" && !runs.some((r) => r.conclusion === "success")) {
-            aggregate = "no_checks";
-          }
+              const rawRuns = items.map((item) => {
+                // M1: Missing status defaults to in_progress (not completed) to avoid false-green aggregate.
+                const status = (item.status ?? "in_progress") as CheckRun["status"];
+                // H1: Unknown conclusion values are mapped conservatively to failure.
+                const rawConclusion = item.conclusion ?? null;
+                const conclusion: CheckRun["conclusion"] = rawConclusion === null
+                  ? null
+                  : (conclusionMap[rawConclusion] ?? "failure");
 
-          resolvePromise({ aggregate, runs, fetchedAt: now });
-        } catch {
-          resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
+                let durationMs: number | null = null;
+                if (status === "completed" && item.startedAt && item.completedAt) {
+                  durationMs = new Date(item.completedAt).getTime() - new Date(item.startedAt).getTime();
+                }
+
+                return {
+                  name: item.name ?? "unknown",
+                  status,
+                  conclusion,
+                  durationMs,
+                  startedAt: item.startedAt ?? null,
+                  // appId is used only for dedup scoping; it is stripped before the result is returned.
+                  appId: typeof item.appId === "number" ? item.appId : 0,
+                };
+              });
+
+              // D1: Deduplicate runs with the same (name, appId), keeping the most recently started one.
+              // GitHub returns check runs from every check suite on a commit, so re-runs or
+              // workflows triggered by multiple events produce duplicate entries (e.g., a passing
+              // run from suite A alongside a failing run from the newly-triggered suite B).
+              // Without dedup the aggregate can be stale and the list shows ghost duplicates.
+              //
+              // The dedup key includes appId so that two different GitHub Apps that both create a
+              // check named "validate-pr" (e.g., GitHub Actions + Greptile) are NOT collapsed,
+              // only runs from the same app are candidates for deduplication.
+              //
+              // Tie-breaking: null startedAt maps to "" which is lexicographically less than any
+              // ISO string, so a run with a known timestamp always wins over one without. When
+              // two runs share the same timestamp (or both are null), the first in API response
+              // order is kept because GitHub does not guarantee ordering between suite siblings.
+              const dedupMap = new Map<string, typeof rawRuns[0]>();
+              for (const run of rawRuns) {
+                const key = `${run.name}\0${run.appId}`;
+                const existing = dedupMap.get(key);
+                const existingTs = existing?.startedAt ?? "";
+                const runTs = run.startedAt ?? "";
+                if (!existing || runTs > existingTs) {
+                  dedupMap.set(key, run);
+                }
+              }
+              // Strip the internal appId field before passing runs to the caller.
+              const runs: CheckRun[] = [...dedupMap.values()].map(({ appId: _appId, ...run }) => run);
+
+              let aggregate: "passing" | "failing" | "pending" | "no_checks";
+              if (runs.some((r) => r.conclusion === "failure" || r.conclusion === "timed_out")) {
+                aggregate = "failing";
+              } else if (runs.some((r) => r.status !== "completed")) {
+                aggregate = "pending";
+              } else {
+                aggregate = "passing";
+              }
+
+              // If all runs completed but none succeeded (all skipped/cancelled/neutral),
+              // treat as no_checks to avoid a misleading green badge.
+              if (aggregate === "passing" && !runs.some((r) => r.conclusion === "success")) {
+                aggregate = "no_checks";
+              }
+
+              resolvePromise({ aggregate, runs, fetchedAt: now });
+            } catch {
+              resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: now });
+            }
+          },
+        );
+        activeProcess.current = this.trackProcess(child, {
+          repoPath,
+          checkRunsKey: inflightKey,
+        });
+      } catch {
+        releaseOnce();
+        if (!inflightController.cancelled) {
+          resolvePromise({ aggregate: "no_checks", runs: [], fetchedAt: Date.now() });
         }
-      },
-    );
+      }
+    })();
 
     try {
       return await promise;
     } finally {
-      // M3: Guard covers the synchronous-throw path; the callback path already called releaseOnce().
       releaseOnce();
-      this.checkRunsInflight.delete(inflightKey);
+      if (this.checkRunsInflight.get(inflightKey) === inflightController) {
+        this.checkRunsInflight.delete(inflightKey);
+      }
+      activeProcess.current?.finish();
     }
   }
 
@@ -399,11 +528,13 @@ export class GithubService {
     if (cached) this.slugCache.delete(repoPath);
 
     const pending = new Promise<string>((resolve, reject) => {
-      execFile(
+      let tracked: TrackedGithubProcess | null = null;
+      const child = execFile(
         "gh",
         ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
         { cwd: repoPath, encoding: "utf-8", timeout: 10_000, windowsHide: true },
         (error, stdout) => {
+          tracked?.finish();
           if (error || !stdout.trim()) {
             this.slugCache.delete(repoPath); // evict so next call can retry
             reject(error ?? new Error("Failed to resolve repo slug"));
@@ -419,6 +550,7 @@ export class GithubService {
           resolve(trimmed);
         },
       );
+      tracked = this.trackProcess(child, { repoPath });
     });
 
     this.slugCache.set(repoPath, { promise: pending, expiresAt: Date.now() + GithubService.SLUG_TTL_MS });
@@ -482,4 +614,28 @@ export class GithubService {
       );
     });
   }
+}
+
+interface TrackedGithubProcess {
+  child: ChildProcess;
+  repoPath: string | null;
+  checkRunsKey: string | null;
+  done: Promise<void>;
+  finish(): void;
+}
+
+interface CheckRunsInflight {
+  promise: Promise<ChecksStatus>;
+  resolve: (value: ChecksStatus) => void;
+  repoPath: string | null;
+  branch: string;
+  cancelled: boolean;
+}
+
+function noChecks(): ChecksStatus {
+  return { aggregate: "no_checks", runs: [], fetchedAt: Date.now() };
+}
+
+function normalizeRepoPath(repoPath: string | null | undefined): string | null {
+  return repoPath ? repoPath.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase() : null;
 }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -327,7 +327,13 @@ function watchReturnedThreadWorktree(deps: RouterDeps, thread: unknown): void {
 async function teardownWorkspaceThreads(deps: RouterDeps, workspaceId: string): Promise<void> {
   const threads = deps.threadRepo.listAllByWorkspace(workspaceId);
   const results = await Promise.allSettled(
-    threads.map((thread) => deps.threadTeardownService.teardownThread(thread.id)),
+    threads.map(async (thread) => {
+      if (thread.worktree_path) {
+        await deps.githubService.cancelForRepoPath(thread.worktree_path);
+      }
+      await deps.ciWatcherService.teardownThread(thread.id);
+      await deps.threadTeardownService.teardownThread(thread.id);
+    }),
   );
   const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
   if (failures.length > 0) {
@@ -442,7 +448,11 @@ async function dispatch(
       return thread;
     }
     case "thread.delete": {
-      deps.ciWatcherService.unwatch(params.threadId);
+      const thread = deps.threadRepo.findById(params.threadId);
+      if (thread?.worktree_path) {
+        await deps.githubService.cancelForRepoPath(thread.worktree_path);
+      }
+      await deps.ciWatcherService.teardownThread(params.threadId);
       await deps.threadTeardownService.teardownThread(params.threadId);
       const deleted = await deps.threadService.delete(
         params.threadId,

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -476,7 +476,16 @@ describe("routeMessage workspace.delete watcher teardown", () => {
     const deleteWorkspace = vi.fn();
     const deps = {
       threadRepo: {
-        listAllByWorkspace: vi.fn().mockReturnValue([{ id: "thread-1" }, { id: "thread-2" }]),
+        listAllByWorkspace: vi.fn().mockReturnValue([
+          { id: "thread-1", worktree_path: null },
+          { id: "thread-2", worktree_path: null },
+        ]),
+      },
+      githubService: {
+        cancelForRepoPath: vi.fn().mockResolvedValue(undefined),
+      },
+      ciWatcherService: {
+        teardownThread: vi.fn().mockResolvedValue(undefined),
       },
       threadTeardownService: {
         teardownThread: vi
@@ -511,7 +520,16 @@ describe("routeMessage workspace.delete watcher teardown", () => {
     const teardownThread = vi.fn().mockResolvedValue(undefined);
     const deps = {
       threadRepo: {
-        listAllByWorkspace: vi.fn().mockReturnValue([{ id: "thread-1" }, { id: "thread-2" }]),
+        listAllByWorkspace: vi.fn().mockReturnValue([
+          { id: "thread-1", worktree_path: null },
+          { id: "thread-2", worktree_path: null },
+        ]),
+      },
+      githubService: {
+        cancelForRepoPath: vi.fn().mockResolvedValue(undefined),
+      },
+      ciWatcherService: {
+        teardownThread: vi.fn().mockResolvedValue(undefined),
       },
       threadTeardownService: {
         teardownThread,
@@ -557,7 +575,16 @@ describe("routeMessage thread.delete watcher teardown", () => {
       .mockImplementation(options.deleteThread ?? (() => Promise.resolve(true)));
     const deps = {
       ciWatcherService: {
-        unwatch: vi.fn(),
+        teardownThread: vi.fn().mockResolvedValue(undefined),
+      },
+      githubService: {
+        cancelForRepoPath: vi.fn().mockResolvedValue(undefined),
+      },
+      threadRepo: {
+        findById: vi.fn().mockReturnValue({
+          id: "thread-1",
+          worktree_path: "C:/repo-worktree",
+        }),
       },
       gitWatcherService: {
         unwatchThreadWorktree,


### PR DESCRIPTION
## What
Fixes server teardown so GitHub CI polling is cancellable before a thread or workspace worktree is deleted.

## Why
CI polling could leave `gh` children, queued check lookups, or delayed post-push refresh timers alive after thread deletion or app shutdown. On Windows, those processes can keep handles open inside the worktree, which can block folder deletion and make restart or update shutdown hang.

## Key Changes
- Track `gh` child processes in `GithubService` and cancel matching work by branch, repo path, or shutdown.
- Cancel queued, slug-resolving, and active CI check lookups so teardown does not wait for old work.
- Clear CI watcher post-push bump timers on unwatch, thread teardown, and service disposal.
- Wire thread and workspace delete RPCs to cancel CI work before runtime teardown and cleanup enqueue.
- Add regression coverage for active process cancellation, queued lookup cancellation, slug-resolution cancellation, repo-path cancellation, timer cleanup, and delete ordering.

## Verification
- `bun run verify`: passed
- `git diff --check`: passed
- Secret-pattern scan over the diff: no matches

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785582972&installation_id=129163861&pr_number=833&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F833&signature=74dedd924be1ea1f40ada344ce41bf18d6e23a5f09d61248f8ee954c6f478bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->