### PR TITLE
feat(ui): normalize design system spacing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,35 +19,107 @@ colors:
   oxide-clay: "oklch(0.78 0.13 25)"
   destructive: "oklch(0.65 0.2 25)"
 typography:
-  heading:
-    fontFamily: "SF Mono, Cascadia Code, Consolas, monospace"
-    fontSize: "0.65rem"
-    fontWeight: 600
-    lineHeight: 1.2
-    letterSpacing: "0.16em"
-  body:
+  h1:
     fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
-    fontSize: "0.875rem"
-    fontWeight: 400
-    lineHeight: 1.55
-    letterSpacing: "normal"
-  title:
-    fontFamily: "Public Sans, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "1rem"
+    fontSize: "4.8rem"
     fontWeight: 600
-    lineHeight: 1.3
+    lineHeight: "5.6rem"
+    letterSpacing: "-0.03em"
+  h2:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "4rem"
+    fontWeight: 600
+    lineHeight: "4.8rem"
+    letterSpacing: "-0.025em"
+  h3:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "3.2rem"
+    fontWeight: 600
+    lineHeight: "4rem"
+    letterSpacing: "-0.02em"
+  h4:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "2.8rem"
+    fontWeight: 600
+    lineHeight: "3.2rem"
+    letterSpacing: "-0.015em"
+  h5:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "2.4rem"
+    fontWeight: 600
+    lineHeight: "2.8rem"
     letterSpacing: "-0.01em"
-  label:
-    fontFamily: "SF Mono, Cascadia Code, Consolas, monospace"
-    fontSize: "0.625rem"
-    fontWeight: 500
-    lineHeight: 1.2
-    letterSpacing: "0.18em"
-  mono:
-    fontFamily: "SF Mono, Cascadia Code, Consolas, monospace"
-    fontSize: "0.75rem"
+  h6:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "2rem"
+    fontWeight: 600
+    lineHeight: "2.4rem"
+    letterSpacing: "normal"
+  body-md:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "1.6rem"
     fontWeight: 400
-    lineHeight: 1.4
+    lineHeight: "2rem"
+    letterSpacing: "normal"
+  body-md-semibold:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.6rem"
+    fontWeight: 600
+    lineHeight: "2rem"
+    letterSpacing: "normal"
+  body-sm:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "1.4rem"
+    fontWeight: 400
+    lineHeight: "1.6rem"
+    letterSpacing: "normal"
+  body-sm-semibold:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "1.4rem"
+    fontWeight: 600
+    lineHeight: "1.6rem"
+    letterSpacing: "normal"
+  body-lg:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "2rem"
+    fontWeight: 400
+    lineHeight: "2.4rem"
+    letterSpacing: "normal"
+  body-lg-semibold:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "2rem"
+    fontWeight: 600
+    lineHeight: "2.4rem"
+    letterSpacing: "normal"
+  button-link:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "1.6rem"
+    fontWeight: 500
+    lineHeight: "2rem"
+    letterSpacing: "normal"
+  button-link-sm:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "1.4rem"
+    fontWeight: 500
+    lineHeight: "1.6rem"
+    letterSpacing: "normal"
+  button-link-lg:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "2rem"
+    fontWeight: 500
+    lineHeight: "2.4rem"
+    letterSpacing: "normal"
+  caption:
+    fontFamily: "Public Sans, ui-sans-serif, system-ui, -apple-system, sans-serif"
+    fontSize: "1.2rem"
+    fontWeight: 400
+    lineHeight: "1.6rem"
+    letterSpacing: "normal"
+  mono-data:
+    fontFamily: "SF Mono, Cascadia Code, Consolas, monospace"
+    fontSize: "1.2rem"
+    fontWeight: 400
+    lineHeight: "1.6rem"
     letterSpacing: "normal"
 rounded:
   sm: "0.375rem"
@@ -55,30 +127,44 @@ rounded:
   lg: "0.625rem"
   xl: "0.875rem"
   2xl: "1.125rem"
+spacing:
+  1: "0.4rem"
+  2: "0.8rem"
+  3: "1.2rem"
+  4: "1.6rem"
+  5: "2rem"
+  6: "2.4rem"
+  8: "3.2rem"
+  10: "4rem"
+  12: "4.8rem"
+  14: "5.6rem"
 components:
   button-primary:
     backgroundColor: "{colors.amber-primary}"
     textColor: "{colors.ink}"
+    typography: "{typography.button-link-sm}"
     rounded: "{rounded.lg}"
-    padding: "0 0.625rem"
-    height: "2rem"
+    padding: "0 1.2rem"
+    height: "3.2rem"
   button-ghost:
     backgroundColor: "transparent"
     textColor: "{colors.ink}"
+    typography: "{typography.button-link-sm}"
     rounded: "{rounded.lg}"
-    padding: "0 0.625rem"
-    height: "2rem"
+    padding: "0 1.2rem"
+    height: "3.2rem"
   input:
     backgroundColor: "{colors.slate-accent}"
     textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
     rounded: "{rounded.lg}"
-    padding: "0 0.625rem"
-    height: "2rem"
+    padding: "0 1.2rem"
+    height: "3.2rem"
   panel:
     backgroundColor: "{colors.slate-card}"
     textColor: "{colors.ink}"
     rounded: "{rounded.xl}"
-    padding: "0.75rem"
+    padding: "1.2rem"
 ---
 
 # Design System: Mcode
@@ -100,6 +186,7 @@ This system explicitly rejects the consumer-app reflexes: no softened "Oops, som
 - Monospace carries machine facts (SHAs, counts, timestamps, status labels); Public Sans carries human prose.
 - Keyboard-first: shortcuts are first-class, not hidden.
 - Information-dense by intent: tight, tabular, no decorative padding.
+- Four-point spacing: every layout gap, inset, control size, and icon size lands on a 4px step.
 
 ## 2. Colors
 
@@ -141,19 +228,28 @@ Light theme mirrors this on cool neutrals: page `oklch(0.955 0.005 260)`, backgr
 **Display / Body Font:** Public Sans (with `ui-sans-serif, system-ui, -apple-system, sans-serif`)
 **Label / Mono Font:** SF Mono (with `Cascadia Code, Consolas, monospace`)
 
-**Character:** A single humanist sans does the human-facing work — prose, titles, controls — at a calm 14px baseline. Monospace is not a "developer vibe"; it is reserved for facts a machine produced. The contrast between the two is the entire type system: if it came from a person, it is Public Sans; if it is a SHA, a count, a timestamp, or a status label, it is mono.
+**Character:** A single humanist sans does the human-facing work: headings, prose, controls, and captions. Monospace is not a "developer vibe"; it is reserved for facts a machine produced. The contrast between the two is the entire type system: if it came from a person, it is Public Sans; if it is a SHA, a count, a timestamp, or a status label, it is mono.
 
 ### Hierarchy
-- **Title** (Public Sans, 600, 1rem, line-height 1.3, letter-spacing -0.01em): Panel and dialog titles. The largest type in the app; this is product UI, not a hero — there is no display scale above ~1rem.
-- **Body** (Public Sans, 400, 0.875rem / 14px, line-height 1.55): Agent prose, descriptions, the Whisper narrative timeline. Cap prose at 65–75ch.
-- **Heading / Eyebrow** (mono, 600, ~0.65rem, letter-spacing 0.16em, uppercase small-caps): Section headings inside panels. Wide-tracked mono small-caps, used sparingly as structure, not on every block.
-- **Label** (mono, 500, 0.625rem / 10.5px, letter-spacing 0.18em, uppercase): Status labels ("ERRORED", "IDLE"), empty-state captions, micro-meta.
-- **Mono Data** (mono, 400, 0.75rem, tabular-nums): SHAs, file counts, timestamps, durations. Always `tabular-nums` so columns of numerals align.
+- **H1** (Public Sans, 600, `4.8rem / 5.6rem`): Rare screen-level or document-level heading. Use only when the surface has room to carry it.
+- **H2** (Public Sans, 600, `4rem / 4.8rem`): Major panel heading or document section heading.
+- **H3** (Public Sans, 600, `3.2rem / 4rem`): Section title inside a full surface.
+- **H4** (Public Sans, 600, `2.8rem / 3.2rem`): Dialog title or high-emphasis panel title.
+- **H5** (Public Sans, 600, `2.4rem / 2.8rem`): Compact panel title.
+- **H6** (Public Sans, 600, `2rem / 2.4rem`): Dense subsection heading.
+- **Body MD** (Public Sans, 400 or 600, `1.6rem / 2rem`): Default prose, forms, list rows, and primary readable UI copy.
+- **Body SM** (Public Sans, 400 or 600, `1.4rem / 1.6rem`): Dense rows, helper text, compact controls, and secondary metadata.
+- **Body LG** (Public Sans, 400 or 600, `2rem / 2.4rem`): High-emphasis readable copy where H6 would feel too structural.
+- **Button Link** (Public Sans, 500, `1.6rem / 2rem`; small `1.4rem / 1.6rem`; large `2rem / 2.4rem`): Text inside buttons and link-styled actions.
+- **Caption** (Public Sans, 400, `1.2rem / 1.6rem`): Fine print, timestamps, and low-emphasis labels.
+- **Mono Data** (mono, 400, `1.2rem / 1.6rem`, tabular-nums): SHAs, file counts, timestamps, durations. Always `tabular-nums` so columns of numerals align.
 
 ### Named Rules
 **The Mono-Is-Machine Rule.** Monospace marks machine-authored facts only. Prose in mono, or numerals in Public Sans, is a category error. Counts and timestamps additionally take `tabular-nums`.
 
-**The No-Hero Rule.** This is an app, not a landing page. Type tops out near 1rem. There is no `clamp()` display scale, no oversized headline; hierarchy comes from weight and mono/sans contrast, not size.
+**The Fixed-Type Rule.** Product UI uses fixed rem sizes, never fluid type. H1 through H6 are available for document and spacious panel hierarchy, but dense app chrome defaults to Body SM or Body MD. Do not invent in-between sizes.
+
+**The Decimal Rem Rule.** The root font size is `62.5%`, making `1rem` equal to 10px in default browser settings. Express fixed dimensions in rem or em whenever practical, so `12px` becomes `1.2rem`, `32px` becomes `3.2rem`, and `48px` becomes `4.8rem`. Use raw px only for true hairlines, bitmap dimensions, canvas pixels, and sub-pixel optical fixes.
 
 ## 4. Elevation
 
@@ -175,12 +271,16 @@ Shadows exist only as a response to interactive state, never as ambient decorati
 
 ### Buttons
 - **Shape:** Gently rounded (`var(--radius-lg)`, 10px); smaller sizes step down to `min(var(--radius-md), 12px)`.
-- **Primary:** Filament Amber fill, ink text, `h-8 px-2.5`, `text-sm font-medium`. Hover drops opacity to 80%.
+- **Control scale:** Small is `3.2rem` (32px), medium is `4.8rem` (48px), large is `5.6rem` (56px). Default dense toolbar buttons use small. Medium is for primary row actions and dialogs. Large is rare and belongs only to spacious confirmation or onboarding surfaces.
+- **Icon-button scale:** Small is `3.2rem` (32px), medium is `4.8rem` (48px), large is `5.6rem` (56px). Icon-only buttons use the same outer box scale as text buttons so hit targets stay predictable.
+- **Icon scale:** Small icons are `1.6rem` (16px), medium icons are `2.4rem` (24px), large icons are `3.2rem` (32px). Do not invent intermediate icon sizes unless the source artwork demands optical correction.
+- **Primary:** Filament Amber fill, ink text, small height `3.2rem`, horizontal padding `1.2rem`, `text-sm font-medium`. Hover drops opacity to 80%.
 - **Ghost / Secondary:** Transparent or slate-secondary fill; hover lifts to `--muted`. Ghost is the default for dense toolbars — most buttons are not primary.
 - **Hover / Focus:** `transition-all`; `active:translate-y-px` for a tactile press; focus-visible draws `ring-3 ring-ring/50` plus a border shift. Destructive uses a 10% destructive tint, not a solid red fill.
 
 ### Inputs / Fields
 - **Style:** Slate-accent well (`--input`), 10px radius, no heavy stroke; the well's tone separates it from the panel.
+- **Typography:** Default inputs use Body SM (`1.4rem / 1.6rem`). Use Body MD (`1.6rem / 2rem`) for standard forms and dialogs. Use Body LG (`2rem / 2.4rem`) only when the input is the primary task on the surface.
 - **Focus:** Cool-ring glow (`0 0 0 3px ring/20%`) with a border shift to `--ring`. No bounce, no color flash.
 - **Error / Disabled:** `aria-invalid` draws a destructive border and ring; disabled drops to 50% opacity and `pointer-events-none`.
 
@@ -213,6 +313,9 @@ The interface expression of the "Anticipate the next step" product principle. A 
 ## 6. Do's and Don'ts
 
 ### Do:
+- **Do** use the 4-point spacing scale: `0.4rem` (4px), `0.8rem` (8px), `1.2rem` (12px), `1.6rem` (16px), `2.4rem` (24px), `3.2rem` (32px), `4.8rem` (48px), and `5.6rem` (56px).
+- **Do** write fixed dimensions in rem or em where practical. With the `62.5%` root, divide px by 10 to get the rem value.
+- **Do** keep buttons, icon buttons, and icons on their named small, medium, and large scales.
 - **Do** ration Filament Amber. One accent, small footprint, reserved for the active row, the primary action, and live indicators.
 - **Do** carry separation with tonal lift; step a surface along the lightness ramp before adding a line.
 - **Do** set SHAs, counts, timestamps, and status labels in mono, with `tabular-nums` for any numerals.
@@ -220,10 +323,12 @@ The interface expression of the "Anticipate the next step" product principle. A 
 - **Do** set hyperlinks and link-styled text in Cool Link (`text-link`), never amber. Cold for plumbing, warm for the lamp.
 - **Do** write technical copy: "Errored", "Idle", "Empty". Match PRODUCT.md's voice.
 - **Do** give every animation a `prefers-reduced-motion` alternative, and reuse the existing `wizard-*` and `narrative-*` curves (`cubic-bezier(0.25, 1, 0.5, 1)` and `cubic-bezier(0.22, 1, 0.36, 1)`) rather than inventing new ones.
-- **Do** keep type capped near 1rem; build hierarchy from weight and mono/sans contrast.
+- **Do** use the documented type scale exactly; dense chrome defaults to Body SM or Body MD, while H1-H6 are reserved for document and spacious panel hierarchy.
 - **Do** elevate exactly one next-step per state in Filament Amber, bound to the Tab accept key, and auto-advance only single-outcome transitions.
 
 ### Don't:
+- **Don't** add off-scale gaps or control sizes for visual convenience. If a value is not a 4px step, it needs an optical reason.
+- **Don't** mix px and rem for the same sizing system. Raw px is reserved for hairlines, bitmap dimensions, canvas pixels, and sub-pixel fixes.
 - **Don't** use `border-left` or `border-right` greater than 1px as a colored accent stripe on rows, cards, callouts, or alerts. Selection is a row-fill.
 - **Don't** add nested guide rails (`border-l border-border/50 pl-2`) for tree indentation. Indentation alone.
 - **Don't** use gradient text (`background-clip: text` over a gradient). Solid colors only.

--- a/apps/web/e2e/architecture.spec.ts
+++ b/apps/web/e2e/architecture.spec.ts
@@ -387,7 +387,9 @@ test.describe("Architecture: Thread lifecycle", () => {
       activeThreadId: THREAD_WORKTREE.id,
     });
 
-    // The worktree thread has branch "feature-x"
+    await page.getByTestId("header-workspace-menu").click();
+
+    // The worktree thread has branch "feature-x" in Thread Overview.
     await expect(page.locator("text=feature-x")).toBeVisible();
   });
 

--- a/apps/web/e2e/branchless-create-pr.spec.ts
+++ b/apps/web/e2e/branchless-create-pr.spec.ts
@@ -132,7 +132,6 @@ test.describe("Branchless Create PR", () => {
     await page.waitForSelector("[data-testid='chat-header-title']");
 
     await ensureOverviewOpen(page);
-    await expect(page.getByText("HEAD").first()).toBeVisible();
     await expect(page.getByTestId("thread-overview-create-branch")).toBeVisible();
     await expect(page.getByTestId("workspace-menu-branch")).toHaveCount(0);
     await expect(page.getByTestId("workspace-menu-create-pr")).toHaveCount(0);

--- a/apps/web/e2e/design-system-scale.spec.ts
+++ b/apps/web/e2e/design-system-scale.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+
+async function setup(page: Page): Promise<void> {
+  await mockWebSocketServer(page);
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+}
+
+async function measuredStyles(
+  page: Page,
+  className: string,
+  tagName = "div",
+): Promise<{
+  fontSize: string;
+  height: string;
+  lineHeight: string;
+  paddingLeft: string;
+  borderRadius: string;
+  gap: string;
+  width: string;
+}> {
+  return page.evaluate(
+    ({ className: klass, tagName: tag }) => {
+      const el = document.createElement(tag);
+      el.className = klass;
+      el.textContent = "Scale";
+      document.body.append(el);
+      const styles = getComputedStyle(el);
+      const result = {
+        fontSize: styles.fontSize,
+        height: styles.height,
+        lineHeight: styles.lineHeight,
+        paddingLeft: styles.paddingLeft,
+        borderRadius: styles.borderRadius,
+        gap: styles.gap,
+        width: styles.width,
+      };
+      el.remove();
+      return result;
+    },
+    { className, tagName },
+  );
+}
+
+test.describe("Design system scale", () => {
+  test.beforeEach(async ({ page }) => {
+    await setup(page);
+  });
+
+  test("sets the decimal rem root and preserves Tailwind spacing math", async ({ page }) => {
+    const rootFontSize = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    expect(rootFontSize).toBe("10px");
+
+    await expect
+      .poll(() => measuredStyles(page, "h-8 w-8 p-4 gap-4 flex"))
+      .toEqual(expect.objectContaining({
+        gap: "16px",
+        height: "32px",
+        paddingLeft: "16px",
+        width: "32px",
+      }));
+  });
+
+  test("maps Tailwind text utilities to the documented type scale", async ({ page }) => {
+    const expected = [
+      ["text-xs", "12px", "16px"],
+      ["text-sm", "14px", "16px"],
+      ["text-base", "16px", "20px"],
+      ["text-lg", "20px", "24px"],
+      ["text-xl", "24px", "28px"],
+      ["text-2xl", "28px", "32px"],
+      ["text-3xl", "32px", "40px"],
+      ["text-4xl", "40px", "48px"],
+      ["text-5xl", "48px", "56px"],
+    ];
+
+    for (const [className, fontSize, lineHeight] of expected) {
+      await expect
+        .poll(() => measuredStyles(page, className))
+        .toEqual(expect.objectContaining({ fontSize, lineHeight }));
+    }
+  });
+
+  test("maps radius utilities to the documented radius tokens", async ({ page }) => {
+    const expected = [
+      ["rounded-sm", "6px"],
+      ["rounded-md", "8px"],
+      ["rounded-lg", "10px"],
+      ["rounded-xl", "14px"],
+      ["rounded-2xl", "18px"],
+      ["rounded-3xl", "22px"],
+      ["rounded-4xl", "26px"],
+    ];
+
+    for (const [className, borderRadius] of expected) {
+      await expect
+        .poll(() => measuredStyles(page, className))
+        .toEqual(expect.objectContaining({ borderRadius }));
+    }
+  });
+
+  test("maps Button, Input, and Badge classes to documented computed sizes", async ({ page }) => {
+    const buttonBase =
+      "inline-flex items-center justify-center rounded-lg border border-transparent font-medium [&_svg:not([class*='size-'])]:size-4";
+    const buttonSmall =
+      "h-8 gap-1.5 px-2.5 text-sm";
+    const buttonMedium =
+      "h-12 gap-2 px-3 text-base [&_svg:not([class*='size-'])]:size-6";
+    const buttonLarge =
+      "h-14 gap-2.5 px-4 text-lg [&_svg:not([class*='size-'])]:size-8";
+    const inputSmall =
+      "flex h-8 w-full rounded-lg border border-input bg-input px-3 py-1 text-sm";
+    const badgeDefault =
+      "inline-flex h-5 items-center justify-center rounded-4xl px-2 py-0 text-xs leading-4";
+    const badgeSmall =
+      "inline-flex h-4 items-center justify-center rounded-4xl px-1 py-0 text-xs leading-4";
+
+    await expect
+      .poll(() => measuredStyles(page, `${buttonBase} ${buttonSmall}`, "button"))
+      .toEqual(expect.objectContaining({ height: "32px", fontSize: "14px", lineHeight: "16px" }));
+    await expect
+      .poll(() => measuredStyles(page, `${buttonBase} ${buttonMedium}`, "button"))
+      .toEqual(expect.objectContaining({ height: "48px", fontSize: "16px", lineHeight: "20px" }));
+    await expect
+      .poll(() => measuredStyles(page, `${buttonBase} ${buttonLarge}`, "button"))
+      .toEqual(expect.objectContaining({ height: "56px", fontSize: "20px", lineHeight: "24px" }));
+    await expect
+      .poll(() => measuredStyles(page, "inline-flex size-8 [&_svg:not([class*='size-'])]:size-4", "button"))
+      .toEqual(expect.objectContaining({ height: "32px", width: "32px" }));
+    await expect
+      .poll(() => measuredStyles(page, "inline-flex size-12 [&_svg:not([class*='size-'])]:size-6", "button"))
+      .toEqual(expect.objectContaining({ height: "48px", width: "48px" }));
+    await expect
+      .poll(() => measuredStyles(page, "inline-flex size-14 [&_svg:not([class*='size-'])]:size-8", "button"))
+      .toEqual(expect.objectContaining({ height: "56px", width: "56px" }));
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const button = document.createElement("button");
+          button.className = "inline-flex h-12 [&_svg:not([class*='size-'])]:size-6";
+          const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+          button.append(svg);
+          document.body.append(button);
+          const styles = getComputedStyle(svg);
+          const result = { height: styles.height, width: styles.width };
+          button.remove();
+          return result;
+        }),
+      )
+      .toEqual({ height: "24px", width: "24px" });
+    await expect
+      .poll(() => measuredStyles(page, inputSmall, "input"))
+      .toEqual(expect.objectContaining({ height: "32px", fontSize: "14px", lineHeight: "16px" }));
+    await expect
+      .poll(() => measuredStyles(page, badgeDefault, "span"))
+      .toEqual(expect.objectContaining({ height: "20px", fontSize: "12px", lineHeight: "16px", paddingLeft: "8px" }));
+    await expect
+      .poll(() => measuredStyles(page, badgeSmall, "span"))
+      .toEqual(expect.objectContaining({ height: "16px", fontSize: "12px", lineHeight: "16px", paddingLeft: "4px" }));
+  });
+
+  test("captures scale evidence screenshots", async ({ page }, testInfo) => {
+    for (const size of [
+      { width: 1440, height: 900, name: "design-scale-1440x900.png" },
+      { width: 900, height: 700, name: "design-scale-900x700.png" },
+      { width: 390, height: 844, name: "design-scale-390x844.png" },
+    ]) {
+      await page.setViewportSize({ width: size.width, height: size.height });
+      await page.screenshot({
+        path: testInfo.outputPath(size.name),
+        fullPage: false,
+      });
+    }
+  });
+});

--- a/apps/web/e2e/design-system-scale.spec.ts
+++ b/apps/web/e2e/design-system-scale.spec.ts
@@ -1,4 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
+import { badgeVariants } from "../src/components/ui/badge";
+import { buttonVariants } from "../src/components/ui/button";
+import { inputVariants } from "../src/components/ui/input";
 import { mockWebSocketServer } from "./helpers/e2e-helpers";
 
 async function setup(page: Page): Promise<void> {
@@ -103,44 +106,47 @@ test.describe("Design system scale", () => {
   });
 
   test("maps Button, Input, and Badge classes to documented computed sizes", async ({ page }) => {
-    const buttonBase =
-      "inline-flex items-center justify-center rounded-lg border border-transparent font-medium [&_svg:not([class*='size-'])]:size-4";
-    const buttonSmall =
-      "h-8 gap-1.5 px-2.5 text-sm";
-    const buttonMedium =
-      "h-12 gap-2 px-3 text-base [&_svg:not([class*='size-'])]:size-6";
-    const buttonLarge =
-      "h-14 gap-2.5 px-4 text-lg [&_svg:not([class*='size-'])]:size-8";
-    const inputSmall =
-      "flex h-8 w-full rounded-lg border border-input bg-input px-3 py-1 text-sm";
-    const badgeDefault =
-      "inline-flex h-5 items-center justify-center rounded-4xl px-2 py-0 text-xs leading-4";
-    const badgeSmall =
-      "inline-flex h-4 items-center justify-center rounded-4xl px-1 py-0 text-xs leading-4";
-
     await expect
-      .poll(() => measuredStyles(page, `${buttonBase} ${buttonSmall}`, "button"))
-      .toEqual(expect.objectContaining({ height: "32px", fontSize: "14px", lineHeight: "16px" }));
+      .poll(() => measuredStyles(page, buttonVariants({ size: "sm" }), "button"))
+      .toEqual(expect.objectContaining({
+        gap: "8px",
+        height: "32px",
+        fontSize: "14px",
+        lineHeight: "16px",
+        paddingLeft: "12px",
+      }));
     await expect
-      .poll(() => measuredStyles(page, `${buttonBase} ${buttonMedium}`, "button"))
-      .toEqual(expect.objectContaining({ height: "48px", fontSize: "16px", lineHeight: "20px" }));
+      .poll(() => measuredStyles(page, buttonVariants({ size: "md" }), "button"))
+      .toEqual(expect.objectContaining({
+        gap: "8px",
+        height: "48px",
+        fontSize: "16px",
+        lineHeight: "20px",
+        paddingLeft: "12px",
+      }));
     await expect
-      .poll(() => measuredStyles(page, `${buttonBase} ${buttonLarge}`, "button"))
-      .toEqual(expect.objectContaining({ height: "56px", fontSize: "20px", lineHeight: "24px" }));
+      .poll(() => measuredStyles(page, buttonVariants({ size: "lg" }), "button"))
+      .toEqual(expect.objectContaining({
+        gap: "8px",
+        height: "56px",
+        fontSize: "20px",
+        lineHeight: "24px",
+        paddingLeft: "16px",
+      }));
     await expect
-      .poll(() => measuredStyles(page, "inline-flex size-8 [&_svg:not([class*='size-'])]:size-4", "button"))
+      .poll(() => measuredStyles(page, buttonVariants({ size: "icon-sm" }), "button"))
       .toEqual(expect.objectContaining({ height: "32px", width: "32px" }));
     await expect
-      .poll(() => measuredStyles(page, "inline-flex size-12 [&_svg:not([class*='size-'])]:size-6", "button"))
+      .poll(() => measuredStyles(page, buttonVariants({ size: "icon-md" }), "button"))
       .toEqual(expect.objectContaining({ height: "48px", width: "48px" }));
     await expect
-      .poll(() => measuredStyles(page, "inline-flex size-14 [&_svg:not([class*='size-'])]:size-8", "button"))
+      .poll(() => measuredStyles(page, buttonVariants({ size: "icon-lg" }), "button"))
       .toEqual(expect.objectContaining({ height: "56px", width: "56px" }));
     await expect
       .poll(() =>
-        page.evaluate(() => {
+        page.evaluate((className) => {
           const button = document.createElement("button");
-          button.className = "inline-flex h-12 [&_svg:not([class*='size-'])]:size-6";
+          button.className = className;
           const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
           button.append(svg);
           document.body.append(button);
@@ -148,17 +154,17 @@ test.describe("Design system scale", () => {
           const result = { height: styles.height, width: styles.width };
           button.remove();
           return result;
-        }),
+        }, buttonVariants({ size: "icon-md" })),
       )
       .toEqual({ height: "24px", width: "24px" });
     await expect
-      .poll(() => measuredStyles(page, inputSmall, "input"))
+      .poll(() => measuredStyles(page, inputVariants({ size: "sm" }), "input"))
       .toEqual(expect.objectContaining({ height: "32px", fontSize: "14px", lineHeight: "16px" }));
     await expect
-      .poll(() => measuredStyles(page, badgeDefault, "span"))
+      .poll(() => measuredStyles(page, badgeVariants({ size: "default" }), "span"))
       .toEqual(expect.objectContaining({ height: "20px", fontSize: "12px", lineHeight: "16px", paddingLeft: "8px" }));
     await expect
-      .poll(() => measuredStyles(page, badgeSmall, "span"))
+      .poll(() => measuredStyles(page, badgeVariants({ size: "sm" }), "span"))
       .toEqual(expect.objectContaining({ height: "16px", fontSize: "12px", lineHeight: "16px", paddingLeft: "4px" }));
   });
 

--- a/apps/web/e2e/final-response-continuity.spec.ts
+++ b/apps/web/e2e/final-response-continuity.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 import { interceptZustandStores, mockWebSocketServer } from "./helpers/e2e-helpers";
 
 const now = new Date().toISOString();
+const MAX_FINAL_RESPONSE_HEIGHT_DELTA_PX = 40;
 
 const WORKSPACE = {
   id: "ws-final-response",
@@ -307,7 +308,9 @@ test.describe("final response continuity", () => {
       };
     }, continuity.scrollTop);
     expect(continuity.nestedScrollableCount).toBe(0);
-    expect(Math.abs(result.height - continuity.height)).toBeLessThan(36);
+    expect(Math.abs(result.height - continuity.height)).toBeLessThan(
+      MAX_FINAL_RESPONSE_HEIGHT_DELTA_PX,
+    );
     expect(result.sameNode).toBe(true);
     expect(result.scrollDelta).toBeLessThan(2);
 

--- a/apps/web/src/__tests__/Badge.test.tsx
+++ b/apps/web/src/__tests__/Badge.test.tsx
@@ -10,11 +10,11 @@ describe("Badge", () => {
     expect(badge.className).toContain("px-2");
   });
 
-  it("renders sm size with h-4 and px-1.5", () => {
+  it("renders sm size with h-4 and px-1", () => {
     const { container } = render(<Badge size="sm">Status</Badge>);
     const badge = container.firstElementChild!;
     expect(badge.className).toContain("h-4");
-    expect(badge.className).toContain("px-1.5");
+    expect(badge.className).toContain("px-1");
   });
 
   it("applies variant alongside size", () => {

--- a/apps/web/src/__tests__/Button.test.tsx
+++ b/apps/web/src/__tests__/Button.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buttonVariants } from "@/components/ui/button";
+
+describe("buttonVariants", () => {
+  it("maps legacy text sizes to the small control scale", () => {
+    for (const size of ["xs", "sm", "default"] as const) {
+      const className = buttonVariants({ size });
+      expect(className).toContain("h-8");
+      expect(className).toContain("text-sm");
+    }
+  });
+
+  it("maps md and lg text sizes to documented control scales", () => {
+    const medium = buttonVariants({ size: "md" });
+    const large = buttonVariants({ size: "lg" });
+
+    expect(medium).toContain("h-12");
+    expect(medium).toContain("text-base");
+    expect(medium).toContain("size-6");
+    expect(large).toContain("h-14");
+    expect(large).toContain("text-lg");
+    expect(large).toContain("size-8");
+  });
+
+  it("maps icon-only sizes to documented outer boxes", () => {
+    for (const size of ["icon-xs", "icon-sm", "icon"] as const) {
+      expect(buttonVariants({ size })).toContain("size-8");
+    }
+
+    expect(buttonVariants({ size: "icon-md" })).toContain("size-12");
+    expect(buttonVariants({ size: "icon-lg" })).toContain("size-14");
+  });
+});

--- a/apps/web/src/__tests__/Input.test.tsx
+++ b/apps/web/src/__tests__/Input.test.tsx
@@ -10,24 +10,38 @@ describe("Input", () => {
     expect(input.className).toContain("text-sm");
   });
 
-  it("renders sm size with h-7 and text-xs", () => {
+  it("renders sm size as the small input alias", () => {
     const { container } = render(<Input size="sm" placeholder="test" />);
     const input = container.querySelector("input")!;
-    expect(input.className).toContain("h-7");
-    expect(input.className).toContain("text-xs");
+    expect(input.className).toContain("h-8");
+    expect(input.className).toContain("text-sm");
   });
 
-  it("renders xs size with h-6 and text-xs", () => {
+  it("renders xs size as the small input alias", () => {
     const { container } = render(<Input size="xs" placeholder="test" />);
     const input = container.querySelector("input")!;
-    expect(input.className).toContain("h-6");
-    expect(input.className).toContain("text-xs");
+    expect(input.className).toContain("h-8");
+    expect(input.className).toContain("text-sm");
+  });
+
+  it("renders md and lg sizes on the documented control scale", () => {
+    const { container } = render(
+      <>
+        <Input size="md" placeholder="medium" />
+        <Input size="lg" placeholder="large" />
+      </>
+    );
+    const [md, lg] = Array.from(container.querySelectorAll("input"));
+    expect(md.className).toContain("h-12");
+    expect(md.className).toContain("text-base");
+    expect(lg.className).toContain("h-14");
+    expect(lg.className).toContain("text-lg");
   });
 
   it("applies custom className alongside size", () => {
     const { container } = render(<Input size="sm" className="w-40" placeholder="test" />);
     const input = container.querySelector("input")!;
-    expect(input.className).toContain("h-7");
+    expect(input.className).toContain("h-8");
     expect(input.className).toContain("w-40");
   });
 });

--- a/apps/web/src/__tests__/MessageBubble.test.tsx
+++ b/apps/web/src/__tests__/MessageBubble.test.tsx
@@ -201,6 +201,10 @@ describe("MessageBubble user messages", () => {
     expect(getByTestId("sent-preview-annotation-bundle-chip")).toHaveTextContent(
       "1 annotation",
     );
+    expect(getByTestId("sent-preview-annotation-bundle-chip")).toHaveClass(
+      "bg-accent",
+      "text-accent-foreground",
+    );
     expect(queryByText("bundle")).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -387,7 +387,7 @@ export function App() {
             {!rightPanelMaximized && (
             <main
               className="flex-1 overflow-hidden bg-background"
-              style={{ minWidth: COMPOSER_MIN_WIDTH }}
+              style={{ minWidth: showLanding ? 0 : COMPOSER_MIN_WIDTH }}
             >
               {settingsOpen ? (
                 <Suspense fallback={null}>

--- a/apps/web/src/components/Toast.tsx
+++ b/apps/web/src/components/Toast.tsx
@@ -67,10 +67,10 @@ function ToastItem({ toast }: { toast: ToastData }) {
         variant="ghost"
         size="icon-xs"
         onClick={handleDismiss}
-        className="shrink-0 mt-0.5 h-5 w-5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100"
+        className="shrink-0 mt-0.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100"
         aria-label="Dismiss"
       >
-        <X size={12} />
+        <X />
       </Button>
     </div>
   );

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -467,9 +467,6 @@ export function ChatView() {
               onCancel={() => setEditingThreadId(null)}
             />
           </div>
-          <Badge variant="secondary">
-            {activeWorkspaceName}
-          </Badge>
           {activeThread.parent_thread_id && parentThreadExists && (
             <Tooltip>
               <TooltipTrigger

--- a/apps/web/src/components/chat/Composer.footer-checkout.test.tsx
+++ b/apps/web/src/components/chat/Composer.footer-checkout.test.tsx
@@ -3,13 +3,14 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
 
-describe("Composer footer checkout label", () => {
-  it("uses the shared checkout label helper for the locked existing-thread branch control", () => {
+describe("Composer footer visibility", () => {
+  it("hides the workspace and branch strip on normal active threads", () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const source = readFileSync(resolve(here, "Composer.tsx"), "utf8");
 
-    expect(source).toContain('import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";');
-    expect(source).toContain(") : activeThread && isGitRepo ? (");
-    expect(source).toContain("selectedBranch={resolveThreadCheckoutLabel(activeThread)}");
+    expect(source).toContain("const showComposerStatusBar = isNewThread === true || !!branchFromMessageId;");
+    expect(source).toContain("aria-hidden={!showComposerStatusBar}");
+    expect(source).not.toContain('import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";');
+    expect(source).not.toContain("selectedBranch={resolveThreadCheckoutLabel(activeThread)}");
   });
 });

--- a/apps/web/src/components/chat/Composer.footer-checkout.test.tsx
+++ b/apps/web/src/components/chat/Composer.footer-checkout.test.tsx
@@ -10,6 +10,7 @@ describe("Composer footer visibility", () => {
 
     expect(source).toContain("const showComposerStatusBar = isNewThread === true || !!branchFromMessageId;");
     expect(source).toContain("aria-hidden={!showComposerStatusBar}");
+    expect(source).toContain("inert={showComposerStatusBar ? undefined : true}");
     expect(source).not.toContain('import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";');
     expect(source).not.toContain("selectedBranch={resolveThreadCheckoutLabel(activeThread)}");
   });

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -3374,6 +3374,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           showComposerStatusBar ? "grid-rows-[1fr] opacity-100 translate-y-0" : "grid-rows-[0fr] opacity-0 translate-y-1 pointer-events-none",
         )}
         aria-hidden={!showComposerStatusBar}
+        inert={showComposerStatusBar ? undefined : true}
       >
         <div className="min-h-0">
           <div className="flex items-center justify-between px-1 pt-1.5">

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -124,7 +124,6 @@ import {
 } from "@/lib/preview-annotation-append";
 import { usePreviewAnnotationStore } from "@/stores/previewAnnotationStore";
 import { usePreviewDesignModeStore } from "@/stores/previewDesignModeStore";
-import { resolveThreadCheckoutLabel } from "@/lib/checkout-label";
 import { PreviewAnnotationBundleChip } from "./PreviewAnnotationBundleChip";
 import {
   collectBrowserCaptureSpillPaths,
@@ -886,9 +885,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   // token-count badge + send button fit comfortably on one row with the
   // standard gaps and breathing room. Below this the row collapses to a
   // single "Composer options" trigger so the send button never gets clipped.
-  // Empirically the row needs roughly 720–740px of container width to render
-  // without crowding; 760 leaves a small safety margin for longer model names.
-  const COMPOSER_INLINE_OPTIONS_THRESHOLD = 760;
+  // With 32px small controls, the 1280px shell still has room for inline
+  // options after the sidebar and right rail are reserved. Keep the collapse
+  // point below that shell width while preserving the 600px overflow behavior.
+  const COMPOSER_INLINE_OPTIONS_THRESHOLD = 560;
   // Default to inline before the first measurement lands so the first frame
   // doesn't briefly render the popover trigger and snap to inline buttons.
   const showInlineComposerOptions =
@@ -2680,6 +2680,8 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     }
   }, [pendingCheckoutConfirmation, checkoutConfirming]);
 
+  const showComposerStatusBar = isNewThread === true || !!branchFromMessageId;
+
   return (
     <div className="relative px-8 py-4">
       {/* Soft gradient hint above the composer — short enough that it doesn't
@@ -3295,8 +3297,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           })()}
 
           {/* Send / Queue / Stop button */}
-          <button
+          <Button
             type="button"
+            size="icon-sm"
             onClick={
               isThreadScaffold
                 ? undefined
@@ -3314,7 +3317,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
               (!isAgentRunning && !hasContent)
             }
             className={cn(
-              "rounded-full p-1.5 transition-colors",
+              "rounded-full transition-colors",
               isThreadScaffold
                 ? "bg-primary text-primary-foreground"
                 : isAgentRunning && hasContent
@@ -3347,13 +3350,13 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             {isThreadScaffold ? (
               <Spinner size={14} className="text-current" />
             ) : isAgentRunning && hasContent ? (
-              <ArrowUp size={14} />
+              <ArrowUp />
             ) : isAgentRunning ? (
-              <div className="h-3 w-3 rounded-sm bg-current" />
+              <div className="h-4 w-4 rounded-sm bg-current" />
             ) : (
-              <ArrowUp size={14} />
+              <ArrowUp />
             )}
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -3365,50 +3368,34 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       )}
 
       {/* Status bar - below the container */}
-      <div className="flex items-center justify-between px-1 pt-1.5">
-        {!isGitRepo && isNewThread ? (
-          <span className="flex h-6 items-center rounded-md px-1.5 py-0.5 text-[10px] text-muted-foreground/40">
-            Not a git repo
-          </span>
-        ) : (
-          <ModeSelector
-            mode={branchFromMessageId ? branchExecMode : composerMode}
-            onModeChange={branchFromMessageId ? setBranchExecMode : setComposerMode}
-            locked={!isNewThread && !branchFromMessageId}
-            options={modeOptions}
-          />
+      <div
+        className={cn(
+          "grid overflow-hidden transition-[grid-template-rows,opacity,transform] duration-200 ease-[cubic-bezier(0.25,1,0.5,1)] motion-reduce:transition-none",
+          showComposerStatusBar ? "grid-rows-[1fr] opacity-100 translate-y-0" : "grid-rows-[0fr] opacity-0 translate-y-1 pointer-events-none",
         )}
-        <div className="flex items-center gap-3">
-          <TerminalStatusIndicator />
-        </div>
-        <div className="ml-auto flex items-center gap-1">
-          {isNewThread ? (
-            !isGitRepo ? null :
-            composerMode === "direct" ? (
-              <BranchPicker
-                branches={branches}
-                selectedBranch={newThreadBranch || "main"}
-                onSelect={setNewThreadBranch}
-                loading={branchesLoading}
-                locked={false}
+        aria-hidden={!showComposerStatusBar}
+      >
+        <div className="min-h-0">
+          <div className="flex items-center justify-between px-1 pt-1.5">
+            {!isGitRepo && isNewThread ? (
+              <span className="flex h-6 items-center rounded-md px-1.5 py-0.5 text-[10px] text-muted-foreground/40">
+                Not a git repo
+              </span>
+            ) : (
+              <ModeSelector
+                mode={branchFromMessageId ? branchExecMode : composerMode}
+                onModeChange={branchFromMessageId ? setBranchExecMode : setComposerMode}
+                locked={!isNewThread && !branchFromMessageId}
+                options={modeOptions}
               />
-            ) : composerMode === "worktree" ? (
-              <>
-                <BranchPicker
-                  branches={branches}
-                  selectedBranch={newThreadBranch || "main"}
-                  onSelect={setNewThreadBranch}
-                  loading={branchesLoading}
-                  locked={false}
-                  pullRequests={openPrs}
-                  prsLoading={openPrsLoading}
-                  fetchingBranch={fetchingBranch}
-                  onFetchAndSelect={handleFetchAndSelect}
-                />
-              </>
-            ) : composerMode === "existing-worktree" ? (
-              <>
-                {selectedWorktreeIsDetached && (
+            )}
+            <div className="flex items-center gap-3">
+              <TerminalStatusIndicator />
+            </div>
+            <div className="ml-auto flex items-center gap-1">
+              {isNewThread ? (
+                !isGitRepo ? null :
+                composerMode === "direct" ? (
                   <BranchPicker
                     branches={branches}
                     selectedBranch={newThreadBranch || "main"}
@@ -3416,64 +3403,82 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                     loading={branchesLoading}
                     locked={false}
                   />
-                )}
-                <Suspense fallback={<div className="h-7" />}><LazyWorktreePicker
-                  worktrees={worktrees}
-                  selectedPath={selectedWorktree?.path ?? ""}
-                  onSelect={setSelectedWorktree}
-                  loading={worktreesLoading}
-                /></Suspense>
-              </>
-            ) : null
-          ) : branchFromMessageId ? (
-            // Branch mode: show execution controls for the child thread
-            !isGitRepo ? null :
-            branchExecMode === "direct" ? (
-              <BranchPicker
-                branches={branches}
-                selectedBranch={branchTargetBranch || activeThread?.branch || ""}
-                onSelect={setBranchTargetBranch}
-                loading={branchesLoading}
-                locked={false}
-              />
-            ) : branchExecMode === "worktree" ? (
-              <>
-                <BranchPicker
-                  branches={branches}
-                  selectedBranch={branchTargetBranch || activeThread?.branch || ""}
-                  onSelect={setBranchTargetBranch}
-                  loading={branchesLoading}
-                  locked={false}
-                />
-              </>
-            ) : (
-              <>
-                {branchWorktreeIsDetached && (
+                ) : composerMode === "worktree" ? (
+                  <>
+                    <BranchPicker
+                      branches={branches}
+                      selectedBranch={newThreadBranch || "main"}
+                      onSelect={setNewThreadBranch}
+                      loading={branchesLoading}
+                      locked={false}
+                      pullRequests={openPrs}
+                      prsLoading={openPrsLoading}
+                      fetchingBranch={fetchingBranch}
+                      onFetchAndSelect={handleFetchAndSelect}
+                    />
+                  </>
+                ) : composerMode === "existing-worktree" ? (
+                  <>
+                    {selectedWorktreeIsDetached && (
+                      <BranchPicker
+                        branches={branches}
+                        selectedBranch={newThreadBranch || "main"}
+                        onSelect={setNewThreadBranch}
+                        loading={branchesLoading}
+                        locked={false}
+                      />
+                    )}
+                    <Suspense fallback={<div className="h-7" />}><LazyWorktreePicker
+                      worktrees={worktrees}
+                      selectedPath={selectedWorktree?.path ?? ""}
+                      onSelect={setSelectedWorktree}
+                      loading={worktreesLoading}
+                    /></Suspense>
+                  </>
+                ) : null
+              ) : branchFromMessageId ? (
+                // Branch mode: show execution controls for the child thread
+                !isGitRepo ? null :
+                branchExecMode === "direct" ? (
                   <BranchPicker
                     branches={branches}
-                    selectedBranch={branchTargetBranch || activeThread?.base_branch || activeThread?.branch || "main"}
+                    selectedBranch={branchTargetBranch || activeThread?.branch || ""}
                     onSelect={setBranchTargetBranch}
                     loading={branchesLoading}
                     locked={false}
                   />
-                )}
-                <Suspense fallback={<div className="h-7" />}><LazyWorktreePicker
-                  worktrees={worktrees}
-                  selectedPath={branchWorktreePath}
-                  onSelect={(wt) => setBranchWorktreePath(wt.path)}
-                  loading={worktreesLoading}
-                /></Suspense>
-              </>
-            )
-          ) : activeThread && isGitRepo ? (
-            <BranchPicker
-              branches={[]}
-              selectedBranch={resolveThreadCheckoutLabel(activeThread)}
-              onSelect={() => {}}
-              loading={false}
-              locked={true}
-            />
-          ) : null}
+                ) : branchExecMode === "worktree" ? (
+                  <>
+                    <BranchPicker
+                      branches={branches}
+                      selectedBranch={branchTargetBranch || activeThread?.branch || ""}
+                      onSelect={setBranchTargetBranch}
+                      loading={branchesLoading}
+                      locked={false}
+                    />
+                  </>
+                ) : (
+                  <>
+                    {branchWorktreeIsDetached && (
+                      <BranchPicker
+                        branches={branches}
+                        selectedBranch={branchTargetBranch || activeThread?.base_branch || activeThread?.branch || "main"}
+                        onSelect={setBranchTargetBranch}
+                        loading={branchesLoading}
+                        locked={false}
+                      />
+                    )}
+                    <Suspense fallback={<div className="h-7" />}><LazyWorktreePicker
+                      worktrees={worktrees}
+                      selectedPath={branchWorktreePath}
+                      onSelect={(wt) => setBranchWorktreePath(wt.path)}
+                      loading={worktreesLoading}
+                    /></Suspense>
+                  </>
+                )
+              ) : null}
+            </div>
+          </div>
         </div>
       </div>
       </div>{/* end max-width wrapper */}

--- a/apps/web/src/components/chat/ComposerQueueList.tsx
+++ b/apps/web/src/components/chat/ComposerQueueList.tsx
@@ -248,7 +248,7 @@ const QueueRow = memo(function QueueRow({
         className="min-w-0 flex-1 cursor-text text-left"
       >
         {previewText ? (
-          <span className="block truncate text-[12px] leading-snug text-foreground/90">
+          <span className="block truncate text-xs leading-snug text-foreground/90">
             {previewText}
           </span>
         ) : hasAnnotations ? (

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -496,8 +496,12 @@ describe("HeaderActions - consolidated header", () => {
     renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
 
     const usageTrigger = screen.getByTestId("thread-overview-usage");
+    const prAction = screen.getByTestId("thread-overview-pr");
+    const recap = screen.getByTestId("thread-overview-recap");
     expect(usageTrigger).toHaveAttribute("aria-label", "Usage, 5-hour 12%, weekly 47%");
     expect(usageTrigger).toHaveAttribute("aria-expanded", "true");
+    expect(Boolean(prAction.compareDocumentPosition(usageTrigger) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(Boolean(usageTrigger.compareDocumentPosition(recap) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(usageTrigger).toHaveTextContent("Usage");
     expect(usageTrigger).not.toHaveTextContent("5-hour 12%, weekly 47%");
     expect(screen.getByTestId("thread-overview-usage-details")).toBeVisible();

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -500,7 +500,7 @@ describe("HeaderActions - consolidated header", () => {
     const recap = screen.getByTestId("thread-overview-recap");
     expect(usageTrigger).toHaveAttribute("aria-label", "Usage, 5-hour 12%, weekly 47%");
     expect(usageTrigger).toHaveAttribute("aria-expanded", "true");
-    expect(Boolean(prAction.compareDocumentPosition(usageTrigger) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(Boolean(usageTrigger.compareDocumentPosition(prAction) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(Boolean(usageTrigger.compareDocumentPosition(recap) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(usageTrigger).toHaveTextContent("Usage");
     expect(usageTrigger).not.toHaveTextContent("5-hour 12%, weekly 47%");

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -196,7 +196,7 @@ function GoalPill({ label, condition, hint }: { label: string; condition?: strin
             aria-expanded="true"
             aria-label="Collapse goal condition"
             dir="auto"
-            className="cursor-pointer text-left font-serif text-[14px] italic leading-snug text-foreground [overflow-wrap:anywhere] hover:text-foreground/80"
+            className="cursor-pointer text-left font-serif text-sm italic leading-snug text-foreground [overflow-wrap:anywhere] hover:text-foreground/80"
           >
             &ldquo;{condition}&rdquo;
           </button>
@@ -226,7 +226,7 @@ function GoalPill({ label, condition, hint }: { label: string; condition?: strin
             aria-label="Expand full goal condition"
             title={condition}
             dir="auto"
-            className="min-w-0 cursor-pointer truncate text-left font-serif text-[14px] italic leading-snug text-foreground hover:text-foreground/80"
+            className="min-w-0 cursor-pointer truncate text-left font-serif text-sm italic leading-snug text-foreground hover:text-foreground/80"
           >
             &ldquo;{condition}&rdquo;
           </button>

--- a/apps/web/src/components/chat/OpenInAppButton.tsx
+++ b/apps/web/src/components/chat/OpenInAppButton.tsx
@@ -94,14 +94,13 @@ export function OpenInAppButton({ dirPath, threadId, threadOverride }: OpenInApp
             render={
               <Button
                 variant="ghost"
-                size="xs"
-                className="gap-1 text-xs text-foreground/70 hover:text-foreground hover:bg-muted/40 h-6 rounded-r-none"
+                size="icon-xs"
+                className="text-foreground/70 hover:text-foreground hover:bg-muted/40 rounded-r-none"
                 onClick={openDefault}
                 disabled={disabled}
                 aria-label={`Open in ${resolvedLabel}`}
               >
-                {openInAppIcon(resolvedApp?.iconKey ?? FILE_EXPLORER_ID, 14)}
-                <span>Open</span>
+                {openInAppIcon(resolvedApp?.iconKey ?? FILE_EXPLORER_ID, 16)}
               </Button>
             }
           />
@@ -115,7 +114,7 @@ export function OpenInAppButton({ dirPath, threadId, threadOverride }: OpenInApp
             aria-label="Choose app to open in"
             disabled={disabled}
             className={cn(
-              "inline-flex items-center px-1 h-6 text-xs border-l border-border/20 rounded-r transition-colors outline-none",
+              "inline-flex h-8 items-center px-1.5 text-xs border-l border-border/20 rounded-r transition-colors outline-none",
               "text-foreground/70 hover:text-foreground hover:bg-muted/40 focus-visible:ring-1 focus-visible:ring-ring",
               "disabled:opacity-50 disabled:pointer-events-none",
             )}

--- a/apps/web/src/components/chat/PlanQuestionWizard.tsx
+++ b/apps/web/src/components/chat/PlanQuestionWizard.tsx
@@ -274,13 +274,13 @@ export function PlanQuestionWizard({ threadId }: PlanQuestionWizardProps) {
                 <span className="font-mono text-[10px] tabular-nums tracking-[0.12em] text-muted-foreground/45">
                   {formatStep(i + 1, displayQuestions.length)}
                 </span>
-                <span className="flex-1 truncate text-[12px] text-muted-foreground/60">
+                <span className="flex-1 truncate text-xs text-muted-foreground/60">
                   {prev.question}
                 </span>
                 <span className="flex-shrink-0 max-w-[140px] truncate text-[11.5px] font-medium text-muted-foreground">
                   {answerLabel}
                 </span>
-                <span className="text-[12px] text-[oklch(0.48_0.14_145)]" aria-hidden="true">
+                <span className="text-xs text-[oklch(0.48_0.14_145)]" aria-hidden="true">
                   ✓
                 </span>
               </button>

--- a/apps/web/src/components/chat/PreviewAnnotationBundleChip.tsx
+++ b/apps/web/src/components/chat/PreviewAnnotationBundleChip.tsx
@@ -67,7 +67,7 @@ export function PreviewAnnotationBundleChip({
             tabIndex={0}
             aria-label={`${label}. Annotation details available.`}
             className={cn(
-              "group inline-flex max-w-full items-center gap-2 rounded-lg border border-primary/35 bg-primary/10 px-2 py-1 text-xs font-medium text-primary shadow-sm transition-colors hover:border-primary/55 hover:bg-primary/15 focus-visible:border-primary/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35",
+              "group inline-flex max-w-full items-center gap-2 rounded-lg border border-accent-foreground/10 bg-accent px-2 py-1 text-xs font-medium text-accent-foreground shadow-sm transition-colors hover:border-accent-foreground/15 hover:bg-accent/90 focus-visible:border-accent-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-foreground/20",
               className,
             )}
           >
@@ -83,7 +83,7 @@ export function PreviewAnnotationBundleChip({
                   event.stopPropagation();
                   onRemove();
                 }}
-                className="pointer-events-none -ml-1 text-primary opacity-0 transition-opacity hover:bg-primary/10 focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+                className="pointer-events-none -ml-1 text-accent-foreground/70 opacity-0 transition-opacity hover:bg-accent-foreground/10 hover:text-accent-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
               >
                 <X size={12} aria-hidden />
               </Button>

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -2003,6 +2003,18 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
               </Button>
             ) : null}
 
+            {usageSummary && (
+              <>
+                <Separator className="my-1.5" />
+                <ThreadOverviewUsageBars
+                  categories={usageCategories}
+                  summary={usageSummary}
+                  sessionCostSummary={sessionCostSummary}
+                  usageStatus={usageInfo?.usageStatus}
+                />
+              </>
+            )}
+
             {canShowPrActions && (
               <ThreadOverviewPrRow
                 pr={pr}
@@ -2014,18 +2026,6 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                 onCreatePr={() => setCreatePrOpen(true)}
                 onOpenPr={handleOpenPr}
               />
-            )}
-
-            {usageSummary && (
-              <>
-                <Separator className="my-1.5" />
-                <ThreadOverviewUsageBars
-                  categories={usageCategories}
-                  summary={usageSummary}
-                  sessionCostSummary={sessionCostSummary}
-                  usageStatus={usageInfo?.usageStatus}
-                />
-              </>
             )}
 
             {sources.length > 0 && (

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1988,15 +1988,6 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
               </Popover>
             )}
 
-            {usageSummary && (
-              <ThreadOverviewUsageBars
-                categories={usageCategories}
-                summary={usageSummary}
-                sessionCostSummary={sessionCostSummary}
-                usageStatus={usageInfo?.usageStatus}
-              />
-            )}
-
             {branchlessCreatePr ? (
               <Button
                 variant="ghost"
@@ -2023,6 +2014,18 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                 onCreatePr={() => setCreatePrOpen(true)}
                 onOpenPr={handleOpenPr}
               />
+            )}
+
+            {usageSummary && (
+              <>
+                <Separator className="my-1.5" />
+                <ThreadOverviewUsageBars
+                  categories={usageCategories}
+                  summary={usageSummary}
+                  sessionCostSummary={sessionCostSummary}
+                  usageStatus={usageInfo?.usageStatus}
+                />
+              </>
             )}
 
             {sources.length > 0 && (

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -321,6 +321,7 @@ describe("Composer checkout confirmation", () => {
     expect(mockTransport.createAndSendMessage).not.toHaveBeenCalled();
     expect(screen.getByLabelText("Message Mcode")).toHaveValue("Build this");
     expect(screen.getByLabelText("Send message")).toBeEnabled();
+    expect(screen.getByLabelText("Send message")).toHaveClass("size-8");
   });
 
   it("does not inspect or checkout the workspace branch for worktree modes", async () => {
@@ -367,6 +368,10 @@ describe("Composer checkout confirmation", () => {
 
     expect(screen.getByTestId("composer-annotation-bundle")).toHaveTextContent(
       "1 annotation",
+    );
+    expect(screen.getByTestId("composer-annotation-bundle")).toHaveClass(
+      "bg-accent",
+      "text-accent-foreground",
     );
     await userEvent.click(screen.getByLabelText("Send message"));
 

--- a/apps/web/src/components/diff/CommitsView.tsx
+++ b/apps/web/src/components/diff/CommitsView.tsx
@@ -81,7 +81,7 @@ export function CommitsView() {
   if (!commits || commits.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-14">
-        <span aria-hidden="true" className="font-mono text-[28px] leading-none text-muted-foreground/15">
+        <span aria-hidden="true" className="font-mono text-2xl leading-none text-muted-foreground/15">
           ◌
         </span>
         <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">

--- a/apps/web/src/components/diff/CumulativeView.tsx
+++ b/apps/web/src/components/diff/CumulativeView.tsx
@@ -90,7 +90,7 @@ export function CumulativeView({ snapshots, threadId }: CumulativeViewProps) {
   if (files.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 py-14">
-        <span aria-hidden="true" className="font-mono text-[28px] leading-none text-muted-foreground/15">
+        <span aria-hidden="true" className="font-mono text-2xl leading-none text-muted-foreground/15">
           ⊘
         </span>
         <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">

--- a/apps/web/src/components/diff/DiffContent.tsx
+++ b/apps/web/src/components/diff/DiffContent.tsx
@@ -67,7 +67,7 @@ export function DiffContent() {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-4 border-t border-border/20">
         {/* Registration mark — a typographic blank canvas */}
-        <span aria-hidden="true" className="font-mono text-[28px] leading-none text-muted-foreground/15">
+        <span aria-hidden="true" className="font-mono text-2xl leading-none text-muted-foreground/15">
           ⊕
         </span>
         <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">

--- a/apps/web/src/components/diff/DiffPreviewMarkdown.tsx
+++ b/apps/web/src/components/diff/DiffPreviewMarkdown.tsx
@@ -31,7 +31,7 @@ const COMPONENTS: Components = {
       return (
         <Suspense
           fallback={
-            <pre className="rounded bg-muted/30 p-3 text-[12px] font-mono overflow-x-auto">
+            <pre className="rounded bg-muted/30 p-3 text-xs font-mono overflow-x-auto">
               <code>{code}</code>
             </pre>
           }
@@ -106,8 +106,8 @@ export default function DiffPreviewMarkdown({
         "[&_p]:leading-relaxed",
         "[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5",
         "[&_li]:my-1",
-        "[&_code]:rounded [&_code]:bg-muted/40 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[12px] [&_code]:font-mono",
-        "[&_pre]:rounded [&_pre]:bg-muted/30 [&_pre]:p-3 [&_pre]:text-[12px] [&_pre]:font-mono [&_pre]:overflow-x-auto",
+        "[&_code]:rounded [&_code]:bg-muted/40 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-xs [&_code]:font-mono",
+        "[&_pre]:rounded [&_pre]:bg-muted/30 [&_pre]:p-3 [&_pre]:text-xs [&_pre]:font-mono [&_pre]:overflow-x-auto",
         // Blockquote: indented italic with a faint bg tint instead of a
         // left stripe (border-l > 1px is banned per impeccable).
         "[&_blockquote]:bg-muted/15 [&_blockquote]:px-3 [&_blockquote]:py-1 [&_blockquote]:italic [&_blockquote]:text-muted-foreground [&_blockquote]:rounded-sm",

--- a/apps/web/src/components/diff/GitDiffView.tsx
+++ b/apps/web/src/components/diff/GitDiffView.tsx
@@ -45,7 +45,7 @@ function branchRangeForReview(
 function EmptyState({ label }: { label: string }) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-3 py-14">
-      <span aria-hidden="true" className="font-mono text-[28px] leading-none text-muted-foreground/15">
+      <span aria-hidden="true" className="font-mono text-2xl leading-none text-muted-foreground/15">
         ⊘
       </span>
       <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">

--- a/apps/web/src/components/diff/LastTurnView.tsx
+++ b/apps/web/src/components/diff/LastTurnView.tsx
@@ -95,7 +95,7 @@ export function LastTurnView({ snapshots, threadId }: LastTurnViewProps) {
     }
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 py-14">
-        <span aria-hidden="true" className="font-mono text-[28px] leading-none text-muted-foreground/15">
+        <span aria-hidden="true" className="font-mono text-2xl leading-none text-muted-foreground/15">
           ⊘
         </span>
         <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">

--- a/apps/web/src/components/diff/SideBySideDiff.tsx
+++ b/apps/web/src/components/diff/SideBySideDiff.tsx
@@ -136,7 +136,7 @@ export const SideBySideDiff = memo(function SideBySideDiff({
   };
 
   return (
-    <div className="flex select-text text-[12px] font-mono leading-5">
+    <div className="flex select-text text-xs font-mono leading-5">
       {/* Left (removed) */}
       <div className={`flex-1 border-r border-border/15 ${lineWrap ? "overflow-x-hidden" : "overflow-x-auto"}`}>
         <div className={lineWrap ? "w-full" : "w-fit min-w-full"}>

--- a/apps/web/src/components/diff/SummaryView.tsx
+++ b/apps/web/src/components/diff/SummaryView.tsx
@@ -321,7 +321,7 @@ export function SummaryView() {
   // Empty state — glyph + mono small-caps matching sibling diff views
   return (
     <div className="flex flex-col items-center justify-center gap-3 py-14">
-      <span aria-hidden="true" className="font-mono text-[28px] leading-none text-muted-foreground/20">Σ</span>
+      <span aria-hidden="true" className="font-mono text-2xl leading-none text-muted-foreground/20">Σ</span>
       <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">
         no summary
       </p>

--- a/apps/web/src/components/diff/TurnTimeline.tsx
+++ b/apps/web/src/components/diff/TurnTimeline.tsx
@@ -15,7 +15,7 @@ export function TurnTimeline({ snapshots }: TurnTimelineProps) {
   if (withFiles.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-14">
-        <span aria-hidden="true" className="font-mono text-[28px] leading-none text-muted-foreground/15">
+        <span aria-hidden="true" className="font-mono text-2xl leading-none text-muted-foreground/15">
           ⊘
         </span>
         <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">

--- a/apps/web/src/components/diff/UnifiedDiff.tsx
+++ b/apps/web/src/components/diff/UnifiedDiff.tsx
@@ -35,7 +35,7 @@ export const UnifiedDiff = memo(function UnifiedDiff({
   const firstHunkHeaderIndex = skipLeadingHunkSeparator ? getFirstHunkHeaderIndex(lines) : -1;
 
   return (
-    <div className={`select-text text-[12px] font-mono leading-5 ${lineWrap ? "overflow-x-hidden" : "overflow-x-auto"}`}>
+    <div className={`select-text text-xs font-mono leading-5 ${lineWrap ? "overflow-x-hidden" : "overflow-x-auto"}`}>
       <div className={lineWrap ? "w-full" : "w-fit min-w-full"}>
       {lines.map((line, i) => {
         if (line.type === "header") {

--- a/apps/web/src/components/palette/CommandPalette.tsx
+++ b/apps/web/src/components/palette/CommandPalette.tsx
@@ -158,7 +158,7 @@ function PaletteInput({
           // Reserve right padding for the Add chip when it's visible so the
           // typed path doesn't get hidden under it.
           "flex h-10 w-full rounded-md bg-transparent py-3 text-[13.5px] outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 " +
-          (browseMode ? "pe-[5.5rem]" : "")
+          (browseMode ? "pe-44" : "")
         }
       />
       {browseMode && (
@@ -173,7 +173,7 @@ function PaletteInput({
           }}
           onClick={onAddClick}
           title={`Add this folder as a project (${modKey}+Enter)`}
-          className="absolute end-2.5 top-1/2 -translate-y-1/2"
+          className="absolute end-3 top-1/2 -translate-y-1/2"
         >
           Add
           <Kbd variant="inline">{modKey}+Enter</Kbd>

--- a/apps/web/src/components/palette/CommandPalette.tsx
+++ b/apps/web/src/components/palette/CommandPalette.tsx
@@ -173,7 +173,7 @@ function PaletteInput({
           }}
           onClick={onAddClick}
           title={`Add this folder as a project (${modKey}+Enter)`}
-          className="absolute end-2.5 top-1/2 -translate-y-1/2 h-7 gap-1 px-2 text-[11px]"
+          className="absolute end-2.5 top-1/2 -translate-y-1/2"
         >
           Add
           <Kbd variant="inline">{modKey}+Enter</Kbd>

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -339,12 +339,12 @@ function RailAddControl({
       <Button
         variant="ghost"
         size="icon-xs"
-        className="h-9 w-9 text-muted-foreground hover:text-foreground"
+        className="text-muted-foreground hover:text-foreground"
         title={`New ${only.label}`}
         aria-label={`New ${only.label}`}
         onClick={() => onCreate(only.id as RightPanelTab)}
       >
-        <Plus size={16} />
+        <Plus />
       </Button>
     );
   }
@@ -356,11 +356,11 @@ function RailAddControl({
           <Button
             variant="ghost"
             size="icon-xs"
-            className="h-9 w-9 text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:text-foreground"
             title="New tab"
             aria-label="New tab"
           >
-            <Plus size={16} />
+            <Plus />
           </Button>
         }
       />
@@ -444,13 +444,13 @@ export function ActivityRail({
         variant="ghost"
         size="icon-xs"
         onClick={onToggleMaximized}
-        className="h-7 w-7 shrink-0 text-muted-foreground/70 transition-colors hover:bg-transparent hover:text-foreground"
+        className="shrink-0 text-muted-foreground/70 transition-colors hover:bg-transparent hover:text-foreground"
         aria-label={maximized ? "Restore panel" : "Maximize panel"}
         title={maximized ? "Restore panel" : "Maximize panel"}
         data-testid="rail-maximize-toggle"
         data-preview-design-keep-open="true"
       >
-        {maximized ? <Minimize2 size={13} /> : <Maximize2 size={13} />}
+        {maximized ? <Minimize2 /> : <Maximize2 />}
       </Button>
 
       {openTabs.map((id) => {

--- a/apps/web/src/components/panels/BrowserOverflowMenu.tsx
+++ b/apps/web/src/components/panels/BrowserOverflowMenu.tsx
@@ -124,9 +124,9 @@ export function BrowserOverflowMenu({
             variant="ghost"
             size="icon-xs"
             aria-label="More browser tools"
-            className="size-7 text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:text-foreground"
           >
-            <EllipsisVertical size={15} aria-hidden />
+            <EllipsisVertical aria-hidden />
           </Button>
         }
       />
@@ -211,10 +211,9 @@ export function BrowserOverflowMenu({
               size="icon-xs"
               aria-label="Zoom out"
               disabled={!hasLoadedPage}
-              className="size-5"
               onClick={() => applyZoom(zoom - ZOOM_STEP)}
             >
-              <Minus size={12} aria-hidden />
+              <Minus aria-hidden />
             </Button>
             <span className="w-9 text-center tabular-nums" aria-live="polite">
               {Math.round(zoom * 100)}%
@@ -225,10 +224,9 @@ export function BrowserOverflowMenu({
               size="icon-xs"
               aria-label="Zoom in"
               disabled={!hasLoadedPage}
-              className="size-5"
               onClick={() => applyZoom(zoom + ZOOM_STEP)}
             >
-              <Plus size={12} aria-hidden />
+              <Plus aria-hidden />
             </Button>
             <Button
               type="button"
@@ -236,10 +234,10 @@ export function BrowserOverflowMenu({
               size="icon-xs"
               aria-label="Reset zoom"
               disabled={!hasLoadedPage}
-              className="ml-1 size-5"
+              className="ml-1"
               onClick={() => applyZoom(1)}
             >
-              <RotateCw size={11} aria-hidden />
+              <RotateCw aria-hidden />
             </Button>
           </span>
         </div>

--- a/apps/web/src/components/panels/plan/PlanDocument.tsx
+++ b/apps/web/src/components/panels/plan/PlanDocument.tsx
@@ -126,7 +126,7 @@ export function PlanDocument({
             aria-label={`${text}. Activate to ${isOpen ? "close" : "add"} a section note.`}
             className={cn(
               HEADING_BASE,
-              level === 1 && "text-sm font-semibold",
+              level === 1 && "text-base font-semibold",
               level === 2 && "text-[13.5px] font-semibold",
               level === 3 && "text-[13px] font-medium",
             )}

--- a/apps/web/src/components/panels/plan/PlanDocument.tsx
+++ b/apps/web/src/components/panels/plan/PlanDocument.tsx
@@ -126,7 +126,7 @@ export function PlanDocument({
             aria-label={`${text}. Activate to ${isOpen ? "close" : "add"} a section note.`}
             className={cn(
               HEADING_BASE,
-              level === 1 && "text-[14px] font-semibold",
+              level === 1 && "text-sm font-semibold",
               level === 2 && "text-[13.5px] font-semibold",
               level === 3 && "text-[13px] font-medium",
             )}

--- a/apps/web/src/components/projects/ProjectSelectorLanding.tsx
+++ b/apps/web/src/components/projects/ProjectSelectorLanding.tsx
@@ -4,6 +4,7 @@ import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
 import { useProjectSelectorStore } from "@/stores/projectSelectorStore";
 import { useRecentThreadsStore } from "@/stores/recentThreadsStore";
 import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
 import { ProjectRow } from "./ProjectRow";
 import { RecentThreadRow } from "./RecentThreadRow";
 import { Kbd } from "../palette/Kbd";
@@ -168,11 +169,12 @@ export function ProjectSelectorLanding() {
             data-testid="landing-add-project"
             variant="outline"
             draggable={false}
+            size="sm"
             onDragStart={(e) => e.preventDefault()}
             onClick={handleAdd}
-            className="group mt-2 w-full gap-2 py-2.5 text-[12.5px] text-foreground/80"
+            className="group mt-2 w-full gap-2 text-foreground/80"
           >
-            <span aria-hidden className="text-base leading-none text-muted-foreground/60 group-hover:text-foreground">+</span>
+            <Plus aria-hidden className="text-muted-foreground/60 group-hover:text-foreground" />
             Add project
           </Button>
         </div>
@@ -185,11 +187,12 @@ export function ProjectSelectorLanding() {
           <Button
             data-testid="landing-add-project"
             draggable={false}
+            size="md"
             onDragStart={(e) => e.preventDefault()}
             onClick={handleAdd}
-            className="gap-2 px-4 py-2 text-[13px]"
+            className="gap-2"
           >
-            <span aria-hidden className="text-base leading-none">+</span>
+            <Plus aria-hidden />
             Open a folder
           </Button>
         </div>

--- a/apps/web/src/components/settings/SearchableGroupedPicker.tsx
+++ b/apps/web/src/components/settings/SearchableGroupedPicker.tsx
@@ -107,7 +107,7 @@ export function SearchableGroupedPicker({
             aria-expanded={open}
             aria-haspopup="dialog"
             className={cn(
-              "h-8 min-w-[220px] max-w-[280px] justify-between gap-2 px-2.5 text-xs font-normal",
+              "min-w-[220px] max-w-[280px] justify-between font-normal",
               (disabled || loading) && "opacity-60",
             )}
           >

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -753,7 +753,7 @@ export function ProjectTree() {
             return (filteredThreadsByWorkspace.get(ws.id) ?? []).length === 0;
           }) && serverResults.length === 0 && (
             <div className="flex flex-col items-center justify-center gap-2 px-4 py-8">
-              <span className="font-mono text-[28px] text-muted-foreground/15" aria-hidden>&#x2298;</span>
+              <span className="font-mono text-2xl text-muted-foreground/15" aria-hidden>&#x2298;</span>
               <p className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/40">
                 No matching threads
               </p>
@@ -1664,7 +1664,7 @@ const ProjectNode = memo(function ProjectNode({
         <div className="pl-2">
           {threads.length === 0 ? (
             <div className="flex items-center gap-2 px-2 py-2">
-              <span aria-hidden="true" className="font-mono text-[12px] leading-none text-muted-foreground/25">
+              <span aria-hidden="true" className="font-mono text-xs leading-none text-muted-foreground/25">
                 ◌
               </span>
               <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground/40">

--- a/apps/web/src/components/terminal/TerminalList.tsx
+++ b/apps/web/src/components/terminal/TerminalList.tsx
@@ -63,7 +63,7 @@ export const TerminalList = memo(function TerminalList({
                 />
               }
             >
-              <ChevronsLeft className="size-3.5 rotate-180" />
+              <ChevronsLeft className="rotate-180" />
             </TooltipTrigger>
             <TooltipContent side="right" className="text-xs">
               Expand sidebar
@@ -83,13 +83,13 @@ export const TerminalList = memo(function TerminalList({
                         variant="ghost"
                         size="icon-xs"
                         onClick={() => setActiveTerminal(threadId, terminal.id)}
-                        className="size-7 bg-transparent hover:bg-transparent active:translate-y-0 active:bg-transparent"
+                        className="bg-transparent hover:bg-transparent active:translate-y-0 active:bg-transparent"
                         aria-label={terminal.label}
                         aria-current={isActive ? "true" : undefined}
                       />
                     }
                   >
-                    <Terminal className="size-3.5" />
+                    <Terminal />
                   </TooltipTrigger>
                   <TooltipContent side="right" className="text-xs">
                     {terminal.label}
@@ -119,7 +119,7 @@ export const TerminalList = memo(function TerminalList({
               />
             }
           >
-            <ChevronsLeft className="size-3.5" />
+            <ChevronsLeft />
           </TooltipTrigger>
           <TooltipContent side="bottom" className="text-xs">
             Collapse
@@ -137,7 +137,7 @@ export const TerminalList = memo(function TerminalList({
               />
             }
           >
-            <Plus className="size-3.5" />
+            <Plus />
           </TooltipTrigger>
           <TooltipContent side="bottom" className="text-xs">
             New terminal
@@ -155,7 +155,7 @@ export const TerminalList = memo(function TerminalList({
               />
             }
           >
-            <Trash2 className="size-3.5" />
+            <Trash2 />
           </TooltipTrigger>
           <TooltipContent side="bottom" className="text-xs">
             Kill all
@@ -178,7 +178,7 @@ export const TerminalList = memo(function TerminalList({
               >
                 <Terminal
                   className={cn(
-                    "size-3.5 shrink-0",
+                    "shrink-0",
                     isActive ? "opacity-70" : "opacity-40",
                   )}
                 />
@@ -195,11 +195,11 @@ export const TerminalList = memo(function TerminalList({
                 type="button"
                 variant="ghost"
                 size="icon-xs"
-                className="size-6 shrink-0 bg-transparent opacity-0 transition-opacity hover:bg-transparent active:translate-y-0 active:bg-transparent focus-visible:opacity-100 group-hover:opacity-60"
+                className="shrink-0 bg-transparent opacity-0 transition-opacity hover:bg-transparent active:translate-y-0 active:bg-transparent focus-visible:opacity-100 group-hover:opacity-60"
                 onClick={() => onClose(terminal.id)}
                 aria-label={`Close ${terminal.label}`}
               >
-                <X className="size-2.5" />
+                <X />
               </Button>
             </div>
           );

--- a/apps/web/src/components/terminal/TerminalToolbar.tsx
+++ b/apps/web/src/components/terminal/TerminalToolbar.tsx
@@ -33,7 +33,7 @@ export const TerminalToolbar = memo(function TerminalToolbar({
             />
           }
         >
-          <Columns2 className="size-3.5" />
+          <Columns2 />
         </TooltipTrigger>
         <TooltipContent side="bottom" className="text-xs">
           Toggle terminal list
@@ -51,7 +51,7 @@ export const TerminalToolbar = memo(function TerminalToolbar({
             />
           }
         >
-          <Plus className="size-3.5" />
+          <Plus />
         </TooltipTrigger>
         <TooltipContent side="bottom" className="text-xs">
           New terminal
@@ -69,7 +69,7 @@ export const TerminalToolbar = memo(function TerminalToolbar({
             />
           }
         >
-          <Trash2 className="size-3.5" />
+          <Trash2 />
         </TooltipTrigger>
         <TooltipContent side="bottom" className="text-xs">
           Kill all

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent text-xs leading-4 font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {
@@ -21,8 +21,8 @@ const badgeVariants = cva(
         link: "text-link underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-5 px-2 py-0.5",
-        sm: "h-4 px-1.5 py-0 [&>svg]:size-2.5!",
+        default: "h-5 px-2 py-0",
+        sm: "h-4 px-1 py-0 [&>svg]:size-3!",
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -23,11 +23,11 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 text-sm has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-8 gap-1.5 px-2.5 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        sm: "h-8 gap-1.5 px-2.5 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+          "h-8 gap-2 px-3 text-sm has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-8 gap-2 px-3 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-8 gap-2 px-3 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         md: "h-12 gap-2 px-3 text-base has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3 [&_svg:not([class*='size-'])]:size-6",
-        lg: "h-14 gap-2.5 px-4 text-lg has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4 [&_svg:not([class*='size-'])]:size-8",
+        lg: "h-14 gap-2 px-4 text-lg has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4 [&_svg:not([class*='size-'])]:size-8",
         icon: "size-8",
         "icon-xs": "size-8 in-data-[slot=button-group]:rounded-lg",
         "icon-sm": "size-8 in-data-[slot=button-group]:rounded-lg",

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -23,16 +23,16 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+          "h-8 gap-1.5 px-2.5 text-sm has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-8 gap-1.5 px-2.5 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-8 gap-1.5 px-2.5 text-sm in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        md: "h-12 gap-2 px-3 text-base has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3 [&_svg:not([class*='size-'])]:size-6",
+        lg: "h-14 gap-2.5 px-4 text-lg has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4 [&_svg:not([class*='size-'])]:size-8",
         icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
+        "icon-xs": "size-8 in-data-[slot=button-group]:rounded-lg",
+        "icon-sm": "size-8 in-data-[slot=button-group]:rounded-lg",
+        "icon-md": "size-12 [&_svg:not([class*='size-'])]:size-6",
+        "icon-lg": "size-14 [&_svg:not([class*='size-'])]:size-8",
       },
     },
     defaultVariants: {
@@ -42,6 +42,7 @@ const buttonVariants = cva(
   }
 )
 
+/** Shared button primitive with Mcode control-scale variants. */
 function Button({
   className,
   variant = "default",

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -4,13 +4,15 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const inputVariants = cva(
-  "flex w-full border border-input bg-background shadow-xs transition-colors file:border-0 file:bg-transparent file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+  "flex w-full border border-input bg-input shadow-xs transition-colors file:border-0 file:bg-transparent file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       size: {
         default: "h-8 rounded-lg px-3 py-1 text-sm file:text-sm",
-        sm: "h-7 rounded-[min(var(--radius-md),12px)] px-2 py-0.5 text-xs file:text-xs",
-        xs: "h-6 rounded-[min(var(--radius-md),10px)] px-1.5 py-0.5 text-xs file:text-xs",
+        sm: "h-8 rounded-lg px-3 py-1 text-sm file:text-sm",
+        xs: "h-8 rounded-lg px-3 py-1 text-sm file:text-sm",
+        md: "h-12 rounded-lg px-3 py-2 text-base file:text-base",
+        lg: "h-14 rounded-lg px-4 py-2 text-lg file:text-lg",
       },
     },
     defaultVariants: {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -38,7 +38,6 @@
   --chart-3: oklch(0.439 0.005 260);
   --chart-4: oklch(0.371 0.005 260);
   --chart-5: oklch(0.269 0.005 260);
-  --radius: 1rem;
   --sidebar: oklch(0.945 0.008 260);
   --sidebar-foreground: oklch(0.18 0.005 260);
   --sidebar-primary: oklch(0.52 0.17 75);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3,6 +3,8 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
+@source inline("text-xs text-sm text-base text-lg text-xl text-2xl text-3xl text-4xl text-5xl rounded-sm rounded-md rounded-lg rounded-xl rounded-2xl rounded-3xl rounded-4xl h-8 h-12 h-14 w-8 w-12 w-14 size-8 size-12 size-14 p-4 gap-4");
+
 @custom-variant dark (&:is(.dark *));
 
 :root {
@@ -36,7 +38,7 @@
   --chart-3: oklch(0.439 0.005 260);
   --chart-4: oklch(0.371 0.005 260);
   --chart-5: oklch(0.269 0.005 260);
-  --radius: 0.625rem;
+  --radius: 1rem;
   --sidebar: oklch(0.945 0.008 260);
   --sidebar-foreground: oklch(0.18 0.005 260);
   --sidebar-primary: oklch(0.52 0.17 75);
@@ -110,6 +112,25 @@
 }
 
 @theme inline {
+  --spacing: 0.4rem;
+  --text-xs: 1.2rem;
+  --text-xs--line-height: 1.6rem;
+  --text-sm: 1.4rem;
+  --text-sm--line-height: 1.6rem;
+  --text-base: 1.6rem;
+  --text-base--line-height: 2rem;
+  --text-lg: 2rem;
+  --text-lg--line-height: 2.4rem;
+  --text-xl: 2.4rem;
+  --text-xl--line-height: 2.8rem;
+  --text-2xl: 2.8rem;
+  --text-2xl--line-height: 3.2rem;
+  --text-3xl: 3.2rem;
+  --text-3xl--line-height: 4rem;
+  --text-4xl: 4rem;
+  --text-4xl--line-height: 4.8rem;
+  --text-5xl: 4.8rem;
+  --text-5xl--line-height: 5.6rem;
   --font-sans: "Public Sans", ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-mono: "SF Mono", "Cascadia Code", "Consolas", monospace;
   --color-page: var(--page);
@@ -145,13 +166,13 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-sm: 0.6rem;
+  --radius-md: 0.8rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.4rem;
+  --radius-2xl: 1.8rem;
+  --radius-3xl: 2.2rem;
+  --radius-4xl: 2.6rem;
 }
 
 
@@ -564,6 +585,7 @@
   }
   html {
     @apply font-sans;
+    font-size: 62.5%;
     overflow: hidden;
     height: 100%;
   }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -14,21 +14,21 @@ function renderTransportError(root: HTMLElement, error: unknown): void {
   const container = document.createElement("div");
   container.style.cssText =
     "display:flex;flex-direction:column;align-items:center;justify-content:center;" +
-    "height:100vh;font-family:system-ui,sans-serif;color:#e5e5e5;background:#18181b;gap:16px;padding:24px;";
+    "height:100vh;font-family:var(--font-sans);color:var(--foreground);background:var(--background);gap:1.6rem;padding:2.4rem;";
 
   const heading = document.createElement("h1");
   heading.textContent = "Failed to connect";
-  heading.style.cssText = "margin:0;font-size:1.5rem;";
+  heading.style.cssText = "margin:0;font-size:2.4rem;line-height:2.8rem;";
 
   const detail = document.createElement("p");
   detail.textContent = message;
-  detail.style.cssText = "margin:0;color:#a1a1aa;max-width:480px;text-align:center;";
+  detail.style.cssText = "margin:0;color:var(--muted-foreground);max-width:48rem;text-align:center;font-size:1.4rem;line-height:1.6rem;";
 
   const button = document.createElement("button");
   button.textContent = "Retry";
   button.style.cssText =
-    "padding:8px 20px;border-radius:6px;border:1px solid #3f3f46;background:#27272a;" +
-    "color:#e5e5e5;cursor:pointer;font-size:0.875rem;";
+    "height:3.2rem;padding:0 1.2rem;border-radius:var(--radius-lg);border:1px solid var(--border);background:var(--secondary);" +
+    "color:var(--secondary-foreground);cursor:pointer;font-size:1.4rem;line-height:1.6rem;font-weight:500;";
   button.addEventListener("click", () => window.location.reload());
 
   container.append(heading, detail, button);
@@ -40,11 +40,11 @@ function renderConnecting(container: HTMLElement): void {
   const el = document.createElement("div");
   el.style.cssText =
     "display:flex;flex-direction:column;align-items:center;justify-content:center;" +
-    "height:100vh;font-family:system-ui,sans-serif;color:#a1a1aa;background:#18181b;gap:12px;";
+    "height:100vh;font-family:var(--font-sans);color:var(--muted-foreground);background:var(--background);gap:1.2rem;";
 
   const spinner = document.createElement("div");
   spinner.style.cssText =
-    "width:24px;height:24px;border:2px solid #3f3f46;border-top-color:#a1a1aa;" +
+    "width:2.4rem;height:2.4rem;border:0.2rem solid var(--border);border-top-color:var(--muted-foreground);" +
     "border-radius:50%;animation:spin 0.8s linear infinite;";
 
   const style = document.createElement("style");
@@ -52,7 +52,7 @@ function renderConnecting(container: HTMLElement): void {
 
   const label = document.createElement("p");
   label.textContent = "Connecting to server...";
-  label.style.cssText = "margin:0;font-size:0.875rem;";
+  label.style.cssText = "margin:0;font-size:1.4rem;line-height:1.6rem;";
 
   el.append(spinner, label);
   container.append(style, el);

--- a/docs/design-scale-audit.md
+++ b/docs/design-scale-audit.md
@@ -1,0 +1,200 @@
+# Design Scale Audit
+
+Audit date: July 7, 2026.
+
+## Scope
+
+This phase normalized the global design primitives, shared Button/Input/Badge scale, and obvious scale values in bounded shared UI surfaces. The audit covered every file under `apps/web/src`.
+
+## Commands And Patterns
+
+Counts came from `rg` over `apps/web/src` with these patterns:
+
+| Category | Pattern |
+| --- | --- |
+| Raw px | `rg -n -P "(?<![A-Za-z0-9_-])\d+(?:\.\d+)?px" apps/web/src` |
+| Arbitrary text | `text-\[[^\]]+\]` |
+| Arbitrary spacing/sizing | `(?:h\|w\|min-h\|min-w\|max-h\|max-w\|size\|p\|px\|py\|pt\|pr\|pb\|pl\|m\|mx\|my\|mt\|mr\|mb\|ml\|gap\|space-x\|space-y\|top\|right\|bottom\|left\|inset\|translate-x\|translate-y)-\[[^\]]+\]` |
+| Arbitrary radii | `rounded(?:-[trbl]{1,2})?-\[[^\]]+\]` |
+| Raw colors | `(?:#[0-9a-fA-F]{3,8}\|rgb\(\|rgba\(\|hsl\(\|hsla\()` |
+| Raw buttons | `<button(?:\s\|>)` |
+| Raw inputs | `<input(?:\s\|>)` |
+| Off-scale icons | `(?:size\|h\|w)-(?:2\.5\|3\|3\.5\|4\.5\|5\|6\|7\|9\|10\|11\|12)(?![\d.])` plus arbitrary icon pixel sizes |
+
+## Counts
+
+| Category | Before | After |
+| --- | ---: | ---: |
+| Raw px | 501 | 501 |
+| Arbitrary text | 355 | 335 |
+| Arbitrary spacing/sizing | 145 | 145 |
+| Arbitrary radii | 26 | 20 |
+| Raw colors | 136 | 130 |
+| Raw buttons | 299 | 299 |
+| Raw inputs | 30 | 32 |
+| Off-scale icons | 0 | 0 |
+
+The raw input count rose because focused component tests now render `Input` variants directly.
+
+The raw-px count uses PCRE2 lookbehind through `rg -P`; the current documented count matches `rg -n -P "(?<![A-Za-z0-9_-])\d+(?:\.\d+)?px" apps/web/src | Measure-Object`.
+
+## Files Normalized
+
+- `apps/web/src/index.css`
+- `apps/web/src/app/App.tsx`
+- `apps/web/src/main.tsx`
+- `apps/web/src/components/ui/button.tsx`
+- `apps/web/src/components/ui/input.tsx`
+- `apps/web/src/components/ui/badge.tsx`
+- `apps/web/src/components/chat/ComposerQueueList.tsx`
+- `apps/web/src/components/chat/MessageBubble.tsx`
+- `apps/web/src/components/chat/PlanQuestionWizard.tsx`
+- `apps/web/src/components/diff/CommitsView.tsx`
+- `apps/web/src/components/diff/CumulativeView.tsx`
+- `apps/web/src/components/diff/DiffContent.tsx`
+- `apps/web/src/components/diff/DiffPreviewMarkdown.tsx`
+- `apps/web/src/components/diff/GitDiffView.tsx`
+- `apps/web/src/components/diff/LastTurnView.tsx`
+- `apps/web/src/components/diff/SideBySideDiff.tsx`
+- `apps/web/src/components/diff/SummaryView.tsx`
+- `apps/web/src/components/diff/TurnTimeline.tsx`
+- `apps/web/src/components/diff/UnifiedDiff.tsx`
+- `apps/web/src/components/panels/plan/PlanDocument.tsx`
+- `apps/web/src/components/sidebar/ProjectTree.tsx`
+
+## Remaining Violations
+
+### Raw Px
+
+Count: 501.
+
+Representative paths:
+
+- `apps/web/src/index.css:180`
+- `apps/web/src/index.css:337`
+- `apps/web/src/index.css:618`
+- `apps/web/src/main.tsx:30`
+- `apps/web/src/components/panels/PreviewPanel.tsx:138`
+
+Reason: hairline, optical sub-pixel, bitmap/canvas, generated preview geometry, or pending follow-up. `index.css` keeps pixel values for motion offsets, spinner masks, scrollbar/range-control micro-geometry, and focus rings. Preview/capture surfaces keep raw pixels where they model browser, canvas, screenshot, or DOM geometry. `main.tsx` keeps `1px` for the startup fallback border hairline.
+
+### Arbitrary Text
+
+Count: 335.
+
+Representative paths:
+
+- `apps/web/src/lib/ci-status.ts:40`
+- `apps/web/src/components/diff/BranchRefPicker.tsx:156`
+- `apps/web/src/components/chat/AttachmentPreview.tsx:147`
+- `apps/web/src/components/diff/CommitEntry.tsx:82`
+- `apps/web/src/components/panels/plan/PlanAnnotation.tsx:83`
+
+Reason: pending follow-up. Many values are dense mono captions, tiny file badges, generated preview labels, or status-token color references. They need component-by-component review instead of a blind replacement.
+
+### Arbitrary Spacing And Sizing
+
+Count: 145.
+
+Representative paths:
+
+- `apps/web/src/components/palette/CommandPalette.tsx:63`
+- `apps/web/src/components/panels/BrowserOverflowMenu.tsx:136`
+- `apps/web/src/components/diff/DiffPreviewMarkdown.tsx:100`
+- `apps/web/src/components/panels/plan/PlanSkeleton.tsx:13`
+- `apps/web/src/components/diff/CommitEntry.tsx:82`
+
+Reason: pending follow-up, generated preview geometry, or optical layout. Width clamps, character clamps, preview shadows, skeleton animation widths, and file-count pills need local visual review.
+
+### Arbitrary Radii
+
+Count: 20.
+
+Representative paths:
+
+- `apps/web/src/components/diff/CommitEntry.tsx:82`
+- `apps/web/src/components/chat/Composer.tsx:351`
+- `apps/web/src/components/chat/ImageAttachmentLightbox.tsx:250`
+- `apps/web/src/components/ui/tooltip.tsx:72`
+- `apps/web/src/components/sidebar/ThreadSearchBar.tsx:82`
+
+Reason: optical sub-pixel fixes or pending follow-up. Tooltip arrows, favicon corners, and tiny file-count pills need local component treatment.
+
+### Raw Colors
+
+Count: 130.
+
+Representative paths:
+
+- `apps/web/src/index.css:199`
+- `apps/web/src/index.css:339`
+- `apps/web/src/components/chat/EditorIcons.tsx:28`
+- `apps/web/src/components/chat/FileTagPopup.tsx:255`
+- `apps/web/src/hooks/useDiffHighlighter.test.ts:49`
+
+Reason: bitmap/icon assets, optical shadows, tests, or pending follow-up. Provider/editor logos keep source asset colors.
+
+### Raw Buttons
+
+Count: 299.
+
+Representative paths:
+
+- `apps/web/src/app/App.tsx:361`
+- `apps/web/src/components/chat/AttachmentPreview.tsx:168`
+- `apps/web/src/components/chat/BranchPicker.tsx:123`
+- `apps/web/src/components/chat/ChatView.tsx:75`
+- `apps/web/src/components/chat/tool-renderers/ToolCallWrapper.tsx:64`
+
+Reason: pending follow-up. Some raw buttons are semantic wrappers inside interactive rows where changing to the shared Button would alter nesting or event behavior.
+
+### Raw Inputs
+
+Count: 32.
+
+Representative paths:
+
+- `apps/web/src/components/ui/input.tsx:36`
+- `apps/web/src/components/sidebar/ThreadSearchBar.tsx:75`
+- `apps/web/src/components/settings/RangeControl.tsx:47`
+- `apps/web/src/components/chat/Composer.tsx:2947`
+- `apps/web/src/components/panels/BrowserHeader.tsx:248`
+
+Reason: component primitive internals, range controls, composer internals, and pending follow-up.
+
+## Exceptions
+
+- Hairline: 1px borders and focus outlines remain where they are tokenized through Tailwind or CSS variables.
+- Bitmap/canvas: editor icons, favicons, provider artwork, image preview dimensions, and generated preview geometry keep source-specific values.
+- Optical sub-pixel: tooltip arrow corners, favicon micro-radii, spinner masks, scrollbars, and timeline cursor offsets keep small pixel values.
+- Generated preview geometry: preview panel capture, annotation, and embedded browser geometry remain audited for later phase work.
+- Pending follow-up: raw buttons and raw inputs in behavior-sensitive rows remain counted until each component can be replaced with shared primitives without changing semantics.
+
+## Impeccable Polish Findings
+
+Attempted tools:
+
+- `node .agents/skills/impeccable/scripts/context.mjs --target apps/web/src/index.css` failed because `.agents/skills/impeccable/scripts/context.mjs` is not present in this checkout.
+- `node C:\Users\chukwudi.nwobodo\.codex\skills\impeccable\scripts\context.mjs --target apps/web/src/index.css` succeeded and loaded the product register plus `DESIGN.md`.
+- `node C:\Users\chukwudi.nwobodo\.codex\skills\impeccable\scripts\detect.mjs --json apps/web/src/index.css apps/web/src/components/ui/button.tsx apps/web/src/components/ui/input.tsx apps/web/src/components/ui/badge.tsx apps/web/src/app/App.tsx apps/web/src/main.tsx` ran and returned advisory findings.
+
+Findings:
+
+- `apps/web/src/index.css:339`: spinner uses `border-radius: 9999px`. Kept as optical circular geometry.
+- `apps/web/src/index.css:625`, `632`, `635`, `708`, `715`: scrollbar colors are outside `DESIGN.md`. Kept as existing scrollbar optical treatment for this phase.
+- `apps/web/src/index.css:626`, `645`, `651`, `681`, `709`: scrollbar and range control radii use `2px` or `3px`. Kept as optical sub-pixel controls.
+- Manual polish check from `polish.md` and `product.md`: screenshots show the shell remains dense and calm, amber remains limited to project state and the primary landing action, and the 390px view no longer clips the landing content after scoping the composer minimum width to non-landing surfaces.
+
+Screenshot evidence:
+
+- `apps/web/e2e/screenshots/design-scale-live-1440x900.png`
+- `apps/web/e2e/screenshots/design-scale-live-900x700.png`
+- `apps/web/e2e/screenshots/design-scale-live-390x844.png`
+
+## Next Phases
+
+1. Normalize dense diff controls: `apps/web/src/components/diff/**`, including branch and commit pickers.
+2. Normalize sidebar rows and filters: `apps/web/src/components/sidebar/**`.
+3. Normalize chat tool renderers and narrative rows: `apps/web/src/components/chat/tool-renderers/**` and `apps/web/src/components/chat/narrative/**`.
+4. Normalize preview and browser geometry: `apps/web/src/components/panels/PreviewPanel.tsx`, `BrowserHeader.tsx`, and preview annotation components.
+5. Replace raw buttons and inputs in behavior-sensitive rows with shared primitives after local interaction tests are written.

--- a/docs/design-scale-audit.md
+++ b/docs/design-scale-audit.md
@@ -8,18 +8,71 @@ This phase normalized the global design primitives, shared Button/Input/Badge sc
 
 ## Commands And Patterns
 
-Counts came from `rg` over `apps/web/src` with these patterns:
+Counts came from `rg` over `apps/web/src`.
 
-| Category | Pattern |
-| --- | --- |
-| Raw px | `rg -n -P "(?<![A-Za-z0-9_-])\d+(?:\.\d+)?px" apps/web/src` |
-| Arbitrary text | `text-\[[^\]]+\]` |
-| Arbitrary spacing/sizing | `(?:h\|w\|min-h\|min-w\|max-h\|max-w\|size\|p\|px\|py\|pt\|pr\|pb\|pl\|m\|mx\|my\|mt\|mr\|mb\|ml\|gap\|space-x\|space-y\|top\|right\|bottom\|left\|inset\|translate-x\|translate-y)-\[[^\]]+\]` |
-| Arbitrary radii | `rounded(?:-[trbl]{1,2})?-\[[^\]]+\]` |
-| Raw colors | `(?:#[0-9a-fA-F]{3,8}\|rgb\(\|rgba\(\|hsl\(\|hsla\()` |
-| Raw buttons | `<button(?:\s\|>)` |
-| Raw inputs | `<input(?:\s\|>)` |
-| Off-scale icons | `(?:size\|h\|w)-(?:2\.5\|3\|3\.5\|4\.5\|5\|6\|7\|9\|10\|11\|12)(?![\d.])` plus arbitrary icon pixel sizes |
+Copy-paste raw pixel count:
+
+```powershell
+rg -n -P "(?<![A-Za-z0-9_-])\d+(?:\.\d+)?px" apps/web/src | Measure-Object
+```
+
+Cross-shell raw pixel count:
+
+```bash
+rg -n -P "(?<![A-Za-z0-9_-])\d+(?:\.\d+)?px" apps/web/src | wc -l
+```
+
+Audit patterns:
+
+- Raw px:
+
+```regex
+(?<![A-Za-z0-9_-])\d+(?:\.\d+)?px
+```
+
+- Arbitrary text:
+
+```regex
+text-\[[^\]]+\]
+```
+
+- Arbitrary spacing/sizing:
+
+```regex
+(?:h|w|min-h|min-w|max-h|max-w|size|p|px|py|pt|pr|pb|pl|m|mx|my|mt|mr|mb|ml|gap|space-x|space-y|top|right|bottom|left|inset|translate-x|translate-y)-\[[^\]]+\]
+```
+
+- Arbitrary radii:
+
+```regex
+rounded(?:-[trbl]{1,2})?-\[[^\]]+\]
+```
+
+- Raw colors:
+
+```regex
+(?:#[0-9a-fA-F]{3,8}|rgb\(|rgba\(|hsl\(|hsla\()
+```
+
+- Raw buttons:
+
+```regex
+<button(?:\s|>)
+```
+
+- Raw inputs:
+
+```regex
+<input(?:\s|>)
+```
+
+- Off-scale icons:
+
+```regex
+(?:size|h|w)-(?:2\.5|3|3\.5|4\.5|5|6|7|9|10|11|12)(?![\d.])
+```
+
+Also search for arbitrary icon pixel sizes with the raw px pattern.
 
 ## Counts
 
@@ -36,7 +89,7 @@ Counts came from `rg` over `apps/web/src` with these patterns:
 
 The raw input count rose because focused component tests now render `Input` variants directly.
 
-The raw-px count uses PCRE2 lookbehind through `rg -P`; the current documented count matches `rg -n -P "(?<![A-Za-z0-9_-])\d+(?:\.\d+)?px" apps/web/src | Measure-Object`.
+The raw-px count uses PCRE2 lookbehind through `rg -P`; the current documented count matches the PowerShell count command above.
 
 ## Files Normalized
 

--- a/docs/guides/ui-components.md
+++ b/docs/guides/ui-components.md
@@ -23,7 +23,8 @@ All UI primitives live in `apps/web/src/components/ui/`. **Always use these inst
 
 ```tsx
 // Variants: default, outline, secondary, ghost, destructive, link
-// Sizes: default (h-8), xs (h-6), sm (h-7), lg (h-9), icon (8x8), icon-xs (6x6), icon-sm (7x7), icon-lg (9x9)
+// Text sizes: xs/sm/default = small (h-8, text-sm), md = medium (h-12, text-base), lg = large (h-14, text-lg)
+// Icon-only sizes: icon-xs/icon-sm/icon = small (size-8), icon-md = medium (size-12), icon-lg = large (size-14)
 <Button variant="ghost" size="sm">Click me</Button>
 <Button variant="outline" size="icon-xs"><Icon /></Button>
 ```
@@ -31,17 +32,18 @@ All UI primitives live in `apps/web/src/components/ui/`. **Always use these inst
 ## Input Sizes
 
 ```tsx
-// Sizes: default (h-8), sm (h-7), xs (h-6)
+// Sizes: xs/sm/default = small (h-8, text-sm), md = medium (h-12, text-base), lg = large (h-14, text-lg)
 <Input placeholder="Default input" />
 <Input size="sm" placeholder="Compact search input" />
-<Input size="xs" placeholder="Inline edit input" />
+<Input size="md" placeholder="Dialog input" />
 ```
 
 ## Badge Variants
 
 ```tsx
 // Variants: default, secondary, destructive, outline, ghost, link
-// Sizes: default (h-5), sm (h-4)
+// Sizes: default (h-5, text-xs, px-2), sm (h-4, text-xs, px-1)
+// Badge is a passive-label exception: compact caption sizing is allowed here, not for interactive controls.
 <Badge variant="secondary">Status</Badge>
 <Badge variant="secondary" size="sm">Tag</Badge>
 ```
@@ -52,7 +54,7 @@ All UI primitives live in `apps/web/src/components/ui/`. **Always use these inst
 2. **Never use raw `<input>` with Tailwind classes.** Use `<Input>` with the appropriate size.
 3. **Never use styled `<span>` for status labels or counts.** Use `<Badge>` with the appropriate variant and size.
 4. **If no existing component fits**, create a new one in `components/ui/` with CVA variants following the existing pattern. Then use it wherever needed.
-5. **Stick to the Tailwind text scale** (`text-xs`, `text-sm`, `text-base`). Do not use arbitrary values like `text-[10px]` or `text-[11px]`.
+5. **Stick to the documented Tailwind text scale** (`text-xs` through `text-5xl`). Do not use arbitrary values like `text-[10px]` or `text-[11px]` unless the value is an audited exception.
 
 ## Testing UI Changes
 
@@ -80,4 +82,4 @@ Run `cd apps/web && bun run e2e` (or target a single spec with `bunx playwright 
 
 ### Minimum bar
 
-For every change that matches a trigger, run at least the specs that touch the components you modified, plus `ui-improvements-floating.spec.ts` if layout or tokens moved. Report the pass count in the PR — "N/N of touched specs pass; unrelated pre-existing failures out of scope" is the expected shape. Do not claim success without fresh output.
+For every change that matches a trigger, run at least the specs that touch the components you modified, plus `ui-improvements-floating.spec.ts` if layout or tokens moved. Report the pass count in the PR: "N/N of touched specs pass; unrelated pre-existing failures out of scope" is the expected shape. Do not claim success without fresh output.


### PR DESCRIPTION
## What
Normalize the web app design system around the new spacing and type rules.

## Why
The app had mixed control sizes, pixel-based sizing, and one-off UI treatments. This makes shared primitives and major app surfaces follow the 4px scale, the 62.5% rem base, and the agreed button and icon sizes.

## Key Changes
- Updated shared Button, Input, and Badge primitives with the new size scale.
- Added design-system documentation, a scale audit, unit tests, and Playwright coverage for the scale rules.
- Cleaned up button and icon sizing across chat, composer, thread overview, panels, terminal, command palette, settings, toast, and diff views.
- Polished active-thread chat UI by removing redundant header chrome, hiding the normal composer status strip, moving usage below PR actions, matching annotation chips to the user bubble, and reducing the send button to 32px.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786034603&installation_id=129163861&pr_number=843&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F843&signature=2d1f865cfd74b20320dec7074bc1e1c152190dc83fccac7fc7edfcd649e02465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage to verify computed design-system styling (typography, spacing, radius, and component sizing) with evidence screenshots.
* **Bug Fixes**
  * Updated Button, Input, and Badge sizing/typography mappings and refined related UI empty states, chips, and icon/button presentation for consistency.
  * Improved composer layout behavior and status-bar show/hide behavior across thread states.
* **Documentation**
  * Refreshed design-system and UI component guidance, plus added a design scale audit.
* **Tests**
  * Updated and expanded unit/E2E tests to match the new sizing rules and UI rendering expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->