### PR TITLE
feat: add Sonnet 5 and lift Fable 5 availability end date

### DIFF
--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -35,18 +35,25 @@ describe("pickProviderModelsForSettings", () => {
 });
 
 describe("ModelRegistry", () => {
-  it("MODEL_PROVIDERS contains Claude with 6 models", () => {
+  it("MODEL_PROVIDERS contains Claude with 7 models", () => {
     const claude = MODEL_PROVIDERS.find((p) => p.id === "claude");
     expect(claude).toBeTruthy();
-    expect(claude?.models).toHaveLength(6);
+    expect(claude?.models).toHaveLength(7);
     expect(claude?.comingSoon).toBe(false);
   });
 
-  it("findModelById returns Fable 5 with an availability end date", () => {
+  it("findModelById returns Fable 5 with no availability end date", () => {
     const model = findModelById("claude-fable-5");
     expect(model?.label).toBe("Claude Fable 5");
     expect(model?.providerId).toBe("claude");
-    expect(model?.availableUntil).toBe("2026-06-22");
+    expect(model?.availableUntil).toBeUndefined();
+    expect(isModelAvailable(model!)).toBe(true);
+  });
+
+  it("findModelById returns Sonnet 5", () => {
+    const model = findModelById("claude-sonnet-5");
+    expect(model?.label).toBe("Claude Sonnet 5");
+    expect(model?.providerId).toBe("claude");
   });
 
   it("isModelAvailable honors availableUntil inclusively in local time", () => {

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -84,11 +84,10 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     comingSoon: false,
     supportsCompletion: true,
     models: [
-      // Anthropic ends Fable 5 subscription access on 2026-06-22; Mcode
-      // auths via subscription, so the entry gates itself after that date.
       { id: "claude-fable-5", label: "Claude Fable 5", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-fable-5"],
-        availableUntil: "2026-06-22" },
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-fable-5"] },
+      { id: "claude-sonnet-5", label: "Claude Sonnet 5", providerId: "claude",
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-sonnet-5"] },
       { id: "claude-opus-4-8", label: "Claude Opus 4.8", providerId: "claude",
         contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-8"] },
       { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude",

--- a/packages/shared/src/model-context/index.ts
+++ b/packages/shared/src/model-context/index.ts
@@ -11,6 +11,7 @@ import type { ContextWindowMode } from "@mcode/contracts";
  */
 export const MODEL_CONTEXT_WINDOWS_DEFAULT: Readonly<Record<string, number>> = {
   "claude-fable-5": 200_000,
+  "claude-sonnet-5": 200_000,
   "claude-opus-4-8": 200_000,
   "claude-opus-4-7": 200_000,
   "claude-opus-4-6": 200_000,
@@ -26,6 +27,7 @@ export const MODEL_CONTEXT_WINDOWS_DEFAULT: Readonly<Record<string, number>> = {
  */
 export const MODEL_CONTEXT_WINDOWS_EXTENDED: Readonly<Record<string, number>> = {
   "claude-fable-5": 1_000_000,
+  "claude-sonnet-5": 1_000_000,
   "claude-opus-4-8": 1_000_000,
   "claude-opus-4-7": 1_000_000,
   "claude-opus-4-6": 1_000_000,

--- a/packages/shared/src/model-effort/index.ts
+++ b/packages/shared/src/model-effort/index.ts
@@ -36,6 +36,7 @@ const XHIGH_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-8", "claude-op
 /** Claude model IDs that support the "max" effort tier. */
 const MAX_EFFORT_MODEL_IDS: readonly string[] = [
   "claude-fable-5",
+  "claude-sonnet-5",
   "claude-opus-4-8",
   "claude-opus-4-7",
   "claude-opus-4-6",
@@ -54,6 +55,7 @@ const ULTRATHINK_MODEL_IDS: readonly string[] = MAX_EFFORT_MODEL_IDS;
  */
 const ONE_M_CONTEXT_MODEL_IDS: readonly string[] = [
   "claude-fable-5",
+  "claude-sonnet-5",
   "claude-opus-4-8",
   "claude-opus-4-7",
   "claude-opus-4-6",
@@ -145,7 +147,7 @@ export function isXhighEffortModel(modelId: string): boolean {
 /**
  * Returns true when the model supports the "max" effort tier.
  *
- * Applies to the fable-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
+ * Applies to the fable-5, sonnet-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
  */
 export function isMaxEffortModel(modelId: string): boolean {
   return MAX_EFFORT_MODEL_IDS.includes(normalizeModelId(modelId));
@@ -154,7 +156,7 @@ export function isMaxEffortModel(modelId: string): boolean {
 /**
  * Returns true when the model supports the "ultrathink" virtual tier.
  *
- * Applies to the fable-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
+ * Applies to the fable-5, sonnet-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
  * Ultrathink resolves to "max" effort at the SDK boundary and additionally
  * prepends "Ultrathink:\n" to the user prompt.
  */
@@ -164,7 +166,7 @@ export function supportsUltrathink(modelId: string): boolean {
 
 /**
  * Returns true when the model supports the extended 1,000,000-token context
- * window. Applies to fable-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6.
+ * window. Applies to fable-5, sonnet-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6.
  *
  * The window is opted into by appending `[1m]` to the model slug at send
  * time; the Claude Agent SDK handles the beta header internally.


### PR DESCRIPTION
## What
Adds Claude Sonnet 5 to the Claude model catalog and removes the availability end date that greyed out Claude Fable 5 after 22 June 2026.

## Why
Anthropic no longer end-dates Fable 5 subscription access, so the picker should not gate it. Sonnet 5 is part of the Claude 5 family and belongs in the selectable model list.

## Key Changes
- `apps/web/src/lib/model-registry.ts`: removed `availableUntil: "2026-06-22"` from `claude-fable-5`; added `claude-sonnet-5` ("Claude Sonnet 5") after Fable 5. The generic `availableUntil` picker mechanism is unchanged.
- `packages/shared/src/model-context/index.ts`: `claude-sonnet-5` gets the 200k default window and the 1M extended window.
- `packages/shared/src/model-effort/index.ts`: `claude-sonnet-5` joins the max effort, ultrathink, and 1M context cohorts (no xhigh, matching Fable 5).
- `apps/web/src/__tests__/model-registry.test.ts`: Claude model count 6 to 7, Fable 5 now asserts no end date, new Sonnet 5 lookup test.

## Verification
`bun run verify`: typecheck PASS, lint PASS. Unit tests: model-registry 78/78; two unrelated Codex provider server tests timed out under turbo parallel load and pass in isolation (known Windows load flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785612129&installation_id=129163861&pr_number=835&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F835&signature=ddc8ec1aa1ee0cac7c5c85efe3814a0b02c05e8cda2767759a5e4b66e36e3b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Sonnet 5 across model selection, context window handling, and reasoning-effort options.
  * Claude Sonnet 5 now supports larger context windows, including the extended 1M option where available.

* **Bug Fixes**
  * Updated Claude model availability so Sonnet 5 and Fable 5 are treated as selectable without an end date.
  * Improved model lookup accuracy for Claude Sonnet 5 details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->