### PR TITLE
fix(desktop): scale preview bounds by host zoom factor

### DIFF
--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -101,6 +101,7 @@ function makeWindow() {
       send: vi.fn(),
       on: vi.fn(),
       setWindowOpenHandler: vi.fn(),
+      getZoomFactor: vi.fn().mockReturnValue(1),
     },
   };
 }
@@ -277,6 +278,33 @@ describe("preview-browser", () => {
       expect(statusCalls.length).toBeGreaterThan(0);
       const last = statusCalls[statusCalls.length - 1]![1] as { phase: string };
       expect(last.phase).not.toBe("loading");
+    });
+  });
+
+  describe("bounds zoom scaling", () => {
+    it("converts renderer CSS-pixel bounds to DIPs using the host zoom factor", async () => {
+      const win = createWindow();
+      win.webContents.getZoomFactor.mockReturnValue(0.8);
+
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      expect(view.setBounds).toHaveBeenCalledWith({
+        x: 80,
+        y: 80,
+        width: 640,
+        height: 480,
+      });
+    });
+
+    it("falls back to zoom 1 when the sender reports a non-finite factor", async () => {
+      const win = createWindow();
+      win.webContents.getZoomFactor.mockReturnValue(Number.NaN);
+
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      expect(view.setBounds).toHaveBeenCalledWith(VALID_BOUNDS);
     });
   });
 

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -146,8 +146,18 @@ export function registerNavigationHandlers(): void {
       const tid = payload.threadId ?? null;
       const switchedThread = tid != null && tid !== s.lastPreviewThreadId;
       const prevBounds = s.lastBounds;
+      // The renderer measures in CSS pixels but setBounds expects DIPs; they
+      // only match at zoom factor 1. Chromium persists per-origin zoom, so an
+      // accidental Ctrl+-/Ctrl+= would otherwise skew the view permanently.
+      const rawZoom = _event.sender.getZoomFactor();
+      const zoom = Number.isFinite(rawZoom) && rawZoom > 0 ? rawZoom : 1;
       const incomingBounds = hasValidBounds
-        ? { x: b.x, y: b.y, width: b.width, height: b.height }
+        ? {
+            x: Math.round(b.x * zoom),
+            y: Math.round(b.y * zoom),
+            width: Math.round(b.width * zoom),
+            height: Math.round(b.height * zoom),
+          }
         : null;
       if (hasValidBounds) {
         s.lastBounds = incomingBounds;


### PR DESCRIPTION
## What

Convert preview panel bounds from CSS pixels to DIPs at the `preview:sync` IPC boundary, using the host window zoom factor.

## Why

The renderer measures the preview surface with `getBoundingClientRect()` (CSS pixels), and the main process passed those values straight to `WebContentsView.setBounds()`, which expects DIPs. The two units only match when the host window zoom factor is exactly 1. Chromium persists per-origin zoom in the user-data dir, so a single accidental Ctrl+- or Ctrl+= skews the embedded browser on that machine permanently: the view renders pushed to the right, oversized, and clipped. Because the bad zoom lives in one profile, the bug looks machine-specific.

## Key Changes

- `preview-navigation.ts`: the `preview:sync` handler now multiplies incoming bounds by `_event.sender.getZoomFactor()` before storing and applying them, falling back to 1 for non-finite or non-positive values. Downstream consumers of `lastBounds` (tab switching, crash recovery, design mode) inherit correct DIP values.
- `preview-browser.test.ts`: added `getZoomFactor` to the host window mock and two regression tests (zoom 0.8 scales bounds; NaN falls back to identity).

## Verification

`bun run verify` full gate passes: typecheck 5/5, lint, unit tests green (frontend 1868 passed; preview-browser suite 70/70 including the new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785638943&installation_id=129163861&pr_number=837&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F837&signature=657582bbef28903386f8e87af16d97f048306a276bdd2ec522daace6b85e6f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview window positioning now respects display zoom levels, improving accuracy when syncing bounds from the renderer.
  * Falls back safely to default sizing when zoom information is invalid, preventing incorrect preview placement.
  * Test coverage was expanded to verify zoom-based scaling behavior and safeguard against non-finite zoom values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->