### PR TITLE
feat(web): prefer cool colors for surfaces and links

### DIFF
--- a/.claude/hookify.block-process-kill-by-name.local.md
+++ b/.claude/hookify.block-process-kill-by-name.local.md
@@ -1,0 +1,19 @@
+---
+name: block-process-kill-by-name
+enabled: true
+event: all
+action: block
+conditions:
+  - field: command
+    operator: regex_match
+    pattern: Stop-Process\s+-Name|taskkill[^\n]*[/-][Ii][Mm]|Get-Process[^|\n]*\|\s*Stop-Process|\bpkill\b|\bkillall\b|kill\s[^\n]*\$\(\s*pgrep
+---
+
+🛑 **Blocked: process kill by name.**
+
+Name-based or broad process kills (`Stop-Process -Name`, `taskkill /IM`, `Get-Process | Stop-Process`, `pkill`, `killall`) are forbidden in this repo. The user's **production Mcode app** shares process names (bun, node, electron) with dev processes, and this has repeatedly killed their live app.
+
+Allowed alternatives:
+- Stop harness background tasks with TaskStop.
+- Kill only by explicit PID (`Stop-Process -Id <pid>`, `taskkill /PID <pid>`) **after** verifying ownership: `Get-CimInstance Win32_Process -Filter "ProcessId=<pid>" | Select-Object CommandLine, ExecutablePath` and confirming the path is under the dev worktree (`~\.mcode\worktrees\...`), never the installed app.
+- If a port is busy, do not kill its owner — ask the user or use another port.

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -105,7 +105,7 @@
     "shadows": [
       { "name": "focus-ring", "value": "0 0 0 3px oklch(0.62 0.19 264 / 0.2)", "purpose": "Cool-ring focus affordance on inputs and buttons." },
       { "name": "focus-ring-offset", "value": "0 0 0 2px var(--background), 0 0 0 4px var(--ring)", "purpose": "Keyboard focus on dense adjacent controls where a flat ring would bleed into the neighbor." },
-      { "name": "lamp-edge-glow", "value": "-2px 0 8px -1px color-mix(in oklch, var(--primary), transparent 65%)", "purpose": "Single deliberate lamp edge cue at a panel boundary. Not a card style." }
+      { "name": "lamp-edge-glow", "value": "-2px 0 8px -1px oklch(0.72 0.17 75 / 0.35)", "purpose": "Single deliberate lamp edge cue at a panel boundary. Not a card style." }
     ],
     "motion": [
       { "name": "ease-out-quart", "value": "cubic-bezier(0.25, 1, 0.5, 1)", "purpose": "Primary UI easing: wizard reveals, tile and nav entrances, question transitions." },

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -19,6 +19,21 @@
           "oklch(0.92 0.06 75)"
         ]
       },
+      "cool-link": {
+        "role": "secondary",
+        "displayName": "Cool Link",
+        "canonical": "oklch(0.7 0.14 260)",
+        "tonalRamp": [
+          "oklch(0.20 0.06 260)",
+          "oklch(0.30 0.09 260)",
+          "oklch(0.40 0.12 260)",
+          "oklch(0.50 0.16 260)",
+          "oklch(0.60 0.15 260)",
+          "oklch(0.70 0.14 260)",
+          "oklch(0.80 0.10 260)",
+          "oklch(0.92 0.04 260)"
+        ]
+      },
       "patina-sage": {
         "role": "tertiary",
         "displayName": "Patina Sage",
@@ -64,19 +79,19 @@
           "oklch(0.93 0 0)"
         ]
       },
-      "warm-neutral": {
+      "cool-off-white": {
         "role": "neutral",
-        "displayName": "Warm Off-White",
-        "canonical": "oklch(0.99 0.005 75)",
+        "displayName": "Cool Off-White",
+        "canonical": "oklch(0.99 0.005 260)",
         "tonalRamp": [
-          "oklch(0.18 0.005 75)",
-          "oklch(0.50 0.005 75)",
-          "oklch(0.90 0.005 75)",
-          "oklch(0.945 0.008 75)",
-          "oklch(0.955 0.005 75)",
-          "oklch(0.985 0.005 75)",
-          "oklch(0.99 0.005 75)",
-          "oklch(0.995 0.003 75)"
+          "oklch(0.18 0.005 260)",
+          "oklch(0.50 0.005 260)",
+          "oklch(0.90 0.005 260)",
+          "oklch(0.945 0.008 260)",
+          "oklch(0.955 0.005 260)",
+          "oklch(0.985 0.005 260)",
+          "oklch(0.99 0.005 260)",
+          "oklch(0.995 0.003 260)"
         ]
       }
     },
@@ -90,7 +105,7 @@
     "shadows": [
       { "name": "focus-ring", "value": "0 0 0 3px oklch(0.62 0.19 264 / 0.2)", "purpose": "Cool-ring focus affordance on inputs and buttons." },
       { "name": "focus-ring-offset", "value": "0 0 0 2px var(--background), 0 0 0 4px var(--ring)", "purpose": "Keyboard focus on dense adjacent controls where a flat ring would bleed into the neighbor." },
-      { "name": "amber-edge-glow", "value": "-2px 0 8px -1px oklch(0.72 0.17 75 / 0.35)", "purpose": "Single deliberate amber edge cue at a panel boundary. Not a card style." }
+      { "name": "lamp-edge-glow", "value": "-2px 0 8px -1px color-mix(in oklch, var(--primary), transparent 65%)", "purpose": "Single deliberate lamp edge cue at a panel boundary. Not a card style." }
     ],
     "motion": [
       { "name": "ease-out-quart", "value": "cubic-bezier(0.25, 1, 0.5, 1)", "purpose": "Primary UI easing: wizard reveals, tile and nav entrances, question transitions." },
@@ -106,7 +121,7 @@
       "refersTo": "button-primary",
       "description": "The single primary action. Filament Amber fill, used once per surface.",
       "html": "<button class=\"ds-btn-primary\">Run agent</button>",
-      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; height: 2rem; padding: 0 0.625rem; font-family: 'Public Sans', ui-sans-serif, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; color: oklch(0.98 0 0); background: oklch(0.72 0.17 75); border: 1px solid transparent; border-radius: 0.625rem; cursor: pointer; transition: background 0.15s, transform 0.1s; } .ds-btn-primary:hover { background: oklch(0.72 0.17 75 / 0.8); } .ds-btn-primary:active { transform: translateY(1px); } .ds-btn-primary:focus-visible { outline: none; border-color: oklch(0.62 0.19 264); box-shadow: 0 0 0 3px oklch(0.62 0.19 264 / 0.5); }"
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; height: 2rem; padding: 0 0.625rem; font-family: 'Public Sans', ui-sans-serif, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; color: oklch(0.15 0.005 260); background: oklch(0.72 0.17 75); border: 1px solid transparent; border-radius: 0.625rem; cursor: pointer; transition: background 0.15s, transform 0.1s; } .ds-btn-primary:hover { background: oklch(0.72 0.17 75 / 0.8); } .ds-btn-primary:active { transform: translateY(1px); } .ds-btn-primary:focus-visible { outline: none; border-color: oklch(0.62 0.19 264); box-shadow: 0 0 0 3px oklch(0.62 0.19 264 / 0.5); }"
     },
     {
       "name": "Ghost Button",
@@ -162,7 +177,7 @@
     "overview": "Mcode is the surface a developer keeps open all evening on a second monitor while five agents run in parallel. It is not a destination; it is an instrument panel that sits next to the editor, the terminal, and the browser, built for the glance rather than the read. The register is editorial and typeset, closer to a code editor or terminal than a SaaS dashboard; density is a feature. Color is rationed: a warm amber primary on a matte cool-slate canvas, with sage for additions and clay for removals. Dark is the default canvas because the product is used in the evening; a warm light counterpart exists for daytime.",
     "keyCharacteristics": [
       "Glance-first: status communicated by tinted dots and small monochrome glyphs, never paragraphs.",
-      "Dark-primary, warm-amber accent on cool-slate surfaces; light theme is the warm-neutral counterpart.",
+      "Dark-primary, Filament Amber accent on cool-slate surfaces; light theme is the cool-neutral counterpart.",
       "Tonal lift instead of divider lines: panels float a few percent off the page.",
       "Monospace carries machine facts (SHAs, counts, timestamps, status labels); Public Sans carries human prose.",
       "Keyboard-first: shortcuts are first-class, not hidden.",
@@ -170,6 +185,7 @@
     ],
     "rules": [
       { "name": "The One Lamp Rule", "body": "Filament Amber is the only brand color. It appears on a small fraction of any screen (the active row, the primary action, the live dot). Its rarity is what makes a glance land.", "section": "colors" },
+      { "name": "The Cold-Surface Rule", "body": "Anything with area is cold; only points of light are warm. Surfaces, fills, and blocks of content (including the user's message bubble) are slate neutrals, never a field of amber. Links, focus, and charts take the cool family (cool-link, cool-ring), not the lamp.", "section": "colors" },
       { "name": "The Semantic-Only Sage/Clay Rule", "body": "Sage and clay are never decoration. They mean addition/good and removal/error.", "section": "colors" },
       { "name": "The Tinted-Neutral Rule", "body": "Neutrals are never pure gray. Dark surfaces carry 0.005 chroma toward cool hue 260; light surfaces 0.005 toward warm hue 75.", "section": "colors" },
       { "name": "The Mono-Is-Machine Rule", "body": "Monospace marks machine-authored facts only. Counts and timestamps additionally take tabular-nums.", "section": "typography" },

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,6 +13,8 @@ colors:
   slate-accent: "oklch(0.24 0.005 260)"
   slate-border: "oklch(0.28 0.005 260)"
   cool-ring: "oklch(0.62 0.19 264)"
+  cool-link: "oklch(0.7 0.14 260)"
+  cool-link-light: "oklch(0.5 0.16 260)"
   patina-sage: "oklch(0.78 0.13 145)"
   oxide-clay: "oklch(0.78 0.13 25)"
   destructive: "oklch(0.65 0.2 25)"
@@ -87,13 +89,13 @@ components:
 
 Mcode is the surface a developer keeps open all evening on a second monitor while five agents run in parallel. It is not a destination; it is an instrument panel that sits next to the editor, the terminal, and the browser. So the whole system is built for the *glance*, not the read. The user is rarely studying the agent's prose; they are flicking their eyes to the sidebar to see what finished, what errored, and what branch each run is on. Everything here optimizes that one-second scan: a status dot read at flick-speed is worth more than a paragraph.
 
-The register is editorial and typeset, closer to a well-made code editor or a terminal than a CRM or a SaaS dashboard. Density is a feature. Developers tolerate and prefer tight layouts with monospaced, tabular numerics; we do not pad with marketing whitespace. Color is rationed: a warm amber primary on a matte cool-slate canvas, with sage for additions and clay for removals. The amber is the workbench lamp, the slate is the room around it after dark. Dark is the default canvas because the product is used in the evening; a warm light counterpart exists for daytime, built on near-white warm neutrals.
+The register is editorial and typeset, closer to a well-made code editor or a terminal than a CRM or a SaaS dashboard. Density is a feature. Developers tolerate and prefer tight layouts with monospaced, tabular numerics; we do not pad with marketing whitespace. Color is rationed: a warm amber primary on a matte cool-slate canvas, with sage for additions and clay for removals. The amber is the single point of warmth; the slate is the cool room around it after dark. Dark is the default canvas because the product is used in the evening; a cool light counterpart exists for daytime.
 
 This system explicitly rejects the consumer-app reflexes: no softened "Oops, something went wrong" copy (we say "Errored", "Idle", "Empty"), no emoji decoration, no colorful status chips, no glassmorphism, no gradient hero metrics, no marketing voice in the diff. If it looks like it wants to convert a visitor, it is wrong. It should look like it wants to get out of the way.
 
 **Key Characteristics:**
 - Glance-first: status communicated by tinted dots and small monochrome glyphs, never paragraphs.
-- Dark-primary, warm-amber accent on cool-slate surfaces; light theme is the warm-neutral counterpart.
+- Dark-primary, Filament Amber accent on cool-slate surfaces; light theme is the cool-neutral counterpart.
 - Tonal lift instead of divider lines: panels float a few percent off the page.
 - Monospace carries machine facts (SHAs, counts, timestamps, status labels); Public Sans carries human prose.
 - Keyboard-first: shortcuts are first-class, not hidden.
@@ -104,17 +106,18 @@ This system explicitly rejects the consumer-app reflexes: no softened "Oops, som
 A warm amber accent rationed over a matte cool-slate canvas, with a sage/clay pair reserved exclusively for diff and run-state semantics.
 
 ### Primary
-- **Filament Amber** (`oklch(0.72 0.17 75)` dark / `oklch(0.52 0.17 75)` light): The single accent. Primary buttons, active selection fill, focus pulse, running-indicator dots, the typing cursor color stop. Hue 75 reads as a warm workbench lamp, not a brand purple. The same hue and chroma shift only in lightness between themes so identity holds across both.
+- **Filament Amber** (`oklch(0.72 0.17 75)` dark / `oklch(0.52 0.17 75)` light): The single accent. Primary buttons, active selection fill, focus pulse, running-indicator dots, the typing cursor color stop. Hue 75 reads as a warm workbench lamp, not a brand purple. The same hue and chroma shift only in lightness between themes so identity holds across both. In dark theme the accent carries ink text (`oklch(0.15 0.005 260)`), not white, to hold 4.5:1.
 
 ### Secondary
 - **Cool Ring** (`oklch(0.62 0.19 264)`): The dark-theme focus ring and sidebar-primary tint. A cooler blue-violet used only for focus affordance and charts, never as a second brand voice.
+- **Cool Link** (`oklch(0.7 0.14 260)` dark / `oklch(0.5 0.16 260)` light): Hyperlinks and link-styled actions (`--link` / `text-link`). Links are navigational plumbing, not brand moments, so they take the surface's own cool hue at higher chroma rather than borrowing the amber lamp. Holds ≥4.5:1 on every slate surface including the accent message bubble.
 
 ### Tertiary
 - **Patina Sage** (`oklch(0.78 0.13 145)` strong): Additions and completed/idle-good state. Diff add gutters, add text, the "succeeded" reading of a status dot.
 - **Oxide Clay** (`oklch(0.78 0.13 25)` strong): Removals and the errored reading. Diff remove gutters and remove text. Closely related to `destructive` (`oklch(0.65 0.2 25)`) but desaturated for inline diff legibility.
 
 ### Neutral
-- **Ink** (`oklch(0.93 0 0)` dark / `oklch(0.18 0.005 75)` light): Primary text. Near-white in dark, near-black-warm in light. Never pure `#fff` or `#000`.
+- **Ink** (`oklch(0.93 0 0)` dark / `oklch(0.18 0.005 260)` light): Primary text. Near-white in dark, near-black-cool in light. Never pure `#fff` or `#000`.
 - **Muted Ink** (`oklch(0.65 0.005 260)`): Secondary text, meta, captions. Holds ≥4.5:1 on slate surfaces; do not push muted text lighter "for elegance."
 - **Slate Page** (`oklch(0.12 0.005 260)`): The darkest layer, page chrome. Panels sit *above* it.
 - **Slate Background** (`oklch(0.16 0.005 260)`): App background, one step up from page.
@@ -122,14 +125,16 @@ A warm amber accent rationed over a matte cool-slate canvas, with a sage/clay pa
 - **Slate Muted / Accent** (`oklch(0.22–0.24 0.005 260)`): Hover fills, secondary surfaces, input wells, selection backgrounds.
 - **Slate Border** (`oklch(0.28 0.005 260)`): The rare explicit hairline, only where tonal lift cannot carry the separation.
 
-Light theme mirrors this on warm neutrals: page `oklch(0.955 0.005 75)`, background `oklch(0.99 0.005 75)`, card `oklch(0.985 0.005 75)`, all at hue 75 with 0.005 chroma so the surfaces harmonize with the amber rather than read as cream.
+Light theme mirrors this on cool neutrals: page `oklch(0.955 0.005 260)`, background `oklch(0.99 0.005 260)`, card `oklch(0.985 0.005 260)`, all at hue 260 with 0.005 chroma so the lamp remains a point accent instead of tinting the surface system.
 
 ### Named Rules
-**The One Lamp Rule.** Filament Amber is the only brand color. It appears on a small fraction of any screen — the active row, the primary action, the live dot. Its rarity is what makes a glance land. Adding a second accent for variety breaks the instrument.
+**The One Lamp Rule.** Filament Amber is the only brand color. It appears on a small fraction of any screen: the active row, the primary action, the live dot. Its rarity is what makes a glance land. Adding a second accent for variety breaks the instrument.
+
+**The Cold-Surface Rule.** Anything with area is cold; only points of light are warm. Surfaces, fills, and blocks of content, including the user's message bubble, are slate neutrals. Filament Amber is confined to point-scale accents: a dot, a button, a cursor, an active row. Functional affordances that are not brand moments, such as links, focus, and charts, take the cool family (`cool-link`, `cool-ring`). If a warm color covers more than a control's worth of pixels, it is wrong.
 
 **The Semantic-Only Sage/Clay Rule.** Sage and clay are never decoration. They mean addition/good and removal/error. A green that does not mean "added or succeeded" and a red that does not mean "removed or errored" are forbidden.
 
-**The Tinted-Neutral Rule.** Neutrals are never pure gray. Dark surfaces carry 0.005 chroma toward cool hue 260; light surfaces carry 0.005 toward warm hue 75. The tint is subliminal and load-bearing for cohesion.
+**The Tinted-Neutral Rule.** Neutrals are never pure gray. Both themes carry 0.005 chroma toward cool hue 260. The tint is subliminal and load-bearing for cohesion.
 
 ## 3. Typography
 
@@ -159,7 +164,7 @@ Shadows exist only as a response to interactive state, never as ambient decorati
 ### Shadow Vocabulary
 - **Focus ring** (`box-shadow: 0 0 0 3px oklch(0.62 0.19 264 / 0.2)`): The cool-ring focus affordance on inputs and buttons.
 - **Focus ring, offset** (`box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--ring)`): Keyboard focus on dense, adjacent controls where a flat ring would bleed into the neighbor.
-- **Edge glow** (`box-shadow: -2px 0 8px -1px oklch(0.72 0.17 75 / 0.35)`): A single amber edge cue at a panel boundary; used once, deliberately, not as a card style.
+- **Edge glow** (`box-shadow: -2px 0 8px -1px color-mix(in oklch, var(--primary), transparent 65%)`): A single lamp edge cue at a panel boundary; used once, deliberately, not as a card style.
 
 ### Named Rules
 **The Tonal-Lift Rule.** Separation between surfaces is carried by a step on the lightness ramp, not by a line. A divider line is a failure of the tonal system. Use `--border` only where two surfaces share the same tone and must still be distinguished.
@@ -189,19 +194,19 @@ Shadows exist only as a response to interactive state, never as ambient decorati
 ### Navigation (Sidebar)
 - **Style:** Projects-and-threads tree, drag-reorderable, one status dot per thread. The first thing the user scans, every time.
 - **States:** Selection is a full row-fill with `bg-accent` — never a left side-stripe. Indentation alone carries tree depth; no nested guide rails.
-- **Status dot:** 1.5–2px tinted dot in a tokenized color (amber running, sage idle/ok, clay errored). Active/running dots pulse at 6px `bg-primary`.
+- **Status dot:** 1.5–2px tinted dot in a tokenized color (lamp running, sage idle/ok, clay errored). Active/running dots pulse at 6px `bg-primary`.
 
 ### Status Dot (signature)
-The smallest and most important component. A 6px dot whose tokenized color is the entire status message. Running pulses amber via `color-mix(in oklch, var(--primary), transparent 85%)`; idle is steady sage; errored is steady clay. It must be legible and distinguishable at flick-speed and at 100% zoom. It is never accompanied by a colored chip or a word when the dot alone suffices.
+The smallest and most important component. A 6px dot whose tokenized color is the entire status message. Running pulses lamp via `color-mix(in oklch, var(--primary), transparent 85%)`; idle is steady sage; errored is steady clay. It must be legible and distinguishable at flick-speed and at 100% zoom. It is never accompanied by a colored chip or a word when the dot alone suffices.
 
 ### Empty States (signature)
 A single large glyph (28px `font-mono`, `text-muted-foreground/15`: ◌, ⊘, ⊕, ⌂) over a small-caps mono caption (10.5px, `tracking-[0.18em]`, `text-muted-foreground/40`). No illustrations, no "Nothing here yet!" hand-holding, no primary CTA. The glyph and the technical caption are the whole empty state.
 
 ### Next-Step Slot (signature)
-The interface expression of the "Anticipate the next step" product principle. A thin slot at the seam between the narrative and the composer, in the same place in every thread. When the thread reaches a state with a likely next move, the slot shows it: a single Filament Amber primary action (`View diff`, `Re-run`, `Switch to Build`) with any other valid moves beside it as quiet ghost buttons. When there is no next move, the slot collapses to nothing — no empty chrome. The primary is bound to a consistent accept key (Tab) so the gesture is the same everywhere. Safe, single-outcome transitions (add project → new chat) do not render here; they auto-advance, landing the user on the next surface with one quiet cue (the breadcrumb lights briefly), per Quiet-over-loud.
+The interface expression of the "Anticipate the next step" product principle. A thin slot at the seam between the narrative and the composer, in the same place in every thread. When the thread reaches a state with a likely next move, the slot shows it: a single Filament Amber primary action (`View diff`, `Re-run`, `Switch to Build`) with any other valid moves beside it as quiet ghost buttons. When there is no next move, the slot collapses to nothing, no empty chrome. The primary is bound to a consistent accept key (Tab) so the gesture is the same everywhere. Safe, single-outcome transitions (add project -> new chat) do not render here; they auto-advance, landing the user on the next surface with one quiet cue (the breadcrumb lights briefly), per Quiet-over-loud.
 
 ### Named Rules
-**The One Next-Step Rule.** Each state elevates exactly one primary next action, in amber. Everything else stays a quiet ghost. Never two competing primaries; the rarity of the amber is what makes the suggestion legible at a glance.
+**The One Next-Step Rule.** Each state elevates exactly one primary next action in Filament Amber. Everything else stays a quiet ghost. Never two competing primaries; the rarity of the lamp is what makes the suggestion legible at a glance.
 
 **The Curated-Not-Clever Rule.** The next step is a fixed function of state, the same every time. It does not learn, reorder, or guess. Predictability is the feature; a suggestion the user has to second-guess is worse than none.
 
@@ -212,10 +217,11 @@ The interface expression of the "Anticipate the next step" product principle. A 
 - **Do** carry separation with tonal lift; step a surface along the lightness ramp before adding a line.
 - **Do** set SHAs, counts, timestamps, and status labels in mono, with `tabular-nums` for any numerals.
 - **Do** use full row-fill (`bg-accent`) for selection, and indentation alone for tree depth.
+- **Do** set hyperlinks and link-styled text in Cool Link (`text-link`), never amber. Cold for plumbing, warm for the lamp.
 - **Do** write technical copy: "Errored", "Idle", "Empty". Match PRODUCT.md's voice.
 - **Do** give every animation a `prefers-reduced-motion` alternative, and reuse the existing `wizard-*` and `narrative-*` curves (`cubic-bezier(0.25, 1, 0.5, 1)` and `cubic-bezier(0.22, 1, 0.36, 1)`) rather than inventing new ones.
 - **Do** keep type capped near 1rem; build hierarchy from weight and mono/sans contrast.
-- **Do** elevate exactly one next-step per state in amber, bound to the Tab accept key, and auto-advance only single-outcome transitions.
+- **Do** elevate exactly one next-step per state in Filament Amber, bound to the Tab accept key, and auto-advance only single-outcome transitions.
 
 ### Don't:
 - **Don't** use `border-left` or `border-right` greater than 1px as a colored accent stripe on rows, cards, callouts, or alerts. Selection is a row-fill.
@@ -225,5 +231,6 @@ The interface expression of the "Anticipate the next step" product principle. A 
 - **Don't** introduce a second brand accent, or use green/red for anything other than added-or-good / removed-or-errored.
 - **Don't** soften copy into consumer language ("Oops, something went wrong"), add emoji decoration, or use colorful status chips where a tinted dot suffices.
 - **Don't** use raw Tailwind state colors (`bg-yellow-500`, `bg-green-500`). Use the tokenized diff/status colors.
+- **Don't** fill a content surface with the lamp color (`bg-primary` on message bubbles, panels, or any block of prose). Lamp at area scale violates the Cold-Surface Rule; content surfaces are slate neutrals.
 - **Don't** pad with marketing whitespace or build a hero-metric layout. This is a dense instrument, not a landing page.
 - **Don't** show two competing primary next-steps, auto-advance a transition that has a real choice, or let the next-step suggestion learn or reorder itself. Curated and singular, or nothing.

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -62,7 +62,7 @@ describe("MarkdownContent link handling", () => {
     const link = container.querySelector("a");
     const favicon = screen.getByTestId("markdown-link-favicon");
 
-    expect(link).toHaveClass("text-primary");
+    expect(link).toHaveClass("text-link");
     expect(screen.getByTestId("markdown-link-favicon-frame")).toBeInTheDocument();
     expect(favicon).toHaveAttribute("src", "https://example.com/favicon.ico");
     expect(favicon).toHaveClass("favicon-image-shadow");
@@ -377,12 +377,12 @@ describe("MarkdownContent variant styling", () => {
       expect(code?.className).toContain("bg-muted");
     });
 
-    it("renders links with text-primary", () => {
+    it("renders links with cool text-link", () => {
       const { container } = render(
         <MarkdownContent content="[link](https://example.com)" />,
       );
       const link = container.querySelector("a");
-      expect(link?.className).toContain("text-primary");
+      expect(link?.className).toContain("text-link");
     });
 
     it("passes disableHighlighting=false to CodeBlock", () => {
@@ -395,20 +395,20 @@ describe("MarkdownContent variant styling", () => {
   });
 
   describe("variant='user'", () => {
-    it("renders inline code with bg-primary-foreground/15", () => {
+    it("renders inline code with a foreground tint visible on the accent bubble", () => {
       const { container } = render(
         <MarkdownContent content="Use `foo` here" variant="user" />,
       );
       const code = container.querySelector("code");
-      expect(code?.className).toContain("bg-primary-foreground/15");
+      expect(code?.className).toContain("bg-foreground/10");
     });
 
-    it("renders links with text-primary-foreground", () => {
+    it("renders links with cool text-link", () => {
       const { container } = render(
         <MarkdownContent content="[link](https://example.com)" variant="user" />,
       );
       const link = container.querySelector("a");
-      expect(link?.className).toContain("text-primary-foreground");
+      expect(link?.className).toContain("text-link");
     });
 
     it("renders user links with the same favicon treatment", () => {
@@ -420,12 +420,12 @@ describe("MarkdownContent variant styling", () => {
       );
     });
 
-    it("renders blockquote with border-primary-foreground/40", () => {
+    it("renders blockquote with the neutral border treatment", () => {
       const { container } = render(
         <MarkdownContent content="> quote" variant="user" />,
       );
       const blockquote = container.querySelector("blockquote");
-      expect(blockquote?.className).toContain("border-primary-foreground/40");
+      expect(blockquote?.className).toContain("border-border");
     });
 
     it("passes disableHighlighting=true to CodeBlock", () => {

--- a/apps/web/src/components/chat/HookActivitySection.tsx
+++ b/apps/web/src/components/chat/HookActivitySection.tsx
@@ -149,7 +149,7 @@ const HookRow = memo(function HookRow({ hook }: { hook: HookExecution }) {
               <button
                 type="button"
                 onClick={() => setShowAll((v) => !v)}
-                className="text-xs text-primary hover:underline mt-0.5 cursor-pointer"
+                className="text-xs text-link hover:underline mt-0.5 cursor-pointer"
               >
                 {showAll ? `Show preview (${OUTPUT_LINE_CAP} lines)` : `Show all (${hook.fullOutput.length} lines)`}
               </button>

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -14,7 +14,6 @@ import { SiteFavicon } from "@/components/ui/favicon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { resolveCodeBlockLanguage } from "@/lib/resolve-code-block-language";
 import { isMac } from "@/lib/platform";
-import { cn } from "@/lib/utils";
 import {
   isModifierClick,
   isPreviewableUrl,
@@ -36,7 +35,7 @@ interface MarkdownContentProps {
   /** When true, code blocks skip syntax highlighting. Defaults to false. */
   isStreaming?: boolean;
   /**
-   * Controls prose styling. 'user' adapts colors for the primary-colored user bubble.
+   * Controls prose styling. 'user' adapts colors for the accent-surfaced user bubble.
    * Defaults to 'assistant'.
    */
   variant?: "assistant" | "user";
@@ -213,17 +212,14 @@ function getMarkdownFileIconPath(args: {
 interface MarkdownLinkProps {
   href?: string;
   children?: React.ReactNode;
-  variant: "assistant" | "user";
   workspacePath: string | null;
 }
 
 function MarkdownLink({
   href,
   children,
-  variant,
   workspacePath,
 }: MarkdownLinkProps) {
-  const isUser = variant === "user";
   const safeHref = resolveMarkdownHref(href, workspacePath);
   const isPreviewable = !!safeHref && isPreviewableUrl(safeHref);
   const showHint = isPreviewable && hasPreview();
@@ -236,10 +232,7 @@ function MarkdownLink({
   const anchor = (
     <a
       href={safeHref}
-      className={cn(
-        "inline-flex max-w-full items-center gap-1 align-baseline no-underline transition-colors hover:underline",
-        isUser ? "text-primary-foreground" : "text-primary",
-      )}
+      className="inline-flex max-w-full items-center gap-1 align-baseline text-link no-underline transition-colors hover:underline"
       target="_blank"
       rel="noopener noreferrer"
       data-testid="markdown-link"
@@ -272,10 +265,7 @@ function MarkdownLink({
         <ExternalLink
           size={12}
           aria-hidden
-          className={cn(
-            "shrink-0",
-            isUser ? "text-primary-foreground/75" : "text-muted-foreground",
-          )}
+          className="shrink-0 text-muted-foreground"
         />
       ) : null}
     </a>
@@ -308,43 +298,27 @@ function makeStaticComponents(variant: "assistant" | "user", workspacePath: stri
     strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-semibold">{children}</strong>,
     em: ({ children }: { children?: React.ReactNode }) => <em className="italic">{children}</em>,
     a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
-      <MarkdownLink href={href} variant={variant} workspacePath={workspacePath}>
+      <MarkdownLink href={href} workspacePath={workspacePath}>
         {children}
       </MarkdownLink>
     ),
     blockquote: ({ children }: { children?: React.ReactNode }) => (
-      <blockquote
-        className={
-          isUser
-            ? "border-l-2 pl-3 my-2 italic border-primary-foreground/40 text-primary-foreground/80"
-            : "border-l-2 border-border pl-3 my-2 text-muted-foreground italic"
-        }
-      >
+      <blockquote className="border-l-2 border-border pl-3 my-2 text-muted-foreground italic">
         {children}
       </blockquote>
     ),
     pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
-    hr: () => (
-      <hr className={isUser ? "my-4 border-primary-foreground/20" : "my-4 border-border"} />
-    ),
+    hr: () => <hr className="my-4 border-border" />,
     table: ({ children }: { children?: React.ReactNode }) => (
       <div className="overflow-x-auto my-2">
-        <table
-          className={
-            isUser
-              ? "min-w-full border rounded border-primary-foreground/20"
-              : "min-w-full border border-border rounded"
-          }
-        >
-          {children}
-        </table>
+        <table className="min-w-full border border-border rounded">{children}</table>
       </div>
     ),
     th: ({ children }: { children?: React.ReactNode }) => (
       <th
         className={
           isUser
-            ? "border border-primary-foreground/20 bg-primary-foreground/10 px-3 py-1.5 text-left text-sm font-semibold"
+            ? "border border-border bg-foreground/10 px-3 py-1.5 text-left text-sm font-semibold"
             : "border border-border bg-muted/50 px-3 py-1.5 text-left text-sm font-semibold"
         }
       >
@@ -352,15 +326,7 @@ function makeStaticComponents(variant: "assistant" | "user", workspacePath: stri
       </th>
     ),
     td: ({ children }: { children?: React.ReactNode }) => (
-      <td
-        className={
-          isUser
-            ? "border border-primary-foreground/20 px-3 py-1.5 text-sm"
-            : "border border-border px-3 py-1.5 text-sm"
-        }
-      >
-        {children}
-      </td>
+      <td className="border border-border px-3 py-1.5 text-sm">{children}</td>
     ),
   };
 }
@@ -386,16 +352,16 @@ function makeComponents(
       const isInline = !className && !rawContent.includes("\n");
 
       if (isInline) {
+        // Inside the user bubble the surface is already `accent`, so `bg-muted`
+        // would vanish against it; a foreground tint stays visible on both themes.
         const codeClass = isUser
-          ? "bg-primary-foreground/15 rounded px-1.5 py-0.5 text-sm font-mono"
+          ? "bg-foreground/10 rounded px-1.5 py-0.5 text-sm font-mono"
           : "bg-muted rounded px-1.5 py-0.5 text-sm font-mono";
 
         // Detect URLs inside inline code and make them clickable
         const text = rawContent.trim();
         if (HTTP_URL_RE.test(text)) {
-          const linkClass = isUser
-            ? "text-primary-foreground underline decoration-dotted hover:opacity-80 cursor-pointer"
-            : "text-primary underline decoration-dotted hover:text-primary cursor-pointer";
+          const linkClass = "text-link underline decoration-dotted hover:opacity-80 cursor-pointer";
           const codeEl = (
             <code
               role="link"
@@ -418,9 +384,7 @@ function makeComponents(
 
         if (workspacePath && looksLikeWorkspaceRelativeFileRef(text)) {
           const previewUrl = mcodeWorkspacePreviewHref(text);
-          const linkClass = isUser
-            ? "text-primary-foreground underline decoration-dotted hover:opacity-80 cursor-pointer"
-            : "text-primary underline decoration-dotted hover:text-primary cursor-pointer";
+          const linkClass = "text-link underline decoration-dotted hover:opacity-80 cursor-pointer";
           const codeEl = (
             <code
               role="link"

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -77,7 +77,7 @@ function MentionedUserText({
     nodes.push(
       <span
         key={`${mention.id}-${mention.range.start}`}
-        className="rounded-md bg-primary-foreground/20 px-1 py-0.5 font-medium"
+        className="rounded-md bg-foreground/10 px-1 py-0.5 font-medium"
       >
         {text.slice(mention.range.start, mention.range.end)}
       </span>,
@@ -620,7 +620,7 @@ export const MessageBubble = memo(function MessageBubble({
             )}
 
           {userDisplayText.trim() && (
-            <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow-sm shadow-primary/15">
+            <div className="overflow-hidden break-words rounded-lg rounded-br-md bg-accent px-3 py-1.5 text-sm text-accent-foreground">
               {!userGoal && message.mentions?.length ? (
                 <MentionedUserText text={userDisplayText} mentions={message.mentions} />
               ) : (

--- a/apps/web/src/components/chat/StickyUserMessage.tsx
+++ b/apps/web/src/components/chat/StickyUserMessage.tsx
@@ -122,7 +122,7 @@ export function StickyUserMessage({
       data-testid="sticky-user-message"
     >
       <div className="mx-auto w-full min-w-0 max-w-4xl">
-        <div className="pointer-events-auto flex items-start gap-0.5 overflow-hidden rounded-lg bg-primary text-sm text-primary-foreground shadow-sm shadow-primary/15">
+        <div className="pointer-events-auto flex items-start gap-0.5 overflow-hidden rounded-lg border border-border/60 bg-accent text-sm text-accent-foreground shadow-sm">
           <Button
             type="button"
             variant="ghost"
@@ -131,7 +131,7 @@ export function StickyUserMessage({
             aria-expanded={expandable ? expanded : undefined}
             aria-describedby={expandable ? STICKY_PREVIEW_HINT_ID : undefined}
             aria-label={previewAriaLabel}
-            className="h-auto min-w-0 flex-1 cursor-pointer justify-start px-3 py-1.5 text-left font-normal text-primary-foreground transition-colors hover:bg-primary-foreground/10 hover:text-primary-foreground"
+            className="h-auto min-w-0 flex-1 cursor-pointer justify-start px-3 py-1.5 text-left font-normal text-accent-foreground transition-colors hover:bg-foreground/5 hover:text-accent-foreground"
           >
             <p
               className={cn(
@@ -151,7 +151,7 @@ export function StickyUserMessage({
                 </span>
                 <span
                   aria-hidden
-                  className="mt-1 inline-flex items-center gap-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-primary-foreground/65"
+                  className="mt-1 inline-flex items-center gap-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
                 >
                   <ChevronDown
                     size={11}
@@ -160,7 +160,7 @@ export function StickyUserMessage({
                   />
                   {expanded ? "Collapse" : "Expand"}
                   {!expanded && (
-                    <span className="normal-case tracking-normal text-primary-foreground/50">
+                    <span className="normal-case tracking-normal text-muted-foreground/70">
                       · Double-click to jump
                     </span>
                   )}
@@ -177,7 +177,7 @@ export function StickyUserMessage({
                   variant="ghost"
                   size="icon-sm"
                   onClick={onJumpToMessage}
-                  className="mt-0.5 mr-0.5 size-11 shrink-0 text-primary-foreground/80 hover:bg-primary-foreground/10 hover:text-primary-foreground"
+                  className="mt-0.5 mr-0.5 size-11 shrink-0 text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
                   aria-label="Jump to your last message"
                 >
                   <ArrowUp size={15} aria-hidden />

--- a/apps/web/src/components/diff/DiffPreviewMarkdown.tsx
+++ b/apps/web/src/components/diff/DiffPreviewMarkdown.tsx
@@ -111,7 +111,7 @@ export default function DiffPreviewMarkdown({
         // Blockquote: indented italic with a faint bg tint instead of a
         // left stripe (border-l > 1px is banned per impeccable).
         "[&_blockquote]:bg-muted/15 [&_blockquote]:px-3 [&_blockquote]:py-1 [&_blockquote]:italic [&_blockquote]:text-muted-foreground [&_blockquote]:rounded-sm",
-        "[&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2",
+        "[&_a]:text-link [&_a]:underline [&_a]:underline-offset-2",
         "[&_hr]:my-4 [&_hr]:border-border/40",
         "[&_table]:border-collapse [&_table]:my-2",
         "[&_th]:border [&_th]:border-border/40 [&_th]:px-2 [&_th]:py-1",

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ const badgeVariants = cva(
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost:
           "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-link underline-offset-4 hover:underline",
       },
       size: {
         default: "h-5 px-2 py-0.5",

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -19,7 +19,7 @@ const buttonVariants = cva(
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-link underline-offset-4 hover:underline",
       },
       size: {
         default:

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6,44 +6,47 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  /* Warm light theme — minimal chroma (0.005) at hue 75 to harmonize with amber primary */
+  /* Cool light theme: minimal chroma (0.005) at hue 260 so the amber lamp remains a point accent */
   /* --page sits a few percent below --background so floating panel surfaces read as
      slightly elevated against the page chrome. Replaces inter-panel divider lines. */
-  --page: oklch(0.955 0.005 75);
-  --background: oklch(0.99 0.005 75);
-  --foreground: oklch(0.18 0.005 75);
-  --card: oklch(0.985 0.005 75);
-  --card-foreground: oklch(0.18 0.005 75);
-  --popover: oklch(0.99 0.005 75);
-  --popover-foreground: oklch(0.18 0.005 75);
+  --page: oklch(0.955 0.005 260);
+  --background: oklch(0.99 0.005 260);
+  --foreground: oklch(0.18 0.005 260);
+  --card: oklch(0.985 0.005 260);
+  --card-foreground: oklch(0.18 0.005 260);
+  --popover: oklch(0.99 0.005 260);
+  --popover-foreground: oklch(0.18 0.005 260);
   --primary: oklch(0.52 0.17 75);
   --primary-foreground: oklch(0.984 0 0);
-  --secondary: oklch(0.95 0.005 75);
-  --secondary-foreground: oklch(0.22 0.005 75);
-  --muted: oklch(0.955 0.005 75);
-  --muted-foreground: oklch(0.5 0.005 75);
-  --accent: oklch(0.95 0.005 75);
-  --accent-foreground: oklch(0.18 0.005 75);
+  --secondary: oklch(0.95 0.005 260);
+  --secondary-foreground: oklch(0.22 0.005 260);
+  --muted: oklch(0.955 0.005 260);
+  --muted-foreground: oklch(0.5 0.005 260);
+  --accent: oklch(0.95 0.005 260);
+  --accent-foreground: oklch(0.18 0.005 260);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.9 0.005 75);
-  --input: oklch(0.9 0.005 75);
+  --border: oklch(0.9 0.005 260);
+  --input: oklch(0.9 0.005 260);
   --ring: oklch(0.52 0.17 75);
-  --chart-1: oklch(0.87 0.005 75);
-  --chart-2: oklch(0.556 0.005 75);
-  --chart-3: oklch(0.439 0.005 75);
-  --chart-4: oklch(0.371 0.005 75);
-  --chart-5: oklch(0.269 0.005 75);
+  /* Links stay distinct from the primary: slightly hue-shifted so the accent
+     is reserved for actions and live state (One Lamp Rule). */
+  --link: oklch(0.5 0.16 260);
+  --chart-1: oklch(0.87 0.005 260);
+  --chart-2: oklch(0.556 0.005 260);
+  --chart-3: oklch(0.439 0.005 260);
+  --chart-4: oklch(0.371 0.005 260);
+  --chart-5: oklch(0.269 0.005 260);
   --radius: 0.625rem;
-  --sidebar: oklch(0.945 0.008 75);
-  --sidebar-foreground: oklch(0.18 0.005 75);
+  --sidebar: oklch(0.945 0.008 260);
+  --sidebar-foreground: oklch(0.18 0.005 260);
   --sidebar-primary: oklch(0.52 0.17 75);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.92 0.008 75);
-  --sidebar-accent-foreground: oklch(0.22 0.005 75);
-  --sidebar-border: oklch(0.88 0.008 75);
+  --sidebar-accent: oklch(0.92 0.008 260);
+  --sidebar-accent-foreground: oklch(0.22 0.005 260);
+  --sidebar-border: oklch(0.88 0.008 260);
   --sidebar-ring: oklch(0.52 0.17 75);
 
-  /* Diff palette — sage (additions) and clay (removals), hue-shifted to harmonize with warm amber */
+  /* Diff palette — sage (additions) and clay (removals), semantic hues independent of the brand accent */
   --diff-add-bg: oklch(0.96 0.035 145);
   --diff-add-bg-hover: oklch(0.93 0.055 145);
   --diff-add-gutter: oklch(0.78 0.10 145);
@@ -66,8 +69,10 @@
   --card-foreground: oklch(0.93 0 0);
   --popover: oklch(0.19 0.005 260);
   --popover-foreground: oklch(0.93 0 0);
+  /* Dark text on amber accent: at L 0.72 a near-white foreground
+     cannot reach 4.5:1, ink can. */
   --primary: oklch(0.72 0.17 75);
-  --primary-foreground: oklch(0.98 0 0);
+  --primary-foreground: oklch(0.15 0.005 260);
   --secondary: oklch(0.24 0.005 260);
   --secondary-foreground: oklch(0.93 0 0);
   --muted: oklch(0.22 0.005 260);
@@ -78,6 +83,7 @@
   --border: oklch(0.28 0.005 260);
   --input: oklch(0.24 0.005 260);
   --ring: oklch(0.62 0.19 264);
+  --link: oklch(0.7 0.14 260);
   --chart-1: oklch(0.62 0.19 264);
   --chart-2: oklch(0.55 0.005 260);
   --chart-3: oklch(0.44 0.005 260);
@@ -127,6 +133,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-link: var(--link);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);
@@ -369,7 +376,7 @@
   }
 }
 
-/* Changes-tab freshness ring: a short amber pulse that fires when new changed
+/* Changes-tab freshness ring: a short accent pulse that fires when new changed
  * files land while the user is on another tab, then settles to the steady
  * amber count. Two iterations so it registers without nagging. */
 @keyframes changes-fresh-ring {
@@ -490,7 +497,7 @@
    accent the first time it persists, acknowledging the submit. */
 @keyframes wizard-marker-echo {
   0%   { background-color: transparent; }
-  30%  { background-color: oklch(0.72 0.17 75 / 0.12); }
+  30%  { background-color: color-mix(in oklch, var(--primary), transparent 88%); }
   100% { background-color: transparent; }
 }
 .animate-wizard-marker-echo {
@@ -512,7 +519,7 @@
 }
 
 .glow-primary {
-  box-shadow: -2px 0 8px -1px oklch(0.72 0.17 75 / 0.35);
+  box-shadow: -2px 0 8px -1px color-mix(in oklch, var(--primary), transparent 65%);
 }
 
 .animate-shimmer-text {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -519,7 +519,7 @@
 }
 
 .glow-primary {
-  box-shadow: -2px 0 8px -1px color-mix(in oklch, var(--primary), transparent 65%);
+  box-shadow: -2px 0 8px -1px oklch(0.72 0.17 75 / 0.35);
 }
 
 .animate-shimmer-text {


### PR DESCRIPTION
## What

The user message bubble is restyled from a solid amber fill to a cool slate surface with ink text. Links across the app use a new dedicated `--link` token (markdown links, inline-code links, diff preview, button and badge link variants). Light theme neutrals are retinted from warm hue 75 to cool hue 260. Dark-theme primary buttons carry ink text instead of white. Brand primary remains Filament Amber `oklch(0.72 0.17 75)`. DESIGN.md and `.impeccable/design.json` codify the Cold-Surface Rule and Cool Link role. Also adds a hookify guardrail blocking process-kills-by-name to protect the running production Mcode app.

## Why

Amber at area scale (a full message bubble) competed with the narrative and failed WCAG contrast at 2.7:1. Cold surfaces with a rationed warm accent read calmer and are more legible, inspired by the Codex app direction. The One Lamp Rule is restored: amber only appears at point scale (icons, accents), never as a filled surface.

## Key Changes

- User message bubble: solid amber fill replaced with cool slate surface (`bg-surface-alt`) and ink text
- New `--link` CSS token wired to a cool blue-violet across both themes; replaces amber for all hyperlinks and link-styled actions
- Light theme neutral palette retinted from warm hue 75 to cool hue 260
- Dark theme primary button text switched to ink so the amber accent clears 4.5:1 contrast
- `MarkdownContent`, `DiffPreviewMarkdown`, `HookActivitySection`, `StickyUserMessage`, `badge.tsx`, `button.tsx` all updated to use the new token
- `MarkdownContent.test.tsx` updated to assert the new class names
- `DESIGN.md` documents the Cold-Surface Rule; `.impeccable/design.json` records the design decision
- `.claude/hookify.block-process-kill-by-name.local.md` adds a PreToolUse guardrail that blocks name- and port-based process kills in agent tooling

## Testing

- `bun run verify`: typecheck pass, lint pass, unit tests pass (one timeout in `TerminalStatusIndicator.test.tsx` under parallel load, confirmed as a pre-existing flake by running the file in isolation: 6/6 pass)
- Visual verification in the running web app, both light and dark themes, zero console errors
- `MarkdownContent` unit tests updated and passing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785624208&installation_id=129163861&pr_number=836&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F836&signature=106c4998aa33bf9b1fad742287cdc43d35319bdfa3190d4921b29f327aab5f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default Hookify safety rule that blocks broad “kill by name” process patterns and points users to safer alternatives.
  * Introduced a dedicated link color/style for clearer hyperlink and external-link visibility.
* **Style**
  * Refreshed the UI theme toward a cooler, more neutral palette and updated shadow/edge-glow behavior.
  * Updated chat + markdown presentation for links, mentions, buttons, badges, sticky message controls, and diff markdown styling for more consistent visuals.
* **Tests**
  * Updated Markdown rendering expectations to match the new link/code/blockquote styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->