### PR TITLE
fix(composer): remember worktree mode

### DIFF
--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -45,6 +45,7 @@ import { isCursorPermissionLockedToFull } from "@/lib/cursor-permission";
 import { isGoalControlCommand } from "@/lib/goal-command";
 import { PRIMARY_CONTENT_RAIL_CLASS } from "@/lib/layout-rails";
 import { isDetachedWorktree, normalizeWorktreePath } from "@/lib/worktree";
+import { rememberComposerMode } from "@/lib/composer-mode-preference";
 import { getDefaultModelId, getDefaultReasoningLevel, getDefaultProviderId, isMaxEffortModel, isXhighEffortModel, supportsEffortParameter, supportsUltrathink, supports1MContextWindow, supportsThinkingToggle, normalizeReasoningLevelForModel, getCodexReasoningLevels, providerSupportsReasoningLevels } from "@/lib/model-registry";
 import { ModelSelector } from "./ModelSelector";
 import { ModeSelector, ALL_MODE_OPTIONS } from "./ModeSelector";
@@ -1519,6 +1520,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     (mode: ComposerMode) => {
       setComposerModeLocal(mode);
       setNewThreadMode(mode);
+      rememberComposerMode(mode);
       if (mode === "existing-worktree" && workspaceId) {
         loadWorktrees(workspaceId);
       }
@@ -1526,27 +1528,16 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     [setNewThreadMode, loadWorktrees, workspaceId],
   );
 
+  // Resolve capability and thread state together so a remembered worktree mode
+  // cannot fight the direct-only constraint of a non-git project.
   useEffect(() => {
-    if (isNewThread && composerMode !== newThreadMode) {
-      setComposerModeLocal(newThreadMode);
+    const targetMode = isNewThread
+      ? (isGitRepo ? newThreadMode : "direct")
+      : (activeThread?.mode === "worktree" ? "worktree" : "direct");
+    if (composerMode !== targetMode) {
+      setComposerModeLocal(targetMode);
     }
-  }, [isNewThread, composerMode, newThreadMode]);
-
-  // Sync composerMode with thread's persisted mode when switching threads
-  useEffect(() => {
-    if (isNewThread) return;
-    const mode = activeThread?.mode === "worktree" ? "worktree" : "direct";
-    setComposerModeLocal(mode);
-    setNewThreadMode(mode);
-  }, [activeThread?.mode, isNewThread, setNewThreadMode]);
-
-  // Force direct mode for non-git workspaces — worktree modes are not available without git
-  useEffect(() => {
-    if (!isGitRepo && composerMode !== "direct") {
-      setComposerModeLocal("direct");
-      setNewThreadMode("direct");
-    }
-  }, [isGitRepo, composerMode, setNewThreadMode]);
+  }, [activeThread?.mode, composerMode, isGitRepo, isNewThread, newThreadMode]);
 
   // Load branches when entering new thread mode (always refresh to pick up live changes)
   useEffect(() => {

--- a/apps/web/src/components/chat/ModeSelector.test.tsx
+++ b/apps/web/src/components/chat/ModeSelector.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ModeSelector } from "./ModeSelector";
+
+describe("ModeSelector", () => {
+  it.each(["worktree", "existing-worktree"] as const)(
+    "uses the shared worktree glyph for %s mode",
+    (mode) => {
+      const { container } = render(
+        <ModeSelector mode={mode} onModeChange={vi.fn()} locked />,
+      );
+
+      expect(container.querySelector('[data-slot="worktree-mode-icon"]')).not.toBeNull();
+      expect(screen.getByText("Worktree")).toBeInTheDocument();
+    },
+  );
+});

--- a/apps/web/src/components/chat/ModeSelector.tsx
+++ b/apps/web/src/components/chat/ModeSelector.tsx
@@ -1,5 +1,7 @@
-import { FolderOpen, GitBranch, GitFork, Check, ChevronDown } from "lucide-react";
+import { FolderOpen, Check, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { WorktreeModeIcon } from "@/components/icons/WorktreeModeIcon";
+import type { ComponentType } from "react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -19,14 +21,14 @@ export type ComposerMode = "direct" | "worktree" | "existing-worktree";
 export interface ModeOption {
   value: ComposerMode;
   label: string;
-  icon: typeof FolderOpen;
+  icon: ComponentType<{ size?: number; className?: string }>;
 }
 
 /** All available mode options. Consumers can filter this list before passing to ModeSelector. */
 export const ALL_MODE_OPTIONS: ModeOption[] = [
   { value: "direct", label: "Local", icon: FolderOpen },
-  { value: "worktree", label: "New worktree", icon: GitBranch },
-  { value: "existing-worktree", label: "Existing worktree", icon: GitFork },
+  { value: "worktree", label: "New worktree", icon: WorktreeModeIcon },
+  { value: "existing-worktree", label: "Existing worktree", icon: WorktreeModeIcon },
 ];
 
 interface ModeSelectorProps {

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -204,8 +204,11 @@ vi.mock("../ProviderUnavailableBanner", () => ({
   ProviderUnavailableBanner: () => <div />,
 }));
 
-function seedComposerState(mode: "direct" | "worktree" | "existing-worktree") {
-  const workspace = createMockWorkspace({ id: "ws-1", is_git_repo: true });
+function seedComposerState(
+  mode: "direct" | "worktree" | "existing-worktree",
+  isGitRepo = true,
+) {
+  const workspace = createMockWorkspace({ id: "ws-1", is_git_repo: isGitRepo });
   useWorkspaceStore.setState({
     workspaces: [workspace],
     activeWorkspaceId: workspace.id,
@@ -314,6 +317,14 @@ describe("Composer checkout confirmation", () => {
     expect(within(strip).getByText(workspace.name)).toBeInTheDocument();
     expect(within(strip).getByTestId("mode-selector")).toHaveTextContent("direct");
     expect(within(strip).getByTestId("branch-picker")).toHaveTextContent("feature/base");
+  });
+
+  it("renders Local for a non-git project without overwriting the remembered mode", () => {
+    seedComposerState("worktree", false);
+    render(<Composer isNewThread workspaceId="ws-1" />);
+
+    expect(screen.getByTestId("mode-selector")).toHaveTextContent("direct");
+    expect(useWorkspaceStore.getState().newThreadMode).toBe("worktree");
   });
 
   it("clears the selected project without deleting it", async () => {

--- a/apps/web/src/components/icons/WorktreeModeIcon.tsx
+++ b/apps/web/src/components/icons/WorktreeModeIcon.tsx
@@ -18,6 +18,7 @@ export function WorktreeModeIcon({
       strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"
+      data-slot="worktree-mode-icon"
       className={cn("shrink-0", className)}
       {...props}
     >

--- a/apps/web/src/lib/__tests__/composer-mode-preference.test.ts
+++ b/apps/web/src/lib/__tests__/composer-mode-preference.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  readRememberedComposerMode,
+  rememberComposerMode,
+} from "../composer-mode-preference";
+
+describe("composer mode preference", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it.each(["direct", "worktree", "existing-worktree"] as const)(
+    "remembers %s",
+    (mode) => {
+      rememberComposerMode(mode);
+      expect(readRememberedComposerMode()).toBe(mode);
+    },
+  );
+
+  it("falls back to direct when stored data is invalid", () => {
+    window.localStorage.setItem("mcode-composer-mode", "invalid");
+    expect(readRememberedComposerMode()).toBe("direct");
+  });
+});

--- a/apps/web/src/lib/composer-mode-preference.ts
+++ b/apps/web/src/lib/composer-mode-preference.ts
@@ -1,0 +1,31 @@
+/** Composer modes that can be reused when opening a new thread. */
+export type RememberedComposerMode = "direct" | "worktree" | "existing-worktree";
+
+const STORAGE_KEY = "mcode-composer-mode";
+
+function isRememberedComposerMode(value: string | null): value is RememberedComposerMode {
+  return value === "direct" || value === "worktree" || value === "existing-worktree";
+}
+
+/** Reads the last composer mode selected by the user. */
+export function readRememberedComposerMode(): RememberedComposerMode {
+  if (typeof window === "undefined") return "direct";
+
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    return isRememberedComposerMode(value) ? value : "direct";
+  } catch {
+    return "direct";
+  }
+}
+
+/** Remembers the composer mode selected by the user for future new threads. */
+export function rememberComposerMode(mode: RememberedComposerMode): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // Browser storage can be unavailable; the in-memory composer state still works.
+  }
+}

--- a/apps/web/src/stores/__tests__/workspaceStore.actions.test.ts
+++ b/apps/web/src/stores/__tests__/workspaceStore.actions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useWorkspaceStore, type WorkspaceRpcCall } from "../workspaceStore";
 import { useDiffStore } from "../diffStore";
 import type { Workspace } from "@/transport/types";
+import { rememberComposerMode } from "@/lib/composer-mode-preference";
 
 function makeWs(overrides?: Partial<Workspace>): Workspace {
   return {
@@ -21,6 +22,7 @@ function makeWs(overrides?: Partial<Workspace>): Workspace {
 }
 
 beforeEach(() => {
+  window.localStorage.clear();
   useWorkspaceStore.setState({ workspaces: [makeWs()], activeWorkspaceId: null });
   useDiffStore.setState({
     rightPanelByThread: {},
@@ -111,7 +113,8 @@ describe("workspaceStore new-thread panel transition", () => {
     });
   });
 
-  it("enters a clean pending composer for the selected workspace", () => {
+  it("enters a clean pending composer with the last selected mode", () => {
+    rememberComposerMode("existing-worktree");
     useWorkspaceStore.setState({
       workspaces: [makeWs(), makeWs({ id: "ws-2", name: "second" })],
       activeWorkspaceId: "ws-2",
@@ -127,7 +130,7 @@ describe("workspaceStore new-thread panel transition", () => {
       activeWorkspaceId: "ws-2",
       activeThreadId: null,
       pendingNewThread: true,
-      newThreadMode: "direct",
+      newThreadMode: "existing-worktree",
       newThreadBranch: "",
     });
   });

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -19,6 +19,7 @@ import { usePreviewTabsStore } from "./previewTabsStore";
 import type { ContextWindowMode, NamingMode, ReasoningLevel, InteractionMode } from "@mcode/contracts";
 import { sanitizeCustomBranchInput } from "@/lib/branch-name";
 import { isDetachedWorktree, normalizeWorktreePath } from "@/lib/worktree";
+import { readRememberedComposerMode } from "@/lib/composer-mode-preference";
 
 /** Generate a short random branch name for auto-mode worktrees (e.g. `mcode-a1b2c3d4`). */
 function generateBranchId(): string {
@@ -425,7 +426,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
   error: null,
   branches: [],
   branchesLoading: false,
-  newThreadMode: "direct" as const,
+  newThreadMode: readRememberedComposerMode(),
   newThreadBranch: "",
   newThreadBranchSource: "branch" as const,
   worktrees: [],
@@ -1172,7 +1173,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       pendingNewThread: value,
       ...(value
         ? {
-            newThreadMode: "direct" as const,
+            newThreadMode: readRememberedComposerMode(),
             newThreadBranch: "",
             newThreadBranchSource: "branch" as const,
             namingMode: "auto" as const,


### PR DESCRIPTION
## What

Remember the selected composer mode for future new threads and use the shared worktree glyph in the mode selector.

## Why

The new-thread composer reset to Local, which made users repeat the same worktree selection. The selector also used different worktree icons from thread rows.

## Key Changes

- Persist and validate the last Local, New worktree, or Existing worktree selection.
- Restore that selection when a new composer opens without letting non-git projects overwrite it.
- Use the shared worktree icon for both worktree options and cover the behavior with focused tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786846707&installation_id=129163861&pr_number=858&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F858&signature=4a3572da8792e2b987670b580bfdb5d0d00c63263cf3dbe4c8b9c8ed27a416e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Composer mode selection is now remembered and restored when starting a new thread.
  - Invalid or unavailable saved preferences safely fall back to Direct mode.
  - Worktree-related modes now use a consistent icon.

- **Bug Fixes**
  - Starting a new thread preserves the previously selected composer mode instead of resetting based on the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->