### PR TITLE
fix(chat): polish narrative layout and hook rows

### DIFF
--- a/apps/web/src/__tests__/virtual-items.test.ts
+++ b/apps/web/src/__tests__/virtual-items.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@/components/chat/virtual-items";
 import type { ChatVirtualItem } from "@/components/chat/virtual-items";
 import type { ThoughtSegment } from "@/components/chat/narrative/types";
-import type { Message, ToolCall, HookExecution } from "@/transport/types";
+import type { Message, ToolCall, HookExecution, ToolCallRecord, HookExecutionRecord } from "@/transport/types";
 
 function makeMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -43,6 +43,39 @@ function makeToolCall(overrides: Partial<ToolCall> = {}): ToolCall {
   };
 }
 
+function makeToolRecord(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
+  return {
+    id: "record-tool-1",
+    message_id: "a1",
+    parent_tool_call_id: null,
+    tool_name: "Read",
+    input_summary: "",
+    output_summary: "",
+    status: "completed",
+    started_at: "2026-01-01T00:00:00Z",
+    completed_at: "2026-01-01T00:00:01Z",
+    sort_order: 1,
+    ...overrides,
+  };
+}
+
+function makeHookRecord(overrides: Partial<HookExecutionRecord> = {}): HookExecutionRecord {
+  return {
+    id: "hook-1",
+    message_id: "a1",
+    hook_name: "PreToolUse",
+    tool_name: "Bash",
+    phase: "permission",
+    payload: "{}",
+    duration_ms: 12,
+    did_block: false,
+    started_at: "2026-01-01T00:00:00Z",
+    ended_at: "2026-01-01T00:00:00.012Z",
+    sort_order: 1,
+    ...overrides,
+  };
+}
+
 /** Helper: build virtual items from raw inputs using the 3-function API. */
 function buildAll(
   messages: readonly Message[],
@@ -57,29 +90,50 @@ function buildAll(
 }
 
 describe("buildStableItems", () => {
-  it("returns message items plus a persisted-narrative placeholder before each assistant message", () => {
+  it("does not emit empty persisted chrome before records are loaded", () => {
     const messages: Message[] = [
       makeMessage({ id: "u1", role: "user", content: "hi" }),
       makeMessage({ id: "a1", role: "assistant", content: "hello" }),
     ];
     const items = buildStableItems(messages);
-    // user msg, persisted-narrative(a1), assistant msg, persisted-late-hooks(a1), persisted-turn-footer(a1)
-    expect(items.map((i) => i.type)).toEqual([
-      "message",
-      "persisted-narrative",
-      "message",
-      "persisted-late-hooks",
-      "persisted-turn-footer",
-    ]);
+    expect(items.map((i) => i.type)).toEqual(["message", "message"]);
   });
 
-  it("includes one persisted-narrative placeholder per assistant message", () => {
+  it("emits persisted chrome only for visible loaded rows", () => {
     const messages: Message[] = [
       makeMessage({ id: "u1", role: "user", content: "hi" }),
       makeMessage({ id: "a1", role: "assistant", content: "hello" }),
     ];
-    const items = buildStableItems(messages);
+    const items = buildStableItems(messages, undefined, undefined, undefined, {
+      a1: {
+        tools: [makeToolRecord({ message_id: "a1" })],
+        thoughts: [],
+        hooks: [makeHookRecord({ message_id: "a1", phase: "stop", sort_order: 2 })],
+      },
+    });
     expect(items.filter((i) => i.type === "persisted-narrative")).toHaveLength(1);
+    expect(items.filter((i) => i.type === "persisted-late-hooks")).toHaveLength(1);
+    expect(items.filter((i) => i.type === "persisted-turn-footer")).toHaveLength(1);
+  });
+
+  it("renders stop-only persisted hooks after the assistant message", () => {
+    const messages: Message[] = [
+      makeMessage({ id: "u1", role: "user", content: "hi" }),
+      makeMessage({ id: "a1", role: "assistant", content: "hello" }),
+    ];
+    const items = buildStableItems(messages, undefined, undefined, undefined, {
+      a1: {
+        tools: [],
+        thoughts: [],
+        hooks: [makeHookRecord({ message_id: "a1", phase: "stop" })],
+      },
+    });
+
+    expect(items.map((i) => i.type)).toEqual([
+      "message",
+      "message",
+      "persisted-late-hooks",
+    ]);
   });
 });
 
@@ -331,22 +385,15 @@ describe("buildVirtualItems (combined)", () => {
     expect(result).toEqual([]);
   });
 
-  it("messages only: one 'message' item per message, plus persisted-narrative before each assistant", () => {
+  it("messages only: one 'message' item per message when persisted records are missing", () => {
     const messages = [
       makeMessage({ id: "msg-1", sequence: 1 }), // assistant by default
       makeMessage({ id: "msg-2", sequence: 2, role: "user", content: "Hi" }),
     ];
     const result = buildAll(messages, [], undefined, false, undefined);
-    // persisted-narrative(msg-1), msg-1, persisted-late-hooks(msg-1), persisted-turn-footer(msg-1), msg-2
-    expect(result.map((i) => i.type)).toEqual([
-      "persisted-narrative",
-      "message",
-      "persisted-late-hooks",
-      "persisted-turn-footer",
-      "message",
-    ]);
-    expect(result[1]).toMatchObject({ type: "message", key: "msg-1" });
-    expect(result[4]).toMatchObject({ type: "message", key: "msg-2" });
+    expect(result.map((i) => i.type)).toEqual(["message", "message"]);
+    expect(result[0]).toMatchObject({ type: "message", key: "msg-1" });
+    expect(result[1]).toMatchObject({ type: "message", key: "msg-2" });
   });
 
   it("active tool calls split the last assistant message after the narrative-flow item", () => {
@@ -358,21 +405,15 @@ describe("buildVirtualItems (combined)", () => {
     const result = buildAll(messages, toolCalls, undefined, false, undefined);
 
     const types = result.map((item) => item.type);
-    // msg-1, narrative-flow, msg-2, narrative-indicator,
-    // persisted-late-hooks(msg-2), persisted-turn-footer(msg-2). The
-    // persisted-narrative for msg-2 is filtered out (live narrative-flow
-    // above the bubble owns the timeline), but the persisted-turn-footer is
-    // NOT filtered — it sits AFTER the bubble and owns the post-response
-    // summary that closes the turn. The narrative-indicator lingers after the
-    // turn (isAgentRunning=false, tool calls still volatile) so it can play
-    // its exit transition, and sits right after the bubble.
+    // Persisted chrome is absent until records load and contain visible rows.
+    // The narrative-indicator lingers after the turn (isAgentRunning=false,
+    // tool calls still volatile) so it can play its exit transition, and sits
+    // right after the bubble.
     expect(types).toEqual([
       "message",
       "narrative-flow",
       "message",
       "narrative-indicator",
-      "persisted-late-hooks",
-      "persisted-turn-footer",
     ]);
     expect(result[0]).toMatchObject({ type: "message", key: "msg-1" });
     expect(result[1]).toMatchObject({ type: "narrative-flow" });
@@ -580,20 +621,13 @@ describe("buildVirtualItems (combined)", () => {
     expect(indicatorItem.startTime).toBe(startTime);
   });
 
-  it("emits persisted-narrative placeholder before each assistant message", () => {
+  it("omits persisted chrome for unloaded assistant narrative records", () => {
     const messages = [
       makeMessage({ id: "msg-1", sequence: 1, role: "user", content: "hi" }),
       makeMessage({ id: "msg-2", sequence: 2, role: "assistant", content: "done" }),
     ];
     const result = buildAll(messages, [], undefined, false, undefined);
-    // user, persisted-narrative(msg-2), assistant, persisted-late-hooks(msg-2), persisted-turn-footer(msg-2)
-    expect(result.map((item) => item.type)).toEqual([
-      "message",
-      "persisted-narrative",
-      "message",
-      "persisted-late-hooks",
-      "persisted-turn-footer",
-    ]);
+    expect(result.map((item) => item.type)).toEqual(["message", "message"]);
   });
 
   it("includes narrative-flow with both streaming and running state when agent running and streaming", () => {
@@ -615,17 +649,12 @@ describe("buildVirtualItems (combined)", () => {
     const toolCalls = [makeToolCall({ id: "tc-1" })];
     const result = buildAll(messages, toolCalls, undefined, false, undefined);
 
-    // Persisted-narrative(msg-1) precedes the assistant message, then
-    // persisted-late-hooks(msg-1) and persisted-turn-footer(msg-1) follow it,
-    // then user, then narrative-flow and the lingering narrative-indicator
-    // appended at the tail (no split because the trailing message isn't an
-    // assistant).
+    // Persisted chrome is absent until loaded records contain visible rows.
+    // The live narrative is appended at the tail because the trailing message
+    // is not an assistant.
     const types = result.map((item) => item.type);
     expect(types).toEqual([
-      "persisted-narrative",
       "message",
-      "persisted-late-hooks",
-      "persisted-turn-footer",
       "message",
       "narrative-flow",
       "narrative-indicator",
@@ -647,7 +676,7 @@ describe("buildVirtualItems (combined)", () => {
     // user msg, narrative-flow (before split assistant msg), split assistant
     // msg, narrative-indicator (status footer below the response — it stays
     // under the bubble through the persist swap so its exit transition plays
-    // in place), persisted-late-hooks(msg-2), persisted-turn-footer(msg-2).
+    // in place). Persisted chrome is absent until records load.
     // live assistant response is suppressed because a tool is still running —
     // `computeLiveStreamingText` returns "" while any top-level tool is in
     // flight, since the model isn't streaming user-facing text during tool
@@ -659,8 +688,6 @@ describe("buildVirtualItems (combined)", () => {
       "narrative-flow",
       "message",
       "narrative-indicator",
-      "persisted-late-hooks",
-      "persisted-turn-footer",
     ]);
     expect(result[0]).toMatchObject({ key: "msg-1" });
     expect(result[2]).toMatchObject({ key: "msg-2" });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -387,7 +387,7 @@ export function App() {
             {!rightPanelMaximized && (
             <main
               className="flex-1 overflow-hidden bg-background"
-              style={{ minWidth: showLanding ? 0 : COMPOSER_MIN_WIDTH }}
+              style={{ minWidth: showLanding || settingsOpen ? 0 : `min(100%, ${COMPOSER_MIN_WIDTH}px)` }}
             >
               {settingsOpen ? (
                 <Suspense fallback={null}>

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -43,6 +43,7 @@ import { cn } from "@/lib/utils";
 import { isWindows } from "@/lib/platform";
 import { isCursorPermissionLockedToFull } from "@/lib/cursor-permission";
 import { isGoalControlCommand } from "@/lib/goal-command";
+import { PRIMARY_CONTENT_RAIL_CLASS } from "@/lib/layout-rails";
 import { isDetachedWorktree, normalizeWorktreePath } from "@/lib/worktree";
 import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, supportsUltrathink, supports1MContextWindow, supportsThinkingToggle, normalizeReasoningLevelForModel, getCodexReasoningLevels, providerSupportsReasoningLevels } from "@/lib/model-registry";
 import { ModelSelector } from "./ModelSelector";
@@ -885,10 +886,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   // token-count badge + send button fit comfortably on one row with the
   // standard gaps and breathing room. Below this the row collapses to a
   // single "Composer options" trigger so the send button never gets clipped.
-  // With 32px small controls, the 1280px shell still has room for inline
-  // options after the sidebar and right rail are reserved. Keep the collapse
-  // point below that shell width while preserving the 600px overflow behavior.
-  const COMPOSER_INLINE_OPTIONS_THRESHOLD = 560;
+  // Keep the compact 600px layout behind the overflow trigger while allowing
+  // the widened desktop rail to keep its inline controls.
+  const COMPOSER_INLINE_OPTIONS_THRESHOLD = 640;
   // Default to inline before the first measurement lands so the first frame
   // doesn't briefly render the popover trigger and snap to inline buttons.
   const showInlineComposerOptions =
@@ -2690,7 +2690,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const showComposerStatusBar = isNewThread === true || !!branchFromMessageId;
 
   return (
-    <div className="relative px-8 py-4">
+    <div className="relative px-4 py-4 sm:px-8">
       {/* Soft gradient hint above the composer — short enough that it doesn't
           bury the last line of content (e.g. the turn footer) when the chat is
           scrolled to its tail. Reduced from h-5/opaque to h-3/70% so the band
@@ -2705,7 +2705,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       )}
 
       {/* Max-width wrapper to align with message list column */}
-      <div className="mx-auto w-full max-w-4xl">
+      <div className={PRIMARY_CONTENT_RAIL_CLASS}>
       {threadId && workspaceId && planPreview && !planPanelOpen && !branchFromMessageId && !isNewThread && (
         <div className="mb-2">
           <PlanPreview workspaceId={workspaceId} threadId={threadId} preview={planPreview} />

--- a/apps/web/src/components/chat/HookActivitySection.tsx
+++ b/apps/web/src/components/chat/HookActivitySection.tsx
@@ -3,9 +3,7 @@ import { ChevronRight } from "lucide-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import type { HookExecution } from "@/transport/types";
-
-/** Maximum output lines shown before "show all" toggle. */
-const OUTPUT_LINE_CAP = 20;
+import { HOOK_OUTPUT_LINE_CAP, getHookOutputLines } from "./hook-output";
 
 /** Collapsible section displaying hook execution activity for a turn. */
 export function HookActivitySection({ hooks }: { hooks: readonly HookExecution[] }) {
@@ -113,9 +111,9 @@ function HookRowContent({ hook, hasOutput, detailOpen }: { hook: HookExecution; 
 const HookRow = memo(function HookRow({ hook }: { hook: HookExecution }) {
   const [detailOpen, setDetailOpen] = useState(false);
   const [showAll, setShowAll] = useState(false);
-  const hasOutput = hook.fullOutput.length > 0;
-  const displayLines = showAll ? hook.fullOutput : hook.outputLines;
-  const hasMore = hook.fullOutput.length > OUTPUT_LINE_CAP;
+  const { previewLines, fullLines, hasOutput } = getHookOutputLines(hook);
+  const displayLines = showAll ? fullLines : previewLines;
+  const hasMore = fullLines.length > HOOK_OUTPUT_LINE_CAP;
   const outputText = useMemo(() => displayLines.join("\n"), [displayLines]);
 
   const rowClasses = "flex items-center gap-2 py-0.5 w-full text-left";
@@ -151,7 +149,7 @@ const HookRow = memo(function HookRow({ hook }: { hook: HookExecution }) {
                 onClick={() => setShowAll((v) => !v)}
                 className="text-xs text-link hover:underline mt-0.5 cursor-pointer"
               >
-                {showAll ? `Show preview (${OUTPUT_LINE_CAP} lines)` : `Show all (${hook.fullOutput.length} lines)`}
+                {showAll ? `Show preview (${HOOK_OUTPUT_LINE_CAP} lines)` : `Show all (${fullLines.length} lines)`}
               </button>
             )}
           </div>

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -576,7 +576,7 @@ export const MessageBubble = memo(function MessageBubble({
     return (
       <>
         <div className="group/msg flex justify-end" data-message-id={message.id} data-message-role={message.role} data-thread-id={message.thread_id}>
-          <div className="min-w-0 max-w-[75%] space-y-1.5">
+          <div className="min-w-0 max-w-[min(82%,56rem)] space-y-1.5">
             {/* Quote block — shown when this message is a reply */}
             {message.reply_to_message_id && (
               <QuoteBlock

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -34,6 +34,7 @@ import { PersistedLateHooks } from "./PersistedLateHooks";
 import { StickyUserMessage, STICKY_USER_MESSAGE_ESTIMATED_HEIGHT } from "./StickyUserMessage";
 import { registerCommand } from "@/lib/command-registry";
 import { isGoalStatusNotice } from "@/lib/goal-message";
+import { PRIMARY_CONTENT_RAIL_CLASS } from "@/lib/layout-rails";
 import { shouldShowStickyUserMessage, type StickyVisibilityVirtualizer } from "./sticky-user-message-visibility";
 import { resolveUserMessagePreview } from "./user-message-preview";
 
@@ -317,6 +318,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const permissions = useActiveThreadRecord((r) => r.permissions);
   const hooks = useActiveThreadRecord((r) => r.hooks);
   const thoughtSegments = useActiveThreadRecord((r) => r.thoughtSegments);
+  const persistedNarrativeByMessage = useActiveThreadRecord((r) => r.narrativeByMessage);
+  const loadNarrativeForMessage = useThreadStore((s) => s.loadNarrativeForMessage);
   const currentTurnMessageId = useActiveThreadRecord((r) => r.currentTurnMessageId);
   const currentTurnResponseKey = useActiveThreadRecord((r) => r.currentTurnResponseKey);
   const assistantResponseKeys = useActiveThreadRecord((r) => r.assistantResponseKeys);
@@ -458,13 +461,21 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     prevScrollTopRef.current = el.scrollTop;
   }, [activeThreadId, hasMore, isLoadingMore, loadOlderMessages, syncStickyUserMessageVisibility]);
 
+  useEffect(() => {
+    for (const message of messages) {
+      if (message.role !== "assistant") continue;
+      if (persistedNarrativeByMessage[message.id] !== undefined) continue;
+      void loadNarrativeForMessage(message.id);
+    }
+  }, [messages, persistedNarrativeByMessage, loadNarrativeForMessage]);
+
   const stableItems = useMemo(
     () => buildStableItems(messages, persistedFilesChanged, latestTurnWithChanges, {
       threadId: currentThreadId ?? "",
       messageId: currentTurnMessageId || undefined,
       responseKey: currentTurnResponseKey || undefined,
       responseKeysByMessageId: assistantResponseKeys,
-    }),
+    }, persistedNarrativeByMessage),
     [
       messages,
       persistedFilesChanged,
@@ -473,6 +484,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       currentTurnMessageId,
       currentTurnResponseKey,
       assistantResponseKeys,
+      persistedNarrativeByMessage,
     ],
   );
 
@@ -1161,10 +1173,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
                 key={vi.key}
                 ref={virtualizer.measureElement}
                 data-index={vi.index}
-                className="absolute left-0 w-full px-8 py-2"
+                className="absolute left-0 w-full px-4 py-2 sm:px-8"
                 style={{ transform: `translateY(${vi.start}px)` }}
               >
-                <div className="mx-auto w-full min-w-0 max-w-4xl overflow-x-hidden">
+                <div className={cn(PRIMARY_CONTENT_RAIL_CLASS, "min-w-0 overflow-x-hidden")}>
                   <VirtualItemRenderer item={item} turnExpandRef={turnExpandRef} onBranch={onBranch} onReply={onReply} onScrollToMessage={scrollToMessage} currentTurnMessageIdByThread={currentTurnMessageIdByThread} />
                 </div>
               </div>
@@ -1177,8 +1189,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
           Conditions: handoff still generating and only the initial user message has been submitted
           (no assistant reply yet), so the user sees something happening rather than an empty thread. */}
       {handoffStatus === "generating" && messages.filter((m) => m.role !== "system").length <= 1 && (
-        <div className="px-8 py-4">
-          <div className="mx-auto w-full max-w-4xl space-y-2">
+        <div className="px-4 py-4 sm:px-8">
+          <div className={cn(PRIMARY_CONTENT_RAIL_CLASS, "space-y-2")}>
             <div className="h-3.5 w-3/4 animate-pulse rounded bg-muted" />
             <div className="h-3.5 w-1/2 animate-pulse rounded bg-muted" />
             <div className="h-3.5 w-2/3 animate-pulse rounded bg-muted" />

--- a/apps/web/src/components/chat/PersistedLateHooks.tsx
+++ b/apps/web/src/components/chat/PersistedLateHooks.tsx
@@ -8,33 +8,13 @@
 import { useMemo } from "react";
 import { useActiveThreadRecord } from "@/stores/thread-selectors";
 import { HookRow } from "@/components/chat/narrative/HookRow";
-import type { HookExecution } from "@/transport/types";
+import { recordToHookExecution } from "@/components/chat/narrative/build-persisted-narrative";
 import type { HookExecutionRecord } from "@mcode/contracts";
 
 /** Props for `PersistedLateHooks`. */
 interface PersistedLateHooksProps {
   /** Assistant message id whose late stop hooks to render. */
   messageId: string;
-}
-
-/**
- * Adapts a persisted `HookExecutionRecord` to the volatile `HookExecution`
- * shape expected by `HookRow`. No live output is available for persisted hooks
- * so `outputLines` and `fullOutput` are empty arrays.
- */
-function recordToExecution(record: HookExecutionRecord): HookExecution {
-  return {
-    hookName: record.hook_name,
-    hookType: "stop",
-    toolName: record.tool_name ?? undefined,
-    status: "completed",
-    outputLines: [],
-    fullOutput: [],
-    exitCode: 0,
-    durationMs: record.duration_ms ?? undefined,
-    didBlock: record.did_block,
-    startedAt: Date.parse(record.started_at) || 0,
-  };
 }
 
 /**
@@ -57,7 +37,7 @@ export function PersistedLateHooks({ messageId }: PersistedLateHooksProps) {
   return (
     <div className="mt-1 flex flex-col gap-0.5">
       {lateHooks.map((record, i) => (
-        <HookRow key={`${record.hook_name}-${record.started_at}-${i}`} hook={recordToExecution(record)} />
+        <HookRow key={`${record.hook_name}-${record.started_at}-${i}`} hook={recordToHookExecution(record)} />
       ))}
     </div>
   );

--- a/apps/web/src/components/chat/PlanQuestionWizard.tsx
+++ b/apps/web/src/components/chat/PlanQuestionWizard.tsx
@@ -5,6 +5,7 @@ import { OptionTile } from "./plan-questions/OptionTile";
 import { AcceptRecommended } from "./plan-questions/AcceptRecommended";
 import { useWizardKeyboard } from "./plan-questions/useWizardKeyboard";
 import { cn } from "@/lib/utils";
+import { PRIMARY_CONTENT_RAIL_CLASS } from "@/lib/layout-rails";
 import type { PlanAnswer, PlanQuestionOption } from "@mcode/contracts";
 
 /** Sentinel ID for the user-written "Other" option. */
@@ -250,7 +251,8 @@ export function PlanQuestionWizard({ threadId }: PlanQuestionWizardProps) {
       aria-label="Plan questions"
       data-direction={slideDirection}
       className={cn(
-        "mx-auto mb-1.5 w-full max-w-4xl",
+        PRIMARY_CONTENT_RAIL_CLASS,
+        "mb-1.5",
         "rounded-xl border border-border bg-card",
         "px-5 pt-4 pb-3",
         "animate-wizard-float-rise",

--- a/apps/web/src/components/chat/StickyUserMessage.tsx
+++ b/apps/web/src/components/chat/StickyUserMessage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type MouseEvent } from "react";
 import { ArrowUp, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PRIMARY_CONTENT_RAIL_CLASS } from "@/lib/layout-rails";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -118,10 +119,10 @@ export function StickyUserMessage({
   return (
     <div
       ref={rootRef}
-      className="pointer-events-none absolute inset-x-0 top-0 z-10 border-b border-border/25 bg-background/90 px-8 pb-2 pt-1 backdrop-blur-sm"
+      className="pointer-events-none absolute inset-x-0 top-0 z-10 border-b border-border/25 bg-background/90 px-4 pb-2 pt-1 backdrop-blur-sm sm:px-8"
       data-testid="sticky-user-message"
     >
-      <div className="mx-auto w-full min-w-0 max-w-4xl">
+      <div className={cn(PRIMARY_CONTENT_RAIL_CLASS, "min-w-0")}>
         <div className="pointer-events-auto flex items-start gap-0.5 overflow-hidden rounded-lg border border-border/60 bg-accent text-sm text-accent-foreground shadow-sm">
           <Button
             type="button"

--- a/apps/web/src/components/chat/__tests__/command-palette-positioning.test.tsx
+++ b/apps/web/src/components/chat/__tests__/command-palette-positioning.test.tsx
@@ -78,13 +78,13 @@ describe("CommandPalette popup positioning", () => {
 describe("SettingsView padding", () => {
   it("does NOT have px-10 in the outer div className", () => {
     const { container } = render(<SettingsView section="model" />);
-    const innerDiv = container.querySelector(".max-w-4xl");
+    const innerDiv = container.querySelector(".max-w-\\[96rem\\]");
     expect(innerDiv?.className ?? "").not.toContain("px-10");
   });
 
-  it("DOES have px-8 in the outer div className", () => {
+  it("keeps px-8 padding at the sm breakpoint", () => {
     const { container } = render(<SettingsView section="model" />);
-    const innerDiv = container.querySelector(".max-w-4xl");
-    expect(innerDiv?.className ?? "").toContain("px-8");
+    const innerDiv = container.querySelector(".max-w-\\[96rem\\]");
+    expect(innerDiv?.className ?? "").toContain("sm:px-8");
   });
 });

--- a/apps/web/src/components/chat/hook-output.ts
+++ b/apps/web/src/components/chat/hook-output.ts
@@ -1,0 +1,27 @@
+import type { HookExecution } from "@/transport/types";
+
+/** Maximum hook output lines shown before expanding to the full buffer. */
+export const HOOK_OUTPUT_LINE_CAP = 20;
+
+/** Returns the bounded preview and full hook output lines for hook renderers. */
+export function getHookOutputLines(hook: HookExecution): {
+  previewLines: string[];
+  fullLines: string[];
+  hasOutput: boolean;
+  hasMoreThanPreview: boolean;
+} {
+  const previewLines =
+    hook.outputLines.length > 0
+      ? hook.outputLines
+      : hook.fullOutput.slice(0, HOOK_OUTPUT_LINE_CAP);
+  const fullLines =
+    hook.fullOutput.length > 0
+      ? hook.fullOutput
+      : hook.detailLines ?? hook.outputLines;
+  return {
+    previewLines,
+    fullLines,
+    hasOutput: previewLines.length > 0 || fullLines.length > 0,
+    hasMoreThanPreview: fullLines.length > previewLines.length,
+  };
+}

--- a/apps/web/src/components/chat/narrative/DeltaBlock.tsx
+++ b/apps/web/src/components/chat/narrative/DeltaBlock.tsx
@@ -260,13 +260,13 @@ export function DeltaBlock({ text, isStreaming = true, showCursor = true }: Delt
   return (
     <div ref={rootRef} className="relative">
       {isStreaming ? (
-        <p className="whitespace-pre-wrap text-[0.9375rem] leading-relaxed">
+        <p className="whitespace-pre-wrap text-sm leading-relaxed">
           {displayed}
         </p>
       ) : (
         <Suspense
           fallback={
-            <p className="whitespace-pre-wrap text-[0.9375rem] leading-relaxed">
+            <p className="whitespace-pre-wrap text-sm leading-relaxed">
               {displayed}
             </p>
           }

--- a/apps/web/src/components/chat/narrative/HookRow.tsx
+++ b/apps/web/src/components/chat/narrative/HookRow.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect, useRef } from "react";
-import { Check, X, ChevronRight } from "lucide-react";
+import { Webhook, X } from "lucide-react";
 import { AnimatedCollapsible } from "@/components/ui/animated-collapsible";
 import type { HookExecution } from "@/transport/types";
+import { NarrativeSummaryLine } from "./ToolSummaryLine";
+import { getHookOutputLines } from "@/components/chat/hook-output";
+import { NARRATIVE_TOOL_ROW, narrativeToolDetailClass } from "./narrative-layout";
 
 interface HookRowProps {
   /** The hook execution to display. */
@@ -21,7 +24,7 @@ function formatDuration(ms: number): string {
  * Compact inline row for displaying hook executions in the narrative timeline.
  *
  * Renders three visual states:
- * - **Passed** (status "completed", exitCode 0, !didBlock): green check, hook name, trigger, duration, expandable output.
+ * - **Passed** (status "completed", exitCode 0, !didBlock): hook icon, hook name, trigger, duration, expandable output.
  * - **Running** (status "running"): spinning clock, hook name, trigger, live elapsed timer, "running" badge.
  * - **Blocked** (didBlock true): red X, hook name, trigger, duration, "blocked" badge, error output in red.
  *
@@ -38,13 +41,7 @@ export function HookRow({ hook }: HookRowProps) {
   const isBlocked = hook.didBlock === true;
   const hasPassed = !isBlocked && hook.status === "completed";
 
-  const hasOutput =
-    hook.fullOutput.length > 0 || hook.outputLines.length > 0;
-
-  const outputText =
-    hook.fullOutput.length > 0
-      ? hook.fullOutput.join("\n")
-      : hook.outputLines.join("\n");
+  const { fullLines, hasOutput } = getHookOutputLines(hook);
 
   useEffect(() => {
     if (!isRunning) return;
@@ -63,97 +60,84 @@ export function HookRow({ hook }: HookRowProps) {
   };
 
   return (
-    <div className="rounded-md">
+    <div className="min-w-0 max-w-full rounded-md">
       {/* Main row */}
-      <button
-        type="button"
-        onClick={handleClick}
+      <NarrativeSummaryLine
+        open={open}
+        onToggle={handleClick}
         disabled={!hasOutput}
-        className={`flex w-full items-center gap-1.5 px-2 py-1 text-left rounded-md transition-colors duration-100 text-xs ${
-          hasOutput ? "hover:bg-muted/30 cursor-pointer" : "cursor-default"
-        }`}
-        aria-expanded={hasOutput ? open : undefined}
-      >
-        {/* Status icon */}
-        {isRunning ? (
-          <span aria-label="running" className="flex items-center justify-center shrink-0">
+        expandable={hasOutput}
+        icon={isRunning ? (
+          <span aria-label="running" className="flex w-3 h-3 items-center justify-center shrink-0">
             <span className="size-1.5 rounded-full bg-primary animate-pulse" />
           </span>
         ) : isBlocked ? (
-          <span aria-label="blocked" className="flex w-[13px] h-[13px] items-center justify-center shrink-0">
-            <X className="w-[13px] h-[13px] text-[var(--diff-remove)]" />
+          <span aria-label="blocked" className="flex w-3 h-3 items-center justify-center shrink-0">
+            <X className="w-3 h-3 text-[var(--diff-remove)]" />
           </span>
         ) : (
-          <span aria-label="passed" className="flex w-[13px] h-[13px] items-center justify-center shrink-0">
-            <Check className="w-[13px] h-[13px] text-[var(--diff-add)]" />
+          <span aria-label="hook completed" className="flex w-3 h-3 items-center justify-center shrink-0">
+            <Webhook className="w-3 h-3 text-muted-foreground/55" />
           </span>
         )}
+        badge={isRunning ? (
+          <span className="font-mono text-[0.625rem] font-medium px-1.5 py-px rounded-sm bg-primary/15 text-primary shrink-0">
+            running
+          </span>
+        ) : isBlocked ? (
+          <span className="font-mono text-[0.625rem] font-medium px-1.5 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
+            blocked
+          </span>
+        ) : undefined}
+      >
 
         {/* Hook name */}
-        <span className="font-medium text-foreground/60 shrink-0">
+        <span className="min-w-0 truncate text-muted-foreground/60 flex-1">
           {hook.hookName}
         </span>
 
         {/* Trigger label */}
         {hook.toolName && (
-          <span className="font-mono text-[0.6875rem] text-muted-foreground/70 shrink-0">
+          <span className="min-w-0 truncate font-mono text-[0.6875rem] text-muted-foreground/50">
             on {hook.toolName}
           </span>
         )}
 
-        {/* Spacer */}
-        <span className="flex-1" />
-
         {/* Duration or elapsed timer - hide for sub-5ms instant hooks */}
         {(isRunning || (hook.durationMs != null && hook.durationMs >= 5)) && (
-          <span className="font-mono text-[0.6875rem] tabular-nums text-muted-foreground/60 shrink-0">
+          <span className="font-mono text-[0.6875rem] tabular-nums text-muted-foreground/50 shrink-0">
             {isRunning ? `${elapsedSeconds}s` : formatDuration(hook.durationMs!)}
           </span>
         )}
+      </NarrativeSummaryLine>
 
-        {/* Status badge */}
-        {isRunning && (
-          <span className="font-mono text-[0.625rem] font-medium px-1.5 py-px rounded-sm bg-primary/15 text-primary shrink-0">
-            running
-          </span>
-        )}
-        {isBlocked && (
-          <span className="font-mono text-[0.625rem] font-medium px-1.5 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
-            blocked
-          </span>
-        )}
-
-        {/* Chevron - only when output exists */}
-        {hasOutput && (
-          <ChevronRight
-            className={`h-3.5 w-3.5 text-muted-foreground/60 shrink-0 transition-transform duration-200 ${
-              open ? "rotate-90" : ""
-            }`}
-          />
-        )}
-      </button>
-
-      {/* Expandable output */}
       {hasOutput && (
         <AnimatedCollapsible open={open}>
-          <div className="pl-6 pb-1 mt-0.5">
-            <pre
-              className={`font-mono text-[0.6875rem] leading-normal bg-[var(--code-bg)] rounded-md px-2.5 py-1.5 whitespace-pre-wrap max-h-24 overflow-auto ${
-                isBlocked || (hasPassed && hook.exitCode !== 0)
-                  ? "text-[var(--diff-remove)]"
-                  : ""
-              }`}
-            >
-              {isRunning ? (
-                <>
-                  {outputText}
-                  <span aria-hidden="true" className="typing-cursor" />
-                </>
-              ) : (
-                outputText
-              )}
-            </pre>
-          </div>
+          <ul className="min-w-0 max-w-full pl-6 mt-0.5 space-y-0.5 pb-1">
+            {fullLines.map((line, index) => (
+              <li key={`${index}-${line}`} className="flex min-w-0 max-w-full flex-col gap-0.5">
+                <div className={`${NARRATIVE_TOOL_ROW} text-sm`}>
+                  <Webhook className="w-[14px] h-[14px] text-muted-foreground/75 shrink-0" />
+                  <span className="text-foreground/65 font-medium shrink-0">
+                    Hook detail
+                  </span>
+                  <span
+                    className={
+                      isBlocked || (hasPassed && hook.exitCode !== 0)
+                        ? `${narrativeToolDetailClass("md")} text-[var(--diff-remove)]`
+                        : narrativeToolDetailClass("md")
+                    }
+                    title={line}
+                  >
+                    {line}
+                    {isRunning && index === fullLines.length - 1 && (
+                      <span aria-hidden="true" className="typing-cursor" />
+                    )}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
         </AnimatedCollapsible>
       )}
     </div>

--- a/apps/web/src/components/chat/narrative/ThoughtBlock.tsx
+++ b/apps/web/src/components/chat/narrative/ThoughtBlock.tsx
@@ -26,7 +26,7 @@ interface ThoughtBlockProps {
  */
 export function ThoughtBlock({ segment, isActive }: ThoughtBlockProps) {
   return (
-    <div className="px-2 py-1">
+    <div className="px-2 py-1 text-sm text-foreground">
       {/* `showCursor={false}` — a thought rendered in the timeline is either
           settled (turn over) or just-closed because a tool_use boundary
           fired. In neither case is the agent actively typing INTO this block:

--- a/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
+++ b/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { ReactNode } from "react";
 import { ChevronRight } from "lucide-react";
 import { AnimatedCollapsible } from "@/components/ui/animated-collapsible";
 import {
@@ -22,6 +23,57 @@ interface ToolSummaryLineProps {
   hasError: boolean;
   /** Whether any call in the group was cancelled. */
   hasCancelled: boolean;
+}
+
+interface NarrativeSummaryLineProps {
+  /** Whether the row is currently expanded. */
+  open: boolean;
+  /** Called when the row is clicked. */
+  onToggle: () => void;
+  /** Leading status or type icon. */
+  icon: ReactNode;
+  /** Primary summary text. */
+  children: ReactNode;
+  /** Optional status badge rendered before the chevron. */
+  badge?: ReactNode;
+  /** Whether the row can be expanded. */
+  expandable?: boolean;
+  /** Whether clicking the row is disabled. */
+  disabled?: boolean;
+}
+
+/** Shared compact narrative summary row used by tool and hook groups. */
+export function NarrativeSummaryLine({
+  open,
+  onToggle,
+  icon,
+  children,
+  badge,
+  expandable = true,
+  disabled = false,
+}: NarrativeSummaryLineProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      className={`${NARRATIVE_TOOL_ROW} w-full px-2 py-1 text-left rounded-md transition-colors duration-100 text-sm ${
+        disabled ? "cursor-default" : "hover:bg-muted/30"
+      }`}
+      aria-expanded={expandable ? open : undefined}
+    >
+      {icon}
+      {children}
+      {badge}
+      {expandable && (
+        <ChevronRight
+          className={`h-3 w-3 text-muted-foreground/30 shrink-0 transition-transform duration-150 ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+      )}
+    </button>
+  );
 }
 
 /**
@@ -91,26 +143,16 @@ export function ToolSummaryLine({
   return (
     <div className="min-w-0 max-w-full rounded-md">
       {/* Summary row */}
-      <button
-        type="button"
-        onClick={() => setOpen((prev) => !prev)}
-        className={`${NARRATIVE_TOOL_ROW} w-full px-2 py-1 text-left hover:bg-muted/30 rounded-md transition-colors duration-100 text-[0.8125rem]`}
-        aria-expanded={open}
+      <NarrativeSummaryLine
+        open={open}
+        onToggle={() => setOpen((prev) => !prev)}
+        icon={<LeadingIcon className="w-3 h-3 shrink-0 text-muted-foreground/40" />}
+        badge={worstBadge ? <StatusBadge status={worstBadge} /> : undefined}
       >
-        <LeadingIcon className="w-3 h-3 shrink-0 text-muted-foreground/40" />
-
         <span className="text-muted-foreground/60 flex-1 min-w-0 truncate">
           {summaryText}
         </span>
-
-        {worstBadge && <StatusBadge status={worstBadge} />}
-
-        <ChevronRight
-          className={`h-3 w-3 text-muted-foreground/30 shrink-0 transition-transform duration-150 ${
-            open ? "rotate-90" : ""
-          }`}
-        />
-      </button>
+      </NarrativeSummaryLine>
 
       {/* Expanded detail list */}
       <AnimatedCollapsible open={open}>
@@ -125,7 +167,7 @@ export function ToolSummaryLine({
             return (
               <li key={tc.id} className="flex min-w-0 max-w-full flex-col gap-0.5">
                 {/* Row: icon + label + detail + badge */}
-                <div className={`${NARRATIVE_TOOL_ROW} text-[0.8125rem]`}>
+                <div className={`${NARRATIVE_TOOL_ROW} text-sm`}>
                   <Icon className="w-[14px] h-[14px] text-muted-foreground/75 shrink-0" />
                   <span className="text-foreground/65 font-medium shrink-0">
                     {label}
@@ -140,7 +182,7 @@ export function ToolSummaryLine({
                 {tc.isComplete && !tc.isError && isShellTool(tc.toolName) && tc.output && (
                   <div className="flex min-w-0 max-w-full flex-col gap-1">
                     <ToolOutputTruncationNotice toolCall={tc} />
-                    <pre className="max-w-full text-[0.75rem] font-mono rounded px-2 py-1 bg-[var(--code-bg)] text-foreground/80 overflow-x-auto whitespace-pre-wrap break-words max-h-40">
+                    <pre className="max-w-full text-sm font-mono rounded px-2 py-1 bg-[var(--code-bg)] text-foreground/80 overflow-x-auto whitespace-pre-wrap break-words max-h-40">
                       {tc.output}
                     </pre>
                   </div>
@@ -149,7 +191,7 @@ export function ToolSummaryLine({
                 {tc.isError && tc.output && (
                   <div className="flex min-w-0 max-w-full flex-col gap-1">
                     <ToolOutputTruncationNotice toolCall={tc} />
-                    <pre className="max-w-full text-[0.75rem] font-mono rounded px-2 py-1 bg-[var(--diff-remove)]/10 text-[var(--diff-remove)] overflow-x-auto whitespace-pre-wrap break-words max-h-40">
+                    <pre className="max-w-full text-sm font-mono rounded px-2 py-1 bg-[var(--diff-remove)]/10 text-[var(--diff-remove)] overflow-x-auto whitespace-pre-wrap break-words max-h-40">
                       {tc.output}
                     </pre>
                   </div>

--- a/apps/web/src/components/chat/narrative/TurnFooter.tsx
+++ b/apps/web/src/components/chat/narrative/TurnFooter.tsx
@@ -49,7 +49,7 @@ export function TurnFooter({ counts, durationMs }: TurnFooterProps) {
   if (parts.length === 0 && durationMs == null) return null;
 
   return (
-    <div className="mt-2 flex items-baseline gap-3 pl-[18px] font-mono uppercase text-[0.625rem] tracking-[0.16em] text-muted-foreground/40">
+    <div className="mt-2 flex items-baseline gap-3 pl-[18px] font-mono uppercase text-xs tracking-[0.08em] text-muted-foreground/45">
       {parts.length > 0 && <span>{parts.join(" · ")}</span>}
       <span className="flex-1 h-px bg-border/40" aria-hidden="true" />
       <span className="tabular-nums">{formatDuration(durationMs)}</span>

--- a/apps/web/src/components/chat/narrative/__tests__/HookRow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/HookRow.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { HookRow } from "../HookRow";
+import type { HookExecution } from "@/transport/types";
+
+function makeHook(overrides: Partial<HookExecution> = {}): HookExecution {
+  return {
+    hookName: "SessionStart:startup",
+    hookType: "stop",
+    status: "completed",
+    outputLines: [],
+    fullOutput: [],
+    startedAt: 1_700_000_000_000,
+    durationMs: 32,
+    exitCode: 0,
+    didBlock: false,
+    ...overrides,
+  };
+}
+
+describe("HookRow", () => {
+  function closestCollapsible(element: HTMLElement): HTMLElement {
+    const collapsible = element.closest(".grid");
+    if (!(collapsible instanceof HTMLElement)) {
+      throw new Error("Expected hook detail to be inside AnimatedCollapsible");
+    }
+    return collapsible;
+  }
+
+  it("renders the hook row with the shared tool summary row scale", () => {
+    render(<HookRow hook={makeHook()} />);
+
+    const row = screen.getByRole("button", { name: /SessionStart:startup/ });
+
+    expect(row).toHaveClass("text-sm");
+    expect(row).toHaveClass("px-2", "py-1", "rounded-md");
+    expect(screen.getByText("SessionStart:startup")).toHaveClass("text-muted-foreground/60");
+  });
+
+  it("renders expanded output at narrative text size", async () => {
+    const user = userEvent.setup();
+    render(<HookRow hook={makeHook({ outputLines: ["startup ok"], fullOutput: ["startup ok"] })} />);
+
+    const detail = screen.getByText("startup ok");
+    expect(closestCollapsible(detail)).toHaveClass("grid-rows-[0fr]");
+
+    await user.click(screen.getByRole("button", { name: /SessionStart:startup/ }));
+
+    expect(detail).toHaveClass("text-sm");
+    expect(closestCollapsible(detail)).toHaveClass("grid-rows-[1fr]");
+  });
+
+  it("previews live output lines and expands to full output", async () => {
+    const user = userEvent.setup();
+    render(
+      <HookRow
+        hook={makeHook({
+          outputLines: ["preview line"],
+          fullOutput: ["preview line", "full line"],
+        })}
+      />,
+    );
+
+    const detail = screen.getByText("preview line");
+    expect(screen.getByText("full line")).toHaveClass("text-sm");
+    expect(closestCollapsible(detail)).toHaveClass("grid-rows-[0fr]");
+
+    await user.click(screen.getByRole("button", { name: /SessionStart:startup/ }));
+
+    expect(closestCollapsible(detail)).toHaveClass("grid-rows-[1fr]");
+  });
+
+  it("renders persisted hook detail after expansion when stdout is unavailable", async () => {
+    const user = userEvent.setup();
+    render(
+      <HookRow
+        hook={makeHook({
+          outputLines: ["phase: stop", "tool: Bash", "blocked: yes"],
+          fullOutput: ["phase: stop", "tool: Bash", "blocked: yes"],
+          detailLines: ["phase: stop", "tool: Bash", "blocked: yes"],
+          didBlock: true,
+        })}
+      />,
+    );
+
+    const detail = screen.getByText(/phase: stop/);
+    expect(screen.getByText(/tool: Bash/)).toHaveClass("text-sm");
+    expect(screen.getByText(/blocked: yes/)).toHaveClass("text-sm");
+    expect(closestCollapsible(detail)).toHaveClass("grid-rows-[0fr]");
+
+    await user.click(screen.getByRole("button", { name: /SessionStart:startup/ }));
+
+    expect(closestCollapsible(detail)).toHaveClass("grid-rows-[1fr]");
+  });
+
+  it("does not overflow narrow containers with long hook names", () => {
+    const { container } = render(
+      <div style={{ width: 360 }}>
+        <HookRow
+          hook={makeHook({
+            hookName: "SessionStart:startup:with-a-long-single-token-hook-name",
+            toolName: "VeryLongToolNameWithoutNaturalBreaks",
+          })}
+        />
+      </div>,
+    );
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    const row = screen.getByRole("button", { name: /SessionStart:startup/ });
+
+    expect(row).toHaveClass("min-w-0", "overflow-hidden");
+    expect(screen.getByText(/SessionStart:startup/)).toHaveClass("min-w-0", "truncate");
+    expect(wrapper.scrollWidth).toBeLessThanOrEqual(wrapper.clientWidth);
+  });
+});

--- a/apps/web/src/components/chat/narrative/build-persisted-narrative.test.ts
+++ b/apps/web/src/components/chat/narrative/build-persisted-narrative.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { buildPersistedNarrativeItems } from "./build-persisted-narrative";
+import {
+  buildPersistedNarrativeItems,
+  recordToHookExecution,
+} from "./build-persisted-narrative";
 import type {
   ToolCallRecord,
   ThoughtSegmentRecord,
@@ -115,6 +118,44 @@ describe("buildPersistedNarrativeItems", () => {
     });
     expect(items).toHaveLength(1);
     expect(items[0].type).toBe("hook");
+  });
+
+  it("omits stop hooks from the pre-message narrative", () => {
+    const items = buildPersistedNarrativeItems({
+      tools: [],
+      thoughts: [],
+      hooks: [
+        makeHook({
+          id: "hk-1",
+          phase: "stop",
+        }),
+      ],
+    });
+
+    expect(items).toEqual([]);
+  });
+
+  it("maps persisted hook metadata into readable detail lines", () => {
+    const hook = recordToHookExecution(
+      makeHook({
+        id: "hk-1",
+        phase: "stop",
+        tool_name: "Bash",
+        payload: "{\"command\":\"bun test\"}",
+        duration_ms: 42,
+        did_block: true,
+      }),
+    );
+
+    expect(hook.hookType).toBe("stop");
+    expect(hook.outputLines).toEqual([
+      "phase: stop",
+      "tool: Bash",
+      "duration: 42ms",
+      "blocked: yes",
+      "payload: {\"command\":\"bun test\"}",
+    ]);
+    expect(hook.fullOutput).toEqual(hook.outputLines);
   });
 
   it("nests child tool calls under their parent Agent as a subagent row", () => {

--- a/apps/web/src/components/chat/narrative/build-persisted-narrative.ts
+++ b/apps/web/src/components/chat/narrative/build-persisted-narrative.ts
@@ -57,21 +57,36 @@ function recordToThoughtSegment(r: ThoughtSegmentRecord): ThoughtSegment {
 }
 
 /** Map a persisted hook record to the live `HookExecution` shape. */
-function recordToHookExecution(r: HookExecutionRecord): HookExecution {
+export function recordToHookExecution(r: HookExecutionRecord): HookExecution {
   // Phase strings from server are arbitrary; coerce to the live discriminator.
   const hookType: HookExecution["hookType"] =
     r.phase === "stop" ? "stop" : "permission";
+  const detailLines = persistedHookDetailLines(r);
   return {
     hookName: r.hook_name,
     hookType,
     toolName: r.tool_name ?? undefined,
     status: "completed",
-    outputLines: [],
-    fullOutput: [],
+    outputLines: detailLines,
+    fullOutput: detailLines,
+    detailLines,
     durationMs: r.duration_ms ?? undefined,
     didBlock: r.did_block,
     startedAt: isoToMs(r.started_at),
   };
+}
+
+/** Format persisted hook metadata into bounded detail lines for HookRow. */
+export function persistedHookDetailLines(r: HookExecutionRecord): string[] {
+  const lines: string[] = [`phase: ${r.phase}`];
+  if (r.tool_name) lines.push(`tool: ${r.tool_name}`);
+  if (r.duration_ms != null) lines.push(`duration: ${r.duration_ms}ms`);
+  lines.push(`blocked: ${r.did_block ? "yes" : "no"}`);
+  const payload = r.payload.trim();
+  if (payload.length > 0 && payload !== "{}") {
+    lines.push(`payload: ${payload.length > 500 ? `${payload.slice(0, 500)}...` : payload}`);
+  }
+  return lines;
 }
 
 /** A unified timeline event sorted by persisted `sort_order` ascending. */
@@ -174,6 +189,7 @@ export function buildPersistedNarrativeItems(
     });
   }
   for (const h of hooks) {
+    if (h.phase === "stop") continue;
     timeline.push({
       kind: "hook",
       hook: recordToHookExecution(h),

--- a/apps/web/src/components/chat/narrative/narrative-layout.ts
+++ b/apps/web/src/components/chat/narrative/narrative-layout.ts
@@ -18,7 +18,7 @@ export const NARRATIVE_TOOL_ROW =
 export function narrativeToolDetailClass(size: "sm" | "md"): string {
   const tone =
     size === "md"
-      ? "text-[0.75rem] text-muted-foreground/80"
+      ? "text-sm text-muted-foreground/80"
       : "text-[0.6875rem] text-muted-foreground/50";
   return `font-mono ${tone} truncate flex-1 min-w-0 [overflow-wrap:anywhere]`;
 }

--- a/apps/web/src/components/chat/tool-renderers/ToolCallWrapper.tsx
+++ b/apps/web/src/components/chat/tool-renderers/ToolCallWrapper.tsx
@@ -64,7 +64,7 @@ function ToolCallWrapperInner({
       <button
         type="button"
         onClick={() => hasContent && setExpanded((p) => !p)}
-        className={`flex w-full flex-col gap-0.5 pl-3 pr-1 py-1.5 text-left text-xs ${
+        className={`flex w-full flex-col gap-0.5 pl-3 pr-1 py-1.5 text-left text-sm ${
           hasContent ? "cursor-pointer hover:bg-muted/30" : "cursor-default"
         }`}
       >
@@ -95,7 +95,7 @@ function ToolCallWrapperInner({
         </div>
 
         {badge && (
-          <span className="truncate pl-[21px] text-xs text-muted-foreground/50 font-mono">
+          <span className="truncate pl-[21px] text-sm text-muted-foreground/50 font-mono">
             {badge}
           </span>
         )}

--- a/apps/web/src/components/chat/virtual-items.ts
+++ b/apps/web/src/components/chat/virtual-items.ts
@@ -1,7 +1,8 @@
 import type { PermissionDecision } from "@mcode/contracts";
-import type { Message, ToolCall, HookExecution } from "@/transport/types";
+import type { Message, ToolCall, HookExecution, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord } from "@/transport/types";
 import type { ThoughtSegment } from "./narrative/types";
 import { computeLiveStreamingText } from "./narrative/build-narrative";
+import { buildPersistedNarrativeItems } from "./narrative/build-persisted-narrative";
 import { isGoalStatusNotice } from "@/lib/goal-message";
 
 /** Compile-time exhaustive check; throws at runtime for unhandled discriminants. */
@@ -28,6 +29,16 @@ export const STREAMING_CARD_COLLAPSED_HEIGHT = 56;
 
 const EMPTY_HOOKS: readonly HookExecution[] = [];
 const EMPTY_THOUGHT_SEGMENTS: readonly ThoughtSegment[] = [];
+
+/** Cached persisted narrative rows for an assistant message. */
+export type PersistedNarrativeRecords = {
+  tools: ToolCallRecord[];
+  thoughts: ThoughtSegmentRecord[];
+  hooks: HookExecutionRecord[];
+} | undefined;
+
+/** Persisted narrative cache keyed by assistant message id. */
+export type PersistedNarrativeRecordsByMessage = Record<string, PersistedNarrativeRecords>;
 
 /** State that lets the current turn's live and persisted assistant rows share one React key. */
 export interface CurrentTurnResponseIdentity {
@@ -174,22 +185,37 @@ export function buildStableItems(
   persistedFilesChanged?: Record<string, string[]>,
   latestTurnWithChanges?: string | null,
   currentTurn?: CurrentTurnResponseIdentity,
+  persistedNarrativeByMessage?: PersistedNarrativeRecordsByMessage,
 ): ChatVirtualItem[] {
   const items: ChatVirtualItem[] = [];
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
-    // Persisted narrative timeline appears immediately BEFORE each
-    // assistant message so the audit trail visually precedes the response
-    // text - matching the live narrative-flow placement. The component
-    // renders `null` until records are fetched, so emitting a placeholder
-    // here doesn't cause layout jitter once records land.
+    const persistedRecords =
+      msg.role === "assistant" ? persistedNarrativeByMessage?.[msg.id] : undefined;
+    const persistedRows =
+      persistedRecords && msg.role === "assistant"
+        ? buildPersistedNarrativeItems({ ...persistedRecords, messageContent: msg.content })
+        : undefined;
+    const hasPersistedNarrativeRows =
+      persistedRows != null && persistedRows.length > 0;
+    const hasLateHookRows =
+      persistedRecords?.hooks.some((h) => h.phase === "stop") === true;
+    const hasPersistedFooter =
+      persistedRecords?.tools.some((t) => t.parent_tool_call_id == null) === true;
+
+    // Persisted narrative timeline appears immediately BEFORE each assistant
+    // message so the audit trail visually precedes the response text. Only
+    // visible persisted chrome is emitted; lazy loading is handled by
+    // MessageList so null renderers do not reserve virtualized rail height.
     if (msg.role === "assistant") {
-      items.push({
-        key: `persisted-narrative-${msg.id}`,
-        type: "persisted-narrative",
-        messageId: msg.id,
-        messageContent: msg.content,
-      });
+      if (hasPersistedNarrativeRows) {
+        items.push({
+          key: `persisted-narrative-${msg.id}`,
+          type: "persisted-narrative",
+          messageId: msg.id,
+          messageContent: msg.content,
+        });
+      }
     }
     const isCurrentAssistant =
       msg.role === "assistant" &&
@@ -213,20 +239,24 @@ export function buildStableItems(
       // after the assistant bubble, before the files-changed summary.
       // The component renders null when no late hooks are present, so this
       // placeholder costs nothing for turns without stop hooks.
-      items.push({
-        key: `persisted-late-hooks-${msg.id}`,
-        type: "persisted-late-hooks",
-        messageId: msg.id,
-      });
+      if (hasLateHookRows) {
+        items.push({
+          key: `persisted-late-hooks-${msg.id}`,
+          type: "persisted-late-hooks",
+          messageId: msg.id,
+        });
+      }
 
       // Turn footer (step / sub-agent counts + duration) renders AFTER the
       // assistant body — closing the turn rather than separating its actions
       // from its answer.
-      items.push({
-        key: `persisted-turn-footer-${msg.id}`,
-        type: "persisted-turn-footer",
-        messageId: msg.id,
-      });
+      if (hasPersistedFooter) {
+        items.push({
+          key: `persisted-turn-footer-${msg.id}`,
+          type: "persisted-turn-footer",
+          messageId: msg.id,
+        });
+      }
 
       // File change summary appears after the late hook rows
       const files = persistedFilesChanged?.[msg.id];

--- a/apps/web/src/components/projects/ProjectRow.tsx
+++ b/apps/web/src/components/projects/ProjectRow.tsx
@@ -75,7 +75,7 @@ export function ProjectRow({ workspace, isActive, onSelect, onPin, onRemove, hom
         }
       }}
       className={cn(
-        "group flex w-full min-w-0 cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-[13px] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "group flex w-full min-w-0 cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-[13px] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring max-[520px]:flex-col max-[520px]:items-stretch max-[520px]:gap-1.5",
         // group-aria-selected/cmd responds to parent CommandItem keyboard focus in the palette.
         // has no effect in landing page context (no parent with group/cmd).
         "hover:bg-accent/60 data-[active=true]:bg-accent group-aria-selected/cmd:bg-accent",
@@ -113,7 +113,7 @@ export function ProjectRow({ workspace, isActive, onSelect, onPin, onRemove, hom
           Cap the column fraction so the project title + path keep priority; inner
           layout uses a grid so the branch absorbs remaining width inside that cap
           instead of an arbitrary 10rem clip (impeccable: information-dense, mono meta). */}
-      <div className="flex shrink-0 min-w-0 max-w-[52%] flex-col items-end gap-0.5 font-mono text-[11px] text-muted-foreground/60">
+      <div className="flex shrink-0 min-w-0 max-w-[52%] flex-col items-end gap-0.5 font-mono text-[11px] text-muted-foreground/60 max-[520px]:max-w-none max-[520px]:flex-row max-[520px]:items-center max-[520px]:justify-between">
         {enrichment ? (
           <>
             <div className="grid w-full min-w-0 grid-cols-[auto_auto_minmax(0,1fr)_auto] items-center gap-1.5">
@@ -150,13 +150,13 @@ export function ProjectRow({ workspace, isActive, onSelect, onPin, onRemove, hom
               )}
             </div>
             {lastOpenedLabel && (
-              <span className="tabular-nums">{lastOpenedLabel}</span>
+              <span className="whitespace-nowrap tabular-nums">{lastOpenedLabel}</span>
             )}
           </>
         ) : (
           // Show timestamp as skeleton while enrichment is loading
           lastOpenedLabel && (
-            <span className="tabular-nums">{lastOpenedLabel}</span>
+            <span className="whitespace-nowrap tabular-nums">{lastOpenedLabel}</span>
           )
         )}
       </div>

--- a/apps/web/src/components/projects/ProjectSelectorLanding.tsx
+++ b/apps/web/src/components/projects/ProjectSelectorLanding.tsx
@@ -116,7 +116,7 @@ export function ProjectSelectorLanding() {
           <McodeLogo variant="landing" />
 
           {hasContent ? (
-        <div className="w-full max-w-lg">
+        <div className="w-full max-w-3xl">
           {hasRecentThreads && (
             <section className="mb-5">
               <h2 className="mb-2 px-1 font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/70">

--- a/apps/web/src/components/projects/RecentThreadRow.tsx
+++ b/apps/web/src/components/projects/RecentThreadRow.tsx
@@ -83,7 +83,7 @@ export function RecentThreadRow({ thread, isActive, onSelect, onRemove, home }: 
         }
       }}
       className={cn(
-        "group flex cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-[13px] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "group flex cursor-pointer items-center gap-3 rounded-sm px-3 py-2 text-[13px] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring max-[520px]:flex-col max-[520px]:items-stretch max-[520px]:gap-1.5",
         "hover:bg-accent/60 data-[active=true]:bg-accent",
       )}
       onClick={() => onSelect(thread)}
@@ -101,7 +101,7 @@ export function RecentThreadRow({ thread, isActive, onSelect, onRemove, home }: 
       </div>
 
       {/* Right: status dot, branch, ago time */}
-      <div className="flex shrink-0 flex-col items-end gap-0.5 font-mono text-[11px] text-muted-foreground/60">
+      <div className="flex shrink-0 flex-col items-end gap-0.5 font-mono text-[11px] text-muted-foreground/60 max-[520px]:flex-row max-[520px]:items-center max-[520px]:justify-between">
         <div className="flex items-center gap-1.5">
           {dot && (
             <span
@@ -120,7 +120,7 @@ export function RecentThreadRow({ thread, isActive, onSelect, onRemove, home }: 
           )}
         </div>
         {updatedLabel && (
-          <span className="tabular-nums">{updatedLabel}</span>
+          <span className="whitespace-nowrap tabular-nums">{updatedLabel}</span>
         )}
       </div>
 

--- a/apps/web/src/components/settings/SettingsView.tsx
+++ b/apps/web/src/components/settings/SettingsView.tsx
@@ -1,4 +1,6 @@
 import { SECTION_MAP, type SettingsSection } from "./settings-nav";
+import { PRIMARY_CONTENT_RAIL_CLASS } from "@/lib/layout-rails";
+import { cn } from "@/lib/utils";
 
 interface SettingsViewProps {
   /** Active settings section to render. */
@@ -14,7 +16,7 @@ export function SettingsView({ section }: SettingsViewProps) {
 
   return (
     <div className="h-full overflow-y-auto bg-background">
-      <div className="mx-auto max-w-4xl px-8 py-8">
+      <div className={cn(PRIMARY_CONTENT_RAIL_CLASS, "px-4 py-6 sm:px-8 sm:py-8")}>
         <ActiveSection />
       </div>
     </div>

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import { UpdateIndicator } from "./UpdateIndicator";
 import { PanelCollapseIcon } from "./SidebarRevealButton";
 import { useUiStore } from "@/stores/uiStore";
 import { McodeLogo } from "@/components/brand/McodeLogo";
+import { cn } from "@/lib/utils";
 
 /** True when running inside the Electron shell. */
 const IS_DESKTOP = typeof window !== "undefined" && !!window.desktopBridge;
@@ -41,7 +42,14 @@ export function Sidebar({
   };
 
   return (
-    <div className="flex h-full w-72 max-w-[55vw] flex-col bg-page md:max-w-none">
+    <div
+      className={cn(
+        "flex h-full flex-col bg-page",
+        settingsOpen
+          ? "w-40 max-w-[42vw] sm:w-56 md:w-72 md:max-w-none"
+          : "w-72 max-w-[55vw] md:max-w-none",
+      )}
+    >
       {/* Header */}
       <div className="flex h-11 items-center justify-between border-b border-border/40 pl-2 pr-2.5">
         {settingsOpen ? (

--- a/apps/web/src/lib/composer-layout.ts
+++ b/apps/web/src/lib/composer-layout.ts
@@ -77,7 +77,7 @@ export function preferredSplitPanelWidth(contentRowWidth: number, fraction = 0.5
  */
 export const OVERVIEW_AUTO_OPEN_MIN_ROW = 1024;
 
-/** Visual thread column width from the shared `max-w-4xl` message/composer shell. */
+/** Visual thread column width used for Overview collision spacing. */
 export const OVERVIEW_THREAD_CONTENT_MAX_WIDTH_PX = 896;
 
 /** Right-side popover footprint for Overview (`w-80`) plus collision padding. */

--- a/apps/web/src/lib/layout-rails.ts
+++ b/apps/web/src/lib/layout-rails.ts
@@ -1,0 +1,2 @@
+/** Shared responsive rail for primary content surfaces. */
+export const PRIMARY_CONTENT_RAIL_CLASS = "mx-auto w-full max-w-[96rem]";

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -117,6 +117,8 @@ export interface HookExecution {
   outputLines: string[];
   /** Full hook output buffer, available via "show all" toggle. */
   fullOutput: string[];
+  /** Persisted hook metadata rendered when stdout is unavailable. */
+  detailLines?: string[];
   exitCode?: number;
   durationMs?: number;
   didBlock?: boolean;


### PR DESCRIPTION
## What
Polishes the chat narrative layout, hook rows, and responsive content rails.

## Why
The chat surface had several visual and interaction issues: narrow content rails, tiny narrative text, hook rows that looked like checklist items, and persisted stop hooks that could leave empty rows or duplicate placement.

## Key Changes
- Expands shared chat, composer, settings, and landing rails with responsive constraints.
- Reworks hook rows to use the same summary and expansion pattern as tool rows, with hook-specific icons and shared detail styling.
- Prevents stop hooks from rendering in the pre-message narrative slot while keeping them after the assistant response.
- Raises narrative, tool detail, command output, and turn footer text to readable product UI sizes.
- Adds focused coverage for hook rows, persisted hook mapping, and virtual item placement.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786181928&installation_id=129163861&pr_number=848&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F848&signature=ae013120f02c59650d9b8375e5bb8974d5fee6e3f8689bf8a3cd7bb007ab7398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat and settings layout with wider, more responsive content areas.
  * Added richer hook and tool output display, including expandable details and better preview handling.
  * Narrative content now loads more reliably as messages appear.

* **Bug Fixes**
  * Fixed virtual chat items so placeholder chrome only appears when there’s real content to show.
  * Updated message, composer, and sidebar sizing to behave better across screen sizes.
  * Improved handling for persisted hook details when standard output isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->