### PR TITLE
fix(codex): improve app-server exit diagnostics

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
@@ -434,6 +434,37 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
     expect(logFields?.stderrTail?.[0]).toContain("oversized crash cause");
   }, 10_000);
 
+  it("truncates and strips backticks in the fatal message excerpt while keeping the full line in stderrTail", async () => {
+    const { child, stderr } = harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-backtick-stderr" } } } : { result: {} },
+    );
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+    const fatal = vi.fn();
+    server.on("fatal", fatal);
+
+    await server.start();
+    const longBadLine = "run `rm -rf ~` now ".repeat(30);
+    stderr.write(longBadLine + "\n");
+    child.emit("exit", 2, null);
+
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("latest stderr:"));
+
+    const fatalMsg: string = vi.mocked(fatal).mock.calls
+      .flatMap((args) => args)
+      .find((a): a is string => typeof a === "string" && a.includes("latest stderr:")) ?? "";
+
+    expect(fatalMsg).not.toContain("`");
+
+    const excerptMatch = fatalMsg.match(/latest stderr: ([\s\S]*)\)$/);
+    expect(excerptMatch).not.toBeNull();
+    const excerpt = excerptMatch![1];
+    // 256-code-point cap plus the trailing ellipsis character.
+    expect([...excerpt].length).toBeLessThanOrEqual(257);
+
+    const logFields = findUnexpectedExitLogFields();
+    expect(logFields?.stderrTail?.some((l) => l.includes("`"))).toBe(true);
+  }, 10_000);
+
   it("does not split surrogate pairs when bounding an oversized stderr line", async () => {
     const { child, stderr } = harnessFakeServer((req): Record<string, unknown> =>
       req.method === "thread/start" ? { result: { thread: { id: "thread-emoji-stderr" } } } : { result: {} },

--- a/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
@@ -166,8 +166,15 @@ interface RpcRequest {
   method?: string;
 }
 
+function findUnexpectedExitLogFields(): { stderrTail?: string[] } | undefined {
+  const call = (vi.mocked(logger.error).mock.calls as unknown[][]).find(([message]) =>
+    String(message).includes("Codex app-server exited unexpectedly"),
+  );
+  return call?.[1] as { stderrTail?: string[] } | undefined;
+}
+
 /** Builds an EventEmitter-backed fake child with stream-backed stdio. */
-function makeFakeChild(): { child: FakeChild; stdin: PassThrough; stdout: PassThrough } {
+function makeFakeChild(): { child: FakeChild; stdin: PassThrough; stdout: PassThrough; stderr: PassThrough } {
   const stdin = new PassThrough();
   const stdout = new PassThrough();
   const stderr = new PassThrough();
@@ -177,7 +184,7 @@ function makeFakeChild(): { child: FakeChild; stdin: PassThrough; stdout: PassTh
   child.stderr = stderr;
   child.pid = 4321;
   child.kill = vi.fn();
-  return { child, stdin, stdout };
+  return { child, stdin, stdout, stderr };
 }
 
 /**
@@ -188,8 +195,8 @@ function makeFakeChild(): { child: FakeChild; stdin: PassThrough; stdout: PassTh
  */
 function harnessFakeServer(
   respond: (req: RpcRequest) => Record<string, unknown> | null,
-): { child: FakeChild } {
-  const { child, stdin, stdout } = makeFakeChild();
+): { child: FakeChild; stderr: PassThrough } {
+  const { child, stdin, stdout, stderr } = makeFakeChild();
 
   mockWhich.mockResolvedValue("/usr/bin/codex");
   mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
@@ -212,7 +219,7 @@ function harnessFakeServer(
     }
   });
 
-  return { child };
+  return { child, stderr };
 }
 
 describe("CodexAppServer.start (failed handshake teardown)", () => {
@@ -307,5 +314,154 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
     // Clean up the live fake session (taskkill is mocked under the forced win32 platform).
     await server.kill();
     void child;
+  }, 10_000);
+
+  it("emits decoded unexpected-exit diagnostics with the latest non-benign stderr", async () => {
+    const { child, stderr } = harnessFakeServer((req): Record<string, unknown> => {
+      switch (req.method) {
+        case "thread/start":
+          return { result: { thread: { id: "thread-crash" } } };
+        default:
+          return { result: {} };
+      }
+    });
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+    const fatal = vi.fn();
+    server.on("fatal", fatal);
+
+    await server.start();
+    stderr.write("ExperimentalWarning: ignore me\n");
+    stderr.write("\u001b[31mfirst useful line\u001b[0m\n");
+    stderr.write("latest crash cause\n");
+    child.emit("exit", 4294967295, null);
+
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("Codex app-server exited unexpectedly"));
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("raw code=4294967295"));
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("signal=null"));
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("signed int32=-1"));
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("hex=0xffffffff"));
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("latest stderr: latest crash cause"));
+    expect(fatal).not.toHaveBeenCalledWith(expect.stringContaining("ExperimentalWarning"));
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+      expect.stringContaining("Codex app-server exited unexpectedly"),
+      expect.objectContaining({
+        exit: expect.objectContaining({
+          rawCode: 4294967295,
+          signal: null,
+          signedInt32: -1,
+          hexCode: "0xffffffff",
+        }),
+        stderrTail: ["first useful line", "latest crash cause"],
+      }),
+    );
+  }, 10_000);
+
+  it("reports when unexpected exit has no captured non-benign stderr", async () => {
+    const { child, stderr } = harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-no-stderr" } } } : { result: {} },
+    );
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+    const fatal = vi.fn();
+    server.on("fatal", fatal);
+
+    await server.start();
+    stderr.write("Reading prompt from stdin\n");
+    child.emit("exit", 1, "SIGTERM");
+
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("no stderr was captured"));
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+      expect.stringContaining("Codex app-server exited unexpectedly"),
+      expect.objectContaining({ stderrTail: [] }),
+    );
+  }, 10_000);
+
+  it("bounds unexpected-exit stderr tail by line count and evicts oldest lines", async () => {
+    const { child, stderr } = harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-bounded" } } } : { result: {} },
+    );
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+
+    await server.start();
+    for (let i = 0; i < 60; i++) {
+      stderr.write(`line-${i}\n`);
+    }
+    child.emit("exit", 2, null);
+
+    expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+      expect.stringContaining("Codex app-server exited unexpectedly"),
+      expect.objectContaining({
+        stderrTail: expect.arrayContaining(["line-10", "line-59"]),
+      }),
+    );
+    const logFields = findUnexpectedExitLogFields();
+    expect(logFields?.stderrTail).toHaveLength(50);
+    expect(logFields?.stderrTail?.[0]).toBe("line-10");
+    expect(logFields?.stderrTail).not.toContain("line-9");
+  }, 10_000);
+
+  it("bounds unexpected-exit stderr tail by bytes and keeps the newest line", async () => {
+    const { child, stderr } = harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-byte-bounded" } } } : { result: {} },
+    );
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+
+    await server.start();
+    stderr.write(`${"A".repeat(12 * 1024)}\n`);
+    stderr.write(`${"B".repeat(12 * 1024)}\n`);
+    child.emit("exit", 2, null);
+
+    const logFields = findUnexpectedExitLogFields();
+    expect(logFields?.stderrTail).toHaveLength(1);
+    expect(logFields?.stderrTail?.[0]).toBe("B".repeat(12 * 1024));
+  }, 10_000);
+
+  it("retains one oversized non-benign stderr line in bounded form", async () => {
+    const { child, stderr } = harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-oversized-stderr" } } } : { result: {} },
+    );
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+    const fatal = vi.fn();
+    server.on("fatal", fatal);
+
+    await server.start();
+    stderr.write(`${"oversized crash cause ".repeat(1024)}\n`);
+    child.emit("exit", 2, null);
+
+    expect(fatal).toHaveBeenCalledWith(expect.stringContaining("latest stderr:"));
+    const logFields = findUnexpectedExitLogFields();
+    expect(logFields?.stderrTail).toHaveLength(1);
+    expect(Buffer.byteLength(logFields?.stderrTail?.[0] ?? "", "utf8")).toBeLessThanOrEqual(16 * 1024);
+    expect(logFields?.stderrTail?.[0]).toContain("oversized crash cause");
+  }, 10_000);
+
+  it("does not split surrogate pairs when bounding an oversized stderr line", async () => {
+    const { child, stderr } = harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-emoji-stderr" } } } : { result: {} },
+    );
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+
+    await server.start();
+    stderr.write(`${"A".repeat(16 * 1024 - 3)}😀${"B".repeat(100)}\n`);
+    child.emit("exit", 2, null);
+
+    const retainedLine = findUnexpectedExitLogFields()?.stderrTail?.[0] ?? "";
+    const lastCodeUnit = retainedLine.charCodeAt(retainedLine.length - 1);
+    expect(Buffer.byteLength(retainedLine, "utf8")).toBeLessThanOrEqual(16 * 1024);
+    expect(lastCodeUnit < 0xd800 || lastCodeUnit > 0xdfff).toBe(true);
+  }, 10_000);
+
+  it("keeps kill-requested teardown silent", async () => {
+    const { child } = harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-kill" } } } : { result: {} },
+    );
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+    const fatal = vi.fn();
+    server.on("fatal", fatal);
+
+    await server.start();
+    await server.kill();
+    child.emit("exit", 1, null);
+
+    expect(fatal).not.toHaveBeenCalledWith(expect.stringContaining("Codex app-server exited unexpectedly"));
   }, 10_000);
 });

--- a/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
@@ -2057,4 +2057,26 @@ describe("CodexEventMapper", () => {
       expect.objectContaining({ method: "unknown/method" }),
     );
   });
+
+  it("logs warning notifications without treating them as unrecognized", async () => {
+    const { logger } = await import("@mcode/shared");
+    const events = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "warning",
+      params: { message: "configuration degraded", code: "config" },
+    });
+
+    expect(events).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Codex warning notification",
+      expect.objectContaining({
+        method: "warning",
+        params: { message: "configuration degraded", code: "config" },
+      }),
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "CodexEventMapper: unrecognized notification",
+      expect.anything(),
+    );
+  });
 });

--- a/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-protocol-coverage.test.ts
@@ -31,6 +31,7 @@ const KNOWN_METHODS = new Set([
   "item/reasoning/summaryPartAdded",
   "item/plan/delta",
   "error",
+  "warning",
   // Silenced lifecycle plus structured plan snapshots.
   "thread/started",
   "thread/status/changed",
@@ -83,6 +84,7 @@ const SYNTHETIC_NOTIFICATIONS: CodexNotification[] = [
   },
   { jsonrpc: "2.0", method: "item/plan/delta", params: { delta: "Planning…" } },
   { jsonrpc: "2.0", method: "item/reasoning/textDelta", params: { delta: "Think" } },
+  { jsonrpc: "2.0", method: "warning", params: { message: "config warning" } },
   { jsonrpc: "2.0", method: "item/agentMessage/delta", params: { delta: "Final" } },
   {
     jsonrpc: "2.0",

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -217,6 +217,71 @@ const INITIALIZE_HANDSHAKE = {
   backoffMs: 500,
 } as const;
 
+/** Maximum non-benign stderr lines retained for app-server diagnostics. */
+const STDERR_TAIL_MAX_LINES = 50;
+/** Maximum UTF-8 bytes retained across non-benign stderr diagnostics. */
+const STDERR_TAIL_MAX_BYTES = 16 * 1024;
+
+/** Decoded child-process exit details used in user-facing and structured diagnostics. */
+interface ExitDiagnostics {
+  /** Raw exit code reported by Node. */
+  rawCode: number | null;
+  /** Signal reported by Node. */
+  signal: string | null;
+  /** Signed int32 representation for unsigned Windows-style exit codes. */
+  signedInt32?: number;
+  /** Hex representation for numeric exit codes. */
+  hexCode?: string;
+}
+
+/** Retains a bounded tail of non-benign stderr lines for Codex crash diagnostics. */
+class StderrTail {
+  private readonly lines: string[] = [];
+  private totalBytes = 0;
+
+  add(line: string): void {
+    const boundedLine = this.boundLine(line);
+    const bytes = Buffer.byteLength(boundedLine, "utf8");
+    this.lines.push(boundedLine);
+    this.totalBytes += bytes;
+    this.evict();
+  }
+
+  latest(): string | null {
+    return this.lines.at(-1) ?? null;
+  }
+
+  snapshot(): string[] {
+    return [...this.lines];
+  }
+
+  private evict(): void {
+    while (
+      this.lines.length > STDERR_TAIL_MAX_LINES
+      || (this.totalBytes > STDERR_TAIL_MAX_BYTES && this.lines.length > 1)
+    ) {
+      const removed = this.lines.shift();
+      if (removed != null) this.totalBytes -= Buffer.byteLength(removed, "utf8");
+    }
+  }
+
+  private boundLine(line: string): string {
+    if (Buffer.byteLength(line, "utf8") <= STDERR_TAIL_MAX_BYTES) {
+      return line;
+    }
+
+    let bytes = 0;
+    let out = "";
+    for (const char of line) {
+      const next = Buffer.byteLength(char, "utf8");
+      if (bytes + next > STDERR_TAIL_MAX_BYTES) break;
+      out += char;
+      bytes += next;
+    }
+    return out;
+  }
+}
+
 /**
  * Minimal RPC surface needed to run the `initialize` step. Lets the handshake
  * be unit-tested against a fake client without spawning a real `codex` CLI.
@@ -324,6 +389,33 @@ export function enrichHandshakeError(err: unknown, stderr: string | null): Error
     return err instanceof Error ? err : new Error(base);
   }
   return new Error(`${base} (codex app-server reported: ${stderr})`);
+}
+
+/** Decodes raw child-process exit metadata for crash diagnostics. */
+function decodeExitDiagnostics(code: number | null, signal: string | null): ExitDiagnostics {
+  if (code == null) {
+    return { rawCode: code, signal };
+  }
+  return {
+    rawCode: code,
+    signal,
+    signedInt32: code > 0x7fffffff ? code | 0 : undefined,
+    hexCode: `0x${(code >>> 0).toString(16).padStart(8, "0")}`,
+  };
+}
+
+/** Formats the unexpected-exit message shown to users and error banners. */
+function formatUnexpectedExitMessage(exit: ExitDiagnostics, latestStderr: string | null): string {
+  const parts = [
+    `raw code=${exit.rawCode}`,
+    `signal=${exit.signal}`,
+    ...(exit.signedInt32 != null ? [`signed int32=${exit.signedInt32}`] : []),
+    ...(exit.hexCode ? [`hex=${exit.hexCode}`] : []),
+  ];
+  const stderr = latestStderr
+    ? `latest stderr: ${latestStderr}`
+    : "no stderr was captured";
+  return `Codex app-server exited unexpectedly (${parts.join(", ")}; ${stderr})`;
 }
 
 /**
@@ -490,12 +582,8 @@ export class CodexAppServer extends EventEmitter {
   /** Shared in-flight teardown so concurrent `kill()` callers await the same work. */
   private teardownPromise: Promise<void> | null = null;
 
-  /**
-   * Most recent non-benign stderr line from the child. Surfaced into the
-   * handshake failure error so a genuine setup problem (auth, version) is
-   * legible instead of appearing as a bare initialize timeout.
-   */
-  private lastStderr: string | null = null;
+  /** Bounded non-benign stderr tail shared by handshake and exit diagnostics. */
+  private readonly stderrTail = new StderrTail();
 
   private readonly options: CodexAppServerOptions;
 
@@ -646,7 +734,7 @@ export class CodexAppServer extends EventEmitter {
       await this.runHandshake();
     } catch (err) {
       await this.kill();
-      throw enrichHandshakeError(err, this.lastStderr);
+      throw enrichHandshakeError(err, this.stderrTail.latest());
     }
   }
 
@@ -882,7 +970,7 @@ export class CodexAppServer extends EventEmitter {
       if (this._threadId === null) {
         for (const pattern of FATAL_PATTERNS) {
           if (line.includes(pattern)) {
-            this.lastStderr = line;
+            this.stderrTail.add(line);
             const msg = `Codex app-server fatal stderr: ${line}`;
             logger.error(msg, { cliPath: this.cliPath });
             this.emit("fatal", msg);
@@ -898,7 +986,7 @@ export class CodexAppServer extends EventEmitter {
       // the real cause. Tool output, Rust tracing, and agent-generated content
       // are often muxed onto stderr; warn-level logs were drowning useful signal
       // in .mcode-dev, so the line itself stays at debug.
-      this.lastStderr = line;
+      this.stderrTail.add(line);
       logger.debug("Codex stderr", { line });
     });
   }
@@ -912,8 +1000,11 @@ export class CodexAppServer extends EventEmitter {
       this.emit("exit", code, signal);
 
       if (!this.killRequested) {
-        const msg = `Codex app-server exited unexpectedly (code=${code}, signal=${signal})`;
-        logger.error(msg, { cliPath });
+        const exit = decodeExitDiagnostics(code, signal);
+        const stderrTail = this.stderrTail.snapshot();
+        const latestStderr = stderrTail.at(-1) ?? null;
+        const msg = formatUnexpectedExitMessage(exit, latestStderr);
+        logger.error(msg, { cliPath, exit, stderrTail });
         this.emit("fatal", msg);
       }
     });
@@ -930,7 +1021,7 @@ export class CodexAppServer extends EventEmitter {
       timeoutMs: INITIALIZE_HANDSHAKE.timeoutMs,
       attempts: INITIALIZE_HANDSHAKE.attempts,
       backoffMs: INITIALIZE_HANDSHAKE.backoffMs,
-      getLastStderr: () => this.lastStderr,
+      getLastStderr: () => this.stderrTail.latest(),
     });
 
     // Step 2: initialized notification (no response expected)

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -256,6 +256,9 @@ class StderrTail {
   }
 
   private evict(): void {
+    // The `lines.length > 1` floor is safe: boundLine caps any single line at
+    // STDERR_TAIL_MAX_BYTES on insertion, so total retention never exceeds
+    // max(STDERR_TAIL_MAX_BYTES, one bounded line).
     while (
       this.lines.length > STDERR_TAIL_MAX_LINES
       || (this.totalBytes > STDERR_TAIL_MAX_BYTES && this.lines.length > 1)
@@ -391,6 +394,29 @@ export function enrichHandshakeError(err: unknown, stderr: string | null): Error
   return new Error(`${base} (codex app-server reported: ${stderr})`);
 }
 
+/** Maximum code points of stderr excerpt embedded in the user-facing fatal message. */
+const STDERR_EXCERPT_MAX_CHARS = 256;
+
+/**
+ * Bounds and sanitizes a stderr line for embedding in the user-facing fatal
+ * message. Backticks are stripped because the web CliErrorBanner extracts
+ * backtick-quoted substrings as copyable commands, and child stderr can carry
+ * agent-generated content. The full line stays in the structured log fields.
+ */
+function excerptForMessage(line: string): string {
+  const stripped = line.replaceAll("`", "'");
+  let codePoints = 0;
+  let out = "";
+  for (const char of stripped) {
+    if (codePoints >= STDERR_EXCERPT_MAX_CHARS) {
+      return out + "…";
+    }
+    out += char;
+    codePoints += 1;
+  }
+  return out;
+}
+
 /** Decodes raw child-process exit metadata for crash diagnostics. */
 function decodeExitDiagnostics(code: number | null, signal: string | null): ExitDiagnostics {
   if (code == null) {
@@ -413,7 +439,7 @@ function formatUnexpectedExitMessage(exit: ExitDiagnostics, latestStderr: string
     ...(exit.hexCode ? [`hex=${exit.hexCode}`] : []),
   ];
   const stderr = latestStderr
-    ? `latest stderr: ${latestStderr}`
+    ? `latest stderr: ${excerptForMessage(latestStderr)}`
     : "no stderr was captured";
   return `Codex app-server exited unexpectedly (${parts.join(", ")}; ${stderr})`;
 }
@@ -1002,7 +1028,7 @@ export class CodexAppServer extends EventEmitter {
       if (!this.killRequested) {
         const exit = decodeExitDiagnostics(code, signal);
         const stderrTail = this.stderrTail.snapshot();
-        const latestStderr = stderrTail.at(-1) ?? null;
+        const latestStderr = this.stderrTail.latest();
         const msg = formatUnexpectedExitMessage(exit, latestStderr);
         logger.error(msg, { cliPath, exit, stderrTail });
         this.emit("fatal", msg);

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -771,6 +771,11 @@ export class CodexEventMapper {
    */
   mapNotification(notification: CodexNotification): AgentEvent[] {
     const { method } = notification;
+    if (method === "warning") {
+      logger.warn("Codex warning notification", { method, params: notification.params });
+      return [];
+    }
+
     const route = this.classifyNotificationThread(notification);
 
     if (route === "unknown") {

--- a/apps/server/src/providers/codex/codex-types.ts
+++ b/apps/server/src/providers/codex/codex-types.ts
@@ -320,10 +320,8 @@ export interface ErrorNotificationPayload {
   [key: string]: unknown;
 }
 
-/** Payload for the `warning` notification. */
+/** Payload for the `warning` notification. Logged wholesale; never routed per-thread. */
 export interface WarningNotificationPayload {
-  threadId?: string;
-  turnId?: string;
   [key: string]: unknown;
 }
 

--- a/apps/server/src/providers/codex/codex-types.ts
+++ b/apps/server/src/providers/codex/codex-types.ts
@@ -320,6 +320,13 @@ export interface ErrorNotificationPayload {
   [key: string]: unknown;
 }
 
+/** Payload for the `warning` notification. */
+export interface WarningNotificationPayload {
+  threadId?: string;
+  turnId?: string;
+  [key: string]: unknown;
+}
+
 /** One Codex account rate-limit window from `account/rateLimits/updated`. */
 export interface CodexRateLimitWindow {
   usedPercent?: number;
@@ -376,4 +383,5 @@ export type CodexNotification =
   | (JsonRpcNotification<ThreadGoalUpdatedPayload> & { method: "thread/goal/updated" })
   | (JsonRpcNotification<ThreadGoalClearedPayload> & { method: "thread/goal/cleared" })
   | (JsonRpcNotification<CodexRateLimitsPayload> & { method: "account/rateLimits/updated" })
-  | (JsonRpcNotification<ErrorNotificationPayload> & { method: "error" });
+  | (JsonRpcNotification<ErrorNotificationPayload> & { method: "error" })
+  | (JsonRpcNotification<WarningNotificationPayload> & { method: "warning" });


### PR DESCRIPTION
## What
Improves Codex app-server crash diagnostics and Codex warning notification logging.

## Why
When the Codex app-server exited unexpectedly, Mcode showed a raw exit code and dropped the child process stderr. Codex warning notifications also fell through the unknown-notification path, so their payloads were not recorded at warn level.

## Key Changes
- Retain a bounded, non-benign stderr tail for Codex app-server diagnostics.
- Decode raw exit codes into signed and hex forms while keeping the existing `exited unexpectedly` banner trigger.
- Include the latest stderr line in fatal messages and the bounded stderr tail in structured error logs.
- Log Codex `warning` notifications at warn level with their payload.
- Add regression coverage for stderr filtering, line and byte caps, oversized Unicode lines, graceful kills, warning notifications, and protocol coverage.

## Verification
- `cd apps/server && bun run test src/providers/codex/__tests__/codex-app-server-handshake.test.ts src/providers/codex/__tests__/codex-event-mapper.test.ts src/providers/codex/__tests__/codex-protocol-coverage.test.ts`: 3 files, 92 tests passed.
- `bun run verify`: typecheck, lint, and unit tests passed.
- Live stub check: a temporary Codex CLI stub wrote `live stub stderr cause from issue 840` to stderr; `CodexAppServer` emitted an `exited unexpectedly` fatal with that line in `latest stderr` and `stderrTail`.

Fixes #840

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785929348&installation_id=129163861&pr_number=841&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F841&signature=a25e6094291a76154e1c9f4763267ba97cc32a8e7fc50339b07d271f16aba183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Codex warning notifications, which are now recognized and logged without creating downstream events.
  * Improved server crash and handshake diagnostics with richer exit details and recent stderr context.

* **Bug Fixes**
  * Better handling of unexpected child exits, including clearer fatal messages.
  * Captured stderr history is now bounded more reliably, preventing overly large or broken log tails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->