### PR TITLE
fix: repair nightly releases and terminal opening

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -60,7 +60,19 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            delay=$((attempt * 10))
+            echo "Dependency installation failed. Retrying in ${delay}s."
+            sleep "$delay"
+          done
 
       - name: Build main & renderer
         run: bun run --cwd apps/desktop build

--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -37,13 +37,17 @@ jobs:
       - id: check
         name: Compare HEAD to last nightly tag
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Find the most recent tag matching our nightly pattern. If none
-          # exists yet, force a build so we bootstrap the first nightly.
-          last_tag=$(git tag --list "v*-nightly.*" --sort=-creatordate | head -n 1)
+          last_tag=$(gh release list \
+            --repo "${{ github.repository }}" \
+            --limit 100 \
+            --json tagName,isDraft,isPrerelease \
+            --jq '[.[] | select(.isDraft == false and .isPrerelease == true and (.tagName | test("^v.*-nightly\\.")))][0].tagName // ""')
           if [ -z "$last_tag" ]; then
-            echo "No prior nightly tag found; will build."
+            echo "No published nightly found; building one."
             echo "should_build=true" >> "$GITHUB_OUTPUT"
             echo "last_nightly_tag=" >> "$GITHUB_OUTPUT"
             exit 0
@@ -53,8 +57,19 @@ jobs:
           echo "last nightly tag: $last_tag ($last_sha)"
           echo "HEAD: $head_sha"
           if [ "$last_sha" = "$head_sha" ]; then
-            echo "No new commits since last nightly; skipping."
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            assets=$(gh release view "$last_tag" \
+              --repo "${{ github.repository }}" \
+              --json assets \
+              --jq '.assets[].name')
+            if grep -Fxq "nightly.yml" <<< "$assets" \
+              && grep -Fxq "nightly-linux.yml" <<< "$assets" \
+              && grep -Fxq "nightly-mac.yml" <<< "$assets"; then
+              echo "No new commits since the last complete nightly; skipping."
+              echo "should_build=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "The last nightly is incomplete; rebuilding it."
+              echo "should_build=true" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           fi
@@ -117,6 +132,7 @@ jobs:
           fi
           short_sha=$(git rev-parse --short HEAD)
           gh release create "$TAG" \
+            --draft \
             --prerelease \
             --title "Mcode Nightly ${{ steps.tag.outputs.version }} (${short_sha})" \
             --notes "Automated nightly build from ${{ github.sha }}. Not marked latest. Channel YAML: \`nightly.yml\`." \
@@ -161,7 +177,19 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            delay=$((attempt * 10))
+            echo "Dependency installation failed. Retrying in ${delay}s."
+            sleep "$delay"
+          done
 
       - name: Set nightly package version
         shell: bash
@@ -281,14 +309,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download arm64 yml
-        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: mac-yml-arm64-nightly
           path: yml-arm64
 
       - name: Download x64 yml
-        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: mac-yml-x64-nightly
@@ -301,12 +327,10 @@ jobs:
           X64_YML="yml-x64/nightly-mac.yml"
 
           if [ ! -f "$ARM64_YML" ] || [ ! -f "$X64_YML" ]; then
-            echo "One or both nightly mac yml files missing, skipping merge"
-            if [ -f "$ARM64_YML" ]; then cp "$ARM64_YML" nightly-mac.yml; fi
-            if [ -f "$X64_YML" ]; then cp "$X64_YML" nightly-mac.yml; fi
-            if [ ! -f nightly-mac.yml ]; then exit 0; fi
-          else
-            node -e "
+            echo "Both macOS update metadata files are required."
+            exit 1
+          fi
+          node -e "
               const fs = require('fs');
               const arm64 = fs.readFileSync('$ARM64_YML', 'utf8');
               const x64 = fs.readFileSync('$X64_YML', 'utf8');
@@ -384,11 +408,9 @@ jobs:
               }
               console.log('Merged nightly-mac.yml:');
               console.log(fs.readFileSync('nightly-mac.yml', 'utf8'));
-            "
-          fi
+          "
 
       - name: Upload merged nightly-mac.yml
-        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.setup.outputs.tag }}
@@ -397,3 +419,39 @@ jobs:
             echo "Uploading merged nightly-mac.yml to $TAG"
             gh release upload "$TAG" nightly-mac.yml --clobber --repo "${{ github.repository }}"
           fi
+
+  publish-nightly:
+    needs: [setup, build, merge-mac-yml-nightly]
+    if: needs.setup.outputs.should_build == 'true'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Publish complete nightly release
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          assets=$(gh release view "$TAG" \
+            --repo "${{ github.repository }}" \
+            --json assets \
+            --jq '.assets[].name')
+          for required in nightly.yml nightly-linux.yml nightly-mac.yml; do
+            if ! grep -Fxq "$required" <<< "$assets"; then
+              echo "Required update metadata is missing: $required"
+              exit 1
+            fi
+          done
+          gh release edit "$TAG" \
+            --repo "${{ github.repository }}" \
+            --draft=false \
+            --prerelease \
+            --latest=false

--- a/apps/web/src/lib/__tests__/summon-tab.test.ts
+++ b/apps/web/src/lib/__tests__/summon-tab.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { summonTab } from "@/lib/summon-tab";
 import { useDiffStore } from "@/stores/diffStore";
+import { useUiStore } from "@/stores/uiStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 const WID = "ws-1";
@@ -23,6 +24,7 @@ describe("summonTab", () => {
       rightPanelByThread: {},
       rightPanelFallbackByWorkspace: {},
     });
+    useUiStore.setState({ primarySurface: "chat" });
     useWorkspaceStore.setState({ activeWorkspaceId: WID, activeThreadId: TID });
   });
 
@@ -155,6 +157,20 @@ describe("summonTab", () => {
 
       summonTab("preview", onFocus); // hide
       expect(onFocus).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns to Chat and shows the requested tab from Pull requests", () => {
+      summonTab("terminal");
+      useUiStore.getState().setPrimarySurface("pullRequests");
+
+      summonTab("terminal");
+
+      expect(useUiStore.getState().primarySurface).toBe("chat");
+      expect(panel()).toMatchObject({
+        visible: true,
+        activeTab: "terminal",
+        openTabs: ["terminal"],
+      });
     });
   });
 });

--- a/apps/web/src/lib/summon-tab.ts
+++ b/apps/web/src/lib/summon-tab.ts
@@ -1,5 +1,6 @@
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore, type RightPanelTab } from "@/stores/diffStore";
+import { useUiStore } from "@/stores/uiStore";
 import { PANEL_TAB_TYPES } from "@/lib/panel-tabs";
 import { hideRightPanelAdaptive, showRightPanelAdaptive } from "@/lib/right-panel-layout";
 
@@ -30,7 +31,16 @@ export function summonTab(tab: RightPanelTab, onFocus?: () => void): void {
   if (tabNeedsThread(tab) && !tid) return;
 
   const { getRightPanel, getRightPanelVisible, setRightPanelTab } = useDiffStore.getState();
+  const ui = useUiStore.getState();
   const panel = getRightPanel(wid, tid);
+
+  if (ui.primarySurface !== "chat") {
+    ui.setPrimarySurface("chat");
+    showRightPanelAdaptive(wid, tid);
+    setRightPanelTab(wid, tid, tab);
+    onFocus?.();
+    return;
+  }
 
   if (!getRightPanelVisible(wid, tid)) {
     showRightPanelAdaptive(wid, tid);


### PR DESCRIPTION
## What

Fix terminal panel commands from the Pull requests screen and harden desktop release workflows against transient installs and incomplete nightlies.

## Why

Pull requests unmounts the Chat right panel, so Ctrl+J changed hidden state without displaying the terminal. The nightly workflow also published releases before every platform finished, which allowed a canceled run to become the updater's newest incomplete release.

## Key Changes

- Return to Chat before opening a right-panel tab from another primary surface.
- Add regression coverage for opening Terminal from Pull requests.
- Retry dependency installation up to three times in desktop release jobs.
- Keep nightlies as drafts until Windows, Linux, and merged macOS update metadata exist.
- Rebuild an incomplete nightly even when its tag points to the current commit.

Related to #854

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786526076&installation_id=129163861&pr_number=855&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F855&signature=6a4bc9cb7f06e244436dfcf1f05e3313c723409158b5c9a0aca3ad5ccec141c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->