### PR TITLE
fix(dev): route dev launchers through agent runtime

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -13,7 +13,7 @@
 
 import { context, build } from "esbuild";
 import { spawn } from "child_process";
-import { watch } from "fs";
+import { mkdirSync, watch } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
@@ -25,11 +25,25 @@ import {
 import { killProcessTree } from "../../../scripts/kill-process-tree.mjs";
 import { ensureElectronBinary } from "../../../scripts/ensure-electron.mjs";
 import { makeCoalescedAsync } from "./coalesce-async.mjs";
+import {
+  buildRuntimeStateEnv,
+  ensureRuntimeRoot,
+} from "../../../scripts/agent/runtime-contract.mjs";
+import { seedFixtureRepo } from "../../../scripts/agent/fixture-repo.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
+const repoRoot = resolve(projectRoot, "..", "..");
 const webRoot = resolve(projectRoot, "..", "web");
 const serverRoot = resolve(projectRoot, "..", "server");
+const runtimePaths = ensureRuntimeRoot(repoRoot);
+mkdirSync(runtimePaths.dbDir, { recursive: true });
+mkdirSync(runtimePaths.logsDir, { recursive: true });
+mkdirSync(runtimePaths.electronDir, { recursive: true });
+const fixtureRepo = seedFixtureRepo(repoRoot);
+const runtimeStateEnv = buildRuntimeStateEnv(repoRoot, {
+  MCODE_AGENT_FIXTURE_REPO: fixtureRepo,
+});
 
 /** Paths to Electron main/preload bundles and server bundle (restart triggers). */
 const mainOutFile = resolve(projectRoot, "dist/main/main.cjs");
@@ -200,7 +214,7 @@ function startViteDevServer() {
     viteProcess = spawn("bun", ["run", "dev"], {
       cwd: webRoot,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, NODE_ENV: "development" },
+      env: { ...process.env, NODE_ENV: "development", ...runtimeStateEnv },
     });
 
     viteProcess.stdout.on("data", (data) => {
@@ -310,16 +324,11 @@ function spawnElectron() {
   const electronBin = desktopRequire("electron");
   const electronEnv = {
     ...process.env,
+    ...runtimeStateEnv,
     ELECTRON_RENDERER_URL: devServerUrl,
     NODE_ENV: "development",
   };
   delete electronEnv.ELECTRON_RUN_AS_NODE;
-  // Normal dev desktop should keep using ~/.mcode-dev; agent:up passes an
-  // explicit .dev data dir and Electron userData dir for worktree isolation.
-  if (electronEnv.MCODE_AGENT_RUNTIME !== "1") {
-    delete electronEnv.MCODE_DATA_DIR;
-    delete electronEnv.MCODE_ELECTRON_USER_DATA_DIR;
-  }
   electronProcess = spawn(electronBin, ["."], {
     cwd: projectRoot,
     stdio: "inherit",

--- a/scripts/agent/__tests__/runtime-contract.test.mjs
+++ b/scripts/agent/__tests__/runtime-contract.test.mjs
@@ -18,6 +18,7 @@ import { join, resolve } from "node:path";
 
 import {
   buildPortsContract,
+  buildRuntimeStateEnv,
   computeAvailablePorts,
   computeDeterministicPort,
   ensureRuntimeRoot,
@@ -39,6 +40,21 @@ test("runtime paths stay under .dev and require .dev to be ignored", () => {
     assert.equal(paths.pidsDir, join(repo, ".dev", "pids"));
     assert.equal(paths.playwrightScratchDir, join(repo, ".dev", "playwright-scratch"));
     assert.equal(paths.electronDir, join(repo, ".dev", "electron"));
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("runtime state env points dev commands at the worktree-local agent state", () => {
+  const repo = makeRepo({ gitignore: ".dev/\n" });
+  try {
+    const env = buildRuntimeStateEnv(repo, { MCODE_AGENT_FIXTURE_REPO: "fixture" });
+
+    assert.equal(env.MCODE_AGENT_RUNTIME, "1");
+    assert.equal(env.MCODE_DATA_DIR, join(repo, ".dev"));
+    assert.equal(env.MCODE_DB_PATH, join(repo, ".dev", "db", "app.sqlite"));
+    assert.equal(env.MCODE_ELECTRON_USER_DATA_DIR, join(repo, ".dev", "electron"));
+    assert.equal(env.MCODE_AGENT_FIXTURE_REPO, "fixture");
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/scripts/agent/agent-up.mjs
+++ b/scripts/agent/agent-up.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { rebuildServerDevBundle } from "../build-server-dev-bundle.mjs";
 import {
   buildPortsContract,
+  buildRuntimeStateEnv,
   computeAvailablePorts,
   ensureRuntimeRoot,
   generateInstanceToken,
@@ -107,17 +108,15 @@ export async function agentUp(repoRoot = resolveRepoRoot()) {
           ...process.env,
           ELECTRON_RUN_AS_NODE: "1",
           NODE_ENV: "development",
-          MCODE_AGENT_RUNTIME: "1",
-          MCODE_AGENT_FIXTURE_REPO: fixtureRepo,
-          MCODE_DATA_DIR: paths.devDir,
-          MCODE_DB_PATH: paths.dbPath,
+          ...buildRuntimeStateEnv(repoRoot, {
+            MCODE_AGENT_FIXTURE_REPO: fixtureRepo,
+          }),
           MCODE_PORT: String(serverPort),
           MCODE_HOST: "127.0.0.1",
           MCODE_AUTH_TOKEN: token,
           MCODE_SINGLE_INSTANCE: "true",
           MCODE_INSTANCE_TOKEN: instanceToken,
           MCODE_WORKTREE_IDENTITY: repoRoot,
-          MCODE_ELECTRON_USER_DATA_DIR: paths.electronDir,
         },
       },
       resolve(paths.logsDir, "server.log"),

--- a/scripts/agent/runtime-contract.mjs
+++ b/scripts/agent/runtime-contract.mjs
@@ -68,6 +68,24 @@ export function getRuntimePaths(repoRoot = resolveRepoRoot()) {
 }
 
 /**
+ * Builds the environment variables that point a dev process at the worktree-local runtime state.
+ *
+ * @param {string} repoRoot
+ * @param {Partial<NodeJS.ProcessEnv>} [overrides]
+ * @returns {NodeJS.ProcessEnv}
+ */
+export function buildRuntimeStateEnv(repoRoot = resolveRepoRoot(), overrides = {}) {
+  const paths = getRuntimePaths(repoRoot);
+  return {
+    MCODE_AGENT_RUNTIME: "1",
+    MCODE_DATA_DIR: paths.devDir,
+    MCODE_DB_PATH: paths.dbPath,
+    MCODE_ELECTRON_USER_DATA_DIR: paths.electronDir,
+    ...overrides,
+  };
+}
+
+/**
  * Verifies `.dev/` is ignored before runtime files are created.
  *
  * @param {string} repoRoot

--- a/scripts/dev-web.mjs
+++ b/scripts/dev-web.mjs
@@ -18,12 +18,14 @@ import { rebuildServerDevBundle } from "./build-server-dev-bundle.mjs";
 import { killProcessTree } from "./kill-process-tree.mjs";
 import {
   buildPortsContract,
+  buildRuntimeStateEnv,
   computeAvailablePorts,
   ensureRuntimeRoot,
   generateInstanceToken,
   resolveRepoRoot,
   writePortsFile,
 } from "./agent/runtime-contract.mjs";
+import { seedFixtureRepo } from "./agent/fixture-repo.mjs";
 import { resolveDevSingleInstanceFlag } from "./agent/single-instance-flag.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -66,7 +68,13 @@ async function waitForHealth(healthUrl, timeoutMs = 15_000) {
 
 const repoRoot = resolveRepoRoot(rootDir);
 const paths = ensureRuntimeRoot(repoRoot);
+mkdirSync(paths.dbDir, { recursive: true });
 mkdirSync(paths.logsDir, { recursive: true });
+mkdirSync(paths.electronDir, { recursive: true });
+const fixtureRepo = seedFixtureRepo(repoRoot);
+const runtimeStateEnv = buildRuntimeStateEnv(repoRoot, {
+  MCODE_AGENT_FIXTURE_REPO: fixtureRepo,
+});
 const { serverPort, webPort: computedWebPort } = await computeAvailablePorts(repoRoot);
 const devToken = randomUUID();
 const instanceToken = generateInstanceToken();
@@ -118,6 +126,8 @@ const server = spawn(
     env: {
       ...process.env,
       ELECTRON_RUN_AS_NODE: "1",
+      NODE_ENV: "development",
+      ...runtimeStateEnv,
       MCODE_PORT: String(serverPort),
       MCODE_HOST: "127.0.0.1",
       MCODE_AUTH_TOKEN: devToken,
@@ -180,6 +190,7 @@ const vite = spawn("bun", viteArgs, {
   env: {
     ...process.env,
     NODE_ENV: "development",
+    ...runtimeStateEnv,
     ...(singleInstance
       ? {
           VITE_MCODE_SINGLE_INSTANCE: "true",


### PR DESCRIPTION
## What
Route `dev:web` and `dev:desktop` through the same worktree-local runtime state used by `agent:up`.

## Why
The old split made local dev confusing because agents and humans could land on different database and settings paths. Using the agent runtime state keeps the web app, desktop app, and agent setup pointed at the same `.dev` directory for this worktree.

## Key Changes
- Add `buildRuntimeStateEnv()` so launchers share the same `.dev` data, database, and Electron user data paths.
- Update `dev:web` and `dev:desktop` to seed `.dev/fixture-repo` and pass the shared runtime environment to their child processes.
- Reuse the helper from `agent:up` and add coverage for the resolved runtime environment.

Related to local dev runtime setup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786094384&installation_id=129163861&pr_number=844&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F844&signature=d29b55b7a08cf8151224fbb658e6239f03c873004c31d7110951d594708e2266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dev startup now prepares local runtime storage automatically, helping the app and backend start with the expected state.
  * Development processes now share the same runtime environment settings, improving consistency between the web server and Electron app.
  * Added coverage to verify the development runtime environment is built correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->