### PR TITLE
feat(diff): virtualize review file list

### DIFF
--- a/.todos/legend-list-application.md
+++ b/.todos/legend-list-application.md
@@ -1,0 +1,53 @@
+# LegendList-style list performance candidates
+
+## Goal
+
+Apply LegendList-inspired architecture where Mcode renders long, dynamic, or
+frequently changing lists. Focus on lower memory use, fewer React renders, stable
+scroll position, and better behavior during streaming updates.
+
+## Candidate areas
+
+1. Chat narrative timeline
+   - Highest value target.
+   - Covers agent turns, tool calls, thoughts, hooks, sub-agent rows, handoff
+     events, and streaming assistant responses.
+   - Needs dynamic row measurement, anchored prepends, and granular updates for
+     streaming text and tool-call status.
+
+2. Thread and message history
+   - Important when loading older messages or switching long-running threads.
+   - Preserve the user's viewport when older history is prepended.
+   - Avoid re-rendering stable messages when the current turn streams.
+
+3. Runtime logs and provider output
+   - Append-heavy and potentially unbounded.
+   - Keep mounted rows and retained log buffers capped.
+   - Batch high-frequency updates before they reach React.
+
+4. Agent and task activity views
+   - Useful for running agents, tool calls, steps, status changes, and queue
+     state.
+   - Each row should subscribe to its own status and metadata.
+
+5. Large search and file result lists
+   - Lower priority than chat and logs.
+   - Virtualization is likely enough unless result rows become dynamic or
+     frequently updated.
+
+## Principles to test in implementation
+
+- Render only visible rows plus a small overscan buffer.
+- Keep row identity stable.
+- Prefer row-level subscriptions over parent list state updates.
+- Cache measured heights and update them deliberately.
+- Preserve scroll anchors when content is prepended, resized, expanded, or
+  streamed.
+- Avoid cloning or replacing the full list for one-row changes.
+- Bound mounted UI, measurement caches, event buffers, and log retention.
+
+## First implementation slice
+
+Audit the chat narrative timeline and identify which updates currently cause
+the full timeline or sibling rows to re-render. Use that audit to choose the
+smallest change that reduces renders without changing the user-facing behavior.

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -78,7 +78,10 @@ export const FileEntry = memo(function FileEntry({
   highlightToken,
 }: FileEntryProps) {
   const contentId = useId();
-  const [expanded, setExpanded] = useState(defaultExpandedProp);
+  // Bulk commands live in global Review state so rows mounted later by
+  // virtualization inherit the user's last expand/collapse choice.
+  const bulkDiffExpand = useDiffStore((s) => s.bulkDiffExpand);
+  const [expanded, setExpanded] = useState(() => bulkDiffExpand?.expand ?? defaultExpandedProp);
   const [showAllLines, setShowAllLines] = useState(false);
   const [previewMode, setPreviewMode] = useState(false);
   const [jumpHighlight, setJumpHighlight] = useState(false);
@@ -104,7 +107,6 @@ export const FileEntry = memo(function FileEntry({
   const scrolledJumpRef = useRef<number | undefined>(undefined);
   // Bulk expand/collapse command from the Review-options menu. The ref tracks the
   // last nonce we applied so we react only to new commands, never on mount.
-  const bulkDiffExpand = useDiffStore((s) => s.bulkDiffExpand);
   const appliedBulkRef = useRef(bulkDiffExpand?.nonce);
 
   // Reset local state when the cache identity changes so a reused component

--- a/apps/web/src/components/diff/FileList.tsx
+++ b/apps/web/src/components/diff/FileList.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   FileSearch,
   WrapText,
@@ -32,7 +33,11 @@ import {
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { DIFF_FILE_LIST_GAP, DIFF_FILE_LIST_PADDING } from "./diff-surface";
+import { DIFF_FILE_LIST_PADDING } from "./diff-surface";
+
+const FILE_ROW_ESTIMATE_PX = 260;
+const FILE_ROW_OVERSCAN = 4;
+const FILE_LIST_VIRTUALIZE_THRESHOLD = 30;
 
 /** Props for FileList. */
 interface FileListProps {
@@ -61,6 +66,10 @@ export function FileList({
   defaultFilesExpanded = false,
   cacheVersion = 0,
 }: FileListProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+  const [fallbackAnchorIndex, setFallbackAnchorIndex] = useState(0);
   const [jumpOpen, setJumpOpen] = useState(false);
   const [jumpTarget, setJumpTarget] = useState<{ path: string; token: number } | null>(null);
   const [highlightTarget, setHighlightTarget] = useState<{ path: string; token: number } | null>(null);
@@ -94,6 +103,50 @@ export function FileList({
   // The expand/collapse toggle reflects the last bulk action, falling back to
   // the view's default expand state when none has run yet.
   const allExpanded = bulkDiffExpand?.expand ?? defaultFilesExpanded;
+  const shouldVirtualize = sortedFiles.length > FILE_LIST_VIRTUALIZE_THRESHOLD;
+
+  useLayoutEffect(() => {
+    const list = listRef.current;
+    const viewport = list?.closest<HTMLElement>("[data-slot='scroll-area-viewport']") ?? null;
+    const nextScrollElement = viewport ?? list;
+    setScrollElement((prev) => (prev === nextScrollElement ? prev : nextScrollElement));
+    setScrollMargin((prev) => {
+      const next = list?.offsetTop ?? 0;
+      return prev === next ? prev : next;
+    });
+  }, [sortedFiles.length]);
+
+  const virtualizer = useVirtualizer({
+    count: sortedFiles.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => FILE_ROW_ESTIMATE_PX,
+    getItemKey: (index) => sortedFiles[index] ?? String(index),
+    overscan: FILE_ROW_OVERSCAN,
+    scrollMargin,
+    useFlushSync: false,
+  });
+  const virtualItems = shouldVirtualize ? virtualizer.getVirtualItems() : [];
+  const fileVirtualItems = useMemo(() => {
+    if (!shouldVirtualize) return [];
+    if (virtualItems.length > 0) return virtualItems;
+
+    const visibleCount = Math.min(
+      sortedFiles.length,
+      Math.max(1, Math.ceil((scrollElement?.clientHeight ?? 0) / FILE_ROW_ESTIMATE_PX) + FILE_ROW_OVERSCAN * 2),
+    );
+    const firstIndex = Math.min(
+      fallbackAnchorIndex,
+      Math.max(0, sortedFiles.length - visibleCount),
+    );
+    return Array.from({ length: visibleCount }, (_, offset) => {
+      const index = firstIndex + offset;
+      return {
+        index,
+        key: sortedFiles[index] ?? String(index),
+        start: index * FILE_ROW_ESTIMATE_PX,
+      };
+    });
+  }, [fallbackAnchorIndex, scrollElement?.clientHeight, shouldVirtualize, sortedFiles, virtualItems]);
 
   // Refresh re-fetches the view: bump the scope revision (clears the inline diff
   // cache + reloads git-view file lists); thread views also need a snapshot
@@ -118,16 +171,21 @@ export function FileList({
 
   const jumpToFile = useCallback((path: string) => {
     const token = ++jumpTokenRef.current;
+    const index = sortedFiles.indexOf(path);
     setJumpOpen(false);
     setJumpTarget({ path, token });
     setHighlightTarget({ path, token });
+    if (index >= 0) {
+      setFallbackAnchorIndex(index);
+      virtualizer.scrollToIndex(index, { align: "start" });
+    }
 
     if (highlightClearRef.current) clearTimeout(highlightClearRef.current);
     highlightClearRef.current = setTimeout(() => {
       setHighlightTarget((current) => (current?.token === token ? null : current));
       highlightClearRef.current = null;
     }, 1500);
-  }, []);
+  }, [sortedFiles, virtualizer]);
 
   const clearJumpTarget = useCallback((token: number) => {
     setJumpTarget((current) => (current?.token === token ? null : current));
@@ -281,21 +339,55 @@ export function FileList({
           </TooltipContent>
         </Tooltip>
       </div>
-      <div className={`flex flex-col ${DIFF_FILE_LIST_GAP} ${DIFF_FILE_LIST_PADDING}`}>
-        {sortedFiles.map((file) => (
-          <FileEntry
-            key={file}
-            filePath={file}
-            source={source}
-            id={id}
-            threadId={threadId}
-            defaultExpanded={defaultFilesExpanded}
-            cacheVersion={cacheVersion}
-            jumpToken={jumpTarget?.path === file ? jumpTarget.token : undefined}
-            onJumpSettled={clearJumpTarget}
-            highlightToken={highlightTarget?.path === file ? highlightTarget.token : undefined}
-          />
-        ))}
+      <div
+        ref={listRef}
+        className={
+          shouldVirtualize
+            ? `${DIFF_FILE_LIST_PADDING} relative`
+            : `flex flex-col gap-2 ${DIFF_FILE_LIST_PADDING}`
+        }
+        style={shouldVirtualize ? { height: virtualizer.getTotalSize() } : undefined}
+      >
+        {shouldVirtualize
+          ? fileVirtualItems.map((virtualItem) => {
+              const file = sortedFiles[virtualItem.index];
+              if (!file) return null;
+              return (
+                <div
+                  key={virtualItem.key}
+                  ref={virtualizer.measureElement}
+                  data-index={virtualItem.index}
+                  className="absolute left-0 w-full pb-2"
+                  style={{ transform: `translateY(${virtualItem.start - scrollMargin}px)` }}
+                >
+                  <FileEntry
+                    filePath={file}
+                    source={source}
+                    id={id}
+                    threadId={threadId}
+                    defaultExpanded={defaultFilesExpanded}
+                    cacheVersion={cacheVersion}
+                    jumpToken={jumpTarget?.path === file ? jumpTarget.token : undefined}
+                    onJumpSettled={clearJumpTarget}
+                    highlightToken={highlightTarget?.path === file ? highlightTarget.token : undefined}
+                  />
+                </div>
+              );
+            })
+          : sortedFiles.map((file) => (
+              <FileEntry
+                key={file}
+                filePath={file}
+                source={source}
+                id={id}
+                threadId={threadId}
+                defaultExpanded={defaultFilesExpanded}
+                cacheVersion={cacheVersion}
+                jumpToken={jumpTarget?.path === file ? jumpTarget.token : undefined}
+                onJumpSettled={clearJumpTarget}
+                highlightToken={highlightTarget?.path === file ? highlightTarget.token : undefined}
+              />
+            ))}
       </div>
     </div>
   );

--- a/apps/web/src/components/diff/__tests__/FileList.test.tsx
+++ b/apps/web/src/components/diff/__tests__/FileList.test.tsx
@@ -4,6 +4,38 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDiffStore } from "@/stores/diffStore";
 import { FileList } from "../FileList";
 
+vi.mock("@tanstack/react-virtual", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    useVirtualizer: (options: {
+      count: number;
+      getItemKey?: (index: number) => React.Key;
+      estimateSize: () => number;
+    }) => {
+      const [anchor, setAnchor] = React.useState(0);
+      const windowSize = Math.min(options.count, 10);
+      const firstIndex = Math.min(anchor, Math.max(0, options.count - windowSize));
+      const estimate = options.estimateSize();
+      return {
+        getTotalSize: () => options.count * estimate,
+        getVirtualItems: () =>
+          Array.from({ length: windowSize }, (_, offset) => {
+            const index = firstIndex + offset;
+            return {
+              index,
+              key: options.getItemKey?.(index) ?? index,
+              start: index * estimate,
+              size: estimate,
+              end: (index + 1) * estimate,
+            };
+          }),
+        measureElement: vi.fn(),
+        scrollToIndex: (index: number) => setAnchor(index),
+      };
+    },
+  };
+});
+
 vi.mock("@/hooks/useOpenInApps", () => ({
   useOpenInApps: () => [],
 }));
@@ -29,6 +61,7 @@ describe("FileList jump to file", () => {
       lineWrapByThread: {},
     });
     Element.prototype.scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollTo = vi.fn();
     window.matchMedia = vi.fn().mockReturnValue({ matches: true });
     class ResizeObserverMock {
       observe = vi.fn();
@@ -73,6 +106,43 @@ describe("FileList jump to file", () => {
       expect(transport.getSnapshotDiff).toHaveBeenCalledWith(
         "snap-1",
         "apps/web/src/beta.ts",
+      ),
+    );
+  }, 15_000);
+
+  it("mounts a bounded virtual window while jump keeps every file selectable", async () => {
+    const files = Array.from(
+      { length: 80 },
+      (_, index) => `apps/web/src/file-${String(index).padStart(2, "0")}.ts`,
+    );
+
+    render(
+      <div data-slot="scroll-area-viewport">
+        <FileList
+          files={files}
+          source="snapshot"
+          id="snap-1"
+          threadId="thread-1"
+        />
+      </div>,
+    );
+
+    expect(screen.getAllByTestId("diff-file-card")).toHaveLength(10);
+    expect(screen.getByText("file-00.ts")).toBeInTheDocument();
+    expect(screen.queryByText("file-79.ts")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("review-file-jump-trigger"));
+    expect(screen.getAllByTestId(/^review-file-jump-item-/)).toHaveLength(80);
+    await userEvent.click(screen.getByTestId("review-file-jump-item-apps/web/src/file-79.ts"));
+
+    await waitFor(() => expect(screen.getByText("file-79.ts")).toBeInTheDocument());
+    expect(screen.getAllByTestId("diff-file-card")).toHaveLength(10);
+    expect(screen.queryByText("file-00.ts")).not.toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText("file-79.ts").closest("[data-review-file]")).toHaveAttribute(
+        "data-jump-highlight",
+        "true",
       ),
     );
   }, 15_000);

--- a/docs/guides/performance-audit.md
+++ b/docs/guides/performance-audit.md
@@ -8,19 +8,30 @@ Performance principles for building a fast, memory-efficient Electron + React ap
 
 Any list that can grow beyond ~30 items must use virtual scrolling. Only DOM nodes visible in the viewport (plus a small overscan) should exist.
 
+For timelines and other high-churn lists, build the UI as a viewport engine with
+fine-grained row subscriptions. A single item, token stream, tool-call status,
+or measurement change should update the affected row or segment, not make React
+reconcile the whole list. Treat visible range, row measurements, scroll anchors,
+and item data as separate concerns so the user keeps their place while the app
+does less work.
+
 **Do:**
 - Use a virtualizer (`@tanstack/react-virtual`, `react-window`, etc.) for dynamic-length lists
 - Set a fixed or estimated item height for the virtualizer
 - Add overscan (2-5 items) for smooth scrolling
+- Subscribe rows to the smallest stable data slice they need
+- Preserve scroll anchors when items are prepended, resized, or streamed
 
 **Don't:**
 - Render all items with `.map()` inside a scrollable container
 - Rely on `max-height` + `overflow-y: auto` as a substitute for virtualization
 - Assume a list will stay small forever
+- Replace whole arrays or parent objects for updates that affect one row
 
 **How to verify:**
 - Open React DevTools, inspect a scrollable container, scroll to the bottom. DOM node count should stay constant regardless of list length.
 - Chrome DevTools Performance tab: DOM node count in any scrollable area should stay under ~500 regardless of data size.
+- React DevTools Profiler: row updates should be limited to changed rows or the active streaming row.
 
 ---
 


### PR DESCRIPTION
## What
Virtualize the Review tab file list when a diff has many changed files.

## Why
Large Review diffs should keep mounted DOM bounded while preserving jump-to-file, expansion, and lazy diff loading behavior.

## Key Changes
- Virtualize changed-file cards above the large-list threshold with the existing `@tanstack/react-virtual` dependency.
- Preserve Review controls, jump popover, row highlighting, and bulk expand or collapse behavior for rows mounted later.
- Add focused coverage for bounded mounted rows and offscreen jump behavior.
- Document the high-churn list principle and track follow-up candidates in `.todos`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786118320&installation_id=129163861&pr_number=847&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F847&signature=21869c650b27ddc74bb81692aab705098985f1c7d4665239c453927bf731c80a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large file lists now load more efficiently by showing only the visible items, helping improve scrolling and responsiveness.
  * Jumping to a file in long lists now keeps the target item visible and highlighted more reliably.

* **Bug Fixes**
  * Expanded or collapsed files now keep their state more consistently when lists are loaded in parts or updated dynamically.
  * Long diff views are less likely to shift scroll position during updates.

* **Documentation**
  * Added and updated guidance for handling large, fast-changing lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->