### PR TITLE
fix(codex): raise thread handshake timeout

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
@@ -375,6 +375,52 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
     void child;
   }, 10_000);
 
+  it("uses the raised thread handshake budget for thread/start", async () => {
+    harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-start-budget" } } } : { result: {} },
+    );
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+
+    try {
+      await server.start();
+
+      const timeoutBudgets = setTimeoutSpy.mock.calls.map(([, delay]) => delay);
+      expect(timeoutBudgets).toContain(10_000);
+      expect(timeoutBudgets).toContain(3_000);
+      expect(timeoutBudgets.filter((delay) => delay === 30_000)).toHaveLength(2);
+      expect(timeoutBudgets).not.toContain(15_000);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      await server.kill();
+    }
+  }, 10_000);
+
+  it("uses the raised thread handshake budget for thread/resume", async () => {
+    harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/resume" ? { result: { thread: { id: "thread-resume-budget" } } } : { result: {} },
+    );
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    const server = new CodexAppServer({
+      cliPath: "codex",
+      workingDirectory: "/tmp",
+      getSpawnEnv: () => ({}),
+      resumeThreadId: "thread-existing",
+    });
+
+    try {
+      await server.start();
+
+      const timeoutBudgets = setTimeoutSpy.mock.calls.map(([, delay]) => delay);
+      expect(timeoutBudgets).toContain(10_000);
+      expect(timeoutBudgets.filter((delay) => delay === 30_000)).toHaveLength(2);
+      expect(timeoutBudgets).not.toContain(15_000);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      await server.kill();
+    }
+  }, 10_000);
+
   it("emits decoded unexpected-exit diagnostics with the latest non-benign stderr", async () => {
     const { child, stderr } = harnessFakeServer((req): Record<string, unknown> => {
       switch (req.method) {

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -219,6 +219,13 @@ const INITIALIZE_HANDSHAKE = {
   backoffMs: 500,
 } as const;
 
+/**
+ * Startup budget for establishing or resuming a Codex thread after the app-server
+ * is initialized. Newer Codex builds can spend longer here while loading session
+ * state, but turn execution remains governed by the separate turn watchdogs.
+ */
+const THREAD_HANDSHAKE_TIMEOUT_MS = 30_000;
+
 /** Maximum non-benign stderr lines retained for app-server diagnostics. */
 const STDERR_TAIL_MAX_LINES = 50;
 /** Maximum UTF-8 bytes retained across non-benign stderr diagnostics. */
@@ -1081,7 +1088,7 @@ export class CodexAppServer extends EventEmitter {
             ...(approvalPolicy && { approvalPolicy }),
             ...(workingDirectory && { cwd: workingDirectory }),
           },
-          15000,
+          THREAD_HANDSHAKE_TIMEOUT_MS,
         );
         // Accept both flat `threadId` and nested `thread.id` shapes,
         // same as the thread/start path. The codex app-server returns the
@@ -1139,7 +1146,7 @@ export class CodexAppServer extends EventEmitter {
         startResult = await this.rpc.sendRequest<ThreadStartParams, ThreadStartResult>(
           "thread/start",
           startParams,
-          15000,
+          THREAD_HANDSHAKE_TIMEOUT_MS,
         );
         logger.debug("Codex thread/start response", { result: startResult });
       } catch (err) {


### PR DESCRIPTION
## What
Raise the Codex app-server thread handshake budget from 15 seconds to 30 seconds.

## Why
Recent Codex builds can take longer than 15 seconds to start or resume a thread after the app-server initializes. Mcode reported `Timed out waiting for thread/start (15000ms)` before the provider could complete startup.

## Key Changes
- Adds a named `THREAD_HANDSHAKE_TIMEOUT_MS` constant for Codex thread start and resume.
- Adds tests that assert `thread/start` and `thread/resume` use the 30 second budget and no longer use 15 seconds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786112100&installation_id=129163861&pr_number=846&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F846&signature=00dfd919d197ea1784bfb3a8899002ebf35d4dd54059565d0566064c7807b5f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the time allowed for Codex thread startup and resume after initialization, reducing the chance of premature handshake failures.
  * Improved reliability when resuming an existing thread or creating a new one, especially in slower environments.
  * Added coverage to ensure the updated timeout behavior remains consistent for both resume and start flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->