### PR TITLE
fix: repair pull request inbox CI gates

### DIFF
--- a/apps/web/e2e/architecture.spec.ts
+++ b/apps/web/e2e/architecture.spec.ts
@@ -290,7 +290,7 @@ test.describe("Architecture: Workspace management", () => {
       activeWorkspaceId: WORKSPACE_A.id,
     });
 
-    await expect(page.getByRole("button", { name: "Select project Architecture Test" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open project Architecture Test" })).toBeVisible();
 
     await page.screenshot({
       path: "e2e/screenshots/arch-workspace-injected.png",
@@ -305,8 +305,8 @@ test.describe("Architecture: Workspace management", () => {
       activeWorkspaceId: WORKSPACE_A.id,
     });
 
-    await expect(page.getByRole("button", { name: "Select project Architecture Test" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Select project Second Project" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open project Architecture Test" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open project Second Project" })).toBeVisible();
   });
 
   test("empty state shows Open a folder when no workspaces", async ({
@@ -345,7 +345,7 @@ test.describe("Architecture: Thread lifecycle", () => {
     expect(threadCount).toBe(3);
 
     // Verify workspace is shown and active
-    await expect(page.getByRole("button", { name: "Select project Architecture Test" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open project Architecture Test" })).toBeVisible();
 
     await page.screenshot({
       path: "e2e/screenshots/arch-thread-list.png",

--- a/apps/web/e2e/pull-request-large-code.spec.ts
+++ b/apps/web/e2e/pull-request-large-code.spec.ts
@@ -276,6 +276,7 @@ async function openPullRequestDetail(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Pull requests" }).click();
   const row = page.getByTestId("pull-request-row");
   await expect(row).toHaveCount(1);
+  await row.click();
   await expect(
     page.getByRole("heading", { name: "Exercise the bounded Code review surface" }),
   ).toBeVisible();

--- a/apps/web/e2e/right-panel-activity-rail.spec.ts
+++ b/apps/web/e2e/right-panel-activity-rail.spec.ts
@@ -215,7 +215,7 @@ test.describe("Right panel activity rail", () => {
     await seed(page, { tabs: ["terminal"] });
 
     const chatMain = page.locator("main").filter({ has: page.getByTestId("new-thread-welcome") });
-    const projectTree = page.getByRole("button", { name: "Select project Activity Rail" });
+    const projectTree = page.getByRole("button", { name: "Open project Activity Rail" });
     const railToggle = page.getByTestId("rail-panel-toggle");
 
     await expect(chatMain).toBeVisible();

--- a/apps/web/e2e/sidebar-search.spec.ts
+++ b/apps/web/e2e/sidebar-search.spec.ts
@@ -146,9 +146,11 @@ test.describe("Sidebar thread actions", () => {
     await expect(page.getByTestId("command-palette")).toHaveCount(0);
   });
 
-  test("selecting a project opens its new-thread workspace", async ({ page }) => {
+  test("project new-thread action opens its workspace", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("button", { name: "Select project Test Workspace" }).click();
+    const projectRow = page.getByTestId("project-row-ws-1");
+    await projectRow.hover();
+    await projectRow.getByRole("button", { name: "New thread in Test Workspace" }).click();
 
     await expect(page.getByRole("heading", { name: "What should we build in Test Workspace?" })).toBeVisible();
     await expect(page.getByTestId("new-thread-context-strip")).toContainText("Test Workspace");
@@ -158,9 +160,9 @@ test.describe("Sidebar thread actions", () => {
     page,
   }) => {
     await page.goto("/");
-    await page
-      .getByRole("button", { name: "Select project Test Workspace" })
-      .click();
+    const projectRow = page.getByTestId("project-row-ws-1");
+    await projectRow.hover();
+    await projectRow.getByRole("button", { name: "New thread in Test Workspace" }).click();
 
     const branchTrigger = page.getByRole("button", { name: "From main" });
     await branchTrigger.click();
@@ -275,7 +277,7 @@ test.describe("Sidebar thread actions", () => {
     await dialog.getByRole("button", { name: "Rename", exact: true }).click();
 
     await expect(
-      page.getByRole("button", { name: "Select project Renamed Workspace" }),
+      page.getByRole("button", { name: "Open project Renamed Workspace" }),
     ).toBeVisible();
   });
 

--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -125,6 +125,9 @@ test.describe("Slash command popup", () => {
     const popup = page.locator("[data-slash-popup]");
     await expect(popup).toBeVisible();
     await expect(popup).toHaveAttribute("data-composer-autocomplete", "true");
+    await popup.evaluate(async (element) => {
+      await Promise.all(element.getAnimations().map((animation) => animation.finished));
+    });
     const [popupBox, composerBox] = await Promise.all([
       popup.boundingBox(),
       page.getByTestId("composer-surface").boundingBox(),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -75,6 +75,7 @@
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.21.0",
     "typescript-eslint": "^8.57.1",
     "vitest": "^4.1.0"
   }

--- a/apps/web/src/lib/__tests__/pull-request-diff-row-model.memory.test.ts
+++ b/apps/web/src/lib/__tests__/pull-request-diff-row-model.memory.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -8,14 +8,7 @@ describe("pull request diff row memory", () => {
   it("keeps a real 20,000-line V8 model within the 16 MiB cache", () => {
     const webRoot = process.cwd();
     const script = resolve(webRoot, "scripts/check-pull-request-code-memory.mts");
-    const bunPackages = resolve(webRoot, "../../node_modules/.bun");
-    const tsxPackage = readdirSync(bunPackages).find((entry) => entry.startsWith("tsx@"));
-    expect(tsxPackage).toBeDefined();
-    const tsxLoader = resolve(
-      bunPackages,
-      tsxPackage!,
-      "node_modules/tsx/dist/loader.mjs",
-    );
+    const tsxLoader = createRequire(import.meta.url).resolve("tsx");
     const result = spawnSync(
       process.execPath,
       ["--expose-gc", "--import", pathToFileURL(tsxLoader).href, script],

--- a/bun.lock
+++ b/bun.lock
@@ -141,6 +141,7 @@
         "rollup-plugin-visualizer": "^7.0.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
+        "tsx": "^4.21.0",
         "typescript-eslint": "^8.57.1",
         "vitest": "^4.1.0",
       },


### PR DESCRIPTION
## What

Repair the unit and browser test gates blocking the pull request inbox branch.

## Why

The memory harness read Bun's private `node_modules/.bun` layout, which is absent in CI's install layout. Browser tests also targeted the previous project controls, expected pull request details to open without a click, and measured the slash popup before its entrance animation finished.

## Key Changes

- Declare `tsx` as a direct test dependency and resolve its loader through package resolution.
- Update project controls to use the current accessible names and new-thread action.
- Open the selected pull request before asserting its detail content.
- Wait for the slash popup animation before checking its geometry.

Related to #854

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786527487&installation_id=129163861&pr_number=856&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F856&signature=ade45c69fe4947fb528e552e2dff85f825809f596bc835ec5452e857ce22094e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->