### PR TITLE
fix: stabilize terminal lifecycle and composer suggestions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -712,17 +712,18 @@ _Avoid_: PTY (implementation term), terminal instance (ambiguous with the view).
 
 ### Active shell
 The one shell session whose terminal view is mounted. At most one terminal
-view exists in the app: the active shell on the active terminal scope, while
-the Terminal tab and right panel are open.
+view exists in the app. Its view may stay warm while the Terminal tab or right
+panel is hidden; all other shells run without a view.
 _Avoid_: Mounting a view for every open shell (background shells stay
 server-side only).
 
 ### Terminal view
 The in-app rendering of one shell session's output in the Terminal tab.
-Only the **active shell** has a view; others keep running without one.
-Remounting replays retained scrollback and opens at the latest output
-(follow). Restoring the prior scroll position within scrollback is a
-planned follow-up, not v1.
+Only the **active shell** has a view; others keep running without one. Hiding
+the terminal surface preserves that view for a fast return. Switching shells
+replaces it. A returning view follows the latest output when the user was at
+the tail, or restores the same retained content when the user was reading
+history.
 _Avoid_: xterm (implementation term), conflating with shell session.
 
 ### Scrollback

--- a/apps/server/src/services/terminal-service.test.ts
+++ b/apps/server/src/services/terminal-service.test.ts
@@ -1,0 +1,90 @@
+import "reflect-metadata";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+
+const { killProcessTree, gracefulKillProcessTree } = vi.hoisted(() => ({
+  killProcessTree: vi.fn().mockResolvedValue(undefined),
+  gracefulKillProcessTree: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./process-kill.js", () => ({
+  killProcessTree,
+  gracefulKillProcessTree,
+  listDirectChildren: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@mcode/shared", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { TerminalService } from "./terminal-service";
+
+describe("TerminalService Windows teardown", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
+  });
+
+  it("uses the ConPTY DLL session as the single Windows process-tree owner", async () => {
+    const pty = {
+      pid: 12_345,
+      kill: vi.fn(),
+    } as unknown as IPty;
+    const pidRegistry = {
+      deregister: vi.fn(),
+      clear: vi.fn(),
+    };
+    const settingsService = {
+      get: () => ({ terminal: { scrollback: 1_000 } }),
+      on: () => vi.fn(),
+    };
+    const service = new TerminalService(
+      {} as never,
+      {} as never,
+      {} as never,
+      settingsService as never,
+      {} as never,
+      pidRegistry as never,
+      {} as never,
+    );
+
+    const session = {
+      id: "pty-1",
+      threadId: "thread-1",
+      shell: "powershell.exe",
+      cwd: "C:\\repo",
+      pty,
+      dataDisposable: { dispose: vi.fn() },
+      exitDisposable: { dispose: vi.fn() },
+    };
+    const internals = service as unknown as {
+      sessions: Map<string, typeof session>;
+      threadIndex: Map<string, Set<string>>;
+    };
+    internals.sessions.set(session.id, session);
+    internals.threadIndex.set(session.threadId, new Set([session.id]));
+
+    await service.kill(session.id);
+
+    expect(pty.kill).toHaveBeenCalledOnce();
+    expect(killProcessTree).not.toHaveBeenCalled();
+    expect(gracefulKillProcessTree).not.toHaveBeenCalled();
+    expect(pidRegistry.deregister).toHaveBeenCalledWith(session.id);
+  });
+});

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -208,6 +208,10 @@ export class TerminalService {
         rows: DEFAULT_ROWS,
         cwd,
         env: this.envService.getEnv(),
+        // The bundled ConPTY DLL closes the pseudo console directly. Native
+        // Windows ConPTY makes node-pty fork a console-list helper on kill;
+        // that helper can fail AttachConsole and crash the server process.
+        ...(process.platform === "win32" ? { useConptyDll: true } : {}),
       });
     } catch (err) {
       logger.error("PTY spawn failed", {
@@ -496,12 +500,13 @@ export class TerminalService {
         error: describeError(err),
       });
     }
-    // Kill the PTY first so node-pty's conpty cleanup agent (conpty_console_list_agent)
-    // can AttachConsole while the shell process is still alive. If we run
-    // killProcessTree first, the shell is already dead when the agent forks and
-    // AttachConsole fails with "AttachConsole failed".
+    // node-pty owns the ConPTY process-tree shutdown on Windows. Windows PTYs
+    // are spawned with useConptyDll so this call closes the pseudo console
+    // directly without launching node-pty's fragile console-list helper.
+    let ptyKillSucceeded = false;
     try {
       session.pty.kill();
+      ptyKillSucceeded = true;
     } catch (err) {
       logger.warn("Failed to kill PTY process", {
         id: session.id,
@@ -512,9 +517,10 @@ export class TerminalService {
         error: describeError(err),
       });
     }
-    // Kill any grandchildren (git, npm, etc.) that were not attached to the
-    // console and therefore missed by node-pty's process list enumeration.
-    // Best-effort: the shell may already be dead at this point.
+    if (process.platform === "win32" && ptyKillSucceeded) return;
+
+    // Unix uses the existing process-tree fallback. Windows reaches this path
+    // only when node-pty could not begin its own process-tree shutdown.
     if (this.useGracefulKill) {
       await gracefulKillProcessTree(session.pty.pid);
     } else {

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -71,15 +71,15 @@ export async function mockWebSocketServer(
       : getDefaultSettings();
 
   let resolveWs: (ws: WebSocketRoute) => void;
+  let wsResolved = false;
   const wsReady = new Promise<WebSocketRoute>((r) => {
     resolveWs = r;
   });
 
-  // Match 5-digit ports (19400-19800 mcode range) to avoid intercepting Vite's
-  // HMR socket at port 5173 (4 digits), which would trigger a page reload.
-  await page.routeWebSocket(/ws:\/\/localhost:\d{5}/, (ws) => {
-    resolveWs(ws);
-
+  // The normal test server uses a four-digit Vite port, while agent runtimes
+  // use five-digit ports for both Vite and Mcode. Resolve the controller only
+  // after the socket sends an RPC method so pushes target Mcode, not HMR.
+  await page.routeWebSocket(/ws:\/\/(?:localhost|127\.0\.0\.1):\d{5}/, (ws) => {
     ws.onMessage(async (data) => {
       let msg: Record<string, unknown>;
       try {
@@ -94,6 +94,10 @@ export async function mockWebSocketServer(
         return;
       }
       const method = msg.method as string;
+      if (!wsResolved && typeof method === "string") {
+        wsResolved = true;
+        resolveWs(ws);
+      }
       // Check overrides first
       if (method in overrides) {
         const handler = overrides[method];

--- a/apps/web/e2e/preview-bubble-visual.spec.ts
+++ b/apps/web/e2e/preview-bubble-visual.spec.ts
@@ -225,11 +225,24 @@ async function seedSkillsStore(page: Page): Promise<void> {
       return "skills" in state && "isLoading" in state && "load" in state;
     });
     if (!skillsStore) throw new Error("[E2E] skillsStore not found");
+    const skills = [
+      { name: "commit", description: "Create a git commit" },
+      { name: "review-pr", description: "Review a pull request" },
+    ];
+    const cacheKey = JSON.stringify(["/test/path", "claude"]);
     skillsStore.setState({
-      skills: [
-        { name: "commit", description: "Create a git commit" },
-        { name: "review-pr", description: "Review a pull request" },
-      ],
+      entries: {
+        [cacheKey]: {
+          skills,
+          isLoading: false,
+          isStale: false,
+          error: null,
+          inflight: null,
+          loadEpoch: 1,
+          lastFetchedAt: Date.now(),
+        },
+      },
+      skills,
       isLoading: false,
       error: null,
     });

--- a/apps/web/e2e/preview-chrome.spec.ts
+++ b/apps/web/e2e/preview-chrome.spec.ts
@@ -887,12 +887,25 @@ async function seedSkillsStore(page: Page): Promise<void> {
       return "skills" in state && "isLoading" in state && "load" in state;
     });
     if (!skillsStore) throw new Error("[E2E] skillsStore not found");
-    // Inject two skills so the popup renders a listbox with items.
+    const skills = [
+      { name: "commit", description: "Create a git commit" },
+      { name: "review-pr", description: "Review a pull request" },
+    ];
+    const cacheKey = JSON.stringify(["/test/path", "claude"]);
+    // Inject the provider-scoped cache entry used by the annotation bubble.
     skillsStore.setState({
-      skills: [
-        { name: "commit", description: "Create a git commit" },
-        { name: "review-pr", description: "Review a pull request" },
-      ],
+      entries: {
+        [cacheKey]: {
+          skills,
+          isLoading: false,
+          isStale: false,
+          error: null,
+          inflight: null,
+          loadEpoch: 1,
+          lastFetchedAt: Date.now(),
+        },
+      },
+      skills,
       isLoading: false,
       error: null,
     });

--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -153,6 +153,28 @@ test.describe("Slash command popup", () => {
     });
   });
 
+  test("popup stays above the composer text", async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 400 });
+    await bootApp(page, { "skill.list": LONG_PLUGIN_SKILLS });
+    await openPopup(page, "/");
+
+    const popup = page.locator("[data-slash-popup]");
+    const editor = page.locator("[contenteditable='true']").first();
+    const [popupBox, editorBox] = await Promise.all([
+      popup.boundingBox(),
+      editor.boundingBox(),
+    ]);
+
+    expect(popupBox).not.toBeNull();
+    expect(editorBox).not.toBeNull();
+    expect(popupBox!.y + popupBox!.height).toBeLessThanOrEqual(editorBox!.y);
+
+    await page.screenshot({
+      path: "e2e/screenshots/slash-command/02b-popup-small-viewport.png",
+      fullPage: true,
+    });
+  });
+
   test("03 - error response surfaces ErrorRow with Retry button", async ({ page }) => {
     // Mirror the shared helper's defaults but force `skill.list` to return a
     // JSON-RPC error. The shared mock helper only supports successful result

--- a/apps/web/e2e/terminal-remount-lifecycle.spec.ts
+++ b/apps/web/e2e/terminal-remount-lifecycle.spec.ts
@@ -1,10 +1,11 @@
 /**
  * Terminal remount lifecycle — ADR-0010
  *
- * Verifies the new single-view-on-demand model:
- *  - At most one xterm is mounted at any time (0 or 1 in the DOM).
- *  - Switching thread/shell disposes the old view and mounts a fresh one.
- *  - terminal.reattach is called on remount so the server replays scrollback.
+ * Verifies the bounded warm-view model:
+ *  - At most one xterm is mounted at any time.
+ *  - Closing the terminal moves that view offscreen without disposing it.
+ *  - Switching thread or shell replaces the warm view after hidden hydration.
+ *  - terminal.reattach requests only output after the last processed sequence.
  *  - The terminal tab still shows an xterm after switching away and back.
  *  - Rendering works when activeTerminalId was null but terminals exist (store
  *    auto-selects the first one — behaviour still valid in the new model).
@@ -420,7 +421,7 @@ test.describe("Terminal remount lifecycle (ADR-0010)", () => {
     }
   });
 
-  test("closing and reopening the terminal tab disposes only the view", async ({
+  test("closing and reopening keeps one warm view and requests only the delta", async ({
     page,
   }) => {
     const calls: {
@@ -428,13 +429,10 @@ test.describe("Terminal remount lifecycle (ADR-0010)", () => {
       kill: number;
       killByThread: number;
     } = { reattach: [], kill: 0, killByThread: 0 };
-    let replaySeq = 0;
-
     const wsController = await mockWebSocketServer(page, {
       ...BASE_OVERRIDES,
       "terminal.reattach": (params: unknown) => {
         calls.reattach.push(params as { ptyId?: string; lastSeq?: number });
-        replaySeq += 1;
         return { gapped: false };
       },
       "terminal.kill": () => {
@@ -459,6 +457,36 @@ test.describe("Terminal remount lifecycle (ADR-0010)", () => {
 
     await seedAndOpenTerminal(page, "thread-a", "pty-thread-a");
     await expect(page.locator(".xterm").first()).toBeVisible({ timeout: 20_000 });
+    const initialBufferLength = await page.evaluate(() => {
+      const harness = (window as unknown as {
+        __mcodeTerminalScrollHarness?: {
+          getViewport: (ptyId: string) => { length: number } | null;
+        };
+      }).__mcodeTerminalScrollHarness;
+      return harness?.getViewport("pty-thread-a")?.length ?? 0;
+    });
+    await wsController.sendPush("terminal.data", {
+      ptyId: "pty-thread-a",
+      data: Array.from(
+        { length: 80 },
+        (_, index) => `before-close-${index + 1}\r\n`,
+      ).join(""),
+      seq: 10,
+    });
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const harness = (window as unknown as {
+              __mcodeTerminalScrollHarness?: {
+                getViewport: (ptyId: string) => { length: number } | null;
+              };
+            }).__mcodeTerminalScrollHarness;
+            return harness?.getViewport("pty-thread-a")?.length ?? 0;
+          }),
+        { timeout: 10_000 },
+      )
+      .toBeGreaterThan(initialBufferLength);
 
     const originalPty = await page.evaluate(() => {
       const stores: unknown[] =
@@ -500,11 +528,11 @@ test.describe("Terminal remount lifecycle (ADR-0010)", () => {
     });
 
     await closeTerminalTab(page, WS_ID, "thread-a");
-    await expect(page.locator(".xterm")).toHaveCount(0, { timeout: 10_000 });
-    await expect(page.locator("[aria-hidden='true'] .xterm")).toHaveCount(0);
+    await expect(page.locator(".xterm")).toHaveCount(1, { timeout: 10_000 });
+    await expect(page.locator("[aria-hidden='true'] .xterm")).toHaveCount(1);
     await expect
       .poll(() => liveTerminalCounter(page), { timeout: 10_000 })
-      .toBe(0);
+      .toBe(1);
 
     const afterClose = await page.evaluate(() => {
       const stores: unknown[] =
@@ -542,18 +570,9 @@ test.describe("Terminal remount lifecycle (ADR-0010)", () => {
     expect(calls.reattach.length).toBeGreaterThanOrEqual(2);
     expect(calls.reattach.at(-1)).toEqual({
       ptyId: "pty-thread-a",
-      lastSeq: -1,
+      lastSeq: 10,
     });
 
-    await wsController.sendPush("terminal.data", {
-      ptyId: "pty-thread-a",
-      data: `scrollback-after-reopen-${replaySeq}\r\n`,
-      seq: replaySeq + 100,
-    });
-    await expect(page.locator(".xterm")).toContainText(
-      /scrollback-after-reopen-/,
-      { timeout: 10_000 },
-    );
   });
 
   // --- Scenario still valid in the new model ---

--- a/apps/web/src/__tests__/TerminalView.focus.test.tsx
+++ b/apps/web/src/__tests__/TerminalView.focus.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import { act } from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { emitPtyData } from "@/components/terminal/ptyDataRegistry";
+import { emitPtyData, emitPtyExit } from "@/components/terminal/ptyDataRegistry";
 import { dropRemountAnchor } from "@/components/terminal/terminalRemountScroll";
 
 // jsdom doesn't implement ResizeObserver; TerminalView instantiates one in
@@ -20,8 +20,10 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 // runs in a trailing write callback) is exercised.
 const bufferActive = { viewportY: 42, length: 100 };
 
+let onDataListener: ((data: string) => void) | null = null;
+
 const term = {
-  options: { scrollback: 0 },
+  options: { scrollback: 0, disableStdin: false },
   buffer: { active: bufferActive },
   cols: 80,
   rows: 24,
@@ -29,7 +31,10 @@ const term = {
   open: vi.fn(),
   attachCustomKeyEventHandler: vi.fn(),
   getSelection: vi.fn(() => ""),
-  onData: vi.fn(() => ({ dispose: vi.fn() })),
+  onData: vi.fn((listener: (data: string) => void) => {
+    onDataListener = listener;
+    return { dispose: vi.fn() };
+  }),
   onScroll: vi.fn(() => ({ dispose: vi.fn() })),
   write: vi.fn((_data: string | Uint8Array, cb?: () => void) => cb?.()),
   paste: vi.fn(),
@@ -44,6 +49,7 @@ const term = {
 const transport = {
   terminalWrite: vi.fn(() => Promise.resolve()),
   terminalResize: vi.fn(() => Promise.resolve()),
+  terminalPause: vi.fn(() => Promise.resolve()),
   terminalResume: vi.fn(() => Promise.resolve()),
   terminalReattach: vi.fn(() => Promise.resolve({ gapped: false })),
   ptySetLastSeq: vi.fn(),
@@ -90,12 +96,24 @@ describe("TerminalView lifecycle (ADR-0010)", () => {
   beforeEach(() => {
     bufferActive.viewportY = 42;
     bufferActive.length = 100;
+    term.options.disableStdin = false;
     vi.clearAllMocks();
+    onDataListener = null;
+    term.write.mockImplementation((_data: string | Uint8Array, cb?: () => void) => cb?.());
     // clearAllMocks resets call history but keeps implementations.
     transport.terminalReattach.mockResolvedValue({ gapped: false });
     // The remount-scroll anchor store is module-global; React Testing Library's
     // per-test unmount captures one, so clear it for deterministic mounts.
-    for (const id of ["pty-1", "pty-2", "pty-a", "pty-b", "pty-batch"]) {
+    for (const id of [
+      "pty-1",
+      "pty-2",
+      "pty-a",
+      "pty-b",
+      "pty-batch",
+      "pty-cold",
+      "pty-exit",
+      "pty-warm",
+    ]) {
       dropRemountAnchor(id);
     }
   });
@@ -223,5 +241,83 @@ describe("TerminalView lifecycle (ADR-0010)", () => {
     );
     expect(dataWrites.length).toBe(1);
     expect(Array.from(dataWrites[0][0] as Uint8Array)).toEqual([65, 66]);
+  });
+
+  it("keeps a cold view hidden until replay has painted", async () => {
+    let resolveReattach: (value: { gapped: boolean }) => void = () => {};
+    let finishReplayWrite: (() => void) | undefined;
+    transport.terminalReattach.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveReattach = resolve;
+      }),
+    );
+    term.write.mockImplementation((data: string | Uint8Array, cb?: () => void) => {
+      if (data instanceof Uint8Array) {
+        finishReplayWrite = cb;
+        return;
+      }
+      cb?.();
+    });
+
+    const { container } = render(
+      <TerminalView ptyId="pty-cold" visible={true} threadActive={true} />,
+    );
+    await settle();
+
+    await act(async () => {
+      emitPtyData({ ptyId: "pty-cold", seq: 0, payload: new Uint8Array([65]) });
+      resolveReattach({ gapped: false });
+    });
+    await settle();
+
+    const terminalRoot = container.firstElementChild as HTMLElement;
+    expect(terminalRoot.dataset.terminalHydrated).toBe("false");
+    expect(terminalRoot.style.visibility).toBe("hidden");
+
+    await act(async () => {
+      finishReplayWrite?.();
+    });
+    await settle();
+
+    expect(terminalRoot.dataset.terminalHydrated).toBe("true");
+    expect(terminalRoot.style.visibility).toBe("visible");
+  });
+
+  it("stops forwarding input as soon as the PTY exits", async () => {
+    render(<TerminalView ptyId="pty-exit" visible={true} threadActive={true} />);
+    await settle();
+    transport.terminalWrite.mockClear();
+
+    await act(async () => {
+      emitPtyExit({ ptyId: "pty-exit", code: 1 });
+      onDataListener?.("echo after exit\r");
+    });
+
+    expect(transport.terminalWrite).not.toHaveBeenCalled();
+    expect(term.options.disableStdin).toBe(true);
+  });
+
+  it("keeps the warm view and requests only output after its last sequence", async () => {
+    const { rerender } = render(
+      <TerminalView ptyId="pty-warm" visible={true} threadActive={true} />,
+    );
+    await settle();
+
+    await act(async () => {
+      emitPtyData({ ptyId: "pty-warm", seq: 5, payload: new Uint8Array([65]) });
+    });
+    rerender(
+      <TerminalView ptyId="pty-warm" visible={false} threadActive={false} />,
+    );
+    await settle();
+    expect(transport.terminalPause).toHaveBeenCalledWith("pty-warm");
+
+    rerender(
+      <TerminalView ptyId="pty-warm" visible={true} threadActive={true} />,
+    );
+    await settle();
+
+    expect(transport.terminalReattach).toHaveBeenLastCalledWith("pty-warm", 5);
+    expect(term.dispose).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -347,6 +347,33 @@ describe("provider-scoped commands", () => {
     expect(mockListSkills).toHaveBeenCalledWith("/my/project", "codex");
   });
 
+  it("settles two mounted consumers with different provider scopes", async () => {
+    const mockListSkills = vi.fn().mockResolvedValue([]);
+    vi.mocked(getTransport).mockReturnValue({ listSkills: mockListSkills } as never);
+    const composerAnchor = makeAnchor();
+    const previewAnchor = makeAnchor();
+
+    renderHook(() => {
+      useSlashCommand({
+        anchorRef: composerAnchor,
+        cwd: "/my/project",
+        providerId: "claude",
+      });
+      useSlashCommand({
+        anchorRef: previewAnchor,
+        cwd: "/my/project",
+        providerId: undefined,
+        includeBuiltins: false,
+      });
+    });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(mockListSkills).toHaveBeenCalledTimes(2);
+    expect(mockListSkills).toHaveBeenCalledWith("/my/project", "claude");
+    expect(mockListSkills).toHaveBeenCalledWith("/my/project", undefined);
+  });
+
   it("hides /m:plan for copilot provider", async () => {
     const ref = makeAnchor();
     const { result } = renderHook(() =>

--- a/apps/web/src/components/chat/FileTagPopup.tsx
+++ b/apps/web/src/components/chat/FileTagPopup.tsx
@@ -250,7 +250,7 @@ export function FileTagPopup({
       aria-label="Mention suggestions"
       style={fixedStyle}
       className={cn(
-        "z-50 overflow-hidden rounded-lg border shadow-lg",
+        "z-50 flex flex-col overflow-hidden rounded-lg border shadow-lg",
         tone === "dark"
           ? "border-white/10 bg-[#1e1e1e] text-neutral-100"
           : "border-border bg-popover",
@@ -261,7 +261,7 @@ export function FileTagPopup({
     >
       <div
         ref={scrollRef}
-        className="p-1"
+        className="min-h-0 flex-1 p-1"
         style={{ maxHeight, overflowY: "auto" }}
       >
         {items.map((item) => {

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -111,7 +111,7 @@ export function SlashCommandPopup({
       data-slash-popup
       style={style}
       className={cn(
-        "z-50 overflow-hidden rounded-lg border shadow-lg",
+        "z-50 flex flex-col overflow-hidden rounded-lg border shadow-lg",
         "animate-in fade-in-0 zoom-in-95 duration-[120ms]",
         tone === "dark"
           ? "border-white/10 bg-[#1e1e1e] text-neutral-100"
@@ -146,6 +146,7 @@ export function SlashCommandPopup({
                   role="listbox"
                   aria-label="Slash commands"
                   aria-activedescendant={items[selectedIndex] ? `slash-cmd-${items[selectedIndex].name}` : undefined}
+                  className="min-h-0 flex-1"
                   style={{ maxHeight: listMaxHeight, overflowY: "auto" }}
                 >
                   {items.map((cmd, i) => (
@@ -160,7 +161,7 @@ export function SlashCommandPopup({
                   ))}
                 </div>
                 <div className={cn(
-                  "flex items-center justify-end border-t px-2 py-1",
+                  "flex shrink-0 items-center justify-end border-t px-2 py-1",
                   tone === "dark" ? "border-white/[0.08]" : "border-border",
                 )}>
                   <button

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
@@ -14,6 +14,10 @@ import type { Command } from "../useSlashCommand";
 // tests that share the same jsdom instance.
 const originalResizeObserver = globalThis.ResizeObserver;
 const originalScrollIntoView = Element.prototype.scrollIntoView;
+const originalVisualViewport = Object.getOwnPropertyDescriptor(
+  window,
+  "visualViewport",
+);
 
 beforeAll(() => {
   if (typeof window.ResizeObserver === "undefined") {
@@ -24,6 +28,10 @@ beforeAll(() => {
     };
   }
   Element.prototype.scrollIntoView = () => {};
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: { width: 1024, height: 768 },
+  });
 });
 
 afterAll(() => {
@@ -34,6 +42,12 @@ afterAll(() => {
     globalThis.ResizeObserver = originalResizeObserver;
   }
   Element.prototype.scrollIntoView = originalScrollIntoView;
+  if (originalVisualViewport) {
+    Object.defineProperty(window, "visualViewport", originalVisualViewport);
+  } else {
+    // @ts-expect-error -- intentional cleanup of the test viewport
+    delete window.visualViewport;
+  }
 });
 
 /** Minimal DOMRect-like object for anchorRect. */
@@ -158,6 +172,6 @@ describe("SlashCommandPopup selection indicator", () => {
     if (row === null) throw new Error(`${state} popup row not found`);
     const popup = row.closest("[data-slash-popup]") as HTMLElement;
 
-    expect(popup.style.top).toBe("352px");
+    expect(popup.style.bottom).toBe("372px");
   });
 });

--- a/apps/web/src/components/chat/popup-position.ts
+++ b/apps/web/src/components/chat/popup-position.ts
@@ -38,21 +38,26 @@ export function computeFixedPopupPosition({
     Math.max(anchorRect.left, viewportPadding),
     viewportWidth - width - viewportPadding,
   );
-  const canPlaceAbove = anchorRect.top > estimatedHeight + gap + viewportPadding;
+  const spaceAbove = Math.max(0, anchorRect.top - gap - viewportPadding);
+  const spaceBelow = Math.max(
+    0,
+    viewportHeight - anchorRect.bottom - gap - viewportPadding,
+  );
+  const canPlaceAbove = spaceAbove >= estimatedHeight;
+  const canPlaceBelow = spaceBelow >= estimatedHeight;
   const placeAbove =
     preferredPlacement === "above" ||
-    (preferredPlacement === "auto" && canPlaceAbove);
-  const top = placeAbove
-    ? Math.max(viewportPadding, anchorRect.top - estimatedHeight - gap)
-    : Math.min(
-        anchorRect.bottom + gap,
-        viewportHeight - estimatedHeight - viewportPadding,
-      );
+    (preferredPlacement === "auto" &&
+      (canPlaceAbove || (!canPlaceBelow && spaceAbove >= spaceBelow)));
+  const verticalPosition = placeAbove
+    ? { bottom: viewportHeight - anchorRect.top + gap }
+    : { top: anchorRect.bottom + gap };
 
   return {
     position: "fixed",
     left,
-    top,
     width,
+    maxHeight: placeAbove ? spaceAbove : spaceBelow,
+    ...verticalPosition,
   };
 }

--- a/apps/web/src/components/chat/useFileAutocomplete.test.ts
+++ b/apps/web/src/components/chat/useFileAutocomplete.test.ts
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listWorkspaceFiles = vi.fn<() => Promise<string[]>>();
+
+vi.mock("@/transport", () => ({
+  getTransport: () => ({
+    listWorkspaceFiles,
+    listCodexAgents: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+import {
+  clearFileListCache,
+  useFileAutocomplete,
+} from "./useFileAutocomplete";
+
+describe("useFileAutocomplete async lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearFileListCache();
+  });
+
+  it("does not reopen after the user dismisses while files are loading", async () => {
+    let resolveFiles!: (files: string[]) => void;
+    listWorkspaceFiles.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFiles = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useFileAutocomplete({ workspaceId: "workspace-1" }),
+    );
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.handleInputChange("@", 1) as unknown as Promise<void>;
+    });
+    act(() => {
+      result.current.dismiss();
+    });
+
+    await act(async () => {
+      resolveFiles(["src/app.ts"]);
+      await pending;
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it("reloads mounted suggestions after the scope cache is invalidated", async () => {
+    listWorkspaceFiles
+      .mockResolvedValueOnce(["src/old.ts"])
+      .mockResolvedValueOnce(["src/new.ts"]);
+    const { result } = renderHook(() =>
+      useFileAutocomplete({ workspaceId: "workspace-1" }),
+    );
+
+    await act(async () => {
+      await result.current.handleInputChange("@", 1);
+    });
+    expect(result.current.suggestions.map((item) => item.path)).toContain(
+      "src/old.ts",
+    );
+
+    act(() => {
+      clearFileListCache("workspace-1");
+    });
+    await act(async () => {
+      await result.current.handleInputChange("@", 1);
+    });
+
+    expect(result.current.suggestions.map((item) => item.path)).toEqual([
+      "src/new.ts",
+    ]);
+    expect(listWorkspaceFiles).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/chat/useFileAutocomplete.ts
+++ b/apps/web/src/components/chat/useFileAutocomplete.ts
@@ -31,7 +31,7 @@ interface UseFileAutocompleteResult {
   suggestions: MentionSuggestion[];
   query: string;
   triggerStart: number;
-  handleInputChange: (text: string, cursorPos: number) => void;
+  handleInputChange: (text: string, cursorPos: number) => Promise<void>;
   selectSuggestion: (suggestion: MentionSuggestion) => MentionSuggestion;
   dismiss: () => void;
 }
@@ -53,6 +53,9 @@ const codexAgentCache = new Map<string, MentionSuggestion[]>();
 /** In-flight Codex agent fetches keyed by scope. */
 const inFlightAgentFetches = new Map<string, Promise<MentionSuggestion[]>>();
 
+/** Mounted hooks that must discard local data after a cache invalidation. */
+const cacheInvalidationListeners = new Set<(key?: string) => void>();
+
 /**
  * Clear the cached file list for a scope.
  * Pass workspaceId (and optionally threadId) to clear a specific scope,
@@ -63,9 +66,11 @@ export function clearFileListCache(workspaceId?: string, threadId?: string): voi
     const key = scopeKey(workspaceId, threadId);
     fileListCache.delete(key);
     codexAgentCache.delete(key);
+    for (const listener of cacheInvalidationListeners) listener(key);
   } else {
     fileListCache.clear();
     codexAgentCache.clear();
+    for (const listener of cacheInvalidationListeners) listener();
   }
 }
 
@@ -87,17 +92,37 @@ export function useFileAutocomplete({
   const [suggestions, setSuggestions] = useState<MentionSuggestion[]>([]);
   const [query, setQuery] = useState("");
   const [triggerStart, setTriggerStart] = useState(-1);
+  const requestEpochRef = useRef(0);
 
   // Reset local state when scope changes so stale data isn't used.
   const prevScopeRef = useRef<string>("");
   useEffect(() => {
     const key = workspaceId ? scopeKey(workspaceId, threadId) : "";
     if (key !== prevScopeRef.current) {
+      requestEpochRef.current += 1;
       prevScopeRef.current = key;
       setAllFiles([]);
       setAllAgents([]);
+      setSuggestions([]);
+      setIsOpen(false);
     }
   }, [workspaceId, threadId]);
+
+  useEffect(() => {
+    const listener = (invalidatedKey?: string) => {
+      if (invalidatedKey && invalidatedKey !== prevScopeRef.current) return;
+      requestEpochRef.current += 1;
+      setAllFiles([]);
+      setAllAgents([]);
+      setSuggestions([]);
+      setIsOpen(false);
+    };
+    cacheInvalidationListeners.add(listener);
+    return () => {
+      requestEpochRef.current += 1;
+      cacheInvalidationListeners.delete(listener);
+    };
+  }, []);
 
   const loadFiles = useCallback(async (): Promise<string[] | undefined> => {
     if (!workspaceId) return;
@@ -138,8 +163,7 @@ export function useFileAutocomplete({
 
     const files = await fetchPromise;
     // Only update state if scope hasn't changed during the async gap.
-    const currentKey = scopeKey(workspaceId, threadId);
-    if (currentKey === key) {
+    if (prevScopeRef.current === key) {
       setAllFiles(files);
     }
     return files;
@@ -191,8 +215,7 @@ export function useFileAutocomplete({
     inFlightAgentFetches.set(key, fetchPromise);
 
     const agents = await fetchPromise;
-    const currentKey = scopeKey(workspaceId, threadId);
-    if (currentKey === key) {
+    if (prevScopeRef.current === key) {
       setAllAgents(agents);
     }
     return agents;
@@ -200,6 +223,8 @@ export function useFileAutocomplete({
 
   const handleInputChange = useCallback(
     async (text: string, cursorPos: number) => {
+      const requestEpoch = ++requestEpochRef.current;
+      const requestScope = workspaceId ? scopeKey(workspaceId, threadId) : "";
       // Find the @ trigger: scan backwards from cursor
       let atPos = -1;
       for (let i = cursorPos - 1; i >= 0; i--) {
@@ -216,11 +241,10 @@ export function useFileAutocomplete({
       }
 
       if (atPos === -1) {
-        if (isOpen) {
-          setIsOpen(false);
-          setQuery("");
-          setTriggerStart(-1);
-        }
+        setIsOpen(false);
+        setSuggestions([]);
+        setQuery("");
+        setTriggerStart(-1);
         return;
       }
 
@@ -238,6 +262,13 @@ export function useFileAutocomplete({
       const loaded = loadedFiles;
       const files = loaded ?? allFiles;
       const agents = providerId === "codex" ? (loadedAgents ?? allAgents) : [];
+
+      if (
+        requestEpochRef.current !== requestEpoch ||
+        prevScopeRef.current !== requestScope
+      ) {
+        return;
+      }
 
       const fileSuggestions: MentionSuggestion[] = files.map((filePath) => ({
         id: `file:${filePath}`,
@@ -264,18 +295,22 @@ export function useFileAutocomplete({
       setSuggestions(filtered);
       setIsOpen(true);
     },
-    [isOpen, allFiles, allAgents, loadFiles, loadAgents, providerId],
+    [workspaceId, threadId, allFiles, allAgents, loadFiles, loadAgents, providerId],
   );
 
   const selectSuggestion = useCallback((suggestion: MentionSuggestion): MentionSuggestion => {
+    requestEpochRef.current += 1;
     setIsOpen(false);
+    setSuggestions([]);
     setQuery("");
     setTriggerStart(-1);
     return suggestion;
   }, []);
 
   const dismiss = useCallback(() => {
+    requestEpochRef.current += 1;
     setIsOpen(false);
+    setSuggestions([]);
     setQuery("");
     setTriggerStart(-1);
   }, []);

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -1,5 +1,9 @@
 import { useState, useRef, useCallback, useEffect } from "react";
-import { useSkillsStore } from "@/stores/skillsStore";
+import {
+  EMPTY_SKILLS_CACHE_ENTRY,
+  skillsCacheKey,
+  useSkillsStore,
+} from "@/stores/skillsStore";
 import type { SkillInfo } from "@/transport";
 import type { SlashCommandNamespace } from "./lexical/SlashCommandNode";
 
@@ -171,11 +175,11 @@ export function useSlashCommand({
   // always appending to the end (which breaks mid-text trigger detection).
   const lastCursorRef = useRef<number | undefined>(undefined);
 
-  const skills = useSkillsStore((s) => s.skills);
-  const cachedCwd = useSkillsStore((s) => s.cwd);
-  const cachedProviderId = useSkillsStore((s) => s.providerId);
-  const isLoading = useSkillsStore((s) => s.isLoading);
-  const error = useSkillsStore((s) => s.error);
+  const cacheKey = skillsCacheKey(cwd, providerId);
+  const cacheEntry = useSkillsStore(
+    (state) => state.entries[cacheKey] ?? EMPTY_SKILLS_CACHE_ENTRY,
+  );
+  const { skills, isLoading, isStale, error } = cacheEntry;
   const load = useSkillsStore((s) => s.load);
 
   // Build the full command list (memoize via skills identity, providerId, and
@@ -234,24 +238,18 @@ export function useSlashCommand({
   // user types `/`, so the popup renders the full list on first paint and
   // the loading skeleton is never visible.
   //
-  // Conditions to trigger a load:
-  //   - cwd differs from the cached cwd (workspace switch)
-  //   - providerId differs (provider switch)
-  //   - skills are null and no prior error (cold start)
+  // Each cwd and provider pair has its own cache entry. Load when that entry
+  // is cold or stale, while retaining old rows during background refresh.
   //
-  // The `!error` gate prevents an infinite retry loop on persistent
-  // failures: when cwd is unchanged, recovery happens via `onRetry`.
-  // When cwd changes, we always load (treating it as a fresh workspace,
-  // ignoring any prior error from the old one).
+  // The error gate prevents an infinite retry loop on persistent failures.
+  // A different cwd or provider selects a different entry with its own error.
   useEffect(() => {
     if (isLoading) return;
-    const cwdChanged = cachedCwd !== cwd;
-    const providerChanged = cachedProviderId !== providerId;
     const noSkills = skills === null;
-    if (cwdChanged || providerChanged || (noSkills && !error)) {
+    if (!error && (isStale || noSkills)) {
       load(cwd, providerId).catch(() => { /* surfaced via `error` */ });
     }
-  }, [skills, cachedCwd, cachedProviderId, cwd, providerId, isLoading, error, load]);
+  }, [skills, cwd, providerId, isLoading, isStale, error, load]);
 
   const onInputChange = useCallback(
     (value: string, cursorPos?: number) => {

--- a/apps/web/src/components/terminal/TerminalPoolHost.tsx
+++ b/apps/web/src/components/terminal/TerminalPoolHost.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { useEffect, useLayoutEffect, useMemo } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore } from "@/stores/diffStore";
 import {
@@ -16,15 +16,21 @@ import { resolveActiveTerminalId } from "./resolveActiveTerminalId";
  * Mounts at most one terminal view (ADR-0010): the active shell on the active
  * scope, portaled into the right-panel slot while the Terminal tab is open.
  *
- * Background shells — other tabs, other threads — keep running server-side with
- * their output draining into the server scrollback buffer; their views are
- * disposed and remounted via `terminal.reattach` (see {@link TerminalView}).
- * This replaces the former persistent pool that kept every shell's xterm
- * mounted and hidden, which scaled memory and main-thread cost with every
- * long-running shell.
+ * The last active view stays warm offscreen when the panel closes. Switching
+ * terminals replaces that view only after the next terminal has hydrated from
+ * server scrollback. Other shells keep running without renderer instances.
  */
 export function TerminalPoolHost() {
-  const { slotEl } = useTerminalPoolSlot();
+  const { slotEl, offScreenEl } = useTerminalPoolSlot();
+  const [mountEl] = useState(() => {
+    const element = document.createElement("div");
+    element.className = "relative h-full min-h-0 w-full overflow-hidden";
+    return element;
+  });
+  const [warmTarget, setWarmTarget] = useState<{
+    readonly scopeId: string;
+    readonly ptyId: string;
+  } | null>(null);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   // The terminal binds to the active thread, or to the workspace itself in the
@@ -84,25 +90,70 @@ export function TerminalPoolHost() {
     }
   }, [terminalScopeId, activeTerminalId, terminalTabVisible, slotEl]);
 
-  // The single shell whose view should be mounted right now, or undefined when
-  // the terminal tab is hidden or the scope has no terminals.
-  const activeTerm =
+  const visibleTerm =
     terminalTabVisible && terminalScopeId && activeTerminalId
       ? terminals[terminalScopeId]?.find((t) => t.id === activeTerminalId)
       : undefined;
 
-  // Mount only into the in-panel slot. When it is absent (panel closed/tab
-  // hidden) the view stays unmounted and the shell keeps draining server-side.
-  if (!slotEl || !activeTerm) return null;
+  useLayoutEffect(() => {
+    if (visibleTerm && terminalScopeId) {
+      if (
+        warmTarget?.scopeId !== terminalScopeId ||
+        warmTarget.ptyId !== visibleTerm.id
+      ) {
+        setWarmTarget({ scopeId: terminalScopeId, ptyId: visibleTerm.id });
+      }
+      return;
+    }
+    if (
+      warmTarget &&
+      !terminals[warmTarget.scopeId]?.some(
+        (terminal) => terminal.id === warmTarget.ptyId,
+      )
+    ) {
+      setWarmTarget(null);
+    }
+  }, [visibleTerm, terminalScopeId, terminals, warmTarget]);
+
+  const target = visibleTerm && terminalScopeId
+    ? { scopeId: terminalScopeId, ptyId: visibleTerm.id }
+    : warmTarget;
+  const mountedTerm = target
+    ? terminals[target.scopeId]?.find((terminal) => terminal.id === target.ptyId)
+    : undefined;
+  const shown = Boolean(
+    visibleTerm &&
+      target &&
+      visibleTerm.id === target.ptyId &&
+      terminalScopeId === target.scopeId,
+  );
+  const displayed = shown && Boolean(slotEl);
+  const portalTarget = displayed ? slotEl : offScreenEl;
+
+  useLayoutEffect(() => {
+    if (portalTarget && mountEl.parentElement !== portalTarget) {
+      portalTarget.appendChild(mountEl);
+    }
+  }, [mountEl, portalTarget]);
+
+  useEffect(
+    () => () => {
+      mountEl.remove();
+    },
+    [mountEl],
+  );
+
+  if (!portalTarget || !mountedTerm) return null;
 
   return createPortal(
-    <div className="relative h-full min-h-0 w-full overflow-hidden">
-      <div className="absolute inset-0 flex min-h-0 flex-col">
-        {/* key by ptyId so switching shell/thread disposes the old view and
-            mounts a fresh one that reattaches at the latest output. */}
-        <TerminalView key={activeTerm.id} ptyId={activeTerm.id} visible threadActive />
-      </div>
+    <div className="absolute inset-0 flex min-h-0 flex-col">
+      <TerminalView
+        key={mountedTerm.id}
+        ptyId={mountedTerm.id}
+        visible={displayed}
+        threadActive={displayed}
+      />
     </div>,
-    slotEl,
+    mountEl,
   );
 }

--- a/apps/web/src/components/terminal/TerminalView.tsx
+++ b/apps/web/src/components/terminal/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useLayoutEffect, useRef } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Terminal, IDisposable } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 import { getTransport } from "@/transport";
@@ -279,8 +279,8 @@ interface TerminalViewProps {
   readonly visible: boolean;
   /**
    * Whether this terminal's owning thread is the active workspace thread.
-   * When false, incoming PTY output is not written to xterm; the renderer
-   * stays attached so scroll position is preserved across thread switches.
+   * When false, the server pauses delivery after any in-flight output and the
+   * renderer stays attached so scroll position survives a return to the thread.
    */
   readonly threadActive: boolean;
 }
@@ -296,6 +296,7 @@ export const TerminalView = memo(function TerminalView({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
   const flushResizeRpcRef = useRef<(() => void) | null>(null);
+  const resumeWarmViewRef = useRef<(() => void) | null>(null);
   const rendererRef = useRef<IDisposable | null>(null);
   /** Cancels in-flight {@link loadRenderer} when the thread goes dormant or the effect cleans up. */
   const rendererInitCancelledRef = useRef(false);
@@ -306,6 +307,7 @@ export const TerminalView = memo(function TerminalView({
   threadActiveRef.current = threadActive;
 
   const prevShownRef = useRef(shown);
+  const [hydrated, setHydrated] = useState(false);
 
   const scrollback = useSettingsStore((s) => s.settings.terminal.scrollback);
   const scrollbackRef = useRef(scrollback);
@@ -363,6 +365,7 @@ export const TerminalView = memo(function TerminalView({
       registerTerminalScrollHarness(ptyId, term);
 
       const transport = getTransport();
+      let exited = false;
 
       const flowSettings =
         useSettingsStore.getState().settings.terminal.flowControl;
@@ -378,6 +381,7 @@ export const TerminalView = memo(function TerminalView({
       // paste mode when the shell requests it, preventing embedded newlines from auto-executing commands.
       const handleContextMenu = (e: MouseEvent) => {
         e.preventDefault();
+        if (exited) return;
         navigator.clipboard
           .readText()
           .then((text) => {
@@ -391,6 +395,7 @@ export const TerminalView = memo(function TerminalView({
 
       // Forward keystrokes to the backend via WS RPC
       const dataDisposable = term.onData((data) => {
+        if (exited) return;
         transport.terminalWrite(ptyId, data).catch(() => {});
       });
 
@@ -411,6 +416,7 @@ export const TerminalView = memo(function TerminalView({
       // until the replay completes, then write in seq order so the viewport
       // shows scrollback-then-tail, not a garbled tail-then-scrollback.
       let replaying = true;
+      let replayMode: "cold" | "warm" = "cold";
       const replayPending: PtyDataPayload[] = [];
       // Highest seq actually written. seq is monotonic per PTY, so anything not
       // strictly newer has already been painted. Guards against double delivery:
@@ -452,7 +458,12 @@ export const TerminalView = memo(function TerminalView({
         // before unmount; otherwise follow the tail. Record remount latency once
         // the replay paints.
         const follow = () => {
-          applyRemountAnchor(ptyId, term);
+          if (replayMode === "cold") {
+            applyRemountAnchor(ptyId, term);
+          } else {
+            terminalScroll.restore(ptyId, term);
+          }
+          setHydrated(true);
           recordMountTiming(performance.now() - mountStart);
         };
 
@@ -492,6 +503,8 @@ export const TerminalView = memo(function TerminalView({
       // pre-renderer for the same reason as pty-data: an early exit should
       // not be silently lost).
       const unsubPtyExit = onPtyExit(ptyId, (detail) => {
+        exited = true;
+        term.options.disableStdin = true;
         term.write(
           `\r\n\x1b[90m[Process exited with code ${detail.code}]\x1b[0m\r\n`,
         );
@@ -524,7 +537,7 @@ export const TerminalView = memo(function TerminalView({
           clearTimeout(rpcTimer);
           rpcTimer = null;
         }
-        if (disposed || terminalScroll.shouldDeferFitRefresh(ptyId)) return;
+        if (disposed || exited || terminalScroll.shouldDeferFitRefresh(ptyId)) return;
         const dims = fitAddonRef.current?.proposeDimensions();
         if (!isSafeTerminalDimensions(dims)) return;
         if (dims.cols === lastSentCols && dims.rows === lastSentRows) return;
@@ -567,6 +580,7 @@ export const TerminalView = memo(function TerminalView({
         if (rafId !== null) cancelAnimationFrame(rafId);
         if (rpcTimer !== null) clearTimeout(rpcTimer);
         flushResizeRpcRef.current = null;
+        resumeWarmViewRef.current = null;
         dataDisposable.dispose();
         scrollDisposable.dispose();
         el.removeEventListener("wheel", onWheel);
@@ -613,8 +627,11 @@ export const TerminalView = memo(function TerminalView({
       // tail. The reattach resolves after all replay frames have been sent (WS
       // ordering puts the data frames ahead of the RPC response), at which point
       // the gate flushes. lastSeq = -1 requests the full retained window.
-      transport
-        .terminalReattach(ptyId, -1)
+      const reattach = (lastSeq: number, mode: "cold" | "warm") => {
+        replaying = true;
+        replayMode = mode;
+        return transport
+          .terminalReattach(ptyId, lastSeq)
         .then(({ gapped }) => {
           if (disposed) return;
           if (gapped) {
@@ -631,12 +648,23 @@ export const TerminalView = memo(function TerminalView({
           // any buffered live frames still paint.
           if (disposed) return;
           flushReplayGate();
+        })
+        .finally(() => {
+          if (!disposed && !exited && shownRef.current) {
+            transport.terminalResume(ptyId).catch(() => {});
+          }
         });
+      };
 
-      // Newly created PTYs are paused server-side so their first prompt waits
-      // for a consumer. Release now that the listeners above are attached; for
-      // an already-running session this is a harmless no-op.
-      transport.terminalResume(ptyId).catch(() => {});
+      resumeWarmViewRef.current = () => {
+        if (disposed || exited || replaying) return;
+        const lastSeq = Number.isFinite(lastWrittenSeq) ? lastWrittenSeq : -1;
+        void reattach(lastSeq, "warm");
+      };
+
+      // Newly created PTYs begin paused. Reattach first so retained output and
+      // any paused live frames share one sequence gate, then resume.
+      void reattach(-1, "cold");
 
       // DOM renderer only at init; WebGL loads when this terminal becomes shown
       // (see shown effect) so the pool never holds multiple GL contexts.
@@ -681,10 +709,12 @@ export const TerminalView = memo(function TerminalView({
     if (term && prevShownRef.current && !shown) {
       terminalScroll.onHide(ptyId, term);
       releaseWebglSlot(ptyId);
+      getTransport().terminalPause(ptyId).catch(() => {});
     }
 
     if (term && shown && !prevShownRef.current) {
       terminalScroll.onShow(ptyId);
+      resumeWarmViewRef.current?.();
     }
 
     prevShownRef.current = shown;
@@ -829,6 +859,11 @@ export const TerminalView = memo(function TerminalView({
   }, [shown, threadActive, ptyId]);
 
   return (
-    <div ref={containerRef} className="h-full min-h-0 w-full" />
+    <div
+      ref={containerRef}
+      className="h-full min-h-0 w-full"
+      data-terminal-hydrated={hydrated}
+      style={{ visibility: shown && hydrated ? "visible" : "hidden" }}
+    />
   );
 });

--- a/apps/web/src/lib/__tests__/summon-tab.test.ts
+++ b/apps/web/src/lib/__tests__/summon-tab.test.ts
@@ -59,6 +59,24 @@ describe("summonTab", () => {
       // No tab was closed — both remain open.
       expect(panel().openTabs).toEqual(["preview", "terminal"]);
     });
+
+    it("recreates a closed active tab instead of hiding the empty panel", () => {
+      summonTab("terminal");
+      useDiffStore.getState().closeRightPanelTab(WID, TID, "terminal");
+      expect(panel()).toMatchObject({
+        visible: true,
+        activeTab: "terminal",
+        openTabs: [],
+      });
+
+      summonTab("terminal");
+
+      expect(panel()).toMatchObject({
+        visible: true,
+        activeTab: "terminal",
+        openTabs: ["terminal"],
+      });
+    });
   });
 
   describe("hide-when-active", () => {

--- a/apps/web/src/lib/summon-tab.ts
+++ b/apps/web/src/lib/summon-tab.ts
@@ -36,7 +36,7 @@ export function summonTab(tab: RightPanelTab, onFocus?: () => void): void {
     showRightPanelAdaptive(wid, tid);
     setRightPanelTab(wid, tid, tab);
     onFocus?.();
-  } else if (panel.activeTab !== tab) {
+  } else if (!panel.openTabs.includes(tab) || panel.activeTab !== tab) {
     setRightPanelTab(wid, tid, tab);
     onFocus?.();
   } else {

--- a/apps/web/src/stores/skillsStore.test.ts
+++ b/apps/web/src/stores/skillsStore.test.ts
@@ -174,4 +174,15 @@ describe("provider-scoped caching", () => {
     expect(p1).not.toBe(p2); // different providers = different in-flight promises
     await Promise.all([p1, p2]);
   });
+
+  it("retains concurrent provider caches without making either consumer refetch", async () => {
+    const claude = useSkillsStore.getState().load("/foo", "claude");
+    const unscoped = useSkillsStore.getState().load("/foo", undefined);
+    await Promise.all([claude, unscoped]);
+
+    await useSkillsStore.getState().load("/foo", "claude");
+    await useSkillsStore.getState().load("/foo", undefined);
+
+    expect(listSkillsMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/stores/skillsStore.ts
+++ b/apps/web/src/stores/skillsStore.ts
@@ -1,84 +1,70 @@
 /**
- * Cache for slash-command skills.
+ * Provider-scoped cache for slash-command skills.
  *
- * Module-scoped so the cache survives Composer remounts. Single-flights
- * concurrent `load()` calls. Reacts to `skills.changed` push events
- * (wired in `ws-events.ts`) by invalidating.
+ * Each cwd and provider pair owns independent data, loading state, errors, and
+ * in-flight work. This lets Composer and Preview request different scopes at
+ * the same time without replacing each other's cache entry.
  */
 
 import { create } from "zustand";
 import { getTransport, type SkillInfo } from "@/transport";
 
+/** Cached skill state for one cwd and provider pair. */
+export interface SkillsCacheEntry {
+  readonly skills: SkillInfo[] | null;
+  readonly isLoading: boolean;
+  readonly isStale: boolean;
+  readonly error: Error | null;
+  readonly inflight: Promise<SkillInfo[]> | null;
+  readonly loadEpoch: number;
+  readonly lastFetchedAt: number;
+}
+
+/** Stable empty entry used by selectors before a scope has loaded. */
+export const EMPTY_SKILLS_CACHE_ENTRY: SkillsCacheEntry = Object.freeze({
+  skills: null,
+  isLoading: false,
+  isStale: true,
+  error: null,
+  inflight: null,
+  loadEpoch: 0,
+  lastFetchedAt: 0,
+});
+
+/** Builds a collision-safe cache key for one cwd and provider pair. */
+export function skillsCacheKey(cwd?: string, providerId?: string): string {
+  return JSON.stringify([cwd ?? null, providerId ?? null]);
+}
+
 /** State and actions for the skills Zustand store. */
 interface SkillsState {
-  /** Fetched skill list, or null if not yet loaded or invalidated. */
+  /** Entries keyed by {@link skillsCacheKey}. */
+  entries: Readonly<Record<string, SkillsCacheEntry>>;
+
+  // Compatibility snapshot of the most recent load. New consumers should read
+  // entries so simultaneous scopes never share render state.
   skills: SkillInfo[] | null;
-  /** The cwd associated with the last load attempt (success OR failure). */
   cwd: string | undefined;
-  /** The providerId associated with the last load attempt. */
   providerId: string | undefined;
-  /** Whether a fetch is currently in-flight. */
   isLoading: boolean;
-  /** Error from the last failed fetch, if any. */
   error: Error | null;
-  /** The in-flight promise. Single-flight only deduplicates same-cwd+providerId callers. */
   inflight: Promise<SkillInfo[]> | null;
-  /** The cwd of the in-flight promise; used to scope single-flight by cwd. */
   inflightCwd: string | undefined;
-  /** The providerId of the in-flight promise; scopes single-flight to cwd + providerId. */
   inflightProviderId: string | undefined;
-  /**
-   * Monotonic counter bumped by each new load() call AND by invalidate()/
-   * reset(). The async closure captures the value it incremented to and
-   * checks `get().loadEpoch === myEpoch` before any set(); a mismatch means
-   * a newer load or an invalidate raced ahead, so the stale resolution is
-   * dropped instead of rehydrating the store.
-   */
   loadEpoch: number;
 
-  /**
-   * Load skills for the given cwd and providerId.
-   *
-   * Returns cached data if still fresh (within TTL) and both cwd and
-   * providerId match. Concurrent calls with the same (cwd, providerId)
-   * while a request is in-flight all receive the same promise. Different
-   * providerId values get separate in-flight promises.
-   */
+  /** Loads one cwd and provider entry with per-key cache and single-flight behavior. */
   load(cwd?: string, providerId?: string, force?: boolean): Promise<SkillInfo[]>;
-
-  /**
-   * Invalidate the cached skills so the next `load()` re-fetches from
-   * the server regardless of TTL.
-   */
+  /** Marks every entry stale while retaining visible rows during refresh. */
   invalidate(): void;
-
-  /**
-   * Reset all store state to initial values, including in-flight tracking.
-   * Used in tests for cleanup between cases.
-   */
+  /** Clears all cache and in-flight state. */
   reset(): void;
 }
 
-/** Skills are considered fresh for 5 minutes after the last successful fetch. */
+/** Skills are considered fresh for five minutes after a successful fetch. */
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
-// Module-level timestamp so TTL survives store resets in tests but still
-// gets cleared when `reset()` or `invalidate()` is explicitly called.
-let lastFetchedAt = 0;
-
-/**
- * The store's "cleared" field values — every data/in-flight field reset to its
- * empty state. `loadEpoch` (bumped, not reset) and `lastFetchedAt` (a module
- * var) are handled separately.
- *
- * Both the initial state and the `invalidate()`/`reset()` actions spread this
- * single object, so a newly added state field can never be cleared in one path
- * but forgotten in another. That divergence is exactly what caused the
- * stuck-popup bug: `invalidate()` once omitted `isLoading: false` while the
- * initial state and `reset()` had it, leaving the flag stuck `true` after a
- * push-during-load and dead-locking the consumer's eager-prefetch effect.
- */
-const CLEARED_STATE = {
+const LEGACY_CLEARED_STATE = {
   skills: null,
   cwd: undefined,
   providerId: undefined,
@@ -89,95 +75,129 @@ const CLEARED_STATE = {
   inflightProviderId: undefined,
 } as const satisfies Partial<SkillsState>;
 
-/** Module-scoped Zustand store for skill caching with single-flight loading. */
+function replaceEntry(
+  entries: Readonly<Record<string, SkillsCacheEntry>>,
+  key: string,
+  entry: SkillsCacheEntry,
+): Readonly<Record<string, SkillsCacheEntry>> {
+  return { ...entries, [key]: entry };
+}
+
+/** Module-scoped Zustand store for provider-scoped skill caching. */
 export const useSkillsStore = create<SkillsState>((set, get) => ({
-  ...CLEARED_STATE,
+  entries: {},
+  ...LEGACY_CLEARED_STATE,
   loadEpoch: 0,
 
-  // Non-async so the return value IS the cached/in-flight promise directly,
-  // enabling identity equality (p1 === p2) for single-flight callers.
   load(cwd, providerId, force = false): Promise<SkillInfo[]> {
+    const key = skillsCacheKey(cwd, providerId);
     const state = get();
+    const existing = state.entries[key] ?? EMPTY_SKILLS_CACHE_ENTRY;
 
-    // Return cache if fresh, same cwd, AND same providerId
     if (
       !force &&
-      state.skills &&
-      state.cwd === cwd &&
-      state.providerId === providerId &&
-      Date.now() - lastFetchedAt < CACHE_TTL_MS
+      !existing.isStale &&
+      existing.skills !== null &&
+      Date.now() - existing.lastFetchedAt < CACHE_TTL_MS
     ) {
-      return Promise.resolve(state.skills);
+      return Promise.resolve(existing.skills);
     }
 
-    // Single-flight scoped to cwd + providerId. A different-providerId request
-    // must not piggyback on an in-flight load or it would receive the wrong data.
-    if (
-      state.inflight &&
-      state.inflightCwd === cwd &&
-      state.inflightProviderId === providerId
-    ) {
-      return state.inflight;
-    }
+    if (existing.inflight) return existing.inflight;
 
-    // Create and register the in-flight promise atomically so a second
-    // synchronous caller (same cwd + providerId) sees it immediately via get().inflight.
     let resolveInflight!: (skills: SkillInfo[]) => void;
-    let rejectInflight!: (err: unknown) => void;
-    const promise = new Promise<SkillInfo[]>((res, rej) => {
-      resolveInflight = res;
-      rejectInflight = rej;
+    let rejectInflight!: (error: unknown) => void;
+    const promise = new Promise<SkillInfo[]>((resolve, reject) => {
+      resolveInflight = resolve;
+      rejectInflight = reject;
     });
-
-    const myEpoch = state.loadEpoch + 1;
+    const myEpoch = existing.loadEpoch + 1;
+    const loadingEntry: SkillsCacheEntry = {
+      ...existing,
+      isLoading: true,
+      isStale: existing.isStale,
+      error: null,
+      inflight: promise,
+      loadEpoch: myEpoch,
+    };
     set({
+      entries: replaceEntry(state.entries, key, loadingEntry),
       isLoading: true,
       error: null,
       inflight: promise,
       inflightCwd: cwd,
       inflightProviderId: providerId,
-      loadEpoch: myEpoch,
+      loadEpoch: state.loadEpoch + 1,
     });
 
-    // Kick off the actual fetch outside the synchronous set() block.
-    (async () => {
+    void (async () => {
       const transport = getTransport();
       const attempt = () => transport.listSkills(cwd, providerId);
       try {
         let skills: SkillInfo[];
         try {
           skills = await attempt();
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          // Retry once if the WebSocket was momentarily disconnected. The
-          // transport may expose waitForConnection; use it if available so
-          // the retry doesn't fire before the socket is back up.
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
           if (message.includes("disconnected") || message.includes("not initialized")) {
-            const t = transport as unknown as { waitForConnection?: (ms: number) => Promise<void> };
-            if (t.waitForConnection) {
-              await t.waitForConnection(5000).catch(() => undefined);
-            }
+            const reconnectable = transport as unknown as {
+              waitForConnection?: (timeoutMs: number) => Promise<void>;
+            };
+            await reconnectable.waitForConnection?.(5_000).catch(() => undefined);
             skills = await attempt();
           } else {
-            throw err;
+            throw error;
           }
         }
-        // Fence: skip set() if invalidate(), reset(), or a newer load()
-        // bumped the epoch while we were awaiting. Still resolve the promise
-        // so callers don't hang — they'll get the data they asked for, just
-        // without polluting the now-fresher store state.
-        if (get().loadEpoch === myEpoch) {
-          lastFetchedAt = Date.now();
-          set({ skills, cwd, providerId, isLoading: false, inflight: null, inflightCwd: undefined, inflightProviderId: undefined, error: null });
+
+        const current = get();
+        const currentEntry = current.entries[key];
+        if (currentEntry?.loadEpoch === myEpoch) {
+          const readyEntry: SkillsCacheEntry = {
+            skills,
+            isLoading: false,
+            isStale: false,
+            error: null,
+            inflight: null,
+            loadEpoch: myEpoch,
+            lastFetchedAt: Date.now(),
+          };
+          set({
+            entries: replaceEntry(current.entries, key, readyEntry),
+            skills,
+            cwd,
+            providerId,
+            isLoading: false,
+            error: null,
+            inflight: null,
+            inflightCwd: undefined,
+            inflightProviderId: undefined,
+          });
         }
         resolveInflight(skills);
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
+      } catch (value) {
+        const error = value instanceof Error ? value : new Error(String(value));
         console.warn("[skillsStore] load failed after retry", error);
-        // Track the attempted cwd even on failure so the consumer hook can
-        // detect a cwd change vs. a same-cwd retry and handle each correctly.
-        if (get().loadEpoch === myEpoch) {
-          set({ cwd, providerId, isLoading: false, inflight: null, inflightCwd: undefined, inflightProviderId: undefined, error });
+        const current = get();
+        const currentEntry = current.entries[key];
+        if (currentEntry?.loadEpoch === myEpoch) {
+          const failedEntry: SkillsCacheEntry = {
+            ...currentEntry,
+            isLoading: false,
+            error,
+            inflight: null,
+          };
+          set({
+            entries: replaceEntry(current.entries, key, failedEntry),
+            skills: failedEntry.skills,
+            cwd,
+            providerId,
+            isLoading: false,
+            error,
+            inflight: null,
+            inflightCwd: undefined,
+            inflightProviderId: undefined,
+          });
         }
         rejectInflight(error);
       }
@@ -187,17 +207,33 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   },
 
   invalidate() {
-    // Bumping loadEpoch fences any in-flight load() so its eventual set() is
-    // dropped instead of rehydrating the store with pre-invalidation data.
-    // Spreading CLEARED_STATE guarantees isLoading is reset to false even when
-    // the fenced load skips its own reset — see CLEARED_STATE for why that
-    // matters (the stuck-popup bug).
-    set({ ...CLEARED_STATE, loadEpoch: get().loadEpoch + 1 });
-    lastFetchedAt = 0;
+    const state = get();
+    const entries = Object.fromEntries(
+      Object.entries(state.entries).map(([key, entry]) => [
+        key,
+        {
+          ...entry,
+          isLoading: false,
+          isStale: true,
+          error: null,
+          inflight: null,
+          loadEpoch: entry.loadEpoch + 1,
+        } satisfies SkillsCacheEntry,
+      ]),
+    );
+    set({
+      entries,
+      ...LEGACY_CLEARED_STATE,
+      loadEpoch: state.loadEpoch + 1,
+    });
   },
 
   reset() {
-    set({ ...CLEARED_STATE, loadEpoch: get().loadEpoch + 1 });
-    lastFetchedAt = 0;
+    const state = get();
+    set({
+      entries: {},
+      ...LEGACY_CLEARED_STATE,
+      loadEpoch: state.loadEpoch + 1,
+    });
   },
 }));

--- a/apps/web/src/stores/terminalStore.test.ts
+++ b/apps/web/src/stores/terminalStore.test.ts
@@ -54,4 +54,32 @@ describe("terminalStore pause/resume wiring", () => {
     store.toggleTerminalPanel("thread-2");
     expect(terminalResume).toHaveBeenCalledOnce();
   });
+
+  it("reconciles stale client PTYs when the restarted server reports none", () => {
+    const store = useTerminalStore.getState();
+    store.addTerminal("thread-1", "stale-pty");
+
+    store.reconcileActiveSessions([]);
+
+    expect(useTerminalStore.getState().terminals["thread-1"]).toBeUndefined();
+    expect(useTerminalStore.getState().ptyToThread["stale-pty"]).toBeUndefined();
+  });
+
+  it("restores server-only PTYs and removes client-only PTYs on reconnect", () => {
+    const store = useTerminalStore.getState();
+    store.addTerminal("thread-1", "client-only");
+
+    store.reconcileActiveSessions([
+      { ptyId: "server-pty", threadId: "thread-2" },
+    ]);
+
+    const next = useTerminalStore.getState();
+    expect(next.terminals["thread-1"]).toBeUndefined();
+    expect(next.terminals["thread-2"]?.map((terminal) => terminal.id)).toEqual([
+      "server-pty",
+    ]);
+    expect(next.terminalPanelByThread["thread-2"]?.activeTerminalId).toBe(
+      "server-pty",
+    );
+  });
 });

--- a/apps/web/src/stores/terminalStore.ts
+++ b/apps/web/src/stores/terminalStore.ts
@@ -9,6 +9,12 @@ export interface TerminalInstance {
   readonly label: string;
 }
 
+/** Server-authoritative PTY identity returned during reconnect. */
+export interface ActiveTerminalSession {
+  readonly ptyId: string;
+  readonly threadId: string;
+}
+
 /** Per-thread terminal panel state (visibility, height, active terminal). */
 export type TerminalPanelState = {
   readonly visible: boolean;
@@ -37,6 +43,8 @@ interface TerminalState {
   setTerminalPanelHeight: (threadId: string, height: number) => void;
   setActiveTerminal: (threadId: string, ptyId: string | null) => void;
   addTerminal: (threadId: string, ptyId: string, shell?: string) => void;
+  /** Replaces stale client identities with the server's active PTY set. */
+  reconcileActiveSessions: (sessions: readonly ActiveTerminalSession[]) => void;
   removeTerminal: (ptyId: string) => void;
   removeAllTerminals: (threadId: string) => void;
   clearThread: (threadId: string) => void;
@@ -156,6 +164,50 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
           [threadId]: { ...currentPanel, visible: true, activeTerminalId: ptyId },
         },
       };
+    }),
+
+  reconcileActiveSessions: (sessions) =>
+    set((state) => {
+      const existingById = new Map(
+        Object.values(state.terminals)
+          .flat()
+          .map((terminal) => [terminal.id, terminal] as const),
+      );
+      const terminals: Record<string, readonly TerminalInstance[]> = {};
+      const ptyToThread: Record<string, string> = {};
+
+      for (const session of sessions) {
+        const existing = existingById.get(session.ptyId);
+        const scopeTerminals = terminals[session.threadId] ?? [];
+        const terminal: TerminalInstance = existing
+          ? { ...existing, threadId: session.threadId }
+          : {
+              id: session.ptyId,
+              threadId: session.threadId,
+              label: generateLabel(scopeTerminals),
+            };
+        terminals[session.threadId] = [...scopeTerminals, terminal];
+        ptyToThread[session.ptyId] = session.threadId;
+      }
+
+      const terminalPanelByThread = { ...state.terminalPanelByThread };
+      const allScopes = new Set([
+        ...Object.keys(state.terminals),
+        ...Object.keys(terminals),
+      ]);
+      for (const scopeId of allScopes) {
+        const current =
+          terminalPanelByThread[scopeId] ?? TERMINAL_PANEL_DEFAULTS;
+        const active = terminals[scopeId] ?? [];
+        const activeTerminalId = active.some(
+          (terminal) => terminal.id === current.activeTerminalId,
+        )
+          ? current.activeTerminalId
+          : (active[0]?.id ?? null);
+        terminalPanelByThread[scopeId] = { ...current, activeTerminalId };
+      }
+
+      return { terminals, ptyToThread, terminalPanelByThread };
     }),
 
   removeTerminal: (ptyId) =>

--- a/apps/web/src/transport/ws-events.test.ts
+++ b/apps/web/src/transport/ws-events.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Thread } from "@/transport";
 
 vi.mock("@/transport", () => ({
@@ -8,6 +8,7 @@ vi.mock("@/transport", () => ({
 import { pushEmitter } from "./ws-transport";
 import { startPushListeners, stopPushListeners } from "./ws-events";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useSkillsStore } from "@/stores/skillsStore";
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {
@@ -86,5 +87,26 @@ describe("ws-events thread.checkoutChanged", () => {
     expect(state.checksById).toEqual({
       other: { aggregate: "no_checks", runs: [], fetchedAt: 2 },
     });
+  });
+});
+
+describe("ws-events skills.changed", () => {
+  afterEach(() => {
+    stopPushListeners();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("coalesces a burst of provider invalidations into one cache refresh", () => {
+    vi.useFakeTimers();
+    const invalidate = vi.spyOn(useSkillsStore.getState(), "invalidate");
+    startPushListeners();
+
+    pushEmitter.emit("skills.changed", {});
+    pushEmitter.emit("skills.changed", {});
+    pushEmitter.emit("skills.changed", {});
+    vi.advanceTimersByTime(100);
+
+    expect(invalidate).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -17,6 +17,8 @@ import { emitPtyData, emitPtyExit } from "@/components/terminal/ptyDataRegistry"
 
 /** Unsubscribe handles for all push listeners. */
 let unsubs: (() => void)[] = [];
+let skillsInvalidationTimer: ReturnType<typeof setTimeout> | null = null;
+const SKILLS_INVALIDATION_DEBOUNCE_MS = 100;
 
 /** Encoder reused across all legacy JSON terminal.data frames. */
 const _legacyEncoder = new TextEncoder();
@@ -326,7 +328,13 @@ export function startPushListeners(): void {
   // skills.changed: invalidate skill cache so the popup re-fetches on next open
   unsubs.push(
     pushEmitter.on("skills.changed", () => {
-      useSkillsStore.getState().invalidate();
+      if (skillsInvalidationTimer !== null) {
+        clearTimeout(skillsInvalidationTimer);
+      }
+      skillsInvalidationTimer = setTimeout(() => {
+        skillsInvalidationTimer = null;
+        useSkillsStore.getState().invalidate();
+      }, SKILLS_INVALIDATION_DEBOUNCE_MS);
     }),
   );
 
@@ -547,6 +555,10 @@ export function startPushListeners(): void {
 
 /** Remove all push channel listeners. Safe to call multiple times. */
 export function stopPushListeners(): void {
+  if (skillsInvalidationTimer !== null) {
+    clearTimeout(skillsInvalidationTimer);
+    skillsInvalidationTimer = null;
+  }
   for (const unsub of unsubs) {
     unsub();
   }

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -267,7 +267,7 @@ export function createWsTransport(
             "terminal.listActive",
             {},
           );
-          if (activePtys.length === 0) return;
+          useTerminalStore.getState().reconcileActiveSessions(activePtys);
 
           const clientPtyIds = new Set(
             Object.values(useTerminalStore.getState().terminals)

--- a/docs/adr/0010-terminal-view-detach-shell-session-persists.md
+++ b/docs/adr/0010-terminal-view-detach-shell-session-persists.md
@@ -17,7 +17,8 @@ The server already had `terminal.reattach` and a replay buffer, but the
 `terminal.scrollback` setting applied only to the client xterm buffer.
 
 ADR-0002 established discard semantics for browser preview tabs. The terminal
-needed an equivalent split: kill the expensive view, keep the cheap session.
+needed an equivalent split: dispose inactive views, retain one warm view, and
+keep every cheap shell session.
 
 ## Decision
 
@@ -26,19 +27,26 @@ Split **shell session** (server PTY, long-lived) from **terminal view**
 
 - **Shell sessions** survive thread switches, tab hides, and view disposal.
   Output always drains into server-side scrollback, even with no mounted view.
-  Pause/resume applies only to client backpressure when a view is mounted and
-  cannot keep up, not to "nobody is watching."
-- **Terminal views** mount for at most one shell at a time: the active shell
-  on the active terminal scope, while the Terminal tab and right panel are
-  open. All other shells run headless.
+  Hiding the warm view pauses client delivery, not the shell or server-side
+  retention. Reopening requests the buffered delta before delivery resumes.
+- **Terminal views** mount for at most one shell at a time. The active shell's
+  view stays warm when the Terminal tab or right panel is hidden. Switching
+  shells or terminal scopes replaces that view. All other shells run headless.
 - **Scrollback** uses one knob: `terminal.scrollback` drives both server
   retention (for reattach replay) and the mounted view's buffer. Output
   beyond the limit is dropped oldest-first.
-- **Remount** replays retained scrollback via `terminal.reattach` and opens
-  at the latest output (follow). Smart scroll-position restore is a planned
-  follow-up, not v1.
-- **Mount/unmount speed** is a first-class requirement: remount must feel
-  instant; optimize replay and xterm init accordingly.
+- **Return to the same shell** reveals the warm view and requests only output
+  after its last processed sequence. The view follows new output when the user
+  was at the tail, or restores the same retained content when the user was
+  reading history.
+- **Switch to another shell** hydrates a new view while hidden. It applies a
+  bounded scrollback replay or checkpoint plus delta, restores the viewport,
+  then reveals the completed frame. Users never watch history paint from top
+  to bottom.
+- **Performance** keeps the terminal module lazy until first use, retains no
+  more than one view, and releases rendering acceleration while the warm view
+  is hidden. This follows the lazy-loading and bounded-renderer guidance in the
+  [performance audit](../guides/performance-audit.md).
 
 ## Considered Options
 
@@ -50,19 +58,24 @@ Split **shell session** (server PTY, long-lived) from **terminal view**
   one setting should mean one retention policy.
 - **Mount all shells for the active scope (rejected).** Up to four xterm
   instances per thread; still too heavy for the idle-memory target.
-- **Detach views, persist scrollback server-side, max one mounted view
-  (chosen).** Mirrors ADR-0002's discard pattern; reuses existing reattach
-  infrastructure once the replay buffer is sized from `terminal.scrollback`.
+- **Dispose every hidden view (rejected).** Keeps renderer memory lowest, but
+  pays xterm creation, replay, parsing, layout, and viewport restoration on
+  every reopen.
+- **Persist scrollback server-side with one warm view (chosen).** Preserves the
+  strict one-renderer bound while making the most recently used terminal fast
+  to reopen. Cold shell switches hydrate before becoming visible.
 
 ## Consequences
 
-- `TerminalPoolHost`'s always-mounted pool is replaced by mount-on-demand
-  for the active shell only. Background shell tabs remount on select.
+- `TerminalPoolHost`'s many-view pool is replaced by one lazy terminal view.
+  The view moves between the visible terminal surface and an offscreen host.
+  Background shell tabs stay server-side only.
 - Server replay buffer capacity must derive from `terminal.scrollback`, not
   the fixed 512 KB default.
-- Tab switches within a thread trigger remount + replay; this must be fast
-  enough to feel seamless.
-- Smart follow (restore scroll position when the user had scrolled up) is
-  deferred; v1 always follows latest output on remount.
+- Closing and reopening the terminal surface keeps the active view and viewport
+  intact. Shell or scope switches use hidden hydration and restore the saved
+  tail or history anchor before reveal.
+- Warm views process bounded output deltas. Cold views replay bounded retained
+  scrollback without exposing intermediate render frames.
 - E2E specs that assume all terminals stay mounted (`__mcodeLiveTerminals`,
   scroll-on-thread-switch harness) need updating for the new lifecycle.


### PR DESCRIPTION
## What

Fix terminal crashes, stale sessions, slow reopen behavior, and repeated composer suggestion refreshes.

## Why

Production logs showed Windows ConPTY teardown failures and client terminal IDs surviving server restarts. Terminal views also replayed full scrollback visibly after reopening. Composer suggestion consumers could replace one shared cache entry with different provider scopes, which caused repeated loading.

## Key Changes

- Use node-pty's bundled ConPTY DLL teardown path on Windows.
- Reconcile client terminal state with active server sessions after reconnect.
- Keep one lazy terminal view warm and resume it with output deltas.
- Hydrate cold terminal switches before revealing the renderer.
- Reopen a closed Terminal tab correctly through Ctrl+J.
- Cache slash-command suggestions by working directory and provider.
- Fence delayed file suggestions and debounce skill invalidations.
- Keep autocomplete overlays clear of editable text on constrained viewports.
- Document the terminal lifecycle and performance decision in ADR-0010.

## Verification

- Typecheck passed in all five packages.
- Lint passed.
- 80 focused web tests passed.
- The focused server teardown test passed.
- 14 terminal and slash-command Playwright scenarios passed.
- 8 composer popup and 5 annotation popup browser scenarios passed, including an 800 by 400 viewport.
- Electron desktop smoke passed.
- A real PowerShell terminal accepted commands before and after close and reopen, reopened in 118 ms through Ctrl+J, and terminated without a new AttachConsole failure.

The full monorepo unit gate remains blocked in this checkout because the local better-sqlite3 Node 24 native binding is missing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786231985&installation_id=129163861&pr_number=851&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F851&signature=2deb4e30130c33c51ed00d0ea12054ea1d85d9a0446353698d226166bfce487d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal views now remain warm when hidden, preserving shell output and restoring the latest content or reading position when reopened.
  * Terminal sessions are reconciled reliably after reconnects, including when no active sessions remain.
  * Skills and slash commands load independently by workspace and provider.

* **Bug Fixes**
  * Improved Windows terminal shutdown reliability.
  * Prevented stale file and agent autocomplete results after scope changes or cache updates.
  * Reduced redundant refreshes from rapid skills updates.
  * Terminal input is disabled immediately after a shell exits.

* **Documentation**
  * Updated terminal lifecycle documentation to clarify view retention and switching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
