### PR TITLE
feat: add resilient provider usage limits

### DIFF
--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -2553,6 +2553,14 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
         error: error instanceof Error ? error.message : String(error),
       });
     }
+    const hasThreadMetrics =
+      this.lastSessionCostUsd !== undefined ||
+      this.lastServiceTier !== undefined ||
+      this.lastNumTurns !== undefined ||
+      this.lastDurationMs !== undefined;
+    if (categories === null && !hasThreadMetrics) {
+      throw new Error("Claude usage source unavailable");
+    }
     return {
       providerId: "claude",
       quotaCategories: categories ?? [],

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -104,7 +104,7 @@ interface QuotaSnapshot {
  * Converts a raw Copilot quota snapshot map into an array of normalized QuotaCategory objects
  * suitable for the QuotaUpdate AgentEvent.
  */
-function normalizeQuotaSnapshots(
+export function normalizeQuotaSnapshots(
   snapshots: Record<string, QuotaSnapshot>,
 ): QuotaCategory[] {
   return Object.entries(snapshots).map(([key, snap]) => {
@@ -493,20 +493,15 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
 
   /** Return current usage/quota state by fetching from account.getQuota(). */
   async getUsage(): Promise<ProviderUsageInfo> {
-    try {
-      await this.refreshClient();
-      if (this.lastResolution?.source === "not-found" || !this.client) {
-        return { providerId: "copilot", quotaCategories: [] };
-      }
-      const result = await this.client.rpc.account.getQuota();
-      const categories = result?.quotaSnapshots
-        ? normalizeQuotaSnapshots(result.quotaSnapshots)
-        : [];
-      return { providerId: "copilot", quotaCategories: categories };
-    } catch (error) {
-      logger.warn("Failed to fetch Copilot quota", { error });
-      return { providerId: "copilot", quotaCategories: [] };
+    await this.refreshClient();
+    if (this.lastResolution?.source === "not-found" || !this.client) {
+      throw new Error("Copilot client unavailable");
     }
+    const result = await this.client.rpc.account.getQuota();
+    const categories = result?.quotaSnapshots
+      ? normalizeQuotaSnapshots(result.quotaSnapshots)
+      : [];
+    return { providerId: "copilot", quotaCategories: categories };
   }
 
   /**

--- a/apps/server/src/providers/copilot/copilot-usage.test.ts
+++ b/apps/server/src/providers/copilot/copilot-usage.test.ts
@@ -1,0 +1,27 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { normalizeQuotaSnapshots } from "./copilot-provider.js";
+
+describe("normalizeQuotaSnapshots", () => {
+  it("preserves SDK reset dates on quota categories", () => {
+    expect(
+      normalizeQuotaSnapshots({
+        premium_interactions: {
+          entitlementRequests: 100,
+          usedRequests: 25,
+          remainingPercentage: 75,
+          resetDate: "2026-07-31T00:00:00.000Z",
+        },
+      }),
+    ).toEqual([
+      {
+        label: "Premium usage",
+        used: 25,
+        total: 100,
+        remainingPercent: 0.75,
+        resetDate: "2026-07-31T00:00:00.000Z",
+        isUnlimited: false,
+      },
+    ]);
+  });
+});

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -7,13 +7,12 @@
  */
 
 import { injectable, inject } from "tsyringe";
-import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import { randomUUID } from "node:crypto";
-import { promisify } from "node:util";
 import { logger } from "@mcode/shared";
 import {
   ClientSideConnection,
@@ -50,7 +49,6 @@ import type {
   PermissionRequest,
   ProviderId,
   ProviderModelInfo,
-  ProviderUsageInfo,
   Settings,
 } from "@mcode/contracts";
 import {
@@ -95,10 +93,8 @@ import {
 } from "./cursor-acp-session-trace.js";
 import { cursorTaskExtToAgentEvents } from "./cursor-acp-task.js";
 import { extractCursorCreatePlanMarkdown } from "./cursor-create-plan.js";
-import { CursorAdminUsageSource } from "./usage/cursor-admin-usage-source.js";
 
 const CURSOR_STDERR_TAIL_MAX = 48;
-const execFileAsync = promisify(execFile);
 
 /**
  * Wrap a message as a transient (ETIMEDOUT) error. `classifyProviderError` maps
@@ -137,18 +133,6 @@ type CursorSideChannelConnector = (args: {
 function cursorCliProbeBinaries(settings: Settings): string[] {
   const configured = settings.provider.cli.cursor?.trim();
   return configured ? [configured] : [getCatalogEntry("cursor").cliBinary, "agent"];
-}
-
-function readCursorStatusEmail(stdout: string): string | undefined {
-  try {
-    const parsed = JSON.parse(stdout) as {
-      userInfo?: { email?: unknown };
-    };
-    const email = parsed.userInfo?.email;
-    return typeof email === "string" && email.trim() ? email.trim() : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 interface PendingAcpPermission {
@@ -216,10 +200,6 @@ export class CursorProvider
 
   /** Owns the session pool, idle eviction (with busy guard), and JobObject/kill. */
   private readonly runtime: SessionRuntime<CursorSessionState>;
-  /** Cached source for account-level Cursor usage limits. */
-  private readonly usageSource: CursorAdminUsageSource;
-  private accountEmail: string | null = null;
-  private accountEmailPromise: Promise<string | undefined> | null = null;
   private sdkSessionIds = new Map<string, string>();
   /**
    * Session IDs for which a stop was requested before the session was created.
@@ -249,57 +229,6 @@ export class CursorProvider
       envService: this.envService,
       idleTtlMs: this.settingsService.get().provider.cursor.idleSessionTtlMinutes * 60 * 1000,
     });
-    this.usageSource = new CursorAdminUsageSource({
-      apiKey: () => this.resolveCursorAdminApiKey(),
-      usageEmail: () => this.resolveCursorUsageEmail(),
-    });
-  }
-
-  private resolveCursorAdminApiKey(): string | undefined {
-    const env = this.envService.getEnv();
-    return (
-      process.env.MCODE_CURSOR_ADMIN_API_KEY
-      ?? env.MCODE_CURSOR_ADMIN_API_KEY
-      ?? process.env.CURSOR_ADMIN_API_KEY
-      ?? env.CURSOR_ADMIN_API_KEY
-    );
-  }
-
-  private async resolveCursorUsageEmail(): Promise<string | undefined> {
-    const configured = this.settingsService.get().provider.cursor.usageEmail.trim();
-    if (configured) return configured;
-    if (this.accountEmail) return this.accountEmail;
-    if (!this.accountEmailPromise) {
-      this.accountEmailPromise = this.readCursorAgentAccountEmail()
-        .then((email) => {
-          if (email) this.accountEmail = email;
-          return email;
-        })
-        .finally(() => {
-          this.accountEmailPromise = null;
-        });
-    }
-    return this.accountEmailPromise;
-  }
-
-  private async readCursorAgentAccountEmail(): Promise<string | undefined> {
-    for (const cliPath of cursorCliProbeBinaries(this.settingsService.get())) {
-      try {
-        const { stdout } = await execFileAsync(cliPath, ["status", "--format", "json"], {
-          shell: process.platform === "win32",
-          env: this.envService.getEnv(),
-          timeout: 5_000,
-          maxBuffer: 64 * 1024,
-          windowsHide: true,
-        });
-        const email = readCursorStatusEmail(String(stdout));
-        if (email) return email;
-      } catch {
-        // Try the next binary name. Usage fetch will simply return empty if
-        // no authenticated Cursor Agent account can be discovered.
-      }
-    }
-    return undefined;
   }
 
   /** Lists models by running `cursor-agent models` (falls back when discovery fails). */
@@ -315,12 +244,6 @@ export class CursorProvider
 
     logger.info("Cursor listModels: using static fallback (CLI discovery unavailable)");
     return [...CURSOR_STATIC_MODEL_FALLBACK];
-  }
-
-  /** Return current Cursor usage-limit state from the configured Admin API source. */
-  async getUsage(): Promise<ProviderUsageInfo> {
-    const quotaCategories = await this.usageSource.fetch();
-    return { providerId: "cursor", quotaCategories };
   }
 
   /** Queues an ACP `session/prompt` on the session subprocess (serialized per thread). */

--- a/apps/server/src/providers/cursor/cursor-usage.test.ts
+++ b/apps/server/src/providers/cursor/cursor-usage.test.ts
@@ -1,0 +1,9 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { CursorProvider } from "./cursor-provider.js";
+
+describe("CursorProvider usage limits", () => {
+  it("does not expose team or admin usage through provider.getUsage", () => {
+    expect("getUsage" in CursorProvider.prototype).toBe(false);
+  });
+});

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -65,6 +65,26 @@ import type { HandoffStorage } from "../services/handoff/handoff-storage.js";
 import { loadConversationPage } from "../services/conversation-page.js";
 import type { ThreadTeardownService } from "../services/thread-teardown-service.js";
 
+function redactedUsageDiagnostic(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return raw
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(/(token|api[_-]?key|authorization|password|secret)=\S+/gi, "$1=[redacted]")
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
+    .slice(0, 240);
+}
+
+function readyUsageSnapshot(usage: ProviderUsageInfo): ProviderUsageInfo {
+  const fetchedAt = new Date().toISOString();
+  return {
+    ...usage,
+    usageStatus: usage.quotaCategories.length > 0 ? "ready" : "ready-empty",
+    fetchedAt,
+    diagnostic: undefined,
+    failedAt: undefined,
+  };
+}
+
 function teardownFailureMessage(result: PromiseRejectedResult): string {
   return result.reason instanceof Error ? result.reason.message : String(result.reason);
 }
@@ -1004,9 +1024,32 @@ async function dispatch(
       deps.providerAvailability.assertUsable(params.providerId);
       const provider = deps.providerRegistry.resolve(params.providerId);
       if (!provider.getUsage) {
-        return { providerId: provider.id, quotaCategories: [] } satisfies ProviderUsageInfo;
+        return {
+          providerId: provider.id,
+          quotaCategories: [],
+          usageStatus: "unsupported",
+          failedAt: new Date().toISOString(),
+          diagnostic: "Provider usage is not supported",
+        } satisfies ProviderUsageInfo;
       }
-      return provider.getUsage();
+      try {
+        return readyUsageSnapshot(await provider.getUsage());
+      } catch (error) {
+        const diagnostic = redactedUsageDiagnostic(error);
+        logger.warn("Provider usage refresh failed", {
+          providerId: provider.id,
+          sourceKind: "getUsage",
+          lastRefreshTime: new Date().toISOString(),
+          reason: diagnostic,
+        });
+        return {
+          providerId: provider.id,
+          quotaCategories: [],
+          usageStatus: "unavailable",
+          failedAt: new Date().toISOString(),
+          diagnostic,
+        } satisfies ProviderUsageInfo;
+      }
     }
     case "providers.listAvailability": {
       return deps.providerAvailability.listAvailability();

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -668,14 +668,14 @@ test.describe("Consolidated chat header usage states", () => {
     await page.waitForSelector("[data-testid='chat-header-title']");
     await ensureOverviewOpen(page);
     await expect(page.getByTestId("thread-overview-usage")).toBeVisible();
-    await expect(page.getByText("Stale usage")).toHaveCount(0);
+    await expect(page.getByText("STALE")).toHaveCount(0);
     await page.screenshot({ path: "e2e/screenshots/thread-overview-usage-ready-desktop.png", fullPage: true });
 
     await page.getByTestId("header-workspace-menu").click();
     await expect(overviewContent(page)).toBeHidden();
     await page.getByTestId("header-workspace-menu").click();
     await expect(page.getByTestId("thread-overview-usage")).toBeVisible();
-    await expect(page.getByText("Stale usage")).toBeVisible();
+    await expect(page.getByText("STALE")).toBeVisible();
     await expect(page.getByRole("progressbar", { name: /5-hour usage 12 percent\. Resets in/ })).toBeVisible();
     await page.screenshot({ path: "e2e/screenshots/thread-overview-usage-stale-desktop.png", fullPage: true });
 
@@ -684,7 +684,7 @@ test.describe("Consolidated chat header usage states", () => {
       await page.getByTestId("header-workspace-menu").click();
     }
     await expect(page.getByTestId("thread-overview-usage")).toBeVisible();
-    await expect(page.getByText("Stale usage")).toBeVisible();
+    await expect(page.getByText("STALE")).toBeVisible();
     await expect(page.getByTestId("thread-overview-body")).toHaveJSProperty("scrollWidth", await page.getByTestId("thread-overview-body").evaluate((node) => node.clientWidth));
     await page.screenshot({ path: "e2e/screenshots/thread-overview-usage-stale-narrow.png", fullPage: true });
     expect(consoleErrors).toEqual([]);

--- a/apps/web/e2e/chat-header-consolidated.spec.ts
+++ b/apps/web/e2e/chat-header-consolidated.spec.ts
@@ -8,6 +8,8 @@ import { getDefaultSettings } from "@mcode/contracts";
 
 const MOCK_SETTINGS = getDefaultSettings();
 const now = new Date().toISOString();
+const fiveHourReset = new Date(Date.now() + 2 * 60 * 60_000 + 14 * 60_000).toISOString();
+const weeklyReset = new Date(Date.now() + 4 * 24 * 60 * 60_000 + 6 * 60 * 60_000).toISOString();
 const WS_ID = "ws-1";
 
 const workspace = {
@@ -66,12 +68,15 @@ const openPr = {
 
 const usage = {
   providerId: "claude",
+  usageStatus: "ready",
+  fetchedAt: now,
   quotaCategories: [
     {
       label: "5-hour limit",
       used: 12,
       total: 100,
       remainingPercent: 0.88,
+      resetDate: fiveHourReset,
       isUnlimited: false,
     },
     {
@@ -79,6 +84,7 @@ const usage = {
       used: 47,
       total: 100,
       remainingPercent: 0.53,
+      resetDate: weeklyReset,
       isUnlimited: false,
     },
   ],
@@ -355,20 +361,22 @@ test.describe("Consolidated chat header", () => {
     );
     await expect(page.getByTestId("thread-overview-usage")).toHaveAttribute("aria-expanded", "true");
     await expect(page.getByTestId("thread-overview-usage")).not.toContainText("5-hour 12%, weekly 47%");
-    await expect(page.getByRole("progressbar", { name: "5-hour usage" })).toHaveAttribute(
+    await expect(page.getByRole("progressbar", { name: /5-hour usage 12 percent\. Resets in/ })).toHaveAttribute(
       "aria-valuenow",
       "12",
     );
-    await expect(page.getByRole("progressbar", { name: "weekly usage" })).toHaveAttribute(
+    await expect(page.getByRole("progressbar", { name: /weekly usage 47 percent\. Resets in/ })).toHaveAttribute(
       "aria-valuenow",
       "47",
     );
+    await expect(page.getByText(/Resets in/)).toHaveCount(2);
     await expect(page.getByText("usage unavailable")).toHaveCount(0);
     await expect(page.getByTestId("thread-overview-usage-popover")).toHaveCount(0);
     await expect(page.getByTestId("workspace-menu-create-pr")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-commit")).toHaveCount(0);
     await expect(page.getByTestId("thread-overview-sources")).toHaveCount(0);
     await expect(page.locator(".animate-overview-enter").first()).toBeVisible();
+    await page.screenshot({ path: "e2e/screenshots/thread-overview-usage-ready-1440.png", fullPage: true });
 
     await expect(page.getByTestId("thread-overview-local")).toContainText("Worktree");
     await expect(page.getByTestId("thread-overview-repository")).toContainText(
@@ -484,6 +492,243 @@ test.describe("Consolidated chat header", () => {
       .evaluate((node) => getComputedStyle(node).paddingRight);
 
     expect(messageAreaPaddingRight).toBe("0px");
+  });
+});
+
+test.describe("Consolidated chat header usage states", () => {
+  for (const providerId of ["claude", "codex", "copilot"] as const) {
+    test(`renders ${providerId} current-user usage limits with reset text`, async ({ page }) => {
+      const providerThread = {
+        ...thread,
+        id: `thread-${providerId}`,
+        provider: providerId,
+        model: `${providerId}-test-model`,
+      };
+      const providerUsage = {
+        ...usage,
+        providerId,
+      };
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.addInitScript((wsId: string) => {
+        localStorage.setItem(
+          "mcode-expanded-projects",
+          JSON.stringify({ [wsId]: true }),
+        );
+      }, WS_ID);
+      await mockWebSocketServer(page, {
+        "workspace.list": [workspace],
+        "workspace.enrich": { items: [] },
+        "workspace.touchLastOpened": null,
+        "thread.list": [providerThread],
+        "settings.get": MOCK_SETTINGS,
+        "provider.getUsage": providerUsage,
+        "github.branchPr": null,
+        "git.log": [gitCommit],
+        "snapshot.listByThread": [{ ...snapshot, thread_id: providerThread.id }],
+        "snapshot.getDiffStats": [],
+        "git.listBranches": branches,
+        "git.getRemoteUrl": {
+          label: "Mzeey-Empire/mcode",
+          webUrl: "https://github.com/Mzeey-Empire/mcode",
+        },
+        "git.workingTreeFiles": [],
+      });
+
+      await page.goto("/");
+      await page.waitForSelector("[data-testid='thread-item']");
+      await page.locator("[data-testid='thread-item']").first().click();
+      await page.waitForSelector("[data-testid='chat-header-title']");
+      await ensureOverviewOpen(page);
+
+      await expect(page.getByTestId("thread-overview-usage")).toHaveAttribute(
+        "aria-label",
+        "Usage, 5-hour 12%, weekly 47%",
+      );
+      await expect(page.getByRole("progressbar", { name: /5-hour usage 12 percent\. Resets in/ })).toBeVisible();
+      await expect(page.getByRole("progressbar", { name: /weekly usage 47 percent\. Resets in/ })).toBeVisible();
+      await expect(page.getByText(/Resets in/)).toHaveCount(2);
+      await page.screenshot({
+        path: `e2e/screenshots/thread-overview-usage-${providerId}-ready.png`,
+        fullPage: true,
+      });
+    });
+  }
+
+  test("excludes Cursor admin usage from current-user Overview limits", async ({ page }) => {
+    const cursorThread = {
+      ...thread,
+      id: "thread-cursor",
+      provider: "cursor",
+      model: "cursor-test-model",
+    };
+    const cursorUsage = {
+      providerId: "cursor",
+      usageStatus: "ready",
+      fetchedAt: now,
+      quotaCategories: [
+        {
+          label: "API usage",
+          used: 63,
+          total: 100,
+          remainingPercent: 0.37,
+          resetDate: fiveHourReset,
+          isUnlimited: false,
+        },
+        {
+          label: "Auto and Composer",
+          used: 21,
+          total: 100,
+          remainingPercent: 0.79,
+          resetDate: weeklyReset,
+          isUnlimited: false,
+        },
+      ],
+    };
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript((wsId: string) => {
+      localStorage.setItem(
+        "mcode-expanded-projects",
+        JSON.stringify({ [wsId]: true }),
+      );
+    }, WS_ID);
+    await mockWebSocketServer(page, {
+      "workspace.list": [workspace],
+      "workspace.enrich": { items: [] },
+      "workspace.touchLastOpened": null,
+      "thread.list": [cursorThread],
+      "settings.get": MOCK_SETTINGS,
+      "provider.getUsage": cursorUsage,
+      "github.branchPr": null,
+      "git.log": [gitCommit],
+      "snapshot.listByThread": [{ ...snapshot, thread_id: cursorThread.id }],
+      "snapshot.getDiffStats": [],
+      "git.listBranches": branches,
+      "git.getRemoteUrl": {
+        label: "Mzeey-Empire/mcode",
+        webUrl: "https://github.com/Mzeey-Empire/mcode",
+      },
+      "git.workingTreeFiles": [],
+    });
+
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-item']");
+    await page.locator("[data-testid='thread-item']").first().click();
+    await page.waitForSelector("[data-testid='chat-header-title']");
+    await ensureOverviewOpen(page);
+
+    await expect(page.getByTestId("thread-overview-usage")).toHaveCount(0);
+    await expect(page.getByText("API usage")).toHaveCount(0);
+    await expect(page.getByText("Auto and Composer")).toHaveCount(0);
+    await page.screenshot({
+      path: "e2e/screenshots/thread-overview-usage-cursor-excluded.png",
+      fullPage: true,
+    });
+  });
+
+  test("keeps stale provider usage visible across desktop and narrow layouts", async ({ page }) => {
+    const consoleErrors: string[] = [];
+    let usageCalls = 0;
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript((wsId: string) => {
+      localStorage.setItem(
+        "mcode-expanded-projects",
+        JSON.stringify({ [wsId]: true }),
+      );
+    }, WS_ID);
+    await mockWebSocketServer(page, {
+      "workspace.list": [workspace],
+      "workspace.enrich": { items: [] },
+      "workspace.touchLastOpened": null,
+      "thread.list": [thread],
+      "settings.get": MOCK_SETTINGS,
+      "provider.getUsage": () => {
+        usageCalls += 1;
+        if (usageCalls === 1) return usage;
+        throw new Error("usage provider unavailable");
+      },
+      "github.branchPr": null,
+      "git.log": [gitCommit],
+      "snapshot.listByThread": [snapshot],
+      "snapshot.getDiffStats": [],
+      "git.listBranches": branches,
+      "git.getRemoteUrl": {
+        label: "Mzeey-Empire/mcode",
+        webUrl: "https://github.com/Mzeey-Empire/mcode",
+      },
+      "git.workingTreeFiles": [],
+    });
+
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-item']");
+    await page.locator("[data-testid='thread-item']").first().click();
+    await page.waitForSelector("[data-testid='chat-header-title']");
+    await ensureOverviewOpen(page);
+    await expect(page.getByTestId("thread-overview-usage")).toBeVisible();
+    await expect(page.getByText("Stale usage")).toHaveCount(0);
+    await page.screenshot({ path: "e2e/screenshots/thread-overview-usage-ready-desktop.png", fullPage: true });
+
+    await page.getByTestId("header-workspace-menu").click();
+    await expect(overviewContent(page)).toBeHidden();
+    await page.getByTestId("header-workspace-menu").click();
+    await expect(page.getByTestId("thread-overview-usage")).toBeVisible();
+    await expect(page.getByText("Stale usage")).toBeVisible();
+    await expect(page.getByRole("progressbar", { name: /5-hour usage 12 percent\. Resets in/ })).toBeVisible();
+    await page.screenshot({ path: "e2e/screenshots/thread-overview-usage-stale-desktop.png", fullPage: true });
+
+    await page.setViewportSize({ width: 420, height: 900 });
+    if (!(await overviewContent(page).isVisible().catch(() => false))) {
+      await page.getByTestId("header-workspace-menu").click();
+    }
+    await expect(page.getByTestId("thread-overview-usage")).toBeVisible();
+    await expect(page.getByText("Stale usage")).toBeVisible();
+    await expect(page.getByTestId("thread-overview-body")).toHaveJSProperty("scrollWidth", await page.getByTestId("thread-overview-body").evaluate((node) => node.clientWidth));
+    await page.screenshot({ path: "e2e/screenshots/thread-overview-usage-stale-narrow.png", fullPage: true });
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("hides the Overview usage row on first-refresh unavailable state in a narrow layout", async ({ page }) => {
+    let usageCalls = 0;
+    await page.setViewportSize({ width: 420, height: 900 });
+    await page.addInitScript((wsId: string) => {
+      localStorage.setItem(
+        "mcode-expanded-projects",
+        JSON.stringify({ [wsId]: true }),
+      );
+    }, WS_ID);
+    await mockWebSocketServer(page, {
+      "workspace.list": [workspace],
+      "workspace.enrich": { items: [] },
+      "workspace.touchLastOpened": null,
+      "thread.list": [thread],
+      "settings.get": MOCK_SETTINGS,
+      "provider.getUsage": () => {
+        usageCalls += 1;
+        throw new Error("usage provider unavailable");
+      },
+      "github.branchPr": null,
+      "git.log": [gitCommit],
+      "snapshot.listByThread": [snapshot],
+      "snapshot.getDiffStats": [],
+      "git.listBranches": branches,
+      "git.getRemoteUrl": {
+        label: "Mzeey-Empire/mcode",
+        webUrl: "https://github.com/Mzeey-Empire/mcode",
+      },
+      "git.workingTreeFiles": [],
+    });
+
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='thread-item']");
+    await page.locator("[data-testid='thread-item']").first().click();
+    await page.waitForSelector("[data-testid='chat-header-title']");
+    await ensureOverviewOpen(page);
+    await expect.poll(() => usageCalls).toBeGreaterThan(0);
+    await expect(page.getByTestId("thread-overview-usage")).toHaveCount(0);
+    await page.screenshot({ path: "e2e/screenshots/thread-overview-usage-unavailable-narrow.png", fullPage: true });
   });
 });
 

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -11,11 +11,13 @@ const {
   mockUseHasCommitsAhead,
   mockSetPendingPrefill,
   mockWorkspaceSelector,
+  mockGetProviderUsage,
 } = vi.hoisted(() => ({
   mockUseBranchPr: vi.fn().mockReturnValue(null),
   mockUseHasCommitsAhead: vi.fn().mockReturnValue(null),
   mockSetPendingPrefill: vi.fn(),
   mockWorkspaceSelector: vi.fn(),
+  mockGetProviderUsage: vi.fn<() => Promise<ProviderUsageInfo>>(),
 }));
 
 vi.mock("@/stores/workspaceStore", () => {
@@ -31,6 +33,28 @@ vi.mock("@/stores/composerDraftStore", () => ({
     selector({ setPendingPrefill: mockSetPendingPrefill }),
   ),
 }));
+
+vi.mock("@/transport", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/transport")>();
+  return {
+    ...actual,
+    getTransport: () => ({
+      getProviderUsage: mockGetProviderUsage,
+      listSnapshots: vi.fn().mockResolvedValue([]),
+      getSnapshotDiffStats: vi.fn().mockResolvedValue([]),
+      getWorkingTreeFiles: vi.fn().mockResolvedValue([]),
+      getReviewDiffStats: vi.fn().mockResolvedValue({ additions: 0, deletions: 0 }),
+      getBranchComparison: vi.fn().mockResolvedValue(null),
+      getBranchFiles: vi.fn().mockResolvedValue([]),
+      getRemoteUrl: vi.fn().mockResolvedValue({
+        label: "Mzeey-Empire/mcode",
+        webUrl: "https://github.com/Mzeey-Empire/mcode",
+      }),
+      listBranches: vi.fn().mockResolvedValue([]),
+      createBranch: vi.fn().mockResolvedValue({ branch: "feat/my-feature" }),
+    }),
+  };
+});
 
 vi.mock("@/stores/terminalStore", () => ({
   useTerminalStore: vi.fn((selector: (s: unknown) => unknown) =>
@@ -174,12 +198,15 @@ const WORKSPACE = {
 
 const CLAUDE_USAGE: ProviderUsageInfo = {
   providerId: "claude",
+  usageStatus: "ready",
+  fetchedAt: "2026-07-03T12:00:00.000Z",
   quotaCategories: [
     {
       label: "5-hour limit",
       used: 12,
       total: 100,
       remainingPercent: 0.88,
+      resetDate: "2099-07-03T14:14:00.000Z",
       isUnlimited: false,
     },
     {
@@ -187,6 +214,7 @@ const CLAUDE_USAGE: ProviderUsageInfo = {
       used: 47,
       total: 100,
       remainingPercent: 0.53,
+      resetDate: "2099-07-07T14:14:00.000Z",
       isUnlimited: false,
     },
   ],
@@ -226,6 +254,11 @@ function defaultWorkspaceState() {
 function renderHeaderActions(thread: Thread = makeThread()) {
   return render(<HeaderActions thread={thread} threadPaneWidth={1400} />);
 }
+
+beforeEach(() => {
+  mockGetProviderUsage.mockReset();
+  mockGetProviderUsage.mockImplementation(() => new Promise(() => {}));
+});
 
 describe("HeaderActions - Create PR menu item", () => {
   beforeEach(() => {
@@ -458,6 +491,7 @@ describe("HeaderActions - consolidated header", () => {
   });
 
   it("renders usage limits as compact progress bars when quota data exists", () => {
+    mockGetProviderUsage.mockResolvedValue(CLAUDE_USAGE);
     seedThreadUsage("thread-1", CLAUDE_USAGE);
     renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
 
@@ -469,20 +503,21 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.getByTestId("thread-overview-usage-details")).toBeVisible();
     expect(screen.getByText("5-hour limit")).toBeInTheDocument();
     expect(screen.getByText("Weekly limit")).toBeInTheDocument();
-    expect(screen.getByRole("progressbar", { name: "5-hour usage" })).toHaveAttribute(
+    expect(screen.getByRole("progressbar", { name: /5-hour usage 12 percent\. Resets in/ })).toHaveAttribute(
       "aria-valuenow",
       "12",
     );
-    expect(screen.getByRole("progressbar", { name: "weekly usage" })).toHaveAttribute(
+    expect(screen.getByRole("progressbar", { name: /weekly usage 47 percent\. Resets in/ })).toHaveAttribute(
       "aria-valuenow",
       "47",
     );
+    expect(screen.getAllByText(/Resets in/)).toHaveLength(2);
 
     fireEvent.click(usageTrigger);
 
     expect(usageTrigger).toHaveAttribute("aria-expanded", "false");
     expect(usageTrigger).toHaveTextContent("5-hour 12%, weekly 47%");
-    expect(screen.queryByRole("progressbar", { name: "5-hour usage" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("progressbar", { name: /5-hour usage/ })).not.toBeInTheDocument();
     expect(screen.queryByText("usage unavailable")).not.toBeInTheDocument();
     expect(screen.queryByTestId("thread-overview-usage-popover")).not.toBeInTheDocument();
   });
@@ -492,6 +527,25 @@ describe("HeaderActions - consolidated header", () => {
 
     expect(screen.queryByTestId("thread-overview-usage")).not.toBeInTheDocument();
     expect(screen.queryByRole("progressbar", { name: "5-hour usage" })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["ready-empty", "No capped quota"],
+    ["unsupported", "Usage not supported"],
+    ["unavailable", "Usage unavailable"],
+  ] as const)("renders explicit %s usage status rows", (usageStatus, summary) => {
+    seedThreadUsage("thread-1", {
+      providerId: "claude",
+      quotaCategories: [],
+      usageStatus,
+    });
+
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
+
+    const usageTrigger = screen.getByTestId("thread-overview-usage");
+    expect(usageTrigger).toHaveAttribute("aria-label", `Usage, ${summary}`);
+    expect(usageTrigger).toHaveTextContent(summary);
+    expect(screen.queryByTestId("thread-overview-usage-details")).not.toBeInTheDocument();
   });
 
   it("hides empty or unlimited-only usage without API-key billing mode", () => {
@@ -636,28 +690,31 @@ describe("formatThreadOverviewUsage", () => {
     ).toBe("5-hour 42%, weekly 18%");
   });
 
-  it("renders Cursor API and Auto limits", () => {
+  it("excludes Cursor team or admin usage limits from the Overview", () => {
     expect(
-      formatThreadOverviewUsage({
-        providerId: "cursor",
-        quotaCategories: [
-          {
-            label: "API usage",
-            used: 63,
-            total: 100,
-            remainingPercent: 0.37,
-            isUnlimited: false,
-          },
-          {
-            label: "Auto and Composer",
-            used: 21,
-            total: 100,
-            remainingPercent: 0.79,
-            isUnlimited: false,
-          },
-        ],
-      }),
-    ).toBe("API 63%, Auto 21%");
+      formatThreadOverviewUsage(
+        {
+          providerId: "cursor",
+          quotaCategories: [
+            {
+              label: "API usage",
+              used: 63,
+              total: 100,
+              remainingPercent: 0.37,
+              isUnlimited: false,
+            },
+            {
+              label: "Auto and Composer",
+              used: 21,
+              total: 100,
+              remainingPercent: 0.79,
+              isUnlimited: false,
+            },
+          ],
+        },
+        "cursor",
+      ),
+    ).toBeNull();
   });
 
   it("ignores unlimited cost-like categories and empty usage", () => {

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -62,6 +62,7 @@ import { sanitizeCustomBranchInput, trimTrailingBranchChars } from "@/lib/branch
 import { showRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { cn } from "@/lib/utils";
 import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";
+import { formatUsageResetText } from "@/lib/usage-reset-format";
 import {
   getTransport,
   type GitBranch as GitBranchRecord,
@@ -227,8 +228,9 @@ export function formatThreadOverviewSessionCost(
  */
 export function getThreadOverviewUsageCategories(
   usageInfo: ProviderUsageInfo | undefined,
-  _providerId = usageInfo?.providerId,
+  providerId = usageInfo?.providerId,
 ): QuotaCategory[] {
+  if (providerId === "cursor") return [];
   return (
     usageInfo?.quotaCategories
       .filter((category) => !category.isUnlimited)
@@ -246,6 +248,7 @@ export function formatThreadOverviewUsage(
   usageInfo: ProviderUsageInfo | undefined,
   providerId = usageInfo?.providerId,
 ): string | null {
+  if (providerId === "cursor") return null;
   const categories = getThreadOverviewUsageCategories(usageInfo, providerId);
   const costSummary = formatThreadOverviewSessionCost(usageInfo);
 
@@ -259,13 +262,22 @@ export function formatThreadOverviewUsage(
       .join(", ")
     : null;
 
-  return [quotaSummary, costSummary].filter(Boolean).join(", ") || null;
+  const statusSummary = (() => {
+    if (quotaSummary || costSummary) return null;
+    if (usageInfo?.usageStatus === "ready-empty") return "No capped quota";
+    if (usageInfo?.usageStatus === "unsupported") return "Usage not supported";
+    if (usageInfo?.usageStatus === "unavailable") return "Usage unavailable";
+    return null;
+  })();
+
+  return [quotaSummary, costSummary, statusSummary].filter(Boolean).join(", ") || null;
 }
 
 interface ThreadOverviewUsageBarsProps {
   categories: QuotaCategory[];
   summary: string;
   sessionCostSummary: string | null;
+  usageStatus?: ProviderUsageInfo["usageStatus"];
 }
 
 const THREAD_OVERVIEW_USAGE_DETAILS_ID = "thread-overview-usage-details-panel";
@@ -275,6 +287,7 @@ function ThreadOverviewUsageBars({
   categories,
   summary,
   sessionCostSummary,
+  usageStatus,
 }: ThreadOverviewUsageBarsProps) {
   const [open, setOpen] = useState(true);
 
@@ -346,6 +359,10 @@ function ThreadOverviewUsageBars({
             const rounded = Math.round(percent);
             const shortLabel = usageCategoryShortLabel(category.label);
             const displayLabel = category.label.trim();
+            const resetText = formatUsageResetText(category.resetDate);
+            const progressDescription = resetText
+              ? `${shortLabel} usage ${rounded} percent. ${resetText}`
+              : `${shortLabel} usage ${rounded} percent`;
             return (
               <div key={category.label} className="space-y-1">
                 <div className="flex items-baseline justify-between gap-3">
@@ -356,7 +373,7 @@ function ThreadOverviewUsageBars({
                 </div>
                 <div
                   role="progressbar"
-                  aria-label={`${shortLabel} usage`}
+                  aria-label={progressDescription}
                   aria-valuemin={0}
                   aria-valuemax={100}
                   aria-valuenow={rounded}
@@ -371,9 +388,19 @@ function ThreadOverviewUsageBars({
                     style={{ width: `${percent}%` }}
                   />
                 </div>
+                {resetText ? (
+                  <div className="font-mono text-xs tabular-nums text-muted-foreground/70">
+                    {resetText}
+                  </div>
+                ) : null}
               </div>
             );
           })}
+          {usageStatus === "stale" ? (
+            <div className="font-mono text-xs text-muted-foreground/70">
+              Stale usage
+            </div>
+          ) : null}
           {sessionCostSummary ? (
             <div className="flex items-baseline justify-between gap-3 pt-0.5">
               <span className="min-w-0 truncate text-xs text-foreground/80">Session cost</span>
@@ -1966,6 +1993,7 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                 categories={usageCategories}
                 summary={usageSummary}
                 sessionCostSummary={sessionCostSummary}
+                usageStatus={usageInfo?.usageStatus}
               />
             )}
 

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -397,8 +397,8 @@ function ThreadOverviewUsageBars({
             );
           })}
           {usageStatus === "stale" ? (
-            <div className="font-mono text-xs text-muted-foreground/70">
-              Stale usage
+            <div className="font-mono text-xs uppercase tracking-wider text-muted-foreground/60">
+              STALE
             </div>
           ) : null}
           {sessionCostSummary ? (

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -5,6 +5,7 @@ import { useThreadRecord } from "../../stores/thread-selectors";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import type { QuotaCategory } from "@mcode/contracts";
 import { useEffect, useRef, type ReactNode } from "react";
+import { formatUsageResetText } from "@/lib/usage-reset-format";
 
 interface UsagePopoverProps {
   threadId: string | undefined;
@@ -19,13 +20,6 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
-}
-
-/** Days until a quota reset date. */
-function daysUntil(iso: string | undefined): number | undefined {
-  if (!iso) return undefined;
-  const diff = new Date(iso).getTime() - Date.now();
-  return diff > 0 ? Math.ceil(diff / 86_400_000) : 0;
 }
 
 /** Horizontal fill bar for usage visualization. */
@@ -58,6 +52,7 @@ function QuotaRow({ category }: { category: QuotaCategory }) {
       ? `${category.used} / ${category.total}`
       : `${category.used}`;
   const percent = category.isUnlimited ? 0 : (1 - category.remainingPercent);
+  const resetText = formatUsageResetText(category.resetDate);
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between text-xs">
@@ -66,7 +61,19 @@ function QuotaRow({ category }: { category: QuotaCategory }) {
           {category.isUnlimited ? "unlimited" : usedDisplay}
         </span>
       </div>
-      {!category.isUnlimited && <UsageBar percent={percent} label={`${category.label} usage`} />}
+      {!category.isUnlimited && (
+        <>
+          <UsageBar
+            percent={percent}
+            label={resetText ? `${category.label} usage. ${resetText}` : `${category.label} usage`}
+          />
+          {resetText ? (
+            <div className="font-mono text-xs tabular-nums text-muted-foreground/70">
+              {resetText}
+            </div>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }
@@ -101,12 +108,6 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
   const hasContext = tokensIn > 0 && contextWindow;
   const hasTurn = tokensIn > 0 || tokensOut > 0;
 
-  // Earliest reset date across quota categories
-  const resetDays = categories
-    .map((c) => daysUntil(c.resetDate ?? undefined))
-    .filter((d): d is number => d !== undefined)
-    .sort((a, b) => a - b)[0];
-
   return (
     <Popover onOpenChange={handleOpenChange}>
       <PopoverTrigger render={<span style={{ display: "contents" }} />}>
@@ -125,12 +126,11 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
                 </div>
               )}
             </div>
-            {resetDays !== undefined && (
-              <div className="text-right">
-                <div className="text-[10px] text-muted-foreground">resets in</div>
-                <div className="text-xs text-foreground/70">{resetDays}d</div>
+            {usageInfo?.usageStatus === "stale" ? (
+              <div className="text-right font-mono text-xs text-muted-foreground">
+                Stale
               </div>
-            )}
+            ) : null}
           </div>
 
           {/* Quota section */}
@@ -145,7 +145,20 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
             </div>
           ) : (
             <div className="text-xs text-muted-foreground">
-              Quota data not available for this provider
+              {usageInfo?.usageStatus === "unsupported"
+                ? "Usage not supported for this provider"
+                : usageInfo?.usageStatus === "ready-empty"
+                  ? "No capped quota reported"
+                  : "Usage unavailable"}
+            </div>
+          )}
+
+          {(usageInfo?.usageStatus === "stale" || usageInfo?.usageStatus === "unavailable") && (
+            <div className="text-xs text-muted-foreground">
+              {usageInfo.usageStatus === "stale"
+                ? `Could not refresh. Showing last update from ${usageInfo.fetchedAt ?? "this session"}.`
+                : "Usage unavailable."}
+              {usageInfo.diagnostic ? ` ${usageInfo.diagnostic}` : ""}
             </div>
           )}
 

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -127,8 +127,8 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
               )}
             </div>
             {usageInfo?.usageStatus === "stale" ? (
-              <div className="text-right font-mono text-xs text-muted-foreground">
-                Stale
+              <div className="text-right font-mono text-xs uppercase tracking-wider text-muted-foreground/60">
+                STALE
               </div>
             ) : null}
           </div>

--- a/apps/web/src/lib/usage-reset-format.test.ts
+++ b/apps/web/src/lib/usage-reset-format.test.ts
@@ -6,14 +6,14 @@ describe("formatUsageResetText", () => {
 
   it("formats relative and compact exact reset text", () => {
     expect(formatUsageResetText("2026-07-03T14:14:00.000Z", now)).toContain(
-      "Resets in 2h 14m -",
+      "Resets in 2h 14m ·",
     );
     expect(formatUsageResetText("2026-07-03T14:14:00.000Z", now)).toContain("Jul 3");
   });
 
   it("formats day and hour resets", () => {
     expect(formatUsageResetText("2026-07-05T15:00:00.000Z", now)).toContain(
-      "Resets in 2d 3h -",
+      "Resets in 2d 3h ·",
     );
   });
 

--- a/apps/web/src/lib/usage-reset-format.test.ts
+++ b/apps/web/src/lib/usage-reset-format.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatUsageResetText } from "./usage-reset-format";
+
+describe("formatUsageResetText", () => {
+  const now = new Date("2026-07-03T12:00:00.000Z");
+
+  it("formats relative and compact exact reset text", () => {
+    expect(formatUsageResetText("2026-07-03T14:14:00.000Z", now)).toContain(
+      "Resets in 2h 14m -",
+    );
+    expect(formatUsageResetText("2026-07-03T14:14:00.000Z", now)).toContain("Jul 3");
+  });
+
+  it("formats day and hour resets", () => {
+    expect(formatUsageResetText("2026-07-05T15:00:00.000Z", now)).toContain(
+      "Resets in 2d 3h -",
+    );
+  });
+
+  it("rejects expired timestamps", () => {
+    expect(formatUsageResetText("2026-07-03T11:59:59.000Z", now)).toBeNull();
+  });
+
+  it("rejects invalid timestamps", () => {
+    expect(formatUsageResetText("not-a-date", now)).toBeNull();
+  });
+
+  it("rejects missing timestamps", () => {
+    expect(formatUsageResetText(undefined, now)).toBeNull();
+    expect(formatUsageResetText(null, now)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/usage-reset-format.ts
+++ b/apps/web/src/lib/usage-reset-format.ts
@@ -1,0 +1,31 @@
+/** Formats a quota reset timestamp for compact usage surfaces. */
+export function formatUsageResetText(
+  resetDate: string | null | undefined,
+  now = new Date(),
+): string | null {
+  if (!resetDate) return null;
+  const reset = new Date(resetDate);
+  const resetMs = reset.getTime();
+  const nowMs = now.getTime();
+  if (!Number.isFinite(resetMs) || resetMs <= nowMs) return null;
+
+  const diffMinutes = Math.max(1, Math.ceil((resetMs - nowMs) / 60_000));
+  const days = Math.floor(diffMinutes / 1_440);
+  const hours = Math.floor((diffMinutes % 1_440) / 60);
+  const minutes = diffMinutes % 60;
+  const relative =
+    days > 0
+      ? `${days}d ${hours}h`
+      : hours > 0
+        ? `${hours}h ${minutes}m`
+        : `${minutes}m`;
+  const exact = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(reset);
+
+  return `Resets in ${relative} - ${exact}`;
+}

--- a/apps/web/src/lib/usage-reset-format.ts
+++ b/apps/web/src/lib/usage-reset-format.ts
@@ -27,5 +27,5 @@ export function formatUsageResetText(
     hour12: false,
   }).format(reset);
 
-  return `Resets in ${relative} - ${exact}`;
+  return `Resets in ${relative} · ${exact}`;
 }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, ToolCallRecord, ThoughtSegmentRecord } from "@/transport";
-import type { ContextWindowMode, MessageMention, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory, ProviderBillingMode, GoalLookupResult, GoalState } from "@mcode/contracts";
+import type { ContextWindowMode, MessageMention, ReasoningLevel, PlanQuestion, PlanAnswer, QuotaCategory, ProviderBillingMode, ProviderUsageInfo, GoalLookupResult, GoalState } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import type { ThoughtSegment } from "@/components/chat/narrative/types";
 import { PlanQuestionSchema, PERMISSION_MODES, INTERACTION_MODES, isGoalOpen } from "@mcode/contracts";
@@ -181,6 +181,114 @@ const dequeueTimers = new Map<string, ReturnType<typeof setTimeout>>();
  * without triggering re-renders for the inflight bookkeeping.
  */
 const narrativeInflight = new Map<string, Promise<void>>();
+const USAGE_STALE_TTL_MS = 24 * 60 * 60 * 1000;
+const providerUsageSnapshots = new Map<string, ProviderUsageInfo>();
+
+function hasProviderUsageData(usage: ProviderUsageInfo | undefined): boolean {
+  return (
+    (usage?.quotaCategories.length ?? 0) > 0 ||
+    usage?.sessionCostUsd !== undefined ||
+    usage?.serviceTier !== undefined ||
+    usage?.numTurns !== undefined ||
+    usage?.durationMs !== undefined
+  );
+}
+
+function isFreshUsageSnapshot(usage: ProviderUsageInfo | undefined, now = Date.now()): boolean {
+  if (!usage?.fetchedAt) return hasProviderUsageData(usage);
+  const fetchedAt = Date.parse(usage.fetchedAt);
+  return Number.isFinite(fetchedAt) && now - fetchedAt <= USAGE_STALE_TTL_MS;
+}
+
+function providerQuotaSnapshot(usage: ProviderUsageInfo): ProviderUsageInfo {
+  return {
+    providerId: usage.providerId,
+    quotaCategories: usage.quotaCategories,
+    billingMode: usage.billingMode,
+    usageStatus: usage.usageStatus,
+    fetchedAt: usage.fetchedAt,
+    failedAt: usage.failedAt,
+    diagnostic: usage.diagnostic,
+  };
+}
+
+function mergeThreadUsageSnapshot(
+  existing: ProviderUsageInfo | undefined,
+  providerSnapshot: ProviderUsageInfo | undefined,
+  incoming: ProviderUsageInfo,
+  now = Date.now(),
+): ProviderUsageInfo {
+  const existingThreadMetrics = existing
+    ? {
+        sessionCostUsd: existing.sessionCostUsd,
+        serviceTier: existing.serviceTier,
+        numTurns: existing.numTurns,
+        durationMs: existing.durationMs,
+      }
+    : {};
+  const baseProviderSnapshot = providerSnapshot && hasProviderUsageData(providerSnapshot)
+    ? providerSnapshot
+    : existing;
+  return {
+    ...mergeProviderUsageSnapshot(baseProviderSnapshot, providerQuotaSnapshot(incoming), now),
+    ...existingThreadMetrics,
+    sessionCostUsd: incoming.sessionCostUsd ?? existing?.sessionCostUsd,
+    serviceTier: incoming.serviceTier ?? existing?.serviceTier,
+    numTurns: incoming.numTurns ?? existing?.numTurns,
+    durationMs: incoming.durationMs ?? existing?.durationMs,
+  };
+}
+
+/**
+ * Merges incoming provider quota data with a prior last-known-good snapshot.
+ */
+export function mergeProviderUsageSnapshot(
+  existing: ProviderUsageInfo | undefined,
+  incoming: ProviderUsageInfo,
+  now = Date.now(),
+): ProviderUsageInfo {
+  const status = incoming.usageStatus
+    ?? (incoming.quotaCategories.length === 0 ? "unavailable" : "ready");
+  if (status === "unavailable" || status === "unsupported") {
+    if (existing && hasProviderUsageData(existing) && isFreshUsageSnapshot(existing, now)) {
+      return {
+        ...existing,
+        providerId: existing.providerId,
+        quotaCategories: existing.quotaCategories,
+        usageStatus: "stale",
+        failedAt: incoming.failedAt ?? new Date(now).toISOString(),
+        diagnostic: incoming.diagnostic,
+      };
+    }
+    return { ...incoming, usageStatus: status };
+  }
+
+  if (status === "ready-empty") {
+    return {
+      providerId: incoming.providerId,
+      quotaCategories: [],
+      billingMode: incoming.billingMode,
+      sessionCostUsd: incoming.sessionCostUsd,
+      serviceTier: incoming.serviceTier,
+      numTurns: incoming.numTurns,
+      durationMs: incoming.durationMs,
+      usageStatus: "ready-empty",
+      fetchedAt: incoming.fetchedAt ?? new Date(now).toISOString(),
+    };
+  }
+
+  return {
+    ...existing,
+    ...incoming,
+    quotaCategories: incoming.quotaCategories.length > 0
+      ? incoming.quotaCategories
+      : (existing?.quotaCategories ?? []),
+    usageStatus: incoming.quotaCategories.length > 0 ? "ready" : (incoming.usageStatus ?? "ready-empty"),
+    fetchedAt: incoming.fetchedAt ?? new Date(now).toISOString(),
+    failedAt: undefined,
+    diagnostic: undefined,
+  };
+}
 
 function clearDequeueTimer(threadId: string) {
   const timer = dequeueTimers.get(threadId);
@@ -2673,6 +2781,22 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const numTurns = params.numTurns as number | undefined;
       const durationMs = params.durationMs as number | undefined;
       if (providerId) {
+        const incoming: ProviderUsageInfo = {
+          providerId,
+          quotaCategories: categories,
+          billingMode,
+          sessionCostUsd,
+          serviceTier,
+          numTurns,
+          durationMs,
+          usageStatus: categories.length > 0 ? "ready" : "ready-empty",
+          fetchedAt: new Date().toISOString(),
+        };
+        const providerSnapshot = mergeProviderUsageSnapshot(
+          providerUsageSnapshots.get(providerId),
+          providerQuotaSnapshot(incoming),
+        );
+        providerUsageSnapshots.set(providerId, providerSnapshot);
         set((state) => {
           const rec = getThreadRecord(state.records, threadId);
           const existing = rec.usageByProvider[providerId];
@@ -2680,15 +2804,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             records: patchThreadRecord(state.records, threadId, {
               usageByProvider: {
                 ...rec.usageByProvider,
-                [providerId]: {
-                  providerId,
-                  quotaCategories: categories.length > 0 ? categories : (existing?.quotaCategories ?? []),
-                  billingMode: billingMode ?? existing?.billingMode,
-                  sessionCostUsd: sessionCostUsd ?? existing?.sessionCostUsd,
-                  serviceTier: serviceTier ?? existing?.serviceTier,
-                  numTurns: numTurns ?? existing?.numTurns,
-                  durationMs: durationMs ?? existing?.durationMs,
-                },
+                [providerId]: mergeThreadUsageSnapshot(existing, providerSnapshot, incoming),
               },
             }),
           };
@@ -2885,14 +3001,38 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   fetchProviderUsage: async (threadId, providerId) => {
     try {
       const usage = await getTransport().getProviderUsage(providerId);
+      const providerSnapshot = mergeProviderUsageSnapshot(
+        providerUsageSnapshots.get(providerId),
+        providerQuotaSnapshot(usage),
+      );
+      providerUsageSnapshots.set(providerId, providerSnapshot);
       patchRec(threadId, (rec) => ({
         usageByProvider: {
           ...rec.usageByProvider,
-          [providerId]: { ...rec.usageByProvider[providerId], ...usage },
+          [providerId]: mergeThreadUsageSnapshot(rec.usageByProvider[providerId], providerSnapshot, usage),
         },
       }));
     } catch {
-      // Silently fail — popover shows stale or empty state
+      const usage: ProviderUsageInfo = {
+        providerId,
+        quotaCategories: [],
+        usageStatus: "unavailable",
+        failedAt: new Date().toISOString(),
+        diagnostic: "Usage refresh failed",
+      };
+      const previousProviderSnapshot = providerUsageSnapshots.get(providerId);
+      const providerSnapshot = mergeProviderUsageSnapshot(
+        previousProviderSnapshot,
+        usage,
+      );
+      providerUsageSnapshots.set(providerId, providerSnapshot);
+      if (!hasProviderUsageData(providerSnapshot)) return;
+      patchRec(threadId, (rec) => ({
+        usageByProvider: {
+          ...rec.usageByProvider,
+          [providerId]: mergeThreadUsageSnapshot(rec.usageByProvider[providerId], providerSnapshot, usage),
+        },
+      }));
     }
   },
 

--- a/apps/web/src/stores/threadStore.usage.test.ts
+++ b/apps/web/src/stores/threadStore.usage.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProviderUsageInfo } from "@mcode/contracts";
+import { mergeProviderUsageSnapshot, useThreadStore } from "./threadStore";
+import { createEmptyThreadRecord } from "./thread-record";
+
+const { getProviderUsage } = vi.hoisted(() => ({
+  getProviderUsage: vi.fn<() => Promise<ProviderUsageInfo>>(),
+}));
+
+vi.mock("@/transport", () => ({
+  getTransport: () => ({
+    getProviderUsage,
+  }),
+}));
+
+const READY_USAGE: ProviderUsageInfo = {
+  providerId: "claude",
+  quotaCategories: [
+    {
+      label: "5-hour limit",
+      used: 25,
+      total: 100,
+      remainingPercent: 0.75,
+      resetDate: "2026-07-03T14:00:00.000Z",
+      isUnlimited: false,
+    },
+  ],
+  usageStatus: "ready",
+  fetchedAt: "2026-07-03T12:00:00.000Z",
+};
+
+describe("mergeProviderUsageSnapshot", () => {
+  const now = Date.parse("2026-07-03T13:00:00.000Z");
+
+  it("keeps known-good quota as stale when refresh becomes unavailable", () => {
+    expect(
+      mergeProviderUsageSnapshot(
+        READY_USAGE,
+        {
+          providerId: "claude",
+          quotaCategories: [],
+          usageStatus: "unavailable",
+          failedAt: "2026-07-03T13:00:00.000Z",
+          diagnostic: "network unavailable",
+        },
+        now,
+      ),
+    ).toEqual({
+      ...READY_USAGE,
+      usageStatus: "stale",
+      failedAt: "2026-07-03T13:00:00.000Z",
+      diagnostic: "network unavailable",
+    });
+  });
+
+  it("expires stale known-good quota after 24 hours", () => {
+    expect(
+      mergeProviderUsageSnapshot(
+        READY_USAGE,
+        {
+          providerId: "claude",
+          quotaCategories: [],
+          usageStatus: "unavailable",
+          failedAt: "2026-07-04T13:01:00.000Z",
+          diagnostic: "network unavailable",
+        },
+        Date.parse("2026-07-04T13:01:00.000Z"),
+      ),
+    ).toEqual({
+      providerId: "claude",
+      quotaCategories: [],
+      usageStatus: "unavailable",
+      failedAt: "2026-07-04T13:01:00.000Z",
+      diagnostic: "network unavailable",
+    });
+  });
+
+  it("keeps explicit supported empty quota as ready-empty", () => {
+    expect(
+      mergeProviderUsageSnapshot(
+        READY_USAGE,
+        {
+          providerId: "claude",
+          quotaCategories: [],
+          usageStatus: "ready-empty",
+          fetchedAt: "2026-07-03T13:00:00.000Z",
+        },
+        now,
+      ),
+    ).toEqual({
+      providerId: "claude",
+      quotaCategories: [],
+      usageStatus: "ready-empty",
+      fetchedAt: "2026-07-03T13:00:00.000Z",
+    });
+  });
+
+  it("successful refresh clears stale diagnostics", () => {
+    expect(
+      mergeProviderUsageSnapshot(
+        { ...READY_USAGE, usageStatus: "stale", diagnostic: "old failure" },
+        { ...READY_USAGE, fetchedAt: "2026-07-03T13:00:00.000Z" },
+        now,
+      ),
+    ).toMatchObject({
+      usageStatus: "ready",
+      fetchedAt: "2026-07-03T13:00:00.000Z",
+      failedAt: undefined,
+      diagnostic: undefined,
+    });
+  });
+});
+
+describe("fetchProviderUsage", () => {
+  afterEach(() => {
+    getProviderUsage.mockReset();
+    useThreadStore.setState({
+      records: new Map(),
+      currentThreadId: null,
+      runningThreadIds: new Set(),
+      recapByThread: {},
+      recentlyAnsweredPlanMessageIds: new Set(),
+    });
+  });
+
+  it("reuses same-provider quota after another thread's failed refresh without copying thread metrics", async () => {
+    const providerId = `claude-regression-${crypto.randomUUID()}`;
+    getProviderUsage
+      .mockResolvedValueOnce({
+        ...READY_USAGE,
+        providerId,
+        fetchedAt: new Date().toISOString(),
+        sessionCostUsd: 0.42,
+        serviceTier: "priority",
+        numTurns: 3,
+        durationMs: 1200,
+      })
+      .mockRejectedValueOnce(new Error("provider unavailable"));
+
+    useThreadStore.setState({
+      records: new Map([
+        ["thread-a", createEmptyThreadRecord()],
+        ["thread-b", createEmptyThreadRecord()],
+      ]),
+    });
+
+    await useThreadStore.getState().fetchProviderUsage("thread-a", providerId);
+    await useThreadStore.getState().fetchProviderUsage("thread-b", providerId);
+
+    const threadAUsage = useThreadStore.getState().records.get("thread-a")?.usageByProvider[providerId];
+    const threadBUsage = useThreadStore.getState().records.get("thread-b")?.usageByProvider[providerId];
+
+    expect(threadAUsage).toMatchObject({
+      usageStatus: "ready",
+      sessionCostUsd: 0.42,
+      serviceTier: "priority",
+      numTurns: 3,
+      durationMs: 1200,
+    });
+    expect(threadBUsage).toMatchObject({
+      providerId,
+      quotaCategories: READY_USAGE.quotaCategories,
+      usageStatus: "stale",
+      diagnostic: "Usage refresh failed",
+    });
+    expect(threadBUsage?.sessionCostUsd).toBeUndefined();
+    expect(threadBUsage?.serviceTier).toBeUndefined();
+    expect(threadBUsage?.numTurns).toBeUndefined();
+    expect(threadBUsage?.durationMs).toBeUndefined();
+  });
+});

--- a/docs/prd/2026-07-03-resilient-provider-usage-limits.md
+++ b/docs/prd/2026-07-03-resilient-provider-usage-limits.md
@@ -1,0 +1,107 @@
+# Resilient Provider Usage Limits
+
+Draft status: review before issue publication
+
+## Problem Statement
+
+Developers rely on usage limits to decide whether to keep working in the current provider or switch before a limit blocks them. The display can lose quota data when a provider check returns an empty or failed result, and it does not show reset timing next to each limit.
+
+This is confusing when two machines show different Codex usage. The user cannot tell whether the provider returned no quota, the check failed, the account differs, or refresh cleared known data.
+
+The user also needs reset timing per limit. Five-hour and weekly limits reset at different times, so one provider-level reset label is not enough.
+
+## Solution
+
+Make provider usage a resilient provider-scoped snapshot. A successful snapshot can contain quota categories, billing mode, reset dates, and freshness metadata. Thread-scoped cost stays separate. Failed refresh must not replace known-good quota with empty data.
+
+Show reset information below each capped quota progress bar when the provider reports a reset date. The reset line should be category-specific, for example `Resets in 2h 14m · Jul 3, 14:10`.
+
+Apply the behavior to Claude, Codex, and Copilot where reset data exists. Claude and Codex expose reset dates for known windows. Copilot snapshots include reset dates when supplied. Leave Cursor out until Mcode has a current-user quota source.
+
+## User Stories
+
+1. As a developer using Codex, I want the five-hour usage bar to show when it resets, so that I can decide whether to wait or switch providers.
+2. As a developer using Codex, I want the weekly usage bar to show its own reset time, so that I do not confuse it with five-hour usage.
+3. As a developer using Claude, I want five-hour and weekly limits to show reset timing below their own bars, so that I can see which limit recovers first.
+4. As a developer using Copilot, I want quota snapshots with reset dates to show those dates, so that Copilot follows the same display rule.
+5. As a Cursor user, I want no usage-limit row until Mcode has a current-user source, so that team/admin data is not mistaken for my quota.
+6. As a developer comparing two machines, I want Mcode to preserve the last known good snapshot when refresh fails, so that a local check miss does not look like a quota change.
+7. As a developer, I want Mcode to distinguish unavailable usage from empty quota categories, so that the UI can explain state without wiping data.
+8. As a developer, I want failed refreshes to mark usage as stale and successful refreshes to clear stale state, so that recovery is visible.
+9. As a developer, I want Overview to stay compact, so that reset text adds information without becoming a dashboard.
+10. As a keyboard or screen-reader user, I want each progress bar to expose its percentage and reset text, so that visual information is available.
+11. As a developer, I want no reset text when a reset date is missing, invalid, or unusable, so that the UI avoids placeholders.
+12. As a maintainer, I want provider-specific usage rules inside provider adapters, so that the UI consumes one usage snapshot Interface.
+
+## Data Ownership
+
+Quota categories are provider/account-scoped. Codex, Claude, and Copilot quota belongs to the signed-in account, not one thread. A successful quota refresh should be reusable by every thread using that account.
+
+Session cost, service tier, turns, duration, context, and last-turn tokens are thread-scoped. Provider quota refresh must not overwrite them unless the provider response reports thread data.
+
+The usage snapshot Interface should keep these ownership rules visible. Provider quota and thread metrics can share a display surface, but their refresh and stale rules differ.
+
+## Usage State Model
+
+| State | Trigger | Retained data | Overview | Usage popover | Recovery |
+| --- | --- | --- | --- | --- | --- |
+| `ready` | Provider returns valid quota categories or session usage. | Latest data and `fetchedAt`. | Show usage and reset lines. | Show categories, reset lines, last updated time. | Next successful refresh replaces it. |
+| `ready-empty` | Provider supports usage but has no capped categories. | Empty snapshot and `fetchedAt`. | Hide usage row. | `No capped quota reported`. | Later categories replace it. |
+| `stale` | Refresh fails after `ready`. | Last known good data, `fetchedAt`, failed time, redacted reason. | Show usage with stale indication in details. | `Could not refresh. Showing last update from X`. | Success returns to `ready`; expiry moves to `unavailable`. |
+| `unavailable` | Refresh fails without known-good data, auth/config is missing, or payload is malformed. | Redacted reason and failed time. | Hide usage row. | `Usage unavailable`. | Success returns to `ready` or `ready-empty`. |
+| `unsupported` | Provider has no usage source. | Provider id and reason. | Hide usage row. | `Usage not supported for this provider`. | Requires provider implementation change. |
+
+Last-known-good quota remains actionable for the current app session for up to 24 hours. After that, stale usage becomes unavailable until refresh succeeds. Overview should not show exact diagnostics. Usage popover can show a redacted reason; server logs can hold details.
+
+## Implementation Decisions
+
+- Keep `ProviderUsageInfo` as the successful usage payload, including `quotaCategories` and each category's optional `resetDate`.
+- Add provider usage snapshot state around successful usage data. It must distinguish ready, stale, unavailable, and unsupported usage.
+- Preserve last known good usage per provider. Failed refresh, malformed payload, timeout, or unavailable provider must not overwrite it.
+- Treat explicit empty categories as ready only when the provider source can prove that no capped quotas exist.
+- Keep provider-specific mapping in each provider adapter or usage source. The UI should not know Codex window names, Claude OAuth fields, or Copilot quota fields.
+- Display reset text below each Overview progress bar for categories with a valid future reset date.
+- Use a shared reset formatter for Overview and Usage popover. It should return relative text and compact exact date/time.
+- Hide reset text when `resetDate` is missing, invalid, or cannot be trusted.
+- Keep the five-hour category above the weekly category, regardless of provider return order.
+- Keep Overview limited to capped quota categories and provider-proven API-key session cost. Do not show token prices, paid overage, or dashboard billing rows.
+- For Claude, retain current five-hour and weekly mapping, then inspect the current usage response for the recent shape the user called out.
+- For Codex, keep using machine-readable app-server rate-limit data and reset timestamps.
+- For Copilot, keep using normalized quota snapshots and any SDK-supplied `resetDate`.
+- Leave Cursor out of this usage-limit surface. Existing Cursor team/admin usage sources must not feed Overview usage limits unless they become a current-user quota source.
+- Add safe diagnostics for usage-source failures: provider id, source kind, CLI path or version, last refresh time, and redacted reason. Exclude secrets, tokens, Authorization headers, raw responses, and email.
+- Surface diagnostics in Usage popover and server logs only. Overview should show at most a stale indication when expanded.
+
+## Testing Decisions
+
+- Test through the highest useful Interface: provider usage snapshot fetch, thread usage merge, and Overview rendering.
+- Add shared formatter tests for `Resets in X`, exact date/time output, expired, invalid, and missing timestamps.
+- Add provider tests proving Claude, Codex, and Copilot reset dates reach quota categories when supplied.
+- Add Cursor tests proving no usage-limit row appears while Cursor remains unsupported for current-user quota.
+- Add store tests proving failed or empty refreshes do not erase a known-good snapshot.
+- Add Overview and Usage popover tests for per-category reset text, including five-hour, weekly, and Copilot categories.
+- Add accessibility assertions for progress bars and reset descriptions.
+- Live verification: run the app, open a seeded quota thread, confirm reset lines, simulate refresh failure, and confirm previous data remains visible as stale.
+- Run focused web tests around Overview, then run the repo verification gate before claiming completion.
+
+## Out of Scope
+
+- Scraping provider dashboards.
+- Estimating quota from local token counts.
+- Showing provider pricing, paid overage, token costs, or billing charges in the Overview row.
+- Showing Cursor usage limits from team/admin APIs.
+- Persisting usage history across app restarts.
+- Changing provider plan rules or local account authentication.
+- Long-term modeling of provider plan migrations beyond fields exposed by current machine-readable sources.
+
+## Further Notes
+
+Current code carries `resetDate` on quota categories. Codex, Claude, and Copilot carry reset dates through provider categories. Cursor has team/admin usage plumbing, but this PRD excludes it as a current-user quota source.
+
+The store preserves existing categories for quota update events with empty categories, but direct provider usage fetch can still replace usage with an empty response. That is the first resilience gap.
+
+Open validation questions:
+
+1. Is 24 hours the right stale-data expiry for the current app session?
+2. Should the exact reset date and time always be inline below the bar, or should Overview show relative text inline and the exact timestamp in a tooltip?
+3. For Claude's changed usage payload, should discovery happen before code changes, or inside the same implementation issue?

--- a/packages/contracts/src/providers/usage.ts
+++ b/packages/contracts/src/providers/usage.ts
@@ -44,6 +44,14 @@ export const ProviderBillingModeSchema = lazySchema(() =>
 /** TypeScript type inferred from ProviderBillingModeSchema. */
 export type ProviderBillingMode = z.infer<ReturnType<typeof ProviderBillingModeSchema>>;
 
+/** Provider usage snapshot status around the latest successful usage payload. */
+export const ProviderUsageStatusSchema = lazySchema(() =>
+  z.enum(["ready", "ready-empty", "stale", "unavailable", "unsupported"]),
+);
+
+/** TypeScript type inferred from ProviderUsageStatusSchema. */
+export type ProviderUsageStatus = z.infer<ReturnType<typeof ProviderUsageStatusSchema>>;
+
 /** Provider-level usage state. Quota and cost only - context/turn data is thread-scoped. */
 export const ProviderUsageInfoSchema = lazySchema(() =>
   z.object({
@@ -61,6 +69,14 @@ export const ProviderUsageInfoSchema = lazySchema(() =>
     numTurns: z.number().int().optional(),
     /** Total wall-clock duration of the current session in ms (Claude only). */
     durationMs: z.number().optional(),
+    /** Snapshot status for provider/account-scoped quota freshness. */
+    usageStatus: ProviderUsageStatusSchema().optional(),
+    /** ISO timestamp for the last successful provider usage refresh. */
+    fetchedAt: z.string().optional(),
+    /** ISO timestamp for the failed refresh that made this data stale or unavailable. */
+    failedAt: z.string().optional(),
+    /** Redacted diagnostic suitable for UI diagnostics and logs. */
+    diagnostic: z.string().optional(),
   }),
 );
 


### PR DESCRIPTION
## What
Adds resilient current-user provider usage limits for Claude, Codex, and Copilot. Overview and Usage popover now show reset timing for capped quota bars, preserve known-good quota after refresh failures, and keep Cursor admin/team usage out of current-user limits.

## Why
Usage limits need to reflect provider quota data without turning a temporary refresh failure into missing UI. Cursor is excluded because this work does not add a current-user Cursor quota source.

## Key Changes
- Adds explicit provider usage statuses for ready, ready-empty, stale, unavailable, and unsupported states.
- Preserves provider-level quota snapshots across same-provider threads while keeping thread metrics scoped.
- Shows reset timing and status text in the Overview usage row and Usage popover.
- Adds focused server, store, unit, and Playwright coverage for Claude, Codex, Copilot, Cursor exclusion, stale states, unavailable states, and narrow layouts.
- Adds the source PRD at `docs/prd/2026-07-03-resilient-provider-usage-limits.md`.

## Verification
- `cd apps/web; bun run test -- src/stores/threadStore.usage.test.ts src/lib/usage-reset-format.test.ts src/components/chat/HeaderActions.test.tsx --run`: 3 files passed, 60 tests passed.
- `cd apps/server; bun run test -- src/providers/copilot/copilot-usage.test.ts src/providers/cursor/cursor-usage.test.ts --run`: 2 files passed, 2 tests passed.
- Playwright on isolated Vite `http://127.0.0.1:5181`: 15 passed, server stopped.
- `bun run verify`: typecheck, lint, and unit tests passed.
- `bun audit`: fails with 89 existing advisories. No dependency files changed.

Related to `docs/prd/2026-07-03-resilient-provider-usage-limits.md`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785786318&installation_id=129163861&pr_number=838&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F838&signature=5b3f94b677d7b2c306e92833832d8d51a2f5004c3a1859b815350fbecf5ea319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer usage states, including stale, unavailable, unsupported, and empty-ready results.
  * Usage displays now show quota reset timing and more detailed status text when available.
  * Cursor usage limits are now excluded from the current-user usage surface.

* **Bug Fixes**
  * Preserved the last known good usage data when refreshes fail, instead of clearing the display.
  * Improved error handling and redaction so usage diagnostics are safer and more readable.

* **Tests**
  * Added coverage for reset text formatting, usage snapshot merging, and updated UI behavior across usage states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->