### PR TITLE
fix(worktrees): retry locked cleanup without blocking deletion

### DIFF
--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -2,9 +2,8 @@ import "reflect-metadata";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 
-const { mockRm, mockRename, mockRmdir, mockExistsSync, mockLogger } = vi.hoisted(() => ({
+const { mockRm, mockRmdir, mockExistsSync, mockLogger } = vi.hoisted(() => ({
   mockRm: vi.fn(),
-  mockRename: vi.fn(),
   mockRmdir: vi.fn(),
   mockExistsSync: vi.fn(),
   mockLogger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
@@ -17,7 +16,6 @@ vi.mock("fs", () => ({
 
 vi.mock("fs/promises", () => ({
   rm: mockRm,
-  rename: mockRename,
   rmdir: mockRmdir,
 }));
 
@@ -161,37 +159,15 @@ describe("GitService.removeWorktree", () => {
     );
   });
 
-  it("renames directory then deletes when fs.rm fails on first path", async () => {
+  it("leaves a worktree in place for retry when another application locks it", async () => {
     execFn.mockRejectedValueOnce(new Error("git failed")); // worktree remove
-    execFn.mockResolvedValueOnce({ stdout: "", stderr: "" }); // prune
-    execFn.mockResolvedValueOnce({ stdout: "", stderr: "" }); // branch -d
-    // fs.rm fails on original path
     mockRm.mockRejectedValueOnce(Object.assign(new Error("EBUSY"), { code: "EBUSY" }));
-    mockRename.mockResolvedValue(undefined);
-    // existsSync: true (before rm attempt), true (after rm failure, before rename), false (final verification)
-    mockExistsSync
-      .mockReturnValueOnce(true)  // check before fallback rm
-      .mockReturnValueOnce(true)  // check after rm failure -> try rename
-      .mockReturnValueOnce(false); // final verification
-
-    const result = await gitService.removeWorktree("/repo", "my-worktree");
-
-    expect(mockRename).toHaveBeenCalledWith(
-      expect.stringContaining("my-worktree"),
-      expect.stringMatching(/my-worktree\.deleting-\d+$/),
-    );
-    expect(result).toBe(true);
-  });
-
-  it("returns false when both fs.rm and rename-then-delete fail", async () => {
-    execFn.mockRejectedValue(new Error("git failed"));
-    mockRm.mockRejectedValue(Object.assign(new Error("EBUSY"), { code: "EBUSY" }));
-    mockRename.mockRejectedValue(new Error("rename failed"));
     mockExistsSync.mockReturnValue(true);
 
     const result = await gitService.removeWorktree("/repo", "my-worktree");
 
     expect(result).toBe(false);
+    expect(execFn).toHaveBeenCalledTimes(1);
   });
 
   it("prunes stale metadata after manual fallback before deleting the branch", async () => {

--- a/apps/server/src/__tests__/thread-service.test.ts
+++ b/apps/server/src/__tests__/thread-service.test.ts
@@ -104,15 +104,27 @@ describe("ThreadService.delete", () => {
     expect(jobs[0].workspace_path).toBe("/tmp/test");
     expect(jobs[0].worktree_path).toBe("/tmp/wt/my-worktree");
     expect(jobs[0].branch).toBe("feat/test");
-    expect(mockGitService.withReviewWorktreeMutationLock).toHaveBeenCalledWith(
-      "/tmp/test",
-      expect.any(Function),
-    );
+    expect(mockGitService.withReviewWorktreeMutationLock).not.toHaveBeenCalled();
     expect(mockGitService.assessWorktreeRemovalSafety).toHaveBeenCalledWith(
       "/tmp/wt/my-worktree",
       [],
       false,
     );
+  });
+
+  it("queues cleanup without waiting for the repository mutation lock", async () => {
+    const ws = workspaceRepo.create("test", "/tmp/test");
+    insertWorktreeThread("t-busy", ws.id, "feat/busy", "/tmp/wt/busy");
+    (mockGitService.withReviewWorktreeMutationLock as ReturnType<typeof vi.fn>)
+      .mockImplementation(() => new Promise(() => {}));
+
+    const deletion = threadService.delete("t-busy", true);
+    await Promise.resolve();
+
+    expect(threadRepo.findById("t-busy")?.status).toBe("deleted");
+    expect(cleanupJobRepo.findByThreadId("t-busy")).not.toBeNull();
+    expect(mockGitService.withReviewWorktreeMutationLock).not.toHaveBeenCalled();
+    await expect(deletion).resolves.toBe(true);
   });
 
   it("keeps an unmanaged reused worktree when its thread is deleted", async () => {

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -9,7 +9,7 @@
 import { injectable, inject } from "tsyringe";
 import { createHash } from "crypto";
 import { AsyncLocalStorage } from "async_hooks";
-import { rm, rename, rmdir, realpath } from "fs/promises";
+import { rm, rmdir, realpath } from "fs/promises";
 import { existsSync, mkdirSync } from "fs";
 import { join, basename, dirname, resolve, relative, isAbsolute } from "path";
 import { getMcodeDir, validateBranchName, validateWorktreeName, logger } from "@mcode/shared";
@@ -857,44 +857,14 @@ export class GitService {
       }
     }
 
-    // 3. Rename-then-delete: atomically unblock the path even if deletion is slow.
-    // Renaming succeeds even when the directory has open handles, so the original
-    // path becomes available immediately while the OS drains remaining handles.
-    let deferredRm: Promise<void> | undefined;
-    if (existsSync(wtPath)) {
-      // Use a timestamp suffix to avoid collision with stale .deleting directories
-      // left by previous crashed cleanup attempts.
-      const pendingPath = `${wtPath}.deleting-${Date.now()}`;
-      try {
-        await rename(wtPath, pendingPath);
-        logger.info("Renamed stuck worktree for deferred deletion", { wtPath, pendingPath });
-        // Best-effort: .catch() intentionally swallows errors because the
-        // original worktree path is already gone (renamed). If the deferred rm
-        // fails the .deleting-* dir persists but the worktree is effectively
-        // removed, so retrying the entire cleanup job would be pointless.
-        deferredRm = rm(pendingPath, RM_RETRY_OPTIONS).catch(
-          (err) => {
-            logger.warn("Deferred deletion of renamed worktree failed", {
-              pendingPath,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          },
-        );
-      } catch (err) {
-        logger.error("Rename-then-delete fallback failed", {
-          wtPath,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
-
-    // 4. Verify cleanup
+    // 3. Keep a locked worktree at its registered path so the cleanup worker
+    // can retry after the application holding the directory releases it.
     if (existsSync(wtPath)) {
       logger.error("Worktree directory could not be removed", { wtPath });
       return false;
     }
 
-    // 5. Prune stale worktree metadata after any manual fallback removed the path.
+    // 4. Prune stale worktree metadata after any manual fallback removed the path.
     try {
       await this.gitExecutor.exec(["-C", repoPath, "worktree", "prune"], { timeout: 10_000 });
     } catch (err) {
@@ -903,18 +873,12 @@ export class GitService {
       });
     }
 
-    // 6. Wait for any deferred deletion to finish so the parent directory is
-    //    actually empty before we try to rmdir it.
-    if (deferredRm) {
-      await deferredRm;
-    }
-
-    // 7. Remove empty managed parent directories. Returns false on transient
+    // 5. Remove empty managed parent directories. Returns false on transient
     //    lock errors (EBUSY/EPERM) so the cleanup worker can retry later when
     //    the OS releases handles.
     const parentsCleaned = await removeEmptyManagedParentDirs(wtPath);
 
-    // 8. Delete the branch when explicitly requested (independent of parent
+    // 6. Delete the branch when explicitly requested (independent of parent
     //    dir state - always attempt this).
     if (branch) {
       try {

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -202,33 +202,29 @@ export class ThreadService {
       const worktreePath = thread.worktree_path;
       const workspace = this.workspaceRepo.findById(thread.workspace_id);
       if (workspace) {
-        const queued = await this.gitService.withReviewWorktreeMutationLock(
-          workspace.path,
-          async () => {
-            const current = this.threadRepo.findById(threadId);
-            if (
-              !current
-              || current.deleted_at !== null
-              || !current.worktree_managed
-              || !current.worktree_path
-              || current.worktree_path !== worktreePath
-            ) {
-              return false;
-            }
-            const siblings = this.threadRepo.listActiveSiblingWorktreePaths(threadId);
-            const safety = await this.gitService.assessWorktreeRemovalSafety(
-              current.worktree_path,
-              siblings.paths,
-              siblings.truncated,
-            );
-            if (!safety.safe) {
-              logger.info("Worktree cleanup skipped because ownership is not exclusive", {
-                threadId,
-                worktreePath: current.worktree_path,
-                reason: safety.reason,
-              });
-              return false;
-            }
+        const current = this.threadRepo.findById(threadId);
+        if (
+          current
+          && current.deleted_at === null
+          && current.worktree_managed
+          && current.worktree_path === worktreePath
+        ) {
+          const siblings = this.threadRepo.listActiveSiblingWorktreePaths(threadId);
+          const safety = await this.gitService.assessWorktreeRemovalSafety(
+            current.worktree_path,
+            siblings.paths,
+            siblings.truncated,
+          );
+          if (!safety.safe) {
+            logger.info("Worktree cleanup skipped because ownership is not exclusive", {
+              threadId,
+              worktreePath: current.worktree_path,
+              reason: safety.reason,
+            });
+          } else {
+            // The cleanup worker repeats this ownership check while holding the
+            // repository lock. Keeping that lock out of the foreground RPC
+            // prevents an unrelated cleanup from stalling the delete dialog.
             this.cleanupJobRepo.insert({
               thread_id: threadId,
               workspace_path: workspace.path,
@@ -239,10 +235,9 @@ export class ThreadService {
               threadId,
               worktreePath: current.worktree_path,
             });
-            return this.threadRepo.softDelete(threadId);
-          },
-        );
-        if (queued) return true;
+            if (this.threadRepo.softDelete(threadId)) return true;
+          }
+        }
       } else {
         logger.warn("Worktree cleanup skipped - workspace not found, directory will not be removed", {
           threadId,


### PR DESCRIPTION
## What

Prevent checked worktree deletion from leaving the dialog in a loading state. Keep externally locked worktrees at their registered path for retry.

## Why

The foreground request waited for the repository mutation lock before queueing cleanup. Another cleanup or Git operation could hold that lock and leave the dialog waiting. The locked-directory fallback could also rename the worktree to a `.deleting-*` path and report success after deferred removal failed.

## Key Changes

- Queue cleanup without taking the foreground lock. The worker repeats the ownership check while holding it.
- Return a failed result when an external application locks the worktree, preserving its path for retry.
- Cover foreground lock contention and Windows-style `EBUSY` deletion failures with regression tests.

## Verification

- Focused server suite: 51 tests passed.
- Live Playwright deletion with a PowerShell file lock: passed. Cleanup completed after the lock was released.
- `bun run verify`: typecheck, lint, and all repository test suites passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786846758&installation_id=129163861&pr_number=859&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F859&signature=7cf92063ca725801bd89859d6455e51fcc07e1c2198ba675b38918b8da74ede3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->