### PR TITLE
fix(preview): stabilize webview browser tabs

### DIFF
--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -247,6 +247,18 @@ function createWindow() {
   return win;
 }
 
+it("allows sanitized clipboard writes in the preview partition only", () => {
+  const handler = previewPartition.setPermissionRequestHandler.mock.calls.at(-1)?.[0];
+  expect(handler).toBeTypeOf("function");
+  const callback = vi.fn();
+
+  handler?.({} as never, "clipboard-sanitized-write", callback);
+  expect(callback).toHaveBeenLastCalledWith(true);
+
+  handler?.({} as never, "clipboard-read", callback);
+  expect(callback).toHaveBeenLastCalledWith(false);
+});
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1244,6 +1256,23 @@ describe("preview-browser", () => {
       for (const v of createdViews) {
         expect(v.webContents.close).not.toHaveBeenCalled();
       }
+    });
+
+    it("does not schedule hidden discard when renderer webview hides the native view", async () => {
+      const win = createWindow();
+      const ev = fakeEvent(win);
+
+      await showPreview(win, { threadId: "webview-owner" });
+      await ipcHandlers["preview:sync"]!(ev, {
+        visible: false,
+        bounds: VALID_BOUNDS,
+        threadId: "webview-owner",
+        hideReason: "renderer-webview",
+        workspaceId: "ws-1",
+      });
+
+      const s = sessions.get(win.id)!;
+      expect(s.discardHiddenTimer).toBeNull();
     });
   });
 

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -160,6 +160,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       bounds: { x: number; y: number; width: number; height: number } | null;
       threadId?: string | null;
       resumeUrlHint?: string | null;
+      hideReason?: "renderer-webview";
       workspaceId?: string | null;
     }): Promise<void> {
       return ipcRenderer.invoke("preview:sync", payload);

--- a/apps/desktop/src/main/preview/index.ts
+++ b/apps/desktop/src/main/preview/index.ts
@@ -22,8 +22,8 @@ import { registerDesignModeHandlers } from "./preview-design-mode.js";
 /** Registers all preview:* IPC handlers. Call once at app startup. */
 export function registerPreviewBrowserHandlers(): void {
   const previewPartition = session.fromPartition("persist:mcode-preview");
-  previewPartition.setPermissionRequestHandler((_wc, _permission, callback) => {
-    callback(false);
+  previewPartition.setPermissionRequestHandler((_wc, permission, callback) => {
+    callback(permission === "clipboard-sanitized-write");
   });
 
   registerNavigationHandlers();

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -131,6 +131,7 @@ export function registerNavigationHandlers(): void {
         bounds: Bounds | null;
         threadId?: string | null;
         resumeUrlHint?: string | null;
+        hideReason?: "renderer-webview" | null;
         workspaceId?: string | null;
       },
     ) => {
@@ -168,7 +169,9 @@ export function registerNavigationHandlers(): void {
       }
       if (!payload.visible || !incomingBounds) {
         hidePreview(win, s);
-        onPreviewHidden(win, s);
+        if (payload.hideReason !== "renderer-webview") {
+          onPreviewHidden(win, s);
+        }
         return;
       }
 

--- a/apps/web/e2e/image-attachment-retry.spec.ts
+++ b/apps/web/e2e/image-attachment-retry.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test, type Page } from "@playwright/test";
+import { getDefaultSettings, type Thread } from "@mcode/contracts";
+import {
+  interceptZustandStores,
+  mockWebSocketServer,
+  seedActiveThread,
+} from "./helpers/e2e-helpers";
+
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const THREAD_ID = "thread-e2e-attachment-retry";
+const ATTACHMENT_WS_URL = "ws://localhost:19400";
+
+const WORKSPACE = {
+  id: "ws-attachment-retry",
+  name: "Attachment Retry",
+  path: "/tmp/attachment-retry",
+  provider_config: {},
+  is_git_repo: true,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  pinned: false,
+  last_opened_at: null,
+  sort_order: 0,
+};
+
+const THREAD: Thread = {
+  id: THREAD_ID,
+  workspace_id: "ws-attachment-retry",
+  title: "Retry image",
+  status: "active",
+  mode: "direct",
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  model: null,
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+function makeImageMessage() {
+  return {
+    id: "msg-user-image-retry",
+    thread_id: THREAD_ID,
+    role: "user" as const,
+    content: "",
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: new Date().toISOString(),
+    sequence: 1,
+    attachments: [
+      {
+        id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        name: "fresh-shot.png",
+        mimeType: "image/png",
+        sizeBytes: TINY_PNG.length,
+      },
+    ],
+  };
+}
+
+async function openSeededThread(page: Page): Promise<void> {
+  await mockWebSocketServer(page, { "settings.get": getDefaultSettings() });
+  await interceptZustandStores(page);
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await page.waitForFunction(
+    () =>
+      (window as unknown as { __mcodeHydrationComplete?: boolean }).__mcodeHydrationComplete ===
+      true,
+    { timeout: 30_000 },
+  );
+  await page.evaluate((wsUrl) => {
+    (
+      window as unknown as { __mcodeE2EAttachmentTransportWsUrl?: string }
+    ).__mcodeE2EAttachmentTransportWsUrl = wsUrl;
+  }, ATTACHMENT_WS_URL);
+  await seedActiveThread(page, WORKSPACE, THREAD, [makeImageMessage()]);
+}
+
+test.describe("Image attachment retry", () => {
+  test("keeps a fresh transcript image mounted when the first attachment request 404s", async ({
+    page,
+  }) => {
+    let requestCount = 0;
+    await page.route(
+      /http:\/\/(localhost|127\.0\.0\.1):\d{5}\/attachments\/.+/,
+      async (route) => {
+        requestCount += 1;
+        const retry = new URL(route.request().url()).searchParams.get("mcodeRetry");
+        if (!retry) {
+          await route.fulfill({ status: 404, body: "Not found" });
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "image/png",
+          body: TINY_PNG,
+        });
+      },
+    );
+
+    await openSeededThread(page);
+
+    const thumbnail = page.getByRole("button", { name: "Preview image fresh-shot.png" });
+    await expect(thumbnail).toBeVisible({ timeout: 10_000 });
+    await expect(thumbnail.locator("img")).toHaveAttribute("src", /mcodeRetry=1/, {
+      timeout: 10_000,
+    });
+    expect(requestCount).toBeGreaterThanOrEqual(2);
+
+    await page.screenshot({
+      path: "e2e/screenshots/image-attachment-retry.png",
+      fullPage: false,
+    });
+  });
+});

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -94,17 +94,26 @@ async function injectPreviewBridge(
     const captureFail = (): Promise<{ ok: false; error: string }> =>
       Promise.resolve({ ok: false, error: "no-preview" });
     const unsub = (): (() => void) => () => undefined;
-    const emptyTabSet = (threadId: string): unknown => ({
+    const tabSet = (threadId: string): unknown => ({
       threadId,
-      activeTabId: null,
-      tabs: [],
+      activeTabId: loaded ? "mock-tab" : null,
+      tabs: loaded
+        ? [
+            {
+              id: "mock-tab",
+              url: "https://example.com",
+              title: "Example",
+              faviconUrl: null,
+            },
+          ]
+        : [],
     });
     const tabOk = (threadId: string): Promise<unknown> =>
-      Promise.resolve({ ok: true, data: emptyTabSet(threadId) });
+      Promise.resolve({ ok: true, data: tabSet(threadId) });
     const tabCreateOk = (threadId: string): Promise<unknown> =>
       Promise.resolve({
         ok: true,
-        data: { tabSet: emptyTabSet(threadId), createdTabId: "mock-tab" },
+        data: { tabSet: tabSet(threadId), createdTabId: "mock-tab" },
       });
 
     // The pick promise stays pending until something explicitly cancels it,
@@ -122,6 +131,13 @@ async function injectPreviewBridge(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (window as any).__mcodeNav.push(url);
         return Promise.resolve({ ok: true } as const);
+      },
+      resolveNavigation: (url: string) => {
+        const trimmed = url.trim();
+        const resolved = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+          ? trimmed
+          : `https://${trimmed}`;
+        return Promise.resolve({ ok: true, url: resolved } as const);
       },
       detectLocalPorts: () => Promise.resolve(ports),
       goBack: () => Promise.resolve(false),
@@ -317,6 +333,69 @@ async function openPreviewTab(page: Page): Promise<void> {
     "[data-testid='preview-panel'], [data-testid='preview-panel-unavailable']",
     { timeout: 5000 },
   );
+}
+
+/** Emit the Electron webview title event that Chromium's custom-element stand-in lacks. */
+async function emitMockWebviewTitle(page: Page, title: string): Promise<void> {
+  await page.waitForSelector("[data-testid='preview-webview']", {
+    state: "attached",
+    timeout: 5000,
+  });
+  await page.waitForTimeout(50);
+  await page.evaluate((title) => {
+    const webview = document.querySelector("[data-testid='preview-webview']");
+    if (!webview) throw new Error("Missing preview webview");
+    const event = new Event("page-title-updated") as Event & {
+      title?: string;
+    };
+    Object.defineProperty(event, "title", { value: title });
+    webview.dispatchEvent(event);
+  }, title);
+}
+
+/** Emit the Electron webview load-failure event that drives webview-mode errors. */
+async function emitMockWebviewFailure(
+  page: Page,
+  opts: { url: string; canGoBack: boolean },
+): Promise<void> {
+  await page.waitForSelector("[data-testid='preview-webview']", {
+    state: "attached",
+    timeout: 5000,
+  });
+  await page.waitForTimeout(50);
+  await page.evaluate(({ url, canGoBack }) => {
+    const webview = document.querySelector("[data-testid='preview-webview']");
+    if (!webview) throw new Error("Missing preview webview");
+    Object.defineProperty(webview, "canGoBack", {
+      configurable: true,
+      value: () => canGoBack,
+    });
+    Object.defineProperty(webview, "canGoForward", {
+      configurable: true,
+      value: () => false,
+    });
+    Object.defineProperty(webview, "reload", {
+      configurable: true,
+      value: () => {
+        const w = window as unknown as {
+          __mcodePreview?: { reload: number };
+        };
+        if (w.__mcodePreview) w.__mcodePreview.reload += 1;
+      },
+    });
+    webview.dispatchEvent(new Event("dom-ready"));
+    const event = new Event("did-fail-load") as Event & {
+      errorCode?: number;
+      errorDescription?: string;
+      validatedURL?: string;
+    };
+    Object.defineProperties(event, {
+      errorCode: { value: -105 },
+      errorDescription: { value: "ERR_NAME_NOT_RESOLVED" },
+      validatedURL: { value: url },
+    });
+    webview.dispatchEvent(event);
+  }, opts);
 }
 
 async function waitForAnnotationStores(page: Page): Promise<void> {
@@ -515,6 +594,7 @@ test.describe("PreviewPanel: loaded header", () => {
     await injectPreviewBridge(page, { loaded: true });
     await openAppAtThread(page);
     await openPreviewTab(page);
+    await emitMockWebviewTitle(page, "Example");
     // Opening via mod+shift+b drops focus into the URL field (the focused
     // state) via a deferred rAF. Blur, let any queued re-focus rAF fire, then
     // assert the bar has settled into the loaded-title state (input shows the
@@ -549,6 +629,38 @@ test.describe("PreviewPanel: loaded header", () => {
       header.evaluate((el) => getComputedStyle(el).backgroundColor),
     ]);
     expect(railBackground).toBe(headerBackground);
+  });
+
+  test("webview stretches to the preview surface bottom", async ({ page }) => {
+    await expect(page.getByTestId("preview-webview-surface")).toBeVisible();
+    await expect(page.getByTestId("preview-webview")).toBeVisible();
+
+    const geometry = await page.evaluate(() => {
+      const rectFor = (selector: string) => {
+        const el = document.querySelector(selector);
+        if (!el) throw new Error(`Missing ${selector}`);
+        const rect = el.getBoundingClientRect();
+        return {
+          top: rect.top,
+          bottom: rect.bottom,
+          height: rect.height,
+        };
+      };
+
+      return {
+        panel: rectFor("[data-testid='preview-panel']"),
+        surface: rectFor("[data-testid='preview-surface']"),
+        webviewSurface: rectFor("[data-testid='preview-webview-surface']"),
+        webview: rectFor("[data-testid='preview-webview']"),
+      };
+    });
+
+    expect(geometry.surface.height).toBeGreaterThan(400);
+    expect(Math.abs(geometry.webviewSurface.top - geometry.surface.top)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.webviewSurface.bottom - geometry.surface.bottom)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.webview.top - geometry.surface.top)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.webview.bottom - geometry.surface.bottom)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.panel.bottom - geometry.surface.bottom)).toBeLessThanOrEqual(1);
   });
 
   test("chat and right panel meet at the draggable split line", async ({ page }) => {
@@ -746,13 +858,10 @@ test.describe("PreviewPanel: empty localhost ports", () => {
     await openPreviewTab(page);
 
     await page.getByTestId("browser-local-port").first().click();
-    await expect
-      .poll(() =>
-        page.evaluate(
-          () => (window as unknown as { __mcodeNav: string[] }).__mcodeNav,
-        ),
-      )
-      .toContain("http://localhost:5173");
+    await expect(page.getByTestId("preview-webview")).toHaveAttribute(
+      "src",
+      "http://localhost:5173",
+    );
   });
 });
 
@@ -881,11 +990,15 @@ test.describe("PreviewPanel: error states", () => {
     await injectErrorBridge(page, { url: "https://nope.test", canGoBack: true });
     await openAppAtThread(page);
     await openPreviewTab(page);
+    await emitMockWebviewFailure(page, {
+      url: "https://nope.test",
+      canGoBack: true,
+    });
 
     const panel = page.getByTestId("preview-error-panel");
     await expect(panel).toBeVisible();
     await expect(page.getByTestId("preview-error-headline")).toHaveText(
-      "Can't reach this site",
+      "ERR_NAME_NOT_RESOLVED",
     );
     // Distilled to the essentials: Retry (primary) + Go back (history exists).
     await expect(panel.getByRole("button", { name: "Retry" })).toBeVisible();
@@ -903,6 +1016,10 @@ test.describe("PreviewPanel: error states", () => {
     await injectErrorBridge(page, { url: "https://nope.test", canGoBack: true });
     await openAppAtThread(page);
     await openPreviewTab(page);
+    await emitMockWebviewFailure(page, {
+      url: "https://nope.test",
+      canGoBack: true,
+    });
 
     await page.getByTestId("preview-error-retry").click();
     await expect
@@ -915,6 +1032,10 @@ test.describe("PreviewPanel: error states", () => {
     await injectErrorBridge(page, { url: "https://nope.test", canGoBack: false });
     await openAppAtThread(page);
     await openPreviewTab(page);
+    await emitMockWebviewFailure(page, {
+      url: "https://nope.test",
+      canGoBack: false,
+    });
 
     const panel = page.getByTestId("preview-error-panel");
     await expect(panel.getByRole("button", { name: "Retry" })).toBeVisible();
@@ -926,6 +1047,10 @@ test.describe("PreviewPanel: error states", () => {
     await injectErrorBridge(page, { url: "file:///gone.html", canGoBack: false });
     await openAppAtThread(page);
     await openPreviewTab(page);
+    await emitMockWebviewFailure(page, {
+      url: "file:///gone.html",
+      canGoBack: false,
+    });
 
     const panel = page.getByTestId("preview-error-panel");
     await expect(panel).toBeVisible();

--- a/apps/web/e2e/right-panel-activity-rail.spec.ts
+++ b/apps/web/e2e/right-panel-activity-rail.spec.ts
@@ -153,21 +153,21 @@ test.describe("Right panel activity rail", () => {
     await expect(page.locator('[data-rail-tab="terminal"]')).toHaveCount(0);
     await expect(page.locator('[data-rail-tab="preview"]')).toHaveClass(/text-primary/);
 
-    // Closing the last tab returns to the empty-state tool list; maximize stays on the rail.
+    // Closing the last tab returns to the empty-state tool list; the panel toggle stays on the rail.
     await page.locator('[data-rail-tab="preview"]').hover();
     await page.getByRole("button", { name: "Close Browser" }).click();
     await expect(page.getByTestId("panel-empty-state")).toBeVisible();
-    await expect(page.getByTestId("rail-maximize-toggle")).toBeVisible();
+    await expect(page.getByTestId("rail-panel-toggle")).toBeVisible();
   });
 
-  test("maximize button is visible in the empty state", async ({ page }) => {
+  test("panel toggle is visible in the empty state", async ({ page }) => {
     await seed(page);
 
     await expect(page.getByTestId("panel-empty-state")).toBeVisible();
-    await expect(page.getByTestId("rail-maximize-toggle")).toBeVisible();
-    await expect(page.getByTestId("rail-maximize-toggle")).toHaveAttribute(
+    await expect(page.getByTestId("rail-panel-toggle")).toBeVisible();
+    await expect(page.getByTestId("rail-panel-toggle")).toHaveAttribute(
       "aria-label",
-      "Maximize panel",
+      "Toggle panel",
     );
   });
 
@@ -211,24 +211,29 @@ test.describe("Right panel activity rail", () => {
     await expect(page.locator('[data-rail-tab="terminal"]')).toHaveClass(/text-primary/);
   });
 
-  test("maximize button fills the content area and restores on second click", async ({ page }) => {
+  test("rail panel toggle hides the panel and mod+alt+b reopens it", async ({ page }) => {
     await seed(page, { tabs: ["terminal"] });
 
     const chatMain = page.locator("main").filter({ has: page.getByText("Message Mcode...") });
     const projectTree = page.getByRole("button", { name: "Activity Rail Delete Activity Rail" });
-    const maximize = page.getByTestId("rail-maximize-toggle");
+    const railToggle = page.getByTestId("rail-panel-toggle");
 
     await expect(chatMain).toBeVisible();
     await expect(projectTree).toBeVisible();
-    await expect(maximize).toBeVisible();
+    await expect(railToggle).toBeVisible();
 
-    await maximize.click();
-    await expect(chatMain).toBeHidden();
-    await expect(projectTree).toBeVisible();
-    await expect(maximize).toHaveAttribute("aria-label", "Restore panel");
-
-    await maximize.click();
+    await railToggle.click();
+    await expect(page.getByTestId("right-panel")).toHaveAttribute("aria-hidden", "true");
+    await expect(page.getByTestId("right-panel")).toHaveCSS("width", "0px");
     await expect(chatMain).toBeVisible();
-    await expect(maximize).toHaveAttribute("aria-label", "Maximize panel");
+    await expect(projectTree).toBeVisible();
+
+    await page.keyboard.press("Control+Alt+b");
+    await expect(page.getByTestId("right-panel")).toHaveAttribute("aria-hidden", "false");
+    await expect(page.getByTestId("activity-rail")).toBeVisible();
+    await expect(page.getByTestId("rail-panel-toggle")).toHaveAttribute(
+      "aria-label",
+      "Toggle panel",
+    );
   });
 });

--- a/apps/web/src/__tests__/MessageBubble.test.tsx
+++ b/apps/web/src/__tests__/MessageBubble.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Message, StoredAttachment } from "@/transport";
 import type { PreviewAnnotationBundle } from "@mcode/contracts";
@@ -154,6 +154,44 @@ describe("MessageBubble user messages", () => {
       `mcode-attachment://${threadUuid}/a1.png`,
     );
     expect(lb?.getAttribute("data-active-title")).toBe("shot.png");
+  });
+
+  it("retries a sent image attachment before replacing it with the broken-image fallback", async () => {
+    vi.useFakeTimers();
+    try {
+      const threadUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const message: Message = {
+        ...makeMessage(""),
+        thread_id: threadUuid,
+        attachments: [
+          {
+            id: "a1",
+            name: "shot.png",
+            mimeType: "image/png",
+            sizeBytes: 128,
+          },
+        ],
+      };
+
+      const { container } = render(<MessageBubble message={message} />);
+      const img = container.querySelector('img[alt="shot.png"]');
+      expect(img).toHaveAttribute("src", `mcode-attachment://${threadUuid}/a1.png`);
+
+      fireEvent.error(img!);
+
+      expect(container.querySelector('img[alt="shot.png"]')).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(container.querySelector('img[alt="shot.png"]')).toHaveAttribute(
+        "src",
+        `mcode-attachment://${threadUuid}/a1.png?mcodeRetry=1`,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("passes full slide tray and clicked index when several images attach", async () => {

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -18,6 +18,7 @@ import { PLAN_ANSWER_MESSAGE_PREFIX } from "@mcode/contracts";
 import { DeltaBlock } from "./narrative/DeltaBlock";
 import { parseGoalStatusNotice } from "@/lib/goal-message";
 import { PreviewAnnotationBundleChip } from "./PreviewAnnotationBundleChip";
+import { useRetriableAttachmentImage } from "./useRetriableAttachmentImage";
 
 /**
  * Returns true when the assistant message body collapses to nothing visible
@@ -279,15 +280,14 @@ function ImageThumbnail({
   single: boolean;
   onOpenPreview?: () => void;
 }) {
-  const [failed, setFailed] = useState(false);
-  const handleError = useCallback(() => setFailed(true), []);
+  const image = useRetriableAttachmentImage(src);
 
   const frame = cn(
-    "overflow-hidden rounded-xl ring-1 ring-border/40",
+    "relative overflow-hidden rounded-xl bg-muted/40 ring-1 ring-border/40",
     single ? "max-w-[240px]" : "max-w-[140px]",
   );
 
-  if (failed) {
+  if (image.failed) {
     return (
       <div className={frame}>
         <div className="flex items-center gap-2 rounded-xl bg-muted/50 px-3 py-2.5">
@@ -299,14 +299,25 @@ function ImageThumbnail({
   }
 
   const imgEl = (
-    <img
-      src={src}
-      alt={name}
-      className="block h-auto max-h-[160px] w-full bg-muted/40 object-contain"
-      loading="lazy"
-      onError={handleError}
-      style={{ imageOrientation: "from-image" }}
-    />
+    <>
+      <img
+        src={image.src}
+        alt={name}
+        className={cn(
+          "block h-auto max-h-[160px] w-full object-contain transition-opacity",
+          image.retrying ? "min-h-16 min-w-24 opacity-0" : "opacity-100",
+        )}
+        loading="lazy"
+        onError={image.onError}
+        onLoad={image.onLoad}
+        style={{ imageOrientation: "from-image" }}
+      />
+      {image.retrying ? (
+        <span className="absolute inset-0 flex items-center justify-center text-muted-foreground/70">
+          <ImageIcon size={14} className="animate-pulse" aria-hidden />
+        </span>
+      ) : null}
+    </>
   );
 
   if (onOpenPreview) {

--- a/apps/web/src/components/chat/PreviewAnnotationBundleChip.tsx
+++ b/apps/web/src/components/chat/PreviewAnnotationBundleChip.tsx
@@ -1,11 +1,12 @@
 import type { PreviewAnnotationBundle, PreviewAnnotationPayload } from "@mcode/contracts";
-import { MessageCircle, X } from "lucide-react";
+import { ImageIcon, MessageCircle, X } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { buildStoredAttachmentImageSrc } from "@/lib/attachment-url";
 import { cn } from "@/lib/utils";
+import { useRetriableAttachmentImage } from "./useRetriableAttachmentImage";
 
 const MAX_DETAIL_LENGTH = 220;
 
@@ -29,6 +30,40 @@ function annotationDetail(annotation: PreviewAnnotationPayload): string {
   return text.length <= MAX_DETAIL_LENGTH
     ? text
     : `${text.slice(0, MAX_DETAIL_LENGTH - 3).trimEnd()}...`;
+}
+
+function AnnotationSnapshotThumbnail({ src }: { readonly src: string }) {
+  const image = useRetriableAttachmentImage(src);
+
+  return (
+    <span className="relative block h-14 overflow-hidden rounded-md border border-border/60 bg-muted/30">
+      {image.failed ? (
+        <span className="flex h-full w-full items-center justify-center text-muted-foreground">
+          <ImageIcon size={16} aria-hidden />
+        </span>
+      ) : (
+        <>
+          <img
+            src={image.src}
+            alt=""
+            className={cn(
+              "h-full w-full object-cover transition-opacity",
+              image.retrying ? "opacity-0" : "opacity-100",
+            )}
+            loading="lazy"
+            data-testid="preview-annotation-hover-thumbnail"
+            onError={image.onError}
+            onLoad={image.onLoad}
+          />
+          {image.retrying ? (
+            <span className="absolute inset-0 flex items-center justify-center text-muted-foreground/70">
+              <ImageIcon size={14} className="animate-pulse" aria-hidden />
+            </span>
+          ) : null}
+        </>
+      )}
+    </span>
+  );
 }
 
 /** Props for the compact annotation chip shown in composer and transcript surfaces. */
@@ -67,7 +102,7 @@ export function PreviewAnnotationBundleChip({
             tabIndex={0}
             aria-label={`${label}. Annotation details available.`}
             className={cn(
-              "group inline-flex max-w-full items-center gap-2 rounded-lg border border-accent-foreground/10 bg-accent px-2 py-1 text-xs font-medium text-accent-foreground shadow-sm transition-colors hover:border-accent-foreground/15 hover:bg-accent/90 focus-visible:border-accent-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-foreground/20",
+              "group relative inline-flex max-w-full items-center gap-2 rounded-lg border border-accent-foreground/10 bg-accent px-2 py-1 text-xs font-medium text-accent-foreground shadow-sm transition-colors hover:border-accent-foreground/15 hover:bg-accent/90 focus-visible:border-accent-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-foreground/20",
               className,
             )}
           >
@@ -83,7 +118,7 @@ export function PreviewAnnotationBundleChip({
                   event.stopPropagation();
                   onRemove();
                 }}
-                className="pointer-events-none -ml-1 text-accent-foreground/70 opacity-0 transition-opacity hover:bg-accent-foreground/10 hover:text-accent-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+                className="pointer-events-none absolute -right-2 -top-2 size-5 rounded-full border border-accent-foreground/10 bg-accent text-accent-foreground/70 opacity-0 shadow-sm transition-opacity hover:bg-accent-foreground/10 hover:text-accent-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
               >
                 <X size={12} aria-hidden />
               </Button>
@@ -129,17 +164,7 @@ export function PreviewAnnotationBundleChip({
                     {annotationDetail(annotation)}
                   </p>
                 </div>
-                {snapshotSrc ? (
-                  <span className="block h-14 overflow-hidden rounded-md border border-border/60 bg-muted/30">
-                    <img
-                      src={snapshotSrc}
-                      alt=""
-                      className="h-full w-full object-cover"
-                      loading="lazy"
-                      data-testid="preview-annotation-hover-thumbnail"
-                    />
-                  </span>
-                ) : null}
+                {snapshotSrc ? <AnnotationSnapshotThumbnail src={snapshotSrc} /> : null}
               </div>
             );
           })}

--- a/apps/web/src/components/chat/useRetriableAttachmentImage.ts
+++ b/apps/web/src/components/chat/useRetriableAttachmentImage.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const ATTACHMENT_IMAGE_RETRY_DELAYS_MS = [250, 750, 1500] as const;
+
+function appendRetryParam(src: string, attempt: number): string {
+  if (attempt === 0) return src;
+  const hashIndex = src.indexOf("#");
+  const base = hashIndex >= 0 ? src.slice(0, hashIndex) : src;
+  const hash = hashIndex >= 0 ? src.slice(hashIndex) : "";
+  const separator = base.includes("?") ? "&" : "?";
+  return `${base}${separator}mcodeRetry=${attempt}${hash}`;
+}
+
+/**
+ * Retries persisted attachment images that may be requested before the server finishes copying them.
+ */
+export function useRetriableAttachmentImage(src: string): {
+  readonly src: string;
+  readonly failed: boolean;
+  readonly retrying: boolean;
+  readonly onError: () => void;
+  readonly onLoad: () => void;
+} {
+  const [attempt, setAttempt] = useState(0);
+  const [failed, setFailed] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    setAttempt(0);
+    setFailed(false);
+    setRetrying(false);
+    clearTimeout(timerRef.current);
+    return () => clearTimeout(timerRef.current);
+  }, [src]);
+
+  const renderedSrc = useMemo(() => appendRetryParam(src, attempt), [attempt, src]);
+
+  const onLoad = useCallback(() => {
+    clearTimeout(timerRef.current);
+    setRetrying(false);
+  }, []);
+
+  const onError = useCallback(() => {
+    clearTimeout(timerRef.current);
+    if (attempt >= ATTACHMENT_IMAGE_RETRY_DELAYS_MS.length) {
+      setRetrying(false);
+      setFailed(true);
+      return;
+    }
+
+    setRetrying(true);
+    timerRef.current = setTimeout(() => {
+      setAttempt((current) => current + 1);
+    }, ATTACHMENT_IMAGE_RETRY_DELAYS_MS[attempt]);
+  }, [attempt]);
+
+  return { src: renderedSrc, failed, retrying, onError, onLoad };
+}

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -1,4 +1,4 @@
-import { Globe, Maximize2, Minimize2, Plus, X } from "lucide-react";
+import { Globe, PanelRight, Plus, X } from "lucide-react";
 import type { BrowserTabInfo, BrowserTabSet } from "@mcode/contracts";
 import { Button } from "@/components/ui/button";
 import {
@@ -394,11 +394,10 @@ function RailAddControl({
 }
 
 /**
- * Vertical activity rail for the right panel: maximize/restore at the head, then
+ * Vertical activity rail for the right panel: panel toggle at the head, then
  * open singleton tabs (active lamp, hover-× close, add control when tabs exist).
- * With no tabs open the rail is only the maximize toggle beside the empty-state
- * list. The panel itself is opened and closed from the chat-header toggle.
- * See ADR-0004 / issue #611.
+ * With no tabs open the rail is only the panel toggle beside the empty-state
+ * list. The rail toggle mirrors the chat-header toggle and right-panel shortcut.
  */
 export function ActivityRail({
   openTabs,
@@ -408,8 +407,7 @@ export function ActivityRail({
   changesCount,
   changesFresh,
   browserTabSet,
-  maximized,
-  onToggleMaximized,
+  onTogglePanel,
   onSelect,
   onClose,
   onCreate,
@@ -424,9 +422,7 @@ export function ActivityRail({
   readonly changesFresh: boolean;
   /** The Browser tab's open pages, or null when none are known (web build / not yet loaded). */
   readonly browserTabSet: BrowserTabSet | null;
-  /** Whether the panel is maximized (fills content area beside the project tree). */
-  readonly maximized: boolean;
-  onToggleMaximized: () => void;
+  onTogglePanel: () => void;
   onSelect: (id: RightPanelTab) => void;
   onClose: (id: RightPanelTab) => void;
   onCreate: (id: RightPanelTab) => void;
@@ -438,19 +434,20 @@ export function ActivityRail({
       data-testid="activity-rail"
       className="flex w-12 flex-none flex-col items-center gap-1 bg-background py-2"
     >
-      {/* Maximize / restore sits at the rail head (not the foot) so it stays in
+      {/* The panel toggle sits at the rail head (not the foot) so it stays in
           the first tab stop and never scrolls off-screen on short viewports. */}
       <Button
         variant="ghost"
         size="icon-xs"
-        onClick={onToggleMaximized}
+        onClick={onTogglePanel}
         className="shrink-0 text-muted-foreground/70 transition-colors hover:bg-transparent hover:text-foreground"
-        aria-label={maximized ? "Restore panel" : "Maximize panel"}
-        title={maximized ? "Restore panel" : "Maximize panel"}
-        data-testid="rail-maximize-toggle"
+        aria-label="Toggle panel"
+        aria-pressed={true}
+        title="Toggle panel"
+        data-testid="rail-panel-toggle"
         data-preview-design-keep-open="true"
       >
-        {maximized ? <Minimize2 /> : <Maximize2 />}
+        <PanelRight />
       </Button>
 
       {openTabs.map((id) => {

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1505,11 +1505,11 @@ function draftFromSaved(
 export const PREVIEW_WEBVIEW_FALLBACK_TAB_ID =
   "__mcode_webview_active_fallback__";
 
-/** Returns whether the flagged webview renderer should replace the native preview surface. */
+/** Returns whether the webview renderer should own the preview surface. */
 export function shouldRenderWebviewPreview(
-  engine: string | undefined,
+  _engine: string | undefined,
 ): boolean {
-  return engine === "webview";
+  return true;
 }
 
 export interface PreviewPanelProps {
@@ -1531,7 +1531,7 @@ export interface PreviewPanelProps {
  */
 export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
   const surfaceRef = useRef<HTMLDivElement>(null);
-  const webviewRef = useRef<PreviewWebviewHandle | null>(null);
+  const webviewRefs = useRef<Record<string, PreviewWebviewHandle | null>>({});
 
   const designModeActive = usePreviewDesignModeStore(
     (s) => s.modes[threadId] === true,
@@ -1674,11 +1674,11 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
     surfaceRef,
     forceHidden: showWebviewPreview,
   });
-  const [webviewSrc, setWebviewSrc] = useState<string | null>(null);
+  const [webviewSrcByTab, setWebviewSrcByTab] = useState<Record<string, string | null>>({});
   const webviewSrcRef = useRef<string | null>(null);
-  const setTrackedWebviewSrc = useCallback((nextSrc: string | null): void => {
+  const setTrackedWebviewSrc = useCallback((tabId: string, nextSrc: string | null): void => {
     webviewSrcRef.current = nextSrc;
-    setWebviewSrc(nextSrc);
+    setWebviewSrcByTab((prev) => ({ ...prev, [tabId]: nextSrc }));
   }, []);
   const [webviewNavError, setWebviewNavError] = useState<string | null>(null);
   const [webviewCanBack, setWebviewCanBack] = useState(false);
@@ -1729,16 +1729,89 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
   const tabs = usePreviewTabs(threadId);
   const activeWebviewTabId =
     tabs.tabSet?.activeTabId ?? PREVIEW_WEBVIEW_FALLBACK_TAB_ID;
+  const activeWebviewTab = tabs.tabSet?.tabs.find(
+    (tab) => tab.id === activeWebviewTabId,
+  );
+  const activeWebviewTabUrl = activeWebviewTab?.url ?? null;
+  const activeWebviewTabTitle = activeWebviewTab?.title ?? null;
+  const activeWebviewTabFavicon = activeWebviewTab?.faviconUrl ?? null;
+  const activeWebviewSrc =
+    webviewSrcByTab[activeWebviewTabId] ?? activeWebviewTabUrl;
+  const warmWebviewTabs = useMemo(() => {
+    const sourceTabs =
+      tabs.tabSet?.tabs.length
+        ? tabs.tabSet.tabs
+        : activeWebviewSrc
+          ? [
+              {
+                id: activeWebviewTabId,
+                url: activeWebviewSrc,
+              },
+            ]
+          : [];
+    return sourceTabs
+      .map((tab) => ({
+        id: tab.id,
+        src: webviewSrcByTab[tab.id] ?? tab.url ?? null,
+      }))
+      .filter((tab): tab is { id: string; src: string } => !!tab.src);
+  }, [activeWebviewSrc, activeWebviewTabId, tabs.tabSet, webviewSrcByTab]);
+  const activeWebviewRef = useCallback(
+    (): PreviewWebviewHandle | null =>
+      webviewRefs.current[activeWebviewTabId] ?? null,
+    [activeWebviewTabId],
+  );
 
   useEffect(() => {
-    webviewSrcRef.current = webviewSrc;
-  }, [webviewSrc]);
+    webviewSrcRef.current = activeWebviewSrc;
+  }, [activeWebviewSrc]);
+
+  useEffect(() => {
+    if (!showWebviewPreview) return;
+    if (!activeWebviewTabUrl) return;
+    const active = activeWebviewRef();
+    const nextUrl = active?.getUrl() || activeWebviewSrc || activeWebviewTabUrl;
+    const nextCanBack = active?.canGoBack() ?? false;
+    const nextCanFwd = active?.canGoForward() ?? false;
+    setWebviewPageStatus((status) => {
+      if (
+        status.phase === "error" &&
+        (status.url === nextUrl || status.url === activeWebviewTabUrl)
+      ) {
+        return status;
+      }
+      if (
+        status.url === nextUrl &&
+        status.title === activeWebviewTabTitle &&
+        status.favicon === activeWebviewTabFavicon &&
+        status.phase === "loaded" &&
+        status.error === undefined
+      ) {
+        return status;
+      }
+      return {
+        url: nextUrl,
+        title: activeWebviewTabTitle,
+        favicon: activeWebviewTabFavicon,
+        phase: "loaded",
+      };
+    });
+    setWebviewCanBack((value) => (value === nextCanBack ? value : nextCanBack));
+    setWebviewCanFwd((value) => (value === nextCanFwd ? value : nextCanFwd));
+  }, [
+    activeWebviewRef,
+    activeWebviewSrc,
+    activeWebviewTabFavicon,
+    activeWebviewTabTitle,
+    activeWebviewTabUrl,
+    showWebviewPreview,
+  ]);
 
   useEffect(() => {
     if (!showWebviewPreview) return;
     const stored = bridge.storedUrl.trim();
     if (!stored) {
-      setTrackedWebviewSrc(null);
+      setTrackedWebviewSrc(activeWebviewTabId, null);
       setWebviewPageStatus({
         url: null,
         title: null,
@@ -1747,10 +1820,17 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
       });
       return;
     }
-    if (webviewRef.current?.getUrl() === stored) return;
+    if (activeWebviewRef()?.getUrl() === stored) return;
     if (webviewSrcRef.current === stored) return;
-    setTrackedWebviewSrc(stored);
-  }, [bridge.storedUrl, setTrackedWebviewSrc, showWebviewPreview, threadId]);
+    setTrackedWebviewSrc(activeWebviewTabId, stored);
+  }, [
+    activeWebviewRef,
+    activeWebviewTabId,
+    bridge.storedUrl,
+    setTrackedWebviewSrc,
+    showWebviewPreview,
+    threadId,
+  ]);
 
   const onWebviewPageStatus = useCallback(
     (status: PreviewPageStatus): void => {
@@ -1779,43 +1859,44 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
           favicon: null,
           phase: "loading",
         });
-        const liveUrl = webviewRef.current?.getUrl();
+        const active = activeWebviewRef();
+        const liveUrl = active?.getUrl();
         const mountedSrc = webviewSrcRef.current;
         if (liveUrl === result.url) {
-          webviewRef.current?.reload();
+          active?.reload();
           return;
         }
         if (mountedSrc === result.url) {
-          webviewRef.current?.navigate(result.url);
+          active?.navigate(result.url);
           return;
         }
-        setTrackedWebviewSrc(result.url);
+        setTrackedWebviewSrc(activeWebviewTabId, result.url);
       });
     },
-    [bridge, setTrackedWebviewSrc, threadId],
+    [activeWebviewRef, activeWebviewTabId, bridge, setTrackedWebviewSrc, threadId],
   );
 
   const onWebviewOpenExternal = useCallback((): void => {
-    const url = webviewRef.current?.getUrl() || webviewSrc;
+    const url = activeWebviewRef()?.getUrl() || activeWebviewSrc;
     if (url) void window.desktopBridge?.openExternalUrl(url);
-  }, [webviewSrc]);
+  }, [activeWebviewRef, activeWebviewSrc]);
 
   const onWebviewGetZoom = useCallback(async (): Promise<number> => {
-    return (await webviewRef.current?.getZoom()) ?? 1;
-  }, []);
+    return (await activeWebviewRef()?.getZoom()) ?? 1;
+  }, [activeWebviewRef]);
 
   const onWebviewSetZoom = useCallback(
     async (factor: number): Promise<number> => {
-      return (await webviewRef.current?.setZoom(factor)) ?? factor;
+      return (await activeWebviewRef()?.setZoom(factor)) ?? factor;
     },
-    [],
+    [activeWebviewRef],
   );
 
   const effectivePageStatus = showWebviewPreview
     ? webviewPageStatus
     : bridge.pageStatus;
   const effectiveInputUrl = showWebviewPreview
-    ? (webviewPageStatus.url ?? webviewSrc ?? "")
+    ? (webviewPageStatus.url ?? activeWebviewSrc ?? "")
     : bridge.inputUrl;
   const effectivePageTitle = showWebviewPreview
     ? webviewPageStatus.title
@@ -1835,16 +1916,16 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
     ? onWebviewNavigate
     : bridge.onNavigate;
   const effectiveGoBack = showWebviewPreview
-    ? () => webviewRef.current?.goBack()
+    ? () => activeWebviewRef()?.goBack()
     : bridge.onGoBack;
   const effectiveGoForward = showWebviewPreview
-    ? () => webviewRef.current?.goForward()
+    ? () => activeWebviewRef()?.goForward()
     : bridge.onGoForward;
   const effectiveReload = showWebviewPreview
-    ? () => webviewRef.current?.reload()
+    ? () => activeWebviewRef()?.reload()
     : bridge.onReload;
   const effectiveForceReload = showWebviewPreview
-    ? () => webviewRef.current?.forceReload()
+    ? () => activeWebviewRef()?.forceReload()
     : bridge.onForceReload;
   const effectiveOpenExternal = showWebviewPreview
     ? onWebviewOpenExternal
@@ -2207,7 +2288,7 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
   }
 
   const hasLoadedPage = showWebviewPreview
-    ? !!(webviewSrc ?? webviewPageStatus.url)
+    ? !!(activeWebviewSrc ?? webviewPageStatus.url)
     : bridge.storedUrl.trim().length > 0;
   const pageError =
     effectivePageStatus.phase === "error"
@@ -2215,6 +2296,8 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
       : undefined;
   const showLocalPorts =
     !hasLoadedPage && !effectivePreviewLoading && !pageError;
+  const hasWebviewLayer = showWebviewPreview && warmWebviewTabs.length > 0;
+  const webviewLayerInteractive = hasWebviewLayer && !showLocalPorts && !pageError;
   const requestComposerSubmit = (): void => {
     window.dispatchEvent(
       new CustomEvent("mcode:submit-composer", {
@@ -2350,7 +2433,7 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
   return (
     <div
       data-testid="preview-panel"
-      className="flex min-h-0 min-w-0 flex-1 flex-col"
+      className="flex h-full min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden"
     >
       <div className={cn(showWebviewPreview && "relative z-20")}>
         {showAnnotationCommandBar ? (
@@ -2422,7 +2505,7 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
         aria-label="Page preview"
         data-testid="preview-surface"
         className={cn(
-          "relative min-h-[min(40vh,20rem)] min-w-0 flex-1",
+          "relative min-h-[min(40vh,20rem)] min-w-0 flex-1 basis-0",
           showWebviewPreview
             ? "z-0 overflow-hidden rounded-tl-md"
             : "mx-2 mb-2 mt-1 rounded-md border border-border/40 bg-muted/10",
@@ -2468,25 +2551,45 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
             <span>{CAPTURE_KIND_LABEL[lastCapture]}</span>
           </div>
         ) : null}
-        {showWebviewPreview ? (
+        {hasWebviewLayer ? (
           <div
             data-testid="preview-webview-surface"
-            className="absolute inset-0 z-0 overflow-hidden rounded-tl-md"
+            className={cn(
+              "absolute inset-0 z-0 overflow-hidden rounded-tl-md",
+              !webviewLayerInteractive && "pointer-events-none",
+            )}
           >
-            {webviewSrc ? (
+            {warmWebviewTabs.map((tab) => (
               <PreviewWebview
-                ref={webviewRef}
+                key={tab.id}
+                ref={(handle) => {
+                  webviewRefs.current[tab.id] = handle;
+                }}
                 threadId={threadId}
-                tabId={activeWebviewTabId}
-                src={webviewSrc}
-                className="relative z-0 h-full w-full"
-                onPageStatus={onWebviewPageStatus}
+                tabId={tab.id}
+                src={tab.src}
+                className={cn(
+                  "absolute inset-0 h-full w-full",
+                  tab.id === activeWebviewTabId
+                    ? "z-0 block"
+                    : "pointer-events-none -z-10 opacity-0",
+                )}
+                onPageStatus={(status) => {
+                  usePreviewTabsStore.getState().updateTabChrome(threadId, tab.id, {
+                    title: status.title,
+                    url: status.url,
+                    favicon: status.favicon,
+                  });
+                  if (tab.id !== activeWebviewTabId) return;
+                  onWebviewPageStatus(status);
+                }}
                 onNavigationStateChange={(state) => {
+                  if (tab.id !== activeWebviewTabId) return;
                   setWebviewCanBack(state.canGoBack);
                   setWebviewCanFwd(state.canGoForward);
                 }}
               />
-            ) : null}
+            ))}
           </div>
         ) : null}
         {visiblePageAnnotations.map((annotation) => {

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -97,6 +97,8 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     forwardedRef,
   ) {
   const ref = useRef<ElectronWebviewElement | null>(null);
+  const domReadyRef = useRef(false);
+  const pendingReloadRef = useRef(false);
   const faviconRef = useRef<string | null>(null);
 
   const readUrl = useCallback((): string | null => {
@@ -119,6 +121,10 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
 
   const emitNavigationState = useCallback(() => {
     const el = ref.current;
+    if (!domReadyRef.current || !el) {
+      onNavigationStateChange?.({ canGoBack: false, canGoForward: false });
+      return;
+    }
     onNavigationStateChange?.({
       canGoBack: !!el?.canGoBack?.(),
       canGoForward: !!el?.canGoForward?.(),
@@ -162,9 +168,15 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         }
       },
       reload() {
+        if (!domReadyRef.current) {
+          pendingReloadRef.current = true;
+          return;
+        }
+        pendingReloadRef.current = false;
         ref.current?.reload?.();
       },
       forceReload() {
+        if (!domReadyRef.current) return;
         const el = ref.current;
         if (el?.reloadIgnoringCache) {
           el.reloadIgnoringCache();
@@ -173,24 +185,28 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         }
       },
       goBack() {
-        if (ref.current?.canGoBack?.()) ref.current.goBack?.();
+        if (domReadyRef.current && ref.current?.canGoBack?.()) ref.current.goBack?.();
       },
       goForward() {
-        if (ref.current?.canGoForward?.()) ref.current.goForward?.();
+        if (domReadyRef.current && ref.current?.canGoForward?.()) ref.current.goForward?.();
       },
       canGoBack() {
+        if (!domReadyRef.current) return false;
         return !!ref.current?.canGoBack?.();
       },
       canGoForward() {
+        if (!domReadyRef.current) return false;
         return !!ref.current?.canGoForward?.();
       },
       getUrl() {
         return readUrl() ?? "";
       },
       async getZoom() {
+        if (!domReadyRef.current) return 1;
         return (await Promise.resolve(ref.current?.getZoomFactor?.())) ?? 1;
       },
       async setZoom(factor: number) {
+        if (!domReadyRef.current) return factor;
         await Promise.resolve(ref.current?.setZoomFactor?.(factor));
         return (await Promise.resolve(ref.current?.getZoomFactor?.())) ?? factor;
       },
@@ -237,6 +253,14 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     if (!el) return;
 
     const onStart = () => emitStatus("loading");
+    const onDomReady = () => {
+      domReadyRef.current = true;
+      if (pendingReloadRef.current) {
+        pendingReloadRef.current = false;
+        el.reload?.();
+      }
+      emitNavigationState();
+    };
     const onStop = () => emitStatus("loaded");
     const onNavigate = (ev: WebviewEvent) => {
       onPageStatus?.({
@@ -277,6 +301,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     };
 
     el.addEventListener("did-start-loading", onStart);
+    el.addEventListener("dom-ready", onDomReady);
     el.addEventListener("did-stop-loading", onStop);
     el.addEventListener("did-navigate", onNavigate);
     el.addEventListener("did-navigate-in-page", onNavigate);
@@ -285,6 +310,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     el.addEventListener("did-fail-load", onFail);
     return () => {
       el.removeEventListener("did-start-loading", onStart);
+      el.removeEventListener("dom-ready", onDomReady);
       el.removeEventListener("did-stop-loading", onStop);
       el.removeEventListener("did-navigate", onNavigate);
       el.removeEventListener("did-navigate-in-page", onNavigate);
@@ -292,7 +318,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       el.removeEventListener("page-favicon-updated", onFavicon);
       el.removeEventListener("did-fail-load", onFail);
     };
-  }, [onPageStatus, onNavigationStateChange]);
+  }, [emitNavigationState, emitStatus, onPageStatus, readTitle, readUrl]);
 
   // Use createElement via React JSX since <webview> is a custom Chromium
   // element; React 19 will pass unknown attributes through unchanged.
@@ -308,6 +334,13 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       data-tab-id={tabId}
       partition="persist:mcode-preview"
       className={className}
+      style={{
+        display: "inline-flex",
+        width: "100%",
+        height: "100%",
+        minWidth: 0,
+        minHeight: 0,
+      }}
     />
   );
 });

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -22,6 +22,7 @@ import { usePreviewDisplayTabSet, usePreviewTabsStore } from "@/stores/previewTa
 import { TerminalTabContent } from "@/components/terminal/TerminalTabContent";
 import { TerminalPoolSlot } from "@/components/terminal/TerminalPoolSlotContext";
 import { ensureTerminalForScope } from "@/lib/ensure-terminal";
+import { toggleRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { cn } from "@/lib/utils";
 
 /**
@@ -67,7 +68,6 @@ export function RightPanel() {
   // chat/composer (App.tsx suppresses the chat pane). A transient view toggle,
   // not a stored width — the panel keeps its width so restoring drops back inline.
   const maximized = useUiStore((s) => s.rightPanelMaximized);
-  const toggleMaximized = useUiStore((s) => s.toggleRightPanelMaximized);
 
   // Read the scope's effective panel record: the active thread's own once it has
   // diverged, otherwise the workspace fallback (ADR-0012 copy-on-write). Both
@@ -350,8 +350,7 @@ export function RightPanel() {
           changesCount={changesCount}
           changesFresh={changesFresh}
           browserTabSet={browserTabSet}
-          maximized={maximized}
-          onToggleMaximized={toggleMaximized}
+          onTogglePanel={() => toggleRightPanelAdaptive(activeWorkspaceId, activeThreadId)}
           onSelect={(id) => setRightPanelTab(activeWorkspaceId!, activeThreadId, id)}
           onClose={(id) => closeRightPanelTab(activeWorkspaceId!, activeThreadId, id)}
           onCreate={(id) => setRightPanelTab(activeWorkspaceId!, activeThreadId, id)}

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -12,11 +12,23 @@ import { getDefaultSettings } from "@mcode/contracts";
 
 const {
   mockUsePreviewBridge,
+  mockUsePreviewTabs,
   mockOnAddElementAnnotation,
   mockCaptureAnnotationSnapshot,
   mockListSkills,
 } = vi.hoisted(() => ({
   mockUsePreviewBridge: vi.fn(),
+  mockUsePreviewTabs: vi.fn<() => {
+    tabSet: unknown;
+    newTab: () => unknown;
+    activateTab: () => unknown;
+    closeTab: () => unknown;
+  }>(() => ({
+    tabSet: null,
+    newTab: vi.fn(),
+    activateTab: vi.fn(),
+    closeTab: vi.fn(),
+  })),
   mockOnAddElementAnnotation: vi.fn(),
   mockCaptureAnnotationSnapshot: vi.fn(),
   mockListSkills: vi.fn().mockResolvedValue([
@@ -41,12 +53,7 @@ vi.mock("@/transport", () => ({
 // The panel only consumes usePreviewTabs for the header's "New page" action and
 // the store subscription; page switching/closing lives in the activity rail.
 vi.mock("../hooks/usePreviewTabs", () => ({
-  usePreviewTabs: () => ({
-    tabSet: null,
-    newTab: vi.fn(),
-    activateTab: vi.fn(),
-    closeTab: vi.fn(),
-  }),
+  usePreviewTabs: mockUsePreviewTabs,
 }));
 
 vi.mock("../hooks/usePreviewCapture", () => ({
@@ -78,6 +85,7 @@ import {
 } from "@/stores/previewAnnotationStore";
 import { usePreviewDesignModeStore } from "@/stores/previewDesignModeStore";
 import { useSkillsStore } from "@/stores/skillsStore";
+import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 
 function mockBridgeState(overrides: Record<string, unknown> = {}) {
   const state = {
@@ -324,8 +332,15 @@ describe("PreviewPanel: full panel state", () => {
     usePreviewSuppressionStore.setState({ count: 0 });
     usePreviewAnnotationStore.setState({ byThread: {}, drafts: {} });
     usePreviewDesignModeStore.setState({ modes: {} });
+    usePreviewTabsStore.setState({ tabSetByScope: {}, liveChromeByScope: {} });
     useSkillsStore.getState().reset();
     mockUsePreviewBridge.mockReturnValue(mockBridgeState());
+    mockUsePreviewTabs.mockReturnValue({
+      tabSet: null,
+      newTab: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+    });
   });
 
   afterEach(() => {
@@ -336,8 +351,10 @@ describe("PreviewPanel: full panel state", () => {
     usePreviewSuppressionStore.setState({ count: 0 });
     usePreviewAnnotationStore.setState({ byThread: {}, drafts: {} });
     usePreviewDesignModeStore.setState({ modes: {} });
+    usePreviewTabsStore.setState({ tabSetByScope: {}, liveChromeByScope: {} });
     useSkillsStore.getState().reset();
     mockUsePreviewBridge.mockClear();
+    mockUsePreviewTabs.mockClear();
     mockOnAddElementAnnotation.mockClear();
     mockCaptureAnnotationSnapshot.mockClear();
   });
@@ -384,17 +401,17 @@ describe("PreviewPanel: full panel state", () => {
     expect(screen.queryByTestId("preview-tab-bar")).not.toBeInTheDocument();
   });
 
-  it("uses the native preview path by default", () => {
+  it("uses the webview preview path by default", () => {
     render(<PreviewPanel threadId="thread-1" />);
     expect(screen.queryByTestId("preview-webview-surface")).not.toBeInTheDocument();
     expect(screen.getByTestId("browser-local-ports")).toBeInTheDocument();
     expect(screen.getByTestId("preview-surface")).toHaveClass(
-      "mx-2",
-      "mb-2",
-      "mt-1",
-      "rounded-md",
-      "border",
-      "bg-muted/10",
+      "z-0",
+      "overflow-hidden",
+      "rounded-tl-md",
+    );
+    expect(mockUsePreviewBridge).toHaveBeenLastCalledWith(
+      expect.objectContaining({ forceHidden: true }),
     );
   });
 
@@ -409,7 +426,7 @@ describe("PreviewPanel: full panel state", () => {
 
     render(<PreviewPanel threadId="thread-1" />);
 
-    expect(screen.getByTestId("preview-webview-surface")).toBeInTheDocument();
+    expect(screen.queryByTestId("preview-webview-surface")).not.toBeInTheDocument();
     expect(screen.queryByTestId("preview-webview")).not.toBeInTheDocument();
     expect(screen.getByTestId("browser-local-ports")).toBeInTheDocument();
     expect(screen.getByTestId("preview-surface")).toHaveClass(
@@ -451,11 +468,189 @@ describe("PreviewPanel: full panel state", () => {
     const webview = screen.getByTestId("preview-webview");
     expect(webview).toHaveAttribute("data-tab-id", PREVIEW_WEBVIEW_FALLBACK_TAB_ID);
     expect(webview).toHaveAttribute("src", "https://example.com");
-    expect(webview).toHaveClass("relative", "z-0", "h-full", "w-full");
+    expect(webview).toHaveClass("absolute", "inset-0", "z-0", "h-full", "w-full");
     expect(screen.queryByTestId("browser-local-ports")).not.toBeInTheDocument();
     expect(mockUsePreviewBridge).toHaveBeenLastCalledWith(
       expect.objectContaining({ forceHidden: true }),
     );
+  });
+
+  it("keeps warm webview pages mounted while switching the active tab", () => {
+    mockUsePreviewTabs.mockReturnValue({
+      tabSet: {
+        threadId: "thread-1",
+        activeTabId: "tab-a",
+        tabs: [
+          {
+            id: "tab-a",
+            threadId: "thread-1",
+            title: "A",
+            url: "https://a.example",
+            faviconUrl: null,
+            warm: true,
+            active: true,
+          },
+          {
+            id: "tab-b",
+            threadId: "thread-1",
+            title: "B",
+            url: "https://b.example",
+            faviconUrl: null,
+            warm: true,
+            active: false,
+          },
+        ],
+      },
+      newTab: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+    });
+
+    const { rerender } = render(<PreviewPanel threadId="thread-1" />);
+    expect(screen.getAllByTestId("preview-webview")).toHaveLength(2);
+    expect(screen.getByTestId("preview-webview-surface")).toContainElement(
+      screen.getAllByTestId("preview-webview")[0]!,
+    );
+
+    mockUsePreviewTabs.mockReturnValue({
+      tabSet: {
+        threadId: "thread-1",
+        activeTabId: "tab-b",
+        tabs: [
+          {
+            id: "tab-a",
+            threadId: "thread-1",
+            title: "A",
+            url: "https://a.example",
+            faviconUrl: null,
+            warm: true,
+            active: false,
+          },
+          {
+            id: "tab-b",
+            threadId: "thread-1",
+            title: "B",
+            url: "https://b.example",
+            faviconUrl: null,
+            warm: true,
+            active: true,
+          },
+        ],
+      },
+      newTab: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+    });
+
+    rerender(<PreviewPanel threadId="thread-1" />);
+
+    const webviews = screen.getAllByTestId("preview-webview");
+    expect(webviews).toHaveLength(2);
+    expect(webviews.map((node) => node.getAttribute("data-tab-id"))).toEqual([
+      "tab-a",
+      "tab-b",
+    ]);
+  });
+
+  it("persists favicon updates from inactive warm webview pages", () => {
+    const tabSet = {
+      threadId: "thread-1",
+      activeTabId: "tab-a",
+      tabs: [
+        {
+          id: "tab-a",
+          threadId: "thread-1",
+          title: "A",
+          url: "https://a.example",
+          faviconUrl: null,
+          warm: true,
+          active: true,
+        },
+        {
+          id: "tab-b",
+          threadId: "thread-1",
+          title: "B",
+          url: "https://b.example",
+          faviconUrl: null,
+          warm: true,
+          active: false,
+        },
+      ],
+    };
+    usePreviewTabsStore.getState().setTabSet("thread-1", tabSet);
+    mockUsePreviewTabs.mockReturnValue({
+      tabSet,
+      newTab: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+    });
+
+    render(<PreviewPanel threadId="thread-1" />);
+
+    const inactiveWebview = screen
+      .getAllByTestId("preview-webview")
+      .find((node) => node.getAttribute("data-tab-id") === "tab-b")!;
+    fireEvent(
+      inactiveWebview,
+      Object.assign(new Event("page-favicon-updated"), {
+        favicons: ["https://b.example/favicon.ico"],
+      }),
+    );
+
+    const updatedTabSet = usePreviewTabsStore.getState().tabSetByScope["thread-1"]!;
+    expect(updatedTabSet.tabs.find((tab) => tab.id === "tab-b")?.faviconUrl).toBe(
+      "https://b.example/favicon.ico",
+    );
+  });
+
+  it("does not loop when equivalent active webview tab data is republished", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const restoreWebviewMethods = installMockWebviewMethods({
+      getURL: () => "https://a.example",
+    });
+    const setEquivalentTabs = () => {
+      mockUsePreviewTabs.mockReturnValue({
+        tabSet: {
+          threadId: "thread-1",
+          activeTabId: "tab-a",
+          tabs: [
+            {
+              id: "tab-a",
+              threadId: "thread-1",
+              title: "A",
+              url: "https://a.example",
+              faviconUrl: null,
+              warm: true,
+              active: true,
+            },
+          ],
+        },
+        newTab: vi.fn(),
+        activateTab: vi.fn(),
+        closeTab: vi.fn(),
+      });
+    };
+
+    try {
+      setEquivalentTabs();
+      const { rerender } = render(<PreviewPanel threadId="thread-1" />);
+
+      setEquivalentTabs();
+      rerender(<PreviewPanel threadId="thread-1" />);
+      setEquivalentTabs();
+      rerender(<PreviewPanel threadId="thread-1" />);
+
+      expect(screen.getByTestId("preview-webview")).toHaveAttribute(
+        "src",
+        "https://a.example",
+      );
+      expect(consoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining("Maximum update depth exceeded"),
+      );
+    } finally {
+      restoreWebviewMethods();
+      consoleError.mockRestore();
+    }
   });
 
   it("navigates changed webview URLs through src without an extra loadURL call", async () => {
@@ -484,6 +679,13 @@ describe("PreviewPanel: full panel state", () => {
 
     try {
       render(<PreviewPanel threadId="thread-1" />);
+      await waitFor(() => {
+        expect(screen.getByTestId("preview-webview")).toHaveAttribute(
+          "src",
+          "https://google.com/",
+        );
+      });
+      fireEvent(screen.getByTestId("preview-webview"), new Event("dom-ready"));
 
       const input = screen.getByLabelText("Preview URL");
       fireEvent.focus(input);
@@ -579,6 +781,7 @@ describe("PreviewPanel: full panel state", () => {
       await waitFor(() => {
         expect(resolveNavigation).toHaveBeenCalledWith("https://google.com/");
       });
+      fireEvent(screen.getByTestId("preview-webview"), new Event("dom-ready"));
       await waitFor(() => {
         expect(reload).toHaveBeenCalledTimes(1);
       });
@@ -613,8 +816,8 @@ describe("PreviewPanel: full panel state", () => {
 
   it("honors the webview engine in built and dev renderers", () => {
     expect(shouldRenderWebviewPreview("webview")).toBe(true);
-    expect(shouldRenderWebviewPreview("webContentsView")).toBe(false);
-    expect(shouldRenderWebviewPreview(undefined)).toBe(false);
+    expect(shouldRenderWebviewPreview("webContentsView")).toBe(true);
+    expect(shouldRenderWebviewPreview(undefined)).toBe(true);
   });
 
   it("keeps browser chrome visible while design mode has no saved annotations", () => {

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { useEffect, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+import { PreviewWebview, type PreviewWebviewHandle } from "../PreviewWebview";
+
+describe("PreviewWebview", () => {
+  let canGoBack: Mock<() => boolean>;
+  let canGoForward: Mock<() => boolean>;
+  let domReady = false;
+  const prototype = HTMLElement.prototype as HTMLElement & {
+    canGoBack?: () => boolean;
+    canGoForward?: () => boolean;
+  };
+  const originalCanGoBack = prototype.canGoBack;
+  const originalCanGoForward = prototype.canGoForward;
+
+  beforeEach(() => {
+    domReady = false;
+    canGoBack = vi.fn(() => {
+      if (!domReady) {
+        throw new Error(
+          "The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.",
+        );
+      }
+      return true;
+    });
+    canGoForward = vi.fn(() => {
+      if (!domReady) {
+        throw new Error(
+          "The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.",
+        );
+      }
+      return false;
+    });
+    prototype.canGoBack = canGoBack;
+    prototype.canGoForward = canGoForward;
+  });
+
+  afterEach(() => {
+    prototype.canGoBack = originalCanGoBack;
+    prototype.canGoForward = originalCanGoForward;
+  });
+
+  it("does not call Electron navigation methods before dom-ready", async () => {
+    const observed: { handle: PreviewWebviewHandle | null } = { handle: null };
+
+    function Probe() {
+      const ref = useRef<PreviewWebviewHandle>(null);
+      useEffect(() => {
+        observed.handle = ref.current;
+        ref.current?.canGoBack();
+        ref.current?.canGoForward();
+      }, []);
+      return (
+        <PreviewWebview
+          ref={ref}
+          threadId="thread-1"
+          tabId="tab-1"
+          src="https://example.com"
+        />
+      );
+    }
+
+    render(<Probe />);
+
+    await waitFor(() => expect(observed.handle).not.toBeNull());
+    expect(observed.handle?.canGoBack()).toBe(false);
+    expect(observed.handle?.canGoForward()).toBe(false);
+    expect(canGoBack).not.toHaveBeenCalled();
+    expect(canGoForward).not.toHaveBeenCalled();
+
+    domReady = true;
+    screen.getByTestId("preview-webview").dispatchEvent(new Event("dom-ready"));
+
+    expect(observed.handle?.canGoBack()).toBe(true);
+    expect(observed.handle?.canGoForward()).toBe(false);
+    expect(canGoBack).toHaveBeenCalled();
+    expect(canGoForward).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
+++ b/apps/web/src/components/panels/hooks/__tests__/usePreviewBridge.test.ts
@@ -181,7 +181,7 @@ describe("usePreviewBridge", () => {
     );
   });
 
-  it("forces native sync hidden when forceHidden is enabled", async () => {
+  it("hides native sync without marking the panel hidden when forceHidden is enabled", async () => {
     const mockPreview = makeMockPreview();
     window.desktopBridge = { preview: mockPreview } as unknown as typeof window.desktopBridge;
 
@@ -203,13 +203,16 @@ describe("usePreviewBridge", () => {
       rerender({ threadId: "t-2" });
     });
 
-    expect(mockPreview.sync).toHaveBeenCalled();
+    expect(mockPreview.sync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        visible: false,
+        hideReason: "renderer-webview",
+        threadId: "t-1",
+      }),
+    );
     expect(mockPreview.sync.mock.calls).not.toContainEqual([
       expect.objectContaining({ visible: true }),
     ]);
-    expect(
-      mockPreview.sync.mock.calls.every(([payload]) => payload.visible === false),
-    ).toBe(true);
   });
 
   it("hides the native BrowserView during overlays while preserving panel bounds", async () => {

--- a/apps/web/src/components/panels/hooks/usePreviewBridge.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewBridge.ts
@@ -174,6 +174,7 @@ export function usePreviewBridge({
           bounds: null,
           threadId,
           resumeUrlHint: hint,
+          ...(forceHidden ? { hideReason: "renderer-webview" as const } : {}),
           workspaceId: workspaceId ?? null,
         });
         return;
@@ -191,6 +192,7 @@ export function usePreviewBridge({
           bounds,
           threadId,
           resumeUrlHint: hint,
+          ...(forceHidden ? { hideReason: "renderer-webview" as const } : {}),
           workspaceId: workspaceId ?? null,
         });
         return;

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -160,6 +160,51 @@ describe("previewTabsStore", () => {
     expect(usePreviewTabsStore.getState().liveChromeByScope).not.toBe(first);
   });
 
+  it("updateTabChrome persists renderer-observed favicon for inactive tabs", () => {
+    const { setTabSet, updateTabChrome } = usePreviewTabsStore.getState();
+    setTabSet(
+      SCOPE,
+      set("a", [
+        page("a", { title: "A", faviconUrl: "https://a.test/favicon.ico" }),
+        page("b", { title: "B", url: "https://b.test" }),
+      ]),
+    );
+
+    updateTabChrome(SCOPE, "b", {
+      title: "B updated",
+      url: "https://b.test/path",
+      favicon: "https://b.test/favicon.ico",
+    });
+
+    const tabSet = usePreviewTabsStore.getState().tabSetByScope[SCOPE]!;
+    expect(tabSet.tabs[0]!.faviconUrl).toBe("https://a.test/favicon.ico");
+    expect(tabSet.tabs[1]).toMatchObject({
+      title: "B updated",
+      url: "https://b.test/path",
+      faviconUrl: "https://b.test/favicon.ico",
+    });
+  });
+
+  it("updateTabChrome keeps the same tab set reference when chrome is unchanged", () => {
+    const { setTabSet, updateTabChrome } = usePreviewTabsStore.getState();
+    const tabSet = set("a", [
+      page("a", {
+        title: "A",
+        url: "https://a.test",
+        faviconUrl: "https://a.test/favicon.ico",
+      }),
+    ]);
+    setTabSet(SCOPE, tabSet);
+
+    updateTabChrome(SCOPE, "a", {
+      title: "A",
+      url: "https://a.test",
+      favicon: "https://a.test/favicon.ico",
+    });
+
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(tabSet);
+  });
+
   it("page actions are no-ops without a desktop bridge", async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).desktopBridge = undefined;

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -84,6 +84,8 @@ interface PreviewTabsState {
   setTabSet: (scopeId: string, set: BrowserTabSet | null) => void;
   /** Publish (or clear) the active page's live chrome for a scope. */
   setLiveChrome: (scopeId: string, chrome: PreviewLiveChrome | null) => void;
+  /** Merge renderer-observed chrome into one tab's persisted renderer mirror. */
+  updateTabChrome: (scopeId: string, tabId: string, chrome: PreviewLiveChrome) => void;
 
   /** Create a new page on the scope's browser and focus the omnibox for it. */
   createPage: (scopeId: string) => Promise<void>;
@@ -131,6 +133,34 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
       const prev = s.liveChromeByScope[scopeId] ?? null;
       if (sameLiveChrome(prev, chrome)) return s;
       return { liveChromeByScope: { ...s.liveChromeByScope, [scopeId]: chrome } };
+    }),
+
+  updateTabChrome: (scopeId, tabId, chrome) =>
+    set((s) => {
+      const tabSet = s.tabSetByScope[scopeId] ?? null;
+      if (!tabSet) return s;
+      let changed = false;
+      const tabs = tabSet.tabs.map((tab) => {
+        if (tab.id !== tabId) return tab;
+        const next = {
+          ...tab,
+          title: chrome.title ?? tab.title,
+          url: chrome.url ?? tab.url,
+          faviconUrl: chrome.favicon ?? tab.faviconUrl,
+        };
+        changed =
+          next.title !== tab.title ||
+          next.url !== tab.url ||
+          next.faviconUrl !== tab.faviconUrl;
+        return changed ? next : tab;
+      });
+      if (!changed) return s;
+      return {
+        tabSetByScope: {
+          ...s.tabSetByScope,
+          [scopeId]: { ...tabSet, tabs },
+        },
+      };
     }),
 
   createPage: async (scopeId) => {

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -107,6 +107,8 @@ interface PreviewBridge {
     bounds: PreviewShellBounds | null;
     threadId?: string | null;
     resumeUrlHint?: string | null;
+    /** Why a visible panel is asking the native host to hide its BrowserView. */
+    hideReason?: "renderer-webview";
     /** Active workspace id; scopes preview spill files under the Mcode app data directory. */
     workspaceId?: string | null;
   }): Promise<void>;

--- a/packages/contracts/src/models/__tests__/settings.test.ts
+++ b/packages/contracts/src/models/__tests__/settings.test.ts
@@ -40,9 +40,9 @@ describe("preview.memorySaver", () => {
 });
 
 describe("preview.rendering", () => {
-  it("defaults the rendering engine to WebContentsView", () => {
-    expect(SettingsSchema().parse({}).preview.rendering.engine).toBe("webContentsView");
-    expect(getDefaultSettings().preview.rendering.engine).toBe("webContentsView");
+  it("defaults the rendering engine to webview", () => {
+    expect(SettingsSchema().parse({}).preview.rendering.engine).toBe("webview");
+    expect(getDefaultSettings().preview.rendering.engine).toBe("webview");
   });
 
   it("accepts supported rendering engines", () => {

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -456,8 +456,8 @@ export const SettingsSchema = lazySchema(() =>
         /** Browser preview rendering host. */
         rendering: z
           .object({
-            /** Hidden switch for the renderer-hosted webview path. */
-            engine: PreviewRenderingEngineSchema.default("webContentsView"),
+            /** Hidden legacy switch; preview rendering now uses webview. */
+            engine: PreviewRenderingEngineSchema.default("webview"),
           })
           .default({}),
         /**


### PR DESCRIPTION
## What
Fixes the Browser preview webview path so it is the only renderer, keeps browser tabs warm across tab switches, and makes attachment thumbnails recover from first-load races.

## Why
The preview could call webview APIs before `dom-ready`, reload tabs on switch, lose inactive favicon state, render the guest webview at a shallow height, and show broken thumbnails until thread remount.

## Key Changes
- Default preview rendering to the renderer webview path and hide the native view when webview is active.
- Keep per-tab webviews mounted, gate navigation APIs on `dom-ready`, persist tab chrome from background webviews, and allow clipboard writes from preview pages.
- Retry persisted attachment and annotation thumbnails when the first request lands before the file is available.
- Add regression coverage for webview lifecycle, tab chrome, attachment retry, and preview chrome behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786205070&installation_id=129163861&pr_number=849&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F849&signature=acad461b69373408b8241f71867e4cc2a947b46dbcb8d618a5b0f848e0cce300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview rendering now defaults to the newer webview experience, with improved tab switching and smoother preview loading.
  * Image attachments now retry automatically when they fail to load, helping previews recover from temporary missing-file responses.

* **Bug Fixes**
  * Improved preview error handling and navigation readiness so controls behave more reliably after the preview finishes loading.
  * Fixed hidden-preview behavior to avoid unnecessary discard timers when the preview is being managed by the renderer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->