### PR TITLE
fix(desktop): keep packaged ConPTY runtime

### DIFF
--- a/apps/desktop/scripts/__tests__/packaged-node-pty.test.mjs
+++ b/apps/desktop/scripts/__tests__/packaged-node-pty.test.mjs
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ensurePackagedConptyRuntime } from "../packaged-node-pty.mjs";
+
+describe("ensurePackagedConptyRuntime", () => {
+  /** @type {string} */
+  let nodePtyRoot;
+
+  beforeEach(() => {
+    nodePtyRoot = mkdtempSync(path.join(tmpdir(), "mcode-node-pty-"));
+    const sourceDir = path.join(
+      nodePtyRoot,
+      "third_party",
+      "conpty",
+      "1.2.3",
+      "win10-x64",
+    );
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(path.join(nodePtyRoot, "build", "Release"), { recursive: true });
+    writeFileSync(path.join(sourceDir, "conpty.dll"), "dll-runtime");
+    writeFileSync(path.join(sourceDir, "OpenConsole.exe"), "console-runtime");
+    writeFileSync(path.join(nodePtyRoot, "build", "Release", "conpty.node"), "binding");
+  });
+
+  afterEach(() => {
+    rmSync(nodePtyRoot, { recursive: true, force: true });
+  });
+
+  it("copies the ConPTY runtime beside the rebuilt Windows binding", () => {
+    const result = ensurePackagedConptyRuntime({ nodePtyRoot, arch: "x64" });
+
+    expect(readFileSync(result.dllPath, "utf8")).toBe("dll-runtime");
+    expect(readFileSync(result.openConsolePath, "utf8")).toBe("console-runtime");
+    expect(result.dllPath).toBe(
+      path.join(nodePtyRoot, "build", "Release", "conpty", "conpty.dll"),
+    );
+  });
+
+  it("fails packaging when the rebuilt binding has no matching runtime", () => {
+    rmSync(path.join(nodePtyRoot, "third_party"), { recursive: true, force: true });
+
+    expect(() =>
+      ensurePackagedConptyRuntime({ nodePtyRoot, arch: "x64" }),
+    ).toThrow("Could not find the x64 ConPTY runtime");
+  });
+});

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -3,7 +3,8 @@
  *
  * 1. Built renamed `mcode-server` Electron binary (before fuse flip)
  * 2. Copied Claude Agent SDK native CLI into the asar-unpacked server tree
- * 3. Copied browser V8 snapshot (when generated) and flipped security fuses
+ * 3. Restored node-pty's Windows ConPTY runtime after the native rebuild
+ * 4. Copied browser V8 snapshot (when generated) and flipped security fuses
  *
  * This script is invoked automatically by electron-builder via the
  * "afterPack" config in package.json.
@@ -20,6 +21,7 @@ import {
   electronPlatformToNpm,
   resolvePackagedServerDir,
 } from "../../../scripts/build-server-dev-bundle.mjs";
+import { ensurePackagedConptyRuntime } from "./packaged-node-pty.mjs";
 
 /**
  * @param {import("electron-builder").AfterPackContext} context
@@ -88,6 +90,7 @@ export default async function afterPack(context) {
 
   const serverPackageRoot = resolve(desktopRoot, "..", "server");
   const npmPlatform = electronPlatformToNpm(electronPlatformName);
+  const npmArch = electronArchToNpm(context.arch);
   const packagedServerDir = resolvePackagedServerDir({
     appOutDir,
     electronPlatformName,
@@ -97,9 +100,26 @@ export default async function afterPack(context) {
     destServerDir: packagedServerDir,
     serverPackageRoot,
     platform: npmPlatform,
-    arch: electronArchToNpm(context.arch),
+    arch: npmArch,
   });
   console.log(`[after-pack] Copied Claude SDK CLI (${platformPkg}) to ${binDst}`);
+
+  if (npmPlatform === "win32") {
+    const nodePtyRoot = resolve(
+      packagedServerDir,
+      "..",
+      "..",
+      "node_modules",
+      "node-pty",
+    );
+    // Keep this mandatory: electron-builder can retain conpty.node while
+    // dropping its runtime files, which makes every packaged terminal fail.
+    const { dllPath } = ensurePackagedConptyRuntime({
+      nodePtyRoot,
+      arch: npmArch,
+    });
+    console.log(`[after-pack] Restored packaged ConPTY runtime at ${dllPath}`);
+  }
 
   // -------------------------------------------------------------------------
   // Step 2: V8 snapshot copy + fuse flip.

--- a/apps/desktop/scripts/packaged-node-pty.mjs
+++ b/apps/desktop/scripts/packaged-node-pty.mjs
@@ -1,0 +1,55 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+} from "node:fs";
+import path from "node:path";
+
+const CONPTY_ARCHES = new Set(["x64", "arm64"]);
+const CONPTY_RUNTIME_FILES = ["conpty.dll", "OpenConsole.exe"];
+
+/**
+ * Restores the ConPTY runtime files removed by electron-builder's node-pty rebuild.
+ *
+ * @param {{ nodePtyRoot: string, arch: string }} options
+ * @returns {{ dllPath: string, openConsolePath: string }}
+ */
+export function ensurePackagedConptyRuntime({ nodePtyRoot, arch }) {
+  if (!CONPTY_ARCHES.has(arch)) {
+    throw new Error(`Unsupported Windows architecture for node-pty: ${arch}`);
+  }
+
+  const releaseDir = path.join(nodePtyRoot, "build", "Release");
+  const bindingPath = path.join(releaseDir, "conpty.node");
+  if (!existsSync(bindingPath)) {
+    throw new Error(`Packaged node-pty binding is missing at ${bindingPath}`);
+  }
+
+  const thirdPartyRoot = path.join(nodePtyRoot, "third_party", "conpty");
+  const sourceDirs = existsSync(thirdPartyRoot)
+    ? readdirSync(thirdPartyRoot, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => path.join(thirdPartyRoot, entry.name, `win10-${arch}`))
+        .filter((candidate) =>
+          CONPTY_RUNTIME_FILES.every((file) => existsSync(path.join(candidate, file))),
+        )
+    : [];
+
+  if (sourceDirs.length !== 1) {
+    throw new Error(
+      `Could not find the ${arch} ConPTY runtime under ${thirdPartyRoot}`,
+    );
+  }
+
+  const destinationDir = path.join(releaseDir, "conpty");
+  mkdirSync(destinationDir, { recursive: true });
+  for (const file of CONPTY_RUNTIME_FILES) {
+    copyFileSync(path.join(sourceDirs[0], file), path.join(destinationDir, file));
+  }
+
+  return {
+    dllPath: path.join(destinationDir, "conpty.dll"),
+    openConsolePath: path.join(destinationDir, "OpenConsole.exe"),
+  };
+}

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -53,6 +53,7 @@ function findUnpackedServer() {
       electron: resolve(releaseDir, "win-unpacked/Mcode.exe"),
       sqlite: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
       koffi: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/koffi"),
+      nodePty: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/node-pty"),
     },
     // Linux (electron-builder uses package name as binary name)
     {
@@ -61,6 +62,7 @@ function findUnpackedServer() {
       electron: resolve(releaseDir, "linux-unpacked/mcode-desktop"),
       sqlite: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
       koffi: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/koffi"),
+      nodePty: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/node-pty"),
     },
     // macOS Intel
     {
@@ -69,6 +71,7 @@ function findUnpackedServer() {
       electron: resolve(releaseDir, "mac/Mcode.app/Contents/MacOS/Mcode"),
       sqlite: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
       koffi: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/koffi"),
+      nodePty: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty"),
     },
     // macOS ARM
     {
@@ -77,6 +80,7 @@ function findUnpackedServer() {
       electron: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/MacOS/Mcode"),
       sqlite: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
       koffi: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/koffi"),
+      nodePty: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty"),
     },
   ];
 
@@ -93,7 +97,14 @@ function findUnpackedServer() {
       const nodeBinding = resolve(c.sqlite, "better_sqlite3.node");
       const binding = existsSync(electronBinding) ? electronBinding : existsSync(nodeBinding) ? nodeBinding : undefined;
       const electronDir = useRenamed ? dirname(c.electron) : undefined;
-      return { server: c.server, electron: runtime, binding, electronDir, koffi: c.koffi };
+      return {
+        server: c.server,
+        electron: runtime,
+        binding,
+        electronDir,
+        koffi: c.koffi,
+        nodePty: c.nodePty,
+      };
     }
   }
   return null;
@@ -169,6 +180,61 @@ if (!bundleOnly) {
     process.exit(1);
   }
   console.log(`[smoke-test] Claude SDK CLI: ${claudeCli}`);
+
+  if (sdkTarget.platform === "win32") {
+    const marker = "MCODE_PACKAGED_PTY_OK";
+    const ptyScript = `
+      const { spawn } = require(process.env.MCODE_PACKAGED_NODE_PTY);
+      const marker = ${JSON.stringify(marker)};
+      let output = "";
+      const terminal = spawn(
+        "powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", "Write-Output " + marker],
+        {
+          name: "xterm-256color",
+          cols: 80,
+          rows: 24,
+          cwd: process.cwd(),
+          env: process.env,
+          useConptyDll: true,
+        },
+      );
+      const timeout = setTimeout(() => {
+        console.error("Packaged PTY timed out: " + JSON.stringify(output));
+        process.exit(1);
+      }, 8000);
+      terminal.onData((data) => { output += data; });
+      terminal.onExit(({ exitCode }) => {
+        clearTimeout(timeout);
+        if (exitCode !== 0 || !output.includes(marker)) {
+          console.error("Packaged PTY failed: " + JSON.stringify({ exitCode, output }));
+          process.exit(1);
+        }
+        process.stdout.write(marker, () => process.exit(0));
+      });
+    `;
+
+    try {
+      const output = execFileSync(found.electron, ["-e", ptyScript], {
+        cwd: dirname(found.server),
+        encoding: "utf8",
+        timeout: 10_000,
+        env: {
+          ...process.env,
+          ELECTRON_RUN_AS_NODE: "1",
+          MCODE_PACKAGED_NODE_PTY: found.nodePty,
+        },
+      });
+      if (!output.includes(marker)) {
+        throw new Error(`Packaged PTY marker missing from output: ${output}`);
+      }
+      console.log("[smoke-test] Packaged PTY: PASS");
+    } catch (error) {
+      const details = error.stderr?.toString() || error.stdout?.toString() || error.message;
+      console.error(`[smoke-test] ERROR: Packaged PTY failed to start: ${details}`);
+      process.exit(1);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Restore the Windows ConPTY runtime after electron-builder rebuilds `node-pty`, and make the packaged smoke test launch a real PowerShell shell session.

## Why

The packaged app retained `conpty.node` but omitted `conpty.dll` and `OpenConsole.exe`. Every `terminal.create` call then failed because `node-pty` could not load its runtime.

## Key Changes

- Copy the matching x64 or arm64 ConPTY runtime into the packaged `node-pty` release directory.
- Fail packaging when the rebuilt binding or matching runtime is missing.
- Exercise packaged PowerShell startup in the desktop smoke test.
- Cover successful restoration and missing-runtime failure with focused tests.

## Verification

- `bun run verify`
- Focused packaging tests: 2 passed
- Installed production RPC: `PRODUCTION_TERMINAL_PASS: MCODE_PRODUCTION_TERMINAL_OK`

The local installer build reached the native `node-pty` rebuild, then stopped because Visual Studio C++ build tools are not installed on this machine.
