### PR TITLE
feat(web): predictable sidebar thread-row icons and fading spinner tail

### DIFF
--- a/apps/web/e2e/sidebar-thread-preview.spec.ts
+++ b/apps/web/e2e/sidebar-thread-preview.spec.ts
@@ -124,17 +124,19 @@ test.describe("Sidebar thread preview", () => {
     });
   });
 
-  test("opens on hover and focus with read-only project, branch, and provider", async ({ page }) => {
+  test("opens on hover and focus with read-only project and branch; provider lives on the row", async ({ page }) => {
     const worktreeRow = page.locator('[data-testid="thread-item"][data-thread-id="thread-worktree"]');
     await expect(worktreeRow.getByLabel("Worktree mode")).toBeVisible();
     await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-direct"]').getByLabel("Worktree mode")).toHaveCount(0);
+
+    await expect(worktreeRow.getByLabel("Provider, Codex")).toBeVisible();
 
     await worktreeRow.hover();
     const hoverPreview = page.getByTestId("thread-preview-thread-worktree");
     await expect(hoverPreview).toBeVisible();
     await expect(page.getByLabel("Project, Preview Workspace")).toBeVisible();
     await expect(page.getByLabel("Branch, HEAD")).toBeVisible();
-    await expect(page.getByLabel("Provider, Codex")).toBeVisible();
+    await expect(hoverPreview.getByLabel(/^Provider,/)).toHaveCount(0);
     await expect(page.getByLabel(/^Status,/)).toHaveCount(0);
     await expect(hoverPreview).not.toContainText("Running");
     await expect(hoverPreview).not.toContainText("Ready");
@@ -183,6 +185,18 @@ test.describe("Sidebar thread preview", () => {
     expect(directTitle).not.toBeNull();
     expect(prTitle).not.toBeNull();
     expect(Math.abs((directTitle?.x ?? 0) - (prTitle?.x ?? 0))).toBeLessThanOrEqual(1);
+
+    // PR icons pin to a fixed left column (aligned with the workspace chevron);
+    // the provider icon sits in the row's indent, between the PR column and the title.
+    const prIcon = await prRow.getByTitle(/PR #42/).boundingBox();
+    const directProvider = await directRow.getByLabel("Provider, Claude").boundingBox();
+    const prProvider = await prRow.getByLabel("Provider, Claude").boundingBox();
+    expect(prIcon).not.toBeNull();
+    expect(directProvider).not.toBeNull();
+    expect(prProvider).not.toBeNull();
+    expect(Math.abs((directProvider?.x ?? 0) - (prProvider?.x ?? 0))).toBeLessThanOrEqual(1);
+    expect((prIcon?.x ?? 0) + (prIcon?.width ?? 0)).toBeLessThanOrEqual((prProvider?.x ?? 0) + 1);
+    expect((prProvider?.x ?? 0) + (prProvider?.width ?? 0)).toBeLessThanOrEqual((prTitle?.x ?? 0) + 1);
 
     await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-worktree"]').getByLabel("Running")).toBeVisible();
     await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-completed"]').getByLabel("Completed")).toBeVisible();

--- a/apps/web/e2e/spinner-animation.spec.ts
+++ b/apps/web/e2e/spinner-animation.spec.ts
@@ -74,5 +74,6 @@ test.describe("status indicator animations", () => {
 
     expect(cssText).toMatch(/\.status-spin\s*\{[^}]*animation:[^}]*spin/);
     expect(cssText).toMatch(/\.status-pulse\s*\{[^}]*animation:[^}]*pulse/);
+    expect(cssText).toMatch(/\.spinner-tail-fade\s*\{[^}]*conic-gradient/);
   });
 });

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, fireEvent } from "@testing-library/react";
+import { render, screen, act, fireEvent, within } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { Thread } from "@/transport/types";
 
@@ -617,6 +617,7 @@ describe("ProjectTree PR-ability gating by mode", () => {
     expect(preview).toHaveTextContent("Branchless Thread");
     expect(screen.getByLabelText("Project, Test Project")).toBeInTheDocument();
     expect(screen.getByLabelText("Branch, HEAD")).toBeInTheDocument();
+    expect(within(preview).queryByLabelText(/^Provider,/)).toBeNull();
     expect(screen.getByLabelText("Provider, Codex")).toBeInTheDocument();
     expect(screen.queryByLabelText(/^Status,/)).toBeNull();
     expect(preview).not.toHaveTextContent("Ready");

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1091,10 +1091,9 @@ function SidebarThreadMarker({ marker, dim }: { marker: SidebarThreadMarker; dim
 
   if (marker.kind === "running") {
     return (
-      <Loader2
-        size={13}
+      <span
         aria-label={marker.label}
-        className={cn("shrink-0 status-spin text-primary", dim && "opacity-[0.72]")}
+        className={cn("shrink-0 status-spin spinner-tail-fade text-primary", dim && "opacity-[0.72]")}
       />
     );
   }
@@ -1140,19 +1139,12 @@ function SidebarThreadPreview({
   workspaceName: string;
   thread: WorkspaceThread;
 }) {
-  const provider = getProviderMeta(thread.provider);
-  const ProviderIcon = provider.icon;
   const checkoutLabel = resolveThreadCheckoutLabel(thread);
 
   return (
     <div data-testid={`thread-preview-${thread.id}`} className="w-64 space-y-2 text-popover-foreground">
-      <div className="flex items-start gap-3">
-        <div className="min-w-0 flex-1 font-medium text-xs leading-5">
-          {thread.title}
-        </div>
-        <span aria-label={`Provider, ${provider.label}`} className={cn("shrink-0 pt-0.5", provider.color)}>
-          <ProviderIcon size={14} />
-        </span>
+      <div className="min-w-0 font-medium text-xs leading-5">
+        {thread.title}
       </div>
       <div className="grid gap-1.5">
         <div aria-label={`Project, ${workspaceName}`} className="flex min-w-0 items-center gap-2">
@@ -1306,6 +1298,8 @@ function VirtualizedThreadList({
         // Opacity on the row would compound onto status markers; dim only the title cluster and timestamp.
         const scaffoldDim =
           (thread.clientPreparing || thread.clientError) && "opacity-[0.72]";
+        const providerMeta = getProviderMeta(thread.provider);
+        const RowProviderIcon = providerMeta.icon;
         const row = (
           <div
             role="button"
@@ -1334,20 +1328,30 @@ function VirtualizedThreadList({
                 ? "bg-accent text-foreground"
                 : "text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground"
             )}
-            style={{ paddingLeft: `${24 + depth * 12}px` }}
+            style={{ paddingLeft: `${42 + depth * 12}px` }}
           >
             {prable && thread.pr_number != null ? (() => {
               const { Icon: PrIcon, color: prColor } = getPrVisual(thread.pr_status);
               return (
                 <span
                   title={`PR #${thread.pr_number} \u2013 ${thread.pr_status ?? "open"}`}
-                  className="absolute top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center"
-                  style={{ left: `${6 + depth * 12}px` }}
+                  className="absolute left-1.5 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center"
                 >
                   <PrIcon size={12} className={prColor} />
                 </span>
               );
             })() : null}
+            <span
+              aria-label={`Provider, ${providerMeta.label}`}
+              className={cn(
+                "absolute top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center",
+                providerMeta.color,
+                scaffoldDim,
+              )}
+              style={{ left: `${22 + depth * 12}px` }}
+            >
+              <RowProviderIcon size={12} />
+            </span>
             <div
               className={cn(
                 "flex min-w-0 flex-1 items-center gap-2",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -304,6 +304,17 @@
 .status-pulse {
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
+/* Ring spinner with a fading tail. A conic gradient supplies the fade and a
+ * radial mask hollows the disc into a ring — lucide's Loader2 arc can't fade
+ * because SVG strokes are a single flat color. */
+.spinner-tail-fade {
+  width: 13px;
+  height: 13px;
+  border-radius: 9999px;
+  background: conic-gradient(from 0deg, transparent 10%, currentColor 90%);
+  -webkit-mask-image: radial-gradient(farthest-side, transparent calc(100% - 2px), #000 calc(100% - 1.25px));
+  mask-image: radial-gradient(farthest-side, transparent calc(100% - 2px), #000 calc(100% - 1.25px));
+}
 @media (prefers-reduced-motion: reduce) {
   .status-spin,
   .status-pulse {


### PR DESCRIPTION
## What
Restructures the sidebar thread-row iconography: PR icons pin to a fixed left column aligned with the workspace chevron, each thread row shows its provider icon in the indent before the title, the hover preview drops its provider icon, and the running-thread spinner gets a fading tail.

## Why
PR icons shifted right with nesting depth, so their position was unpredictable when scanning the tree. The provider was only visible by hovering a thread; surfacing it on the row removes that extra step, which also makes the popup's provider icon redundant. The stock Loader2 arc ends abruptly; a fading tail reads sleeker.

## Key Changes
- PR icons render at a fixed `left: 6px` in every thread row instead of `6 + depth * 12`, aligning them with the workspace chevron at all depths.
- Each thread row shows its provider icon (Claude, Codex, Cursor, Gemini, Copilot, OpenCode) in the row's left padding, just before the title; base row padding grows from 24px to 42px so titles stay aligned across rows.
- The hover preview card no longer shows the provider icon; it keeps title, project, and branch.
- The running marker swaps `Loader2` for a `spinner-tail-fade` ring: a conic gradient hollowed by a radial mask, so the trailing edge dissolves. It keeps `status-spin`, so reduced-motion handling is unchanged.
- Tests updated and extended: e2e asserts PR column < provider icon < title ordering, provider icon consistency across rows, provider absence from the preview, and the new CSS class shipping in app css; unit test asserts the provider label moved from preview to row.

Verified with `bun run verify` (typecheck, lint, unit tests all pass) and targeted Playwright runs: `sidebar-thread-preview.spec.ts`, `spinner-animation.spec.ts`, `sidebar-interrupted-state.spec.ts` (9/9), plus the architecture running-marker test.

## Config Changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785601936&installation_id=129163861&pr_number=834&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F834&signature=de03019970acfc16a26e5fc5c12536749ae216a8ba9b6388ac14e94e2e0a7567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new loading spinner style with a fading tail for a smoother in-app loading state.

* **Bug Fixes**
  * Updated sidebar thread previews so provider details no longer appear in the hover preview.
  * Improved sidebar item positioning and spacing for PR and provider icons.
  * Expanded test coverage for spinner styling and sidebar preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->